### PR TITLE
feat: improve quick connect ssh parsing

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -246,7 +246,7 @@ const en: Messages = {
   'vault.hosts.header.live': '{count} live',
 
   // Vault hosts header/actions
-  'vault.hosts.search.placeholder': 'Find a host or ssh user@hostname...',
+  'vault.hosts.search.placeholder': 'Find a host or ssh user@hostname / ssh -p 2222 user@hostname...',
   'vault.hosts.connect': 'Connect',
   'vault.view.grid': 'Grid',
   'vault.view.list': 'List',
@@ -439,6 +439,7 @@ const en: Messages = {
   'quickConnect.knownHost.addQuestion': 'Do you want to add it to the list of known hosts?',
   'quickConnect.knownHost.addAndContinue': 'Add and continue',
   'quickConnect.addKey': 'Add key',
+  'quickConnect.warning.unparsedOptions': 'Some SSH arguments were ignored: {options}',
 
   // Terminal
   'terminal.connectionErrorTitle': 'Connection Error',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -148,7 +148,7 @@ const zhCN: Messages = {
   'vault.hosts.header.live': '{count} 个在线',
 
   // Vault hosts header/actions
-  'vault.hosts.search.placeholder': '查找主机或 ssh user@hostname…',
+  'vault.hosts.search.placeholder': '查找主机或 ssh user@hostname / ssh -p 2222 user@hostname…',
   'vault.hosts.connect': '连接',
   'vault.view.grid': '网格',
   'vault.view.list': '列表',
@@ -312,6 +312,7 @@ const zhCN: Messages = {
   'quickConnect.knownHost.addQuestion': '是否将它加入 Known Hosts？',
   'quickConnect.knownHost.addAndContinue': '加入并继续',
   'quickConnect.addKey': '添加 key',
+  'quickConnect.warning.unparsedOptions': '部分 SSH 参数已被忽略: {options}',
 
   // Protocol select dialog
   'protocolSelect.chooseProtocol': '选择协议',

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -31,6 +31,7 @@ interface QuickConnectWizardProps {
   target: QuickConnectTarget;
   keys: SSHKey[];
   knownHosts: KnownHost[];
+  warnings?: string[];
   onConnect: (host: Host) => void;
   onSaveHost?: (host: Host) => void;
   onAddKey?: () => void;
@@ -42,6 +43,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   target,
   keys,
   knownHosts,
+  warnings,
   onConnect,
   onSaveHost,
   onAddKey,
@@ -643,6 +645,16 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
 
         {/* Progress indicator */}
         <div className="px-6">{renderProgressIndicator()}</div>
+
+        {warnings && warnings.length > 0 && (
+          <div className="px-6 pb-2">
+            <div className="text-xs text-amber-600 bg-amber-500/10 border border-amber-500/30 rounded-lg px-3 py-2">
+              {t("quickConnect.warning.unparsedOptions", {
+                options: warnings.join(", "),
+              })}
+            </div>
+          </div>
+        )}
 
         {/* Content */}
         <div className="px-6 py-4">

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -46,7 +46,7 @@ import KeychainManager from "./KeychainManager";
 import KnownHostsManager from "./KnownHostsManager";
 import PortForwarding from "./PortForwardingNew";
 import QuickConnectWizard from "./QuickConnectWizard";
-import { isQuickConnectInput, parseQuickConnectInput } from "../domain/quickConnect";
+import { isQuickConnectInput, parseQuickConnectInputWithWarnings } from "../domain/quickConnect";
 import SnippetsManager from "./SnippetsManager";
 import { ImportVaultDialog } from "./vault/ImportVaultDialog";
 import { Button } from "./ui/button";
@@ -184,6 +184,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     port?: number;
   } | null>(null);
   const [isQuickConnectOpen, setIsQuickConnectOpen] = useState(false);
+  const [quickConnectWarnings, setQuickConnectWarnings] = useState<string[]>([]);
 
   // Protocol select state (for hosts with multiple protocols)
   const [protocolSelectHost, setProtocolSelectHost] = useState<Host | null>(
@@ -198,9 +199,10 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   // Handle connect button click - detect quick connect or regular search
   const handleConnectClick = useCallback(() => {
     if (isSearchQuickConnect) {
-      const target = parseQuickConnectInput(search);
-      if (target) {
-        setQuickConnectTarget(target);
+      const parsed = parseQuickConnectInputWithWarnings(search);
+      if (parsed.target) {
+        setQuickConnectTarget(parsed.target);
+        setQuickConnectWarnings(parsed.warnings);
         setIsQuickConnectOpen(true);
       }
     } else {
@@ -268,6 +270,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       onConnect(host);
       setIsQuickConnectOpen(false);
       setQuickConnectTarget(null);
+      setQuickConnectWarnings([]);
       setSearch("");
     },
     [onConnect],
@@ -1483,7 +1486,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onClose={() => {
             setIsQuickConnectOpen(false);
             setQuickConnectTarget(null);
+            setQuickConnectWarnings([]);
           }}
+          warnings={quickConnectWarnings}
         />
       )}
 

--- a/domain/quickConnect.ts
+++ b/domain/quickConnect.ts
@@ -4,10 +4,12 @@ export interface QuickConnectTarget {
   port?: number;
 }
 
-// Parse user@host:port format
-export function parseQuickConnectInput(
-  input: string,
-): QuickConnectTarget | null {
+export interface QuickConnectParseResult {
+  target: QuickConnectTarget | null;
+  warnings: string[];
+}
+
+const parseDirectTarget = (input: string): QuickConnectTarget | null => {
   const trimmed = input.trim();
   if (!trimmed) return null;
 
@@ -43,10 +45,230 @@ export function parseQuickConnectInput(
     username: username || undefined,
     port,
   };
+};
+
+const sshArgOptions = new Set([
+  "-b",
+  "-c",
+  "-D",
+  "-E",
+  "-F",
+  "-i",
+  "-I",
+  "-J",
+  "-L",
+  "-m",
+  "-O",
+  "-P",
+  "-R",
+  "-S",
+  "-W",
+  "-w",
+]);
+
+const parseSshOption = (
+  raw: string,
+  nextToken?: string,
+): { key: string; value: string; consumedNext: boolean } | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const parts = trimmed.split("=");
+  if (parts.length >= 2) {
+    const key = parts[0]?.trim();
+    const value = parts.slice(1).join("=").trim();
+    if (key && value) {
+      return { key, value, consumedNext: false };
+    }
+  }
+
+  if (nextToken && !nextToken.startsWith("-")) {
+    return { key: trimmed, value: nextToken, consumedNext: true };
+  }
+
+  return null;
+};
+
+const parseSshCommand = (input: string): QuickConnectParseResult | null => {
+  const trimmed = input.trim();
+  if (!/^ssh(\s|$)/i.test(trimmed)) return null;
+
+  const tokens = trimmed.split(/\s+/);
+  if (tokens.length < 2) return null;
+
+  const warnings: string[] = [];
+  let username: string | undefined;
+  let optionUsername: string | undefined;
+  let port: number | undefined;
+  let optionPort: number | undefined;
+  let portInvalid = false;
+  let optionHostname: string | undefined;
+  let hostToken: string | undefined;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (!token) continue;
+
+    if (token === "-p") {
+      const value = tokens[i + 1];
+      if (value) {
+        port = parseInt(value, 10);
+        if (Number.isNaN(port)) portInvalid = true;
+        i++;
+      }
+      continue;
+    }
+
+    if (token.startsWith("-p") && token.length > 2) {
+      const value = token.replace(/^-p=?/, "");
+      if (value) {
+        port = parseInt(value, 10);
+        if (Number.isNaN(port)) portInvalid = true;
+      }
+      continue;
+    }
+
+    if (token === "-l") {
+      const value = tokens[i + 1];
+      if (value) {
+        username = value;
+        i++;
+      }
+      continue;
+    }
+
+    if (token.startsWith("-l") && token.length > 2) {
+      const value = token.replace(/^-l=?/, "");
+      if (value) username = value;
+      continue;
+    }
+
+    if (token === "-o") {
+      const optionToken = tokens[i + 1];
+      if (optionToken) {
+        const nextToken = tokens[i + 2];
+        const parsed = parseSshOption(optionToken, nextToken);
+        if (parsed) {
+          const key = parsed.key.toLowerCase();
+          if (key === "port") {
+            const parsedPort = parseInt(parsed.value, 10);
+            if (Number.isNaN(parsedPort)) {
+              portInvalid = true;
+            } else {
+              optionPort = parsedPort;
+            }
+          } else if (key === "user") {
+            optionUsername = parsed.value;
+          } else if (key === "hostname") {
+            optionHostname = parsed.value;
+          } else {
+            warnings.push(`-o ${parsed.key}`);
+          }
+          i += parsed.consumedNext ? 2 : 1;
+          continue;
+        }
+        warnings.push("-o");
+        i++;
+      }
+      continue;
+    }
+
+    if (token.startsWith("-o") && token.length > 2) {
+      const parsed = parseSshOption(token.slice(2), tokens[i + 1]);
+      if (parsed) {
+        const key = parsed.key.toLowerCase();
+        if (key === "port") {
+          const parsedPort = parseInt(parsed.value, 10);
+          if (Number.isNaN(parsedPort)) {
+            portInvalid = true;
+          } else {
+            optionPort = parsedPort;
+          }
+        } else if (key === "user") {
+          optionUsername = parsed.value;
+        } else if (key === "hostname") {
+          optionHostname = parsed.value;
+        } else {
+          warnings.push(`-o ${parsed.key}`);
+        }
+        if (parsed.consumedNext) i++;
+        continue;
+      }
+      warnings.push("-o");
+    }
+
+    if (sshArgOptions.has(token)) {
+      warnings.push(token);
+      const next = tokens[i + 1];
+      if (next) i++;
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      warnings.push(token);
+      continue;
+    }
+
+    if (!hostToken) {
+      hostToken = token;
+    } else {
+      warnings.push(token);
+    }
+  }
+
+  if (!hostToken) return null;
+
+  const base = optionHostname
+    ? parseDirectTarget(optionHostname)
+    : parseDirectTarget(hostToken);
+  if (!base) return null;
+
+  if (portInvalid) return null;
+
+  const resolvedPort =
+    port !== undefined && !Number.isNaN(port)
+      ? port
+      : optionPort !== undefined && !Number.isNaN(optionPort)
+        ? optionPort
+        : base.port;
+  if (
+    resolvedPort !== undefined &&
+    (Number.isNaN(resolvedPort) || resolvedPort < 1 || resolvedPort > 65535)
+  ) {
+    return null;
+  }
+
+  return {
+    target: {
+      hostname: base.hostname,
+      username: optionUsername || username || base.username,
+      port: resolvedPort,
+    },
+    warnings: Array.from(new Set(warnings)),
+  };
+};
+
+// Parse user@host:port or ssh command formats with warning details
+export function parseQuickConnectInputWithWarnings(
+  input: string,
+): QuickConnectParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { target: null, warnings: [] };
+
+  const sshTarget = parseSshCommand(trimmed);
+  if (sshTarget) return sshTarget;
+
+  return { target: parseDirectTarget(trimmed), warnings: [] };
+}
+
+// Parse user@host:port or ssh command formats
+export function parseQuickConnectInput(
+  input: string,
+): QuickConnectTarget | null {
+  return parseQuickConnectInputWithWarnings(input).target;
 }
 
 // Check if input looks like a quick connect address
 export function isQuickConnectInput(input: string): boolean {
   return parseQuickConnectInput(input) !== null;
 }
-


### PR DESCRIPTION
  ## 背景 / 目的
  希望像 VSCode 一样，支持在快速连接入口直接粘贴 `ssh ...` 命令（例如 `ssh -p 2222 user@host`），并在包含未支持参数时给出明确提示，避免用户误以为这些参数被完整应用。

  ## 变更内容
  - 解析增强：支持从 `ssh` 命令中提取 `hostname / username / port`，包含 `-p`、`-l`、`-o Port=...` / `-o User=...` / `-o HostName=...` 等常见写法，并识别其它未处理参数作为 warning。
  - UI 提示：Quick Connect 向导顶部显示被忽略参数的警告文案。
  - 文案更新：新增 warning i18n 文案（EN/中文），以及更新搜索框提示文本以展示 `ssh -p ...` 用法。

  ## 具体实现
  - `domain/quickConnect.ts`
    - 增加 `parseQuickConnectInputWithWarnings`，返回 `{ target, warnings }`。
    - 扩展 `parseSshCommand`：解析 `-p/-l/-o` 并收集未处理参数（去重）。
  - `components/VaultView.tsx`
    - 使用 `parseQuickConnectInputWithWarnings`，并将 warnings 透传至向导。
    - 关闭/连接时清理 warnings。
  - `components/QuickConnectWizard.tsx`
    - 新增 warning banner，展示被忽略的参数列表。
  - `application/i18n/locales/en.ts` / `application/i18n/locales/zh-CN.ts`
    - 新增 `quickConnect.warning.unparsedOptions` 文案
    - 更新搜索框 placeholder，包含 `ssh -p 2222 ...` 示例

  ## 行为示例
  - `ssh -p 2222 user@host` → 端口正确解析，无警告。
  - `ssh -o Port=2222 -o User=ubuntu -o HostName=example.com alias` → 从 `-o` 提取并连接。
  - `ssh -i ~/.ssh/id_rsa -J jump user@host` → 正常解析目标，向导提示忽略 `-i`、`-J`。

  ## 测试
  - 手动验证：
    - Hosts 搜索框输入上述命令，确认 Quick Connect 打开并解析正确
    - 含未支持参数时出现 warning 提示