### PR TITLE
fix: allow importing ssh_config files without extension

### DIFF
--- a/components/vault/ImportVaultDialog.tsx
+++ b/components/vault/ImportVaultDialog.tsx
@@ -47,7 +47,7 @@ const OPTIONS: ImportOption[] = [
     format: "ssh_config",
     label: "ssh_config",
     iconSrc: "/import/file.png",
-    accept: ".conf,.config,.txt",
+    accept: "*",
   },
 ];
 


### PR DESCRIPTION
## Summary

- Fix ssh_config import unable to select files without extension (like `~/.ssh/config`)

## Problem

The file picker filter for ssh_config import was set to only accept `.conf`, `.config`, and `.txt` files. However, the standard SSH config file at `~/.ssh/config` has **no file extension**, making it impossible to select in the import dialog.

## Solution

Changed the `accept` attribute from `.conf,.config,.txt` to `*` to allow selecting any file, including extension-less files like `config`.

## Changes

- `components/vault/ImportVaultDialog.tsx`: Updated accept filter for ssh_config format

## Testing

1. Open Vault → Import → ssh_config
2. Navigate to `~/.ssh/` directory
3. Verify that the `config` file (without extension) is now selectable