### PR TITLE
feat: add ProxyJump support for SSH config import

### DIFF
--- a/domain/vaultImport.ts
+++ b/domain/vaultImport.ts
@@ -1,5 +1,101 @@
-import { Host, HostProtocol } from "./models";
+import { Host, HostChainConfig, HostProtocol } from "./models";
 import { parseQuickConnectInput } from "./quickConnect";
+
+/**
+ * Parsed jump host specification from SSH config ProxyJump directive.
+ * Supports formats: hostname, user@hostname, hostname:port, user@hostname:port
+ */
+interface ParsedJumpHost {
+  hostname: string;
+  username?: string;
+  port?: number;
+}
+
+/**
+ * Parse a single jump host specification from ProxyJump value.
+ * Formats: hostname, user@hostname, hostname:port, user@hostname:port, ssh://user@host:port
+ */
+const parseJumpHostSpec = (spec: string): ParsedJumpHost | null => {
+  const trimmed = spec.trim();
+  if (!trimmed || trimmed.toLowerCase() === "none") return null;
+
+  // Handle ssh:// URI format
+  if (trimmed.startsWith("ssh://")) {
+    try {
+      const url = new URL(trimmed);
+      return {
+        hostname: url.hostname,
+        username: url.username || undefined,
+        port: url.port ? parseInt(url.port, 10) : undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // Parse user@host:port format
+  let username: string | undefined;
+  let hostname: string;
+  let port: number | undefined;
+
+  let rest = trimmed;
+
+  // Extract username if present
+  const atIndex = rest.indexOf("@");
+  if (atIndex !== -1) {
+    username = rest.slice(0, atIndex);
+    rest = rest.slice(atIndex + 1);
+  }
+
+  // Extract port if present (handle IPv6 addresses in brackets)
+  if (rest.startsWith("[")) {
+    // IPv6 format: [::1]:22
+    const bracketEnd = rest.indexOf("]");
+    if (bracketEnd !== -1) {
+      hostname = rest.slice(1, bracketEnd);
+      const portPart = rest.slice(bracketEnd + 1);
+      if (portPart.startsWith(":")) {
+        const p = parseInt(portPart.slice(1), 10);
+        if (Number.isFinite(p) && p >= 1 && p <= 65535) port = p;
+      }
+    } else {
+      hostname = rest;
+    }
+  } else {
+    // Regular format: host:port
+    const colonIndex = rest.lastIndexOf(":");
+    if (colonIndex !== -1) {
+      const portStr = rest.slice(colonIndex + 1);
+      const p = parseInt(portStr, 10);
+      if (Number.isFinite(p) && p >= 1 && p <= 65535) {
+        port = p;
+        hostname = rest.slice(0, colonIndex);
+      } else {
+        hostname = rest;
+      }
+    } else {
+      hostname = rest;
+    }
+  }
+
+  if (!hostname) return null;
+  return { hostname, username, port };
+};
+
+/**
+ * Parse ProxyJump directive value which can contain multiple comma-separated jump hosts.
+ * Example: "user1@jump1:22,jump2,user3@jump3:2222"
+ */
+const parseProxyJump = (value: string): ParsedJumpHost[] => {
+  if (!value || value.toLowerCase() === "none") return [];
+  
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(parseJumpHostSpec)
+    .filter((h): h is ParsedJumpHost => h !== null);
+};
 
 export type VaultImportFormat =
   | "putty"
@@ -442,6 +538,8 @@ const importFromSshConfig = (text: string): VaultImportResult => {
     hostname?: string;
     username?: string;
     port?: number;
+    proxyJump?: string;
+    identityFile?: string;
   };
 
   const blocks: Block[] = [];
@@ -479,11 +577,14 @@ const importFromSshConfig = (text: string): VaultImportResult => {
     if (keyword === "hostname") current.hostname = value;
     else if (keyword === "user") current.username = value;
     else if (keyword === "port") current.port = parsePort(value);
+    else if (keyword === "proxyjump") current.proxyJump = value;
+    else if (keyword === "identityfile") current.identityFile = value;
   }
 
   flush();
 
   const parsedHosts: Host[] = [];
+  const hostProxyJumpMap = new Map<string, string>();
   let parsed = 0;
   let skipped = 0;
 
@@ -505,24 +606,86 @@ const importFromSshConfig = (text: string): VaultImportResult => {
         continue;
       }
 
-      parsedHosts.push(
-        createHost({
-          label: pat,
-          hostname,
-          username: block.username,
-          port: block.port,
-          protocol: "ssh",
-        }),
-      );
+      const host = createHost({
+        label: pat,
+        hostname,
+        username: block.username,
+        port: block.port,
+        protocol: "ssh",
+      });
+
+      parsedHosts.push(host);
+
+      if (block.proxyJump && block.proxyJump.toLowerCase() !== "none") {
+        hostProxyJumpMap.set(host.id, block.proxyJump);
+      }
     }
   }
 
-  const { hosts, duplicates } = dedupeHosts(parsedHosts);
+  const { hosts: dedupedHosts, duplicates } = dedupeHosts(parsedHosts);
+
+  const hostnameToId = new Map<string, string>();
+  const labelToId = new Map<string, string>();
+  for (const host of dedupedHosts) {
+    hostnameToId.set(host.hostname.toLowerCase(), host.id);
+    labelToId.set(host.label.toLowerCase(), host.id);
+  }
+
+  const resolveJumpHostToId = (jumpHost: ParsedJumpHost): string | null => {
+    const hostnameKey = jumpHost.hostname.toLowerCase();
+    if (labelToId.has(hostnameKey)) return labelToId.get(hostnameKey)!;
+    if (hostnameToId.has(hostnameKey)) return hostnameToId.get(hostnameKey)!;
+    return null;
+  };
+
+  for (const host of dedupedHosts) {
+    const proxyJumpValue = hostProxyJumpMap.get(host.id);
+    if (!proxyJumpValue) continue;
+
+    const jumpHosts = parseProxyJump(proxyJumpValue);
+    if (jumpHosts.length === 0) continue;
+
+    const resolvedIds: string[] = [];
+    const unresolvedJumps: string[] = [];
+
+    for (const jumpHost of jumpHosts) {
+      const existingId = resolveJumpHostToId(jumpHost);
+      if (existingId) {
+        resolvedIds.push(existingId);
+      } else {
+        const inlineHost = createHost({
+          label: jumpHost.hostname,
+          hostname: jumpHost.hostname,
+          username: jumpHost.username,
+          port: jumpHost.port,
+          protocol: "ssh",
+        });
+        dedupedHosts.push(inlineHost);
+        hostnameToId.set(inlineHost.hostname.toLowerCase(), inlineHost.id);
+        labelToId.set(inlineHost.label.toLowerCase(), inlineHost.id);
+        resolvedIds.push(inlineHost.id);
+        unresolvedJumps.push(jumpHost.hostname);
+      }
+    }
+
+    if (resolvedIds.length > 0) {
+      const hostChain: HostChainConfig = { hostIds: resolvedIds };
+      host.hostChain = hostChain;
+    }
+
+    if (unresolvedJumps.length > 0) {
+      issues.push({
+        level: "warning",
+        message: `ssh_config: created inline jump host(s) for "${host.label}": ${unresolvedJumps.join(", ")}`,
+      });
+    }
+  }
+
   return {
-    hosts,
+    hosts: dedupedHosts,
     groups: [],
     issues,
-    stats: { parsed, imported: hosts.length, skipped, duplicates },
+    stats: { parsed, imported: dedupedHosts.length, skipped, duplicates },
   };
 };
 


### PR DESCRIPTION
## Summary

This PR adds support for parsing the `ProxyJump` directive when importing SSH config files, enabling jump host / bastion configurations to be automatically recognized and mapped to Netcatty's host chaining feature.

## Changes

- **Parse ProxyJump directive**: Extracts `ProxyJump` values from SSH config blocks
- **Support all standard formats**:
  - Simple hostname: `ProxyJump bastion`
  - With username: `ProxyJump admin@bastion`
  - With port: `ProxyJump bastion:2222`
  - Full spec: `ProxyJump admin@bastion:2222`
  - SSH URI: `ProxyJump ssh://user@host:port`
  - **Chained jumps**: `ProxyJump jump1,jump2,jump3` (comma-separated)
- **Smart host resolution**:
  - First attempts to resolve jump host references to existing hosts in the import
  - Creates inline hosts for unresolved jump specifications
  - Maps resolved chain to `HostChainConfig.hostIds` for connection chaining
- **Also parses IdentityFile** directive (for future use)

## Example

Given this SSH config:
```
Host bastion
    HostName bastion.example.com
    User admin

Host internal-server
    HostName 10.0.0.50
    User deploy
    ProxyJump bastion
```

After import:
- `internal-server` will have `hostChain.hostIds` pointing to the `bastion` host
- Connection to `internal-server` will automatically tunnel through `bastion`

## Testing

- [x] Build passes (`npm run build`)
- [x] Handles single jump hosts
- [x] Handles chained jump hosts (comma-separated)
- [x] Handles inline specs (user@host:port)
- [x] Resolves references to other hosts in same config file
- [x] Creates inline hosts for unresolved jumps with warning