### PR TITLE
fix: skip encrypted default SSH keys to allow password auth fallback

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -22,6 +22,11 @@ const DEFAULT_KEY_NAMES = ["id_ed25519", "id_ecdsa", "id_rsa"];
  * @returns {boolean} - True if the key is encrypted
  */
 function isKeyEncrypted(keyContent) {
+  // Check for PKCS#8 encrypted format (-----BEGIN ENCRYPTED PRIVATE KEY-----)
+  if (keyContent.includes("-----BEGIN ENCRYPTED PRIVATE KEY-----")) {
+    return true;
+  }
+
   // Check for legacy PEM format encryption (e.g., RSA PRIVATE KEY with encryption)
   if (keyContent.includes("Proc-Type:") && keyContent.includes("ENCRYPTED")) {
     return true;


### PR DESCRIPTION
## Summary
- Add `isKeyEncrypted()` function to detect passphrase-protected SSH keys (supports both legacy PEM and OpenSSH formats)
- Modify `findDefaultPrivateKey()` to skip encrypted keys during fallback
- This allows password/keyboard-interactive authentication to proceed when users have encrypted default keys

## Problem
When no auth method is configured, the fallback logic always uses the default SSH key from `~/.ssh/id_*`. If this key is passphrase-protected, `ssh2` rejects it without a passphrase, aborting authentication before password prompts can occur. Users who previously left credentials empty to type a password interactively now see immediate failures.

## Solution
Detect encrypted keys by checking:
1. Legacy PEM format: `Proc-Type: 4,ENCRYPTED` header
2. OpenSSH format: Parse the binary structure to check if ciphername is not "none"

If a default key is encrypted, skip it and allow other auth methods to proceed.

## Test plan
- [ ] Test with unencrypted default key - should still use it as fallback
- [ ] Test with encrypted default key and no password configured - should skip key and allow password prompt
- [ ] Test with encrypted default key and password configured - should use password auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)