### PR TITLE
fix: improve QuickSwitcher performance and remove host limit

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -625,7 +625,7 @@ function App({ settings }: { settings: SettingsState }) {
         (h.group || '').toLowerCase().includes(term)
       )
       : hosts;
-    return filtered.slice(0, 8);
+    return filtered;
   }, [hosts, quickSearch, isQuickSwitcherOpen]);
 
   const handleDeleteHost = useCallback((hostId: string) => {


### PR DESCRIPTION
## Summary
- Remove the 8-host limit in QuickSwitcher to display all hosts
- Optimize QuickSwitcher performance by memoizing computed values and extracting HostItem as a memo component

## Changes
- **Remove host limit**: Previously QuickSwitcher only showed up to 8 hosts; now all hosts are displayed
- **Performance optimizations**:
  - Move `isMac` detection to module level (computed once instead of every render)
  - Memoize `orphanSessions` with `useMemo`
  - Memoize `flatItems` and build `itemIndexMap` for O(1) index lookup (previously O(n²))
  - Extract `HostItem` as a standalone `memo` component to prevent unnecessary re-renders
  - Wrap `getHotkeyLabel` with `useCallback`

## Test plan
- [x] Open QuickSwitcher with more than 8 hosts and verify all hosts are displayed
- [x] Verify QuickSwitcher opens smoothly without lag
- [x] Test keyboard navigation (arrow up/down, enter) works correctly
- [x] Test mouse hover and click selection works correctly
- [x] Test search filtering works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)