### PR TITLE
Fix release note script for ESM

### DIFF
--- a/.github/scripts/generate-release-note.js
+++ b/.github/scripts/generate-release-note.js
@@ -1,6 +1,9 @@
-/* global __dirname, console, process, require */
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Determine version priority:
 // 1. VERSION env variable


### PR DESCRIPTION
### Motivation
- Fix GitHub Actions failure where `require` is undefined because the repo uses `"type": "module"`, causing `.github/scripts/generate-release-note.js` to be executed as an ES module.

### Description
- Convert the script to ESM by replacing `require` with `import` (e.g. `node:fs`, `node:path`) and restore `__dirname` via `fileURLToPath(import.meta.url)` in `.github/scripts/generate-release-note.js`.

### Testing
- No automated tests were run; this is a small script-only change to make the generator ESM-compatible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972757ad734832b9e7d06e267b91eba)