### PR TITLE
Format SFTP timestamps as YYYY-MM-DD hh:mm:ss

### DIFF
--- a/components/SFTPModal.tsx
+++ b/components/SFTPModal.tsx
@@ -77,7 +77,7 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
     downloadSftpToTempAndOpen,
     cancelSftpUpload,
   } = useSftpBackend();
-  const { t, resolvedLocale } = useI18n();
+  const { t } = useI18n();
   const { sftpAutoSync, sftpShowHiddenFiles } = useSettingsState();
   const isLocalSession = host.protocol === "local";
   const [filenameEncoding, setFilenameEncoding] = useState<SftpFilenameEncoding>(
@@ -540,7 +540,6 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
           loading={loading}
           loadingTextContent={loadingTextContent}
           reconnecting={reconnecting}
-          resolvedLocale={resolvedLocale}
           columnWidths={columnWidths}
           sortField={sortField}
           sortOrder={sortOrder}

--- a/components/sftp-modal/SftpModalFileList.tsx
+++ b/components/sftp-modal/SftpModalFileList.tsx
@@ -23,7 +23,6 @@ interface SftpModalFileListProps {
   loading: boolean;
   loadingTextContent: boolean;
   reconnecting: boolean;
-  resolvedLocale: string | undefined;
   columnWidths: { name: number; size: number; modified: number; actions: number };
   sortField: "name" | "size" | "modified";
   sortOrder: "asc" | "desc";
@@ -53,7 +52,7 @@ interface SftpModalFileListProps {
   handleDeleteSelected: () => void;
   loadFiles: (path: string, options?: { force?: boolean }) => void;
   formatBytes: (bytes: number | string) => string;
-  formatDate: (dateStr: string | number | undefined, locale?: string) => string;
+  formatDate: (dateStr: string | number | undefined) => string;
 }
 
 export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
@@ -66,7 +65,6 @@ export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
   loading,
   loadingTextContent,
   reconnecting,
-  resolvedLocale,
   columnWidths,
   sortField,
   sortOrder,
@@ -279,7 +277,7 @@ export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
                         {isNavigableDirectory ? "--" : formatBytes(file.size)}
                       </div>
                       <div className="text-xs text-muted-foreground truncate">
-                        {formatDate(file.lastModified, resolvedLocale)}
+                        {formatDate(file.lastModified)}
                       </div>
                       <div className="flex items-center justify-end gap-1">
                         {isDownloadableFile && (

--- a/components/sftp-modal/utils.ts
+++ b/components/sftp-modal/utils.ts
@@ -7,9 +7,10 @@ export const formatBytes = (bytes: number | string): string => {
   return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 };
 
-export const formatDate = (dateStr: string | number | undefined, locale?: string): string => {
+export const formatDate = (dateStr: string | number | undefined): string => {
   if (!dateStr) return "--";
   const date = typeof dateStr === "number" ? new Date(dateStr) : new Date(dateStr);
   if (isNaN(date.getTime())) return String(dateStr);
-  return date.toLocaleString(locale || undefined);
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 };

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -48,7 +48,7 @@ export const formatTransferBytes = (bytes: number): string => {
 };
 
 /**
- * Format date as YYYY-MM-DD HH:mm:ss in local timezone
+ * Format date as YYYY-MM-DD hh:mm:ss in local timezone
  */
 export const formatDate = (timestamp: number | undefined): string => {
     if (!timestamp) return '--';


### PR DESCRIPTION
### Motivation
- Make SFTP file timestamps deterministic and easy to scan by rendering them in a fixed `YYYY-MM-DD hh:mm:ss` pattern instead of using locale-dependent output.

### Description
- Implement a fixed timestamp formatter in `components/sftp-modal/utils.ts` that returns `YYYY-MM-DD hh:mm:ss` for file dates.
- Remove the unused `locale` parameter and related `resolvedLocale` plumbing from the SFTP modal file list and modal (`components/sftp-modal/SftpModalFileList.tsx` and `components/SFTPModal.tsx`).
- Update the SFTP view utils documentation to reflect the `YYYY-MM-DD hh:mm:ss` pattern (`components/sftp/utils.ts`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697283d5a640832b87d730a397f7eac4)