### PR TITLE
fix: prevent terminal blackscreen when changing right-click behavior

### DIFF
--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -61,6 +61,8 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   const splitVShortcut = isMac ? '⌘E' : 'Ctrl+Shift+E';
   const clearShortcut = isMac ? '⌘K' : 'Ctrl+L';
 
+  const showContextMenu = rightClickBehavior === 'context-menu';
+
   const handleRightClick = useCallback(
     (e: React.MouseEvent) => {
       if (rightClickBehavior === 'paste') {
@@ -76,71 +78,72 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
     [rightClickBehavior, onPaste, onSelectWord],
   );
 
-  if (rightClickBehavior !== 'context-menu') {
-    return (
-      <div onContextMenu={handleRightClick} className="contents">
-        {children}
-      </div>
-    );
-  }
-
+  // Always use ContextMenu wrapper to maintain consistent React tree structure
+  // This prevents terminal from unmounting when rightClickBehavior changes
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="w-56">
-        <ContextMenuItem onClick={onCopy} disabled={!hasSelection}>
-          <Copy size={14} className="mr-2" />
-          {t('terminal.menu.copy')}
-          <ContextMenuShortcut>{copyShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
-        <ContextMenuItem onClick={onPaste}>
-          <ClipboardPaste size={14} className="mr-2" />
-          {t('terminal.menu.paste')}
-          <ContextMenuShortcut>{pasteShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
-        <ContextMenuItem onClick={onSelectAll}>
-          <TerminalIcon size={14} className="mr-2" />
-          {t('terminal.menu.selectAll')}
-          <ContextMenuShortcut>{selectAllShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
+      <ContextMenuTrigger
+        asChild
+        disabled={!showContextMenu}
+        onContextMenu={!showContextMenu ? handleRightClick : undefined}
+      >
+        {children}
+      </ContextMenuTrigger>
+      {showContextMenu && (
+        <ContextMenuContent className="w-56">
+          <ContextMenuItem onClick={onCopy} disabled={!hasSelection}>
+            <Copy size={14} className="mr-2" />
+            {t('terminal.menu.copy')}
+            <ContextMenuShortcut>{copyShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
+          <ContextMenuItem onClick={onPaste}>
+            <ClipboardPaste size={14} className="mr-2" />
+            {t('terminal.menu.paste')}
+            <ContextMenuShortcut>{pasteShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
+          <ContextMenuItem onClick={onSelectAll}>
+            <TerminalIcon size={14} className="mr-2" />
+            {t('terminal.menu.selectAll')}
+            <ContextMenuShortcut>{selectAllShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
 
-        <ContextMenuSeparator />
+          <ContextMenuSeparator />
 
-        <ContextMenuItem onClick={onSplitVertical}>
-          <SplitSquareHorizontal size={14} className="mr-2" />
-          {t('terminal.menu.splitHorizontal')}
-          <ContextMenuShortcut>{splitVShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
-        <ContextMenuItem onClick={onSplitHorizontal}>
-          <SplitSquareVertical size={14} className="mr-2" />
-          {t('terminal.menu.splitVertical')}
-          <ContextMenuShortcut>{splitHShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
+          <ContextMenuItem onClick={onSplitVertical}>
+            <SplitSquareHorizontal size={14} className="mr-2" />
+            {t('terminal.menu.splitHorizontal')}
+            <ContextMenuShortcut>{splitVShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
+          <ContextMenuItem onClick={onSplitHorizontal}>
+            <SplitSquareVertical size={14} className="mr-2" />
+            {t('terminal.menu.splitVertical')}
+            <ContextMenuShortcut>{splitHShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
 
-        <ContextMenuSeparator />
+          <ContextMenuSeparator />
 
-        <ContextMenuItem onClick={onClear}>
-          <Trash2 size={14} className="mr-2" />
-          {t('terminal.menu.clearBuffer')}
-          <ContextMenuShortcut>{clearShortcut}</ContextMenuShortcut>
-        </ContextMenuItem>
+          <ContextMenuItem onClick={onClear}>
+            <Trash2 size={14} className="mr-2" />
+            {t('terminal.menu.clearBuffer')}
+            <ContextMenuShortcut>{clearShortcut}</ContextMenuShortcut>
+          </ContextMenuItem>
 
-        {onClose && (
-          <>
-            <ContextMenuSeparator />
-            <ContextMenuItem
-              onClick={onClose}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2 size={14} className="mr-2" />
-              {t('terminal.menu.closeTerminal')}
-            </ContextMenuItem>
-          </>
-        )}
-      </ContextMenuContent>
+          {onClose && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                onClick={onClose}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 size={14} className="mr-2" />
+                {t('terminal.menu.closeTerminal')}
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      )}
     </ContextMenu>
   );
 };
 
 export default TerminalContextMenu;
-


### PR DESCRIPTION
## Summary

- Fix terminal going black when changing the "Right Click Behavior" setting in Settings page

## Problem

When changing the right-click behavior setting while terminals were open, all terminals would go black and become unresponsive.

## Root Cause

The `TerminalContextMenu` component returned different JSX structures based on the `rightClickBehavior` setting:
- `context-menu` mode: `<ContextMenu>` wrapper
- `paste` or `select-word` modes: `<div>` wrapper

When the setting changed, React detected a completely different component tree structure and unmounted the entire Terminal subtree, destroying the xterm instance.

## Solution

Always use `<ContextMenu>` as the wrapper to maintain a consistent React tree structure. The behavior is now controlled via:
- `disabled` prop on `ContextMenuTrigger` to prevent menu from opening
- `onContextMenu` handler on the trigger for paste/select-word modes
- Conditional rendering of `ContextMenuContent` (only when context-menu mode)

This ensures changing the setting doesn't cause React to remount the Terminal component.

## Test plan
- [x] Open a terminal and connect to a host
- [x] Go to Settings → Terminal → Right Click Behavior
- [x] Change between "Context Menu", "Paste", and "Select Word"
- [x] Verify terminal content is preserved and no black screen occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)