### PR TITLE
feat: add Copy Tab option to SSH session context menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -242,6 +242,7 @@ function App({ settings }: { settings: SettingsState }) {
     logViews,
     openLogView,
     closeLogView,
+    copySession,
   } = useSessionState();
 
   // isMacClient is used for window controls styling
@@ -864,6 +865,7 @@ function App({ settings }: { settings: SettingsState }) {
         isMacClient={isMacClient}
         onCloseSession={closeSession}
         onRenameSession={startSessionRename}
+        onCopySession={copySession}
         onRenameWorkspace={startWorkspaceRename}
         onCloseWorkspace={closeWorkspace}
         onCloseLogView={closeLogView}

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1110,6 +1110,7 @@ const en: Messages = {
   'tabs.closeLogViewAria': 'Close log view',
   'tabs.logPrefix': 'Log:',
   'tabs.logLocal': 'Local',
+  'tabs.copyTab': 'Copy Tab',
   'keychain.edit.labelRequired': 'Label *',
   'keychain.edit.keyLabelPlaceholder': 'Key label',
   'keychain.edit.privateKeyRequired': 'Private key *',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1099,6 +1099,7 @@ const zhCN: Messages = {
   'tabs.closeLogViewAria': '关闭日志视图',
   'tabs.logPrefix': '日志：',
   'tabs.logLocal': '本地',
+  'tabs.copyTab': '复制标签页',
   'keychain.edit.labelRequired': 'Label *',
   'keychain.edit.keyLabelPlaceholder': '密钥 Label',
   'keychain.edit.privateKeyRequired': '私钥 *',

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -547,6 +547,31 @@ export const useSessionState = () => {
     });
   }, [setActiveTabId]);
 
+  // Copy a session - creates a new session with the same host connection
+  const copySession = useCallback((sessionId: string) => {
+    setSessions(prevSessions => {
+      const session = prevSessions.find(s => s.id === sessionId);
+      if (!session) return prevSessions;
+
+      // Create a new session with the same connection info
+      const newSession: TerminalSession = {
+        id: crypto.randomUUID(),
+        hostId: session.hostId,
+        hostLabel: session.hostLabel,
+        hostname: session.hostname,
+        username: session.username,
+        status: 'connecting',
+        protocol: session.protocol,
+        port: session.port,
+        moshEnabled: session.moshEnabled,
+        serialConfig: session.serialConfig,
+      };
+
+      setActiveTabId(newSession.id);
+      return [...prevSessions, newSession];
+    });
+  }, [setActiveTabId]);
+
   // Toggle broadcast mode for a workspace
   const toggleBroadcast = useCallback((workspaceId: string) => {
     setBroadcastWorkspaceIds(prev => {
@@ -662,5 +687,7 @@ export const useSessionState = () => {
     logViews,
     openLogView,
     closeLogView,
+    // Copy session
+    copySession,
   };
 };

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -25,6 +25,7 @@ interface TopTabsProps {
   isMacClient: boolean;
   onCloseSession: (sessionId: string, e?: React.MouseEvent) => void;
   onRenameSession: (sessionId: string) => void;
+  onCopySession: (sessionId: string) => void;
   onRenameWorkspace: (workspaceId: string) => void;
   onCloseWorkspace: (workspaceId: string) => void;
   onCloseLogView: (logViewId: string) => void;
@@ -121,6 +122,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   isMacClient,
   onCloseSession,
   onRenameSession,
+  onCopySession,
   onRenameWorkspace,
   onCloseWorkspace,
   onCloseLogView,
@@ -409,6 +411,9 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             <ContextMenuContent>
               <ContextMenuItem onClick={() => onRenameSession(session.id)}>
                 {t('common.rename')}
+              </ContextMenuItem>
+              <ContextMenuItem onClick={() => onCopySession(session.id)}>
+                {t('tabs.copyTab')}
               </ContextMenuItem>
               <ContextMenuItem className="text-destructive" onClick={() => onCloseSession(session.id)}>
                 {t('common.close')}


### PR DESCRIPTION
## Summary
- Add "Copy Tab" option to SSH session tab right-click context menu
- Clicking "Copy Tab" creates a new session with the same connection parameters (host, port, protocol, mosh settings, serial config)
- Added i18n translations for English ("Copy Tab") and Chinese ("复制标签页")

## Test plan
- [x] Right-click on an SSH session tab
- [x] Verify "Copy Tab" option appears in the context menu
- [x] Click "Copy Tab" and verify a new tab is created with the same host connection
- [x] Verify the new session connects successfully to the same host

🤖 Generated with [Claude Code](https://claude.com/claude-code)