### PR TITLE
fix: reset upload trigger when new drop entries arrive

### DIFF
--- a/components/SFTPModal.tsx
+++ b/components/SFTPModal.tsx
@@ -389,16 +389,24 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
   // Handle initial entries to upload (from drag-and-drop to terminal)
   const initialUploadTriggeredRef = useRef(false);
   const prevLoadingRef = useRef(loading);
+  const prevEntriesRef = useRef<DropEntry[] | undefined>(undefined);
   useEffect(() => {
     // Detect when loading transitions from true to false (initial load complete)
     const wasLoading = prevLoadingRef.current;
     prevLoadingRef.current = loading;
     const justFinishedLoading = wasLoading && !loading;
 
-    // Reset the flag when initialEntriesToUpload changes
+    // Reset the flag when initialEntriesToUpload is cleared
     if (!initialEntriesToUpload || initialEntriesToUpload.length === 0) {
       initialUploadTriggeredRef.current = false;
+      prevEntriesRef.current = undefined;
       return;
+    }
+
+    // Reset the flag when new entries arrive (different reference = new drop)
+    if (initialEntriesToUpload !== prevEntriesRef.current) {
+      initialUploadTriggeredRef.current = false;
+      prevEntriesRef.current = initialEntriesToUpload;
     }
 
     // Prevent duplicate uploads


### PR DESCRIPTION
## Summary
- Track the previous `initialEntriesToUpload` reference using a ref
- Reset the upload trigger flag when a new array is provided (different reference = new drop)
- Fixes the issue where subsequent drag-to-upload operations would be ignored if the SFTP modal remained open after the first upload completed

## Background
Reported by Codex review on PR #149: If a user drops files again while the SFTP modal remains open (e.g., after the first auto-upload completes), `initialEntriesToUpload` changes but `initialUploadTriggeredRef` stays `true` because it was only reset when the list is empty. This means subsequent drops would be ignored.

## Test plan
- [ ] Drop files to terminal to trigger SFTP upload
- [ ] While SFTP modal is open, drop more files to another terminal in workspace
- [ ] Verify the second drop also triggers upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)