### PR TITLE
Use dynamic package version for sync payload

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -31,6 +31,7 @@ import {
   generateDeviceId,
   getDefaultDeviceName,
 } from '../../domain/sync';
+import packageJson from '../../package.json';
 import { EncryptionService } from './EncryptionService';
 import { createAdapter, type CloudAdapter } from './adapters';
 import type { GitHubAdapter } from './adapters/GitHubAdapter';
@@ -890,7 +891,7 @@ export class CloudSyncManager {
         this.masterPassword,
         this.state.deviceId,
         this.state.deviceName,
-        '1.0.0', // TODO: Get from package.json
+        packageJson.version,
         this.state.localVersion
       );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "DOM.Iterable"
     ],
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "types": [
       "node",
       "vite/client"


### PR DESCRIPTION
This change ensures that the sync payload uses the actual package version defined in `package.json` instead of a hardcoded string.

Changes:
- Modified `infrastructure/services/CloudSyncManager.ts` to import `package.json` and use `packageJson.version`.
- Updated `tsconfig.json` to enable `resolveJsonModule`, allowing the import of JSON files.

---
*PR created automatically by Jules for task [15383585016535607847](https://jules.google.com/task/15383585016535607847) started by @binaricat*