### PR TITLE
Implement device name update for cloud sync

### DIFF
--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -358,8 +358,8 @@ export const useCloudSync = (): CloudSyncHook => {
     manager.setAutoSync(enabled, intervalMinutes);
   }, []);
   
-  const setDeviceName = useCallback((_name: string) => {
-    // TODO: Add setDeviceName to CloudSyncManager if needed
+  const setDeviceName = useCallback((name: string) => {
+    manager.setDeviceName(name);
   }, []);
   
   // ========== Utilities ==========

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1072,6 +1072,12 @@ export class CloudSyncManager {
   // Auto-Sync
   // ==========================================================================
 
+  setDeviceName(name: string): void {
+    this.state.deviceName = name;
+    this.saveToStorage(SYNC_STORAGE_KEYS.DEVICE_NAME, name);
+    this.notifyStateChange();
+  }
+
   setAutoSync(enabled: boolean, intervalMinutes?: number): void {
     this.state.autoSyncEnabled = enabled;
     if (intervalMinutes) {


### PR DESCRIPTION
Implemented the missing `setDeviceName` functionality in `CloudSyncManager` and exposed it through the `useCloudSync` hook. This allows the application to update and persist the device name used for cloud synchronization.

Changes:
- `infrastructure/services/CloudSyncManager.ts`: Added `setDeviceName` method.
- `application/state/useCloudSync.ts`: Updated `setDeviceName` callback to use the manager's method.

---
*PR created automatically by Jules for task [3755414904683764957](https://jules.google.com/task/3755414904683764957) started by @binaricat*