### PR TITLE
Block sync uploads when conflict checks fail

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1167,7 +1167,9 @@ export class CloudSyncManager {
     const checkResults = await Promise.all(checkTasks);
 
     // 2. Analyze Results & Handle Conflicts
-    const conflict = checkResults.find((r) => !r.error && r.check?.conflict);
+    const conflict = checkResults.find(
+      (r) => !r.error && !r.check?.error && r.check?.conflict
+    );
 
     if (conflict && conflict.check?.remoteFile) {
       const { provider, check } = conflict;
@@ -1191,15 +1193,20 @@ export class CloudSyncManager {
 
       // Populate results
       for (const r of checkResults) {
-        if (r.error) {
+        const checkError = r.error ?? r.check?.error;
+        if (checkError) {
           results.set(r.provider as CloudProvider, {
             success: false,
             provider: r.provider as CloudProvider,
             action: 'none',
-            error: r.error,
+            error: checkError,
           });
-          this.updateProviderStatus(r.provider as CloudProvider, 'error', r.error);
-          this.emit({ type: 'SYNC_ERROR', provider: r.provider as CloudProvider, error: r.error });
+          this.updateProviderStatus(r.provider as CloudProvider, 'error', checkError);
+          this.emit({
+            type: 'SYNC_ERROR',
+            provider: r.provider as CloudProvider,
+            error: checkError,
+          });
         } else if (r.provider === provider) {
           results.set(provider as CloudProvider, {
             success: false,
@@ -1222,21 +1229,26 @@ export class CloudSyncManager {
 
     // 3. Encrypt Once
     const validUploads = checkResults.filter(
-      (r) => !r.error && !r.check?.conflict && r.adapter
+      (r) => !r.error && !r.check?.error && !r.check?.conflict && r.adapter
     ) as { provider: CloudProvider; adapter: CloudAdapter }[];
 
     if (validUploads.length === 0) {
       // Process errors if any
       checkResults.forEach((r) => {
-        if (r.error) {
+        const checkError = r.error ?? r.check?.error;
+        if (checkError) {
           results.set(r.provider as CloudProvider, {
             success: false,
             provider: r.provider as CloudProvider,
             action: 'none',
-            error: r.error,
+            error: checkError,
           });
-          this.updateProviderStatus(r.provider as CloudProvider, 'error', r.error);
-          this.emit({ type: 'SYNC_ERROR', provider: r.provider as CloudProvider, error: r.error });
+          this.updateProviderStatus(r.provider as CloudProvider, 'error', checkError);
+          this.emit({
+            type: 'SYNC_ERROR',
+            provider: r.provider as CloudProvider,
+            error: checkError,
+          });
         }
       });
       this.state.syncState = 'ERROR';
@@ -1291,15 +1303,20 @@ export class CloudSyncManager {
 
     // Process errors from initial checks (if any)
     checkResults.forEach((r) => {
-      if (r.error) {
+      const checkError = r.error ?? r.check?.error;
+      if (checkError) {
         results.set(r.provider as CloudProvider, {
           success: false,
           provider: r.provider as CloudProvider,
           action: 'none',
-          error: r.error,
+          error: checkError,
         });
-        this.updateProviderStatus(r.provider as CloudProvider, 'error', r.error);
-        this.emit({ type: 'SYNC_ERROR', provider: r.provider as CloudProvider, error: r.error });
+        this.updateProviderStatus(r.provider as CloudProvider, 'error', checkError);
+        this.emit({
+          type: 'SYNC_ERROR',
+          provider: r.provider as CloudProvider,
+          error: checkError,
+        });
       }
     });
 


### PR DESCRIPTION
### Motivation

- Prevent providers whose conflict check download failed from proceeding to upload and potentially overwriting remote data.
- Ensure conflict-check errors are surfaced in provider status, sync results, and error events so the UI and logs reflect the true failure cause.

### Description

- Modified `syncAllProviders` to treat `checkProviderConflict` download errors as blockers by requiring `!r.check?.error` when detecting conflicts and selecting `validUploads`.
- Propagated check errors into the main error handling path by computing `const checkError = r.error ?? r.check?.error` and using that value for result entries, `updateProviderStatus`, and `emit({ type: 'SYNC_ERROR', ... })`.
- Adjusted conflict handling to skip uploads for providers with check failures and mark them as errored in `results` (file updated: `infrastructure/services/CloudSyncManager.ts`).

### Testing

- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef785fa3c832b8af4c4a2a137154c)