### PR TITLE
Fix conflict check error handling in parallel sync

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1165,9 +1165,18 @@ export class CloudSyncManager {
     });
 
     const checkResults = await Promise.all(checkTasks);
+    const normalizedCheckResults = checkResults.map((result) => {
+      if (!result.error && result.check?.error) {
+        return {
+          ...result,
+          error: result.check.error,
+        };
+      }
+      return result;
+    });
 
     // 2. Analyze Results & Handle Conflicts
-    const conflict = checkResults.find((r) => !r.error && r.check?.conflict);
+    const conflict = normalizedCheckResults.find((r) => !r.error && r.check?.conflict);
 
     if (conflict && conflict.check?.remoteFile) {
       const { provider, check } = conflict;
@@ -1190,7 +1199,7 @@ export class CloudSyncManager {
       });
 
       // Populate results
-      for (const r of checkResults) {
+      for (const r of normalizedCheckResults) {
         if (r.error) {
           results.set(r.provider as CloudProvider, {
             success: false,
@@ -1221,13 +1230,13 @@ export class CloudSyncManager {
     }
 
     // 3. Encrypt Once
-    const validUploads = checkResults.filter(
+    const validUploads = normalizedCheckResults.filter(
       (r) => !r.error && !r.check?.conflict && r.adapter
     ) as { provider: CloudProvider; adapter: CloudAdapter }[];
 
     if (validUploads.length === 0) {
       // Process errors if any
-      checkResults.forEach((r) => {
+      normalizedCheckResults.forEach((r) => {
         if (r.error) {
           results.set(r.provider as CloudProvider, {
             success: false,
@@ -1257,7 +1266,7 @@ export class CloudSyncManager {
       const msg = String(error);
       this.state.syncState = 'ERROR';
       this.state.lastError = msg;
-      
+
       // Fail all
       for (const r of validUploads) {
         this.updateProviderStatus(r.provider, 'error', msg);
@@ -1290,7 +1299,7 @@ export class CloudSyncManager {
     }
 
     // Process errors from initial checks (if any)
-    checkResults.forEach((r) => {
+    normalizedCheckResults.forEach((r) => {
       if (r.error) {
         results.set(r.provider as CloudProvider, {
           success: false,


### PR DESCRIPTION
### Motivation
- `checkProviderConflict` returned `{ conflict: false, error: ... }` for download failures but `syncAllProviders` only filtered `r.error`, allowing providers with `r.check.error` to proceed to upload and potentially overwrite remote data.
- The parallel `syncAllProviders` flow needed unified error handling so download/check failures block uploads the same way adapter connection errors do.

### Description
- Added a `normalizedCheckResults` array that promotes `check.error` into the top-level `error` field so all check failures are treated uniformly.
- Replaced usages of the original `checkResults` with `normalizedCheckResults` for conflict detection, result population, the `validUploads` filter, and post-check error reporting in `infrastructure/services/CloudSyncManager.ts`.
- Minor whitespace/cleanup around error handling to keep behavior consistent when encryption or uploads fail.

### Testing
- No automated tests were run for this change (no test execution was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ef96a8f6c832bb1ff16993def4a0c)