### PR TITLE
Return per-provider errors when syncAllProviders is called while locked

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1131,19 +1131,37 @@ export class CloudSyncManager {
       return results;
     }
 
-    if (this.state.securityState !== 'UNLOCKED') {
-      return results; // Or throw? Caller handles it.
-    }
-
-    if (!this.masterPassword) {
-      return results;
-    }
-
     const connectedProviders = Object.entries(this.state.providers)
       .filter(([_, conn]) => conn.status === 'connected')
       .map(([p]) => p as CloudProvider);
 
     if (connectedProviders.length === 0) {
+      return results;
+    }
+
+    if (this.state.securityState !== 'UNLOCKED') {
+      const error = 'Vault is locked';
+      connectedProviders.forEach((provider) => {
+        results.set(provider, {
+          success: false,
+          provider,
+          action: 'none',
+          error,
+        });
+      });
+      return results;
+    }
+
+    if (!this.masterPassword) {
+      const error = 'Master password not available';
+      connectedProviders.forEach((provider) => {
+        results.set(provider, {
+          success: false,
+          provider,
+          action: 'none',
+          error,
+        });
+      });
       return results;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent silent successes when `syncAllProviders` is invoked while the vault is locked or `masterPassword` is missing, since prior behavior returned an empty `Map` and callers could interpret that as a successful sync.

### Description
- Update `syncAllProviders` in `infrastructure/services/CloudSyncManager.ts` to populate the results `Map` with per-provider error `SyncResult` entries when `this.state.securityState !== 'UNLOCKED'` or `this.masterPassword` is not set, instead of returning an empty `Map` early.

### Testing
- No automated tests were run for this change (`not run / not requested`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efb26a224832b8582b49cfa7df495)