### PR TITLE
Set lastError when parallel uploads all fail

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1286,7 +1286,10 @@ export class CloudSyncManager {
       this.state.syncState = 'IDLE';
     } else {
       this.state.syncState = 'ERROR';
-      // lastError is set by uploadToProvider
+      const firstError = Array.from(results.values()).find((r) => !r.success && r.error)?.error;
+      if (firstError) {
+        this.state.lastError = firstError;
+      }
     }
 
     // Process errors from initial checks (if any)


### PR DESCRIPTION
### Motivation
- Ensure `lastError` is populated when `syncAllProviders` finishes with no successful uploads so the UI (e.g., `SyncStatusButton`) shows an error, matching the prior sequential `syncToProvider` behavior.

### Description
- In `infrastructure/services/CloudSyncManager.ts` updated the final state update in `syncAllProviders` to set `this.state.lastError` from the first failed `SyncResult` when all parallel uploads fail.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f517b3198832bb7e73aa05f6b195f)