### PR TITLE
Block uploads when conflict checks fail

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1158,6 +1158,9 @@ export class CloudSyncManager {
         this.emit({ type: 'SYNC_STARTED', provider });
 
         const check = await this.checkProviderConflict(provider, adapter);
+        if (check.error) {
+          return { provider, adapter, check, error: check.error };
+        }
         return { provider, adapter, check };
       } catch (error) {
         return { provider, error: String(error) };


### PR DESCRIPTION
### Motivation
- Prevent providers whose `checkProviderConflict` download check failed from proceeding to upload and potentially overwriting newer remote data by treating conflict-check errors as sync errors before upload.

### Description
- In `infrastructure/services/CloudSyncManager.ts` the parallel check task now propagates `check.error` by returning `{ provider, adapter, check, error: check.error }` when `checkProviderConflict` reports an error, ensuring those providers are excluded from the `validUploads` path.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f569f4354832bbc0556bee79101c4)