### PR TITLE
Fix lastError update for parallel upload failures

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -872,6 +872,7 @@ export class CloudSyncManager {
       this.emit({ type: 'SYNC_COMPLETED', provider, result });
       return result;
     } catch (error) {
+      this.state.lastError = String(error);
       this.updateProviderStatus(provider, 'error', String(error));
 
       // Add to sync history


### PR DESCRIPTION
### Motivation
- Parallel `syncAllProviders` relied on `uploadToProvider` to populate `this.state.lastError`, but upload failures in the parallel path left `lastError` unset and the UI could lose the error message.

### Description
- Set `this.state.lastError = String(error)` in the `catch` block of `uploadToProvider` to ensure upload failures populate `lastError` so the final sync state and UI show the error (change made in `infrastructure/services/CloudSyncManager.ts`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5fad1b24832b9b25acaec2c052c1)