### PR TITLE
Normalize conflict-check errors in parallel sync

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1165,9 +1165,15 @@ export class CloudSyncManager {
     });
 
     const checkResults = await Promise.all(checkTasks);
+    const normalizedCheckResults = checkResults.map((result) => {
+      if (!result.error && result.check?.error) {
+        return { ...result, error: result.check.error };
+      }
+      return result;
+    });
 
     // 2. Analyze Results & Handle Conflicts
-    const conflict = checkResults.find((r) => !r.error && r.check?.conflict);
+    const conflict = normalizedCheckResults.find((r) => !r.error && r.check?.conflict);
 
     if (conflict && conflict.check?.remoteFile) {
       const { provider, check } = conflict;
@@ -1190,7 +1196,7 @@ export class CloudSyncManager {
       });
 
       // Populate results
-      for (const r of checkResults) {
+      for (const r of normalizedCheckResults) {
         if (r.error) {
           results.set(r.provider as CloudProvider, {
             success: false,
@@ -1221,13 +1227,13 @@ export class CloudSyncManager {
     }
 
     // 3. Encrypt Once
-    const validUploads = checkResults.filter(
+    const validUploads = normalizedCheckResults.filter(
       (r) => !r.error && !r.check?.conflict && r.adapter
     ) as { provider: CloudProvider; adapter: CloudAdapter }[];
 
     if (validUploads.length === 0) {
       // Process errors if any
-      checkResults.forEach((r) => {
+      normalizedCheckResults.forEach((r) => {
         if (r.error) {
           results.set(r.provider as CloudProvider, {
             success: false,
@@ -1290,7 +1296,7 @@ export class CloudSyncManager {
     }
 
     // Process errors from initial checks (if any)
-    checkResults.forEach((r) => {
+    normalizedCheckResults.forEach((r) => {
       if (r.error) {
         results.set(r.provider as CloudProvider, {
           success: false,


### PR DESCRIPTION
### Motivation
- Prevent providers whose conflict check download failed from being treated as valid upload targets and potentially overwriting newer remote data.
- Propagate download/check errors from `checkProviderConflict` into the parallel-sync error path so error reporting and status updates remain consistent with the sequential flow.

### Description
- Add a `normalizedCheckResults` mapping that converts any `check?.error` into a top-level `error` on the check result.
- Use `normalizedCheckResults` everywhere in `syncAllProviders` for conflict detection, upload eligibility (`validUploads`), and post-check error handling instead of the raw `checkResults` array.
- Ensure providers with failed checks are marked with error state and emitted via existing `SYNC_ERROR` handling before uploads proceed.

### Testing
- No automated tests were run for this change.
- Basic static verification was performed by compiling and inspecting `infrastructure/services/CloudSyncManager.ts` to ensure the normalized results are used consistently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6a047da8832b84d9d18c3960657b)