### PR TITLE
Enable MFA for export-key exec

### DIFF
--- a/application/state/useKeychainBackend.ts
+++ b/application/state/useKeychainBackend.ts
@@ -15,6 +15,8 @@ export const useKeychainBackend = () => {
     privateKey?: string;
     command: string;
     timeout?: number;
+    enableKeyboardInteractive?: boolean;
+    sessionId?: string;
   }) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.execCommand) throw new Error("execCommand unavailable");

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -1116,6 +1116,8 @@ echo $3 >> "$FILE"`);
                         privateKey: hostPrivateKey,
                         command,
                         timeout: 30000,
+                        enableKeyboardInteractive: true,
+                        sessionId: `export-key:${exportHost.id}:${panel.key.id}`,
                       });
 
                       // Check result - code 0, null, or undefined with no stderr is success

--- a/components/keychain/ExportKeyPanel.tsx
+++ b/components/keychain/ExportKeyPanel.tsx
@@ -97,6 +97,8 @@ export const ExportKeyPanel: React.FC<ExportKeyPanelProps> = ({
                 privateKey: hostPrivateKey,
                 command,
                 timeout: 30000,
+                enableKeyboardInteractive: true,
+                sessionId: `export-key:${exportHost.id}:${keyItem.id}`,
             });
 
             // Check result

--- a/global.d.ts
+++ b/global.d.ts
@@ -182,6 +182,8 @@ declare global {
       privateKey?: string;
       command: string;
       timeout?: number;
+      enableKeyboardInteractive?: boolean;
+      sessionId?: string;
     }): Promise<{ stdout: string; stderr: string; code: number | null }>;
     /** Get current working directory from an active SSH session */
     getSessionPwd?(sessionId: string): Promise<{ success: boolean; cwd?: string; error?: string }>;


### PR DESCRIPTION
## Summary
- add opt-in execCommand flags for keyboard-interactive MFA
- wire MFA-capable execCommand only for export-key flows
- extend exec timeouts only when MFA is enabled

## Test plan
- [x] Export key to MFA host
- [x] Export key to non-MFA host
- [x] Run snippet
- [x] OS detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)