### PR TITLE
feat(sftp): add visual focus indicator for pane selection

### DIFF
--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -38,7 +38,7 @@ import { SftpContextProvider, activeTabStore } from "./sftp";
 import { useSftpViewPaneCallbacks } from "./sftp/hooks/useSftpViewPaneCallbacks";
 import { useSftpViewTabs } from "./sftp/hooks/useSftpViewTabs";
 import { useSftpKeyboardShortcuts } from "./sftp/hooks/useSftpKeyboardShortcuts";
-import { sftpFocusStore, SftpFocusedSide } from "./sftp/hooks/useSftpFocusedPane";
+import { sftpFocusStore, SftpFocusedSide, useSftpFocusedSide } from "./sftp/hooks/useSftpFocusedPane";
 
 // Wrapper component that subscribes to activeTabId for CSS visibility
 // This isolates the activeTabId subscription - only this component re-renders on tab switch
@@ -92,7 +92,11 @@ const SftpViewInner: React.FC<SftpViewProps> = ({ hosts, keys, identities }) => 
     hotkeyScheme,
     sftpRef,
     isActive,
+    showHiddenFiles: sftpShowHiddenFiles,
   });
+
+  // Subscribe to focused side for visual indicator
+  const focusedSide = useSftpFocusedSide();
 
   // Handle pane focus when clicking on a pane container
   const handlePaneFocus = useCallback((side: SftpFocusedSide) => {
@@ -215,8 +219,11 @@ const SftpViewInner: React.FC<SftpViewProps> = ({ hosts, keys, identities }) => 
         style={containerStyle}
       >
         <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 min-h-0 border-t border-border/70">
-          <div 
-            className="relative border-r border-border/70 flex flex-col"
+          <div
+            className={cn(
+              "relative border-r border-border/70 flex flex-col",
+              focusedSide === "left" && "ring-1 ring-inset ring-primary/70"
+            )}
             onClick={() => handlePaneFocus("left")}
           >
             {/* Left side tab bar - only show when there are tabs */}
@@ -258,8 +265,11 @@ const SftpViewInner: React.FC<SftpViewProps> = ({ hosts, keys, identities }) => 
               )}
             </div>
           </div>
-          <div 
-            className="relative flex flex-col"
+          <div
+            className={cn(
+              "relative flex flex-col",
+              focusedSide === "right" && "ring-1 ring-inset ring-primary/70"
+            )}
             onClick={() => handlePaneFocus("right")}
           >
             {/* Right side tab bar - only show when there are tabs */}

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -12,7 +12,7 @@ import { sftpClipboardStore, SftpClipboardFile } from "./useSftpClipboard";
 import { sftpFocusStore } from "./useSftpFocusedPane";
 import { sftpDialogActionStore } from "./useSftpDialogAction";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
-import { filterHiddenFiles, isNavigableDirectory, useSftpShowHiddenFiles } from "../index";
+import { filterHiddenFiles, isNavigableDirectory } from "../index";
 import { toast } from "../../ui/toast";
 
 // SFTP action names that we handle
@@ -32,6 +32,7 @@ interface UseSftpKeyboardShortcutsParams {
   hotkeyScheme: "disabled" | "mac" | "pc";
   sftpRef: MutableRefObject<SftpStateApi>;
   isActive: boolean;
+  showHiddenFiles: boolean;
 }
 
 /**
@@ -57,8 +58,8 @@ export const useSftpKeyboardShortcuts = ({
   hotkeyScheme,
   sftpRef,
   isActive,
+  showHiddenFiles,
 }: UseSftpKeyboardShortcutsParams) => {
-  const showHiddenFiles = useSftpShowHiddenFiles();
   const handleKeyDown = useCallback(
     async (e: KeyboardEvent) => {
       // Skip if shortcuts are disabled or SFTP is not active
@@ -87,9 +88,9 @@ export const useSftpKeyboardShortcuts = ({
 
       const sftp = sftpRef.current;
       const focusedSide = sftpFocusStore.getFocusedSide();
-      
+
       // Get the active pane for the focused side
-      const pane = focusedSide === "left" 
+      const pane = focusedSide === "left"
         ? sftp.leftTabs.tabs.find(p => p.id === sftp.leftTabs.activeTabId)
         : sftp.rightTabs.tabs.find(p => p.id === sftp.rightTabs.activeTabId);
 
@@ -100,7 +101,7 @@ export const useSftpKeyboardShortcuts = ({
           // Copy selected files to clipboard
           const selectedFiles = Array.from(pane.selectedFiles) as string[];
           if (selectedFiles.length === 0) return;
-          
+
           const clipboardFiles: SftpClipboardFile[] = selectedFiles.map((name: string) => {
             const file = pane.files.find((f) => f.name === name);
             return {
@@ -108,7 +109,7 @@ export const useSftpKeyboardShortcuts = ({
               isDirectory: file ? isNavigableDirectory(file) : false,
             };
           });
-          
+
           sftpClipboardStore.copy(
             clipboardFiles,
             pane.connection.currentPath,
@@ -122,7 +123,7 @@ export const useSftpKeyboardShortcuts = ({
           // Cut selected files to clipboard
           const selectedFiles = Array.from(pane.selectedFiles) as string[];
           if (selectedFiles.length === 0) return;
-          
+
           const clipboardFiles: SftpClipboardFile[] = selectedFiles.map((name: string) => {
             const file = pane.files.find((f) => f.name === name);
             return {
@@ -130,7 +131,7 @@ export const useSftpKeyboardShortcuts = ({
               isDirectory: file ? isNavigableDirectory(file) : false,
             };
           });
-          
+
           sftpClipboardStore.cut(
             clipboardFiles,
             pane.connection.currentPath,
@@ -144,7 +145,7 @@ export const useSftpKeyboardShortcuts = ({
           // Paste files from clipboard
           const clipboard = sftpClipboardStore.get();
           if (!clipboard || clipboard.files.length === 0) return;
-          
+
           // Use startTransfer to paste files from source to current pane
           // The transfer direction is determined by clipboard sourceSide and current focusedSide
           if (clipboard.sourceSide !== focusedSide) {


### PR DESCRIPTION
## Summary

Add a visual focus indicator to the SFTP dual-pane view to make it clear which pane is currently focused and will receive keyboard shortcut actions.

## Changes

- **Visual Focus Indicator**: Added an inset ring border (`ring-1 ring-inset ring-primary/70`) to the focused pane for clear visual distinction
- **Bug Fix**: Fixed `useSftpKeyboardShortcuts` context error - the hook was calling `useSftpShowHiddenFiles()` before being wrapped in `SftpContextProvider`. Now receives `showHiddenFiles` as a parameter instead.
- **Focus Tracking**: Uses `sftpFocusStore` to track which pane (left/right) is currently focused

## Files Changed

- `components/SftpView.tsx` - Added focus state subscription and visual indicator styling
- `components/sftp/hooks/useSftpKeyboardShortcuts.ts` - Fixed context hook usage by accepting `showHiddenFiles` as parameter