### PR TITLE
fix: prevent zombie processes and improve window recovery on restart

### DIFF
--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -707,6 +707,20 @@ function registerHandlers(ipcMain) {
 function cleanup() {
   unregisterGlobalHotkey();
   destroyTray();
+
+  if (trayPanelRefreshTimer) {
+    clearInterval(trayPanelRefreshTimer);
+    trayPanelRefreshTimer = null;
+  }
+
+  if (trayPanelWindow && !trayPanelWindow.isDestroyed()) {
+    try {
+      trayPanelWindow.destroy();
+    } catch {
+      // ignore
+    }
+    trayPanelWindow = null;
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- **Destroy `trayPanelWindow` on cleanup**: The hidden tray panel BrowserWindow was not being destroyed during `will-quit`, keeping the Electron process alive as a zombie. Now `cleanup()` in `globalShortcutBridge` properly destroys it and clears the refresh timer.
- **Add SIGTERM/SIGINT signal handlers**: Ensures graceful shutdown when the OS sends termination signals, triggering the full cleanup chain (terminals, port forwarding, tray panel).
- **Improve `focusMainWindow()` and second-instance recovery**: Detects crashed `webContents` via `isCrashed()` and destroys the broken window. The `second-instance` handler now recreates the window when focus fails, instead of silently doing nothing.

## Root Cause
When "close to tray" is enabled, closing the main window hides it but keeps the process alive. The `trayPanelWindow` (a hidden BrowserWindow for the tray panel) was never destroyed during app quit, which prevented `window-all-closed` from firing properly. Combined with missing signal handlers, this caused zombie processes that blocked the next app launch — the new instance couldn't acquire the single-instance lock or register the `app://` protocol, resulting in "Failed to load the UI. Please relaunch Netcatty."

## Test plan
- [x] Enable "close to tray", close the main window, then quit from tray → verify no zombie processes remain
- [x] Restart the app after quitting → verify it launches normally without the error dialog
- [x] Kill the app with `kill <pid>` (SIGTERM) → verify clean shutdown with no zombie processes
- [x] Launch a second instance while the first is running → verify the first instance's window is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)