### PR TITLE
fix: use i18n keys for VaultView empty hosts copy

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -390,6 +390,9 @@ const en: Messages = {
   'vault.hosts.deselectAll': 'Deselect All',
   'vault.hosts.deleteSelected': 'Delete ({count})',
   'vault.hosts.deleteMultiple.success': 'Deleted {count} hosts',
+  'vault.hosts.empty.title': 'Set up your hosts',
+  'vault.hosts.empty.description':
+    'Save hosts to quickly connect to your servers, VMs, and containers.',
 
   // Vault import
   'vault.import.title': 'Add data to your vault',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -257,6 +257,8 @@ const zhCN: Messages = {
   'vault.hosts.deselectAll': '取消全选',
   'vault.hosts.deleteSelected': '删除 ({count})',
   'vault.hosts.deleteMultiple.success': '已删除 {count} 个主机',
+  'vault.hosts.empty.title': '配置您的主机',
+  'vault.hosts.empty.description': '保存主机以便快速连接到您的服务器、虚拟机和容器。',
 
   // Vault import
   'vault.import.title': '添加数据到你的 Vault',

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -545,7 +545,7 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
       {ungroupedHosts.length === 0 && groupTree.length === 0 && (
         <div className="text-center py-12 text-muted-foreground">
           <Server size={48} className="mx-auto mb-4 opacity-50" />
-          <p className="text-sm">{t("vault.hosts.empty")}</p>
+          <p className="text-sm">{t("vault.hosts.empty.title")}</p>
         </div>
       )}
     </div>

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -2003,10 +2003,10 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                               <LayoutGrid size={32} className="opacity-60" />
                             </div>
                             <h3 className="text-lg font-semibold text-foreground mb-2">
-                              配置您的主机
+                              {t("vault.hosts.empty.title")}
                             </h3>
                             <p className="text-sm text-center max-w-sm">
-                              保存主机以便快速连接到您的服务器、虚拟机和容器。
+                              {t("vault.hosts.empty.description")}
                             </p>
                           </div>
                         )}
@@ -2138,10 +2138,10 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                               <LayoutGrid size={32} className="opacity-60" />
                             </div>
                             <h3 className="text-lg font-semibold text-foreground mb-2">
-                              配置您的主机
+                              {t("vault.hosts.empty.title")}
                             </h3>
                             <p className="text-sm text-center max-w-sm">
-                              保存主机以便快速连接到您的服务器、虚拟机和容器。
+                              {t("vault.hosts.empty.description")}
                             </p>
                           </div>
                         )}


### PR DESCRIPTION
sorry, I just forgot to apply i18n keys just now

## Summary
- Replace hardcoded Chinese text with i18n keys for empty hosts state
- Add translation keys to both en.ts and zh-CN.ts
- Fix localization regression in VaultView


## Test plan
- [ ] Verify empty hosts page displays correct text based on locale