### PR TITLE
fix(macos): restore main window when app activated

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -753,8 +753,24 @@ if (!gotLock) {
       } catch {}
     });
 
-    // Re-create window on macOS dock click
+    // Re-create or focus window on macOS dock click
     app.on("activate", () => {
+      // If the main window was hidden (e.g. "close to tray"), clicking the Dock icon
+      // should bring it back. Fallback to creating a new window if none exists.
+      try {
+        const mainWin = windowManager.getMainWindow?.();
+        if (mainWin && !mainWin.isDestroyed?.()) {
+          if (mainWin.isMinimized?.()) mainWin.restore();
+          mainWin.show?.();
+          mainWin.focus?.();
+          try {
+            app.focus({ steal: true });
+          } catch {}
+          return;
+        }
+      } catch {}
+
+      if (focusMainWindow()) return;
       if (BrowserWindow.getAllWindows().length === 0) {
         void createWindow().catch((err) => {
           console.error("[Main] Failed to create window on activate:", err);


### PR DESCRIPTION
## Problem
On macOS, when close-to-tray / hide-on-close is enabled, clicking the red close button hides the main window (app keeps running, Dock dot stays). Clicking the Dock icon would not restore the hidden window because `app.on("activate")` only recreated the window when there were zero windows.

## Fix
- On app activate, if a tracked main window exists (even if hidden), show + focus it.
- Fallback to existing `focusMainWindow()` and finally `createWindow()` when needed.

## How to test
1. Enable close-to-tray (hide-on-close).
2. Close the main window using the red button.
3. Click the Dock icon.
Expected: main window shows/focuses again.