### PR TITLE
fix(terminal): initialize xterm WebGL addon with valid constructor args

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -262,15 +262,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   if (performanceConfig.useWebGLAddon) {
     try {
-      webglAddon = (() => {
-        const webglOptions: Record<string, unknown> = { useCustomGlyphHandler: true };
-        try {
-          const WebglCtor = WebglAddon as unknown as new (options?: unknown) => WebglAddon;
-          return new WebglCtor(webglOptions);
-        } catch {
-          return new WebglAddon();
-        }
-      })();
+      // WebglAddon constructor only accepts `preserveDrawingBuffer?: boolean`.
+      // Passing an object here (legacy API assumption) unintentionally enables
+      // preserveDrawingBuffer and can cause sporadic glyph artifacts/ghosting.
+      webglAddon = new WebglAddon();
       webglAddon.onContextLoss(() => {
         logger.warn("[XTerm] WebGL context loss detected, disposing addon");
         webglAddon?.dispose();


### PR DESCRIPTION
## Summary
- remove invalid object argument passed to `new WebglAddon(...)`
- use the supported constructor signature directly
- add a short code comment explaining why

## Why
Passing an object here is interpreted as a truthy `preserveDrawingBuffer` value, which can cause intermittent rendering artifacts/ghosting in terminal output (especially with CJK text and heavy output).

## Scope
- only touches terminal runtime WebGL addon initialization
- no behavior change outside renderer setup
