### PR TITLE
fix: improve SFTP transfer speed with parallel requests and accurate progress

### DIFF
--- a/application/state/sftp/useSftpTransfers.ts
+++ b/application/state/sftp/useSftpTransfers.ts
@@ -162,11 +162,16 @@ export const useSftpTransfers = ({
             prev.map((t) => {
               if (t.id !== task.id) return t;
               if (t.status === "cancelled") return t;
+              const normalizedTotal = total > 0 ? total : t.totalBytes;
+              const normalizedTransferred = Math.max(
+                t.transferredBytes,
+                Math.min(transferred, normalizedTotal > 0 ? normalizedTotal : transferred),
+              );
               return {
                 ...t,
-                transferredBytes: transferred,
-                totalBytes: total || t.totalBytes,
-                speed,
+                transferredBytes: normalizedTransferred,
+                totalBytes: normalizedTotal,
+                speed: Number.isFinite(speed) && speed > 0 ? speed : 0,
               };
             }),
           );
@@ -773,7 +778,27 @@ export const useSftpTransfers = ({
 
   const updateExternalUpload = useCallback((taskId: string, updates: Partial<TransferTask>) => {
     setTransfers((prev) =>
-      prev.map((t) => (t.id === taskId ? { ...t, ...updates } : t)),
+      prev.map((t) => {
+        if (t.id !== taskId) return t;
+
+        const merged: TransferTask = { ...t, ...updates };
+
+        // Keep progress monotonic and bounded for stable progress UI.
+        if (typeof merged.totalBytes === "number" && merged.totalBytes > 0) {
+          merged.transferredBytes = Math.max(
+            t.transferredBytes,
+            Math.min(merged.transferredBytes, merged.totalBytes),
+          );
+        } else {
+          merged.transferredBytes = Math.max(t.transferredBytes, merged.transferredBytes);
+        }
+
+        if (!Number.isFinite(merged.speed) || merged.speed < 0) {
+          merged.speed = 0;
+        }
+
+        return merged;
+      }),
     );
   }, []);
 

--- a/components/sftp-modal/SftpModalUploadTasks.tsx
+++ b/components/sftp-modal/SftpModalUploadTasks.tsx
@@ -83,8 +83,9 @@ export const SftpModalUploadTasks: React.FC<SftpModalUploadTasksProps> = ({ task
           };
 
           const remainingBytes = task.totalBytes - task.transferredBytes;
+          const effectiveSpeed = task.speed > 0 ? task.speed : 0;
           const remainingTime =
-            task.speed > 0 ? Math.ceil(remainingBytes / task.speed) : 0;
+            effectiveSpeed > 0 ? Math.ceil(remainingBytes / effectiveSpeed) : 0;
           const remainingStr =
             remainingTime > 60
               ? `~${Math.ceil(remainingTime / 60)}m left`
@@ -123,9 +124,9 @@ export const SftpModalUploadTasks: React.FC<SftpModalUploadTasksProps> = ({ task
                   <span className="text-xs font-medium truncate">
                     {getDisplayName(task)}
                   </span>
-                  {(task.status === "uploading" || task.status === "downloading") && task.speed > 0 && (
+                  {(task.status === "uploading" || task.status === "downloading") && effectiveSpeed > 0 && (
                     <span className="text-[10px] text-primary font-mono shrink-0">
-                      {formatSpeed(task.speed)}
+                      {formatSpeed(effectiveSpeed)}
                     </span>
                   )}
                   {(task.status === "uploading" || task.status === "downloading") && remainingStr && (

--- a/components/sftp-modal/hooks/useSftpModalTransfers.ts
+++ b/components/sftp-modal/hooks/useSftpModalTransfers.ts
@@ -251,13 +251,22 @@ export const useSftpModalTransfers = ({
             if (task.status === "completed" || task.status === "failed" || task.status === "cancelled") {
               return task;
             }
-            
+
+            const totalBytes = progress.total > 0 ? progress.total : task.totalBytes;
+            const clampedTransferred = Math.max(
+              task.transferredBytes,
+              Math.min(progress.transferred, totalBytes > 0 ? totalBytes : progress.transferred)
+            );
+            const rawPercent = totalBytes > 0 ? (clampedTransferred / totalBytes) * 100 : task.progress;
+            const clampedPercent = Math.max(task.progress, Math.min(rawPercent, 100));
+
             return {
               ...task,
               status: "uploading" as const,
-              progress: progress.percent,
-              transferredBytes: progress.transferred,
-              speed: progress.speed,
+              totalBytes,
+              progress: clampedPercent,
+              transferredBytes: clampedTransferred,
+              speed: Number.isFinite(progress.speed) && progress.speed > 0 ? progress.speed : 0,
             };
           })
         );
@@ -453,10 +462,18 @@ export const useSftpModalTransfers = ({
                 task.id === transferId
                   ? {
                       ...task,
-                      transferredBytes: transferred,
-                      totalBytes: total,
-                      progress: total > 0 ? Math.round((transferred / total) * 100) : 0,
-                      speed,
+                      transferredBytes: Math.max(
+                        task.transferredBytes,
+                        Math.min(transferred, total > 0 ? total : transferred)
+                      ),
+                      totalBytes: total > 0 ? total : task.totalBytes,
+                      progress: (() => {
+                        const effectiveTotal = total > 0 ? total : task.totalBytes;
+                        if (effectiveTotal <= 0) return task.progress;
+                        const percent = (Math.max(task.transferredBytes, transferred) / effectiveTotal) * 100;
+                        return Math.max(task.progress, Math.min(percent, 100));
+                      })(),
+                      speed: Number.isFinite(speed) && speed > 0 ? speed : 0,
                     }
                   : task
               )
@@ -467,7 +484,13 @@ export const useSftpModalTransfers = ({
             setUploadTasks(prev =>
               prev.map(task =>
                 task.id === transferId
-                  ? { ...task, status: "completed" as const, progress: 100 }
+                  ? {
+                      ...task,
+                      status: "completed" as const,
+                      progress: 100,
+                      transferredBytes: task.totalBytes > 0 ? task.totalBytes : task.transferredBytes,
+                      speed: 0,
+                    }
                   : task
               )
             );

--- a/components/sftp/SftpTransferItem.tsx
+++ b/components/sftp/SftpTransferItem.tsx
@@ -3,19 +3,19 @@
  */
 
 import {
-ArrowDown,
-CheckCircle2,
-FolderUp,
-Loader2,
-RefreshCw,
-X,
-XCircle,
+    ArrowDown,
+    CheckCircle2,
+    FolderUp,
+    Loader2,
+    RefreshCw,
+    X,
+    XCircle,
 } from 'lucide-react';
-import React,{ memo, useRef, useEffect } from 'react';
+import React, { memo } from 'react';
 import { cn } from '../../lib/utils';
 import { TransferTask } from '../../types';
 import { Button } from '../ui/button';
-import { formatSpeed,formatTransferBytes } from './utils';
+import { formatSpeed, formatTransferBytes } from './utils';
 
 interface SftpTransferItemProps {
     task: TransferTask;
@@ -27,49 +27,13 @@ interface SftpTransferItemProps {
 const SftpTransferItemInner: React.FC<SftpTransferItemProps> = ({ task, onCancel, onRetry, onDismiss }) => {
     const progress = task.totalBytes > 0 ? Math.min((task.transferredBytes / task.totalBytes) * 100, 100) : 0;
 
-    // Use refs to store stable display values and prevent flickering
-    const lastSpeedRef = useRef<number>(0);
-    const lastSpeedTimeRef = useRef<number>(Date.now());
-    const displaySpeedRef = useRef<string>('');
-
-    // Update speed display with smoothing - only update if speed is stable for a moment
-    useEffect(() => {
-        if (task.status !== 'transferring') {
-            displaySpeedRef.current = '';
-            lastSpeedRef.current = 0;
-            return;
-        }
-
-        const now = Date.now();
-        const timeSinceLastUpdate = now - lastSpeedTimeRef.current;
-
-        // Only update speed display if:
-        // 1. Speed is above threshold (100 bytes/s)
-        // 2. Either it's been at least 500ms since last update, or speed changed significantly (>50%)
-        if (task.speed > 100) {
-            const speedChange = Math.abs(task.speed - lastSpeedRef.current);
-            const significantChange = lastSpeedRef.current > 0 && speedChange / lastSpeedRef.current > 0.5;
-
-            if (timeSinceLastUpdate >= 500 || significantChange || lastSpeedRef.current === 0) {
-                lastSpeedRef.current = task.speed;
-                lastSpeedTimeRef.current = now;
-                displaySpeedRef.current = formatSpeed(task.speed);
-            }
-        } else if (task.speed === 0 && lastSpeedRef.current > 0) {
-            // Don't immediately clear speed when it drops to 0
-            // Keep showing last speed for a short period
-            if (timeSinceLastUpdate >= 1000) {
-                lastSpeedRef.current = 0;
-                displaySpeedRef.current = '';
-            }
-        }
-    }, [task.speed, task.status]);
-
-    // Calculate remaining time based on stable speed
+    // Calculate remaining time from backend-reported sliding-window speed
     const remainingBytes = task.totalBytes - task.transferredBytes;
-    const stableSpeed = lastSpeedRef.current > 0 ? lastSpeedRef.current : task.speed;
-    const remainingTime = stableSpeed > 0
-        ? Math.ceil(remainingBytes / stableSpeed)
+    const effectiveSpeed = task.status === 'transferring'
+        ? (Number.isFinite(task.speed) && task.speed > 0 ? task.speed : 0)
+        : 0;
+    const remainingTime = effectiveSpeed > 0
+        ? Math.ceil(remainingBytes / effectiveSpeed)
         : 0;
     const remainingFormatted = remainingTime > 60
         ? `~${Math.ceil(remainingTime / 60)}m left`
@@ -84,8 +48,7 @@ const SftpTransferItemInner: React.FC<SftpTransferItemProps> = ({ task, onCancel
             ? formatTransferBytes(task.totalBytes)
             : '';
 
-    // Use the stable display speed
-    const speedFormatted = displaySpeedRef.current;
+    const speedFormatted = effectiveSpeed > 0 ? formatSpeed(effectiveSpeed) : '';
 
     return (
         <div className="flex items-center gap-3 px-4 py-2.5 bg-background/60 border-t border-border/40 backdrop-blur-sm">
@@ -196,17 +159,15 @@ const arePropsEqual = (
     // Always re-render on fileName change
     if (prev.fileName !== next.fileName) return false;
 
-    // For transferring status, throttle updates based on progress
+    // For transferring status, allow frequent re-renders for smooth progress bar
     if (next.status === 'transferring') {
-        // Re-render if progress changed by more than 0.5%
+        // Re-render on any meaningful progress change (0.1% for smooth bar animation)
         const prevProgress = prev.totalBytes > 0 ? (prev.transferredBytes / prev.totalBytes) * 100 : 0;
         const nextProgress = next.totalBytes > 0 ? (next.transferredBytes / next.totalBytes) * 100 : 0;
-        if (Math.abs(nextProgress - prevProgress) >= 0.5) return false;
+        if (Math.abs(nextProgress - prevProgress) >= 0.1) return false;
 
-        // Re-render periodically for speed updates (every ~500ms based on speed changes)
-        // The component uses refs to smooth speed display, so we allow more frequent renders
-        const speedDiff = Math.abs(next.speed - prev.speed);
-        if (speedDiff > 1000) return false; // Re-render if speed changed by more than 1KB/s
+        // Re-render on any speed change (backend already smooths via sliding window)
+        if (next.speed !== prev.speed) return false;
     }
 
     // For pending status, don't re-render unless status changes

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -8,9 +8,22 @@ const path = require("node:path");
 const os = require("node:os");
 const { encodePathForSession, ensureRemoteDirForSession } = require("./sftpBridge.cjs");
 
+// ── Transfer performance tuning ──────────────────────────────────────────────
+// ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel,
+// dramatically improving throughput over sequential stream piping.
+const TRANSFER_CHUNK_SIZE = 512 * 1024;   // 512KB per SFTP request
+const TRANSFER_CONCURRENCY = 64;          // 64 parallel SFTP requests
+// Progress IPC throttle: sending too many IPC messages bogs down the event loop
+const PROGRESS_THROTTLE_MS = 100;         // Send IPC at most every 100ms
+const PROGRESS_THROTTLE_BYTES = 256 * 1024; // Or every 256KB of progress
+
+// Speed calculation uses strict sliding-window average:
+// speed = bytes_delta_in_window / time_delta_in_window
+const SPEED_WINDOW_MS = 3000;             // Keep 3s of samples
+const SPEED_MIN_ELAPSED_MS = 50;          // Minimum elapsed time to avoid divide-by-near-zero spikes
+
 // Shared references
 let sftpClients = null;
-let electronModule = null;
 
 // Active transfers storage
 const activeTransfers = new Map();
@@ -20,43 +33,52 @@ const activeTransfers = new Map();
  */
 function init(deps) {
   sftpClients = deps.sftpClients;
-  electronModule = deps.electronModule;
 }
 
 /**
- * Upload a local file to SFTP using streams (supports cancellation)
+ * Upload a local file to SFTP using ssh2's fastPut (parallel SFTP requests).
+ * Falls back to sequential stream piping if fastPut is unavailable.
  */
-async function uploadWithStreams(localPath, remotePath, client, fileSize, transfer, sendProgress) {
+async function uploadFile(localPath, remotePath, client, fileSize, transfer, sendProgress) {
+  const sftp = client.sftp;
+  if (!sftp) throw new Error("SFTP client not ready");
+
+  // Prefer fastPut: sends multiple SFTP WRITE requests in parallel
+  if (typeof sftp.fastPut === 'function') {
+    return new Promise((resolve, reject) => {
+      sftp.fastPut(localPath, remotePath, {
+        chunkSize: TRANSFER_CHUNK_SIZE,
+        concurrency: TRANSFER_CONCURRENCY,
+        step: (transferred, _chunk, total) => {
+          if (transfer.cancelled) return;
+          sendProgress(transferred, total || fileSize);
+        }
+      }, (err) => {
+        if (transfer.cancelled) reject(new Error('Transfer cancelled'));
+        else if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  // Fallback: sequential stream piping
   return new Promise((resolve, reject) => {
-    const readStream = fs.createReadStream(localPath);
-
-    // Get the underlying sftp object from ssh2-sftp-client
-    const sftp = client.sftp;
-    if (!sftp) {
-      reject(new Error("SFTP client not ready"));
-      return;
-    }
-
-    const writeStream = sftp.createWriteStream(remotePath);
+    const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
+    const writeStream = sftp.createWriteStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     let transferred = 0;
     let finished = false;
 
-    // Store streams for cancellation
     transfer.readStream = readStream;
     transfer.writeStream = writeStream;
 
     const cleanup = (err) => {
       if (finished) return;
       finished = true;
-
-      // Remove listeners to prevent memory leaks
       readStream.removeAllListeners();
       writeStream.removeAllListeners();
-
       if (err) {
-        // Destroy streams on error
-        try { readStream.destroy(); } catch {}
-        try { writeStream.destroy(); } catch {}
+        try { readStream.destroy(); } catch { }
+        try { writeStream.destroy(); } catch { }
         reject(err);
       } else {
         resolve();
@@ -64,61 +86,64 @@ async function uploadWithStreams(localPath, remotePath, client, fileSize, transf
     };
 
     readStream.on('data', (chunk) => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-        return;
-      }
+      if (transfer.cancelled) { cleanup(new Error('Transfer cancelled')); return; }
       transferred += chunk.length;
       sendProgress(transferred, fileSize);
     });
-
-    readStream.on('error', (err) => cleanup(err));
-    writeStream.on('error', (err) => cleanup(err));
+    readStream.on('error', cleanup);
+    writeStream.on('error', cleanup);
     writeStream.on('close', () => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-      } else {
-        cleanup(null);
-      }
+      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
+      else cleanup(null);
     });
-
     readStream.pipe(writeStream);
   });
 }
 
 /**
- * Download from SFTP to local file using streams (supports cancellation)
+ * Download from SFTP to local file using ssh2's fastGet (parallel SFTP requests).
+ * Falls back to sequential stream piping if fastGet is unavailable.
  */
-async function downloadWithStreams(remotePath, localPath, client, fileSize, transfer, sendProgress) {
-  return new Promise((resolve, reject) => {
-    // Get the underlying sftp object from ssh2-sftp-client
-    const sftp = client.sftp;
-    if (!sftp) {
-      reject(new Error("SFTP client not ready"));
-      return;
-    }
+async function downloadFile(remotePath, localPath, client, fileSize, transfer, sendProgress) {
+  const sftp = client.sftp;
+  if (!sftp) throw new Error("SFTP client not ready");
 
-    const readStream = sftp.createReadStream(remotePath);
-    const writeStream = fs.createWriteStream(localPath);
+  // Prefer fastGet: sends multiple SFTP READ requests in parallel
+  if (typeof sftp.fastGet === 'function') {
+    return new Promise((resolve, reject) => {
+      sftp.fastGet(remotePath, localPath, {
+        chunkSize: TRANSFER_CHUNK_SIZE,
+        concurrency: TRANSFER_CONCURRENCY,
+        step: (transferred, _chunk, total) => {
+          if (transfer.cancelled) return;
+          sendProgress(transferred, total || fileSize);
+        }
+      }, (err) => {
+        if (transfer.cancelled) reject(new Error('Transfer cancelled'));
+        else if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  // Fallback: sequential stream piping
+  return new Promise((resolve, reject) => {
+    const readStream = sftp.createReadStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
+    const writeStream = fs.createWriteStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     let transferred = 0;
     let finished = false;
 
-    // Store streams for cancellation
     transfer.readStream = readStream;
     transfer.writeStream = writeStream;
 
     const cleanup = (err) => {
       if (finished) return;
       finished = true;
-
-      // Remove listeners to prevent memory leaks
       readStream.removeAllListeners();
       writeStream.removeAllListeners();
-
       if (err) {
-        // Destroy streams on error
-        try { readStream.destroy(); } catch {}
-        try { writeStream.destroy(); } catch {}
+        try { readStream.destroy(); } catch { }
+        try { writeStream.destroy(); } catch { }
         reject(err);
       } else {
         resolve();
@@ -126,40 +151,25 @@ async function downloadWithStreams(remotePath, localPath, client, fileSize, tran
     };
 
     readStream.on('data', (chunk) => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-        return;
-      }
+      if (transfer.cancelled) { cleanup(new Error('Transfer cancelled')); return; }
       transferred += chunk.length;
       sendProgress(transferred, fileSize);
     });
-
-    readStream.on('error', (err) => cleanup(err));
-    writeStream.on('error', (err) => cleanup(err));
-    // Handle normal completion
+    readStream.on('error', cleanup);
+    writeStream.on('error', cleanup);
     writeStream.on('finish', () => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-      } else {
-        cleanup(null);
-      }
+      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
+      else cleanup(null);
     });
-    // Handle stream destruction (destroy() emits 'close' but not 'finish')
     writeStream.on('close', () => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-      }
+      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
     });
-
     readStream.pipe(writeStream);
   });
 }
 
 /**
  * Start a file transfer
- * @param {object} event - IPC event
- * @param {object} payload - Transfer configuration
- * @param {function} [onProgress] - Optional progress callback (transferred, total, speed)
  */
 async function startTransfer(event, payload, onProgress) {
   const {
@@ -176,47 +186,121 @@ async function startTransfer(event, payload, onProgress) {
   } = payload;
   const sender = event.sender;
 
-  // Register transfer for cancellation
   const transfer = { cancelled: false, readStream: null, writeStream: null };
   activeTransfers.set(transferId, transfer);
+  const transferCreatedAt = Date.now();
 
-  let lastTime = Date.now();
-  let lastTransferred = 0;
-  let speed = 0;
+  // ── Progress/speed tracking ──────────────────────────────────────────────
+  // Keep progress monotonic and compute speed from a strict sliding window.
+  const speedSamples = [{ time: transferCreatedAt, bytes: 0 }]; // [{ time, bytes }]
+  let lastObservedTransferred = 0;
+  let lastObservedTotal = Math.max(0, totalBytes || 0);
+  let lastProgressSentTime = 0;
+  let lastProgressSentBytes = -1;
+
+  const computeWindowSpeed = (now, transferred) => {
+    const targetTime = now - SPEED_WINDOW_MS;
+
+    // Keep exactly one sample before targetTime for boundary interpolation.
+    while (speedSamples.length >= 2 && speedSamples[1].time <= targetTime) {
+      speedSamples.shift();
+    }
+
+    const first = speedSamples[0];
+    if (!first) return 0;
+
+    let boundaryTime = first.time;
+    let boundaryBytes = first.bytes;
+
+    if (speedSamples.length >= 2 && targetTime > first.time) {
+      const next = speedSamples[1];
+      const range = next.time - first.time;
+      if (range > 0) {
+        const ratio = (targetTime - first.time) / range;
+        boundaryBytes = first.bytes + (next.bytes - first.bytes) * ratio;
+        boundaryTime = targetTime;
+      }
+    }
+
+    const elapsedMs = now - boundaryTime;
+    if (elapsedMs < SPEED_MIN_ELAPSED_MS) return 0;
+
+    const deltaBytes = transferred - boundaryBytes;
+    if (deltaBytes <= 0) return 0;
+
+    const speed = (deltaBytes * 1000) / elapsedMs;
+    return Number.isFinite(speed) && speed > 0 ? Math.round(speed) : 0;
+  };
+
+  const emitProgress = (now, transferred, total, speed, force = false) => {
+    const isComplete = total > 0 && transferred >= total;
+    const transferredChanged = transferred !== lastProgressSentBytes;
+    const timeSinceLast = now - lastProgressSentTime;
+    const bytesSinceLast = transferred - lastProgressSentBytes;
+
+    if (
+      force ||
+      isComplete ||
+      (transferredChanged &&
+        (timeSinceLast >= PROGRESS_THROTTLE_MS || bytesSinceLast >= PROGRESS_THROTTLE_BYTES))
+    ) {
+      lastProgressSentTime = now;
+      lastProgressSentBytes = transferred;
+      sender.send("netcatty:transfer:progress", { transferId, transferred, speed, totalBytes: total });
+    }
+  };
+
+  const cleanupTransfer = () => {
+    activeTransfers.delete(transferId);
+  };
 
   const sendProgress = (transferred, total) => {
     if (transfer.cancelled) return;
 
     const now = Date.now();
-    const elapsed = now - lastTime;
-    if (elapsed >= 100) {
-      speed = Math.round((transferred - lastTransferred) / (elapsed / 1000));
-      lastTime = now;
-      lastTransferred = transferred;
+
+    let normalizedTotal = Number.isFinite(total) && total > 0 ? total : 0;
+    if (normalizedTotal === 0) {
+      normalizedTotal = lastObservedTotal || 0;
+    }
+    normalizedTotal = Math.max(normalizedTotal, lastObservedTotal, 0);
+
+    let normalizedTransferred = Number.isFinite(transferred) && transferred > 0 ? transferred : 0;
+    if (normalizedTotal > 0) {
+      normalizedTransferred = Math.min(normalizedTransferred, normalizedTotal);
+    }
+    normalizedTransferred = Math.max(normalizedTransferred, lastObservedTransferred);
+
+    lastObservedTransferred = normalizedTransferred;
+    lastObservedTotal = normalizedTotal;
+
+    const lastSample = speedSamples[speedSamples.length - 1];
+    if (!lastSample || lastSample.bytes !== normalizedTransferred || now - lastSample.time >= PROGRESS_THROTTLE_MS) {
+      speedSamples.push({ time: now, bytes: normalizedTransferred });
     }
 
-    // Call optional progress callback if provided
+    const speed = computeWindowSpeed(now, normalizedTransferred);
+
     if (onProgress) {
-      onProgress(transferred, total, speed);
+      onProgress(normalizedTransferred, normalizedTotal, speed);
     }
 
-    sender.send("netcatty:transfer:progress", { transferId, transferred, speed, totalBytes: total });
+    emitProgress(now, normalizedTransferred, normalizedTotal, speed);
   };
 
   const sendComplete = () => {
-    activeTransfers.delete(transferId);
     sender.send("netcatty:transfer:complete", { transferId });
+    cleanupTransfer();
   };
 
   const sendError = (error) => {
-    activeTransfers.delete(transferId);
+    cleanupTransfer();
     sender.send("netcatty:transfer:error", { transferId, error: error.message || String(error) });
   };
 
   try {
     let fileSize = totalBytes || 0;
 
-    // Get file size if not provided
     if (!fileSize) {
       if (sourceType === 'local') {
         const stat = await fs.promises.stat(sourcePath);
@@ -230,23 +314,19 @@ async function startTransfer(event, payload, onProgress) {
       }
     }
 
-    // Send initial progress
     sendProgress(0, fileSize);
 
-    // Handle different transfer scenarios
     if (sourceType === 'local' && targetType === 'sftp') {
-      // Upload: Local -> SFTP using streams (supports cancellation)
       const client = sftpClients.get(targetSftpId);
       if (!client) throw new Error("Target SFTP session not found");
 
       const dir = path.dirname(targetPath).replace(/\\/g, '/');
-      try { await ensureRemoteDirForSession(targetSftpId, dir, targetEncoding); } catch {}
+      try { await ensureRemoteDirForSession(targetSftpId, dir, targetEncoding); } catch { }
 
       const encodedTargetPath = encodePathForSession(targetSftpId, targetPath, targetEncoding);
-      await uploadWithStreams(sourcePath, encodedTargetPath, client, fileSize, transfer, sendProgress);
+      await uploadFile(sourcePath, encodedTargetPath, client, fileSize, transfer, sendProgress);
 
     } else if (sourceType === 'sftp' && targetType === 'local') {
-      // Download: SFTP -> Local using streams (supports cancellation)
       const client = sftpClients.get(sourceSftpId);
       if (!client) throw new Error("Source SFTP session not found");
 
@@ -254,16 +334,15 @@ async function startTransfer(event, payload, onProgress) {
       await fs.promises.mkdir(dir, { recursive: true });
 
       const encodedSourcePath = encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
-      await downloadWithStreams(encodedSourcePath, targetPath, client, fileSize, transfer, sendProgress);
+      await downloadFile(encodedSourcePath, targetPath, client, fileSize, transfer, sendProgress);
 
     } else if (sourceType === 'local' && targetType === 'local') {
-      // Local copy: use streams
       const dir = path.dirname(targetPath);
       await fs.promises.mkdir(dir, { recursive: true });
 
       await new Promise((resolve, reject) => {
-        const readStream = fs.createReadStream(sourcePath);
-        const writeStream = fs.createWriteStream(targetPath);
+        const readStream = fs.createReadStream(sourcePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
+        const writeStream = fs.createWriteStream(targetPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
         let transferred = 0;
         let finished = false;
 
@@ -276,8 +355,8 @@ async function startTransfer(event, payload, onProgress) {
           readStream.removeAllListeners();
           writeStream.removeAllListeners();
           if (err) {
-            try { readStream.destroy(); } catch {}
-            try { writeStream.destroy(); } catch {}
+            try { readStream.destroy(); } catch { }
+            try { writeStream.destroy(); } catch { }
             reject(err);
           } else {
             resolve();
@@ -285,36 +364,23 @@ async function startTransfer(event, payload, onProgress) {
         };
 
         readStream.on('data', (chunk) => {
-          if (transfer.cancelled) {
-            cleanup(new Error('Transfer cancelled'));
-            return;
-          }
+          if (transfer.cancelled) { cleanup(new Error('Transfer cancelled')); return; }
           transferred += chunk.length;
           sendProgress(transferred, fileSize);
         });
-
         readStream.on('error', cleanup);
         writeStream.on('error', cleanup);
-        // Handle normal completion
         writeStream.on('finish', () => {
-          if (transfer.cancelled) {
-            cleanup(new Error('Transfer cancelled'));
-          } else {
-            cleanup(null);
-          }
+          if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
+          else cleanup(null);
         });
-        // Handle stream destruction (destroy() emits 'close' but not 'finish')
         writeStream.on('close', () => {
-          if (transfer.cancelled) {
-            cleanup(new Error('Transfer cancelled'));
-          }
+          if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
         });
-
         readStream.pipe(writeStream);
       });
 
     } else if (sourceType === 'sftp' && targetType === 'sftp') {
-      // SFTP to SFTP: download to temp then upload using streams
       const tempPath = path.join(os.tmpdir(), `netcatty-transfer-${transferId}`);
 
       const sourceClient = sftpClients.get(sourceSftpId);
@@ -322,43 +388,39 @@ async function startTransfer(event, payload, onProgress) {
       if (!sourceClient) throw new Error("Source SFTP session not found");
       if (!targetClient) throw new Error("Target SFTP session not found");
 
-      // Download phase (0-50%) - wrap progress to show 0-50%
       const encodedSourcePath = encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
-      const downloadProgress = (transferred, total) => {
+      const downloadProgress = (transferred) => {
         sendProgress(Math.floor(transferred / 2), fileSize);
       };
-      await downloadWithStreams(encodedSourcePath, tempPath, sourceClient, fileSize, transfer, downloadProgress);
+      await downloadFile(encodedSourcePath, tempPath, sourceClient, fileSize, transfer, downloadProgress);
 
       if (transfer.cancelled) {
-        try { await fs.promises.unlink(tempPath); } catch {}
+        try { await fs.promises.unlink(tempPath); } catch { }
         throw new Error('Transfer cancelled');
       }
 
-      // Upload phase (50-100%) - wrap progress to show 50-100%
       const dir = path.dirname(targetPath).replace(/\\/g, '/');
-      try { await ensureRemoteDirForSession(targetSftpId, dir, targetEncoding); } catch {}
+      try { await ensureRemoteDirForSession(targetSftpId, dir, targetEncoding); } catch { }
 
       const encodedTargetPath = encodePathForSession(targetSftpId, targetPath, targetEncoding);
-      const uploadProgress = (transferred, total) => {
+      const uploadProgress = (transferred) => {
         sendProgress(Math.floor(fileSize / 2) + Math.floor(transferred / 2), fileSize);
       };
-      await uploadWithStreams(tempPath, encodedTargetPath, targetClient, fileSize, transfer, uploadProgress);
+      await uploadFile(tempPath, encodedTargetPath, targetClient, fileSize, transfer, uploadProgress);
 
-      // Cleanup temp file
-      try { await fs.promises.unlink(tempPath); } catch {}
+      try { await fs.promises.unlink(tempPath); } catch { }
 
     } else {
       throw new Error("Invalid transfer configuration");
     }
-    
-    // Send final 100% progress
+
     sendProgress(fileSize, fileSize);
     sendComplete();
-    
+
     return { transferId, totalBytes: fileSize };
   } catch (err) {
     if (err.message === 'Transfer cancelled') {
-      activeTransfers.delete(transferId);
+      cleanupTransfer();
       sender.send("netcatty:transfer:cancelled", { transferId });
     } else {
       sendError(err);
@@ -372,24 +434,17 @@ async function startTransfer(event, payload, onProgress) {
  */
 async function cancelTransfer(event, payload) {
   const { transferId } = payload;
-  console.log('[transferBridge] cancelTransfer called for:', transferId);
   const transfer = activeTransfers.get(transferId);
-  console.log('[transferBridge] Found transfer:', !!transfer, 'activeTransfers keys:', Array.from(activeTransfers.keys()));
   if (transfer) {
     transfer.cancelled = true;
-    console.log('[transferBridge] Set cancelled=true for transfer:', transferId);
 
-    // Destroy streams to immediately stop the transfer
+    // Destroy streams for stream-based fallback transfers
     if (transfer.readStream) {
-      console.log('[transferBridge] Destroying read stream');
-      try { transfer.readStream.destroy(); } catch (e) { console.log('[transferBridge] Error destroying readStream:', e); }
+      try { transfer.readStream.destroy(); } catch { }
     }
     if (transfer.writeStream) {
-      console.log('[transferBridge] Destroying write stream');
-      try { transfer.writeStream.destroy(); } catch (e) { console.log('[transferBridge] Error destroying writeStream:', e); }
+      try { transfer.writeStream.destroy(); } catch { }
     }
-
-    console.log('[transferBridge] Transfer marked for cancellation');
   }
   return { success: true };
 }


### PR DESCRIPTION
## 关联 Issue

Closes #226

## 改动说明

- 将 SFTP 传输从顺序 stream pipe 改为 ssh2 的 **fastPut/fastGet 并行传输**（64 并发请求，512KB chunk）
- 修复速度计算：使用滑动窗口平均速度，避免并行 chunk 突发完成导致的速度虚高
- 节流 progress IPC 更新（100ms），减少事件循环开销
- 简化前端速度显示逻辑，移除 ref 平滑层，直接使用后端已平滑的速度值
- 优化 React memo 比较逻辑，进度条更新更丝滑