### PR TITLE
fix(sftp): prevent stale session race when reopening modal

### DIFF
--- a/components/SFTPModal.tsx
+++ b/components/SFTPModal.tsx
@@ -205,6 +205,7 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
     loading,
     setLoading,
     reconnecting,
+    sessionVersion,
     ensureSftp,
     loadFiles,
     closeSftpSession,
@@ -394,7 +395,6 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
     useCompressedUpload: sftpUseCompressedUpload,
   });
   const hasEverOpenedRef = useRef(false);
-  const hiddenCloseHandledRef = useRef(false);
 
   const hasActiveTransferTasks = useMemo(
     () =>
@@ -410,30 +410,21 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
   useEffect(() => {
     if (open) {
       hasEverOpenedRef.current = true;
-      hiddenCloseHandledRef.current = false;
       return;
     }
 
     if (!hasEverOpenedRef.current) return;
-    if (uploading || hasActiveTransferTasks) {
-      hiddenCloseHandledRef.current = false;
-      return;
-    }
+    if (uploading || hasActiveTransferTasks) return;
 
-    if (!hiddenCloseHandledRef.current) {
-      hiddenCloseHandledRef.current = true;
-      void closeSftpSession();
-    }
-  }, [closeSftpSession, hasActiveTransferTasks, open, uploading]);
+    void closeSftpSession();
+  }, [closeSftpSession, hasActiveTransferTasks, open, sessionVersion, uploading]);
 
   const handleClose = async () => {
     if (uploading || hasActiveTransferTasks) {
-      hiddenCloseHandledRef.current = false;
       onClose();
       return;
     }
 
-    hiddenCloseHandledRef.current = true;
     await closeSftpSession();
     onClose();
   };

--- a/components/sftp-modal/hooks/useSftpModalSession.ts
+++ b/components/sftp-modal/hooks/useSftpModalSession.ts
@@ -57,6 +57,7 @@ interface UseSftpModalSessionResult {
   loading: boolean;
   setLoading: (loading: boolean) => void;
   reconnecting: boolean;
+  sessionVersion: number;
   ensureSftp: () => Promise<string>;
   loadFiles: (path: string, options?: { force?: boolean }) => Promise<void>;
   closeSftpSession: () => Promise<void>;
@@ -81,6 +82,7 @@ export const useSftpModalSession = ({
   const [files, setFiles] = useState<RemoteFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
+  const [sessionVersion, setSessionVersion] = useState(0);
   const sftpIdRef = useRef<string | null>(null);
   const closingPromiseRef = useRef<Promise<void> | null>(null);
   const initializedRef = useRef(false);
@@ -96,6 +98,9 @@ export const useSftpModalSession = ({
     Map<string, { files: RemoteFile[]; timestamp: number }>
   >(new Map());
   const loadSeqRef = useRef(0);
+  const bumpSessionVersion = useCallback(() => {
+    setSessionVersion((prev) => prev + 1);
+  }, []);
 
   const ensureSftp = useCallback(async () => {
     if (isLocalSession) throw new Error("Local session does not use SFTP");
@@ -120,7 +125,10 @@ export const useSftpModalSession = ({
       sudo: credentials.sftpSudo,
       legacyAlgorithms: credentials.legacyAlgorithms,
     });
-    sftpIdRef.current = sftpId;
+    if (sftpIdRef.current !== sftpId) {
+      sftpIdRef.current = sftpId;
+      bumpSessionVersion();
+    }
     return sftpId;
   }, [
     isLocalSession,
@@ -139,19 +147,26 @@ export const useSftpModalSession = ({
     credentials.jumpHosts,
     credentials.sftpSudo,
     credentials.legacyAlgorithms,
+    bumpSessionVersion,
     openSftp,
   ]);
 
   const closeSftpSession = useCallback(async () => {
     if (isLocalSession) {
-      sftpIdRef.current = null;
+      if (sftpIdRef.current !== null) {
+        sftpIdRef.current = null;
+        bumpSessionVersion();
+      }
       return;
     }
 
     // Clear ref before awaiting backend close to avoid handing out a stale ID
     // if the modal is reopened while close is still in flight.
     const sftpIdToClose = sftpIdRef.current;
-    sftpIdRef.current = null;
+    if (sftpIdToClose !== null) {
+      sftpIdRef.current = null;
+      bumpSessionVersion();
+    }
     if (!sftpIdToClose) {
       return;
     }
@@ -170,7 +185,7 @@ export const useSftpModalSession = ({
 
     closingPromiseRef.current = currentClosePromise;
     await currentClosePromise;
-  }, [closeSftp, isLocalSession]);
+  }, [bumpSessionVersion, closeSftp, isLocalSession]);
 
   const isSessionError = useCallback((err: unknown): boolean => {
     if (!(err instanceof Error)) return false;
@@ -403,6 +418,7 @@ export const useSftpModalSession = ({
     loading,
     setLoading,
     reconnecting,
+    sessionVersion,
     ensureSftp,
     loadFiles,
     closeSftpSession,


### PR DESCRIPTION
## Summary
- prevent stale SFTP session ID reuse when modal closes and reopens quickly
- serialize close/open with an in-flight close promise gate
- keep hide-with-active-transfer behavior while restoring awaited close path when no active task

## Changes
- clear session id ref before awaiting backend close
- make ensureSftp wait for pending close completion
- route reconnect close through closeSftpSession
- close immediately in handleClose when no active transfers, defer close after hide only when transfers are active

## Validation
- npx eslint components/SFTPModal.tsx components/sftp-modal/hooks/useSftpModalSession.ts
