### PR TITLE
fix: reverse SFTP transfer queue order to show newest tasks first

### DIFF
--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -167,7 +167,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({ hosts, keys, identities }) => 
   });
 
   const visibleTransfers = useMemo(
-    () => sftp.transfers.slice(-5),
+    () => [...sftp.transfers].reverse().slice(0, 5),
     [sftp.transfers],
   );
 

--- a/components/sftp-modal/SftpModalUploadTasks.tsx
+++ b/components/sftp-modal/SftpModalUploadTasks.tsx
@@ -64,7 +64,7 @@ export const SftpModalUploadTasks: React.FC<SftpModalUploadTasksProps> = ({ task
   return (
     <div className="border-t border-border/60 bg-secondary/50 flex-shrink-0">
       <div className="max-h-40 overflow-y-auto overflow-x-hidden">
-        {tasks.map((task) => {
+        {[...tasks].reverse().map((task) => {
           const formatSpeed = (bytesPerSec: number) => {
             if (bytesPerSec <= 0) return "";
             if (bytesPerSec >= 1024 * 1024)


### PR DESCRIPTION
## 关联 Issue

Closes #223

## 改动说明

将 SFTP 传输队列的显示顺序从正序改为**倒序**，最新的传输任务显示在最上面，无需滚动即可看到当前进度。

### 修改文件
- **SftpView.tsx** — 双面板 SFTP 的传输队列倒序
- **SftpModalUploadTasks.tsx** — 侧边栏 SFTP 的传输队列倒序