### PR TITLE
fix: add missing passphrase to SFTP dual-pane credentials

### DIFF
--- a/application/state/sftp/useSftpHostCredentials.ts
+++ b/application/state/sftp/useSftpHostCredentials.ts
@@ -20,12 +20,12 @@ export const useSftpHostCredentials = ({
 
       const proxyConfig = host.proxyConfig
         ? {
-            type: host.proxyConfig.type,
-            host: host.proxyConfig.host,
-            port: host.proxyConfig.port,
-            username: host.proxyConfig.username,
-            password: host.proxyConfig.password,
-          }
+          type: host.proxyConfig.type,
+          host: host.proxyConfig.host,
+          port: host.proxyConfig.port,
+          username: host.proxyConfig.username,
+          password: host.proxyConfig.password,
+        }
         : undefined;
 
       let jumpHosts: NetcattyJumpHost[] | undefined;
@@ -63,6 +63,7 @@ export const useSftpHostCredentials = ({
         password: resolved.password,
         privateKey: key?.privateKey,
         certificate: key?.certificate,
+        passphrase: resolved.passphrase || key?.passphrase,
         publicKey: key?.publicKey,
         keyId: resolved.keyId,
         keySource: key?.source,


### PR DESCRIPTION
## Related Issue

Closes #238

## Root Cause

`useSftpHostCredentials.ts` builds a credentials object for SFTP connections but **omits the `passphrase` field**. When a user has a passphrase-protected private key, the SFTP bridge receives the encrypted key without its passphrase, causing:

```
Error: Cannot parse privateKey: Encrypted private OpenSSH key detected, but no passphrase given
```

SSH terminal connections work fine because the SSH bridge code path (`sshBridge.cjs`) assembles credentials differently and includes the passphrase.

Interestingly, the jump host path in the **same file** (L50) already includes passphrase correctly:
```typescript
passphrase: jumpAuth.passphrase || jumpKey?.passphrase,
```

## Fix

Added the missing `passphrase` field to the target host credentials object, using the same pattern as jump hosts:

```diff
  return {
    hostname: host.hostname,
    username: resolved.username,
    port: host.port || 22,
    password: resolved.password,
    privateKey: key?.privateKey,
    certificate: key?.certificate,
+   passphrase: resolved.passphrase || key?.passphrase,
    publicKey: key?.publicKey,
    ...
  };
```

One-line fix in one file.
