### PR TITLE
fix: split Linux build into x64 and arm64 jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,24 @@ on:
 
 jobs:
   build:
-    name: build-${{ matrix.os }}
+    name: build-${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - name: macos
+            os: macos-latest
+            pack_script: pack:mac
+          - name: windows
+            os: windows-latest
+            pack_script: pack:win
+          - name: linux-x64
+            os: ubuntu-latest
+            pack_script: pack:linux-x64
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            pack_script: pack:linux-arm64
     env:
       VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
@@ -50,29 +62,16 @@ jobs:
           echo "Setting version to ${VERSION}"
           npm pkg set version="${VERSION}"
 
-      - name: Build package (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Build package
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.name == 'macos' && 'false' || '' }}
           ELECTRON_BUILDER_PUBLISH: "never"
-        run: npm run pack:mac
-
-      - name: Build package (Windows)
-        if: matrix.os == 'windows-latest'
-        env:
-          ELECTRON_BUILDER_PUBLISH: "never"
-        run: npm run pack:win
-
-      - name: Build package (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          ELECTRON_BUILDER_PUBLISH: "never"
-        run: npm run pack:linux
+        run: npm run ${{ matrix.pack_script }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: netcatty-${{ matrix.os }}
+          name: netcatty-${{ matrix.name }}
           path: |
             release/*.dmg
             release/*.exe

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "pack:win": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --win --publish=never",
     "pack:mac": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --mac --publish=never",
     "pack:linux": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --publish=never",
+    "pack:linux-x64": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --x64 --publish=never",
+    "pack:linux-arm64": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --arm64 --publish=never",
     "postinstall": "electron-builder install-app-deps && patch-package",
     "rebuild": "electron-builder install-app-deps",
     "lint": "eslint .",


### PR DESCRIPTION
## Problem

ARM64 AppImage (`Netcatty-1.0.38-linux-arm64.AppImage`) contains x86-64 native modules (`node-pty`, `ssh2`), making it unusable on ARM64 systems like UOS with Kirin 9000C CPU.

**Root cause:** Both x64 and arm64 Linux packages were built on the same `ubuntu-latest` (x86-64) runner. While electron-builder can produce ARM64 Electron shells, it doesn't cross-compile native `.node` modules — they remain x86-64 binaries.

## Changes

### CI (`build.yml`)
- Split the single `ubuntu-latest` Linux job into two separate jobs:
  - `linux-x64` on `ubuntu-latest` (x86-64 runner)
  - `linux-arm64` on `ubuntu-24.04-arm` (ARM64 runner)
- Each job only builds for its own architecture
- Unified build step using matrix variables (removes per-OS `if` conditions)

### Package scripts (`package.json`)
- Added `pack:linux-x64` with `--x64` flag
- Added `pack:linux-arm64` with `--arm64` flag
- Original `pack:linux` (both archs) preserved for local use

Closes #222