### PR TITLE
fix: prevent x64 native module rebuild on ARM64 CI runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,17 @@ jobs:
           echo "Setting version to ${VERSION}"
           npm pkg set version="${VERSION}"
 
+      # On ARM64 runners, electron-builder's post-build @electron/rebuild incorrectly
+      # tries to restore native modules to x64, but the ARM g++ doesn't support -m64.
+      # Setting npm_config_arch=arm64 ensures node-gyp uses the correct host architecture.
+      - name: Set native module arch for ARM64
+        if: matrix.name == 'linux-arm64'
+        run: echo "npm_config_arch=arm64" >> "$GITHUB_ENV"
+
       - name: Build package
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.name == 'macos' && 'false' || '' }}
           ELECTRON_BUILDER_PUBLISH: "never"
-          # On ARM64 runners, electron-builder's post-build @electron/rebuild incorrectly
-          # tries to restore native modules to x64, but the ARM g++ doesn't support -m64.
-          # Setting npm_config_arch ensures node-gyp uses the correct host architecture.
-          npm_config_arch: ${{ matrix.name == 'linux-arm64' && 'arm64' || '' }}
         run: npm run ${{ matrix.pack_script }}
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

The `linux-arm64` CI job fails during the `Build package` step with:

```
g++: error: unrecognized command-line option '-m64'
```

**Root cause:** After packaging the arm64 AppImage, electron-builder runs `@electron/rebuild` a second time to "restore" native modules to the host architecture. It incorrectly targets `x64`, but the `ubuntu-24.04-arm` runner uses ARM64 hardware where g++ doesn't support the `-m64` flag.

Build log sequence:
1. ✅ `@electron/rebuild arch=arm64` — native deps rebuilt for arm64
2. ✅ `packaging platform=linux arch=arm64` — app packaged 
3. ✅ `building target=AppImage arch=arm64` — AppImage build starts
4. ❌ `@electron/rebuild arch=x64` — restore step incorrectly targets x64

## Fix

Set `npm_config_arch=arm64` for the `linux-arm64` matrix entry. This tells node-gyp the correct host architecture, so the post-build restore step rebuilds for arm64 instead of x64.

The env var is conditionally applied only for `linux-arm64` — other matrix entries are unaffected.