### PR TITLE
fix: handle quoted ID values in /etc/os-release for RHEL distro detection

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -188,9 +188,9 @@ const runDistroDetection = async (
       timeout: 8000,
     });
     const data = `${res.stdout || ""}\n${res.stderr || ""}`;
-    const idMatch = data.match(/ID=([\\w\\-]+)/i);
+    const idMatch = data.match(/^ID="?([\w-]+)"?$/im);
     const distro = idMatch
-      ? idMatch[1].replace(/"/g, "")
+      ? idMatch[1]
       : (data.split(/\s+/)[0] || "").toLowerCase();
     if (distro) ctx.onOsDetected?.(ctx.host.id, distro);
   } catch (err) {


### PR DESCRIPTION
## Summary

Fix RHEL (Red Hat Enterprise Linux) distro icon not showing due to quoted `ID` value in `/etc/os-release`.

## Root Cause

The distro detection regex `ID=([\w\-]+)` only matched unquoted values like `ID=ubuntu`, but RHEL uses `ID="rhel"` with double quotes — which is valid per the [os-release spec](https://www.freedesktop.org/software/systemd/man/os-release.html). The quotes caused the regex to fail, so no distro was detected and the icon fell back to the generic server icon.

## Fix

Changed the regex to `/^ID="?([\w-]+)"?$/im`:
- `"?` optionally matches surrounding double quotes
- `^...$` with `m` flag anchors to line boundaries for robustness
- Removed the now-unnecessary `.replace(/"/g, "")` post-processing

## Affected Distros

Any distro that quotes its `ID=` value, including:
- Red Hat Enterprise Linux (`ID="rhel"`)
- Potentially other RHEL-based distros

## Verification

- `npm run lint` ✅
- `npm run build` ✅

Fixes #263