### PR TITLE
fix(ci): build Linux x64 in debian:bullseye container for native modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ jobs:
           - name: windows
             os: windows-latest
             pack_script: pack:win
-          - name: linux-x64
-            os: ubuntu-latest
-            pack_script: pack:linux-x64
     env:
       VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
@@ -77,6 +74,59 @@ jobs:
             release/*.deb
             release/*.rpm
             release/*.tar.gz
+          if-no-files-found: ignore
+
+  # Dedicated job for Linux x64 — builds inside Debian Bullseye (GLIBC 2.31)
+  # to ensure native modules (node-pty, ssh2) compile correctly and to
+  # maintain GLIBC compatibility with older distros.
+  build-linux-x64:
+    name: build-linux-x64
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bullseye
+    env:
+      VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
+      VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
+      VITE_SYNC_GOOGLE_CLIENT_SECRET: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_SECRET }}
+      VITE_SYNC_ONEDRIVE_CLIENT_ID: ${{ secrets.VITE_SYNC_ONEDRIVE_CLIENT_ID }}
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y curl build-essential python3 git libfuse2 file rpm
+          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+          apt-get install -y nodejs
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Set version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${GITHUB_SHA:0:7}"
+          fi
+          echo "Setting version to ${VERSION}"
+          npm pkg set version="${VERSION}"
+
+      - name: Build package
+        env:
+          ELECTRON_BUILDER_PUBLISH: "never"
+        run: npm run pack:linux-x64
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: netcatty-linux-x64
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.rpm
           if-no-files-found: ignore
 
   # Dedicated job for Linux ARM64 — builds inside Debian Bullseye (GLIBC 2.31)
@@ -136,7 +186,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: [build, build-linux-arm64]
+    needs: [build, build-linux-x64, build-linux-arm64]
     if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish_release)
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fix Linux x86_64 AppImage crash on launch (missing `node-pty` native module).

## Root Cause

After splitting Linux builds into separate x64/arm64 jobs (#241), the x64 job ran on a bare `ubuntu-latest` runner without `build-essential` or `python3`. This caused `node-gyp` to silently fail when compiling `node-pty`'s native `pty.node` binary, resulting in an AppImage that crashes immediately:

```
Error: .../app.asar.unpacked/node_modules/node-pty/build/Release/pty.node:
无法打开共享目标文件: 没有那个文件或目录
```

Affects v1.0.39 and v1.0.40 (v1.0.38 was the last working release).

## Fix

Move the Linux x64 build from the matrix into a dedicated job using `debian:bullseye` container — matching the ARM64 job's approach:

- ✅ Installs `build-essential`, `python3`, and other native build deps
- ✅ Ensures `node-pty`, `ssh2`, `cpu-features` compile correctly
- ✅ Pins GLIBC to 2.31 for broader distro compatibility (Arch, Debian 11+, Ubuntu 20.04+, etc.)

## Changes

| Before | After |
|--------|-------|
| `ubuntu-latest` bare runner | `debian:bullseye` container |
| No build tools installed | `build-essential python3 git libfuse2 file rpm` |
| Matrix job (shared with macOS/Windows) | Dedicated `build-linux-x64` job |

Fixes #264