### PR TITLE
fix(ci): revert Linux x64 build to ubuntu-latest without container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,29 +76,27 @@ jobs:
             release/*.tar.gz
           if-no-files-found: ignore
 
-  # Dedicated job for Linux x64 — builds inside Debian Bullseye (GLIBC 2.31)
-  # to ensure native modules (node-pty, ssh2) compile correctly and to
-  # maintain GLIBC compatibility with older distros.
+  # Linux x64 — builds directly on ubuntu-latest (no container).
+  # v1.0.39 used a debian:bullseye container which broke native module
+  # packaging (node-pty .node file missing from asar.unpacked). Reverted
+  # to the v1.0.38 approach. See #264.
   build-linux-x64:
     name: build-linux-x64
     runs-on: ubuntu-latest
-    container:
-      image: debian:bullseye
     env:
       VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_SECRET: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_SECRET }}
       VITE_SYNC_ONEDRIVE_CLIENT_ID: ${{ secrets.VITE_SYNC_ONEDRIVE_CLIENT_ID }}
     steps:
-      - name: Install build dependencies
-        run: |
-          apt-get update
-          apt-get install -y curl build-essential python3 git libfuse2 file rpm
-          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-          apt-get install -y nodejs
-
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
 
       - name: Install deps
         run: npm ci


### PR DESCRIPTION
## Problem

v1.0.39 and v1.0.40 AppImage can't launch on ArchLinux (x86_64). Error:

```
node-pty/build/Release/pty.node: 无法打开共享目标文件: 没有那个文件或目录
```

v1.0.38 works fine. See #264.

## Root Cause

In v1.0.39, the Linux x64 build was moved from `ubuntu-latest` to a `debian:bullseye` container to mirror the ARM64 GLIBC fix (#253). However, building inside the container caused `node-pty`'s native `.node` binary to not be included in `app.asar.unpacked`.

## Fix

Revert Linux x64 to build directly on `ubuntu-latest` (the v1.0.38 approach). ARM64 keeps the Debian Bullseye container since it genuinely needs low GLIBC for UOS/Deepin.

Closes #264