### PR TITLE
fix: preserve persisted Red Hat distro aliases

### DIFF
--- a/domain/host.ts
+++ b/domain/host.ts
@@ -12,7 +12,7 @@ export const normalizeDistroId = (value?: string) => {
   if (v.includes('alpine')) return 'alpine';
   if (v.includes('amzn') || v.includes('amazon') || v.includes('aws')) return 'amazon';
   if (v.includes('opensuse') || v.includes('suse') || v.includes('sles')) return 'opensuse';
-  if (v.includes('red hat') || v.includes('rhel')) return 'redhat';
+  if (v.includes('red hat') || v.includes('redhat') || v.includes('rhel')) return 'redhat';
   if (v.includes('oracle')) return 'oracle';
   if (v.includes('kali')) return 'kali';
   return '';


### PR DESCRIPTION
## Summary
- treat persisted `redhat` values as the canonical Red Hat distro id during normalization
- keep startup sanitization and runtime host updates from clearing the distro field for existing cached hosts
- restore Red Hat distro avatars for hosts already saved before the previous fix

## Validation
- npm run lint
- npm run build

Closes #263

Follow-up to the user report in https://github.com/binaricat/Netcatty/issues/263#issuecomment-4009913825