### PR TITLE
fix: cloud sync 401 Unauthorized on first app launch

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -427,6 +427,13 @@ export class CloudSyncManager {
           if (seq === this.providerDecryptSeq[provider]) {
             this.state.providers[provider] = decrypted;
             this.providerDecrypted[provider] = true;
+            // Evict any adapter cached with the old (encrypted) tokens
+            // so a fresh one is built from the decrypted credentials below.
+            const stale = this.adapters.get(provider);
+            if (stale) {
+              stale.signOut();
+              this.adapters.delete(provider);
+            }
             this.notifyStateChange();
           }
         } catch {


### PR DESCRIPTION
## Problem

GitHub Gist sync returns **401 Unauthorized** on first app launch. Syncing from the main window popover always fails until the settings window is opened and a manual sync is triggered there.

## Root Cause

A race condition between `CloudSyncManager` singleton construction and the Electron bridge (`window.netcatty`) availability:

1. `CloudSyncManager` constructs at module import → calls `initProviderDecryption()`
2. `decryptField()` checks for the bridge → **not ready yet** → returns encrypted ciphertext as-is (no-op fallback)
3. `decryptionReady` promise resolves → tokens still encrypted
4. 1s later, `checkRemoteVersion()` → sends ciphertext as `Bearer` token → **401**

Opening the settings window triggers a cross-window `localStorage` event that re-decrypts with the now-available bridge, fixing subsequent syncs.

## Fix

- Added `decryptionEffective` flag to detect when decryption was a no-op (bridge unavailable)
- `initProviderDecryption()` now checks bridge availability first; skips with a console warning if unavailable
- `getConnectedAdapter()` retries decryption for the requested provider if startup decryption was a no-op, ensuring tokens are properly decrypted at the point of actual use