### PR TITLE
fix: skip invalid ssh agent sockets

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -130,7 +130,17 @@ function getSshAgentSocket() {
   if (process.platform === "win32") {
     return "\\\\.\\pipe\\openssh-ssh-agent";
   }
-  return process.env.SSH_AUTH_SOCK || null;
+  const agentSocket = process.env.SSH_AUTH_SOCK;
+  if (!agentSocket) return null;
+
+  try {
+    const stats = fs.statSync(agentSocket);
+    return typeof stats.isSocket === "function" && stats.isSocket()
+      ? agentSocket
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -20,6 +20,7 @@ const {
   safeSend: authSafeSend,
   requestPassphrasesForEncryptedKeys,
   findAllDefaultPrivateKeys: findAllDefaultPrivateKeysFromHelper,
+  getSshAgentSocket,
 } = require("./sshAuthHelper.cjs");
 
 // Default SSH key names in priority order
@@ -163,6 +164,16 @@ function checkWindowsSshAgent() {
       });
     });
   });
+}
+
+async function getAvailableAgentSocket() {
+  if (process.platform === "win32") {
+    const agentStatus = await checkWindowsSshAgent();
+    log("Windows SSH Agent check", agentStatus);
+    return agentStatus.running ? "\\\\.\\pipe\\openssh-ssh-agent" : null;
+  }
+
+  return getSshAgentSocket();
 }
 
 const DEBUG_SSH = process.env.NETCATTY_SSH_DEBUG === "1";
@@ -592,14 +603,7 @@ async function startSSHSession(event, options) {
     // If no primary auth method configured, try ssh-agent first, then ALL default keys
     if (!connectOpts.privateKey && !connectOpts.password && !connectOpts.agent) {
       // First, try to use ssh-agent if available (this is what regular SSH does)
-      let sshAgentSocket;
-      if (process.platform === "win32") {
-        const agentStatus = await checkWindowsSshAgent();
-        log("Windows SSH Agent check", agentStatus);
-        sshAgentSocket = agentStatus.running ? "\\\\.\\pipe\\openssh-ssh-agent" : null;
-      } else {
-        sshAgentSocket = process.env.SSH_AUTH_SOCK;
-      }
+      const sshAgentSocket = await getAvailableAgentSocket();
 
       if (sshAgentSocket) {
         log("No auth method configured, trying ssh-agent first", { agentSocket: sshAgentSocket });
@@ -627,15 +631,7 @@ async function startSSHSession(event, options) {
     // Agent forwarding
     if (options.agentForwarding) {
       if (!connectOpts.agent) {
-        if (process.platform === "win32") {
-          const agentStatus = await checkWindowsSshAgent();
-          log("Windows SSH Agent check (agentForwarding)", agentStatus);
-          if (agentStatus.running) {
-            connectOpts.agent = "\\\\.\\pipe\\openssh-ssh-agent";
-          }
-        } else {
-          connectOpts.agent = process.env.SSH_AUTH_SOCK;
-        }
+        connectOpts.agent = await getAvailableAgentSocket();
       }
       // Only enable forwarding when an agent is actually available
       if (connectOpts.agent) {


### PR DESCRIPTION
## Summary
- ignore invalid Unix ssh-agent sockets before adding agent auth to the fallback chain
- reuse the same agent availability check in the main SSH bridge
- avoid terminal and SFTP failing early with "Failed to connect to agent" when `SSH_AUTH_SOCK` is stale

## Testing
- node -e "require('./electron/bridges/sshAuthHelper.cjs'); console.log('sshAuthHelper ok')"
- node -e "require('./electron/bridges/sshBridge.cjs'); console.log('sshBridge ok')"
- simulated a missing `SSH_AUTH_SOCK` and verified auth fallback no longer returns an agent

Refs #290