### PR TITLE
fix: scroll terminal to bottom on paste when scrollOnPaste is enabled

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -930,12 +930,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const disableBracketedPasteRef = useRef(terminalSettings?.disableBracketedPaste ?? false);
   disableBracketedPasteRef.current = terminalSettings?.disableBracketedPaste ?? false;
 
+  const scrollOnPasteRef = useRef(terminalSettings?.scrollOnPaste ?? true);
+  scrollOnPasteRef.current = terminalSettings?.scrollOnPaste ?? true;
+
   const terminalContextActions = useTerminalContextActions({
     termRef,
     sessionRef,
     terminalBackend,
     onHasSelectionChange: setHasSelection,
     disableBracketedPasteRef,
+    scrollOnPasteRef,
   });
 
   const handleSnippetClick = (cmd: string) => {

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -14,12 +14,14 @@ export const useTerminalContextActions = ({
   terminalBackend,
   onHasSelectionChange,
   disableBracketedPasteRef,
+  scrollOnPasteRef,
 }: {
   termRef: RefObject<XTerm | null>;
   sessionRef: RefObject<string | null>;
   terminalBackend: TerminalBackendWriteApi;
   onHasSelectionChange?: (hasSelection: boolean) => void;
   disableBracketedPasteRef?: RefObject<boolean>;
+  scrollOnPasteRef?: RefObject<boolean>;
 }) => {
   const onCopy = useCallback(() => {
     const term = termRef.current;
@@ -39,11 +41,14 @@ export const useTerminalContextActions = ({
         let data = normalizeLineEndings(text);
         if (term.modes.bracketedPasteMode && !disableBracketedPasteRef?.current) data = wrapBracketedPaste(data);
         terminalBackend.writeToSession(sessionRef.current, data);
+        if (scrollOnPasteRef?.current) {
+          term.scrollToBottom();
+        }
       }
     } catch (err) {
       logger.warn("Failed to paste from clipboard", err);
     }
-  }, [sessionRef, termRef, terminalBackend, disableBracketedPasteRef]);
+  }, [sessionRef, termRef, terminalBackend, disableBracketedPasteRef, scrollOnPasteRef]);
 
   const onSelectAll = useCallback(() => {
     const term = termRef.current;


### PR DESCRIPTION
## Summary

Fix terminal not scrolling to bottom when pasting via context menu or keyboard shortcut.

### Problem

The `scrollOnPaste` setting in Terminal Settings only affected xterm.js **native** paste events. When pasting through Netcatty's custom paste path (context menu → Paste, or keyboard shortcut), the paste was handled by `writeToSession()` which bypasses xterm's built-in scroll-on-paste logic. As a result, the terminal stayed at the current scroll position after paste.

### Solution

Pass the `scrollOnPaste` setting (via ref) to `useTerminalContextActions` and explicitly call `term.scrollToBottom()` after writing paste data when the setting is enabled.

### Changes

- **`useTerminalContextActions.ts`**: Accept `scrollOnPasteRef`, call `term.scrollToBottom()` after `writeToSession()` when enabled
- **`Terminal.tsx`**: Create `scrollOnPasteRef` (synced with `terminalSettings.scrollOnPaste`) and pass to hook

Partially addresses #294