### PR TITLE
docs: add Shift+Drag hint for tmux/vim in copy-on-select setting

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -244,7 +244,7 @@ const en: Messages = {
   'settings.terminal.behavior.rightClick.paste': 'Paste',
   'settings.terminal.behavior.rightClick.selectWord': 'Select word',
   'settings.terminal.behavior.copyOnSelect': 'Copy on select',
-  'settings.terminal.behavior.copyOnSelect.desc': 'Automatically copy selected text',
+  'settings.terminal.behavior.copyOnSelect.desc': 'Automatically copy selected text. In tmux/vim with mouse mode, hold Shift to select',
   'settings.terminal.behavior.middleClickPaste': 'Middle-click paste',
   'settings.terminal.behavior.middleClickPaste.desc':
     'Paste clipboard content on middle-click',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1115,7 +1115,7 @@ const zhCN: Messages = {
   'settings.terminal.behavior.rightClick.paste': '粘贴',
   'settings.terminal.behavior.rightClick.selectWord': '选择单词',
   'settings.terminal.behavior.copyOnSelect': '选择即复制',
-  'settings.terminal.behavior.copyOnSelect.desc': '自动复制选中的文本',
+  'settings.terminal.behavior.copyOnSelect.desc': '自动复制选中的文本。在 tmux/vim 鼠标模式下，按住 Shift 拖选即可选中文本',
   'settings.terminal.behavior.middleClickPaste': '中键粘贴',
   'settings.terminal.behavior.middleClickPaste.desc': '中键点击时粘贴剪贴板内容',
   'settings.terminal.behavior.bracketedPaste': '括号粘贴模式',


### PR DESCRIPTION
## Summary

Add a hint in the "Copy on select" setting description to guide users on text selection in tmux/vim with mouse mode enabled.

### Problem

When tmux has `set -g mouse on` or vim has `set mouse=a`, dragging to select text is captured by the terminal application instead of xterm.js. Users may not know the standard workaround.

### Solution

Update the setting description for "Copy on select" in both EN and zh-CN locales to include a tip:

- **EN**: "Automatically copy selected text. In tmux/vim with mouse mode, hold Shift to select"
- **中文**: "自动复制选中的文本。在 tmux/vim 鼠标模式下，按住 Shift 拖选即可选中文本"

### Changes

- **`en.ts`**: Updated `copyOnSelect.desc`
- **`zh-CN.ts`**: Updated `copyOnSelect.desc`

Partially addresses #294