### PR TITLE
feat: show hidden files (dotfiles) on local filesystem browser

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -741,9 +741,9 @@ const en: Messages = {
 
   // Settings > SFTP Show Hidden Files
   'settings.sftp.showHiddenFiles': 'Show hidden files',
-  'settings.sftp.showHiddenFiles.desc': 'Display files with the Windows hidden attribute in the SFTP file browser when browsing local Windows filesystem.',
+  'settings.sftp.showHiddenFiles.desc': 'Display hidden files (dotfiles on Unix/macOS and files with the hidden attribute on Windows) in the SFTP file browser.',
   'settings.sftp.showHiddenFiles.enable': 'Show hidden files',
-  'settings.sftp.showHiddenFiles.enableDesc': 'Display Windows hidden files when browsing local filesystem',
+  'settings.sftp.showHiddenFiles.enableDesc': 'Display hidden files when browsing both local and remote filesystems',
 
   // Settings > SFTP Compressed Upload
   'settings.sftp.compressedUpload': 'Folder Compression Transfer',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1066,9 +1066,9 @@ const zhCN: Messages = {
 
   // Settings > SFTP Show Hidden Files
   'settings.sftp.showHiddenFiles': '显示隐藏文件',
-  'settings.sftp.showHiddenFiles.desc': '在浏览本地 Windows 文件系统时，显示具有 Windows 隐藏属性的文件。',
+  'settings.sftp.showHiddenFiles.desc': '在 SFTP 文件浏览器中显示隐藏文件（Unix/macOS 点文件和 Windows 隐藏属性文件）。',
   'settings.sftp.showHiddenFiles.enable': '显示隐藏文件',
-  'settings.sftp.showHiddenFiles.enableDesc': '浏览本地文件系统时显示 Windows 隐藏文件',
+  'settings.sftp.showHiddenFiles.enableDesc': '浏览本地和远程文件系统时显示隐藏文件',
 
   // Settings > SFTP Compressed Upload
   'settings.sftp.compressedUpload': '文件夹压缩传输',

--- a/components/SFTPModal.tsx
+++ b/components/SFTPModal.tsx
@@ -481,7 +481,7 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
   // Display files with parent entry (like SftpView)
   const displayFiles = useMemo(() => {
     // Filter hidden files using utility function
-    const visibleFiles = filterHiddenFiles(files, sftpShowHiddenFiles, isLocalSession);
+    const visibleFiles = filterHiddenFiles(files, sftpShowHiddenFiles);
 
     // Check if we're at root
     const atRoot = isRootPathForSession(currentPath);
@@ -495,7 +495,7 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
       lastModified: undefined,
     };
     return [parentEntry, ...visibleFiles.filter((f) => f.name !== "..")];
-  }, [files, currentPath, isRootPathForSession, sftpShowHiddenFiles, isLocalSession]);
+  }, [files, currentPath, isRootPathForSession, sftpShowHiddenFiles]);
 
   // Sorted files
   const sortedFiles = useMemo(() => {

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -238,7 +238,7 @@ export const useSftpKeyboardShortcuts = ({
         case "sftpSelectAll": {
           // Select all files in the current pane
           const term = pane.filter.trim().toLowerCase();
-          let visibleFiles = filterHiddenFiles(pane.files, showHiddenFiles, pane.connection.isLocal);
+          let visibleFiles = filterHiddenFiles(pane.files, showHiddenFiles);
           if (term) {
             visibleFiles = visibleFiles.filter(
               (f) => f.name === ".." || f.name.toLowerCase().includes(term),

--- a/components/sftp/hooks/useSftpPaneFiles.ts
+++ b/components/sftp/hooks/useSftpPaneFiles.ts
@@ -29,12 +29,12 @@ export const useSftpPaneFiles = ({
 }: UseSftpPaneFilesParams): UseSftpPaneFilesResult => {
   const filteredFiles = useMemo(() => {
     const term = filter.trim().toLowerCase();
-    let nextFiles = filterHiddenFiles(files, showHiddenFiles, connection?.isLocal);
+    let nextFiles = filterHiddenFiles(files, showHiddenFiles);
     if (!term) return nextFiles;
     return nextFiles.filter(
       (f) => f.name === ".." || f.name.toLowerCase().includes(term),
     );
-  }, [files, filter, showHiddenFiles, connection?.isLocal]);
+  }, [files, filter, showHiddenFiles]);
 
   const displayFiles = useMemo(() => {
     if (!connection) return [];

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -192,39 +192,37 @@ export const isNavigableDirectory = (entry: SftpFileEntry): boolean => {
  * Check if a file is hidden
  * - Windows: checks the `hidden` attribute (set by localFsBridge)
  * - Unix/Linux (remote): also treats dotfiles (names starting with '.') as hidden
- * The ".." parent directory entry is never considered hidden.
+/**
+ * A file is considered hidden if:
+ * - It has the Windows hidden attribute (`hidden === true`), OR
+ * - Its name starts with a dot (Unix/Linux dotfile convention)
  *
- * @param isLocal  When true, only the Windows hidden attribute is checked.
- *                 This prevents `.gitignore` etc. from disappearing on local Windows panes.
+ * The ".." parent directory entry is never considered hidden.
  */
 export const isHiddenFile = <T extends { name: string; hidden?: boolean }>(
     file: T,
-    isLocal?: boolean
 ): boolean => {
     if (file.name === "..") return false;
-    // Windows hidden attribute — always checked
+    // Windows hidden attribute
     if (file.hidden === true) return true;
-    // Unix/Linux dotfile convention — only on remote/non-local connections
-    if (!isLocal && file.name.startsWith(".")) return true;
+    // Unix/Linux dotfile convention
+    if (file.name.startsWith(".")) return true;
     return false;
 };
 
 /** @deprecated Use isHiddenFile instead */
 export const isWindowsHiddenFile = <T extends { name: string; hidden?: boolean }>(file: T): boolean =>
-    isHiddenFile(file, true);
+    isHiddenFile(file);
 
 /**
  * Filter files based on hidden file visibility setting.
- * Filters Windows hidden files and, on remote connections, Unix/Linux dotfiles.
+ * Filters Windows hidden files and Unix/Linux dotfiles on all connections.
  * Always preserves ".." parent directory entry.
- *
- * @param isLocal  Pass true for local filesystem panes to skip dotfile filtering.
  */
 export const filterHiddenFiles = <T extends { name: string; hidden?: boolean }>(
     files: T[],
     showHiddenFiles: boolean,
-    isLocal?: boolean
 ): T[] => {
     if (showHiddenFiles) return files;
-    return files.filter((f) => !isHiddenFile(f, isLocal));
+    return files.filter((f) => !isHiddenFile(f));
 };


### PR DESCRIPTION
## Summary

Support showing/hiding dotfiles on the **local** filesystem browser in SFTP.

### Problem

The "Show hidden files" setting previously only hid dotfiles (`.gitignore`, `.env`, etc.) on **remote** connections. Local filesystem panes always showed dotfiles regardless of the setting. The setting descriptions in Settings also only mentioned Windows hidden files, which was outdated.

### Solution

Remove the `isLocal` bypass from `isHiddenFile()` and `filterHiddenFiles()` so the setting applies consistently to both local and remote filesystem browsing.

### Changes

| File | Change |
|------|--------|
| `sftp/utils.ts` | Remove `isLocal` parameter from `isHiddenFile()` and `filterHiddenFiles()` — dotfiles are now filtered on all connections |
| `sftp/hooks/useSftpPaneFiles.ts` | Remove `connection?.isLocal` from call and deps |
| `sftp/hooks/useSftpKeyboardShortcuts.ts` | Remove `pane.connection.isLocal` from call |
| `SFTPModal.tsx` | Remove `isLocalSession` from call and deps |
| `en.ts` / `zh-CN.ts` | Update descriptions to be platform-agnostic (mention both dotfiles and Windows hidden attributes) |

Partially addresses #294