### PR TITLE
fix(sftp): display upload destination path on completed task items (#307)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -728,6 +728,7 @@ const en: Messages = {
   'sftp.upload.currentFile': 'Current: {fileName}',
   'sftp.upload.cancelled': 'Upload cancelled',
   'sftp.upload.cancel': 'Cancel',
+  'sftp.upload.completedToPath': 'Uploaded to {path}',
 
   // SFTP Download
   'sftp.download.completed': 'Downloaded',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1053,6 +1053,7 @@ const zhCN: Messages = {
   'sftp.upload.currentFile': '当前: {fileName}',
   'sftp.upload.cancelled': '上传已取消',
   'sftp.upload.cancel': '取消',
+  'sftp.upload.completedToPath': '已上传至 {path}',
 
   // SFTP Download
   'sftp.download.completed': '已下载',

--- a/components/sftp-modal/SftpModalUploadTasks.tsx
+++ b/components/sftp-modal/SftpModalUploadTasks.tsx
@@ -13,6 +13,7 @@ interface TransferTask {
   status: "pending" | "uploading" | "downloading" | "completed" | "failed" | "cancelled";
   error?: string;
   direction: "upload" | "download";
+  targetPath?: string;
 }
 
 interface SftpModalUploadTasksProps {
@@ -166,6 +167,9 @@ export const SftpModalUploadTasks: React.FC<SftpModalUploadTasksProps> = ({ task
                 {task.status === "completed" && (
                   <div className="text-[10px] text-green-600 mt-0.5">
                     {t(task.direction === "download" ? "sftp.download.completed" : "sftp.upload.completed")} - {formatBytes(task.totalBytes)}
+                    {task.targetPath && (
+                      <span className="text-muted-foreground ml-1">→ {task.targetPath}</span>
+                    )}
                   </div>
                 )}
                 {task.status === "cancelled" && (

--- a/components/sftp-modal/hooks/useSftpModalTransfers.ts
+++ b/components/sftp-modal/hooks/useSftpModalTransfers.ts
@@ -27,6 +27,7 @@ interface TransferTask {
   fileCount?: number;
   completedCount?: number;
   direction: "upload" | "download";
+  targetPath?: string;
 }
 
 // Keep UploadTask as alias for backwards compatibility
@@ -246,6 +247,7 @@ export const useSftpModalTransfers = ({
           startTime: Date.now(),
           isDirectory: task.isDirectory,
           direction: "upload",
+          targetPath: currentPath,
         };
         setUploadTasks(prev => [...prev, uploadTask]);
       },
@@ -343,7 +345,7 @@ export const useSftpModalTransfers = ({
         );
       },
     };
-  }, [t]);
+  }, [t, currentPath]);
 
   // Helper function to perform upload with compression setting from user preference
   const performUpload = useCallback(async (


### PR DESCRIPTION
## Summary

Closes #307

After dragging files to a remote terminal for SFTP upload, users had no way to know the exact remote directory where files were uploaded. This PR shows the upload destination path inline on completed task items.

## Changes

- Add `targetPath` field to the modal's `TransferTask` type
- Populate `targetPath` from `currentPath` when upload tasks are created
- Display target path on completed upload items: `Completed - 1.2 MB → /home/user/dir`
- Add i18n key `sftp.upload.completedToPath` for en and zh-CN

## CWD Detection Note

The issue also mentions files occasionally not uploading to the terminal's current directory. This happens when `getSessionPwd()` times out (3s) because the shell is busy (e.g., running `tail -f`, `top`, `vim`). In that case, the SFTP modal falls back to the home directory. This is an architectural limitation of injecting `pwd` into the shell stream. With this PR, the actual upload path is always visible on the task item, so users can immediately see where files landed.

## Files Changed

- `components/sftp-modal/hooks/useSftpModalTransfers.ts`
- `components/sftp-modal/SftpModalUploadTasks.tsx`
- `application/i18n/locales/en.ts`
- `application/i18n/locales/zh-CN.ts`