### PR TITLE
fix: prevent macOS signing credentials from leaking to Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,12 @@ jobs:
       - name: Build package
         env:
           ELECTRON_BUILDER_PUBLISH: "never"
-          # macOS code signing & notarization (ignored on other platforms)
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS code signing & notarization (only for macOS builds)
+          CSC_LINK: ${{ matrix.name == 'macos' && secrets.MAC_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.name == 'macos' && secrets.MAC_CSC_KEY_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.name == 'macos' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.name == 'macos' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.name == 'macos' && secrets.APPLE_TEAM_ID || '' }}
         run: npm run ${{ matrix.pack_script }}
 
       - name: Upload artifacts


### PR DESCRIPTION
## Problem

Windows auto-update fails with:

```
New version 1.0.45 is not signed by the application owner:
publisherNames: Developer ID Application: Qi Chen (H7WS5L2ML4)
```

**Root cause**: The CI workflow passes macOS signing env vars (`CSC_LINK`, `CSC_KEY_PASSWORD`, Apple notarization secrets) to **all** matrix jobs including Windows. This causes `electron-builder` to sign the Windows `.exe` with the Apple Developer ID certificate. Windows doesn't trust Apple's certificate chain, so `electron-updater`'s signature verification fails during auto-update.

## Fix

Use GitHub Actions conditional expressions to only pass signing secrets to the macOS matrix job:

```yaml
CSC_LINK: ${{ matrix.name == 'macos' && secrets.MAC_CSC_LINK || '' }}
```

On Windows, these env vars will be empty strings, so `electron-builder` won't attempt code signing. Unsigned Windows installers skip `electron-updater`'s signature check, allowing auto-update to work correctly.

Closes #309