### PR TITLE
Fix SFTP modal parent navigation in empty directories

### DIFF
--- a/components/SFTPModal.tsx
+++ b/components/SFTPModal.tsx
@@ -544,6 +544,8 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
 
     return parentEntry ? [parentEntry, ...sorted] : sorted;
   }, [displayFiles, sortField, sortOrder]);
+  const hasFiles = files.length > 0;
+  const hasDisplayFiles = sortedFiles.length > 0;
   const {
     fileListRef,
     handleFileListScroll,
@@ -700,7 +702,8 @@ const SFTPModal: React.FC<SFTPModalProps> = ({
           t={t}
           currentPath={currentPath}
           isLocalSession={isLocalSession}
-          files={files}
+          hasFiles={hasFiles}
+          hasDisplayFiles={hasDisplayFiles}
           selectedFiles={selectedFiles}
           dragActive={dragActive}
           loading={loading}

--- a/components/sftp-modal/SftpModalFileList.tsx
+++ b/components/sftp-modal/SftpModalFileList.tsx
@@ -17,7 +17,8 @@ interface SftpModalFileListProps {
   t: (key: string, params?: Record<string, unknown>) => string;
   currentPath: string;
   isLocalSession: boolean;
-  files: RemoteFile[];
+  hasFiles: boolean;
+  hasDisplayFiles: boolean;
   selectedFiles: Set<string>;
   dragActive: boolean;
   loading: boolean;
@@ -60,7 +61,8 @@ export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
   t,
   currentPath,
   isLocalSession,
-  files,
+  hasFiles,
+  hasDisplayFiles,
   selectedFiles,
   dragActive,
   loading,
@@ -169,7 +171,7 @@ export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
         </div>
       )}
 
-      {loading && files.length === 0 && (
+      {loading && !hasFiles && (
         <div className="absolute inset-0 flex items-center justify-center bg-background/80">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
@@ -200,7 +202,7 @@ export const SftpModalFileList: React.FC<SftpModalFileListProps> = ({
         </div>
       )}
 
-      {files.length === 0 && !loading && (
+      {!hasDisplayFiles && !loading && (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
           <Folder size={48} className="mb-3 opacity-50" />
           <div className="text-sm font-medium">{t("sftp.emptyDirectory")}</div>


### PR DESCRIPTION
## Summary
- keep the SFTP modal parent `..` entry visible when a non-root directory is empty
- drive the modal empty state from the rendered file list instead of the raw backend entries
- preserve the existing initial loading behavior for truly empty directories

## Testing
- npx eslint components/SFTPModal.tsx components/sftp-modal/SftpModalFileList.tsx