### PR TITLE
fix: destroy system tray before quitAndInstall on macOS

### DIFF
--- a/electron/bridges/autoUpdateBridge.cjs
+++ b/electron/bridges/autoUpdateBridge.cjs
@@ -302,6 +302,18 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:update:install", () => {
     const updater = getAutoUpdater();
     if (!updater) return;
+
+    // On macOS, the system tray keeps the app process alive even after all
+    // windows are closed, which prevents quitAndInstall from completing.
+    // Destroy the tray (and its panel window) before quitting so the app
+    // can exit cleanly and the installer can proceed.
+    try {
+      const globalShortcutBridge = require("./globalShortcutBridge.cjs");
+      globalShortcutBridge.cleanup();
+    } catch {
+      // ignore — bridge may not be available
+    }
+
     updater.quitAndInstall(false, true);
   });
 


### PR DESCRIPTION
## Summary
- On macOS with system tray enabled, `quitAndInstall` fails to restart the app because the tray keeps the process alive after all windows close
- Fix: call `globalShortcutBridge.cleanup()` to destroy the tray and its panel window before `quitAndInstall`

## Test plan
- [x] Enable system tray (close-to-tray) on macOS
- [x] Trigger an auto-update download
- [x] Click install/restart and verify the app quits and restarts with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)