### PR TITLE
fix: prevent SFTP modal drag-upload from targeting stale directory

### DIFF
--- a/components/sftp-modal/hooks/useSftpModalSession.ts
+++ b/components/sftp-modal/hooks/useSftpModalSession.ts
@@ -89,6 +89,7 @@ export const useSftpModalSession = ({
   const sftpIdRef = useRef<string | null>(null);
   const closingPromiseRef = useRef<Promise<void> | null>(null);
   const initializedRef = useRef(false);
+  const initializingRef = useRef(false);
   const lastInitialPathRef = useRef<string | undefined>(undefined);
   const localHomeRef = useRef<string | null>(null);
 
@@ -316,92 +317,109 @@ export const useSftpModalSession = ({
     if (open) {
       if (!initializedRef.current || lastInitialPathRef.current !== initialPath) {
         initializedRef.current = true;
+        initializingRef.current = true;
         lastInitialPathRef.current = initialPath;
         onClearSelection();
         setLoading(true);
 
         if (isLocalSession) {
           (async () => {
-            const homePath = await getHomeDir();
-            localHomeRef.current = homePath ?? null;
-            const startPath = initialPath || homePath || "/";
             try {
-              const list = await listLocalDir(startPath);
-              setCurrentPath(startPath);
-              setFiles(list);
-              dirCacheRef.current.set(`${host.id}::${startPath}`, {
-                files: list,
-                timestamp: Date.now(),
-              });
-            } catch (e) {
-              toast.error(
-                e instanceof Error ? e.message : t("sftp.error.loadFailed"),
-                "SFTP",
-              );
+              const homePath = await getHomeDir();
+              localHomeRef.current = homePath ?? null;
+              const startPath = initialPath || homePath || "/";
+              try {
+                const list = await listLocalDir(startPath);
+                setCurrentPath(startPath);
+                setFiles(list);
+                dirCacheRef.current.set(`${host.id}::${startPath}`, {
+                  files: list,
+                  timestamp: Date.now(),
+                });
+              } catch (e) {
+                toast.error(
+                  e instanceof Error ? e.message : t("sftp.error.loadFailed"),
+                  "SFTP",
+                );
+              } finally {
+                setLoading(false);
+              }
             } finally {
-              setLoading(false);
+              initializingRef.current = false;
             }
           })();
           return;
         }
 
         (async () => {
-          const homePath = await getHomeDir();
-          localHomeRef.current = homePath ?? null;
-          if (initialPath) {
-            try {
-              const sftpId = await ensureSftp();
-              const list = await listSftp(sftpId, initialPath);
-              setCurrentPath(initialPath);
-              setFiles(list);
-              dirCacheRef.current.set(`${host.id}::${initialPath}`, {
-                files: list,
-                timestamp: Date.now(),
-              });
-              setLoading(false);
-              return;
-            } catch {
-              logger.warn(
-                `[SFTP] Initial path ${initialPath} not accessible, falling back to home`,
-              );
-            }
-          }
-
           try {
-            const sftpId = await ensureSftp();
-            const list = await listSftp(sftpId, homePath || "/");
-            setCurrentPath(homePath || "/");
-            setFiles(list);
-            dirCacheRef.current.set(`${host.id}::${homePath || "/"}`, {
-              files: list,
-              timestamp: Date.now(),
-            });
-            setLoading(false);
-          } catch {
-            logger.warn(`[SFTP] Home ${homePath} not accessible, using /`);
+            const homePath = await getHomeDir();
+            localHomeRef.current = homePath ?? null;
+            if (initialPath) {
+              try {
+                const sftpId = await ensureSftp();
+                const list = await listSftp(sftpId, initialPath);
+                setCurrentPath(initialPath);
+                setFiles(list);
+                dirCacheRef.current.set(`${host.id}::${initialPath}`, {
+                  files: list,
+                  timestamp: Date.now(),
+                });
+                setLoading(false);
+                return;
+              } catch {
+                logger.warn(
+                  `[SFTP] Initial path ${initialPath} not accessible, falling back to home`,
+                );
+              }
+            }
+
             try {
               const sftpId = await ensureSftp();
-              const list = await listSftp(sftpId, "/");
-              setCurrentPath("/");
+              const list = await listSftp(sftpId, homePath || "/");
+              setCurrentPath(homePath || "/");
               setFiles(list);
-              dirCacheRef.current.set(`${host.id}::/`, {
+              dirCacheRef.current.set(`${host.id}::${homePath || "/"}`, {
                 files: list,
                 timestamp: Date.now(),
               });
-            } catch (e) {
-              logger.error("[SFTP] Failed to load root directory", e);
-              toast.error(t("sftp.error.loadFailed"), "SFTP");
-            } finally {
               setLoading(false);
+            } catch {
+              logger.warn(`[SFTP] Home ${homePath} not accessible, using /`);
+              try {
+                const sftpId = await ensureSftp();
+                const list = await listSftp(sftpId, "/");
+                setCurrentPath("/");
+                setFiles(list);
+                dirCacheRef.current.set(`${host.id}::/`, {
+                  files: list,
+                  timestamp: Date.now(),
+                });
+              } catch (e) {
+                logger.error("[SFTP] Failed to load root directory", e);
+                toast.error(t("sftp.error.loadFailed"), "SFTP");
+              } finally {
+                setLoading(false);
+              }
             }
+          } finally {
+            initializingRef.current = false;
           }
         })();
         return;
       }
-      void loadFiles(currentPath);
+      // Skip redundant loadFiles while async initialization is still in flight.
+      // Without this guard, dependency changes (e.g. loadFiles recreation from
+      // files.length change) can re-trigger this effect and call loadFiles with
+      // the stale currentPath before the initialization IIFE has resolved and
+      // updated currentPathRef — causing uploads to target the wrong directory.
+      if (!initializingRef.current) {
+        void loadFiles(currentPath);
+      }
     } else {
       loadSeqRef.current += 1;
       initializedRef.current = false;
+      initializingRef.current = false;
     }
   }, [
     closeSftpSession,


### PR DESCRIPTION
## Summary

- Fix race condition where drag-and-drop upload to terminal opens SFTP modal but uploads files to the **previous session's directory** instead of the terminal's current working directory
- Add `initializingRef` flag to block spurious `loadFiles(staleCurrentPath)` calls while the async initialization IIFE is still in flight

## Root Cause

When the SFTP modal reopens via drag-and-drop:

1. The session effect enters initialization, sets `initializedRef = true`, and starts an async IIFE (~0.5s for `ensureSftp` + `listSftp`)
2. During this window, `useLayoutEffect` detects stale directory cache → calls `setFiles([])` → `files.length` changes → `loadFiles` callback is recreated
3. `loadFiles` is a dependency of the session effect, so the effect re-triggers
4. Since `initializedRef` is already `true`, the effect skips initialization and falls through to `void loadFiles(currentPath)` — but `currentPath` still holds the **previous session's path**
5. If this `loadFiles` resolves before the IIFE, `loading` transitions to `false` prematurely
6. The auto-upload effect detects the `loading: true→false` transition and snapshots `currentPathRef.current` (still stale), uploading to the wrong directory

## Fix

Guard the fallthrough `loadFiles` call with `initializingRef.current` — set when the IIFE starts, cleared in its `finally` block. This ensures only the IIFE's completion triggers the `loading` transition that the auto-upload relies on.

## Test plan

- [ ] Drag file to remote terminal → SFTP modal opens → verify file uploads to terminal's CWD (not a previously visited directory)
- [ ] Repeat rapidly (close modal, navigate terminal, drag again) to confirm no stale path is used
- [ ] Verify normal SFTP modal navigation and manual upload still work correctly
- [ ] Verify local session drag-and-drop upload works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)