### PR TITLE
fix: enable customGlyphs to eliminate gaps between block characters

### DIFF
--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -29,8 +29,9 @@ export const XTERM_PERFORMANCE_CONFIG = {
     // Disabling it improves performance by 15-20%
     allowTransparency: false,
 
-    // Custom glyphs require additional memory and processing
-    customGlyphs: false,
+    // Custom glyphs: xterm.js draws box/block characters on canvas
+    // instead of using font glyphs, eliminating gaps between cells
+    customGlyphs: true,
 
     // Font rendering settings
     letterSpacing: 0,


### PR DESCRIPTION
## Summary
- Enable `customGlyphs: true` in xterm.js config so block/box-drawing characters (`█`, `▄`, `▀`, etc.) are rendered seamlessly by canvas instead of font glyphs

Closes #331

## Test plan
- [ ] Run `echo -e "█████\n█████\n█████"` in the terminal — should render as a solid rectangle with no gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)