### PR TITLE
fix: resolve memory leaks and reduce unnecessary CPU consumption

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -930,7 +930,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
     };
 
-    term.onSelectionChange(onSelectionChange);
+    const disposable = term.onSelectionChange(onSelectionChange);
+    return () => disposable.dispose();
   }, [terminalSettings?.copyOnSelect]);
 
   // Track whether the terminal application has enabled mouse tracking

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -135,12 +135,19 @@ const WindowControls: React.FC = memo(() => {
     // Check initial maximized state
     fetchIsMaximized().then(v => setIsMaximized(!!v));
 
-    // Listen for window resize to update maximized state
+    // Listen for window resize to update maximized state (debounced to avoid IPC storm)
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
     const handleResize = () => {
-      fetchIsMaximized().then(v => setIsMaximized(!!v));
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        fetchIsMaximized().then(v => setIsMaximized(!!v));
+      }, 200);
     };
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (resizeTimer) clearTimeout(resizeTimer);
+    };
   }, [fetchIsMaximized]);
 
   const handleMinimize = () => {

--- a/components/sftp/hooks/useSftpPaneVirtualList.ts
+++ b/components/sftp/hooks/useSftpPaneVirtualList.ts
@@ -30,14 +30,12 @@ export const useSftpPaneVirtualList = ({
     if (!container || !isActive) return;
     const update = () => setViewportHeight(container.clientHeight);
     update();
-    const raf1 = window.requestAnimationFrame(update);
-    const raf2 = window.requestAnimationFrame(update);
+    const raf = window.requestAnimationFrame(update);
     const resizeObserver = new ResizeObserver(update);
     resizeObserver.observe(container);
     return () => {
       resizeObserver.disconnect();
-      window.cancelAnimationFrame(raf1);
-      window.cancelAnimationFrame(raf2);
+      window.cancelAnimationFrame(raf);
     };
   }, [isActive, sortedDisplayFiles.length]);
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -590,7 +590,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   // Register OSC 7 handler using xterm.js parser
   // OSC 7 is the standard way for shells to report the current working directory
-  term.parser.registerOscHandler(7, (data) => {
+  const osc7Disposable = term.parser.registerOscHandler(7, (data) => {
     try {
       // data is the content after "7;" - typically "file://hostname/path"
       if (data.startsWith('file://')) {
@@ -638,6 +638,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     dispose: () => {
       cleanupMiddleClick?.();
       keywordHighlighter.dispose();
+      osc7Disposable.dispose();
       try {
         term.dispose();
       } catch (err) {

--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -104,7 +104,7 @@ async function startPortForward(event, payload) {
     // can reject if the tunnel was killed during SSH handshake.
     let settled = false;
 
-    conn.on('ready', () => {
+    conn.once('ready', () => {
       console.log(`[PortForward] SSH connection ready for tunnel ${tunnelId}`);
 
       if (type === 'local') {
@@ -297,7 +297,7 @@ async function startPortForward(event, payload) {
       }
     });
 
-    conn.on('error', (err) => {
+    conn.once('error', (err) => {
       console.error(`[PortForward] SSH error:`, err.message);
       sendStatus('error', err.message);
       portForwardingTunnels.delete(tunnelId);
@@ -305,7 +305,7 @@ async function startPortForward(event, payload) {
       reject(err);
     });
 
-    conn.on('close', () => {
+    conn.once('close', () => {
       console.log(`[PortForward] SSH connection closed for tunnel ${tunnelId}`);
       const tunnel = portForwardingTunnels.get(tunnelId);
       // Capture the cancelled flag BEFORE cleanup deletes the entry.

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -518,7 +518,7 @@ async function connectThroughChainForSftp(event, options, jumpHosts, targetHost,
 
       // Connect this hop
       await new Promise((resolve, reject) => {
-        conn.on('ready', () => {
+        conn.once('ready', () => {
           console.log(`[SFTP Chain] Hop ${i + 1}/${jumpHosts.length}: ${hopLabel} connected`);
           resolve();
         });
@@ -531,7 +531,7 @@ async function connectThroughChainForSftp(event, options, jumpHosts, targetHost,
           console.error(`[SFTP Chain] Hop ${i + 1}/${jumpHosts.length}: ${hopLabel} error:`, err.message);
           reject(err);
         });
-        conn.on('timeout', () => {
+        conn.once('timeout', () => {
           console.error(`[SFTP Chain] Hop ${i + 1}/${jumpHosts.length}: ${hopLabel} timeout`);
           reject(new Error(`Connection timeout to ${hopLabel}`));
         });

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -416,17 +416,17 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
 
       // Connect this hop
       await new Promise((resolve, reject) => {
-        conn.on('ready', () => {
+        conn.once('ready', () => {
           console.log(`[Chain] Hop ${i + 1}/${totalHops}: ${hopLabel} connected`);
           sendProgress(i + 1, totalHops + 1, hopLabel, 'connected');
           resolve();
         });
-        conn.on('error', (err) => {
+        conn.once('error', (err) => {
           console.error(`[Chain] Hop ${i + 1}/${totalHops}: ${hopLabel} error:`, err.message);
           sendProgress(i + 1, totalHops + 1, hopLabel, 'error');
           reject(err);
         });
-        conn.on('timeout', () => {
+        conn.once('timeout', () => {
           console.error(`[Chain] Hop ${i + 1}/${totalHops}: ${hopLabel} timeout`);
           reject(new Error(`Connection timeout to ${hopLabel}`));
         });
@@ -920,7 +920,7 @@ async function startSSHSession(event, options) {
 
     return new Promise((resolve, reject) => {
       const logPrefix = hasJumpHosts ? '[Chain]' : '[SSH]';
-      conn.on("ready", () => {
+      conn.once("ready", () => {
         console.log(`${logPrefix} ${options.hostname} ready`);
 
         // Cache the successful auth method
@@ -1063,28 +1063,34 @@ async function startSSHSession(event, options) {
 
         safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message });
         sessions.delete(sessionId);
+        sessionEncodings.delete(sessionId);
+        sessionDecoders.delete(sessionId);
         for (const c of chainConnections) {
           try { c.end(); } catch { }
         }
         reject(err);
       });
 
-      conn.on("timeout", () => {
+      conn.once("timeout", () => {
         console.error(`${logPrefix} ${options.hostname} connection timeout`);
         const err = new Error(`Connection timeout to ${options.hostname}`);
         const contents = event.sender;
         safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message });
         sessions.delete(sessionId);
+        sessionEncodings.delete(sessionId);
+        sessionDecoders.delete(sessionId);
         for (const c of chainConnections) {
           try { c.end(); } catch { }
         }
         reject(err);
       });
 
-      conn.on("close", () => {
+      conn.once("close", () => {
         const contents = event.sender;
         safeSend(contents, "netcatty:exit", { sessionId, exitCode: 0 });
         sessions.delete(sessionId);
+        sessionEncodings.delete(sessionId);
+        sessionDecoders.delete(sessionId);
         for (const c of chainConnections) {
           try { c.end(); } catch { }
         }
@@ -1203,7 +1209,7 @@ async function execCommand(event, payload) {
     }, timeoutMs);
 
     conn
-      .on("ready", () => {
+      .once("ready", () => {
         conn.exec(payload.command, (err, stream) => {
           if (err) {
             clearTimeout(timer);
@@ -1227,13 +1233,13 @@ async function execCommand(event, payload) {
             });
         });
       })
-      .on("error", (err) => {
+      .once("error", (err) => {
         if (settled) return;
         clearTimeout(timer);
         settled = true;
         reject(err);
       })
-      .on("end", () => {
+      .once("end", () => {
         if (settled) return;
         clearTimeout(timer);
         settled = true;


### PR DESCRIPTION
## Summary

- **Fix `onSelectionChange` listener leak** (`Terminal.tsx`): 每次 `copyOnSelect` 设置变化时注册新监听器但从未清理，现在正确捕获 disposable 并在 cleanup 中释放
- **Debounce `window.resize` handler** (`TopTabs.tsx`): 窗口缩放时每秒触发 60+ 次 IPC 调用 `fetchIsMaximized()`，添加 200ms debounce
- **SSH/SFTP/PortForward 连接监听器改用 `.once()`**: `ready`/`error`/`timeout`/`close` 等生命周期事件只触发一次，使用 `.on()` 会导致监听器在连接对象上累积
- **补全 `sessionEncodings`/`sessionDecoders` 错误路径清理** (`sshBridge.cjs`): 原先仅在 `stream.on('close')` 正常路径清理，`error`/`timeout`/`close` 处理器中遗漏
- **`execCommand()` 连接监听器改用 `.once()`** (`sshBridge.cjs`): 每次调用创建新连接，`.on()` 导致监听器在短生命周期连接上残留
- **移除重复 `requestAnimationFrame`** (`useSftpPaneVirtualList.ts`): 连续两个 RAF 调用同一函数，浪费 CPU
- **捕获并释放 OSC 7 parser handler** (`createXTermRuntime.ts`): `registerOscHandler` 返回的 disposable 未被追踪，现在在 `dispose()` 中显式清理

## Test plan

- [x] 打开/关闭多个 SSH 终端会话，观察内存是否稳定
- [x] 通过跳板机 (jump host) 连接，验证连接和断开正常工作
- [x] 调整窗口大小，确认 WindowControls 最大化状态更新正常且无卡顿
- [x] 开启 Copy on Select 设置，切换开关多次后验证选中复制功能正常
- [x] SFTP 文件列表滚动验证虚拟列表渲染正常
- [x] 端口转发功能验证创建和停止隧道正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)