### PR TITLE
feat: default theme to dark for new users

### DIFF
--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -39,7 +39,7 @@ import { useAvailableFonts } from './fontStore';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
 
-const DEFAULT_THEME: 'light' | 'dark' | 'system' = 'system';
+const DEFAULT_THEME: 'light' | 'dark' | 'system' = 'dark';
 
 /** Resolve the current OS color scheme preference. */
 const getSystemPreference = (): 'light' | 'dark' =>


### PR DESCRIPTION
## Summary

- 将新用户的默认主题从 `system`（跟随系统）改为 `dark`
- 已有用户不受影响（主题偏好已持久化在 localStorage 中）
- 用户仍可在设置中自由切换为 light 或 system

## Test plan

- [ ] 清除 localStorage 后启动应用，确认默认为深色主题
- [ ] 已有用户启动应用，确认主题设置不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)