### PR TITLE
fix: resolve Gemini API error caused by empty functionResponse name

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -684,12 +684,23 @@ export function useAIChatStreaming({
           }
         } else if (m.role === 'tool' && m.toolResults?.length) {
           // Map tool results to SDK tool message format
+          // Gemini requires functionResponse.name to be non-empty,
+          // so we look up the toolName from the preceding assistant tool calls.
+          const findToolName = (toolCallId: string): string => {
+            for (const prev of currentSession?.messages ?? []) {
+              if (prev.role === 'assistant' && prev.toolCalls) {
+                const tc = prev.toolCalls.find(t => t.id === toolCallId);
+                if (tc) return tc.name;
+              }
+            }
+            return 'unknown';
+          };
           sdkMessages.push({
             role: 'tool',
             content: m.toolResults.map(tr => ({
               type: 'tool-result' as const,
               toolCallId: tr.toolCallId,
-              toolName: '',
+              toolName: findToolName(tr.toolCallId),
               output: { type: 'text' as const, value: tr.content },
             })),
           });


### PR DESCRIPTION
## Summary

- When rebuilding SDK messages from conversation history, `tool-result` messages had `toolName` hardcoded to `''`. Gemini API requires `functionResponse.name` to be non-empty, causing `AI_APICallError: GenerateContentRequest.contents[].parts[].function_response Name cannot be empty` on every follow-up message after a tool call.
- Now resolves the tool name by looking up the matching assistant tool call via `toolCallId`.

## Test plan

- [x] Use Gemini model, trigger a tool call in AI chat, then send follow-up messages — should no longer error
- [x] Verify OpenAI/Claude models still work correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)