### PR TITLE
fix: snippet package rename losing snippets and blocking case changes

### DIFF
--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -28,6 +28,7 @@ interface SnippetsManagerProps {
   hotkeyScheme: HotkeyScheme;
   keyBindings: KeyBinding[];
   onSave: (snippet: Snippet) => void;
+  onBulkSave: (snippets: Snippet[]) => void;
   onDelete: (id: string) => void;
   onPackagesChange: (packages: string[]) => void;
   onRunSnippet?: (snippet: Snippet, targetHosts: Host[]) => void;
@@ -51,6 +52,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   hotkeyScheme,
   keyBindings,
   onSave,
+  onBulkSave,
   onDelete,
   onPackagesChange,
   onRunSnippet,
@@ -486,11 +488,8 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     // Update packages first, then save snippets
     onPackagesChange(keep);
     
-    // Only save snippets that were actually modified
-    const modifiedSnippets = updatedSnippets.filter((s, index) => 
-      s.package !== snippets[index].package
-    );
-    modifiedSnippets.forEach(onSave);
+    // Bulk-save all snippets to avoid stale-closure overwrites
+    onBulkSave(updatedSnippets);
     
     // Reset selected package if it was deleted
     if (selectedPackage && (selectedPackage === path || selectedPackage.startsWith(path + '/'))) {
@@ -527,7 +526,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     });
 
     onPackagesChange(Array.from(new Set(updatedPackages)));
-    updatedSnippets.forEach(onSave);
+    onBulkSave(updatedSnippets);
     if (selectedPackage === source) setSelectedPackage(newPath);
   };
 
@@ -568,8 +567,8 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
       return;
     }
 
-    // Validate: duplicate (case-insensitive)
-    const existingPackage = packages.find(p => p.toLowerCase() === newPath.toLowerCase());
+    // Validate: duplicate (case-insensitive), excluding the package being renamed
+    const existingPackage = packages.find(p => p !== renamingPackagePath && p.toLowerCase() === newPath.toLowerCase());
     if (existingPackage) {
       setRenameError(t('snippets.renameDialog.error.duplicate'));
       return;
@@ -595,7 +594,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     });
 
     onPackagesChange(Array.from(new Set(updatedPackages)));
-    updatedSnippets.forEach(onSave);
+    onBulkSave(updatedSnippets);
 
     // Update selected package if it was renamed
     if (selectedPackage === renamingPackagePath) {

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -2201,6 +2201,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   : [...snippets, s],
               )
             }
+            onBulkSave={onUpdateSnippets}
             onDelete={(id) =>
               onUpdateSnippets(snippets.filter((s) => s.id !== id))
             }


### PR DESCRIPTION
## Summary
- Renaming a snippet package with only case changes (e.g. `Speedtest` → `speedtest`) was incorrectly rejected as a duplicate name. Fixed by excluding the current package from the case-insensitive uniqueness check.
- Renaming/moving/deleting a package caused all its snippets to disappear (count drops to 0). Root cause: `forEach(onSave)` triggered multiple state updates with a stale closure, each overwriting the previous — only the last snippet survived. Fixed by introducing `onBulkSave` to pass the entire updated snippets array in a single call.

Fixes #357

## Test plan
- [x] Rename a snippet package changing only letter case (e.g. `Speedtest` → `speedtest`) — should succeed
- [x] Rename a snippet package to a completely different name — snippets should remain intact
- [x] Move a package into another package — snippets should follow
- [x] Delete a package — snippets should move to root, not disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)