### PR TITLE
fix: split auth button for clear save/no-save options

### DIFF
--- a/components/terminal/TerminalAuthDialog.tsx
+++ b/components/terminal/TerminalAuthDialog.tsx
@@ -10,6 +10,7 @@ import { SSHKey } from '../../types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { Dropdown, DropdownContent, DropdownTrigger } from '../ui/dropdown';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
 export type TerminalAuthMethod = 'password' | 'key' | 'certificate';
@@ -265,25 +266,34 @@ export const TerminalAuthDialog: React.FC<TerminalAuthDialogProps> = ({
                 <Button variant="secondary" onClick={onCancel}>
                     {t("common.close")}
                 </Button>
-                <div className="flex items-center gap-2">
-                    <Popover>
-                        <PopoverTrigger asChild>
-                            <Button disabled={!isValid} onClick={onSubmit}>
-                                {t("terminal.auth.continueSave")}
-                                <ChevronDown size={14} className="ml-2" />
-                            </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-40 p-1 z-50" align="end">
-                            <button
-                                className="w-full px-3 py-2 text-sm text-left hover:bg-secondary rounded-md"
-                                onClick={onSubmitWithoutSave ?? onSubmit}
+                <Dropdown>
+                    <div className="flex items-center rounded-md bg-primary text-primary-foreground">
+                        <Button
+                            disabled={!isValid}
+                            onClick={onSubmit}
+                            className="rounded-r-none bg-transparent hover:bg-white/10 shadow-none"
+                        >
+                            {t("terminal.auth.continueSave")}
+                        </Button>
+                        <DropdownTrigger asChild>
+                            <Button
                                 disabled={!isValid}
+                                className="px-2 rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none"
                             >
-                                {t("common.continue")}
-                            </button>
-                        </PopoverContent>
-                    </Popover>
-                </div>
+                                <ChevronDown size={14} />
+                            </Button>
+                        </DropdownTrigger>
+                    </div>
+                    <DropdownContent className="w-44 p-1 z-50" align="end">
+                        <button
+                            className="w-full px-3 py-2 text-sm text-left hover:bg-secondary rounded-md"
+                            onClick={onSubmitWithoutSave ?? onSubmit}
+                            disabled={!isValid}
+                        >
+                            {t("common.continue")}
+                        </button>
+                    </DropdownContent>
+                </Dropdown>
             </div>
         </>
     );


### PR DESCRIPTION
## Summary
- Refactored the auth dialog's "Continue and Save" button from a Popover-based button (where clicking anywhere triggered save) to a proper **split button** using the Dropdown component
- Left side: "Continue and Save" (primary action)
- Right arrow: opens dropdown with "Continue" (connect without saving credentials)
- Matches the existing split button pattern used in VaultView's "New Host" button

Refs #356

## Test plan
- [x] Click the left "Continue and Save" button — should connect and persist credentials
- [x] Click the right arrow — should open dropdown menu
- [x] Click "Continue" in dropdown — should connect without saving credentials
- [x] Verify button styling matches the rest of the app (primary color, hover states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)