### PR TITLE
fix: use net.connect() for Windows SSH agent pipe detection

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -123,36 +123,46 @@ async function findAllDefaultPrivateKeys(options = {}) {
   return results.filter(Boolean);
 }
 
-/**
- * Check if a Windows named pipe exists (non-blocking).
- * Works for OpenSSH Agent, Bitwarden SSH Agent, 1Password, etc.
- */
-function windowsPipeExists(pipePath) {
-  try {
-    fs.statSync(pipePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 const WIN_SSH_AGENT_PIPE = "\\\\.\\pipe\\openssh-ssh-agent";
 
 /**
+ * Check if a Windows named pipe is connectable.
+ * fs.statSync is unreliable for named pipes (returns EBUSY even when the
+ * pipe is usable), so we attempt an actual net.connect() which is the
+ * authoritative check.
+ * @param {string} pipePath
+ * @param {number} [timeoutMs=1000]
+ * @returns {Promise<boolean>}
+ */
+function windowsPipeConnectable(pipePath, timeoutMs = 1000) {
+  const net = require("net");
+  return new Promise((resolve) => {
+    const socket = net.connect(pipePath);
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      try { socket.destroy(); } catch {}
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
+}
+
+/**
  * Check if an SSH agent is available on Windows.
- * Instead of checking the OpenSSH Authentication Agent *service*, we probe
- * the well-known named pipe directly. This supports any agent that provides
- * the pipe — Bitwarden, 1Password, gpg-agent, etc.
+ * Probes the well-known named pipe via net.connect(). This supports any
+ * agent that provides the pipe — Bitwarden, 1Password, gpg-agent, etc.
  * @returns {Promise<boolean>}
  */
 function checkWindowsSshAgentRunning() {
-  return new Promise((resolve) => {
-    if (process.platform !== "win32") {
-      resolve(true);
-      return;
-    }
-    resolve(windowsPipeExists(WIN_SSH_AGENT_PIPE));
-  });
+  if (process.platform !== "win32") {
+    return Promise.resolve(true);
+  }
+  return windowsPipeConnectable(WIN_SSH_AGENT_PIPE);
 }
 
 /**

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -143,29 +143,33 @@ async function findAllDefaultPrivateKeys() {
 const WIN_SSH_AGENT_PIPE = "\\\\.\\pipe\\openssh-ssh-agent";
 
 /**
- * Check if an SSH agent is available on Windows by probing the well-known
- * named pipe. This detects any agent that provides the pipe — OpenSSH Agent
- * service, Bitwarden, 1Password, gpg-agent, etc.
+ * Check if an SSH agent is available on Windows by connecting to the
+ * well-known named pipe. fs.statSync is unreliable for named pipes (returns
+ * EBUSY even when usable), so we use net.connect() as the authoritative check.
  * @returns {Promise<{ running: boolean, startupType: string | null, error: string | null }>}
  */
 function checkWindowsSshAgent() {
+  if (process.platform !== "win32") {
+    return Promise.resolve({ running: true, startupType: null, error: null });
+  }
+  const net = require("net");
   return new Promise((resolve) => {
-    if (process.platform !== "win32") {
-      resolve({ running: true, startupType: null, error: null });
-      return;
-    }
-    let pipeExists = false;
-    try {
-      fs.statSync(WIN_SSH_AGENT_PIPE);
-      pipeExists = true;
-    } catch {
-      // pipe not found
-    }
-    resolve({
-      running: pipeExists,
-      startupType: pipeExists ? "running" : "stopped",
-      error: pipeExists ? null : "SSH Agent pipe not found",
-    });
+    const socket = net.connect(WIN_SSH_AGENT_PIPE);
+    let settled = false;
+    const finish = (ok, error) => {
+      if (settled) return;
+      settled = true;
+      try { socket.destroy(); } catch {}
+      resolve({
+        running: ok,
+        startupType: ok ? "running" : "stopped",
+        error: ok ? null : (error || "SSH Agent pipe not connectable"),
+      });
+    };
+    socket.setTimeout(1000);
+    socket.once("connect", () => finish(true, null));
+    socket.once("timeout", () => finish(false, "SSH Agent pipe connect timeout"));
+    socket.once("error", (err) => finish(false, err.message));
   });
 }
 


### PR DESCRIPTION
## Summary
- `fs.statSync()` is unreliable for Windows named pipes — returns `EBUSY` even when the pipe is fully functional, causing ssh-agent detection to fail
- Replaced with `net.connect()` which is the authoritative connectivity check for named pipes
- Fixed in both `sshAuthHelper.cjs` and `sshBridge.cjs` (duplicate implementation)
- Supports all agents providing the pipe: OpenSSH, Bitwarden, 1Password, gpg-agent, etc.

Fixes #360

## Test plan
- [ ] On Windows with OpenSSH agent running: verify agent forwarding works
- [ ] On Windows without agent: verify graceful fallback (no crash)
- [ ] On macOS/Linux: verify no behavioral change (SSH_AUTH_SOCK detection unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)