### PR TITLE
fix: widen settings dropdown selects to prevent text wrapping

### DIFF
--- a/components/settings/tabs/SettingsSystemTab.tsx
+++ b/components/settings/tabs/SettingsSystemTab.tsx
@@ -597,7 +597,7 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   value={sessionLogsFormat}
                   options={formatOptions}
                   onChange={(val) => setSessionLogsFormat(val as SessionLogFormat)}
-                  className="w-32"
+                  className="w-44"
                   disabled={!sessionLogsEnabled}
                 />
               </SettingRow>

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -633,7 +633,7 @@ export default function SettingsTerminalTab(props: {
               { value: "meta", label: t("settings.terminal.behavior.linkModifier.meta") },
             ]}
             onChange={(v) => updateTerminalSetting("linkModifier", v as LinkModifier)}
-            className="w-40"
+            className="w-48"
           />
         </SettingRow>
       </div>


### PR DESCRIPTION
## Summary

- Widen Log Format dropdown from `w-32` to `w-44` to fit "Plain Text (.txt)"
- Widen Link modifier key dropdown from `w-40` to `w-48` to fit "None (click directly)"

Ref #294

## Test plan

- [x] Verify Log Format dropdown text displays on one line
- [x] Verify Link modifier key dropdown text displays on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)