### PR TITLE
fix: host-level keyword highlight toggle now overrides global setting

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -238,22 +238,22 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useEffect(() => {
     if (xtermRuntimeRef.current) {
       // Merge global rules with host-level rules
-      // Host-level rules are appended to global rules, allowing hosts to add custom highlighting
       const globalRules = terminalSettings?.keywordHighlightRules ?? [];
       const hostRules = host?.keywordHighlightRules ?? [];
 
-      // Check if highlighting is enabled at either global or host level
       const globalEnabled = terminalSettings?.keywordHighlightEnabled ?? false;
-      const hostEnabled = host?.keywordHighlightEnabled ?? false;
+      // Host-level toggle: undefined = inherit global, true/false = explicit override
+      const hostEnabled = host?.keywordHighlightEnabled;
 
-      // Merge rules: include only rules from enabled sources
+      // If host explicitly disabled highlighting, disable everything for this terminal
+      const effectiveGlobalEnabled = hostEnabled === false ? false : globalEnabled;
+      const effectiveHostEnabled = hostEnabled ?? false;
+
       const mergedRules = [
-        ...(globalEnabled ? globalRules : []),
-        ...(hostEnabled ? hostRules : [])
+        ...(effectiveGlobalEnabled ? globalRules : []),
+        ...(effectiveHostEnabled ? hostRules : [])
       ];
-
-      // Enable highlighting if either global or host-level is enabled
-      const isEnabled = globalEnabled || hostEnabled;
+      const isEnabled = effectiveGlobalEnabled || effectiveHostEnabled;
 
       xtermRuntimeRef.current.keywordHighlighter.setRules(mergedRules, isEnabled);
     }
@@ -538,12 +538,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const globalRules = terminalSettingsRef.current?.keywordHighlightRules ?? [];
         const hostRules = host?.keywordHighlightRules ?? [];
         const globalEnabled = terminalSettingsRef.current?.keywordHighlightEnabled ?? false;
-        const hostEnabled = host?.keywordHighlightEnabled ?? false;
+        const hostEnabled = host?.keywordHighlightEnabled;
+        const effectiveGlobalEnabled = hostEnabled === false ? false : globalEnabled;
+        const effectiveHostEnabled = hostEnabled ?? false;
         const mergedRules = [
-          ...(globalEnabled ? globalRules : []),
-          ...(hostEnabled ? hostRules : [])
+          ...(effectiveGlobalEnabled ? globalRules : []),
+          ...(effectiveHostEnabled ? hostRules : [])
         ];
-        const isEnabled = globalEnabled || hostEnabled;
+        const isEnabled = effectiveGlobalEnabled || effectiveHostEnabled;
         runtime.keywordHighlighter.setRules(mergedRules, isEnabled);
 
         const term = runtime.term;


### PR DESCRIPTION
## Summary

- When a host explicitly disables keyword highlighting, global highlight rules are no longer applied to that terminal
- Previously `isEnabled = globalEnabled || hostEnabled` meant the per-host toggle had no effect when global highlighting was on
- Now: `hostEnabled === false` suppresses global rules; `hostEnabled === undefined` inherits global (backward compatible)

Ref #294

## Test plan

- [ ] Enable global highlighting, disable per-host → highlighting should stop
- [ ] Enable global highlighting, host never toggled (undefined) → highlighting works
- [ ] Disable global, enable per-host → only host rules apply
- [ ] Both disabled → no highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)