### PR TITLE
fix: remove multi_host_execute and fix MissingToolResultsError on stop

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -661,13 +661,35 @@ export function useAIChatStreaming({
     try {
       // Issue #5: Build SDK messages including tool-call and tool-result messages
       // so the LLM maintains full conversation context
+      const allMessages = currentSession?.messages ?? [];
+
+      // Collect all tool call IDs that have a corresponding tool result,
+      // so we can skip orphaned tool calls (e.g. from user stopping mid-execution)
+      const resolvedToolCallIds = new Set<string>();
+      for (const m of allMessages) {
+        if (m.role === 'tool' && m.toolResults) {
+          for (const tr of m.toolResults) resolvedToolCallIds.add(tr.toolCallId);
+        }
+      }
+
+      const findToolName = (toolCallId: string): string => {
+        for (const prev of allMessages) {
+          if (prev.role === 'assistant' && prev.toolCalls) {
+            const tc = prev.toolCalls.find(t => t.id === toolCallId);
+            if (tc) return tc.name;
+          }
+        }
+        return 'unknown';
+      };
+
       const sdkMessages: Array<ModelMessage> = [];
-      for (const m of (currentSession?.messages ?? [])) {
+      for (const m of allMessages) {
         if (m.role === 'user') {
           sdkMessages.push({ role: 'user', content: m.content });
         } else if (m.role === 'assistant') {
           if (m.toolCalls?.length) {
-            // Build assistant content parts: text + tool calls
+            // Only include tool calls that have matching results
+            const resolvedCalls = m.toolCalls.filter(tc => resolvedToolCallIds.has(tc.id));
             const contentParts: Array<
               { type: 'text'; text: string } |
               { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
@@ -675,7 +697,7 @@ export function useAIChatStreaming({
             if (m.content) {
               contentParts.push({ type: 'text' as const, text: m.content });
             }
-            for (const tc of m.toolCalls) {
+            for (const tc of resolvedCalls) {
               contentParts.push({
                 type: 'tool-call' as const,
                 toolCallId: tc.id,
@@ -683,23 +705,14 @@ export function useAIChatStreaming({
                 input: tc.arguments ?? {},
               });
             }
-            sdkMessages.push({ role: 'assistant', content: contentParts });
+            // If all tool calls were orphaned, just include the text content
+            if (contentParts.length > 0) {
+              sdkMessages.push({ role: 'assistant', content: contentParts.length === 1 && contentParts[0].type === 'text' ? (contentParts[0] as { type: 'text'; text: string }).text : contentParts });
+            }
           } else if (m.content) {
             sdkMessages.push({ role: 'assistant', content: m.content });
           }
         } else if (m.role === 'tool' && m.toolResults?.length) {
-          // Map tool results to SDK tool message format
-          // Gemini requires functionResponse.name to be non-empty,
-          // so we look up the toolName from the preceding assistant tool calls.
-          const findToolName = (toolCallId: string): string => {
-            for (const prev of currentSession?.messages ?? []) {
-              if (prev.role === 'assistant' && prev.toolCalls) {
-                const tc = prev.toolCalls.find(t => t.id === toolCallId);
-                if (tc) return tc.name;
-              }
-            }
-            return 'unknown';
-          };
           sdkMessages.push({
             role: 'tool',
             content: m.toolResults.map(tr => ({

--- a/infrastructure/ai/cattyAgent/executor.ts
+++ b/infrastructure/ai/cattyAgent/executor.ts
@@ -7,7 +7,6 @@ import {
   executeSftpWriteFile,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
-  executeMultiHostExecute,
   executeWebSearch,
   executeUrlFetch,
   type ToolDeps,
@@ -187,16 +186,6 @@ export function createToolExecutor(
         case 'workspace_get_session_info': {
           const r = executeWorkspaceGetSessionInfo(deps, {
             sessionId: String(args.sessionId || ''),
-          });
-          return toToolResult(toolCall.id, r);
-        }
-
-        case 'multi_host_execute': {
-          const r = await executeMultiHostExecute(deps, {
-            sessionIds: (args.sessionIds as string[]) || [],
-            command: String(args.command || ''),
-            mode: String(args.mode || 'parallel'),
-            stopOnError: Boolean(args.stopOnError),
           });
           return toToolResult(toolCall.id, r);
         }

--- a/infrastructure/ai/cattyAgent/systemPrompt.ts
+++ b/infrastructure/ai/cattyAgent/systemPrompt.ts
@@ -38,7 +38,7 @@ ${permissionRules}
 
 1. **Plan before acting.** When a task involves multiple steps, present a brief numbered plan to the user before executing. Wait for acknowledgment on complex or risky operations.
 
-2. **Use the right tool.** For operations that target multiple hosts, prefer \`multi_host_execute\` over calling \`terminal_execute\` repeatedly. For normal shell commands, use \`terminal_execute\` so you receive the command output. Use \`terminal_send_input\` only when responding to an interactive prompt that is already running in the terminal. \`terminal_send_input\` writes keystrokes but does not read back the updated terminal screen.
+2. **Use the right tool.** For normal shell commands, use \`terminal_execute\` so you receive the command output. When operating on multiple hosts, call \`terminal_execute\` for each host. Use \`terminal_send_input\` only when responding to an interactive prompt that is already running in the terminal. \`terminal_send_input\` writes keystrokes but does not read back the updated terminal screen.
 
 3. **Never execute dangerous commands.** Commands matching the blocklist (e.g. \`rm -rf /\`, \`mkfs\`, \`dd\` to disk devices, \`shutdown\`, fork bombs, recursive chmod 777 on root) are strictly forbidden and will be automatically denied. Do not attempt to bypass these restrictions.
 
@@ -115,7 +115,7 @@ function buildPermissionRules(
     case 'confirm':
       return [
         'You are in **confirm** mode. Every write or execute operation requires explicit user approval before it runs:',
-        '- Command execution (`terminal_execute`, `multi_host_execute`)',
+        '- Command execution (`terminal_execute`)',
         '- Sending terminal input (`terminal_send_input`)',
         '- Writing files (`sftp_write_file`)',
         '',

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -12,7 +12,6 @@ import {
   executeSftpWriteFile,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
-  executeMultiHostExecute,
   executeWebSearch,
   executeUrlFetch,
   type ToolDeps,
@@ -144,39 +143,6 @@ export function createCattyTools(
       }),
       execute: async ({ sessionId }) => {
         return unwrap(executeWorkspaceGetSessionInfo(deps, { sessionId }));
-      },
-    }),
-
-    multi_host_execute: tool({
-      description:
-        'Execute a command on multiple hosts simultaneously or sequentially. ' +
-        'Use this for batch operations such as checking status across a fleet, ' +
-        'deploying updates, or running maintenance tasks on multiple servers.',
-      inputSchema: z.object({
-        sessionIds: z
-          .array(z.string())
-          .describe('Array of session IDs to execute the command on.'),
-        command: z.string().describe('The shell command to execute on each host.'),
-        mode: z
-          .enum(['parallel', 'sequential'])
-          .optional()
-          .default('parallel')
-          .describe(
-            'Execution mode. "parallel" runs on all hosts at once, ' +
-              '"sequential" runs one at a time. Defaults to "parallel".',
-          ),
-        stopOnError: z
-          .boolean()
-          .optional()
-          .default(false)
-          .describe(
-            'If true and mode is "sequential", stop executing on remaining hosts ' +
-              'when a command fails. Defaults to false.',
-          ),
-      }),
-      needsApproval: writeToolNeedsApproval,
-      execute: async ({ sessionIds, command, mode, stopOnError }) => {
-        return unwrap(await executeMultiHostExecute(deps, { sessionIds, command, mode, stopOnError }));
       },
     }),
 


### PR DESCRIPTION
## Summary

- Remove `multi_host_execute` tool — AI can call `terminal_execute` per host instead (simpler, avoids hang)
- Fix `AI_MissingToolResultsError` after user stops a stream mid-tool-execution — skip orphaned tool calls when building SDK message history

## Test plan

- [ ] Verify `multi_host_execute` no longer appears in AI tool calls
- [ ] AI can still operate on multiple hosts by calling `terminal_execute` for each
- [ ] Stop a stream while a tool is executing → send a new message → should work without error
- [ ] Normal tool call flow (complete execution) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)