### PR TITLE
fix: make global and host-level keyword highlight independent

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -543,7 +543,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const hostRules = host?.keywordHighlightRules ?? [];
         const globalEnabled = terminalSettingsRef.current?.keywordHighlightEnabled ?? false;
         const hostEnabled = host?.keywordHighlightEnabled;
-        const effectiveGlobalEnabled = hostEnabled === false ? false : globalEnabled;
+        const effectiveGlobalEnabled = globalEnabled;
         const effectiveHostEnabled = hostEnabled ?? false;
         const mergedRules = [
           ...(effectiveGlobalEnabled ? globalRules : []),


### PR DESCRIPTION
## Summary
- Global highlight toggle (in Settings) and per-terminal host-level highlight toggle (toolbar popover) are now fully independent
- Previously, disabling host-level highlight would also suppress global highlight rules due to coupling in the merge logic
- Fixes the issue where the toolbar highlight button appeared to have no effect (reported in #294)

## Changes
- `Terminal.tsx`: Removed the `hostEnabled === false ? false : globalEnabled` coupling — `effectiveGlobalEnabled` now always reflects the global setting regardless of host-level state

## Test plan
- [ ] Enable global keyword highlight in Settings, verify it works in all terminals
- [ ] Toggle host-level highlight off in terminal toolbar → global rules should still apply
- [ ] Toggle host-level highlight on and add host-specific rules → both global and host rules should apply
- [ ] Disable global highlight → host-specific rules should still work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)