### PR TITLE
fix: surface streaming provider errors in chat

### DIFF
--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -87,9 +87,17 @@ function extractHeaders(headers?: HeadersInit): Record<string, string> {
 export const API_KEY_PLACEHOLDER = '__IPC_SECURED__';
 
 function toSafeStatusText(message: string, fallback: string): string {
-  const normalized = message.replace(/\s+/g, ' ').trim();
+  const normalized = message
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   if (!normalized) return fallback;
-  return normalized.slice(0, 120);
+  const byteStringSafe = Array.from(normalized, (char) => {
+    const code = char.charCodeAt(0);
+    if (code < 0x20 || code === 0x7f || code > 0xff) return '?';
+    return char;
+  }).join('');
+  return byteStringSafe.slice(0, 120) || fallback;
 }
 
 export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.fetch {


### PR DESCRIPTION
## Summary
- preserve real streaming bridge error text in Response.statusText instead of collapsing all failures to "Bad Gateway"
- improve chat error visibility for provider allowlist, URL validation, and upstream proxy failures

## Testing
- npx eslint infrastructure/ai/sdk/providers.ts
- npm run lint
- npm run build