### PR TITLE
Show raw AI errors instead of inferred causes

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -27,7 +27,7 @@ import { createCattyTools } from '../../../infrastructure/ai/sdk/tools';
 import type { NetcattyBridge, ExecutorContext } from '../../../infrastructure/ai/cattyAgent/executor';
 import { runExternalAgentTurn } from '../../../infrastructure/ai/externalAgentAdapter';
 import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
-import { classifyError, sanitizeErrorMessage } from '../../../infrastructure/ai/errorClassifier';
+import { classifyError } from '../../../infrastructure/ai/errorClassifier';
 
 // -------------------------------------------------------------------
 // Stream chunk type interfaces (Issue #13: replace unsafe casts)
@@ -297,8 +297,6 @@ export function useAIChatStreaming({
     // Log the full unsanitized error for debugging
     console.error('[AIChatSidePanel] Stream error (full):', errorStr);
     const errorInfo = classifyError(errorStr);
-    // Sanitize the displayed message to avoid leaking paths, keys, or other sensitive info
-    errorInfo.message = sanitizeErrorMessage(errorInfo.message);
     updateLastMessage(sessionId, msg => ({
       ...msg,
       statusText: '',

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -1,47 +1,15 @@
 import type { ChatMessage } from './types';
 
 /**
- * Classifies a raw error string into structured error info for display.
+ * Convert a raw error string into display-safe error info.
+ *
+ * Intentionally avoids keyword-based "root cause" attribution because upstream
+ * providers often return generic 4xx/5xx text that would be misclassified.
+ * We show the sanitized upstream message directly instead.
  */
 export function classifyError(error: string): NonNullable<ChatMessage['errorInfo']> {
-  const lower = error.toLowerCase();
-
-  // Network errors
-  if (lower.includes('econnrefused') || lower.includes('enotfound') || lower.includes('enetunreach') || lower.includes('fetch failed') || lower.includes('network')) {
-    return { type: 'network', message: 'Network connection failed. Please check your internet connection and API endpoint.', retryable: true };
-  }
-
-  // Timeout
-  if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('econnreset') || lower.includes('socket hang up')) {
-    return { type: 'timeout', message: 'Request timed out. The server may be overloaded or unreachable.', retryable: true };
-  }
-
-  // Auth errors
-  if (lower.includes('401') || lower.includes('403') || lower.includes('unauthorized') || lower.includes('invalid api key') || lower.includes('authentication')) {
-    return { type: 'auth', message: 'Authentication failed. Please check your API key in Settings \u2192 AI.', retryable: false };
-  }
-
-  // Rate limit
-  if (lower.includes('429') || lower.includes('rate limit') || lower.includes('too many requests')) {
-    return { type: 'provider', message: 'Rate limit exceeded. Please wait a moment before retrying.', retryable: true };
-  }
-
-  // Provider errors (5xx)
-  if (/\b5\d{2}\b/.test(error) || lower.includes('server error') || lower.includes('internal error')) {
-    return { type: 'provider', message: sanitizeErrorMessage(error), retryable: true };
-  }
-
-  // Model not found
-  if (lower.includes('model not found') || lower.includes('does not exist') || lower.includes('404')) {
-    return { type: 'provider', message: 'Model not found. Please check your model selection in Settings \u2192 AI.', retryable: false };
-  }
-
-  // Command blocked
-  if (lower.includes('blocked by safety')) {
-    return { type: 'agent', message: sanitizeErrorMessage(error), retryable: false };
-  }
-
-  return { type: 'unknown', message: sanitizeErrorMessage(error), retryable: true };
+  const message = sanitizeErrorMessage(error).trim() || 'Unknown error';
+  return { type: 'unknown', message, retryable: false };
 }
 
 const MAX_ERROR_MESSAGE_LENGTH = 500;


### PR DESCRIPTION
## Summary
- stop rewriting AI provider errors based on keyword heuristics
- show the sanitized upstream error text directly in chat
- remove the extra second-pass sanitization in the streaming hook

## Testing
- npx eslint infrastructure/ai/errorClassifier.ts components/ai/hooks/useAIChatStreaming.ts