### PR TITLE
Fix SFTP download failing on Windows drive root paths

### DIFF
--- a/electron/bridges/localFsBridge.cjs
+++ b/electron/bridges/localFsBridge.cjs
@@ -161,7 +161,17 @@ async function renameLocalFile(event, payload) {
  * Create a local directory
  */
 async function mkdirLocal(event, payload) {
-  await fs.promises.mkdir(payload.path, { recursive: true });
+  try {
+    await fs.promises.mkdir(payload.path, { recursive: true });
+  } catch (err) {
+    // On Windows, mkdir on drive roots (e.g. "E:\") throws EPERM.
+    // If the directory already exists, that's fine — ignore the error.
+    try {
+      const stat = await fs.promises.stat(payload.path);
+      if (stat.isDirectory()) return true;
+    } catch { /* stat failed, re-throw original */ }
+    throw err;
+  }
   return true;
 }
 

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -8,6 +8,24 @@ const path = require("node:path");
 const os = require("node:os");
 const { encodePathForSession, ensureRemoteDirForSession, requireSftpChannel } = require("./sftpBridge.cjs");
 
+/**
+ * Safely ensure a local directory exists.
+ * On Windows, `mkdir("E:\\", { recursive: true })` throws EPERM for drive roots.
+ * We catch that and verify the directory already exists before re-throwing.
+ */
+async function ensureLocalDir(dir) {
+  try {
+    await fs.promises.mkdir(dir, { recursive: true });
+  } catch (err) {
+    // If the directory already exists, ignore the error (covers EPERM on drive roots)
+    try {
+      const stat = await fs.promises.stat(dir);
+      if (stat.isDirectory()) return;
+    } catch { /* stat failed, re-throw original */ }
+    throw err;
+  }
+}
+
 // ── Transfer performance tuning ──────────────────────────────────────────────
 // ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel,
 // dramatically improving throughput over sequential stream piping.
@@ -430,14 +448,14 @@ async function startTransfer(event, payload, onProgress) {
       if (!client) throw new Error("Source SFTP session not found");
 
       const dir = path.dirname(targetPath);
-      await fs.promises.mkdir(dir, { recursive: true });
+      await ensureLocalDir(dir);
 
       const encodedSourcePath = encodePathForSession(sourceSftpId, sourcePath, sourceEncoding);
       await downloadFile(encodedSourcePath, targetPath, client, fileSize, transfer, sendProgress);
 
     } else if (sourceType === 'local' && targetType === 'local') {
       const dir = path.dirname(targetPath);
-      await fs.promises.mkdir(dir, { recursive: true });
+      await ensureLocalDir(dir);
 
       await new Promise((resolve, reject) => {
         const readStream = fs.createReadStream(sourcePath, { highWaterMark: TRANSFER_CHUNK_SIZE });


### PR DESCRIPTION
## Summary
- On Windows, saving SFTP files to a drive root (e.g. `E:\file.txt`) fails with `EPERM: operation not permitted, mkdir 'E:\'`
- `fs.promises.mkdir("E:\", { recursive: true })` throws EPERM because you can't "create" a drive root directory
- Fixed by catching the error and verifying the directory already exists before re-throwing — applied to both `transferBridge` (file downloads) and `localFsBridge` (directory downloads via `mkdirLocal`)

## Test plan
- [x] Download an SFTP file to a Windows drive root (e.g. `E:\test.txt`)
- [x] Download an SFTP directory to a Windows drive root
- [x] Verify normal downloads to subdirectories still work

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)