### PR TITLE
fix: suppress known_hosts toast on auto-scan at startup

### DIFF
--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -514,7 +514,7 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
             variant="ghost"
             size="sm"
             className="h-9 px-3 text-xs"
-            onClick={handleScanSystem}
+            onClick={() => handleScanSystem()}
             disabled={isScanning}
           >
             <RefreshCw
@@ -571,7 +571,7 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
               <div className="flex gap-2">
                 <Button
                   variant="secondary"
-                  onClick={handleScanSystem}
+                  onClick={() => handleScanSystem()}
                   disabled={isScanning}
                 >
                   <RefreshCw


### PR DESCRIPTION
## Summary
- Auto-scan at startup now runs in silent mode — no toast for missing `known_hosts` file
- Manual "Scan System" button still shows all toasts as before
- Only change: added a `silent` parameter to `handleScanSystem`, auto-scan passes `true`

Closes #398

## Test plan
- [ ] Start app without `~/.ssh/known_hosts` → no toast appears
- [ ] Open Known Hosts page → click "Scan System" → toast appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)