### PR TITLE
fix: allow Unicode characters in snippet package names

### DIFF
--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -439,8 +439,8 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     const name = newPackageName.trim();
     if (!name) return;
     
-    // Allow leading slash and validate the rest - allow hyphens anywhere in package names
-    if (!/^\/?([\w-]+(\/[\w-]+)*)\/?$/.test(name)) {
+    // Allow leading slash and validate the rest - allow hyphens and Unicode letters/numbers
+    if (!/^\/?([\w\p{L}\p{N}-]+(\/[\w\p{L}\p{N}-]+)*)\/?$/u.test(name)) {
       // Could add toast notification here for invalid characters
       return;
     }
@@ -550,9 +550,9 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
       return;
     }
 
-    // Validate: same rules as createPackage - only allow letters, numbers, hyphens, underscores
+    // Validate: same rules as createPackage - allow Unicode letters, numbers, hyphens, underscores
     // Since we're renaming a single segment (no slashes allowed), use the segment-level pattern
-    if (!/^[\w-]+$/.test(newName)) {
+    if (!/^[\w\p{L}\p{N}-]+$/u.test(newName)) {
       setRenameError(t('snippets.renameDialog.error.invalidChars'));
       return;
     }
@@ -1203,7 +1203,6 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                 value={newPackageName}
                 onChange={(e) => setNewPackageName(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && createPackage()}
-                pattern="^/?([\w-]+(/[\w-]+)*)?/?$"
                 title="Package names can contain letters, numbers, hyphens, underscores, and forward slashes. Can optionally start with /"
               />
               <p className="text-[11px] text-muted-foreground">{t('snippets.packageDialog.hint')}</p>


### PR DESCRIPTION
## Summary
- 修复新建/重命名代码包时无法使用中文等 Unicode 字符的问题
- 验证正则从 `\w`（仅 ASCII）改为 `\w\p{L}\p{N}`（支持 Unicode），并添加 `u` flag
- 移除 HTML input 上不支持 Unicode flag 的 `pattern` 属性

Closes #434

## Test plan
- [x] 新建代码包，输入中文名称（如"测试代码包"），确认可以成功创建
- [x] 新建代码包，输入带路径的中文名称（如"中文/子包"），确认可以成功创建
- [x] 重命名代码包为中文名称，确认可以成功重命名
- [x] 输入特殊字符（如 `@#$`）仍然被正确拒绝
- [x] 原有英文、数字、连字符、下划线命名功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)