### PR TITLE
fix: use gzip compression for deb to fix Deepin OS install

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -106,6 +106,11 @@ module.exports = {
         ],
         category: 'Development'
     },
+    deb: {
+        // Use gzip instead of default xz(lzma) for better compatibility with
+        // Deepin OS and other distros that have issues with lzma decompression
+        compression: 'gz'
+    },
     publish: [
         {
             provider: 'github',


### PR DESCRIPTION
## Summary
- Deepin OS 安装 deb 包时报 `lzma 错误：压缩数据已损坏`，影响 1.0.58-1.0.60 多个版本
- 原因是 electron-builder 默认使用 xz (LZMA) 压缩 deb 包，Deepin 的 dpkg 对此存在兼容性问题
- 将 deb 压缩格式改为 gzip，包体积略增但兼容性更好

Closes #435

## Test plan
- [x] 构建 Linux deb 包，确认产物使用 gzip 压缩
- [x] 在 Deepin OS 上安装 deb 包，确认不再报 lzma 错误
- [x] 在 Ubuntu 上安装 deb 包，确认安装正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)