### PR TITLE
fix: provide detailed error messages for cloud sync failures

### DIFF
--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1102,10 +1102,15 @@ export class CloudSyncManager {
       if (checkResult.conflict && checkResult.remoteFile) {
         // Remote is newer — attempt three-way merge instead of blocking
         try {
-          const remotePayload = await EncryptionService.decryptPayload(
-            checkResult.remoteFile,
-            this.masterPassword,
-          );
+          let remotePayload: SyncPayload;
+          try {
+            remotePayload = await EncryptionService.decryptPayload(
+              checkResult.remoteFile,
+              this.masterPassword,
+            );
+          } catch (decryptError) {
+            throw new Error(`Decryption failed (master password may differ between devices): ${decryptError instanceof Error ? decryptError.message : String(decryptError)}`);
+          }
           const base = await this.loadSyncBase(provider);
           const mergeResult = mergeSyncPayloads(base, payload, remotePayload);
 
@@ -1239,13 +1244,23 @@ export class CloudSyncManager {
     const adapter = await this.getConnectedAdapter(provider);
 
     try {
-      const remoteFile = await adapter.download();
+      let remoteFile: SyncedFile | null;
+      try {
+        remoteFile = await adapter.download();
+      } catch (downloadError) {
+        throw new Error(`Download failed: ${downloadError instanceof Error ? downloadError.message : String(downloadError)}`);
+      }
       if (!remoteFile) {
         return null;
       }
 
       // Decrypt
-      const payload = await EncryptionService.decryptPayload(remoteFile, this.masterPassword);
+      let payload: SyncPayload;
+      try {
+        payload = await EncryptionService.decryptPayload(remoteFile, this.masterPassword);
+      } catch (decryptError) {
+        throw new Error(`Decryption failed (master password may differ between devices): ${decryptError instanceof Error ? decryptError.message : String(decryptError)}`);
+      }
 
       // Update local tracking
       this.state.localVersion = remoteFile.meta.version;


### PR DESCRIPTION
## Summary
- 细化云同步失败时的错误提示，区分"下载失败"和"解密失败"
- 解密失败时提示用户主密码可能在不同设备间不一致
- 覆盖两条路径：`downloadFromProvider`（冲突解决/下载云端）和 `syncNow`（三路合并时的解密）

Ref #436

## Test plan
- [x] 使用不同主密码的两台设备同步，确认 toast 显示 "Decryption failed (master password may differ between devices)"
- [x] S3 连接异常时，确认 toast 显示 "Download failed: ..."
- [x] 正常同步流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)