### PR TITLE
fix: preserve SFTP directory when switching between terminal tabs

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -195,16 +195,12 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   // correctly identify tabs when the same host ID has different overrides.
   const tabConnectionKeyMapRef = useRef<Map<string, string>>(new Map());
   const pendingConnectionKeyRef = useRef<string | null>(null);
-  const prevIsVisibleRef = useRef(isVisible);
 
-  // Reset location guard when the panel is reopened so the terminal cwd
-  // is re-applied even if it matches the previous session's path.
-  useEffect(() => {
-    if (isVisible && !prevIsVisibleRef.current) {
-      lastAppliedInitialLocationKeyRef.current = null;
-    }
-    prevIsVisibleRef.current = isVisible;
-  }, [isVisible]);
+  // NOTE: We intentionally do NOT reset lastAppliedInitialLocationKeyRef on
+  // visibility changes. When the user switches terminal tabs, the panel
+  // toggles isVisible but should preserve its navigation state (the user may
+  // have navigated away from initialLocation). When the panel is truly
+  // closed, the component unmounts and all refs are naturally reset.
 
   // Navigate SFTP to the terminal's current working directory
   const handleGoToTerminalCwd = useCallback(async () => {


### PR DESCRIPTION
## Summary

Fixes #440

- When switching between terminal tabs, the SFTP side panel would reset to the initial directory (terminal cwd at open time), discarding user navigation
- Root cause: a visibility-transition effect cleared the `initialLocation` guard every time the panel went from hidden to visible. Since tab switches toggle `isVisible`, every switch triggered the `initialLocation` effect to re-navigate back to the original path
- Fix: remove the visibility-based guard reset. When the panel is truly closed the component unmounts and refs reset naturally; tab switches should preserve navigation state

## Test plan

- [x] Open two SSH tabs (server1, server2)
- [x] Open SFTP side panel on server1, navigate to a subdirectory (e.g. `/root/cq`)
- [x] Switch to server2 tab, open SFTP side panel
- [x] Switch back to server1 tab — verify SFTP stays at `/root/cq` (not reset to `/root`)
- [x] Close SFTP panel on server1, reopen it — verify it correctly navigates to the terminal cwd
- [x] Test workspace mode: focus switch between panes should also preserve SFTP directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)