### PR TITLE
fix: new hosts dynamically inherit global font size and theme

### DIFF
--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -127,8 +127,6 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         os: "linux",
         authMethod: "password",
         charset: "UTF-8",
-        theme: terminalThemeId,
-        fontSize: terminalFontSize,
         distroMode: "auto",
         createdAt: Date.now(),
         group: defaultGroup || undefined, // Pre-fill with current navigation group


### PR DESCRIPTION
## Summary

Fixes #424

- When creating a new host, the global `fontSize` and `theme` were copied into the host config. Since `fontSizeOverride`/`themeOverride` were not set (`undefined`), the legacy detection logic treated the presence of these values as an active override, locking the host to the global values **at creation time**
- Changing the global font size afterward had no effect on these hosts — they appeared to "remember" the old global value
- Fix: stop copying `fontSize` and `theme` into new host configs. Without these fields, `resolveHostTerminalFontSize`/`resolveHostTerminalThemeId` correctly falls back to the current global setting, so hosts dynamically follow global changes unless the user explicitly sets a per-host override

## Test plan

- [x] Create a new host with global font size at 16px — terminal should show 16px
- [x] Change global font size to 14px — the host's terminal should update to 14px automatically
- [ ] Set a per-host font size override to 18px — changing global should NOT affect this host
- [ ] Click "Use Global" on the host — it should follow global again
- [ ] Same test for theme: new hosts should follow global theme changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)