### PR TITLE
fix: pin native module architecture in Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,10 +122,13 @@ jobs:
           npm pkg set version="${VERSION}"
 
       - name: Prepare node-pty Linux runtime
+        env:
+          npm_config_arch: x64
         run: bash scripts/ensure-node-pty-linux.sh prepare x64
 
       - name: Build package
         env:
+          npm_config_arch: x64
           ELECTRON_BUILDER_PUBLISH: "never"
         run: npm run pack:linux-x64
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     productName: 'Netcatty',
     artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
     icon: 'public/icon.png',
+    npmRebuild: false,
     directories: {
         buildResources: 'build',
         output: 'release'

--- a/scripts/ensure-node-pty-linux.sh
+++ b/scripts/ensure-node-pty-linux.sh
@@ -61,7 +61,7 @@ prepare() {
 
   echo "[node-pty] rebuilding native modules for Electron on linux-${arch}"
   log_electron_runtime_info
-  npx electron-rebuild
+  npx electron-rebuild --arch "${arch}"
 
   test -f "${release_dir}/pty.node"
 


### PR DESCRIPTION
## Summary

- `electron-rebuild` 显式传递 `--arch` 参数，不再依赖自动检测
- x64 CI job 补齐 `npm_config_arch: x64` 环境变量（与 arm64 job 对齐）
- 禁用 electron-builder 的 `npmRebuild`，避免打包阶段二次 rebuild 覆盖 prepare 脚本的成果

## Root cause

v1.0.62 的 amd64 deb/AppImage 内 `node-pty/build/Release/pty.node` 是 aarch64 架构，导致 x64 Linux 用户无法启动。

根因是构建流程中 native module 的目标架构从未被显式锁定：
1. `ensure-node-pty-linux.sh` 调用 `npx electron-rebuild` 时没有传 `--arch`
2. electron-builder 打包时默认执行 `npmRebuild`，会再次编译 native module 并可能覆盖 prepare 脚本的输出
3. x64 job 未设置 `npm_config_arch`，而 arm64 job 已设置

## Test plan

- [ ] 触发 CI 构建，确认 x64 和 arm64 的 deb/AppImage 产物中 `pty.node` 架构正确
- [ ] 在 x64 Linux 上验证 AppImage 和 deb 可正常启动

Closes #446, closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)