### PR TITLE
Add 'meslolgs nf' to local fonts list

### DIFF
--- a/lib/localFonts.ts
+++ b/lib/localFonts.ts
@@ -54,6 +54,7 @@ const KNOWN_MONOSPACE_FONTS = new Set([
     'noto sans mono',
     'sarasa mono',
     'maple mono',
+    'meslolgs nf',
 ]);
 
 /**


### PR DESCRIPTION
Fixes an issue on macOS where MesloLGS NF was incorrectly filtered out of the terminal font list