### PR TITLE
Revert: perf(keyword-highlight) #464

### DIFF
--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -10,12 +10,6 @@ interface CompiledRule {
   color: string;
 }
 
-interface CachedDecorationRange {
-  x: number;
-  width: number;
-  color: string;
-}
-
 /**
  * Manages terminal decorations for keyword highlighting.
  * Uses xterm.js Decoration API to overlay styles without modifying the data stream.
@@ -26,8 +20,6 @@ export class KeywordHighlighter implements IDisposable {
   private compiledRules: CompiledRule[] = [];
   private decorations: { decoration: IDecoration; marker: IMarker }[] = [];
   private debounceTimer: NodeJS.Timeout | null = null;
-  private animationFrameId: number | null = null;
-  private matchCache = new Map<string, CachedDecorationRange[]>();
   private enabled: boolean = false;
   private disposables: IDisposable[] = [];
   private lastViewportY: number = -1;
@@ -39,22 +31,23 @@ export class KeywordHighlighter implements IDisposable {
     this.disposables.push(
       // When user scrolls, refresh visible area
       this.term.onScroll(() => {
-        this.triggerRefresh("debounced");
+        // console.log('[KeywordHighlighter] onScroll');
+        this.triggerRefresh();
       }),
-      // When new data is written, refresh on the next frame so highlights land
-      // with the freshly rendered content instead of trailing behind it.
+      // When new data is written, refresh
       this.term.onWriteParsed(() => {
-        this.triggerRefresh("immediate");
+        // console.log('[KeywordHighlighter] onWriteParsed');
+        this.triggerRefresh();
       }),
       // Also refresh on resize as viewport content changes
-      this.term.onResize(() => this.triggerRefresh("debounced")),
+      this.term.onResize(() => this.triggerRefresh()),
       // onRender fires after each render cycle - catch scrolls that onScroll might miss
       this.term.onRender(() => {
         // Only trigger refresh if viewport position changed
         const currentViewportY = this.term.buffer.active?.viewportY ?? 0;
         if (currentViewportY !== this.lastViewportY) {
           this.lastViewportY = currentViewportY;
-          this.triggerRefresh("debounced");
+          this.triggerRefresh();
         }
       })
     );
@@ -62,7 +55,6 @@ export class KeywordHighlighter implements IDisposable {
 
   public setRules(rules: KeywordHighlightRule[], enabled: boolean) {
     this.enabled = enabled;
-    this.matchCache.clear();
 
     // Pre-compile all patterns into regexes for better performance
     // This avoids creating new RegExp objects on every viewport refresh
@@ -84,7 +76,7 @@ export class KeywordHighlighter implements IDisposable {
     // Clear existing and force an immediate refresh if enabling
     this.clearDecorations();
     if (this.enabled && this.compiledRules.length > 0) {
-      this.triggerRefresh("immediate");
+      this.triggerRefresh();
     }
   }
 
@@ -95,14 +87,9 @@ export class KeywordHighlighter implements IDisposable {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
-    if (this.animationFrameId !== null) {
-      cancelAnimationFrame(this.animationFrameId);
-      this.animationFrameId = null;
-    }
-    this.matchCache.clear();
   }
 
-  private triggerRefresh(mode: "immediate" | "debounced") {
+  private triggerRefresh() {
     if (!this.enabled || this.compiledRules.length === 0) return;
 
     // Optimization: Disable highlighting in Alternate Buffer (e.g. Vim, Htop)
@@ -114,34 +101,12 @@ export class KeywordHighlighter implements IDisposable {
       return;
     }
 
-    if (mode === "immediate") {
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = null;
-      }
-      if (this.animationFrameId !== null) {
-        return;
-      }
-      this.animationFrameId = requestAnimationFrame(() => {
-        this.animationFrameId = null;
-        this.refreshViewport();
-      });
-      return;
-    }
-
-    if (this.animationFrameId !== null) {
-      return;
-    }
-
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
 
     const delay = XTERM_PERFORMANCE_CONFIG.highlighting.debounceMs;
-    this.debounceTimer = setTimeout(() => {
-      this.debounceTimer = null;
-      this.refreshViewport();
-    }, delay);
+    this.debounceTimer = setTimeout(() => this.refreshViewport(), delay);
   }
 
   private clearDecorations() {
@@ -212,93 +177,49 @@ export class KeywordHighlighter implements IDisposable {
       const lineText = line.translateToString(true); // true = trim right whitespace
       if (!lineText) continue;
 
-      const cachedRanges = this.getCachedRanges(line, lineText);
-      if (cachedRanges.length === 0) continue;
+      // Build mapping from string index to cell column for wide char support
+      const cellMap = this.buildStringToCellMap(line);
 
-      // Calculate offset relative to the absolute cursor position
-      // offset = targetLineAbs - (baseY + cursorY)
-      const offset = lineY - cursorAbsoluteY;
+      // Process each pre-compiled rule
+      for (const { regex, color } of this.compiledRules) {
+        // Reset regex state for reuse (global flag maintains lastIndex)
+        regex.lastIndex = 0;
+        let match;
 
-      for (const range of cachedRanges) {
-        const marker = this.term.registerMarker(offset);
+        while ((match = regex.exec(lineText)) !== null) {
+          const strStart = match.index;
+          const strEnd = strStart + match[0].length;
 
-        if (marker) {
-          const deco = this.term.registerDecoration({
-            marker,
-            x: range.x,
-            width: range.width,
-            foregroundColor: range.color,
-          });
+          // Map string indices to cell columns
+          const cellStartCol = cellMap[strStart] ?? strStart;
+          const cellEndCol = cellMap[strEnd] ?? strEnd;
+          const cellWidth = cellEndCol - cellStartCol;
 
-          if (deco) {
-            this.decorations.push({ decoration: deco, marker });
-          } else {
-            // If decoration failed, cleanup marker
-            marker.dispose();
+          // Skip if width is 0 or negative (shouldn't happen, but be safe)
+          if (cellWidth <= 0) continue;
+
+          // Calculate offset relative to the absolute cursor position
+          // offset = targetLineAbs - (baseY + cursorY)
+          const offset = lineY - cursorAbsoluteY;
+          const marker = this.term.registerMarker(offset);
+
+          if (marker) {
+            const deco = this.term.registerDecoration({
+              marker,
+              x: cellStartCol,
+              width: cellWidth,
+              foregroundColor: color,
+            });
+
+            if (deco) {
+              this.decorations.push({ decoration: deco, marker });
+            } else {
+              // If decoration failed, cleanup marker
+              marker.dispose();
+            }
           }
         }
       }
     }
-  }
-
-  private getCachedRanges(line: IBufferLine, lineText: string): CachedDecorationRange[] {
-    // Build the cell map up front so we can include its shape in the cache
-    // key.  Two lines can share the same translateToString() output yet
-    // differ in cell layout (e.g. empty cells vs real spaces after a tab
-    // stop), which would produce different x/width decoration ranges.
-    const cellMap = this.buildStringToCellMap(line);
-    const cacheKey = `${lineText}\0${cellMap.join(',')}`;
-
-    const cached = this.matchCache.get(cacheKey);
-    if (cached) {
-      this.matchCache.delete(cacheKey);
-      this.matchCache.set(cacheKey, cached);
-      return cached;
-    }
-
-    const ranges = this.scanLine(cellMap, lineText);
-    this.matchCache.set(cacheKey, ranges);
-
-    const maxEntries = XTERM_PERFORMANCE_CONFIG.highlighting.cacheEntries;
-    if (this.matchCache.size > maxEntries) {
-      const oldestKey = this.matchCache.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.matchCache.delete(oldestKey);
-      }
-    }
-
-    return ranges;
-  }
-
-  private scanLine(cellMap: number[], lineText: string): CachedDecorationRange[] {
-    const ranges: CachedDecorationRange[] = [];
-
-    // Process each pre-compiled rule
-    for (const { regex, color } of this.compiledRules) {
-      // Reset regex state for reuse (global flag maintains lastIndex)
-      regex.lastIndex = 0;
-      let match;
-
-      while ((match = regex.exec(lineText)) !== null) {
-        const strStart = match.index;
-        const strEnd = strStart + match[0].length;
-
-        // Map string indices to cell columns
-        const cellStartCol = cellMap[strStart] ?? strStart;
-        const cellEndCol = cellMap[strEnd] ?? strEnd;
-        const cellWidth = cellEndCol - cellStartCol;
-
-        // Skip if width is 0 or negative (shouldn't happen, but be safe)
-        if (cellWidth <= 0) continue;
-
-        ranges.push({
-          x: cellStartCol,
-          width: cellWidth,
-          color,
-        });
-      }
-    }
-
-    return ranges;
   }
 }

--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -94,10 +94,6 @@ export const XTERM_PERFORMANCE_CONFIG = {
     // Debounce time for viewport scanning (ms)
     // Higher values = better scrolling performance, but slower highlight "catch up"
     debounceMs: 200,
-
-    // Number of unique line scan results to keep cached.
-    // Large enough to cover typical viewport reuse without letting cache grow unbounded.
-    cacheEntries: 1200,
   },
 };
 


### PR DESCRIPTION
## Summary

Reverts #464 — the performance optimization has a few issues that need to be addressed before merging:

- `onWriteParsed` now uses `requestAnimationFrame` without throttling, removing the backpressure that the old 200ms debounce provided. Heavy output (e.g. `tail -f`) will refresh highlights every frame (~60/sec)
- Cache key needs to account for cell layout differences (empty cells vs real spaces) without adding expensive per-line serialization on the hot path

Will work with the author to fix these before re-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)