### PR TITLE
feat: add terminal smooth scrolling setting

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -311,6 +311,9 @@ const en: Messages = {
   'settings.terminal.behavior.scrollOnPaste': 'Scroll on paste',
   'settings.terminal.behavior.scrollOnPaste.desc':
     'Scroll terminal to bottom when pasting text',
+  'settings.terminal.behavior.smoothScrolling': 'Smooth scrolling',
+  'settings.terminal.behavior.smoothScrolling.desc':
+    'Animate terminal viewport scrolling instead of jumping instantly',
   'settings.terminal.behavior.linkModifier': 'Link modifier key',
   'settings.terminal.behavior.linkModifier.desc': 'Hold this key to click on links in terminal',
   'settings.terminal.behavior.linkModifier.none': 'None (click directly)',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1219,6 +1219,8 @@ const zhCN: Messages = {
   'settings.terminal.behavior.scrollOnKeyPress.desc': '按键（例如 Enter）时将终端滚动到底部',
   'settings.terminal.behavior.scrollOnPaste': '粘贴时自动滚动',
   'settings.terminal.behavior.scrollOnPaste.desc': '粘贴文本时将终端滚动到底部',
+  'settings.terminal.behavior.smoothScrolling': '平滑滚动',
+  'settings.terminal.behavior.smoothScrolling.desc': '滚动终端视口时使用平滑动画',
   'settings.terminal.behavior.linkModifier': '链接修饰键',
   'settings.terminal.behavior.linkModifier.desc': '按住此键再点击终端中的链接',
   'settings.terminal.behavior.linkModifier.none': '无（直接点击）',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -764,6 +764,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           terminalSettings.drawBoldInBrightColors;
         termRef.current.options.minimumContrastRatio =
           terminalSettings.minimumContrastRatio;
+        termRef.current.options.smoothScrollDuration =
+          terminalSettings.smoothScrolling
+            ? XTERM_PERFORMANCE_CONFIG.rendering.smoothScrollDuration
+            : 0;
         termRef.current.options.scrollOnUserInput =
           shouldEnableNativeUserInputAutoScroll(terminalSettings);
         termRef.current.options.altClickMovesCursor = !terminalSettings.altAsMeta;

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -617,6 +617,13 @@ export default function SettingsTerminalTab(props: {
         </SettingRow>
 
         <SettingRow
+          label={t("settings.terminal.behavior.smoothScrolling")}
+          description={t("settings.terminal.behavior.smoothScrolling.desc")}
+        >
+          <Toggle checked={terminalSettings.smoothScrolling} onChange={(v) => updateTerminalSetting("smoothScrolling", v)} />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.linkModifier")}
           description={t("settings.terminal.behavior.linkModifier.desc")}
         >

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -161,6 +161,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const lineHeight = 1 + (settings?.linePadding ?? 0) / 10;
   const minimumContrastRatio = settings?.minimumContrastRatio ?? 1;
   const scrollOnUserInput = shouldEnableNativeUserInputAutoScroll(settings);
+  const smoothScrollDuration = settings?.smoothScrolling
+    ? performanceConfig.options.smoothScrollDuration
+    : 0;
   const altIsMeta = settings?.altAsMeta ?? false;
   const wordSeparator = settings?.wordSeparators ?? " ()[]{}'\"";
   const keywordHighlightRules = settings?.keywordHighlightRules ?? [];
@@ -213,6 +216,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     allowProposedApi: true,
     drawBoldTextInBrightColors,
     minimumContrastRatio,
+    smoothScrollDuration,
     scrollOnUserInput,
     macOptionClickForcesSelection: true,
     altClickMovesCursor: !altIsMeta,

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -410,6 +410,8 @@ export interface TerminalSettings {
   scrollOnKeyPress: boolean; // Scroll terminal to bottom on key press
   scrollOnPaste: boolean; // Scroll terminal to bottom on paste
 
+  smoothScrolling: boolean; // Animate viewport scrolling instead of jumping instantly
+
   // Mouse
   rightClickBehavior: RightClickBehavior;
   copyOnSelect: boolean; // Automatically copy selected text
@@ -532,6 +534,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   scrollOnOutput: false,
   scrollOnKeyPress: false,
   scrollOnPaste: true,
+  smoothScrolling: true,
   rightClickBehavior: 'context-menu',
   copyOnSelect: false,
   middleClickPaste: true,

--- a/domain/syncPayload.ts
+++ b/domain/syncPayload.ts
@@ -74,6 +74,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'scrollback', 'drawBoldInBrightColors', 'fontLigatures', 'fontWeight', 'fontWeightBold',
   'linePadding', 'cursorShape', 'cursorBlink', 'minimumContrastRatio',
   'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
+  'smoothScrolling',
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'disableBracketedPaste', 'osc52Clipboard',

--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -36,6 +36,9 @@ export const XTERM_PERFORMANCE_CONFIG = {
     // Font rendering settings
     letterSpacing: 0,
     lineHeight: 1,
+
+    // Keep viewport movement smooth without feeling sluggish.
+    smoothScrollDuration: 120,
   },
 
   // WebGL-specific optimizations
@@ -115,6 +118,7 @@ export type ResolvedXTermPerformance = {
     customGlyphs: boolean;
     letterSpacing: number;
     lineHeight: number;
+    smoothScrollDuration: number;
     documentOverride: boolean;
     tabStopWidth: number;
     convertEol: boolean;
@@ -182,6 +186,7 @@ export function resolveXTermPerformanceConfig({
     customGlyphs: baseConfig.rendering.customGlyphs,
     letterSpacing: baseConfig.rendering.letterSpacing,
     lineHeight: baseConfig.rendering.lineHeight,
+    smoothScrollDuration: baseConfig.rendering.smoothScrollDuration,
     documentOverride: baseConfig.events.documentOverride,
     tabStopWidth: baseConfig.events.tabStopWidth,
     convertEol: baseConfig.events.convertEol,


### PR DESCRIPTION
## Summary

- Add `smoothScrolling` toggle to terminal settings (default: on)
- Uses xterm.js `smoothScrollDuration` (120ms) for animated viewport scrolling
- Setting exposed in UI, synced across devices, with en/zh-CN i18n

Inspired by #467 (@crawt), extracted as a standalone feature without the unrelated keywordHighlight changes.

## Test plan

- [ ] Toggle smooth scrolling on — scrolling is animated
- [ ] Toggle smooth scrolling off — scrolling is instant
- [ ] Setting persists after restart
- [ ] Setting syncs to another device

🤖 Generated with [Claude Code](https://claude.com/claude-code)