### PR TITLE
feat: show detailed auth method logs in connection dialog

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -432,7 +432,13 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
             logLine = `${prefix}${label} - ${tr("terminal.progress.keyExchangeComplete", "Key exchange complete")}`;
             break;
           case 'auth-attempt':
-            logLine = `${prefix}${label} - ${tr("terminal.progress.trying", "Trying")} ${error}...`;
+            if (error?.endsWith('rejected')) {
+              logLine = `${prefix}${label} - ✗ ${error}`;
+            } else if (error === 'all methods exhausted') {
+              logLine = `${prefix}${label} - ✗ ${tr("terminal.progress.allMethodsExhausted", "All authentication methods exhausted")}`;
+            } else {
+              logLine = `${prefix}${label} - ${tr("terminal.progress.trying", "Trying")} ${error}...`;
+            }
             break;
           case 'authenticated':
             logLine = `${prefix}${label} - ${tr("terminal.progress.authenticated", "Authenticated")}`;

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -380,10 +380,16 @@ function buildAuthHandler(options) {
 
   // Use dynamic authHandler to try all keys
   let authIndex = 0;
+  let lastAttemptedLabel = null;
   const attemptedMethodIds = new Set();
 
   const authHandler = (methodsLeft, partialSuccess, callback) => {
     const availableMethods = methodsLeft || ["publickey", "password", "keyboard-interactive", "agent"];
+
+    // Log rejection of previous method (authHandler is called again when server rejects)
+    if (lastAttemptedLabel && !partialSuccess) {
+      onAuthAttempt?.(`${lastAttemptedLabel} rejected`);
+    }
 
     while (authIndex < authMethods.length) {
       const method = authMethods[authIndex];
@@ -394,6 +400,7 @@ function buildAuthHandler(options) {
 
       if (method.type === "agent" && (availableMethods.includes("publickey") || availableMethods.includes("agent"))) {
         console.log(`${logPrefix} Trying agent auth`);
+        lastAttemptedLabel = "SSH agent";
         onAuthAttempt?.("SSH agent");
         return callback("agent");
       } else if (method.type === "publickey" && availableMethods.includes("publickey")) {
@@ -406,6 +413,7 @@ function buildAuthHandler(options) {
             : method.id === "publickey-user"
               ? "configured key"
               : method.id;
+        lastAttemptedLabel = keyLabel;
         onAuthAttempt?.(keyLabel);
         const pubkeyAuth = {
           type: "publickey",
@@ -418,6 +426,7 @@ function buildAuthHandler(options) {
         return callback(pubkeyAuth);
       } else if (method.type === "password" && availableMethods.includes("password")) {
         console.log(`${logPrefix} Trying password auth`);
+        lastAttemptedLabel = "password";
         onAuthAttempt?.("password");
         return callback({
           type: "password",
@@ -425,6 +434,7 @@ function buildAuthHandler(options) {
           password,
         });
       } else if (method.type === "keyboard-interactive" && availableMethods.includes("keyboard-interactive")) {
+        lastAttemptedLabel = "keyboard-interactive";
         onAuthAttempt?.("keyboard-interactive");
         return callback("keyboard-interactive");
       }

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -424,7 +424,7 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
             connOpts.privateKey = keyContent;
             if (isKeyEncrypted(keyContent)) {
               console.log(`[Chain] Hop ${i + 1}: identity file ${resolvedPath} is encrypted, requesting passphrase`);
-              sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'passphrase required');
+              sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', `key ${path.basename(resolvedPath)} requires passphrase`);
               const result = await passphraseHandler.requestPassphrase(
                 sender,
                 resolvedPath,
@@ -440,6 +440,7 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
               }
             }
             console.log(`[Chain] Hop ${i + 1}: loaded identity file ${resolvedPath}`);
+            sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', `loaded key ${path.basename(resolvedPath)}`);
             break;
           } catch (err) {
             console.warn(`[Chain] Hop ${i + 1}: failed to read identity file ${keyPath}:`, err.message);
@@ -660,6 +661,7 @@ async function startSSHSession(event, options) {
           // Check if key is encrypted — if so, prompt for passphrase
           if (isKeyEncrypted(keyContent)) {
             log("Identity file is encrypted, requesting passphrase", { keyPath: resolvedPath });
+            sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', `key ${path.basename(resolvedPath)} requires passphrase`);
             const result = await passphraseHandler.requestPassphrase(
               sender,
               resolvedPath,
@@ -675,6 +677,7 @@ async function startSSHSession(event, options) {
             }
           }
           log("Loaded identity file", { keyPath: resolvedPath, encrypted: isKeyEncrypted(keyContent) });
+          sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', `loaded key ${path.basename(resolvedPath)}`);
           break; // Use the first successfully loaded key
         } catch (err) {
           log("Failed to read identity file", { keyPath, error: err.message });
@@ -853,6 +856,12 @@ async function startSSHSession(event, options) {
         connectOpts.authHandler = (methodsLeft, partialSuccess, callback) => {
           log("authHandler called", { methodsLeft, partialSuccess, authIndex, attemptedMethodIds: Array.from(attemptedMethodIds) });
 
+          // When authHandler is called again after the first attempt, it means the
+          // previous method was rejected by the server. Log this for user visibility.
+          if (lastTriedMethod && !partialSuccess) {
+            sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', `${lastTriedMethod} rejected`);
+          }
+
           // methodsLeft can be null on first call (before server responds with available methods)
           // Include "agent" for SSH agent-based auth (used with agentForwarding)
           const availableMethods = methodsLeft || ["publickey", "password", "keyboard-interactive", "agent"];
@@ -989,6 +998,7 @@ async function startSSHSession(event, options) {
           }
 
           log("All auth methods exhausted");
+          sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'all methods exhausted');
           return callback(false);
         };
 
@@ -1293,12 +1303,15 @@ async function startSSHSession(event, options) {
           return;
         }
 
+        sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'waiting for user input...');
+
         // Forward ALL prompts to user - no auto-fill to avoid semantic detection issues
         // (Prompt text is admin-customizable and may not contain expected keywords)
         const requestId = keyboardInteractiveHandler.generateRequestId('ssh');
 
         keyboardInteractiveHandler.storeRequest(requestId, (userResponses) => {
           console.log(`${logPrefix} Received user responses, finishing keyboard-interactive`);
+          sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'user responded');
           finish(userResponses);
         }, sender.id, sessionId);
 


### PR DESCRIPTION
## Summary

Enhances the connection progress dialog to show the full authentication flow, making it much easier for users to diagnose connection issues.

**Before**: Only showed "Key exchange complete" → "Authenticated" (or error), with no visibility into which auth methods were tried.

**After**: Shows every step:
```
10.2.0.32 - Key exchange complete
10.2.0.32 - Trying SSH agent...
10.2.0.32 - ✗ SSH agent rejected
10.2.0.32 - Trying configured key...
10.2.0.32 - ✗ configured key rejected
10.2.0.32 - Trying password...
10.2.0.32 - Authenticated
```

For keyboard-interactive (2FA):
```
10.2.0.32 - Trying keyboard-interactive...
10.2.0.32 - Trying waiting for user input...
10.2.0.32 - Trying user responded...
10.2.0.32 - Authenticated
```

For encrypted identity files:
```
10.2.0.32 - Trying key id_ed25519 requires passphrase...
10.2.0.32 - Trying loaded key id_ed25519...
```

Changes:
- **sshBridge.cjs**: Log method rejections, keyboard-interactive prompts/responses, identity file loading, and passphrase requirements in the main connection's custom authHandler
- **sshAuthHelper.cjs**: Track `lastAttemptedLabel` in `buildAuthHandler` to log rejections via `onAuthAttempt` callback (used by chain connections and SFTP)
- **createTerminalSessionStarters.ts**: Display rejections with ✗ prefix and "all methods exhausted" with localized text

## Test plan

- [ ] Connect with key auth → verify "Trying configured key..." and "Authenticated" appear
- [ ] Connect with wrong key + password fallback → verify "configured key rejected" then "Trying password..."
- [ ] Connect with keyboard-interactive (2FA) → verify "waiting for user input..." and "user responded"
- [ ] Connect through jump host → verify per-hop auth logs
- [ ] All auth methods fail → verify "All authentication methods exhausted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)