### PR TITLE
fix(sftp): show full filename tooltip on hover

### DIFF
--- a/components/sftp/SftpFileRow.tsx
+++ b/components/sftp/SftpFileRow.tsx
@@ -88,7 +88,7 @@ const SftpFileRowInner: React.FC<SftpFileRowProps> = ({
                         <Link size={8} className="absolute -bottom-0.5 -right-0.5 text-muted-foreground" aria-hidden="true" />
                     )}
                 </div>
-                <span className={cn("truncate", entry.type === 'symlink' && "italic pr-1")}>
+                <span className={cn("truncate", entry.type === 'symlink' && "italic pr-1")} title={entry.name}>
                     {entry.name}
                     {entry.type === 'symlink' && <span className="sr-only"> (symbolic link)</span>}
                 </span>


### PR DESCRIPTION
## Summary
- Adds a `title` attribute to the file name `<span>` in `SftpFileRow` so that truncated filenames show their full name via native browser tooltip on hover.
- Addresses item 3 from #480.

## Test plan
- [x] Open an SFTP panel with files that have long names
- [x] Verify the name column truncates as before
- [x] Hover over a truncated filename and confirm the full name appears as a tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)