### PR TITLE
fix: SFTP permissions dialog shows empty (000) instead of actual file permissions

### DIFF
--- a/application/state/sftp/useSftpDirectoryListing.ts
+++ b/application/state/sftp/useSftpDirectoryListing.ts
@@ -49,6 +49,7 @@ export const useSftpDirectoryListing = () => {
           sizeFormatted: formatFileSize(size),
           lastModified,
           lastModifiedFormatted: formatDate(lastModified),
+          permissions: f.permissions,
           linkTarget: f.linkTarget as "file" | "directory" | null | undefined,
         };
       });


### PR DESCRIPTION
## Summary

Fixes #480 (item 2) — The SFTP permissions dialog showed all checkboxes unchecked (000) and the file list showed "--" in the permissions column.

**Root cause**: `listRemoteFiles()` in `useSftpDirectoryListing.ts` mapped the backend response to `SftpFileEntry` but dropped the `permissions` field. The backend correctly extracts permissions from `longname` or `attrs.mode`, but the frontend never received them.

**Fix**: Add `permissions: f.permissions` to the mapped object (1 line).

## Test plan

- [ ] Open SFTP, right-click a file → Permissions → verify checkboxes reflect actual file permissions
- [ ] Verify permissions column in file list shows values like `rwxr-xr-x` instead of `--`

🤖 Generated with [Claude Code](https://claude.com/claude-code)