### PR TITLE
fix: restore npmRebuild for macOS/Windows to fix local terminal crash

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -6,7 +6,12 @@ module.exports = {
     productName: 'Netcatty',
     artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
     icon: 'public/icon.png',
-    npmRebuild: false,
+    // npmRebuild must stay enabled for macOS and Windows builds — without it,
+    // node-pty's native module is not recompiled for the Electron ABI, causing
+    // "posix_spawnp failed" on macOS. Linux builds set npm_config_arch in CI
+    // and run ensure-node-pty-linux.sh before packaging, so the rebuild is
+    // redundant but harmless there.
+    npmRebuild: true,
     directories: {
         buildResources: 'build',
         output: 'release'


### PR DESCRIPTION
## Summary

Fixes #474 — Local terminal on macOS fails with `posix_spawnp failed` since v1.0.63.

**Root cause**: PR #449 set `npmRebuild: false` in `electron-builder.config.cjs` to fix a Linux-specific architecture mismatch issue. However, this also disabled native module recompilation for **macOS and Windows builds**. Without the rebuild step, `node-pty` ships compiled against the Node.js ABI instead of the Electron ABI, causing `posix_spawnp failed` when trying to spawn a shell process.

**User timeline**: v1.0.62 works fine, v1.0.63 (first release after #449) breaks. No app code changed between these versions — only the build config.

**Fix**: Restore `npmRebuild: true`. Linux builds are unaffected because they already run `ensure-node-pty-linux.sh` with explicit `npm_config_arch` before packaging, and the redundant electron-builder rebuild uses the same architecture setting.

## Test plan

- [x] macOS: Open local terminal → verify it works (no `posix_spawnp failed`)
- [x] Windows: Open local terminal → verify it works
- [x] Linux x64/arm64: Verify node-pty still loads correctly after packaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)