### PR TITLE
fix: default smooth scrolling to off to prevent scroll freeze

### DIFF
--- a/domain/models.ts
+++ b/domain/models.ts
@@ -537,7 +537,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   scrollOnOutput: false,
   scrollOnKeyPress: false,
   scrollOnPaste: true,
-  smoothScrolling: true,
+  smoothScrolling: false,
   rightClickBehavior: 'context-menu',
   copyOnSelect: false,
   middleClickPaste: true,


### PR DESCRIPTION
## Summary

Fixes #490 — Terminal gets stuck and can't scroll to bottom during high-throughput AI agent output.

**Root cause**: xterm.js smooth scrolling (`smoothScrollDuration: 120ms`) can't keep up when data arrives every 8ms. The scroll animation gets stuck mid-buffer, and users can't reach the bottom or Ctrl+C to interrupt.

**Fix**: Change `smoothScrolling` default from `true` to `false`. Users who prefer it can re-enable in Settings > Terminal.

## Test plan

- [x] Fresh install: verify smooth scrolling is off by default
- [x] Run a high-output command (e.g. `yes` or AI agent) → verify terminal stays scrolled to bottom
- [x] Enable smooth scrolling in settings → verify it still works when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)