### PR TITLE
fix: editor find/replace input cannot paste content

### DIFF
--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -151,6 +151,7 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   // Ref to store the latest save function to avoid stale closure in keyboard shortcut
   const handleSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
 
   // Track theme from document.documentElement class (syncs with app theme)
   const [isDarkTheme, setIsDarkTheme] = useState(() =>
@@ -254,6 +255,10 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
     }
   }, [readClipboardTextFromBridge]);
 
+  useEffect(() => {
+    readClipboardTextRef.current = readClipboardText;
+  }, [readClipboardText]);
+
   const handlePaste = useCallback(async () => {
     const editor = editorRef.current;
     if (!editor) return;
@@ -316,7 +321,30 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
     });
 
     // Fallback paste path for Electron environments where Monaco paste can fail.
+    // Skip custom paste when focus is inside the find/replace widget so that
+    // its input fields receive the pasted text via default browser behavior.
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
+      const active = document.activeElement;
+      if (active?.closest('.find-widget')) {
+        // Read clipboard and insert into the find/replace input field.
+        void (async () => {
+          try {
+            const text = await readClipboardTextRef.current();
+            if (!text) return;
+            // Monaco find widget inputs are <textarea> elements inside .monaco-inputbox
+            if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) {
+              const start = active.selectionStart ?? active.value.length;
+              const end = active.selectionEnd ?? active.value.length;
+              active.focus();
+              active.setSelectionRange(start, end);
+              document.execCommand('insertText', false, text);
+            }
+          } catch {
+            // Ignore – paste simply won't work
+          }
+        })();
+        return;
+      }
       void handlePasteRef.current();
     });
   }, []);


### PR DESCRIPTION
## 问题

修复 #512

内置编辑器的查找/替换控件的输入框无法粘贴内容。粘贴操作会"穿透"到编辑器主体中。

## 原因

`TextEditorModal` 中通过 `editor.addCommand` 注册了自定义的 Ctrl+V 处理器，用于在 Electron 环境下正确读取系统剪贴板。但该处理器拦截了**所有** Ctrl+V 事件，包括当焦点在 Monaco 查找/替换控件输入框内时的粘贴操作，导致剪贴板内容被错误地插入到编辑器主体而非输入框。

## 修复方案

- 在自定义粘贴处理器中检测 `document.activeElement` 是否位于 `.find-widget` 内
- 如果是，则通过 `readClipboardText` 读取剪贴板内容，并使用 `document.execCommand('insertText')` 将内容直接插入到查找/替换输入框中
- 如果不是，则按原有逻辑将内容粘贴到编辑器主体
- 添加 `readClipboardTextRef` 以避免 `handleEditorMount` 闭包中的过时引用

## 测试计划

- [ ] 打开内置编辑器，使用 Ctrl+F 打开查找控件
- [ ] 在查找输入框中粘贴文本，确认内容正确出现在输入框中
- [ ] 展开替换控件，在替换输入框中粘贴文本，确认内容正确出现
- [ ] 关闭查找控件，在编辑器中粘贴文本，确认原有粘贴功能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)