### PR TITLE
fix: external editor opens in background on Windows

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -620,6 +620,19 @@ const registerBridges = (win) => {
     
     try {
       let child;
+      // On Windows, minimize the current window before spawning the editor
+      // so the OS allows the new process to take foreground focus.
+      // Windows restricts SetForegroundWindow to the process that currently
+      // owns the foreground — minimizing releases that ownership.
+      let winToRestore = null;
+      if (process.platform === "win32") {
+        const focusedWin = BrowserWindow.getFocusedWindow();
+        if (focusedWin && !focusedWin.isDestroyed()) {
+          winToRestore = focusedWin;
+          focusedWin.minimize();
+        }
+      }
+
       if (process.platform === "darwin") {
         // On macOS, use 'open' command with -a flag for specific app
         const args = ["-a", appPath, filePath];
@@ -675,6 +688,17 @@ const registerBridges = (win) => {
       });
       
       child.unref();
+
+      // On Windows, restore the minimized window after a short delay
+      // to give the editor enough time to take foreground focus.
+      if (winToRestore && !winToRestore.isDestroyed()) {
+        setTimeout(() => {
+          if (!winToRestore.isDestroyed()) {
+            winToRestore.restore();
+          }
+        }, 500);
+      }
+
       return true;
     } catch (err) {
       console.error(`[Main] Error opening file with application:`, err);


### PR DESCRIPTION
## 概要

修复 #511：在 Windows 上通过 netcatty 打开外部编辑器时，编辑器窗口出现在 netcatty 窗口后面，而不是前台显示。

## 原因

Windows 对 `SetForegroundWindow` 有严格限制——只有当前拥有前台窗口的进程才能将窗口设置到前台。当 netcatty 窗口处于前台时，通过 `spawn` 启动的编辑器进程无法抢占前台焦点。

## 修复方案

- 在 Windows 上 spawn 编辑器之前，先最小化当前 Electron 窗口，释放前台窗口所有权
- 编辑器启动后 500ms 自动恢复（restore）netcatty 窗口
- 仅影响 Windows 平台，macOS 和 Linux 行为不变

## 测试计划

- [ ] 在 Windows 上使用外部编辑器打开文件，确认编辑器出现在前台
- [ ] 确认 500ms 后 netcatty 窗口自动恢复到任务栏
- [ ] 确认 macOS / Linux 上行为无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)