### PR TITLE
perf: reduce workspace and theme switch rerenders

### DIFF
--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1415,14 +1415,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   // Track previous focusedSessionId to detect changes
   const prevFocusedSessionIdRef = useRef<string | undefined>(undefined);
 
-  // When focusedSessionId changes in split view, focus the corresponding terminal
+  // When focusedSessionId changes or terminal layer becomes visible,
+  // focus the corresponding terminal to restore :focus-within CSS state
   useEffect(() => {
     // Only handle split view mode (not focus mode)
     if (isFocusMode || !focusedSessionId || !activeWorkspace) return;
 
-    // Only trigger when focusedSessionId actually changes
-    if (prevFocusedSessionIdRef.current === focusedSessionId) return;
-    const prevFocusedId = prevFocusedSessionIdRef.current;
+    // Trigger on focusedSessionId change OR when layer becomes visible again
+    const sessionChanged = prevFocusedSessionIdRef.current !== focusedSessionId;
+    if (!sessionChanged && !isTerminalLayerVisible) return;
+    const prevFocusedId = sessionChanged ? prevFocusedSessionIdRef.current : undefined;
     prevFocusedSessionIdRef.current = focusedSessionId;
 
     // First, blur the currently focused terminal immediately
@@ -1460,7 +1462,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       clearTimeout(timer2);
       clearTimeout(timer3);
     };
-  }, [focusedSessionId, isFocusMode, activeWorkspace]);
+  }, [focusedSessionId, isFocusMode, activeWorkspace, isTerminalLayerVisible]);
 
   // Get sessions for the active workspace in focus mode
   const workspaceSessionIds = useMemo(() => {
@@ -1548,7 +1550,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       <div
         ref={workspaceOuterRef}
         className="absolute inset-0 bg-background flex flex-col"
-        style={{ display: isTerminalLayerVisible ? 'flex' : 'none', zIndex: isTerminalLayerVisible ? 10 : 0 }}
+        style={{
+          visibility: isTerminalLayerVisible ? 'visible' : 'hidden',
+          pointerEvents: isTerminalLayerVisible ? 'auto' : 'none',
+          zIndex: isTerminalLayerVisible ? 10 : 0,
+        }}
       >
         <div className={cn("flex-1 flex min-h-0 relative", sidePanelPosition === 'right' && "flex-row-reverse")}>
         {/* Side panel with tab header + content (SFTP / Scripts / Theme) */}
@@ -1812,7 +1818,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
             const style: React.CSSProperties = { ...layoutStyle };
 
             if (!isVisible) {
-              style.display = 'none';
+              style.visibility = 'hidden';
+              style.pointerEvents = 'none';
+              // Use absolute offscreen position instead of display:none to preserve
+              // xterm canvas state in memory and avoid full re-render on tab switch.
+              style.left = '-9999px';
+              style.top = '-9999px';
             }
 
             // Check if this pane is the focused one in the workspace
@@ -1834,7 +1845,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
                   "absolute bg-background",
                   inActiveWorkspace && "workspace-pane",
                   isVisible && "z-10",
-                  // Focus indicator is handled by CSS .workspace-pane::after dimming overlay
+                  // Focus indicator is handled by CSS .workspace-pane:not(:focus-within)
                 )}
                 style={style}
                 tabIndex={-1}

--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -148,8 +148,8 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
     border: `1px solid ${popupBorder}`,
     borderRadius: "6px",
     boxShadow: expandUpward
-      ? "0 -4px 12px rgba(0, 0, 0, 0.4)"
-      : "0 4px 12px rgba(0, 0, 0, 0.4)",
+      ? "0 -2px 6px rgba(0, 0, 0, 0.15)"
+      : "0 2px 6px rgba(0, 0, 0, 0.15)",
     fontFamily: "inherit",
     fontSize: "13px",
     color: textColor,

--- a/index.css
+++ b/index.css
@@ -328,13 +328,9 @@ body {
   overflow: visible;
 }
 
-/* Dim terminal text in unfocused workspace panes by reducing canvas opacity */
-.workspace-pane .xterm-screen {
-  transition: opacity 150ms ease;
-}
-
+/* Dim terminal text in unfocused workspace panes */
 .workspace-pane:not(:focus-within) .xterm-screen {
-  opacity: 0.7;
+  opacity: 0.65;
 }
 
 /* ── Streamdown code block overrides ── */


### PR DESCRIPTION
## Summary
- preserve hidden terminal panes with `visibility: hidden` so tab switches avoid expensive xterm remounts
- restore terminal focus more reliably when switching back into split workspaces, while replacing the focused-pane ring with subtler text dimming
- reduce unnecessary `TerminalLayer` and terminal rerenders by stabilizing derived session host objects, callback props, and memo boundaries
- speed up UI theme switching by consolidating settings consumers through shared contexts, batching UI theme variable updates into a single style block, and isolating the main workspace content behind a memoized boundary

## Validation
- [x] Reviewed the performance changes for business-logic regressions with multiple parallel agents
- [x] `npx eslint App.tsx application/state/useSettingsState.ts application/state/SettingsContext.tsx components/SftpView.tsx components/HostDetailsPanel.tsx components/SettingsPage.tsx components/settings/tabs/SettingsFileAssociationsTab.tsx`
- [x] `npm run build`

## Manual test plan
- [ ] Open a workspace with 2+ split panes and switch focus between panes
- [ ] Switch between terminal tabs repeatedly and confirm the cached terminal state is preserved
- [ ] Toggle the app theme from the top bar and verify the shell, Vault, SFTP, and settings windows update without obvious stutter
- [ ] Open Host Details, SFTP view, and Settings > File Associations while switching themes to confirm no settings regressions
- [ ] Verify focused panes remain crisp while unfocused panes are subtly dimmed
