### PR TITLE
feat: enable Unicode 11 for improved Nerd Fonts rendering

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1,6 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal as XTerm } from "@xterm/xterm";
@@ -352,6 +353,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
   });
   term.loadAddon(webLinksAddon);
+
+  // Enable Unicode 11 for better Nerd Fonts / Powerline / CJK character width handling
+  term.loadAddon(new Unicode11Addon());
+  term.unicode.activeVersion = '11';
 
   logRenderer();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.15.0",
         "@xterm/addon-serialize": "^0.13.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
@@ -6708,6 +6709,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",
     "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",


### PR DESCRIPTION
## Summary

- Add `@xterm/addon-unicode11` and activate Unicode 11 character width tables
- Improves rendering of Nerd Fonts glyphs, Powerline symbols, and CJK characters
- Matches the approach used by [tabby terminal](https://github.com/Eugeny/tabby)

## Changes

- Install `@xterm/addon-unicode11` dependency
- Load the addon and set `term.unicode.activeVersion = '11'` in `createXTermRuntime.ts`

## Notes

关于链接点击行为：项目已支持 `linkModifier` 设置（Settings → Terminal），可配置为 `ctrl` / `alt` / `meta` 修饰键点击打开链接，默认为直接点击。

Closes #543

## Test plan

- [x] Connect to a remote server with starship prompt and Nerd Font
- [x] Verify Powerline/Nerd Font icons render with correct width
- [x] Verify CJK characters still display correctly
- [x] Verify terminal link clicking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)