### PR TITLE
fix: sort directory symlinks with directories in SFTP file list

### DIFF
--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -274,9 +274,12 @@ export const sortSftpEntries = (
     if (!entries.length) return entries;
 
     const sorted = [...entries].sort((a, b) => {
+        const aIsDir = isNavigableDirectory(a);
+        const bIsDir = isNavigableDirectory(b);
+
         if (sortField !== 'type') {
-            if (a.type === 'directory' && b.type !== 'directory') return -1;
-            if (a.type !== 'directory' && b.type === 'directory') return 1;
+            if (aIsDir && !bIsDir) return -1;
+            if (!aIsDir && bIsDir) return 1;
         }
 
         let cmp = 0;
@@ -291,14 +294,12 @@ export const sortSftpEntries = (
                 cmp = (a.lastModified || 0) - (b.lastModified || 0);
                 break;
             case 'type': {
-                const extA =
-                    a.type === 'directory'
-                        ? 'folder'
-                        : a.name.split('.').pop()?.toLowerCase() || '';
-                const extB =
-                    b.type === 'directory'
-                        ? 'folder'
-                        : b.name.split('.').pop()?.toLowerCase() || '';
+                const extA = aIsDir
+                    ? 'folder'
+                    : a.name.split('.').pop()?.toLowerCase() || '';
+                const extB = bIsDir
+                    ? 'folder'
+                    : b.name.split('.').pop()?.toLowerCase() || '';
                 cmp = extA.localeCompare(extB);
                 break;
             }


### PR DESCRIPTION
## Summary
- Symlinks pointing to directories (DirLinks) are now sorted alongside real directories instead of being mixed with regular files
- Reuses the existing `isNavigableDirectory()` helper for consistency

Closes #549

## Test plan
- [x] Connect to an SFTP server that has symlinks pointing to directories
- [x] Verify directory symlinks appear grouped with directories, not with files
- [x] Verify sorting by name/size/modified/type all correctly treat directory symlinks as directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)