### PR TITLE
fix: widen host edit panel and prevent content overflow

### DIFF
--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -625,6 +625,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
     <AsidePanel
       open={true}
       onClose={onCancel}
+      width="w-[420px]"
       title={
         initialData ? t("hostDetails.title.details") : t("hostDetails.title.new")
       }

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -101,8 +101,8 @@ export const AsidePanelContent: React.FC<{ children: ReactNode; className?: stri
     className,
 }) => {
     return (
-        <ScrollArea className={cn("flex-1", className)}>
-            <div className="p-4 space-y-4 overflow-hidden">
+        <ScrollArea className={cn("flex-1 min-w-0", className)}>
+            <div className="p-4 space-y-4 min-w-0 overflow-x-hidden">
                 {children}
             </div>
         </ScrollArea>
@@ -218,7 +218,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     return (
         <AsidePanelContext.Provider value={{ push, pop, replace, clear, canGoBack, currentItem }}>
             <div className={cn(
-                "absolute right-0 top-0 bottom-0 border-l border-border/60 bg-background z-30 flex flex-col app-no-drag",
+                "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag",
                 width,
                 className
             )}>
@@ -253,7 +253,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
 
     return (
         <div className={cn(
-            "absolute right-0 top-0 bottom-0 border-l border-border/60 bg-background z-30 flex flex-col app-no-drag",
+            "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag",
             width,
             className
         )}>


### PR DESCRIPTION
## Summary
- Increase host edit panel width from 380px to 420px for more content room
- Add `max-w-full` to all AsidePanel variants so panels never exceed parent width
- Fix inner content overflow handling with `min-w-0` and `overflow-x-hidden`

Closes #551

## Test plan
- [x] Open host edit panel — verify it's slightly wider and content is not clipped
- [x] Resize window to be narrower than 420px — panel should shrink to fit
- [x] Verify all content blocks (proxy, env vars, distro, etc.) display correctly without horizontal overflow
- [x] Verify other AsidePanel users (port forwarding) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)