### PR TITLE
fix: dismiss autocomplete popup on click outside

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1963,6 +1963,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
                 containerRef={containerRef}
                 onRequestReposition={autocomplete.repositionPopup}
                 searchBarOffset={isSearchOpen ? 64 : 30}
+                onDismiss={autocompleteClosePopup}
               />,
               document.body,
             )

--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -48,6 +48,8 @@ interface AutocompletePopupProps {
   onRequestReposition?: () => void;
   /** Offset from top of container to terminal content area (toolbar + search bar) */
   searchBarOffset?: number;
+  /** Called when user clicks outside the popup to dismiss it */
+  onDismiss?: () => void;
 }
 
 const SOURCE_LABELS: Record<SuggestionSource, { label: string; fullLabel: string; fallbackColor: string }> = {
@@ -105,7 +107,9 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   containerRef,
   onRequestReposition,
   searchBarOffset: _searchBarOffset = 30,
+  onDismiss,
 }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLDivElement>(null);
   const [hoveredIndex, setHoveredIndex] = useState(-1);
@@ -147,6 +151,18 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
       window.removeEventListener("resize", requestReposition);
     };
   }, [containerRef, onRequestReposition, visible]);
+
+  // Dismiss popup when clicking outside
+  useEffect(() => {
+    if (!visible || !onDismiss) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        onDismiss();
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [visible, onDismiss]);
 
   if (!visible || suggestions.length === 0) return null;
 
@@ -217,6 +233,7 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
 
   return (
     <div
+      ref={wrapperRef}
       style={{
         position: "fixed",
         left: `${clampedLeft}px`,


### PR DESCRIPTION
## Summary
- Fix autocomplete popup not dismissing when clicking outside of it
- Add `pointerdown` event listener to `AutocompletePopup` to automatically close the popup when clicking outside

Closes #572

## Test plan
- [x] Open a terminal session, type a partial command to trigger the history suggestion popup
- [x] Click on a blank area outside the popup and verify it dismisses
- [x] Click on an item inside the popup and verify it selects normally instead of closing
- [x] Verify keyboard interactions (Escape, Tab, Enter) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)