### PR TITLE
fix: resolve tool call duplication and ordering in chat UI

### DIFF
--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -240,28 +240,32 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({ messages, isStreaming
 
                 {/* Pending tool calls from the *last* assistant message are rendered
                     after all tool-result messages (see below) for chronological order.
-                    Unresolved tool calls from earlier messages or cancelled/failed
-                    messages are shown inline as interrupted. */}
-                {message !== lastAssistantMessage && message.toolCalls?.filter((tc) =>
+                    Unresolved tool calls from earlier or cancelled messages are shown
+                    inline — as interrupted, or with approval controls if still pending. */}
+                {(message !== lastAssistantMessage || message.executionStatus === 'cancelled') && message.toolCalls?.filter((tc) =>
                   !resolvedToolCallIds.has(tc.id),
-                ).map((tc) => (
-                  <ToolCall
-                    key={tc.id}
-                    name={tc.name}
-                    args={tc.arguments}
-                    isInterrupted
-                  />
-                ))}
-                {message === lastAssistantMessage && message.executionStatus === 'cancelled' && message.toolCalls?.filter((tc) =>
-                  !resolvedToolCallIds.has(tc.id),
-                ).map((tc) => (
-                  <ToolCall
-                    key={tc.id}
-                    name={tc.name}
-                    args={tc.arguments}
-                    isInterrupted
-                  />
-                ))}
+                ).map((tc) => {
+                  const isPending = pendingApprovals.has(tc.id);
+                  const resolved = resolvedApprovals.get(tc.id);
+                  const approvalStatus = isPending
+                    ? 'pending' as const
+                    : resolved === true
+                      ? 'approved' as const
+                      : resolved === false
+                        ? 'denied' as const
+                        : undefined;
+                  return (
+                    <ToolCall
+                      key={tc.id}
+                      name={tc.name}
+                      args={tc.arguments}
+                      isInterrupted={!isPending}
+                      approvalStatus={approvalStatus}
+                      onApprove={() => handleApprove(tc.id)}
+                      onReject={() => handleReject(tc.id)}
+                    />
+                  );
+                })}
 
                 {/* Status text with shimmer */}
                 {message.statusText && (


### PR DESCRIPTION
## Summary
- Fix tool calls appearing duplicated (both spinning and completed simultaneously) when Catty Agent executes multiple commands
- Fix pending tool calls appearing above completed ones instead of at the bottom in chronological order

## Root Cause
Tool calls were rendered in two places:
1. In the assistant message's `toolCalls` array (showing as spinning)
2. In separate `tool` role messages with results (showing as completed)

This caused the same tool call to appear twice. Additionally, since the assistant message renders before tool-result messages, new pending tool calls appeared at the top.

## Fix
- Completed tool calls: rendered only from tool-result messages (in order)
- Pending tool calls: rendered after all tool-result messages (at the bottom)
- Cancelled tool calls without results: shown inline in the assistant message

## Test plan
- [ ] Send a prompt that triggers multiple tool calls (e.g. "install sub2api on this server")
- [ ] Verify each tool call appears only once
- [ ] Verify pending (spinning) tool calls appear below completed ones
- [ ] Verify cancelled tool calls still show as interrupted
- [ ] Verify tool call approval flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)