### PR TITLE
fix: honor keepaliveInterval=0 as disabled instead of falling back to 10s

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -411,9 +411,9 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
         username: jump.username || 'root',
         readyTimeout: 120000, // 2 minutes to allow for keyboard-interactive (2FA/MFA)
         // Use user-configured keepalive interval from options (in seconds -> convert to ms)
-        // If 0 or not provided, use 10000ms as default
-        keepaliveInterval: options.keepaliveInterval && options.keepaliveInterval > 0 ? options.keepaliveInterval * 1000 : 10000,
-        keepaliveCountMax: 3,
+        // 0 = disabled (no keepalive packets sent)
+        keepaliveInterval: options.keepaliveInterval > 0 ? options.keepaliveInterval * 1000 : 0,
+        keepaliveCountMax: options.keepaliveInterval > 0 ? 3 : 0,
         // Enable keyboard-interactive authentication (required for 2FA/MFA)
         tryKeyboard: true,
         algorithms: buildAlgorithms(options.legacyAlgorithms),
@@ -681,9 +681,9 @@ async function startSSHSession(event, options) {
       // `readyTimeout` covers the entire connection + authentication flow in ssh2.
       readyTimeout: 20000, // Fast failure for non-interactive auth
       // Use user-configured keepalive interval (in seconds -> convert to ms)
-      // If 0 or not provided, use 10000ms as default
-      keepaliveInterval: options.keepaliveInterval && options.keepaliveInterval > 0 ? options.keepaliveInterval * 1000 : 10000,
-      keepaliveCountMax: 3,
+      // 0 = disabled (no keepalive packets sent)
+      keepaliveInterval: options.keepaliveInterval > 0 ? options.keepaliveInterval * 1000 : 0,
+      keepaliveCountMax: options.keepaliveInterval > 0 ? 3 : 0,
       // Enable keyboard-interactive authentication (required for 2FA/MFA)
       tryKeyboard: true,
       algorithms: buildAlgorithms(options.legacyAlgorithms),


### PR DESCRIPTION
## Summary

- Fix SSH keepalive setting where `keepaliveInterval=0` (default, documented as "disabled") was silently falling back to 10 seconds instead of being truly disabled
- This caused connections to NOKIA/ALCATEL and other devices with non-OpenSSH SSH implementations to drop after ~40 seconds, as ssh2's `keepalive@openssh.com` global requests went unanswered and the client-side liveness check terminated the connection

## Root Cause

```javascript
// Before: 0 is falsy, falls back to 10000ms — keepalive is always active
keepaliveInterval: options.keepaliveInterval && options.keepaliveInterval > 0
  ? options.keepaliveInterval * 1000 : 10000

// After: 0 means disabled, non-zero converts seconds → ms
keepaliveInterval: options.keepaliveInterval > 0
  ? options.keepaliveInterval * 1000 : 0
```

The ssh2 library's keepalive sends `SSH_MSG_GLOBAL_REQUEST "keepalive@openssh.com"` with `want_reply=1`. Per the SSH spec, servers should reply with `SSH_MSG_REQUEST_FAILURE` for unknown requests, but some network equipment SSH implementations silently ignore it. After `keepaliveCountMax` (3) unanswered pings at 10s intervals, ssh2 kills the connection — matching the ~35s timeout reported in #581.

## Test plan

- [x] Connect to a standard OpenSSH server with default settings (keepaliveInterval=0) — verify connection stays alive
- [x] Connect to NOKIA/ALCATEL or similar network equipment — verify connection no longer drops after ~35s
- [x] Set keepaliveInterval to a non-zero value (e.g. 15) — verify keepalive packets are sent and connection remains stable
- [x] Test jump host connections with keepaliveInterval=0 — verify no regression

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)