### PR TITLE
feat: show transport error in disconnect dialog

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -172,7 +172,7 @@ const attachSessionToTerminal = (
   term: XTerm,
   id: string,
   opts?: {
-    onExitMessage?: (evt: { exitCode?: number; signal?: number }) => string;
+    onExitMessage?: (evt: { exitCode?: number; signal?: number; error?: string; reason?: string }) => string;
     onConnected?: () => void;
     // For serial: convert lone LF to CRLF to avoid "staircase effect"
     convertLfToCrlf?: boolean;
@@ -209,6 +209,9 @@ const attachSessionToTerminal = (
 
   ctx.disposeExitRef.current = ctx.terminalBackend.onSessionExit(id, (evt) => {
     ctx.updateStatus("disconnected");
+    if (evt.error) {
+      ctx.setError(evt.error);
+    }
     term.writeln(opts?.onExitMessage?.(evt) ?? "\r\n[session closed]");
 
     if (ctx.onTerminalDataCapture && ctx.serializeAddonRef.current) {


### PR DESCRIPTION
## Summary

- Surface `evt.error` from session exit events (e.g. "Keepalive timeout", "ECONNRESET") in the disconnect dialog, instead of showing a generic "Disconnected" label
- Also widens the `onExitMessage` callback type to include `error` and `reason` fields

Follow-up to #582 — now when keepalive timeout (or any transport error) causes a disconnect, the user sees exactly what happened.

## Test plan

- [x] Connect to a server, kill the network → verify the disconnect dialog shows the actual error instead of just "Disconnected"
- [x] Normal `exit` in shell → verify tab auto-closes as before (no regression)
- [x] Reconnect after error → verify error state is cleared on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)