### PR TITLE
fix: deduplicate font list in terminal settings dropdown

### DIFF
--- a/application/state/fontStore.ts
+++ b/application/state/fontStore.ts
@@ -68,8 +68,14 @@ class FontStore {
       // Add default fonts first
       TERMINAL_FONTS.forEach(font => fontMap.set(font.id, font));
 
-      // Add local fonts with a distinct ID namespace to avoid collisions
+      // Build a set of built-in font family names for dedup (case-insensitive)
+      const builtinFamilyNames = new Set(
+        TERMINAL_FONTS.map(f => f.name.toLowerCase())
+      );
+
+      // Add local fonts, skipping those already covered by built-in fonts
       localFonts.forEach(font => {
+        if (builtinFamilyNames.has(font.name.toLowerCase())) return;
         const localId = font.id.startsWith('local-') ? font.id : `local-${font.id}`;
         fontMap.set(localId, { ...font, id: localId });
       });

--- a/lib/localFonts.ts
+++ b/lib/localFonts.ts
@@ -104,11 +104,12 @@ export async function getMonospaceFonts(): Promise<TerminalFont[]> {
         // Filter monospace fonts using robust word boundary matching
         const monoFonts = fonts.filter(f => isMonospaceFont(f.family));
 
-        // Deduplicate by family name (API may return multiple entries per family)
+        // Deduplicate by family name, case-insensitive (API may return multiple entries per family)
         const uniqueFamilies = new Set<string>();
         const dedupedFonts = monoFonts.filter(f => {
-            if (uniqueFamilies.has(f.family)) return false;
-            uniqueFamilies.add(f.family);
+            const key = f.family.toLowerCase();
+            if (uniqueFamilies.has(key)) return false;
+            uniqueFamilies.add(key);
             return true;
         });
 


### PR DESCRIPTION
## Summary

- Skip local fonts whose family name (case-insensitive) already exists in the built-in `TERMINAL_FONTS` list, preventing duplicates like both "Menlo" (built-in) and "local-Menlo" (system) appearing in the dropdown
- Make the within-local-fonts deduplication in `getMonospaceFonts()` case-insensitive to catch variants like "Menlo" vs "menlo"

Closes #586

## Test plan

- [x] Open terminal settings and verify the font dropdown has no duplicate entries
- [x] Confirm built-in fonts (Menlo, Monaco, Hack, etc.) appear exactly once
- [x] Confirm local-only fonts (not in the built-in list) still appear with `local-` prefix
- [x] Verify font selection still works correctly after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)