### PR TITLE
feat: local shell selection with auto-discovery

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,6 +36,7 @@ import { KeyboardInteractiveModal, KeyboardInteractiveRequest } from './componen
 import { PassphraseModal, PassphraseRequest } from './components/PassphraseModal';
 import { cn } from './lib/utils';
 import { classifyLocalShellType } from './lib/localShell';
+import { useDiscoveredShells, resolveShellSetting } from './lib/useDiscoveredShells';
 import { ConnectionLog, Host, HostProtocol, SerialConfig, TerminalSession, TerminalTheme } from './types';
 import { LogView as LogViewType } from './application/state/useSessionState';
 import type { SftpView as SftpViewComponent } from './components/SftpView';
@@ -203,6 +204,8 @@ function App({ settings }: { settings: SettingsState }) {
     reapplyCurrentTheme,
     workspaceFocusStyle,
   } = settings;
+
+  const discoveredShells = useDiscoveredShells();
 
   // Sync workspace focus indicator style to DOM for CSS targeting
   useEffect(() => {
@@ -830,22 +833,27 @@ function App({ settings }: { settings: SettingsState }) {
   addConnectionLogRef.current = addConnectionLog;
 
   const createLocalTerminalWithCurrentShell = useCallback(() => {
+    const resolved = resolveShellSetting(terminalSettings.localShell, discoveredShells);
     return createLocalTerminal({
-      shellType: classifyLocalShellType(terminalSettings.localShell, navigator.userAgent),
+      shellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
+      shell: resolved?.command,
+      shellArgs: resolved?.args,
     });
-  }, [createLocalTerminal, terminalSettings.localShell]);
+  }, [createLocalTerminal, terminalSettings.localShell, discoveredShells]);
 
   const splitSessionWithCurrentShell = useCallback((sessionId: string, direction: 'horizontal' | 'vertical') => {
+    const resolved = resolveShellSetting(terminalSettings.localShell, discoveredShells);
     return splitSession(sessionId, direction, {
-      localShellType: classifyLocalShellType(terminalSettings.localShell, navigator.userAgent),
+      localShellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
     });
-  }, [splitSession, terminalSettings.localShell]);
+  }, [splitSession, terminalSettings.localShell, discoveredShells]);
 
   const copySessionWithCurrentShell = useCallback((sessionId: string) => {
+    const resolved = resolveShellSetting(terminalSettings.localShell, discoveredShells);
     return copySession(sessionId, {
-      localShellType: classifyLocalShellType(terminalSettings.localShell, navigator.userAgent),
+      localShellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
     });
-  }, [copySession, terminalSettings.localShell]);
+  }, [copySession, terminalSettings.localShell, discoveredShells]);
 
   const closeTabKeyStr = useMemo(() => {
     if (hotkeyScheme === 'disabled') return null;
@@ -1093,10 +1101,11 @@ function App({ settings }: { settings: SettingsState }) {
   // Wrapper to create local terminal with logging
   const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[] }) => {
     const { username, hostname } = systemInfoRef.current;
+    const resolved = shell ?? resolveShellSetting(terminalSettings.localShell, discoveredShells);
     const sessionId = createLocalTerminal({
-      shellType: classifyLocalShellType(shell?.command || terminalSettings.localShell, navigator.userAgent),
-      shell: shell?.command,
-      shellArgs: shell?.args,
+      shellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
+      shell: resolved?.command,
+      shellArgs: resolved?.args,
     });
     addConnectionLog({
       sessionId,
@@ -1110,7 +1119,7 @@ function App({ settings }: { settings: SettingsState }) {
       localHostname: hostname,
       saved: false,
     });
-  }, [addConnectionLog, createLocalTerminal, terminalSettings.localShell]);
+  }, [addConnectionLog, createLocalTerminal, terminalSettings.localShell, discoveredShells]);
 
   const resolveEffectiveHost = useCallback((host: Host): Host => {
     if (!host.group) return host;

--- a/App.tsx
+++ b/App.tsx
@@ -1099,18 +1099,22 @@ function App({ settings }: { settings: SettingsState }) {
   }, []);
 
   // Wrapper to create local terminal with logging
-  const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[] }) => {
+  const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[]; name?: string; icon?: string }) => {
     const { username, hostname } = systemInfoRef.current;
     const resolved = shell ?? resolveShellSetting(terminalSettings.localShell, discoveredShells);
+    const shellName = shell?.name ?? (resolved ? discoveredShells.find(s => s.command === resolved.command)?.name : undefined);
+    const shellIcon = shell?.icon ?? (resolved ? discoveredShells.find(s => s.command === resolved.command)?.icon : undefined);
     const sessionId = createLocalTerminal({
       shellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
       shell: resolved?.command,
       shellArgs: resolved?.args,
+      shellName,
+      shellIcon,
     });
     addConnectionLog({
       sessionId,
       hostId: '',
-      hostLabel: 'Local Terminal',
+      hostLabel: shellName || 'Local Terminal',
       hostname: 'localhost',
       username: username,
       protocol: 'local',

--- a/App.tsx
+++ b/App.tsx
@@ -834,10 +834,13 @@ function App({ settings }: { settings: SettingsState }) {
 
   const createLocalTerminalWithCurrentShell = useCallback(() => {
     const resolved = resolveShellSetting(terminalSettings.localShell, discoveredShells);
+    const matchedShell = discoveredShells.find(s => s.id === terminalSettings.localShell);
     return createLocalTerminal({
       shellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
       shell: resolved?.command,
       shellArgs: resolved?.args,
+      shellName: matchedShell?.name,
+      shellIcon: matchedShell?.icon,
     });
   }, [createLocalTerminal, terminalSettings.localShell, discoveredShells]);
 
@@ -1102,8 +1105,10 @@ function App({ settings }: { settings: SettingsState }) {
   const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[]; name?: string; icon?: string }) => {
     const { username, hostname } = systemInfoRef.current;
     const resolved = shell ?? resolveShellSetting(terminalSettings.localShell, discoveredShells);
-    const shellName = shell?.name ?? (resolved ? discoveredShells.find(s => s.command === resolved.command)?.name : undefined);
-    const shellIcon = shell?.icon ?? (resolved ? discoveredShells.find(s => s.command === resolved.command)?.icon : undefined);
+    // Match by ID (not command) to avoid WSL distros all sharing wsl.exe
+    const matchedShell = !shell ? discoveredShells.find(s => s.id === terminalSettings.localShell) : undefined;
+    const shellName = shell?.name ?? matchedShell?.name;
+    const shellIcon = shell?.icon ?? matchedShell?.icon;
     const sessionId = createLocalTerminal({
       shellType: classifyLocalShellType(resolved?.command || terminalSettings.localShell, navigator.userAgent),
       shell: resolved?.command,

--- a/App.tsx
+++ b/App.tsx
@@ -1091,9 +1091,13 @@ function App({ settings }: { settings: SettingsState }) {
   }, []);
 
   // Wrapper to create local terminal with logging
-  const handleCreateLocalTerminal = useCallback(() => {
+  const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[] }) => {
     const { username, hostname } = systemInfoRef.current;
-    const sessionId = createLocalTerminalWithCurrentShell();
+    const sessionId = createLocalTerminal({
+      shellType: classifyLocalShellType(shell?.command || terminalSettings.localShell, navigator.userAgent),
+      shell: shell?.command,
+      shellArgs: shell?.args,
+    });
     addConnectionLog({
       sessionId,
       hostId: '',
@@ -1106,7 +1110,7 @@ function App({ settings }: { settings: SettingsState }) {
       localHostname: hostname,
       saved: false,
     });
-  }, [addConnectionLog, createLocalTerminalWithCurrentShell]);
+  }, [addConnectionLog, createLocalTerminal, terminalSettings.localShell]);
 
   const resolveEffectiveHost = useCallback((host: Host): Host => {
     if (!host.group) return host;
@@ -1513,8 +1517,8 @@ function App({ settings }: { settings: SettingsState }) {
               setIsQuickSwitcherOpen(false);
               setQuickSearch('');
             }}
-            onCreateLocalTerminal={() => {
-              handleCreateLocalTerminal();
+            onCreateLocalTerminal={(shell) => {
+              handleCreateLocalTerminal(shell);
               setIsQuickSwitcherOpen(false);
               setQuickSearch('');
             }}

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -343,6 +343,8 @@ const en: Messages = {
   'settings.terminal.localShell.shell.detected': 'Detected',
   'settings.terminal.localShell.shell.notFound': 'Shell executable not found',
   'settings.terminal.localShell.shell.isDirectory': 'Path is a directory, not an executable',
+  'settings.terminal.localShell.shell.default': 'System Default',
+  'settings.terminal.localShell.shell.custom': 'Custom...',
   'settings.terminal.localShell.startDir': 'Starting directory',
   'settings.terminal.localShell.startDir.desc': 'Directory to start in when opening a local terminal. Leave empty for home directory.',
   'settings.terminal.localShell.startDir.placeholder': 'Home directory',

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -911,6 +911,8 @@ const en: Messages = {
   'qs.search.placeholder': 'Search hosts or tabs',
   'qs.jumpTo': 'Jump To',
   'qs.localTerminal': 'Local Terminal',
+  'qs.localShells': 'Local Shells',
+  'qs.default': 'Default',
 
   // Select Host panel
   'selectHost.title': 'Select Host',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1323,6 +1323,8 @@ const zhCN: Messages = {
   'settings.terminal.localShell.shell.detected': '检测到',
   'settings.terminal.localShell.shell.notFound': '未找到 Shell 可执行文件',
   'settings.terminal.localShell.shell.isDirectory': '路径是目录，不是可执行文件',
+  'settings.terminal.localShell.shell.default': '系统默认',
+  'settings.terminal.localShell.shell.custom': '自定义...',
   'settings.terminal.localShell.startDir': '起始目录',
   'settings.terminal.localShell.startDir.desc': '打开本地终端时的起始目录。留空使用用户主目录。',
   'settings.terminal.localShell.startDir.placeholder': '用户主目录',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -563,6 +563,8 @@ const zhCN: Messages = {
   'qs.search.placeholder': '搜索主机或标签页',
   'qs.jumpTo': '跳转到',
   'qs.localTerminal': '本地终端',
+  'qs.localShells': '本地 Shell',
+  'qs.default': '默认',
 
   // Select Host panel
   'selectHost.title': '选择主机',

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -42,13 +42,15 @@ export const useSessionState = () => {
     shellType?: TerminalSession['shellType'];
     shell?: string;
     shellArgs?: string[];
+    shellName?: string;
+    shellIcon?: string;
   }) => {
     const sessionId = crypto.randomUUID();
     const localHostId = `local-${sessionId}`;
     const newSession: TerminalSession = {
       id: sessionId,
       hostId: localHostId,
-      hostLabel: 'Local Terminal',
+      hostLabel: options?.shellName || 'Local Terminal',
       hostname: 'localhost',
       username: 'local',
       status: 'connecting',
@@ -56,6 +58,8 @@ export const useSessionState = () => {
       shellType: options?.shellType,
       localShell: options?.shell,
       localShellArgs: options?.shellArgs,
+      localShellName: options?.shellName,
+      localShellIcon: options?.shellIcon,
     };
     setSessions(prev => [...prev, newSession]);
     setActiveTabId(sessionId);
@@ -457,6 +461,8 @@ export const useSessionState = () => {
           charset: session.charset,
           localShell: session.localShell,
           localShellArgs: session.localShellArgs,
+          localShellName: session.localShellName,
+          localShellIcon: session.localShellIcon,
         };
 
         // Add pane to existing workspace
@@ -491,6 +497,8 @@ export const useSessionState = () => {
         charset: session.charset,
         localShell: session.localShell,
         localShellArgs: session.localShellArgs,
+        localShellName: session.localShellName,
+        localShellIcon: session.localShellIcon,
       };
 
       const hint: SplitHint = {
@@ -669,6 +677,8 @@ export const useSessionState = () => {
         serialConfig: session.serialConfig,
         localShell: session.localShell,
         localShellArgs: session.localShellArgs,
+        localShellName: session.localShellName,
+        localShellIcon: session.localShellIcon,
       };
 
       setActiveTabId(newSession.id);

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -455,6 +455,8 @@ export const useSessionState = () => {
           moshEnabled: session.moshEnabled,
           shellType: nextShellType,
           charset: session.charset,
+          localShell: session.localShell,
+          localShellArgs: session.localShellArgs,
         };
 
         // Add pane to existing workspace
@@ -487,6 +489,8 @@ export const useSessionState = () => {
         moshEnabled: session.moshEnabled,
         shellType: nextShellType,
         charset: session.charset,
+        localShell: session.localShell,
+        localShellArgs: session.localShellArgs,
       };
 
       const hint: SplitHint = {
@@ -663,6 +667,8 @@ export const useSessionState = () => {
         shellType: nextShellType,
         charset: session.charset,
         serialConfig: session.serialConfig,
+        localShell: session.localShell,
+        localShellArgs: session.localShellArgs,
       };
 
       setActiveTabId(newSession.id);

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -40,6 +40,8 @@ export const useSessionState = () => {
 
   const createLocalTerminal = useCallback((options?: {
     shellType?: TerminalSession['shellType'];
+    shell?: string;
+    shellArgs?: string[];
   }) => {
     const sessionId = crypto.randomUUID();
     const localHostId = `local-${sessionId}`;
@@ -52,6 +54,8 @@ export const useSessionState = () => {
       status: 'connecting',
       protocol: 'local',
       shellType: options?.shellType,
+      localShell: options?.shell,
+      localShellArgs: options?.shellArgs,
     };
     setSessions(prev => [...prev, newSession]);
     setActiveTabId(sessionId);

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -67,7 +67,7 @@ interface QuickSwitcherProps {
   onSelect: (host: Host) => void;
   onSelectTab: (tabId: string) => void;
   onClose: () => void;
-  onCreateLocalTerminal?: (shell?: { command: string; args?: string[] }) => void;
+  onCreateLocalTerminal?: (shell?: { command: string; args?: string[]; name?: string; icon?: string }) => void;
   // onCreateWorkspace removed - feature not currently used
   keyBindings?: KeyBinding[];
 }
@@ -234,7 +234,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
       case "shell": {
         const shell = discoveredShells.find(s => s.id === item.id);
         if (shell && onCreateLocalTerminal) {
-          onCreateLocalTerminal({ command: shell.command, args: shell.args });
+          onCreateLocalTerminal({ command: shell.command, args: shell.args, name: shell.name, icon: shell.icon });
           onClose();
         }
         break;
@@ -418,7 +418,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       }`}
                       onClick={() => {
                         if (onCreateLocalTerminal) {
-                          onCreateLocalTerminal({ command: shell.command, args: shell.args });
+                          onCreateLocalTerminal({ command: shell.command, args: shell.args, name: shell.name, icon: shell.icon });
                           onClose();
                         }
                       }}

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -10,7 +10,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "
 import { useI18n } from "../application/i18n/I18nProvider";
 import { Host, TerminalSession, Workspace } from "../types";
 import { KeyBinding } from "../domain/models";
-import { useDiscoveredShells, getShellIconPath } from "../lib/useDiscoveredShells";
+import { useDiscoveredShells, getShellIconPath, isMonochromeShellIcon } from "../lib/useDiscoveredShells";
 
 type QuickSwitcherItem = {
   type: "host" | "tab" | "workspace" | "action" | "shell";
@@ -428,7 +428,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                         <img
                           src={getShellIconPath(shell.icon)}
                           alt={shell.name}
-                          className="h-5 w-5"
+                          className={`h-5 w-5${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
                         />
                       </div>
                       <span className="text-sm font-medium">{shell.name}</span>

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -3,16 +3,16 @@ import {
   LayoutGrid,
   Search,
   FolderLock,
-  Terminal,
   TerminalSquare,
 } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { Host, TerminalSession, Workspace } from "../types";
 import { KeyBinding } from "../domain/models";
+import { useDiscoveredShells, getShellIconPath } from "../lib/useDiscoveredShells";
 
 type QuickSwitcherItem = {
-  type: "host" | "tab" | "workspace" | "action";
+  type: "host" | "tab" | "workspace" | "action" | "shell";
   id: string;
   data?: Host | TerminalSession | Workspace;
 };
@@ -66,7 +66,7 @@ interface QuickSwitcherProps {
   onSelect: (host: Host) => void;
   onSelectTab: (tabId: string) => void;
   onClose: () => void;
-  onCreateLocalTerminal?: () => void;
+  onCreateLocalTerminal?: (shell?: { command: string; args?: string[] }) => void;
   // onCreateWorkspace removed - feature not currently used
   keyBindings?: KeyBinding[];
 }
@@ -85,6 +85,16 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   keyBindings,
 }) => {
   const { t } = useI18n();
+  const discoveredShells = useDiscoveredShells();
+
+  const filteredShells = useMemo(() => {
+    if (!query.trim()) return discoveredShells;
+    const q = query.toLowerCase();
+    return discoveredShells.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q)
+    );
+  }, [discoveredShells, query]);
+
   // Get hotkey display strings
   const getHotkeyLabel = useCallback((actionId: string) => {
     const binding = keyBindings?.find(k => k.id === actionId);
@@ -155,8 +165,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
       workspaces.forEach((w) =>
         items.push({ type: "workspace", id: w.id, data: w }),
       );
-      // Quick connect actions
-      items.push({ type: "action", id: "local-terminal" });
+      // Local shells
+      filteredShells.forEach((shell) =>
+        items.push({ type: "shell", id: shell.id }),
+      );
     } else {
       // Recent connections only
       results.forEach((host) =>
@@ -171,7 +183,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     });
 
     return { flatItems: items, itemIndexMap: indexMap };
-  }, [showCategorized, results, orphanSessions, workspaces]);
+  }, [showCategorized, results, orphanSessions, workspaces, filteredShells]);
 
   // O(1) index lookup
   const getItemIndex = useCallback((type: string, id: string) => {
@@ -210,6 +222,14 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
           onClose();
         }
         break;
+      case "shell": {
+        const shell = discoveredShells.find(s => s.id === item.id);
+        if (shell && onCreateLocalTerminal) {
+          onCreateLocalTerminal({ command: shell.command, args: shell.args });
+          onClose();
+        }
+        break;
+      }
     }
   };
 
@@ -369,38 +389,49 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
               })}
             </div>
 
-            {/* Quick connect section */}
-            <div>
-              <div className="px-4 py-1.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Quick connect
-                </span>
-              </div>
-
-              {/* Local Terminal */}
-              {onCreateLocalTerminal && (
-                <div
-                  className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${getItemIndex("action", "local-terminal") === selectedIndex
-                    ? "bg-primary/15"
-                    : "hover:bg-muted/50"
-                    }`}
-                  onClick={() => {
-                    onCreateLocalTerminal();
-                    onClose();
-                  }}
-                  onMouseEnter={() =>
-                    setSelectedIndex(getItemIndex("action", "local-terminal"))
-                  }
-                >
-                  <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
-                    <Terminal size={16} />
-                  </div>
-                  <span className="text-sm font-medium">{t("qs.localTerminal")}</span>
+            {/* Local Shells section */}
+            {filteredShells.length > 0 && (
+              <div>
+                <div className="px-4 py-1.5">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t("qs.localShells")}
+                  </span>
                 </div>
-              )}
-
-              {/* Serial removed (not supported) */}
-            </div>
+                {filteredShells.map((shell) => {
+                  const idx = getItemIndex("shell", shell.id);
+                  const isSelected = idx === selectedIndex;
+                  return (
+                    <div
+                      key={shell.id}
+                      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
+                        isSelected ? "bg-primary/15" : "hover:bg-muted/50"
+                      }`}
+                      onClick={() => {
+                        if (onCreateLocalTerminal) {
+                          onCreateLocalTerminal({ command: shell.command, args: shell.args });
+                          onClose();
+                        }
+                      }}
+                      onMouseEnter={() => setSelectedIndex(idx)}
+                    >
+                      <div className="h-6 w-6 rounded flex items-center justify-center">
+                        <img
+                          src={getShellIconPath(shell.icon)}
+                          alt={shell.name}
+                          className="h-5 w-5"
+                        />
+                      </div>
+                      <span className="text-sm font-medium">{shell.name}</span>
+                      {shell.isDefault && (
+                        <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                          {t("qs.default")}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </ScrollArea>
       </div>

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -424,13 +424,11 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                       }}
                       onMouseEnter={() => setSelectedIndex(idx)}
                     >
-                      <div className="h-6 w-6 rounded flex items-center justify-center">
-                        <img
-                          src={getShellIconPath(shell.icon)}
-                          alt={shell.name}
-                          className={`h-5 w-5${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
-                        />
-                      </div>
+                      <img
+                        src={getShellIconPath(shell.icon)}
+                        alt={shell.name}
+                        className={`h-6 w-6 shrink-0${isMonochromeShellIcon(shell.icon) ? " dark:invert" : ""}`}
+                      />
                       <span className="text-sm font-medium">{shell.name}</span>
                       {shell.isDefault && (
                         <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -3,6 +3,7 @@ import {
   LayoutGrid,
   Search,
   FolderLock,
+  Terminal,
   TerminalSquare,
 } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -165,10 +166,14 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
       workspaces.forEach((w) =>
         items.push({ type: "workspace", id: w.id, data: w }),
       );
-      // Local shells
-      filteredShells.forEach((shell) =>
-        items.push({ type: "shell", id: shell.id }),
-      );
+      // Local shells (or fallback action if discovery not ready)
+      if (filteredShells.length > 0) {
+        filteredShells.forEach((shell) =>
+          items.push({ type: "shell", id: shell.id }),
+        );
+      } else {
+        items.push({ type: "action", id: "local-terminal" });
+      }
     } else {
       // Recent connections only
       results.forEach((host) =>
@@ -394,7 +399,8 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
             </div>
 
             {/* Local Shells section */}
-            {filteredShells.length > 0 && (
+            {/* Local Shells or fallback Local Terminal */}
+            {filteredShells.length > 0 ? (
               <div>
                 <div className="px-4 py-1.5">
                   <span className="text-xs font-medium text-muted-foreground">
@@ -434,6 +440,33 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                     </div>
                   );
                 })}
+              </div>
+            ) : onCreateLocalTerminal && (
+              <div>
+                <div className="px-4 py-1.5">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {t("qs.localShells")}
+                  </span>
+                </div>
+                <div
+                  className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
+                    getItemIndex("action", "local-terminal") === selectedIndex
+                      ? "bg-primary/15"
+                      : "hover:bg-muted/50"
+                  }`}
+                  onClick={() => {
+                    onCreateLocalTerminal();
+                    onClose();
+                  }}
+                  onMouseEnter={() =>
+                    setSelectedIndex(getItemIndex("action", "local-terminal"))
+                  }
+                >
+                  <div className="h-6 w-6 rounded flex items-center justify-center text-muted-foreground">
+                    <Terminal size={16} />
+                  </div>
+                  <span className="text-sm font-medium">{t("qs.localTerminal")}</span>
+                </div>
               </div>
             )}
           </div>

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -174,6 +174,10 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
       results.forEach((host) =>
         items.push({ type: "host", id: host.id, data: host }),
       );
+      // Also include matching shells in search results
+      filteredShells.forEach((shell) =>
+        items.push({ type: "shell", id: shell.id }),
+      );
     }
 
     // Build index map for O(1) lookup

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -815,6 +815,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
           charset: session.charset,
           localShell: session.localShell,
           localShellArgs: session.localShellArgs,
+          localShellName: session.localShellName,
+          localShellIcon: session.localShellIcon,
         });
       }
     }

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -813,6 +813,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
           protocol: session.protocol ?? 'local' as const,
           moshEnabled: session.moshEnabled,
           charset: session.charset,
+          localShell: session.localShell,
+          localShellArgs: session.localShellArgs,
         });
       }
     }

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -10,7 +10,7 @@ import { getEffectiveHostDistro } from '../domain/host';
 import { cn } from '../lib/utils';
 import { Host, TerminalSession, Workspace } from '../types';
 import { DISTRO_LOGOS, DISTRO_COLORS } from './DistroAvatar';
-import { getShellIconPath } from '../lib/useDiscoveredShells';
+import { getShellIconPath, isMonochromeShellIcon } from '../lib/useDiscoveredShells';
 import { Button } from './ui/button';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from './ui/context-menu';
 import { SyncStatusButton } from './SyncStatusButton';
@@ -79,7 +79,7 @@ const SessionTabIcon: React.FC<{ host: Host | undefined; isActive: boolean; prot
           <img
             src={getShellIconPath(iconId)}
             alt={iconId}
-            className={cn(iconSize, "object-contain")}
+            className={cn(iconSize, "object-contain", isMonochromeShellIcon(iconId) && "dark:invert")}
           />
         </div>
       );

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -10,6 +10,7 @@ import { getEffectiveHostDistro } from '../domain/host';
 import { cn } from '../lib/utils';
 import { Host, TerminalSession, Workspace } from '../types';
 import { DISTRO_LOGOS, DISTRO_COLORS } from './DistroAvatar';
+import { getShellIconPath } from '../lib/useDiscoveredShells';
 import { Button } from './ui/button';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from './ui/context-menu';
 import { SyncStatusButton } from './SyncStatusButton';
@@ -54,7 +55,7 @@ const localOsId = (() => {
 })();
 
 // Lightweight OS/distro icon for session tabs — matches DistroAvatar "sm" style
-const SessionTabIcon: React.FC<{ host: Host | undefined; isActive: boolean; protocol?: string }> = memo(({ host, isActive, protocol }) => {
+const SessionTabIcon: React.FC<{ host: Host | undefined; isActive: boolean; protocol?: string; shellIcon?: string }> = memo(({ host, isActive, protocol, shellIcon }) => {
   const boxBase = "shrink-0 h-4 w-4 rounded flex items-center justify-center";
   const iconSize = "h-2.5 w-2.5";
   const fallbackStyle = { color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' };
@@ -68,8 +69,21 @@ const SessionTabIcon: React.FC<{ host: Host | undefined; isActive: boolean; prot
     );
   }
 
-  // Local protocol → OS-specific icon (protocol may be undefined for local sessions)
+  // Local protocol → shell-specific icon if available, else OS-specific icon
   if (protocol === 'local' || host?.protocol === 'local' || (!protocol && !host)) {
+    // Use shell icon from discovery when available
+    const iconId = shellIcon || host?.localShellIcon;
+    if (iconId) {
+      return (
+        <div className={boxBase} style={{ backgroundColor: 'color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 15%, transparent)' }}>
+          <img
+            src={getShellIconPath(iconId)}
+            alt={iconId}
+            className={cn(iconSize, "object-contain")}
+          />
+        </div>
+      );
+    }
     const logo = DISTRO_LOGOS[localOsId];
     const bg = DISTRO_COLORS[localOsId] || DISTRO_COLORS.default;
     if (logo) {
@@ -540,7 +554,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                   />
                 )}
                 <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <SessionTabIcon host={hostMap.get(session.hostId)} isActive={activeTabId === session.id} protocol={session.protocol} />
+                  <SessionTabIcon host={hostMap.get(session.hostId)} isActive={activeTabId === session.id} protocol={session.protocol} shellIcon={session.localShellIcon} />
                   <span className="truncate">{session.hostLabel}</span>
                   <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
                 </div>

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -75,13 +75,11 @@ const SessionTabIcon: React.FC<{ host: Host | undefined; isActive: boolean; prot
     const iconId = shellIcon || host?.localShellIcon;
     if (iconId) {
       return (
-        <div className={boxBase} style={{ backgroundColor: 'color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 15%, transparent)' }}>
-          <img
-            src={getShellIconPath(iconId)}
-            alt={iconId}
-            className={cn(iconSize, "object-contain", isMonochromeShellIcon(iconId) && "dark:invert")}
-          />
-        </div>
+        <img
+          src={getShellIconPath(iconId)}
+          alt={iconId}
+          className={cn("shrink-0 h-4 w-4 object-contain", isMonochromeShellIcon(iconId) && "dark:invert")}
+        />
       );
     }
     const logo = DISTRO_LOGOS[localOsId];

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -936,7 +936,7 @@ export default function SettingsTerminalTab(props: {
                 {t("settings.terminal.localShell.shell.default")}
                 {defaultShell ? ` (${defaultShell.split(/[/\\]/).pop()})` : ""}
               </option>
-              {discoveredShells.filter(s => !s.isDefault).map((shell) => (
+              {discoveredShells.map((shell) => (
                 <option key={shell.id} value={shell.id}>
                   {shell.name}
                 </option>

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -934,7 +934,7 @@ export default function SettingsTerminalTab(props: {
             >
               <option value="">
                 {t("settings.terminal.localShell.shell.default")}
-                {defaultShell ? ` (${defaultShell.split(/[\/\\]/).pop()})` : ""}
+                {defaultShell ? ` (${defaultShell.split(/[/\\]/).pop()})` : ""}
               </option>
               {discoveredShells.filter(s => !s.isDefault).map((shell) => (
                 <option key={shell.id} value={shell.id}>

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -14,6 +14,7 @@ import { TERMINAL_THEMES } from "../../../infrastructure/config/terminalThemes";
 import { customThemeStore, useCustomThemes } from "../../../application/state/customThemeStore";
 import { parseItermcolors } from "../../../infrastructure/parsers/itermcolorsParser";
 import { cn } from "../../../lib/utils";
+import { useDiscoveredShells } from "../../../lib/useDiscoveredShells";
 import { Button } from "../../ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../ui/dialog";
 import { Input } from "../../ui/input";
@@ -294,6 +295,18 @@ export default function SettingsTerminalTab(props: {
   const [defaultShell, setDefaultShell] = useState<string>("");
   const [shellValidation, setShellValidation] = useState<{ valid: boolean; message?: string } | null>(null);
   const [dirValidation, setDirValidation] = useState<{ valid: boolean; message?: string } | null>(null);
+
+  const discoveredShells = useDiscoveredShells();
+  const [showCustomShellInput, setShowCustomShellInput] = useState(() => {
+    if (!terminalSettings.localShell) return false;
+    return !discoveredShells.some(s => s.command === terminalSettings.localShell);
+  });
+
+  // Update showCustomShellInput once discovered shells load
+  useEffect(() => {
+    if (!terminalSettings.localShell) return;
+    setShowCustomShellInput(!discoveredShells.some(s => s.command === terminalSettings.localShell));
+  }, [discoveredShells]);
   const [themeModalOpen, setThemeModalOpen] = useState(false);
 
   // Subscribe to custom theme changes so editing in-place triggers re-render
@@ -896,16 +909,46 @@ export default function SettingsTerminalTab(props: {
           description={t("settings.terminal.localShell.shell.desc")}
         >
           <div className="flex flex-col gap-1 items-end">
-            <Input
-              value={terminalSettings.localShell}
-              placeholder={t("settings.terminal.localShell.shell.placeholder")}
-              onChange={(e) => updateTerminalSetting("localShell", e.target.value)}
-              className={cn(
-                "w-48",
-                shellValidation && !shellValidation.valid && "border-destructive focus-visible:ring-destructive"
-              )}
-            />
-            {defaultShell && !terminalSettings.localShell && (
+            <select
+              className="h-9 w-48 rounded-md border border-input bg-background px-3 text-sm"
+              value={
+                showCustomShellInput
+                  ? "__custom__"
+                  : terminalSettings.localShell || ""
+              }
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === "__custom__") {
+                  setShowCustomShellInput(true);
+                } else {
+                  setShowCustomShellInput(false);
+                  updateTerminalSetting("localShell", value);
+                }
+              }}
+            >
+              <option value="">
+                {t("settings.terminal.localShell.shell.default")}
+                {defaultShell ? ` (${defaultShell.split(/[\/\\]/).pop()})` : ""}
+              </option>
+              {discoveredShells.filter(s => !s.isDefault).map((shell) => (
+                <option key={shell.id} value={shell.command}>
+                  {shell.name}
+                </option>
+              ))}
+              <option value="__custom__">{t("settings.terminal.localShell.shell.custom")}</option>
+            </select>
+            {showCustomShellInput && (
+              <Input
+                value={terminalSettings.localShell}
+                placeholder={t("settings.terminal.localShell.shell.placeholder")}
+                onChange={(e) => updateTerminalSetting("localShell", e.target.value)}
+                className={cn(
+                  "w-48",
+                  shellValidation && !shellValidation.valid && "border-destructive focus-visible:ring-destructive"
+                )}
+              />
+            )}
+            {!showCustomShellInput && defaultShell && !terminalSettings.localShell && (
               <span className="text-xs text-muted-foreground">
                 {t("settings.terminal.localShell.shell.detected")}: {defaultShell}
               </span>

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -299,13 +299,13 @@ export default function SettingsTerminalTab(props: {
   const discoveredShells = useDiscoveredShells();
   const [showCustomShellInput, setShowCustomShellInput] = useState(() => {
     if (!terminalSettings.localShell) return false;
-    return !discoveredShells.some(s => s.command === terminalSettings.localShell);
+    return !discoveredShells.some(s => s.id === terminalSettings.localShell);
   });
 
   // Update showCustomShellInput once discovered shells load
   useEffect(() => {
     if (!terminalSettings.localShell) return;
-    setShowCustomShellInput(!discoveredShells.some(s => s.command === terminalSettings.localShell));
+    setShowCustomShellInput(!discoveredShells.some(s => s.id === terminalSettings.localShell));
   }, [discoveredShells]);
   const [themeModalOpen, setThemeModalOpen] = useState(false);
 
@@ -411,12 +411,18 @@ export default function SettingsTerminalTab(props: {
     }
   }, []);
 
-  // Validate shell path when it changes
+  // Validate shell path when it changes (only for custom paths, not discovered shell ids)
   useEffect(() => {
     const bridge = (window as unknown as { netcatty?: NetcattyBridge }).netcatty;
     const shellPath = terminalSettings.localShell;
 
     if (!shellPath) {
+      setShellValidation(null);
+      return;
+    }
+
+    // Skip validation for discovered shell ids — only validate custom paths
+    if (discoveredShells.some(s => s.id === shellPath)) {
       setShellValidation(null);
       return;
     }
@@ -441,7 +447,7 @@ export default function SettingsTerminalTab(props: {
     }, 300);
 
     return () => clearTimeout(timeoutId);
-  }, [terminalSettings.localShell, t]);
+  }, [terminalSettings.localShell, discoveredShells, t]);
 
   // Validate directory path when it changes
   useEffect(() => {
@@ -931,7 +937,7 @@ export default function SettingsTerminalTab(props: {
                 {defaultShell ? ` (${defaultShell.split(/[\/\\]/).pop()})` : ""}
               </option>
               {discoveredShells.filter(s => !s.isDefault).map((shell) => (
-                <option key={shell.id} value={shell.command}>
+                <option key={shell.id} value={shell.id}>
                   {shell.name}
                 </option>
               ))}

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -306,7 +306,7 @@ export default function SettingsTerminalTab(props: {
   useEffect(() => {
     if (!terminalSettings.localShell) return;
     setShowCustomShellInput(!discoveredShells.some(s => s.id === terminalSettings.localShell));
-  }, [discoveredShells]);
+  }, [discoveredShells, terminalSettings.localShell]);
   const [themeModalOpen, setThemeModalOpen] = useState(false);
 
   // Subscribe to custom theme changes so editing in-place triggers re-render

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -764,18 +764,21 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
 
     try {
-      // Per-session shell from discovery takes priority over global setting
+      // Per-session shell (from QuickSwitcher discovery or split/copy) takes priority.
+      // The global terminalSettings.localShell may contain a shell ID (e.g., "wsl-ubuntu")
+      // which was already resolved to command+args and stored on the session object by App.tsx.
+      // Only pass shell/shellArgs when we have concrete per-session values;
+      // otherwise omit them so the backend uses its own default shell detection.
       const sessionShell = ctx.host.localShell;
       const sessionShellArgs = ctx.host.localShellArgs;
-      const localShell = sessionShell || ctx.terminalSettings?.localShell;
       const localStartDir = ctx.terminalSettings?.localStartDir;
 
       const id = await ctx.terminalBackend.startLocalSession({
         sessionId: ctx.sessionId,
         cols: term.cols,
         rows: term.rows,
-        shell: localShell,
-        shellArgs: sessionShellArgs,
+        shell: sessionShell || undefined,
+        shellArgs: sessionShellArgs || undefined,
         cwd: localStartDir,
         env: {
           TERM: ctx.terminalSettings?.terminalEmulationType ?? "xterm-256color",

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -764,8 +764,10 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
 
     try {
-      // Get local shell configuration from terminal settings
-      const localShell = ctx.terminalSettings?.localShell;
+      // Per-session shell from discovery takes priority over global setting
+      const sessionShell = ctx.host.localShell;
+      const sessionShellArgs = ctx.host.localShellArgs;
+      const localShell = sessionShell || ctx.terminalSettings?.localShell;
       const localStartDir = ctx.terminalSettings?.localStartDir;
 
       const id = await ctx.terminalBackend.startLocalSession({
@@ -773,6 +775,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         cols: term.cols,
         rows: term.rows,
         shell: localShell,
+        shellArgs: sessionShellArgs,
         cwd: localStartDir,
         env: {
           TERM: ctx.terminalSettings?.terminalEmulationType ?? "xterm-256color",

--- a/docs/superpowers/plans/2026-04-02-local-shell-selection.md
+++ b/docs/superpowers/plans/2026-04-02-local-shell-selection.md
@@ -1,0 +1,1075 @@
+# Local Shell Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to select from auto-discovered local shells (CMD, PowerShell, WSL, Git Bash, Cygwin, zsh, bash, fish, etc.) in the QuickSwitcher and Settings.
+
+**Architecture:** New `shellDiscovery.cjs` module in Electron main process detects available shells per platform using `reg query` (Windows) and `/etc/shells` (Unix). Results exposed via IPC, consumed by QuickSwitcher (new "Local Shells" section) and Settings (dropdown replacing text input). Shell SVG icons stored in `public/shells/`.
+
+**Tech Stack:** Electron IPC, node child_process (`reg query`, `where.exe`), React, Radix UI Select, SVG icons
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `electron/bridges/shellDiscovery.cjs` | Platform-specific shell detection + IPC handler registration |
+| `public/shells/*.svg` | Colorful SVG icons for each shell type (~12 files) |
+| `lib/useDiscoveredShells.ts` | React hook: calls IPC once, caches result, returns `DiscoveredShell[]` |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `global.d.ts` | Add `DiscoveredShell` type + `discoverShells` bridge method |
+| `electron/preload.cjs` | Expose `netcatty:shells:discover` IPC |
+| `electron/bridges/terminalBridge.cjs` | Accept `shellArgs` in `startLocalSession` payload |
+| `components/QuickSwitcher.tsx` | Add "Local Shells" section with icons, replace single "Local Terminal" action |
+| `components/settings/tabs/SettingsTerminalTab.tsx` | Replace text input with shell dropdown + "Custom" fallback |
+| `application/state/useSessionState.ts` | Extend `createLocalTerminal` to accept shell command/args |
+| `App.tsx` | Pass shell info through `handleCreateLocalTerminal` |
+| `application/i18n/locales/en.ts` | Add i18n strings |
+| `application/i18n/locales/zh-CN.ts` | Add i18n strings |
+
+---
+
+## Task 1: Type definitions and IPC bridge wiring
+
+**Files:**
+- Modify: `global.d.ts:179` (near `startLocalSession`)
+- Modify: `electron/preload.cjs` (near other IPC expose calls)
+
+- [ ] **Step 1: Add DiscoveredShell type and bridge method to global.d.ts**
+
+In `global.d.ts`, add the `DiscoveredShell` interface near the top-level types, and add `discoverShells` to the `NetcattyBridge` interface:
+
+```typescript
+interface DiscoveredShell {
+  id: string;
+  name: string;
+  command: string;
+  args?: string[];
+  icon: string;
+  isDefault?: boolean;
+}
+```
+
+Add to `NetcattyBridge`:
+```typescript
+discoverShells?(): Promise<DiscoveredShell[]>;
+```
+
+Also update `startLocalSession` signature to accept `shellArgs`:
+```typescript
+startLocalSession?(options: {
+  sessionId?: string;
+  cols?: number;
+  rows?: number;
+  shell?: string;
+  shellArgs?: string[];  // ← ADD THIS
+  cwd?: string;
+  env?: Record<string, string>;
+  sessionLog?: { enabled: boolean; directory: string; format: string };
+}): Promise<string>;
+```
+
+- [ ] **Step 2: Expose IPC in preload.cjs**
+
+Find where other IPC methods are exposed in `electron/preload.cjs` (search for `getDefaultShell`). Add nearby:
+
+```javascript
+discoverShells: () => ipcRenderer.invoke("netcatty:shells:discover"),
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add global.d.ts electron/preload.cjs
+git commit -m "feat(shell-selection): add DiscoveredShell type and IPC bridge wiring"
+```
+
+---
+
+## Task 2: Shell discovery backend — Windows detection
+
+**Files:**
+- Create: `electron/bridges/shellDiscovery.cjs`
+
+- [ ] **Step 1: Create shellDiscovery.cjs with Windows shell detection**
+
+```javascript
+// electron/bridges/shellDiscovery.cjs
+"use strict";
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+let cachedShells = null;
+
+/**
+ * Query a Windows registry key and return its values as an object.
+ * Returns null if the key doesn't exist.
+ */
+function regQuery(keyPath) {
+  try {
+    const output = execFileSync("reg", ["query", keyPath], {
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    return output;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Query a specific value from a Windows registry key.
+ * Returns the value string or null.
+ */
+function regQueryValue(keyPath, valueName) {
+  try {
+    const output = execFileSync("reg", ["query", keyPath, "/v", valueName], {
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    // Parse "REG_SZ    value" pattern
+    const match = output.match(new RegExp(`${valueName}\\s+REG_\\w+\\s+(.+)`));
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enumerate registry subkeys under a given path.
+ * Returns array of full subkey paths.
+ */
+function regEnumSubkeys(keyPath) {
+  try {
+    const output = execFileSync("reg", ["query", keyPath], {
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    // Subkeys are lines that start with the keyPath prefix (full paths)
+    return output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("HKEY_") && line !== keyPath && line.startsWith(keyPath + "\\"));
+  } catch {
+    return [];
+  }
+}
+
+function findExecutableOnPath(name) {
+  try {
+    const result = execFileSync("where.exe", [name], {
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    const candidates = result
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    for (const c of candidates) {
+      if (fs.existsSync(c)) return c;
+    }
+  } catch {
+    // not found
+  }
+  return null;
+}
+
+function discoverWindowsShells() {
+  const shells = [];
+
+  // --- CMD ---
+  const comspec = process.env.ComSpec || "cmd.exe";
+  shells.push({
+    id: "cmd",
+    name: "CMD",
+    command: comspec,
+    args: [],
+    icon: "cmd",
+  });
+
+  // --- PowerShell 5.1 (Windows built-in) ---
+  const ps51 =
+    findExecutableOnPath("powershell") ||
+    path.join(
+      process.env.SystemRoot || "C:\\Windows",
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe"
+    );
+  if (fs.existsSync(ps51)) {
+    shells.push({
+      id: "powershell",
+      name: "Windows PowerShell",
+      command: ps51,
+      args: ["-NoLogo"],
+      icon: "powershell",
+    });
+  }
+
+  // --- PowerShell Core (pwsh 7+) ---
+  let pwsh = findExecutableOnPath("pwsh");
+  if (!pwsh) {
+    const regPath = regQueryValue(
+      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\pwsh.exe",
+      ""
+    );
+    if (regPath && fs.existsSync(regPath)) pwsh = regPath;
+  }
+  if (!pwsh) {
+    const defaultPath = path.join(
+      process.env.ProgramFiles || "C:\\Program Files",
+      "PowerShell",
+      "7",
+      "pwsh.exe"
+    );
+    if (fs.existsSync(defaultPath)) pwsh = defaultPath;
+  }
+  if (pwsh && fs.existsSync(pwsh)) {
+    shells.push({
+      id: "pwsh",
+      name: "PowerShell 7",
+      command: pwsh,
+      args: ["-NoLogo"],
+      icon: "pwsh",
+    });
+  }
+
+  // --- WSL distributions ---
+  const lxssPath = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
+  const wslExe =
+    path.join(process.env.SystemRoot || "C:\\Windows", "System32", "wsl.exe");
+  
+  if (fs.existsSync(wslExe)) {
+    const subkeys = regEnumSubkeys(lxssPath);
+    for (const subkey of subkeys) {
+      const distroName = regQueryValue(subkey, "DistributionName");
+      if (!distroName) continue;
+
+      const slug = distroName.toLowerCase().replace(/[^a-z0-9]/g, "-");
+      shells.push({
+        id: `wsl-${slug}`,
+        name: `${distroName} (WSL)`,
+        command: wslExe,
+        args: ["-d", distroName],
+        icon: mapWslDistroIcon(distroName),
+      });
+    }
+  }
+
+  // --- Git Bash ---
+  let gitInstallPath =
+    regQueryValue("HKLM\\Software\\GitForWindows", "InstallPath") ||
+    regQueryValue("HKCU\\Software\\GitForWindows", "InstallPath");
+  if (!gitInstallPath) {
+    // Fallback: check common path
+    const defaultGitPath = path.join(
+      process.env.ProgramFiles || "C:\\Program Files",
+      "Git"
+    );
+    if (fs.existsSync(path.join(defaultGitPath, "bin", "bash.exe"))) {
+      gitInstallPath = defaultGitPath;
+    }
+  }
+  if (gitInstallPath) {
+    const gitBash = path.join(gitInstallPath, "bin", "bash.exe");
+    if (fs.existsSync(gitBash)) {
+      shells.push({
+        id: "git-bash",
+        name: "Git Bash",
+        command: gitBash,
+        args: ["--login", "-i"],
+        icon: "git-bash",
+      });
+    }
+  }
+
+  // --- Cygwin ---
+  const cygwin64Root = regQueryValue(
+    "HKLM\\Software\\Cygwin\\setup",
+    "rootdir"
+  );
+  const cygwin32Root = regQueryValue(
+    "HKLM\\Software\\WOW6432Node\\Cygwin\\setup",
+    "rootdir"
+  );
+  const cygwinRoot = cygwin64Root || cygwin32Root;
+  if (cygwinRoot) {
+    const cygwinBash = path.join(cygwinRoot, "bin", "bash.exe");
+    if (fs.existsSync(cygwinBash)) {
+      shells.push({
+        id: "cygwin",
+        name: "Cygwin",
+        command: cygwinBash,
+        args: ["--login", "-i"],
+        icon: "cygwin",
+      });
+    }
+  }
+
+  // Mark default: prefer pwsh > powershell > cmd
+  const defaultId = shells.find((s) => s.id === "pwsh")
+    ? "pwsh"
+    : shells.find((s) => s.id === "powershell")
+      ? "powershell"
+      : "cmd";
+  const defaultShell = shells.find((s) => s.id === defaultId);
+  if (defaultShell) defaultShell.isDefault = true;
+
+  return shells;
+}
+
+/** Map WSL distro names to icon identifiers. Falls back to generic linux. */
+function mapWslDistroIcon(distroName) {
+  const lower = distroName.toLowerCase();
+  if (lower.includes("ubuntu")) return "ubuntu";
+  if (lower.includes("debian")) return "debian";
+  if (lower.includes("kali")) return "kali";
+  if (lower.includes("alpine")) return "alpine";
+  if (lower.includes("opensuse") || lower.includes("suse")) return "opensuse";
+  if (lower.includes("fedora")) return "fedora";
+  if (lower.includes("arch")) return "arch";
+  if (lower.includes("oracle")) return "oracle";
+  return "linux";
+}
+
+module.exports = { discoverWindowsShells, regQuery, regQueryValue, regEnumSubkeys, findExecutableOnPath, mapWslDistroIcon };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add electron/bridges/shellDiscovery.cjs
+git commit -m "feat(shell-selection): add Windows shell discovery (CMD, PowerShell, WSL, Git Bash, Cygwin)"
+```
+
+---
+
+## Task 3: Shell discovery backend — Unix detection + IPC registration
+
+**Files:**
+- Modify: `electron/bridges/shellDiscovery.cjs`
+- Modify: `electron/bridges/terminalBridge.cjs` (or wherever IPC handlers are registered)
+
+- [ ] **Step 1: Add Unix shell detection and main discover function**
+
+Append to `shellDiscovery.cjs`:
+
+```javascript
+function discoverUnixShells() {
+  const shells = [];
+  const defaultShellPath = process.env.SHELL || "/bin/bash";
+
+  // Read /etc/shells
+  let etcShells = [];
+  try {
+    const content = fs.readFileSync("/etc/shells", "utf8");
+    etcShells = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"));
+  } catch {
+    // /etc/shells not available, use fallback
+    etcShells = ["/bin/bash", "/bin/zsh", "/bin/sh"];
+    if (defaultShellPath && !etcShells.includes(defaultShellPath)) {
+      etcShells.unshift(defaultShellPath);
+    }
+  }
+
+  // Deduplicate and filter to shells that exist
+  const seen = new Set();
+  for (const shellPath of etcShells) {
+    if (seen.has(shellPath)) continue;
+    seen.add(shellPath);
+    if (!fs.existsSync(shellPath)) continue;
+
+    const basename = path.basename(shellPath);
+    const id = basename;
+    const name = mapUnixShellName(basename);
+    const icon = mapUnixShellIcon(basename);
+    const isDefault = shellPath === defaultShellPath;
+
+    shells.push({
+      id,
+      name,
+      command: shellPath,
+      args: isLoginShell(basename) ? ["-l"] : [],
+      icon,
+      isDefault,
+    });
+  }
+
+  // Ensure system default is in the list even if not in /etc/shells
+  if (defaultShellPath && !seen.has(defaultShellPath) && fs.existsSync(defaultShellPath)) {
+    const basename = path.basename(defaultShellPath);
+    shells.unshift({
+      id: basename,
+      name: mapUnixShellName(basename),
+      command: defaultShellPath,
+      args: isLoginShell(basename) ? ["-l"] : [],
+      icon: mapUnixShellIcon(basename),
+      isDefault: true,
+    });
+  }
+
+  return shells;
+}
+
+function mapUnixShellName(basename) {
+  const map = {
+    zsh: "Zsh",
+    bash: "Bash",
+    fish: "Fish",
+    sh: "sh",
+    ksh: "Ksh",
+    tcsh: "Tcsh",
+    csh: "Csh",
+    dash: "Dash",
+    nu: "Nushell",
+    pwsh: "PowerShell",
+  };
+  return map[basename] || basename;
+}
+
+function mapUnixShellIcon(basename) {
+  const map = {
+    zsh: "zsh",
+    bash: "bash",
+    fish: "fish",
+    sh: "terminal",
+    ksh: "terminal",
+    tcsh: "terminal",
+    csh: "terminal",
+    dash: "terminal",
+    nu: "nushell",
+    pwsh: "pwsh",
+  };
+  return map[basename] || "terminal";
+}
+
+function isLoginShell(basename) {
+  return ["bash", "zsh", "fish", "ksh", "sh"].includes(basename);
+}
+
+/**
+ * Main discovery function — platform-dispatched, cached.
+ */
+function discoverShells() {
+  if (cachedShells) return cachedShells;
+
+  if (process.platform === "win32") {
+    cachedShells = discoverWindowsShells();
+  } else {
+    cachedShells = discoverUnixShells();
+  }
+
+  return cachedShells;
+}
+```
+
+Update `module.exports` to include the new functions:
+```javascript
+module.exports = {
+  discoverShells,
+  discoverWindowsShells,
+  discoverUnixShells,
+  // ... keep existing exports
+};
+```
+
+- [ ] **Step 2: Register IPC handler**
+
+Find where IPC handlers are registered (search for `ipcMain.handle("netcatty:` in the main process bridge registration file — likely `terminalBridge.cjs` around line 1040 or the main bridge setup). Add:
+
+```javascript
+const { discoverShells } = require("./shellDiscovery.cjs");
+
+// Near other ipcMain.handle calls:
+ipcMain.handle("netcatty:shells:discover", () => discoverShells());
+```
+
+- [ ] **Step 3: Extend startLocalSession to accept shellArgs**
+
+In `terminalBridge.cjs`, function `startLocalSession` (line 250), change how `shell` and `shellArgs` are resolved:
+
+Current code (lines 254-256):
+```javascript
+const defaultShell = getDefaultLocalShell();
+const shell = normalizeExecutablePath(payload?.shell) || defaultShell;
+const shellArgs = getLocalShellArgs(shell);
+```
+
+Replace with:
+```javascript
+const defaultShell = getDefaultLocalShell();
+const shell = normalizeExecutablePath(payload?.shell) || defaultShell;
+// Use explicit shellArgs from payload if provided (from shell discovery),
+// otherwise auto-detect based on shell path
+const shellArgs = payload?.shellArgs ?? getLocalShellArgs(shell);
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add electron/bridges/shellDiscovery.cjs electron/bridges/terminalBridge.cjs
+git commit -m "feat(shell-selection): add Unix shell discovery, IPC registration, and shellArgs passthrough"
+```
+
+---
+
+## Task 4: Shell icons
+
+**Files:**
+- Create: `public/shells/cmd.svg`
+- Create: `public/shells/powershell.svg`
+- Create: `public/shells/pwsh.svg`
+- Create: `public/shells/git-bash.svg`
+- Create: `public/shells/cygwin.svg`
+- Create: `public/shells/bash.svg`
+- Create: `public/shells/zsh.svg`
+- Create: `public/shells/fish.svg`
+- Create: `public/shells/terminal.svg`
+- Create: `public/shells/nushell.svg`
+
+Note: WSL distro icons (ubuntu, debian, kali, alpine, opensuse, fedora, arch, oracle, linux) already exist in `public/distro/` — we will reuse those, not duplicate them.
+
+- [ ] **Step 1: Source and create shell SVG icons**
+
+Search the web for official/open-source SVG icons for each shell. Create colorful, 24x24 or 32x32 SVGs in `public/shells/`. Some sources:
+- **CMD**: Windows command prompt icon (simple `>_` prompt style, or the Windows Terminal icon)
+- **PowerShell**: Official PowerShell blue chevron logo from Microsoft (MIT licensed from the PowerShell repo)
+- **pwsh**: Same as PowerShell but with dark/black variant, or use the PowerShell 7 specific icon
+- **Git Bash**: Git logo (orange-red branching icon)
+- **Cygwin**: Cygwin logo (the black hat)
+- **Bash**: GNU Bash logo (dark shell icon)
+- **Zsh**: Zsh logo or a distinctive terminal icon
+- **Fish**: Fish shell logo (green fish)
+- **Terminal**: Generic terminal icon (for sh, ksh, tcsh, etc.)
+- **Nushell**: Nushell logo (green/teal)
+
+Each SVG should be self-contained (no external references), roughly square, and look good at 20-24px render size. Use `viewBox="0 0 24 24"` or `viewBox="0 0 32 32"`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add public/shells/
+git commit -m "feat(shell-selection): add colorful SVG icons for shell types"
+```
+
+---
+
+## Task 5: React hook for shell discovery
+
+**Files:**
+- Create: `lib/useDiscoveredShells.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+import { useEffect, useState } from "react";
+import { netcattyBridge } from "../infrastructure/services/netcattyBridge";
+
+interface DiscoveredShell {
+  id: string;
+  name: string;
+  command: string;
+  args?: string[];
+  icon: string;
+  isDefault?: boolean;
+}
+
+let shellCache: DiscoveredShell[] | null = null;
+let shellPromise: Promise<DiscoveredShell[]> | null = null;
+
+/**
+ * Returns the list of locally available shells.
+ * Calls the Electron backend once, caches for the session.
+ */
+export function useDiscoveredShells(): DiscoveredShell[] {
+  const [shells, setShells] = useState<DiscoveredShell[]>(shellCache ?? []);
+
+  useEffect(() => {
+    if (shellCache) {
+      setShells(shellCache);
+      return;
+    }
+
+    const bridge = netcattyBridge.get();
+    if (!bridge?.discoverShells) return;
+
+    if (!shellPromise) {
+      shellPromise = bridge.discoverShells();
+    }
+
+    shellPromise.then((result) => {
+      shellCache = result;
+      setShells(result);
+    }).catch((err) => {
+      console.warn("Failed to discover shells:", err);
+    });
+  }, []);
+
+  return shells;
+}
+
+/**
+ * Resolve the icon path for a shell.
+ * WSL distro icons come from public/distro/, others from public/shells/.
+ */
+export function getShellIconPath(iconId: string): string {
+  // WSL distros reuse existing distro icons
+  const distroIcons = new Set([
+    "ubuntu", "debian", "kali", "alpine", "opensuse",
+    "fedora", "arch", "oracle", "linux",
+  ]);
+  if (distroIcons.has(iconId)) {
+    return `/distro/${iconId}.svg`;
+  }
+  return `/shells/${iconId}.svg`;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/useDiscoveredShells.ts
+git commit -m "feat(shell-selection): add useDiscoveredShells hook with icon path resolver"
+```
+
+---
+
+## Task 6: QuickSwitcher — replace single Local Terminal with discovered shells
+
+**Files:**
+- Modify: `components/QuickSwitcher.tsx`
+
+- [ ] **Step 1: Update QuickSwitcherProps and imports**
+
+Add imports and update props:
+
+```typescript
+// Add to imports at top
+import { useDiscoveredShells, getShellIconPath } from "../lib/useDiscoveredShells";
+
+// Update QuickSwitcherItem type to include shell data:
+type QuickSwitcherItem = {
+  type: "host" | "tab" | "workspace" | "action" | "shell";
+  id: string;
+  data?: Host | TerminalSession | Workspace;
+};
+```
+
+Update `QuickSwitcherProps` — replace `onCreateLocalTerminal` with a more specific callback:
+
+```typescript
+interface QuickSwitcherProps {
+  isOpen: boolean;
+  query: string;
+  results: Host[];
+  sessions: TerminalSession[];
+  workspaces: Workspace[];
+  onQueryChange: (value: string) => void;
+  onSelect: (host: Host) => void;
+  onSelectTab: (tabId: string) => void;
+  onClose: () => void;
+  onCreateLocalTerminal?: (shell?: { command: string; args?: string[] }) => void;
+  keyBindings?: KeyBinding[];
+}
+```
+
+- [ ] **Step 2: Add shells to the flatItems list and render the "Local Shells" section**
+
+Inside `QuickSwitcherInner`, call the hook:
+
+```typescript
+const discoveredShells = useDiscoveredShells();
+```
+
+In the `flatItems` useMemo, replace the single `local-terminal` action with individual shell entries. Before the action items block, add:
+
+```typescript
+// Local shells
+discoveredShells.forEach((shell) =>
+  items.push({ type: "shell", id: shell.id }),
+);
+```
+
+Remove the old `items.push({ type: "action", id: "local-terminal" });` line.
+
+Add `discoveredShells` to the useMemo dependency array.
+
+Update `handleItemSelect` to handle the `"shell"` type:
+
+```typescript
+case "shell": {
+  const shell = discoveredShells.find(s => s.id === item.id);
+  if (shell && onCreateLocalTerminal) {
+    onCreateLocalTerminal({ command: shell.command, args: shell.args });
+    onClose();
+  }
+  break;
+}
+```
+
+- [ ] **Step 3: Render the "Local Shells" section in the JSX**
+
+Replace the "Quick connect" section (the `<div>` containing the `Local Terminal` action, around lines 372-403) with:
+
+```tsx
+{/* Local Shells section */}
+{discoveredShells.length > 0 && (
+  <div>
+    <div className="px-4 py-1.5">
+      <span className="text-xs font-medium text-muted-foreground">
+        {t("qs.localShells")}
+      </span>
+    </div>
+    {discoveredShells.map((shell) => {
+      const idx = getItemIndex("shell", shell.id);
+      const isSelected = idx === selectedIndex;
+      return (
+        <div
+          key={shell.id}
+          className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${
+            isSelected ? "bg-primary/15" : "hover:bg-muted/50"
+          }`}
+          onClick={() => {
+            if (onCreateLocalTerminal) {
+              onCreateLocalTerminal({ command: shell.command, args: shell.args });
+              onClose();
+            }
+          }}
+          onMouseEnter={() => setSelectedIndex(idx)}
+        >
+          <div className="h-6 w-6 rounded flex items-center justify-center">
+            <img
+              src={getShellIconPath(shell.icon)}
+              alt={shell.name}
+              className="h-5 w-5"
+            />
+          </div>
+          <span className="text-sm font-medium">{shell.name}</span>
+          {shell.isDefault && (
+            <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+              {t("qs.default")}
+            </span>
+          )}
+        </div>
+      );
+    })}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Make the search filter work for shells**
+
+Shells need to be filtered by search query. Wrap the `discoveredShells` with a filtered version:
+
+```typescript
+const filteredShells = useMemo(() => {
+  if (!query.trim()) return discoveredShells;
+  const q = query.toLowerCase();
+  return discoveredShells.filter(
+    (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q)
+  );
+}, [discoveredShells, query]);
+```
+
+Use `filteredShells` instead of `discoveredShells` in both the `flatItems` useMemo and the JSX render.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/QuickSwitcher.tsx
+git commit -m "feat(shell-selection): add discovered shells to QuickSwitcher with icons and search"
+```
+
+---
+
+## Task 7: Wire up App.tsx — pass shell info through to session creation
+
+**Files:**
+- Modify: `App.tsx`
+- Modify: `application/state/useSessionState.ts`
+
+- [ ] **Step 1: Update createLocalTerminal in useSessionState.ts**
+
+In `useSessionState.ts`, update `createLocalTerminal` (around line 41) to accept shell command/args:
+
+```typescript
+const createLocalTerminal = useCallback((options?: {
+  shellType?: TerminalSession['shellType'];
+  shell?: string;
+  shellArgs?: string[];
+}) => {
+  const sessionId = crypto.randomUUID();
+  const localHostId = `local-${sessionId}`;
+  const newSession: TerminalSession = {
+    id: sessionId,
+    hostId: localHostId,
+    hostLabel: 'Local Terminal',
+    hostname: 'localhost',
+    username: 'local',
+    status: 'connecting',
+    protocol: 'local',
+    shellType: options?.shellType,
+    localShell: options?.shell,       // Store for use in session starter
+    localShellArgs: options?.shellArgs,
+  };
+  setSessions(prev => [...prev, newSession]);
+```
+
+This requires adding `localShell` and `localShellArgs` to the `TerminalSession` type in `domain/models.ts` (or `types.ts`). Add these optional fields:
+
+```typescript
+// In TerminalSession interface
+localShell?: string;       // Shell command for local terminals
+localShellArgs?: string[]; // Shell args for local terminals
+```
+
+- [ ] **Step 2: Update App.tsx handleCreateLocalTerminal**
+
+Change `handleCreateLocalTerminal` to accept optional shell info:
+
+```typescript
+const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[] }) => {
+  const { username, hostname } = systemInfoRef.current;
+  const shellType = classifyLocalShellType(
+    shell?.command || terminalSettings.localShell,
+    navigator.userAgent
+  );
+  const sessionId = createLocalTerminal({
+    shellType,
+    shell: shell?.command,
+    shellArgs: shell?.args,
+  });
+  addConnectionLog({
+    sessionId,
+    hostId: '',
+    hostLabel: 'Local Terminal',
+    hostname: 'localhost',
+    username: username,
+    protocol: 'local',
+    startTime: Date.now(),
+```
+
+Update `createLocalTerminalWithCurrentShell` similarly:
+
+```typescript
+const createLocalTerminalWithCurrentShell = useCallback(() => {
+  return createLocalTerminal({
+    shellType: classifyLocalShellType(terminalSettings.localShell, navigator.userAgent),
+  });
+}, [createLocalTerminal, terminalSettings.localShell]);
+```
+
+Update the QuickSwitcher's `onCreateLocalTerminal` prop to pass the new callback:
+
+```tsx
+onCreateLocalTerminal={(shell) => {
+  handleCreateLocalTerminal(shell);
+  setIsQuickSwitcherOpen(false);
+  setQuickSearch('');
+}}
+```
+
+- [ ] **Step 3: Pass shell info to session starter**
+
+In `createTerminalSessionStarters.ts`, the `startLocal` function (line 750) currently reads `ctx.terminalSettings?.localShell`. It needs to also check for per-session shell override. Find where `startLocalSession` is called (line 771) and update:
+
+```typescript
+const id = await ctx.terminalBackend.startLocalSession({
+  sessionId: ctx.sessionId,
+  cols: term.cols,
+  rows: term.rows,
+  shell: /* per-session shell override */ || localShell,
+  shellArgs: /* per-session shellArgs */,
+  cwd: localStartDir,
+  env: {
+    TERM: ctx.terminalSettings?.terminalEmulationType ?? "xterm-256color",
+  },
+  sessionLog: ctx.sessionLog?.enabled ? ctx.sessionLog : undefined,
+});
+```
+
+The per-session shell/shellArgs come from the `TerminalSession` object. You need to thread these through the session starter context. The cleanest approach: read them from the host/session object that's available in `ctx`. Check where `ctx` is constructed in `Terminal.tsx` and add `localShell`/`localShellArgs` from the session.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add application/state/useSessionState.ts App.tsx components/terminal/runtime/createTerminalSessionStarters.ts domain/models.ts
+git commit -m "feat(shell-selection): wire shell selection through App → session state → session starter"
+```
+
+---
+
+## Task 8: Settings — replace text input with shell dropdown
+
+**Files:**
+- Modify: `components/settings/tabs/SettingsTerminalTab.tsx`
+
+- [ ] **Step 1: Import hook and update the Local Shell section**
+
+Add import:
+```typescript
+import { useDiscoveredShells, getShellIconPath } from "../../../lib/useDiscoveredShells";
+```
+
+Inside the component, call the hook:
+```typescript
+const discoveredShells = useDiscoveredShells();
+```
+
+Replace the current Input for `localShell` (lines 894-920) with a dropdown:
+
+```tsx
+<SettingRow
+  label={t("settings.terminal.localShell.shell")}
+  description={t("settings.terminal.localShell.shell.desc")}
+>
+  <div className="flex flex-col gap-1 items-end">
+    <select
+      className="h-9 w-48 rounded-md border border-input bg-background px-3 text-sm"
+      value={terminalSettings.localShell || ""}
+      onChange={(e) => {
+        const value = e.target.value;
+        if (value === "__custom__") {
+          // Switch to custom mode — keep current value but let user type
+          updateTerminalSetting("localShell", terminalSettings.localShell || "");
+          setShowCustomShellInput(true);
+        } else {
+          updateTerminalSetting("localShell", value);
+          setShowCustomShellInput(false);
+        }
+      }}
+    >
+      <option value="">{t("settings.terminal.localShell.shell.default")}{defaultShell ? ` (${path.basename(defaultShell)})` : ""}</option>
+      {discoveredShells.filter(s => !s.isDefault).map((shell) => (
+        <option key={shell.id} value={shell.command}>
+          {shell.name}
+        </option>
+      ))}
+      <option value="__custom__">{t("settings.terminal.localShell.shell.custom")}</option>
+    </select>
+    {showCustomShellInput && (
+      <Input
+        value={terminalSettings.localShell}
+        placeholder={t("settings.terminal.localShell.shell.placeholder")}
+        onChange={(e) => updateTerminalSetting("localShell", e.target.value)}
+        className={cn(
+          "w-48",
+          shellValidation && !shellValidation.valid && "border-destructive focus-visible:ring-destructive"
+        )}
+      />
+    )}
+    {shellValidation && !shellValidation.valid && shellValidation.message && (
+      <span className="text-xs text-destructive flex items-center gap-1">
+        <AlertCircle size={12} />
+        {shellValidation.message}
+      </span>
+    )}
+  </div>
+</SettingRow>
+```
+
+Add state for custom mode:
+```typescript
+const [showCustomShellInput, setShowCustomShellInput] = useState(() => {
+  // Show custom input if current value doesn't match any discovered shell
+  if (!terminalSettings.localShell) return false;
+  return !discoveredShells.some(s => s.command === terminalSettings.localShell);
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/settings/tabs/SettingsTerminalTab.tsx
+git commit -m "feat(shell-selection): replace shell text input with dropdown in Settings"
+```
+
+---
+
+## Task 9: i18n strings
+
+**Files:**
+- Modify: `application/i18n/locales/en.ts`
+- Modify: `application/i18n/locales/zh-CN.ts`
+
+- [ ] **Step 1: Add English strings**
+
+Search for `qs.localTerminal` in `en.ts` and add nearby:
+
+```typescript
+"qs.localShells": "Local Shells",
+"qs.default": "default",
+```
+
+Search for `settings.terminal.localShell.shell` and update:
+
+```typescript
+"settings.terminal.localShell.shell.default": "System Default",
+"settings.terminal.localShell.shell.custom": "Custom...",
+```
+
+- [ ] **Step 2: Add Chinese strings**
+
+Same keys in `zh-CN.ts`:
+
+```typescript
+"qs.localShells": "本地终端",
+"qs.default": "默认",
+"settings.terminal.localShell.shell.default": "系统默认",
+"settings.terminal.localShell.shell.custom": "自定义...",
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add application/i18n/locales/en.ts application/i18n/locales/zh-CN.ts
+git commit -m "feat(shell-selection): add i18n strings for shell selection UI"
+```
+
+---
+
+## Task 10: Integration testing and cleanup
+
+- [ ] **Step 1: Manual test on macOS**
+
+1. Open QuickSwitcher — verify "Local Shells" section shows zsh, bash, sh, fish (if installed), each with correct icon
+2. Default shell (zsh on macOS) should have "default" badge
+3. Click a shell — new local terminal tab opens with that shell
+4. Type in search "fish" — only Fish shell shows (if installed)
+5. Open Settings → Terminal → verify dropdown shows discovered shells + "Custom..." option
+
+- [ ] **Step 2: Manual test on Windows (if available)**
+
+1. Verify CMD, PowerShell, PowerShell Core (if installed), WSL distros, Git Bash, Cygwin are all detected
+2. Each WSL distro shows its correct distro icon
+3. Selecting a WSL distro opens a terminal in that distro
+4. Settings dropdown works correctly
+
+- [ ] **Step 3: Verify backward compatibility**
+
+1. Users with existing `localShell` string in settings should still work
+2. If `localShell` doesn't match any discovered shell, Settings shows "Custom..." with the text input
+3. Empty `localShell` (default) still uses system default shell
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(shell-selection): final integration polish"
+```

--- a/docs/superpowers/specs/2026-04-01-local-shell-selection-design.md
+++ b/docs/superpowers/specs/2026-04-01-local-shell-selection-design.md
@@ -1,0 +1,146 @@
+# Local Shell Selection Design
+
+**Issues:** #493 (支持选择本地终端), #426 (Supports WSL)
+**Date:** 2026-04-01
+
+## Goal
+
+Allow users to select from auto-discovered local shells (CMD, PowerShell, WSL distros, Git Bash, Cygwin, etc.) when opening a local terminal tab. Currently netcatty only supports a single manually-typed shell path in settings.
+
+## Non-Goals
+
+- Shell Profile system (custom args/env/cwd per shell) — YAGNI for now
+- Host-level shell binding — local shells are local, not tied to remote hosts
+- MSYS2, Cmder, VS Dev Tools detection
+- Shell-specific settings (e.g., PowerShell execution policy)
+
+## Shell Discovery
+
+### Architecture
+
+New module `electron/bridges/shellDiscovery.cjs` in the Electron main process. Discovery runs once on first IPC call, results cached in memory for the session lifetime.
+
+### Windows Detection
+
+| Shell | Detection Method |
+|-------|-----------------|
+| CMD | `%ComSpec%` env var, fallback `cmd.exe` |
+| PowerShell 5.1 | `where.exe powershell` + fallback `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe` |
+| PowerShell Core | `where.exe pwsh` + `reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\pwsh.exe"` |
+| WSL distros | `reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Lxss"` — enumerate subkeys, read `DistributionName`. Each distro launched via `wsl.exe -d <name>` |
+| Git Bash | `reg query "HKLM\Software\GitForWindows"` read `InstallPath` → `<path>\bin\bash.exe` with args `['--login', '-i']` |
+| Cygwin 64-bit | `reg query "HKLM\Software\Cygwin\setup"` read `rootdir` → `<path>\bin\bash.exe` with args `['--login', '-i']` |
+| Cygwin 32-bit | `reg query "HKLM\Software\WOW6432Node\Cygwin\setup"` read `rootdir` (fallback) |
+
+Registry access is done via `child_process.execSync('reg query ...')` — no native npm dependency needed. Follows the existing pattern of `where.exe` calls in `terminalBridge.cjs`.
+
+### macOS / Linux Detection
+
+- Parse `/etc/shells` to get all available shells
+- Mark `$SHELL` as the default
+- Common shells: zsh, bash, fish, sh, ksh, tcsh
+
+### Data Structure
+
+```typescript
+interface DiscoveredShell {
+  id: string;           // 'cmd', 'powershell', 'pwsh', 'wsl-ubuntu', 'git-bash', 'cygwin', 'zsh', ...
+  name: string;         // 'CMD', 'PowerShell', 'Ubuntu (WSL)', 'Git Bash', 'Zsh', ...
+  command: string;      // Executable path
+  args?: string[];      // Launch args, e.g., ['-d', 'Ubuntu'] or ['--login', '-i']
+  icon: string;         // Icon identifier for the shell (maps to SVG asset)
+  isDefault?: boolean;  // Whether this is the system default shell
+}
+```
+
+Not persisted — discovered fresh each app launch, cached in memory.
+
+### IPC Interface
+
+- `netcatty:shells:discover` → returns `DiscoveredShell[]` (discovers on first call, caches thereafter)
+- `netcatty:local:start` — extend existing payload with optional `shell?: { command: string; args?: string[] }`. When omitted, uses the default shell (from settings or system default).
+
+## Shell Icons
+
+Colorful SVG icons stored in `assets/shells/`:
+
+| Shell | Icon |
+|-------|------|
+| CMD | Windows command prompt icon |
+| PowerShell | Official PowerShell blue icon |
+| PowerShell Core (pwsh) | PowerShell dark/black icon |
+| Ubuntu (WSL) | Ubuntu circle-of-friends logo (orange) |
+| Debian (WSL) | Debian swirl (red) |
+| Kali (WSL) | Kali dragon |
+| Alpine (WSL) | Alpine mountain (blue) |
+| openSUSE (WSL) | openSUSE chameleon |
+| Generic Linux (WSL fallback) | Tux penguin |
+| Git Bash | Git logo (orange-red) |
+| Cygwin | Cygwin logo |
+| Zsh | Zsh logo or terminal icon |
+| Bash | Bash logo (dark) |
+| Fish | Fish shell logo (green) |
+| Generic shell (fallback) | Terminal icon |
+
+Icons are sourced from official project assets / open-source icon sets, stored as SVG files, and rendered inline in the QuickSwitcher and Settings UI.
+
+## UI Changes
+
+### QuickSwitcher Integration
+
+Add discovered shells as selectable entries in the QuickSwitcher:
+
+- Each shell is an entry with its colorful icon and name
+- Selecting a shell opens a new local terminal tab using that shell
+- Supports search filtering (typing "wsl" shows WSL distros, "bash" shows Git Bash / Bash, etc.)
+- Shells appear in a "Local Shells" section/category within the QuickSwitcher
+
+### Settings → Terminal
+
+Replace the current `localShell` manual text input with a dropdown select:
+
+- First option: "Default" (system default — shows detected default in hint text)
+- Followed by all discovered shells
+- Last option: "Custom..." — when selected, expands a text input for manual path entry
+- Storage unchanged: `localShell` remains a `string` in `TerminalSettings`. Empty string = system default. Otherwise stores the shell command path.
+
+### No Changes to
+
+- Host/Group configuration (local shell is not host-specific)
+- Terminal appearance or behavior per shell type
+
+## Data Flow
+
+```
+App startup
+  → User opens QuickSwitcher or Settings
+  → Frontend calls netcatty:shells:discover (IPC)
+  → shellDiscovery.cjs runs platform-specific detection (first call only)
+  → Returns DiscoveredShell[] (cached for subsequent calls)
+  → QuickSwitcher renders shells with icons
+  → User selects a shell
+  → Frontend calls netcatty:local:start with shell.command + shell.args
+  → terminalBridge.cjs spawns node-pty with specified shell
+  → New terminal tab opens
+```
+
+## Implementation Scope
+
+### New Files
+- `electron/bridges/shellDiscovery.cjs` — shell discovery logic
+- `assets/shells/*.svg` — shell icons (approx. 15 files)
+- Type definitions for `DiscoveredShell` in `global.d.ts` or `domain/models.ts`
+
+### Modified Files
+- `electron/preload.cjs` — expose `netcatty:shells:discover` IPC
+- `electron/main.cjs` or bridge registration — register IPC handler
+- `electron/bridges/terminalBridge.cjs` — accept optional `shell` in `startLocalSession` payload
+- QuickSwitcher component — add shell entries with icons
+- `components/settings/tabs/SettingsTerminalTab.tsx` — replace text input with dropdown
+- `global.d.ts` — add bridge type for discover method
+- `application/i18n/locales/en.ts` + `zh-CN.ts` — i18n strings
+
+### Unchanged
+- Terminal rendering, xterm configuration, session lifecycle
+- SSH/Telnet/Serial terminal paths
+- The actual node-pty spawn logic (just receives different command/args)

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -129,6 +129,8 @@ export interface Host {
   // Per-session shell override for local terminals (from shell discovery)
   localShell?: string;
   localShellArgs?: string[];
+  localShellName?: string;
+  localShellIcon?: string;
 }
 
 export type KeyType = 'RSA' | 'ECDSA' | 'ED25519';
@@ -671,6 +673,8 @@ export interface TerminalSession {
   serialConfig?: SerialConfig;
   localShell?: string;       // Shell command for local terminals (from discovery)
   localShellArgs?: string[]; // Shell args for local terminals (from discovery)
+  localShellName?: string;   // Display name for local shell (e.g., "Zsh", "Ubuntu (WSL)")
+  localShellIcon?: string;   // Icon identifier for local shell (e.g., "zsh", "ubuntu")
 }
 
 export interface RemoteFile {

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -126,6 +126,9 @@ export interface Host {
   pinned?: boolean;
   // Timestamp of last successful connection, used for Recently Connected section
   lastConnectedAt?: number;
+  // Per-session shell override for local terminals (from shell discovery)
+  localShell?: string;
+  localShellArgs?: string[];
 }
 
 export type KeyType = 'RSA' | 'ECDSA' | 'ED25519';
@@ -666,6 +669,8 @@ export interface TerminalSession {
   charset?: string; // Connection-time charset override (e.g. for quick-connect serial)
   // Serial-specific connection settings
   serialConfig?: SerialConfig;
+  localShell?: string;       // Shell command for local terminals (from discovery)
+  localShellArgs?: string[]; // Shell args for local terminals (from discovery)
 }
 
 export interface RemoteFile {

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -1,0 +1,469 @@
+/**
+ * Shell Discovery — Windows shell detection
+ *
+ * Detects available shells on Windows: CMD, PowerShell 5.1, PowerShell Core
+ * (pwsh), WSL distros, Git Bash, and Cygwin.
+ *
+ * Registry access uses `reg.exe` via child_process — no native npm dependency.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const EXEC_OPTS = { encoding: "utf8", timeout: 5000, windowsHide: true };
+
+/** Module-level cache for later use by the unified discoverShells() (Task 3). */
+let cachedShells = null;
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Query a specific value from a Windows registry key.
+ * Returns the value string, or `null` on failure.
+ *
+ * @param {string} keyPath  e.g. "HKLM\\SOFTWARE\\GitForWindows"
+ * @param {string} valueName  e.g. "InstallPath"
+ * @returns {string|null}
+ */
+function regQueryValue(keyPath, valueName) {
+  try {
+    // /ve queries the default (unnamed) value; /v queries a named value.
+    const args =
+      valueName === "" || valueName == null
+        ? ["query", keyPath, "/ve"]
+        : ["query", keyPath, "/v", valueName];
+    const output = execFileSync("reg", args, EXEC_OPTS);
+    // Output format:
+    //   HKEY_LOCAL_MACHINE\SOFTWARE\GitForWindows
+    //       InstallPath    REG_SZ    C:\Program Files\Git
+    const lines = output.split(/\r?\n/).filter(Boolean);
+    for (const line of lines) {
+      const match = line.match(/^\s+.+?\s+REG_\w+\s+(.+)$/);
+      if (match) {
+        return match[1].trim();
+      }
+    }
+  } catch (_err) {
+    // Key or value not found — expected on many systems.
+  }
+  return null;
+}
+
+/**
+ * Enumerate immediate subkey names under a registry key.
+ * Returns an array of full subkey paths, or an empty array on failure.
+ *
+ * @param {string} keyPath  e.g. "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss"
+ * @returns {string[]}
+ */
+function regEnumSubkeys(keyPath) {
+  try {
+    const output = execFileSync(
+      "reg",
+      ["query", keyPath],
+      EXEC_OPTS,
+    );
+    // `reg query <key>` prints the key itself, then each subkey on its own line
+    // prefixed with the full path. Values appear with leading whitespace.
+    const lines = output.split(/\r?\n/).filter(Boolean);
+    const subkeys = [];
+    const normalizedParent = keyPath.toLowerCase();
+    for (const line of lines) {
+      const trimmed = line.trim();
+      // Subkeys start with "HK" and are longer than the parent key.
+      if (
+        trimmed.toLowerCase().startsWith("hk") &&
+        trimmed.toLowerCase() !== normalizedParent &&
+        trimmed.toLowerCase().startsWith(normalizedParent + "\\")
+      ) {
+        subkeys.push(trimmed);
+      }
+    }
+    return subkeys;
+  } catch (_err) {
+    // Key not found or access denied.
+  }
+  return [];
+}
+
+/**
+ * Locate an executable on the system PATH using `where.exe`.
+ * Returns the first valid, non-alias path, or `null` if not found.
+ *
+ * @param {string} name  Executable name, e.g. "pwsh"
+ * @returns {string|null}
+ */
+function findExecutableOnPath(name) {
+  try {
+    const result = execFileSync("where.exe", [name], EXEC_OPTS);
+    const candidates = result
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+    for (const candidate of candidates) {
+      if (!fs.existsSync(candidate)) continue;
+      // Skip Windows App Execution Aliases (WindowsApps zero-byte stubs).
+      try {
+        const localAppData = (process.env.LOCALAPPDATA || "").toLowerCase();
+        if (
+          localAppData &&
+          candidate.toLowerCase().startsWith(
+            path.join(localAppData, "Microsoft", "WindowsApps").toLowerCase() +
+              path.sep,
+          )
+        ) {
+          continue;
+        }
+      } catch (_e) {
+        // Ignore — just use the candidate.
+      }
+      return candidate;
+    }
+  } catch (_err) {
+    // Not found on PATH.
+  }
+  return null;
+}
+
+/**
+ * Map a WSL distro name to an icon identifier for SVG lookup.
+ *
+ * @param {string} distroName  e.g. "Ubuntu-22.04", "Debian", "kali-linux"
+ * @returns {string}
+ */
+function mapWslDistroIcon(distroName) {
+  const lower = (distroName || "").toLowerCase();
+
+  if (lower.includes("ubuntu")) return "ubuntu";
+  if (lower.includes("debian")) return "debian";
+  if (lower.includes("kali")) return "kali";
+  if (lower.includes("alpine")) return "alpine";
+  if (lower.includes("opensuse") || lower.includes("suse")) return "opensuse";
+  if (lower.includes("fedora")) return "fedora";
+  if (lower.includes("arch")) return "arch";
+  if (lower.includes("oracle")) return "oracle";
+
+  return "linux";
+}
+
+// ---------------------------------------------------------------------------
+// Individual shell detectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect CMD.
+ * @returns {object|null} DiscoveredShell or null
+ */
+function detectCmd() {
+  try {
+    const comSpec = process.env.ComSpec;
+    const cmdPath = comSpec || "cmd.exe";
+    // Verify the path actually exists when ComSpec provides a full path.
+    if (comSpec && !fs.existsSync(comSpec)) {
+      // Fallback to bare name — Windows will resolve it.
+      return {
+        id: "cmd",
+        name: "CMD",
+        command: "cmd.exe",
+        args: [],
+        icon: "cmd",
+      };
+    }
+    return {
+      id: "cmd",
+      name: "CMD",
+      command: cmdPath,
+      args: [],
+      icon: "cmd",
+    };
+  } catch (_err) {
+    // Should never fail, but guard anyway.
+  }
+  return null;
+}
+
+/**
+ * Detect Windows PowerShell 5.1.
+ * @returns {object|null}
+ */
+function detectPowerShell() {
+  try {
+    // Try where.exe first.
+    const found = findExecutableOnPath("powershell");
+    if (found) {
+      return {
+        id: "powershell",
+        name: "Windows PowerShell",
+        command: found,
+        args: ["-NoLogo"],
+        icon: "powershell",
+      };
+    }
+
+    // Fallback: well-known path.
+    const fallback = path.join(
+      process.env.SystemRoot || "C:\\Windows",
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    );
+    if (fs.existsSync(fallback)) {
+      return {
+        id: "powershell",
+        name: "Windows PowerShell",
+        command: fallback,
+        args: ["-NoLogo"],
+        icon: "powershell",
+      };
+    }
+  } catch (_err) {
+    // Detection failed — not critical.
+  }
+  return null;
+}
+
+/**
+ * Detect PowerShell Core (pwsh 7+).
+ * @returns {object|null}
+ */
+function detectPwsh() {
+  try {
+    // 1. where.exe
+    const found = findExecutableOnPath("pwsh");
+    if (found) {
+      return {
+        id: "pwsh",
+        name: "PowerShell 7",
+        command: found,
+        args: ["-NoLogo"],
+        icon: "pwsh",
+      };
+    }
+
+    // 2. Registry App Paths
+    const regPath = regQueryValue(
+      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\pwsh.exe",
+      "",
+    );
+    if (regPath && fs.existsSync(regPath)) {
+      return {
+        id: "pwsh",
+        name: "PowerShell 7",
+        command: regPath,
+        args: ["-NoLogo"],
+        icon: "pwsh",
+      };
+    }
+
+    // 3. Common fallback path.
+    const fallback = path.join(
+      process.env.ProgramFiles || "C:\\Program Files",
+      "PowerShell",
+      "7",
+      "pwsh.exe",
+    );
+    if (fs.existsSync(fallback)) {
+      return {
+        id: "pwsh",
+        name: "PowerShell 7",
+        command: fallback,
+        args: ["-NoLogo"],
+        icon: "pwsh",
+      };
+    }
+  } catch (_err) {
+    // Detection failed.
+  }
+  return null;
+}
+
+/**
+ * Detect installed WSL distributions via the registry.
+ * @returns {object[]} Array of DiscoveredShell objects (may be empty).
+ */
+function detectWslDistros() {
+  const distros = [];
+  try {
+    const lxssKey = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
+    const subkeys = regEnumSubkeys(lxssKey);
+
+    for (const subkey of subkeys) {
+      try {
+        const distroName = regQueryValue(subkey, "DistributionName");
+        if (!distroName) continue;
+
+        distros.push({
+          id: `wsl-${distroName.toLowerCase().replace(/[^a-z0-9-]/g, "-")}`,
+          name: `${distroName} (WSL)`,
+          command: "wsl.exe",
+          args: ["-d", distroName],
+          icon: mapWslDistroIcon(distroName),
+        });
+      } catch (_err) {
+        // Skip this distro but continue with others.
+      }
+    }
+  } catch (_err) {
+    // WSL not installed or registry not accessible.
+  }
+  return distros;
+}
+
+/**
+ * Detect Git Bash (from Git for Windows).
+ * @returns {object|null}
+ */
+function detectGitBash() {
+  try {
+    // Try registry first.
+    const installPath = regQueryValue(
+      "HKLM\\SOFTWARE\\GitForWindows",
+      "InstallPath",
+    );
+    if (installPath) {
+      const bashExe = path.join(installPath, "bin", "bash.exe");
+      if (fs.existsSync(bashExe)) {
+        return {
+          id: "git-bash",
+          name: "Git Bash",
+          command: bashExe,
+          args: ["--login", "-i"],
+          icon: "git-bash",
+        };
+      }
+    }
+
+    // Fallback: common installation path.
+    const fallbackPaths = [
+      path.join(
+        process.env.ProgramFiles || "C:\\Program Files",
+        "Git",
+        "bin",
+        "bash.exe",
+      ),
+      path.join(
+        process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)",
+        "Git",
+        "bin",
+        "bash.exe",
+      ),
+    ];
+    for (const p of fallbackPaths) {
+      if (fs.existsSync(p)) {
+        return {
+          id: "git-bash",
+          name: "Git Bash",
+          command: p,
+          args: ["--login", "-i"],
+          icon: "git-bash",
+        };
+      }
+    }
+  } catch (_err) {
+    // Git Bash not installed.
+  }
+  return null;
+}
+
+/**
+ * Detect Cygwin bash.
+ * @returns {object|null}
+ */
+function detectCygwin() {
+  try {
+    // Try 64-bit registry key first, then 32-bit (WOW6432Node).
+    const rootDir =
+      regQueryValue("HKLM\\SOFTWARE\\Cygwin\\setup", "rootdir") ||
+      regQueryValue("HKLM\\SOFTWARE\\WOW6432Node\\Cygwin\\setup", "rootdir");
+
+    if (rootDir) {
+      const bashExe = path.join(rootDir, "bin", "bash.exe");
+      if (fs.existsSync(bashExe)) {
+        return {
+          id: "cygwin",
+          name: "Cygwin",
+          command: bashExe,
+          args: ["--login", "-i"],
+          icon: "cygwin",
+        };
+      }
+    }
+
+    // Fallback: common path.
+    const fallback = "C:\\cygwin64\\bin\\bash.exe";
+    if (fs.existsSync(fallback)) {
+      return {
+        id: "cygwin",
+        name: "Cygwin",
+        command: fallback,
+        args: ["--login", "-i"],
+        icon: "cygwin",
+      };
+    }
+  } catch (_err) {
+    // Cygwin not installed.
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main discovery entry point for Windows
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover all available shells on a Windows system.
+ * Returns an array of DiscoveredShell objects. Exactly one shell will have
+ * `isDefault: true` based on priority: pwsh > powershell > cmd.
+ *
+ * @returns {Array<{id: string, name: string, command: string, args: string[], icon: string, isDefault?: boolean}>}
+ */
+function discoverWindowsShells() {
+  const shells = [];
+
+  // Detect each shell type independently — failures are isolated.
+  const cmd = detectCmd();
+  if (cmd) shells.push(cmd);
+
+  const powershell = detectPowerShell();
+  if (powershell) shells.push(powershell);
+
+  const pwsh = detectPwsh();
+  if (pwsh) shells.push(pwsh);
+
+  const wslDistros = detectWslDistros();
+  shells.push(...wslDistros);
+
+  const gitBash = detectGitBash();
+  if (gitBash) shells.push(gitBash);
+
+  const cygwin = detectCygwin();
+  if (cygwin) shells.push(cygwin);
+
+  // Assign default: pwsh > powershell > cmd
+  const defaultShell =
+    shells.find((s) => s.id === "pwsh") ||
+    shells.find((s) => s.id === "powershell") ||
+    shells.find((s) => s.id === "cmd");
+  if (defaultShell) {
+    defaultShell.isDefault = true;
+  }
+
+  return shells;
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+module.exports = {
+  discoverWindowsShells,
+  regQueryValue,
+  regEnumSubkeys,
+  findExecutableOnPath,
+  mapWslDistroIcon,
+};

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -286,7 +286,49 @@ function detectPwsh() {
  * @returns {object[]} Array of DiscoveredShell objects (may be empty).
  */
 function detectWslDistros() {
+  const wslExe = path.join(
+    process.env.SystemRoot || "C:\\Windows",
+    "System32",
+    "wsl.exe",
+  );
+  if (!fs.existsSync(wslExe)) return [];
+
   const distros = [];
+
+  // Primary: use `wsl.exe -l -q` which lists installed distros one per line.
+  // More reliable than registry parsing across Windows versions.
+  // Note: wsl.exe outputs UTF-16LE on some builds, so we read as buffer and decode.
+  try {
+    const buf = execFileSync(wslExe, ["-l", "-q"], {
+      timeout: 5000,
+      windowsHide: true,
+      maxBuffer: 1024 * 64,
+    });
+    // Decode as UTF-16LE first (common), then try UTF-8 if it looks wrong
+    let output = buf.toString("utf16le");
+    if (output.includes("\ufffd") || output.length === 0) {
+      output = buf.toString("utf8");
+    }
+    const names = output
+      .split(/\r?\n/)
+      .map((l) => l.replace(/\0/g, "").trim())
+      .filter(Boolean);
+
+    for (const distroName of names) {
+      distros.push({
+        id: `wsl-${distroName.toLowerCase().replace(/[^a-z0-9-]/g, "-")}`,
+        name: `${distroName} (WSL)`,
+        command: wslExe,
+        args: ["-d", distroName],
+        icon: mapWslDistroIcon(distroName),
+      });
+    }
+    if (distros.length > 0) return distros;
+  } catch (_err) {
+    // wsl.exe -l -q failed, fall through to registry method.
+  }
+
+  // Fallback: enumerate registry subkeys under Lxss
   try {
     const lxssKey = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
     const subkeys = regEnumSubkeys(lxssKey);
@@ -299,7 +341,7 @@ function detectWslDistros() {
         distros.push({
           id: `wsl-${distroName.toLowerCase().replace(/[^a-z0-9-]/g, "-")}`,
           name: `${distroName} (WSL)`,
-          command: "wsl.exe",
+          command: wslExe,
           args: ["-d", distroName],
           icon: mapWslDistroIcon(distroName),
         });

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -304,11 +304,10 @@ function detectWslDistros() {
       windowsHide: true,
       maxBuffer: 1024 * 64,
     });
-    // Decode as UTF-16LE first (common), then try UTF-8 if it looks wrong
-    let output = buf.toString("utf16le");
-    if (output.includes("\ufffd") || output.length === 0) {
-      output = buf.toString("utf8");
-    }
+    // wsl.exe outputs UTF-16LE on most Windows builds (has NUL bytes between chars).
+    // Detect by checking for NUL bytes in the raw buffer; if present → UTF-16LE, else UTF-8.
+    const isUtf16 = buf.length >= 2 && buf.includes(0x00);
+    const output = buf.toString(isUtf16 ? "utf16le" : "utf8");
     const names = output
       .split(/\r?\n/)
       .map((l) => l.replace(/\0/g, "").trim())

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -565,10 +565,10 @@ function discoverUnixShells() {
   for (const shellPath of validPaths) {
     const base = path.basename(shellPath);
     const args = isLoginShell(base) ? ["-l"] : [];
-    // Use basename as id when unique, otherwise include parent dir to disambiguate
+    // Use basename as id when unique, otherwise use path slug to guarantee uniqueness
     const needsDisambiguation = baseCount.get(base) > 1;
     const id = needsDisambiguation
-      ? `${base}-${path.basename(path.dirname(shellPath))}`
+      ? shellPath.replace(/^\/+/, "").replace(/[/\\]+/g, "-")
       : base;
     const name = needsDisambiguation
       ? `${mapUnixShellName(base)} (${shellPath})`
@@ -593,7 +593,7 @@ function discoverUnixShells() {
         // Check if basename already exists in the list to disambiguate
         const hasDuplicate = shells.some((s) => path.basename(s.command) === base);
         const id = hasDuplicate
-          ? `${base}-${path.basename(path.dirname(envShell))}`
+          ? envShell.replace(/^\/+/, "").replace(/[/\\]+/g, "-")
           : base;
         const name = hasDuplicate
           ? `${mapUnixShellName(base)} (${envShell})`

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -457,11 +457,189 @@ function discoverWindowsShells() {
 }
 
 // ---------------------------------------------------------------------------
+// Unix shell detection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a Unix shell binary basename to a human-readable display name.
+ *
+ * @param {string} basename  e.g. "zsh", "bash", "nu"
+ * @returns {string}
+ */
+function mapUnixShellName(basename) {
+  const map = {
+    zsh: "Zsh",
+    bash: "Bash",
+    fish: "Fish",
+    sh: "sh",
+    ksh: "Ksh",
+    tcsh: "Tcsh",
+    csh: "Csh",
+    dash: "Dash",
+    nu: "Nushell",
+    pwsh: "PowerShell",
+  };
+  return map[basename] || basename;
+}
+
+/**
+ * Map a Unix shell binary basename to an icon identifier.
+ *
+ * @param {string} basename  e.g. "zsh", "fish", "nu"
+ * @returns {string}
+ */
+function mapUnixShellIcon(basename) {
+  const map = {
+    zsh: "zsh",
+    bash: "bash",
+    fish: "fish",
+    sh: "terminal",
+    ksh: "terminal",
+    tcsh: "terminal",
+    csh: "terminal",
+    dash: "terminal",
+    nu: "nushell",
+    pwsh: "pwsh",
+  };
+  return map[basename] || "terminal";
+}
+
+/**
+ * Returns true for shells that should be launched with the `-l` (login) flag.
+ *
+ * @param {string} basename
+ * @returns {boolean}
+ */
+function isLoginShell(basename) {
+  return ["bash", "zsh", "fish", "ksh", "sh"].includes(basename);
+}
+
+// ---------------------------------------------------------------------------
+// Main discovery entry point for Unix
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover all available shells on a Unix/macOS system by reading /etc/shells.
+ * The shell referenced by $SHELL is marked as default. If $SHELL is not in
+ * /etc/shells it is prepended to the list.
+ *
+ * @returns {Array<{id: string, name: string, command: string, args: string[], icon: string, isDefault?: boolean}>}
+ */
+function discoverUnixShells() {
+  const shells = [];
+  const seen = new Set();
+
+  // Read /etc/shells — each non-comment line is an absolute path.
+  let etcShellPaths = [];
+  try {
+    const content = fs.readFileSync("/etc/shells", "utf8");
+    etcShellPaths = content
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+  } catch (_err) {
+    // /etc/shells not readable — fall through to $SHELL only.
+  }
+
+  // Filter to existing files and deduplicate by real path.
+  const validPaths = [];
+  for (const shellPath of etcShellPaths) {
+    try {
+      if (!fs.existsSync(shellPath)) continue;
+      const real = fs.realpathSync(shellPath);
+      if (seen.has(real)) continue;
+      seen.add(real);
+      validPaths.push(shellPath);
+    } catch (_err) {
+      // Skip unresolvable paths.
+    }
+  }
+
+  // Build DiscoveredShell objects.
+  for (const shellPath of validPaths) {
+    const base = path.basename(shellPath);
+    const args = isLoginShell(base) ? ["-l"] : [];
+    shells.push({
+      id: base,
+      name: mapUnixShellName(base),
+      command: shellPath,
+      args,
+      icon: mapUnixShellIcon(base),
+    });
+  }
+
+  // Ensure $SHELL is present — prepend it if missing.
+  const envShell = process.env.SHELL;
+  if (envShell) {
+    try {
+      const envReal = fs.realpathSync(envShell);
+      if (!seen.has(envReal) && fs.existsSync(envShell)) {
+        const base = path.basename(envShell);
+        const args = isLoginShell(base) ? ["-l"] : [];
+        shells.unshift({
+          id: base,
+          name: mapUnixShellName(base),
+          command: envShell,
+          args,
+          icon: mapUnixShellIcon(base),
+        });
+      }
+    } catch (_err) {
+      // $SHELL path invalid — ignore.
+    }
+  }
+
+  // Mark $SHELL as default (match by command path or basename).
+  if (envShell) {
+    const defaultShell =
+      shells.find((s) => s.command === envShell) ||
+      shells.find((s) => s.id === path.basename(envShell));
+    if (defaultShell) {
+      defaultShell.isDefault = true;
+    }
+  }
+
+  // Fallback: mark first shell as default if none matched.
+  if (shells.length > 0 && !shells.some((s) => s.isDefault)) {
+    shells[0].isDefault = true;
+  }
+
+  return shells;
+}
+
+// ---------------------------------------------------------------------------
+// Unified shell discovery entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover all available shells for the current platform.
+ * Results are cached after the first call.
+ *
+ * @returns {Array<{id: string, name: string, command: string, args: string[], icon: string, isDefault?: boolean}>}
+ */
+function discoverShells() {
+  if (cachedShells) return cachedShells;
+
+  if (process.platform === "win32") {
+    cachedShells = discoverWindowsShells();
+  } else {
+    cachedShells = discoverUnixShells();
+  }
+
+  return cachedShells;
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
 module.exports = {
+  discoverShells,
   discoverWindowsShells,
+  discoverUnixShells,
+  mapUnixShellName,
+  mapUnixShellIcon,
+  isLoginShell,
   regQueryValue,
   regEnumSubkeys,
   findExecutableOnPath,

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -590,9 +590,17 @@ function discoverUnixShells() {
       if (!seen.has(envReal) && fs.existsSync(envShell)) {
         const base = path.basename(envShell);
         const args = isLoginShell(base) ? ["-l"] : [];
+        // Check if basename already exists in the list to disambiguate
+        const hasDuplicate = shells.some((s) => path.basename(s.command) === base);
+        const id = hasDuplicate
+          ? `${base}-${path.basename(path.dirname(envShell))}`
+          : base;
+        const name = hasDuplicate
+          ? `${mapUnixShellName(base)} (${envShell})`
+          : mapUnixShellName(base);
         shells.unshift({
-          id: base,
-          name: mapUnixShellName(base),
+          id,
+          name,
           command: envShell,
           args,
           icon: mapUnixShellIcon(base),

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -556,12 +556,27 @@ function discoverUnixShells() {
   }
 
   // Build DiscoveredShell objects.
+  // Track basename counts to detect duplicates (e.g., /bin/bash vs /usr/local/bin/bash)
+  const baseCount = new Map();
+  for (const shellPath of validPaths) {
+    const base = path.basename(shellPath);
+    baseCount.set(base, (baseCount.get(base) || 0) + 1);
+  }
+
   for (const shellPath of validPaths) {
     const base = path.basename(shellPath);
     const args = isLoginShell(base) ? ["-l"] : [];
+    // Use basename as id when unique, otherwise include parent dir to disambiguate
+    const needsDisambiguation = baseCount.get(base) > 1;
+    const id = needsDisambiguation
+      ? `${base}-${path.basename(path.dirname(shellPath))}`
+      : base;
+    const name = needsDisambiguation
+      ? `${mapUnixShellName(base)} (${shellPath})`
+      : mapUnixShellName(base);
     shells.push({
-      id: base,
-      name: mapUnixShellName(base),
+      id,
+      name,
       command: shellPath,
       args,
       icon: mapUnixShellIcon(base),

--- a/electron/bridges/shellDiscovery.cjs
+++ b/electron/bridges/shellDiscovery.cjs
@@ -1,10 +1,9 @@
 /**
- * Shell Discovery — Windows shell detection
+ * Shell Discovery — cross-platform shell detection
  *
- * Detects available shells on Windows: CMD, PowerShell 5.1, PowerShell Core
- * (pwsh), WSL distros, Git Bash, and Cygwin.
- *
- * Registry access uses `reg.exe` via child_process — no native npm dependency.
+ * Detects available shells on Windows (CMD, PowerShell, WSL, Git Bash, Cygwin)
+ * and Unix/macOS (via /etc/shells). Registry access on Windows uses `reg.exe`
+ * via child_process — no native npm dependency.
  */
 
 const fs = require("node:fs");

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -253,8 +253,20 @@ function startLocalSession(event, payload) {
     payload?.sessionId ||
     `${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const defaultShell = getDefaultLocalShell();
-  const shell = normalizeExecutablePath(payload?.shell) || defaultShell;
-  const shellArgs = payload?.shellArgs ?? getLocalShellArgs(shell);
+  // payload.shell may be a discovered shell ID (e.g., "wsl-ubuntu") — resolve it
+  let resolvedShell = payload?.shell;
+  let resolvedArgs = payload?.shellArgs;
+  if (resolvedShell && !/[/\\]/.test(resolvedShell)) {
+    // Looks like a shell ID, not a path — try to resolve from discovery cache
+    const shells = discoverShells();
+    const match = shells.find((s) => s.id === resolvedShell);
+    if (match) {
+      resolvedShell = match.command;
+      resolvedArgs = resolvedArgs ?? match.args;
+    }
+  }
+  const shell = normalizeExecutablePath(resolvedShell) || defaultShell;
+  const shellArgs = resolvedArgs ?? getLocalShellArgs(shell);
   const shellKind = detectShellKind(shell);
   const env = applyLocaleDefaults({
     ...process.env,

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -15,6 +15,7 @@ const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
 const { detectShellKind } = require("./ai/ptyExec.cjs");
 const { trackSessionIdlePrompt } = require("./ai/shellUtils.cjs");
 const { createZmodemSentry } = require("./zmodemHelper.cjs");
+const { discoverShells } = require("./shellDiscovery.cjs");
 
 // Shared references
 let sessions = null;
@@ -253,7 +254,7 @@ function startLocalSession(event, payload) {
     `${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const defaultShell = getDefaultLocalShell();
   const shell = normalizeExecutablePath(payload?.shell) || defaultShell;
-  const shellArgs = getLocalShellArgs(shell);
+  const shellArgs = payload?.shellArgs ?? getLocalShellArgs(shell);
   const shellKind = detectShellKind(shell);
   const env = applyLocaleDefaults({
     ...process.env,
@@ -1044,6 +1045,7 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:serial:list", listSerialPorts);
   ipcMain.handle("netcatty:local:defaultShell", getDefaultShell);
   ipcMain.handle("netcatty:local:validatePath", validatePath);
+  ipcMain.handle("netcatty:shells:discover", () => discoverShells());
   ipcMain.on("netcatty:write", writeToSession);
   ipcMain.on("netcatty:resize", resizeSession);
   ipcMain.on("netcatty:close", closeSession);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -561,6 +561,7 @@ const api = {
   getDefaultShell: async () => {
     return ipcRenderer.invoke("netcatty:local:defaultShell");
   },
+  discoverShells: () => ipcRenderer.invoke("netcatty:shells:discover"),
   validatePath: async (path, type) => {
     return ipcRenderer.invoke("netcatty:local:validatePath", { path, type });
   },

--- a/global.d.ts
+++ b/global.d.ts
@@ -25,6 +25,16 @@ declare global {
     password?: string;
   }
 
+  // Discovered local shell (e.g. CMD, PowerShell, WSL, Git Bash)
+  interface DiscoveredShell {
+    id: string;
+    name: string;
+    command: string;
+    args?: string[];
+    icon: string;
+    isDefault?: boolean;
+  }
+
   // Jump host configuration for SSH tunneling
   interface NetcattyJumpHost {
     hostname: string;
@@ -176,7 +186,7 @@ declare global {
       env?: Record<string, string>;
       sessionLog?: { enabled: boolean; directory: string; format: string };
     }): Promise<string>;
-    startLocalSession?(options: { sessionId?: string; cols?: number; rows?: number; shell?: string; cwd?: string; env?: Record<string, string>; sessionLog?: { enabled: boolean; directory: string; format: string } }): Promise<string>;
+    startLocalSession?(options: { sessionId?: string; cols?: number; rows?: number; shell?: string; shellArgs?: string[]; cwd?: string; env?: Record<string, string>; sessionLog?: { enabled: boolean; directory: string; format: string } }): Promise<string>;
     startSerialSession?(options: {
       sessionId?: string;
       path: string;
@@ -197,6 +207,7 @@ declare global {
       pnpId: string;
     }>>;
     getDefaultShell?(): Promise<string>;
+    discoverShells?(): Promise<DiscoveredShell[]>;
     validatePath?(path: string, type?: 'file' | 'directory' | 'any'): Promise<{ exists: boolean; isFile: boolean; isDirectory: boolean }>;
     generateKeyPair?(options: {
       type: 'RSA' | 'ECDSA' | 'ED25519';

--- a/lib/localShell.ts
+++ b/lib/localShell.ts
@@ -4,7 +4,9 @@ export type LocalOs = 'linux' | 'macos' | 'windows';
 const POWERSHELL_SHELLS = new Set(['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe']);
 const CMD_SHELLS = new Set(['cmd', 'cmd.exe']);
 const FISH_SHELLS = new Set(['fish']);
-const POSIX_SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'ash']);
+const POSIX_SHELLS = new Set(['sh', 'bash', 'zsh', 'ksh', 'dash', 'ash', 'bash.exe']);
+// WSL launcher — runs a Linux shell inside WSL, classify as posix
+const WSL_SHELLS = new Set(['wsl', 'wsl.exe']);
 
 const getExecutableBaseName = (filePath: string | undefined): string => {
   const normalized = String(filePath || '').trim();
@@ -29,6 +31,7 @@ export const classifyLocalShellType = (
   if (CMD_SHELLS.has(shellName)) return 'cmd';
   if (FISH_SHELLS.has(shellName)) return 'fish';
   if (POSIX_SHELLS.has(shellName)) return 'posix';
+  if (WSL_SHELLS.has(shellName)) return 'posix';
   if (!shellName) {
     return detectLocalOs(platformLike) === 'windows' ? 'powershell' : 'posix';
   }

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -52,20 +52,20 @@ export function resolveShellSetting(
     return { command: shell.command, args: shell.args };
   }
 
-  // If discovery has loaded (non-empty list) and no ID matched,
-  // this is a custom value — pass it through as-is.
+  // Check if the value looks like a file path or bare executable name
+  const looksLikePath = /[/\\]/.test(localShell);
+  const looksLikeShellId = /-/.test(localShell) && !looksLikePath;
+
   if (discoveredShells.length > 0) {
-    return { command: localShell };
+    // Discovery loaded. If value looks like a path/executable, pass through as custom.
+    // If it looks like a shell ID (has hyphens, e.g. "wsl-ubuntu") but didn't match,
+    // it's stale/unavailable — return null to fall back to system default.
+    return looksLikeShellId ? null : { command: localShell };
   }
 
-  // Discovery hasn't loaded yet. If the value looks like a path or bare
-  // executable (no hyphens — shell IDs like "wsl-ubuntu" always have hyphens),
-  // pass through. Otherwise return null to use the system default.
-  if (/[/\\]/.test(localShell) || !/-/.test(localShell)) {
-    return { command: localShell };
-  }
-
-  return null;
+  // Discovery hasn't loaded yet. Pass through paths and bare names,
+  // but hold back shell-ID-like values until discovery completes.
+  return looksLikeShellId ? null : { command: localShell };
 }
 
 const DISTRO_ICONS = new Set([

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -34,19 +34,11 @@ export function useDiscoveredShells(): DiscoveredShell[] {
 }
 
 /**
- * Check whether a localShell value looks like a file path (custom entry)
- * rather than a discovered shell ID. Paths contain slashes or backslashes,
- * or end with common executable extensions.
- */
-function looksLikePath(value: string): boolean {
-  return /[/\\]/.test(value) || /\.\w+$/.test(value);
-}
-
-/**
  * Resolve a localShell setting value to shell command and args.
  * The value can be a discovered shell id (e.g., "wsl-ubuntu", "pwsh")
- * or a custom path (e.g., "/usr/local/bin/fish").
- * Returns { command, args } or null if unresolved / discovery not ready.
+ * or a custom path/command (e.g., "/usr/local/bin/fish" or "fish").
+ * Returns { command, args } or null when discovery hasn't loaded yet
+ * and the value might be a shell ID that can't be resolved yet.
  */
 export function resolveShellSetting(
   localShell: string,
@@ -60,14 +52,19 @@ export function resolveShellSetting(
     return { command: shell.command, args: shell.args };
   }
 
-  // If it looks like a file path, treat as custom shell (backward compat)
-  if (looksLikePath(localShell)) {
+  // If discovery has loaded (non-empty list) and no ID matched,
+  // this is a custom value — pass it through as-is.
+  if (discoveredShells.length > 0) {
     return { command: localShell };
   }
 
-  // Value looks like a shell ID but discovery hasn't loaded yet or no match.
-  // Return null so the caller falls back to the system default shell,
-  // rather than trying to execute an ID string like "wsl-ubuntu" as a command.
+  // Discovery hasn't loaded yet. If the value looks like a path or bare
+  // executable (no hyphens — shell IDs like "wsl-ubuntu" always have hyphens),
+  // pass through. Otherwise return null to use the system default.
+  if (/[/\\]/.test(localShell) || !/\-/.test(localShell)) {
+    return { command: localShell };
+  }
+
   return null;
 }
 

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -52,20 +52,11 @@ export function resolveShellSetting(
     return { command: shell.command, args: shell.args };
   }
 
-  // Check if the value looks like a file path or bare executable name
-  const looksLikePath = /[/\\]/.test(localShell);
-  const looksLikeShellId = /-/.test(localShell) && !looksLikePath;
-
-  if (discoveredShells.length > 0) {
-    // Discovery loaded. If value looks like a path/executable, pass through as custom.
-    // If it looks like a shell ID (has hyphens, e.g. "wsl-ubuntu") but didn't match,
-    // it's stale/unavailable — return null to fall back to system default.
-    return looksLikeShellId ? null : { command: localShell };
-  }
-
-  // Discovery hasn't loaded yet. Pass through paths and bare names,
-  // but hold back shell-ID-like values until discovery completes.
-  return looksLikeShellId ? null : { command: localShell };
+  // No ID match — treat as a custom shell path/command and pass through.
+  // This handles both custom executables (e.g., "/usr/local/bin/fish", "pwsh-preview")
+  // and stale/synced IDs that no longer exist on this machine (graceful fallback
+  // to whatever the OS resolves the name to, or a spawn error the user can see).
+  return { command: localShell };
 }
 
 const DISTRO_ICONS = new Set([

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -31,6 +31,28 @@ export function useDiscoveredShells(): DiscoveredShell[] {
   return shells;
 }
 
+/**
+ * Resolve a localShell setting value to shell command and args.
+ * The value can be a discovered shell id (e.g., "wsl-ubuntu", "pwsh")
+ * or a custom path (e.g., "/usr/local/bin/fish").
+ * Returns { command, args } or null if unresolved.
+ */
+export function resolveShellSetting(
+  localShell: string,
+  discoveredShells: DiscoveredShell[]
+): { command: string; args?: string[] } | null {
+  if (!localShell) return null;
+
+  // Try to match as a discovered shell id
+  const shell = discoveredShells.find(s => s.id === localShell);
+  if (shell) {
+    return { command: shell.command, args: shell.args };
+  }
+
+  // Treat as a custom shell path (backward compat with existing settings)
+  return { command: localShell };
+}
+
 const DISTRO_ICONS = new Set([
   "ubuntu", "debian", "kali", "alpine", "opensuse",
   "fedora", "arch", "oracle", "linux",

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { netcattyBridge } from "../infrastructure/services/netcattyBridge";
+
+let shellCache: DiscoveredShell[] | null = null;
+let shellPromise: Promise<DiscoveredShell[]> | null = null;
+
+export function useDiscoveredShells(): DiscoveredShell[] {
+  const [shells, setShells] = useState<DiscoveredShell[]>(shellCache ?? []);
+
+  useEffect(() => {
+    if (shellCache) {
+      setShells(shellCache);
+      return;
+    }
+
+    const bridge = netcattyBridge.get();
+    if (!bridge?.discoverShells) return;
+
+    if (!shellPromise) {
+      shellPromise = bridge.discoverShells();
+    }
+
+    shellPromise.then((result) => {
+      shellCache = result;
+      setShells(result);
+    }).catch((err) => {
+      console.warn("Failed to discover shells:", err);
+    });
+  }, []);
+
+  return shells;
+}
+
+const DISTRO_ICONS = new Set([
+  "ubuntu", "debian", "kali", "alpine", "opensuse",
+  "fedora", "arch", "oracle", "linux",
+]);
+
+export function getShellIconPath(iconId: string): string {
+  if (DISTRO_ICONS.has(iconId)) {
+    return `/distro/${iconId}.svg`;
+  }
+  return `/shells/${iconId}.svg`;
+}

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -79,3 +79,8 @@ export function getShellIconPath(iconId: string): string {
   }
   return `/shells/${iconId}.svg`;
 }
+
+/** Distro icons are monochrome black and need `dark:invert` in dark mode */
+export function isMonochromeShellIcon(iconId: string): boolean {
+  return DISTRO_ICONS.has(iconId);
+}

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -61,7 +61,7 @@ export function resolveShellSetting(
   // Discovery hasn't loaded yet. If the value looks like a path or bare
   // executable (no hyphens — shell IDs like "wsl-ubuntu" always have hyphens),
   // pass through. Otherwise return null to use the system default.
-  if (/[/\\]/.test(localShell) || !/\-/.test(localShell)) {
+  if (/[/\\]/.test(localShell) || !/-/.test(localShell)) {
     return { command: localShell };
   }
 

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -25,6 +25,8 @@ export function useDiscoveredShells(): DiscoveredShell[] {
       setShells(result);
     }).catch((err) => {
       console.warn("Failed to discover shells:", err);
+      // Clear the failed promise so the next mount can retry
+      shellPromise = null;
     });
   }, []);
 
@@ -32,10 +34,19 @@ export function useDiscoveredShells(): DiscoveredShell[] {
 }
 
 /**
+ * Check whether a localShell value looks like a file path (custom entry)
+ * rather than a discovered shell ID. Paths contain slashes or backslashes,
+ * or end with common executable extensions.
+ */
+function looksLikePath(value: string): boolean {
+  return /[/\\]/.test(value) || /\.\w+$/.test(value);
+}
+
+/**
  * Resolve a localShell setting value to shell command and args.
  * The value can be a discovered shell id (e.g., "wsl-ubuntu", "pwsh")
  * or a custom path (e.g., "/usr/local/bin/fish").
- * Returns { command, args } or null if unresolved.
+ * Returns { command, args } or null if unresolved / discovery not ready.
  */
 export function resolveShellSetting(
   localShell: string,
@@ -49,8 +60,15 @@ export function resolveShellSetting(
     return { command: shell.command, args: shell.args };
   }
 
-  // Treat as a custom shell path (backward compat with existing settings)
-  return { command: localShell };
+  // If it looks like a file path, treat as custom shell (backward compat)
+  if (looksLikePath(localShell)) {
+    return { command: localShell };
+  }
+
+  // Value looks like a shell ID but discovery hasn't loaded yet or no match.
+  // Return null so the caller falls back to the system default shell,
+  // rather than trying to execute an ID string like "wsl-ubuntu" as a command.
+  return null;
 }
 
 const DISTRO_ICONS = new Set([

--- a/public/shells/bash.svg
+++ b/public/shells/bash.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#2D2D2D"/>
+  <rect x="0" y="0" width="32" height="7" rx="3" fill="#3C3C3C"/>
+  <rect x="0" y="4" width="32" height="3" fill="#3C3C3C"/>
+  <!-- Title bar dots -->
+  <circle cx="5" cy="3.5" r="1.5" fill="#FF5F57"/>
+  <circle cx="10" cy="3.5" r="1.5" fill="#FEBC2E"/>
+  <circle cx="15" cy="3.5" r="1.5" fill="#28C840"/>
+  <!-- $ prompt -->
+  <text x="4" y="20" font-family="monospace" font-size="11" font-weight="bold" fill="#E8E8E8">$</text>
+  <text x="13" y="20" font-family="monospace" font-size="11" fill="#AAAAAA">_</text>
+  <!-- bash label -->
+  <text x="4" y="29" font-family="monospace" font-size="7" fill="#888888">bash</text>
+</svg>

--- a/public/shells/cmd.svg
+++ b/public/shells/cmd.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#1E1E1E"/>
+  <rect x="0" y="0" width="32" height="7" rx="3" fill="#333333"/>
+  <rect x="0" y="4" width="32" height="3" fill="#333333"/>
+  <circle cx="5" cy="3.5" r="1.5" fill="#FF5F57"/>
+  <circle cx="10" cy="3.5" r="1.5" fill="#FEBC2E"/>
+  <circle cx="15" cy="3.5" r="1.5" fill="#28C840"/>
+  <text x="4" y="21" font-family="monospace" font-size="11" font-weight="bold" fill="#00FF00">C:\&gt;_</text>
+</svg>

--- a/public/shells/cygwin.svg
+++ b/public/shells/cygwin.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cygwin: dark circle with "CY" text, penguin-inspired dark bg -->
+  <circle cx="16" cy="16" r="15" fill="#1A1A2E"/>
+  <circle cx="16" cy="16" r="15" fill="none" stroke="#FFD700" stroke-width="1.5"/>
+  <!-- Simple Cygwin-style hat/arc at top -->
+  <path d="M8 12 Q16 4 24 12" fill="none" stroke="#FFD700" stroke-width="2" stroke-linecap="round"/>
+  <text x="16" y="22" font-family="monospace" font-size="9" font-weight="bold" fill="#FFD700" text-anchor="middle">CY</text>
+</svg>

--- a/public/shells/fish.svg
+++ b/public/shells/fish.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Fish shell: simple fish shape in Fish shell green -->
+  <rect width="32" height="32" rx="16" fill="#1A2E1A"/>
+  <!-- Fish body -->
+  <ellipse cx="15" cy="16" rx="9" ry="6" fill="#4DB380"/>
+  <!-- Fish tail -->
+  <path d="M24 16 L29 11 L29 21 Z" fill="#3A9966"/>
+  <!-- Fish eye -->
+  <circle cx="10" cy="14" r="1.5" fill="#FFFFFF"/>
+  <circle cx="10" cy="14" r="0.8" fill="#1A2E1A"/>
+  <!-- Fish fin -->
+  <path d="M13 11 Q16 8 19 11" fill="none" stroke="#98C379" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Subtle highlight -->
+  <ellipse cx="14" cy="14" rx="4" ry="2" fill="#98C379" opacity="0.3"/>
+</svg>

--- a/public/shells/git-bash.svg
+++ b/public/shells/git-bash.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Git logo inspired icon -->
+  <rect width="32" height="32" rx="5" fill="#F05032"/>
+  <!-- Git diamond shape -->
+  <path d="M16 4 L28 16 L16 28 L4 16 Z" fill="none" stroke="#FFFFFF" stroke-width="2.5"/>
+  <!-- Git branch lines inside -->
+  <circle cx="16" cy="11" r="2.5" fill="#FFFFFF"/>
+  <circle cx="11" cy="16" r="2.5" fill="#FFFFFF"/>
+  <circle cx="21" cy="16" r="2.5" fill="#FFFFFF"/>
+  <line x1="16" y1="13.5" x2="16" y2="22" stroke="#FFFFFF" stroke-width="2"/>
+  <line x1="13.3" y1="17.5" x2="16" y2="22" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="16" cy="22" r="2" fill="#FFFFFF"/>
+</svg>

--- a/public/shells/nushell.svg
+++ b/public/shells/nushell.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Nushell: teal/green accent, modern terminal style -->
+  <rect width="32" height="32" rx="3" fill="#0D1117"/>
+  <!-- Top accent bar in teal -->
+  <rect x="0" y="0" width="32" height="4" rx="2" fill="#4EAA97"/>
+  <rect x="0" y="2" width="32" height="2" fill="#4EAA97"/>
+  <!-- nu label in teal -->
+  <text x="4" y="16" font-family="monospace" font-size="9" font-weight="bold" fill="#4EAA97">nu</text>
+  <!-- > prompt -->
+  <text x="4" y="27" font-family="monospace" font-size="11" font-weight="bold" fill="#56D4C0">&gt;</text>
+  <text x="13" y="27" font-family="monospace" font-size="11" fill="#3A9985">_</text>
+</svg>

--- a/public/shells/powershell.svg
+++ b/public/shells/powershell.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#012456"/>
+  <text x="3" y="14" font-family="monospace" font-size="10" font-weight="bold" fill="#FFFFFF">PS</text>
+  <text x="3" y="26" font-family="monospace" font-size="10" font-weight="bold" fill="#2CA5E0">&gt;_</text>
+</svg>

--- a/public/shells/pwsh.svg
+++ b/public/shells/pwsh.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#00001A"/>
+  <rect x="0" y="0" width="32" height="4" rx="2" fill="#012456"/>
+  <rect x="0" y="2" width="32" height="2" fill="#012456"/>
+  <text x="3" y="14" font-family="monospace" font-size="8" font-weight="bold" fill="#2CA5E0">PS 7</text>
+  <text x="3" y="26" font-family="monospace" font-size="10" font-weight="bold" fill="#5BC4F5">&gt;_</text>
+</svg>

--- a/public/shells/terminal.svg
+++ b/public/shells/terminal.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Generic terminal: dark window with >_ prompt -->
+  <rect width="32" height="32" rx="3" fill="#282828"/>
+  <!-- Title bar -->
+  <rect x="0" y="0" width="32" height="7" rx="3" fill="#404040"/>
+  <rect x="0" y="4" width="32" height="3" fill="#404040"/>
+  <!-- Title bar dots -->
+  <circle cx="5" cy="3.5" r="1.5" fill="#FF5F57"/>
+  <circle cx="10" cy="3.5" r="1.5" fill="#FEBC2E"/>
+  <circle cx="15" cy="3.5" r="1.5" fill="#28C840"/>
+  <!-- >_ prompt in white -->
+  <text x="4" y="20" font-family="monospace" font-size="11" font-weight="bold" fill="#FFFFFF">&gt;_</text>
+</svg>

--- a/public/shells/zsh.svg
+++ b/public/shells/zsh.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="3" fill="#1A1A2E"/>
+  <rect x="0" y="0" width="32" height="7" rx="3" fill="#16213E"/>
+  <rect x="0" y="4" width="32" height="3" fill="#16213E"/>
+  <!-- Title bar dots -->
+  <circle cx="5" cy="3.5" r="1.5" fill="#FF5F57"/>
+  <circle cx="10" cy="3.5" r="1.5" fill="#FEBC2E"/>
+  <circle cx="15" cy="3.5" r="1.5" fill="#28C840"/>
+  <!-- % prompt in teal -->
+  <text x="4" y="20" font-family="monospace" font-size="12" font-weight="bold" fill="#00D4AA">%</text>
+  <text x="14" y="20" font-family="monospace" font-size="11" fill="#4ECDC4">_</text>
+  <!-- zsh label -->
+  <text x="4" y="29" font-family="monospace" font-size="7" fill="#4ECDC4">zsh</text>
+</svg>


### PR DESCRIPTION
## Summary

- Auto-discover available local shells on Windows (CMD, PowerShell, PowerShell Core, WSL distros, Git Bash, Cygwin) and Unix/macOS (via `/etc/shells`)
- Add "Local Shells" section to QuickSwitcher with colorful SVG icons, search filtering, and default badge
- Replace manual shell path text input in Settings with dropdown showing discovered shells + "Custom..." fallback
- Wire shell selection end-to-end: QuickSwitcher → session state → terminal session starter → node-pty spawn
- WSL distros launched via `wsl.exe -d <DistroName>` with correct args preserved through all code paths

Closes #493
Closes #426

## Technical details

- Shell discovery in `electron/bridges/shellDiscovery.cjs` using `reg.exe` (Windows) and `/etc/shells` (Unix) — no new native dependencies
- Results cached in memory per app session, exposed via `netcatty:shells:discover` IPC
- Settings stores shell ID (not command path), resolved to command+args at launch via `resolveShellSetting()`
- 10 new colorful SVG shell icons in `public/shells/`; WSL distros reuse existing `public/distro/` icons

## Test plan

- [ ] Open QuickSwitcher — verify "Local Shells" section shows system shells with icons
- [ ] Search "zsh" / "bash" / "fish" — verify filtering works
- [ ] Click a shell — verify new terminal opens with correct shell
- [ ] Settings → Terminal → verify dropdown shows discovered shells
- [ ] Select a non-default shell in Settings, use hotkey to open terminal — verify correct shell opens
- [ ] Verify "Custom..." option in Settings reveals text input for manual path entry
- [ ] Verify existing `localShell` string settings still work (backward compatibility)
- [ ] (Windows) Verify WSL distros detected and launchable via QuickSwitcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)