### PR TITLE
fix: prevent Chromium from consuming Alt+Arrow as browser navigation

### DIFF
--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -721,6 +721,16 @@ async function createWindow(electronModule, options) {
   win.webContents.on("will-navigate", blockUntrustedNavigation);
   win.webContents.on("will-redirect", blockUntrustedNavigation);
 
+  // Prevent Chromium from consuming Alt+Arrow as browser back/forward navigation.
+  // Terminal apps need these keys to pass through to the remote shell (e.g., byobu, tmux).
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.alt && !input.control && !input.meta && !input.shift) {
+      if (input.key === "ArrowLeft" || input.key === "ArrowRight") {
+        event.preventDefault();
+      }
+    }
+  });
+
   // Restore maximized state if it was saved
   if (savedState?.isMaximized && !savedState?.isFullScreen) {
     win.once("ready-to-show", () => {

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -723,12 +723,16 @@ async function createWindow(electronModule, options) {
 
   // Prevent Chromium from consuming Alt+Arrow as browser back/forward navigation.
   // Terminal apps need these keys to pass through to the remote shell (e.g., byobu, tmux).
-  win.webContents.on("before-input-event", (event, input) => {
-    if (input.alt && !input.control && !input.meta && !input.shift) {
+  // Using setIgnoreMenuShortcuts lets the keydown still reach the page (xterm.js)
+  // while preventing Chromium's built-in shortcuts from triggering.
+  win.webContents.on("before-input-event", (_event, input) => {
+    if (input.alt && !input.control && !input.meta) {
       if (input.key === "ArrowLeft" || input.key === "ArrowRight") {
-        event.preventDefault();
+        win.webContents.setIgnoreMenuShortcuts(true);
+        return;
       }
     }
+    win.webContents.setIgnoreMenuShortcuts(false);
   });
 
   // Restore maximized state if it was saved


### PR DESCRIPTION
## Summary

- Chromium intercepts `Alt+Left/Right` as browser back/forward navigation shortcuts, preventing these keys from reaching the terminal
- This breaks byobu/tmux window switching (`Alt+Arrow`) and any other terminal app that uses `Alt+Arrow`
- Fix: block Chromium's default navigation behavior via `before-input-event` on the main window's webContents

Closes #606

## Test plan

- [x] SSH into a server with byobu/tmux installed
- [x] Press `Alt+Left` / `Alt+Right` — verify byobu window switching works
- [x] Verify normal terminal navigation still works (Ctrl+Left/Right for word movement, etc.)
- [x] Verify Alt+Arrow doesn't trigger browser-style back/forward navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)