### PR TITLE
feat: add xterm-container class for custom CSS bottom spacing (#614)

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2012,7 +2012,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         >
           <div
             ref={containerRef}
-            className="absolute inset-x-0 bottom-0"
+            className="xterm-container absolute inset-x-0 bottom-0"
             style={{
               top: isSearchOpen ? "64px" : "30px",
               paddingLeft: 6,


### PR DESCRIPTION
## Summary

- Add a stable `.xterm-container` CSS class to the terminal container div so users can customize bottom spacing via Settings → Appearance → Custom CSS

## Usage

In Custom CSS:
```css
.xterm-container {
  bottom: 10px !important;
}
```

This moves the terminal up, with the gap filled by the parent container's theme-matched background color — no color mismatch.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)