### PR TITLE
fix: sort default shell to top in quick switcher (#613)

### DIFF
--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -89,11 +89,13 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   const discoveredShells = useDiscoveredShells();
 
   const filteredShells = useMemo(() => {
-    if (!query.trim()) return discoveredShells;
-    const q = query.toLowerCase();
-    return discoveredShells.filter(
-      (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q)
-    );
+    const list = !query.trim()
+      ? discoveredShells
+      : discoveredShells.filter(
+          (s) => s.name.toLowerCase().includes(query.toLowerCase()) || s.id.toLowerCase().includes(query.toLowerCase())
+        );
+    // Default shell first
+    return [...list].sort((a, b) => (a.isDefault === b.isDefault ? 0 : a.isDefault ? -1 : 1));
   }, [discoveredShells, query]);
 
   // Get hotkey display strings


### PR DESCRIPTION
## Summary

- Default shell (marked with 「默认」badge) is now sorted to the top of the local shells list in the Quick Switcher
- Previously sorted alphabetically, burying Zsh (default on macOS) at the bottom

Closes #613

## Test plan

- [x] Open Quick Switcher (Cmd+J) → default shell should be first in the list
- [x] Search for a shell → default still appears first among matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)