### PR TITLE
fix: reset mouse tracking on start over to prevent escape sequence leak (#616)

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1430,6 +1430,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const handleRetry = () => {
     if (!termRef.current) return;
     cleanupSession();
+    // Reset terminal state: disable mouse tracking modes and clear screen so
+    // stale SGR mouse sequences don't leak into the new session as text input.
+    termRef.current.write('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l');
+    termRef.current.reset();
     auth.resetForRetry();
     terminalDataCapturedRef.current = false;
     hasRunStartupCommandRef.current = false;


### PR DESCRIPTION
## Summary

- "Start Over" (reconnect) retained xterm mouse tracking modes from the previous session
- Mouse movements during reconnection generated SGR mouse sequences (`35;XX;YYM`) that appeared as visible text in the new session
- Fix: send `\e[?1000l\e[?1002l\e[?1003l\e[?1006l` to disable all mouse tracking modes, then `reset()` the terminal before reconnecting

Closes #616

## Test plan

- [x] Connect to SSH host → run `tmux` or `vim` (enables mouse tracking) → disconnect → click "Start Over" → move mouse → no garbled text should appear
- [x] Normal reconnect without mouse-tracking apps → still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)