### PR TITLE
fix: add missing props destructuring in HostTreeView causing white screen

### DIFF
--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -443,9 +443,11 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
   isMultiSelectMode,
   selectedHostIds,
   toggleHostSelection,
+  getDropTargetClasses,
+  setDragOverDropTarget,
 }) => {
   const { t } = useI18n();
-  
+
   // Use external state if provided, otherwise use local persistent state
   const localTreeState = useTreeExpandedState(STORAGE_KEY_VAULT_HOSTS_TREE_EXPANDED);
   


### PR DESCRIPTION
## Summary
- v1.0.81 白屏的根因：`f284fb05` 给 `HostTreeViewProps` 接口添加了 `getDropTargetClasses` 和 `setDragOverDropTarget` 两个 optional 属性，在 JSX 中也传递了，但**漏了在组件 props 解构中添加**
- TypeScript 不报错（接口定义了这些属性），但运行时变量不存在 → `ReferenceError: getDropTargetClasses is not defined` → React 崩溃 → 白屏
- 修复：在 `HostTreeView` 的 props 解构中补上这两个属性

Closes #625

## Test plan
- [x] 启动应用，确认不再白屏
- [x] 在 Vault 树形视图中拖拽 host 到不同分组，确认 drop 高亮反馈正常
- [x] 确认构建产物中 `getDropTargetClasses` 已被正确 minify（不再有裸变量引用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)