### PR TITLE
fix: stop deduplicating pinned/recent hosts from main host list

### DIFF
--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -960,16 +960,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       .slice(0, 20);
   }, [hosts, selectedGroupPath, search, selectedTags]);
 
-  // IDs of hosts already shown in Pinned/Recent sections at root level,
-  // so the main host list can exclude them to avoid duplicates.
-  const pinnedRecentIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const h of pinnedHosts) ids.add(h.id);
-    if (showRecentHosts) {
-      for (const h of recentHosts) ids.add(h.id);
-    }
-    return ids;
-  }, [pinnedHosts, recentHosts, showRecentHosts]);
+  // No longer deduplicate pinned/recent hosts from the main list,
+  // so hosts always appear in their groups regardless of pinned/recent status.
+  const pinnedRecentIds = useMemo(() => new Set<string>(), []);
 
   // For tree view: apply search, tag filter, and sorting, but not group filtering
   const treeViewHosts = useMemo(() => {


### PR DESCRIPTION
## Summary
- Pinned and recently-connected hosts are no longer excluded from the main host list and group view
- Fixes incomplete group counts and missing hosts when using group sort mode

Closes #632

## Test plan
- [x] Switch to "按分组" sort mode, verify all hosts appear in their groups with correct counts
- [x] Verify pinned hosts appear both in the pinned section and in the main list
- [x] Verify recently-connected hosts appear both in the recent section and in the main list
- [x] Check other sort modes (A-Z, Z-A, newest, oldest) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)