### PR TITLE
fix: prevent crash when codex-acp binary is not found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,11 +49,13 @@ jobs:
           # npm ci only installs optional deps for the host platform, but
           # electron-builder produces both arm64 and x64 binaries, so we
           # need the native codex-acp binary for the other architecture too.
+          # Platform-specific codex-acp packages declare cpu/os constraints,
+          # so --force is needed to install the non-host-arch binary.
           CODEX_VER=$(node -e "console.log(require('./node_modules/@zed-industries/codex-acp/package.json').version)")
           if [[ "${{ matrix.name }}" == "macos" ]]; then
-            npm install "@zed-industries/codex-acp-darwin-x64@${CODEX_VER}" "@zed-industries/codex-acp-darwin-arm64@${CODEX_VER}" --no-save
+            npm install "@zed-industries/codex-acp-darwin-x64@${CODEX_VER}" "@zed-industries/codex-acp-darwin-arm64@${CODEX_VER}" --no-save --force
           elif [[ "${{ matrix.name }}" == "windows" ]]; then
-            npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" "@zed-industries/codex-acp-win32-arm64@${CODEX_VER}" --no-save
+            npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" "@zed-industries/codex-acp-win32-arm64@${CODEX_VER}" --no-save --force
           fi
 
       - name: Set version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,19 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Install cross-platform native binaries
+        shell: bash
+        run: |
+          # npm ci only installs optional deps for the host platform, but
+          # electron-builder produces both arm64 and x64 binaries, so we
+          # need the native codex-acp binary for the other architecture too.
+          CODEX_VER=$(node -e "console.log(require('./node_modules/@zed-industries/codex-acp/package.json').version)")
+          if [[ "${{ matrix.name }}" == "macos" ]]; then
+            npm install "@zed-industries/codex-acp-darwin-x64@${CODEX_VER}" "@zed-industries/codex-acp-darwin-arm64@${CODEX_VER}" --no-save
+          elif [[ "${{ matrix.name }}" == "windows" ]]; then
+            npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" "@zed-industries/codex-acp-win32-arm64@${CODEX_VER}" --no-save
+          fi
+
       - name: Set version
         shell: bash
         run: |

--- a/electron/bridges/ai/codexHelpers.cjs
+++ b/electron/bridges/ai/codexHelpers.cjs
@@ -82,13 +82,13 @@ function resolveCodexAcpBinaryPath(shellEnv, electronModule) {
   // Packaged build (or dev fallback): use npm-bundled binary
   try {
     const pkgName = getCodexPackageName();
-    if (!pkgName) return binaryName;
+    if (!pkgName) return null;
 
     const pkgRoot = path.dirname(require.resolve("@zed-industries/codex-acp/package.json"));
     const resolved = require.resolve(`${pkgName}/bin/${binaryName}`, { paths: [pkgRoot] });
     return toUnpackedAsarPath(resolved);
   } catch {
-    return binaryName;
+    return null;
   }
 }
 

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -1208,8 +1208,14 @@ function registerHandlers(ipcMain) {
 
     const { createACPProvider } = require("@mcpc-tech/acp-ai-provider");
     const shellEnv = await getShellEnv();
+    const resolvedCommand = resolveCodexAcpBinaryPath(shellEnv, electronModule);
+    if (!resolvedCommand) {
+      const result = { ok: false, checkedAt: now, error: "codex-acp binary not found", code: "ENOENT" };
+      setCodexValidationCache(result);
+      return result;
+    }
     const provider = createACPProvider({
-      command: resolveCodexAcpBinaryPath(shellEnv, electronModule),
+      command: resolvedCommand,
       env: shellEnv,
       session: {
         cwd: process.cwd(),
@@ -1927,6 +1933,9 @@ function registerHandlers(ipcMain) {
         : claudeAcp
           ? claudeAcp.command
           : acpCommand;
+      if (!resolvedCommand) {
+        return { ok: false, models: [], error: `${agentLabel} binary not found` };
+      }
       const resolvedArgs = claudeAcp
         ? [...claudeAcp.prependArgs, ...(acpArgs || [])]
         : acpArgs || [];
@@ -2117,6 +2126,9 @@ function registerHandlers(ipcMain) {
           : claudeAcp
             ? claudeAcp.command
             : acpCommand;
+        if (!resolvedCommand) {
+          throw new Error(`${agentLabel} binary not found`);
+        }
         const resolvedArgs = claudeAcp
           ? [...claudeAcp.prependArgs, ...(acpArgs || [])]
           : acpArgs || [];
@@ -2185,12 +2197,16 @@ function registerHandlers(ipcMain) {
         cleanupAcpProvider(chatSessionId);
 
         const fallbackClaudeAcp = isClaudeAgent ? resolveClaudeAcpBinaryPath(shellEnv, electronModule) : null;
+        const fallbackCommand = isCodexAgent
+          ? resolveCodexAcpBinaryPath(shellEnv, electronModule)
+          : fallbackClaudeAcp
+            ? fallbackClaudeAcp.command
+            : acpCommand;
+        if (!fallbackCommand) {
+          throw new Error(`${agentLabel} binary not found`);
+        }
         const fallbackProvider = createACPProvider({
-          command: isCodexAgent
-            ? resolveCodexAcpBinaryPath(shellEnv, electronModule)
-            : fallbackClaudeAcp
-              ? fallbackClaudeAcp.command
-              : acpCommand,
+          command: fallbackCommand,
           args: fallbackClaudeAcp
             ? [...fallbackClaudeAcp.prependArgs, ...(acpArgs || [])]
             : acpArgs || [],


### PR DESCRIPTION
Closes #645

## Summary

- `resolveCodexAcpBinaryPath` 在找不到 `codex-acp` 二进制文件时，原先会返回裸名 `"codex-acp"` 作为 fallback，导致 `createACPProvider` 尝试 spawn 不存在的进程，触发异步 ENOENT 错误使应用崩溃
- 现在改为返回 `null`，并在所有 `createACPProvider` 调用点检查 null，优雅地返回错误而不是崩溃

## Root Cause

```
Error: spawn codex-acp ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
```

`spawn` 的 ENOENT 错误通过 ChildProcess 的 `error` 事件异步触发，无法被 `try-catch` 或 `await` 捕获，最终成为 `uncaughtException` 导致程序崩溃。

## Changes

1. **`codexHelpers.cjs`**: `resolveCodexAcpBinaryPath` 在无法找到二进制文件时返回 `null` 而非裸名
2. **`aiBridge.cjs`**: 在 4 个 `createACPProvider` 调用点增加 null 检查：
   - `validateCodexChatGptAuth` — 返回 `{ ok: false }` 结果
   - `list-models` handler — 返回 `{ ok: false, models: [] }` 
   - `send-message` handler (主路径 + fallback) — 抛出错误由上层 catch 处理

## Test plan

- [ ] 在未安装 codex-acp 的环境下打开设置 → AI 菜单，确认不崩溃
- [ ] 在已安装 codex-acp 的环境下确认 AI 功能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)