### PR TITLE
fix: prevent host details panel from being clipped on narrow windows

### DIFF
--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -1723,7 +1723,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       </TooltipProvider>
 
       {/* Main Area */}
-      <div className="flex-1 flex flex-col min-h-0 relative">
+      <div className="flex-1 min-w-0 flex flex-col min-h-0 relative">
         <header
           className={cn(
             "border-b border-border/50 bg-secondary/80 backdrop-blur app-drag",
@@ -1832,14 +1832,25 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                 <CheckSquare size={16} />
               </Button>
             </div>
-            {/* New Host split button */}
-            <div className="flex items-center app-no-drag">
+            {/* New Host split button — collapses with an animation when the
+                host details / new-host aside panel is open, since the button
+                would be a no-op in that state. */}
+            <div
+              className={cn(
+                "flex items-center app-no-drag overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-in-out",
+                isHostPanelOpen
+                  ? "max-w-0 opacity-0 -ml-2 pointer-events-none"
+                  : "max-w-[260px] opacity-100",
+              )}
+              aria-hidden={isHostPanelOpen}
+            >
               <Dropdown>
                 <div className="flex items-center rounded-md bg-primary text-primary-foreground">
                   <Button
                     size="sm"
                     className="h-10 px-3 rounded-r-none bg-transparent hover:bg-white/10 shadow-none app-no-drag"
                     onClick={handleNewHost}
+                    tabIndex={isHostPanelOpen ? -1 : 0}
                   >
                     <Plus size={14} className="mr-2" /> {t("vault.hosts.newHost")}
                   </Button>
@@ -1847,6 +1858,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                     <Button
                       size="sm"
                       className="h-10 px-2 rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none app-no-drag"
+                      tabIndex={isHostPanelOpen ? -1 : 0}
                     >
                       <ChevronDown size={14} />
                     </Button>
@@ -1883,22 +1895,37 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                 </DropdownContent>
               </Dropdown>
             </div>
-            <Button
-              size="sm"
-              variant="secondary"
-              className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
-              onClick={onCreateLocalTerminal}
+            {/* Terminal + Serial — collapse together with an animation when
+                the host details / new-host aside panel is open, freeing
+                horizontal space for the panel. */}
+            <div
+              className={cn(
+                "flex items-center gap-3 overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-in-out",
+                isHostPanelOpen
+                  ? "max-w-0 opacity-0 -ml-3 pointer-events-none"
+                  : "max-w-[320px] opacity-100",
+              )}
+              aria-hidden={isHostPanelOpen}
             >
-              <TerminalSquare size={14} className="mr-2" /> {t("common.terminal")}
-            </Button>
-            <Button
-              size="sm"
-              variant="secondary"
-              className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
-              onClick={() => setIsSerialModalOpen(true)}
-            >
-              <Usb size={14} className="mr-2" /> {t("serial.button")}
-            </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+                onClick={onCreateLocalTerminal}
+                tabIndex={isHostPanelOpen ? -1 : 0}
+              >
+                <TerminalSquare size={14} className="mr-2" /> {t("common.terminal")}
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+                onClick={() => setIsSerialModalOpen(true)}
+                tabIndex={isHostPanelOpen ? -1 : 0}
+              >
+                <Usb size={14} className="mr-2" /> {t("serial.button")}
+              </Button>
+            </div>
           </div>
         </header>
 

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -44,6 +44,10 @@ const OAUTH_LOOPBACK_PORT = 45678; // must match electron/bridges/oauthBridge.cj
 const WINDOW_STATE_FILE = "window-state.json";
 const DEFAULT_WINDOW_WIDTH = 1400;
 const DEFAULT_WINDOW_HEIGHT = 900;
+// Minimum window size: enough to render the expanded sidebar + a usable
+// host list + the 420px host details / new-host aside panel without overflow.
+const MIN_WINDOW_WIDTH = 1100;
+const MIN_WINDOW_HEIGHT = 640;
 
 function debugLog(...args) {
   if (!DEBUG_WINDOWS) return;
@@ -626,9 +630,10 @@ async function createWindow(electronModule, options) {
   };
 
   if (savedState) {
-    // Use saved dimensions
-    windowBounds.width = savedState.width;
-    windowBounds.height = savedState.height;
+    // Use saved dimensions, but clamp to the minimum so a previously
+    // shrunk window from an older build cannot start below the minimum.
+    windowBounds.width = Math.max(savedState.width, MIN_WINDOW_WIDTH);
+    windowBounds.height = Math.max(savedState.height, MIN_WINDOW_HEIGHT);
 
     // Only use saved position if the screen is available at that location
     if (typeof savedState.x === "number" && typeof savedState.y === "number") {
@@ -658,6 +663,8 @@ async function createWindow(electronModule, options) {
 
   const win = new BrowserWindow({
     ...windowBounds,
+    minWidth: MIN_WINDOW_WIDTH,
+    minHeight: MIN_WINDOW_HEIGHT,
     backgroundColor,
     icon: appIcon,
     show: false,


### PR DESCRIPTION
## Summary

修复 host details / new-host aside panel 在窗口较窄时会被裁切的问题，并优化窗口空间利用。

## Changes

### Layout fix
- **`min-w-0` on main area** — 真正的 root cause。原本主内容区缺少 \`min-w-0\`，flexbox 无法收缩主内容部分，导致 420px 的 aside panel 被挤出窗口右边。加上后窗口变窄时主列表会自动收缩让 panel 始终可见

### Window minimum size
- 将 \`BrowserWindow\` 的 \`minWidth\` / \`minHeight\` 设为 \`1100 × 640\`，防止用户拖到比 sidebar + 主列表 + 420px panel 还小的尺寸
- 加载已保存的窗口尺寸时也 clamp 到最小值，避免老版本留下的小窗口启动后就违反约束
- ⚠️ 需要重启 app 才能生效（Electron 只在窗口创建时读取 minWidth）

### UI 动画优化
打开 host details / new-host panel 时折叠以下控件，节省横向空间：
- **New Host** 按钮（含下拉箭头）— 面板打开时这个按钮就是 no-op
- **Terminal** + **Serial** 按钮 — 200ms 过渡动画

折叠通过 \`max-width\`、\`opacity\`、\`margin\` 三个属性的过渡实现。\`aria-hidden\` + \`tabIndex=-1\` 防止屏幕阅读器和键盘 tab 到隐藏的按钮。

## Test plan

- [x] 重启 app 后无法将窗口拖到 1100×640 以下
- [x] 打开 host details panel 时 New Host / Terminal / Serial 按钮以动画方式消失
- [x] 关闭 panel 时按钮以动画方式恢复
- [x] 窗口拖到接近最小尺寸时 panel 内容完整显示，主列表自动收缩
- [x] 之前已经被拖小的窗口启动时自动 clamp 到 1100×640

🤖 Generated with [Claude Code](https://claude.com/claude-code)