### PR TITLE
feat: add data-section hooks for Custom CSS targeting (#642)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -237,9 +237,9 @@ const en: Messages = {
   'settings.appearance.themeColor.dark': 'Dark palette',
   'settings.appearance.customCss': 'Custom CSS',
   'settings.appearance.customCss.desc':
-    'Add custom CSS to personalize the app appearance. Changes apply immediately.',
+    'Add custom CSS to personalize the app appearance. Changes apply immediately. Major UI regions expose a [data-section="..."] attribute you can target — e.g. snippets-panel, host-details-panel, group-details-panel, serial-host-details-panel, ai-chat-panel, vault-sidebar, vault-main, vault-hosts-header, vault-host-list, vault-view, terminal-workspace, terminal-workspace-sidebar, top-tabs.',
   'settings.appearance.customCss.placeholder':
-    '/* Example: */\n.terminal { background: #1a1a2e !important; }\n:root { --radius: 0.25rem; }',
+    '/* Examples — use !important to beat Tailwind utility specificity */\n\n/* Make snippet sidebar text larger */\n[data-section="snippets-panel"] {\n  font-size: 14px !important;\n}\n\n/* Custom terminal background */\n.terminal { background: #1a1a2e !important; }\n\n/* Tweak global border radius */\n:root { --radius: 0.25rem; }',
   'settings.appearance.language': 'Language',
   'settings.appearance.language.desc': 'Choose the UI language',
   'settings.appearance.uiFont': 'Interface Font',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -220,9 +220,10 @@ const zhCN: Messages = {
   'settings.appearance.themeColor.light': '浅色主题',
   'settings.appearance.themeColor.dark': '深色主题',
   'settings.appearance.customCss': '自定义 CSS',
-  'settings.appearance.customCss.desc': '使用自定义 CSS 个性化界面，修改会立即生效。',
+  'settings.appearance.customCss.desc':
+    '使用自定义 CSS 个性化界面，修改会立即生效。主要 UI 区块都暴露了 [data-section="..."] 属性供你定位，比如：snippets-panel、host-details-panel、group-details-panel、serial-host-details-panel、ai-chat-panel、vault-sidebar、vault-main、vault-hosts-header、vault-host-list、vault-view、terminal-workspace、terminal-workspace-sidebar、top-tabs。',
   'settings.appearance.customCss.placeholder':
-    '/* 示例：*/\n.terminal { background: #1a1a2e !important; }\n:root { --radius: 0.25rem; }',
+    '/* 示例 — 由于 Tailwind 优先级较高，需要使用 !important */\n\n/* 放大代码片段侧边栏字号 */\n[data-section="snippets-panel"] {\n  font-size: 14px !important;\n}\n\n/* 自定义终端背景色 */\n.terminal { background: #1a1a2e !important; }\n\n/* 调整全局圆角 */\n:root { --radius: 0.25rem; }',
   'settings.appearance.language': '语言',
   'settings.appearance.language.desc': '选择界面语言',
   'settings.appearance.uiFont': '界面字体',

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -775,7 +775,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   if (!isVisible) return null;
 
   return (
-    <div className="flex flex-col h-full bg-background">
+    <div className="flex flex-col h-full bg-background" data-section="ai-chat-panel">
       {/* ── Header ── */}
       <div className="px-2.5 py-1.5 flex items-center justify-between border-b border-border/50 shrink-0">
         <AgentSelector

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -433,6 +433,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
       open={true}
       onClose={onCancel}
       width="w-[380px]"
+      dataSection="group-details-panel"
       title={t("vault.groups.details")}
       layout={layout}
       actions={

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -634,6 +634,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       onClose={onCancel}
       width="w-[420px]"
       layout={layout}
+      dataSection="host-details-panel"
       title={
         initialData ? t("hostDetails.title.details") : t("hostDetails.title.new")
       }

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -124,7 +124,10 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   const hasAnyContent = snippets.length > 0 || packages.length > 0;
 
   return (
-    <div className="h-full flex flex-col bg-background overflow-hidden">
+    <div
+      className="h-full flex flex-col bg-background overflow-hidden"
+      data-section="snippets-panel"
+    >
       {/* Search */}
       <div className="shrink-0 px-2 py-1.5 border-b border-border/50">
         <div className="relative">

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -168,6 +168,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
       subtitle={initialData.label}
       className="z-40"
       layout={layout}
+      dataSection="serial-host-details-panel"
     >
       <AsidePanelContent>
         {/* Label */}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1819,7 +1819,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     if (!activeWorkspace || !isFocusMode) return null;
 
     return (
-      <div className="w-56 flex-shrink-0 bg-secondary/50 border-r border-border/50 flex flex-col">
+      <div
+        className="w-56 flex-shrink-0 bg-secondary/50 border-r border-border/50 flex flex-col"
+        data-section="terminal-workspace-sidebar"
+      >
         {/* Header with view toggle */}
         <div className="h-10 flex items-center justify-between px-3 border-b border-border/50">
           <span className="text-xs font-medium text-muted-foreground">
@@ -1890,6 +1893,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       <div
         ref={workspaceOuterRef}
         className="absolute inset-0 bg-background flex flex-col"
+        data-section="terminal-workspace"
         style={{
           visibility: isTerminalLayerVisible ? 'visible' : 'hidden',
           pointerEvents: isTerminalLayerVisible ? 'auto' : 'none',

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -765,6 +765,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   return (
     <div
       data-top-tabs-root
+      data-section="top-tabs"
       className="relative w-full bg-secondary app-drag"
       style={{
         ...dragRegionNoSelect,

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -1554,13 +1554,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
   // Component no longer handles visibility - that's done by VaultViewWrapper
   return (
-    <div ref={rootRef} className="absolute inset-0 min-h-0 flex">
+    <div ref={rootRef} className="absolute inset-0 min-h-0 flex" data-section="vault-view">
       {/* Sidebar */}
       <TooltipProvider delayDuration={100}>
-        <div className={cn(
-          "bg-secondary/80 border-r border-border/60 flex flex-col transition-all duration-200",
-          sidebarCollapsed ? "w-14" : "w-52"
-        )}>
+        <div
+          className={cn(
+            "bg-secondary/80 border-r border-border/60 flex flex-col transition-all duration-200",
+            sidebarCollapsed ? "w-14" : "w-52"
+          )}
+          data-section="vault-sidebar"
+        >
           <div className={cn(
             "py-4 flex items-center",
             sidebarCollapsed ? "px-2 justify-center" : "px-4"
@@ -1723,12 +1726,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       </TooltipProvider>
 
       {/* Main Area */}
-      <div className="flex-1 min-w-0 flex flex-col min-h-0 relative">
+      <div
+        className="flex-1 min-w-0 flex flex-col min-h-0 relative"
+        data-section="vault-main"
+      >
         <header
           className={cn(
             "border-b border-border/50 bg-secondary/80 backdrop-blur app-drag",
             !isHostsSectionActive && "hidden",
           )}
+          data-section="vault-hosts-header"
         >
           <div className="h-14 px-4 py-2 flex items-center gap-3">
             <div className="relative flex-1 app-no-drag">
@@ -1935,6 +1942,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
             "flex-1 overflow-auto px-4 py-4 space-y-6",
             !isHostsSectionActive && "hidden",
           )}
+          data-section="vault-host-list"
           onDragEndCapture={() => setDragOverDropTarget(null)}
         >
                 <section className="space-y-2">

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -45,6 +45,11 @@ interface AsidePanelProps {
     className?: string;
     width?: string;
     layout?: AsidePanelLayout;
+    /**
+     * Optional stable identifier emitted as `data-section` on the panel
+     * root. Used as a targeting hook for Custom CSS (Settings → Appearance).
+     */
+    dataSection?: string;
 }
 
 interface AsidePanelHeaderProps {
@@ -173,6 +178,11 @@ interface AsidePanelStackProps {
     className?: string;
     width?: string;
     layout?: AsidePanelLayout;
+    /**
+     * Optional stable identifier emitted as `data-section` on the panel
+     * root. Used as a targeting hook for Custom CSS.
+     */
+    dataSection?: string;
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
@@ -200,6 +210,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     className,
     width = 'w-[380px]',
     layout = 'overlay',
+    dataSection,
 }) => {
     const [stack, setStack] = useState<AsideContentItem[]>([initialItem]);
 
@@ -252,7 +263,8 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
                 layout === 'overlay' && width,
                 className
             )}
-            style={inlineStyle}>
+            style={inlineStyle}
+            data-section={dataSection}>
                 <AsidePanelHeader
                     title={currentItem.title}
                     subtitle={currentItem.subtitle}
@@ -280,6 +292,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     className,
     width = 'w-[380px]',
     layout = 'overlay',
+    dataSection,
 }) => {
     if (!open) return null;
 
@@ -299,7 +312,8 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
             layout === 'overlay' && width,
             className
         )}
-        style={inlineStyle}>
+        style={inlineStyle}
+        data-section={dataSection}>
             {title && (
                 <AsidePanelHeader
                     title={title}


### PR DESCRIPTION
Closes #642

## Summary

Custom CSS 功能之前已经实现（Settings → Appearance → Custom CSS），但主要 UI 组件只用 Tailwind 工具类，用户很难可靠地定位到特定区块。

本 PR 给常见的 UI 区块根元素加上稳定的 \`data-section="..."\` 属性，用户可以在自定义 CSS 里写 \`[data-section=\"snippets-panel\"] { font-size: 14px !important; }\` 这样的选择器，不再依赖实现细节。

## Changes

### 新增 data-section 钩子

| 组件 | data-section |
|------|---|
| \`ScriptsSidePanel\` | \`snippets-panel\` |
| \`HostDetailsPanel\` (via AsidePanel) | \`host-details-panel\` |
| \`GroupDetailsPanel\` | \`group-details-panel\` |
| \`SerialHostDetailsPanel\` | \`serial-host-details-panel\` |
| \`AIChatSidePanel\` | \`ai-chat-panel\` |
| \`VaultView\` root | \`vault-view\` |
| \`VaultView\` sidebar | \`vault-sidebar\` |
| \`VaultView\` main | \`vault-main\` |
| \`VaultView\` hosts header | \`vault-hosts-header\` |
| \`VaultView\` host list | \`vault-host-list\` |
| \`TerminalLayer\` workspace | \`terminal-workspace\` |
| \`TerminalLayer\` workspace sidebar | \`terminal-workspace-sidebar\` |
| \`TopTabs\` | \`top-tabs\` |

\`AsidePanel\` / \`AsidePanelStack\` 新增了可选的 \`dataSection\` prop，这样所有基于 AsidePanel 的面板都可以按需传入而不需要改动内部结构。

### 更新 Custom CSS 描述与 placeholder (en + zh-CN)

- Description 列出可用的 \`data-section\` 值
- Placeholder 加入真实可用的示例（放大 snippet 面板字号 / 自定义终端背景 / 调整圆角）
- 说明 Tailwind 工具类优先级较高，需要 \`!important\`

## Test plan

- [x] \`npx vite build\` 通过
- [x] 打开 Settings → Appearance → Custom CSS，在输入框里粘贴 \`[data-section="snippets-panel"] { font-size: 14px !important; }\`，确认代码片段侧边栏字号变大
- [x] 确认 \`HostDetailsPanel\` / \`GroupDetailsPanel\` 等 aside panel 根元素的 DOM 上有 \`data-section\` 属性

🤖 Generated with [Claude Code](https://claude.com/claude-code)