### PR TITLE
fix: open quick-add snippet modal in place instead of navigating

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,6 +32,7 @@ import { Input } from './components/ui/input';
 import { Label } from './components/ui/label';
 import { ToastProvider, toast } from './components/ui/toast';
 import { VaultView, VaultSection } from './components/VaultView';
+import { QuickAddSnippetDialog } from './components/QuickAddSnippetDialog';
 import { KeyboardInteractiveModal, KeyboardInteractiveRequest } from './components/KeyboardInteractiveModal';
 import { PassphraseModal, PassphraseRequest } from './components/PassphraseModal';
 import { cn } from './lib/utils';
@@ -171,10 +172,6 @@ function App({ settings }: { settings: SettingsState }) {
   const [protocolSelectHost, setProtocolSelectHost] = useState<Host | null>(null);
   // Navigation state for VaultView sections
   const [navigateToSection, setNavigateToSection] = useState<VaultSection | null>(null);
-  // One-shot "pending add snippet" flag. Set true when the terminal-side
-  // ScriptsSidePanel "+" button is clicked. Cleared by SnippetsManager
-  // once it has consumed the request and opened its add panel.
-  const [pendingSnippetAdd, setPendingSnippetAdd] = useState(false);
   // Keyboard-interactive authentication queue (2FA/MFA) - queue-based to handle multiple concurrent sessions
   const [keyboardInteractiveQueue, setKeyboardInteractiveQueue] = useState<KeyboardInteractiveRequest[]>([]);
   // Passphrase request queue for encrypted SSH keys
@@ -580,24 +577,6 @@ function App({ settings }: { settings: SettingsState }) {
       setIsQuickSwitcherOpen(false);
     }
   });
-
-  // Listen for "add snippet" requests from the terminal-side ScriptsSidePanel.
-  // Switches the active tab to the vault, navigates to the Snippets section,
-  // and raises a one-shot pending flag so SnippetsManager opens its add panel
-  // on mount. SnippetsManager clears the flag via the handled callback.
-  useEffect(() => {
-    const handler = () => {
-      setActiveTabId('vault');
-      setNavigateToSection('snippets');
-      setPendingSnippetAdd(true);
-    };
-    window.addEventListener('netcatty:snippets:add', handler);
-    return () => window.removeEventListener('netcatty:snippets:add', handler);
-  }, [setActiveTabId]);
-
-  const handlePendingSnippetAddHandled = useCallback(() => {
-    setPendingSnippetAdd(false);
-  }, []);
 
   // Show toast notification when update is available (only when auto-download is idle)
   useEffect(() => {
@@ -1469,8 +1448,6 @@ function App({ settings }: { settings: SettingsState }) {
             onOpenLogView={openLogView}
             navigateToSection={navigateToSection}
             onNavigateToSectionHandled={() => setNavigateToSection(null)}
-            pendingSnippetAdd={pendingSnippetAdd}
-            onPendingSnippetAddHandled={handlePendingSnippetAddHandled}
           />
         </VaultViewContainer>
 
@@ -1561,6 +1538,17 @@ function App({ settings }: { settings: SettingsState }) {
           );
         })}
       </div>
+
+      {/* Global "quick add snippet" dialog, triggered by the
+          netcatty:snippets:add window event (from ScriptsSidePanel "+"). */}
+      <QuickAddSnippetDialog
+        snippets={snippets}
+        packages={snippetPackages}
+        onCreateSnippet={(snippet) => updateSnippets([...snippets, snippet])}
+        onCreatePackage={(pkg) =>
+          updateSnippetPackages(Array.from(new Set([...snippetPackages, pkg])))
+        }
+      />
 
       {isQuickSwitcherOpen && (
         <Suspense fallback={null}>

--- a/components/QuickAddSnippetDialog.tsx
+++ b/components/QuickAddSnippetDialog.tsx
@@ -1,0 +1,185 @@
+/**
+ * QuickAddSnippetDialog — lightweight "new snippet" modal mounted at the
+ * App root and triggered by the `netcatty:snippets:add` window event.
+ *
+ * Intentionally minimal: label + command + package only. Advanced fields
+ * (target hosts, shortkey, tags) can be set later via the full Snippets
+ * manager. This keeps the user in their terminal context instead of
+ * navigating to the Vault view just to add a command.
+ */
+
+import { Package } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useI18n } from '../application/i18n/I18nProvider';
+import type { Snippet } from '../domain/models';
+import { Button } from './ui/button';
+import { Combobox } from './ui/combobox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
+
+export interface QuickAddSnippetDialogProps {
+  snippets: Snippet[];
+  packages: string[];
+  onCreateSnippet: (snippet: Snippet) => void;
+  onCreatePackage?: (packagePath: string) => void;
+}
+
+export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
+  snippets,
+  packages,
+  onCreateSnippet,
+  onCreatePackage,
+}) => {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState('');
+  const [command, setCommand] = useState('');
+  const [packagePath, setPackagePath] = useState('');
+  const labelInputRef = useRef<HTMLInputElement>(null);
+
+  // Listen for the global "add snippet" request dispatched by the
+  // terminal-side ScriptsSidePanel + button. We reset form state on
+  // every open so stale input from a previous cancel does not leak.
+  useEffect(() => {
+    const handler = () => {
+      setLabel('');
+      setCommand('');
+      setPackagePath('');
+      setOpen(true);
+    };
+    window.addEventListener('netcatty:snippets:add', handler);
+    return () => window.removeEventListener('netcatty:snippets:add', handler);
+  }, []);
+
+  // Auto-focus the label input once the dialog renders, so the user can
+  // start typing immediately after clicking the + button.
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => labelInputRef.current?.focus(), 50);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  // Derive combobox options from the union of existing packages (from
+  // props) and any package path referenced by an existing snippet, so
+  // the user can reuse anything they see in the main snippets view.
+  const packageOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of packages) {
+      if (p) set.add(p);
+    }
+    for (const s of snippets) {
+      if (s.package) set.add(s.package);
+    }
+    return Array.from(set).sort().map((value) => ({ value, label: value }));
+  }, [packages, snippets]);
+
+  const canSave = label.trim().length > 0 && command.trim().length > 0;
+
+  const handleSave = useCallback(() => {
+    if (!canSave) return;
+    const trimmedPackage = packagePath.trim();
+    // If the user typed a brand new package name, surface it to the parent
+    // so it can be added to the user's package list alongside the snippet.
+    if (trimmedPackage && !packages.includes(trimmedPackage)) {
+      onCreatePackage?.(trimmedPackage);
+    }
+    onCreateSnippet({
+      id: crypto.randomUUID(),
+      label: label.trim(),
+      command, // preserve whitespace in multi-line commands
+      tags: [],
+      package: trimmedPackage || '',
+      targets: [],
+    });
+    setOpen(false);
+  }, [canSave, packagePath, packages, onCreatePackage, onCreateSnippet, label, command]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Cmd/Ctrl+Enter from anywhere in the dialog saves the snippet.
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canSave) {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [canSave, handleSave],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md" onKeyDown={handleKeyDown}>
+        <DialogHeader>
+          <DialogTitle>{t('snippets.panel.newTitle')}</DialogTitle>
+          <DialogDescription>
+            {t('snippets.empty.desc')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="quick-add-snippet-label" className="text-xs">
+              {t('snippets.field.description')}
+            </Label>
+            <Input
+              id="quick-add-snippet-label"
+              ref={labelInputRef}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t('snippets.field.descriptionPlaceholder')}
+              className="h-9"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="quick-add-snippet-command" className="text-xs">
+              {t('snippets.field.scriptRequired')}
+            </Label>
+            <Textarea
+              id="quick-add-snippet-command"
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="echo hello"
+              className="min-h-[120px] font-mono text-xs"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs flex items-center gap-1.5">
+              <Package size={12} /> {t('snippets.field.package')}
+            </Label>
+            <Combobox
+              value={packagePath}
+              onValueChange={setPackagePath}
+              options={packageOptions}
+              placeholder={t('snippets.field.packagePlaceholder')}
+              allowCreate
+              onCreateNew={setPackagePath}
+              createText={t('snippets.field.createPackage')}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            {t('common.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default QuickAddSnippetDialog;

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -38,12 +38,6 @@ interface SnippetsManagerProps {
   managedSources?: ManagedSource[];
   onSaveHost?: (host: Host) => void;
   onCreateGroup?: (groupPath: string) => void;
-  // One-shot pending flag: when true, the manager opens its "add snippet"
-  // panel and then invokes onPendingAddHandled to clear the flag. Used so
-  // the terminal-side ScriptsSidePanel "+" button can jump straight into
-  // the add flow even when SnippetsManager is mounting for the first time.
-  pendingAdd?: boolean;
-  onPendingAddHandled?: () => void;
 }
 
 type RightPanelMode = 'none' | 'edit-snippet' | 'history' | 'select-targets';
@@ -67,8 +61,6 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   managedSources = [],
   onSaveHost,
   onCreateGroup,
-  pendingAdd,
-  onPendingAddHandled,
 }) => {
   const { t } = useI18n();
   // Panel state
@@ -300,28 +292,6 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     }
     setRightPanelMode('edit-snippet');
   };
-
-  // When the parent raises the pendingAdd flag (e.g. user clicked "+" on
-  // the terminal-side ScriptsSidePanel), open the add panel on mount /
-  // when the flag turns true, then clear the flag via the handled callback.
-  // Using a one-shot flag (vs. a monotonic trigger) avoids the edge case
-  // where the trigger is already non-zero on first mount and the naive
-  // "last-seen" comparison would skip the initial open.
-  useEffect(() => {
-    if (!pendingAdd) return;
-    setEditingSnippet({
-      label: '',
-      command: '',
-      package: selectedPackage || '',
-      targets: [],
-    });
-    setTargetSelection([]);
-    setRightPanelMode('edit-snippet');
-    onPendingAddHandled?.();
-    // selectedPackage is intentionally not a dep — we snapshot it when
-    // opening the panel, not on every selectedPackage change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingAdd, onPendingAddHandled]);
 
   const handleSubmit = () => {
     if (editingSnippet.label && editingSnippet.command) {

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -150,11 +150,6 @@ interface VaultViewProps {
   // Optional: navigate to a specific section on mount or when changed
   navigateToSection?: VaultSection | null;
   onNavigateToSectionHandled?: () => void;
-  // One-shot pending flag from the terminal-side ScriptsSidePanel "+"
-  // button. When true, SnippetsManager opens its add panel and then
-  // calls onPendingSnippetAddHandled to clear the flag.
-  pendingSnippetAdd?: boolean;
-  onPendingSnippetAddHandled?: () => void;
 }
 
 const VaultViewInner: React.FC<VaultViewProps> = ({
@@ -200,8 +195,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   onUpdateGroupConfigs,
   navigateToSection,
   onNavigateToSectionHandled,
-  pendingSnippetAdd,
-  onPendingSnippetAddHandled,
 }) => {
   const { t } = useI18n();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -2794,8 +2787,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                 Array.from(new Set([...customGroups, groupPath])),
               )
             }
-            pendingAdd={pendingSnippetAdd}
-            onPendingAddHandled={onPendingSnippetAddHandled}
           />
         )}
         {currentSection === "keys" && (


### PR DESCRIPTION
## Problem

上一个 PR (#656) 把终端侧边栏 + 按钮的实现做成了"跳到 Vault 主页 → 切到 Snippets 页 → 打开新增面板"。这把用户从当前的终端上下文中拽走了，和这个功能本来要解决的问题是相反的。

## Fix

用一个轻量级的 **modal dialog** 替代跨面板导航，dialog 挂在 App 根节点，在终端里直接弹出，不离开当前 tab。

### 变更

- **新组件 \`QuickAddSnippetDialog\`**
  - 自己管理 form 状态，字段：label、command（多行）、package（combobox，允许新建）
  - 响应 \`netcatty:snippets:add\` window 事件自动打开
  - \`Cmd/Ctrl+Enter\` 任意位置保存
  - 打开时自动 focus 到 label 输入框
- **App.tsx** 全局挂载 dialog，连接到 \`updateSnippets\` / \`updateSnippetPackages\`，无需通过 TerminalLayer 穿透 props
- **回退**：移除 \`navigateToSection/pendingSnippetAdd/openAddTrigger\` 相关的 plumbing（App.tsx、VaultView、SnippetsManager）

高级字段（targets、shortkey、tags）仍然可以通过完整的 Snippets 管理页面后续编辑。

## Test plan

- [x] \`npm run lint\` 通过
- [x] \`npx vite build\` 通过
- [ ] 在终端里点击 Scripts 侧边栏的 \`+\` → 应该在当前位置弹出 modal，**不跳转**到 Vault 页
- [ ] 填入 label + command，点 Save → 新片段立即出现在侧边栏
- [ ] 新建 package 也能生效
- [ ] Cmd/Ctrl+Enter 能快速保存
- [ ] Esc / 点击遮罩 / 取消按钮都能关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)