### PR TITLE
fix: pin toolbar above content on KeychainManager page

### DIFF
--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -513,7 +513,12 @@ echo $3 >> "$FILE"`);
       />
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col min-h-0">
+      <div
+        className={cn(
+          "flex-1 flex flex-col min-h-0 transition-all duration-200",
+          panel.type !== "closed" && "mr-[380px]",
+        )}
+      >
         {/* Toolbar */}
         <div className="flex flex-wrap items-center gap-3 bg-secondary/60 border-b border-border/70 px-3 py-1.5 shrink-0">
           {/* Filter Tabs */}
@@ -680,12 +685,7 @@ echo $3 >> "$FILE"`);
         </div>
 
         {/* Scrollable Content */}
-        <div
-          className={cn(
-            "flex-1 overflow-y-auto transition-all duration-200",
-            panel.type !== "closed" && "mr-[380px]",
-          )}
-        >
+        <div className="flex-1 overflow-y-auto">
           {/* Keys Section */}
           <div className="space-y-3 p-3">
           <div className="flex items-center justify-between">

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -513,14 +513,9 @@ echo $3 >> "$FILE"`);
       />
 
       {/* Main Content */}
-      <div
-        className={cn(
-          "flex-1 overflow-y-auto transition-all duration-200",
-          panel.type !== "closed" && "mr-[380px]",
-        )}
-      >
+      <div className="flex-1 flex flex-col min-h-0">
         {/* Toolbar */}
-        <div className="flex flex-wrap items-center gap-3 bg-secondary/60 border-b border-border/70 px-3 py-1.5">
+        <div className="flex flex-wrap items-center gap-3 bg-secondary/60 border-b border-border/70 px-3 py-1.5 shrink-0">
           {/* Filter Tabs */}
           <div className="flex items-center gap-1">
             {/* KEY button with split interaction: left=switch view, right=dropdown */}
@@ -684,8 +679,15 @@ echo $3 >> "$FILE"`);
           </div>
         </div>
 
-        {/* Keys Section */}
-        <div className="space-y-3 p-3">
+        {/* Scrollable Content */}
+        <div
+          className={cn(
+            "flex-1 overflow-y-auto transition-all duration-200",
+            panel.type !== "closed" && "mr-[380px]",
+          )}
+        >
+          {/* Keys Section */}
+          <div className="space-y-3 p-3">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold text-muted-foreground">
               {t("keychain.section.keys")}
@@ -817,6 +819,7 @@ echo $3 >> "$FILE"`);
             </div>
           </div>
         )}
+        </div>
       </div>
 
       {/* Slide-out Panel */}


### PR DESCRIPTION
## Summary
- Restructure the KeychainManager layout so the toolbar (filter tabs, search, actions) stays pinned at the top while the list below scrolls independently
- Previously the toolbar scrolled away with the content when the key/snippet list was long, making filtering and searching inconvenient

## Changes
- Wrap the main content in a `flex flex-col min-h-0` container
- Add `shrink-0` to the toolbar so it never collapses
- Move `flex-1 overflow-y-auto` (and the slide-out panel offset `mr-[380px]`) onto a new inner scroll container that holds the keys section

## Test plan
- [x] Open the Keychain page with enough keys/snippets to require scrolling
- [x] Scroll the list — verify the toolbar stays visible at the top
- [x] Toggle a slide-out panel and verify the content area still reserves the 380px right margin
- [x] Verify filter tabs, search, and action buttons in the toolbar still work as before