### PR TITLE
fix: preserve file permissions when saving edited file via SFTP

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1388,7 +1388,12 @@ async function readSftpBinary(event, payload) {
 }
 
 /**
- * Write file content
+ * Write file content.
+ *
+ * If the target file already exists, its mode is preserved — ssh2-sftp-client's
+ * `put()` otherwise overwrites existing files with the server's default mode
+ * (typically 0o666 after umask), which would silently change permissions on
+ * files edited through the built-in text editor.
  */
 async function writeSftp(event, payload) {
   const client = sftpClients.get(payload.sftpId);
@@ -1397,7 +1402,30 @@ async function writeSftp(event, payload) {
   await requireSftpChannel(client);
   const encoding = resolveEncodingForRequest(payload.sftpId, payload.encoding);
   const encodedPath = encodePath(payload.path, encoding);
+
+  let existingMode = null;
+  try {
+    const stat = await client.stat(encodedPath);
+    if (typeof stat.mode === "number") {
+      existingMode = stat.mode & 0o777;
+    }
+  } catch (_err) {
+    // File does not exist — treat as a new file and let the server apply defaults.
+  }
+
   await client.put(Buffer.from(payload.content, "utf-8"), encodedPath);
+
+  if (existingMode !== null) {
+    try {
+      await client.chmod(encodedPath, existingMode);
+    } catch (err) {
+      console.warn(
+        `[sftp] Failed to restore permissions on ${payload.path}:`,
+        err && err.message ? err.message : err,
+      );
+    }
+  }
+
   return true;
 }
 

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1407,7 +1407,8 @@ async function writeSftp(event, payload) {
   try {
     const stat = await client.stat(encodedPath);
     if (typeof stat.mode === "number") {
-      existingMode = stat.mode & 0o777;
+      // Mask with 0o7777 so special bits (setuid/setgid/sticky) are preserved too.
+      existingMode = stat.mode & 0o7777;
     }
   } catch (_err) {
     // File does not exist — treat as a new file and let the server apply defaults.


### PR DESCRIPTION
## Summary
- Stat the target file before `client.put()` to capture its existing mode, then `chmod` it back after write completes
- Fixes permissions silently changing from e.g. `755` to `666` after editing a file through the built-in text editor

Closes #665

## Root cause
`ssh2-sftp-client`'s `put()` overwrites existing files with the server's default mode (typically `0o666` after umask), so any file edited through the built-in editor loses its original permissions.

## Approach
Handled entirely in the bridge layer (`electron/bridges/sftpBridge.cjs`):

1. Stat the target path before writing — if it exists, capture `stat.mode & 0o777`
2. Perform the `put()` as before
3. If an existing mode was captured, `chmod` the file back to that mode after write
4. For new files, stat fails and we skip the chmod — server defaults apply, preserving current behavior for file creation

No frontend, preload, or IPC changes needed.

## Test plan
- [ ] Create a file on a remote host with `chmod 755 test.sh`
- [ ] Edit it in Netcatty's built-in editor and save
- [ ] Verify `ls -l test.sh` still shows `-rwxr-xr-x` (not `-rw-rw-rw-`)
- [ ] Create a new file via "New file" in the SFTP view — verify it still gets server default permissions
- [ ] Edit a file with unusual permissions (e.g., `700`, `644`, `4755`) and verify they're all preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)