### PR TITLE
Polish vault inline panel transitions and compact header control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,3 @@ Directory.Build.props
 Directory.Build.targets
 build_with_vs.bat
 build_with_vs2022.bat
-.omx/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Directory.Build.props
 Directory.Build.targets
 build_with_vs.bat
 build_with_vs2022.bat
+.omx/

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -521,7 +521,7 @@ const en: Messages = {
   'vault.hosts.header.live': '{count} live',
 
   // Vault hosts header/actions
-  'vault.hosts.search.placeholder': 'Find a host or ssh user@hostname / ssh -p 2222 user@hostname...',
+  'vault.hosts.search.placeholder': 'Find a host or enter ssh -p 2222 user@hostname...',
   'vault.hosts.connect': 'Connect',
   'vault.view.grid': 'Grid',
   'vault.view.list': 'List',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -340,7 +340,7 @@ const zhCN: Messages = {
   'vault.hosts.header.live': '{count} 个在线',
 
   // Vault hosts header/actions
-  'vault.hosts.search.placeholder': '查找主机或 ssh user@hostname / ssh -p 2222 user@hostname…',
+  'vault.hosts.search.placeholder': '查找主机，或输入 ssh -p 2222 user@hostname…',
   'vault.hosts.connect': '连接',
   'vault.view.grid': '网格',
   'vault.view.list': '列表',

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -68,6 +68,7 @@ interface GroupDetailsPanelProps {
   onSave: (config: GroupConfig, newName?: string, newParent?: string | null) => void;
   onCancel: () => void;
   layout?: AsidePanelLayout;
+  disableInitialInlineAnimation?: boolean;
 }
 
 const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
@@ -84,6 +85,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   onSave,
   onCancel,
   layout = "overlay",
+  disableInitialInlineAnimation = false,
 }) => {
   const { t } = useI18n();
   const availableFonts = useAvailableFonts();
@@ -453,6 +455,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
       onClose={onCancel}
       width="w-[340px]"
       dataSection="group-details-panel"
+      disableInitialInlineAnimation={disableInitialInlineAnimation}
       title={t("vault.groups.details")}
       layout={layout}
       actions={

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -451,7 +451,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
     <AsidePanel
       open={open}
       onClose={onCancel}
-      width="w-[380px]"
+      width="w-[340px]"
       dataSection="group-details-panel"
       title={t("vault.groups.details")}
       layout={layout}

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -40,6 +40,7 @@ import {
 import {
   AsidePanel,
   AsidePanelContent,
+  type InlinePanelAnimationStateChange,
   type AsidePanelLayout,
 } from "./ui/aside-panel";
 import { Badge } from "./ui/badge";
@@ -69,6 +70,7 @@ interface GroupDetailsPanelProps {
   onCancel: () => void;
   layout?: AsidePanelLayout;
   disableInitialInlineAnimation?: boolean;
+  onInlineAnimationStateChange?: InlinePanelAnimationStateChange;
 }
 
 const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
@@ -86,6 +88,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   onCancel,
   layout = "overlay",
   disableInitialInlineAnimation = false,
+  onInlineAnimationStateChange,
 }) => {
   const { t } = useI18n();
   const availableFonts = useAvailableFonts();
@@ -456,6 +459,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
       width="w-[340px]"
       dataSection="group-details-panel"
       disableInitialInlineAnimation={disableInitialInlineAnimation}
+      onInlineAnimationStateChange={onInlineAnimationStateChange}
       title={t("vault.groups.details")}
       layout={layout}
       actions={

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -55,6 +55,7 @@ import { useAvailableFonts } from "../application/state/fontStore";
 type SubPanel = "none" | "proxy" | "chain" | "env-vars" | "theme-select";
 
 interface GroupDetailsPanelProps {
+  open?: boolean;
   groupPath: string;
   config: GroupConfig | undefined;
   availableKeys: SSHKey[];
@@ -70,6 +71,7 @@ interface GroupDetailsPanelProps {
 }
 
 const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
+  open = true,
   groupPath,
   config,
   availableKeys,
@@ -359,6 +361,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   if (activeSubPanel === "proxy") {
     return (
       <ProxyPanel
+        open={open}
         proxyConfig={form.proxyConfig}
         onUpdateProxy={updateProxyConfig}
         onClearProxy={clearProxyConfig}
@@ -372,6 +375,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   if (activeSubPanel === "chain") {
     return (
       <ChainPanel
+        open={open}
         formLabel={groupName}
         formHostname={groupPath}
         form={{ id: "", label: groupName, hostname: groupPath, port: 22, username: "", tags: [], os: "linux" }}
@@ -390,6 +394,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   if (activeSubPanel === "env-vars") {
     return (
       <EnvVarsPanel
+        open={open}
         hostLabel={groupName}
         hostHostname={groupPath}
         environmentVariables={form.environmentVariables || []}
@@ -418,7 +423,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   if (activeSubPanel === "theme-select") {
     return (
       <ThemeSelectPanel
-        open={true}
+        open={open}
         selectedThemeId={effectiveThemeId}
         onSelect={(themeId) => {
           if (themeId === effectiveThemeId && !hasActiveThemeOverride) {
@@ -444,7 +449,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   // --- Main panel ---
   return (
     <AsidePanel
-      open={true}
+      open={open}
       onClose={onCancel}
       width="w-[380px]"
       dataSection="group-details-panel"

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -112,6 +112,7 @@ interface HostDetailsPanelProps {
   groupDefaults?: Partial<import('../domain/models').GroupConfig>;
   groupConfigs?: GroupConfig[];
   layout?: AsidePanelLayout;
+  disableInitialInlineAnimation?: boolean;
 }
 
 const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
@@ -133,6 +134,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   groupDefaults,
   groupConfigs = [],
   layout = "overlay",
+  disableInitialInlineAnimation = false,
 }) => {
   const { t } = useI18n();
   const { checkSshAgent } = useApplicationBackend();
@@ -663,6 +665,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       onClose={onCancel}
       width="w-[340px]"
       layout={layout}
+      disableInitialInlineAnimation={disableInitialInlineAnimation}
       dataSection="host-details-panel"
       title={
         initialData ? t("hostDetails.title.details") : t("hostDetails.title.new")

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -136,6 +136,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
 }) => {
   const { t } = useI18n();
   const { checkSshAgent } = useApplicationBackend();
+  const isCompactInlineLayout = layout === "inline";
   const [form, setForm] = useState<Host>(
     () =>
       initialData ||
@@ -660,7 +661,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
     <AsidePanel
       open={open}
       onClose={onCancel}
-      width="w-[420px]"
+      width="w-[340px]"
       layout={layout}
       dataSection="host-details-panel"
       title={
@@ -784,20 +785,25 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
+            <div
+              className={cn(
+                "flex-1 min-w-0 bg-secondary/70 border border-border/70 rounded-md",
+                isCompactInlineLayout
+                  ? "grid grid-cols-[minmax(0,1fr)_72px_auto] items-center gap-2 p-2"
+                  : "h-10 flex items-center gap-2 px-3",
+              )}
+            >
               <span className="text-xs text-muted-foreground">SSH on</span>
-              <div className="ml-auto w-1/2 min-w-0 flex items-center gap-2 justify-end">
-                <Input
-                  type="number"
-                  value={form.port ?? ""}
-                  onChange={(e) => update("port", e.target.value ? Number(e.target.value) : undefined)}
-                  placeholder={groupDefaults?.port ? String(groupDefaults.port) : "22"}
-                  className="h-8 flex-1 min-w-0 text-center"
-                />
-                <span className="text-xs text-muted-foreground">
-                  {t("hostDetails.port")}
-                </span>
-              </div>
+              <Input
+                type="number"
+                value={form.port ?? ""}
+                onChange={(e) => update("port", e.target.value ? Number(e.target.value) : undefined)}
+                placeholder={groupDefaults?.port ? String(groupDefaults.port) : "22"}
+                className="h-8 min-w-0 text-center"
+              />
+              <span className="text-xs text-muted-foreground">
+                {t("hostDetails.port")}
+              </span>
             </div>
           </div>
           <div className="grid gap-2">
@@ -1302,7 +1308,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
             </p>
           )}
           <div className="flex items-center justify-between gap-4">
-            <div className="space-y-0.5">
+            <div className="space-y-0.5 min-w-0">
               <div className="text-sm font-medium">
                 {t("hostDetails.sftp.encoding")}
               </div>
@@ -1314,7 +1320,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
               value={form.sftpEncoding || "auto"}
               onValueChange={(val) => update("sftpEncoding", val as Host["sftpEncoding"])}
             >
-              <SelectTrigger className="h-8 w-28">
+              <SelectTrigger className="h-8 w-fit min-w-[84px] shrink-0 px-2.5">
                 <SelectValue placeholder={t("sftp.encoding.label")} />
               </SelectTrigger>
               <SelectContent>

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -56,6 +56,7 @@ import {
   AsidePanel,
   AsidePanelContent,
   AsidePanelFooter,
+  type InlinePanelAnimationStateChange,
   type AsidePanelLayout,
 } from "./ui/aside-panel";
 import { Badge } from "./ui/badge";
@@ -113,6 +114,7 @@ interface HostDetailsPanelProps {
   groupConfigs?: GroupConfig[];
   layout?: AsidePanelLayout;
   disableInitialInlineAnimation?: boolean;
+  onInlineAnimationStateChange?: InlinePanelAnimationStateChange;
 }
 
 const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
@@ -135,6 +137,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   groupConfigs = [],
   layout = "overlay",
   disableInitialInlineAnimation = false,
+  onInlineAnimationStateChange,
 }) => {
   const { t } = useI18n();
   const { checkSshAgent } = useApplicationBackend();
@@ -666,6 +669,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       width="w-[340px]"
       layout={layout}
       disableInitialInlineAnimation={disableInitialInlineAnimation}
+      onInlineAnimationStateChange={onInlineAnimationStateChange}
       dataSection="host-details-panel"
       title={
         initialData ? t("hostDetails.title.details") : t("hostDetails.title.new")

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -94,6 +94,7 @@ const LINUX_DISTRO_OPTION_IDS = [
 ];
 
 interface HostDetailsPanelProps {
+  open?: boolean;
   initialData?: Host | null;
   availableKeys: SSHKey[];
   identities: Identity[];
@@ -114,6 +115,7 @@ interface HostDetailsPanelProps {
 }
 
 const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
+  open = true,
   initialData,
   availableKeys,
   identities,
@@ -515,6 +517,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "create-group") {
     return (
       <CreateGroupPanel
+        open={open}
         newGroupName={newGroupName}
         setNewGroupName={setNewGroupName}
         newGroupParent={newGroupParent}
@@ -531,6 +534,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "proxy") {
     return (
       <ProxyPanel
+        open={open}
         proxyConfig={form.proxyConfig}
         onUpdateProxy={updateProxyConfig}
         onClearProxy={clearProxyConfig}
@@ -544,6 +548,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "chain") {
     return (
       <ChainPanel
+        open={open}
         formLabel={form.label}
         formHostname={form.hostname}
         form={form}
@@ -563,6 +568,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "env-vars") {
     return (
       <EnvVarsPanel
+        open={open}
         hostLabel={form.label}
         hostHostname={form.hostname}
         environmentVariables={form.environmentVariables || []}
@@ -592,7 +598,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "theme-select") {
     return (
       <ThemeSelectPanel
-        open={true}
+        open={open}
         selectedThemeId={effectiveThemeId}
         onSelect={(themeId) => {
           if (themeId === effectiveThemeId && !hasEffectiveThemeOverride) {
@@ -614,7 +620,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   if (activeSubPanel === "telnet-theme-select") {
     return (
       <ThemeSelectPanel
-        open={true}
+        open={open}
         selectedThemeId={effectiveTelnetThemeId}
         onSelect={(themeId) => {
           // Update telnet protocol theme
@@ -652,7 +658,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   // Main panel
   return (
     <AsidePanel
-      open={true}
+      open={open}
       onClose={onCancel}
       width="w-[420px]"
       layout={layout}

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -38,6 +38,7 @@ interface SerialHostDetailsPanelProps {
   onSave: (host: Host) => void;
   onCancel: () => void;
   layout?: AsidePanelLayout;
+  disableInitialInlineAnimation?: boolean;
 }
 
 const BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
@@ -54,6 +55,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
   onSave,
   onCancel,
   layout = 'overlay',
+  disableInitialInlineAnimation = false,
 }) => {
   const { t } = useI18n();
   const terminalBackend = useTerminalBackend();
@@ -171,6 +173,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
       subtitle={initialData.label}
       className="z-40"
       layout={layout}
+      disableInitialInlineAnimation={disableInitialInlineAnimation}
       dataSection="serial-host-details-panel"
     >
       <AsidePanelContent>

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -17,6 +17,7 @@ import {
   AsidePanel,
   AsidePanelContent,
   AsidePanelFooter,
+  type InlinePanelAnimationStateChange,
   type AsidePanelLayout,
 } from './ui/aside-panel';
 
@@ -39,6 +40,7 @@ interface SerialHostDetailsPanelProps {
   onCancel: () => void;
   layout?: AsidePanelLayout;
   disableInitialInlineAnimation?: boolean;
+  onInlineAnimationStateChange?: InlinePanelAnimationStateChange;
 }
 
 const BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
@@ -56,6 +58,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
   onCancel,
   layout = 'overlay',
   disableInitialInlineAnimation = false,
+  onInlineAnimationStateChange,
 }) => {
   const { t } = useI18n();
   const terminalBackend = useTerminalBackend();
@@ -174,6 +177,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
       className="z-40"
       layout={layout}
       disableInitialInlineAnimation={disableInitialInlineAnimation}
+      onInlineAnimationStateChange={onInlineAnimationStateChange}
       dataSection="serial-host-details-panel"
     >
       <AsidePanelContent>

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -31,6 +31,7 @@ interface SerialPort {
 }
 
 interface SerialHostDetailsPanelProps {
+  open?: boolean;
   initialData: Host;
   allTags?: string[];
   groups?: string[];
@@ -46,6 +47,7 @@ const PARITY_OPTIONS: SerialParity[] = ['none', 'even', 'odd', 'mark', 'space'];
 const FLOW_CONTROL_OPTIONS: SerialFlowControl[] = ['none', 'xon/xoff', 'rts/cts'];
 
 export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
+  open = true,
   initialData,
   allTags = [],
   groups = [],
@@ -162,7 +164,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
 
   return (
     <AsidePanel
-      open={true}
+      open={open}
       onClose={onCancel}
       title={t('serial.edit.title')}
       subtitle={initialData.label}

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -166,6 +166,7 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
     <AsidePanel
       open={open}
       onClose={onCancel}
+      width="w-[340px]"
       title={t('serial.edit.title')}
       subtitle={initialData.label}
       className="z-40"

--- a/components/ThemeSelectPanel.tsx
+++ b/components/ThemeSelectPanel.tsx
@@ -30,6 +30,7 @@ const ThemeSelectPanel: React.FC<ThemeSelectPanelProps> = ({
         <AsidePanel
             open={open}
             onClose={onClose}
+            width="w-[340px]"
             title="Select Color Theme"
             showBackButton={showBackButton}
             onBack={onBack}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -130,6 +130,27 @@ const useDeferredPanelPresence = (open: boolean) => {
   return present;
 };
 
+const useDelayedBoolean = (value: boolean, delayMs: number) => {
+  const [delayedValue, setDelayedValue] = useState(value);
+
+  useEffect(() => {
+    if (value) {
+      setDelayedValue(true);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDelayedValue(false);
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [delayMs, value]);
+
+  return delayedValue;
+};
+
 // Props without isActive - it's now subscribed internally
 interface VaultViewProps {
   hosts: Host[];
@@ -1581,9 +1602,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const isGroupPanelPresent = useDeferredPanelPresence(
     isHostsSectionActive && isGroupPanelOpen && !!editingGroupPath,
   );
-  const isHostsHeaderCompact = isHostsSidePanelActive;
+  const isHostsHeaderCompact = useDelayedBoolean(isHostsSidePanelActive, 50);
   const hostsHeaderTransitionClass =
-    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[320ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
+    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
@@ -2006,7 +2027,15 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                 </Button>
               </div>
 
-              <div className={cn("flex min-w-0 shrink-0 items-center justify-end", hostsHeaderTransitionClass, isHostsHeaderCompact ? "gap-1.5" : "gap-3")}>
+              <div
+                className={cn(
+                  "flex min-w-0 shrink-0 items-center justify-end overflow-hidden origin-right",
+                  hostsHeaderTransitionClass,
+                  isHostsHeaderCompact
+                    ? "max-w-[168px] gap-1.5 translate-x-0.5"
+                    : "max-w-[360px] gap-3 translate-x-0",
+                )}
+              >
                 <Dropdown>
                   <div className="flex items-center rounded-md bg-primary text-primary-foreground">
                     <Button
@@ -2131,7 +2160,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
         {/* Keep hosts mounted so switching sections does not reset scroll or remount the list. */}
         <div
           className={cn(
-            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[320ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
+            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
             isHostsSidePanelActive && "pr-3",
             !isHostsSectionActive && "hidden",
           )}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -1581,12 +1581,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const isGroupPanelPresent = useDeferredPanelPresence(
     isHostsSectionActive && isGroupPanelOpen && !!editingGroupPath,
   );
-  const isHostsSidePanelPresent =
-    isHostsSectionActive &&
-    (isGroupPanelPresent || isHostPanelPresent);
   const isHostsHeaderCompact = isHostsSidePanelActive;
   const hostsHeaderTransitionClass =
-    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[260ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
+    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[320ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
@@ -2134,8 +2131,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
         {/* Keep hosts mounted so switching sections does not reset scroll or remount the list. */}
         <div
           className={cn(
-            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[260ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
-            isHostsSidePanelPresent && "pr-3",
+            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[320ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
+            isHostsSidePanelActive && "pr-3",
             !isHostsSectionActive && "hidden",
           )}
           data-section="vault-host-list"

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -29,7 +29,7 @@ import {
   Usb,
   X,
 } from "lucide-react";
-import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
@@ -97,7 +97,7 @@ import { TagFilterDropdown } from "./ui/tag-filter-dropdown";
 import { toast } from "./ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./ui/tooltip";
 import { Badge } from "./ui/badge";
-import { INLINE_ASIDE_PANEL_ANIMATION_MS, type InlinePanelAnimationState } from "./ui/aside-panel";
+import { INLINE_ASIDE_PANEL_ANIMATION_MS } from "./ui/aside-panel";
 import { HotkeyScheme, KeyBinding } from "../domain/models";
 
 const LazyProtocolSelectDialog = lazy(() => import("./ProtocolSelectDialog"));
@@ -108,13 +108,6 @@ export type VaultSection = "hosts" | "keys" | "snippets" | "port" | "knownhosts"
 type DropTarget =
   | { kind: "root" }
   | { kind: "group"; path: string };
-
-type CardRectSnapshot = {
-  left: number;
-  top: number;
-  width: number;
-  height: number;
-};
 
 const useDeferredPanelPresence = (open: boolean, skipCloseDelay = false) => {
   const [present, setPresent] = useState(open);
@@ -303,108 +296,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const mainHostsGridRef = useRef<HTMLDivElement>(null);
   const groupedHostsGridRef = useRef<HTMLDivElement>(null);
-  const pendingMainHostsCardRectsRef = useRef<Map<string, CardRectSnapshot> | null>(null);
-  const [mainHostsLockedWidth, setMainHostsLockedWidth] = useState<number | null>(null);
-  const [isMainHostsFrozen, setIsMainHostsFrozen] = useState(false);
-  const mainHostsFreezeTimeoutRef = useRef<number | null>(null);
-  const mainHostsFreezeReleaseFrameRef = useRef<number | null>(null);
-  const mainHostsFreezeSecondReleaseFrameRef = useRef<number | null>(null);
-
-  const clearMainHostsFreezeTimers = useCallback(() => {
-    if (mainHostsFreezeTimeoutRef.current !== null) {
-      window.clearTimeout(mainHostsFreezeTimeoutRef.current);
-      mainHostsFreezeTimeoutRef.current = null;
-    }
-    if (mainHostsFreezeReleaseFrameRef.current !== null) {
-      window.cancelAnimationFrame(mainHostsFreezeReleaseFrameRef.current);
-      mainHostsFreezeReleaseFrameRef.current = null;
-    }
-    if (mainHostsFreezeSecondReleaseFrameRef.current !== null) {
-      window.cancelAnimationFrame(mainHostsFreezeSecondReleaseFrameRef.current);
-      mainHostsFreezeSecondReleaseFrameRef.current = null;
-    }
-  }, []);
-
-  const getActiveHostsCardsContainer = useCallback(() => {
-    if (sortMode === "group") {
-      return groupedHostsGridRef.current;
-    }
-    return mainHostsGridRef.current;
-  }, [sortMode]);
-
-  const finishMainHostsFreeze = useCallback(() => {
-    if (currentSection !== "hosts" || viewMode !== "grid") {
-      setMainHostsLockedWidth(null);
-      setIsMainHostsFrozen(false);
-      clearMainHostsFreezeTimers();
-      return;
-    }
-
-    clearMainHostsFreezeTimers();
-    mainHostsFreezeReleaseFrameRef.current = window.requestAnimationFrame(() => {
-      mainHostsFreezeSecondReleaseFrameRef.current = window.requestAnimationFrame(() => {
-        const gridEl = getActiveHostsCardsContainer();
-        if (!gridEl) {
-          setMainHostsLockedWidth(null);
-          setIsMainHostsFrozen(false);
-          mainHostsFreezeReleaseFrameRef.current = null;
-          mainHostsFreezeSecondReleaseFrameRef.current = null;
-          return;
-        }
-
-        const rects = new Map<string, CardRectSnapshot>();
-        gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
-          const cardId = cardEl.dataset.hostCardId;
-          if (!cardId) return;
-          const rect = cardEl.getBoundingClientRect();
-          rects.set(cardId, {
-            left: rect.left,
-            top: rect.top,
-            width: rect.width,
-            height: rect.height,
-          });
-        });
-
-        pendingMainHostsCardRectsRef.current = rects;
-        setMainHostsLockedWidth(null);
-        setIsMainHostsFrozen(false);
-        mainHostsFreezeReleaseFrameRef.current = null;
-        mainHostsFreezeSecondReleaseFrameRef.current = null;
-      });
-    });
-  }, [clearMainHostsFreezeTimers, currentSection, getActiveHostsCardsContainer, viewMode]);
-
-  const captureMainHostsFreeze = useCallback(() => {
-    if (currentSection !== "hosts" || viewMode !== "grid") {
-      setMainHostsLockedWidth(null);
-      setIsMainHostsFrozen(false);
-      clearMainHostsFreezeTimers();
-      return;
-    }
-
-    const gridEl = getActiveHostsCardsContainer();
-    if (!gridEl) return;
-
-    const currentWidth = gridEl.getBoundingClientRect().width;
-
-    clearMainHostsFreezeTimers();
-    pendingMainHostsCardRectsRef.current = null;
-    setMainHostsLockedWidth(currentWidth);
-    setIsMainHostsFrozen(true);
-
-    mainHostsFreezeTimeoutRef.current = window.setTimeout(() => {
-      finishMainHostsFreeze();
-    }, INLINE_ASIDE_PANEL_ANIMATION_MS + 80);
-  }, [clearMainHostsFreezeTimers, currentSection, finishMainHostsFreeze, getActiveHostsCardsContainer, viewMode]);
-
-  useEffect(() => () => clearMainHostsFreezeTimers(), [clearMainHostsFreezeTimers]);
-
-  const handleInlinePanelAnimationStateChange = useCallback((state: InlinePanelAnimationState) => {
-    if (state !== "open" && state !== "closed") {
-      return;
-    }
-    finishMainHostsFreeze();
-  }, [finishMainHostsFreeze]);
 
   // Host panel state (local to hosts section)
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
@@ -425,22 +316,20 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openHostPanel = useCallback((host: Host | null, groupPath: string | null = null) => {
-    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     setEditingHost(host);
     setNewHostGroupPath(groupPath);
     setIsHostPanelOpen(true);
-  }, [captureMainHostsFreeze, clearPendingHostPanelReset]);
+  }, [clearPendingHostPanelReset]);
 
   const closeHostPanel = useCallback(() => {
-    captureMainHostsFreeze();
     setIsHostPanelOpen(false);
     clearPendingHostPanelReset();
     hostPanelResetTimeoutRef.current = window.setTimeout(() => {
       clearHostPanelDraft();
       hostPanelResetTimeoutRef.current = null;
     }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [captureMainHostsFreeze, clearHostPanelDraft, clearPendingHostPanelReset]);
+  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
 
   // Close host panel if the host being edited was deleted.
   // Track previous host IDs so we only close for actual deletions, not for
@@ -488,15 +377,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openGroupPanel = useCallback((groupPath: string) => {
-    captureMainHostsFreeze();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
     setEditingGroupPath(groupPath);
     setIsGroupPanelOpen(true);
-  }, [captureMainHostsFreeze, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   const closeGroupPanel = useCallback(() => {
-    captureMainHostsFreeze();
     setIsGroupPanelOpen(false);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -504,10 +391,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       clearGroupPanelDraft();
       groupPanelResetTimeoutRef.current = null;
     }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [captureMainHostsFreeze, clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+  }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   const switchHostPanelToGroup = useCallback((groupPath: string) => {
-    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -517,7 +403,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     setEditingGroupPath(groupPath);
     setIsGroupPanelOpen(true);
   }, [
-    captureMainHostsFreeze,
     clearHostPanelDraft,
     clearPendingGroupPanelOpen,
     clearPendingGroupPanelReset,
@@ -525,7 +410,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   ]);
 
   const switchGroupPanelToHost = useCallback((host: Host | null, groupPath: string | null = null) => {
-    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -536,7 +420,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     setNewHostGroupPath(groupPath);
     setIsHostPanelOpen(true);
   }, [
-    captureMainHostsFreeze,
     clearGroupPanelDraft,
     clearPendingGroupPanelOpen,
     clearPendingGroupPanelReset,
@@ -1248,71 +1131,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     [displayedHosts, selectedGroupPath, pinnedRecentIds],
   );
 
-  useLayoutEffect(() => {
-    if (currentSection !== "hosts" || viewMode !== "grid" || sortMode === "group") {
-      pendingMainHostsCardRectsRef.current = null;
-      return;
-    }
-
-    if (isMainHostsFrozen) return;
-
-    const firstRects = pendingMainHostsCardRectsRef.current;
-    if (!firstRects || firstRects.size === 0) return;
-
-    const gridEl = mainHostsGridRef.current;
-    if (!gridEl) return;
-
-    const activeAnimations: Animation[] = [];
-
-    gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
-      const cardId = cardEl.dataset.hostCardId;
-      if (!cardId) return;
-      const firstRect = firstRects.get(cardId);
-      if (!firstRect) return;
-
-      const lastRect = cardEl.getBoundingClientRect();
-      const deltaX = firstRect.left - lastRect.left;
-      const deltaY = firstRect.top - lastRect.top;
-      const scaleX = firstRect.width / Math.max(lastRect.width, 1);
-      const scaleY = firstRect.height / Math.max(lastRect.height, 1);
-
-      if (
-        Math.abs(deltaX) < 0.5 &&
-        Math.abs(deltaY) < 0.5 &&
-        Math.abs(scaleX - 1) < 0.01 &&
-        Math.abs(scaleY - 1) < 0.01
-      ) {
-        return;
-      }
-
-      activeAnimations.push(
-        cardEl.animate(
-          [
-            {
-              transformOrigin: "top left",
-              transform: `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`,
-            },
-            {
-              transformOrigin: "top left",
-              transform: "translate(0px, 0px) scale(1, 1)",
-            },
-          ],
-          {
-            duration: 260,
-            easing: "cubic-bezier(0.24, 0.84, 0.32, 1)",
-            fill: "both",
-          },
-        ),
-      );
-    });
-
-    pendingMainHostsCardRectsRef.current = null;
-
-    return () => {
-      activeAnimations.forEach((animation) => animation.cancel());
-    };
-  }, [displayedHosts, currentSection, isMainHostsFrozen, sortMode, viewMode]);
-
   // For tree view: apply search, tag filter, and sorting, but not group filtering
   const treeViewHosts = useMemo(() => {
     let filtered = hosts;
@@ -1826,30 +1644,19 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   );
   const [isHostsHeaderCompact, setIsHostsHeaderCompact] = useState(isHostsSidePanelActive);
   useEffect(() => {
-    if (isMainHostsFrozen) return;
     setIsHostsHeaderCompact(isHostsSidePanelActive);
-  }, [isHostsSidePanelActive, isMainHostsFrozen]);
+  }, [isHostsSidePanelActive]);
   const disableHostPanelInitialInlineAnimation = isSwitchingGroupToHost;
   const disableGroupPanelInitialInlineAnimation = isSwitchingHostToGroup;
   const hostsHeaderTransitionClass =
     "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
-  const hostsHeaderMotionClass = isMainHostsFrozen
-    ? "transition-none"
-    : hostsHeaderTransitionClass;
+  const hostsHeaderMotionClass = hostsHeaderTransitionClass;
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
   };
-  const hostsGridAnimatedStyle =
-    viewMode === "grid"
-      ? (mainHostsLockedWidth !== null
-          ? { ...splitViewGridStyle, width: `${mainHostsLockedWidth}px` }
-          : splitViewGridStyle)
-      : undefined;
-  const frozenHostsGridClass =
-    viewMode === "grid" && isMainHostsFrozen
-      ? "overflow-clip [overflow-clip-margin:12px]"
-      : undefined;
+  const hostsGridAnimatedStyle = viewMode === "grid" ? splitViewGridStyle : undefined;
+  const frozenHostsGridClass = undefined;
 
   const isSameDropTarget = useCallback((a: DropTarget | null, b: DropTarget | null) => {
     if (!a || !b) return a === b;
@@ -2599,6 +2406,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                             <ContextMenu key={host.id}>
                               <ContextMenuTrigger>
                                 <div
+                                  data-host-card-id={host.id}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
@@ -2960,6 +2768,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                   <ContextMenu key={host.id}>
                                     <ContextMenuTrigger>
                                       <div
+                                        data-host-card-id={host.id}
                                         className={cn(
                                           "group cursor-pointer relative",
                                           viewMode === "grid"
@@ -3104,6 +2913,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                             <ContextMenu key={host.id}>
                               <ContextMenuTrigger>
                                 <div
+                                  data-host-card-id={host.id}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
@@ -3359,7 +3169,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeGroupPanel}
           layout="inline"
           disableInitialInlineAnimation={disableGroupPanelInitialInlineAnimation}
-          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3397,7 +3206,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           }}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
-          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3417,7 +3225,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeHostPanel}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
-          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -28,7 +28,6 @@ import {
   Upload,
   Usb,
   X,
-  Zap,
 } from "lucide-react";
 import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
@@ -98,6 +97,7 @@ import { TagFilterDropdown } from "./ui/tag-filter-dropdown";
 import { toast } from "./ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./ui/tooltip";
 import { Badge } from "./ui/badge";
+import { INLINE_ASIDE_PANEL_ANIMATION_MS } from "./ui/aside-panel";
 import { HotkeyScheme, KeyBinding } from "../domain/models";
 
 const LazyProtocolSelectDialog = lazy(() => import("./ProtocolSelectDialog"));
@@ -108,6 +108,27 @@ export type VaultSection = "hosts" | "keys" | "snippets" | "port" | "knownhosts"
 type DropTarget =
   | { kind: "root" }
   | { kind: "group"; path: string };
+
+const useDeferredPanelPresence = (open: boolean) => {
+  const [present, setPresent] = useState(open);
+
+  useEffect(() => {
+    if (open) {
+      setPresent(true);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPresent(false);
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [open]);
+
+  return present;
+};
 
 // Props without isActive - it's now subscribed internally
 interface VaultViewProps {
@@ -269,6 +290,35 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
   const [editingHost, setEditingHost] = useState<Host | null>(null);
   const [newHostGroupPath, setNewHostGroupPath] = useState<string | null>(null);
+  const hostPanelResetTimeoutRef = useRef<number | null>(null);
+
+  const clearPendingHostPanelReset = useCallback(() => {
+    if (hostPanelResetTimeoutRef.current !== null) {
+      window.clearTimeout(hostPanelResetTimeoutRef.current);
+      hostPanelResetTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearHostPanelDraft = useCallback(() => {
+    setEditingHost(null);
+    setNewHostGroupPath(null);
+  }, []);
+
+  const openHostPanel = useCallback((host: Host | null, groupPath: string | null = null) => {
+    clearPendingHostPanelReset();
+    setEditingHost(host);
+    setNewHostGroupPath(groupPath);
+    setIsHostPanelOpen(true);
+  }, [clearPendingHostPanelReset]);
+
+  const closeHostPanel = useCallback(() => {
+    setIsHostPanelOpen(false);
+    clearPendingHostPanelReset();
+    hostPanelResetTimeoutRef.current = window.setTimeout(() => {
+      clearHostPanelDraft();
+      hostPanelResetTimeoutRef.current = null;
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
 
   // Close host panel if the host being edited was deleted.
   // Track previous host IDs so we only close for actual deletions, not for
@@ -278,12 +328,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     const currentIds = new Set(hosts.map(h => h.id));
     // Check against previous IDs before updating the ref
     if (editingHost && knownHostIdsRef.current.has(editingHost.id) && !currentIds.has(editingHost.id)) {
-      setIsHostPanelOpen(false);
-      setEditingHost(null);
-      setNewHostGroupPath(null);
+      closeHostPanel();
     }
     knownHostIdsRef.current = currentIds;
-  }, [hosts, editingHost]);
+  }, [hosts, editingHost, closeHostPanel]);
+
+  useEffect(() => {
+    return () => {
+      clearPendingHostPanelReset();
+    };
+  }, [clearPendingHostPanelReset]);
 
   // Group panel state
   const [isGroupPanelOpen, setIsGroupPanelOpen] = useState(false);
@@ -412,17 +466,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const handleNewHost = useCallback(() => {
     setIsGroupPanelOpen(false);
     setEditingGroupPath(null);
-    setEditingHost(null);
-    setNewHostGroupPath(null);
-    setIsHostPanelOpen(true);
-  }, []);
+    openHostPanel(null, null);
+  }, [openHostPanel]);
 
   const handleEditHost = useCallback((host: Host) => {
     setIsGroupPanelOpen(false);
     setEditingGroupPath(null);
-    setEditingHost(host);
-    setIsHostPanelOpen(true);
-  }, []);
+    openHostPanel(host);
+  }, [openHostPanel]);
 
   const handleDuplicateHost = useCallback((host: Host) => {
     // Create a copy of the host with a new ID and modified label
@@ -435,9 +486,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       lastConnectedAt: undefined,
     };
     // Open the edit panel with the duplicated host for modification
-    setEditingHost(duplicatedHost);
-    setIsHostPanelOpen(true);
-  }, [t]);
+    openHostPanel(duplicatedHost);
+  }, [openHostPanel, t]);
 
   // Export hosts to CSV
   const handleExportHosts = useCallback(() => {
@@ -1288,11 +1338,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   };
 
   const handleEditGroupConfig = useCallback((groupPath: string) => {
+    clearPendingHostPanelReset();
     setIsHostPanelOpen(false);
-    setEditingHost(null);
+    clearHostPanelDraft();
     setEditingGroupPath(groupPath);
     setIsGroupPanelOpen(true);
-  }, []);
+  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
 
   const handleSaveGroupConfig = useCallback((config: GroupConfig, _newName?: string, _newParent?: string | null) => {
     const oldPath = editingGroupPath!;
@@ -1474,15 +1525,22 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, [managedSources]);
 
   const isHostsSectionActive = currentSection === "hosts";
-  const hasHostsSidePanel =
+  const isHostsSidePanelActive =
     isHostsSectionActive &&
     ((isGroupPanelOpen && !!editingGroupPath) || isHostPanelOpen);
-  const splitViewGridStyle = hasHostsSidePanel
-    ? {
-      gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 280px))",
-      justifyContent: "start" as const,
-    }
-    : undefined;
+  const isHostPanelPresent = useDeferredPanelPresence(
+    isHostsSectionActive && isHostPanelOpen,
+  );
+  const isHostsSidePanelPresent =
+    isHostsSectionActive &&
+    ((isGroupPanelOpen && !!editingGroupPath) || isHostPanelPresent);
+  const isHostsHeaderCompact = isHostsSidePanelActive;
+  const hostsHeaderTransitionClass =
+    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[260ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
+  const hasSearchValue = search.trim().length > 0;
+  const splitViewGridStyle = {
+    gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
+  };
 
   const isSameDropTarget = useCallback((a: DropTarget | null, b: DropTarget | null) => {
     if (!a || !b) return a === b;
@@ -1768,201 +1826,257 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           )}
           data-section="vault-hosts-header"
         >
-          <div className="h-14 px-4 py-2 flex items-center gap-3">
-            <div className="relative flex-1 app-no-drag">
-              <Search
-                size={14}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                placeholder={t("vault.hosts.search.placeholder")}
-                className={cn(
-                  "pl-9 h-10 bg-secondary border-border/60 text-sm",
-                  isSearchQuickConnect &&
-                  "border-primary/50 ring-1 ring-primary/20",
-                )}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-              />
-              {isSearchQuickConnect && (
-                <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                  <Zap size={14} className="text-primary" />
-                </div>
-              )}
-            </div>
-            <Button
-              variant={isSearchQuickConnect ? "default" : "secondary"}
-              className={cn(
-                "h-10 px-4 app-no-drag",
-                !isSearchQuickConnect &&
-                "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40",
-              )}
-              onClick={handleConnectClick}
-            >
-              {t("vault.hosts.connect")}
-            </Button>
-            {/* View mode, tag filter, and sort controls */}
-            <div className="flex items-center gap-1 app-no-drag">
-              <Dropdown>
-                <DropdownTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-10 w-10 app-no-drag">
-                    {viewMode === "grid" ? (
-                      <LayoutGrid size={16} />
-                    ) : viewMode === "list" ? (
-                      <List size={16} />
-                    ) : (
-                      <Network size={16} />
-                    )}
-                    <ChevronDown size={10} className="ml-0.5" />
-                  </Button>
-                </DropdownTrigger>
-                <DropdownContent className="w-32" align="end">
-                  <Button
-                    variant={viewMode === "grid" ? "secondary" : "ghost"}
-                    className="w-full justify-start gap-2 h-9"
-                    onClick={() => setViewMode("grid")}
-                  >
-                    <LayoutGrid size={14} /> {t("vault.view.grid")}
-                  </Button>
-                  <Button
-                    variant={viewMode === "list" ? "secondary" : "ghost"}
-                    className="w-full justify-start gap-2 h-9"
-                    onClick={() => setViewMode("list")}
-                  >
-                    <List size={14} /> {t("vault.view.list")}
-                  </Button>
-                  <Button
-                    variant={viewMode === "tree" ? "secondary" : "ghost"}
-                    className="w-full justify-start gap-2 h-9"
-                    onClick={() => setViewMode("tree")}
-                  >
-                    <Network size={14} /> {t("vault.view.tree")}
-                  </Button>
-                </DropdownContent>
-              </Dropdown>
-              <TagFilterDropdown
-                allTags={allTags}
-                selectedTags={selectedTags}
-                onChange={setSelectedTags}
-                onEditTag={handleEditTag}
-                onDeleteTag={handleDeleteTag}
-                className="h-10 w-10"
-              />
-              <SortDropdown
-                value={sortMode}
-                onChange={setSortMode}
-                className="h-10 w-10"
-              />
-              <Button
-                variant={isMultiSelectMode ? "secondary" : "ghost"}
-                size="icon"
-                className="h-10 w-10"
-                onClick={() => {
-                  if (isMultiSelectMode) {
-                    clearHostSelection();
-                  } else {
-                    setIsMultiSelectMode(true);
-                  }
-                }}
-                title={t("vault.hosts.multiSelect")}
-              >
-                <CheckSquare size={16} />
-              </Button>
-            </div>
-            {/* New Host split button — collapses with an animation when the
-                host details / new-host aside panel is open, since the button
-                would be a no-op in that state. */}
+          <div
+            className={cn(
+              "h-14 px-4 py-2 flex min-w-0 items-center app-no-drag",
+              hostsHeaderTransitionClass,
+              isHostsHeaderCompact ? "gap-2" : "gap-3",
+            )}
+          >
             <div
               className={cn(
-                "flex items-center app-no-drag overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-in-out",
-                isHostPanelOpen
-                  ? "max-w-0 opacity-0 -ml-2 pointer-events-none"
-                  : "max-w-[260px] opacity-100",
+                "flex min-w-0 flex-1 items-center",
+                hostsHeaderTransitionClass,
+                isHostsHeaderCompact ? "gap-2" : "gap-3",
               )}
-              aria-hidden={isHostPanelOpen}
             >
-              <Dropdown>
-                <div className="flex items-center rounded-md bg-primary text-primary-foreground">
-                  <Button
-                    size="sm"
-                    className="h-10 px-3 rounded-r-none bg-transparent hover:bg-white/10 shadow-none app-no-drag"
-                    onClick={handleNewHost}
-                    tabIndex={isHostPanelOpen ? -1 : 0}
-                  >
-                    <Plus size={14} className="mr-2" /> {t("vault.hosts.newHost")}
-                  </Button>
+              <div className="relative min-w-0 flex-1">
+                <Search
+                  size={14}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                />
+                <Input
+                  placeholder={t("vault.hosts.search.placeholder")}
+                  className={cn(
+                    "pl-9 bg-secondary border-border/60 text-sm",
+                    hostsHeaderTransitionClass,
+                    isHostsHeaderCompact ? "h-9 pr-[84px]" : "h-10 pr-[90px]",
+                    isSearchQuickConnect &&
+                    "border-primary/50 ring-1 ring-primary/20",
+                  )}
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className={cn(
+                    "absolute right-1.5 top-1/2 z-10 -translate-y-1/2 rounded-md overflow-hidden whitespace-nowrap",
+                    hostsHeaderTransitionClass,
+                    isHostsHeaderCompact ? "h-[28px] px-2 gap-1" : "h-[30px] px-2.5 gap-1.5",
+                    hasSearchValue || isSearchQuickConnect
+                      ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                      : "bg-foreground/6 text-muted-foreground hover:bg-foreground/10 hover:text-foreground",
+                  )}
+                  onClick={handleConnectClick}
+                  aria-label={t("vault.hosts.connect")}
+                  title={t("vault.hosts.connect")}
+                >
+                  <Plug size={14} className="shrink-0" />
+                  <span className="text-[11px] font-medium tracking-tight">{t("vault.hosts.connect")}</span>
+                </Button>
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                "flex min-w-0 shrink-0 items-center justify-end",
+                hostsHeaderTransitionClass,
+                isHostsHeaderCompact ? "gap-2" : "gap-3",
+              )}
+            >
+              {/* View mode, tag filter, and sort controls */}
+              <div className={cn("flex items-center shrink-0", hostsHeaderTransitionClass, isHostsHeaderCompact ? "gap-0.5" : "gap-1")}>
+                <Dropdown>
                   <DropdownTrigger asChild>
                     <Button
-                      size="sm"
-                      className="h-10 px-2 rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none app-no-drag"
-                      tabIndex={isHostPanelOpen ? -1 : 0}
+                      variant="ghost"
+                      size="icon"
+                      className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
                     >
-                      <ChevronDown size={14} />
+                      {viewMode === "grid" ? (
+                        <LayoutGrid size={16} />
+                      ) : viewMode === "list" ? (
+                        <List size={16} />
+                      ) : (
+                        <Network size={16} />
+                      )}
+                      <ChevronDown size={10} className="ml-0.5" />
                     </Button>
                   </DropdownTrigger>
-                </div>
-                <DropdownContent className="w-44" align="end" alignToParent>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      setTargetParentPath(selectedGroupPath);
-                      setNewFolderName("");
-                      setIsNewFolderOpen(true);
-                    }}
+                  <DropdownContent className="w-32" align="end">
+                    <Button
+                      variant={viewMode === "grid" ? "secondary" : "ghost"}
+                      className="w-full justify-start gap-2 h-9"
+                      onClick={() => setViewMode("grid")}
+                    >
+                      <LayoutGrid size={14} /> {t("vault.view.grid")}
+                    </Button>
+                    <Button
+                      variant={viewMode === "list" ? "secondary" : "ghost"}
+                      className="w-full justify-start gap-2 h-9"
+                      onClick={() => setViewMode("list")}
+                    >
+                      <List size={14} /> {t("vault.view.list")}
+                    </Button>
+                    <Button
+                      variant={viewMode === "tree" ? "secondary" : "ghost"}
+                      className="w-full justify-start gap-2 h-9"
+                      onClick={() => setViewMode("tree")}
+                    >
+                      <Network size={14} /> {t("vault.view.tree")}
+                    </Button>
+                  </DropdownContent>
+                </Dropdown>
+                <TagFilterDropdown
+                  allTags={allTags}
+                  selectedTags={selectedTags}
+                  onChange={setSelectedTags}
+                  onEditTag={handleEditTag}
+                  onDeleteTag={handleDeleteTag}
+                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                />
+                <SortDropdown
+                  value={sortMode}
+                  onChange={setSortMode}
+                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                />
+                <Button
+                  variant={isMultiSelectMode ? "secondary" : "ghost"}
+                  size="icon"
+                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                  onClick={() => {
+                    if (isMultiSelectMode) {
+                      clearHostSelection();
+                    } else {
+                      setIsMultiSelectMode(true);
+                    }
+                  }}
+                  title={t("vault.hosts.multiSelect")}
+                >
+                  <CheckSquare size={15} />
+                </Button>
+              </div>
+
+              <div className={cn("flex min-w-0 shrink-0 items-center justify-end", hostsHeaderTransitionClass, isHostsHeaderCompact ? "gap-1.5" : "gap-3")}>
+                <Dropdown>
+                  <div className="flex items-center rounded-md bg-primary text-primary-foreground">
+                    <Button
+                      size="sm"
+                      className={cn(
+                        "rounded-r-none bg-transparent hover:bg-white/10 shadow-none overflow-hidden whitespace-nowrap",
+                        hostsHeaderTransitionClass,
+                        isHostsHeaderCompact ? "h-9 px-2.5 w-[42px]" : "h-10 px-3 w-[114px]",
+                      )}
+                      onClick={handleNewHost}
+                      aria-label={t("vault.hosts.newHost")}
+                      title={t("vault.hosts.newHost")}
+                    >
+                      <Plus size={14} className="shrink-0" />
+                      <span
+                        className={cn(
+                          "overflow-hidden whitespace-nowrap",
+                          hostsHeaderTransitionClass,
+                          isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-24 opacity-100 ml-2",
+                        )}
+                      >
+                        {t("vault.hosts.newHost")}
+                      </span>
+                    </Button>
+                    <DropdownTrigger asChild>
+                      <Button
+                        size="sm"
+                        className={cn(
+                          "rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none",
+                          hostsHeaderTransitionClass,
+                          isHostsHeaderCompact ? "h-9 px-1.5" : "h-10 px-2",
+                        )}
+                        aria-label={t("vault.hosts.newHost")}
+                        title={t("vault.hosts.newHost")}
+                      >
+                        <ChevronDown size={14} />
+                      </Button>
+                    </DropdownTrigger>
+                  </div>
+                  <DropdownContent className="w-44" align="end" alignToParent>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start gap-2"
+                      onClick={() => {
+                        setTargetParentPath(selectedGroupPath);
+                        setNewFolderName("");
+                        setIsNewFolderOpen(true);
+                      }}
+                    >
+                      <FolderTree size={14} /> {t("vault.hosts.newGroup")}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start gap-2"
+                      onClick={() => {
+                        setIsImportOpen(true);
+                      }}
+                    >
+                      <Upload size={14} /> {t("vault.hosts.import")}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="w-full justify-start gap-2"
+                      onClick={handleExportHosts}
+                    >
+                      <Download size={14} /> {t("vault.hosts.export")}
+                    </Button>
+                  </DropdownContent>
+                </Dropdown>
+
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className={cn(
+                    "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40 overflow-hidden whitespace-nowrap",
+                    hostsHeaderTransitionClass,
+                    isHostsHeaderCompact ? "h-9 w-9 px-0" : "h-10 w-[106px] px-3",
+                  )}
+                  onClick={onCreateLocalTerminal}
+                  aria-label={t("common.terminal")}
+                  title={t("common.terminal")}
+                >
+                  <TerminalSquare size={14} className="shrink-0" />
+                  <span
+                    className={cn(
+                      "overflow-hidden whitespace-nowrap",
+                      hostsHeaderTransitionClass,
+                      isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-24 opacity-100 ml-2",
+                    )}
                   >
-                    <FolderTree size={14} /> {t("vault.hosts.newGroup")}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start gap-2"
-                    onClick={() => {
-                      setIsImportOpen(true);
-                    }}
+                    {t("common.terminal")}
+                  </span>
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  className={cn(
+                    "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40 overflow-hidden whitespace-nowrap",
+                    hostsHeaderTransitionClass,
+                    isHostsHeaderCompact ? "h-9 w-9 px-0" : "h-10 w-[92px] px-3",
+                  )}
+                  onClick={() => setIsSerialModalOpen(true)}
+                  aria-label={t("serial.button")}
+                  title={t("serial.button")}
+                >
+                  <Usb size={14} className="shrink-0" />
+                  <span
+                    className={cn(
+                      "overflow-hidden whitespace-nowrap",
+                      hostsHeaderTransitionClass,
+                      isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-20 opacity-100 ml-2",
+                    )}
                   >
-                    <Upload size={14} /> {t("vault.hosts.import")}
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start gap-2"
-                    onClick={handleExportHosts}
-                  >
-                    <Download size={14} /> {t("vault.hosts.export")}
-                  </Button>
-                </DropdownContent>
-              </Dropdown>
-            </div>
-            {/* Terminal + Serial — collapse together with an animation when
-                the host details / new-host aside panel is open, freeing
-                horizontal space for the panel. */}
-            <div
-              className={cn(
-                "flex items-center gap-3 overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-in-out",
-                isHostPanelOpen
-                  ? "max-w-0 opacity-0 -ml-3 pointer-events-none"
-                  : "max-w-[320px] opacity-100",
-              )}
-              aria-hidden={isHostPanelOpen}
-            >
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
-                onClick={onCreateLocalTerminal}
-                tabIndex={isHostPanelOpen ? -1 : 0}
-              >
-                <TerminalSquare size={14} className="mr-2" /> {t("common.terminal")}
-              </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
-                onClick={() => setIsSerialModalOpen(true)}
-                tabIndex={isHostPanelOpen ? -1 : 0}
-              >
-                <Usb size={14} className="mr-2" /> {t("serial.button")}
-              </Button>
+                    {t("serial.button")}
+                  </span>
+                </Button>
+              </div>
             </div>
           </div>
         </header>
@@ -1970,7 +2084,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
         {/* Keep hosts mounted so switching sections does not reset scroll or remount the list. */}
         <div
           className={cn(
-            "flex-1 overflow-auto px-4 py-4 space-y-6",
+            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[260ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
+            isHostsSidePanelPresent && "pr-3",
             !isHostsSectionActive && "hidden",
           )}
           data-section="vault-host-list"
@@ -2050,8 +2165,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? cn(
                             "grid gap-3",
-                            !hasHostsSidePanel && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-                          )
+                                                      )
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}>
@@ -2154,8 +2268,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? cn(
                             "grid gap-3",
-                            !hasHostsSidePanel && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-                          )
+                                                      )
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}>
@@ -2259,8 +2372,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? cn(
                             "grid gap-3",
-                            !hasHostsSidePanel && "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-                          )
+                                                      )
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -2460,9 +2572,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       onCopyCredentials={handleCopyCredentials}
 
                       onNewHost={(groupPath) => {
-                        setEditingHost(null);
-                        setNewHostGroupPath(groupPath || null);
-                        setIsHostPanelOpen(true);
+                        openHostPanel(null, groupPath || null);
                       }}
                       onNewGroup={(parentPath) => {
                         setTargetParentPath(parentPath || null);
@@ -2504,8 +2614,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                 viewMode === "grid"
                                   ? cn(
                                     "grid gap-3",
-                                    !hasHostsSidePanel && "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-                                  )
+                                                                      )
                                   : "flex flex-col gap-0",
                               )}
                               style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -2649,8 +2758,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? cn(
                             "grid gap-3",
-                            !hasHostsSidePanel && "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
-                          )
+                                                      )
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -2906,6 +3014,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       {/* Group Details Panel */}
       {currentSection === "hosts" && isGroupPanelOpen && editingGroupPath && (
         <GroupDetailsPanel
+          open={isGroupPanelOpen}
           key={editingGroupPath}
           groupPath={editingGroupPath}
           config={groupConfigs.find(c => c.path === editingGroupPath)}
@@ -2926,8 +3035,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       )}
 
       {/* Host Details Panel - positioned at VaultView root level for correct top alignment */}
-      {currentSection === "hosts" && isHostPanelOpen && editingHost?.protocol !== 'serial' && (
+      {currentSection === "hosts" && isHostPanelPresent && editingHost?.protocol !== 'serial' && (
         <HostDetailsPanel
+          open={isHostPanelOpen}
           initialData={editingHost}
           availableKeys={keys}
           identities={identities}
@@ -2948,15 +3058,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                 ? hosts.map((h) => (h.id === host.id ? host : h))
                 : [...hosts, host],
             );
-            setIsHostPanelOpen(false);
-            setEditingHost(null);
-            setNewHostGroupPath(null);
+            closeHostPanel();
           }}
-          onCancel={() => {
-            setIsHostPanelOpen(false);
-            setEditingHost(null);
-            setNewHostGroupPath(null);
-          }}
+          onCancel={closeHostPanel}
           onCreateGroup={(groupPath) => {
             onUpdateCustomGroups(
               Array.from(new Set([...customGroups, groupPath])),
@@ -2967,8 +3071,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       )}
 
       {/* Serial Host Details Panel - for editing serial port hosts */}
-      {currentSection === "hosts" && isHostPanelOpen && editingHost?.protocol === 'serial' && (
+      {currentSection === "hosts" && isHostPanelPresent && editingHost?.protocol === 'serial' && (
         <SerialHostDetailsPanel
+          open={isHostPanelOpen}
           initialData={editingHost}
           allTags={allTags}
           groups={allGroupPaths}
@@ -2976,13 +3081,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
             onUpdateHosts(
               hosts.map((h) => (h.id === host.id ? host : h)),
             );
-            setIsHostPanelOpen(false);
-            setEditingHost(null);
+            closeHostPanel();
           }}
-          onCancel={() => {
-            setIsHostPanelOpen(false);
-            setEditingHost(null);
-          }}
+          onCancel={closeHostPanel}
           layout="inline"
         />
       )}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -339,9 +339,53 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     };
   }, [clearPendingHostPanelReset]);
 
+  useEffect(() => {
+    return () => {
+      clearPendingGroupPanelReset();
+      clearPendingGroupPanelOpen();
+    };
+  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+
   // Group panel state
   const [isGroupPanelOpen, setIsGroupPanelOpen] = useState(false);
   const [editingGroupPath, setEditingGroupPath] = useState<string | null>(null);
+  const groupPanelResetTimeoutRef = useRef<number | null>(null);
+  const groupPanelOpenTimeoutRef = useRef<number | null>(null);
+
+  const clearPendingGroupPanelReset = useCallback(() => {
+    if (groupPanelResetTimeoutRef.current !== null) {
+      window.clearTimeout(groupPanelResetTimeoutRef.current);
+      groupPanelResetTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearPendingGroupPanelOpen = useCallback(() => {
+    if (groupPanelOpenTimeoutRef.current !== null) {
+      window.clearTimeout(groupPanelOpenTimeoutRef.current);
+      groupPanelOpenTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearGroupPanelDraft = useCallback(() => {
+    setEditingGroupPath(null);
+  }, []);
+
+  const openGroupPanel = useCallback((groupPath: string) => {
+    clearPendingGroupPanelReset();
+    clearPendingGroupPanelOpen();
+    setEditingGroupPath(groupPath);
+    setIsGroupPanelOpen(true);
+  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+
+  const closeGroupPanel = useCallback(() => {
+    setIsGroupPanelOpen(false);
+    clearPendingGroupPanelReset();
+    clearPendingGroupPanelOpen();
+    groupPanelResetTimeoutRef.current = window.setTimeout(() => {
+      clearGroupPanelDraft();
+      groupPanelResetTimeoutRef.current = null;
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+  }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   // Compute inherited group defaults for the host being edited
   const editingHostGroupDefaults = useMemo(() => {
@@ -464,16 +508,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   );
 
   const handleNewHost = useCallback(() => {
-    setIsGroupPanelOpen(false);
-    setEditingGroupPath(null);
+    closeGroupPanel();
     openHostPanel(null, null);
-  }, [openHostPanel]);
+  }, [closeGroupPanel, openHostPanel]);
 
   const handleEditHost = useCallback((host: Host) => {
-    setIsGroupPanelOpen(false);
-    setEditingGroupPath(null);
+    closeGroupPanel();
     openHostPanel(host);
-  }, [openHostPanel]);
+  }, [closeGroupPanel, openHostPanel]);
 
   const handleDuplicateHost = useCallback((host: Host) => {
     // Create a copy of the host with a new ID and modified label
@@ -1338,12 +1380,18 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   };
 
   const handleEditGroupConfig = useCallback((groupPath: string) => {
-    clearPendingHostPanelReset();
-    setIsHostPanelOpen(false);
-    clearHostPanelDraft();
-    setEditingGroupPath(groupPath);
-    setIsGroupPanelOpen(true);
-  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
+    if (isHostPanelOpen) {
+      closeHostPanel();
+      clearPendingGroupPanelOpen();
+      groupPanelOpenTimeoutRef.current = window.setTimeout(() => {
+        openGroupPanel(groupPath);
+        groupPanelOpenTimeoutRef.current = null;
+      }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+      return;
+    }
+
+    openGroupPanel(groupPath);
+  }, [clearPendingGroupPanelOpen, closeHostPanel, isHostPanelOpen, openGroupPanel]);
 
   const handleSaveGroupConfig = useCallback((config: GroupConfig, _newName?: string, _newParent?: string | null) => {
     const oldPath = editingGroupPath!;
@@ -1396,9 +1444,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       onUpdateGroupConfigs(updatedConfigs);
     }
 
-    setIsGroupPanelOpen(false);
-    setEditingGroupPath(null);
-  }, [groupConfigs, editingGroupPath, customGroups, hosts, managedSources, selectedGroupPath, onUpdateGroupConfigs, onUpdateCustomGroups, onUpdateHosts, onUpdateManagedSources, t]);
+    closeGroupPanel();
+  }, [closeGroupPanel, groupConfigs, editingGroupPath, customGroups, hosts, managedSources, selectedGroupPath, onUpdateGroupConfigs, onUpdateCustomGroups, onUpdateHosts, onUpdateManagedSources, t]);
 
   const deleteGroupPath = async (path: string, deleteHosts: boolean = false) => {
     const keepGroups = customGroups.filter(
@@ -1531,9 +1578,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const isHostPanelPresent = useDeferredPanelPresence(
     isHostsSectionActive && isHostPanelOpen,
   );
+  const isGroupPanelPresent = useDeferredPanelPresence(
+    isHostsSectionActive && isGroupPanelOpen && !!editingGroupPath,
+  );
   const isHostsSidePanelPresent =
     isHostsSectionActive &&
-    ((isGroupPanelOpen && !!editingGroupPath) || isHostPanelPresent);
+    (isGroupPanelPresent || isHostPanelPresent);
   const isHostsHeaderCompact = isHostsSidePanelActive;
   const hostsHeaderTransitionClass =
     "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[260ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
@@ -2163,9 +2213,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       </h3>
                       <div className={cn(
                         viewMode === "grid"
-                          ? cn(
-                            "grid gap-3",
-                                                      )
+                          ? "grid gap-3"
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}>
@@ -2266,9 +2314,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       </h3>
                       <div className={cn(
                         viewMode === "grid"
-                          ? cn(
-                            "grid gap-3",
-                                                      )
+                          ? "grid gap-3"
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}>
@@ -2370,9 +2416,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       className={cn(
                         displayedGroups.length === 0 ? "hidden" : "",
                         viewMode === "grid"
-                          ? cn(
-                            "grid gap-3",
-                                                      )
+                          ? "grid gap-3"
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -2612,9 +2656,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                             <div
                               className={cn(
                                 viewMode === "grid"
-                                  ? cn(
-                                    "grid gap-3",
-                                                                      )
+                                  ? "grid gap-3"
                                   : "flex flex-col gap-0",
                               )}
                               style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -2756,9 +2798,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                     <div
                       className={cn(
                         viewMode === "grid"
-                          ? cn(
-                            "grid gap-3",
-                                                      )
+                          ? "grid gap-3"
                           : "flex flex-col gap-0",
                       )}
                       style={viewMode === "grid" ? splitViewGridStyle : undefined}
@@ -3012,7 +3052,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       </div>
 
       {/* Group Details Panel */}
-      {currentSection === "hosts" && isGroupPanelOpen && editingGroupPath && (
+      {currentSection === "hosts" && isGroupPanelPresent && editingGroupPath && (
         <GroupDetailsPanel
           open={isGroupPanelOpen}
           key={editingGroupPath}
@@ -3026,10 +3066,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           groupConfigs={groupConfigs}
           terminalFontSize={terminalFontSize}
           onSave={handleSaveGroupConfig}
-          onCancel={() => {
-            setIsGroupPanelOpen(false);
-            setEditingGroupPath(null);
-          }}
+          onCancel={closeGroupPanel}
           layout="inline"
         />
       )}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -97,7 +97,7 @@ import { TagFilterDropdown } from "./ui/tag-filter-dropdown";
 import { toast } from "./ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./ui/tooltip";
 import { Badge } from "./ui/badge";
-import { INLINE_ASIDE_PANEL_ANIMATION_MS } from "./ui/aside-panel";
+import { INLINE_ASIDE_PANEL_ANIMATION_MS, type InlinePanelAnimationState } from "./ui/aside-panel";
 import { HotkeyScheme, KeyBinding } from "../domain/models";
 
 const LazyProtocolSelectDialog = lazy(() => import("./ProtocolSelectDialog"));
@@ -307,11 +307,21 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [mainHostsLockedWidth, setMainHostsLockedWidth] = useState<number | null>(null);
   const [isMainHostsFrozen, setIsMainHostsFrozen] = useState(false);
   const mainHostsFreezeTimeoutRef = useRef<number | null>(null);
+  const mainHostsFreezeReleaseFrameRef = useRef<number | null>(null);
+  const mainHostsFreezeSecondReleaseFrameRef = useRef<number | null>(null);
 
   const clearMainHostsFreezeTimers = useCallback(() => {
     if (mainHostsFreezeTimeoutRef.current !== null) {
       window.clearTimeout(mainHostsFreezeTimeoutRef.current);
       mainHostsFreezeTimeoutRef.current = null;
+    }
+    if (mainHostsFreezeReleaseFrameRef.current !== null) {
+      window.cancelAnimationFrame(mainHostsFreezeReleaseFrameRef.current);
+      mainHostsFreezeReleaseFrameRef.current = null;
+    }
+    if (mainHostsFreezeSecondReleaseFrameRef.current !== null) {
+      window.cancelAnimationFrame(mainHostsFreezeSecondReleaseFrameRef.current);
+      mainHostsFreezeSecondReleaseFrameRef.current = null;
     }
   }, []);
 
@@ -322,7 +332,49 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     return mainHostsGridRef.current;
   }, [sortMode]);
 
-  const captureMainHostsFreeze = useCallback((_nextSidePanelOpen: boolean) => {
+  const finishMainHostsFreeze = useCallback(() => {
+    if (currentSection !== "hosts" || viewMode !== "grid") {
+      setMainHostsLockedWidth(null);
+      setIsMainHostsFrozen(false);
+      clearMainHostsFreezeTimers();
+      return;
+    }
+
+    clearMainHostsFreezeTimers();
+    mainHostsFreezeReleaseFrameRef.current = window.requestAnimationFrame(() => {
+      mainHostsFreezeSecondReleaseFrameRef.current = window.requestAnimationFrame(() => {
+        const gridEl = getActiveHostsCardsContainer();
+        if (!gridEl) {
+          setMainHostsLockedWidth(null);
+          setIsMainHostsFrozen(false);
+          mainHostsFreezeReleaseFrameRef.current = null;
+          mainHostsFreezeSecondReleaseFrameRef.current = null;
+          return;
+        }
+
+        const rects = new Map<string, CardRectSnapshot>();
+        gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
+          const cardId = cardEl.dataset.hostCardId;
+          if (!cardId) return;
+          const rect = cardEl.getBoundingClientRect();
+          rects.set(cardId, {
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+          });
+        });
+
+        pendingMainHostsCardRectsRef.current = rects;
+        setMainHostsLockedWidth(null);
+        setIsMainHostsFrozen(false);
+        mainHostsFreezeReleaseFrameRef.current = null;
+        mainHostsFreezeSecondReleaseFrameRef.current = null;
+      });
+    });
+  }, [clearMainHostsFreezeTimers, currentSection, getActiveHostsCardsContainer, viewMode]);
+
+  const captureMainHostsFreeze = useCallback(() => {
     if (currentSection !== "hosts" || viewMode !== "grid") {
       setMainHostsLockedWidth(null);
       setIsMainHostsFrozen(false);
@@ -336,30 +388,23 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     const currentWidth = gridEl.getBoundingClientRect().width;
 
     clearMainHostsFreezeTimers();
+    pendingMainHostsCardRectsRef.current = null;
     setMainHostsLockedWidth(currentWidth);
     setIsMainHostsFrozen(true);
 
     mainHostsFreezeTimeoutRef.current = window.setTimeout(() => {
-      const rects = new Map<string, CardRectSnapshot>();
-      gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
-        const cardId = cardEl.dataset.hostCardId;
-        if (!cardId) return;
-        const rect = cardEl.getBoundingClientRect();
-        rects.set(cardId, {
-          left: rect.left,
-          top: rect.top,
-          width: rect.width,
-          height: rect.height,
-        });
-      });
-      pendingMainHostsCardRectsRef.current = rects;
-      setMainHostsLockedWidth(null);
-      setIsMainHostsFrozen(false);
-      mainHostsFreezeTimeoutRef.current = null;
-    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [clearMainHostsFreezeTimers, currentSection, getActiveHostsCardsContainer, viewMode]);
+      finishMainHostsFreeze();
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS + 80);
+  }, [clearMainHostsFreezeTimers, currentSection, finishMainHostsFreeze, getActiveHostsCardsContainer, viewMode]);
 
   useEffect(() => () => clearMainHostsFreezeTimers(), [clearMainHostsFreezeTimers]);
+
+  const handleInlinePanelAnimationStateChange = useCallback((state: InlinePanelAnimationState) => {
+    if (state !== "open" && state !== "closed") {
+      return;
+    }
+    finishMainHostsFreeze();
+  }, [finishMainHostsFreeze]);
 
   // Host panel state (local to hosts section)
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
@@ -380,7 +425,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openHostPanel = useCallback((host: Host | null, groupPath: string | null = null) => {
-    captureMainHostsFreeze(true);
+    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     setEditingHost(host);
     setNewHostGroupPath(groupPath);
@@ -388,7 +433,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, [captureMainHostsFreeze, clearPendingHostPanelReset]);
 
   const closeHostPanel = useCallback(() => {
-    captureMainHostsFreeze(false);
+    captureMainHostsFreeze();
     setIsHostPanelOpen(false);
     clearPendingHostPanelReset();
     hostPanelResetTimeoutRef.current = window.setTimeout(() => {
@@ -443,7 +488,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openGroupPanel = useCallback((groupPath: string) => {
-    captureMainHostsFreeze(true);
+    captureMainHostsFreeze();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
     setEditingGroupPath(groupPath);
@@ -451,7 +496,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, [captureMainHostsFreeze, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   const closeGroupPanel = useCallback(() => {
-    captureMainHostsFreeze(false);
+    captureMainHostsFreeze();
     setIsGroupPanelOpen(false);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -462,7 +507,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, [captureMainHostsFreeze, clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   const switchHostPanelToGroup = useCallback((groupPath: string) => {
-    captureMainHostsFreeze(true);
+    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -480,7 +525,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   ]);
 
   const switchGroupPanelToHost = useCallback((host: Host | null, groupPath: string | null = null) => {
-    captureMainHostsFreeze(true);
+    captureMainHostsFreeze();
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -3314,6 +3359,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeGroupPanel}
           layout="inline"
           disableInitialInlineAnimation={disableGroupPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3351,6 +3397,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           }}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3370,6 +3417,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeHostPanel}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -146,27 +146,6 @@ const useDeferredPanelPresence = (open: boolean, skipCloseDelay = false) => {
   return open || present;
 };
 
-const useDelayedBoolean = (value: boolean, delayMs: number) => {
-  const [delayedValue, setDelayedValue] = useState(value);
-
-  useEffect(() => {
-    if (value) {
-      setDelayedValue(true);
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setDelayedValue(false);
-    }, delayMs);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [delayMs, value]);
-
-  return delayedValue;
-};
-
 // Props without isActive - it's now subscribed internally
 interface VaultViewProps {
   hosts: Host[];
@@ -1800,11 +1779,18 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     isHostsSectionActive && isGroupPanelOpen && !!editingGroupPath,
     isSwitchingGroupToHost,
   );
-  const isHostsHeaderCompact = useDelayedBoolean(isHostsSidePanelActive, 50);
+  const [isHostsHeaderCompact, setIsHostsHeaderCompact] = useState(isHostsSidePanelActive);
+  useEffect(() => {
+    if (isMainHostsFrozen) return;
+    setIsHostsHeaderCompact(isHostsSidePanelActive);
+  }, [isHostsSidePanelActive, isMainHostsFrozen]);
   const disableHostPanelInitialInlineAnimation = isSwitchingGroupToHost;
   const disableGroupPanelInitialInlineAnimation = isSwitchingHostToGroup;
   const hostsHeaderTransitionClass =
     "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
+  const hostsHeaderMotionClass = isMainHostsFrozen
+    ? "transition-none"
+    : hostsHeaderTransitionClass;
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
@@ -2107,14 +2093,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           <div
             className={cn(
               "h-14 px-4 py-2 flex min-w-0 items-center app-no-drag",
-              hostsHeaderTransitionClass,
+              hostsHeaderMotionClass,
               isHostsHeaderCompact ? "gap-2" : "gap-3",
             )}
           >
             <div
               className={cn(
                 "flex min-w-0 flex-1 items-center",
-                hostsHeaderTransitionClass,
+                hostsHeaderMotionClass,
                 isHostsHeaderCompact ? "gap-2" : "gap-3",
               )}
             >
@@ -2127,7 +2113,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   placeholder={t("vault.hosts.search.placeholder")}
                   className={cn(
                     "pl-9 bg-secondary border-border/60 text-sm",
-                    hostsHeaderTransitionClass,
+                    hostsHeaderMotionClass,
                     isHostsHeaderCompact ? "h-9 pr-[84px]" : "h-10 pr-[90px]",
                     isSearchQuickConnect &&
                     "border-primary/50 ring-1 ring-primary/20",
@@ -2141,7 +2127,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   variant="ghost"
                   className={cn(
                     "absolute right-1.5 top-1/2 z-10 -translate-y-1/2 rounded-md overflow-hidden whitespace-nowrap",
-                    hostsHeaderTransitionClass,
+                    hostsHeaderMotionClass,
                     isHostsHeaderCompact ? "h-[28px] px-2 gap-1" : "h-[30px] px-2.5 gap-1.5",
                     hasSearchValue || isSearchQuickConnect
                       ? "bg-primary text-primary-foreground hover:bg-primary/90"
@@ -2160,18 +2146,18 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
             <div
               className={cn(
                 "flex min-w-0 shrink-0 items-center justify-end",
-                hostsHeaderTransitionClass,
+                hostsHeaderMotionClass,
                 isHostsHeaderCompact ? "gap-2" : "gap-3",
               )}
             >
               {/* View mode, tag filter, and sort controls */}
-              <div className={cn("flex items-center shrink-0", hostsHeaderTransitionClass, isHostsHeaderCompact ? "gap-0.5" : "gap-1")}>
+              <div className={cn("flex items-center shrink-0", hostsHeaderMotionClass, isHostsHeaderCompact ? "gap-0.5" : "gap-1")}>
                 <Dropdown>
                   <DropdownTrigger asChild>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                      className={cn(hostsHeaderMotionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
                     >
                       {viewMode === "grid" ? (
                         <LayoutGrid size={16} />
@@ -2213,17 +2199,17 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   onChange={setSelectedTags}
                   onEditTag={handleEditTag}
                   onDeleteTag={handleDeleteTag}
-                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                  className={cn(hostsHeaderMotionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
                 />
                 <SortDropdown
                   value={sortMode}
                   onChange={setSortMode}
-                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                  className={cn(hostsHeaderMotionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
                 />
                 <Button
                   variant={isMultiSelectMode ? "secondary" : "ghost"}
                   size="icon"
-                  className={cn(hostsHeaderTransitionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
+                  className={cn(hostsHeaderMotionClass, isHostsHeaderCompact ? "h-9 w-9" : "h-10 w-10")}
                   onClick={() => {
                     if (isMultiSelectMode) {
                       clearHostSelection();
@@ -2240,7 +2226,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
               <div
                 className={cn(
                   "flex min-w-0 shrink-0 items-center justify-end overflow-hidden origin-right",
-                  hostsHeaderTransitionClass,
+                  hostsHeaderMotionClass,
                   isHostsHeaderCompact
                     ? "max-w-[168px] gap-1.5 translate-x-0.5"
                     : "max-w-[360px] gap-3 translate-x-0",
@@ -2252,7 +2238,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       size="sm"
                       className={cn(
                         "rounded-r-none bg-transparent hover:bg-white/10 shadow-none overflow-hidden whitespace-nowrap",
-                        hostsHeaderTransitionClass,
+                        hostsHeaderMotionClass,
                         isHostsHeaderCompact ? "h-9 px-2.5 w-[42px]" : "h-10 px-3 w-[114px]",
                       )}
                       onClick={handleNewHost}
@@ -2263,7 +2249,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       <span
                         className={cn(
                           "overflow-hidden whitespace-nowrap",
-                          hostsHeaderTransitionClass,
+                          hostsHeaderMotionClass,
                           isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-24 opacity-100 ml-2",
                         )}
                       >
@@ -2275,7 +2261,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         size="sm"
                         className={cn(
                           "rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none",
-                          hostsHeaderTransitionClass,
+                          hostsHeaderMotionClass,
                           isHostsHeaderCompact ? "h-9 px-1.5" : "h-10 px-2",
                         )}
                         aria-label={t("vault.hosts.newHost")}
@@ -2321,7 +2307,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   variant="secondary"
                   className={cn(
                     "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40 overflow-hidden whitespace-nowrap",
-                    hostsHeaderTransitionClass,
+                    hostsHeaderMotionClass,
                     isHostsHeaderCompact ? "h-9 w-9 px-0" : "h-10 w-[106px] px-3",
                   )}
                   onClick={onCreateLocalTerminal}
@@ -2332,7 +2318,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   <span
                     className={cn(
                       "overflow-hidden whitespace-nowrap",
-                      hostsHeaderTransitionClass,
+                      hostsHeaderMotionClass,
                       isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-24 opacity-100 ml-2",
                     )}
                   >
@@ -2344,7 +2330,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   variant="secondary"
                   className={cn(
                     "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40 overflow-hidden whitespace-nowrap",
-                    hostsHeaderTransitionClass,
+                    hostsHeaderMotionClass,
                     isHostsHeaderCompact ? "h-9 w-9 px-0" : "h-10 w-[92px] px-3",
                   )}
                   onClick={() => setIsSerialModalOpen(true)}
@@ -2355,7 +2341,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   <span
                     className={cn(
                       "overflow-hidden whitespace-nowrap",
-                      hostsHeaderTransitionClass,
+                      hostsHeaderMotionClass,
                       isHostsHeaderCompact ? "max-w-0 opacity-0 ml-0" : "max-w-20 opacity-100 ml-2",
                     )}
                   >

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -339,13 +339,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     };
   }, [clearPendingHostPanelReset]);
 
-  useEffect(() => {
-    return () => {
-      clearPendingGroupPanelReset();
-      clearPendingGroupPanelOpen();
-    };
-  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
-
   // Group panel state
   const [isGroupPanelOpen, setIsGroupPanelOpen] = useState(false);
   const [editingGroupPath, setEditingGroupPath] = useState<string | null>(null);
@@ -386,6 +379,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       groupPanelResetTimeoutRef.current = null;
     }, INLINE_ASIDE_PANEL_ANIMATION_MS);
   }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+
+  useEffect(() => {
+    return () => {
+      clearPendingGroupPanelReset();
+      clearPendingGroupPanelOpen();
+    };
+  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   // Compute inherited group defaults for the host being edited
   const editingHostGroupDefaults = useMemo(() => {

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -1942,7 +1942,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const disableHostPanelInitialInlineAnimation = isSwitchingGroupToHost;
   const disableGroupPanelInitialInlineAnimation = isSwitchingHostToGroup;
   const hostsHeaderTransitionClass =
-    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[1100ms] ease-[cubic-bezier(0.42,0,0.58,1)]";
+    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[400ms] ease-[cubic-bezier(0.42,0,0.58,1)]";
   const hostsHeaderMotionClass = hostsHeaderTransitionClass;
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
@@ -2539,7 +2539,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
         <div
           ref={hostsListRef}
           className={cn(
-            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[1100ms] ease-[cubic-bezier(0.42,0,0.58,1)]",
+            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[400ms] ease-[cubic-bezier(0.42,0,0.58,1)]",
             isHostsSidePanelActive && "pr-3",
             !isHostsSectionActive && "hidden",
             ghostCards.length > 0 && "ghost-hosts-card-grid-placeholder",

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -128,6 +128,7 @@ type GhostCardTransitionBatch = {
   cards: GhostCardTransition[];
   startHeight: number;
   endHeight: number;
+  secondaryGridHeights: Map<string, { startHeight: number; endHeight: number }>;
 };
 
 // Must match the inline details panel width used by Host/Group/Serial details.
@@ -337,6 +338,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     endHeight: number;
   } | null>(null);
   const [ghostHiddenHostIds, setGhostHiddenHostIds] = useState<Set<string>>(new Set());
+  const [secondaryGridHeights, setSecondaryGridHeights] = useState<Map<string, { startHeight: number; endHeight: number }>>(new Map());
 
   const getActiveHostsCardsContainer = useCallback(() => {
     return hostsListRef.current;
@@ -360,6 +362,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     setGhostCardsActive(false);
     setGhostGridTransition(null);
     setGhostHiddenHostIds(new Set());
+    setSecondaryGridHeights(new Map());
   }, []);
 
   const handleInlinePanelAnimationStateChange = useCallback((state: "opening" | "open" | "closing" | "closed") => {
@@ -465,6 +468,20 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     mainAreaEl.appendChild(measurementRoot);
     const endGridHeight = measurementClone.getBoundingClientRect().height;
 
+    // Measure per-grid heights for secondary grids (pinned, recent, groups)
+    const secondaryGridHeights = new Map<string, { startHeight: number; endHeight: number }>();
+    for (const gridKey of ["pinned", "recent", "groups"]) {
+      const realGrid = gridEl.querySelector(`[data-hosts-grid="${gridKey}"]`);
+      const cloneGrid = measurementClone.querySelector(`[data-hosts-grid="${gridKey}"]`);
+      if (realGrid && cloneGrid) {
+        const start = realGrid.getBoundingClientRect().height;
+        const end = cloneGrid.getBoundingClientRect().height;
+        if (Math.abs(start - end) > 0.5) {
+          secondaryGridHeights.set(gridKey, { startHeight: start, endHeight: end });
+        }
+      }
+    }
+
     const nextGhostCards: GhostCardTransition[] = [];
 
     measurementClone.querySelectorAll<HTMLElement>("[data-vault-card-id]").forEach((cardEl) => {
@@ -510,6 +527,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       cards: nextGhostCards,
       startHeight: startGridHeight,
       endHeight: endGridHeight,
+      secondaryGridHeights,
     };
   }, [
     clearGhostCardTransition,
@@ -1401,6 +1419,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     });
     setGhostHiddenHostIds(new Set(nextGhostBatch.cards.map(({ id }) => id)));
     setGhostCardsActive(false);
+    setSecondaryGridHeights(nextGhostBatch.secondaryGridHeights);
 
     ghostActivationFrameRef.current = window.requestAnimationFrame(() => {
       setGhostCardsActive(true);
@@ -1964,6 +1983,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const ghostGridPlaceholderClass = ghostGridTransition
     ? "ghost-hosts-card-grid-placeholder"
     : undefined;
+  const secondaryGridStyleFor = useCallback((key: string): React.CSSProperties | undefined => {
+    const entry = secondaryGridHeights.get(key);
+    if (!entry) return undefined;
+    return {
+      height: ghostCardsActive ? entry.endHeight : entry.startHeight,
+      minHeight: ghostCardsActive ? entry.endHeight : entry.startHeight,
+      overflow: "hidden",
+      transition: `height ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1), min-height ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1)`,
+    };
+  }, [secondaryGridHeights, ghostCardsActive]);
   const mainHostsGridAnimatedStyle =
     viewMode === "grid"
       ? ({
@@ -2617,13 +2646,15 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         <Pin size={14} className="shrink-0 -translate-y-[1px]" />
                         {t("vault.hosts.pinned")}
                       </h3>
-                      <div className={cn(
-                        viewMode === "grid"
-                          ? "grid gap-3"
-                          : "flex flex-col gap-0",
-                        frozenHostsGridClass,
-                      )}
-                      style={hostsGridAnimatedStyle}>
+                      <div
+                        data-hosts-grid="pinned"
+                        className={cn(
+                          viewMode === "grid"
+                            ? "grid gap-3"
+                            : "flex flex-col gap-0",
+                          frozenHostsGridClass,
+                        )}
+                        style={{ ...hostsGridAnimatedStyle, ...secondaryGridStyleFor("pinned") }}>
                         {pinnedHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
                           const effectiveDistro = getEffectiveHostDistro(safeHost);
@@ -2722,13 +2753,15 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         <Clock size={14} className="shrink-0 -translate-y-[1px]" />
                         {t("vault.hosts.recentlyConnected")}
                       </h3>
-                      <div className={cn(
-                        viewMode === "grid"
-                          ? "grid gap-3"
-                          : "flex flex-col gap-0",
-                        frozenHostsGridClass,
-                      )}
-                      style={hostsGridAnimatedStyle}>
+                      <div
+                        data-hosts-grid="recent"
+                        className={cn(
+                          viewMode === "grid"
+                            ? "grid gap-3"
+                            : "flex flex-col gap-0",
+                          frozenHostsGridClass,
+                        )}
+                        style={{ ...hostsGridAnimatedStyle, ...secondaryGridStyleFor("recent") }}>
                         {recentHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
                           const effectiveDistro = getEffectiveHostDistro(safeHost);
@@ -2827,6 +2860,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   )}
                   {viewMode !== "tree" && (
                     <div
+                      data-hosts-grid="groups"
                       className={cn(
                         displayedGroups.length === 0 ? "hidden" : "",
                         viewMode === "grid"
@@ -2834,7 +2868,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                           : "flex flex-col gap-0",
                         frozenHostsGridClass,
                       )}
-                      style={hostsGridAnimatedStyle}
+                      style={{ ...hostsGridAnimatedStyle, ...secondaryGridStyleFor("groups") }}
                       onDragOver={(e) => {
                         e.preventDefault();
                       }}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -29,7 +29,7 @@ import {
   Usb,
   X,
 } from "lucide-react";
-import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
@@ -109,6 +109,32 @@ type DropTarget =
   | { kind: "root" }
   | { kind: "group"; path: string };
 
+type CardRectSnapshot = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+type GhostCardTransition = {
+  id: string;
+  className: string;
+  html: string;
+  startRect: CardRectSnapshot;
+  endRect: CardRectSnapshot;
+};
+
+type GhostCardTransitionBatch = {
+  cards: GhostCardTransition[];
+  startHeight: number;
+  endHeight: number;
+};
+
+// Must match the inline details panel width used by Host/Group/Serial details.
+const VAULT_INLINE_DETAILS_PANEL_WIDTH_PX = 340;
+const VAULT_INLINE_PANEL_RELEASE_DELAY_MS = INLINE_ASIDE_PANEL_ANIMATION_MS + 220;
+const VAULT_CARD_OPEN_RELEASE_DELAY_MS = 120;
+
 const useDeferredPanelPresence = (open: boolean, skipCloseDelay = false) => {
   const [present, setPresent] = useState(open);
 
@@ -125,7 +151,7 @@ const useDeferredPanelPresence = (open: boolean, skipCloseDelay = false) => {
 
     const timeoutId = window.setTimeout(() => {
       setPresent(false);
-    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+    }, VAULT_INLINE_PANEL_RELEASE_DELAY_MS);
 
     return () => {
       window.clearTimeout(timeoutId);
@@ -294,8 +320,203 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedHostIds, setSelectedHostIds] = useState<Set<string>>(new Set());
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
+  const mainAreaRef = useRef<HTMLDivElement>(null);
+  const hostsListRef = useRef<HTMLDivElement>(null);
   const mainHostsGridRef = useRef<HTMLDivElement>(null);
   const groupedHostsGridRef = useRef<HTMLDivElement>(null);
+  const pendingGhostCardTransitionsRef = useRef<GhostCardTransitionBatch | null>(null);
+  const ghostAnimationTimeoutRef = useRef<number | null>(null);
+  const ghostActivationFrameRef = useRef<number | null>(null);
+  const ghostCompletionFrameRef = useRef<number | null>(null);
+  const isHostPanelOpenRef = useRef(false);
+  const isGroupPanelOpenRef = useRef(false);
+  const [ghostCards, setGhostCards] = useState<GhostCardTransition[]>([]);
+  const [ghostCardsActive, setGhostCardsActive] = useState(false);
+  const [ghostGridTransition, setGhostGridTransition] = useState<{
+    startHeight: number;
+    endHeight: number;
+  } | null>(null);
+  const [ghostHiddenHostIds, setGhostHiddenHostIds] = useState<Set<string>>(new Set());
+
+  const getActiveHostsCardsContainer = useCallback(() => {
+    return hostsListRef.current;
+  }, []);
+
+  const clearGhostCardTransition = useCallback(() => {
+    pendingGhostCardTransitionsRef.current = null;
+    if (ghostAnimationTimeoutRef.current !== null) {
+      window.clearTimeout(ghostAnimationTimeoutRef.current);
+      ghostAnimationTimeoutRef.current = null;
+    }
+    if (ghostActivationFrameRef.current !== null) {
+      window.cancelAnimationFrame(ghostActivationFrameRef.current);
+      ghostActivationFrameRef.current = null;
+    }
+    if (ghostCompletionFrameRef.current !== null) {
+      window.cancelAnimationFrame(ghostCompletionFrameRef.current);
+      ghostCompletionFrameRef.current = null;
+    }
+    setGhostCards([]);
+    setGhostCardsActive(false);
+    setGhostGridTransition(null);
+    setGhostHiddenHostIds(new Set());
+  }, []);
+
+  const handleInlinePanelAnimationStateChange = useCallback((state: "opening" | "open" | "closing" | "closed") => {
+    if (state !== "open" && state !== "closed") {
+      return;
+    }
+    if (ghostCards.length === 0) {
+      return;
+    }
+    if (ghostAnimationTimeoutRef.current !== null) {
+      window.clearTimeout(ghostAnimationTimeoutRef.current);
+    }
+    if (state === "open") {
+      ghostAnimationTimeoutRef.current = window.setTimeout(() => {
+        clearGhostCardTransition();
+      }, VAULT_CARD_OPEN_RELEASE_DELAY_MS);
+      return;
+    }
+
+    ghostCompletionFrameRef.current = window.requestAnimationFrame(() => {
+      clearGhostCardTransition();
+      ghostCompletionFrameRef.current = null;
+    });
+  }, [clearGhostCardTransition, ghostCards.length]);
+
+  const queueMainHostsGhostTransition = useCallback((nextSidePanelActive: boolean) => {
+    if (currentSection !== "hosts" || viewMode !== "grid") {
+      clearGhostCardTransition();
+      return;
+    }
+
+    const isSidePanelActive = isHostPanelOpenRef.current || isGroupPanelOpenRef.current;
+    if (nextSidePanelActive === isSidePanelActive) {
+      clearGhostCardTransition();
+      return;
+    }
+
+    const gridEl = getActiveHostsCardsContainer();
+    const mainAreaEl = mainAreaRef.current;
+    if (!gridEl || !mainAreaEl) {
+      clearGhostCardTransition();
+      return;
+    }
+
+    const areaRect = mainAreaEl.getBoundingClientRect();
+    const gridRect = gridEl.getBoundingClientRect();
+    const startGridHeight = gridRect.height;
+    const targetGridWidth = Math.max(
+      0,
+      gridRect.width + (nextSidePanelActive ? -VAULT_INLINE_DETAILS_PANEL_WIDTH_PX : VAULT_INLINE_DETAILS_PANEL_WIDTH_PX),
+    );
+
+    if (targetGridWidth <= 0) {
+      clearGhostCardTransition();
+      return;
+    }
+
+    const rects = new Map<string, CardRectSnapshot>();
+    gridEl.querySelectorAll<HTMLElement>("[data-vault-card-id]").forEach((cardEl) => {
+      const cardId = cardEl.dataset.vaultCardId;
+      if (!cardId) return;
+      const rect = cardEl.getBoundingClientRect();
+      rects.set(cardId, {
+        left: rect.left - areaRect.left,
+        top: rect.top - areaRect.top,
+        width: rect.width,
+        height: rect.height,
+      });
+    });
+
+    if (rects.size === 0) {
+      clearGhostCardTransition();
+      return;
+    }
+
+    const measurementRoot = document.createElement("div");
+    measurementRoot.setAttribute("aria-hidden", "true");
+    measurementRoot.style.position = "absolute";
+    measurementRoot.style.left = `${gridRect.left - areaRect.left}px`;
+    measurementRoot.style.top = `${gridRect.top - areaRect.top}px`;
+    measurementRoot.style.width = `${targetGridWidth}px`;
+    measurementRoot.style.minWidth = `${targetGridWidth}px`;
+    measurementRoot.style.maxWidth = `${targetGridWidth}px`;
+    measurementRoot.style.visibility = "hidden";
+    measurementRoot.style.pointerEvents = "none";
+    measurementRoot.style.overflow = "hidden";
+    measurementRoot.style.contain = "layout paint style";
+
+    const measurementClone = gridEl.cloneNode(true) as HTMLElement;
+    measurementClone.style.width = "100%";
+    measurementClone.style.minWidth = "0";
+    measurementClone.style.maxWidth = "100%";
+    measurementClone.classList.remove("ghost-hosts-card-grid-placeholder");
+    if (nextSidePanelActive) {
+      measurementClone.classList.add("pr-3");
+    } else {
+      measurementClone.classList.remove("pr-3");
+    }
+    measurementClone.querySelectorAll<HTMLElement>("[data-vault-card-id]").forEach((cardEl) => {
+      cardEl.classList.remove("hidden", "invisible", "opacity-0", "pointer-events-none");
+    });
+    measurementRoot.appendChild(measurementClone);
+    mainAreaEl.appendChild(measurementRoot);
+    const endGridHeight = measurementClone.getBoundingClientRect().height;
+
+    const nextGhostCards: GhostCardTransition[] = [];
+
+    measurementClone.querySelectorAll<HTMLElement>("[data-vault-card-id]").forEach((cardEl) => {
+      const cardId = cardEl.dataset.vaultCardId;
+      if (!cardId) return;
+
+      const startRect = rects.get(cardId);
+      if (!startRect) return;
+
+      const rect = cardEl.getBoundingClientRect();
+      const endRect: CardRectSnapshot = {
+        left: rect.left - areaRect.left,
+        top: rect.top - areaRect.top,
+        width: rect.width,
+        height: rect.height,
+      };
+
+      if (
+        Math.abs(startRect.left - endRect.left) < 0.5 &&
+        Math.abs(startRect.top - endRect.top) < 0.5 &&
+        Math.abs(startRect.width - endRect.width) < 0.5 &&
+        Math.abs(startRect.height - endRect.height) < 0.5
+      ) {
+        return;
+      }
+
+      nextGhostCards.push({
+        id: cardId,
+        className: cardEl.className,
+        html: cardEl.innerHTML,
+        startRect,
+        endRect,
+      });
+    });
+
+    mainAreaEl.removeChild(measurementRoot);
+    if (nextGhostCards.length === 0) {
+      clearGhostCardTransition();
+      return;
+    }
+
+    pendingGhostCardTransitionsRef.current = {
+      cards: nextGhostCards,
+      startHeight: startGridHeight,
+      endHeight: endGridHeight,
+    };
+  }, [
+    clearGhostCardTransition,
+    currentSection,
+    getActiveHostsCardsContainer,
+    viewMode,
+  ]);
 
   // Host panel state (local to hosts section)
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
@@ -316,20 +537,22 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openHostPanel = useCallback((host: Host | null, groupPath: string | null = null) => {
+    queueMainHostsGhostTransition(true);
     clearPendingHostPanelReset();
     setEditingHost(host);
     setNewHostGroupPath(groupPath);
     setIsHostPanelOpen(true);
-  }, [clearPendingHostPanelReset]);
+  }, [clearPendingHostPanelReset, queueMainHostsGhostTransition]);
 
   const closeHostPanel = useCallback(() => {
+    queueMainHostsGhostTransition(false);
     setIsHostPanelOpen(false);
     clearPendingHostPanelReset();
     hostPanelResetTimeoutRef.current = window.setTimeout(() => {
       clearHostPanelDraft();
       hostPanelResetTimeoutRef.current = null;
-    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
+    }, VAULT_INLINE_PANEL_RELEASE_DELAY_MS);
+  }, [clearHostPanelDraft, clearPendingHostPanelReset, queueMainHostsGhostTransition]);
 
   // Close host panel if the host being edited was deleted.
   // Track previous host IDs so we only close for actual deletions, not for
@@ -358,6 +581,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [isSwitchingHostToGroup, setIsSwitchingHostToGroup] = useState(false);
   const [isSwitchingGroupToHost, setIsSwitchingGroupToHost] = useState(false);
 
+  useEffect(() => {
+    isHostPanelOpenRef.current = isHostPanelOpen;
+  }, [isHostPanelOpen]);
+
+  useEffect(() => {
+    isGroupPanelOpenRef.current = isGroupPanelOpen;
+  }, [isGroupPanelOpen]);
+
   const clearPendingGroupPanelReset = useCallback(() => {
     if (groupPanelResetTimeoutRef.current !== null) {
       window.clearTimeout(groupPanelResetTimeoutRef.current);
@@ -377,23 +608,26 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openGroupPanel = useCallback((groupPath: string) => {
+    queueMainHostsGhostTransition(true);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
     setEditingGroupPath(groupPath);
     setIsGroupPanelOpen(true);
-  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset, queueMainHostsGhostTransition]);
 
   const closeGroupPanel = useCallback(() => {
+    queueMainHostsGhostTransition(false);
     setIsGroupPanelOpen(false);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
     groupPanelResetTimeoutRef.current = window.setTimeout(() => {
       clearGroupPanelDraft();
       groupPanelResetTimeoutRef.current = null;
-    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+    }, VAULT_INLINE_PANEL_RELEASE_DELAY_MS);
+  }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset, queueMainHostsGhostTransition]);
 
   const switchHostPanelToGroup = useCallback((groupPath: string) => {
+    queueMainHostsGhostTransition(true);
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -407,9 +641,11 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     clearPendingGroupPanelOpen,
     clearPendingGroupPanelReset,
     clearPendingHostPanelReset,
+    queueMainHostsGhostTransition,
   ]);
 
   const switchGroupPanelToHost = useCallback((host: Host | null, groupPath: string | null = null) => {
+    queueMainHostsGhostTransition(true);
     clearPendingHostPanelReset();
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -424,6 +660,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     clearPendingGroupPanelOpen,
     clearPendingGroupPanelReset,
     clearPendingHostPanelReset,
+    queueMainHostsGhostTransition,
   ]);
 
   useEffect(() => {
@@ -1131,6 +1368,62 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     [displayedHosts, selectedGroupPath, pinnedRecentIds],
   );
 
+  useLayoutEffect(() => {
+    if (currentSection !== "hosts" || viewMode !== "grid") {
+      pendingGhostCardTransitionsRef.current = null;
+      clearGhostCardTransition();
+      return;
+    }
+
+    const nextGhostBatch = pendingGhostCardTransitionsRef.current;
+    if (!nextGhostBatch || nextGhostBatch.cards.length === 0) {
+      return;
+    }
+    pendingGhostCardTransitionsRef.current = null;
+
+    if (ghostAnimationTimeoutRef.current !== null) {
+      window.clearTimeout(ghostAnimationTimeoutRef.current);
+      ghostAnimationTimeoutRef.current = null;
+    }
+    if (ghostActivationFrameRef.current !== null) {
+      window.cancelAnimationFrame(ghostActivationFrameRef.current);
+      ghostActivationFrameRef.current = null;
+    }
+    if (ghostCompletionFrameRef.current !== null) {
+      window.cancelAnimationFrame(ghostCompletionFrameRef.current);
+      ghostCompletionFrameRef.current = null;
+    }
+
+    setGhostCards(nextGhostBatch.cards);
+    setGhostGridTransition({
+      startHeight: nextGhostBatch.startHeight,
+      endHeight: nextGhostBatch.endHeight,
+    });
+    setGhostHiddenHostIds(new Set(nextGhostBatch.cards.map(({ id }) => id)));
+    setGhostCardsActive(false);
+
+    ghostActivationFrameRef.current = window.requestAnimationFrame(() => {
+      setGhostCardsActive(true);
+      ghostActivationFrameRef.current = null;
+    });
+
+    ghostAnimationTimeoutRef.current = window.setTimeout(() => {
+      clearGhostCardTransition();
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS + 180);
+  }, [
+    clearGhostCardTransition,
+    currentSection,
+    isGroupPanelOpen,
+    isHostPanelOpen,
+    viewMode,
+  ]);
+
+  useEffect(() => {
+    if (currentSection !== "hosts" || viewMode !== "grid") {
+      clearGhostCardTransition();
+    }
+  }, [clearGhostCardTransition, currentSection, viewMode]);
+
   // For tree view: apply search, tag filter, and sorting, but not group filtering
   const treeViewHosts = useMemo(() => {
     let filtered = hosts;
@@ -1649,13 +1942,43 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const disableHostPanelInitialInlineAnimation = isSwitchingGroupToHost;
   const disableGroupPanelInitialInlineAnimation = isSwitchingHostToGroup;
   const hostsHeaderTransitionClass =
-    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
+    "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[1100ms] ease-[cubic-bezier(0.42,0,0.58,1)]";
   const hostsHeaderMotionClass = hostsHeaderTransitionClass;
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
   };
   const hostsGridAnimatedStyle = viewMode === "grid" ? splitViewGridStyle : undefined;
+  const ghostGridPlaceholderStyle = ghostGridTransition
+    ? ({
+        height: ghostCardsActive
+          ? ghostGridTransition.endHeight
+          : ghostGridTransition.startHeight,
+        minHeight: ghostCardsActive
+          ? ghostGridTransition.endHeight
+          : ghostGridTransition.startHeight,
+        overflow: "visible",
+        transition: `height ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1), min-height ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1)`,
+      } as React.CSSProperties)
+    : undefined;
+  const ghostGridPlaceholderClass = ghostGridTransition
+    ? "ghost-hosts-card-grid-placeholder"
+    : undefined;
+  const mainHostsGridAnimatedStyle =
+    viewMode === "grid"
+      ? ({
+          ...splitViewGridStyle,
+          ...(sortMode !== "group" ? ghostGridPlaceholderStyle : undefined),
+        } as React.CSSProperties)
+      : undefined;
+  const groupedHostsGridAnimatedStyle =
+    viewMode === "grid" && sortMode === "group"
+      ? ghostGridPlaceholderStyle
+      : undefined;
+  const mainHostsGridPlaceholderClass =
+    sortMode !== "group" ? ghostGridPlaceholderClass : undefined;
+  const groupedHostsGridPlaceholderClass =
+    sortMode === "group" ? ghostGridPlaceholderClass : undefined;
   const frozenHostsGridClass = undefined;
 
   const isSameDropTarget = useCallback((a: DropTarget | null, b: DropTarget | null) => {
@@ -1731,6 +2054,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       isSameDropTarget(confirmedDropTarget, target) &&
         "!bg-[#dde3ea] dark:!bg-white/[0.14]",
     );
+
+  const getGhostedCardClassName = useCallback((hostId: string) => (
+    ghostHiddenHostIds.has(hostId)
+      ? "pointer-events-none"
+      : undefined
+  ), [ghostHiddenHostIds]);
 
   const handleUnmanageGroup = useCallback((groupPath: string) => {
     const source = managedSources.find(s => s.groupName === groupPath);
@@ -1932,6 +2261,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
       {/* Main Area */}
       <div
+        ref={mainAreaRef}
         className="flex-1 min-w-0 flex flex-col min-h-0 relative"
         data-section="vault-main"
       >
@@ -2207,10 +2537,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
         {/* Keep hosts mounted so switching sections does not reset scroll or remount the list. */}
         <div
+          ref={hostsListRef}
           className={cn(
-            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]",
+            "flex-1 min-w-0 overflow-auto px-4 py-4 space-y-6 transition-[padding] duration-[1100ms] ease-[cubic-bezier(0.42,0,0.58,1)]",
             isHostsSidePanelActive && "pr-3",
             !isHostsSectionActive && "hidden",
+            ghostCards.length > 0 && "ghost-hosts-card-grid-placeholder",
           )}
           data-section="vault-host-list"
           onDragEndCapture={() => setDragOverDropTarget(null)}
@@ -2304,11 +2636,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                               <ContextMenuTrigger>
                                 <div
                                   data-host-card-id={host.id}
+                                  data-vault-card-id={`pinned:${host.id}`}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
                                       ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                                       : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
+                                    getGhostedCardClassName(`pinned:${host.id}`),
                                   )}
                                   style={lastPinnedId === host.id ? { animation: "pop-in 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both" } : undefined}
                                   onAnimationEnd={() => { if (lastPinnedId === host.id) setLastPinnedId(null); }}
@@ -2407,11 +2741,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                               <ContextMenuTrigger>
                                 <div
                                   data-host-card-id={host.id}
+                                  data-vault-card-id={`recent:${host.id}`}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
                                       ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                                       : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
+                                    getGhostedCardClassName(`recent:${host.id}`),
                                   )}
                                   draggable={!isMultiSelectMode}
                                   onDragStart={(e) => {
@@ -2516,12 +2852,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         <ContextMenu key={node.path}>
                           <ContextMenuTrigger asChild>
                             <div
+                              data-vault-card-id={`group:${node.path}`}
                               className={cn(
                                 "group cursor-pointer transition-colors duration-150",
                                 viewMode === "grid"
                                   ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                                   : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
                                 getDropTargetClasses({ kind: "group", path: node.path }),
+                                getGhostedCardClassName(`group:${node.path}`),
                               )}
                               draggable
                               onDragStart={(e) =>
@@ -2727,7 +3065,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                   ) : sortMode === "group" && groupedDisplayHosts ? (
                     <div
                       ref={viewMode === "grid" ? groupedHostsGridRef : null}
-                      className={cn("space-y-6", frozenHostsGridClass)}
+                      className={cn("space-y-6", frozenHostsGridClass, groupedHostsGridPlaceholderClass)}
+                      style={groupedHostsGridAnimatedStyle}
                     >
                         {groupedDisplayHosts.map((group) => (
                           <div
@@ -2769,11 +3108,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                     <ContextMenuTrigger>
                                       <div
                                         data-host-card-id={host.id}
+                                        data-vault-card-id={`grouped:${group.name || "__ungrouped__"}:${host.id}`}
                                         className={cn(
                                           "group cursor-pointer relative",
                                           viewMode === "grid"
                                             ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                                             : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
+                                          getGhostedCardClassName(`grouped:${group.name || "__ungrouped__"}:${host.id}`),
                                         )}
                                         draggable
                                         onDragStart={(e) => {
@@ -2899,8 +3240,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                           ? "grid gap-3"
                           : "flex flex-col gap-0",
                         frozenHostsGridClass,
+                        mainHostsGridPlaceholderClass,
                       )}
-                      style={hostsGridAnimatedStyle}
+                      style={mainHostsGridAnimatedStyle}
                     >
                       {visibleDisplayedHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
@@ -2914,11 +3256,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                               <ContextMenuTrigger>
                                 <div
                                   data-host-card-id={host.id}
+                                  data-vault-card-id={`host:${host.id}`}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
                                       ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                                       : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
+                                    getGhostedCardClassName(`host:${host.id}`),
                                   )}
                                   draggable
                                   onDragStart={(e) => {
@@ -3149,6 +3493,46 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
             />
           </Suspense>
         )}
+
+        {ghostCards.length > 0 && (
+          <div className="pointer-events-none absolute inset-0 z-20 overflow-hidden">
+            {ghostCards.map(({ id, className, html, startRect, endRect }) => {
+              const deltaX = endRect.left - startRect.left;
+              const deltaY = endRect.top - startRect.top;
+
+              return (
+                <div
+                  key={`ghost-${id}`}
+                  className="absolute"
+                  data-ghost-card-id={id}
+                  data-ghost-host-id={id.startsWith("host:") ? id.slice(5) : undefined}
+                  style={{
+                    left: startRect.left,
+                    top: startRect.top,
+                    width: ghostCardsActive ? endRect.width : startRect.width,
+                    height: ghostCardsActive ? endRect.height : startRect.height,
+                    transformOrigin: "top left",
+                    transform: ghostCardsActive
+                      ? `translate(${deltaX}px, ${deltaY}px)`
+                      : "translate(0px, 0px)",
+                    willChange: "transform, width, height",
+                    transition: [
+                      `transform ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1)`,
+                      `width ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1)`,
+                      `height ${INLINE_ASIDE_PANEL_ANIMATION_MS}ms cubic-bezier(0.42, 0, 0.58, 1)`,
+                    ].join(", "),
+                  }}
+                >
+                  <div
+                    className={cn(className, "pointer-events-none")}
+                    style={{ width: "100%", height: "100%" }}
+                    dangerouslySetInnerHTML={{ __html: html }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {/* Group Details Panel */}
@@ -3169,6 +3553,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeGroupPanel}
           layout="inline"
           disableInitialInlineAnimation={disableGroupPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3206,6 +3591,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           }}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 
@@ -3225,6 +3611,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onCancel={closeHostPanel}
           layout="inline"
           disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
+          onInlineAnimationStateChange={handleInlinePanelAnimationStateChange}
         />
       )}
 

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -29,7 +29,7 @@ import {
   Usb,
   X,
 } from "lucide-react";
-import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
@@ -109,12 +109,24 @@ type DropTarget =
   | { kind: "root" }
   | { kind: "group"; path: string };
 
-const useDeferredPanelPresence = (open: boolean) => {
+type CardRectSnapshot = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+const useDeferredPanelPresence = (open: boolean, skipCloseDelay = false) => {
   const [present, setPresent] = useState(open);
 
   useEffect(() => {
     if (open) {
       setPresent(true);
+      return;
+    }
+
+    if (skipCloseDelay) {
+      setPresent(false);
       return;
     }
 
@@ -125,9 +137,13 @@ const useDeferredPanelPresence = (open: boolean) => {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [open]);
+  }, [open, skipCloseDelay]);
 
-  return present;
+  if (skipCloseDelay && !open) {
+    return false;
+  }
+
+  return open || present;
 };
 
 const useDelayedBoolean = (value: boolean, delayMs: number) => {
@@ -306,6 +322,65 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedHostIds, setSelectedHostIds] = useState<Set<string>>(new Set());
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
+  const mainHostsGridRef = useRef<HTMLDivElement>(null);
+  const groupedHostsGridRef = useRef<HTMLDivElement>(null);
+  const pendingMainHostsCardRectsRef = useRef<Map<string, CardRectSnapshot> | null>(null);
+  const [mainHostsLockedWidth, setMainHostsLockedWidth] = useState<number | null>(null);
+  const [isMainHostsFrozen, setIsMainHostsFrozen] = useState(false);
+  const mainHostsFreezeTimeoutRef = useRef<number | null>(null);
+
+  const clearMainHostsFreezeTimers = useCallback(() => {
+    if (mainHostsFreezeTimeoutRef.current !== null) {
+      window.clearTimeout(mainHostsFreezeTimeoutRef.current);
+      mainHostsFreezeTimeoutRef.current = null;
+    }
+  }, []);
+
+  const getActiveHostsCardsContainer = useCallback(() => {
+    if (sortMode === "group") {
+      return groupedHostsGridRef.current;
+    }
+    return mainHostsGridRef.current;
+  }, [sortMode]);
+
+  const captureMainHostsFreeze = useCallback((_nextSidePanelOpen: boolean) => {
+    if (currentSection !== "hosts" || viewMode !== "grid") {
+      setMainHostsLockedWidth(null);
+      setIsMainHostsFrozen(false);
+      clearMainHostsFreezeTimers();
+      return;
+    }
+
+    const gridEl = getActiveHostsCardsContainer();
+    if (!gridEl) return;
+
+    const currentWidth = gridEl.getBoundingClientRect().width;
+
+    clearMainHostsFreezeTimers();
+    setMainHostsLockedWidth(currentWidth);
+    setIsMainHostsFrozen(true);
+
+    mainHostsFreezeTimeoutRef.current = window.setTimeout(() => {
+      const rects = new Map<string, CardRectSnapshot>();
+      gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
+        const cardId = cardEl.dataset.hostCardId;
+        if (!cardId) return;
+        const rect = cardEl.getBoundingClientRect();
+        rects.set(cardId, {
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+        });
+      });
+      pendingMainHostsCardRectsRef.current = rects;
+      setMainHostsLockedWidth(null);
+      setIsMainHostsFrozen(false);
+      mainHostsFreezeTimeoutRef.current = null;
+    }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+  }, [clearMainHostsFreezeTimers, currentSection, getActiveHostsCardsContainer, viewMode]);
+
+  useEffect(() => () => clearMainHostsFreezeTimers(), [clearMainHostsFreezeTimers]);
 
   // Host panel state (local to hosts section)
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
@@ -326,20 +401,22 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openHostPanel = useCallback((host: Host | null, groupPath: string | null = null) => {
+    captureMainHostsFreeze(true);
     clearPendingHostPanelReset();
     setEditingHost(host);
     setNewHostGroupPath(groupPath);
     setIsHostPanelOpen(true);
-  }, [clearPendingHostPanelReset]);
+  }, [captureMainHostsFreeze, clearPendingHostPanelReset]);
 
   const closeHostPanel = useCallback(() => {
+    captureMainHostsFreeze(false);
     setIsHostPanelOpen(false);
     clearPendingHostPanelReset();
     hostPanelResetTimeoutRef.current = window.setTimeout(() => {
       clearHostPanelDraft();
       hostPanelResetTimeoutRef.current = null;
     }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [clearHostPanelDraft, clearPendingHostPanelReset]);
+  }, [captureMainHostsFreeze, clearHostPanelDraft, clearPendingHostPanelReset]);
 
   // Close host panel if the host being edited was deleted.
   // Track previous host IDs so we only close for actual deletions, not for
@@ -365,6 +442,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [editingGroupPath, setEditingGroupPath] = useState<string | null>(null);
   const groupPanelResetTimeoutRef = useRef<number | null>(null);
   const groupPanelOpenTimeoutRef = useRef<number | null>(null);
+  const [isSwitchingHostToGroup, setIsSwitchingHostToGroup] = useState(false);
+  const [isSwitchingGroupToHost, setIsSwitchingGroupToHost] = useState(false);
 
   const clearPendingGroupPanelReset = useCallback(() => {
     if (groupPanelResetTimeoutRef.current !== null) {
@@ -385,13 +464,15 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const openGroupPanel = useCallback((groupPath: string) => {
+    captureMainHostsFreeze(true);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
     setEditingGroupPath(groupPath);
     setIsGroupPanelOpen(true);
-  }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+  }, [captureMainHostsFreeze, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
 
   const closeGroupPanel = useCallback(() => {
+    captureMainHostsFreeze(false);
     setIsGroupPanelOpen(false);
     clearPendingGroupPanelReset();
     clearPendingGroupPanelOpen();
@@ -399,7 +480,44 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       clearGroupPanelDraft();
       groupPanelResetTimeoutRef.current = null;
     }, INLINE_ASIDE_PANEL_ANIMATION_MS);
-  }, [clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+  }, [captureMainHostsFreeze, clearGroupPanelDraft, clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+
+  const switchHostPanelToGroup = useCallback((groupPath: string) => {
+    captureMainHostsFreeze(true);
+    clearPendingHostPanelReset();
+    clearPendingGroupPanelReset();
+    clearPendingGroupPanelOpen();
+    setIsSwitchingHostToGroup(true);
+    setIsHostPanelOpen(false);
+    clearHostPanelDraft();
+    setEditingGroupPath(groupPath);
+    setIsGroupPanelOpen(true);
+  }, [
+    captureMainHostsFreeze,
+    clearHostPanelDraft,
+    clearPendingGroupPanelOpen,
+    clearPendingGroupPanelReset,
+    clearPendingHostPanelReset,
+  ]);
+
+  const switchGroupPanelToHost = useCallback((host: Host | null, groupPath: string | null = null) => {
+    captureMainHostsFreeze(true);
+    clearPendingHostPanelReset();
+    clearPendingGroupPanelReset();
+    clearPendingGroupPanelOpen();
+    setIsSwitchingGroupToHost(true);
+    setIsGroupPanelOpen(false);
+    clearGroupPanelDraft();
+    setEditingHost(host);
+    setNewHostGroupPath(groupPath);
+    setIsHostPanelOpen(true);
+  }, [
+    captureMainHostsFreeze,
+    clearGroupPanelDraft,
+    clearPendingGroupPanelOpen,
+    clearPendingGroupPanelReset,
+    clearPendingHostPanelReset,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -407,6 +525,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       clearPendingGroupPanelOpen();
     };
   }, [clearPendingGroupPanelOpen, clearPendingGroupPanelReset]);
+
+  useEffect(() => {
+    if (!isSwitchingHostToGroup || !isGroupPanelOpen) return;
+    setIsSwitchingHostToGroup(false);
+  }, [isGroupPanelOpen, isSwitchingHostToGroup]);
+
+  useEffect(() => {
+    if (!isSwitchingGroupToHost || !isHostPanelOpen) return;
+    setIsSwitchingGroupToHost(false);
+  }, [isHostPanelOpen, isSwitchingGroupToHost]);
 
   // Compute inherited group defaults for the host being edited
   const editingHostGroupDefaults = useMemo(() => {
@@ -529,14 +657,22 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   );
 
   const handleNewHost = useCallback(() => {
-    closeGroupPanel();
+    if (isGroupPanelOpen) {
+      switchGroupPanelToHost(null, null);
+      return;
+    }
+
     openHostPanel(null, null);
-  }, [closeGroupPanel, openHostPanel]);
+  }, [isGroupPanelOpen, openHostPanel, switchGroupPanelToHost]);
 
   const handleEditHost = useCallback((host: Host) => {
-    closeGroupPanel();
+    if (isGroupPanelOpen) {
+      switchGroupPanelToHost(host);
+      return;
+    }
+
     openHostPanel(host);
-  }, [closeGroupPanel, openHostPanel]);
+  }, [isGroupPanelOpen, openHostPanel, switchGroupPanelToHost]);
 
   const handleDuplicateHost = useCallback((host: Host) => {
     // Create a copy of the host with a new ID and modified label
@@ -549,8 +685,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       lastConnectedAt: undefined,
     };
     // Open the edit panel with the duplicated host for modification
-    openHostPanel(duplicatedHost);
-  }, [openHostPanel, t]);
+    handleEditHost(duplicatedHost);
+  }, [handleEditHost, t]);
 
   // Export hosts to CSV
   const handleExportHosts = useCallback(() => {
@@ -1088,6 +1224,71 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     [displayedHosts, selectedGroupPath, pinnedRecentIds],
   );
 
+  useLayoutEffect(() => {
+    if (currentSection !== "hosts" || viewMode !== "grid" || sortMode === "group") {
+      pendingMainHostsCardRectsRef.current = null;
+      return;
+    }
+
+    if (isMainHostsFrozen) return;
+
+    const firstRects = pendingMainHostsCardRectsRef.current;
+    if (!firstRects || firstRects.size === 0) return;
+
+    const gridEl = mainHostsGridRef.current;
+    if (!gridEl) return;
+
+    const activeAnimations: Animation[] = [];
+
+    gridEl.querySelectorAll<HTMLElement>("[data-host-card-id]").forEach((cardEl) => {
+      const cardId = cardEl.dataset.hostCardId;
+      if (!cardId) return;
+      const firstRect = firstRects.get(cardId);
+      if (!firstRect) return;
+
+      const lastRect = cardEl.getBoundingClientRect();
+      const deltaX = firstRect.left - lastRect.left;
+      const deltaY = firstRect.top - lastRect.top;
+      const scaleX = firstRect.width / Math.max(lastRect.width, 1);
+      const scaleY = firstRect.height / Math.max(lastRect.height, 1);
+
+      if (
+        Math.abs(deltaX) < 0.5 &&
+        Math.abs(deltaY) < 0.5 &&
+        Math.abs(scaleX - 1) < 0.01 &&
+        Math.abs(scaleY - 1) < 0.01
+      ) {
+        return;
+      }
+
+      activeAnimations.push(
+        cardEl.animate(
+          [
+            {
+              transformOrigin: "top left",
+              transform: `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`,
+            },
+            {
+              transformOrigin: "top left",
+              transform: "translate(0px, 0px) scale(1, 1)",
+            },
+          ],
+          {
+            duration: 260,
+            easing: "cubic-bezier(0.24, 0.84, 0.32, 1)",
+            fill: "both",
+          },
+        ),
+      );
+    });
+
+    pendingMainHostsCardRectsRef.current = null;
+
+    return () => {
+      activeAnimations.forEach((animation) => animation.cancel());
+    };
+  }, [displayedHosts, currentSection, isMainHostsFrozen, sortMode, viewMode]);
+
   // For tree view: apply search, tag filter, and sorting, but not group filtering
   const treeViewHosts = useMemo(() => {
     let filtered = hosts;
@@ -1402,17 +1603,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
   const handleEditGroupConfig = useCallback((groupPath: string) => {
     if (isHostPanelOpen) {
-      closeHostPanel();
-      clearPendingGroupPanelOpen();
-      groupPanelOpenTimeoutRef.current = window.setTimeout(() => {
-        openGroupPanel(groupPath);
-        groupPanelOpenTimeoutRef.current = null;
-      }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+      switchHostPanelToGroup(groupPath);
       return;
     }
 
     openGroupPanel(groupPath);
-  }, [clearPendingGroupPanelOpen, closeHostPanel, isHostPanelOpen, openGroupPanel]);
+  }, [isHostPanelOpen, openGroupPanel, switchHostPanelToGroup]);
 
   const handleSaveGroupConfig = useCallback((config: GroupConfig, _newName?: string, _newParent?: string | null) => {
     const oldPath = editingGroupPath!;
@@ -1598,17 +1794,31 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     ((isGroupPanelOpen && !!editingGroupPath) || isHostPanelOpen);
   const isHostPanelPresent = useDeferredPanelPresence(
     isHostsSectionActive && isHostPanelOpen,
+    isSwitchingHostToGroup,
   );
   const isGroupPanelPresent = useDeferredPanelPresence(
     isHostsSectionActive && isGroupPanelOpen && !!editingGroupPath,
+    isSwitchingGroupToHost,
   );
   const isHostsHeaderCompact = useDelayedBoolean(isHostsSidePanelActive, 50);
+  const disableHostPanelInitialInlineAnimation = isSwitchingGroupToHost;
+  const disableGroupPanelInitialInlineAnimation = isSwitchingHostToGroup;
   const hostsHeaderTransitionClass =
     "transition-[width,height,padding,gap,margin,opacity,max-width] duration-[430ms] ease-[cubic-bezier(0.24,0.84,0.32,1)]";
   const hasSearchValue = search.trim().length > 0;
   const splitViewGridStyle = {
     gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 1fr))",
   };
+  const hostsGridAnimatedStyle =
+    viewMode === "grid"
+      ? (mainHostsLockedWidth !== null
+          ? { ...splitViewGridStyle, width: `${mainHostsLockedWidth}px` }
+          : splitViewGridStyle)
+      : undefined;
+  const frozenHostsGridClass =
+    viewMode === "grid" && isMainHostsFrozen
+      ? "overflow-clip [overflow-clip-margin:12px]"
+      : undefined;
 
   const isSameDropTarget = useCallback((a: DropTarget | null, b: DropTarget | null) => {
     if (!a || !b) return a === b;
@@ -2241,8 +2451,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? "grid gap-3"
                           : "flex flex-col gap-0",
+                        frozenHostsGridClass,
                       )}
-                      style={viewMode === "grid" ? splitViewGridStyle : undefined}>
+                      style={hostsGridAnimatedStyle}>
                         {pinnedHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
                           const effectiveDistro = getEffectiveHostDistro(safeHost);
@@ -2254,6 +2465,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                             <ContextMenu key={host.id}>
                               <ContextMenuTrigger>
                                 <div
+                                  data-host-card-id={host.id}
                                   className={cn(
                                     "group cursor-pointer relative",
                                     viewMode === "grid"
@@ -2342,8 +2554,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? "grid gap-3"
                           : "flex flex-col gap-0",
+                        frozenHostsGridClass,
                       )}
-                      style={viewMode === "grid" ? splitViewGridStyle : undefined}>
+                      style={hostsGridAnimatedStyle}>
                         {recentHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
                           const effectiveDistro = getEffectiveHostDistro(safeHost);
@@ -2444,8 +2657,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                         viewMode === "grid"
                           ? "grid gap-3"
                           : "flex flex-col gap-0",
+                        frozenHostsGridClass,
                       )}
-                      style={viewMode === "grid" ? splitViewGridStyle : undefined}
+                      style={hostsGridAnimatedStyle}
                       onDragOver={(e) => {
                         e.preventDefault();
                       }}
@@ -2642,6 +2856,11 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       onCopyCredentials={handleCopyCredentials}
 
                       onNewHost={(groupPath) => {
+                        if (isGroupPanelOpen) {
+                          switchGroupPanelToHost(null, groupPath || null);
+                          return;
+                        }
+
                         openHostPanel(null, groupPath || null);
                       }}
                       onNewGroup={(parentPath) => {
@@ -2667,15 +2886,26 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       setDragOverDropTarget={setGroupDragOverDropTarget}
                     />
                   ) : sortMode === "group" && groupedDisplayHosts ? (
-                    <div className="space-y-6">
+                    <div
+                      ref={viewMode === "grid" ? groupedHostsGridRef : null}
+                      className={cn("space-y-6", frozenHostsGridClass)}
+                    >
                         {groupedDisplayHosts.map((group) => (
-                          <div key={group.name || "__ungrouped__"}>
-                            <div className="flex items-center gap-2 mb-3 pb-2 border-b border-border/40">
-                              <FolderTree size={14} className="text-muted-foreground" />
-                              <span className="text-sm font-medium text-muted-foreground">
+                          <div
+                            key={group.name || "__ungrouped__"}
+                            className="min-w-0 overflow-hidden"
+                          >
+                            <div
+                              className="flex w-full min-w-0 max-w-full items-center gap-2 mb-3 pb-2 overflow-hidden border-b border-border/40"
+                            >
+                              <FolderTree
+                                size={14}
+                                className="shrink-0 text-muted-foreground"
+                              />
+                              <span className="min-w-0 truncate text-sm font-medium text-muted-foreground">
                                 {group.name || t("vault.groups.ungrouped")}
                               </span>
-                              <span className="text-xs text-muted-foreground/60">
+                              <span className="shrink-0 text-xs text-muted-foreground/60">
                                 ({selectedGroupPath ? group.hosts.length : group.hosts.filter((h) => !pinnedRecentIds.has(h.id)).length})
                               </span>
                             </div>
@@ -2684,8 +2914,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                 viewMode === "grid"
                                   ? "grid gap-3"
                                   : "flex flex-col gap-0",
+                                frozenHostsGridClass,
                               )}
-                              style={viewMode === "grid" ? splitViewGridStyle : undefined}
+                              style={hostsGridAnimatedStyle}
                             >
                               {group.hosts.filter((h) => selectedGroupPath || !pinnedRecentIds.has(h.id)).map((host) => {
                                 const safeHost = sanitizeHost(host);
@@ -2807,7 +3038,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                           </div>
                         ))}
                         {groupedDisplayHosts.length === 0 && (
-                          <div className="col-span-full flex flex-col items-center justify-center py-24 text-muted-foreground">
+                          <div className="w-full flex flex-col items-center justify-center py-24 text-muted-foreground">
                             <div className="h-16 w-16 rounded-2xl bg-secondary/80 flex items-center justify-center mb-4">
                               <LayoutGrid size={32} className="opacity-60" />
                             </div>
@@ -2822,12 +3053,14 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                     </div>
                   ) : (
                     <div
+                      ref={viewMode === "grid" ? mainHostsGridRef : null}
                       className={cn(
                         viewMode === "grid"
                           ? "grid gap-3"
                           : "flex flex-col gap-0",
+                        frozenHostsGridClass,
                       )}
-                      style={viewMode === "grid" ? splitViewGridStyle : undefined}
+                      style={hostsGridAnimatedStyle}
                     >
                       {visibleDisplayedHosts.map((host) => {
                           const safeHost = sanitizeHost(host);
@@ -2946,7 +3179,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                           );
                       })}
                       {displayedHosts.length === 0 && (
-                        <div className="col-span-full flex flex-col items-center justify-center py-24 text-muted-foreground">
+                        <div className="w-full flex flex-col items-center justify-center py-24 text-muted-foreground">
                           <div className="h-16 w-16 rounded-2xl bg-secondary/80 flex items-center justify-center mb-4">
                             <LayoutGrid size={32} className="opacity-60" />
                           </div>
@@ -3078,7 +3311,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       </div>
 
       {/* Group Details Panel */}
-      {currentSection === "hosts" && isGroupPanelPresent && editingGroupPath && (
+      {currentSection === "hosts" && isGroupPanelPresent && !isSwitchingGroupToHost && editingGroupPath && (
         <GroupDetailsPanel
           open={isGroupPanelOpen}
           key={editingGroupPath}
@@ -3094,11 +3327,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           onSave={handleSaveGroupConfig}
           onCancel={closeGroupPanel}
           layout="inline"
+          disableInitialInlineAnimation={disableGroupPanelInitialInlineAnimation}
         />
       )}
 
       {/* Host Details Panel - positioned at VaultView root level for correct top alignment */}
-      {currentSection === "hosts" && isHostPanelPresent && editingHost?.protocol !== 'serial' && (
+      {currentSection === "hosts" && isHostPanelPresent && !isSwitchingHostToGroup && editingHost?.protocol !== 'serial' && (
         <HostDetailsPanel
           open={isHostPanelOpen}
           initialData={editingHost}
@@ -3130,11 +3364,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
             );
           }}
           layout="inline"
+          disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
         />
       )}
 
       {/* Serial Host Details Panel - for editing serial port hosts */}
-      {currentSection === "hosts" && isHostPanelPresent && editingHost?.protocol === 'serial' && (
+      {currentSection === "hosts" && isHostPanelPresent && !isSwitchingHostToGroup && editingHost?.protocol === 'serial' && (
         <SerialHostDetailsPanel
           open={isHostPanelOpen}
           initialData={editingHost}
@@ -3148,6 +3383,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           }}
           onCancel={closeHostPanel}
           layout="inline"
+          disableInitialInlineAnimation={disableHostPanelInitialInlineAnimation}
         />
       )}
 

--- a/components/host-details/ChainPanel.tsx
+++ b/components/host-details/ChainPanel.tsx
@@ -55,6 +55,7 @@ export const ChainPanel: React.FC<ChainPanelProps> = ({
         <AsidePanel
             open={open}
             onClose={onCancel}
+            width="w-[340px]"
             title={t('hostDetails.chain.title')}
             showBackButton={true}
             onBack={onBack}

--- a/components/host-details/ChainPanel.tsx
+++ b/components/host-details/ChainPanel.tsx
@@ -14,6 +14,7 @@ import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
 
 export interface ChainPanelProps {
+    open?: boolean;
     formLabel: string;
     formHostname: string;
     form: Host;
@@ -28,6 +29,7 @@ export interface ChainPanelProps {
 }
 
 export const ChainPanel: React.FC<ChainPanelProps> = ({
+    open = true,
     formLabel,
     formHostname,
     form,
@@ -51,7 +53,7 @@ export const ChainPanel: React.FC<ChainPanelProps> = ({
     }, [availableHostsForChain, searchQuery]);
     return (
         <AsidePanel
-            open={true}
+            open={open}
             onClose={onCancel}
             title={t('hostDetails.chain.title')}
             showBackButton={true}

--- a/components/host-details/CreateGroupPanel.tsx
+++ b/components/host-details/CreateGroupPanel.tsx
@@ -34,6 +34,7 @@ const ToggleRow: React.FC<ToggleRowProps> = ({ label, enabled, onToggle }) => (
 );
 
 export interface CreateGroupPanelProps {
+    open?: boolean;
     newGroupName: string;
     setNewGroupName: (name: string) => void;
     newGroupParent: string;
@@ -46,6 +47,7 @@ export interface CreateGroupPanelProps {
 }
 
 export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
+    open = true,
     newGroupName,
     setNewGroupName,
     newGroupParent,
@@ -59,7 +61,7 @@ export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
     const { t } = useI18n();
     return (
         <AsidePanel
-            open={true}
+            open={open}
             onClose={onCancel}
             title={t('hostDetails.group.title')}
             showBackButton={true}

--- a/components/host-details/CreateGroupPanel.tsx
+++ b/components/host-details/CreateGroupPanel.tsx
@@ -63,6 +63,7 @@ export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
         <AsidePanel
             open={open}
             onClose={onCancel}
+            width="w-[340px]"
             title={t('hostDetails.group.title')}
             showBackButton={true}
             onBack={onBack}

--- a/components/host-details/EnvVarsPanel.tsx
+++ b/components/host-details/EnvVarsPanel.tsx
@@ -51,6 +51,7 @@ export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
         <AsidePanel
             open={open}
             onClose={onCancel}
+            width="w-[340px]"
             title={t('hostDetails.envVars.title')}
             showBackButton={true}
             onBack={onBack}

--- a/components/host-details/EnvVarsPanel.tsx
+++ b/components/host-details/EnvVarsPanel.tsx
@@ -12,6 +12,7 @@ import { Card } from '../ui/card';
 import { Input } from '../ui/input';
 
 export interface EnvVarsPanelProps {
+    open?: boolean;
     hostLabel: string;
     hostHostname: string;
     environmentVariables: EnvVar[];
@@ -29,6 +30,7 @@ export interface EnvVarsPanelProps {
 }
 
 export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
+    open = true,
     hostLabel,
     hostHostname,
     environmentVariables,
@@ -47,7 +49,7 @@ export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
     const { t } = useI18n();
     return (
         <AsidePanel
-            open={true}
+            open={open}
             onClose={onCancel}
             title={t('hostDetails.envVars.title')}
             showBackButton={true}

--- a/components/host-details/ProxyPanel.tsx
+++ b/components/host-details/ProxyPanel.tsx
@@ -14,6 +14,7 @@ import { Card } from '../ui/card';
 import { Input } from '../ui/input';
 
 export interface ProxyPanelProps {
+    open?: boolean;
     proxyConfig?: ProxyConfig;
     onUpdateProxy: (field: keyof ProxyConfig, value: string | number) => void;
     onClearProxy: () => void;
@@ -23,6 +24,7 @@ export interface ProxyPanelProps {
 }
 
 export const ProxyPanel: React.FC<ProxyPanelProps> = ({
+    open = true,
     proxyConfig,
     onUpdateProxy,
     onClearProxy,
@@ -33,7 +35,7 @@ export const ProxyPanel: React.FC<ProxyPanelProps> = ({
     const { t } = useI18n();
     return (
         <AsidePanel
-            open={true}
+            open={open}
             onClose={onCancel}
             title={t('hostDetails.proxyPanel.title')}
             showBackButton={true}

--- a/components/host-details/ProxyPanel.tsx
+++ b/components/host-details/ProxyPanel.tsx
@@ -37,6 +37,7 @@ export const ProxyPanel: React.FC<ProxyPanelProps> = ({
         <AsidePanel
             open={open}
             onClose={onCancel}
+            width="w-[340px]"
             title={t('hostDetails.proxyPanel.title')}
             showBackButton={true}
             onBack={onBack}

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -50,6 +50,7 @@ interface AsidePanelProps {
      * root. Used as a targeting hook for Custom CSS (Settings → Appearance).
      */
     dataSection?: string;
+    disableInitialInlineAnimation?: boolean;
 }
 
 interface AsidePanelHeaderProps {
@@ -183,15 +184,20 @@ interface AsidePanelStackProps {
      * root. Used as a targeting hook for Custom CSS.
      */
     dataSection?: string;
+    disableInitialInlineAnimation?: boolean;
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
 export const INLINE_ASIDE_PANEL_ANIMATION_MS = 430;
 
-const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
+const useInlinePanelPresence = (
+    open: boolean,
+    layout: AsidePanelLayout,
+    disableInitialInlineAnimation = false,
+) => {
     const isInline = layout === 'inline';
     const [isMounted, setIsMounted] = useState(open);
-    const [isVisible, setIsVisible] = useState(false);
+    const [isVisible, setIsVisible] = useState(() => open && disableInitialInlineAnimation);
 
     useEffect(() => {
         if (!isInline) {
@@ -205,6 +211,10 @@ const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
 
         if (open) {
             setIsMounted(true);
+            if (!isMounted && disableInitialInlineAnimation) {
+                setIsVisible(true);
+                return;
+            }
             frameId = window.requestAnimationFrame(() => {
                 setIsVisible(true);
             });
@@ -223,7 +233,7 @@ const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
                 window.clearTimeout(timeoutId);
             }
         };
-    }, [isInline, isMounted, open]);
+    }, [disableInitialInlineAnimation, isInline, isMounted, open]);
 
     return {
         isMounted: isInline ? isMounted : open,
@@ -255,9 +265,10 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     width = 'w-[380px]',
     layout = 'overlay',
     dataSection,
+    disableInitialInlineAnimation = false,
 }) => {
     const [stack, setStack] = useState<AsideContentItem[]>([initialItem]);
-    const { isMounted, dataState } = useInlinePanelPresence(open, layout);
+    const { isMounted, dataState } = useInlinePanelPresence(open, layout, disableInitialInlineAnimation);
 
     const push = useCallback((item: AsideContentItem) => {
         setStack(prev => [...prev, item]);
@@ -353,8 +364,9 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     width = 'w-[380px]',
     layout = 'overlay',
     dataSection,
+    disableInitialInlineAnimation = false,
 }) => {
-    const { isMounted, dataState } = useInlinePanelPresence(open, layout);
+    const { isMounted, dataState } = useInlinePanelPresence(open, layout, disableInitialInlineAnimation);
 
     if (!isMounted) return null;
 

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -190,11 +190,13 @@ interface AsidePanelStackProps {
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
-export const INLINE_ASIDE_PANEL_ANIMATION_MS = 1200;
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 1100;
+export const DEFAULT_INLINE_ASIDE_PANEL_WIDTH_PX = 380;
 export type InlinePanelAnimationState = 'opening' | 'open' | 'closing' | 'closed';
 export type InlinePanelAnimationStateChange = (state: InlinePanelAnimationState) => void;
 
 const INLINE_PANEL_TRANSITION_FALLBACK_MS = INLINE_ASIDE_PANEL_ANIMATION_MS + 80;
+const INLINE_PANEL_CLOSE_UNMOUNT_DELAY_MS = 180;
 
 const useInlinePanelPresence = (
     open: boolean,
@@ -210,14 +212,34 @@ const useInlinePanelPresence = (
         }
         return open ? (disableInitialInlineAnimation ? 'open' : 'opening') : 'closed';
     });
+    const isMountedRef = useRef(isMounted);
+    const inlinePhaseRef = useRef(inlinePhase);
+    const openRef = useRef(false);
     const panelRef = useRef<HTMLDivElement | null>(null);
+    const visualRef = useRef<HTMLDivElement | null>(null);
     const visualTransitionFallbackTimeoutRef = useRef<number | null>(null);
+    const closeUnmountTimeoutRef = useRef<number | null>(null);
     const lastReportedStateRef = useRef<InlinePanelAnimationState | null>(null);
 
     const clearVisualTransitionFallback = useCallback(() => {
         if (visualTransitionFallbackTimeoutRef.current !== null) {
             window.clearTimeout(visualTransitionFallbackTimeoutRef.current);
             visualTransitionFallbackTimeoutRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        isMountedRef.current = isMounted;
+    }, [isMounted]);
+
+    useEffect(() => {
+        inlinePhaseRef.current = inlinePhase;
+    }, [inlinePhase]);
+
+    const clearCloseUnmountDelay = useCallback(() => {
+        if (closeUnmountTimeoutRef.current !== null) {
+            window.clearTimeout(closeUnmountTimeoutRef.current);
+            closeUnmountTimeoutRef.current = null;
         }
     }, []);
 
@@ -232,6 +254,7 @@ const useInlinePanelPresence = (
     const finishInlineTransition = useCallback((nextState: 'open' | 'closed') => {
         clearVisualTransitionFallback();
         if (nextState === 'open') {
+            clearCloseUnmountDelay();
             setInlinePhase('open');
             emitState('open');
             return;
@@ -239,11 +262,19 @@ const useInlinePanelPresence = (
 
         setInlinePhase('closed');
         emitState('closed');
-        setIsMounted(false);
-    }, [clearVisualTransitionFallback, emitState]);
+        clearCloseUnmountDelay();
+        closeUnmountTimeoutRef.current = window.setTimeout(() => {
+            setIsMounted(false);
+            closeUnmountTimeoutRef.current = null;
+        }, INLINE_PANEL_CLOSE_UNMOUNT_DELAY_MS);
+    }, [clearCloseUnmountDelay, clearVisualTransitionFallback, emitState]);
 
     useEffect(() => {
+        const wasOpen = openRef.current;
+        openRef.current = open;
+
         if (!isInline) {
+            clearCloseUnmountDelay();
             setIsMounted(open);
             setInlinePhase(open ? 'open' : 'closed');
             emitState(open ? 'open' : 'closed');
@@ -253,8 +284,12 @@ const useInlinePanelPresence = (
         let frameId: number | null = null;
 
         if (open) {
+            clearCloseUnmountDelay();
             setIsMounted(true);
-            if (!isMounted && disableInitialInlineAnimation) {
+            if (
+                disableInitialInlineAnimation ||
+                (wasOpen && inlinePhaseRef.current === 'open')
+            ) {
                 setInlinePhase('open');
                 emitState('open');
                 return;
@@ -268,7 +303,7 @@ const useInlinePanelPresence = (
                     finishInlineTransition('open');
                 }, INLINE_PANEL_TRANSITION_FALLBACK_MS);
             });
-        } else if (isMounted) {
+        } else if (isMountedRef.current) {
             setInlinePhase('closing');
             emitState('closing');
             clearVisualTransitionFallback();
@@ -283,12 +318,12 @@ const useInlinePanelPresence = (
             }
         };
     }, [
+        clearCloseUnmountDelay,
         clearVisualTransitionFallback,
         disableInitialInlineAnimation,
         emitState,
         finishInlineTransition,
         isInline,
-        isMounted,
         open,
     ]);
 
@@ -319,13 +354,17 @@ const useInlinePanelPresence = (
         };
     }, [finishInlineTransition, isInline, isMounted, open]);
 
-    useEffect(() => () => clearVisualTransitionFallback(), [clearVisualTransitionFallback]);
+    useEffect(() => () => {
+        clearVisualTransitionFallback();
+        clearCloseUnmountDelay();
+    }, [clearCloseUnmountDelay, clearVisualTransitionFallback]);
 
     return {
         isMounted: isInline ? isMounted : open,
         dataState: isInline ? (inlinePhase === 'open' ? 'open' : 'closed') : undefined,
         inlinePhase: isInline ? inlinePhase : (open ? 'open' : 'closed'),
         panelRef,
+        visualRef,
     };
 };
 
@@ -341,7 +380,7 @@ const resolveInlineWidth = (width: string) => {
         case 'w-screen':
             return '100vw';
         default:
-            return '380px';
+            return `${DEFAULT_INLINE_ASIDE_PANEL_WIDTH_PX}px`;
     }
 };
 
@@ -357,7 +396,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     onInlineAnimationStateChange,
 }) => {
     const [stack, setStack] = useState<AsideContentItem[]>([initialItem]);
-    const { isMounted, dataState, inlinePhase, panelRef } = useInlinePanelPresence(
+    const { isMounted, dataState, inlinePhase, panelRef, visualRef } = useInlinePanelPresence(
         open,
         layout,
         disableInitialInlineAnimation,
@@ -425,6 +464,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
                 data-inline-phase={layout === 'inline' ? inlinePhase : undefined}
                 aria-hidden={layout === 'inline' ? !open : undefined}>
                 <div
+                    ref={visualRef}
                     className={cn(
                         "h-full min-h-0 flex flex-col",
                         layout === 'inline' && "overflow-hidden split-panel-visual border-l border-border/60 bg-background shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
@@ -463,7 +503,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     disableInitialInlineAnimation = false,
     onInlineAnimationStateChange,
 }) => {
-    const { isMounted, dataState, inlinePhase, panelRef } = useInlinePanelPresence(
+    const { isMounted, dataState, inlinePhase, panelRef, visualRef } = useInlinePanelPresence(
         open,
         layout,
         disableInitialInlineAnimation,
@@ -500,6 +540,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
         data-inline-phase={layout === 'inline' ? inlinePhase : undefined}
         aria-hidden={layout === 'inline' ? !open : undefined}>
             <div
+                ref={visualRef}
                 className={cn(
                     "h-full min-h-0 flex flex-col",
                     layout === 'inline' && "overflow-hidden split-panel-visual border-l border-border/60 bg-background shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, MoreVertical, X } from 'lucide-react';
-import React, { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { cn } from '../../lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { ScrollArea } from './scroll-area';
@@ -186,6 +186,50 @@ interface AsidePanelStackProps {
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 260;
+
+const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
+    const isInline = layout === 'inline';
+    const [isMounted, setIsMounted] = useState(open);
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        if (!isInline) {
+            setIsMounted(open);
+            setIsVisible(open);
+            return;
+        }
+
+        let frameId: number | null = null;
+        let timeoutId: number | null = null;
+
+        if (open) {
+            setIsMounted(true);
+            frameId = window.requestAnimationFrame(() => {
+                setIsVisible(true);
+            });
+        } else if (isMounted) {
+            setIsVisible(false);
+            timeoutId = window.setTimeout(() => {
+                setIsMounted(false);
+            }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+        }
+
+        return () => {
+            if (frameId !== null) {
+                window.cancelAnimationFrame(frameId);
+            }
+            if (timeoutId !== null) {
+                window.clearTimeout(timeoutId);
+            }
+        };
+    }, [isInline, isMounted, open]);
+
+    return {
+        isMounted: isInline ? isMounted : open,
+        dataState: isInline ? (isVisible ? 'open' : 'closed') : undefined,
+    };
+};
 
 const resolveInlineWidth = (width: string) => {
     const arbitraryWidthMatch = width.match(/w-\[(.+)\]/);
@@ -213,6 +257,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     dataSection,
 }) => {
     const [stack, setStack] = useState<AsideContentItem[]>([initialItem]);
+    const { isMounted, dataState } = useInlinePanelPresence(open, layout);
 
     const push = useCallback((item: AsideContentItem) => {
         setStack(prev => [...prev, item]);
@@ -252,19 +297,21 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
         }
     }, [open, initialItem]);
 
-    if (!open) return null;
+    if (!isMounted) return null;
 
     return (
         <AsidePanelContext.Provider value={{ push, pop, replace, clear, canGoBack, currentItem }}>
             <div className={cn(
                 layout === 'inline'
-                    ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
+                    ? "relative split-panel shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
                     : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
                 layout === 'overlay' && width,
                 className
             )}
             style={inlineStyle}
-            data-section={dataSection}>
+            data-section={dataSection}
+            data-state={dataState}
+            aria-hidden={layout === 'inline' ? !open : undefined}>
                 <AsidePanelHeader
                     title={currentItem.title}
                     subtitle={currentItem.subtitle}
@@ -294,7 +341,9 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     layout = 'overlay',
     dataSection,
 }) => {
-    if (!open) return null;
+    const { isMounted, dataState } = useInlinePanelPresence(open, layout);
+
+    if (!isMounted) return null;
 
     const inlineWidth = resolveInlineWidth(width);
     const inlineStyle = layout === 'inline'
@@ -307,13 +356,15 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     return (
         <div className={cn(
             layout === 'inline'
-                ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
+                ? "relative split-panel shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
                 : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
             layout === 'overlay' && width,
             className
         )}
         style={inlineStyle}
-        data-section={dataSection}>
+        data-section={dataSection}
+        data-state={dataState}
+        aria-hidden={layout === 'inline' ? !open : undefined}>
             {title && (
                 <AsidePanelHeader
                     title={title}

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -186,7 +186,7 @@ interface AsidePanelStackProps {
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
-export const INLINE_ASIDE_PANEL_ANIMATION_MS = 260;
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 320;
 
 const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
     const isInline = layout === 'inline';
@@ -283,10 +283,15 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     const currentItem = stack[stack.length - 1];
     const canGoBack = stack.length > 1;
     const inlineWidth = useMemo(() => resolveInlineWidth(width), [width]);
-    const inlineStyle = layout === 'inline'
+    const rootInlineStyle = layout === 'inline'
+        ? ({
+            ['--aside-inline-width' as string]: inlineWidth,
+        } as React.CSSProperties)
+        : undefined;
+    const contentInlineStyle = layout === 'inline'
         ? ({
             width: inlineWidth,
-            ['--aside-inline-width' as string]: inlineWidth,
+            minWidth: inlineWidth,
         } as React.CSSProperties)
         : undefined;
 
@@ -308,19 +313,27 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
                 layout === 'overlay' && width,
                 className
             )}
-            style={inlineStyle}
+            style={rootInlineStyle}
             data-section={dataSection}
             data-state={dataState}
             aria-hidden={layout === 'inline' ? !open : undefined}>
-                <AsidePanelHeader
-                    title={currentItem.title}
-                    subtitle={currentItem.subtitle}
-                    actions={currentItem.actions}
-                    onBack={canGoBack ? pop : undefined}
-                    onClose={onClose}
-                    showBackButton={canGoBack}
-                />
-                {currentItem.content}
+                <div
+                    className={cn(
+                        "h-full min-h-0 flex flex-col",
+                        layout === 'inline' && "overflow-hidden"
+                    )}
+                    style={contentInlineStyle}
+                >
+                    <AsidePanelHeader
+                        title={currentItem.title}
+                        subtitle={currentItem.subtitle}
+                        actions={currentItem.actions}
+                        onBack={canGoBack ? pop : undefined}
+                        onClose={onClose}
+                        showBackButton={canGoBack}
+                    />
+                    {currentItem.content}
+                </div>
             </div>
         </AsidePanelContext.Provider>
     );
@@ -346,10 +359,15 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     if (!isMounted) return null;
 
     const inlineWidth = resolveInlineWidth(width);
-    const inlineStyle = layout === 'inline'
+    const rootInlineStyle = layout === 'inline'
+        ? ({
+            ['--aside-inline-width' as string]: inlineWidth,
+        } as React.CSSProperties)
+        : undefined;
+    const contentInlineStyle = layout === 'inline'
         ? ({
             width: inlineWidth,
-            ['--aside-inline-width' as string]: inlineWidth,
+            minWidth: inlineWidth,
         } as React.CSSProperties)
         : undefined;
 
@@ -361,21 +379,29 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
             layout === 'overlay' && width,
             className
         )}
-        style={inlineStyle}
+        style={rootInlineStyle}
         data-section={dataSection}
         data-state={dataState}
         aria-hidden={layout === 'inline' ? !open : undefined}>
-            {title && (
-                <AsidePanelHeader
-                    title={title}
-                    subtitle={subtitle}
-                    actions={actions}
-                    onClose={onClose}
-                    showBackButton={showBackButton}
-                    onBack={onBack}
-                />
-            )}
-            {children}
+            <div
+                className={cn(
+                    "h-full min-h-0 flex flex-col",
+                    layout === 'inline' && "overflow-hidden"
+                )}
+                style={contentInlineStyle}
+            >
+                {title && (
+                    <AsidePanelHeader
+                        title={title}
+                        subtitle={subtitle}
+                        actions={actions}
+                        onClose={onClose}
+                        showBackButton={showBackButton}
+                        onBack={onBack}
+                    />
+                )}
+                {children}
+            </div>
         </div>
     );
 };

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -186,7 +186,7 @@ interface AsidePanelStackProps {
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
-export const INLINE_ASIDE_PANEL_ANIMATION_MS = 320;
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 430;
 
 const useInlinePanelPresence = (open: boolean, layout: AsidePanelLayout) => {
     const isInline = layout === 'inline';

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -340,7 +340,7 @@ const useInlinePanelPresence = (
         const handleTransitionEnd = (event: TransitionEvent) => {
             if (
                 event.target !== panelEl ||
-                (event.propertyName !== 'width' && event.propertyName !== 'flex-basis')
+                event.propertyName !== 'width'
             ) {
                 return;
             }

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -190,7 +190,7 @@ interface AsidePanelStackProps {
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
-export const INLINE_ASIDE_PANEL_ANIMATION_MS = 1100;
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 400;
 export const DEFAULT_INLINE_ASIDE_PANEL_WIDTH_PX = 380;
 export type InlinePanelAnimationState = 'opening' | 'open' | 'closing' | 'closed';
 export type InlinePanelAnimationStateChange = (state: InlinePanelAnimationState) => void;

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, MoreVertical, X } from 'lucide-react';
-import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '../../lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { ScrollArea } from './scroll-area';
@@ -51,6 +51,7 @@ interface AsidePanelProps {
      */
     dataSection?: string;
     disableInitialInlineAnimation?: boolean;
+    onInlineAnimationStateChange?: InlinePanelAnimationStateChange;
 }
 
 interface AsidePanelHeaderProps {
@@ -185,59 +186,146 @@ interface AsidePanelStackProps {
      */
     dataSection?: string;
     disableInitialInlineAnimation?: boolean;
+    onInlineAnimationStateChange?: InlinePanelAnimationStateChange;
 }
 
 export type AsidePanelLayout = 'overlay' | 'inline';
-export const INLINE_ASIDE_PANEL_ANIMATION_MS = 430;
+export const INLINE_ASIDE_PANEL_ANIMATION_MS = 1200;
+export type InlinePanelAnimationState = 'opening' | 'open' | 'closing' | 'closed';
+export type InlinePanelAnimationStateChange = (state: InlinePanelAnimationState) => void;
+
+const INLINE_PANEL_TRANSITION_FALLBACK_MS = INLINE_ASIDE_PANEL_ANIMATION_MS + 80;
 
 const useInlinePanelPresence = (
     open: boolean,
     layout: AsidePanelLayout,
     disableInitialInlineAnimation = false,
+    onInlineAnimationStateChange?: InlinePanelAnimationStateChange,
 ) => {
     const isInline = layout === 'inline';
     const [isMounted, setIsMounted] = useState(open);
-    const [isVisible, setIsVisible] = useState(() => open && disableInitialInlineAnimation);
+    const [inlinePhase, setInlinePhase] = useState<InlinePanelAnimationState>(() => {
+        if (!isInline) {
+            return open ? 'open' : 'closed';
+        }
+        return open ? (disableInitialInlineAnimation ? 'open' : 'opening') : 'closed';
+    });
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const visualTransitionFallbackTimeoutRef = useRef<number | null>(null);
+    const lastReportedStateRef = useRef<InlinePanelAnimationState | null>(null);
+
+    const clearVisualTransitionFallback = useCallback(() => {
+        if (visualTransitionFallbackTimeoutRef.current !== null) {
+            window.clearTimeout(visualTransitionFallbackTimeoutRef.current);
+            visualTransitionFallbackTimeoutRef.current = null;
+        }
+    }, []);
+
+    const emitState = useCallback((state: InlinePanelAnimationState) => {
+        if (lastReportedStateRef.current === state) {
+            return;
+        }
+        lastReportedStateRef.current = state;
+        onInlineAnimationStateChange?.(state);
+    }, [onInlineAnimationStateChange]);
+
+    const finishInlineTransition = useCallback((nextState: 'open' | 'closed') => {
+        clearVisualTransitionFallback();
+        if (nextState === 'open') {
+            setInlinePhase('open');
+            emitState('open');
+            return;
+        }
+
+        setInlinePhase('closed');
+        emitState('closed');
+        setIsMounted(false);
+    }, [clearVisualTransitionFallback, emitState]);
 
     useEffect(() => {
         if (!isInline) {
             setIsMounted(open);
-            setIsVisible(open);
+            setInlinePhase(open ? 'open' : 'closed');
+            emitState(open ? 'open' : 'closed');
             return;
         }
 
         let frameId: number | null = null;
-        let timeoutId: number | null = null;
 
         if (open) {
             setIsMounted(true);
             if (!isMounted && disableInitialInlineAnimation) {
-                setIsVisible(true);
+                setInlinePhase('open');
+                emitState('open');
                 return;
             }
+            setInlinePhase('opening');
+            emitState('opening');
             frameId = window.requestAnimationFrame(() => {
-                setIsVisible(true);
+                setInlinePhase('open');
+                clearVisualTransitionFallback();
+                visualTransitionFallbackTimeoutRef.current = window.setTimeout(() => {
+                    finishInlineTransition('open');
+                }, INLINE_PANEL_TRANSITION_FALLBACK_MS);
             });
         } else if (isMounted) {
-            setIsVisible(false);
-            timeoutId = window.setTimeout(() => {
-                setIsMounted(false);
-            }, INLINE_ASIDE_PANEL_ANIMATION_MS);
+            setInlinePhase('closing');
+            emitState('closing');
+            clearVisualTransitionFallback();
+            visualTransitionFallbackTimeoutRef.current = window.setTimeout(() => {
+                finishInlineTransition('closed');
+            }, INLINE_PANEL_TRANSITION_FALLBACK_MS);
         }
 
         return () => {
             if (frameId !== null) {
                 window.cancelAnimationFrame(frameId);
             }
-            if (timeoutId !== null) {
-                window.clearTimeout(timeoutId);
-            }
         };
-    }, [disableInitialInlineAnimation, isInline, isMounted, open]);
+    }, [
+        clearVisualTransitionFallback,
+        disableInitialInlineAnimation,
+        emitState,
+        finishInlineTransition,
+        isInline,
+        isMounted,
+        open,
+    ]);
+
+    useEffect(() => {
+        if (!isInline) {
+            return;
+        }
+
+        const panelEl = panelRef.current;
+        if (!panelEl || !isMounted) {
+            return;
+        }
+
+        const handleTransitionEnd = (event: TransitionEvent) => {
+            if (
+                event.target !== panelEl ||
+                (event.propertyName !== 'width' && event.propertyName !== 'flex-basis')
+            ) {
+                return;
+            }
+
+            finishInlineTransition(open ? 'open' : 'closed');
+        };
+
+        panelEl.addEventListener('transitionend', handleTransitionEnd);
+        return () => {
+            panelEl.removeEventListener('transitionend', handleTransitionEnd);
+        };
+    }, [finishInlineTransition, isInline, isMounted, open]);
+
+    useEffect(() => () => clearVisualTransitionFallback(), [clearVisualTransitionFallback]);
 
     return {
         isMounted: isInline ? isMounted : open,
-        dataState: isInline ? (isVisible ? 'open' : 'closed') : undefined,
+        dataState: isInline ? (inlinePhase === 'open' ? 'open' : 'closed') : undefined,
+        inlinePhase: isInline ? inlinePhase : (open ? 'open' : 'closed'),
+        panelRef,
     };
 };
 
@@ -266,9 +354,15 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
     layout = 'overlay',
     dataSection,
     disableInitialInlineAnimation = false,
+    onInlineAnimationStateChange,
 }) => {
     const [stack, setStack] = useState<AsideContentItem[]>([initialItem]);
-    const { isMounted, dataState } = useInlinePanelPresence(open, layout, disableInitialInlineAnimation);
+    const { isMounted, dataState, inlinePhase, panelRef } = useInlinePanelPresence(
+        open,
+        layout,
+        disableInitialInlineAnimation,
+        onInlineAnimationStateChange,
+    );
 
     const push = useCallback((item: AsideContentItem) => {
         setStack(prev => [...prev, item]);
@@ -319,19 +413,21 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
         <AsidePanelContext.Provider value={{ push, pop, replace, clear, canGoBack, currentItem }}>
             <div className={cn(
                 layout === 'inline'
-                    ? "relative split-panel shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
+                    ? "relative split-panel shrink-0 h-full min-h-0 max-w-full z-30 flex flex-col app-no-drag overflow-hidden"
                     : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
                 layout === 'overlay' && width,
                 className
             )}
+            ref={panelRef}
             style={rootInlineStyle}
             data-section={dataSection}
             data-state={dataState}
-            aria-hidden={layout === 'inline' ? !open : undefined}>
+                data-inline-phase={layout === 'inline' ? inlinePhase : undefined}
+                aria-hidden={layout === 'inline' ? !open : undefined}>
                 <div
                     className={cn(
                         "h-full min-h-0 flex flex-col",
-                        layout === 'inline' && "overflow-hidden"
+                        layout === 'inline' && "overflow-hidden split-panel-visual border-l border-border/60 bg-background shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
                     )}
                     style={contentInlineStyle}
                 >
@@ -365,8 +461,14 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     layout = 'overlay',
     dataSection,
     disableInitialInlineAnimation = false,
+    onInlineAnimationStateChange,
 }) => {
-    const { isMounted, dataState } = useInlinePanelPresence(open, layout, disableInitialInlineAnimation);
+    const { isMounted, dataState, inlinePhase, panelRef } = useInlinePanelPresence(
+        open,
+        layout,
+        disableInitialInlineAnimation,
+        onInlineAnimationStateChange,
+    );
 
     if (!isMounted) return null;
 
@@ -386,19 +488,21 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     return (
         <div className={cn(
             layout === 'inline'
-                ? "relative split-panel shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
+                ? "relative split-panel shrink-0 h-full min-h-0 max-w-full z-30 flex flex-col app-no-drag overflow-hidden"
                 : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
             layout === 'overlay' && width,
             className
         )}
+        ref={panelRef}
         style={rootInlineStyle}
         data-section={dataSection}
         data-state={dataState}
+        data-inline-phase={layout === 'inline' ? inlinePhase : undefined}
         aria-hidden={layout === 'inline' ? !open : undefined}>
             <div
                 className={cn(
                     "h-full min-h-0 flex flex-col",
-                    layout === 'inline' && "overflow-hidden"
+                    layout === 'inline' && "overflow-hidden split-panel-visual border-l border-border/60 bg-background shadow-[-10px_0_20px_-12px_hsl(var(--foreground)/0.22)]"
                 )}
                 style={contentInlineStyle}
             >

--- a/index.css
+++ b/index.css
@@ -106,12 +106,13 @@
   width: var(--aside-inline-width);
   min-width: 0;
   flex-basis: var(--aside-inline-width);
+  contain: layout paint style;
   will-change: width, flex-basis;
   transition:
-    width 260ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    flex-basis 260ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    border-color 160ms ease-out,
-    box-shadow 160ms ease-out;
+    width 320ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    flex-basis 320ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    border-color 220ms ease-out,
+    box-shadow 220ms ease-out;
 }
 
 .split-panel[data-state="closed"] {

--- a/index.css
+++ b/index.css
@@ -109,21 +109,36 @@
   contain: layout paint style;
   will-change: width, flex-basis;
   transition:
-    width 380ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    flex-basis 380ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    border-color 260ms ease-out,
-    box-shadow 260ms ease-out;
+    width 1200ms cubic-bezier(0.42, 0, 0.58, 1),
+    flex-basis 1200ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
-.split-panel[data-state="closed"] {
+.split-panel[data-inline-phase="open"] {
+  width: var(--aside-inline-width);
+  flex-basis: var(--aside-inline-width);
+}
+
+.split-panel[data-inline-phase="opening"],
+.split-panel[data-inline-phase="closing"],
+.split-panel[data-inline-phase="closed"] {
   width: 0;
   min-width: 0;
   flex-basis: 0;
+  pointer-events: none;
+}
+
+.split-panel-visual {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  will-change: border-color, box-shadow;
+  transition:
+    border-color 1200ms cubic-bezier(0.42, 0, 0.58, 1),
+    box-shadow 1200ms cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.split-panel[data-inline-phase="closed"] .split-panel-visual {
   border-left-color: transparent;
   box-shadow: none;
-  pointer-events: none;
-  transition-duration: 430ms, 430ms, 280ms, 280ms;
-  transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 :root {

--- a/index.css
+++ b/index.css
@@ -106,32 +106,28 @@
   position: relative;
   width: 0;
   min-width: 0;
-  flex-basis: 0;
+  flex-basis: auto;
   contain: layout paint style;
   overflow: hidden;
-  will-change: width, flex-basis;
+  will-change: width;
   transition:
-    width 1100ms cubic-bezier(0.42, 0, 0.58, 1),
-    flex-basis 1100ms cubic-bezier(0.42, 0, 0.58, 1);
+    width 1100ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 .split-panel[data-inline-phase="opening"] {
   width: 0;
   min-width: 0;
-  flex-basis: 0;
   pointer-events: none;
 }
 
 .split-panel[data-inline-phase="open"] {
   width: var(--aside-inline-width);
-  flex-basis: var(--aside-inline-width);
 }
 
 .split-panel[data-inline-phase="closing"],
 .split-panel[data-inline-phase="closed"] {
   width: 0;
   min-width: 0;
-  flex-basis: 0;
   pointer-events: none;
 }
 

--- a/index.css
+++ b/index.css
@@ -109,10 +109,10 @@
   contain: layout paint style;
   will-change: width, flex-basis;
   transition:
-    width 320ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    flex-basis 320ms cubic-bezier(0.24, 0.84, 0.32, 1),
-    border-color 220ms ease-out,
-    box-shadow 220ms ease-out;
+    width 380ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    flex-basis 380ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    border-color 260ms ease-out,
+    box-shadow 260ms ease-out;
 }
 
 .split-panel[data-state="closed"] {
@@ -122,6 +122,8 @@
   border-left-color: transparent;
   box-shadow: none;
   pointer-events: none;
+  transition-duration: 430ms, 430ms, 280ms, 280ms;
+  transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 :root {

--- a/index.css
+++ b/index.css
@@ -111,7 +111,7 @@
   overflow: hidden;
   will-change: width;
   transition:
-    width 1100ms cubic-bezier(0.42, 0, 0.58, 1);
+    width 400ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 .split-panel[data-inline-phase="opening"] {
@@ -138,8 +138,8 @@
   height: 100%;
   will-change: border-color, box-shadow;
   transition:
-    border-color 1100ms cubic-bezier(0.42, 0, 0.58, 1),
-    box-shadow 1100ms cubic-bezier(0.42, 0, 0.58, 1);
+    border-color 400ms cubic-bezier(0.42, 0, 0.58, 1),
+    box-shadow 400ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 .split-panel[data-inline-phase="closed"] .split-panel-visual {

--- a/index.css
+++ b/index.css
@@ -102,27 +102,25 @@
   }
 }
 
-@keyframes split-panel-enter {
-  0% {
-    width: 0;
-    min-width: 0;
-    opacity: 0;
-    transform: translateX(22px);
-  }
-  55% {
-    opacity: 0.88;
-  }
-  100% {
-    width: var(--aside-inline-width);
-    min-width: var(--aside-inline-width);
-    opacity: 1;
-    transform: translateX(0);
-  }
+.split-panel {
+  width: var(--aside-inline-width);
+  min-width: 0;
+  flex-basis: var(--aside-inline-width);
+  will-change: width, flex-basis;
+  transition:
+    width 260ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    flex-basis 260ms cubic-bezier(0.24, 0.84, 0.32, 1),
+    border-color 160ms ease-out,
+    box-shadow 160ms ease-out;
 }
 
-.split-panel-enter {
-  animation: split-panel-enter 220ms cubic-bezier(0.24, 0.84, 0.32, 1) both;
-  will-change: width, opacity, transform;
+.split-panel[data-state="closed"] {
+  width: 0;
+  min-width: 0;
+  flex-basis: 0;
+  border-left-color: transparent;
+  box-shadow: none;
+  pointer-events: none;
 }
 
 :root {

--- a/index.css
+++ b/index.css
@@ -103,14 +103,23 @@
 }
 
 .split-panel {
-  width: var(--aside-inline-width);
+  position: relative;
+  width: 0;
   min-width: 0;
-  flex-basis: var(--aside-inline-width);
+  flex-basis: 0;
   contain: layout paint style;
+  overflow: hidden;
   will-change: width, flex-basis;
   transition:
-    width 1200ms cubic-bezier(0.42, 0, 0.58, 1),
-    flex-basis 1200ms cubic-bezier(0.42, 0, 0.58, 1);
+    width 1100ms cubic-bezier(0.42, 0, 0.58, 1),
+    flex-basis 1100ms cubic-bezier(0.42, 0, 0.58, 1);
+}
+
+.split-panel[data-inline-phase="opening"] {
+  width: 0;
+  min-width: 0;
+  flex-basis: 0;
+  pointer-events: none;
 }
 
 .split-panel[data-inline-phase="open"] {
@@ -118,7 +127,6 @@
   flex-basis: var(--aside-inline-width);
 }
 
-.split-panel[data-inline-phase="opening"],
 .split-panel[data-inline-phase="closing"],
 .split-panel[data-inline-phase="closed"] {
   width: 0;
@@ -128,17 +136,28 @@
 }
 
 .split-panel-visual {
-  opacity: 1;
-  transform: translateX(0) scale(1);
+  position: relative;
+  width: var(--aside-inline-width);
+  min-width: var(--aside-inline-width);
+  height: 100%;
   will-change: border-color, box-shadow;
   transition:
-    border-color 1200ms cubic-bezier(0.42, 0, 0.58, 1),
-    box-shadow 1200ms cubic-bezier(0.42, 0, 0.58, 1);
+    border-color 1100ms cubic-bezier(0.42, 0, 0.58, 1),
+    box-shadow 1100ms cubic-bezier(0.42, 0, 0.58, 1);
 }
 
 .split-panel[data-inline-phase="closed"] .split-panel-visual {
   border-left-color: transparent;
   box-shadow: none;
+}
+
+.ghost-hosts-card-grid-placeholder [data-vault-card-id] {
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.ghost-hosts-card-grid-placeholder {
+  overflow: hidden !important;
 }
 
 :root {


### PR DESCRIPTION
## Summary
  This PR refines the Hosts/Vault editing experience by making the inline side panel and main content transitions feel more coherent, while keeping the top toolbar usable within the existing minimum window width.

  ## What Changed
  - improved the inline side panel open/close behavior so the panel and main content resize feel more synchronized
  - kept inline panels mounted long enough to animate closed cleanly instead of disappearing abruptly
  - refined the Hosts header so actions stay on a single row and compact smoothly when the side panel opens
  - moved the Connect action into the search input and tuned its styling/behavior for both empty and active states
  - updated host/group/serial inline panel wrappers and related sub-panels so close animations can complete correctly
  - adjusted search placeholder copy to better match the quick-connect flow

  ## Notes
  - no new dependencies were added
  - existing inline editing behavior and minimum window width constraints were preserved
  - the compact header state is intentionally tied to the real side-panel state to avoid desynchronized layout behavior

  ## Testing
  - `npm run lint -- --max-warnings=0`
  - `npm run build`