### PR TITLE
fix: send SSH keepalive on idle SFTP sessions to prevent NAT drop

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -954,6 +954,14 @@ async function openSftp(event, options) {
     // Enable keyboard-interactive authentication (required for 2FA/MFA)
     tryKeyboard: true,
     readyTimeout: 120000, // 2 minutes for 2FA input
+    // Keep SFTP sessions alive while the panel is idle. Without SSH-level
+    // keepalive packets the connection sits with zero data flow while the
+    // user is just browsing files, and NAT/firewall state tables drop the
+    // idle TCP connection after ~30-60s (the exact symptom of #669).
+    // Honor an explicitly configured positive keepaliveInterval (seconds);
+    // otherwise default to 10s, matching the SFTP jump host path below.
+    keepaliveInterval: options.keepaliveInterval > 0 ? options.keepaliveInterval * 1000 : 10000,
+    keepaliveCountMax: 3,
     algorithms: buildSftpAlgorithms(options.legacyAlgorithms),
   };
 


### PR DESCRIPTION
## Summary
- Add `keepaliveInterval: 10000` and `keepaliveCountMax: 3` to the main SFTP connect options in `openSftp()`
- Fixes idle SFTP connections silently dying after ~30 seconds while the SSH terminal on the same host stays healthy

Closes #669

## Root cause
The main SFTP connection path at `electron/bridges/sftpBridge.cjs:950-958` was building ssh2 connect options **without any keepalive configuration**, so ssh2 used its default (disabled). No SSH-level keepalive packets were sent on the SFTP channel, which is fine for a busy session but fatal for an idle one — NAT/firewall state tables drop the idle TCP connection after ~30–60 seconds. That's the exact symptom from the issue ("sftp 没几秒就断了").

Meanwhile the SSH terminal next to it kept working because `sshBridge.cjs:415-416,685-686` honors `options.keepaliveInterval` from terminal settings and the SSH channel also sees frequent low-volume I/O (cursor, shell echo) that keeps NAT tables warm on its own.

The SFTP jump host path (`sftpBridge.cjs:466-467`) already hardcodes a 10s keepalive, so the main path being unset is most likely an oversight from when that block was written.

## Approach
Minimal bridge-side change — no frontend, IPC, or protocol changes:

1. Default the main SFTP connection to `keepaliveInterval: 10000ms` (matches the existing SFTP jump host path)
2. Honor `options.keepaliveInterval` (in seconds) if a positive value is passed, so the frontend can thread the user setting through in a follow-up without another bridge change

## Why not honor `keepaliveInterval=0 = disabled` here?
`sshBridge.cjs` honors 0 as disabled (#582), but SSH terminals are rarely fully idle so disabling keepalive is usually safe. An SFTP panel sitting open on a file listing has **no** traffic at all, so honoring 0 would bring back this exact bug. SFTP needs a floor, and 10s matches the existing jump host precedent.

## Test plan
- [x] Open an SFTP panel to a host behind NAT/firewall (most cellular and home networks work)
- [x] Leave the panel idle for ≥ 2 minutes without clicking anything
- [x] Verify the panel stays connected and a subsequent file click still works without reconnecting
- [x] Open the SFTP panel to a jump host chain — verify it still works (path already had keepalive, should be unchanged)
- [x] Verify normal SFTP operations (upload, download, rename, delete) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)