### PR TITLE
fix: pass legacyAlgorithms to port forwarding SSH connections

### DIFF
--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -10,7 +10,7 @@ const net = require("node:net");
 const { Client: SSHClient } = require("ssh2");
 const { NetcattyAgent } = require("./netcattyAgent.cjs");
 const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
-const { connectThroughChain } = require("./sshBridge.cjs");
+const { connectThroughChain, buildAlgorithms } = require("./sshBridge.cjs");
 const { createProxySocket } = require("./proxyUtils.cjs");
 const { 
   buildAuthHandler, 
@@ -59,6 +59,7 @@ async function startPortForward(event, payload) {
     proxy,
     jumpHosts = [],
     identityFilePaths,
+    legacyAlgorithms,
   } = payload;
 
   const conn = new SSHClient();
@@ -92,6 +93,7 @@ async function startPortForward(event, payload) {
     keepaliveInterval: 10000,
     // Enable keyboard-interactive authentication (required for 2FA/MFA)
     tryKeyboard: true,
+    algorithms: buildAlgorithms(legacyAlgorithms),
   };
 
   const hasCertificate = typeof certificate === "string" && certificate.trim().length > 0;
@@ -188,6 +190,7 @@ async function startPortForward(event, payload) {
           passphrase,
           proxy,
           jumpHosts,
+          legacyAlgorithms,
           _defaultKeys: defaultKeys,
           _connectionsRef: chainConnections,
           _tunnelRef: tunnelState,

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2527,4 +2527,5 @@ module.exports = {
   init,
   registerHandlers,
   connectThroughChain,
+  buildAlgorithms,
 };

--- a/global.d.ts
+++ b/global.d.ts
@@ -137,6 +137,7 @@ declare global {
     proxy?: NetcattyProxyConfig;
     jumpHosts?: NetcattyJumpHost[];
     identityFilePaths?: string[];
+    legacyAlgorithms?: boolean;
   }
 
   interface PortForwardResult {

--- a/infrastructure/services/portForwardingService.ts
+++ b/infrastructure/services/portForwardingService.ts
@@ -496,6 +496,7 @@ export const startPortForward = async (
       proxy,
       jumpHosts: jumpHosts && jumpHosts.length > 0 ? jumpHosts : undefined,
       identityFilePaths: host.identityFilePaths,
+      legacyAlgorithms: host.legacyAlgorithms,
     });
     
     if (!result.success) {


### PR DESCRIPTION
## Summary
- Thread the host's `legacyAlgorithms` setting through to the port forwarding SSH connection, so tunnels to older SSH servers (e.g. OpenSSH 7.4) can negotiate legacy key exchange and cipher algorithms

Closes #678

## Root cause
The SSH terminal path correctly passes `legacyAlgorithms` through `buildAlgorithms()` to enable older algorithms like `diffie-hellman-group14-sha1`, `aes128-cbc`, and `ssh-rsa` when the host setting is toggled on. But the port forwarding path was never wired up — it always used modern-only algorithms, causing "Connection lost before handshake" when the jump server or target host only supports legacy algorithms.

## Changes (3 files, +6 / -1)
- **`sshBridge.cjs`**: export `buildAlgorithms` so `portForwardingBridge` can reuse it
- **`portForwardingBridge.cjs`**: destructure `legacyAlgorithms` from payload, add `algorithms: buildAlgorithms(legacyAlgorithms)` to `connectOpts`, thread `legacyAlgorithms` into the `connectThroughChain` options for jump host connections
- **`portForwardingService.ts`**: pass `host.legacyAlgorithms` in the `startPortForward` bridge call

## Test plan
- [ ] Configure a host with `legacyAlgorithms` enabled that runs an older SSH server (OpenSSH 7.4 or similar)
- [ ] Create a local port forwarding rule through that host
- [ ] Verify the tunnel connects successfully (no "Connection lost before handshake")
- [ ] Verify tunnels to modern SSH servers still work with `legacyAlgorithms` disabled
- [ ] Verify jump host chain forwarding also works with `legacyAlgorithms` enabled on the jump host

🤖 Generated with [Claude Code](https://claude.com/claude-code)