### PR TITLE
feat: add Windows portable build target

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -87,8 +87,15 @@ module.exports = {
             {
                 target: 'nsis',
                 arch: ['x64', 'arm64']
+            },
+            {
+                target: 'portable',
+                arch: ['x64', 'arm64']
             }
         ]
+    },
+    portable: {
+        artifactName: '${productName}-${version}-portable-${os}-${arch}.${ext}',
     },
     nsis: {
         oneClick: false,


### PR DESCRIPTION
## Summary
- Add a `portable` build target for Windows alongside the existing NSIS installer
- Produces a single `.exe` that runs without installation

Closes #668

## Changes (1 file, +7 lines)
- `electron-builder.config.cjs`: add `portable` to `win.target` array (x64 + arm64), with a `-portable-` infix in the artifact name

## Result
Release assets will now include:
- `Netcatty-x.y.z-win-x64.exe` — NSIS installer (existing)
- `Netcatty-x.y.z-portable-win-x64.exe` — portable version (new)
- Same for arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)