### PR TITLE
fix: normalize CRLF to LF when saving text files via SFTP

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -1878,7 +1878,12 @@ async function writeSftp(event, payload) {
     // File does not exist — treat as a new file and let the server apply defaults.
   }
 
-  await client.put(Buffer.from(payload.content, "utf-8"), encodedPath);
+  // Normalize CRLF → LF so scripts edited on Windows don't break when
+  // saved to a Linux/macOS host. LF is universally supported (Windows
+  // 10+ notepad handles it), while CRLF in shell scripts causes
+  // "command not found" and syntax errors on Linux.
+  const normalized = payload.content.replace(/\r\n/g, '\n');
+  await client.put(Buffer.from(normalized, "utf-8"), encodedPath);
 
   if (existingMode !== null) {
     try {


### PR DESCRIPTION
## Summary
- Normalize Windows line endings (CRLF) to Unix line endings (LF) when saving text files through the built-in SFTP editor

Closes #681

## Root cause
On Windows, the built-in text editor produces `\r\n` line endings. When saved to a Linux host via SFTP, the `\r` characters break shell scripts with errors like `command not found` or `syntax error: unexpected end of file`.

## Fix
One line added to `writeSftp()` in `sftpBridge.cjs`:
```js
const normalized = payload.content.replace(/\r\n/g, '\n');
```

LF is universally supported — Windows 10+ notepad handles LF-only files — so normalizing to LF is safe for all target platforms.

## Test plan
- [ ] On Windows, edit a shell script via the built-in SFTP editor and save
- [ ] Verify the saved file uses LF line endings (`file script.sh` or `cat -A script.sh`)
- [ ] Verify the script executes without `\r`-related errors
- [ ] Edit a non-script text file — verify content is preserved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)