### PR TITLE
fix: mouse wheel scrolling broken when scrollback set to 0

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -989,7 +989,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (terminalSettings) {
         termRef.current.options.cursorStyle = terminalSettings.cursorShape;
         termRef.current.options.cursorBlink = terminalSettings.cursorBlink;
-        termRef.current.options.scrollback = terminalSettings.scrollback;
+        termRef.current.options.scrollback = terminalSettings.scrollback === 0 ? 999999 : terminalSettings.scrollback;
         termRef.current.options.fontWeight = effectiveFontWeight as
           | 100
           | 200

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -182,7 +182,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   const cursorStyle = settings?.cursorShape ?? "block";
   const cursorBlink = settings?.cursorBlink ?? true;
-  const scrollback = settings?.scrollback ?? 10000;
+  // xterm.js treats scrollback=0 as "no scrollback buffer", which breaks mouse
+  // wheel scrolling (events become arrow-key sequences).  The UI uses 0 to mean
+  // "no limit", so map it to a large value instead.
+  const rawScrollback = settings?.scrollback ?? 10000;
+  const scrollback = rawScrollback === 0 ? 999999 : rawScrollback;
   const drawBoldTextInBrightColors = settings?.drawBoldInBrightColors ?? true;
   const fontWeight = resolveHostTerminalFontWeight(ctx.host, settings?.fontWeight ?? 400);
   const fontWeightBold = settings?.fontWeightBold ?? 700;


### PR DESCRIPTION
## Summary

- xterm.js treats `scrollback=0` as "no scrollback buffer", causing `hasScrollback` to return `false` — wheel events are then converted to arrow-key sequences instead of scrolling
- The UI uses 0 to mean "no limit", so we now map `scrollback=0` to `999999` before passing to xterm.js, both at terminal creation and runtime settings update

Closes #689

## Test plan

- [x] Set Rollback Lines to 0, open a connection, output enough content, verify mouse wheel scrolls normally
- [x] Set Rollback Lines to a non-zero value (e.g. 10000), verify scrolling still works
- [x] Change Rollback Lines from non-zero to 0 at runtime (without reopening terminal), verify scrolling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)