### PR TITLE
fix: remove hardcoded Ctrl+F handler bypassing configurable shortcuts

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1154,7 +1154,7 @@ const en: Messages = {
   'terminal.toolbar.library': 'Library',
   'terminal.toolbar.noSnippets': 'No snippets available',
   'terminal.toolbar.terminalSettings': 'Terminal settings',
-  'terminal.toolbar.searchTerminal': 'Search terminal (Ctrl+F)',
+  'terminal.toolbar.searchTerminal': 'Search terminal',
   'terminal.toolbar.search': 'Search',
   'terminal.toolbar.broadcast': 'Broadcast',
   'terminal.toolbar.broadcastEnable': 'Enable Broadcast Mode',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -767,7 +767,7 @@ const zhCN: Messages = {
   'terminal.toolbar.library': '库',
   'terminal.toolbar.noSnippets': '暂无代码片段',
   'terminal.toolbar.terminalSettings': '终端设置',
-  'terminal.toolbar.searchTerminal': '搜索终端 (Ctrl+F)',
+  'terminal.toolbar.searchTerminal': '搜索终端',
   'terminal.toolbar.search': '搜索',
   'terminal.toolbar.broadcast': '广播',
   'terminal.toolbar.broadcastEnable': '启用广播模式',

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -425,12 +425,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (!consumed) return false; // Event was consumed by autocomplete
     }
 
-    if ((e.ctrlKey || e.metaKey) && e.key === "f" && e.type === "keydown") {
-      e.preventDefault();
-      ctx.setIsSearchOpen(true);
-      return false;
-    }
-
     const currentScheme = ctx.hotkeySchemeRef.current;
     // Use shared utility for platform detection when hotkey scheme is disabled
     const isMac = currentScheme === "mac" || (currentScheme === "disabled" && isMacPlatform());

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -396,7 +396,7 @@ export const DEFAULT_KEY_BINDINGS: KeyBinding[] = [
   { id: 'paste', action: 'paste', label: 'Paste to Terminal', mac: '⌘ + V', pc: 'Ctrl + Shift + V', category: 'terminal' },
   { id: 'select-all', action: 'selectAll', label: 'Select All in Terminal', mac: '⌘ + A', pc: 'Ctrl + Shift + A', category: 'terminal' },
   { id: 'clear-buffer', action: 'clearBuffer', label: 'Clear Terminal Buffer', mac: '⌘ + ⌃ + K', pc: 'Ctrl + Shift + K', category: 'terminal' },
-  { id: 'search-terminal', action: 'searchTerminal', label: 'Open Terminal Search', mac: '⌘ + F', pc: 'Ctrl + Shift + F', category: 'terminal' },
+  { id: 'search-terminal', action: 'searchTerminal', label: 'Open Terminal Search', mac: '⌘ + F', pc: 'Ctrl + F', category: 'terminal' },
 
   // Navigation / Split View
   { id: 'move-focus', action: 'moveFocus', label: 'Move focus between Split View panes', mac: '⌘ + ⌥ + arrows', pc: 'Ctrl + Alt + arrows', category: 'navigation' },


### PR DESCRIPTION
## Summary
- Remove a hardcoded `Ctrl+F` / `Cmd+F` interceptor in the xterm custom key handler that opened terminal search regardless of the user's Shortcut settings. This conflicted with zsh's forward-char (Ctrl+F) and couldn't be disabled via the Shortcuts tab.
- The configurable keybinding system below the removed branch already routes the `searchTerminal` action through `checkAppShortcut` — so the existing settings UI now takes effect as intended.
- Update the PC default for `searchTerminal` from `Ctrl+Shift+F` to `Ctrl+F` to match the historical effective behavior (the hardcoded handler meant users always experienced `Ctrl+F` regardless of the declared default). This keeps existing users' muscle memory intact; anyone who needs plain `Ctrl+F` for the shell can now remap or disable it in Settings → Shortcuts.
- Drop the stale `(Ctrl+F)` suffix from the toolbar tooltip in `en` and `zh-CN` locales, since the shortcut is now user-configurable.

Fixes #694

## Test plan
- [x] Fresh install on PC: default `Ctrl+F` opens terminal search (backward compat for existing users).
- [x] Fresh install on Mac: default `⌘+F` opens terminal search.
- [x] On PC, remapping `searchTerminal` to a different key in Settings → Shortcuts makes plain `Ctrl+F` pass through to the shell (zsh forward-char works).
- [x] Setting hotkey scheme to `disabled` means no shortcut opens the terminal search bar.
- [x] Toolbar search button tooltip reads "Search terminal" / "搜索终端" without a stale shortcut hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)