### PR TITLE
fix: decouple Codex agent auth from netcatty provider list (#705)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1764,7 +1764,6 @@ const en: Messages = {
   'ai.codex.logout': 'Logout',
   'ai.codex.connectChatGPT': 'Connect ChatGPT',
   'ai.codex.refreshStatus': 'Refresh Status',
-  'ai.codex.apiKeyHint': 'Detected an enabled OpenAI-compatible provider API key. Codex ACP can use it without ChatGPT login.',
 
   // AI Claude Code
   'ai.claude.title': 'Claude Code',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1772,7 +1772,6 @@ const zhCN: Messages = {
   'ai.codex.logout': '退出登录',
   'ai.codex.connectChatGPT': '连接 ChatGPT',
   'ai.codex.refreshStatus': '刷新状态',
-  'ai.codex.apiKeyHint': '检测到已启用的兼容 OpenAI 的 API Key。Codex ACP 也可以不走 ChatGPT 登录直接使用它。',
 
   // AI Claude Code
   'ai.claude.title': 'Claude Code',

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -611,15 +611,11 @@ export function useAIChatStreaming({
 
       // Pass only the provider ID — the main process resolves and decrypts the API key itself,
       // avoiding plaintext key transit across the IPC boundary.
-      // Resolve the correct provider based on agent type:
-      // - Claude agent → anthropic provider (prefer over generic custom)
-      // - Codex agent  → openai provider (fallback to openai-compatible custom)
+      // Codex agent auth is owned entirely by ~/.codex/auth.json or ~/.codex/config.toml
+      // and must not be affected by netcatty's provider list (see issue #705).
       const agentProviderId = (() => {
         if (matchesManagedAgentConfig(agentConfig, 'claude')) {
           return findManagedAgentProvider(context.providers, 'claude')?.id;
-        }
-        if (matchesManagedAgentConfig(agentConfig, 'codex')) {
-          return findManagedAgentProvider(context.providers, 'codex')?.id;
         }
         return undefined;
       })();

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -18,7 +18,6 @@ import type {
   WebSearchConfig,
 } from "../../../infrastructure/ai/types";
 import {
-  findManagedAgentProvider,
   getManagedAgentStoredPath,
   matchesManagedAgentConfig,
   type ManagedAgentKey,
@@ -309,8 +308,6 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
       .map((a) => ({ value: a.id, label: a.name, icon: <AgentIconBadge agent={a} size="xs" variant="plain" /> })),
   ], [externalAgents, t]);
 
-  const hasCodexCompatibleProvider = Boolean(findManagedAgentProvider(providers, "codex"));
-
   const refreshCodexIntegration = useCallback(async (opts?: { refreshShellEnv?: boolean }) => {
     const bridge = getBridge();
     if (!bridge?.aiCodexGetIntegration) return;
@@ -575,7 +572,6 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               integration={codexIntegration}
               loginSession={codexLoginSession}
               isLoading={isCodexLoading}
-              hasCompatibleProvider={hasCodexCompatibleProvider}
               error={codexError}
               onRefresh={() => void refreshCodexIntegration({ refreshShellEnv: true })}
               onConnect={() => void handleStartCodexLogin()}

--- a/components/settings/tabs/ai/CodexConnectionCard.tsx
+++ b/components/settings/tabs/ai/CodexConnectionCard.tsx
@@ -15,7 +15,6 @@ export const CodexConnectionCard: React.FC<{
   integration: CodexIntegrationStatus | null;
   loginSession: CodexLoginSession | null;
   isLoading: boolean;
-  hasCompatibleProvider: boolean;
   error: string | null;
   onRefresh: () => void;
   onConnect: () => void;
@@ -31,7 +30,6 @@ export const CodexConnectionCard: React.FC<{
   integration,
   loginSession,
   isLoading,
-  hasCompatibleProvider,
   error,
   onRefresh,
   onConnect,
@@ -191,12 +189,6 @@ export const CodexConnectionCard: React.FC<{
                 </p>
               )}
             </>
-          )}
-
-          {hasCompatibleProvider && integration?.state !== "connected_custom_config" && (
-            <p className="text-xs text-emerald-500">
-              {t('ai.codex.apiKeyHint')}
-            </p>
           )}
         </>
       )}

--- a/infrastructure/ai/managedAgents.ts
+++ b/infrastructure/ai/managedAgents.ts
@@ -68,17 +68,13 @@ export function getManagedAgentStoredPath(
   return fallbackAgent?.command ?? null;
 }
 
+// Codex agent deliberately excluded: its auth is owned by ~/.codex/auth.json
+// or ~/.codex/config.toml and must not be affected by netcatty's provider list
+// (see issue #705).
 export function findManagedAgentProvider(
   providers: ProviderConfig[],
   agentKey: ManagedAgentKey,
 ): ProviderConfig | undefined {
-  if (agentKey === 'codex') {
-    return (
-      providers.find((provider) => provider.providerId === 'openai' && provider.enabled && !!provider.apiKey)
-      ?? providers.find((provider) => provider.providerId === 'custom' && provider.enabled && !!provider.apiKey && !!provider.baseURL)
-    );
-  }
-
   if (agentKey === 'claude') {
     return (
       providers.find((provider) => provider.providerId === 'anthropic' && provider.enabled && !!provider.apiKey)


### PR DESCRIPTION
## Summary
- Codex agent auth is now determined **entirely** by `~/.codex/auth.json` (ChatGPT login) or `~/.codex/config.toml`, independent of netcatty's AI provider list — matches the owner's conclusion in #705
- Removes the `codex` branch from `findManagedAgentProvider` and from the `agentProviderId` resolver in `useAIChatStreaming.ts`, so a user-configured custom/openai provider is no longer silently borrowed for Codex
- Drops the now-meaningless "detected compatible provider" hint on the Codex settings card and its i18n copy

## Why this fixes #705
Before this change, if the user configured any OpenAI-compatible API provider in netcatty settings (intended for Catty agent), `useAIChatStreaming` would hand that provider's apiKey to the Codex agent as well. `aiBridge` would then spawn codex-acp with `authMethodId: "codex-api-key"`, completely overriding the user's ChatGPT login. The user saw "API mode" after every refresh even though they never asked for it.

The regression was introduced in PR #702 (v1.0.89) when `findManagedAgentProvider` started matching generic `custom` providers for Codex. Claude agent's behavior is unchanged.

## Test plan
- [x] Launch netcatty with:
  - A `custom` / `openai` provider configured in Settings → AI (enabled, with apiKey) 
  - Codex CLI logged in via ChatGPT (`codex login`)
  - `~/.codex/config.toml` left at default (no `model_provider` set)
- [x] Open AI chat with Codex CLI agent → should stay "connected via ChatGPT", not flip to API mode
- [x] Refresh the page several times → Codex connection status stays `connected_chatgpt`, auth.json is not deleted
- [x] Verify Codex settings card no longer shows the "Detected an enabled OpenAI-compatible provider API key" hint
- [x] Verify Claude agent still picks up its anthropic/custom provider correctly (unchanged)
- [x] Verify `~/.codex/config.toml` with a real custom `model_provider` still works (connected_custom_config path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)