### PR TITLE
fix: decouple Claude agent auth from netcatty provider list

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -30,7 +30,6 @@ import { createCattyTools } from '../../../infrastructure/ai/sdk/tools';
 import type { NetcattyBridge, ExecutorContext } from '../../../infrastructure/ai/cattyAgent/executor';
 import { runExternalAgentTurn } from '../../../infrastructure/ai/externalAgentAdapter';
 import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
-import { findManagedAgentProvider, matchesManagedAgentConfig } from '../../../infrastructure/ai/managedAgents';
 import { classifyError } from '../../../infrastructure/ai/errorClassifier';
 
 // -------------------------------------------------------------------
@@ -609,17 +608,6 @@ export function useAIChatStreaming({
         await bridge.aiMcpUpdateSessions(context.terminalSessions, sessionId);
       }
 
-      // Pass only the provider ID — the main process resolves and decrypts the API key itself,
-      // avoiding plaintext key transit across the IPC boundary.
-      // Codex agent auth is owned entirely by ~/.codex/auth.json or ~/.codex/config.toml
-      // and must not be affected by netcatty's provider list (see issue #705).
-      const agentProviderId = (() => {
-        if (matchesManagedAgentConfig(agentConfig, 'claude')) {
-          return findManagedAgentProvider(context.providers, 'claude')?.id;
-        }
-        return undefined;
-      })();
-
       // Mutable flag: set after tool-result, cleared when new assistant msg is created
       let needsNewAssistantMsg = false;
       const maybeCreateAssistantMsg = () => {
@@ -701,7 +689,10 @@ export function useAIChatStreaming({
           onDone: () => {},
         },
         abortController.signal,
-        agentProviderId,
+        // Managed ACP agents (codex, claude) must resolve auth from their own
+        // CLI config/login state, so we deliberately pass no providerId here.
+        // See issue #705 for Codex; same reasoning for Claude.
+        undefined,
         context.selectedAgentModel,
         context.existingSessionId,
         context.historyMessages,

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2229,12 +2229,9 @@ function registerHandlers(ipcMain) {
       if (isCodexAgent && resolvedProvider?.provider?.baseURL) {
         agentEnv.OPENAI_BASE_URL = resolvedProvider.provider.baseURL;
       }
-      if (isClaudeAgent && apiKey) {
-        agentEnv.ANTHROPIC_API_KEY = apiKey;
-      }
-      if (isClaudeAgent && resolvedProvider?.provider?.baseURL) {
-        agentEnv.ANTHROPIC_BASE_URL = resolvedProvider.provider.baseURL;
-      }
+      // Claude agent auth is owned entirely by its CLI config/login state
+      // (`claude auth login`, ~/.claude settings, or ANTHROPIC_* in the user's
+      // shell env). netcatty's provider list must not override it.
 
       if (isCopilotAgent) {
         copilotConfigInfo = prepareCopilotHome(shellEnv, [], chatSessionId || `models_${Date.now()}`);
@@ -2416,7 +2413,7 @@ function registerHandlers(ipcMain) {
         }
       }
 
-      const authFingerprint = isCodexAgent || isClaudeAgent
+      const authFingerprint = isCodexAgent
         ? getAcpProviderAuthFingerprint(apiKey, resolvedProvider?.provider, codexCustomConfig)
         : null;
       const mcpSnapshot = isCodexAgent
@@ -2491,12 +2488,7 @@ function registerHandlers(ipcMain) {
         if (isCodexAgent && resolvedProvider?.provider?.baseURL) {
           agentEnv.OPENAI_BASE_URL = resolvedProvider.provider.baseURL;
         }
-        if (isClaudeAgent && apiKey) {
-          agentEnv.ANTHROPIC_API_KEY = apiKey;
-        }
-        if (isClaudeAgent && resolvedProvider?.provider?.baseURL) {
-          agentEnv.ANTHROPIC_BASE_URL = resolvedProvider.provider.baseURL;
-        }
+        // See comment above: Claude auth is CLI-owned, not provider-driven.
         let copilotConfigInfo = null;
         if (isCopilotAgent) {
           copilotConfigInfo = prepareCopilotHome(shellEnv, mcpSnapshot.mcpServers, chatSessionId);
@@ -2618,12 +2610,7 @@ function registerHandlers(ipcMain) {
             if (isCodexAgent && resolvedProvider?.provider?.baseURL) {
               fallbackEnv.OPENAI_BASE_URL = resolvedProvider.provider.baseURL;
             }
-            if (isClaudeAgent && apiKey) {
-              fallbackEnv.ANTHROPIC_API_KEY = apiKey;
-            }
-            if (isClaudeAgent && resolvedProvider?.provider?.baseURL) {
-              fallbackEnv.ANTHROPIC_BASE_URL = resolvedProvider.provider.baseURL;
-            }
+            // See comment above: Claude auth is CLI-owned, not provider-driven.
             if (isCopilotAgent) {
               const fallbackCopilotConfig = prepareCopilotHome(shellEnv, mcpSnapshot.mcpServers, chatSessionId);
               fallbackEnv.COPILOT_HOME = fallbackCopilotConfig.copilotHome;

--- a/infrastructure/ai/managedAgents.ts
+++ b/infrastructure/ai/managedAgents.ts
@@ -1,4 +1,4 @@
-import type { DiscoveredAgent, ExternalAgentConfig, ProviderConfig } from './types';
+import type { DiscoveredAgent, ExternalAgentConfig } from './types';
 
 export type ManagedAgentKey = 'codex' | 'claude' | 'copilot';
 
@@ -68,19 +68,3 @@ export function getManagedAgentStoredPath(
   return fallbackAgent?.command ?? null;
 }
 
-// Codex agent deliberately excluded: its auth is owned by ~/.codex/auth.json
-// or ~/.codex/config.toml and must not be affected by netcatty's provider list
-// (see issue #705).
-export function findManagedAgentProvider(
-  providers: ProviderConfig[],
-  agentKey: ManagedAgentKey,
-): ProviderConfig | undefined {
-  if (agentKey === 'claude') {
-    return (
-      providers.find((provider) => provider.providerId === 'anthropic' && provider.enabled && !!provider.apiKey)
-      ?? providers.find((provider) => provider.providerId === 'custom' && provider.enabled && !!provider.apiKey && !!provider.baseURL)
-    );
-  }
-
-  return undefined;
-}


### PR DESCRIPTION
## Summary
- Apply the symmetric fix of #706 to the Claude Code agent: `claude-agent-acp` auth is now resolved entirely by the `claude` CLI's own config / login state and shell env, not by netcatty's provider list.
- Stops silently injecting a user-configured \`ANTHROPIC_API_KEY\` / \`ANTHROPIC_BASE_URL\` into claude-agent-acp, which could override a Claude Max/Pro subscription login (\`claude auth login\`) and route charges to the user's API balance without their knowledge.
- Cleans up the now-dead helper \`findManagedAgentProvider\` and all three ANTHROPIC_* injection sites in \`aiBridge.cjs\`.

## Why
The \`claude\` CLI has a full auth surface — \`claude auth login / logout / status\` — analogous to \`codex login\`. \`claude auth status\` can report a \`claude.ai\` subscription login (Max / Pro) that has nothing to do with any \`ANTHROPIC_API_KEY\` the user may have exported or configured in netcatty. Before this change, any enabled \`anthropic\` or \`custom\` provider with an apiKey in netcatty's settings would be forwarded to claude-agent-acp, causing it to authenticate via API key and completely bypass the subscription login.

This is structurally identical to the Codex bug fixed in #706 (see issue #705). The only reason it's less visible is that the Claude settings card doesn't display \`claude auth status\`, so users had no way to notice their subscription was being ignored.

Chosen approach (option A from discussion): complete symmetric fix. We accept that users who want \`claude-agent-acp\` to use a non-subscription API key must now configure it via \`claude\` CLI / shell env directly, which is how other Anthropic tooling already works.

## Test plan
- [x] With \`claude auth login\` (subscription mode) and any enabled anthropic/custom provider configured in netcatty:
  - Start a chat with the Claude agent → verify it runs against the subscription, not the API key
  - \`claude auth status\` should remain \`loggedIn: true\` and unchanged after the session
- [x] With \`claude auth logout\` and \`ANTHROPIC_API_KEY\` exported in the shell env:
  - Start a chat with Claude agent → should work using that env var
- [x] With \`claude auth logout\` and no env var:
  - Expect claude-agent-acp to error out with its own "not authenticated" message (netcatty does not provide a fallback)
- [x] Codex and Copilot agents unchanged — smoke-test each
- [x] Catty agent (built-in) unchanged — still uses netcatty's provider list normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)