### PR TITLE
feat: dynamically probe claude-agent-acp for available models

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -601,7 +601,20 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
       undefined,
       `models_${currentAgentId}`,
     ).then((result) => {
-      if (cancelled || !result?.ok || !Array.isArray(result.models) || result.models.length === 0) return;
+      if (cancelled || !result?.ok || !Array.isArray(result.models)) return;
+      // If the probe came back empty, drop any stale cached catalog for this
+      // agent so `agentModelPresets` falls back to the hardcoded presets via
+      // the `?? getAgentModelPresets(...)` branch. Without this, a previously
+      // successful probe would keep surfacing models the backend no longer
+      // advertises.
+      if (result.models.length === 0) {
+        setRuntimeAgentModelPresets((prev) => {
+          if (!(currentAgentId in prev)) return prev;
+          const { [currentAgentId]: _removed, ...rest } = prev;
+          return rest;
+        });
+        return;
+      }
       const knownModelIds = new Set(result.models.map((model) => model.id));
       setRuntimeAgentModelPresets((prev) => ({
         ...prev,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -541,6 +541,10 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     () => currentAgentConfig ? matchesManagedAgentConfig(currentAgentConfig, 'codex') : false,
     [currentAgentConfig],
   );
+  const isClaudeManagedAgent = useMemo(
+    () => currentAgentConfig ? matchesManagedAgentConfig(currentAgentConfig, 'claude') : false,
+    [currentAgentConfig],
+  );
 
   // For Codex, pick up the model declared in ~/.codex/config.toml (if any)
   // so the picker can show just that model instead of the hardcoded ChatGPT
@@ -579,7 +583,12 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
 
   useEffect(() => {
     if (!currentAgentConfig?.acpCommand) return;
-    if (!isCopilotExternalAgent) return;
+    // Codex has its own path via aiCodexGetIntegration (reads config.toml).
+    // Everyone else that speaks ACP can be asked for their available models
+    // directly — in particular, Claude Code through claude-agent-acp
+    // advertises the real catalog (including Bedrock/Vertex model ids when
+    // the user configured those) instead of the hardcoded CLAUDE_MODEL_PRESETS.
+    if (!isCopilotExternalAgent && !isClaudeManagedAgent) return;
 
     const bridge = getNetcattyBridge();
     if (!bridge?.aiAcpListModels) return;
@@ -592,7 +601,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
       undefined,
       `models_${currentAgentId}`,
     ).then((result) => {
-      if (cancelled || !result?.ok || !Array.isArray(result.models)) return;
+      if (cancelled || !result?.ok || !Array.isArray(result.models) || result.models.length === 0) return;
       const knownModelIds = new Set(result.models.map((model) => model.id));
       setRuntimeAgentModelPresets((prev) => ({
         ...prev,
@@ -611,7 +620,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentAgentConfig, currentAgentId, isCopilotExternalAgent, setAgentModel]);
+  }, [currentAgentConfig, currentAgentId, isCopilotExternalAgent, isClaudeManagedAgent, setAgentModel]);
 
   // When Codex is backed by a ~/.codex/config.toml custom provider, the
   // stock CODEX_MODEL_PRESETS catalog is invalid for that endpoint.


### PR DESCRIPTION
## Summary
- Ask `claude-agent-acp` for its real model catalog via ACP `initSession` instead of surfacing the three hardcoded entries in `CLAUDE_MODEL_PRESETS`.
- Closes the "what if the user has a custom Claude model" gap raised in discussion around #707: when a user points Claude at a third-party proxy / Bedrock / Vertex, or just sets a custom model name in `~/.claude/settings.json`, the CLI already knows the real set of models and netcatty should reflect that.
- Codex keeps its existing path via `aiCodexGetIntegration` (reads `~/.codex/config.toml`). We deliberately **do not** probe `codex-acp`, because probing returns the stock OpenAI list regardless of the active provider — already documented in the surrounding code.

## What gets picked up for Claude

Verified locally against the bundled `node_modules/.bin/claude-agent-acp`:

| User state | Probe result |
|---|---|
| Default subscription login, no custom settings | 3 standard entries (`default` / `sonnet` / `haiku`), `currentModelId: "default"` |
| `~/.claude/settings.json`: `{"model":"sonnet"}` | Same 3 entries, `currentModelId: "sonnet"` (default selection follows user pref) |
| `~/.claude/settings.json`: `{"model":"my-proxy-model-xxx"}` | **4 entries** — the 3 standard ones plus a new `{modelId: "my-proxy-model-xxx", description: "Custom model"}`, with `currentModelId` set to that custom id |
| `CLAUDE_CODE_USE_BEDROCK=1` + AWS creds | Bedrock-specific model ids as advertised by Claude CLI |

Sample response for the custom-name case:
```json
{
  "availableModels": [
    { "modelId": "default", "name": "Default (recommended)", "description": "Opus 4.6 with 1M context [NEW] · Most capable for complex work" },
    { "modelId": "sonnet",  "name": "Sonnet",                "description": "Sonnet 4.6 · Best for everyday tasks" },
    { "modelId": "haiku",   "name": "Haiku",                 "description": "Haiku 4.5 · Fastest for quick answers" },
    { "modelId": "my-proxy-model-xxx", "name": "my-proxy-model-xxx", "description": "Custom model" }
  ],
  "currentModelId": "my-proxy-model-xxx"
}
```

The \"Custom model\" entry is injected by Claude CLI itself during session initialization when `settings.model` doesn't match any known preset — netcatty just surfaces whatever the CLI returns. So descriptions stay in sync with future Claude releases and we get proxy/Bedrock/Vertex catalogs for free.

## Safety / fallback
- If probe fails (`result.ok === false` or `models` not an array) → keep hardcoded `CLAUDE_MODEL_PRESETS` (existing fallback at the `agentModelPresets` memo).
- **New guard**: also fall back when the probe returns an empty list, so a flaky response doesn't disable the picker entirely. This also protects Copilot from the same edge case.

## Test plan
- [ ] With a standard Claude Code subscription login: Claude model picker shows 3 models with up-to-date descriptions from the CLI
- [ ] Set `~/.claude/settings.json` → `{\"model\":\"sonnet\"}`: picker defaults to Sonnet on a fresh agent switch
- [ ] Set `~/.claude/settings.json` → `{\"model\":\"some-custom-id\"}`: picker shows the 3 standard entries plus a 4th \"Custom model\" entry, and that id is the default selection
- [ ] Store a previous model selection, switch to Claude agent → selection preserved if still in probed catalog
- [ ] Simulate a probe failure (e.g. rename the binary briefly) → picker falls back to hardcoded presets, no empty-state crash
- [ ] Codex and other agent types unaffected
- [ ] (Optional) Bedrock / Vertex setup: verify the model picker shows provider-specific model ids instead of \"Opus 4.6 / Sonnet 4.6 / Haiku 4.5\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)