### PR TITLE
[codex] Fix mac fullscreen close-to-tray behavior

### DIFF
--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -34,11 +34,79 @@ let trayMenuData = {
 let trayPanelWindow = null;
 
 let trayPanelRefreshTimer = null;
+const FULLSCREEN_HIDE_POLL_MS = 100;
+const FULLSCREEN_HIDE_TIMEOUT_MS = 5000;
+const pendingFullscreenHideByWindow = new WeakMap();
+
+function clearPendingFullscreenHide(win) {
+  if (!win || typeof win !== "object") return;
+  const pending = pendingFullscreenHideByWindow.get(win);
+  if (!pending) return;
+
+  if (pending.timer) {
+    clearTimeout(pending.timer);
+    pending.timer = null;
+  }
+
+  try {
+    win.removeListener?.("leave-full-screen", pending.onLeaveFullScreen);
+    win.removeListener?.("closed", pending.onClosed);
+    win.removeListener?.("show", pending.onShow);
+  } catch {
+    // ignore
+  }
+
+  pendingFullscreenHideByWindow.delete(win);
+}
+
+function finalizePendingFullscreenHide(win) {
+  const pending = pendingFullscreenHideByWindow.get(win);
+  if (!pending) return "cancelled";
+  if (!win || win.isDestroyed?.()) {
+    clearPendingFullscreenHide(win);
+    return "cancelled";
+  }
+  if (win.isFullScreen?.()) {
+    return "waiting";
+  }
+
+  clearPendingFullscreenHide(win);
+
+  try {
+    win.hide();
+    return "hidden";
+  } catch (err) {
+    console.warn("[GlobalShortcut] Error hiding window after leaving fullscreen:", err);
+    return "failed";
+  }
+}
+
+function schedulePendingFullscreenHideCheck(win) {
+  const pending = pendingFullscreenHideByWindow.get(win);
+  if (!pending) return;
+
+  pending.timer = setTimeout(() => {
+    pending.timer = null;
+
+    const result = finalizePendingFullscreenHide(win);
+    if (result === "hidden" || result === "cancelled" || result === "failed") {
+      return;
+    }
+
+    if (!pending.warned && Date.now() >= pending.deadline) {
+      pending.warned = true;
+      console.warn("[GlobalShortcut] Timed out waiting for fullscreen exit before hiding window");
+    }
+
+    schedulePendingFullscreenHideCheck(win);
+  }, FULLSCREEN_HIDE_POLL_MS);
+}
 
 function openMainWindow() {
   const { app } = electronModule;
   const win = getMainWindow();
   if (!win) return;
+  clearPendingFullscreenHide(win);
   if (win.isMinimized()) win.restore();
   win.show();
   win.focus();
@@ -221,41 +289,34 @@ function getMainWindow() {
 function hideWindowRespectingMacFullscreen(win) {
   if (!win || win.isDestroyed?.()) return false;
 
+  clearPendingFullscreenHide(win);
+
   if (process.platform === "darwin" && win.isFullScreen?.()) {
-    let fallbackTimer = null;
-
-    const cleanup = () => {
-      if (fallbackTimer) {
-        clearTimeout(fallbackTimer);
-        fallbackTimer = null;
-      }
-      try {
-        win.removeListener?.("leave-full-screen", finalizeHide);
-        win.removeListener?.("closed", cleanup);
-      } catch {
-        // ignore
-      }
-    };
-
-    const finalizeHide = () => {
-      cleanup();
-      try {
-        if (!win.isDestroyed?.()) {
-          win.hide();
-        }
-      } catch (err) {
-        console.warn("[GlobalShortcut] Error hiding window after leaving fullscreen:", err);
-      }
+    const pending = {
+      timer: null,
+      deadline: Date.now() + FULLSCREEN_HIDE_TIMEOUT_MS,
+      warned: false,
+      onLeaveFullScreen: () => {
+        finalizePendingFullscreenHide(win);
+      },
+      onClosed: () => {
+        clearPendingFullscreenHide(win);
+      },
+      onShow: () => {
+        clearPendingFullscreenHide(win);
+      },
     };
 
     try {
-      win.once?.("leave-full-screen", finalizeHide);
-      win.once?.("closed", cleanup);
-      fallbackTimer = setTimeout(finalizeHide, 1000);
+      pendingFullscreenHideByWindow.set(win, pending);
+      win.once?.("leave-full-screen", pending.onLeaveFullScreen);
+      win.once?.("closed", pending.onClosed);
+      win.once?.("show", pending.onShow);
+      schedulePendingFullscreenHideCheck(win);
       win.setFullScreen(false);
       return true;
     } catch (err) {
-      cleanup();
+      clearPendingFullscreenHide(win);
       console.warn("[GlobalShortcut] Error leaving fullscreen before hiding window:", err);
     }
   }
@@ -334,6 +395,7 @@ function toggleWindowVisibility() {
   try {
     // Check if window is minimized first - minimized windows may still report isVisible() = true
     if (win.isMinimized()) {
+      clearPendingFullscreenHide(win);
       win.restore();
       win.show();
       win.focus();
@@ -346,9 +408,10 @@ function toggleWindowVisibility() {
     } else if (win.isVisible()) {
       if (win.isFocused()) {
         // Window is visible and focused - hide it
-        win.hide();
+        hideWindowRespectingMacFullscreen(win);
       } else {
         // Window is visible but not focused - focus it
+        clearPendingFullscreenHide(win);
         win.focus();
         const { app } = electronModule;
         try {
@@ -359,6 +422,7 @@ function toggleWindowVisibility() {
       }
     } else {
       // Window is hidden - show and focus it
+      clearPendingFullscreenHide(win);
       win.show();
       win.focus();
       const { app } = electronModule;
@@ -488,17 +552,7 @@ function buildTrayMenuTemplate() {
   menuTemplate.push({
     label: "Open Main Window",
     click: () => {
-      const win = getMainWindow();
-      if (win) {
-        if (win.isMinimized()) win.restore();
-        win.show();
-        win.focus();
-        try {
-          app.focus({ steal: true });
-        } catch {
-          // ignore
-        }
-      }
+      openMainWindow();
     },
   });
 
@@ -638,6 +692,7 @@ function setCloseToTray(enabled) {
       createTray();
     }
   } else {
+    clearPendingFullscreenHide(getMainWindow());
     // Destroy tray if it exists
     destroyTray();
   }
@@ -668,7 +723,8 @@ function getHotkeyStatus() {
 function handleWindowClose(event, win) {
   if (closeToTray && tray) {
     event.preventDefault();
-    return hideWindowRespectingMacFullscreen(win); // Prevented close
+    hideWindowRespectingMacFullscreen(win);
+    return true; // Prevented close
   }
   return false; // Allow close
 }

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -218,6 +218,57 @@ function getMainWindow() {
   return mainWins && mainWins.length ? mainWins[0] : null;
 }
 
+function hideWindowRespectingMacFullscreen(win) {
+  if (!win || win.isDestroyed?.()) return false;
+
+  if (process.platform === "darwin" && win.isFullScreen?.()) {
+    let fallbackTimer = null;
+
+    const cleanup = () => {
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+      try {
+        win.removeListener?.("leave-full-screen", finalizeHide);
+        win.removeListener?.("closed", cleanup);
+      } catch {
+        // ignore
+      }
+    };
+
+    const finalizeHide = () => {
+      cleanup();
+      try {
+        if (!win.isDestroyed?.()) {
+          win.hide();
+        }
+      } catch (err) {
+        console.warn("[GlobalShortcut] Error hiding window after leaving fullscreen:", err);
+      }
+    };
+
+    try {
+      win.once?.("leave-full-screen", finalizeHide);
+      win.once?.("closed", cleanup);
+      fallbackTimer = setTimeout(finalizeHide, 1000);
+      win.setFullScreen(false);
+      return true;
+    } catch (err) {
+      cleanup();
+      console.warn("[GlobalShortcut] Error leaving fullscreen before hiding window:", err);
+    }
+  }
+
+  try {
+    win.hide();
+    return true;
+  } catch (err) {
+    console.warn("[GlobalShortcut] Error hiding window:", err);
+    return false;
+  }
+}
+
 /**
  * Convert a hotkey string from frontend format to Electron accelerator format
  * e.g., "⌘ + Space" -> "CommandOrControl+Space"
@@ -617,8 +668,7 @@ function getHotkeyStatus() {
 function handleWindowClose(event, win) {
   if (closeToTray && tray) {
     event.preventDefault();
-    win.hide();
-    return true; // Prevented close
+    return hideWindowRespectingMacFullscreen(win); // Prevented close
   }
   return false; // Allow close
 }

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -2,6 +2,59 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
 
+function withPatchedTimers(run) {
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  let nextTimerId = 1;
+  const timers = new Map();
+
+  global.setTimeout = (fn, _delay, ...args) => {
+    const id = nextTimerId++;
+    timers.set(id, () => fn(...args));
+    return id;
+  };
+
+  global.clearTimeout = (id) => {
+    timers.delete(id);
+  };
+
+  const flushNextTimer = () => {
+    const nextEntry = timers.entries().next().value;
+    if (!nextEntry) return false;
+    const [id, fn] = nextEntry;
+    timers.delete(id);
+    fn();
+    return true;
+  };
+
+  const getPendingTimerCount = () => timers.size;
+
+  return Promise.resolve()
+    .then(() => run({ flushNextTimer, getPendingTimerCount }))
+    .finally(() => {
+      global.setTimeout = originalSetTimeout;
+      global.clearTimeout = originalClearTimeout;
+    });
+}
+
+function withPatchedDateNow(initialValue, run) {
+  const originalDateNow = Date.now;
+  let currentValue = initialValue;
+
+  Date.now = () => currentValue;
+
+  return Promise.resolve()
+    .then(() =>
+      run({
+        setNow(nextValue) {
+          currentValue = nextValue;
+        },
+      }))
+    .finally(() => {
+      Date.now = originalDateNow;
+    });
+}
+
 function loadBridge() {
   const bridgePath = require.resolve("./globalShortcutBridge.cjs");
   delete require.cache[bridgePath];
@@ -26,6 +79,17 @@ function createElectronStub() {
   return {
     Tray: FakeTray,
     Menu: {},
+    BrowserWindow: {
+      getAllWindows() {
+        return [];
+      },
+    },
+    globalShortcut: {
+      register() {
+        return true;
+      },
+      unregister() {},
+    },
     nativeImage: {
       createFromPath() {
         return {
@@ -63,8 +127,14 @@ class FakeWindow extends EventEmitter {
     super();
     this.fullscreen = fullscreen;
     this.hideCalls = 0;
+    this.showCalls = 0;
+    this.focusCalls = 0;
+    this.restoreCalls = 0;
     this.setFullScreenCalls = [];
     this.destroyed = false;
+    this.minimized = false;
+    this.visible = true;
+    this.focused = true;
   }
 
   isDestroyed() {
@@ -77,29 +147,62 @@ class FakeWindow extends EventEmitter {
 
   setFullScreen(nextValue) {
     this.setFullScreenCalls.push(nextValue);
-    this.fullscreen = nextValue;
+    if (nextValue) {
+      this.fullscreen = true;
+    }
+  }
+
+  isMinimized() {
+    return this.minimized;
+  }
+
+  restore() {
+    this.restoreCalls += 1;
+    this.minimized = false;
+  }
+
+  isVisible() {
+    return this.visible;
+  }
+
+  isFocused() {
+    return this.focused;
   }
 
   hide() {
     this.hideCalls += 1;
+    this.visible = false;
+    this.focused = false;
+  }
+
+  show() {
+    this.showCalls += 1;
+    this.visible = true;
+    this.emit("show");
+  }
+
+  focus() {
+    this.focusCalls += 1;
+    this.focused = true;
   }
 }
 
-function withPlatform(platform, run) {
+async function withPlatform(platform, run) {
   const original = Object.getOwnPropertyDescriptor(process, "platform");
   Object.defineProperty(process, "platform", { configurable: true, value: platform });
   try {
-    return run();
+    return await run();
   } finally {
     Object.defineProperty(process, "platform", original);
   }
 }
 
-async function enableCloseToTray(bridge) {
-  bridge.init({ electronModule: createElectronStub() });
+async function enableCloseToTray(bridge, electronModule = createElectronStub()) {
+  bridge.init({ electronModule });
   const ipcMain = createIpcMainStub();
   bridge.registerHandlers(ipcMain);
   await ipcMain.handlers.get("netcatty:tray:setCloseToTray")(null, { enabled: true });
+  return { ipcMain, electronModule };
 }
 
 test("handleWindowClose allows normal close when close-to-tray is disabled", () => {
@@ -115,23 +218,228 @@ test("handleWindowClose allows normal close when close-to-tray is disabled", () 
 });
 
 test("handleWindowClose exits mac fullscreen before hiding to tray", async () => {
-  await withPlatform("darwin", async () => {
-    const bridge = loadBridge();
-    await enableCloseToTray(bridge);
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      await enableCloseToTray(bridge);
 
-    const win = new FakeWindow({ fullscreen: true });
-    let prevented = false;
+      const win = new FakeWindow({ fullscreen: true });
+      let prevented = false;
 
-    const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
+      const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
 
-    assert.equal(result, true);
-    assert.equal(prevented, true);
-    assert.deepEqual(win.setFullScreenCalls, [false]);
-    assert.equal(win.hideCalls, 0);
+      assert.equal(result, true);
+      assert.equal(prevented, true);
+      assert.deepEqual(win.setFullScreenCalls, [false]);
+      assert.equal(win.hideCalls, 0);
+      assert.equal(getPendingTimerCount(), 1);
 
-    win.emit("leave-full-screen");
+      flushNextTimer();
+      assert.equal(win.hideCalls, 0);
+      assert.equal(getPendingTimerCount(), 1);
 
-    assert.equal(win.hideCalls, 1);
+      win.fullscreen = false;
+      flushNextTimer();
+      assert.equal(win.hideCalls, 1);
+      assert.equal(getPendingTimerCount(), 0);
+    });
+  });
+});
+
+test("pending fullscreen hide keeps waiting after the deadline and hides once fullscreen exits", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPatchedDateNow(1000, async ({ setNow }) => {
+      await withPlatform("darwin", async () => {
+        const bridge = loadBridge();
+        await enableCloseToTray(bridge);
+
+        const win = new FakeWindow({ fullscreen: true });
+
+        const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+        assert.equal(result, true);
+        assert.equal(getPendingTimerCount(), 1);
+
+        flushNextTimer();
+        assert.equal(win.hideCalls, 0);
+        assert.equal(getPendingTimerCount(), 1);
+
+        setNow(6000);
+        flushNextTimer();
+        assert.equal(win.hideCalls, 0);
+        assert.equal(getPendingTimerCount(), 1);
+        assert.equal(win.listenerCount("leave-full-screen"), 1);
+        assert.equal(win.listenerCount("show"), 1);
+        assert.equal(win.listenerCount("closed"), 1);
+
+        win.fullscreen = false;
+        flushNextTimer();
+        assert.equal(win.hideCalls, 1);
+        assert.equal(getPendingTimerCount(), 0);
+        assert.equal(win.listenerCount("leave-full-screen"), 0);
+        assert.equal(win.listenerCount("show"), 0);
+        assert.equal(win.listenerCount("closed"), 0);
+      });
+    });
+  });
+});
+
+test("leave-full-screen hides immediately and clears the pending timer", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      await enableCloseToTray(bridge);
+
+      const win = new FakeWindow({ fullscreen: true });
+
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(getPendingTimerCount(), 1);
+
+      win.fullscreen = false;
+      win.emit("leave-full-screen");
+
+      assert.equal(win.hideCalls, 1);
+      assert.equal(getPendingTimerCount(), 0);
+      assert.equal(flushNextTimer(), false);
+    });
+  });
+});
+
+test("show event cancels a pending fullscreen hide", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      await enableCloseToTray(bridge);
+
+      const win = new FakeWindow({ fullscreen: true });
+
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(win.listenerCount("show"), 1);
+      assert.equal(getPendingTimerCount(), 1);
+
+      win.emit("show");
+
+      assert.equal(win.listenerCount("show"), 0);
+      assert.equal(getPendingTimerCount(), 0);
+      assert.equal(win.listenerCount("leave-full-screen"), 0);
+      assert.equal(win.listenerCount("closed"), 0);
+      assert.equal(flushNextTimer(), false);
+      assert.equal(win.hideCalls, 0);
+    });
+  });
+});
+
+test("focusing a visible window cancels a pending fullscreen hide", async () => {
+  await withPatchedTimers(async ({ getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      const win = new FakeWindow({ fullscreen: true });
+      win.focused = false;
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      let toggleWindow = null;
+      electronModule.globalShortcut.register = (_accelerator, handler) => {
+        toggleWindow = handler;
+        return true;
+      };
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+
+      await ipcMain.handlers.get("netcatty:globalHotkey:register")(null, { hotkey: "Ctrl + `" });
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(getPendingTimerCount(), 1);
+
+      toggleWindow();
+
+      assert.equal(win.focusCalls, 1);
+      assert.equal(getPendingTimerCount(), 0);
+      assert.equal(win.listenerCount("leave-full-screen"), 0);
+      assert.equal(win.listenerCount("show"), 0);
+      assert.equal(win.listenerCount("closed"), 0);
+    });
+  });
+});
+
+test("openMainWindow cancels a pending fullscreen hide before showing the window", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      const win = new FakeWindow({ fullscreen: true });
+      win.show = function showWithoutEmit() {
+        this.showCalls += 1;
+        this.visible = true;
+      };
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(getPendingTimerCount(), 1);
+
+      await ipcMain.handlers.get("netcatty:trayPanel:openMainWindow")();
+
+      assert.equal(win.showCalls, 1);
+      assert.equal(getPendingTimerCount(), 0);
+
+      const flushed = flushNextTimer();
+      assert.equal(flushed, false);
+      assert.equal(win.hideCalls, 0);
+    });
+  });
+});
+
+test("closing the window clears a pending fullscreen hide", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      await enableCloseToTray(bridge);
+
+      const win = new FakeWindow({ fullscreen: true });
+
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(getPendingTimerCount(), 1);
+      assert.equal(win.listenerCount("leave-full-screen"), 1);
+      assert.equal(win.listenerCount("show"), 1);
+      assert.equal(win.listenerCount("closed"), 1);
+
+      win.destroyed = true;
+      win.emit("closed");
+
+      assert.equal(getPendingTimerCount(), 0);
+      assert.equal(win.listenerCount("leave-full-screen"), 0);
+      assert.equal(win.listenerCount("show"), 0);
+      assert.equal(win.listenerCount("closed"), 0);
+      assert.equal(flushNextTimer(), false);
+      assert.equal(win.hideCalls, 0);
+    });
+  });
+});
+
+test("disabling close-to-tray clears a pending fullscreen hide", async () => {
+  await withPatchedTimers(async ({ flushNextTimer, getPendingTimerCount }) => {
+    await withPlatform("darwin", async () => {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      const win = new FakeWindow({ fullscreen: true });
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+
+      const result = bridge.handleWindowClose({ preventDefault() {} }, win);
+      assert.equal(result, true);
+      assert.equal(getPendingTimerCount(), 1);
+
+      await ipcMain.handlers.get("netcatty:tray:setCloseToTray")(null, { enabled: false });
+
+      assert.equal(getPendingTimerCount(), 0);
+      assert.equal(win.listenerCount("leave-full-screen"), 0);
+      assert.equal(win.listenerCount("show"), 0);
+      assert.equal(win.listenerCount("closed"), 0);
+      assert.equal(flushNextTimer(), false);
+      assert.equal(win.hideCalls, 0);
+    });
   });
 });
 
@@ -149,5 +457,24 @@ test("handleWindowClose hides immediately when tray close is used outside fullsc
     assert.equal(prevented, true);
     assert.deepEqual(win.setFullScreenCalls, []);
     assert.equal(win.hideCalls, 1);
+  });
+});
+
+test("handleWindowClose stays in close-to-tray mode even if hide fails", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    await enableCloseToTray(bridge);
+
+    const win = new FakeWindow({ fullscreen: false });
+    win.hide = function failingHide() {
+      throw new Error("hide failed");
+    };
+    let prevented = false;
+
+    const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
+
+    assert.equal(result, true);
+    assert.equal(prevented, true);
+    assert.equal(win.visible, true);
   });
 });

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -1,0 +1,153 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+function loadBridge() {
+  const bridgePath = require.resolve("./globalShortcutBridge.cjs");
+  delete require.cache[bridgePath];
+  return require("./globalShortcutBridge.cjs");
+}
+
+function createElectronStub() {
+  class FakeTray {
+    constructor() {
+      this.handlers = new Map();
+    }
+
+    setToolTip() {}
+    setContextMenu() {}
+    destroy() {}
+
+    on(eventName, handler) {
+      this.handlers.set(eventName, handler);
+    }
+  }
+
+  return {
+    Tray: FakeTray,
+    Menu: {},
+    nativeImage: {
+      createFromPath() {
+        return {
+          resize() {
+            return this;
+          },
+          setTemplateImage() {},
+        };
+      },
+      createEmpty() {
+        return {};
+      },
+    },
+    app: {
+      getAppPath() {
+        return process.cwd();
+      },
+      quit() {},
+    },
+  };
+}
+
+function createIpcMainStub() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+class FakeWindow extends EventEmitter {
+  constructor({ fullscreen = false } = {}) {
+    super();
+    this.fullscreen = fullscreen;
+    this.hideCalls = 0;
+    this.setFullScreenCalls = [];
+    this.destroyed = false;
+  }
+
+  isDestroyed() {
+    return this.destroyed;
+  }
+
+  isFullScreen() {
+    return this.fullscreen;
+  }
+
+  setFullScreen(nextValue) {
+    this.setFullScreenCalls.push(nextValue);
+    this.fullscreen = nextValue;
+  }
+
+  hide() {
+    this.hideCalls += 1;
+  }
+}
+
+function withPlatform(platform, run) {
+  const original = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  try {
+    return run();
+  } finally {
+    Object.defineProperty(process, "platform", original);
+  }
+}
+
+async function enableCloseToTray(bridge) {
+  bridge.init({ electronModule: createElectronStub() });
+  const ipcMain = createIpcMainStub();
+  bridge.registerHandlers(ipcMain);
+  await ipcMain.handlers.get("netcatty:tray:setCloseToTray")(null, { enabled: true });
+}
+
+test("handleWindowClose allows normal close when close-to-tray is disabled", () => {
+  const bridge = loadBridge();
+  const win = new FakeWindow();
+  let prevented = false;
+
+  const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
+
+  assert.equal(result, false);
+  assert.equal(prevented, false);
+  assert.equal(win.hideCalls, 0);
+});
+
+test("handleWindowClose exits mac fullscreen before hiding to tray", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    await enableCloseToTray(bridge);
+
+    const win = new FakeWindow({ fullscreen: true });
+    let prevented = false;
+
+    const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
+
+    assert.equal(result, true);
+    assert.equal(prevented, true);
+    assert.deepEqual(win.setFullScreenCalls, [false]);
+    assert.equal(win.hideCalls, 0);
+
+    win.emit("leave-full-screen");
+
+    assert.equal(win.hideCalls, 1);
+  });
+});
+
+test("handleWindowClose hides immediately when tray close is used outside fullscreen", async () => {
+  await withPlatform("darwin", async () => {
+    const bridge = loadBridge();
+    await enableCloseToTray(bridge);
+
+    const win = new FakeWindow({ fullscreen: false });
+    let prevented = false;
+
+    const result = bridge.handleWindowClose({ preventDefault() { prevented = true; } }, win);
+
+    assert.equal(result, true);
+    assert.equal(prevented, true);
+    assert.deepEqual(win.setFullScreenCalls, []);
+    assert.equal(win.hideCalls, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- fix the macOS close-to-tray path so closing a fullscreen window leaves fullscreen before hiding the app window
- keep the existing close behavior after leaving fullscreen instead of turning the close button into a fullscreen toggle
- add regression coverage for normal close, tray close, and fullscreen tray close flows

## Root Cause
When close-to-tray was enabled, clicking the window close button always hid the main window immediately. On macOS, doing that while the window was in native fullscreen could leave behind an empty fullscreen Space, which showed up as a black or blank screen.

## Validation
- `node --test electron/bridges/globalShortcutBridge.test.cjs`
- `npm run lint`
- `npm run build`

Fixes #716