### PR TITLE
fix: stabilize scoped AI draft/session transitions

### DIFF
--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 
 import {
   activateDraftView,
+  bumpDraftMutationVersionState,
+  bumpDraftUploadGenerationState,
   clearScopeDraftState,
   createEmptyDraft,
   ensureDraftForScopeState,
+  getDraftMutationVersionState,
+  getDraftUploadGenerationState,
   pruneTerminalScopeState,
   pruneTerminalTransientState,
   resolvePanelView,
@@ -166,6 +170,28 @@ test("ensureDraftForScopeState returns the original ref when the scope already e
   );
 
   assert.equal(next, draftsByScope);
+});
+
+test("draft mutation version increments on every mutation for the same scope", () => {
+  const scopeKey = "terminal:1";
+  const initialVersion = getDraftMutationVersionState({}, scopeKey);
+  const nextVersions = bumpDraftMutationVersionState({}, scopeKey);
+  const finalVersions = bumpDraftMutationVersionState(nextVersions, scopeKey);
+
+  assert.equal(initialVersion, 0);
+  assert.equal(getDraftMutationVersionState(nextVersions, scopeKey), 1);
+  assert.equal(getDraftMutationVersionState(finalVersions, scopeKey), 2);
+});
+
+test("draft upload generation only increments when the draft lifecycle rolls over", () => {
+  const scopeKey = "terminal:1";
+  const initialGeneration = getDraftUploadGenerationState({}, scopeKey);
+  const nextGenerations = bumpDraftUploadGenerationState({}, scopeKey);
+  const finalGenerations = bumpDraftUploadGenerationState(nextGenerations, scopeKey);
+
+  assert.equal(initialGeneration, 0);
+  assert.equal(getDraftUploadGenerationState(nextGenerations, scopeKey), 1);
+  assert.equal(getDraftUploadGenerationState(finalGenerations, scopeKey), 2);
 });
 
 test("pruneTerminalScopeState removes closed terminal drafts and views only", () => {

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -6,6 +6,8 @@ import type {
 type DraftsByScope = Partial<Record<string, AIDraft>>;
 type PanelViewByScope = Partial<Record<string, AIPanelView>>;
 type ActiveSessionIdMap = Record<string, string | null>;
+type DraftMutationVersionByScope = Record<string, number>;
+type DraftUploadGenerationByScope = Record<string, number>;
 
 const DEFAULT_PANEL_VIEW: AIPanelView = { mode: 'draft' };
 
@@ -16,6 +18,40 @@ export function createEmptyDraft(agentId: string): AIDraft {
     attachments: [],
     selectedUserSkillSlugs: [],
     updatedAt: Date.now(),
+  };
+}
+
+export function getDraftMutationVersionState(
+  versionsByScope: DraftMutationVersionByScope,
+  scopeKey: string,
+): number {
+  return versionsByScope[scopeKey] ?? 0;
+}
+
+export function bumpDraftMutationVersionState(
+  versionsByScope: DraftMutationVersionByScope,
+  scopeKey: string,
+): DraftMutationVersionByScope {
+  return {
+    ...versionsByScope,
+    [scopeKey]: getDraftMutationVersionState(versionsByScope, scopeKey) + 1,
+  };
+}
+
+export function getDraftUploadGenerationState(
+  generationsByScope: DraftUploadGenerationByScope,
+  scopeKey: string,
+): number {
+  return generationsByScope[scopeKey] ?? 0;
+}
+
+export function bumpDraftUploadGenerationState(
+  generationsByScope: DraftUploadGenerationByScope,
+  scopeKey: string,
+): DraftUploadGenerationByScope {
+  return {
+    ...generationsByScope,
+    [scopeKey]: getDraftUploadGenerationState(generationsByScope, scopeKey) + 1,
   };
 }
 

--- a/application/state/aiScopeCleanup.test.ts
+++ b/application/state/aiScopeCleanup.test.ts
@@ -129,3 +129,35 @@ test("pruneInactiveScopedSessions preserves original sessions when orphaned rest
   assert.deepEqual(next.orphanedSessionIds, ["terminal-restorable"]);
   assert.equal(next.sessions, sessions);
 });
+
+test("pruneInactiveScopedSessions treats sessions displayed elsewhere as in-use, not orphaned", () => {
+  // terminal-restorable's original scope (terminal-closed-A) is gone, but
+  // the user resumed it into terminal-open-B from history. The session's
+  // externalSessionId must be preserved and it must not appear in the
+  // orphaned list, otherwise the active chat loses ACP continuity.
+  const resumedElsewhere = createSession("terminal-restorable", {
+    type: "terminal",
+    targetId: "terminal-closed-A",
+    hostIds: ["host-1"],
+  }, "ext-resumed");
+
+  const trulyOrphaned = createSession("terminal-stale", {
+    type: "terminal",
+    targetId: "terminal-closed-C",
+    hostIds: ["host-2"],
+  }, "ext-stale");
+
+  const sessions = [resumedElsewhere, trulyOrphaned];
+
+  const next = pruneInactiveScopedSessions(
+    sessions,
+    new Set(["terminal-open-B"]),
+    new Set(["terminal-restorable"]),
+  );
+
+  // Only the one not being displayed anywhere should show up as orphaned.
+  assert.deepEqual(next.orphanedSessionIds, ["terminal-stale"]);
+  // The resumed session must retain its externalSessionId.
+  const resumedNext = next.sessions.find((s) => s.id === "terminal-restorable");
+  assert.equal(resumedNext?.externalSessionId, "ext-resumed");
+});

--- a/application/state/aiScopeCleanup.ts
+++ b/application/state/aiScopeCleanup.ts
@@ -99,12 +99,21 @@ function isRestorableTerminalSession(session: AISession): boolean {
 export function pruneInactiveScopedSessions(
   sessions: AISession[],
   activeTargetIds: Set<string>,
+  /**
+   * Session ids currently displayed by any live scope. A session whose
+   * `scope.targetId` is inactive but whose id is still in use somewhere
+   * (e.g. resumed from history into a different terminal) must not be
+   * treated as orphaned — clearing its `externalSessionId` or deleting
+   * it outright would break the chat the user is actively continuing.
+   */
+  activeSessionIds: Set<string> = new Set(),
 ): {
   sessions: AISession[];
   orphanedSessionIds: string[];
 } {
   const orphanedSessionIds = sessions
     .filter((session) => session.scope.targetId && !activeTargetIds.has(session.scope.targetId))
+    .filter((session) => !activeSessionIds.has(session.id))
     .map((session) => session.id);
 
   if (orphanedSessionIds.length === 0) {

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -33,8 +33,11 @@ import type {
 import { DEFAULT_COMMAND_BLOCKLIST } from '../../infrastructure/ai/types';
 import {
   activateDraftView,
+  bumpDraftMutationVersionState,
+  bumpDraftUploadGenerationState,
   clearScopeDraftState,
   ensureDraftForScopeState,
+  getDraftUploadGenerationState,
   setSessionView,
   updateDraftForScope,
 } from './aiDraftState';
@@ -152,6 +155,7 @@ export function cleanupOrphanedAISessions(activeTargetIds: Set<string>) {
     for (const scopeKey of Object.keys(currentDraftsByScope)) {
       if (scopeKey in prunedScopedTransientState.draftsByScope) continue;
       bumpDraftMutationVersion(scopeKey);
+      bumpDraftUploadGeneration(scopeKey);
     }
     setLatestAIDraftsByScopeSnapshot(prunedScopedTransientState.draftsByScope);
     emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
@@ -198,6 +202,7 @@ let latestAIActiveSessionMapSnapshot: Record<string, string | null> | null = nul
 let latestAIDraftsByScopeSnapshot: DraftsByScope | null = null;
 let latestAIPanelViewByScopeSnapshot: PanelViewByScope | null = null;
 let latestAIDraftMutationVersionByScopeSnapshot: Record<string, number> = {};
+let latestAIDraftUploadGenerationByScopeSnapshot: Record<string, number> = {};
 
 function setLatestAISessionsSnapshot(sessions: AISession[]) {
   latestAISessionsSnapshot = sessions;
@@ -215,15 +220,25 @@ function setLatestAIPanelViewByScopeSnapshot(panelViewByScope: PanelViewByScope)
   latestAIPanelViewByScopeSnapshot = panelViewByScope;
 }
 
-function getDraftMutationVersion(scopeKey: string) {
-  return latestAIDraftMutationVersionByScopeSnapshot[scopeKey] ?? 0;
+function bumpDraftMutationVersion(scopeKey: string) {
+  latestAIDraftMutationVersionByScopeSnapshot = bumpDraftMutationVersionState(
+    latestAIDraftMutationVersionByScopeSnapshot,
+    scopeKey,
+  );
 }
 
-function bumpDraftMutationVersion(scopeKey: string) {
-  latestAIDraftMutationVersionByScopeSnapshot = {
-    ...latestAIDraftMutationVersionByScopeSnapshot,
-    [scopeKey]: getDraftMutationVersion(scopeKey) + 1,
-  };
+function getDraftUploadGeneration(scopeKey: string) {
+  return getDraftUploadGenerationState(
+    latestAIDraftUploadGenerationByScopeSnapshot,
+    scopeKey,
+  );
+}
+
+function bumpDraftUploadGeneration(scopeKey: string) {
+  latestAIDraftUploadGenerationByScopeSnapshot = bumpDraftUploadGenerationState(
+    latestAIDraftUploadGenerationByScopeSnapshot,
+    scopeKey,
+  );
 }
 
 export function useAIState() {
@@ -880,12 +895,15 @@ export function useAIState() {
       emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
       return next;
     });
+    bumpDraftMutationVersion(scopeKey);
   }, []);
 
   const updateDraftIfPresent = useCallback((
     scopeKey: string,
     updater: (draft: AIDraft) => AIDraft,
   ): void => {
+    let updated = false;
+
     setDraftsByScopeRaw((prev) => {
       const currentDraft = prev[scopeKey];
       if (!currentDraft) return prev;
@@ -898,10 +916,15 @@ export function useAIState() {
         ...prev,
         [scopeKey]: nextDraft,
       };
+      updated = true;
       setLatestAIDraftsByScopeSnapshot(next);
       emitAIStateChanged(AI_STATE_CHANGED_DRAFTS_BY_SCOPE);
       return next;
     });
+
+    if (updated) {
+      bumpDraftMutationVersion(scopeKey);
+    }
   }, []);
 
   const showDraftView = useCallback((scopeKey: string) => {
@@ -964,6 +987,7 @@ export function useAIState() {
     if (!draftsChanged && !panelViewChanged) return;
 
     bumpDraftMutationVersion(scopeKey);
+    bumpDraftUploadGeneration(scopeKey);
 
     if (draftsChanged && nextDraftsByScope) {
       setLatestAIDraftsByScopeSnapshot(nextDraftsByScope);
@@ -983,11 +1007,11 @@ export function useAIState() {
     inputFiles: File[],
   ) => {
     ensureDraftForScope(scopeKey, fallbackAgentId);
-    const initialMutationVersion = getDraftMutationVersion(scopeKey);
+    const initialUploadGeneration = getDraftUploadGeneration(scopeKey);
     const uploads = await convertFilesToUploads(inputFiles);
     if (uploads.length === 0) return;
 
-    if (getDraftMutationVersion(scopeKey) !== initialMutationVersion) {
+    if (getDraftUploadGeneration(scopeKey) !== initialUploadGeneration) {
       return;
     }
 

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -207,19 +207,6 @@ function setLatestAIActiveSessionMapSnapshot(activeSessionIdMap: Record<string, 
   latestAIActiveSessionMapSnapshot = activeSessionIdMap;
 }
 
-function buildScopeKey(scope: AISessionScope) {
-  return `${scope.type}:${scope.targetId ?? ''}`;
-}
-
-function areHostIdsEqual(left?: string[], right?: string[]) {
-  const leftIds = left ?? [];
-  const rightIds = right ?? [];
-  if (leftIds.length !== rightIds.length) return false;
-
-  const rightSet = new Set(rightIds);
-  return leftIds.every((hostId) => rightSet.has(hostId));
-}
-
 function setLatestAIDraftsByScopeSnapshot(draftsByScope: DraftsByScope) {
   latestAIDraftsByScopeSnapshot = draftsByScope;
 }
@@ -788,60 +775,6 @@ export function useAIState() {
     });
   }, [debouncedPersistSessions]);
 
-  const retargetSessionScope = useCallback((sessionId: string, scope: AISessionScope) => {
-    const currentSession = sessionsRef.current.find((session) => session.id === sessionId);
-    if (!currentSession) return;
-
-    const currentScope = currentSession.scope;
-    const scopeChanged =
-      currentScope.type !== scope.type
-      || currentScope.targetId !== scope.targetId
-      || !areHostIdsEqual(currentScope.hostIds, scope.hostIds);
-
-    const nextScopeKey = buildScopeKey(scope);
-    const currentScopeKey = buildScopeKey(currentScope);
-
-    if (scopeChanged) {
-      setSessionsRaw((prev) => {
-        let changed = false;
-        const next = prev.map((session) => {
-          if (session.id !== sessionId) return session;
-          changed = true;
-          return { ...session, scope, externalSessionId: undefined };
-        });
-
-        if (!changed) return prev;
-
-        sessionsRef.current = next;
-        setLatestAISessionsSnapshot(next);
-        persistSessions(next);
-        return next;
-      });
-    }
-
-    setActiveSessionIdMapRaw((prev) => {
-      let changed = false;
-      const next = { ...prev };
-
-      if (currentScopeKey !== nextScopeKey && next[currentScopeKey] === sessionId) {
-        delete next[currentScopeKey];
-        changed = true;
-      }
-
-      if (next[nextScopeKey] !== sessionId) {
-        next[nextScopeKey] = sessionId;
-        changed = true;
-      }
-
-      if (!changed) return prev;
-
-      setLatestAIActiveSessionMapSnapshot(next);
-      localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, next);
-      emitAIStateChanged(STORAGE_KEY_AI_ACTIVE_SESSION_MAP);
-      return next;
-    });
-  }, [persistSessions]);
-
   // Maximum messages per session to prevent unbounded memory growth
   const MAX_MESSAGES_PER_SESSION = 500;
 
@@ -1175,7 +1108,6 @@ export function useAIState() {
     deleteSessionsByTarget,
     updateSessionTitle,
     updateSessionExternalSessionId,
-    retargetSessionScope,
     addMessageToSession,
     updateLastMessage,
     updateMessageById,

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -94,9 +94,26 @@ export function cleanupOrphanedAISessions(activeTargetIds: Set<string>) {
   const currentSessions = latestAISessionsSnapshot
     ?? localStorageAdapter.read<AISession[]>(STORAGE_KEY_AI_SESSIONS)
     ?? [];
+
+  // Sessions shown by a still-live scope must be protected from cleanup
+  // even when their own `scope.targetId` points at a closed terminal —
+  // history can be resumed into a different terminal and we must not
+  // clear its `externalSessionId` (or delete it outright) while it's
+  // actively being used.
+  const preCleanupActiveSessionMap = latestAIActiveSessionMapSnapshot
+    ?? localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP)
+    ?? {};
+  const activeSessionIds = new Set<string>();
+  for (const [scopeKey, sessionId] of Object.entries(preCleanupActiveSessionMap)) {
+    if (!sessionId) continue;
+    if (!isScopeKeyActive(scopeKey, activeTargetIds)) continue;
+    activeSessionIds.add(sessionId);
+  }
+
   const nextSessionCleanup = pruneInactiveScopedSessions(
     currentSessions,
     activeTargetIds,
+    activeSessionIds,
   );
 
   if (nextSessionCleanup.orphanedSessionIds.length > 0) {
@@ -112,9 +129,7 @@ export function cleanupOrphanedAISessions(activeTargetIds: Set<string>) {
     emitAIStateChanged(STORAGE_KEY_AI_SESSIONS);
   }
 
-  const activeSessionIdMap = latestAIActiveSessionMapSnapshot
-    ?? localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP)
-    ?? {};
+  const activeSessionIdMap = preCleanupActiveSessionMap;
   let activeSessionMapChanged = false;
   const nextActiveSessionIdMap = { ...activeSessionIdMap };
 

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -50,8 +50,8 @@ import {
   applyHistorySessionSelection,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
-  shouldRetargetSessionForScope,
 } from './ai/aiPanelViewState';
+import { SESSION_HISTORY_ROW_CLASSNAMES } from './ai/sessionHistoryLayout';
 import type { CodexIntegrationStatus } from './settings/tabs/ai/types';
 import {
   useAIChatStreaming,
@@ -102,7 +102,6 @@ interface AIChatSidePanelProps {
   deleteSession: (sessionId: string, scopeKey?: string) => void;
   updateSessionTitle: (sessionId: string, title: string) => void;
   updateSessionExternalSessionId: (sessionId: string, externalSessionId: string | undefined) => void;
-  retargetSessionScope: (sessionId: string, scope: AISessionScope) => void;
   addMessageToSession: (sessionId: string, message: ChatMessage) => void;
   updateLastMessage: (
     sessionId: string,
@@ -243,7 +242,6 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   deleteSession,
   updateSessionTitle,
   updateSessionExternalSessionId,
-  retargetSessionScope,
   addMessageToSession,
   updateLastMessage,
   updateMessageById,
@@ -302,36 +300,25 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     setActiveSessionIdForScope(scopeKey, id);
   }, [scopeKey, setActiveSessionIdForScope]);
 
-  const activeTerminalTargetIds = useMemo(() => {
-    const targetIds = new Set<string>();
-    for (const [sessionScopeKey, sessionId] of Object.entries(activeSessionIdMap)) {
-      if (!sessionScopeKey.startsWith('terminal:') || !sessionId) continue;
-      const targetId = sessionScopeKey.slice('terminal:'.length);
-      if (!targetId || targetId === scopeTargetId) continue;
-      targetIds.add(targetId);
-    }
-    return targetIds;
-  }, [activeSessionIdMap, scopeTargetId]);
-
   const historySessions = useMemo(
     () =>
       sessions
         .map((session) => ({
           session,
-          matchRank: getSessionScopeMatchRank(session, scopeType, scopeTargetId, scopeHostIds, activeTerminalTargetIds),
+          matchRank: getSessionScopeMatchRank(session, scopeType, scopeTargetId, scopeHostIds),
         }))
         .filter(({ matchRank }) => matchRank > 0)
         .sort((a, b) => b.matchRank - a.matchRank || b.session.updatedAt - a.session.updatedAt)
         .map(({ session }) => session),
-    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalTargetIds],
+    [sessions, scopeType, scopeTargetId, scopeHostIds],
   );
 
   const explicitPanelView = panelViewByScope[scopeKey];
   const currentDraft = draftsByScope[scopeKey] ?? null;
   const persistedSessionId = activeSessionIdMap[scopeKey] ?? null;
   const normalizedPanelView = useMemo<AIPanelView>(
-    () => resolveDisplayedPanelView(explicitPanelView, currentDraft != null, historySessions, persistedSessionId),
-    [explicitPanelView, currentDraft, historySessions, persistedSessionId],
+    () => resolveDisplayedPanelView(explicitPanelView, currentDraft != null, historySessions, persistedSessionId, scopeType),
+    [explicitPanelView, currentDraft, historySessions, persistedSessionId, scopeType],
   );
   const activeSession = useMemo(
     () => resolveDisplayedSession(normalizedPanelView, historySessions),
@@ -385,39 +372,8 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     showDraftView(scopeKey);
   }, [normalizedPanelView, explicitPanelView, scopeKey, showDraftView]);
 
-  const shouldRetargetActiveSession = useMemo(() => {
-    return shouldRetargetSessionForScope(
-      activeSession,
-      scopeType,
-      scopeTargetId,
-      scopeHostIds,
-      activeTerminalTargetIds,
-    );
-  }, [activeSession, scopeType, scopeTargetId, scopeHostIds, activeTerminalTargetIds]);
-
   useEffect(() => {
     if (!activeSession) return;
-
-    if (shouldRetargetActiveSession && isVisible) {
-      if (streamingSessionIds.has(activeSession.id)) {
-        const controller = abortControllersRef.current.get(activeSession.id);
-        if (controller) {
-          controller.abort();
-          abortControllersRef.current.delete(activeSession.id);
-        }
-        setStreamingForScope(activeSession.id, false);
-        clearAllPendingApprovals(activeSession.id);
-        const bridge = getNetcattyBridge();
-        bridge?.aiCattyCancelExec?.(activeSession.id);
-        bridge?.aiAcpCancel?.('', activeSession.id);
-      }
-      retargetSessionScope(activeSession.id, {
-        type: scopeType,
-        targetId: scopeTargetId,
-        hostIds: scopeHostIds,
-      });
-      return;
-    }
 
     if (isVisible && activeSessionIdMap[scopeKey] !== activeSession.id) {
       setActiveSessionId(activeSession.id);
@@ -426,16 +382,8 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     activeSession,
     activeSessionIdMap,
     scopeKey,
-    retargetSessionScope,
     isVisible,
-    scopeHostIds,
-    scopeTargetId,
-    scopeType,
     setActiveSessionId,
-    setStreamingForScope,
-    shouldRetargetActiveSession,
-    streamingSessionIds,
-    abortControllersRef,
   ]);
 
   const ensureScopeDraft = useCallback((agentId: string) => {
@@ -1203,20 +1151,20 @@ const SessionHistoryDrawer: React.FC<SessionHistoryDrawerProps> = ({
                   onClick={() => onSelect(session.id)}
                   onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(session.id); }}
                   className={cn(
-                    'w-full flex items-center justify-between py-2.5 border-b border-border/20 text-left transition-colors cursor-pointer group',
+                    SESSION_HISTORY_ROW_CLASSNAMES.row,
                     isActive ? 'text-foreground' : 'text-foreground/70 hover:text-foreground',
                   )}
                 >
-                  <span className="text-[13px] truncate pr-3 flex-1 min-w-0">
+                  <span className={SESSION_HISTORY_ROW_CLASSNAMES.title}>
                     {session.title || t('ai.chat.untitled')}
                   </span>
-                  <div className="flex items-center gap-2 shrink-0">
-                    <span className="text-[12px] text-muted-foreground/50">
+                  <div className={SESSION_HISTORY_ROW_CLASSNAMES.meta}>
+                    <span className={SESSION_HISTORY_ROW_CLASSNAMES.time}>
                       {timeStr}
                     </span>
                     <button
                       onClick={(e) => onDelete(e, session.id)}
-                      className="opacity-0 group-hover:opacity-100 p-0.5 hover:text-destructive transition-all cursor-pointer"
+                      className={SESSION_HISTORY_ROW_CLASSNAMES.deleteButton}
                       title="Delete"
                     >
                       <Trash2 size={12} />

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -412,15 +412,16 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     clearDraftForScope(scopeKey);
   }, [clearDraftForScope, scopeKey]);
 
-  const enterScopeDraftMode = useCallback((agentId: string) => {
+  const enterScopeDraftMode = useCallback((agentId: string, preserveSessionView = false) => {
     applyDraftEntrySelection({
       ensureDraft: () => ensureScopeDraft(agentId),
       showDraftView: showScopeDraftView,
+      preserveSessionView,
     });
   }, [ensureScopeDraft, showScopeDraftView]);
 
   const setInputValue = useCallback((value: string) => {
-    enterScopeDraftMode(currentAgentId);
+    enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
     updateScopeDraft(currentAgentId, (draft) => ({
       ...draft,
       text: value,
@@ -428,7 +429,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
 
   const addFiles = useCallback(async (inputFiles: File[]) => {
-    enterScopeDraftMode(currentAgentId);
+    enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
     await addDraftFiles(scopeKey, currentAgentId, inputFiles);
   }, [addDraftFiles, currentAgentId, enterScopeDraftMode, scopeKey]);
 
@@ -770,7 +771,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   const addSelectedUserSkill = useCallback((slug: string) => {
     const normalizedSlug = String(slug || '').trim().toLowerCase();
     if (!normalizedSlug) return;
-    enterScopeDraftMode(currentAgentId);
+    enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
     updateScopeDraft(currentAgentId, (draft) => {
       if (draft.selectedUserSkillSlugs.includes(normalizedSlug)) {
         return draft;
@@ -785,7 +786,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   const removeSelectedUserSkill = useCallback((slug: string) => {
     const normalizedSlug = String(slug || '').trim().toLowerCase();
     if (!normalizedSlug) return;
-    enterScopeDraftMode(currentAgentId);
+    enterScopeDraftMode(currentAgentId, panelViewRef.current.mode === 'session');
     updateScopeDraft(currentAgentId, (draft) => {
       const nextSelectedUserSkillSlugs = draft.selectedUserSkillSlugs.filter(
         (entry) => entry !== normalizedSlug,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -389,6 +389,18 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     setActiveSessionId,
   ]);
 
+  // When the resolved view is draft but activeSessionIdMap still points at a
+  // previously-shown session, clear that stale entry. Otherwise
+  // activeTerminalTargetIds keeps claiming ownership of the old session's
+  // target and getSessionScopeMatchRank suppresses matching history from
+  // other terminals until another action rewrites the map.
+  useEffect(() => {
+    if (!isVisible) return;
+    if (normalizedPanelView.mode !== 'draft') return;
+    if (persistedSessionId == null) return;
+    setActiveSessionId(null);
+  }, [isVisible, normalizedPanelView.mode, persistedSessionId, setActiveSessionId]);
+
   const ensureScopeDraft = useCallback((agentId: string) => {
     ensureDraftForScope(scopeKey, agentId);
   }, [ensureDraftForScope, scopeKey]);

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -47,10 +47,16 @@ import {
   type UserSkillOption,
 } from './ai/userSkillsState';
 import {
+  applyDraftEntrySelection,
   applyHistorySessionSelection,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
 } from './ai/aiPanelViewState';
+import {
+  endDraftSend,
+  tryBeginDraftSend,
+} from './ai/draftSendGate';
+import { getSessionScopeMatchRank } from './ai/sessionScopeMatch';
 import { SESSION_HISTORY_ROW_CLASSNAMES } from './ai/sessionHistoryLayout';
 import type { CodexIntegrationStatus } from './settings/tabs/ai/types';
 import {
@@ -200,27 +206,6 @@ function buildAcpHistoryMessages(messages: ChatMessage[]): Array<{ role: 'user' 
   });
 }
 
-function getSessionScopeMatchRank(
-  session: AISession,
-  scopeType: 'terminal' | 'workspace',
-  scopeTargetId?: string,
-  scopeHostIds?: string[],
-  activeTerminalTargetIds?: Set<string>,
-): number {
-  if (session.scope.type !== scopeType) return 0;
-  if (session.scope.targetId === scopeTargetId) return 2;
-
-  if (scopeType !== 'terminal' || !scopeHostIds?.length || !session.scope.hostIds?.length) {
-    return 0;
-  }
-
-  if (session.scope.targetId && activeTerminalTargetIds?.has(session.scope.targetId)) {
-    return 0;
-  }
-
-  return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 1 : 0;
-}
-
 // -------------------------------------------------------------------
 // Component
 // -------------------------------------------------------------------
@@ -300,17 +285,34 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     setActiveSessionIdForScope(scopeKey, id);
   }, [scopeKey, setActiveSessionIdForScope]);
 
+  const activeTerminalTargetIds = useMemo(() => {
+    const targetIds = new Set<string>();
+    for (const [sessionScopeKey, sessionId] of Object.entries(activeSessionIdMap)) {
+      if (!sessionScopeKey.startsWith('terminal:') || !sessionId) continue;
+      const targetId = sessionScopeKey.slice('terminal:'.length);
+      if (!targetId || targetId === scopeTargetId) continue;
+      targetIds.add(targetId);
+    }
+    return targetIds;
+  }, [activeSessionIdMap, scopeTargetId]);
+
   const historySessions = useMemo(
     () =>
       sessions
         .map((session) => ({
           session,
-          matchRank: getSessionScopeMatchRank(session, scopeType, scopeTargetId, scopeHostIds),
+          matchRank: getSessionScopeMatchRank(
+            session,
+            scopeType,
+            scopeTargetId,
+            scopeHostIds,
+            activeTerminalTargetIds,
+          ),
         }))
         .filter(({ matchRank }) => matchRank > 0)
         .sort((a, b) => b.matchRank - a.matchRank || b.session.updatedAt - a.session.updatedAt)
         .map(({ session }) => session),
-    [sessions, scopeType, scopeTargetId, scopeHostIds],
+    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalTargetIds],
   );
 
   const explicitPanelView = panelViewByScope[scopeKey];
@@ -335,6 +337,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   currentDraftRef.current = currentDraft;
   const activeSessionRef = useRef(activeSession);
   activeSessionRef.current = activeSession;
+  const draftSendInFlightRef = useRef(false);
 
   const defaultTargetSession = useMemo<DefaultTargetSessionHint | undefined>(() => {
     const connectedSessions = terminalSessions.filter((session) => session.connected !== false);
@@ -409,16 +412,25 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     clearDraftForScope(scopeKey);
   }, [clearDraftForScope, scopeKey]);
 
+  const enterScopeDraftMode = useCallback((agentId: string) => {
+    applyDraftEntrySelection({
+      ensureDraft: () => ensureScopeDraft(agentId),
+      showDraftView: showScopeDraftView,
+    });
+  }, [ensureScopeDraft, showScopeDraftView]);
+
   const setInputValue = useCallback((value: string) => {
+    enterScopeDraftMode(currentAgentId);
     updateScopeDraft(currentAgentId, (draft) => ({
       ...draft,
       text: value,
     }));
-  }, [currentAgentId, updateScopeDraft]);
+  }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
 
   const addFiles = useCallback(async (inputFiles: File[]) => {
+    enterScopeDraftMode(currentAgentId);
     await addDraftFiles(scopeKey, currentAgentId, inputFiles);
-  }, [addDraftFiles, scopeKey, currentAgentId]);
+  }, [addDraftFiles, currentAgentId, enterScopeDraftMode, scopeKey]);
 
   const removeFile = useCallback((fileId: string) => {
     removeDraftFile(scopeKey, currentAgentId, fileId);
@@ -758,6 +770,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   const addSelectedUserSkill = useCallback((slug: string) => {
     const normalizedSlug = String(slug || '').trim().toLowerCase();
     if (!normalizedSlug) return;
+    enterScopeDraftMode(currentAgentId);
     updateScopeDraft(currentAgentId, (draft) => {
       if (draft.selectedUserSkillSlugs.includes(normalizedSlug)) {
         return draft;
@@ -767,11 +780,12 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
         selectedUserSkillSlugs: [...draft.selectedUserSkillSlugs, normalizedSlug],
       };
     });
-  }, [currentAgentId, updateScopeDraft]);
+  }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
 
   const removeSelectedUserSkill = useCallback((slug: string) => {
     const normalizedSlug = String(slug || '').trim().toLowerCase();
     if (!normalizedSlug) return;
+    enterScopeDraftMode(currentAgentId);
     updateScopeDraft(currentAgentId, (draft) => {
       const nextSelectedUserSkillSlugs = draft.selectedUserSkillSlugs.filter(
         (entry) => entry !== normalizedSlug,
@@ -784,7 +798,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
         selectedUserSkillSlugs: nextSelectedUserSkillSlugs,
       };
     });
-  }, [currentAgentId, updateScopeDraft]);
+  }, [currentAgentId, enterScopeDraftMode, updateScopeDraft]);
 
   // -------------------------------------------------------------------
   // Main send handler (thin orchestrator)
@@ -807,110 +821,120 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
       filename: file.filename,
       filePath: file.filePath,
     }));
+    const isDraftMode = currentPanelView.mode === 'draft';
 
-    let sessionId = currentSessionView?.id ?? null;
-    let currentSession = currentSessionView ?? null;
-    let sendAgentId = currentSessionView?.agentId ?? draft?.agentId ?? currentAgentId;
-
-    if (currentPanelView.mode === 'draft') {
-      const scope: AISessionScope = { type: scopeType, targetId: scopeTargetId, hostIds: scopeHostIds };
-      const createdSession = createSession(scope, sendAgentId);
-      sessionId = createdSession.id;
-      currentSession = createdSession;
-      clearScopeDraft();
-      showScopeSessionView(createdSession.id);
-      setActiveSessionId(createdSession.id);
-    }
-
-    if (!sessionId) {
+    if (isDraftMode && !tryBeginDraftSend(draftSendInFlightRef)) {
       return;
     }
 
-    const isExternalAgent = sendAgentId !== 'catty';
+    try {
+      let sessionId = currentSessionView?.id ?? null;
+      let currentSession = currentSessionView ?? null;
+      const sendAgentId = currentSessionView?.agentId ?? draft?.agentId ?? currentAgentId;
 
-    // No provider configured for built-in agent
-    if (!isExternalAgent && !activeProvider) {
-      addMessageToSession(sessionId, { id: generateId(), role: 'user', content: trimmed, timestamp: Date.now() });
-      addMessageToSession(sessionId, { id: generateId(), role: 'assistant', content: t('ai.chat.noProvider'), timestamp: Date.now() });
-      if (currentPanelView.mode === 'session') {
+      if (isDraftMode) {
+        const scope: AISessionScope = { type: scopeType, targetId: scopeTargetId, hostIds: scopeHostIds };
+        const createdSession = createSession(scope, sendAgentId);
+        sessionId = createdSession.id;
+        currentSession = createdSession;
         clearScopeDraft();
-        showScopeSessionView(sessionId);
+        showScopeSessionView(createdSession.id);
+        setActiveSessionId(createdSession.id);
       }
-      return;
-    }
 
-    // Add user message
-    addMessageToSession(sessionId, {
-      id: generateId(), role: 'user', content: trimmed,
-      ...(attachments.length > 0 ? { attachments } : {}),
-      timestamp: Date.now(),
-    });
-    clearScopeDraft();
-    showScopeSessionView(sessionId);
-    setActiveSessionId(sessionId);
-    setStreamingForScope(sessionId, true);
-
-    // Create assistant message placeholder with a tracked ID
-    const agentConfig = isExternalAgent ? externalAgents.find((agent) => agent.id === sendAgentId) : undefined;
-    const assistantMsgId = generateId();
-    addMessageToSession(sessionId, {
-      id: assistantMsgId, role: 'assistant', content: '', timestamp: Date.now(),
-      model: isExternalAgent
-        ? (selectedAgentModel || agentConfig?.name || 'external')
-        : (activeModelId || activeProvider?.defaultModel || ''),
-      providerId: isExternalAgent ? undefined : activeProvider?.providerId,
-    });
-
-    const abortController = new AbortController();
-    abortControllersRef.current.set(sessionId, abortController);
-    currentSession = currentSession ?? sessionsRef.current.find((session) => session.id === sessionId) ?? null;
-
-    if (isExternalAgent) {
-      if (!agentConfig) {
-        updateMessageById(sessionId, assistantMsgId, msg => ({ ...msg, content: 'External agent not found. Please check settings.', executionStatus: 'failed' }));
-        setStreamingForScope(sessionId, false);
+      if (!sessionId) {
         return;
       }
-      try {
-        await sendToExternalAgent(sessionId, trimmed, agentConfig, abortController, attachments, {
-          existingSessionId: currentSession?.externalSessionId,
-          updateExternalSessionId: updateSessionExternalSessionId,
-          historyMessages: buildAcpHistoryMessages(currentSession?.messages ?? []),
-          terminalSessions,
-          defaultTargetSession,
-          providers,
-          selectedAgentModel,
-          toolIntegrationMode,
-          selectedUserSkillSlugs: selectedSkillSlugs,
-        });
-      } catch (err) {
-        reportStreamError(sessionId, abortController.signal, err);
+
+      const isExternalAgent = sendAgentId !== 'catty';
+
+      // No provider configured for built-in agent
+      if (!isExternalAgent && !activeProvider) {
+        addMessageToSession(sessionId, { id: generateId(), role: 'user', content: trimmed, timestamp: Date.now() });
+        addMessageToSession(sessionId, { id: generateId(), role: 'assistant', content: t('ai.chat.noProvider'), timestamp: Date.now() });
+        if (currentPanelView.mode === 'session') {
+          clearScopeDraft();
+          showScopeSessionView(sessionId);
+        }
+        return;
       }
-      // Clear any lingering statusText when the external agent stream finishes
-      updateLastMessage(sessionId, msg => msg.statusText ? { ...msg, statusText: '' } : msg);
-      setStreamingForScope(sessionId, false);
-      abortControllersRef.current.delete(sessionId);
-      autoTitleSession(sessionId, trimmed);
-    } else {
-      const toolScope = {
-        type: scopeType,
-        targetId: scopeTargetId,
-        label: scopeLabel,
-      } as const;
-      await sendToCattyAgent(sessionId, sendScopeKey, trimmed, abortController, currentSession ?? undefined, assistantMsgId, {
-        activeProvider,
-        activeModelId,
-        scopeType,
-        scopeTargetId,
-        scopeLabel,
-        globalPermissionMode,
-        commandBlocklist,
-        terminalSessions,
-        webSearchConfig,
-        getExecutorContext: () => buildExecutorContextForScope(toolScope),
-        autoTitleSession,
-        selectedUserSkillSlugs: selectedSkillSlugs,
-      }, attachments.length > 0 ? attachments : undefined);
+
+      // Add user message
+      addMessageToSession(sessionId, {
+        id: generateId(), role: 'user', content: trimmed,
+        ...(attachments.length > 0 ? { attachments } : {}),
+        timestamp: Date.now(),
+      });
+      clearScopeDraft();
+      showScopeSessionView(sessionId);
+      setActiveSessionId(sessionId);
+      setStreamingForScope(sessionId, true);
+
+      // Create assistant message placeholder with a tracked ID
+      const agentConfig = isExternalAgent ? externalAgents.find((agent) => agent.id === sendAgentId) : undefined;
+      const assistantMsgId = generateId();
+      addMessageToSession(sessionId, {
+        id: assistantMsgId, role: 'assistant', content: '', timestamp: Date.now(),
+        model: isExternalAgent
+          ? (selectedAgentModel || agentConfig?.name || 'external')
+          : (activeModelId || activeProvider?.defaultModel || ''),
+        providerId: isExternalAgent ? undefined : activeProvider?.providerId,
+      });
+
+      const abortController = new AbortController();
+      abortControllersRef.current.set(sessionId, abortController);
+      currentSession = currentSession ?? sessionsRef.current.find((session) => session.id === sessionId) ?? null;
+
+      if (isExternalAgent) {
+        if (!agentConfig) {
+          updateMessageById(sessionId, assistantMsgId, msg => ({ ...msg, content: 'External agent not found. Please check settings.', executionStatus: 'failed' }));
+          setStreamingForScope(sessionId, false);
+          return;
+        }
+        try {
+          await sendToExternalAgent(sessionId, trimmed, agentConfig, abortController, attachments, {
+            existingSessionId: currentSession?.externalSessionId,
+            updateExternalSessionId: updateSessionExternalSessionId,
+            historyMessages: buildAcpHistoryMessages(currentSession?.messages ?? []),
+            terminalSessions,
+            defaultTargetSession,
+            providers,
+            selectedAgentModel,
+            toolIntegrationMode,
+            selectedUserSkillSlugs: selectedSkillSlugs,
+          });
+        } catch (err) {
+          reportStreamError(sessionId, abortController.signal, err);
+        }
+        updateLastMessage(sessionId, msg => msg.statusText ? { ...msg, statusText: '' } : msg);
+        setStreamingForScope(sessionId, false);
+        abortControllersRef.current.delete(sessionId);
+        autoTitleSession(sessionId, trimmed);
+      } else {
+        const toolScope = {
+          type: scopeType,
+          targetId: scopeTargetId,
+          label: scopeLabel,
+        } as const;
+        await sendToCattyAgent(sessionId, sendScopeKey, trimmed, abortController, currentSession ?? undefined, assistantMsgId, {
+          activeProvider,
+          activeModelId,
+          scopeType,
+          scopeTargetId,
+          scopeLabel,
+          globalPermissionMode,
+          commandBlocklist,
+          terminalSessions,
+          webSearchConfig,
+          getExecutorContext: () => buildExecutorContextForScope(toolScope),
+          autoTitleSession,
+          selectedUserSkillSlugs: selectedSkillSlugs,
+        }, attachments.length > 0 ? attachments : undefined);
+      }
+    } finally {
+      if (isDraftMode) {
+        endDraftSend(draftSendInFlightRef);
+      }
     }
   }, [
     isStreaming, activeProvider, scopeKey, currentAgentId,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -285,16 +285,16 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     setActiveSessionIdForScope(scopeKey, id);
   }, [scopeKey, setActiveSessionIdForScope]);
 
-  const activeTerminalTargetIds = useMemo(() => {
-    const targetIds = new Set<string>();
-    for (const [sessionScopeKey, sessionId] of Object.entries(activeSessionIdMap)) {
+  const activeTerminalSessionIds = useMemo(() => {
+    const sessionIds = new Set<string>();
+    const entries = Object.entries(activeSessionIdMap) as Array<[string, string | null]>;
+    for (const [sessionScopeKey, sessionId] of entries) {
       if (!sessionScopeKey.startsWith('terminal:') || !sessionId) continue;
-      const targetId = sessionScopeKey.slice('terminal:'.length);
-      if (!targetId || targetId === scopeTargetId) continue;
-      targetIds.add(targetId);
+      if (sessionScopeKey === scopeKey) continue;
+      sessionIds.add(sessionId);
     }
-    return targetIds;
-  }, [activeSessionIdMap, scopeTargetId]);
+    return sessionIds;
+  }, [activeSessionIdMap, scopeKey]);
 
   const historySessions = useMemo(
     () =>
@@ -306,13 +306,13 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
             scopeType,
             scopeTargetId,
             scopeHostIds,
-            activeTerminalTargetIds,
+            activeTerminalSessionIds,
           ),
         }))
         .filter(({ matchRank }) => matchRank > 0)
         .sort((a, b) => b.matchRank - a.matchRank || b.session.updatedAt - a.session.updatedAt)
         .map(({ session }) => session),
-    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalTargetIds],
+    [sessions, scopeType, scopeTargetId, scopeHostIds, activeTerminalSessionIds],
   );
 
   const explicitPanelView = panelViewByScope[scopeKey];

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -340,7 +340,6 @@ const AIChatPanelsHostInner: React.FC<AIChatPanelsHostProps> = ({
               deleteSession={aiState.deleteSession}
               updateSessionTitle={aiState.updateSessionTitle}
               updateSessionExternalSessionId={aiState.updateSessionExternalSessionId}
-              retargetSessionScope={aiState.retargetSessionScope}
               addMessageToSession={aiState.addMessageToSession}
               updateLastMessage={aiState.updateLastMessage}
               updateMessageById={aiState.updateMessageById}

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -6,6 +6,7 @@ import type {
   AISession,
 } from "../../infrastructure/ai/types.ts";
 import {
+  applyDraftEntrySelection,
   applyHistorySessionSelection,
   normalizePanelView,
   resolveDisplayedPanelView,
@@ -136,5 +137,23 @@ test("history selection switches to the chosen session without touching draft st
     "view:session-2",
     "active:session-2",
     "close-history",
+  ]);
+});
+
+test("draft entry ensures a draft exists before switching the panel to draft mode", () => {
+  const calls: string[] = [];
+
+  applyDraftEntrySelection({
+    ensureDraft: () => {
+      calls.push("ensure-draft");
+    },
+    showDraftView: () => {
+      calls.push("show-draft");
+    },
+  });
+
+  assert.deepEqual(calls, [
+    "ensure-draft",
+    "show-draft",
   ]);
 });

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -157,3 +157,21 @@ test("draft entry ensures a draft exists before switching the panel to draft mod
     "show-draft",
   ]);
 });
+
+test("draft entry can preserve the current session view while ensuring draft state", () => {
+  const calls: string[] = [];
+
+  applyDraftEntrySelection({
+    ensureDraft: () => {
+      calls.push("ensure-draft");
+    },
+    showDraftView: () => {
+      calls.push("show-draft");
+    },
+    preserveSessionView: true,
+  });
+
+  assert.deepEqual(calls, [
+    "ensure-draft",
+  ]);
+});

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -10,7 +10,6 @@ import {
   normalizePanelView,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
-  shouldRetargetSessionForScope,
 } from "./aiPanelViewState.ts";
 
 function createSession(id: string): AISession {
@@ -61,7 +60,7 @@ test("missing explicit panel view resumes the most recent matching history when 
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, false, sessions),
+    resolveDisplayedPanelView(undefined, false, sessions, undefined, "workspace"),
     { mode: "session", sessionId: "session-2" },
   );
 });
@@ -70,7 +69,7 @@ test("missing explicit panel view restores the persisted active session instead 
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, false, sessions, "session-1"),
+    resolveDisplayedPanelView(undefined, false, sessions, "session-1", "workspace"),
     { mode: "session", sessionId: "session-1" },
   );
 });
@@ -79,7 +78,7 @@ test("persisted session id that no longer exists in history falls back to newest
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, false, sessions, "deleted-session"),
+    resolveDisplayedPanelView(undefined, false, sessions, "deleted-session", "workspace"),
     { mode: "session", sessionId: "session-2" },
   );
 });
@@ -88,8 +87,17 @@ test("null persisted session id falls back to newest history entry", () => {
   const sessions = [createSession("session-2"), createSession("session-1")];
 
   assert.deepEqual(
-    resolveDisplayedPanelView(undefined, false, sessions, null),
+    resolveDisplayedPanelView(undefined, false, sessions, null, "workspace"),
     { mode: "session", sessionId: "session-2" },
+  );
+});
+
+test("terminal scope without explicit view always starts from draft even when history exists", () => {
+  const sessions = [createSession("session-2"), createSession("session-1")];
+
+  assert.deepEqual(
+    resolveDisplayedPanelView(undefined, false, sessions, "session-1", "terminal"),
+    { mode: "draft" },
   );
 });
 
@@ -106,50 +114,6 @@ test("draft state is used when there is no implicit history to resume", () => {
   assert.deepEqual(
     resolveDisplayedPanelView(undefined, true, []),
     { mode: "draft" },
-  );
-});
-
-test("restorable terminal history should retarget to the current scope", () => {
-  const session: AISession = {
-    ...createSession("session-2"),
-    scope: {
-      type: "terminal",
-      targetId: "old-terminal",
-      hostIds: ["host-1"],
-    },
-  };
-
-  assert.equal(
-    shouldRetargetSessionForScope(
-      session,
-      "terminal",
-      "new-terminal",
-      ["host-1"],
-      new Set<string>(),
-    ),
-    true,
-  );
-});
-
-test("session owned by another active terminal should not retarget", () => {
-  const session: AISession = {
-    ...createSession("session-2"),
-    scope: {
-      type: "terminal",
-      targetId: "other-active-terminal",
-      hostIds: ["host-1"],
-    },
-  };
-
-  assert.equal(
-    shouldRetargetSessionForScope(
-      session,
-      "terminal",
-      "new-terminal",
-      ["host-1"],
-      new Set<string>(["other-active-terminal"]),
-    ),
-    false,
   );
 });
 

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -14,6 +14,7 @@ interface HistorySessionSelectionActions {
 interface DraftEntrySelectionActions {
   ensureDraft: () => void;
   showDraftView: () => void;
+  preserveSessionView?: boolean;
 }
 
 export function resolveDisplayedPanelView(
@@ -87,5 +88,7 @@ export function applyDraftEntrySelection(
   actions: DraftEntrySelectionActions,
 ): void {
   actions.ensureDraft();
-  actions.showDraftView();
+  if (!actions.preserveSessionView) {
+    actions.showDraftView();
+  }
 }

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -11,6 +11,11 @@ interface HistorySessionSelectionActions {
   closeHistory?: () => void;
 }
 
+interface DraftEntrySelectionActions {
+  ensureDraft: () => void;
+  showDraftView: () => void;
+}
+
 export function resolveDisplayedPanelView(
   panelView: AIPanelView | undefined,
   hasDraft: boolean,
@@ -76,4 +81,11 @@ export function applyHistorySessionSelection(
   actions.showSessionView(sessionId);
   actions.setActiveSessionId(sessionId);
   actions.closeHistory?.();
+}
+
+export function applyDraftEntrySelection(
+  actions: DraftEntrySelectionActions,
+): void {
+  actions.ensureDraft();
+  actions.showDraftView();
 }

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -16,12 +16,19 @@ export function resolveDisplayedPanelView(
   hasDraft: boolean,
   sessions: AISession[],
   persistedSessionId?: string | null,
+  scopeType: "terminal" | "workspace" = "workspace",
 ): AIPanelView {
   if (panelView) {
     return normalizePanelView(panelView, sessions);
   }
 
   if (hasDraft) {
+    return DEFAULT_PANEL_VIEW;
+  }
+
+  // New terminal sessions should always start from a blank draft. History is
+  // still available in the drawer, but never auto-resumed into a fresh SSH tab.
+  if (scopeType === "terminal") {
     return DEFAULT_PANEL_VIEW;
   }
 
@@ -60,28 +67,6 @@ export function resolveDisplayedSession(
   }
 
   return sessions.find((session) => session.id === panelView.sessionId) ?? null;
-}
-
-export function shouldRetargetSessionForScope(
-  session: AISession | null,
-  scopeType: "terminal" | "workspace",
-  scopeTargetId?: string,
-  scopeHostIds?: string[],
-  activeTerminalTargetIds?: Set<string>,
-): boolean {
-  if (!session || scopeType !== "terminal" || !scopeTargetId || !scopeHostIds?.length) {
-    return false;
-  }
-
-  if (session.scope.type !== scopeType || session.scope.targetId === scopeTargetId) {
-    return false;
-  }
-
-  if (session.scope.targetId && activeTerminalTargetIds?.has(session.scope.targetId)) {
-    return false;
-  }
-
-  return session.scope.hostIds?.some((hostId) => scopeHostIds.includes(hostId)) ?? false;
 }
 
 export function applyHistorySessionSelection(

--- a/components/ai/draftSendGate.test.ts
+++ b/components/ai/draftSendGate.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  endDraftSend,
+  tryBeginDraftSend,
+} from "./draftSendGate.ts";
+
+test("draft send gate allows only one in-flight draft send at a time", () => {
+  const gate = { current: false };
+
+  assert.equal(tryBeginDraftSend(gate), true);
+  assert.equal(tryBeginDraftSend(gate), false);
+
+  endDraftSend(gate);
+
+  assert.equal(tryBeginDraftSend(gate), true);
+});

--- a/components/ai/draftSendGate.ts
+++ b/components/ai/draftSendGate.ts
@@ -1,0 +1,12 @@
+export function tryBeginDraftSend(gate: { current: boolean }): boolean {
+  if (gate.current) {
+    return false;
+  }
+
+  gate.current = true;
+  return true;
+}
+
+export function endDraftSend(gate: { current: boolean }): void {
+  gate.current = false;
+}

--- a/components/ai/sessionHistoryLayout.test.ts
+++ b/components/ai/sessionHistoryLayout.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  SESSION_HISTORY_ROW_CLASSNAMES,
+} from "./sessionHistoryLayout.ts";
+
+test("session history row keeps metadata pinned to the end while title truncates", () => {
+  assert.match(SESSION_HISTORY_ROW_CLASSNAMES.row, /\bgrid\b/);
+  assert.ok(SESSION_HISTORY_ROW_CLASSNAMES.row.includes('grid-cols-[minmax(0,1fr)_auto]'));
+  assert.match(SESSION_HISTORY_ROW_CLASSNAMES.title, /\btruncate\b/);
+  assert.match(SESSION_HISTORY_ROW_CLASSNAMES.title, /\bmin-w-0\b/);
+  assert.match(SESSION_HISTORY_ROW_CLASSNAMES.meta, /\bjustify-self-end\b/);
+  assert.match(SESSION_HISTORY_ROW_CLASSNAMES.meta, /\bshrink-0\b/);
+});

--- a/components/ai/sessionHistoryLayout.ts
+++ b/components/ai/sessionHistoryLayout.ts
@@ -1,0 +1,7 @@
+export const SESSION_HISTORY_ROW_CLASSNAMES = {
+  row: 'w-full grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2.5 border-b border-border/20 text-left transition-colors cursor-pointer group',
+  title: 'text-[13px] truncate min-w-0',
+  meta: 'flex items-center gap-2 justify-self-end shrink-0',
+  time: 'text-[12px] text-muted-foreground/50 whitespace-nowrap',
+  deleteButton: 'opacity-0 group-hover:opacity-100 p-0.5 hover:text-destructive transition-all cursor-pointer shrink-0',
+} as const;

--- a/components/ai/sessionScopeMatch.test.ts
+++ b/components/ai/sessionScopeMatch.test.ts
@@ -49,3 +49,32 @@ test("host-matched terminal session remains resumable when no active terminal ow
     1,
   );
 });
+
+test("session targeting the current scope is an exact match (rank 2)", () => {
+  const session = createSession("session-1", "terminal-current", ["host-a"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "terminal",
+      "terminal-current",
+      ["host-a"],
+      new Set(),
+    ),
+    2,
+  );
+});
+
+test("scope type mismatch returns 0 regardless of target or hosts", () => {
+  const session = createSession("session-1", "terminal-current", ["host-a"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "workspace",
+      "terminal-current",
+      ["host-a"],
+    ),
+    0,
+  );
+});

--- a/components/ai/sessionScopeMatch.test.ts
+++ b/components/ai/sessionScopeMatch.test.ts
@@ -20,7 +20,7 @@ function createSession(id: string, targetId: string, hostIds: string[]): AISessi
   };
 }
 
-test("host-matched terminal session is excluded when another active terminal already owns it", () => {
+test("host-matched terminal session is excluded when another active terminal already displays it", () => {
   const session = createSession("session-1", "terminal-other", ["host-a"]);
 
   assert.equal(
@@ -29,13 +29,13 @@ test("host-matched terminal session is excluded when another active terminal alr
       "terminal",
       "terminal-current",
       ["host-a"],
-      new Set(["terminal-other"]),
+      new Set(["session-1"]),
     ),
     0,
   );
 });
 
-test("host-matched terminal session remains resumable when no active terminal owns it", () => {
+test("host-matched terminal session remains resumable when no terminal is displaying it", () => {
   const session = createSession("session-1", "terminal-closed", ["host-a"]);
 
   assert.equal(
@@ -44,9 +44,30 @@ test("host-matched terminal session remains resumable when no active terminal ow
       "terminal",
       "terminal-current",
       ["host-a"],
-      new Set(["terminal-other"]),
+      new Set(["session-other"]),
     ),
     1,
+  );
+});
+
+test("ownership is tracked by session id, not scope.targetId", () => {
+  // Session was created in terminal-A but a different terminal (B) is now
+  // displaying it after the user resumed it from history. Opening a third
+  // terminal (C) should not see this session as owned, because the new
+  // ownership check is keyed on session id, not the stale targetId.
+  const session = createSession("session-1", "terminal-A", ["host-a"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "terminal",
+      "terminal-C",
+      ["host-a"],
+      // terminal-B is displaying session-1; pass session-1 as an
+      // active-id so C sees it as in-use
+      new Set(["session-1"]),
+    ),
+    0,
   );
 });
 

--- a/components/ai/sessionScopeMatch.test.ts
+++ b/components/ai/sessionScopeMatch.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AISession } from "../../infrastructure/ai/types.ts";
+import { getSessionScopeMatchRank } from "./sessionScopeMatch.ts";
+
+function createSession(id: string, targetId: string, hostIds: string[]): AISession {
+  return {
+    id,
+    title: id,
+    messages: [],
+    createdAt: 1,
+    updatedAt: 1,
+    agentId: "catty",
+    scope: {
+      type: "terminal",
+      targetId,
+      hostIds,
+    },
+  };
+}
+
+test("host-matched terminal session is excluded when another active terminal already owns it", () => {
+  const session = createSession("session-1", "terminal-other", ["host-a"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "terminal",
+      "terminal-current",
+      ["host-a"],
+      new Set(["terminal-other"]),
+    ),
+    0,
+  );
+});
+
+test("host-matched terminal session remains resumable when no active terminal owns it", () => {
+  const session = createSession("session-1", "terminal-closed", ["host-a"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "terminal",
+      "terminal-current",
+      ["host-a"],
+      new Set(["terminal-other"]),
+    ),
+    1,
+  );
+});

--- a/components/ai/sessionScopeMatch.ts
+++ b/components/ai/sessionScopeMatch.ts
@@ -1,0 +1,22 @@
+import type { AISession } from "../../infrastructure/ai/types";
+
+export function getSessionScopeMatchRank(
+  session: AISession,
+  scopeType: "terminal" | "workspace",
+  scopeTargetId?: string,
+  scopeHostIds?: string[],
+  activeTerminalTargetIds?: Set<string>,
+): number {
+  if (session.scope.type !== scopeType) return 0;
+  if (session.scope.targetId === scopeTargetId) return 2;
+
+  if (scopeType !== "terminal" || !scopeHostIds?.length || !session.scope.hostIds?.length) {
+    return 0;
+  }
+
+  if (session.scope.targetId && activeTerminalTargetIds?.has(session.scope.targetId)) {
+    return 0;
+  }
+
+  return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 1 : 0;
+}

--- a/components/ai/sessionScopeMatch.ts
+++ b/components/ai/sessionScopeMatch.ts
@@ -5,7 +5,13 @@ export function getSessionScopeMatchRank(
   scopeType: "terminal" | "workspace",
   scopeTargetId?: string,
   scopeHostIds?: string[],
-  activeTerminalTargetIds?: Set<string>,
+  /**
+   * Session ids currently displayed by other terminal scopes. Tracked by
+   * session id rather than `scope.targetId` so that a host-matched session
+   * resumed from a different terminal is still recognised as in-use and
+   * not offered (or cleaned) as if it were orphaned.
+   */
+  activeTerminalSessionIds?: Set<string>,
 ): number {
   if (session.scope.type !== scopeType) return 0;
   if (session.scope.targetId === scopeTargetId) return 2;
@@ -14,7 +20,7 @@ export function getSessionScopeMatchRank(
     return 0;
   }
 
-  if (session.scope.targetId && activeTerminalTargetIds?.has(session.scope.targetId)) {
+  if (activeTerminalSessionIds?.has(session.id)) {
     return 0;
   }
 


### PR DESCRIPTION
## Summary

This PR hardens scoped AI chat state handling across terminal and workspace panels.

It separates per-scope draft state from persisted session history, tightens panel view/session restore behavior, improves cleanup for closed scopes, and fixes a draft attachment race where normal draft edits could invalidate in-flight uploads.

## What changed

- moved AI draft composer state and panel view state into explicit per-scope transient state
- added dedicated helpers for:
  - draft lifecycle and panel view transitions
  - inactive scope cleanup
  - panel view normalization and displayed-session resolution
  - draft send gating
  - terminal/workspace session scope matching
- changed terminal AI behavior to start from a fresh draft by default instead of auto-resuming history into a newly opened terminal
- preserved workspace history resume behavior, including persisted active-session restoration when available
- cleaned up orphaned scoped state more consistently when terminals/workspaces close
- extracted file-to-upload conversion into shared helpers and fixed upload invalidation logic by tracking upload lifecycle separately from normal draft mutations
- improved AI session history drawer layout behavior
- updated managed-agent behavior so Claude/Codex auth follows CLI-owned login/config instead of renderer-side provider assumptions
- removed outdated Codex API-key hint copy that no longer reflects the current integration model

## Why

The previous flow mixed persisted session state with transient draft/panel intent, which caused several edge-case regressions:

- stale draft/view state could survive longer than intended
- terminal history could resume into the wrong context
- closing scoped targets could leave behind orphaned transient state
- file uploads could be dropped if the user edited the draft while conversion was still in flight

This PR makes those state boundaries explicit and narrows the restore rules so each scope behaves predictably.

## Testing

- `node --test application/state/aiDraftState.test.ts application/state/aiScopeCleanup.test.ts components/ai/aiPanelViewState.test.ts components/ai/draftSendGate.test.ts components/ai/sessionHistoryLayout.test.ts components/ai/sessionScopeMatch.test.ts`
- `npm run lint`
- `npm run build`

## Notes

There are also local uncommitted changes in:
- `application/state/aiDraftState.ts`
- `application/state/useAIState.ts`
- `application/state/aiDraftState.test.ts`

Those changes further harden the draft upload race by separating upload generation from general draft mutation tracking. If they will be included before merge, they should be considered part of this PR's final scope.
