### PR TITLE
fix: remove invalid `eval --` in fish shell wrapper (#721)

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -88,7 +88,7 @@ function buildWrappedCommand(command, shellKind, marker) {
         `set ${marker} 0; function __ncmcp_int --on-signal INT; printf '%s\\n' '${marker}_E:130'; functions -e __ncmcp_int; end; ` +
         `set -l ${marker}_cmd '${escapeFishSingleQuoted(command)}'; ` +
         `begin; set -gx PAGER cat; set -gx SYSTEMD_PAGER ''; set -gx GIT_PAGER cat; set -gx LESS ''; ` +
-        `printf '%s\\n' '${marker}_S'; eval -- \$${marker}_cmd; set __NCMCP_rc $status; ` +
+        `printf '%s\\n' '${marker}_S'; eval \$${marker}_cmd; set __NCMCP_rc $status; ` +
         `functions -e __ncmcp_int; printf '%s\\n' '${marker}_E:'\$__NCMCP_rc; end\n`
       );
 


### PR DESCRIPTION
## Summary

- Fish's `eval` builtin does not accept `--` as an end-of-options marker, so every AI Agent command executed under fish failed with `fish: Unknown command: --`.
- Drop the `--` in the fish branch of `buildWrappedCommand`. Fish's `eval` takes no options, so no terminator is needed.
- bash/zsh (`posix` branch) use `"$@"` and are unaffected; powershell/cmd branches untouched.

Fixes #721

## Test plan

- [x] Set user shell to fish; launch Catty Agent and run `ls -a` — expect normal output, no `Unknown command: --`.
- [ ] Regression: run the same command under bash, zsh, powershell, cmd to confirm no change in behavior.
- [ ] Try a command with single quotes (e.g. `echo "it's fine"`) under fish to confirm escaping still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)