### PR TITLE
feat(ai-chat): fit-to-content popovers + keyboard nav for @/slash menus

### DIFF
--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -7,7 +7,7 @@
  */
 
 import { AtSign, Check, ChevronDown, ChevronRight, Cpu, Expand, Eye, FileText, ImageIcon, Package, Plus, ShieldCheck, X, Zap } from 'lucide-react';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { createPortal } from 'react-dom';
 import type { FormEvent } from 'react';
@@ -100,6 +100,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const [hoveredModelId, setHoveredModelId] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState('');
   const [slashRange, setSlashRange] = useState<{ start: number; end: number } | null>(null);
+  // Active highlight index for @ mention / slash skill keyboard navigation
+  const [activeMenuIndex, setActiveMenuIndex] = useState(0);
 
   // Derived booleans for readability
   const showModelPicker = activeMenu === 'model';
@@ -203,11 +205,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setActiveMenu(menu);
   }, [getInputPanelMenuPos]);
 
-  const filteredUserSkills = userSkills.filter((skill) => {
+  const filteredUserSkills = useMemo(() => userSkills.filter((skill) => {
     if (!slashQuery) return true;
     const lowerQuery = slashQuery.toLowerCase();
     return skill.slug.toLowerCase().startsWith(lowerQuery) || skill.name.toLowerCase().includes(lowerQuery);
-  });
+  }), [userSkills, slashQuery]);
 
   const removeSlashQueryFromInput = useCallback(() => {
     if (!slashRange) return value;
@@ -226,6 +228,66 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }
     closeAllMenus();
   }, [closeAllMenus, onAddUserSkill, onChange, removeSlashQueryFromInput, slashRange]);
+
+  // Reset active highlight when a menu opens or its visible items change
+  useEffect(() => {
+    if (showAtMention) setActiveMenuIndex(0);
+  }, [showAtMention, hosts.length]);
+  useEffect(() => {
+    if (showSlashSkillPicker) setActiveMenuIndex(0);
+  }, [showSlashSkillPicker, filteredUserSkills.length]);
+
+  const handleTextareaKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    // @ mention popover keyboard navigation
+    if (showAtMention && hosts.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveMenuIndex((i) => (i + 1) % hosts.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveMenuIndex((i) => (i - 1 + hosts.length) % hosts.length);
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        const host = hosts[Math.min(activeMenuIndex, hosts.length - 1)];
+        if (host) handleSelectAtMention(host);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAllMenus();
+        return;
+      }
+    }
+    // / skill popover keyboard navigation
+    if (showSlashSkillPicker && filteredUserSkills.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveMenuIndex((i) => (i + 1) % filteredUserSkills.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveMenuIndex((i) => (i - 1 + filteredUserSkills.length) % filteredUserSkills.length);
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        const skill = filteredUserSkills[Math.min(activeMenuIndex, filteredUserSkills.length - 1)];
+        if (skill) insertUserSkillToken(skill);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeAllMenus();
+        return;
+      }
+    }
+  }, [showAtMention, hosts, showSlashSkillPicker, filteredUserSkills, activeMenuIndex, handleSelectAtMention, insertUserSkillToken, closeAllMenus]);
 
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
     const pastedFiles = Array.from(e.clipboardData.items)
@@ -367,6 +429,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
             ref={textareaRef}
             value={value}
             onChange={(e) => handleInputChange(e.target.value)}
+            onKeyDown={handleTextareaKeyDown}
             placeholder={placeholder || defaultPlaceholder}
             disabled={disabled}
             className={[
@@ -392,31 +455,38 @@ const ChatInput: React.FC<ChatInputProps> = ({
             <div
               role="listbox"
               aria-label="Mention host"
+              aria-activedescendant={hosts[activeMenuIndex] ? `at-mention-${hosts[activeMenuIndex].sessionId}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-[20px] border border-border/60 bg-popover shadow-2xl"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
             >
               <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuHosts')}</div>
               <ScrollArea className="max-h-[300px]">
                 <div className="px-2.5 pb-2.5">
-                  {hosts.map(host => (
-                    <button
-                      key={host.sessionId}
-                      type="button"
-                      role="option"
-                      onClick={() => handleSelectAtMention(host)}
-                      className="w-full rounded-[16px] px-3 py-1.5 text-left hover:bg-muted/30 transition-colors cursor-pointer"
-                    >
-                      <div className="flex items-center gap-2 text-[12px] text-foreground/90">
-                        <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
-                        <span className="truncate">{host.label || host.hostname}</span>
-                      </div>
-                      {host.label && host.hostname !== host.label ? (
-                        <div className="mt-0.5 pl-3.5 text-[10px] text-muted-foreground/60 truncate">
-                          {host.hostname}
+                  {hosts.map((host, idx) => {
+                    const isActive = idx === activeMenuIndex;
+                    return (
+                      <button
+                        id={`at-mention-${host.sessionId}`}
+                        key={host.sessionId}
+                        type="button"
+                        role="option"
+                        aria-selected={isActive}
+                        onMouseEnter={() => setActiveMenuIndex(idx)}
+                        onClick={() => handleSelectAtMention(host)}
+                        className={`w-full rounded-[16px] px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                      >
+                        <div className="flex items-center gap-2 text-[12px] text-foreground/90">
+                          <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
+                          <span className="truncate">{host.label || host.hostname}</span>
                         </div>
-                      ) : null}
-                    </button>
-                  ))}
+                        {host.label && host.hostname !== host.label ? (
+                          <div className="mt-0.5 pl-3.5 text-[10px] text-muted-foreground/60 truncate">
+                            {host.hostname}
+                          </div>
+                        ) : null}
+                      </button>
+                    );
+                  })}
                 </div>
               </ScrollArea>
             </div>
@@ -431,31 +501,38 @@ const ChatInput: React.FC<ChatInputProps> = ({
             <div
               role="listbox"
               aria-label="Insert user skill"
+              aria-activedescendant={filteredUserSkills[activeMenuIndex] ? `slash-skill-${filteredUserSkills[activeMenuIndex].id}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-[20px] border border-border/60 bg-popover shadow-2xl"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
             >
               <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuUserSkills')}</div>
               <ScrollArea className="max-h-[300px]">
                 <div className="px-2.5 pb-2.5">
-                  {filteredUserSkills.map((skill) => (
-                    <button
-                      key={skill.id}
-                      type="button"
-                      role="option"
-                      onClick={() => insertUserSkillToken(skill)}
-                      className="w-full rounded-[16px] px-3 py-1.5 text-left hover:bg-muted/30 transition-colors cursor-pointer"
-                    >
-                      <div className="flex items-center gap-2 text-[12px]">
-                        <Package size={12} className="text-muted-foreground/55 shrink-0" />
-                        <span className="text-foreground/90">/{skill.slug}</span>
-                      </div>
-                      {skill.description ? (
-                        <div className="mt-0.5 pl-5 text-[10px] leading-4.5 text-muted-foreground/62 line-clamp-2">
-                          {skill.description}
+                  {filteredUserSkills.map((skill, idx) => {
+                    const isActive = idx === activeMenuIndex;
+                    return (
+                      <button
+                        id={`slash-skill-${skill.id}`}
+                        key={skill.id}
+                        type="button"
+                        role="option"
+                        aria-selected={isActive}
+                        onMouseEnter={() => setActiveMenuIndex(idx)}
+                        onClick={() => insertUserSkillToken(skill)}
+                        className={`w-full rounded-[16px] px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                      >
+                        <div className="flex items-center gap-2 text-[12px]">
+                          <Package size={12} className="text-muted-foreground/55 shrink-0" />
+                          <span className="text-foreground/90">/{skill.slug}</span>
                         </div>
-                      ) : null}
-                    </button>
-                  ))}
+                        {skill.description ? (
+                          <div className="mt-0.5 pl-5 text-[10px] leading-4.5 text-muted-foreground/62 line-clamp-2">
+                            {skill.description}
+                          </div>
+                        ) : null}
+                      </button>
+                    );
+                  })}
                 </div>
               </ScrollArea>
             </div>

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -456,7 +456,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               role="listbox"
               aria-label="Mention host"
               aria-activedescendant={hosts[activeMenuIndex] ? `at-mention-${hosts[activeMenuIndex].sessionId}` : undefined}
-              className="fixed z-[1000] overflow-hidden rounded-[20px] border border-border/60 bg-popover shadow-2xl"
+              className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
               style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
             >
               <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuHosts')}</div>
@@ -473,7 +473,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         aria-selected={isActive}
                         onMouseEnter={() => setActiveMenuIndex(idx)}
                         onClick={() => handleSelectAtMention(host)}
-                        className={`w-full rounded-[16px] px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                        className={`w-full rounded-md px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
                       >
                         <div className="flex items-center gap-2 text-[12px] text-foreground/90">
                           <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
@@ -502,7 +502,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               role="listbox"
               aria-label="Insert user skill"
               aria-activedescendant={filteredUserSkills[activeMenuIndex] ? `slash-skill-${filteredUserSkills[activeMenuIndex].id}` : undefined}
-              className="fixed z-[1000] overflow-hidden rounded-[20px] border border-border/60 bg-popover shadow-2xl"
+              className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
               style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
             >
               <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuUserSkills')}</div>
@@ -519,7 +519,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         aria-selected={isActive}
                         onMouseEnter={() => setActiveMenuIndex(idx)}
                         onClick={() => insertUserSkillToken(skill)}
-                        className={`w-full rounded-[16px] px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                        className={`w-full rounded-md px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
                       >
                         <div className="flex items-center gap-2 text-[12px]">
                           <Package size={12} className="text-muted-foreground/55 shrink-0" />

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -229,13 +229,25 @@ const ChatInput: React.FC<ChatInputProps> = ({
     closeAllMenus();
   }, [closeAllMenus, onAddUserSkill, onChange, removeSlashQueryFromInput, slashRange]);
 
-  // Reset active highlight when a menu opens or its visible items change
+  // Reset active highlight when a menu opens or when the *identity* of the
+  // visible items changes. Watching only `.length` misses cases where the
+  // filter produces a different set with the same count (e.g. user types
+  // another character into the slash query) — Enter would then commit an
+  // unexpected item. Derive a stable key from the visible ids instead.
+  const atMentionKey = useMemo(
+    () => hosts.map((h) => h.sessionId).join('|'),
+    [hosts],
+  );
+  const slashSkillKey = useMemo(
+    () => filteredUserSkills.map((s) => s.id).join('|'),
+    [filteredUserSkills],
+  );
   useEffect(() => {
     if (showAtMention) setActiveMenuIndex(0);
-  }, [showAtMention, hosts.length]);
+  }, [showAtMention, atMentionKey]);
   useEffect(() => {
     if (showSlashSkillPicker) setActiveMenuIndex(0);
-  }, [showSlashSkillPicker, filteredUserSkills.length]);
+  }, [showSlashSkillPicker, slashSkillKey]);
 
   const handleTextareaKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.nativeEvent.isComposing) return;
@@ -457,7 +469,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               aria-label="Mention host"
               aria-activedescendant={hosts[activeMenuIndex] ? `at-mention-${hosts[activeMenuIndex].sessionId}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 200, maxWidth: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: Math.min(200, inputPanelPos.width), maxWidth: inputPanelPos.width }}
             >
               <ScrollArea className="max-h-[280px]">
                 <div className="p-1">
@@ -505,7 +517,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               aria-label="Insert user skill"
               aria-activedescendant={filteredUserSkills[activeMenuIndex] ? `slash-skill-${filteredUserSkills[activeMenuIndex].id}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 200, maxWidth: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: Math.min(200, inputPanelPos.width), maxWidth: inputPanelPos.width }}
             >
               <ScrollArea className="max-h-[280px]">
                 <div className="p-1">

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -457,13 +457,15 @@ const ChatInput: React.FC<ChatInputProps> = ({
               aria-label="Mention host"
               aria-activedescendant={hosts[activeMenuIndex] ? `at-mention-${hosts[activeMenuIndex].sessionId}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 200, maxWidth: inputPanelPos.width }}
             >
-              <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuHosts')}</div>
-              <ScrollArea className="max-h-[300px]">
-                <div className="px-2.5 pb-2.5">
+              <ScrollArea className="max-h-[280px]">
+                <div className="p-1">
                   {hosts.map((host, idx) => {
                     const isActive = idx === activeMenuIndex;
+                    const showHostnameLine = host.label
+                      && host.hostname !== host.label
+                      && !host.label.includes(host.hostname);
                     return (
                       <button
                         id={`at-mention-${host.sessionId}`}
@@ -473,14 +475,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         aria-selected={isActive}
                         onMouseEnter={() => setActiveMenuIndex(idx)}
                         onClick={() => handleSelectAtMention(host)}
-                        className={`w-full rounded-md px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                        className={`w-full rounded-md px-2 py-1 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
                       >
                         <div className="flex items-center gap-2 text-[12px] text-foreground/90">
                           <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${host.connected ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
                           <span className="truncate">{host.label || host.hostname}</span>
                         </div>
-                        {host.label && host.hostname !== host.label ? (
-                          <div className="mt-0.5 pl-3.5 text-[10px] text-muted-foreground/60 truncate">
+                        {showHostnameLine ? (
+                          <div className="pl-3.5 text-[10px] text-muted-foreground/60 truncate">
                             {host.hostname}
                           </div>
                         ) : null}
@@ -503,11 +505,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
               aria-label="Insert user skill"
               aria-activedescendant={filteredUserSkills[activeMenuIndex] ? `slash-skill-${filteredUserSkills[activeMenuIndex].id}` : undefined}
               className="fixed z-[1000] overflow-hidden rounded-lg border border-border/50 bg-popover shadow-lg"
-              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 220, maxWidth: inputPanelPos.width }}
+              style={{ left: inputPanelPos.left, bottom: inputPanelPos.bottom, width: 'auto', minWidth: 200, maxWidth: inputPanelPos.width }}
             >
-              <div className="px-4 pt-3 pb-1.5 text-[10px] font-medium text-muted-foreground/62 tracking-wide">{t('ai.chat.menuUserSkills')}</div>
-              <ScrollArea className="max-h-[300px]">
-                <div className="px-2.5 pb-2.5">
+              <ScrollArea className="max-h-[280px]">
+                <div className="p-1">
                   {filteredUserSkills.map((skill, idx) => {
                     const isActive = idx === activeMenuIndex;
                     return (
@@ -519,14 +520,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
                         aria-selected={isActive}
                         onMouseEnter={() => setActiveMenuIndex(idx)}
                         onClick={() => insertUserSkillToken(skill)}
-                        className={`w-full rounded-md px-3 py-1.5 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
+                        className={`w-full rounded-md px-2 py-1 text-left transition-colors cursor-pointer ${isActive ? 'bg-muted/40' : 'hover:bg-muted/30'}`}
                       >
                         <div className="flex items-center gap-2 text-[12px]">
                           <Package size={12} className="text-muted-foreground/55 shrink-0" />
                           <span className="text-foreground/90">/{skill.slug}</span>
                         </div>
                         {skill.description ? (
-                          <div className="mt-0.5 pl-5 text-[10px] leading-4.5 text-muted-foreground/62 line-clamp-2">
+                          <div className="pl-5 text-[10px] leading-4.5 text-muted-foreground/62 line-clamp-2">
                             {skill.description}
                           </div>
                         ) : null}


### PR DESCRIPTION
## Summary

- The `@` host picker and `/skill` picker in the AI chat input now shrink to fit their content (min 220px, max = input width) instead of always matching the full input width. Short lists no longer leave a wide empty box.
- Added keyboard navigation to both popovers:
  - `↑` / `↓` cycle through items (wrap at ends)
  - `Enter` commits the highlighted item; does not fall through to message submit while a menu is open
  - `Esc` closes the menu
  - Mouse hover syncs the active index so keyboard and pointer never disagree
- Exposed `aria-selected` / `aria-activedescendant` on the listbox for assistive tech.

## Test plan

- [ ] Type `@` in the chat input with ≥1 connected host — popover hugs the host rows.
- [ ] Use `↑`/`↓` to move the highlight, press `Enter` to insert `@hostname ` into the input (no message submit).
- [ ] Press `Esc` to close the menu; typing resumes normally.
- [ ] Hover a different row with the mouse; pressing `Enter` now selects that row.
- [ ] Repeat for `/skill` popover (type a leading `/`): same width/keyboard behavior.
- [ ] Before/after screenshots on a single-host list to confirm the width is tighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)