### PR TITLE
[codex] Fix duplicated serial hosts not saving

### DIFF
--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -36,7 +36,7 @@ import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
 import { useTreeExpandedState } from "../application/state/useTreeExpandedState";
 import { resolveGroupDefaults, applyGroupDefaults } from "../domain/groupConfig";
-import { getEffectiveHostDistro, sanitizeHost } from "../domain/host";
+import { getEffectiveHostDistro, sanitizeHost, upsertHostById } from "../domain/host";
 import { importVaultHostsFromText, exportHostsToCsvWithStats } from "../domain/vaultImport";
 import type { VaultImportFormat } from "../domain/vaultImport";
 import {
@@ -2941,13 +2941,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           groupDefaults={editingHostGroupDefaults}
           groupConfigs={groupConfigs}
           onSave={(host) => {
-            // Check if host already exists in the list (for updates vs. new/duplicate)
-            const hostExists = hosts.some((h) => h.id === host.id);
-            onUpdateHosts(
-              hostExists
-                ? hosts.map((h) => (h.id === host.id ? host : h))
-                : [...hosts, host],
-            );
+            onUpdateHosts(upsertHostById(hosts, host));
             setIsHostPanelOpen(false);
             setEditingHost(null);
             setNewHostGroupPath(null);
@@ -2973,15 +2967,15 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
           allTags={allTags}
           groups={allGroupPaths}
           onSave={(host) => {
-            onUpdateHosts(
-              hosts.map((h) => (h.id === host.id ? host : h)),
-            );
+            onUpdateHosts(upsertHostById(hosts, host));
             setIsHostPanelOpen(false);
             setEditingHost(null);
+            setNewHostGroupPath(null);
           }}
           onCancel={() => {
             setIsHostPanelOpen(false);
             setEditingHost(null);
+            setNewHostGroupPath(null);
           }}
           layout="inline"
         />

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host } from "./models.ts";
+import { upsertHostById } from "./host.ts";
+
+const makeHost = (overrides: Partial<Host> = {}): Host => ({
+  id: "host-1",
+  label: "Primary Host",
+  hostname: "127.0.0.1",
+  port: 22,
+  username: "root",
+  authType: "password",
+  createdAt: 1,
+  protocol: "ssh",
+  ...overrides,
+});
+
+test("upsertHostById updates an existing host in place", () => {
+  const existing = makeHost();
+  const updated = makeHost({ label: "Updated Host" });
+
+  assert.deepEqual(upsertHostById([existing], updated), [updated]);
+});
+
+test("upsertHostById appends a duplicated host with a fresh id", () => {
+  const existing = makeHost({
+    id: "serial-original",
+    label: "Serial Config",
+    protocol: "serial",
+    hostname: "/dev/ttyUSB0",
+    port: 115200,
+    serialConfig: {
+      path: "/dev/ttyUSB0",
+      baudRate: 115200,
+      dataBits: 8,
+      stopBits: 1,
+      parity: "none",
+      flowControl: "none",
+      localEcho: false,
+      lineMode: false,
+    },
+  });
+  const duplicate = makeHost({
+    ...existing,
+    id: "serial-duplicate",
+    label: "Serial Config (copy)",
+  });
+
+  assert.deepEqual(upsertHostById([existing], duplicate), [existing, duplicate]);
+});

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -153,6 +153,13 @@ export const formatHostPort = (hostname: string, port?: number | null): string =
   return `${display}:${port}`;
 };
 
+export const upsertHostById = (hosts: Host[], host: Host): Host[] => {
+  const hostExists = hosts.some((entry) => entry.id === host.id);
+  return hostExists
+    ? hosts.map((entry) => (entry.id === host.id ? host : entry))
+    : [...hosts, host];
+};
+
 export const sanitizeHost = (host: Host): Host => {
   const cleanHostname = (host.hostname || '').split(/\s+/)[0];
   const cleanDistro = normalizeDistroId(host.distro);


### PR DESCRIPTION
## Summary
- fix serial host saves so duplicated entries with a fresh id are added instead of silently dropped
- reuse the same host upsert path for both normal hosts and serial hosts to keep save behavior consistent
- add a focused regression test for duplicate serial host saves

## Root cause
Serial host edits only replaced an existing host by id. When a user duplicated a saved serial configuration, the duplicate got a new id, so save tried to update a host that did not exist and nothing was persisted.

## Impact
Duplicated serial configurations can now be edited and saved as new entries, matching the behavior of regular hosts.

Closes #731

## Validation
- `npx --yes tsx --test /Users/chenqi/projects/personal/netcatty/domain/host.test.ts`
- `npx eslint /Users/chenqi/projects/personal/netcatty/components/VaultView.tsx /Users/chenqi/projects/personal/netcatty/domain/host.ts /Users/chenqi/projects/personal/netcatty/domain/host.test.ts`
- `npm run build`