### PR TITLE
[codex] Accept empty SSH identification banners for compatibility

### DIFF
--- a/electron/bridges/sshIdentificationCompatibility.test.cjs
+++ b/electron/bridges/sshIdentificationCompatibility.test.cjs
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const Protocol = require("ssh2/lib/protocol/Protocol");
+
+function parseIdentification(line) {
+  let header;
+  const protocol = new Protocol({
+    onWrite() {},
+    onError(err) {
+      throw err;
+    },
+    onHeader(nextHeader) {
+      header = nextHeader;
+    },
+  });
+
+  const data = Buffer.from(`${line}\r\n`, "latin1");
+  protocol.parse(data, 0, data.length);
+
+  assert.ok(header, "expected SSH header to be parsed");
+  return header;
+}
+
+test("ssh2 accepts an empty softwareversion for compatibility", () => {
+  const header = parseIdentification("SSH-2.0-");
+
+  assert.equal(header.versions.protocol, "2.0");
+  assert.equal(header.versions.software, "");
+  assert.equal(header.comments, undefined);
+});
+
+test("ssh2 still accepts standard identification strings", () => {
+  const header = parseIdentification("SSH-2.0-OpenSSH_9.9 Netcatty");
+
+  assert.equal(header.versions.protocol, "2.0");
+  assert.equal(header.versions.software, "OpenSSH_9.9");
+  assert.equal(header.comments, "Netcatty");
+});
+
+test("ssh2 still rejects malformed identification strings", () => {
+  assert.throws(
+    () => parseIdentification("SSH-2.0"),
+    /Invalid identification string/,
+  );
+});

--- a/patches/ssh2+1.17.0.patch
+++ b/patches/ssh2+1.17.0.patch
@@ -33,7 +33,7 @@ index 7291c2c..8943c9a 100644
  }
  
 diff --git a/node_modules/ssh2/lib/protocol/Protocol.js b/node_modules/ssh2/lib/protocol/Protocol.js
-index 7302488..95584c5 100644
+index 7302488..634acdd 100644
 --- a/node_modules/ssh2/lib/protocol/Protocol.js
 +++ b/node_modules/ssh2/lib/protocol/Protocol.js
 @@ -701,11 +701,19 @@ class Protocol {
@@ -107,6 +107,18 @@ index 7302488..95584c5 100644
        packet.set(signature, p += 4);
  
        this._authsQueue.push('hostbased');
+@@ -1916,7 +1932,10 @@ class Protocol {
+ }
+ 
+ // SSH-protoversion-softwareversion (SP comments) CR LF
+-const RE_IDENT = /^SSH-(2\.0|1\.99)-([^ ]+)(?: (.*))?$/;
++// RFC 4253 requires a non-empty softwareversion, but some embedded SSH
++// daemons send "SSH-2.0-" with an empty token. Accept that specific
++// compatibility case while still rejecting whitespace in the token itself.
++const RE_IDENT = /^SSH-(2\.0|1\.99)-([^ ]*)(?: (.*))?$/;
+ 
+ // TODO: optimize this by starting n bytes from the end of this._buffer instead
+ // of the beginning
 diff --git a/node_modules/ssh2/lib/protocol/SFTP.js b/node_modules/ssh2/lib/protocol/SFTP.js
 index 9f33c02..9751164 100644
 --- a/node_modules/ssh2/lib/protocol/SFTP.js


### PR DESCRIPTION
## Summary
- accept remote SSH banners like `SSH-2.0-` instead of failing during header parsing
- keep the validation narrow so malformed banners are still rejected
- add a regression test covering empty, normal, and malformed identification strings

## Root cause
Netcatty uses `ssh2` for SSH transport. Its header parser required the `softwareversion` token in the remote identification string to be non-empty, so servers that send `SSH-2.0-` failed immediately with `Invalid identification string` before authentication even started.

## Notes
This is a targeted compatibility exception for non-compliant servers.

- The SSH spec still defines `softwareversion` as non-empty: [RFC 4253 §4.2](https://www.rfc-editor.org/rfc/inline-errata/rfc4253.html#section-4.2)
- OpenSSH also rejects empty software versions in banner parsing: [openssh-portable `kex.c`](https://github.com/openssh/openssh-portable/blob/b433d015a6547598e568808d9cae16325bc8928f/kex.c)

So this patch only relaxes the empty-token case and keeps other malformed banners rejected.

Closes #730

## Validation
- `node --test /Users/chenqi/projects/personal/netcatty/electron/bridges/sshIdentificationCompatibility.test.cjs`
- `npm run build`