### PR TITLE
[codex] Preserve terminal focus when clicking the toolbar overlay

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -49,6 +49,7 @@ import { ZmodemProgressIndicator } from "./terminal/ZmodemProgressIndicator";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import { createTerminalSessionStarters, type PendingAuth } from "./terminal/runtime/createTerminalSessionStarters";
 import { createXTermRuntime, primaryFontFamily, type XTermRuntime } from "./terminal/runtime/createXTermRuntime";
+import { shouldPreserveTerminalFocusOnMouseDown } from "./terminal/toolbarFocus";
 import { preserveTerminalViewportInScrollback } from "./terminal/clearTerminalViewport";
 import { XTERM_PERFORMANCE_CONFIG } from "../infrastructure/config/xtermPerformance";
 import { useTerminalSearch } from "./terminal/hooks/useTerminalSearch";
@@ -618,6 +619,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     osc52ReadResolverRef.current = null;
     // Restore focus to terminal
     termRef.current?.focus();
+  }, []);
+
+  const handleTopOverlayMouseDownCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    if (!shouldPreserveTerminalFocusOnMouseDown(e.target)) return;
+    e.preventDefault();
   }, []);
 
   // Subscribe to custom theme changes so editing triggers re-render
@@ -1706,6 +1713,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         <div className="absolute left-0 right-0 top-0 z-20 pointer-events-none">
           <div
             className="flex items-center gap-1 px-2 py-0.5 backdrop-blur-md pointer-events-auto min-w-0"
+            onMouseDownCapture={handleTopOverlayMouseDownCapture}
             style={{
               backgroundColor: 'var(--terminal-ui-bg)',
               color: 'var(--terminal-ui-fg)',

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1261,6 +1261,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   // Close the entire side panel for the current tab
   const handleCloseSidePanel = useCallback(() => {
     if (!activeTabId) return;
+    const sessionIdToRefocus = activeWorkspace?.focusedSessionId ?? activeSession?.id;
     setSidePanelOpenTabs(prev => {
       const next = new Map(prev);
       next.delete(activeTabId);
@@ -1283,7 +1284,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.delete(activeTabId);
       return next;
     });
-  }, [activeTabId]);
+    refocusTerminalSession(sessionIdToRefocus);
+  }, [activeTabId, activeWorkspace?.focusedSessionId, activeSession?.id, refocusTerminalSession]);
 
   // Switch side panel to a specific tab (or toggle if already on that tab)
   const handleSwitchSidePanelTab = useCallback((tab: SidePanelTab) => {
@@ -1397,6 +1399,21 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
     textarea?.focus();
   }, [activeWorkspace?.focusedSessionId, activeSession?.id, terminalBackend]);
+
+  const refocusTerminalSession = useCallback((sessionId?: string | null) => {
+    if (!sessionId) return;
+
+    const focusTarget = () => {
+      const pane = document.querySelector(`[data-session-id="${sessionId}"]`);
+      const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
+      textarea?.focus();
+    };
+
+    requestAnimationFrame(() => {
+      focusTarget();
+      setTimeout(focusTarget, 50);
+    });
+  }, []);
 
   // Resolve theme change handler for the focused session
   const focusedHost = useMemo((): Host | null => {
@@ -2402,14 +2419,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
             onSend={handleComposeSend}
             onClose={() => {
               setIsComposeBarOpen(false);
-              // Refocus the terminal pane (matching solo-session behavior)
-              if (focusedSessionId) {
-                requestAnimationFrame(() => {
-                  const pane = document.querySelector(`[data-session-id="${focusedSessionId}"]`);
-                  const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
-                  textarea?.focus();
-                });
-              }
+              refocusTerminalSession(focusedSessionId);
             }}
             isBroadcastEnabled={isBroadcastEnabled?.(activeWorkspace.id)}
             themeColors={composeBarThemeColors}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1258,6 +1258,21 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
   }, [activeWorkspace?.focusedSessionId, activeSession?.id, terminalBackend]);
 
+  const refocusTerminalSession = useCallback((sessionId?: string | null) => {
+    if (!sessionId) return;
+
+    const focusTarget = () => {
+      const pane = document.querySelector(`[data-session-id="${sessionId}"]`);
+      const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
+      textarea?.focus();
+    };
+
+    requestAnimationFrame(() => {
+      focusTarget();
+      setTimeout(focusTarget, 50);
+    });
+  }, []);
+
   // Close the entire side panel for the current tab
   const handleCloseSidePanel = useCallback(() => {
     if (!activeTabId) return;
@@ -1399,21 +1414,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
     textarea?.focus();
   }, [activeWorkspace?.focusedSessionId, activeSession?.id, terminalBackend]);
-
-  const refocusTerminalSession = useCallback((sessionId?: string | null) => {
-    if (!sessionId) return;
-
-    const focusTarget = () => {
-      const pane = document.querySelector(`[data-session-id="${sessionId}"]`);
-      const textarea = pane?.querySelector('textarea.xterm-helper-textarea') as HTMLTextAreaElement | null;
-      textarea?.focus();
-    };
-
-    requestAnimationFrame(() => {
-      focusTarget();
-      setTimeout(focusTarget, 50);
-    });
-  }, []);
 
   // Resolve theme change handler for the focused session
   const focusedHost = useMemo((): Host | null => {

--- a/components/terminal/toolbarFocus.test.ts
+++ b/components/terminal/toolbarFocus.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldPreserveTerminalFocusOnMouseDown } from "./toolbarFocus.ts";
+
+test("preserves terminal focus for non-editable overlay clicks", () => {
+  const buttonLikeTarget = {
+    tagName: "button",
+    isContentEditable: false,
+    closest() {
+      return null;
+    },
+    getAttribute() {
+      return null;
+    },
+  };
+
+  assert.equal(shouldPreserveTerminalFocusOnMouseDown(buttonLikeTarget as unknown as EventTarget), true);
+});
+
+test("allows native focus for direct editable targets", () => {
+  const inputTarget = {
+    tagName: "input",
+    isContentEditable: false,
+    closest() {
+      return null;
+    },
+    getAttribute() {
+      return null;
+    },
+  };
+
+  assert.equal(shouldPreserveTerminalFocusOnMouseDown(inputTarget as unknown as EventTarget), false);
+});
+
+test("allows native focus for descendants inside editable controls", () => {
+  const nestedTarget = {
+    tagName: "span",
+    isContentEditable: false,
+    closest(selector: string) {
+      return selector.includes("input") ? { tagName: "INPUT" } : null;
+    },
+    getAttribute() {
+      return null;
+    },
+  };
+
+  assert.equal(shouldPreserveTerminalFocusOnMouseDown(nestedTarget as unknown as EventTarget), false);
+});
+
+test("allows native focus for contenteditable regions", () => {
+  const editableTarget = {
+    tagName: "div",
+    isContentEditable: false,
+    closest() {
+      return null;
+    },
+    getAttribute(name: string) {
+      return name === "contenteditable" ? "true" : null;
+    },
+  };
+
+  assert.equal(shouldPreserveTerminalFocusOnMouseDown(editableTarget as unknown as EventTarget), false);
+});

--- a/components/terminal/toolbarFocus.ts
+++ b/components/terminal/toolbarFocus.ts
@@ -1,0 +1,44 @@
+type FocusTargetLike = {
+  tagName?: string | null;
+  isContentEditable?: boolean;
+  closest?: (selector: string) => unknown;
+  getAttribute?: (name: string) => string | null;
+};
+
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable=""], [contenteditable="true"], [role="textbox"]';
+
+/**
+ * The terminal's top overlay sits above the xterm textarea. Pointer clicks on
+ * that layer should usually keep focus in the terminal so typing can continue.
+ * Only allow native focus changes for genuinely editable controls.
+ */
+export const shouldPreserveTerminalFocusOnMouseDown = (target: EventTarget | null): boolean => {
+  if (!target || typeof target !== "object") return true;
+
+  const candidate = target as FocusTargetLike;
+  const tagName = typeof candidate.tagName === "string"
+    ? candidate.tagName.toUpperCase()
+    : "";
+
+  if (tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT") {
+    return false;
+  }
+
+  if (candidate.isContentEditable) {
+    return false;
+  }
+
+  if (typeof candidate.getAttribute === "function") {
+    const contentEditable = candidate.getAttribute("contenteditable");
+    const role = candidate.getAttribute("role");
+    if (contentEditable === "" || contentEditable === "true" || role === "textbox") {
+      return false;
+    }
+  }
+
+  if (typeof candidate.closest === "function" && candidate.closest(EDITABLE_SELECTOR)) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary
- keep terminal input focus when clicking the top terminal overlay in non-editable areas
- still allow native focus changes for genuinely editable controls
- add a focused regression test for the overlay focus-preservation rule

## Root cause
The terminal status/toolbar overlay sits above the xterm textarea. Clicking buttons or stats in that overlay could move focus away from the terminal, which made the cursor stop blinking and caused keys like Space to stop reaching the SSH session even though the connection was still alive.

## Impact
After interacting with the top overlay, users can keep typing in the terminal without needing to manually refocus it.

Closes #729

## Validation
- `npx --yes tsx --test /Users/chenqi/projects/personal/netcatty/components/terminal/toolbarFocus.test.ts`
- `npm run build`