### PR TITLE
[codex] Ignore Hermes custom SSE progress events in AI stream bridge

### DIFF
--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -33,6 +33,7 @@ const {
   serializeStreamChunk,
   toUnpackedAsarPath,
 } = require("./ai/shellUtils.cjs");
+const { createFilteredSseForwarder } = require("./aiStreamSse.cjs");
 
 const {
   codexLoginSessions,
@@ -689,11 +690,18 @@ function streamRequest(url, options, event, requestId, skipTLS) {
         // Resolve with success status — data will flow via stream events
         resolve({ statusCode, statusText });
 
+        const sseForwarder = createFilteredSseForwarder((data) => {
+          safeSend(event.sender, "netcatty:ai:stream:data", {
+            requestId,
+            data,
+          });
+        });
         let buffer = "";
         const MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB safety limit
 
         res.on("data", (chunk) => {
-          buffer += chunk.toString();
+          const text = chunk.toString();
+          buffer += text;
           // Guard against unbounded buffer growth
           if (buffer.length > MAX_BUFFER_SIZE) {
             safeSend(event.sender, "netcatty:ai:stream:error", {
@@ -704,31 +712,12 @@ function streamRequest(url, options, event, requestId, skipTLS) {
             activeStreams.delete(requestId);
             return;
           }
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-
-            // Forward raw SSE data line to renderer
-            if (trimmed.startsWith("data: ")) {
-              safeSend(event.sender, "netcatty:ai:stream:data", {
-                requestId,
-                data: trimmed.slice(6),
-              });
-            }
-          }
+          sseForwarder.processChunk(text);
+          buffer = "";
         });
 
         res.on("end", () => {
-          // Flush any remaining buffer
-          if (buffer.trim().startsWith("data: ")) {
-            safeSend(event.sender, "netcatty:ai:stream:data", {
-              requestId,
-              data: buffer.trim().slice(6),
-            });
-          }
+          sseForwarder.flush();
           safeSend(event.sender, "netcatty:ai:stream:end", { requestId });
           activeStreams.delete(requestId);
         });

--- a/electron/bridges/aiStreamSse.cjs
+++ b/electron/bridges/aiStreamSse.cjs
@@ -1,0 +1,75 @@
+const DEFAULT_SSE_EVENT_NAME = "message";
+
+function shouldForwardSseEvent(eventName) {
+  return !eventName || eventName === DEFAULT_SSE_EVENT_NAME;
+}
+
+function dispatchPendingEvent(state, onData) {
+  if (state.dataLines.length === 0) {
+    state.eventName = DEFAULT_SSE_EVENT_NAME;
+    return;
+  }
+
+  if (shouldForwardSseEvent(state.eventName)) {
+    onData(state.dataLines.join("\n"));
+  }
+
+  state.dataLines = [];
+  state.eventName = DEFAULT_SSE_EVENT_NAME;
+}
+
+function processLine(state, rawLine, onData) {
+  const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+
+  if (line === "") {
+    dispatchPendingEvent(state, onData);
+    return;
+  }
+
+  if (line.startsWith(":")) {
+    return;
+  }
+
+  if (line.startsWith("event:")) {
+    state.eventName = line.slice(6).trimStart() || DEFAULT_SSE_EVENT_NAME;
+    return;
+  }
+
+  if (line.startsWith("data:")) {
+    const value = line.slice(5);
+    state.dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+  }
+}
+
+function createFilteredSseForwarder(onData) {
+  const state = {
+    buffer: "",
+    eventName: DEFAULT_SSE_EVENT_NAME,
+    dataLines: [],
+  };
+
+  return {
+    processChunk(chunk) {
+      state.buffer += chunk;
+      const lines = state.buffer.split("\n");
+      state.buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        processLine(state, line, onData);
+      }
+    },
+
+    flush() {
+      if (state.buffer) {
+        processLine(state, state.buffer, onData);
+        state.buffer = "";
+      }
+      dispatchPendingEvent(state, onData);
+    },
+  };
+}
+
+module.exports = {
+  createFilteredSseForwarder,
+  shouldForwardSseEvent,
+};

--- a/electron/bridges/aiStreamSse.test.cjs
+++ b/electron/bridges/aiStreamSse.test.cjs
@@ -1,0 +1,52 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createFilteredSseForwarder } = require("./aiStreamSse.cjs");
+
+test("forwards standard message events", () => {
+  const seen = [];
+  const forwarder = createFilteredSseForwarder((data) => {
+    seen.push(data);
+  });
+
+  forwarder.processChunk('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n');
+
+  assert.deepEqual(seen, ['{"choices":[{"delta":{"content":"hi"}}]}']);
+});
+
+test("ignores Hermes tool progress events", () => {
+  const seen = [];
+  const forwarder = createFilteredSseForwarder((data) => {
+    seen.push(data);
+  });
+
+  forwarder.processChunk("event: hermes.tool.progress\n");
+  forwarder.processChunk('data: {"tool":"terminal","emoji":"💻","label":"ls -la /root"}\n\n');
+  forwarder.processChunk('data: {"choices":[{"delta":{"content":"done"}}]}\n\n');
+
+  assert.deepEqual(seen, ['{"choices":[{"delta":{"content":"done"}}]}']);
+});
+
+test("joins multi-line data payloads for forwarded events", () => {
+  const seen = [];
+  const forwarder = createFilteredSseForwarder((data) => {
+    seen.push(data);
+  });
+
+  forwarder.processChunk("data: first line\n");
+  forwarder.processChunk("data: second line\n\n");
+
+  assert.deepEqual(seen, ["first line\nsecond line"]);
+});
+
+test("flushes trailing message events on stream end", () => {
+  const seen = [];
+  const forwarder = createFilteredSseForwarder((data) => {
+    seen.push(data);
+  });
+
+  forwarder.processChunk('data: {"choices":[{"delta":{"content":"tail"}}]}');
+  forwarder.flush();
+
+  assert.deepEqual(seen, ['{"choices":[{"delta":{"content":"tail"}}]}']);
+});


### PR DESCRIPTION
## Summary
- filter non-standard SSE event types out of the AI stream bridge before they reach OpenAI chat chunk parsing
- keep forwarding normal `message` events unchanged
- add a focused regression test for Hermes-style `hermes.tool.progress` events

## Root cause
Hermes emits custom SSE events such as `hermes.tool.progress` during chat streaming. Netcatty's bridge dropped the `event:` metadata and forwarded only raw `data:` payloads, so those Hermes progress payloads were misinterpreted as normal OpenAI chat chunks. The downstream parser then failed because the payload had neither `choices` nor `error`.

## Impact
Hermes-style tool progress payloads no longer break terminal tool calls, while standard OpenAI-compatible streaming remains unchanged.

Closes #727

## Validation
- `node --test /Users/chenqi/projects/personal/netcatty/electron/bridges/aiStreamSse.test.cjs`
- `npm run build`