### PR TITLE
Let single Tab fall through to shell when only ghost text is shown

### DIFF
--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -690,7 +690,9 @@ export function useTerminalAutocomplete(
         }
       }
 
-      // Tab: accept selected popup suggestion, or accept ghost text
+      // Tab: accept selected popup suggestion. Ghost text is accepted via → only —
+      // letting Tab pass through lets the shell's native completion (bash/zsh) run,
+      // which is otherwise shadowed by our single-Tab ghost accept.
       if (e.key === "Tab" && !e.ctrlKey && !e.metaKey && !e.altKey && s.subDirFocusLevel < 0) {
         if (s.popupVisible && s.suggestions.length > 0) {
           e.preventDefault();
@@ -698,16 +700,10 @@ export function useTerminalAutocomplete(
           if (selected) insertSuggestion(selected, false);
           return false;
         }
+        // Hide stale ghost text before Tab reaches the shell — the shell's
+        // completion will rewrite the line and the old ghost would mislead.
         if (ghost?.isVisible()) {
-          e.preventDefault();
-          const ghostText = ghost.getGhostText();
-          if (ghostText) {
-            writeToTerminal(ghostText);
-            lastAcceptedCommandRef.current = ghost.getSuggestion();
-            ghost.hide();
-            clearState();
-          }
-          return false;
+          ghost.hide();
         }
       }
 


### PR DESCRIPTION
## Summary
- Fixes #741 — on Linux/bash (and zsh), single-Tab was being consumed by our inline-suggestion acceptance before it could reach the PTY, shadowing the shell's native completion.
- After this change, Tab only accepts a suggestion when the popup menu is visible. In ghost-text-only mode, Tab falls through to the shell and the ghost is hidden (so stale text doesn't linger once the shell rewrites the line).
- Accepting ghost text with → is unchanged.

## Why this approach
- Popup menu is an explicit UI — Tab there is an obvious, intentional accept (IDE-style), so it stays.
- Ghost text is passive and easily misread as bash's own hint; intercepting Tab there is the actual source of the reported conflict.
- A double-Tab scheme was considered but rejected: the first Tab would still be swallowed, so bash never sees it and the conflict isn't really fixed.

## Test plan
- [x] Linux bash session: type `system` → ghost text shows `systemctl status firewalld`; press Tab → bash completes `systemctl ` (shell completion runs, ghost disappears).
- [x] Press → on the same ghost text → still accepts the full suggestion.
- [x] Enable popup menu in settings: Tab still inserts the highlighted suggestion.
- [x] Windows PowerShell/cmd session: Tab behavior unchanged (no ghost, no regression).
- [x] Sub-directory panel navigation (focus level ≥ 0): Tab still selects the sub-dir entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)