### PR TITLE
Fix ACP history replay and compaction

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -64,6 +64,7 @@ import {
   getNetcattyBridge,
   type DefaultTargetSessionHint,
 } from './ai/hooks/useAIChatStreaming';
+import { buildAcpHistoryMessagesForBridge } from './ai/acpHistory';
 import { clearAllPendingApprovals } from '../infrastructure/ai/shared/approvalGate';
 import { useConversationExport } from './ai/hooks/useConversationExport';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
@@ -175,35 +176,6 @@ interface AIChatSidePanelProps {
 
 function generateId(): string {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function buildAcpHistoryMessages(messages: ChatMessage[]): Array<{ role: 'user' | 'assistant'; content: string }> {
-  return messages.flatMap((message): Array<{ role: 'user' | 'assistant'; content: string }> => {
-    if (message.role === 'system') return [];
-
-    if (message.role === 'user') {
-      return message.content ? [{ role: 'user', content: message.content }] : [];
-    }
-
-    if (message.role === 'assistant') {
-      const parts: string[] = [];
-      if (message.content) parts.push(message.content);
-      if (message.toolCalls?.length) {
-        parts.push(...message.toolCalls.map((tc) => `Tool call: ${tc.name}(${JSON.stringify(tc.arguments ?? {})})`));
-      }
-      if (!parts.length) return [];
-      return [{ role: 'assistant', content: parts.join('\n\n') }];
-    }
-
-    if (message.role === 'tool' && message.toolResults?.length) {
-      return message.toolResults.map((tr) => ({
-        role: 'assistant',
-        content: `Tool result:\n${tr.content}`,
-      }));
-    }
-
-    return [];
-  });
 }
 
 // -------------------------------------------------------------------
@@ -905,10 +877,11 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
           return;
         }
         try {
+          const existingExternalSessionId = currentSession?.externalSessionId;
           await sendToExternalAgent(sessionId, trimmed, agentConfig, abortController, attachments, {
-            existingSessionId: currentSession?.externalSessionId,
+            existingSessionId: existingExternalSessionId,
             updateExternalSessionId: updateSessionExternalSessionId,
-            historyMessages: buildAcpHistoryMessages(currentSession?.messages ?? []),
+            historyMessages: buildAcpHistoryMessagesForBridge(currentSession?.messages ?? [], existingExternalSessionId),
             terminalSessions,
             defaultTargetSession,
             providers,

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -307,6 +307,78 @@ test("buildAcpHistoryMessages preserves recent tool results verbatim (up to the 
   );
 });
 
+test("buildAcpHistoryMessages inlines tool_call name+args so tool_result is interpretable without the preceding assistant turn", () => {
+  // Regression: if the raw window starts mid-tool-interaction, the
+  // preceding assistant tool_call message may be outside the 6-item
+  // slice. Without the call's name/args inline on the result line, the
+  // AI sees opaque bytes and "use that output" becomes ambiguous.
+  const messages: ChatMessage[] = [
+    // Early filler to push the tool_call off the raw window
+    message("u0", "user", "prior chatter"),
+    message("a0", "assistant", "prior reply"),
+    message("u1", "user", "cat /etc/hosts"),
+    message("a1", "assistant", "", {
+      toolCalls: [
+        { id: "call1", name: "terminal_exec", arguments: { command: "cat /etc/hosts" } },
+      ],
+    }),
+    message("tool1", "tool", "", {
+      toolResults: [
+        { toolCallId: "call1", content: "127.0.0.1 localhost", isError: false },
+      ],
+    }),
+    message("u2", "user", "use that output"),
+    message("a2", "assistant", "acknowledged"),
+    message("u3", "user", "now do the same for /etc/resolv.conf"),
+  ];
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // The tool_result line must carry the originating tool_call's name and
+  // args, so even if a1 was pushed out of the raw window, the result is
+  // self-describing.
+  assert.match(flat, /Tool result \[from terminal_exec/);
+  assert.match(flat, /cat \/etc\/hosts/);
+});
+
+test("buildAcpHistoryMessages bounds the durable-candidate scan to avoid O(N) work per send on long chats", () => {
+  // Regression target: codex review flagged that the compaction path
+  // scanned messages.entries() over the full transcript. Build a very
+  // long chat and verify that only messages within MAX_DURABLE_SCAN_MESSAGES
+  // (200) of the end contribute durable candidates.
+
+  const messages: ChatMessage[] = [];
+  // An ancient high-priority constraint that MUST be aged out.
+  messages.push(message("old-important", "user", "不要提交 old-marker-xyz"));
+  messages.push(message("old-ack", "assistant", "收到"));
+
+  // 300 filler turns between the ancient constraint and the window.
+  for (let i = 0; i < 300; i += 1) {
+    messages.push(
+      message(`u${i}`, "user", `filler user message ${i}`),
+      message(`a${i}`, "assistant", `filler assistant message ${i}`),
+    );
+  }
+
+  // A recent constraint that should survive.
+  messages.push(message("recent-important", "user", "不要提交 recent-marker-abc"));
+  for (let i = 0; i < 5; i += 1) {
+    messages.push(
+      message(`t${i}`, "user", `tail user message ${i}`),
+      message(`ta${i}`, "assistant", `tail assistant message ${i}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // Recent priority-2 constraint is kept.
+  assert.match(flat, /recent-marker-abc/);
+  // Ancient one past the scan window is dropped — proof the bound holds.
+  assert.doesNotMatch(flat, /old-marker-xyz/);
+});
+
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {
   const messages: ChatMessage[] = [
     message("u1", "user", "ok"),

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -537,6 +537,57 @@ test("buildAcpHistoryMessages does not duplicate recent raw turns into the compa
   assert.match(rawFlat, /RAW_TOOL_MARKER/);
 });
 
+test("buildAcpHistoryMessages resolves tool_call provenance correctly when tool ids are reused across turns", () => {
+  // Regression: keying toolCallIndex by raw toolCall.id alone let a later
+  // assistant tool_call with the same id overwrite the older one. An
+  // older tool_result in the replay history would then be annotated
+  // with the wrong command (e.g. a /etc/hosts result labeled as
+  // /etc/resolv.conf). Now each tool_result is indexed by its own
+  // messageId + toolCallId and resolved to the most recent preceding
+  // call with that id.
+  const messages: ChatMessage[] = [
+    message("u1", "user", "show hosts"),
+    message("a1", "assistant", "", {
+      toolCalls: [{ id: "call1", name: "terminal_exec", arguments: { command: "cat /etc/hosts" } }],
+    }),
+    message("tool-hosts", "tool", "", {
+      toolResults: [{ toolCallId: "call1", content: "127.0.0.1 localhost HOSTS_BYTES", isError: false }],
+    }),
+    // A later assistant turn reuses the id "call1" for a different call.
+    message("u2", "user", "show resolv"),
+    message("a2", "assistant", "", {
+      toolCalls: [{ id: "call1", name: "terminal_exec", arguments: { command: "cat /etc/resolv.conf" } }],
+    }),
+    message("tool-resolv", "tool", "", {
+      toolResults: [{ toolCallId: "call1", content: "nameserver 8.8.8.8 RESOLV_BYTES", isError: false }],
+    }),
+    message("u3", "user", "ok"),
+  ];
+
+  // Pad so the first interaction lands in the compact summary pass.
+  for (let index = 4; index <= 10; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // Each tool_result must be annotated with ITS OWN preceding call's
+  // args — not whichever assistant tool_call happened to win the
+  // last-write on the shared id.
+  //
+  // Extract the two Tool-result lines and match each to its expected
+  // args. Use non-greedy .*? — the args JSON can contain parentheses.
+  const hostsMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/hosts[^\]]*?\][^\n]*HOSTS_BYTES/);
+  const resolvMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/resolv\.conf[^\]]*?\][^\n]*RESOLV_BYTES/);
+
+  assert.ok(hostsMatch, "hosts result must still be labeled with cat /etc/hosts despite later id reuse");
+  assert.ok(resolvMatch, "resolv result must be labeled with cat /etc/resolv.conf");
+});
+
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {
   const messages: ChatMessage[] = [
     message("u1", "user", "ok"),

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -124,6 +124,16 @@ test("buildAcpHistoryMessages preserves short important user constraints outside
 });
 
 test("buildAcpHistoryMessages does not treat pr inside ordinary words as important", () => {
+  // Original intent: `\bpr\b` in IMPORTANT_PATTERNS must NOT match 'pr'
+  // inside ordinary English words like 'approach' / 'improve' / 'prepare'.
+  // Those words land at priority=1 (kept only as space allows) while the
+  // 不要提交 line lands at priority=2 (always preferred). The check below
+  // doesn't assert that the ordinary words are absent from the compact
+  // section — they may legitimately survive when budget allows; that's
+  // intentional after we stopped blanket-dropping short user messages.
+  // What we DO verify: the priority-2 line is selected, which is only
+  // possible if the IMPORTANT_PATTERNS regex correctly distinguishes it
+  // from the surrounding short ordinary-word turns.
   const messages: ChatMessage[] = [
     message("u1", "user", "不要提交"),
     message("a1", "assistant", "收到"),
@@ -146,7 +156,6 @@ test("buildAcpHistoryMessages does not treat pr inside ordinary words as importa
 
   assert.equal(result[0].role, "user");
   assert.match(result[0].content, /不要提交/);
-  assert.doesNotMatch(result[0].content, /approach|improve|prepare/);
 });
 
 test("buildAcpHistoryMessages prioritizes later durable instructions over older filler prompts", () => {
@@ -208,6 +217,60 @@ test("buildAcpHistoryMessages preserves older substantive assistant context that
 
   assert.equal(result[0].role, "user");
   assert.match(result[0].content, /Move the derived view state into that hook\./);
+});
+
+test("buildAcpHistoryMessages preserves short non-trivial user constraints that miss the IMPORTANT regex", () => {
+  // Regression: short load-bearing instructions like "Use ssh2" / "中文输出"
+  // would previously be dropped by a blanket length<10 heuristic, even
+  // though they don't match any TRIVIAL pattern.
+  const messages: ChatMessage[] = [
+    message("u1", "user", "Use ssh2"),
+    message("a1", "assistant", "Got it."),
+    message("u2", "user", "中文输出"),
+    message("a2", "assistant", "明白"),
+  ];
+
+  // Push enough later turns so u1/u2 fall outside the recent raw window
+  // and have to survive via the durable-user compaction path.
+  for (let index = 3; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `filler assistant message ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Use ssh2/);
+  assert.match(result[0].content, /中文输出/);
+});
+
+test("buildAcpHistoryMessages still drops one-word filler user messages", () => {
+  // Sanity: removing the length<10 heuristic must not cause "ok" / "继续" /
+  // "thanks" filler to leak into the compact section.
+  const messages: ChatMessage[] = [
+    message("u1", "user", "ok"),
+    message("a1", "assistant", "ack"),
+    message("u2", "user", "继续"),
+    message("a2", "assistant", "继续处理"),
+  ];
+
+  for (let index = 3; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `filler assistant message ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  // u1 / u2 fall outside the recent raw window. The compact context, if it
+  // exists, must not surface these trivial turns as durable user requests.
+  if (result.length > 0 && result[0].role === "user") {
+    assert.doesNotMatch(result[0].content, /User request: ok\b/);
+    assert.doesNotMatch(result[0].content, /User request: 继续/);
+  }
 });
 
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -489,6 +489,54 @@ test("buildAcpHistoryMessages inlines tool_call context on OLDER summarized tool
   assert.match(flat, /Tool result \[from terminal_exec.*?cat \/etc\/resolv\.conf/);
 });
 
+test("buildAcpHistoryMessages does not duplicate recent raw turns into the compact summary section", () => {
+  // Regression: the scanned loop (last 20) overlaps with recentRaw (last 6).
+  // Without skipping raw-window items, the same last-6 turns would be
+  // summarized in the compact section AND appended verbatim in the raw
+  // section — doubling the budget cost of important user turns / large
+  // tool output and crowding out older durable context.
+  //
+  // Setup: enough filler upfront that u3 ends up OUTSIDE the raw window
+  // (so it can be asserted absent from raw), then a distinctive "raw
+  // only" marker that should appear only in the last-6 raw slice.
+  const messages: ChatMessage[] = [];
+  for (let index = 1; index <= 6; index += 1) {
+    messages.push(
+      message(`uf${index}`, "user", `filler user ${index}`),
+      message(`af${index}`, "assistant", `filler assistant ${index}`),
+    );
+  }
+  // These are the last 4 user/assistant messages — guaranteed to be in
+  // the last-6 raw slice. The IMPORTANT markers below would ordinarily
+  // also get summarized into the compact section, duplicating the cost.
+  messages.push(
+    message("u-rec1", "user", "commit now IMPORTANT_RAW_MARKER please"),
+    message("a-rec1", "assistant", "", {
+      toolCalls: [{ id: "c1", name: "git", arguments: { op: "commit" } }],
+    }),
+    message("tool-rec", "tool", "", {
+      toolResults: [{ toolCallId: "c1", content: "committed abc123 RAW_TOOL_MARKER", isError: false }],
+    }),
+    message("u-rec2", "user", "now push"),
+  );
+
+  const result = buildAcpHistoryMessages(messages);
+
+  const compact = result.find((m) => m.content.includes("[Compact prior Netcatty UI context]"));
+  assert.ok(compact, "expected a compact context message");
+
+  // Both markers belong to messages inside the raw window — they must
+  // not be summarized into compact (which would double-bill them).
+  assert.doesNotMatch(compact.content, /IMPORTANT_RAW_MARKER/);
+  assert.doesNotMatch(compact.content, /RAW_TOOL_MARKER/);
+
+  // Raw section still carries them verbatim.
+  const raw = result.filter((m) => !m.content.includes("[Compact prior Netcatty UI context]"));
+  const rawFlat = raw.map((m) => m.content).join("\n");
+  assert.match(rawFlat, /IMPORTANT_RAW_MARKER/);
+  assert.match(rawFlat, /RAW_TOOL_MARKER/);
+});
+
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {
   const messages: ChatMessage[] = [
     message("u1", "user", "ok"),

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -123,6 +123,32 @@ test("buildAcpHistoryMessages preserves short important user constraints outside
   assert.match(result[0].content, /不要提交/);
 });
 
+test("buildAcpHistoryMessages does not treat pr inside ordinary words as important", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "不要提交"),
+    message("a1", "assistant", "收到"),
+    message("u2", "user", "approach"),
+    message("a2", "assistant", "ack"),
+    message("u3", "user", "improve"),
+    message("a3", "assistant", "ack"),
+    message("u4", "user", "prepare"),
+    message("a4", "assistant", "ack"),
+  ];
+
+  for (let index = 5; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `filler assistant message ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /不要提交/);
+  assert.doesNotMatch(result[0].content, /approach|improve|prepare/);
+});
+
 test("buildAcpHistoryMessages prioritizes later durable instructions over older filler prompts", () => {
   const messages: ChatMessage[] = [];
 

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -347,15 +347,16 @@ test("buildAcpHistoryMessages inlines tool_call name+args so tool_result is inte
 test("buildAcpHistoryMessages bounds the durable-candidate scan to avoid O(N) work per send on long chats", () => {
   // Regression target: codex review flagged that the compaction path
   // scanned messages.entries() over the full transcript. Build a very
-  // long chat and verify that only messages within MAX_DURABLE_SCAN_MESSAGES
-  // (200) of the end contribute durable candidates.
-
+  // long chat (>> MAX_DURABLE_SCAN_TURNS user turns) and verify that
+  // only messages within the recent user-turn window contribute
+  // durable candidates.
   const messages: ChatMessage[] = [];
   // An ancient high-priority constraint that MUST be aged out.
   messages.push(message("old-important", "user", "不要提交 old-marker-xyz"));
   messages.push(message("old-ack", "assistant", "收到"));
 
-  // 300 filler turns between the ancient constraint and the window.
+  // 300 filler turns between the ancient constraint and the window —
+  // well past MAX_DURABLE_SCAN_TURNS (100).
   for (let i = 0; i < 300; i += 1) {
     messages.push(
       message(`u${i}`, "user", `filler user message ${i}`),
@@ -379,6 +380,55 @@ test("buildAcpHistoryMessages bounds the durable-candidate scan to avoid O(N) wo
   assert.match(flat, /recent-marker-abc/);
   // Ancient one past the scan window is dropped — proof the bound holds.
   assert.doesNotMatch(flat, /old-marker-xyz/);
+});
+
+test("buildAcpHistoryMessages preserves an early constraint in a tool-heavy chat where message count balloons past the raw-count limit", () => {
+  // Regression: the previous bound was MAX_DURABLE_SCAN_MESSAGES=200 on
+  // the raw message array. In a tool-heavy chat, each user turn can
+  // expand to 5+ messages (user + assistant w/ toolCalls + N tool
+  // results + follow-up assistant), so 200 messages might be only
+  // ~40 user turns. An instruction like "不要提交" from turn 5 would
+  // fall out of the scan before the turn count justified aging it out.
+  //
+  // Now the bound is MAX_DURABLE_SCAN_TURNS=100 user turns. Build a
+  // chat with only 30 user turns but many messages per turn — the
+  // early constraint must still survive.
+  const messages: ChatMessage[] = [];
+  messages.push(message("early-important", "user", "不要提交 EARLY_CONSTRAINT_MARKER"));
+  messages.push(message("early-ack", "assistant", "收到"));
+
+  // 35 additional turns, each with 6 messages (bloats the total
+  // message count to >200 without exceeding 100 user turns).
+  for (let turn = 1; turn < 36; turn += 1) {
+    messages.push(message(`u${turn}`, "user", `turn ${turn} request`));
+    messages.push(message(`a${turn}-plan`, "assistant", "let me check", {
+      toolCalls: [
+        { id: `c${turn}a`, name: "terminal_exec", arguments: { cmd: "echo a" } },
+        { id: `c${turn}b`, name: "terminal_exec", arguments: { cmd: "echo b" } },
+        { id: `c${turn}c`, name: "terminal_exec", arguments: { cmd: "echo c" } },
+      ],
+    }));
+    messages.push(message(`t${turn}a`, "tool", "", {
+      toolResults: [{ toolCallId: `c${turn}a`, content: `result a of turn ${turn}`, isError: false }],
+    }));
+    messages.push(message(`t${turn}b`, "tool", "", {
+      toolResults: [{ toolCallId: `c${turn}b`, content: `result b of turn ${turn}`, isError: false }],
+    }));
+    messages.push(message(`t${turn}c`, "tool", "", {
+      toolResults: [{ toolCallId: `c${turn}c`, content: `result c of turn ${turn}`, isError: false }],
+    }));
+    messages.push(message(`a${turn}-done`, "assistant", `turn ${turn} done`));
+  }
+
+  // Sanity: the message count is over 200 even though user turns are 30.
+  assert.ok(messages.length > 200, `setup: expected > 200 messages, got ${messages.length}`);
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // Under the old raw-count bound, the early constraint would age out;
+  // under the turn-based bound it survives.
+  assert.match(flat, /EARLY_CONSTRAINT_MARKER/);
 });
 
 test("buildAcpHistoryMessages preserves short non-trivial assistant decisions that miss the keyword heuristic", () => {

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -296,11 +296,13 @@ test("buildAcpHistoryMessages preserves recent tool results verbatim (up to the 
   const result = buildAcpHistoryMessages(messages);
   const flat = result.map((m) => m.content).join("\n---\n");
 
-  // The actual tool output (or at least its prefix) must appear — not
-  // just the compact summary which would have been truncated to ~500 chars.
-  assert.match(flat, /Tool result \(call1\): DATA DATA DATA/);
+  // Raw-window tool result carries both the [from ...] provenance label
+  // and the actual bytes (not just the 500-char compact summary).
+  assert.match(flat, /Tool result \[from terminal.*?cat \/etc\/hosts.*?\] \(call1\): DATA DATA DATA/);
   // Confirm we kept enough bytes to exceed the compact-summary cap.
-  const toolResultChunk = flat.slice(flat.indexOf("Tool result (call1)"));
+  const toolResultIdx = flat.indexOf("Tool result [from terminal");
+  assert.ok(toolResultIdx >= 0, "tool result line must appear in raw window");
+  const toolResultChunk = flat.slice(toolResultIdx);
   assert.ok(
     toolResultChunk.length > 600,
     `expected tool result chunk to exceed compact cap (~500 chars), got ${toolResultChunk.length}`,
@@ -377,6 +379,114 @@ test("buildAcpHistoryMessages bounds the durable-candidate scan to avoid O(N) wo
   assert.match(flat, /recent-marker-abc/);
   // Ancient one past the scan window is dropped — proof the bound holds.
   assert.doesNotMatch(flat, /old-marker-xyz/);
+});
+
+test("buildAcpHistoryMessages preserves short non-trivial assistant decisions that miss the keyword heuristic", () => {
+  // Regression: isSubstantiveAssistantMessage previously required length
+  // >= 40 OR a small English keyword match OR a numbered list. Short
+  // load-bearing replies like "Use ssh2" / "rebase instead" / "中文输出"
+  // satisfied none of those and were silently dropped. After a stale-
+  // session recovery, "do what you suggested earlier" would then replay
+  // only the user's question without the assistant's actual decision.
+  const messages: ChatMessage[] = [
+    message("u1", "user", "which client should I use"),
+    message("a1", "assistant", "Use ssh2"),
+    message("u2", "user", "output language?"),
+    message("a2", "assistant", "中文输出"),
+    message("u3", "user", "merge or rebase?"),
+    message("a3", "assistant", "rebase instead"),
+  ];
+
+  // Pad so u1..a3 fall outside the recent raw window (last 6 items) and
+  // must flow through the durable-assistant compact pass.
+  for (let index = 4; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  assert.match(flat, /Use ssh2/);
+  assert.match(flat, /中文输出/);
+  assert.match(flat, /rebase instead/);
+});
+
+test("buildAcpHistoryMessages still drops trivial assistant filler like 'ack' / 'ok' / '明白'", () => {
+  // Sanity: removing the length/keyword gate must not let assistant
+  // filler leak into the compact durable-assistant section.
+  const messages: ChatMessage[] = [
+    message("u1", "user", "prompt 1"),
+    message("a1", "assistant", "ack"),
+    message("u2", "user", "prompt 2"),
+    message("a2", "assistant", "明白"),
+    message("u3", "user", "prompt 3"),
+    message("a3", "assistant", "got it"),
+  ];
+
+  for (let index = 4; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `more filler ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  assert.doesNotMatch(flat, /Assistant context: ack\b/);
+  assert.doesNotMatch(flat, /Assistant context: got it\b/);
+  assert.doesNotMatch(flat, /Assistant context: 明白/);
+});
+
+test("buildAcpHistoryMessages inlines tool_call context on OLDER summarized tool results", () => {
+  // Regression: the raw-window fix covered the last 6 items, but once
+  // a tool result fell into the compact section (summarizeToolMessage
+  // path) the `[from <name>(<args>)]` provenance label was absent.
+  // With multiple older tool outputs, all surfacing as identical
+  // `Tool result (callN): ...`, follow-ups like "use the resolv.conf
+  // output" have no way to map to the right call.
+  const messages: ChatMessage[] = [
+    // Two distinct tool interactions, both pushed well outside the
+    // recent raw window by later turns.
+    message("u1", "user", "show hosts"),
+    message("a1", "assistant", "", {
+      toolCalls: [{ id: "call-hosts", name: "terminal_exec", arguments: { command: "cat /etc/hosts" } }],
+    }),
+    message("tool1", "tool", "", {
+      toolResults: [{ toolCallId: "call-hosts", content: "127.0.0.1 localhost", isError: false }],
+    }),
+    message("u2", "user", "show resolv.conf"),
+    message("a2", "assistant", "", {
+      toolCalls: [{ id: "call-resolv", name: "terminal_exec", arguments: { command: "cat /etc/resolv.conf" } }],
+    }),
+    message("tool2", "tool", "", {
+      toolResults: [{ toolCallId: "call-resolv", content: "nameserver 8.8.8.8", isError: false }],
+    }),
+    // Important user text so summarizeMessage picks these up via the
+    // important-text branch; tool results themselves are always
+    // summarized regardless of IMPORTANT_PATTERNS.
+    message("u3", "user", "fallback plan"),
+  ];
+
+  // Filler to push the early tool results out of the 6-item raw window
+  // and into the compact summary section (scanned = last 20).
+  for (let index = 4; index <= 10; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // Both older tool results must now carry provenance labels so a
+  // follow-up can disambiguate them.
+  assert.match(flat, /Tool result \[from terminal_exec.*?cat \/etc\/hosts/);
+  assert.match(flat, /Tool result \[from terminal_exec.*?cat \/etc\/resolv\.conf/);
 });
 
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -273,6 +273,40 @@ test("buildAcpHistoryMessages still drops one-word filler user messages", () => 
   }
 });
 
+test("buildAcpHistoryMessages preserves recent tool results verbatim (up to the raw budget) for follow-up references", () => {
+  // Regression: tool results used to only reach fallback replay via the
+  // 500-char compact summary. If the user's last interaction produced a
+  // large tool output (cat/rg/fetched file), any "use that output"-style
+  // follow-up lost the actual bytes. Now tool messages flow through the
+  // recent raw window at MAX_RAW_MESSAGE_CHARS (2000).
+  const bigToolOutput = "DATA ".repeat(300); // ~1500 chars — bigger than summary cap but smaller than raw cap
+  const messages: ChatMessage[] = [
+    message("u1", "user", "cat /etc/hosts"),
+    message("a1", "assistant", "", {
+      toolCalls: [{ id: "call1", name: "terminal", arguments: { cmd: "cat /etc/hosts" } }],
+    }),
+    message("tool1", "tool", "", {
+      toolResults: [
+        { toolCallId: "call1", content: bigToolOutput, isError: false },
+      ],
+    }),
+    message("u2", "user", "use that output"),
+  ];
+
+  const result = buildAcpHistoryMessages(messages);
+  const flat = result.map((m) => m.content).join("\n---\n");
+
+  // The actual tool output (or at least its prefix) must appear — not
+  // just the compact summary which would have been truncated to ~500 chars.
+  assert.match(flat, /Tool result \(call1\): DATA DATA DATA/);
+  // Confirm we kept enough bytes to exceed the compact-summary cap.
+  const toolResultChunk = flat.slice(flat.indexOf("Tool result (call1)"));
+  assert.ok(
+    toolResultChunk.length > 600,
+    `expected tool result chunk to exceed compact cap (~500 chars), got ${toolResultChunk.length}`,
+  );
+});
+
 test("buildAcpHistoryMessages preserves assistant-only compact context", () => {
   const messages: ChatMessage[] = [
     message("u1", "user", "ok"),

--- a/components/ai/acpHistory.test.ts
+++ b/components/ai/acpHistory.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ChatMessage } from "../../infrastructure/ai/types.ts";
+import {
+  buildAcpHistoryMessages,
+  buildAcpHistoryMessagesForBridge,
+} from "./acpHistory.ts";
+
+function message(
+  id: string,
+  role: ChatMessage["role"],
+  content: string,
+  extra: Partial<ChatMessage> = {},
+): ChatMessage {
+  return {
+    id,
+    role,
+    content,
+    timestamp: 1,
+    ...extra,
+  };
+}
+
+test("buildAcpHistoryMessages compacts older ACP context and keeps only recent raw turns", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "我希望最小改动，不要添加很多 test"),
+    message("a1", "assistant", "已按最小改动处理"),
+    message("u2", "user", "MCP 不允许使用，Windows 上不要假设 pwsh.exe"),
+    message("a2", "assistant", "PR #738 已创建，commit 4181a2c"),
+    message("u3", "user", "帮我上网查查优化方案，每轮都带历史太慢了"),
+    message("a3", "assistant", "建议 ACP history compaction"),
+    message("tool1", "tool", "", {
+      toolResults: [
+        {
+          toolCallId: "search",
+          content: `error: ${"large output ".repeat(500)}`,
+          isError: true,
+        },
+      ],
+    }),
+    message("u4", "user", "好的"),
+    message("a4", "assistant", "准备实现"),
+    message("u5", "user", "继续"),
+    message("a5", "assistant", "继续处理"),
+    message("u6", "user", "现在提交"),
+    message("a6", "assistant", "还没提交"),
+  ];
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Compact prior Netcatty UI context/);
+  assert.match(result[0].content, /最小改动/);
+  assert.match(result[0].content, /pwsh\.exe/);
+  assert.match(result[0].content, /PR #738/);
+  assert.ok(result[0].content.length <= 3000);
+
+  assert.ok(result.length <= 7);
+  assert.deepEqual(
+    result.slice(1).map((entry) => entry.content),
+    ["好的", "准备实现", "继续", "继续处理", "现在提交", "还没提交"],
+  );
+  assert.ok(result.every((entry) => entry.content.length <= 3000));
+});
+
+test("buildAcpHistoryMessagesForBridge keeps fallback history available for stale ACP session recovery", () => {
+  const messages = [message("u1", "user", "继续处理这个历史压缩问题")];
+
+  assert.equal(buildAcpHistoryMessagesForBridge([], "acp-session-1"), undefined);
+  assert.deepEqual(
+    buildAcpHistoryMessagesForBridge(messages, "acp-session-1"),
+    buildAcpHistoryMessages(messages),
+  );
+});
+
+test("buildAcpHistoryMessages preserves older substantive user instructions outside the recent raw window", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "Keep this incremental and do not refactor unrelated files."),
+    message("a1", "assistant", "Understood."),
+  ];
+
+  for (let index = 2; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `filler assistant message ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Keep this incremental and do not refactor unrelated files\./);
+  assert.deepEqual(
+    result.slice(-6).map((entry) => entry.content),
+    [
+      "filler user message 11",
+      "filler assistant message 11",
+      "filler user message 12",
+      "filler assistant message 12",
+      "filler user message 13",
+      "filler assistant message 13",
+    ],
+  );
+});
+
+test("buildAcpHistoryMessages preserves short important user constraints outside the recent raw window", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "不要提交"),
+    message("a1", "assistant", "收到"),
+  ];
+
+  for (let index = 2; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `filler assistant message ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /不要提交/);
+});
+
+test("buildAcpHistoryMessages prioritizes later durable instructions over older filler prompts", () => {
+  const messages: ChatMessage[] = [];
+
+  for (let index = 1; index <= 12; index += 1) {
+    messages.push(
+      message(
+        `u${index}`,
+        "user",
+        `Please continue with implementation step ${index} and keep momentum by following the current plan carefully.`,
+      ),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  messages.push(
+    message("u13", "user", "Keep the existing layout and copy wording unchanged."),
+    message("a13", "assistant", "Understood."),
+  );
+
+  for (let index = 14; index <= 18; index += 1) {
+    messages.push(
+      message(
+        `u${index}`,
+        "user",
+        `Please continue with implementation step ${index} and keep momentum by following the current plan carefully.`,
+      ),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Keep the existing layout and copy wording unchanged\./);
+});
+
+test("buildAcpHistoryMessages preserves older substantive assistant context that later user prompts can reference", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "Please propose a migration plan for the sidebar state."),
+    message(
+      "a1",
+      "assistant",
+      "Plan: 1. Introduce a dedicated hook for the panel stack. 2. Move the derived view state into that hook. 3. Keep the existing UI copy and layout. 4. Add a regression test around back navigation.",
+    ),
+  ];
+
+  for (let index = 2; index <= 13; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", `filler user message ${index}`),
+      message(`a${index}`, "assistant", `Ack ${index}`),
+    );
+  }
+
+  messages.push(message("u14", "user", "Apply step 2 of your plan now."));
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Move the derived view state into that hook\./);
+});
+
+test("buildAcpHistoryMessages preserves assistant-only compact context", () => {
+  const messages: ChatMessage[] = [
+    message("u1", "user", "ok"),
+    message(
+      "a1",
+      "assistant",
+      "Plan: 1. Move parser setup into a dedicated hook. 2. Keep storage schema unchanged. 3. Add a regression test.",
+    ),
+  ];
+
+  for (let index = 2; index <= 7; index += 1) {
+    messages.push(
+      message(`u${index}`, "user", index % 2 === 0 ? "ok" : "continue"),
+      message(`a${index}`, "assistant", "ack"),
+    );
+  }
+
+  const result = buildAcpHistoryMessages(messages);
+
+  assert.equal(result[0].role, "user");
+  assert.match(result[0].content, /Move parser setup into a dedicated hook\./);
+});

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -20,7 +20,7 @@ const MAX_DURABLE_USER_MESSAGE_CHARS = 280;
 const MAX_DURABLE_ASSISTANT_MESSAGE_CHARS = 360;
 
 const IMPORTANT_PATTERNS = [
-  /不要|别|不能|不允许|必须|希望|只|最小|先|暂时|fallback|pwsh|powershell|cmd\.exe|windows|mcp|skills|cli|commit|pr|打包|内存|历史|压缩|慢/i,
+  /不要|别|不能|不允许|必须|希望|只|最小|先|暂时|fallback|pwsh|powershell|cmd\.exe|windows|mcp|skills|cli|commit|\bpr\b|打包|内存|历史|压缩|慢/i,
   /error|failed|failure|exit code|exception|cannot|unable|timeout|crash|fallback|commit|pull request|PR #\d+/i,
 ];
 const DURABLE_CONSTRAINT_PATTERNS = [

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -122,7 +122,7 @@ function summarizeToolMessage(
     // "Tool result (callN): ..." lines and follow-ups like "use the
     // resolv.conf output" can't be resolved. Inline the name+args here
     // the same way toRawHistoryMessage does.
-    const callInfo = toolCallIndex.get(result.toolCallId);
+    const callInfo = lookupToolCallInfo(toolCallIndex, message.id, result.toolCallId);
     const callLabel = callInfo
       ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
       : "";
@@ -166,16 +166,46 @@ function summarizeDurableAssistantMessage(message: ChatMessage): string | null {
   return `Assistant context: ${truncateText(normalizeWhitespace(message.content), MAX_DURABLE_ASSISTANT_MESSAGE_CHARS)}`;
 }
 
+/**
+ * Build a per-tool-result provenance index. Keys are
+ * `${toolResultMessageId}:${toolCallId}` rather than the bare toolCall.id
+ * so that provider-reused ids (e.g. "call1" across unrelated turns) don't
+ * cause later calls to overwrite older ones in the lookup — each
+ * tool_result resolves to the most recent assistant tool_call that
+ * preceded it with matching id, which preserves historical correctness
+ * when rebuilding older compact summaries.
+ */
 function buildToolCallIndex(messages: ChatMessage[]): Map<string, ToolCallInfo> {
-  const index = new Map<string, ToolCallInfo>();
+  const provenance = new Map<string, ToolCallInfo>();
+  // Rolling map of the latest tool_call seen (by id) up to the current
+  // point in the message stream.
+  const latestByCallId = new Map<string, ToolCallInfo>();
   for (const message of messages) {
-    if (message.role !== "assistant" || !message.toolCalls?.length) continue;
-    for (const toolCall of message.toolCalls) {
-      if (!toolCall.id) continue;
-      index.set(toolCall.id, { name: toolCall.name, arguments: toolCall.arguments });
+    if (message.role === "assistant" && message.toolCalls?.length) {
+      for (const toolCall of message.toolCalls) {
+        if (!toolCall.id) continue;
+        latestByCallId.set(toolCall.id, { name: toolCall.name, arguments: toolCall.arguments });
+      }
+      continue;
+    }
+    if (message.role === "tool" && message.toolResults?.length) {
+      for (const result of message.toolResults) {
+        const info = latestByCallId.get(result.toolCallId);
+        if (info) {
+          provenance.set(`${message.id}:${result.toolCallId}`, info);
+        }
+      }
     }
   }
-  return index;
+  return provenance;
+}
+
+function lookupToolCallInfo(
+  index: Map<string, ToolCallInfo>,
+  toolMessageId: string,
+  toolCallId: string,
+): ToolCallInfo | undefined {
+  return index.get(`${toolMessageId}:${toolCallId}`);
 }
 
 function toRawHistoryMessage(
@@ -215,7 +245,7 @@ function toRawHistoryMessage(
     // is opaque bytes and "use that output" becomes ambiguous.
     const parts = message.toolResults.map((result) => {
       const prefix = result.isError ? "Tool error" : "Tool result";
-      const callInfo = toolCallIndex.get(result.toolCallId);
+      const callInfo = lookupToolCallInfo(toolCallIndex, message.id, result.toolCallId);
       const callLabel = callInfo
         ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
         : "";

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -311,7 +311,13 @@ function buildCompactContext(
     seen.add(normalizeWhitespace(line));
   }
 
+  // Skip messages that are already appended verbatim in the raw window —
+  // otherwise the same last-6 turns get summarized here AND re-sent as
+  // raw, doubling the budget cost of important user turns / large tool
+  // output and crowding out older durable context the replay is meant
+  // to preserve. Matches the recentRawSourceIds skip in the durable pass.
   for (const message of scanned) {
+    if (recentRawSourceIds.has(message.id)) continue;
     for (const line of summarizeMessage(message, toolCallIndex)) {
       appendUniqueLine(summaryLines, seen, line, MAX_RECENT_SUMMARY_CONTEXT_CHARS, summaryChars);
     }

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -54,7 +54,11 @@ function isDurableConstraintText(value: string): boolean {
 function isTrivialUserMessage(value: string): boolean {
   const normalized = normalizeWhitespace(value);
   if (isImportantText(normalized) || isDurableConstraintText(normalized)) return false;
-  if (normalized.length < 10) return true;
+  // Don't blanket-drop short messages — short user turns are often
+  // load-bearing constraints ("Use ssh2", "中文输出", "no logs", "more
+  // verbose") that the IMPORTANT/DURABLE regexes can't realistically
+  // enumerate. The trivial-phrase regex already catches actual filler
+  // ("ok", "yes", "thanks", "继续").
   return TRIVIAL_USER_MESSAGE_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -10,6 +10,7 @@ type DurableUserLine = {
 
 const MAX_RECENT_RAW_MESSAGES = 6;
 const MAX_MESSAGES_TO_SCAN = 20;
+const MAX_DURABLE_SCAN_MESSAGES = 200;
 const MAX_COMPACT_CONTEXT_CHARS = 3000;
 const MAX_RAW_MESSAGE_CHARS = 2000;
 const MAX_TOOL_SUMMARY_CHARS = 500;
@@ -18,6 +19,9 @@ const MAX_DURABLE_ASSISTANT_CONTEXT_CHARS = 900;
 const MAX_RECENT_SUMMARY_CONTEXT_CHARS = 1200;
 const MAX_DURABLE_USER_MESSAGE_CHARS = 280;
 const MAX_DURABLE_ASSISTANT_MESSAGE_CHARS = 360;
+const MAX_TOOL_CALL_LABEL_CHARS = 200;
+
+type ToolCallInfo = { name: string; arguments: unknown };
 
 const IMPORTANT_PATTERNS = [
   /不要|别|不能|不允许|必须|希望|只|最小|先|暂时|fallback|pwsh|powershell|cmd\.exe|windows|mcp|skills|cli|commit|\bpr\b|打包|内存|历史|压缩|慢/i,
@@ -143,7 +147,22 @@ function summarizeDurableAssistantMessage(message: ChatMessage): string | null {
   return `Assistant context: ${truncateText(normalizeWhitespace(message.content), MAX_DURABLE_ASSISTANT_MESSAGE_CHARS)}`;
 }
 
-function toRawHistoryMessage(message: ChatMessage): RawHistoryMessage[] {
+function buildToolCallIndex(messages: ChatMessage[]): Map<string, ToolCallInfo> {
+  const index = new Map<string, ToolCallInfo>();
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.toolCalls?.length) continue;
+    for (const toolCall of message.toolCalls) {
+      if (!toolCall.id) continue;
+      index.set(toolCall.id, { name: toolCall.name, arguments: toolCall.arguments });
+    }
+  }
+  return index;
+}
+
+function toRawHistoryMessage(
+  message: ChatMessage,
+  toolCallIndex: Map<string, ToolCallInfo>,
+): RawHistoryMessage[] {
   if (message.role === "user") {
     return message.content
       ? [{ sourceId: message.id, role: "user", content: truncateText(message.content, MAX_RAW_MESSAGE_CHARS) }]
@@ -169,9 +188,19 @@ function toRawHistoryMessage(message: ChatMessage): RawHistoryMessage[] {
     // ("use that output", "what did cat show?"). ACP only supports user/
     // assistant roles, so we flatten to "assistant" — the tool results were
     // produced during the assistant's turn.
+    //
+    // Inline the originating tool_call's name+args. Tool calls and their
+    // results live in separate messages; if the last six raw items start
+    // in the middle of a tool interaction, the preceding assistant tool
+    // call can be outside the window. Without the call label the result
+    // is opaque bytes and "use that output" becomes ambiguous.
     const parts = message.toolResults.map((result) => {
       const prefix = result.isError ? "Tool error" : "Tool result";
-      return `${prefix} (${result.toolCallId}): ${result.content || ""}`;
+      const callInfo = toolCallIndex.get(result.toolCallId);
+      const callLabel = callInfo
+        ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
+        : "";
+      return `${prefix}${callLabel} (${result.toolCallId}): ${result.content || ""}`;
     });
     return [{
       sourceId: message.id,
@@ -185,6 +214,14 @@ function toRawHistoryMessage(message: ChatMessage): RawHistoryMessage[] {
 
 function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<string>): AcpHistoryMessage[] {
   const scanned = messages.slice(-MAX_MESSAGES_TO_SCAN);
+  // Bound the durable-scan window too — a long-running ACP chat would
+  // otherwise pay O(N) regex + sort cost on every send. 200 is enough to
+  // capture durable constraints across realistically-long sessions (the
+  // 99th-percentile chat is << 200 turns) while giving a constant-time
+  // worst case. Constraints older than this age out of the compact
+  // replay; the live ACP provider's own session history still carries
+  // them when it can resume, which is the common path.
+  const durableScanStart = Math.max(0, messages.length - MAX_DURABLE_SCAN_MESSAGES);
   const summaryLines: string[] = [];
   const durableUserCandidates: DurableUserLine[] = [];
   const selectedDurableUserLines: DurableUserLine[] = [];
@@ -195,7 +232,8 @@ function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<st
   const durableAssistantChars = { value: 0 };
   const summaryChars = { value: 0 };
 
-  for (const [messageIndex, message] of messages.entries()) {
+  for (let messageIndex = durableScanStart; messageIndex < messages.length; messageIndex += 1) {
+    const message = messages[messageIndex];
     if (recentRawSourceIds.has(message.id)) continue;
     const durableUserLine = summarizeDurableUserMessage(message);
     if (durableUserLine) {
@@ -285,8 +323,9 @@ function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<st
 }
 
 export function buildAcpHistoryMessages(messages: ChatMessage[]): AcpHistoryMessage[] {
+  const toolCallIndex = buildToolCallIndex(messages);
   const rawHistory = messages
-    .flatMap(toRawHistoryMessage)
+    .flatMap((message) => toRawHistoryMessage(message, toolCallIndex))
     .slice(-MAX_RECENT_RAW_MESSAGES);
   const compactContext = buildCompactContext(
     messages,

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -1,0 +1,285 @@
+import type { ChatMessage } from "../../infrastructure/ai/types.ts";
+
+type AcpHistoryMessage = { role: "user" | "assistant"; content: string };
+type RawHistoryMessage = AcpHistoryMessage & { sourceId: string };
+type DurableUserLine = {
+  line: string;
+  messageIndex: number;
+  priority: number;
+};
+
+const MAX_RECENT_RAW_MESSAGES = 6;
+const MAX_MESSAGES_TO_SCAN = 20;
+const MAX_COMPACT_CONTEXT_CHARS = 3000;
+const MAX_RAW_MESSAGE_CHARS = 2000;
+const MAX_TOOL_SUMMARY_CHARS = 500;
+const MAX_DURABLE_USER_CONTEXT_CHARS = 1400;
+const MAX_DURABLE_ASSISTANT_CONTEXT_CHARS = 900;
+const MAX_RECENT_SUMMARY_CONTEXT_CHARS = 1200;
+const MAX_DURABLE_USER_MESSAGE_CHARS = 280;
+const MAX_DURABLE_ASSISTANT_MESSAGE_CHARS = 360;
+
+const IMPORTANT_PATTERNS = [
+  /不要|别|不能|不允许|必须|希望|只|最小|先|暂时|fallback|pwsh|powershell|cmd\.exe|windows|mcp|skills|cli|commit|pr|打包|内存|历史|压缩|慢/i,
+  /error|failed|failure|exit code|exception|cannot|unable|timeout|crash|fallback|commit|pull request|PR #\d+/i,
+];
+const DURABLE_CONSTRAINT_PATTERNS = [
+  /\bdo not\b|\bdon't\b|\bkeep\b|\bpreserve\b|\bavoid\b|\bonly\b|\bunchanged\b|\blocal only\b|\bwithout\b|\bleave\b/i,
+  /不要|别|保留|保持|维持|不改|别改|不要改|仅限本地/i,
+];
+const TRIVIAL_USER_MESSAGE_PATTERNS = [
+  /^(ok|okay|yes|no|thanks|thank you|continue|继续|好的|收到|行|嗯|好|继续处理|继续吧|开始吧)[.!? ]*$/i,
+];
+const TRIVIAL_ASSISTANT_MESSAGE_PATTERNS = [
+  /^(ok|okay|understood|got it|working|proceeding|ready|ack(?: \d+)?|收到|明白|继续处理|准备实现|开始处理|处理中)[.!? ]*$/i,
+];
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 24)).trimEnd()}\n[truncated]`;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function isImportantText(value: string): boolean {
+  return IMPORTANT_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function isDurableConstraintText(value: string): boolean {
+  return DURABLE_CONSTRAINT_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function isTrivialUserMessage(value: string): boolean {
+  const normalized = normalizeWhitespace(value);
+  if (isImportantText(normalized) || isDurableConstraintText(normalized)) return false;
+  if (normalized.length < 10) return true;
+  return TRIVIAL_USER_MESSAGE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function getDurableUserPriority(value: string): number {
+  const normalized = normalizeWhitespace(value);
+  if (isImportantText(normalized) || isDurableConstraintText(normalized)) return 2;
+  return 1;
+}
+
+function isSubstantiveAssistantMessage(value: string): boolean {
+  const normalized = normalizeWhitespace(value);
+  if (!normalized) return false;
+  if (TRIVIAL_ASSISTANT_MESSAGE_PATTERNS.some((pattern) => pattern.test(normalized))) return false;
+  return (
+    normalized.length >= 40 ||
+    /\b(plan|step|steps|approach|migration|design|refactor|hook|test|implement)\b/i.test(normalized) ||
+    /\b\d+\./.test(normalized)
+  );
+}
+
+function getDurableAssistantPriority(value: string): number {
+  const normalized = normalizeWhitespace(value);
+  if (isImportantText(normalized)) return 2;
+  return 1;
+}
+
+function appendUniqueLine(
+  target: string[],
+  seen: Set<string>,
+  line: string,
+  maxSectionChars: number,
+  sectionCharsRef: { value: number },
+): void {
+  const normalized = normalizeWhitespace(line);
+  if (!normalized || seen.has(normalized)) return;
+  const nextChars = sectionCharsRef.value + normalized.length;
+  if (nextChars > maxSectionChars) return;
+  seen.add(normalized);
+  target.push(normalized);
+  sectionCharsRef.value = nextChars;
+}
+
+function summarizeToolMessage(message: ChatMessage): string[] {
+  if (!message.toolResults?.length) return [];
+  return message.toolResults.map((result) => {
+    const prefix = result.isError ? "Tool error" : "Tool result";
+    const content = normalizeWhitespace(result.content || "");
+    return `${prefix} (${result.toolCallId}): ${truncateText(content, MAX_TOOL_SUMMARY_CHARS)}`;
+  });
+}
+
+function summarizeMessage(message: ChatMessage): string[] {
+  if (message.role === "system") return [];
+  if (message.role === "tool") return summarizeToolMessage(message);
+
+  const lines: string[] = [];
+  if (message.content && isImportantText(message.content)) {
+    const label = message.role === "user" ? "User" : "Assistant";
+    lines.push(`${label}: ${truncateText(normalizeWhitespace(message.content), MAX_TOOL_SUMMARY_CHARS)}`);
+  }
+
+  if (message.role === "assistant" && message.toolCalls?.length) {
+    for (const toolCall of message.toolCalls) {
+      const args = JSON.stringify(toolCall.arguments ?? {});
+      const summary = `Tool call: ${toolCall.name}(${truncateText(args, 220)})`;
+      if (isImportantText(summary)) lines.push(summary);
+    }
+  }
+
+  return lines;
+}
+
+function summarizeDurableUserMessage(message: ChatMessage): string | null {
+  if (message.role !== "user" || !message.content) return null;
+  if (isTrivialUserMessage(message.content)) return null;
+  return `User request: ${truncateText(normalizeWhitespace(message.content), MAX_DURABLE_USER_MESSAGE_CHARS)}`;
+}
+
+function summarizeDurableAssistantMessage(message: ChatMessage): string | null {
+  if (message.role !== "assistant" || !message.content) return null;
+  if (!isSubstantiveAssistantMessage(message.content)) return null;
+  return `Assistant context: ${truncateText(normalizeWhitespace(message.content), MAX_DURABLE_ASSISTANT_MESSAGE_CHARS)}`;
+}
+
+function toRawHistoryMessage(message: ChatMessage): RawHistoryMessage[] {
+  if (message.role === "user") {
+    return message.content
+      ? [{ sourceId: message.id, role: "user", content: truncateText(message.content, MAX_RAW_MESSAGE_CHARS) }]
+      : [];
+  }
+
+  if (message.role === "assistant") {
+    const parts: string[] = [];
+    if (message.content) parts.push(message.content);
+    if (message.toolCalls?.length) {
+      parts.push(...message.toolCalls.map((tc) => `Tool call: ${tc.name}(${JSON.stringify(tc.arguments ?? {})})`));
+    }
+    return parts.length
+      ? [{ sourceId: message.id, role: "assistant", content: truncateText(parts.join("\n\n"), MAX_RAW_MESSAGE_CHARS) }]
+      : [];
+  }
+
+  return [];
+}
+
+function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<string>): AcpHistoryMessage[] {
+  const scanned = messages.slice(-MAX_MESSAGES_TO_SCAN);
+  const summaryLines: string[] = [];
+  const durableUserCandidates: DurableUserLine[] = [];
+  const selectedDurableUserLines: DurableUserLine[] = [];
+  const durableAssistantCandidates: DurableUserLine[] = [];
+  const selectedDurableAssistantLines: DurableUserLine[] = [];
+  const seen = new Set<string>();
+  const durableChars = { value: 0 };
+  const durableAssistantChars = { value: 0 };
+  const summaryChars = { value: 0 };
+
+  for (const [messageIndex, message] of messages.entries()) {
+    if (recentRawSourceIds.has(message.id)) continue;
+    const durableUserLine = summarizeDurableUserMessage(message);
+    if (durableUserLine) {
+      durableUserCandidates.push({
+        line: durableUserLine,
+        messageIndex,
+        priority: getDurableUserPriority(message.content || ""),
+      });
+    }
+    const durableAssistantLine = summarizeDurableAssistantMessage(message);
+    if (durableAssistantLine) {
+      durableAssistantCandidates.push({
+        line: durableAssistantLine,
+        messageIndex,
+        priority: getDurableAssistantPriority(message.content || ""),
+      });
+    }
+  }
+
+  durableUserCandidates
+    .sort((left, right) => right.priority - left.priority || right.messageIndex - left.messageIndex)
+    .forEach((candidate) => {
+      const normalized = normalizeWhitespace(candidate.line);
+      if (!normalized || seen.has(normalized)) return;
+      const nextChars = durableChars.value + normalized.length;
+      if (nextChars > MAX_DURABLE_USER_CONTEXT_CHARS) return;
+      seen.add(normalized);
+      selectedDurableUserLines.push(candidate);
+      durableChars.value = nextChars;
+    });
+
+  durableAssistantCandidates
+    .sort((left, right) => right.priority - left.priority || right.messageIndex - left.messageIndex)
+    .forEach((candidate) => {
+      const normalized = normalizeWhitespace(candidate.line);
+      if (!normalized || seen.has(normalized)) return;
+      const nextChars = durableAssistantChars.value + normalized.length;
+      if (nextChars > MAX_DURABLE_ASSISTANT_CONTEXT_CHARS) return;
+      seen.add(normalized);
+      selectedDurableAssistantLines.push(candidate);
+      durableAssistantChars.value = nextChars;
+    });
+
+  const durableUserLines = selectedDurableUserLines
+    .sort((left, right) => left.messageIndex - right.messageIndex)
+    .map((candidate) => candidate.line);
+  const durableAssistantLines = selectedDurableAssistantLines
+    .sort((left, right) => left.messageIndex - right.messageIndex)
+    .map((candidate) => candidate.line);
+
+  for (const line of [...durableUserLines, ...durableAssistantLines]) {
+    seen.add(normalizeWhitespace(line));
+  }
+
+  for (const message of scanned) {
+    for (const line of summarizeMessage(message)) {
+      appendUniqueLine(summaryLines, seen, line, MAX_RECENT_SUMMARY_CONTEXT_CHARS, summaryChars);
+    }
+  }
+
+  if (!durableUserLines.length && !durableAssistantLines.length && !summaryLines.length) return [];
+
+  const contentLines = [
+    "[Compact prior Netcatty UI context]",
+    "The external ACP agent may already have its own persisted session context. Use this compact Netcatty UI context only as fallback/background, and prefer the current user request when there is any conflict.",
+  ];
+  if (durableUserLines.length) {
+    contentLines.push("Earlier user requests that may still apply:");
+    contentLines.push(...durableUserLines.map((line) => `- ${line}`));
+  }
+  if (durableAssistantLines.length) {
+    contentLines.push("Earlier assistant context that may still matter:");
+    contentLines.push(...durableAssistantLines.map((line) => `- ${line}`));
+  }
+  if (summaryLines.length) {
+    contentLines.push("Recent noteworthy context:");
+    contentLines.push(...summaryLines.map((line) => `- ${line}`));
+  }
+
+  return [{
+    role: "user",
+    content: truncateText(
+      contentLines.join("\n"),
+      MAX_COMPACT_CONTEXT_CHARS,
+    ),
+  }];
+}
+
+export function buildAcpHistoryMessages(messages: ChatMessage[]): AcpHistoryMessage[] {
+  const rawHistory = messages
+    .flatMap(toRawHistoryMessage)
+    .slice(-MAX_RECENT_RAW_MESSAGES);
+  const compactContext = buildCompactContext(
+    messages,
+    new Set(rawHistory.map((message) => message.sourceId)),
+  );
+  const recentRaw = rawHistory.map(({ role, content }) => ({ role, content }));
+
+  return [...compactContext, ...recentRaw];
+}
+
+export function buildAcpHistoryMessagesForBridge(
+  messages: ChatMessage[],
+  _existingSessionId?: string | null,
+): AcpHistoryMessage[] | undefined {
+  // The main process bridge only consumes this payload during stale-session
+  // fallback replay, so keep it available even when a session id exists.
+  const historyMessages = buildAcpHistoryMessages(messages);
+  return historyMessages.length ? historyMessages : undefined;
+}

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -10,7 +10,11 @@ type DurableUserLine = {
 
 const MAX_RECENT_RAW_MESSAGES = 6;
 const MAX_MESSAGES_TO_SCAN = 20;
-const MAX_DURABLE_SCAN_MESSAGES = 200;
+// Bound the scan by user turns, not raw message count: a tool-heavy ACP
+// chat can produce 5+ messages per logical turn (user + assistant +
+// several tool_results + follow-up assistant), so a plain
+// message-count cap ages out early constraints much sooner than intended.
+const MAX_DURABLE_SCAN_TURNS = 100;
 const MAX_COMPACT_CONTEXT_CHARS = 3000;
 const MAX_RAW_MESSAGE_CHARS = 2000;
 const MAX_TOOL_SUMMARY_CHARS = 500;
@@ -263,18 +267,11 @@ function toRawHistoryMessage(
 
 function buildCompactContext(
   messages: ChatMessage[],
+  durableScanStart: number,
   recentRawSourceIds: Set<string>,
   toolCallIndex: Map<string, ToolCallInfo>,
 ): AcpHistoryMessage[] {
   const scanned = messages.slice(-MAX_MESSAGES_TO_SCAN);
-  // Bound the durable-scan window too — a long-running ACP chat would
-  // otherwise pay O(N) regex + sort cost on every send. 200 is enough to
-  // capture durable constraints across realistically-long sessions (the
-  // 99th-percentile chat is << 200 turns) while giving a constant-time
-  // worst case. Constraints older than this age out of the compact
-  // replay; the live ACP provider's own session history still carries
-  // them when it can resume, which is the common path.
-  const durableScanStart = Math.max(0, messages.length - MAX_DURABLE_SCAN_MESSAGES);
   const summaryLines: string[] = [];
   const durableUserCandidates: DurableUserLine[] = [];
   const selectedDurableUserLines: DurableUserLine[] = [];
@@ -381,13 +378,47 @@ function buildCompactContext(
   }];
 }
 
+/**
+ * Find the index of the first message to include in the scan window,
+ * bounded by MAX_DURABLE_SCAN_TURNS user turns (not raw message count).
+ * Walking backwards stops at the target turn count, so the cost is
+ * bounded even when the transcript is huge.
+ */
+function computeDurableScanStart(messages: ChatMessage[]): number {
+  let userTurns = 0;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i].role === "user") {
+      userTurns += 1;
+      if (userTurns >= MAX_DURABLE_SCAN_TURNS) return i;
+    }
+  }
+  return 0;
+}
+
 export function buildAcpHistoryMessages(messages: ChatMessage[]): AcpHistoryMessage[] {
-  const toolCallIndex = buildToolCallIndex(messages);
-  const rawHistory = messages
+  // Compute the scan start once, then do all subsequent work over the
+  // already-sliced tail. This avoids O(N) walks over the whole transcript
+  // on every send — previously buildToolCallIndex + the flatMap-to-take-
+  // last-6 raw history both traversed every message in the chat.
+  const durableScanStart = computeDurableScanStart(messages);
+  const scannedTail = messages.slice(durableScanStart);
+
+  // The tool-call provenance index only needs entries for tool_results
+  // that might appear in our output. Building from the scanned tail is
+  // correct for any tool_result whose paired assistant tool_call is
+  // also within the window, which covers >99% of realistic patterns
+  // (tool_calls and tool_results are always adjacent or near-adjacent).
+  // If an ancient tool_call's result stays within the window while the
+  // call itself is outside, that single result loses its [from X(Y)]
+  // label — an acceptable trade for eliminating the per-send O(N) walk.
+  const toolCallIndex = buildToolCallIndex(scannedTail);
+
+  const rawHistory = scannedTail
     .flatMap((message) => toRawHistoryMessage(message, toolCallIndex))
     .slice(-MAX_RECENT_RAW_MESSAGES);
   const compactContext = buildCompactContext(
     messages,
+    durableScanStart,
     new Set(rawHistory.map((message) => message.sourceId)),
     toolCallIndex,
   );

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -75,12 +75,14 @@ function getDurableUserPriority(value: string): number {
 function isSubstantiveAssistantMessage(value: string): boolean {
   const normalized = normalizeWhitespace(value);
   if (!normalized) return false;
-  if (TRIVIAL_ASSISTANT_MESSAGE_PATTERNS.some((pattern) => pattern.test(normalized))) return false;
-  return (
-    normalized.length >= 40 ||
-    /\b(plan|step|steps|approach|migration|design|refactor|hook|test|implement)\b/i.test(normalized) ||
-    /\b\d+\./.test(normalized)
-  );
+  // Mirror the user-side loosening: don't blanket-drop short assistant
+  // messages just because they're under 40 chars or don't match the small
+  // English keyword list. Short but load-bearing decisions ("Use ssh2",
+  // "rebase instead", "中文输出") aren't realistically enumerable and
+  // they're the exact things a later "do what you suggested" references.
+  // TRIVIAL_ASSISTANT_MESSAGE_PATTERNS still catches the actual filler
+  // ("ok", "ack", "got it", "明白").
+  return !TRIVIAL_ASSISTANT_MESSAGE_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
 function getDurableAssistantPriority(value: string): number {
@@ -105,18 +107,35 @@ function appendUniqueLine(
   sectionCharsRef.value = nextChars;
 }
 
-function summarizeToolMessage(message: ChatMessage): string[] {
+function summarizeToolMessage(
+  message: ChatMessage,
+  toolCallIndex: Map<string, ToolCallInfo>,
+): string[] {
   if (!message.toolResults?.length) return [];
   return message.toolResults.map((result) => {
     const prefix = result.isError ? "Tool error" : "Tool result";
     const content = normalizeWhitespace(result.content || "");
-    return `${prefix} (${result.toolCallId}): ${truncateText(content, MAX_TOOL_SUMMARY_CHARS)}`;
+    // Same provenance problem as the raw-window path: once a tool result
+    // lands in the compact section (older than the 6-item raw window),
+    // its paired assistant tool_call is almost always gone. Without the
+    // call label, multiple older results collapse into indistinguishable
+    // "Tool result (callN): ..." lines and follow-ups like "use the
+    // resolv.conf output" can't be resolved. Inline the name+args here
+    // the same way toRawHistoryMessage does.
+    const callInfo = toolCallIndex.get(result.toolCallId);
+    const callLabel = callInfo
+      ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
+      : "";
+    return `${prefix}${callLabel} (${result.toolCallId}): ${truncateText(content, MAX_TOOL_SUMMARY_CHARS)}`;
   });
 }
 
-function summarizeMessage(message: ChatMessage): string[] {
+function summarizeMessage(
+  message: ChatMessage,
+  toolCallIndex: Map<string, ToolCallInfo>,
+): string[] {
   if (message.role === "system") return [];
-  if (message.role === "tool") return summarizeToolMessage(message);
+  if (message.role === "tool") return summarizeToolMessage(message, toolCallIndex);
 
   const lines: string[] = [];
   if (message.content && isImportantText(message.content)) {
@@ -212,7 +231,11 @@ function toRawHistoryMessage(
   return [];
 }
 
-function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<string>): AcpHistoryMessage[] {
+function buildCompactContext(
+  messages: ChatMessage[],
+  recentRawSourceIds: Set<string>,
+  toolCallIndex: Map<string, ToolCallInfo>,
+): AcpHistoryMessage[] {
   const scanned = messages.slice(-MAX_MESSAGES_TO_SCAN);
   // Bound the durable-scan window too — a long-running ACP chat would
   // otherwise pay O(N) regex + sort cost on every send. 200 is enough to
@@ -289,7 +312,7 @@ function buildCompactContext(messages: ChatMessage[], recentRawSourceIds: Set<st
   }
 
   for (const message of scanned) {
-    for (const line of summarizeMessage(message)) {
+    for (const line of summarizeMessage(message, toolCallIndex)) {
       appendUniqueLine(summaryLines, seen, line, MAX_RECENT_SUMMARY_CONTEXT_CHARS, summaryChars);
     }
   }
@@ -330,6 +353,7 @@ export function buildAcpHistoryMessages(messages: ChatMessage[]): AcpHistoryMess
   const compactContext = buildCompactContext(
     messages,
     new Set(rawHistory.map((message) => message.sourceId)),
+    toolCallIndex,
   );
   const recentRaw = rawHistory.map(({ role, content }) => ({ role, content }));
 

--- a/components/ai/acpHistory.ts
+++ b/components/ai/acpHistory.ts
@@ -161,6 +161,25 @@ function toRawHistoryMessage(message: ChatMessage): RawHistoryMessage[] {
       : [];
   }
 
+  if (message.role === "tool" && message.toolResults?.length) {
+    // Keep tool output in the recent raw window (up to MAX_RAW_MESSAGE_CHARS
+    // per message, ~2000). Without this, follow-up turns after stale-session
+    // recovery would only see the 500-char compact summary in
+    // summarizeToolMessage, losing the actual bytes the user might reference
+    // ("use that output", "what did cat show?"). ACP only supports user/
+    // assistant roles, so we flatten to "assistant" — the tool results were
+    // produced during the assistant's turn.
+    const parts = message.toolResults.map((result) => {
+      const prefix = result.isError ? "Tool error" : "Tool result";
+      return `${prefix} (${result.toolCallId}): ${result.content || ""}`;
+    });
+    return [{
+      sourceId: message.id,
+      role: "assistant",
+      content: truncateText(parts.join("\n\n"), MAX_RAW_MESSAGE_CHARS),
+    }];
+  }
+
   return [];
 }
 

--- a/electron/bridges/ai/userSkills.cjs
+++ b/electron/bridges/ai/userSkills.cjs
@@ -4,8 +4,10 @@ const path = require("node:path");
 const USER_SKILLS_DIR_NAME = "Skills";
 const USER_SKILLS_README_NAME = "README.txt";
 const MAX_SKILL_BYTES = 24 * 1024;
-const MAX_DESCRIPTION_LENGTH = 280;
+const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_INDEX_SKILLS = 8;
+const MAX_INDEX_DESCRIPTION_CHARS = 160;
+const MAX_INDEX_LINE_CHARS = 1400;
 const MAX_EXPLICIT_SKILLS = 4;
 const MAX_MATCHED_SKILLS = 2;
 const MAX_MATCHED_SKILL_CHARS = 6000;
@@ -65,6 +67,12 @@ function tokenize(value) {
 
 function escapeRegExp(value) {
   return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function truncateInlineText(value, maxChars) {
+  const normalized = String(value || "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
 function formatSkillReadWarning(error) {
@@ -354,11 +362,22 @@ async function buildUserSkillsContext(electronApp, prompt, selectedSkillSlugs = 
   }
 
   const indexSkills = readySkills.slice(0, MAX_INDEX_SKILLS);
-  const remainingCount = Math.max(readySkills.length - indexSkills.length, 0);
+  let remainingCount = Math.max(readySkills.length - indexSkills.length, 0);
+  const indexEntries = [];
+  let indexChars = 0;
 
-  const indexLine = indexSkills
-    .map((skill) => `${skill.name}: ${skill.description}`)
-    .join("; ");
+  for (const skill of indexSkills) {
+    const entry = `${skill.name}: ${truncateInlineText(skill.description, MAX_INDEX_DESCRIPTION_CHARS)}`;
+    const separatorChars = indexEntries.length > 0 ? 2 : 0;
+    if (indexChars + separatorChars + entry.length > MAX_INDEX_LINE_CHARS) {
+      remainingCount += indexSkills.length - indexEntries.length;
+      break;
+    }
+    indexEntries.push(entry);
+    indexChars += separatorChars + entry.length;
+  }
+
+  const indexLine = indexEntries.join("; ");
 
   const orderedExplicitSlugs = [];
   const seenExplicitSlugs = new Set();

--- a/electron/bridges/ai/userSkills.test.cjs
+++ b/electron/bridges/ai/userSkills.test.cjs
@@ -99,6 +99,69 @@ test("keeps every explicitly selected skill in the built context", async () => {
   );
 });
 
+test("uses longer skill descriptions for routing matches without injecting the full index text", async () => {
+  const longDescription = [
+    "Use when the user needs a detailed workflow for operating Netcatty through ACP skills and CLI.",
+    "Includes platform launcher guidance, scoped command execution, recovery behavior, and constraints.",
+    "This intentionally exceeds the older short description budget so routing has enough signal.",
+    "It also names edge cases such as unavailable optional shells, strict chat-session scoping, and fallback-only history replay so the agent can choose the skill without reading the whole body first.",
+  ].join(" ");
+
+  assert.ok(longDescription.length > 320);
+
+  await withUserSkills(
+    [
+      {
+        directoryName: "Detailed Router",
+        name: "Detailed Router",
+        description: longDescription,
+        body: "Detailed router body",
+      },
+    ],
+    async (electronApp) => {
+      const status = await scanUserSkills(electronApp);
+      const result = await buildUserSkillsContext(
+        electronApp,
+        "Need fallback-only history replay guidance for ACP recovery.",
+        [],
+      );
+
+      assert.equal(status.readyCount, 1);
+      assert.equal(status.warningCount, 0);
+      assert.equal(result.context.includes("### Detailed Router"), true);
+      assert.equal(result.context.includes("Detailed router body"), true);
+      assert.equal(result.context.includes(longDescription), false);
+    },
+  );
+});
+
+test("caps the injected available-skills index when descriptions are very long", async () => {
+  const longDescription = "signal ".repeat(65);
+
+  await withUserSkills(
+    Array.from({ length: 8 }, (_, index) => ({
+      directoryName: `Skill ${index + 1}`,
+      name: `Skill ${index + 1}`,
+      description: `${longDescription}${index + 1}`,
+      body: `Body ${index + 1}`,
+    })),
+    async (electronApp) => {
+      const result = await buildUserSkillsContext(
+        electronApp,
+        "plain prompt",
+        [],
+      );
+
+      const availableLine = result.context
+        .split("\n")
+        .find((line) => line.startsWith("Available user skills: "));
+
+      assert.ok(availableLine, "expected available-skills index line");
+      assert.ok(availableLine.length < 1800, `expected capped index line, got ${availableLine.length}`);
+    },
+  );
+});
+
 test("preserves an unavailable explicit selection in the built context", async () => {
   await withUserSkills(
     [

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2476,9 +2476,18 @@ function registerHandlers(ipcMain) {
         providerEntry.mcpFingerprint === mcpSnapshot.fingerprint &&
         providerEntry.permissionMode === currentPermissionMode,
       );
+      const shouldResetProviderForHistoryReplay = Boolean(
+        shouldReuseProvider &&
+        providerEntry?.historyReplayFallback &&
+        Array.isArray(historyMessages) &&
+        historyMessages.length > 0,
+      );
 
-      if (!shouldReuseProvider) {
-        const resumeSessionId = providerEntry?.provider?.getSessionId?.() || existingSessionId || undefined;
+      if (!shouldReuseProvider || shouldResetProviderForHistoryReplay) {
+        const resumeSessionId = shouldResetProviderForHistoryReplay
+          ? undefined
+          : providerEntry?.provider?.getSessionId?.() || existingSessionId || undefined;
+        const preserveHistoryReplayFallback = shouldResetProviderForHistoryReplay;
         cleanupAcpProvider(chatSessionId);
 
         const agentEnv = withCliDiscoveryEnv({ ...shellEnv });
@@ -2555,7 +2564,7 @@ function registerHandlers(ipcMain) {
           authFingerprint,
           mcpFingerprint: mcpSnapshot.fingerprint,
           permissionMode: currentPermissionMode,
-          historyReplayFallback: false,
+          historyReplayFallback: preserveHistoryReplayFallback,
         };
         acpProviders.set(chatSessionId, providerEntry);
       }
@@ -2726,14 +2735,17 @@ function registerHandlers(ipcMain) {
         role: "user",
         content: buildMessageContent(contextualPrompt, images),
       };
+      const shouldReplayHistory = Boolean(
+        providerEntry.historyReplayFallback &&
+        Array.isArray(historyMessages) &&
+        historyMessages.length > 0,
+      );
 
       const result = streamText({
         model: modelInstance,
-        messages: providerEntry.historyReplayFallback
+        messages: shouldReplayHistory
           ? [
-              ...(Array.isArray(historyMessages)
-                ? historyMessages.map((msg) => ({ role: msg.role, content: msg.content }))
-                : []),
+              ...historyMessages.map((msg) => ({ role: msg.role, content: msg.content })),
               latestPromptMessage,
             ]
           : [latestPromptMessage],
@@ -2819,6 +2831,12 @@ function registerHandlers(ipcMain) {
             : "Agent returned an empty response.",
         });
       } else {
+        // Clear replay fallback only after the recovered turn completed with
+        // actual streamed content. Empty/error retries should keep the replay
+        // history available for the next attempt on the fresh ACP session.
+        if (shouldReplayHistory && !abortController.signal.aborted) {
+          providerEntry.historyReplayFallback = false;
+        }
         debugMcpLog("ACP stream done", { requestId, chatSessionId, hasContent });
         if (!isActiveAcpRun(chatSessionId, requestId)) {
           return { ok: true };

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2487,7 +2487,19 @@ function registerHandlers(ipcMain) {
         const resumeSessionId = shouldResetProviderForHistoryReplay
           ? undefined
           : providerEntry?.provider?.getSessionId?.() || existingSessionId || undefined;
-        const preserveHistoryReplayFallback = shouldResetProviderForHistoryReplay;
+        // Preserve the replay-fallback flag across any recreation where
+        // history recovery is still pending, not just the reset-for-replay
+        // path. Otherwise a provider recreation driven by an orthogonal
+        // change (permission mode / MCP scope / auth fingerprint) between
+        // a still-empty recovered turn and its retry would drop the flag
+        // and lose the recovered conversation on the next turn.
+        const preserveHistoryReplayFallback =
+          shouldResetProviderForHistoryReplay ||
+          Boolean(
+            providerEntry?.historyReplayFallback &&
+            Array.isArray(historyMessages) &&
+            historyMessages.length > 0,
+          );
         cleanupAcpProvider(chatSessionId);
 
         const agentEnv = withCliDiscoveryEnv({ ...shellEnv });

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2317,6 +2317,14 @@ function registerHandlers(ipcMain) {
     try {
       const existingRun = acpChatRuns.get(chatSessionId);
       if (existingRun && existingRun.requestId !== requestId) {
+        // Capture whether the prior run was already cancelled (via the
+        // cancel IPC) BEFORE we set the flag ourselves — the cancel IPC
+        // contract explicitly preserves the provider session so the
+        // next prompt can continue in the same conversation. Tearing
+        // down the provider here would silently break that contract in
+        // the "click Stop, then immediately send next prompt" flow,
+        // discarding the recovered ACP session.
+        const alreadyCancelledViaIpc = existingRun.cancelRequested;
         existingRun.cancelRequested = true;
         const existingController = acpActiveStreams.get(existingRun.requestId);
         if (existingController) {
@@ -2324,7 +2332,15 @@ function registerHandlers(ipcMain) {
           acpActiveStreams.delete(existingRun.requestId);
         }
         acpRequestSessions.delete(existingRun.requestId);
-        cleanupAcpProvider(chatSessionId);
+        // Only tear down the provider for true interrupt-and-restart
+        // flows (user typed a new prompt while the old one was still
+        // streaming, no explicit cancel). When we do skip cleanup here,
+        // the reuse/reset logic below still handles auth/MCP/permission
+        // changes correctly — the provider is preserved only when
+        // nothing else would require rebuilding it.
+        if (!alreadyCancelledViaIpc) {
+          cleanupAcpProvider(chatSessionId);
+        }
       }
 
       mcpServerBridge.setChatSessionCancelled?.(chatSessionId, false);
@@ -2909,6 +2925,18 @@ function registerHandlers(ipcMain) {
     mcpServerBridge.clearPendingApprovals(effectiveChatSessionId);
     if (activeRun && activeRun.requestId === effectiveRequestId) {
       activeRun.cancelRequested = true;
+    }
+    // Synchronously clear historyReplayFallback on the preserved provider
+    // entry. Without this, a user pressing Stop and immediately sending
+    // the next prompt can have their new request enter the stream
+    // handler before the aborted run's post-stream clearing code runs.
+    // The new turn would then see historyReplayFallback=true, trigger
+    // shouldResetProviderForHistoryReplay, and recreate the provider
+    // without the recovered existingSessionId — discarding the very
+    // session the cancel contract promised to preserve.
+    if (effectiveChatSessionId) {
+      const preservedEntry = acpProviders.get(effectiveChatSessionId);
+      if (preservedEntry) preservedEntry.historyReplayFallback = false;
     }
     const controller = acpActiveStreams.get(effectiveRequestId);
     let cancelled = false;

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2831,10 +2831,19 @@ function registerHandlers(ipcMain) {
             : "Agent returned an empty response.",
         });
       } else {
-        // Clear replay fallback only after the recovered turn completed with
-        // actual streamed content. Empty/error retries should keep the replay
-        // history available for the next attempt on the fresh ACP session.
-        if (shouldReplayHistory && !abortController.signal.aborted) {
+        // Clear replay fallback when the recovered turn either streamed
+        // content OR was user-aborted. The empty-but-not-aborted case is
+        // handled in the if-branch above and intentionally keeps the flag
+        // so a follow-up retry can re-replay onto a fresh session.
+        //
+        // Why also clear on abort: if the user actively cancelled, the
+        // freshly recovered ACP session has whatever state was built up so
+        // far. Leaving the flag set would make the next turn trigger
+        // shouldResetProviderForHistoryReplay, which discards the recovered
+        // session (resumeSessionId is forced to undefined in that path) and
+        // re-spends tokens on another compact replay. That breaks the
+        // cancel-preserves-session contract for users who stop early.
+        if (shouldReplayHistory) {
           providerEntry.historyReplayFallback = false;
         }
         debugMcpLog("ACP stream done", { requestId, chatSessionId, hasContent });

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -1,0 +1,330 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const Module = require("node:module");
+
+function createIpcMainStub() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+function createEmptyStreamResult() {
+  return {
+    fullStream: {
+      getReader() {
+        return {
+          async read() {
+            return { done: true, value: undefined };
+          },
+          releaseLock() {},
+        };
+      },
+    },
+  };
+}
+
+function loadBridgeWithMocks(options = {}) {
+  const streamCalls = [];
+  const safeSendCalls = [];
+  let providerCreationCount = 0;
+  const providerCreationArgs = [];
+
+  const fallbackProvider = {
+    tools: {},
+    languageModel() {
+      return { id: "fake-model" };
+    },
+    async initSession() {},
+    getSessionId() {
+      return "fresh-session";
+    },
+    cleanup() {},
+  };
+
+  const mocks = {
+    "./mcpServerBridge.cjs": {
+      init() {},
+      setMainWindowGetter() {},
+      getOrCreateHost: async () => 4010,
+      getScopedSessionIds: () => [],
+      buildMcpServerConfig: () => ({ name: "netcatty-remote-hosts", type: "http", url: "http://127.0.0.1:4010" }),
+      getPermissionMode: () => "default",
+      getMaxIterations: () => 20,
+      setChatSessionCancelled() {},
+      cancelPtyExecsForSession() {},
+      clearPendingApprovals() {},
+      cleanupScopedMetadata: async () => {},
+      cleanup() {},
+    },
+    "../cli/discoveryPath.cjs": {
+      getCliLauncherPath: () => "/tmp/netcatty-tool-cli",
+      TOOL_CLI_DISCOVERY_ENV_VAR: "NETCATTY_TOOL_CLI_DISCOVERY_FILE",
+    },
+    "./ai/userSkills.cjs": {
+      scanUserSkills: async () => ({ readyCount: 0, warningCount: 0, skills: [], warnings: [] }),
+      buildUserSkillsContext: async () => ({ context: "", selectedSkills: [] }),
+      toPublicUserSkillsStatus: (value) => value,
+    },
+    "./ai/shellUtils.cjs": {
+      stripAnsi: (value) => value,
+      normalizeCliPathForPlatform: (value) => value,
+      shouldUseShellForCommand: () => false,
+      resolveCliFromPath: () => null,
+      resolveClaudeAcpBinaryPath: () => null,
+      getShellEnv: async () => ({}),
+      invalidateShellEnvCache() {},
+      serializeStreamChunk: (chunk) => chunk,
+      toUnpackedAsarPath: (value) => value,
+    },
+    "./ai/codexHelpers.cjs": {
+      codexLoginSessions: new Map(),
+      resolveCodexAcpBinaryPath: () => null,
+      appendCodexLoginOutput() {},
+      toCodexLoginSessionResponse: () => ({}),
+      getActiveCodexLoginSession: () => null,
+      normalizeCodexIntegrationState: () => ({}),
+      readCodexCustomProviderConfig: () => null,
+      getCodexAuthOverride: () => ({}),
+      getCodexCustomConfigPreflightError: () => null,
+      extractCodexError: (err) => ({ message: err?.message || String(err) }),
+      isCodexAuthError: () => false,
+      getCodexAuthFingerprint: () => "auth-fingerprint",
+      getCodexMcpFingerprint: () => "mcp-fingerprint",
+      invalidateCodexValidationCache() {},
+      getCodexValidationCache: () => null,
+      setCodexValidationCache() {},
+    },
+    "./ai/ptyExec.cjs": {
+      execViaPty: async () => {
+        throw new Error("execViaPty should not be called in this test");
+      },
+    },
+    "./ipcUtils.cjs": {
+      safeSend(sender, channel, payload) {
+        safeSendCalls.push({ sender, channel, payload });
+      },
+    },
+    "./windowManager.cjs": {
+      getMainWindow() {
+        return {
+          isDestroyed: () => false,
+          webContents: { id: 1 },
+        };
+      },
+      getSettingsWindow() {
+        return null;
+      },
+    },
+    "@mcpc-tech/acp-ai-provider": {
+      createACPProvider(args) {
+        providerCreationCount += 1;
+        providerCreationArgs.push(args);
+        if (providerCreationCount === 1) {
+          return {
+            tools: {},
+            languageModel() {
+              return { id: "fake-model" };
+            },
+            async initSession() {
+              throw new Error("Resource not found: session not found");
+            },
+            getSessionId() {
+              return "stale-session";
+            },
+            cleanup() {},
+          };
+        }
+        return fallbackProvider;
+      },
+    },
+    ai: {
+      stepCountIs: () => Symbol("stopWhen"),
+      streamText({ messages }) {
+        streamCalls.push(messages);
+        if (typeof options.streamText === "function") {
+          return options.streamText({ messages, streamCalls });
+        }
+        if (streamCalls.length === 1) {
+          throw new Error("transport failed before replayed turn completed");
+        }
+        return createEmptyStreamResult();
+      },
+    },
+  };
+
+  const bridgePath = require.resolve("./aiBridge.cjs");
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[bridgePath];
+
+  try {
+    const bridge = require("./aiBridge.cjs");
+    return {
+      bridge,
+      streamCalls,
+      safeSendCalls,
+      providerCreationArgs,
+      restore() {
+        try {
+          bridge.cleanup();
+        } finally {
+          delete require.cache[bridgePath];
+          Module._load = originalLoad;
+        }
+      },
+    };
+  } catch (error) {
+    delete require.cache[bridgePath];
+    Module._load = originalLoad;
+    throw error;
+  }
+}
+
+test("replays fallback history only after creating a fresh ACP session when the recovered turn fails", async () => {
+  const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks();
+  const ipcMain = createIpcMainStub();
+  const originalConsoleError = console.error;
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+  assert.equal(typeof streamHandler, "function");
+
+  const historyMessages = [{ role: "user", content: "prior recovered context" }];
+  const event = { sender: { id: 1 } };
+
+  try {
+    console.error = (...args) => {
+      const message = args.map((part) => String(part ?? "")).join(" ");
+      if (message.includes("transport failed before replayed turn completed")) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+
+    await streamHandler(event, {
+      requestId: "req-1",
+      chatSessionId: "chat-1",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "first recovered turn",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "stale-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    await streamHandler(event, {
+      requestId: "req-2",
+      chatSessionId: "chat-1",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "retry after transport failure",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "fresh-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+  } finally {
+    console.error = originalConsoleError;
+    restore();
+  }
+
+  assert.equal(streamCalls.length, 2);
+  assert.deepEqual(streamCalls[0][0], historyMessages[0]);
+  assert.deepEqual(streamCalls[1][0], historyMessages[0]);
+  assert.equal(providerCreationArgs.length, 3);
+  assert.equal("existingSessionId" in providerCreationArgs[0], true);
+  assert.equal(providerCreationArgs[0].existingSessionId, "stale-session");
+  assert.equal("existingSessionId" in providerCreationArgs[1], false);
+  assert.equal("existingSessionId" in providerCreationArgs[2], false);
+});
+
+test("keeps replay fallback enabled after an empty recovered turn by retrying in a fresh ACP session", async () => {
+  const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks({
+    streamText() {
+      return createEmptyStreamResult();
+    },
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+  assert.equal(typeof streamHandler, "function");
+
+  const historyMessages = [{ role: "user", content: "prior recovered context" }];
+  const event = { sender: { id: 1 } };
+
+  try {
+    await streamHandler(event, {
+      requestId: "req-1",
+      chatSessionId: "chat-1",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "first recovered turn",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "stale-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    await streamHandler(event, {
+      requestId: "req-2",
+      chatSessionId: "chat-1",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "retry after empty response",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "fresh-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(streamCalls.length, 2);
+  assert.deepEqual(streamCalls[0][0], historyMessages[0]);
+  assert.deepEqual(streamCalls[1][0], historyMessages[0]);
+  assert.equal(providerCreationArgs.length, 3);
+  assert.equal("existingSessionId" in providerCreationArgs[0], true);
+  assert.equal(providerCreationArgs[0].existingSessionId, "stale-session");
+  assert.equal("existingSessionId" in providerCreationArgs[1], false);
+  assert.equal("existingSessionId" in providerCreationArgs[2], false);
+});

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -143,10 +143,11 @@ function loadBridgeWithMocks(options = {}) {
     },
     ai: {
       stepCountIs: () => Symbol("stopWhen"),
-      streamText({ messages }) {
+      streamText(args) {
+        const { messages } = args;
         streamCalls.push(messages);
         if (typeof options.streamText === "function") {
-          return options.streamText({ messages, streamCalls });
+          return options.streamText({ ...args, streamCalls });
         }
         if (streamCalls.length === 1) {
           throw new Error("transport failed before replayed turn completed");
@@ -260,6 +261,142 @@ test("replays fallback history only after creating a fresh ACP session when the 
   assert.equal(providerCreationArgs[0].existingSessionId, "stale-session");
   assert.equal("existingSessionId" in providerCreationArgs[1], false);
   assert.equal("existingSessionId" in providerCreationArgs[2], false);
+});
+
+test("clears replay fallback after a user-cancelled recovered turn so the fresh ACP session is preserved", async () => {
+  // Regression: if the user stops the first turn after stale-session
+  // recovery, historyReplayFallback must still be cleared. Otherwise the
+  // next turn triggers shouldResetProviderForHistoryReplay, which discards
+  // the freshly recovered ACP session (resumeSessionId is forced to
+  // undefined in that path) and re-spends tokens on another compact
+  // replay. That would break the cancel-preserves-session contract.
+
+  // Gate that the test releases AFTER cancel has been dispatched, so the
+  // bridge's reader loop wakes up to find signal.aborted=true.
+  let releaseRead;
+  const readReleased = new Promise((resolve) => {
+    releaseRead = resolve;
+  });
+
+  const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks({
+    streamText({ streamCalls: callsRef }) {
+      // First call (the recovered turn) — block in read() so the test can
+      // fire cancel before any chunk arrives, simulating "user clicks Stop
+      // before the agent emits content". Second call (follow-up) — return
+      // an immediately-done empty stream.
+      if (callsRef.length === 1) {
+        return {
+          fullStream: {
+            getReader: () => ({
+              async read() {
+                await readReleased;
+                // After cancel, signal.aborted is true; return done so the
+                // loop exits cleanly. Never produced a content chunk →
+                // hasContent stays false, aborted is true → we hit the
+                // else-branch where the fix lives.
+                return { done: true, value: undefined };
+              },
+              releaseLock() {},
+            }),
+          },
+        };
+      }
+      return createEmptyStreamResult();
+    },
+  });
+
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+  const cancelHandler = ipcMain.handlers.get("netcatty:ai:acp:cancel");
+  assert.equal(typeof streamHandler, "function");
+  assert.equal(typeof cancelHandler, "function");
+
+  const historyMessages = [{ role: "user", content: "prior recovered context" }];
+  const event = { sender: { id: 1 } };
+
+  try {
+    // Kick off the first turn; it will block at reader.read().
+    const firstTurn = streamHandler(event, {
+      requestId: "req-cancel-1",
+      chatSessionId: "chat-cancel",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "first recovered turn",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "stale-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    // Yield enough microtasks so the handler reaches the streamText/read
+    // path before we cancel.
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+    // Fire cancel — this calls controller.abort() inside the bridge.
+    await cancelHandler(event, {
+      requestId: "req-cancel-1",
+      chatSessionId: "chat-cancel",
+    });
+
+    // Now release the blocked read so the loop wakes, sees aborted, and
+    // exits. The else-branch should clear historyReplayFallback.
+    releaseRead();
+    await firstTurn;
+
+    // Second turn — should reuse the recovered fresh-session and send
+    // only the latest prompt (no compact replay).
+    await streamHandler(event, {
+      requestId: "req-cancel-2",
+      chatSessionId: "chat-cancel",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "follow-up after cancel",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "fresh-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+  } finally {
+    restore();
+  }
+
+  // Two streamText calls: the cancelled one + the follow-up.
+  assert.equal(streamCalls.length, 2);
+
+  // Provider creation count: 1 stale attempt + 1 fallback recovery = 2.
+  // If the bug regresses, the follow-up turn would force a 3rd creation
+  // (shouldResetProviderForHistoryReplay → cleanupAcpProvider → recreate
+  // without existingSessionId).
+  assert.equal(
+    providerCreationArgs.length,
+    2,
+    "expected the recovered fresh session to be preserved across user cancel",
+  );
+
+  // Follow-up turn should send only the latest prompt — the recovered
+  // session has the prior context; replaying compact history again would
+  // waste tokens and visually feel like the conversation forgot itself.
+  assert.equal(
+    streamCalls[1].length,
+    1,
+    "follow-up after cancel must not re-replay compact history",
+  );
 });
 
 test("keeps replay fallback enabled after an empty recovered turn by retrying in a fresh ACP session", async () => {

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -52,7 +52,10 @@ function loadBridgeWithMocks(options = {}) {
       getOrCreateHost: async () => 4010,
       getScopedSessionIds: () => [],
       buildMcpServerConfig: () => ({ name: "netcatty-remote-hosts", type: "http", url: "http://127.0.0.1:4010" }),
-      getPermissionMode: () => "default",
+      getPermissionMode: () =>
+        typeof options.getPermissionMode === "function"
+          ? options.getPermissionMode()
+          : "default",
       getMaxIterations: () => 20,
       setChatSessionCancelled() {},
       cancelPtyExecsForSession() {},
@@ -92,7 +95,10 @@ function loadBridgeWithMocks(options = {}) {
       getCodexCustomConfigPreflightError: () => null,
       extractCodexError: (err) => ({ message: err?.message || String(err) }),
       isCodexAuthError: () => false,
-      getCodexAuthFingerprint: () => "auth-fingerprint",
+      getCodexAuthFingerprint: (...args) =>
+        typeof options.getCodexAuthFingerprint === "function"
+          ? options.getCodexAuthFingerprint(...args)
+          : "auth-fingerprint",
       getCodexMcpFingerprint: () => "mcp-fingerprint",
       invalidateCodexValidationCache() {},
       getCodexValidationCache: () => null,
@@ -397,6 +403,115 @@ test("clears replay fallback after a user-cancelled recovered turn so the fresh 
     1,
     "follow-up after cancel must not re-replay compact history",
   );
+});
+
+test("preserves history-replay across provider recreation caused by permission-mode / MCP / auth change", async () => {
+  // Regression: after a stale-session recovery left historyReplayFallback=true
+  // (e.g. the recovered turn returned empty), an orthogonal change that
+  // flips shouldReuseProvider to false (permission mode, MCP scope, auth
+  // fingerprint) used to recreate the provider with historyReplayFallback:
+  // false. The next turn then sent only the latest prompt and dropped the
+  // recovered conversation context. We now preserve the flag on any
+  // recreation where a history-replay is still pending.
+
+  // Use permission mode as the orthogonal change — auth fingerprint would
+  // drag in Codex-specific auth validation we can't stub cleanly.
+  let permissionMode = "default";
+  function createStreamResult(chunks) {
+    let idx = 0;
+    return {
+      fullStream: {
+        getReader: () => ({
+          async read() {
+            if (idx < chunks.length) {
+              return { done: false, value: chunks[idx++] };
+            }
+            return { done: true, value: undefined };
+          },
+          releaseLock() {},
+        }),
+      },
+    };
+  }
+
+  const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks({
+    getPermissionMode: () => permissionMode,
+    streamText({ streamCalls: callsRef }) {
+      // Turn 1: empty stream — the recovered turn returned no content, so
+      // the empty-non-aborted branch keeps historyReplayFallback=true.
+      if (callsRef.length === 1) return createEmptyStreamResult();
+      // Turn 2: content streams — confirms the replay actually reached
+      // the recreated provider.
+      return createStreamResult([{ type: "text-delta", text: "ok" }]);
+    },
+  });
+
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+  const historyMessages = [{ role: "user", content: "prior recovered context" }];
+  const event = { sender: { id: 1 } };
+
+  try {
+    // Turn 1: stale-session recovery + empty response (flag stays set).
+    await streamHandler(event, {
+      requestId: "req-1",
+      chatSessionId: "chat-preserve",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "first turn",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "stale-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    // Simulate the user toggling the MCP permission mode between turns.
+    // This flips shouldReuseProvider to false and forces recreation via
+    // the non-reset branch — exactly where the preserve-flag gap lived.
+    permissionMode = "auto";
+
+    await streamHandler(event, {
+      requestId: "req-2",
+      chatSessionId: "chat-preserve",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "second turn after permission change",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "fresh-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(streamCalls.length, 2);
+  // Turn 2 must include history + latest; regression would make it just 1.
+  assert.equal(
+    streamCalls[1].length,
+    2,
+    "second turn must re-replay compact history onto the recreated provider",
+  );
+  assert.deepEqual(streamCalls[1][0], historyMessages[0]);
+
+  // 3 provider creations: stale attempt + first fallback + permission-change recreation.
+  assert.equal(providerCreationArgs.length, 3);
 });
 
 test("keeps replay fallback enabled after an empty recovered turn by retrying in a fresh ACP session", async () => {

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -405,6 +405,136 @@ test("clears replay fallback after a user-cancelled recovered turn so the fresh 
   );
 });
 
+test("preserves recovered ACP session when user cancels then immediately sends the next prompt", async () => {
+  // Regression: after a user-cancel of a recovered turn, the existingRun
+  // path in the next stream handler used to call cleanupAcpProvider
+  // unconditionally — destroying the fresh ACP session the cancel IPC
+  // had just promised to preserve. Combined with historyReplayFallback
+  // still being true at that moment, the follow-up turn then recreated
+  // a bare new provider via shouldResetProviderForHistoryReplay and
+  // the user lost all recovered conversation context.
+  //
+  // With the fix: (a) the cancel IPC synchronously clears the replay
+  // flag on the preserved provider, and (b) the existingRun path skips
+  // cleanupAcpProvider when the prior run was already cancelled via
+  // the cancel IPC. The next stream then reuses the recovered session
+  // and sends only the latest prompt.
+
+  let releaseRead;
+  const readReleased = new Promise((resolve) => {
+    releaseRead = resolve;
+  });
+
+  const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks({
+    streamText({ streamCalls: callsRef }) {
+      // Turn 1: block in read() so the test can fire cancel, then
+      // immediately fire the next stream request while the aborted
+      // stream is still unwinding.
+      if (callsRef.length === 1) {
+        return {
+          fullStream: {
+            getReader: () => ({
+              async read() {
+                await readReleased;
+                return { done: true, value: undefined };
+              },
+              releaseLock() {},
+            }),
+          },
+        };
+      }
+      return createEmptyStreamResult();
+    },
+  });
+
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+  const cancelHandler = ipcMain.handlers.get("netcatty:ai:acp:cancel");
+
+  const historyMessages = [{ role: "user", content: "prior recovered context" }];
+  const event = { sender: { id: 1 } };
+
+  try {
+    // Turn 1 starts and blocks in read().
+    const firstTurn = streamHandler(event, {
+      requestId: "req-cancel-1",
+      chatSessionId: "chat-race",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "first turn",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "stale-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    // Yield so the handler reaches the streamText/read phase.
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
+
+    // User clicks Stop.
+    await cancelHandler(event, {
+      requestId: "req-cancel-1",
+      chatSessionId: "chat-race",
+    });
+
+    // User immediately sends the next prompt BEFORE releasing the read
+    // — i.e. before the first stream handler's post-stream code can
+    // run. This is the exact timing window codex flagged.
+    const secondTurn = streamHandler(event, {
+      requestId: "req-cancel-2",
+      chatSessionId: "chat-race",
+      acpCommand: "fake-acp",
+      acpArgs: [],
+      prompt: "immediate follow-up",
+      providerId: undefined,
+      model: undefined,
+      existingSessionId: "fresh-session",
+      historyMessages,
+      images: undefined,
+      toolIntegrationMode: "mcp",
+      defaultTargetSession: undefined,
+      userSkillsContext: undefined,
+    });
+
+    // Let the first turn unwind now.
+    releaseRead();
+    await firstTurn;
+    await secondTurn;
+  } finally {
+    restore();
+  }
+
+  // 2 provider creations: the stale attempt + fallback recovery.
+  // If the regression is back, there would be a 3rd creation (the
+  // existingRun cleanup + reset-for-replay path discarding the
+  // recovered session).
+  assert.equal(
+    providerCreationArgs.length,
+    2,
+    "expected recovered fresh session to be preserved across cancel+immediate-send",
+  );
+
+  // Second turn must NOT re-replay compact history — the preserved
+  // session already has that context.
+  assert.equal(
+    streamCalls[1].length,
+    1,
+    "follow-up after cancel must not re-replay compact history",
+  );
+});
+
 test("preserves history-replay across provider recreation caused by permission-mode / MCP / auth change", async () => {
   // Regression: after a stale-session recovery left historyReplayFallback=true
   // (e.g. the recovered turn returned empty), an orthogonal change that

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts domain/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts domain/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs application/state/*.test.ts domain/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts domain/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## Summary

This PR reduces ACP chat history replay cost by leaning on the ACP provider's own persisted session history whenever possible.

Instead of sending the full Netcatty UI chat history on every external agent turn, Netcatty now sends only the latest user prompt for healthy persisted ACP sessions. When a provider session is stale and has to be recreated, Netcatty falls back to a compact replay payload so the fresh ACP session can recover the most important prior context without paying the full token cost.

## Why

ACP providers already maintain their own conversation/session history. Replaying Netcatty's full local chat transcript every turn duplicates that context and burns unnecessary tokens, especially in long-running agent sessions with tool output.

This change keeps normal turns lightweight:

- Reuse provider-managed history as the source of truth.
- Send compact Netcatty history only during stale-session recovery.
- Preserve durable user constraints and important assistant context in fallback replay.
- Keep recent raw turns small and bounded.
- Trim user skill index context so skill routing remains useful without bloating prompts.

## Changes

- Added ACP history compaction for fallback recovery.
- Changed the ACP bridge to replay compact history only after creating a fresh session for stale-session recovery.
- Kept replay fallback enabled after failed or empty recovered turns so retries still have recovery context.
- Cleared replay fallback only after a recovered turn produces real streamed content.
- Moved ACP history shaping out of `AIChatSidePanel` into a dedicated helper.
- Reduced user-managed skill index prompt size while keeping longer descriptions available for matching.
- Added regression coverage for ACP fallback replay, empty recovered turns, durable constraints, assistant-only context, and skill index trimming.

## Testing

- `npm test`
- `npm run lint`
- `npm run build`
