### PR TITLE
Honor CSI 3 J by default; add toggle to preserve scrollback on `clear`

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -306,6 +306,9 @@ const en: Messages = {
   'settings.terminal.behavior.bracketedPaste': 'Bracketed paste mode',
   'settings.terminal.behavior.bracketedPaste.desc':
     'Wrap pasted text with escape sequences so the shell can distinguish paste from typed input. Disable if you see ^[[200~ artifacts.',
+  'settings.terminal.behavior.clearWipesScrollback': '`clear` wipes scrollback',
+  'settings.terminal.behavior.clearWipesScrollback.desc':
+    'When the shell `clear` command (or any program) sends CSI 3 J, also wipe the scrollback buffer. Standard POSIX/ncurses behavior since 2013. Disable to keep history visible after `clear` (matches iTerm2). The right-click "Clear Buffer" menu item always preserves scrollback regardless of this setting.',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 clipboard',
   'settings.terminal.behavior.osc52Clipboard.desc':
     'Allow remote programs (tmux, vim, etc.) to access the local clipboard via OSC-52 escape sequences.',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1389,6 +1389,9 @@ const zhCN: Messages = {
   'settings.terminal.behavior.bracketedPaste': '括号粘贴模式',
   'settings.terminal.behavior.bracketedPaste.desc':
     '粘贴文本时使用转义序列包裹，以便终端区分粘贴和键入。如果出现 ^[[200~ 字样请关闭此选项。',
+  'settings.terminal.behavior.clearWipesScrollback': '`clear` 同时清空回滚历史',
+  'settings.terminal.behavior.clearWipesScrollback.desc':
+    '启用时，shell 的 clear 命令（或任何程序发送 CSI 3 J）会同时清空回滚历史，这是 2013 年以来 POSIX/ncurses 的标准行为。关闭后 clear 仅清屏、回滚历史保留（与 iTerm2 一致）。右键菜单的"清空缓冲区"始终保留历史，不受此设置影响。',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 剪贴板',
   'settings.terminal.behavior.osc52Clipboard.desc':
     '允许远程程序（tmux、vim 等）通过 OSC-52 转义序列访问本地剪贴板。',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -108,7 +108,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'smoothScrolling',
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
-  'keepaliveInterval', 'disableBracketedPaste', 'osc52Clipboard',
+  'keepaliveInterval', 'disableBracketedPaste', 'clearWipesScrollback', 'osc52Clipboard',
   'autocompleteEnabled', 'autocompleteGhostText', 'autocompletePopupMenu',
   'autocompleteDebounceMs', 'autocompleteMinChars', 'autocompleteMaxSuggestions',
 ] as const;

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -816,6 +816,13 @@ export default function SettingsTerminalTab(props: {
         </SettingRow>
 
         <SettingRow
+          label={t("settings.terminal.behavior.clearWipesScrollback")}
+          description={t("settings.terminal.behavior.clearWipesScrollback.desc")}
+        >
+          <Toggle checked={terminalSettings.clearWipesScrollback ?? true} onChange={(v) => updateTerminalSetting("clearWipesScrollback", v)} />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.osc52Clipboard")}
           description={t("settings.terminal.behavior.osc52Clipboard.desc")}
         >

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -664,7 +664,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (!isEraseScrollbackSequence(params)) {
       return false;
     }
-    return true;
+    // CSI 3 J — POSIX/ncurses default `clear` emits this to wipe scrollback.
+    // Honor it unless the user opts into the legacy "preserve history" behavior.
+    const wipeAllowed = ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true;
+    return !wipeAllowed;
   });
 
   // Register OSC 7 handler using xterm.js parser

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -497,6 +497,12 @@ export interface TerminalSettings {
   // Paste
   disableBracketedPaste: boolean; // Disable bracketed paste mode (avoid ^[[200~ artifacts)
 
+  // Shell `clear` command behavior — controls whether CSI 3 J (erase scrollback)
+  // from the shell is honored. Default true matches POSIX/ncurses since 2013:
+  // `clear` clears both visible screen and scrollback. Disable to keep history
+  // across `clear` (matches iTerm2 default and pre-2013 behavior).
+  clearWipesScrollback: boolean;
+
   // Clipboard
   osc52Clipboard: 'off' | 'write-only' | 'read-write' | 'prompt'; // OSC-52 clipboard access: off, write-only (default), read-write, or prompt on read
 
@@ -625,6 +631,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   showServerStats: true, // Show server stats by default
   serverStatsRefreshInterval: 5, // Refresh every 5 seconds
   disableBracketedPaste: false, // Bracketed paste enabled by default
+  clearWipesScrollback: true, // POSIX-standard: shell `clear` clears scrollback too
   osc52Clipboard: 'write-only', // OSC-52: allow remote programs to write clipboard by default
   rendererType: 'auto', // Auto-detect best renderer based on hardware
   autocompleteEnabled: true, // Autocomplete enabled by default


### PR DESCRIPTION
## Summary

- Restore POSIX/ncurses-standard behavior for the shell `clear` command: it now wipes the scrollback buffer (CSI 3 J) again by default
- Add an opt-in setting `clearWipesScrollback` for users who prefer the iTerm2-style "history survives clear" behavior introduced by #633
- Right-click **Clear Buffer** menu action remains independent and always preserves scrollback

## Background

ncurses ≥ 2013 ships `clear` such that the default invocation emits both `\e[H\e[2J` (clear visible) **and** `\e[3J` (E3 — wipe scrollback). The `-x` flag *suppresses* the CSI 3 J. PR #633 unconditionally intercepted CSI 3 J inside the xterm.js parser, which preserved scrollback across `clear` (fixing #622's complaint that "clear loses my last page") but broke standard `clear` for users who actually wanted history wiped (#757). Even `clear -x` couldn't help, because by definition `-x` doesn't emit the sequence in the first place.

## Behavior matrix

| Action | `clearWipesScrollback = true` (default, new) | `clearWipesScrollback = false` (legacy) |
|---|---|---|
| `clear` (POSIX default) | Wipes screen + scrollback | Wipes screen, keeps scrollback |
| `clear -x` | Wipes screen only (POSIX) | Wipes screen only (POSIX) |
| Right-click → Clear Buffer | Wipes screen, keeps scrollback | Wipes screen, keeps scrollback |

## Files

- `domain/models.ts` — new boolean field, default `true`
- `components/terminal/runtime/createXTermRuntime.ts` — CSI 3 J handler reads the setting
- `components/settings/tabs/SettingsTerminalTab.tsx` — Toggle in Behavior section
- `application/i18n/locales/{en,zh-CN}.ts` — labels + description

## Migration note for release notes

Users who upgraded to ≥ 1.0.81 (when #633 landed) and grew to rely on `clear` preserving history should be told they can flip the new toggle off to keep the legacy behavior.

## Test plan

- [x] Default install: open a local shell, fill more than one page of output, run `clear` — scrollback should be empty
- [x] Default install: same as above with `clear -x` — scrollback should be preserved
- [ ] Toggle off the setting: `clear` should preserve scrollback (legacy #633 behavior)
- [ ] Right-click → Clear Buffer: scrollback always preserved regardless of the setting
- [ ] Switching the setting takes effect on the next `clear` without restart

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)