### PR TITLE
Add opt-in setting to preserve mouse selection across keystrokes (#755)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -309,6 +309,9 @@ const en: Messages = {
   'settings.terminal.behavior.clearWipesScrollback': '`clear` wipes scrollback',
   'settings.terminal.behavior.clearWipesScrollback.desc':
     'When the shell `clear` command (or any program) sends CSI 3 J, also wipe the scrollback buffer. Standard POSIX/ncurses behavior since 2013. Disable to keep history visible after `clear` (matches iTerm2). The right-click "Clear Buffer" menu item always preserves scrollback regardless of this setting.',
+  'settings.terminal.behavior.preserveSelectionOnInput': 'Keep selection while typing',
+  'settings.terminal.behavior.preserveSelectionOnInput.desc':
+    'Stop xterm.js from clearing your mouse-selected text the moment you press a key. Useful for selecting a path, typing a command prefix like `sz `, then pasting the still-live selection. Matches iTerm2 / GNOME Terminal / Windows Terminal default. Selection is still cleared on mouse click in empty space or when the terminal scrolls past it.',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 clipboard',
   'settings.terminal.behavior.osc52Clipboard.desc':
     'Allow remote programs (tmux, vim, etc.) to access the local clipboard via OSC-52 escape sequences.',

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -308,10 +308,10 @@ const en: Messages = {
     'Wrap pasted text with escape sequences so the shell can distinguish paste from typed input. Disable if you see ^[[200~ artifacts.',
   'settings.terminal.behavior.clearWipesScrollback': '`clear` wipes scrollback',
   'settings.terminal.behavior.clearWipesScrollback.desc':
-    'When the shell `clear` command (or any program) sends CSI 3 J, also wipe the scrollback buffer. Standard POSIX/ncurses behavior since 2013. Disable to keep history visible after `clear` (matches iTerm2). The right-click "Clear Buffer" menu item always preserves scrollback regardless of this setting.',
+    'Make `clear` also wipe the scrollback buffer (POSIX default). Disable to keep history visible after `clear`.',
   'settings.terminal.behavior.preserveSelectionOnInput': 'Keep selection while typing',
   'settings.terminal.behavior.preserveSelectionOnInput.desc':
-    'Stop xterm.js from clearing your mouse-selected text the moment you press a key. Useful for selecting a path, typing a command prefix like `sz `, then pasting the still-live selection. Matches iTerm2 / GNOME Terminal / Windows Terminal default. Selection is still cleared on mouse click in empty space or when the terminal scrolls past it.',
+    'Don\'t clear mouse-selected text when typing — useful for selecting a path then pasting it after a command prefix like `sz `.',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 clipboard',
   'settings.terminal.behavior.osc52Clipboard.desc':
     'Allow remote programs (tmux, vim, etc.) to access the local clipboard via OSC-52 escape sequences.',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1392,6 +1392,9 @@ const zhCN: Messages = {
   'settings.terminal.behavior.clearWipesScrollback': '`clear` 同时清空回滚历史',
   'settings.terminal.behavior.clearWipesScrollback.desc':
     '启用时，shell 的 clear 命令（或任何程序发送 CSI 3 J）会同时清空回滚历史，这是 2013 年以来 POSIX/ncurses 的标准行为。关闭后 clear 仅清屏、回滚历史保留（与 iTerm2 一致）。右键菜单的"清空缓冲区"始终保留历史，不受此设置影响。',
+  'settings.terminal.behavior.preserveSelectionOnInput': '输入时保留选区',
+  'settings.terminal.behavior.preserveSelectionOnInput.desc':
+    '默认按下任何键就会清掉鼠标选中的文本，启用后键盘输入不会清除选区。适合"选中路径 → 输入 sz → 粘贴选中内容下载文件"这类工作流。与 iTerm2 / GNOME Terminal / Windows Terminal 的默认行为一致。鼠标在空白处点击或终端输出滚过选区时，仍会自动清除。',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 剪贴板',
   'settings.terminal.behavior.osc52Clipboard.desc':
     '允许远程程序（tmux、vim 等）通过 OSC-52 转义序列访问本地剪贴板。',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1391,10 +1391,10 @@ const zhCN: Messages = {
     '粘贴文本时使用转义序列包裹，以便终端区分粘贴和键入。如果出现 ^[[200~ 字样请关闭此选项。',
   'settings.terminal.behavior.clearWipesScrollback': '`clear` 同时清空回滚历史',
   'settings.terminal.behavior.clearWipesScrollback.desc':
-    '启用时，shell 的 clear 命令（或任何程序发送 CSI 3 J）会同时清空回滚历史，这是 2013 年以来 POSIX/ncurses 的标准行为。关闭后 clear 仅清屏、回滚历史保留（与 iTerm2 一致）。右键菜单的"清空缓冲区"始终保留历史，不受此设置影响。',
+    '`clear` 命令同时清空回滚历史（POSIX 默认行为）。关闭则保留历史。',
   'settings.terminal.behavior.preserveSelectionOnInput': '输入时保留选区',
   'settings.terminal.behavior.preserveSelectionOnInput.desc':
-    '默认按下任何键就会清掉鼠标选中的文本，启用后键盘输入不会清除选区。适合"选中路径 → 输入 sz → 粘贴选中内容下载文件"这类工作流。与 iTerm2 / GNOME Terminal / Windows Terminal 的默认行为一致。鼠标在空白处点击或终端输出滚过选区时，仍会自动清除。',
+    '键盘输入时不清除鼠标选中的文本，方便选中路径后输入 `sz ` 之类命令再粘贴。',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 剪贴板',
   'settings.terminal.behavior.osc52Clipboard.desc':
     '允许远程程序（tmux、vim 等）通过 OSC-52 转义序列访问本地剪贴板。',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -108,7 +108,8 @@ const SYNCABLE_TERMINAL_KEYS = [
   'smoothScrolling',
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
-  'keepaliveInterval', 'disableBracketedPaste', 'clearWipesScrollback', 'osc52Clipboard',
+  'keepaliveInterval', 'disableBracketedPaste', 'clearWipesScrollback',
+  'preserveSelectionOnInput', 'osc52Clipboard',
   'autocompleteEnabled', 'autocompleteGhostText', 'autocompletePopupMenu',
   'autocompleteDebounceMs', 'autocompleteMinChars', 'autocompleteMaxSuggestions',
 ] as const;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -800,6 +800,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           // Autocomplete integration
           onAutocompleteKeyEvent: (e: KeyboardEvent) => autocompleteKeyEventRef.current?.(e) ?? true,
           onAutocompleteInput: (data: string) => autocompleteInputRef.current?.(data),
+          isRestoringSelectionRef,
         });
 
         xtermRuntimeRef.current = runtime;
@@ -1237,7 +1238,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       const hasText = !!selection && selection.length > 0;
       setHasSelection(hasText);
 
-      if (hasText && terminalSettings?.copyOnSelect) {
+      if (hasText && terminalSettings?.copyOnSelect && !isRestoringSelectionRef.current) {
         navigator.clipboard.writeText(selection).catch((err) => {
           logger.warn("Copy on select failed:", err);
         });
@@ -1327,6 +1328,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const disableBracketedPasteRef = useRef(terminalSettings?.disableBracketedPaste ?? false);
   disableBracketedPasteRef.current = terminalSettings?.disableBracketedPaste ?? false;
+
+  // True only while createXTermRuntime is programmatically restoring the
+  // selection right after a keystroke (preserveSelectionOnInput). Lets
+  // copy-on-select skip a redundant clipboard write that would otherwise
+  // clobber whatever the user copied elsewhere in the meantime.
+  const isRestoringSelectionRef = useRef(false);
 
   const scrollOnPasteRef = useRef(terminalSettings?.scrollOnPaste ?? true);
   scrollOnPasteRef.current = terminalSettings?.scrollOnPaste ?? true;

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -823,6 +823,13 @@ export default function SettingsTerminalTab(props: {
         </SettingRow>
 
         <SettingRow
+          label={t("settings.terminal.behavior.preserveSelectionOnInput")}
+          description={t("settings.terminal.behavior.preserveSelectionOnInput.desc")}
+        >
+          <Toggle checked={terminalSettings.preserveSelectionOnInput ?? false} onChange={(v) => updateTerminalSetting("preserveSelectionOnInput", v)} />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.osc52Clipboard")}
           description={t("settings.terminal.behavior.osc52Clipboard.desc")}
         >

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -114,6 +114,10 @@ export type CreateXTermRuntimeContext = {
   onAutocompleteKeyEvent?: (e: KeyboardEvent) => boolean;
   // Autocomplete input handler — called on every character input
   onAutocompleteInput?: (data: string) => void;
+
+  // Set to true while we're programmatically restoring a selection so that
+  // copy-on-select listeners can suppress redundant clipboard writes.
+  isRestoringSelectionRef?: RefObject<boolean>;
 };
 
 const detectPlatform = (): XTermPlatform => {
@@ -417,6 +421,38 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
     if (e.type !== "keydown") {
       return true;
+    }
+
+    // Preserve mouse selection across keystrokes when enabled. xterm.js
+    // unconditionally clears the selection on user input
+    // (SelectionService.ts: coreService.onUserInput → clearSelection).
+    // Capture the selection here, then re-apply it after xterm has
+    // processed the key + cleared. The microtask runs after both
+    // synchronous listeners, so by then either the selection is gone (and
+    // we restore) or it's still there (we no-op).
+    if (
+      ctx.terminalSettingsRef.current?.preserveSelectionOnInput &&
+      term.hasSelection()
+    ) {
+      const sel = term.getSelectionPosition();
+      if (sel) {
+        const length =
+          (sel.end.y - sel.start.y) * term.cols + (sel.end.x - sel.start.x);
+        const savedStartX = sel.start.x;
+        const savedStartY = sel.start.y;
+        queueMicrotask(() => {
+          if (term.hasSelection()) return;
+          // Bail out if scrollback trim invalidated the row index.
+          if (savedStartY >= term.buffer.active.length) return;
+          const restoreFlag = ctx.isRestoringSelectionRef;
+          if (restoreFlag) restoreFlag.current = true;
+          try {
+            term.select(savedStartX, savedStartY, length);
+          } finally {
+            if (restoreFlag) restoreFlag.current = false;
+          }
+        });
+      }
     }
 
     // Autocomplete key handler (must be checked before other handlers)

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -503,6 +503,12 @@ export interface TerminalSettings {
   // across `clear` (matches iTerm2 default and pre-2013 behavior).
   clearWipesScrollback: boolean;
 
+  // When true, typing on the keyboard does NOT clear an existing mouse
+  // selection. Lets the user select text, type a command prefix (e.g. `sz `),
+  // and then paste the still-live selection. xterm.js's default is to clear
+  // on input; this opt-in toggle restores the selection right after.
+  preserveSelectionOnInput: boolean;
+
   // Clipboard
   osc52Clipboard: 'off' | 'write-only' | 'read-write' | 'prompt'; // OSC-52 clipboard access: off, write-only (default), read-write, or prompt on read
 
@@ -632,6 +638,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   serverStatsRefreshInterval: 5, // Refresh every 5 seconds
   disableBracketedPaste: false, // Bracketed paste enabled by default
   clearWipesScrollback: true, // POSIX-standard: shell `clear` clears scrollback too
+  preserveSelectionOnInput: false, // Opt-in: keep selection alive when typing
   osc52Clipboard: 'write-only', // OSC-52: allow remote programs to write clipboard by default
   rendererType: 'auto', // Auto-detect best renderer based on hardware
   autocompleteEnabled: true, // Autocomplete enabled by default


### PR DESCRIPTION
## Summary

- Add a new opt-in terminal setting **Keep selection while typing** that stops xterm.js from clearing the mouse-selected text on the first keystroke
- Default `false` (zero behavior change for existing users); flip on to match iTerm2 / GNOME Terminal / Windows Terminal default
- Selection still clears on mouse click in empty space and when output scrolls past it

Closes #755

## The user's workflow this enables

1. \`ls\` a directory, see a file path
2. Mouse-select the path
3. Type \`sz \` (or any command prefix)
4. Middle-click paste the still-selected path → \`sz /var/log/foo.log\`

Today step 3 wipes the selection, so step 4 has nothing to paste.

## Why xterm.js can't just be configured

\`@xterm/xterm/src/browser/services/SelectionService.ts:139-143\` hardcodes:

\`\`\`ts
this._coreService.onUserInput(() => {
  if (this.hasSelection) {
    this.clearSelection();
  }
});
\`\`\`

There's no public option to disable. Filing an upstream issue is the long-term clean fix, but in the meantime this PR works around it via the public \`getSelectionPosition\` / \`select\` API.

## Implementation

In the existing \`attachCustomKeyEventHandler\` in \`createXTermRuntime.ts\`:

\`\`\`ts
if (preserveSelectionOnInput && term.hasSelection()) {
  const sel = term.getSelectionPosition();
  if (sel) {
    const length = (sel.end.y - sel.start.y) * term.cols + (sel.end.x - sel.start.x);
    queueMicrotask(() => {
      if (term.hasSelection()) return;            // already there → no-op
      if (sel.start.y >= term.buffer.active.length) return; // trim invalidated coords
      isRestoringSelectionRef.current = true;
      try {
        term.select(sel.start.x, sel.start.y, length);
      } finally {
        isRestoringSelectionRef.current = false;
      }
    });
  }
}
\`\`\`

The \`isRestoringSelectionRef\` gate is owned by \`Terminal.tsx\` and checked in its existing copy-on-select listener. Without it, the restore would re-fire \`onSelectionChange\` and redundantly rewrite the clipboard with the same text — clobbering anything the user copied in another app between the original selection and the keystroke.

## Files

| File | Change |
|---|---|
| \`domain/models.ts\` | New \`preserveSelectionOnInput: boolean\` field, default \`false\` |
| \`application/syncPayload.ts\` | Added to \`SYNCABLE_TERMINAL_KEYS\` (cloud-sync the toggle across devices) |
| \`components/terminal/runtime/createXTermRuntime.ts\` | Capture-and-restore in keydown handler; new \`isRestoringSelectionRef\` context field |
| \`components/Terminal.tsx\` | Owns the ref, passes via context, checks before copy-on-select |
| \`components/settings/tabs/SettingsTerminalTab.tsx\` | Toggle |
| \`application/i18n/locales/{en,zh-CN}.ts\` | Labels |

## Why default off

This is a behavior change with edge cases (potential one-frame visual flicker; scrollback-trim invalidates restore coords; word/line selection mode reverts to NORMAL on restore). Shipping opt-in lets early adopters validate before defaulting on.

## Test plan

- [ ] Setting off (default): no behavior change — typing still clears selection
- [ ] Setting on: select text, type a character → selection stays; the typed character is sent to shell
- [ ] Setting on + copy-on-select on: select text X (copied to clipboard), copy Y in another app, return and type a key in netcatty → clipboard still has Y (NOT overwritten by X)
- [ ] Setting on: select text, click in empty area → selection clears (mouse path unaffected)
- [ ] Setting on: multi-line selection across rows survives keystroke
- [ ] Setting on: Ctrl+C / Ctrl+V / arrow keys all preserve selection
- [ ] Setting on: terminal output scrolls past selected rows → selection drops naturally (no infinite restore)
- [ ] Setting on: cloud-sync flips it on/off across devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)