### PR TITLE
Classify AI proxy / size-limit errors instead of showing raw Zod output (#765)

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -355,14 +355,13 @@ export function useAIChatStreaming({
     err: unknown,
   ) => {
     if (abortSignal.aborted) return;
-    let errorStr: string;
-    if (err instanceof Error) errorStr = err.message;
-    else if (typeof err === 'object' && err !== null && 'message' in err) errorStr = String((err as { message: unknown }).message);
-    else if (typeof err === 'string') errorStr = err;
-    else { try { errorStr = JSON.stringify(err) ?? 'Unknown error'; } catch { errorStr = 'Unknown error'; } }
     // Log the full unsanitized error for debugging
-    console.error('[AIChatSidePanel] Stream error (full):', errorStr);
-    const errorInfo = classifyError(errorStr);
+    console.error('[AIChatSidePanel] Stream error (full):', err);
+    // Pass the raw error to classifyError so it can inspect structured
+    // fields (statusCode, responseBody) from APICallError and friends;
+    // string-coercing here would strip the metadata we need to detect
+    // 413 / HTML-error-page / parse-failure scenarios.
+    const errorInfo = classifyError(err);
     updateLastMessage(sessionId, msg => ({
       ...msg,
       statusText: '',
@@ -560,11 +559,10 @@ export function useAIChatStreaming({
             id: generateId(),
             role: 'assistant',
             content: '',
-            errorInfo: classifyError(
-              typedChunk.error instanceof Error ? typedChunk.error.message
-                : typeof typedChunk.error === 'string' ? typedChunk.error
-                : (() => { try { return JSON.stringify(typedChunk.error) ?? 'Unknown error'; } catch { return 'Unknown error'; } })(),
-            ),
+            // Pass the raw error so classifyError can detect 413 / HTML /
+            // schema-parse scenarios via structured fields (statusCode,
+            // responseBody) instead of lossy string conversion.
+            errorInfo: classifyError(typedChunk.error),
             timestamp: Date.now(),
           });
           break;

--- a/infrastructure/ai/errorClassifier.test.ts
+++ b/infrastructure/ai/errorClassifier.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyError, sanitizeErrorMessage } from "./errorClassifier.ts";
+
+// -------------------------------------------------------------------
+// sanitizeErrorMessage — regression guard for pre-existing behavior
+// -------------------------------------------------------------------
+
+test("sanitizeErrorMessage strips absolute user paths", () => {
+  const result = sanitizeErrorMessage("ENOENT at /Users/alice/project/file.ts");
+  assert.match(result, /<path>/);
+  assert.doesNotMatch(result, /alice/);
+});
+
+test("sanitizeErrorMessage redacts URL credentials", () => {
+  const result = sanitizeErrorMessage("Failed https://api.example.com/v1?api_key=SECRET123");
+  assert.match(result, /<url-redacted>/);
+  assert.doesNotMatch(result, /SECRET123/);
+});
+
+test("sanitizeErrorMessage truncates very long messages", () => {
+  const long = "a".repeat(1000);
+  const result = sanitizeErrorMessage(long);
+  assert.ok(result.length < 600, `expected truncation, got ${result.length} chars`);
+  assert.match(result, /\.\.\.$/);
+});
+
+// -------------------------------------------------------------------
+// classifyError — 413 detection
+// -------------------------------------------------------------------
+
+test("classifyError surfaces a friendly 413 message when statusCode is 413", () => {
+  const err = Object.assign(new Error("Request failed with status 413"), {
+    statusCode: 413,
+    responseBody: "<html>nginx 413</html>",
+  });
+  const info = classifyError(err);
+  assert.equal(info.type, "network");
+  assert.match(info.message, /Request too large/i);
+  assert.match(info.message, /client_max_body_size/i);
+  assert.match(info.message, /Raw:/);
+});
+
+test("classifyError detects 'Request Entity Too Large' in a string error", () => {
+  const info = classifyError("413 Request Entity Too Large");
+  assert.equal(info.type, "network");
+  assert.match(info.message, /Request too large/i);
+});
+
+test("classifyError handles 413 via the message when no statusCode field is set", () => {
+  const info = classifyError(new Error("AI_APICallError: 413 payload rejected"));
+  assert.equal(info.type, "network");
+  assert.match(info.message, /Request too large/i);
+});
+
+// -------------------------------------------------------------------
+// classifyError — 502 / 503 / 504 upstream gateway
+// -------------------------------------------------------------------
+
+test("classifyError marks 502/503/504 as network+retryable", () => {
+  for (const code of [502, 503, 504]) {
+    const info = classifyError(Object.assign(new Error(`status ${code}`), { statusCode: code }));
+    assert.equal(info.type, "network");
+    assert.equal(info.retryable, true, `code ${code} should be retryable`);
+    assert.match(info.message, new RegExp(String(code)));
+  }
+});
+
+// -------------------------------------------------------------------
+// classifyError — HTML response body
+// -------------------------------------------------------------------
+
+test("classifyError detects HTML in responseBody even when status is unknown", () => {
+  const err = Object.assign(new Error("Invalid JSON"), {
+    responseBody: "<!DOCTYPE html>\n<html><body>nginx error</body></html>",
+  });
+  const info = classifyError(err);
+  assert.equal(info.type, "provider");
+  assert.match(info.message, /HTML error page/i);
+  assert.match(info.message, /proxy/i);
+});
+
+test("classifyError detects HTML directly embedded in the error message", () => {
+  const info = classifyError("Parse failed: <html><body>...</body></html>");
+  assert.equal(info.type, "provider");
+  assert.match(info.message, /HTML error page/i);
+});
+
+// -------------------------------------------------------------------
+// classifyError — Zod / schema parse failures
+// -------------------------------------------------------------------
+
+test("classifyError surfaces a friendlier message for 'Expected \\'id\\' to be a string.'", () => {
+  // This is the exact error pattern reported in #765.
+  const info = classifyError("Expected 'id' to be a string.");
+  assert.equal(info.type, "provider");
+  assert.match(info.message, /could not be parsed/i);
+  assert.match(info.message, /request-size limit/i);
+  // Raw error must still be visible for debugging / user reports.
+  assert.match(info.message, /Expected 'id' to be a string/);
+});
+
+test("classifyError handles a variety of schema validation wordings", () => {
+  for (const raw of [
+    "Invalid JSON response: missing field",
+    "Type validation failed: expected number",
+    "Expected 'choices' to be an array.",
+  ]) {
+    const info = classifyError(raw);
+    assert.equal(info.type, "provider", `wording: ${raw}`);
+    assert.match(info.message, /could not be parsed|HTML error page/i);
+  }
+});
+
+// -------------------------------------------------------------------
+// classifyError — fallthrough
+// -------------------------------------------------------------------
+
+test("classifyError falls through to 'unknown' for unclassified errors", () => {
+  const info = classifyError(new Error("Some other provider failure"));
+  assert.equal(info.type, "unknown");
+  assert.match(info.message, /Some other provider failure/);
+});
+
+test("classifyError handles null, undefined, and non-Error shapes without throwing", () => {
+  assert.doesNotThrow(() => classifyError(null));
+  assert.doesNotThrow(() => classifyError(undefined));
+  assert.doesNotThrow(() => classifyError({ foo: "bar" }));
+  assert.doesNotThrow(() => classifyError(42));
+});

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -1,15 +1,173 @@
 import type { ChatMessage } from './types';
 
+type ErrorInfo = NonNullable<ChatMessage['errorInfo']>;
+
 /**
- * Convert a raw error string into display-safe error info.
- *
- * Intentionally avoids keyword-based "root cause" attribution because upstream
- * providers often return generic 4xx/5xx text that would be misclassified.
- * We show the sanitized upstream message directly instead.
+ * Extract the human-readable message from anything that might surface as an
+ * error (Error instance, string, SDK error object with `.message`, etc.).
  */
-export function classifyError(error: string): NonNullable<ChatMessage['errorInfo']> {
-  const message = sanitizeErrorMessage(error).trim() || 'Unknown error';
-  return { type: 'unknown', message, retryable: false };
+function extractMessage(error: unknown): string {
+  if (error instanceof Error) return error.message || '';
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const m = (error as { message: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  try {
+    return JSON.stringify(error) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Pull the HTTP status code out of an error when the SDK layer attached one.
+ * Vercel AI SDK's APICallError exposes `.statusCode`; some shims use
+ * `.status` or `.cause.statusCode`. Falls back to parsing the message text
+ * when no structured field is available.
+ */
+function extractStatusCode(error: unknown, message: string): number | undefined {
+  if (error && typeof error === 'object') {
+    const obj = error as Record<string, unknown>;
+    if (typeof obj.statusCode === 'number') return obj.statusCode;
+    if (typeof obj.status === 'number') return obj.status;
+    if (obj.cause && typeof obj.cause === 'object') {
+      const causeStatus = (obj.cause as Record<string, unknown>).statusCode;
+      if (typeof causeStatus === 'number') return causeStatus;
+    }
+  }
+  // Last resort: look for a standalone 3-digit HTTP status in the message.
+  // Bound by word boundaries to avoid picking up "in 413 ms" etc.
+  const match = message.match(/\b(4\d{2}|5\d{2})\b/);
+  if (match) return Number(match[1]);
+  return undefined;
+}
+
+/**
+ * Pull the response body out of an error object if the SDK attached it.
+ * Nginx / CDN proxy error pages ship as HTML, so we can detect them here.
+ */
+function extractResponseBody(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const body = (error as Record<string, unknown>).responseBody;
+  if (typeof body === 'string') return body;
+  return undefined;
+}
+
+function looksLikeHtml(text: string): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  const trimmedStart = lower.trimStart().slice(0, 200);
+  // Start-of-body: responseBody captured verbatim by the SDK lands here.
+  if (
+    trimmedStart.startsWith('<!doctype html') ||
+    trimmedStart.startsWith('<html') ||
+    trimmedStart.startsWith('<head') ||
+    trimmedStart.startsWith('<body')
+  ) {
+    return true;
+  }
+  // Embedded: some SDKs wrap the HTML body inside an error message like
+  // "Parse failed: <html>...". Look for unmistakable HTML tags anywhere
+  // in the text. Kept narrow to avoid flagging errors that casually
+  // mention "html" as a word.
+  if (
+    lower.includes('<!doctype html') ||
+    lower.includes('<html>') ||
+    lower.includes('<html ') ||
+    // Common nginx default error-page opener.
+    /<center>\s*<h1>/.test(lower)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function looksLikeZodParseError(message: string): boolean {
+  // Zod and Vercel AI SDK schema errors look like:
+  //   Expected 'id' to be a string.
+  //   Expected 'choices' to be an array.
+  //   Invalid JSON response: ...
+  //   Type validation failed: ...
+  return (
+    /\bExpected '[^']+' to be (a|an) /i.test(message) ||
+    /\binvalid json response\b/i.test(message) ||
+    /\btype validation failed\b/i.test(message)
+  );
+}
+
+/**
+ * Map an arbitrary error surface to display-safe error info shown in the
+ * chat UI. Known hostile scenarios get a concrete, actionable message; the
+ * raw SDK text is appended so users can still report it verbatim.
+ *
+ * Covers:
+ *   - HTTP 413 (proxy request-size limit, e.g. nginx client_max_body_size)
+ *   - HTTP 502/504 (upstream proxy failures)
+ *   - HTML error page returned in place of JSON (any proxy)
+ *   - Schema/parse failures ("Expected 'id' to be a string.") that typically
+ *     mean the server swapped the response body for an error page
+ */
+export function classifyError(error: unknown): ErrorInfo {
+  const rawMessage = extractMessage(error).trim() || 'Unknown error';
+  const statusCode = extractStatusCode(error, rawMessage);
+  const responseBody = extractResponseBody(error);
+
+  const hasHtml =
+    looksLikeHtml(rawMessage) ||
+    (responseBody !== undefined && looksLikeHtml(responseBody));
+  const looksLikeParseError = looksLikeZodParseError(rawMessage);
+
+  const sanitizedRaw = sanitizeErrorMessage(rawMessage);
+
+  if (statusCode === 413 || /\brequest entity too large\b/i.test(rawMessage)) {
+    return {
+      type: 'network',
+      message:
+        `Request too large (HTTP 413). The AI gateway rejected the payload — this usually means ` +
+        `the request body exceeded the proxy's size limit (for example nginx \`client_max_body_size\`). ` +
+        `Try sending a shorter message, fewer/smaller attachments, or raising the proxy limit.\n\n` +
+        `Raw: ${sanitizedRaw}`,
+      retryable: false,
+    };
+  }
+
+  if (statusCode === 502 || statusCode === 503 || statusCode === 504) {
+    return {
+      type: 'network',
+      message:
+        `AI gateway error (HTTP ${statusCode}). The proxy in front of the provider returned an error — ` +
+        `the upstream AI service may be unreachable or timing out.\n\n` +
+        `Raw: ${sanitizedRaw}`,
+      retryable: true,
+    };
+  }
+
+  if (hasHtml) {
+    return {
+      type: 'provider',
+      message:
+        `The server returned an HTML error page instead of a JSON response. ` +
+        `This almost always means a proxy (nginx / CDN / gateway) between you and the AI provider ` +
+        `intercepted the request — commonly due to a size limit, auth failure, or the upstream service being down.\n\n` +
+        `Raw: ${sanitizedRaw}`,
+      retryable: false,
+    };
+  }
+
+  if (looksLikeParseError) {
+    return {
+      type: 'provider',
+      message:
+        `The AI response could not be parsed as a valid chat completion. ` +
+        `A proxy may have replaced or truncated the response body, or the provider returned a non-standard format. ` +
+        `If you just sent a large request, check for a request-size limit on any intermediate proxy.\n\n` +
+        `Raw: ${sanitizedRaw}`,
+      retryable: false,
+    };
+  }
+
+  return { type: 'unknown', message: sanitizedRaw, retryable: false };
 }
 
 const MAX_ERROR_MESSAGE_LENGTH = 500;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts domain/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## Summary

Fixes #765 — when an AI request goes through a proxy (nginx / CDN / API gateway) and the proxy rejects it (413, HTML error page, etc.), the UI now shows an actionable message instead of a cryptic \`Expected 'id' to be a string.\` Zod error.

## Root cause

The reported failure path:

1. User sends an AI chat request that's larger than \`client_max_body_size\`
2. Nginx intercepts and returns a **413 HTML error page**
3. Vercel AI SDK tries to parse the HTML body as a chat completion → internal Zod validation fails → \`Expected 'id' to be a string.\`
4. \`classifyError\` was:
   - Only doing light sanitization (no classification of known shapes)
   - Being called with \`.message\` instead of the raw error, throwing away the structured \`statusCode\` / \`responseBody\` fields that \`APICallError\` attaches
5. UI shows the raw Zod text → user assumes the app crashed

## Fix

\`classifyError\` now accepts \`unknown\` and inspects the full error shape. Known hostile scenarios each get an actionable message:

| Signal | User-facing message |
|---|---|
| \`statusCode === 413\` or \"Request Entity Too Large\" | \"Request too large (HTTP 413). Exceeded proxy size limit. Try shorter message, fewer attachments, or raise \`client_max_body_size\`.\" |
| \`statusCode in [502, 503, 504]\` | \"AI gateway error. Upstream may be unreachable.\" (retryable) |
| Response body starts with or contains \`<html>\` / \`<!DOCTYPE html>\` | \"Server returned HTML error page. Likely a proxy intercepted.\" |
| Zod parse shape (\"Expected 'X' to be …\", \"Invalid JSON response\", \"Type validation failed\") | \"Response could not be parsed; proxy may have replaced/truncated the body.\" |

In every classified case, the raw SDK text is still appended (\"Raw: …\") so users can report the underlying error verbatim.

\`components/ai/hooks/useAIChatStreaming.ts\`: both call sites (stream-error handler and error-chunk handler) now pass the raw error to \`classifyError\` instead of \`.message\`, so the structured branches actually trigger.

## Files

| File | Change |
|---|---|
| \`infrastructure/ai/errorClassifier.ts\` | Rewrite \`classifyError(unknown)\` with shape inspection + pattern branches |
| \`infrastructure/ai/errorClassifier.test.ts\` | **New**, 13 tests covering each branch + regression guards |
| \`components/ai/hooks/useAIChatStreaming.ts\` | Pass raw error to \`classifyError\` at both call sites |
| \`package.json\` | Wire \`infrastructure/ai/*.test.ts\` into the test glob |

## Test plan

- [x] Reproduce #765 scenario: configure a self-hosted OpenAI-compatible provider behind nginx with \`client_max_body_size 1k\`, send a larger request — UI should show the new friendly 413 message, not \`Expected 'id' to be a string.\`
- [x] Send a request to an unreachable proxy → retryable 502/503/504 message
- [x] Simulate a provider returning malformed JSON → parse-error message
- [x] Normal errors (auth failures, bad models) still fall through to the \"unknown\" message unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)