### PR TITLE
[codex] avoid main-process runtime crashes

### DIFF
--- a/electron/bridges/mainProcessErrorGuards.test.cjs
+++ b/electron/bridges/mainProcessErrorGuards.test.cjs
@@ -1,7 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
 const {
   classifyProcessError,
+  createProcessErrorController,
+  installProcessErrorHandlers,
   isNonFatalNetworkError,
 } = require("./processErrorGuards.cjs");
 
@@ -55,4 +58,151 @@ test("generic runtime promise rejections are also suppressed after startup", () 
 
   assert.equal(result.action, "suppress");
   assert.match(result.reason, /runtime/i);
+});
+
+test("controller keeps startup strict until the main window is actually shown", () => {
+  const controller = createProcessErrorController();
+
+  controller.beginMainWindowStartup();
+  assert.equal(controller.isRuntimeProtectionActive(), false);
+
+  controller.completeMainWindowStartup({ windowShown: true });
+  assert.equal(controller.isRuntimeProtectionActive(), true);
+});
+
+test("controller becomes strict again while recreating a missing main window", () => {
+  const controller = createProcessErrorController();
+
+  controller.beginMainWindowStartup();
+  controller.completeMainWindowStartup({ windowShown: true });
+  assert.equal(controller.isRuntimeProtectionActive(), true);
+
+  controller.beginMainWindowStartup();
+  assert.equal(controller.isRuntimeProtectionActive(), false);
+
+  controller.completeMainWindowStartup({ windowShown: false });
+  assert.equal(controller.isRuntimeProtectionActive(), true);
+});
+
+test("installed handlers suppress runtime failures but fatal startup failures", () => {
+  const fakeProcess = new EventEmitter();
+  const captured = [];
+  const fatals = [];
+  const errors = [];
+  const warnings = [];
+  const controller = createProcessErrorController({
+    captureError(source, err) {
+      captured.push([source, err.message]);
+    },
+    onFatalError(err) {
+      fatals.push(err.message);
+    },
+    logError(...args) {
+      errors.push(args.map(String).join(" "));
+    },
+    logWarn(...args) {
+      warnings.push(args.map(String).join(" "));
+    },
+  });
+
+  installProcessErrorHandlers(fakeProcess, controller);
+
+  fakeProcess.emit("uncaughtException", new Error("startup boom"));
+  assert.deepEqual(fatals, ["startup boom"]);
+  assert.deepEqual(captured, [["uncaughtException", "startup boom"]]);
+
+  controller.beginMainWindowStartup();
+  controller.completeMainWindowStartup({ windowShown: true });
+
+  fakeProcess.emit("uncaughtException", new Error("runtime boom"));
+  assert.deepEqual(fatals, ["startup boom"]);
+  assert.deepEqual(captured, [
+    ["uncaughtException", "startup boom"],
+    ["uncaughtException", "runtime boom"],
+  ]);
+  assert.equal(errors.some((line) => line.includes("runtime error after startup")), true);
+  assert.equal(warnings.length, 0);
+});
+
+test("unhandled rejection marks the forwarded error so uncaught follow-up is not double-captured", () => {
+  const captured = [];
+  const fatals = [];
+  const controller = createProcessErrorController({
+    captureError(source, err) {
+      captured.push([source, err.message]);
+    },
+    onFatalError(err) {
+      fatals.push(err);
+    },
+    logError() {},
+    logWarn() {},
+  });
+
+  controller.handleUnhandledRejection(new Error("startup rejection"));
+  assert.equal(fatals.length, 1);
+  assert.equal(fatals[0].__fromUnhandledRejection, true);
+  assert.deepEqual(captured, [["unhandledRejection", "startup rejection"]]);
+
+  controller.handleUncaughtException(fatals[0]);
+  assert.deepEqual(captured, [["unhandledRejection", "startup rejection"]]);
+});
+
+test("benign stream teardown errors are ignored by the installed handlers", () => {
+  const fakeProcess = new EventEmitter();
+  let captureCount = 0;
+  let fatalCount = 0;
+  const controller = createProcessErrorController({
+    captureError() {
+      captureCount += 1;
+    },
+    onFatalError() {
+      fatalCount += 1;
+    },
+    logError() {},
+    logWarn() {},
+  });
+
+  installProcessErrorHandlers(fakeProcess, controller);
+  const err = new Error("broken pipe");
+  err.code = "EPIPE";
+  fakeProcess.emit("uncaughtException", err);
+
+  assert.equal(captureCount, 0);
+  assert.equal(fatalCount, 0);
+});
+
+test("controller suppresses wrapped network errors from err.cause", () => {
+  const controller = createProcessErrorController({
+    captureError() {},
+    onFatalError() {
+      throw new Error("should not be fatal");
+    },
+    logError() {},
+    logWarn() {},
+  });
+  controller.beginMainWindowStartup();
+  controller.completeMainWindowStartup({ windowShown: true });
+
+  const err = new Error("request failed");
+  err.cause = new Error("net::ERR_NETWORK_CHANGED");
+
+  assert.doesNotThrow(() => controller.handleUnhandledRejection(err));
+});
+
+test("controller suppresses ssh-style errors with a level property", () => {
+  const controller = createProcessErrorController({
+    captureError() {},
+    onFatalError() {
+      throw new Error("should not be fatal");
+    },
+    logError() {},
+    logWarn() {},
+  });
+  controller.beginMainWindowStartup();
+  controller.completeMainWindowStartup({ windowShown: true });
+
+  const err = new Error("connection lost before handshake");
+  err.level = "client-socket";
+
+  assert.doesNotThrow(() => controller.handleUncaughtException(err));
 });

--- a/electron/bridges/mainProcessErrorGuards.test.cjs
+++ b/electron/bridges/mainProcessErrorGuards.test.cjs
@@ -94,10 +94,61 @@ test("controller becomes strict again while recreating a missing main window", (
   assert.equal(controller.isRuntimeProtectionActive(), true);
 });
 
-test("installed handlers suppress runtime failures but fatal startup failures", () => {
+test("startup-period errors stay fatal while recreating the main window", () => {
+  const fakeProcess = new EventEmitter();
+  const fatals = [];
+  const controller = createProcessErrorController({
+    captureError() {},
+    onFatalError(err) {
+      fatals.push(err.message);
+      throw err;
+    },
+    logError() {},
+    logWarn() {},
+  });
+
+  installProcessErrorHandlers(fakeProcess, controller);
+  controller.completeMainWindowStartup({ windowShown: true });
+  controller.beginMainWindowStartup();
+
+  assert.throws(() => {
+    fakeProcess.emit("uncaughtException", new Error("recreate boom"));
+  }, /recreate boom/);
+  assert.deepEqual(fatals, ["recreate boom"]);
+});
+
+test("fatal startup failures uninstall listeners and keep throwing", () => {
   const fakeProcess = new EventEmitter();
   const captured = [];
   const fatals = [];
+  let uninstall = null;
+  const controller = createProcessErrorController({
+    captureError(source, err) {
+      captured.push([source, err.message]);
+    },
+    onFatalError(err) {
+      fatals.push(err.message);
+      uninstall?.();
+      throw err;
+    },
+    logError() {},
+    logWarn() {},
+  });
+
+  uninstall = installProcessErrorHandlers(fakeProcess, controller);
+
+  assert.throws(() => {
+    fakeProcess.emit("uncaughtException", new Error("startup boom"));
+  }, /startup boom/);
+  assert.deepEqual(fatals, ["startup boom"]);
+  assert.deepEqual(captured, [["uncaughtException", "startup boom"]]);
+  assert.equal(fakeProcess.listenerCount("uncaughtException"), 0);
+  assert.equal(fakeProcess.listenerCount("unhandledRejection"), 0);
+});
+
+test("installed handlers suppress runtime failures after startup", () => {
+  const fakeProcess = new EventEmitter();
+  const captured = [];
   const errors = [];
   const warnings = [];
   const controller = createProcessErrorController({
@@ -105,7 +156,7 @@ test("installed handlers suppress runtime failures but fatal startup failures", 
       captured.push([source, err.message]);
     },
     onFatalError(err) {
-      fatals.push(err.message);
+      throw err;
     },
     logError(...args) {
       errors.push(args.map(String).join(" "));
@@ -117,18 +168,12 @@ test("installed handlers suppress runtime failures but fatal startup failures", 
 
   installProcessErrorHandlers(fakeProcess, controller);
 
-  fakeProcess.emit("uncaughtException", new Error("startup boom"));
-  assert.deepEqual(fatals, ["startup boom"]);
-  assert.deepEqual(captured, [["uncaughtException", "startup boom"]]);
-
   controller.beginMainWindowStartup();
   controller.completeMainWindowStartup({ windowShown: true });
 
   fakeProcess.emit("uncaughtException", new Error("runtime boom"));
   fakeProcess.emit("unhandledRejection", new Error("runtime rejection"));
-  assert.deepEqual(fatals, ["startup boom"]);
   assert.deepEqual(captured, [
-    ["uncaughtException", "startup boom"],
     ["uncaughtException", "runtime boom"],
     ["unhandledRejection", "runtime rejection"],
   ]);

--- a/electron/bridges/mainProcessErrorGuards.test.cjs
+++ b/electron/bridges/mainProcessErrorGuards.test.cjs
@@ -1,0 +1,58 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  classifyProcessError,
+  isNonFatalNetworkError,
+} = require("./processErrorGuards.cjs");
+
+test("treats Chromium ERR_NETWORK_CHANGED as non-fatal", () => {
+  assert.equal(
+    isNonFatalNetworkError(new Error("net::ERR_NETWORK_CHANGED")),
+    true,
+  );
+});
+
+test("treats other Chromium net::ERR_* failures as non-fatal network errors", () => {
+  assert.equal(
+    isNonFatalNetworkError(new Error("net::ERR_INTERNET_DISCONNECTED")),
+    true,
+  );
+  assert.equal(
+    isNonFatalNetworkError(new Error("net::ERR_NAME_NOT_RESOLVED")),
+    true,
+  );
+});
+
+test("keeps non-network errors fatal", () => {
+  assert.equal(
+    isNonFatalNetworkError(new Error("Something else broke")),
+    false,
+  );
+});
+
+test("generic startup exceptions stay fatal before the app is up", () => {
+  const result = classifyProcessError(new Error("boom"), {
+    runtimeStarted: false,
+  });
+
+  assert.equal(result.action, "fatal");
+});
+
+test("generic runtime exceptions are suppressed after startup", () => {
+  const result = classifyProcessError(new Error("boom"), {
+    runtimeStarted: true,
+  });
+
+  assert.equal(result.action, "suppress");
+  assert.match(result.reason, /runtime/i);
+});
+
+test("generic runtime promise rejections are also suppressed after startup", () => {
+  const result = classifyProcessError(new Error("promise boom"), {
+    runtimeStarted: true,
+    origin: "unhandledRejection",
+  });
+
+  assert.equal(result.action, "suppress");
+  assert.match(result.reason, /runtime/i);
+});

--- a/electron/bridges/mainProcessErrorGuards.test.cjs
+++ b/electron/bridges/mainProcessErrorGuards.test.cjs
@@ -26,6 +26,16 @@ test("treats other Chromium net::ERR_* failures as non-fatal network errors", ()
   );
 });
 
+test("treats Node socket error codes as non-fatal network errors", () => {
+  const err = new Error("socket reset");
+  err.code = "ECONNRESET";
+  assert.equal(isNonFatalNetworkError(err), true);
+
+  const dnsErr = new Error("dns failed");
+  dnsErr.code = "ENOTFOUND";
+  assert.equal(isNonFatalNetworkError(dnsErr), true);
+});
+
 test("keeps non-network errors fatal", () => {
   assert.equal(
     isNonFatalNetworkError(new Error("Something else broke")),
@@ -115,10 +125,12 @@ test("installed handlers suppress runtime failures but fatal startup failures", 
   controller.completeMainWindowStartup({ windowShown: true });
 
   fakeProcess.emit("uncaughtException", new Error("runtime boom"));
+  fakeProcess.emit("unhandledRejection", new Error("runtime rejection"));
   assert.deepEqual(fatals, ["startup boom"]);
   assert.deepEqual(captured, [
     ["uncaughtException", "startup boom"],
     ["uncaughtException", "runtime boom"],
+    ["unhandledRejection", "runtime rejection"],
   ]);
   assert.equal(errors.some((line) => line.includes("runtime error after startup")), true);
   assert.equal(warnings.length, 0);
@@ -172,37 +184,25 @@ test("benign stream teardown errors are ignored by the installed handlers", () =
 });
 
 test("controller suppresses wrapped network errors from err.cause", () => {
-  const controller = createProcessErrorController({
-    captureError() {},
-    onFatalError() {
-      throw new Error("should not be fatal");
-    },
-    logError() {},
-    logWarn() {},
-  });
-  controller.beginMainWindowStartup();
-  controller.completeMainWindowStartup({ windowShown: true });
-
   const err = new Error("request failed");
   err.cause = new Error("net::ERR_NETWORK_CHANGED");
 
-  assert.doesNotThrow(() => controller.handleUnhandledRejection(err));
+  const result = classifyProcessError(err, {
+    runtimeStarted: false,
+  });
+
+  assert.equal(isNonFatalNetworkError(err), true);
+  assert.equal(result.action, "suppress");
 });
 
 test("controller suppresses ssh-style errors with a level property", () => {
-  const controller = createProcessErrorController({
-    captureError() {},
-    onFatalError() {
-      throw new Error("should not be fatal");
-    },
-    logError() {},
-    logWarn() {},
-  });
-  controller.beginMainWindowStartup();
-  controller.completeMainWindowStartup({ windowShown: true });
-
   const err = new Error("connection lost before handshake");
   err.level = "client-socket";
 
-  assert.doesNotThrow(() => controller.handleUncaughtException(err));
+  const result = classifyProcessError(err, {
+    runtimeStarted: false,
+  });
+
+  assert.equal(isNonFatalNetworkError(err), true);
+  assert.equal(result.action, "suppress");
 });

--- a/electron/bridges/processErrorGuards.cjs
+++ b/electron/bridges/processErrorGuards.cjs
@@ -75,8 +75,119 @@ function classifyProcessError(err, options = {}) {
   };
 }
 
+function createProcessErrorController(options = {}) {
+  const captureError = typeof options.captureError === "function" ? options.captureError : () => {};
+  const onFatalError = typeof options.onFatalError === "function"
+    ? options.onFatalError
+    : (err) => { throw err; };
+  const logError = typeof options.logError === "function" ? options.logError : (...args) => console.error(...args);
+  const logWarn = typeof options.logWarn === "function" ? options.logWarn : (...args) => console.warn(...args);
+
+  let hasShownMainWindow = false;
+  let pendingMainWindowStartupCount = 0;
+
+  const isRuntimeProtectionActive = () => (
+    hasShownMainWindow && pendingMainWindowStartupCount === 0
+  );
+
+  const beginMainWindowStartup = () => {
+    pendingMainWindowStartupCount += 1;
+  };
+
+  const completeMainWindowStartup = ({ windowShown = false } = {}) => {
+    if (pendingMainWindowStartupCount > 0) {
+      pendingMainWindowStartupCount -= 1;
+    }
+    if (windowShown) {
+      hasShownMainWindow = true;
+    }
+  };
+
+  const handleUncaughtException = (err) => {
+    const decision = classifyProcessError(err, {
+      runtimeStarted: isRuntimeProtectionActive(),
+      origin: "uncaughtException",
+    });
+
+    if (decision.action === "ignore") {
+      logWarn("Ignored process error:", decision.reason, err?.code || err?.message || err);
+      return;
+    }
+
+    if (decision.action === "suppress") {
+      if (!err?.__fromUnhandledRejection) {
+        captureError("uncaughtException", err);
+      }
+      logError(`Suppressed uncaught exception (${decision.reason}):`, err);
+      return;
+    }
+
+    if (!err?.__fromUnhandledRejection) {
+      captureError("uncaughtException", err);
+    }
+    onFatalError(err, {
+      origin: "uncaughtException",
+      decision,
+      reason: err,
+    });
+  };
+
+  const handleUnhandledRejection = (reason) => {
+    const decision = classifyProcessError(reason, {
+      runtimeStarted: isRuntimeProtectionActive(),
+      origin: "unhandledRejection",
+    });
+
+    if (decision.action === "ignore") {
+      return;
+    }
+
+    if (decision.action === "suppress") {
+      captureError("unhandledRejection", reason);
+      logError(`Suppressed unhandled rejection (${decision.reason}):`, reason);
+      return;
+    }
+
+    captureError("unhandledRejection", reason);
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    err.__fromUnhandledRejection = true;
+    onFatalError(err, {
+      origin: "unhandledRejection",
+      decision,
+      reason,
+    });
+  };
+
+  return {
+    beginMainWindowStartup,
+    completeMainWindowStartup,
+    handleUncaughtException,
+    handleUnhandledRejection,
+    isRuntimeProtectionActive,
+  };
+}
+
+function installProcessErrorHandlers(processObject, controller) {
+  if (!processObject?.on || !processObject?.removeListener) {
+    throw new Error("A process-like EventEmitter is required");
+  }
+  if (!controller?.handleUncaughtException || !controller?.handleUnhandledRejection) {
+    throw new Error("A process error controller is required");
+  }
+
+  processObject.on("uncaughtException", controller.handleUncaughtException);
+  processObject.on("unhandledRejection", controller.handleUnhandledRejection);
+
+  return () => {
+    processObject.removeListener("uncaughtException", controller.handleUncaughtException);
+    processObject.removeListener("unhandledRejection", controller.handleUnhandledRejection);
+  };
+}
+
 module.exports = {
   classifyProcessError,
+  createProcessErrorController,
+  installProcessErrorHandlers,
   isBenignStreamError,
   isNonFatalNetworkError,
 };

--- a/electron/bridges/processErrorGuards.cjs
+++ b/electron/bridges/processErrorGuards.cjs
@@ -1,0 +1,82 @@
+function isNonFatalNetworkError(err) {
+  if (!err) return false;
+  // Any error with an ssh2 `level` property is a connection/auth-level error,
+  // never a reason to kill the entire multi-session app.
+  if (err.level) return true;
+
+  const candidates = [err, err.cause].filter(Boolean);
+  for (const candidate of candidates) {
+    const code = candidate.code;
+    // Common TCP/DNS/routing errors that can surface from Node.js sockets
+    // without an ssh2 `level` (e.g. proxy sockets, raw net.connect calls).
+    switch (code) {
+      case "ECONNRESET":
+      case "ECONNREFUSED":
+      case "ECONNABORTED":
+      case "ETIMEDOUT":
+      case "ENOTFOUND":
+      case "EHOSTUNREACH":
+      case "EHOSTDOWN":
+      case "ENETUNREACH":
+      case "ENETDOWN":
+      case "EADDRNOTAVAIL":
+      case "EPROTO":
+      case "EPERM":
+        return true;
+      default:
+        break;
+    }
+
+    // Chromium/Electron networking often rejects with a message like
+    // "net::ERR_NETWORK_CHANGED" but without a useful `code` property.
+    // These are transport failures for background fetch/update/sync work,
+    // not reasons to kill the whole app.
+    const message = String(candidate.message || "");
+    if (/net::ERR_(?:NETWORK_[A-Z_]+|INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|CONNECTION_[A-Z_]+|ADDRESS_[A-Z_]+|SSL_[A-Z_]+|CERT_[A-Z_]+|PROXY_[A-Z_]+|TUNNEL_[A-Z_]+|SOCKS_[A-Z_]+)/.test(message)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isBenignStreamError(err) {
+  const code = err?.code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
+function classifyProcessError(err, options = {}) {
+  const runtimeStarted = options.runtimeStarted === true;
+
+  if (isBenignStreamError(err)) {
+    return {
+      action: "ignore",
+      reason: "benign stream teardown",
+    };
+  }
+
+  if (isNonFatalNetworkError(err)) {
+    return {
+      action: "suppress",
+      reason: "non-fatal network error",
+    };
+  }
+
+  if (runtimeStarted) {
+    return {
+      action: "suppress",
+      reason: "runtime error after startup",
+    };
+  }
+
+  return {
+    action: "fatal",
+    reason: "startup error before app became usable",
+  };
+}
+
+module.exports = {
+  classifyProcessError,
+  isBenignStreamError,
+  isNonFatalNetworkError,
+};

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -36,6 +36,8 @@ let menuDeps = null;
 let electronApp = null; // Reference to Electron app for userData path
 let isQuitting = false;
 const rendererReadyCallbacksByWebContentsId = new Map();
+const rendererReadySeenByWebContentsId = new Set();
+const rendererReadyWaitersByWebContentsId = new Map();
 const DEBUG_WINDOWS = process.env.NETCATTY_DEBUG_WINDOWS === "1";
 const OAUTH_DEFAULT_WIDTH = 600;
 const OAUTH_DEFAULT_HEIGHT = 700;
@@ -791,6 +793,90 @@ function setupDeferredShow(win, { timeoutMs = 3000, waitForRendererReady = true 
   return { showOnce, markRendererReady };
 }
 
+function resolveRendererReady(wcId) {
+  if (!wcId) return;
+  rendererReadySeenByWebContentsId.add(wcId);
+  const cb = rendererReadyCallbacksByWebContentsId.get(wcId);
+  if (cb) cb();
+  const waiters = rendererReadyWaitersByWebContentsId.get(wcId);
+  if (!waiters || waiters.size === 0) return;
+  rendererReadyWaitersByWebContentsId.delete(wcId);
+  for (const resolve of waiters) {
+    try {
+      resolve();
+    } catch {
+      // ignore waiter errors
+    }
+  }
+}
+
+function waitForRendererReady(win, { timeoutMs = 15000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const wcId = (() => {
+      try {
+        return win?.webContents?.id;
+      } catch {
+        return null;
+      }
+    })();
+
+    if (!win || win.isDestroyed?.() || !wcId) {
+      reject(new Error("Main window is unavailable before renderer ready."));
+      return;
+    }
+
+    if (rendererReadySeenByWebContentsId.has(wcId)) {
+      resolve();
+      return;
+    }
+
+    let timer = null;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      try { win.removeListener("closed", handleClosed); } catch {}
+      try { win.webContents?.removeListener?.("render-process-gone", handleGone); } catch {}
+      const waiters = rendererReadyWaitersByWebContentsId.get(wcId);
+      if (waiters) {
+        waiters.delete(handleReady);
+        if (waiters.size === 0) {
+          rendererReadyWaitersByWebContentsId.delete(wcId);
+        }
+      }
+    };
+
+    const handleReady = () => {
+      cleanup();
+      resolve();
+    };
+    const handleClosed = () => {
+      cleanup();
+      reject(new Error("Main window closed before renderer became ready."));
+    };
+    const handleGone = (_event, details) => {
+      cleanup();
+      reject(new Error(`Renderer process exited before ready: ${details?.reason || "unknown"}`));
+    };
+
+    let waiters = rendererReadyWaitersByWebContentsId.get(wcId);
+    if (!waiters) {
+      waiters = new Set();
+      rendererReadyWaitersByWebContentsId.set(wcId, waiters);
+    }
+    waiters.add(handleReady);
+
+    win.once("closed", handleClosed);
+    win.webContents?.once?.("render-process-gone", handleGone);
+
+    if (Number(timeoutMs) > 0) {
+      timer = setTimeout(() => {
+        cleanup();
+        reject(new Error("Renderer did not report ready before timeout."));
+      }, timeoutMs);
+    }
+  });
+}
+
 /**
  * Create the main application window
  */
@@ -1515,8 +1601,7 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
   ipcMain.on("netcatty:renderer:ready", (event) => {
     const wcId = event?.sender?.id;
     if (!wcId) return;
-    const cb = rendererReadyCallbacksByWebContentsId.get(wcId);
-    if (cb) cb();
+    resolveRendererReady(wcId);
   });
 }
 
@@ -1606,6 +1691,7 @@ module.exports = {
   buildAppMenu,
   getMainWindow,
   getSettingsWindow,
+  waitForRendererReady,
   setIsQuitting,
   openFallbackBrowser,
   tryOpenExternalWithFallback,

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -38,6 +38,7 @@ let isQuitting = false;
 const rendererReadyCallbacksByWebContentsId = new Map();
 const rendererReadySeenByWebContentsId = new Set();
 const rendererReadyWaitersByWebContentsId = new Map();
+const unhealthyWebContentsIds = new Set();
 const DEBUG_WINDOWS = process.env.NETCATTY_DEBUG_WINDOWS === "1";
 const OAUTH_DEFAULT_WIDTH = 600;
 const OAUTH_DEFAULT_HEIGHT = 700;
@@ -795,6 +796,7 @@ function setupDeferredShow(win, { timeoutMs = 3000, waitForRendererReady = true 
 
 function resolveRendererReady(wcId) {
   if (!wcId) return;
+  unhealthyWebContentsIds.delete(wcId);
   rendererReadySeenByWebContentsId.add(wcId);
   const cb = rendererReadyCallbacksByWebContentsId.get(wcId);
   if (cb) cb();
@@ -808,6 +810,34 @@ function resolveRendererReady(wcId) {
       // ignore waiter errors
     }
   }
+}
+
+function isWindowUsable(win) {
+  if (!win || typeof win.isDestroyed !== "function" || win.isDestroyed()) {
+    return false;
+  }
+  const contents = win.webContents;
+  if (!contents || typeof contents.isDestroyed !== "function" || contents.isDestroyed()) {
+    return false;
+  }
+  const wcId = (() => {
+    try {
+      return contents.id;
+    } catch {
+      return null;
+    }
+  })();
+  if (wcId && unhealthyWebContentsIds.has(wcId)) {
+    return false;
+  }
+  if (typeof contents.isCrashed === "function") {
+    try {
+      if (contents.isCrashed()) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
 }
 
 function waitForRendererReady(win, { timeoutMs = 15000 } = {}) {
@@ -955,12 +985,27 @@ async function createWindow(electronModule, options) {
 
   // Clear reference when the main window is destroyed
   win.on('closed', () => {
+    try {
+      if (win?.webContents?.id) {
+        unhealthyWebContentsIds.delete(win.webContents.id);
+        rendererReadySeenByWebContentsId.delete(win.webContents.id);
+      }
+    } catch {
+      // ignore
+    }
     if (mainWindow === win) mainWindow = null;
   });
 
   // Log renderer crashes for diagnostics (skip normal clean exits)
   win.webContents.on("render-process-gone", (_event, details) => {
     if (details?.reason === "clean-exit") return;
+    try {
+      if (win.webContents?.id) {
+        unhealthyWebContentsIds.add(win.webContents.id);
+      }
+    } catch {
+      // ignore
+    }
     try {
       const crashLogBridge = require("./crashLogBridge.cjs");
       crashLogBridge.captureError("render-process-gone", new Error(
@@ -1691,6 +1736,7 @@ module.exports = {
   buildAppMenu,
   getMainWindow,
   getSettingsWindow,
+  isWindowUsable,
   waitForRendererReady,
   setIsQuitting,
   openFallbackBrowser,

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -812,9 +812,18 @@ function resolveRendererReady(wcId) {
   }
 }
 
-function isWindowUsable(win) {
+function isWindowUsable(win, options = {}) {
+  const requireVisible = options.requireVisible === true;
   if (!win || typeof win.isDestroyed !== "function" || win.isDestroyed()) {
     return false;
+  }
+  if (requireVisible) {
+    if (typeof win.isVisible !== "function") return false;
+    try {
+      if (!win.isVisible()) return false;
+    } catch {
+      return false;
+    }
   }
   const contents = win.webContents;
   if (!contents || typeof contents.isDestroyed !== "function" || contents.isDestroyed()) {

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -1,0 +1,43 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { isWindowUsable } = require("./windowManager.cjs");
+
+function createWindowStub({ destroyed = false, webContents } = {}) {
+  return {
+    isDestroyed() {
+      return destroyed;
+    },
+    webContents,
+  };
+}
+
+test("isWindowUsable returns false when webContents is crashed", () => {
+  const win = createWindowStub({
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      isCrashed() {
+        return true;
+      },
+    },
+  });
+
+  assert.equal(isWindowUsable(win), false);
+});
+
+test("isWindowUsable returns true for a healthy live window", () => {
+  const win = createWindowStub({
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      isCrashed() {
+        return false;
+      },
+    },
+  });
+
+  assert.equal(isWindowUsable(win), true);
+});

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -8,6 +8,9 @@ function createWindowStub({ destroyed = false, webContents } = {}) {
     isDestroyed() {
       return destroyed;
     },
+    isVisible() {
+      return true;
+    },
     webContents,
   };
 }
@@ -40,4 +43,25 @@ test("isWindowUsable returns true for a healthy live window", () => {
   });
 
   assert.equal(isWindowUsable(win), true);
+});
+
+test("isWindowUsable can require a visible window", () => {
+  const hiddenWin = {
+    ...createWindowStub({
+      webContents: {
+        isDestroyed() {
+          return false;
+        },
+        isCrashed() {
+          return false;
+        },
+      },
+    }),
+    isVisible() {
+      return false;
+    },
+  };
+
+  assert.equal(isWindowUsable(hiddenWin, { requireVisible: true }), false);
+  assert.equal(isWindowUsable(hiddenWin, { requireVisible: false }), true);
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -20,53 +20,29 @@ if (process.env.ELECTRON_RUN_AS_NODE) {
 
 // Load crash log bridge early so process-level error handlers can use it
 const crashLogBridge = require("./bridges/crashLogBridge.cjs");
-
-// SSH / network errors that must never crash the process.
-// ssh2 can emit multiple 'error' events per connection (e.g. ECONNRESET followed
-// by "Connection lost before handshake"). If a listener is consumed after the first
-// event, the second becomes an uncaught exception. These are non-fatal for the app.
-function isNonFatalNetworkError(err) {
-  if (!err) return false;
-  // Any error with an ssh2 `level` property is a connection/auth-level error,
-  // never a reason to kill the entire multi-session app.
-  if (err.level) return true;
-  const code = err.code;
-  // Common TCP/DNS/routing errors that can surface from Node.js sockets
-  // without an ssh2 `level` (e.g. proxy sockets, raw net.connect calls).
-  switch (code) {
-    case 'ECONNRESET':
-    case 'ECONNREFUSED':
-    case 'ECONNABORTED':
-    case 'ETIMEDOUT':
-    case 'ENOTFOUND':
-    case 'EHOSTUNREACH':
-    case 'EHOSTDOWN':
-    case 'ENETUNREACH':
-    case 'ENETDOWN':
-    case 'EADDRNOTAVAIL':
-    case 'EPROTO':
-    case 'EPERM':
-      return true;
-    default:
-      return false;
-  }
-}
+const { classifyProcessError } = require("./bridges/processErrorGuards.cjs");
+let runtimeErrorProtectionArmed = false;
 
 // Handle uncaught exceptions — log all, only re-throw truly fatal ones
 process.on('uncaughtException', (err) => {
-  // Skip benign stream teardown errors — don't pollute crash logs with false positives
-  if (err.code === 'EPIPE' || err.code === 'ERR_STREAM_DESTROYED') {
-    console.warn('Ignored stream error:', err.code);
+  const decision = classifyProcessError(err, {
+    runtimeStarted: runtimeErrorProtectionArmed,
+    origin: 'uncaughtException',
+  });
+
+  if (decision.action === 'ignore') {
+    console.warn('Ignored process error:', decision.reason, err?.code || err?.message || err);
     return;
   }
-  // Non-fatal SSH/network errors: log but do NOT crash the process
-  if (isNonFatalNetworkError(err)) {
+
+  if (decision.action === 'suppress') {
     if (!err.__fromUnhandledRejection) {
       try { crashLogBridge.captureError('uncaughtException', err); } catch {}
     }
-    console.warn('Non-fatal uncaught exception (suppressed):', err.message);
+    console.error(`Suppressed uncaught exception (${decision.reason}):`, err);
     return;
   }
+
   // Skip logging if already captured by unhandledRejection handler
   if (!err.__fromUnhandledRejection) {
     try { crashLogBridge.captureError('uncaughtException', err); } catch {}
@@ -76,15 +52,21 @@ process.on('uncaughtException', (err) => {
 });
 
 process.on('unhandledRejection', (reason) => {
-  // Skip benign stream teardown errors
-  const code = reason?.code;
-  if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') return;
-  // Non-fatal SSH/network errors: log but do NOT re-throw
-  if (isNonFatalNetworkError(reason)) {
-    try { crashLogBridge.captureError('unhandledRejection', reason); } catch {}
-    console.warn('Non-fatal unhandled rejection (suppressed):', reason?.message || reason);
+  const decision = classifyProcessError(reason, {
+    runtimeStarted: runtimeErrorProtectionArmed,
+    origin: 'unhandledRejection',
+  });
+
+  if (decision.action === 'ignore') {
     return;
   }
+
+  if (decision.action === 'suppress') {
+    try { crashLogBridge.captureError('unhandledRejection', reason); } catch {}
+    console.error(`Suppressed unhandled rejection (${decision.reason}):`, reason);
+    return;
+  }
+
   try { crashLogBridge.captureError('unhandledRejection', reason); } catch {}
   console.error('Unhandled rejection:', reason);
   // Re-throw to preserve fatal semantics. Mark so uncaughtException handler
@@ -1081,6 +1063,7 @@ if (!gotLock) {
 
     // Create the main window
     void createWindow().then(() => {
+      runtimeErrorProtectionArmed = true;
       // Trigger auto-update check 5 s after window creation.
       // startAutoCheck() is a no-op on unsupported platforms (Linux deb/rpm/snap).
       getAutoUpdateBridge().startAutoCheck(5000);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -979,6 +979,7 @@ function waitForWindowToShow(win) {
     const cleanup = () => {
       try { win.removeListener("show", handleShow); } catch {}
       try { win.removeListener("closed", handleClosed); } catch {}
+      try { win.webContents?.removeListener?.("render-process-gone", handleGone); } catch {}
     };
 
     const handleShow = () => {
@@ -989,9 +990,14 @@ function waitForWindowToShow(win) {
       cleanup();
       reject(new Error("Main window closed before first show."));
     };
+    const handleGone = (_event, details) => {
+      cleanup();
+      reject(new Error(`Renderer process exited before first show: ${details?.reason || "unknown"}`));
+    };
 
     win.once("show", handleShow);
     win.once("closed", handleClosed);
+    win.webContents?.once?.("render-process-gone", handleGone);
   });
 }
 
@@ -1004,12 +1010,12 @@ async function createAndShowMainWindow() {
     processErrorController.beginMainWindowStartup();
     try {
       const win = await createWindow();
-      await Promise.all([
-        waitForWindowToShow(win),
-        getWindowManager().waitForRendererReady(win, {
-          timeoutMs: isDev ? 30000 : 15000,
-        }),
-      ]);
+      await waitForWindowToShow(win);
+      void getWindowManager().waitForRendererReady(win, {
+        timeoutMs: isDev ? 30000 : 15000,
+      }).catch((err) => {
+        console.warn("[Main] Renderer ready signal was late or missing after first show:", err?.message || err);
+      });
       processErrorController.completeMainWindowStartup({ windowShown: true });
       return win;
     } catch (err) {
@@ -1027,7 +1033,7 @@ function hasUsableWindow() {
   try {
     const windowManager = getWindowManager();
     return [windowManager.getMainWindow?.(), windowManager.getSettingsWindow?.()]
-      .some((win) => win && !win.isDestroyed?.());
+      .some((win) => windowManager.isWindowUsable?.(win));
   } catch {
     return false;
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -29,6 +29,7 @@ const processErrorController = createProcessErrorController({
     try { crashLogBridge.captureError(source, err); } catch {}
   },
   onFatalError(err, context) {
+    uninstallProcessErrorHandlers();
     if (context?.origin === 'unhandledRejection') {
       console.error('Unhandled rejection:', context.reason);
     } else {
@@ -43,7 +44,7 @@ const processErrorController = createProcessErrorController({
     console.warn(...args);
   },
 });
-installProcessErrorHandlers(process, processErrorController);
+let uninstallProcessErrorHandlers = installProcessErrorHandlers(process, processErrorController);
 
 // Load Electron
 let electronModule;
@@ -994,17 +995,32 @@ function waitForWindowToShow(win) {
   });
 }
 
+let mainWindowStartupPromise = null;
+
 async function createAndShowMainWindow() {
-  processErrorController.beginMainWindowStartup();
-  try {
-    const win = await createWindow();
-    await waitForWindowToShow(win);
-    processErrorController.completeMainWindowStartup({ windowShown: true });
-    return win;
-  } catch (err) {
-    processErrorController.completeMainWindowStartup({ windowShown: false });
-    throw err;
-  }
+  if (mainWindowStartupPromise) return mainWindowStartupPromise;
+
+  mainWindowStartupPromise = (async () => {
+    processErrorController.beginMainWindowStartup();
+    try {
+      const win = await createWindow();
+      await Promise.all([
+        waitForWindowToShow(win),
+        getWindowManager().waitForRendererReady(win, {
+          timeoutMs: isDev ? 30000 : 15000,
+        }),
+      ]);
+      processErrorController.completeMainWindowStartup({ windowShown: true });
+      return win;
+    } catch (err) {
+      processErrorController.completeMainWindowStartup({ windowShown: false });
+      throw err;
+    } finally {
+      mainWindowStartupPromise = null;
+    }
+  })();
+
+  return mainWindowStartupPromise;
 }
 
 function hasUsableWindow() {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1033,7 +1033,7 @@ function hasUsableWindow() {
   try {
     const windowManager = getWindowManager();
     return [windowManager.getMainWindow?.(), windowManager.getSettingsWindow?.()]
-      .some((win) => windowManager.isWindowUsable?.(win));
+      .some((win) => windowManager.isWindowUsable?.(win, { requireVisible: true }));
   } catch {
     return false;
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -20,61 +20,30 @@ if (process.env.ELECTRON_RUN_AS_NODE) {
 
 // Load crash log bridge early so process-level error handlers can use it
 const crashLogBridge = require("./bridges/crashLogBridge.cjs");
-const { classifyProcessError } = require("./bridges/processErrorGuards.cjs");
-let runtimeErrorProtectionArmed = false;
-
-// Handle uncaught exceptions — log all, only re-throw truly fatal ones
-process.on('uncaughtException', (err) => {
-  const decision = classifyProcessError(err, {
-    runtimeStarted: runtimeErrorProtectionArmed,
-    origin: 'uncaughtException',
-  });
-
-  if (decision.action === 'ignore') {
-    console.warn('Ignored process error:', decision.reason, err?.code || err?.message || err);
-    return;
-  }
-
-  if (decision.action === 'suppress') {
-    if (!err.__fromUnhandledRejection) {
-      try { crashLogBridge.captureError('uncaughtException', err); } catch {}
+const {
+  createProcessErrorController,
+  installProcessErrorHandlers,
+} = require("./bridges/processErrorGuards.cjs");
+const processErrorController = createProcessErrorController({
+  captureError(source, err) {
+    try { crashLogBridge.captureError(source, err); } catch {}
+  },
+  onFatalError(err, context) {
+    if (context?.origin === 'unhandledRejection') {
+      console.error('Unhandled rejection:', context.reason);
+    } else {
+      console.error('Uncaught exception:', err);
     }
-    console.error(`Suppressed uncaught exception (${decision.reason}):`, err);
-    return;
-  }
-
-  // Skip logging if already captured by unhandledRejection handler
-  if (!err.__fromUnhandledRejection) {
-    try { crashLogBridge.captureError('uncaughtException', err); } catch {}
-  }
-  console.error('Uncaught exception:', err);
-  throw err;
+    throw err;
+  },
+  logError(...args) {
+    console.error(...args);
+  },
+  logWarn(...args) {
+    console.warn(...args);
+  },
 });
-
-process.on('unhandledRejection', (reason) => {
-  const decision = classifyProcessError(reason, {
-    runtimeStarted: runtimeErrorProtectionArmed,
-    origin: 'unhandledRejection',
-  });
-
-  if (decision.action === 'ignore') {
-    return;
-  }
-
-  if (decision.action === 'suppress') {
-    try { crashLogBridge.captureError('unhandledRejection', reason); } catch {}
-    console.error(`Suppressed unhandled rejection (${decision.reason}):`, reason);
-    return;
-  }
-
-  try { crashLogBridge.captureError('unhandledRejection', reason); } catch {}
-  console.error('Unhandled rejection:', reason);
-  // Re-throw to preserve fatal semantics. Mark so uncaughtException handler
-  // can skip duplicate logging.
-  const err = reason instanceof Error ? reason : new Error(String(reason));
-  err.__fromUnhandledRejection = true;
-  throw err;
-});
+installProcessErrorHandlers(process, processErrorController);
 
 // Load Electron
 let electronModule;
@@ -995,6 +964,59 @@ async function createWindow() {
   return win;
 }
 
+function waitForWindowToShow(win) {
+  return new Promise((resolve, reject) => {
+    if (!win || win.isDestroyed?.()) {
+      reject(new Error("Main window was destroyed before first show."));
+      return;
+    }
+    if (win.isVisible?.()) {
+      resolve();
+      return;
+    }
+
+    const cleanup = () => {
+      try { win.removeListener("show", handleShow); } catch {}
+      try { win.removeListener("closed", handleClosed); } catch {}
+    };
+
+    const handleShow = () => {
+      cleanup();
+      resolve();
+    };
+    const handleClosed = () => {
+      cleanup();
+      reject(new Error("Main window closed before first show."));
+    };
+
+    win.once("show", handleShow);
+    win.once("closed", handleClosed);
+  });
+}
+
+async function createAndShowMainWindow() {
+  processErrorController.beginMainWindowStartup();
+  try {
+    const win = await createWindow();
+    await waitForWindowToShow(win);
+    processErrorController.completeMainWindowStartup({ windowShown: true });
+    return win;
+  } catch (err) {
+    processErrorController.completeMainWindowStartup({ windowShown: false });
+    throw err;
+  }
+}
+
+function hasUsableWindow() {
+  try {
+    const windowManager = getWindowManager();
+    return [windowManager.getMainWindow?.(), windowManager.getSettingsWindow?.()]
+      .some((win) => win && !win.isDestroyed?.());
+  } catch {
+    return false;
+  }
+}
+
 function showStartupError(err) {
   const title = "Netcatty";
   const code = err && typeof err === "object" ? err.code : null;
@@ -1020,9 +1042,12 @@ if (!gotLock) {
   app.on("second-instance", () => {
     if (!focusMainWindow()) {
       // Window is missing or crashed — try to recreate it
-      void createWindow().catch((err) => {
+      void createAndShowMainWindow().catch((err) => {
         console.error("[Main] Failed to recreate window on second-instance:", err);
         showStartupError(err);
+        if (!hasUsableWindow()) {
+          try { app.quit(); } catch {}
+        }
       });
     }
   });
@@ -1040,9 +1065,17 @@ if (!gotLock) {
       }
     }
 
-    // Build and set application menu
-    const menu = getWindowManager().buildAppMenu(Menu, app, isMac);
-    Menu.setApplicationMenu(menu);
+    // Build and set application menu. A broken menu should not take down
+    // the entire app — fall back to no custom menu and continue startup.
+    try {
+      const menu = getWindowManager().buildAppMenu(Menu, app, isMac);
+      Menu.setApplicationMenu(menu);
+    } catch (err) {
+      console.error("[Main] Failed to build application menu:", err);
+      try {
+        Menu.setApplicationMenu(null);
+      } catch {}
+    }
 
     app.on("browser-window-created", (_event, win) => {
       try {
@@ -1062,8 +1095,7 @@ if (!gotLock) {
     });
 
     // Create the main window
-    void createWindow().then(() => {
-      runtimeErrorProtectionArmed = true;
+    void createAndShowMainWindow().then(() => {
       // Trigger auto-update check 5 s after window creation.
       // startAutoCheck() is a no-op on unsupported platforms (Linux deb/rpm/snap).
       getAutoUpdateBridge().startAutoCheck(5000);
@@ -1113,9 +1145,12 @@ if (!gotLock) {
 
       if (focusMainWindow()) return;
       // Main window doesn't exist — create it even if other windows (e.g. settings) are open
-      void createWindow().catch((err) => {
+      void createAndShowMainWindow().catch((err) => {
         console.error("[Main] Failed to create window on activate:", err);
         showStartupError(err);
+        if (!hasUsableWindow()) {
+          try { app.quit(); } catch {}
+        }
       });
     });
   });


### PR DESCRIPTION
## What changed
- switched the main-process crash policy to distinguish startup failures from runtime failures
- keep startup errors fatal, but suppress runtime uncaught exceptions and unhandled rejections after the main window is up
- moved the process-error rules into a dedicated helper and added regression tests for startup-vs-runtime behavior and Chromium-style network errors

## Why
Issue #771 showed that a transient network change could surface as an unhandled rejection in the main process and bring down the whole app. The deeper problem was that runtime failures were still treated like startup failures, so a single background task error could terminate Netcatty.

## Impact
- Netcatty now stays open when a runtime task crashes or a background promise rejects after startup
- startup remains strict, so broken boot paths still fail loudly instead of hiding a bad launch
- the behavior is covered by regression tests so we do not drift back to the old crash policy

## Validation
- `node --test electron/bridges/mainProcessErrorGuards.test.cjs`
- `npm test`
- `node --check electron/main.cjs`
