### PR TITLE
Add 'Set to disabled' button for individual keybindings (#781)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -415,6 +415,7 @@ const en: Messages = {
   'settings.shortcuts.resetAll': 'Reset All',
   'settings.shortcuts.recording': 'Press keys...',
   'settings.shortcuts.none': 'None',
+  'settings.shortcuts.setDisabled': 'Set to disabled',
   'settings.shortcuts.category.tabs': 'Tabs',
   'settings.shortcuts.category.terminal': 'Terminal',
   'settings.shortcuts.category.navigation': 'Navigation',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1487,6 +1487,7 @@ const zhCN: Messages = {
   'settings.shortcuts.resetAll': '全部重置',
   'settings.shortcuts.recording': '请按键...',
   'settings.shortcuts.none': '无',
+  'settings.shortcuts.setDisabled': '设为禁用',
   'settings.shortcuts.category.tabs': '标签页',
   'settings.shortcuts.category.terminal': '终端',
   'settings.shortcuts.category.navigation': '导航',

--- a/components/settings/tabs/SettingsShortcutsTab.tsx
+++ b/components/settings/tabs/SettingsShortcutsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { RotateCcw } from "lucide-react";
+import { Ban, RotateCcw } from "lucide-react";
 import type { HotkeyScheme, KeyBinding } from "../../../domain/models";
 import { keyEventToString } from "../../../domain/models";
 import { useI18n } from "../../../application/i18n/I18nProvider";
@@ -221,7 +221,18 @@ export default function SettingsShortcutsTab(props: {
                             >
                               {isRecordingThis
                                 ? t("settings.shortcuts.recording")
-                                : currentKey || t("settings.shortcuts.scheme.disabled")}
+                                : currentKey === "Disabled"
+                                  ? t("settings.shortcuts.scheme.disabled")
+                                  : currentKey || t("settings.shortcuts.scheme.disabled")}
+                            </button>
+                          )}
+                          {!isSpecialBinding && (
+                            <button
+                              onClick={() => updateKeyBinding?.(binding.id, scheme, "Disabled")}
+                              className="p-1 hover:bg-muted rounded"
+                              title={t("settings.shortcuts.setDisabled")}
+                            >
+                              <Ban size={12} />
                             </button>
                           )}
                           <button


### PR DESCRIPTION
## Summary
- Adds a Ban-icon button next to each keybinding's "Reset to default" so a single shortcut can be disabled without touching the global scheme.
- Clicking it writes the existing `Disabled` sentinel — already understood by `matchesKeyBinding` — via the current scheme (mac/pc).
- Renders the button label as the localized "Disabled" string when the sentinel is stored (instead of the raw English word).
- en/zh-CN: adds `settings.shortcuts.setDisabled`.

Closes #781

## Test plan
- [x] Open Settings → Shortcuts, click the Ban icon on any non-special binding → slot shows "Disabled"/"禁用".
- [x] Verify the corresponding shortcut no longer fires.
- [x] Click "Reset to default" → restores the original key.
- [x] Switch language to Chinese → label shows "设为禁用" (tooltip) and "禁用" (slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)