### PR TITLE
Add delete button in snippet edit panel (#780)

### DIFF
--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -734,16 +734,35 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
           title={editingSnippet.id ? t('snippets.panel.editTitle') : t('snippets.panel.newTitle')}
           layout="inline"
           actions={
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={handleSubmit}
-              disabled={!editingSnippet.label || !editingSnippet.command}
-              aria-label={t('common.save')}
-            >
-              <Check size={16} />
-            </Button>
+            <>
+              {editingSnippet.id && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-destructive hover:text-destructive"
+                  onClick={() => {
+                    const id = editingSnippet.id;
+                    if (!id) return;
+                    onDelete(id);
+                    handleClosePanel();
+                  }}
+                  aria-label={t('common.delete')}
+                  title={t('common.delete')}
+                >
+                  <Trash2 size={16} />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={handleSubmit}
+                disabled={!editingSnippet.label || !editingSnippet.command}
+                aria-label={t('common.save')}
+              >
+                <Check size={16} />
+              </Button>
+            </>
           }
         >
           <AsidePanelContent>


### PR DESCRIPTION
## Summary
- Snippets can already be deleted via the grid's right-click context menu, but users typically open a snippet by clicking — and the edit panel exposed no delete, so many concluded the feature didn't exist.
- Add a Trash icon next to the Save check in the edit panel's action area. Only shown when editing an existing snippet (not when creating). Clicking calls the existing `onDelete` and closes the panel.

Closes #780

## Test plan
- [x] Create a snippet → open it → trash icon is visible next to save.
- [x] Click trash → snippet disappears from the list; panel closes.
- [x] Open the "new snippet" panel → no trash icon (only save).
- [x] Existing right-click context menu Delete still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)