### PR TITLE
Block empty/shrunk pushes when sync base is null (#779)

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -51,10 +51,35 @@ const AUTO_SYNC_PROVIDER_ORDER: CloudProvider[] = ['github', 'google', 'onedrive
 
 // Cross-window restore barrier: stored as an epoch-ms deadline. Any value
 // in the future means a restore is applying in some window and auto-sync
-// must not push concurrently.
+// must not push concurrently. The writer (`withRestoreBarrier`) heartbeats
+// the deadline to keep it alive; a crashed window naturally expires within
+// ~RESTORE_BARRIER_HOLD_MS. We still defend against two degenerate cases:
+// (1) a stale deadline sitting in the past — harmless but pollutes debug
+//     state, so we opportunistically clear it; (2) a deadline absurdly far
+//     in the future (clock skew between windows, pathological holdMs, or a
+//     tampered value) — would otherwise lock auto-sync indefinitely, so we
+//     clear it and treat the barrier as inactive.
+const RESTORE_BARRIER_SANITY_MAX_MS = 10 * 60 * 1000; // 10 minutes
 const isRestoreInProgress = (): boolean => {
   const raw = localStorageAdapter.readNumber(STORAGE_KEY_VAULT_RESTORE_IN_PROGRESS_UNTIL);
-  return typeof raw === 'number' && raw > Date.now();
+  if (typeof raw !== 'number' || raw <= 0) return false;
+  const now = Date.now();
+  if (raw <= now) {
+    // Deadline is in the past — either a clean finish that failed to
+    // overwrite the key, or a crashed heartbeat. Clear so subsequent
+    // reads are cheap and the key doesn't linger forever.
+    localStorageAdapter.writeNumber(STORAGE_KEY_VAULT_RESTORE_IN_PROGRESS_UNTIL, 0);
+    return false;
+  }
+  if (raw - now > RESTORE_BARRIER_SANITY_MAX_MS) {
+    console.warn(
+      '[useAutoSync] Restore barrier deadline is absurdly far in the future; treating as corrupt and clearing.',
+      { deadline: raw, now },
+    );
+    localStorageAdapter.writeNumber(STORAGE_KEY_VAULT_RESTORE_IN_PROGRESS_UNTIL, 0);
+    return false;
+  }
+  return true;
 };
 
 type SyncTrigger = 'auto' | 'manual';

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -364,7 +364,16 @@ export type SyncEvent =
   | { type: 'AUTH_REQUIRED'; provider: CloudProvider }
   | { type: 'AUTH_COMPLETED'; provider: CloudProvider; account: ProviderAccount }
   | { type: 'SECURITY_STATE_CHANGED'; state: SecurityState }
-  | { type: 'SYNC_BLOCKED_CLEARED' };
+  | { type: 'SYNC_BLOCKED_CLEARED' }
+  | {
+      type: 'PROVIDERS_DIVERGED';
+      summaries: Array<{
+        provider: CloudProvider;
+        hosts: number;
+        keys: number;
+        snippets: number;
+      }>;
+    };
 
 // ============================================================================
 // Storage Keys

--- a/domain/syncGuards.test.ts
+++ b/domain/syncGuards.test.ts
@@ -32,9 +32,43 @@ function hosts(n: number): SyncPayload["hosts"] {
   })) as SyncPayload["hosts"];
 }
 
-test("null base → not suspicious (first sync / null after re-auth)", () => {
+test("null base, no remote fallback → not suspicious (nothing to compare)", () => {
   const result = detectSuspiciousShrink(payload({ hosts: hosts(1) }), null);
   assert.deepEqual(result, { suspicious: false });
+});
+
+test("null base + empty remote → not suspicious (genuinely empty cloud)", () => {
+  const result = detectSuspiciousShrink(payload({ hosts: hosts(5) }), null, payload());
+  assert.deepEqual(result, { suspicious: false });
+});
+
+test("null base + populated remote + empty outgoing → suspicious via remote (#779 scenario)", () => {
+  // Fresh install with no stored base; remote already holds user's keychain.
+  // Local payload is empty (degraded vault / load race) → must be blocked.
+  const remote = payload({ keys: Array.from({ length: 8 }, (_, i) => ({ id: `k${i}`, label: `k${i}`, privateKey: "x" })) as SyncPayload["keys"] });
+  const out = payload();
+  const result = detectSuspiciousShrink(out, null, remote);
+  assert.equal(result.suspicious, true);
+  if (result.suspicious) {
+    assert.equal(result.entityType, "keys");
+    assert.equal(result.viaRemote, true);
+    assert.equal(result.lost, 8);
+  }
+});
+
+test("null base + larger remote + outgoing growth → not suspicious (lost is negative)", () => {
+  const remote = payload({ hosts: hosts(3) });
+  const out = payload({ hosts: hosts(10) });
+  assert.deepEqual(detectSuspiciousShrink(out, null, remote), { suspicious: false });
+});
+
+test("base present takes precedence over remote fallback", () => {
+  // base=10, outgoing=10 → not suspicious; remote=0 should NOT trigger a
+  // via-remote warning because a real base is available.
+  const base = payload({ hosts: hosts(10) });
+  const remote = payload();
+  const out = payload({ hosts: hosts(10) });
+  assert.deepEqual(detectSuspiciousShrink(out, base, remote), { suspicious: false });
 });
 
 test("no shrink — same counts → not suspicious", () => {

--- a/domain/syncGuards.ts
+++ b/domain/syncGuards.ts
@@ -18,6 +18,8 @@ export type ShrinkFinding =
       baseCount: number;
       outgoingCount: number;
       lost: number;
+      /** True when the comparison reference was the current remote (base was null). */
+      viaRemote?: boolean;
     };
 
 // Keep in sync with all array-typed fields of SyncPayload. When a new
@@ -49,11 +51,21 @@ function countOf(p: SyncPayload, key: CheckedEntityType): number {
 export function detectSuspiciousShrink(
   outgoing: SyncPayload,
   base: SyncPayload | null,
+  remote?: SyncPayload | null,
 ): ShrinkFinding {
-  if (!base) return { suspicious: false };
+  // Fall back to the current remote when we have no stored base — a null base
+  // happens on first sync, after unlock key re-derivation, or when the base
+  // blob failed to decrypt. Without this fallback, a degraded/empty local
+  // payload would be admitted unconditionally and could overwrite populated
+  // remote data (#779). We only use `remote` when `base` is unavailable so
+  // legitimate resurrections (device that legitimately grew past an older
+  // remote snapshot) remain unaffected.
+  const reference = base ?? remote ?? null;
+  const viaRemote = !base && !!remote;
+  if (!reference) return { suspicious: false };
 
   for (const entityType of CHECKED_ENTITIES) {
-    const baseCount = countOf(base, entityType);
+    const baseCount = countOf(reference, entityType);
     const outgoingCount = countOf(outgoing, entityType);
     const lost = baseCount - outgoingCount;
     if (lost <= 0) continue;
@@ -66,6 +78,7 @@ export function detectSuspiciousShrink(
         baseCount,
         outgoingCount,
         lost,
+        ...(viaRemote ? { viaRemote: true } : {}),
       };
     }
 
@@ -77,6 +90,7 @@ export function detectSuspiciousShrink(
         baseCount,
         outgoingCount,
         lost,
+        ...(viaRemote ? { viaRemote: true } : {}),
       };
     }
   }

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1345,7 +1345,7 @@ export class CloudSyncManager {
           // entities we still have in base. The merge itself is correct if local
           // state is trustworthy — but a degraded local (keychain failure,
           // partial load) can make merge produce a smaller-than-expected result.
-          const mergedShrink = detectSuspiciousShrink(mergeResult.payload, base);
+          const mergedShrink = detectSuspiciousShrink(mergeResult.payload, base, remotePayload);
           const shouldBlockMerged = mergedShrink.suspicious && !overrideShrinkRequested;
           const shouldForceMerged = mergedShrink.suspicious && overrideShrinkRequested;
           if (shouldBlockMerged) {
@@ -1440,9 +1440,28 @@ export class CloudSyncManager {
       }
 
       // Shrink guard (no-conflict path): same rationale as the merge branch —
-      // refuse a payload that drops entities versus the stored base.
+      // refuse a payload that drops entities versus the stored base. When the
+      // stored base is absent (first sync, re-auth, or decrypt failure) fall
+      // back to the current remote payload if one exists — the guard must
+      // have *some* reference to catch a degraded local from wiping the
+      // cloud (#779).
       const directBase = await this.loadSyncBase(provider);
-      const directShrink = detectSuspiciousShrink(payload, directBase);
+      let directRemoteRef: SyncPayload | null = null;
+      if (!directBase && checkResult.remoteFile) {
+        try {
+          directRemoteRef = await EncryptionService.decryptPayload(
+            checkResult.remoteFile,
+            this.masterPassword,
+          );
+        } catch {
+          // Decrypt failure means we can't trust the remote contents as a
+          // reference; leave `null` and let the guard return not-suspicious
+          // rather than block on garbage. The upload itself will likely fail
+          // downstream if the password mismatch is real.
+          directRemoteRef = null;
+        }
+      }
+      const directShrink = detectSuspiciousShrink(payload, directBase, directRemoteRef);
       const shouldBlockDirect = directShrink.suspicious && !overrideShrinkRequested;
       const shouldForceDirect = directShrink.suspicious && overrideShrinkRequested;
       if (shouldBlockDirect) {
@@ -1907,7 +1926,26 @@ export class CloudSyncManager {
       .map((r) => r.provider as CloudProvider);
     for (const provider of candidateProviders) {
       const providerBase = await this.loadSyncBase(provider);
-      const finding = detectSuspiciousShrink(payload, providerBase);
+      // When no stored base exists, fall back to the remote payload fetched
+      // during the parallel check above — the shrink guard needs a reference
+      // or it fails open and lets degraded local state overwrite remote
+      // (#779). checkResults carries the per-provider remoteFile already.
+      let providerRemoteRef: SyncPayload | null = null;
+      if (!providerBase) {
+        const entry = checkResults.find((r) => r.provider === provider);
+        const remoteFile = entry?.check?.remoteFile;
+        if (remoteFile) {
+          try {
+            providerRemoteRef = await EncryptionService.decryptPayload(
+              remoteFile,
+              this.masterPassword,
+            );
+          } catch {
+            providerRemoteRef = null;
+          }
+        }
+      }
+      const finding = detectSuspiciousShrink(payload, providerBase, providerRemoteRef);
       if (finding.suspicious) {
         shrinkSuspectByProvider.push({ provider, finding });
       }

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1827,6 +1827,18 @@ export class CloudSyncManager {
             '[CloudSyncManager] syncAll: connected providers hold divergent bases (multi-account setup?). Uploading the conflict-merged payload will replace each provider\'s current remote. See I-7 in PR #720 for context.',
             summaries,
           );
+          // Surface the same finding to the UI so multi-account / intentionally
+          // diverged configurations can be warned visibly instead of silently
+          // having one provider's data merged over another's (#779 follow-up).
+          this.emit({
+            type: 'PROVIDERS_DIVERGED',
+            summaries: summaries.map((s) => ({
+              provider: s.provider as CloudProvider,
+              hosts: s.hosts,
+              keys: s.keys,
+              snippets: s.snippets,
+            })),
+          });
         }
       } catch (diagError) {
         // Non-fatal diagnostic; never let it block the sync.

--- a/infrastructure/services/adapters/OneDriveAdapter.ts
+++ b/infrastructure/services/adapters/OneDriveAdapter.ts
@@ -309,41 +309,69 @@ export const validateToken = async (accessToken: string): Promise<boolean> => {
 
 const APP_FOLDER_PATH = '/drive/special/approot';
 
+// Eventual-consistency retry for OneDrive "not found" lookups. The Graph API
+// can briefly 404 a file that was uploaded seconds ago from another device
+// (most commonly when the other device is syncing through the OneDrive
+// desktop client and the change has not yet reached Graph). Treating every
+// 404 as authoritative "cloud is empty" lets a second device proceed to an
+// empty-cloud upload path and overwrite real data (#779). We retry a small
+// bounded number of times with short backoff to flush through that window.
+const NOT_FOUND_RETRIES = 2;
+const NOT_FOUND_BACKOFF_MS = 1500;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function retryOnNotFound<T>(
+  fetchOnce: () => Promise<T | null>,
+): Promise<T | null> {
+  let result = await fetchOnce();
+  for (let attempt = 1; attempt <= NOT_FOUND_RETRIES && result === null; attempt++) {
+    await sleep(NOT_FOUND_BACKOFF_MS * attempt);
+    result = await fetchOnce();
+  }
+  return result;
+}
+
 /**
  * Ensure app folder exists and find sync file
  */
 export const findSyncFile = async (accessToken: string): Promise<string | null> => {
-  const bridge = netcattyBridge.get();
-  if (bridge?.onedriveFindSyncFile) {
-    const result = await bridge.onedriveFindSyncFile({
-      accessToken,
-      fileName: SYNC_CONSTANTS.SYNC_FILE_NAME,
-    });
-    return result.fileId || null;
-  }
-  try {
-    const response = await fetch(
-      `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me${APP_FOLDER_PATH}:/${SYNC_CONSTANTS.SYNC_FILE_NAME}`,
-      {
-        headers: {
-          'Authorization': `Bearer ${accessToken}`,
-        },
-      }
-    );
+  const fetchOnce = async (): Promise<string | null> => {
+    const bridge = netcattyBridge.get();
+    if (bridge?.onedriveFindSyncFile) {
+      const result = await bridge.onedriveFindSyncFile({
+        accessToken,
+        fileName: SYNC_CONSTANTS.SYNC_FILE_NAME,
+      });
+      return result.fileId || null;
+    }
+    try {
+      const response = await fetch(
+        `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me${APP_FOLDER_PATH}:/${SYNC_CONSTANTS.SYNC_FILE_NAME}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${accessToken}`,
+          },
+        }
+      );
 
-    if (response.status === 404) {
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error('Failed to find sync file');
+      }
+
+      const item: DriveItem = await response.json();
+      return item.id;
+    } catch {
       return null;
     }
+  };
 
-    if (!response.ok) {
-      throw new Error('Failed to find sync file');
-    }
-
-    const item: DriveItem = await response.json();
-    return item.id;
-  } catch {
-    return null;
-  }
+  return retryOnNotFound(fetchOnce);
 };
 
 /**
@@ -394,39 +422,43 @@ export const downloadSyncFile = async (
   accessToken: string,
   fileId?: string
 ): Promise<SyncedFile | null> => {
-  const bridge = netcattyBridge.get();
-  if (bridge?.onedriveDownloadSyncFile) {
-    const result = await bridge.onedriveDownloadSyncFile({
-      accessToken,
-      fileId,
-      fileName: SYNC_CONSTANTS.SYNC_FILE_NAME,
-    });
-    return (result.syncedFile as SyncedFile | null) || null;
-  }
-  try {
-    // Can use either file ID or path
-    const url = fileId
-      ? `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me/drive/items/${fileId}/content`
-      : `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me${APP_FOLDER_PATH}:/${SYNC_CONSTANTS.SYNC_FILE_NAME}:/content`;
+  const fetchOnce = async (): Promise<SyncedFile | null> => {
+    const bridge = netcattyBridge.get();
+    if (bridge?.onedriveDownloadSyncFile) {
+      const result = await bridge.onedriveDownloadSyncFile({
+        accessToken,
+        fileId,
+        fileName: SYNC_CONSTANTS.SYNC_FILE_NAME,
+      });
+      return (result.syncedFile as SyncedFile | null) || null;
+    }
+    try {
+      // Can use either file ID or path
+      const url = fileId
+        ? `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me/drive/items/${fileId}/content`
+        : `${SYNC_CONSTANTS.ONEDRIVE_GRAPH_API}/me${APP_FOLDER_PATH}:/${SYNC_CONSTANTS.SYNC_FILE_NAME}:/content`;
 
-    const response = await fetch(url, {
-      headers: {
-        'Authorization': `Bearer ${accessToken}`,
-      },
-    });
+      const response = await fetch(url, {
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+        },
+      });
 
-    if (response.status === 404) {
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error('Failed to download sync file');
+      }
+
+      return response.json();
+    } catch {
       return null;
     }
+  };
 
-    if (!response.ok) {
-      throw new Error('Failed to download sync file');
-    }
-
-    return response.json();
-  } catch {
-    return null;
-  }
+  return retryOnNotFound(fetchOnce);
 };
 
 /**


### PR DESCRIPTION
## Summary

Root cause of #779 + three related sync-robustness gaps surfaced during the investigation. All four land in this PR since they share test surface.

### 1. Shrink guard ignored null base (primary #779 root cause)

`detectSuspiciousShrink` short-circuited to `{suspicious:false}` whenever `base === null`. That happens on:

- First sync on a new install (no base yet)
- Post-unlock window where `unlockedKey` was re-derived and `loadSyncBase` returns null
- Cases where the encrypted base blob fails to decrypt

Combined with OneDrive treating a not-yet-delivered remote file as 404 (see #2) and timing races where a fresh device's local keychain hasn't fully hydrated, a device in this state would quietly push an empty payload that overwrites the populated cloud copy. The other device then pulled the empty cloud, merge concluded "both sides deleted", and the data was gone on both ends — exactly what the reporter experienced (Mac → OneDrive → Win11 keychain wipe).

**Fix:** `domain/syncGuards.ts` accepts an optional `remote` fallback. When `base` is null, the guard compares against the remote payload instead. Three call sites in `CloudSyncManager.ts` now pass the already-decrypted remote (merge branch) or decrypt `checkResult.remoteFile` on demand (direct-upload and `syncAllProviders`). `ShrinkFinding` gains an optional `viaRemote` marker.

Legitimate scenarios remain unaffected:
- No base **and** no remote → still `not suspicious` (genuinely empty cloud).
- Outgoing larger than remote (first-sync growth) → `lost` is negative, guard skips.
- Base present → behaviour unchanged.

### 2. OneDrive 404 eventual-consistency retry

`findSyncFile` / `downloadSyncFile` in `OneDriveAdapter.ts` treated every `null`/404 result as authoritative "cloud is empty". That was a critical step in how #779 escalated: the second device sees 404 before OneDrive has propagated the upload, decides the cloud is empty, and proceeds to overwrite.

**Fix:** both functions now retry on null results with 1.5s / 3s backoff (bounded to 2 extra attempts). Non-404 error paths are unchanged.

### 3. Restore-barrier self-heal

`isRestoreInProgress` in `useAutoSync.ts` trusts the stored epoch-ms deadline without sanity-checking it. The heartbeat-based `withRestoreBarrier` already handles the normal crash case (deadline naturally expires within ~60s), but a stale past-deadline would linger in localStorage and a pathological future-deadline could wedge auto-sync indefinitely.

**Fix:** when `isRestoreInProgress()` sees a deadline in the past, clear the key. When it sees a deadline more than 10 minutes in the future, treat as corrupt, log, and clear.

### 4. Multi-provider divergence now emits an event

The existing divergent-provider-bases detection in `syncAllProviders` only logged a `console.warn` — the UI had no way to notice that uploading a merged payload would overwrite a differently-configured provider's data.

**Fix:** added a `PROVIDERS_DIVERGED` member to `SyncEvent`, emitted next to the existing `console.warn`. UI consumers can subscribe via the existing `manager.subscribe` path; no other event shapes changed.

## Test plan

- [x] `domain/syncGuards.test.ts` — 4 new cases (null base + various remote states), all 17 pass.
- [x] `tsc --noEmit` clean on all touched files.
- [ ] Reproduce #779: fresh Win11 with OneDrive, Mac with populated keychain → Win11's first sync is blocked by the shrink banner instead of pushing empty.
- [ ] Legitimate first sync: fresh install with real local data, empty cloud → upload succeeds (no block).
- [ ] OneDrive race: rapid successive syncs from two devices → no data loss; second device sees the file via retry instead of 404-as-empty.
- [ ] Kill app mid-restore → auto-sync unblocks within the normal hold window; no lingering localStorage key next time `isRestoreInProgress` runs.
- [ ] Connect two providers pointed at different accounts → a `PROVIDERS_DIVERGED` event fires on the next conflict-triggering sync.

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)