### PR TITLE
Vault global search spans all groups/packages (#777)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1682,6 +1682,8 @@ const en: Messages = {
   'snippets.breadcrumb.separator': '›',
   'snippets.empty.title': 'Create snippet',
   'snippets.empty.desc': 'Save your most used commands as snippets to reuse them in one click.',
+  'snippets.search.noResults.title': 'No matches',
+  'snippets.search.noResults.desc': 'No snippets or packages match "{query}". Try a different search term or clear the search to browse.',
   'snippets.section.packages': 'Packages',
   'snippets.section.snippets': 'Snippets',
   'snippets.package.count': '{count} snippet(s)',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1690,6 +1690,8 @@ const zhCN: Messages = {
   'snippets.breadcrumb.separator': '›',
   'snippets.empty.title': '创建代码片段',
   'snippets.empty.desc': '将常用命令保存为代码片段，一键复用。',
+  'snippets.search.noResults.title': '无匹配结果',
+  'snippets.search.noResults.desc': '没有代码片段或代码包与"{query}"匹配。换一个关键字，或清除搜索进行浏览。',
   'snippets.section.packages': '代码包',
   'snippets.section.snippets': '代码片段',
   'snippets.package.count': '{count} 个代码片段',

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1225,10 +1225,14 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
             </div>
           )}
 
-          {/* Search-with-no-results feedback (#777 codex follow-up). Without
-              this, when a query matches no snippets AND the package tile
-              grid is hidden, the content area would be completely blank. */}
-          {search.trim() && displayedSnippets.length === 0 && displayedPackages.length === 0 && snippets.length > 0 && (
+          {/* Search-with-no-results feedback (#777 codex follow-up). Package
+              tiles are already hidden during search, so the only visible
+              surface is the flat snippet list — if that's empty the content
+              area would be blank without this fallback. We don't gate on
+              displayedPackages.length because those tiles aren't rendered
+              while search is active (workspaces with packages were still
+              getting a blank area). */}
+          {search.trim() && displayedSnippets.length === 0 && snippets.length > 0 && (
             <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
               <div className="h-14 w-14 rounded-2xl bg-secondary/80 flex items-center justify-center mb-3">
                 <Search size={24} className="opacity-60" />

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1164,14 +1164,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                             <FileCode size={18} />
                           </div>
                           <div className="w-0 flex-1">
-                            <div className="flex items-center gap-1.5 min-w-0">
-                              <span className="text-sm font-semibold truncate">{snippet.label}</span>
-                              {search.trim() && (snippet.package || '').trim() && (
-                                <span className="shrink-0 text-[10px] px-1.5 py-0 h-4 rounded border border-border text-muted-foreground flex items-center">
-                                  {snippet.package}
-                                </span>
-                              )}
-                            </div>
+                            <div className="text-sm font-semibold truncate">{snippet.label}</div>
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <div className="text-[11px] text-muted-foreground font-mono leading-4 truncate">

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1231,6 +1231,23 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               </div>
             </div>
           )}
+
+          {/* Search-with-no-results feedback (#777 codex follow-up). Without
+              this, when a query matches no snippets AND the package tile
+              grid is hidden, the content area would be completely blank. */}
+          {search.trim() && displayedSnippets.length === 0 && displayedPackages.length === 0 && snippets.length > 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <div className="h-14 w-14 rounded-2xl bg-secondary/80 flex items-center justify-center mb-3">
+                <Search size={24} className="opacity-60" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground mb-1">
+                {t('snippets.search.noResults.title')}
+              </h3>
+              <p className="text-xs text-center max-w-sm">
+                {t('snippets.search.noResults.desc', { query: search.trim() })}
+              </p>
+            </div>
+          )}
         </div>
       </div>
 

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1228,11 +1228,13 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
           {/* Search-with-no-results feedback (#777 codex follow-up). Package
               tiles are already hidden during search, so the only visible
               surface is the flat snippet list — if that's empty the content
-              area would be blank without this fallback. We don't gate on
-              displayedPackages.length because those tiles aren't rendered
-              while search is active (workspaces with packages were still
-              getting a blank area). */}
-          {search.trim() && displayedSnippets.length === 0 && snippets.length > 0 && (
+              area would be blank without this fallback. The gate intentionally
+              excludes the fully-empty workspace (snippets.length === 0 AND
+              displayedPackages.length === 0), which the global "Create
+              snippet" empty state renders instead — avoids stacking two
+              empty states. Package-only workspaces (no snippets yet) still
+              get this feedback when searching. */}
+          {search.trim() && displayedSnippets.length === 0 && (snippets.length > 0 || displayedPackages.length > 0) && (
             <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
               <div className="h-14 w-14 rounded-2xl bg-secondary/80 flex items-center justify-center mb-3">
                 <Search size={24} className="opacity-60" />

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -402,9 +402,15 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   }, [packages, selectedPackage, snippets]);
 
   const displayedSnippets = useMemo(() => {
-    let result = snippets.filter((s) => (s.package || '') === (selectedPackage || ''));
-    // Apply search filter
-    if (search.trim()) {
+    // Search spans all packages (#777): when the user types in the search
+    // box we drop the current-package scoping so cross-package matches are
+    // reachable without navigating into each one. Otherwise the user is
+    // browsing and we keep the package scope.
+    const hasSearch = search.trim().length > 0;
+    let result = hasSearch
+      ? snippets
+      : snippets.filter((s) => (s.package || '') === (selectedPackage || ''));
+    if (hasSearch) {
       const s = search.toLowerCase();
       result = result.filter(sn =>
         sn.label.toLowerCase().includes(s) ||
@@ -1068,7 +1074,10 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
         )}
 
         <div className="flex-1 space-y-3 overflow-y-auto px-4 pb-4">
-          {displayedPackages.length > 0 && (
+          {/* Hide the sub-package grid while searching (#777) — search spans
+              all packages, so showing the package tiles alongside a flat
+              cross-package snippet list is noisy. */}
+          {displayedPackages.length > 0 && !search.trim() && (
             <>
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-semibold text-muted-foreground">{t('snippets.section.packages')}</h3>
@@ -1155,7 +1164,14 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                             <FileCode size={18} />
                           </div>
                           <div className="w-0 flex-1">
-                            <div className="text-sm font-semibold truncate">{snippet.label}</div>
+                            <div className="flex items-center gap-1.5 min-w-0">
+                              <span className="text-sm font-semibold truncate">{snippet.label}</span>
+                              {search.trim() && (snippet.package || '').trim() && (
+                                <span className="shrink-0 text-[10px] px-1.5 py-0 h-4 rounded border border-border text-muted-foreground flex items-center">
+                                  {snippet.package}
+                                </span>
+                              )}
+                            </div>
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <div className="text-[11px] text-muted-foreground font-mono leading-4 truncate">

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -2725,11 +2725,6 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                             managed
                                           </Badge>
                                         )}
-                                        {search.trim() && (safeHost.group || "").trim() && (
-                                          <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 shrink-0 font-normal text-muted-foreground">
-                                            {safeHost.group}
-                                          </Badge>
-                                        )}
                                       </div>
                                       <div className="text-[11px] text-muted-foreground font-mono truncate leading-4">
                                         {safeHost.username}@{safeHost.hostname}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -867,23 +867,30 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
   const displayedHosts = useMemo(() => {
     let filtered = hosts;
-    if (selectedGroupPath) {
-      // Match hosts whose group equals the selected path
-      // For "General" group, also match hosts with empty/undefined group
-      filtered = filtered.filter((h) => {
-        const hostGroup = h.group || "";
-        if (selectedGroupPath === "General") {
-          return hostGroup === "" || hostGroup === "General";
-        }
-        return hostGroup === selectedGroupPath;
-      });
-    } else if (showOnlyUngroupedHostsInRoot) {
-      filtered = filtered.filter((h) => {
-        const hostGroup = (h.group || "").trim();
-        return hostGroup === "";
-      });
+    // Search spans all groups (#777): when the user types in the search box
+    // we skip group/ungrouped-root scoping, so a matching host in another
+    // group is still reachable without having to navigate into it first.
+    // The tree view already uses this shape — see `treeViewHosts` below.
+    const hasSearch = search.trim().length > 0;
+    if (!hasSearch) {
+      if (selectedGroupPath) {
+        // Match hosts whose group equals the selected path
+        // For "General" group, also match hosts with empty/undefined group
+        filtered = filtered.filter((h) => {
+          const hostGroup = h.group || "";
+          if (selectedGroupPath === "General") {
+            return hostGroup === "" || hostGroup === "General";
+          }
+          return hostGroup === selectedGroupPath;
+        });
+      } else if (showOnlyUngroupedHostsInRoot) {
+        filtered = filtered.filter((h) => {
+          const hostGroup = (h.group || "").trim();
+          return hostGroup === "";
+        });
+      }
     }
-    if (search.trim()) {
+    if (hasSearch) {
       const s = search.toLowerCase();
       filtered = filtered.filter(
         (h) =>
@@ -2716,6 +2723,11 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                         {safeHost.managedSourceId && (
                                           <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 shrink-0">
                                             managed
+                                          </Badge>
+                                        )}
+                                        {search.trim() && (safeHost.group || "").trim() && (
+                                          <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 shrink-0 font-normal text-muted-foreground">
+                                            {safeHost.group}
                                           </Badge>
                                         )}
                                       </div>


### PR DESCRIPTION
## Summary

Search was scoped to the current group (hosts page) or the current package (snippets page). If a host lived in a group the user hadn't drilled into — or if "root only shows ungrouped hosts" was turned on — a matching name would silently not appear in the search results. Report: #777.

### Hosts (`VaultView.tsx`)
- `displayedHosts` now skips the `selectedGroupPath` / `showOnlyUngroupedHostsInRoot` branches when the search box is non-empty.
- Each matching card shows a small outline badge with the host's group so cross-group results are recognizable.
- `treeViewHosts` already did this — the change makes the flat grid/list views consistent with the tree.

### Snippets (`SnippetsManager.tsx`)
- `displayedSnippets` skips the `selectedPackage` filter when search is active.
- Sub-package tile grid is hidden while searching (would be redundant alongside a flat cross-package list).
- Each snippet card shows the package path as a small bordered tag.

Empty state, sort, and tag filters are unchanged.

Closes #777

## Test plan
- [ ] Enable "root only shows ungrouped hosts", type a name that's in a group → host appears with its group badge.
- [ ] Inside a sub-group, search for a host that lives in a sibling group → appears.
- [ ] Clear search → list returns to the current group's scope as before.
- [ ] Snippets: navigate into a package, search for a snippet in another package → appears with package badge; sub-package tiles hide while search active.
- [ ] Clear snippet search → package tiles and current-package scoping return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)