### PR TITLE
Right-click Edit/Delete on sidepanel snippets (#780)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1623,6 +1623,19 @@ function App({ settings }: { settings: SettingsState }) {
     };
   }, [handleOpenSettings, t]);
 
+  // Delete-from-sidepanel plumbing: ScriptsSidePanel's right-click menu
+  // dispatches `netcatty:snippets:delete` with the snippet id. Handled here
+  // (rather than in QuickAddSnippetDialog) because delete needs no UI.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const id = (e as CustomEvent<{ id?: string }>).detail?.id;
+      if (!id) return;
+      updateSnippets(snippets.filter((s) => s.id !== id));
+    };
+    window.addEventListener('netcatty:snippets:delete', handler);
+    return () => window.removeEventListener('netcatty:snippets:delete', handler);
+  }, [snippets, updateSnippets]);
+
   const handleEndSessionDrag = useCallback(() => {
     setDraggingSessionId(null);
   }, [setDraggingSessionId]);
@@ -1827,12 +1840,17 @@ function App({ settings }: { settings: SettingsState }) {
         })}
       </div>
 
-      {/* Global "quick add snippet" dialog, triggered by the
-          netcatty:snippets:add window event (from ScriptsSidePanel "+"). */}
+      {/* Global "quick add / edit snippet" dialog, triggered by the
+          netcatty:snippets:add and :edit window events (from ScriptsSidePanel
+          "+" button and right-click menu). Delete is handled by a sibling
+          useEffect above — it does not need a dialog. */}
       <QuickAddSnippetDialog
         snippets={snippets}
         packages={snippetPackages}
         onCreateSnippet={(snippet) => updateSnippets([...snippets, snippet])}
+        onUpdateSnippet={(snippet) =>
+          updateSnippets(snippets.map((s) => (s.id === snippet.id ? snippet : s)))
+        }
         onCreatePackage={(pkg) =>
           updateSnippetPackages(Array.from(new Set([...snippetPackages, pkg])))
         }

--- a/components/QuickAddSnippetDialog.tsx
+++ b/components/QuickAddSnippetDialog.tsx
@@ -30,6 +30,7 @@ export interface QuickAddSnippetDialogProps {
   snippets: Snippet[];
   packages: string[];
   onCreateSnippet: (snippet: Snippet) => void;
+  onUpdateSnippet?: (snippet: Snippet) => void;
   onCreatePackage?: (packagePath: string) => void;
 }
 
@@ -37,6 +38,7 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   snippets,
   packages,
   onCreateSnippet,
+  onUpdateSnippet,
   onCreatePackage,
 }) => {
   const { t } = useI18n();
@@ -44,6 +46,7 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   const [label, setLabel] = useState('');
   const [command, setCommand] = useState('');
   const [packagePath, setPackagePath] = useState('');
+  const [editing, setEditing] = useState<Snippet | null>(null);
   const labelInputRef = useRef<HTMLInputElement>(null);
 
   // Listen for the global "add snippet" request dispatched by the
@@ -51,6 +54,7 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
   // every open so stale input from a previous cancel does not leak.
   useEffect(() => {
     const handler = () => {
+      setEditing(null);
       setLabel('');
       setCommand('');
       setPackagePath('');
@@ -58,6 +62,23 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     };
     window.addEventListener('netcatty:snippets:add', handler);
     return () => window.removeEventListener('netcatty:snippets:add', handler);
+  }, []);
+
+  // Sibling event for editing an existing snippet from the ScriptsSidePanel
+  // context menu. Prefills the form and flips the dialog into update mode.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ snippet?: Snippet }>).detail;
+      const snippet = detail?.snippet;
+      if (!snippet) return;
+      setEditing(snippet);
+      setLabel(snippet.label ?? '');
+      setCommand(snippet.command ?? '');
+      setPackagePath(snippet.package ?? '');
+      setOpen(true);
+    };
+    window.addEventListener('netcatty:snippets:edit', handler);
+    return () => window.removeEventListener('netcatty:snippets:edit', handler);
   }, []);
 
   // Auto-focus the label input once the dialog renders, so the user can
@@ -92,16 +113,27 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     if (trimmedPackage && !packages.includes(trimmedPackage)) {
       onCreatePackage?.(trimmedPackage);
     }
-    onCreateSnippet({
-      id: crypto.randomUUID(),
-      label: label.trim(),
-      command, // preserve whitespace in multi-line commands
-      tags: [],
-      package: trimmedPackage || '',
-      targets: [],
-    });
+    if (editing && onUpdateSnippet) {
+      // Preserve tags/targets/shortkey/noAutoRun etc. that this lightweight
+      // dialog does not expose — only the three quick-edit fields change.
+      onUpdateSnippet({
+        ...editing,
+        label: label.trim(),
+        command,
+        package: trimmedPackage || '',
+      });
+    } else {
+      onCreateSnippet({
+        id: crypto.randomUUID(),
+        label: label.trim(),
+        command, // preserve whitespace in multi-line commands
+        tags: [],
+        package: trimmedPackage || '',
+        targets: [],
+      });
+    }
     setOpen(false);
-  }, [canSave, packagePath, packages, onCreatePackage, onCreateSnippet, label, command]);
+  }, [canSave, packagePath, packages, onCreatePackage, onCreateSnippet, onUpdateSnippet, editing, label, command]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -118,7 +150,9 @@ export const QuickAddSnippetDialog: React.FC<QuickAddSnippetDialogProps> = ({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-md" onKeyDown={handleKeyDown}>
         <DialogHeader>
-          <DialogTitle>{t('snippets.panel.newTitle')}</DialogTitle>
+          <DialogTitle>
+            {t(editing ? 'snippets.panel.editTitle' : 'snippets.panel.newTitle')}
+          </DialogTitle>
           <DialogDescription>
             {t('snippets.empty.desc')}
           </DialogDescription>

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -5,11 +5,17 @@
  * Clicking a snippet executes it in the focused terminal session.
  */
 
-import { ChevronRight, Package, Plus, Search, Zap } from 'lucide-react';
+import { ChevronRight, Edit2, Package, Plus, Search, Trash2, Zap } from 'lucide-react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { cn } from '../lib/utils';
 import { Snippet } from '../types';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from './ui/context-menu';
 import { Input } from './ui/input';
 import { ScrollArea } from './ui/scroll-area';
 
@@ -126,6 +132,18 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     window.dispatchEvent(new CustomEvent('netcatty:snippets:add'));
   }, []);
 
+  const handleEditSnippet = useCallback((snippet: Snippet) => {
+    window.dispatchEvent(
+      new CustomEvent('netcatty:snippets:edit', { detail: { snippet } }),
+    );
+  }, []);
+
+  const handleDeleteSnippet = useCallback((id: string) => {
+    window.dispatchEvent(
+      new CustomEvent('netcatty:snippets:delete', { detail: { id } }),
+    );
+  }, []);
+
   if (!isVisible) return null;
 
   const hasAnyContent = snippets.length > 0 || packages.length > 0;
@@ -213,16 +231,30 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
 
           {/* Snippets */}
           {displayedSnippets.map((s) => (
-            <button
-              key={s.id}
-              onClick={() => handleSnippetClick(s.command, s.noAutoRun)}
-              className="w-full text-left px-3 py-2 hover:bg-accent/50 transition-colors flex flex-col gap-0.5"
-            >
-              <span className="text-xs font-medium truncate">{s.label}</span>
-              <span className="text-muted-foreground truncate font-mono text-[10px] max-w-full">
-                {s.command}
-              </span>
-            </button>
+            <ContextMenu key={s.id}>
+              <ContextMenuTrigger asChild>
+                <button
+                  onClick={() => handleSnippetClick(s.command, s.noAutoRun)}
+                  className="w-full text-left px-3 py-2 hover:bg-accent/50 transition-colors flex flex-col gap-0.5"
+                >
+                  <span className="text-xs font-medium truncate">{s.label}</span>
+                  <span className="text-muted-foreground truncate font-mono text-[10px] max-w-full">
+                    {s.command}
+                  </span>
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem onClick={() => handleEditSnippet(s)}>
+                  <Edit2 className="mr-2 h-4 w-4" /> {t('action.edit')}
+                </ContextMenuItem>
+                <ContextMenuItem
+                  className="text-destructive"
+                  onClick={() => handleDeleteSnippet(s.id)}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> {t('action.delete')}
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
           ))}
 
           {hasAnyContent && displayedSnippets.length === 0 && filteredPackages.length === 0 && search.trim() && (


### PR DESCRIPTION
## Summary

Closes the gap left by #783 on the actual surface the #780 reporter was looking at — the terminal's right-side **ScriptsSidePanel**, not the Vault > Snippets edit panel.

Issue #780 asked for right-click Delete/Edit on snippets in the side panel (\"直接在代码片段上右键可以弹出一个菜单, 可以包含'删除, 修改'等操作\"). PR #783 added a trash icon to the Vault edit panel and closed the issue, but the snippet rows in \`ScriptsSidePanel\` were still plain buttons with no context menu, so the original request was never wired up at that spot.

## Changes

### \`components/ScriptsSidePanel.tsx\`
- Wrap each snippet row in a \`ContextMenu\` with **Edit** and **Delete** items (destructive styling on Delete).
- Menu actions dispatch window events rather than threading new callbacks, matching the existing \`netcatty:snippets:add\` pattern used by the \`+\` button.

### \`components/QuickAddSnippetDialog.tsx\`
- Accepts an optional \`onUpdateSnippet\` prop and listens for \`netcatty:snippets:edit\`.
- Prefills label / command / package from the dispatched snippet and flips into edit mode.
- On save, preserves the original \`tags\`, \`targets\`, \`shortkey\`, \`noAutoRun\` etc. — the dialog still only exposes the three quick-edit fields, so advanced properties survive untouched.
- Title flips to \`snippets.panel.editTitle\` (already localised EN/zh-CN) in edit mode.

### \`App.tsx\`
- Pass \`onUpdateSnippet\` wired to \`updateSnippets(snippets.map(...))\`.
- Register a window listener for \`netcatty:snippets:delete\` that filters the deleted id out of \`snippets\`. Delete needs no UI so it stays outside the dialog.

## Test plan

- [x] Open a terminal → Scripts side panel → right-click a snippet → menu shows **Edit** and **Delete**.
- [x] Click **Edit** → dialog opens prefilled; change label/command/package → Save → snippet updates in both the sidepanel and the Vault > Snippets grid.
- [x] Edit a snippet that had tags / a shortkey / \`noAutoRun\` → after saving via the quick-edit dialog, those advanced fields are still present in Vault > Snippets.
- [x] Click **Delete** → snippet disappears from the sidepanel and Vault grid immediately.
- [x] The existing \`+\` button flow (\`netcatty:snippets:add\`) still opens the dialog in create mode with empty fields.
- [x] Right-click menu does not interfere with the left-click \"run snippet\" behaviour.

Partially re-closes #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)