### PR TITLE
Immersive borderless terminal compose bar

### DIFF
--- a/components/terminal/TerminalComposeBar.tsx
+++ b/components/terminal/TerminalComposeBar.tsx
@@ -1,9 +1,11 @@
 /**
  * Terminal Compose Bar
- * A modern text input bar for composing commands before sending them.
- * Supports pre-reviewing passwords/commands and broadcasting to multiple sessions.
+ * An immersive, borderless prompt bar that blends into the terminal's
+ * background — like the Claude Code compose area. Enter sends, Escape
+ * closes, Shift+Enter inserts a newline. The only visible chrome is a
+ * hair-line top border separating it from the terminal output.
  */
-import { Radio, Send, X } from 'lucide-react';
+import { Radio, X } from 'lucide-react';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { cn } from '../../lib/utils';
@@ -73,10 +75,9 @@ export const TerminalComposeBar: React.FC<TerminalComposeBarProps> = ({
         <div
             className="flex-shrink-0"
             style={{
-                background: `linear-gradient(to top, ${resolvedBg}, color-mix(in srgb, ${resolvedFg} 4%, ${resolvedBg} 96%))`,
-                borderTop: `1px solid color-mix(in srgb, ${resolvedFg} 10%, ${resolvedBg} 90%)`,
-                borderRadius: '0 0 8px 8px',
-                padding: '6px 10px',
+                backgroundColor: resolvedBg,
+                borderTop: `1px solid color-mix(in srgb, ${resolvedFg} 8%, ${resolvedBg} 92%)`,
+                padding: '8px 12px',
             }}
         >
             <div className="flex items-center gap-2">
@@ -90,77 +91,48 @@ export const TerminalComposeBar: React.FC<TerminalComposeBarProps> = ({
                     </div>
                 )}
 
-                {/* Input field */}
+                {/* Borderless input — lives flush on the terminal bg so the
+                    bar feels like part of the terminal rather than a panel. */}
                 <textarea
                     ref={textareaRef}
                     className={cn(
-                        "flex-1 min-w-0 resize-none rounded-md px-3 py-1.5 text-xs font-mono leading-relaxed",
-                        "outline-none transition-all duration-200",
-                        "placeholder:opacity-40",
+                        "flex-1 min-w-0 resize-none bg-transparent border-none px-0 py-0",
+                        "text-xs font-mono leading-relaxed outline-none",
+                        "placeholder:opacity-70",
                     )}
                     style={{
-                        backgroundColor: `color-mix(in srgb, ${resolvedFg} 6%, ${resolvedBg} 94%)`,
                         color: resolvedFg,
-                        border: `1px solid color-mix(in srgb, ${resolvedFg} 25%, ${resolvedBg} 75%)`,
-                        minHeight: '28px',
+                        minHeight: '20px',
                         maxHeight: '120px',
-                        boxShadow: `inset 0 1px 3px color-mix(in srgb, ${resolvedBg} 80%, transparent)`,
                     }}
                     rows={1}
                     placeholder={t("terminal.composeBar.placeholder")}
                     onInput={handleInput}
                     onKeyDown={handleKeyDown}
-                    onFocus={(e) => {
-                        e.currentTarget.style.borderColor = `color-mix(in srgb, ${resolvedFg} 40%, ${resolvedBg} 60%)`;
-                        e.currentTarget.style.boxShadow = `inset 0 1px 3px color-mix(in srgb, ${resolvedBg} 80%, transparent), 0 0 0 1px color-mix(in srgb, ${resolvedFg} 8%, transparent)`;
-                    }}
-                    onBlur={(e) => {
-                        e.currentTarget.style.borderColor = `color-mix(in srgb, ${resolvedFg} 25%, ${resolvedBg} 75%)`;
-                        e.currentTarget.style.boxShadow = `inset 0 1px 3px color-mix(in srgb, ${resolvedBg} 80%, transparent)`;
-                    }}
                     onCompositionStart={() => { isComposingRef.current = true; }}
                     onCompositionEnd={() => { isComposingRef.current = false; }}
                 />
 
-                {/* Action buttons */}
-                <div className="flex items-center gap-0.5">
-                    <button
-                        className="h-7 w-7 flex items-center justify-center rounded-md transition-colors duration-150"
-                        style={{
-                            color: resolvedFg,
-                            background: `color-mix(in srgb, ${resolvedFg} 20%, ${resolvedBg} 80%)`,
-                        }}
-                        onMouseEnter={(e) => {
-                            e.currentTarget.style.background = `color-mix(in srgb, ${resolvedFg} 30%, ${resolvedBg} 70%)`;
-                        }}
-                        onMouseLeave={(e) => {
-                            e.currentTarget.style.background = `color-mix(in srgb, ${resolvedFg} 20%, ${resolvedBg} 80%)`;
-                        }}
-                        onClick={handleSend}
-                        title={t("terminal.composeBar.send")}
-                    >
-                        <Send size={13} />
-                    </button>
-                    <button
-                        className="h-7 w-7 flex items-center justify-center rounded-md transition-colors duration-150"
-                        style={{
-                            color: `color-mix(in srgb, ${resolvedFg} 60%, ${resolvedBg} 40%)`,
-                            background: `color-mix(in srgb, ${resolvedFg} 12%, ${resolvedBg} 88%)`,
-                        }}
-                        onMouseEnter={(e) => {
-                            e.currentTarget.style.background = `color-mix(in srgb, ${resolvedFg} 22%, ${resolvedBg} 78%)`;
-                            e.currentTarget.style.color = resolvedFg;
-                        }}
-                        onMouseLeave={(e) => {
-                            e.currentTarget.style.background = `color-mix(in srgb, ${resolvedFg} 12%, ${resolvedBg} 88%)`;
-                            e.currentTarget.style.color = `color-mix(in srgb, ${resolvedFg} 60%, ${resolvedBg} 40%)`;
-                        }}
-                        onClick={onClose}
-                        title={t("terminal.composeBar.close")}
-                    >
-                        <X size={13} />
-                    </button>
-                </div>
+                {/* Minimal close button — no filled bg, hover only. */}
+                <button
+                    className="h-6 w-6 flex items-center justify-center rounded-md transition-colors duration-150 flex-shrink-0"
+                    style={{
+                        color: `color-mix(in srgb, ${resolvedFg} 50%, ${resolvedBg} 50%)`,
+                        background: 'transparent',
+                    }}
+                    onMouseEnter={(e) => {
+                        e.currentTarget.style.background = `color-mix(in srgb, ${resolvedFg} 10%, ${resolvedBg} 90%)`;
+                        e.currentTarget.style.color = resolvedFg;
+                    }}
+                    onMouseLeave={(e) => {
+                        e.currentTarget.style.background = 'transparent';
+                        e.currentTarget.style.color = `color-mix(in srgb, ${resolvedFg} 50%, ${resolvedBg} 50%)`;
+                    }}
+                    onClick={onClose}
+                    title={t("terminal.composeBar.close")}
+                >
+                    <X size={12} />
+                </button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

The workspace terminal's compose bar had a rounded gradient card with an inset box shadow, a bordered inner textarea, and a filled Send button — visually heavy, and it sat on top of the terminal looking like a distinct panel instead of a prompt line.

Rework it to feel like part of the terminal (Claude Code compose-area style):

- **Outer container** paints directly with the terminal theme \`background\` — no gradient, no border-radius, no box-shadow. Separator from the terminal output is a single 8%-alpha hairline \`border-top\`.
- **Textarea** is fully borderless and transparent: no bg, no border, no focus ring, no inner shadow. Text sits directly on the terminal bg.
- **Send button removed.** Enter was already the send key, and a filled button was just visual weight. \`Shift+Enter\` still inserts a newline, \`Esc\` still closes.
- **Close (X) button** shrunk to a minimal \`6x6\` ghost — transparent at rest, 10% fg overlay + full fg on hover only.
- **Placeholder** bumped from \`opacity-40\` to \`opacity-70\` so the \"press Enter to send\" hint is legible against both dark and light terminal themes (previous alpha was too faint to read on near-black terminals).

## Test plan

- [x] Open Workspace → compose bar pops at the bottom and blends flush with the terminal background; only a faint top hairline separates it from the output.
- [x] Placeholder \"Type command here, press Enter to send...\" is clearly legible.
- [x] Type text → \`Enter\` sends; \`Shift+Enter\` inserts a newline; \`Esc\` closes the bar.
- [x] Click the X → bar closes.
- [x] Broadcast (amber radio icon) still appears when broadcast is on.
- [x] Swap terminal theme between dark and light — bar bg and text colour follow the theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)