### PR TITLE
Match Settings wordmark with Vault sidebar

### DIFF
--- a/components/SettingsApplicationTab.tsx
+++ b/components/SettingsApplicationTab.tsx
@@ -152,7 +152,14 @@ export default function SettingsApplicationTab({ updateState, checkNow, openRele
           <div className="flex items-center gap-4">
             <AppLogo className="w-16 h-16" />
             <div>
-              <div className="text-3xl font-semibold leading-none">{appInfo.name}</div>
+              {/* Match the Vault sidebar wordmark so the Netcatty brand
+                  reads consistently across surfaces — same italic heavy
+                  cut, just scaled up for the Settings hero area and
+                  using the branded mixed-case "Netcatty" instead of
+                  the lowercase electron app name. */}
+              <div className="text-3xl font-black italic tracking-tight leading-none text-foreground">
+                Netcatty
+              </div>
               <div className="flex items-center gap-2 mt-1">
                 <span className="text-sm text-muted-foreground">
                   {appInfo.version ? appInfo.version : " "}


### PR DESCRIPTION
## Summary

Settings → Application and the Vault sidebar were showing the same brand, but with two visually different wordmarks next to the same logo:

- **Settings**: \`text-3xl font-semibold\` on \`{appInfo.name}\`, resolving to lowercase \"netcatty\" (sourced from Electron's \`app.getName()\` / \`package.json\` \`name\` field).
- **Vault sidebar**: \`text-xl font-black italic tracking-tight\` with mixed-case \"Netcatty\".

## Changes

\`components/SettingsApplicationTab.tsx\`:

- Swap \`font-semibold\` → \`font-black italic tracking-tight\` so the type treatment matches the Vault sidebar's.
- Keep \`text-3xl\` (the Settings surface has a larger logo, so the hero size stays; the style is what's being unified, not the size).
- Hardcode \"Netcatty\" instead of \`{appInfo.name}\` so the brand name reads mixed-case instead of the lowercase package name.

## Test plan

- [x] Open Settings → Application: wordmark renders as **Netcatty** in italic heavy with tight tracking, next to the logo.
- [x] Compare against Vault sidebar \"Netcatty\" label — same cut (same italic, same heavy, same tracking feel), just scaled larger.
- [x] Version string below the wordmark is unchanged.
- [x] Light and dark themes: text color follows \`text-foreground\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)