### PR TITLE
Collapse four terminal toolbar actions behind a More popover

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1193,6 +1193,7 @@ const en: Messages = {
   'terminal.toolbar.openSftp': 'Open SFTP',
   'terminal.toolbar.availableAfterConnect': 'Available after connect',
   'terminal.toolbar.sftp': 'SFTP',
+  'terminal.toolbar.more': 'More actions',
   'terminal.toolbar.scripts': 'Scripts',
   'terminal.toolbar.library': 'Library',
   'terminal.toolbar.noSnippets': 'No snippets available',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -799,6 +799,7 @@ const zhCN: Messages = {
   'terminal.toolbar.openSftp': '打开 SFTP',
   'terminal.toolbar.availableAfterConnect': '连接后可用',
   'terminal.toolbar.sftp': 'SFTP',
+  'terminal.toolbar.more': '更多操作',
   'terminal.toolbar.scripts': '脚本',
   'terminal.toolbar.library': '库',
   'terminal.toolbar.noSnippets': '暂无代码片段',

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -2,7 +2,7 @@
  * Terminal Toolbar
  * Displays SFTP, Scripts, Theme, Highlight, Search buttons and close button in terminal status bar
  */
-import { Check, FolderInput, Languages, MoreHorizontal, X, Zap, Palette, Search, TextCursorInput } from 'lucide-react';
+import { Check, FolderInput, Languages, MoreVertical, X, Zap, Palette, Search, TextCursorInput } from 'lucide-react';
 import React, { useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { Host } from '../../types';
@@ -61,6 +61,46 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
 
     return (
         <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
+            <HostKeywordHighlightPopover
+                host={host}
+                onUpdateHost={onUpdateHost}
+                isOpen={highlightPopoverOpen}
+                setIsOpen={setHighlightPopoverOpen}
+                buttonClassName={buttonBase}
+            />
+
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="secondary"
+                        size="icon"
+                        className={buttonBase}
+                        aria-label={t("terminal.toolbar.composeBar")}
+                        aria-pressed={isComposeBarOpen}
+                        onClick={onToggleComposeBar}
+                    >
+                        <TextCursorInput size={12} />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("terminal.toolbar.composeBar")}</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        variant="secondary"
+                        size="icon"
+                        className={buttonBase}
+                        aria-label={t("terminal.toolbar.searchTerminal")}
+                        aria-pressed={isSearchOpen}
+                        onClick={onToggleSearch}
+                    >
+                        <Search size={12} />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
+            </Tooltip>
+
             {/* Overflow menu — collapses the four opener-style actions
                 (SFTP / Encoding / Scripts / Terminal Settings) behind a
                 single ⋮ trigger so the toolbar doesn't feel crowded.
@@ -76,13 +116,13 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                                 className={buttonBase}
                                 aria-label={t("terminal.toolbar.more")}
                             >
-                                <MoreHorizontal size={14} />
+                                <MoreVertical size={14} />
                             </Button>
                         </PopoverTrigger>
                     </TooltipTrigger>
                     <TooltipContent>{t("terminal.toolbar.more")}</TooltipContent>
                 </Tooltip>
-                <PopoverContent className="w-48 p-1" align="start">
+                <PopoverContent className="w-48 p-1" align="end">
                     {!hidesSftp && (
                         <PopoverClose asChild>
                             <button
@@ -139,46 +179,6 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                     )}
                 </PopoverContent>
             </Popover>
-
-            <HostKeywordHighlightPopover
-                host={host}
-                onUpdateHost={onUpdateHost}
-                isOpen={highlightPopoverOpen}
-                setIsOpen={setHighlightPopoverOpen}
-                buttonClassName={buttonBase}
-            />
-
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="secondary"
-                        size="icon"
-                        className={buttonBase}
-                        aria-label={t("terminal.toolbar.composeBar")}
-                        aria-pressed={isComposeBarOpen}
-                        onClick={onToggleComposeBar}
-                    >
-                        <TextCursorInput size={12} />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.composeBar")}</TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="secondary"
-                        size="icon"
-                        className={buttonBase}
-                        aria-label={t("terminal.toolbar.searchTerminal")}
-                        aria-pressed={isSearchOpen}
-                        onClick={onToggleSearch}
-                    >
-                        <Search size={12} />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
-            </Tooltip>
 
             {showClose && onClose && (
                 <Tooltip>

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -2,7 +2,7 @@
  * Terminal Toolbar
  * Displays SFTP, Scripts, Theme, Highlight, Search buttons and close button in terminal status bar
  */
-import { Check, FolderInput, Languages, X, Zap, Palette, Search, TextCursorInput } from 'lucide-react';
+import { Check, FolderInput, Languages, MoreHorizontal, X, Zap, Palette, Search, TextCursorInput } from 'lucide-react';
 import React, { useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { Host } from '../../types';
@@ -57,99 +57,88 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     const isSSHSession = !isLocalTerminal && !isSerialTerminal && host?.protocol !== 'telnet' && host?.protocol !== 'mosh' && !host?.moshEnabled && host?.hostname !== 'localhost';
     const hidesSftp = isLocalTerminal || isSerialTerminal;
 
+    const menuItemClass = "w-full flex items-center gap-2 px-2 py-1.5 text-xs rounded-sm hover:bg-secondary transition-colors";
+
     return (
         <TooltipProvider delayDuration={500} skipDelayDuration={100} disableHoverableContent>
-            {!hidesSftp && (
+            {/* Overflow menu — collapses the four opener-style actions
+                (SFTP / Encoding / Scripts / Terminal Settings) behind a
+                single ⋮ trigger so the toolbar doesn't feel crowded.
+                Highlight / Compose / Search stay visible because they
+                are toggled mid-session, not just once. */}
+            <Popover>
                 <Tooltip>
                     <TooltipTrigger asChild>
-                        <Button
-                            variant="secondary"
-                            size="icon"
-                            className={buttonBase}
-                            disabled={status !== 'connected'}
-                            aria-label={t("terminal.toolbar.openSftp")}
-                            onClick={onOpenSFTP}
-                        >
-                            <FolderInput size={12} />
-                        </Button>
+                        <PopoverTrigger asChild>
+                            <Button
+                                variant="secondary"
+                                size="icon"
+                                className={buttonBase}
+                                aria-label={t("terminal.toolbar.more")}
+                            >
+                                <MoreHorizontal size={14} />
+                            </Button>
+                        </PopoverTrigger>
                     </TooltipTrigger>
-                    <TooltipContent>
-                        {status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
-                    </TooltipContent>
+                    <TooltipContent>{t("terminal.toolbar.more")}</TooltipContent>
                 </Tooltip>
-            )}
-
-            {isSSHSession && onSetTerminalEncoding && (
-                <Popover>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="secondary"
-                                    size="icon"
-                                    className={buttonBase}
-                                    aria-label={t("terminal.toolbar.encoding")}
-                                >
-                                    <Languages size={12} />
-                                </Button>
-                            </PopoverTrigger>
-                        </TooltipTrigger>
-                        <TooltipContent>{t("terminal.toolbar.encoding")}</TooltipContent>
-                    </Tooltip>
-                    <PopoverContent className="w-36 p-1" align="start">
-                        {(["utf-8", "gb18030"] as const).map((enc) => (
-                            <PopoverClose asChild key={enc}>
-                                <button
-                                    className={cn(
-                                        "w-full flex items-center gap-2 px-2 py-1.5 text-xs rounded-sm hover:bg-secondary transition-colors",
-                                        terminalEncoding === enc && "font-medium"
-                                    )}
-                                    onClick={() => onSetTerminalEncoding(enc)}
-                                >
-                                    <Check
-                                        size={12}
-                                        className={cn(
-                                            "shrink-0",
-                                            terminalEncoding === enc ? "opacity-100" : "opacity-0"
-                                        )}
-                                    />
-                                    {t(`terminal.toolbar.encoding.${enc === "utf-8" ? "utf8" : enc}`)}
-                                </button>
-                            </PopoverClose>
-                        ))}
-                    </PopoverContent>
-                </Popover>
-            )}
-
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="secondary"
-                        size="icon"
-                        className={buttonBase}
-                        aria-label={t("terminal.toolbar.scripts")}
-                        onClick={onOpenScripts}
-                    >
-                        <Zap size={12} />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.scripts")}</TooltipContent>
-            </Tooltip>
-
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="secondary"
-                        size="icon"
-                        className={buttonBase}
-                        aria-label={t("terminal.toolbar.terminalSettings")}
-                        onClick={onOpenTheme}
-                    >
-                        <Palette size={12} />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.terminalSettings")}</TooltipContent>
-            </Tooltip>
+                <PopoverContent className="w-48 p-1" align="start">
+                    {!hidesSftp && (
+                        <PopoverClose asChild>
+                            <button
+                                type="button"
+                                className={cn(menuItemClass, status !== 'connected' && "opacity-50 pointer-events-none")}
+                                onClick={onOpenSFTP}
+                                disabled={status !== 'connected'}
+                            >
+                                <FolderInput size={12} className="shrink-0" />
+                                <span className="flex-1 text-left truncate">
+                                    {status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
+                                </span>
+                            </button>
+                        </PopoverClose>
+                    )}
+                    <PopoverClose asChild>
+                        <button type="button" className={menuItemClass} onClick={onOpenScripts}>
+                            <Zap size={12} className="shrink-0" />
+                            <span className="flex-1 text-left truncate">{t("terminal.toolbar.scripts")}</span>
+                        </button>
+                    </PopoverClose>
+                    <PopoverClose asChild>
+                        <button type="button" className={menuItemClass} onClick={onOpenTheme}>
+                            <Palette size={12} className="shrink-0" />
+                            <span className="flex-1 text-left truncate">{t("terminal.toolbar.terminalSettings")}</span>
+                        </button>
+                    </PopoverClose>
+                    {isSSHSession && onSetTerminalEncoding && (
+                        <>
+                            <div className="h-px bg-border/60 my-1 mx-1" />
+                            <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground flex items-center gap-1.5">
+                                <Languages size={11} />
+                                {t("terminal.toolbar.encoding")}
+                            </div>
+                            {(["utf-8", "gb18030"] as const).map((enc) => (
+                                <PopoverClose asChild key={enc}>
+                                    <button
+                                        type="button"
+                                        className={cn(menuItemClass, "pl-6", terminalEncoding === enc && "font-medium")}
+                                        onClick={() => onSetTerminalEncoding(enc)}
+                                    >
+                                        <Check
+                                            size={12}
+                                            className={cn(
+                                                "shrink-0",
+                                                terminalEncoding === enc ? "opacity-100" : "opacity-0",
+                                            )}
+                                        />
+                                        {t(`terminal.toolbar.encoding.${enc === "utf-8" ? "utf8" : enc}`)}
+                                    </button>
+                                </PopoverClose>
+                            ))}
+                        </>
+                    )}
+                </PopoverContent>
+            </Popover>
 
             <HostKeywordHighlightPopover
                 host={host}


### PR DESCRIPTION
## Summary

The terminal status-bar toolbar currently shows seven icon buttons (SFTP, Encoding, Scripts, Theme, Highlight, Compose, Search) plus the close button — visually noisy and pushes the host label around on narrow tabs.

Fold the four \"opener\" actions — **SFTP**, **Encoding**, **Scripts**, **Terminal Settings** — behind a single \`MoreHorizontal\` (⋮) popover. The three mid-session toggles (Highlight, Compose, Search) stay in the bar because they're used repeatedly during a session.

## Changes

### \`components/terminal/TerminalToolbar.tsx\`
- Add \`MoreHorizontal\` import and a shared \`menuItemClass\` for popover rows.
- Replace the four inline Buttons with one Popover whose content lists each action as an \`icon + label\` row.
- Inline the old Encoding sub-popover into the same menu: a \`Languages\` section header followed by two \`Check\`-marked radio-like rows for UTF-8 / GB18030 (still only rendered when \`isSSHSession && onSetTerminalEncoding\`).
- SFTP row respects the existing connected-state: disabled + 50% opacity until the session is connected; label falls back to \`terminal.toolbar.availableAfterConnect\`.

### \`application/i18n/locales/en.ts\`, \`zh-CN.ts\`
- New \`terminal.toolbar.more\` key — \"More actions\" / \"更多操作\" — used as the ⋮ button's aria-label and tooltip.

## Test plan

- [x] Open any SSH terminal → toolbar shows **⋮** + Highlight + Compose + Search (+ close button if applicable).
- [x] Click ⋮ → popover lists: Open SFTP / Scripts / Terminal settings / Encoding header with UTF-8 + GB18030 rows.
- [x] Click any row → action fires (panel opens / encoding switches) and popover closes.
- [x] Reconnect a session: before \"connected\" state the SFTP row is disabled and reads \"Available after connect\".
- [x] Local-terminal / serial tabs: SFTP row is omitted from the popover (it was \`hidesSftp\` before).
- [x] Non-SSH sessions: Encoding section is omitted from the popover.
- [x] Tooltips on ⋮ trigger render \"More actions\" / \"更多操作\" in EN / zh-CN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)