### PR TITLE
Fix blurry Windows tray icon on high-DPI displays (#794)

### DIFF
--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -589,12 +589,21 @@ function createTray() {
     const resolvedIconPath = resolveTrayIconPath();
     if (resolvedIconPath) {
       trayIcon = nativeImage.createFromPath(resolvedIconPath);
-      // Resize for tray (16x16 on most platforms, 22x22 on some Linux)
       if (process.platform === "darwin") {
         trayIcon = trayIcon.resize({ width: 16, height: 16 });
         trayIcon.setTemplateImage(true);
       } else {
-        trayIcon = trayIcon.resize({ width: 16, height: 16 });
+        // Windows/Linux: attach the @2x representation so the OS can pick
+        // the right pixel size per DPI scale. Force-resizing to 16x16 here
+        // produces blurry icons on HiDPI displays where the tray slot is
+        // rendered larger than 16px.
+        const hiDpiPath = resolvedIconPath.replace(/\.png$/i, "@2x.png");
+        if (fs.existsSync(hiDpiPath)) {
+          trayIcon.addRepresentation({
+            scaleFactor: 2,
+            buffer: fs.readFileSync(hiDpiPath),
+          });
+        }
       }
     }
 

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -97,6 +97,7 @@ function createElectronStub() {
             return this;
           },
           setTemplateImage() {},
+          addRepresentation() {},
         };
       },
       createEmpty() {


### PR DESCRIPTION
## Summary
- Tray icon was force-resized to 16x16 on Windows/Linux, so the OS had to upscale at every DPI > 100% — visibly blurry, per #794.
- Attach the existing `tray-icon@2x.png` (32x32) as a HiDPI representation via `nativeImage.addRepresentation({ scaleFactor: 2 })` and drop the manual resize on the non-macOS path.
- macOS template image path is unchanged — `setTemplateImage` + 16x16 is still correct there.

Covers 100% DPI (pixel-perfect 1x), 200% DPI (pixel-perfect 2x), and 125-175% DPI (Windows downscales 2x cleanly). ≥250% DPI still upscales from 32px and could be improved later by adding a 3x rep or shipping a multi-size `.ico` — out of scope for this fix.

## Test plan
- [x] `node --test electron/bridges/globalShortcutBridge.test.cjs` — 11/11 pass (test stub's `nativeImage` mock updated with a no-op `addRepresentation`).
- [x] Manual: build Windows package and verify tray icon is sharp at 100% / 150% / 200% DPI.
- [ ] Manual (macOS): confirm tray template image still renders correctly (unchanged code path).

Fixes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)