### PR TITLE
Render snippets sidebar as an expandable tree (#800)

### DIFF
--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -8,7 +8,7 @@
  */
 
 import { ChevronRight, Edit2, FileCode, Package, Plus, Search, Trash2, Zap } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { cn } from '../lib/utils';
 import { Snippet } from '../types';
@@ -89,13 +89,28 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     return set;
   }, [packages, snippets]);
 
-  // Default: expand every package so the user sees everything without drilling.
-  // Also re-runs when packages change so newly added ones are shown expanded.
+  // Track every package we've ever observed so we can tell "new" from
+  // "previously-seen-but-user-collapsed". Without this, any unrelated refresh
+  // that reduced prev.size (because the user collapsed a row) would
+  // incorrectly trip a bulk re-expand.
+  const seenPackagesRef = useRef<Set<string>>(new Set());
+
+  // Default: auto-expand packages the first time they appear, so the user sees
+  // everything without drilling in. After that, respect the user's collapse
+  // choices across unrelated refreshes.
   useEffect(() => {
+    const seen = seenPackagesRef.current;
+    const newlySeen: string[] = [];
+    normalizedPackages.forEach((p) => {
+      if (!seen.has(p)) {
+        seen.add(p);
+        newlySeen.push(p);
+      }
+    });
+    if (newlySeen.length === 0) return;
     setExpandedPaths((prev) => {
-      if (prev.size >= normalizedPackages.size) return prev;
       const next = new Set(prev);
-      normalizedPackages.forEach((p) => next.add(p));
+      newlySeen.forEach((p) => next.add(p));
       return next;
     });
   }, [normalizedPackages]);

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -7,7 +7,7 @@
  * list of matching snippets regardless of package nesting.
  */
 
-import { ChevronRight, Edit2, Package, Plus, Search, Trash2, Zap } from 'lucide-react';
+import { ChevronRight, Edit2, FileCode, Package, Plus, Search, Trash2, Zap } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { cn } from '../lib/utils';
@@ -20,6 +20,7 @@ import {
 } from './ui/context-menu';
 import { Input } from './ui/input';
 import { ScrollArea } from './ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 
 interface ScriptsSidePanelProps {
   snippets: Snippet[];
@@ -217,6 +218,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   const hasAnyContent = snippets.length > 0 || packages.length > 0;
 
   return (
+    <TooltipProvider delayDuration={300}>
     <div
       className="h-full flex flex-col bg-background overflow-hidden"
       data-section="snippets-panel"
@@ -301,6 +303,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
         </div>
       </ScrollArea>
     </div>
+    </TooltipProvider>
   );
 };
 
@@ -354,17 +357,32 @@ const SnippetRow: React.FC<SnippetRowProps> = ({
 }) => (
   <ContextMenu>
     <ContextMenuTrigger asChild>
-      <button
-        type="button"
-        onClick={onClick}
-        className="w-full text-left pr-3 py-1.5 hover:bg-accent/50 transition-colors flex flex-col gap-0.5"
-        style={{ paddingLeft: 8 + depth * 14 + 14 }}
-      >
-        <span className="text-xs font-medium truncate">{snippet.label}</span>
-        <span className="text-muted-foreground truncate font-mono text-[10px] max-w-full">
-          {subtitle ?? snippet.command}
-        </span>
-      </button>
+      <div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onClick}
+              className="w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors overflow-hidden"
+              style={{ paddingLeft: 8 + depth * 14 + 14 }}
+            >
+              <FileCode size={12} className="shrink-0 text-muted-foreground" />
+              <span className="flex-1 min-w-0 truncate text-xs font-medium">{snippet.label}</span>
+              {subtitle && (
+                <span className="shrink-0 max-w-[40%] truncate text-[10px] text-muted-foreground">
+                  {subtitle}
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" align="start" className="max-w-[480px]">
+            <div className="font-medium text-xs mb-1 break-all">{snippet.label}</div>
+            <pre className="font-mono text-[11px] whitespace-pre-wrap break-all leading-snug opacity-90">
+              {snippet.command}
+            </pre>
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </ContextMenuTrigger>
     <ContextMenuContent>
       <ContextMenuItem onClick={onEdit}>

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -1,12 +1,14 @@
 /**
  * ScriptsSidePanel - Lightweight scripts browser for the terminal side panel
  *
- * Shows snippets organized by package hierarchy with breadcrumb navigation.
- * Clicking a snippet executes it in the focused terminal session.
+ * Shows snippets organized by package hierarchy as a single tree view.
+ * Packages expand / collapse via a chevron; clicking a snippet executes it
+ * in the focused terminal session. Typing in the search box flattens to a
+ * list of matching snippets regardless of package nesting.
  */
 
 import { ChevronRight, Edit2, Package, Plus, Search, Trash2, Zap } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { cn } from '../lib/utils';
 import { Snippet } from '../types';
@@ -26,6 +28,33 @@ interface ScriptsSidePanelProps {
   isVisible?: boolean;
 }
 
+type TreeRow =
+  | {
+      type: 'package';
+      id: string;
+      path: string;
+      name: string;
+      depth: number;
+      count: number;
+      hasChildren: boolean;
+      isExpanded: boolean;
+    }
+  | {
+      type: 'snippet';
+      id: string;
+      depth: number;
+      snippet: Snippet;
+      packagePath: string;
+    };
+
+const pkgDisplayName = (path: string) => {
+  const clean = path.startsWith('/') ? path.slice(1) : path;
+  const last = clean.split('/').filter(Boolean).pop() ?? clean;
+  // Preserve the leading slash on absolute root packages so they stay
+  // distinguishable from relative ones (matches the previous breadcrumb UI).
+  return path.startsWith('/') && !clean.includes('/') ? `/${last}` : last;
+};
+
 const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   snippets,
   packages,
@@ -33,97 +62,136 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
   isVisible = true,
 }) => {
   const { t } = useI18n();
-  const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
 
-  const displayedPackages = useMemo(() => {
-    if (!selectedPackage) {
-      const absolutePaths = packages.filter(p => p.startsWith('/'));
-      const relativePaths = packages.filter(p => !p.startsWith('/'));
+  // Normalize the package list + derive ancestor packages implied by each path
+  // (e.g. package "a/b/c" implies roots "a" and "a/b" even when not listed).
+  const normalizedPackages = useMemo(() => {
+    const set = new Set<string>();
+    const addWithAncestors = (raw: string) => {
+      const path = raw.trim();
+      if (!path) return;
+      const isAbs = path.startsWith('/');
+      const body = isAbs ? path.slice(1) : path;
+      const parts = body.split('/').filter(Boolean);
+      for (let i = 1; i <= parts.length; i++) {
+        const sub = parts.slice(0, i).join('/');
+        set.add(isAbs ? `/${sub}` : sub);
+      }
+    };
+    packages.forEach(addWithAncestors);
+    // A snippet may reference a package path that's not in `packages` yet.
+    snippets.forEach((s) => {
+      if (s.package) addWithAncestors(s.package);
+    });
+    return set;
+  }, [packages, snippets]);
 
-      const results: { name: string; path: string; count: number }[] = [];
+  // Default: expand every package so the user sees everything without drilling.
+  // Also re-runs when packages change so newly added ones are shown expanded.
+  useEffect(() => {
+    setExpandedPaths((prev) => {
+      if (prev.size >= normalizedPackages.size) return prev;
+      const next = new Set(prev);
+      normalizedPackages.forEach((p) => next.add(p));
+      return next;
+    });
+  }, [normalizedPackages]);
 
-      const relativeRoots = relativePaths
-        .map((p) => p.split('/')[0])
-        .filter((name): name is string => Boolean(name) && name.length > 0);
+  const togglePackage = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
 
-      Array.from(new Set(relativeRoots)).forEach((name: string) => {
-        const path: string = name;
-        const count = snippets.filter((s) => {
-          const pkg = s.package || '';
-          return pkg === path || pkg.startsWith(path + '/');
-        }).length;
-        results.push({ name, path, count });
-      });
+  // When search is active, flatten everything (no tree, no packages).
+  const searchMatches = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return null;
+    return snippets.filter(
+      (s) =>
+        s.label.toLowerCase().includes(q) ||
+        s.command.toLowerCase().includes(q),
+    );
+  }, [snippets, search]);
 
-      const absoluteRoots = absolutePaths
-        .map((p) => {
-          const cleanPath = p.substring(1);
-          return cleanPath.split('/')[0];
+  const rows = useMemo<TreeRow[]>(() => {
+    if (searchMatches !== null) return [];
+
+    const out: TreeRow[] = [];
+    const paths: string[] = [];
+    normalizedPackages.forEach((p) => paths.push(p));
+
+    const childPackagesOf = (parent: string | null): string[] => {
+      const prefix = parent === null ? '' : parent + '/';
+      return paths
+        .filter((p) => {
+          if (parent === null) {
+            // Root-level: no "/" inside the body
+            const body = p.startsWith('/') ? p.slice(1) : p;
+            return !body.includes('/');
+          }
+          if (!p.startsWith(prefix)) return false;
+          const rest = p.slice(prefix.length);
+          return rest.length > 0 && !rest.includes('/');
         })
-        .filter((name): name is string => Boolean(name) && name.length > 0);
+        .sort((a, b) => pkgDisplayName(a).localeCompare(pkgDisplayName(b)));
+    };
 
-      Array.from(new Set(absoluteRoots)).forEach((name: string) => {
-        const path: string = `/${name}`;
-        const displayName: string = `/${name}`;
-        const count = snippets.filter((s) => {
-          const pkg = s.package || '';
-          return pkg === path || pkg.startsWith(path + '/');
-        }).length;
-        results.push({ name: displayName, path, count });
+    const snippetsIn = (pkg: string | null): Snippet[] =>
+      snippets
+        .filter((s) => (s.package || '') === (pkg ?? ''))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+    const countDescendants = (pkg: string): number =>
+      snippets.filter((s) => {
+        const sp = s.package || '';
+        return sp === pkg || sp.startsWith(pkg + '/');
+      }).length;
+
+    const walk = (pkg: string, depth: number) => {
+      const children = childPackagesOf(pkg);
+      const localSnippets = snippetsIn(pkg);
+      const hasChildren = children.length > 0 || localSnippets.length > 0;
+      const isExpanded = expandedPaths.has(pkg);
+
+      out.push({
+        type: 'package',
+        id: pkg,
+        path: pkg,
+        name: pkgDisplayName(pkg),
+        depth,
+        count: countDescendants(pkg),
+        hasChildren,
+        isExpanded,
       });
 
-      return results;
-    }
-
-    const prefix = selectedPackage + '/';
-    const children = packages
-      .filter((p) => p.startsWith(prefix))
-      .map((p) => p.replace(prefix, '').split('/')[0])
-      .filter((name): name is string => Boolean(name) && name.length > 0);
-    return Array.from(new Set(children)).map((name) => {
-      const path = `${selectedPackage}/${name}`;
-      const count = snippets.filter((s) => {
-        const pkg = s.package || '';
-        return pkg === path || pkg.startsWith(path + '/');
-      }).length;
-      return { name, path, count };
-    });
-  }, [packages, selectedPackage, snippets]);
-
-  const displayedSnippets = useMemo(() => {
-    let result = snippets.filter((s) => (s.package || '') === (selectedPackage || ''));
-    if (search.trim()) {
-      const s = search.toLowerCase();
-      result = result.filter(sn =>
-        sn.label.toLowerCase().includes(s) ||
-        sn.command.toLowerCase().includes(s)
+      if (!isExpanded) return;
+      children.forEach((c) => walk(c, depth + 1));
+      localSnippets.forEach((s) =>
+        out.push({ type: 'snippet', id: s.id, depth: depth + 1, snippet: s, packagePath: pkg }),
       );
-    }
-    return result;
-  }, [snippets, selectedPackage, search]);
+    };
 
-  // Also filter packages by search when at root level
-  const filteredPackages = useMemo(() => {
-    if (!search.trim()) return displayedPackages;
-    const s = search.toLowerCase();
-    return displayedPackages.filter(pkg => pkg.name.toLowerCase().includes(s));
-  }, [displayedPackages, search]);
+    // Orphan / uncategorized snippets first (package === '')
+    snippetsIn(null).forEach((s) =>
+      out.push({ type: 'snippet', id: s.id, depth: 0, snippet: s, packagePath: '' }),
+    );
+    childPackagesOf(null).forEach((root) => walk(root, 0));
 
-  const breadcrumb = useMemo(() => {
-    if (!selectedPackage) return [];
-    const isAbsolute = selectedPackage.startsWith('/');
-    const parts = selectedPackage.split('/').filter(Boolean);
-    return parts.map((name, idx) => {
-      const pathSegments = parts.slice(0, idx + 1);
-      const path = isAbsolute ? `/${pathSegments.join('/')}` : pathSegments.join('/');
-      return { name, path };
-    });
-  }, [selectedPackage]);
+    return out;
+  }, [normalizedPackages, snippets, expandedPaths, searchMatches]);
 
-  const handleSnippetClick = useCallback((command: string, noAutoRun?: boolean) => {
-    onSnippetClick(command, noAutoRun);
-  }, [onSnippetClick]);
+  const handleSnippetClick = useCallback(
+    (command: string, noAutoRun?: boolean) => {
+      onSnippetClick(command, noAutoRun);
+    },
+    [onSnippetClick],
+  );
 
   const handleAddSnippet = useCallback(() => {
     // Let the App shell listen and navigate to the Snippets section with
@@ -175,30 +243,6 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
         </button>
       </div>
 
-      {/* Breadcrumb */}
-      <div className="shrink-0 flex items-center gap-1 px-3 py-1.5 text-[11px] border-b border-border/30 min-h-[28px]">
-        <button
-          className={cn(
-            "hover:text-primary transition-colors truncate",
-            !selectedPackage ? "text-foreground font-medium" : "text-muted-foreground"
-          )}
-          onClick={() => setSelectedPackage(null)}
-        >
-          {t('terminal.toolbar.library')}
-        </button>
-        {breadcrumb.map((b) => (
-          <React.Fragment key={b.path}>
-            <ChevronRight size={10} className="text-muted-foreground shrink-0" />
-            <button
-              className="text-muted-foreground hover:text-primary transition-colors truncate"
-              onClick={() => setSelectedPackage(b.path)}
-            >
-              {b.name}
-            </button>
-          </React.Fragment>
-        ))}
-      </div>
-
       {/* Content */}
       <ScrollArea className="flex-1">
         <div className="py-1">
@@ -209,55 +253,47 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
             </div>
           )}
 
-          {/* Packages */}
-          {filteredPackages.map((pkg) => (
-            <button
-              key={pkg.path}
-              className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50 transition-colors"
-              onClick={() => { setSelectedPackage(pkg.path); setSearch(''); }}
-            >
-              <div className="w-6 h-6 rounded-md bg-primary/10 text-primary flex items-center justify-center shrink-0">
-                <Package size={12} />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-xs font-medium truncate">{pkg.name}</div>
-                <div className="text-[10px] text-muted-foreground">
-                  {t('snippets.package.count', { count: pkg.count })}
-                </div>
-              </div>
-              <ChevronRight size={12} className="text-muted-foreground shrink-0" />
-            </button>
-          ))}
+          {/* Search flat list */}
+          {searchMatches !== null && searchMatches.length > 0 &&
+            searchMatches.map((s) => (
+              <SnippetRow
+                key={s.id}
+                snippet={s}
+                depth={0}
+                subtitle={s.package || t('terminal.toolbar.library')}
+                onClick={() => handleSnippetClick(s.command, s.noAutoRun)}
+                onEdit={() => handleEditSnippet(s)}
+                onDelete={() => handleDeleteSnippet(s.id)}
+                editLabel={t('action.edit')}
+                deleteLabel={t('action.delete')}
+              />
+            ))}
 
-          {/* Snippets */}
-          {displayedSnippets.map((s) => (
-            <ContextMenu key={s.id}>
-              <ContextMenuTrigger asChild>
-                <button
-                  onClick={() => handleSnippetClick(s.command, s.noAutoRun)}
-                  className="w-full text-left px-3 py-2 hover:bg-accent/50 transition-colors flex flex-col gap-0.5"
-                >
-                  <span className="text-xs font-medium truncate">{s.label}</span>
-                  <span className="text-muted-foreground truncate font-mono text-[10px] max-w-full">
-                    {s.command}
-                  </span>
-                </button>
-              </ContextMenuTrigger>
-              <ContextMenuContent>
-                <ContextMenuItem onClick={() => handleEditSnippet(s)}>
-                  <Edit2 className="mr-2 h-4 w-4" /> {t('action.edit')}
-                </ContextMenuItem>
-                <ContextMenuItem
-                  className="text-destructive"
-                  onClick={() => handleDeleteSnippet(s.id)}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" /> {t('action.delete')}
-                </ContextMenuItem>
-              </ContextMenuContent>
-            </ContextMenu>
-          ))}
+          {/* Tree */}
+          {searchMatches === null &&
+            rows.map((row) =>
+              row.type === 'package' ? (
+                <PackageRow
+                  key={`pkg:${row.id}`}
+                  row={row}
+                  countLabel={t('snippets.package.count', { count: row.count })}
+                  onToggle={() => togglePackage(row.path)}
+                />
+              ) : (
+                <SnippetRow
+                  key={`snip:${row.id}`}
+                  snippet={row.snippet}
+                  depth={row.depth}
+                  onClick={() => handleSnippetClick(row.snippet.command, row.snippet.noAutoRun)}
+                  onEdit={() => handleEditSnippet(row.snippet)}
+                  onDelete={() => handleDeleteSnippet(row.snippet.id)}
+                  editLabel={t('action.edit')}
+                  deleteLabel={t('action.delete')}
+                />
+              ),
+            )}
 
-          {hasAnyContent && displayedSnippets.length === 0 && filteredPackages.length === 0 && search.trim() && (
+          {hasAnyContent && searchMatches !== null && searchMatches.length === 0 && (
             <div className="px-3 py-4 text-xs text-muted-foreground italic text-center">
               {t('common.noResultsFound')}
             </div>
@@ -267,6 +303,79 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
     </div>
   );
 };
+
+interface PackageRowProps {
+  row: Extract<TreeRow, { type: 'package' }>;
+  countLabel: string;
+  onToggle: () => void;
+}
+
+const PackageRow: React.FC<PackageRowProps> = ({ row, countLabel, onToggle }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    className="w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors"
+    style={{ paddingLeft: 8 + row.depth * 14 }}
+  >
+    <ChevronRight
+      size={12}
+      className={cn(
+        'shrink-0 text-muted-foreground transition-transform',
+        row.isExpanded && 'rotate-90',
+        !row.hasChildren && 'opacity-0',
+      )}
+    />
+    <Package size={12} className="shrink-0 text-primary/80" />
+    <span className="flex-1 min-w-0 truncate text-xs font-medium">{row.name}</span>
+    <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">{countLabel}</span>
+  </button>
+);
+
+interface SnippetRowProps {
+  snippet: Snippet;
+  depth: number;
+  subtitle?: string;
+  onClick: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  editLabel: string;
+  deleteLabel: string;
+}
+
+const SnippetRow: React.FC<SnippetRowProps> = ({
+  snippet,
+  depth,
+  subtitle,
+  onClick,
+  onEdit,
+  onDelete,
+  editLabel,
+  deleteLabel,
+}) => (
+  <ContextMenu>
+    <ContextMenuTrigger asChild>
+      <button
+        type="button"
+        onClick={onClick}
+        className="w-full text-left pr-3 py-1.5 hover:bg-accent/50 transition-colors flex flex-col gap-0.5"
+        style={{ paddingLeft: 8 + depth * 14 + 14 }}
+      >
+        <span className="text-xs font-medium truncate">{snippet.label}</span>
+        <span className="text-muted-foreground truncate font-mono text-[10px] max-w-full">
+          {subtitle ?? snippet.command}
+        </span>
+      </button>
+    </ContextMenuTrigger>
+    <ContextMenuContent>
+      <ContextMenuItem onClick={onEdit}>
+        <Edit2 className="mr-2 h-4 w-4" /> {editLabel}
+      </ContextMenuItem>
+      <ContextMenuItem className="text-destructive" onClick={onDelete}>
+        <Trash2 className="mr-2 h-4 w-4" /> {deleteLabel}
+      </ContextMenuItem>
+    </ContextMenuContent>
+  </ContextMenu>
+);
 
 export const ScriptsSidePanel = memo(ScriptsSidePanelInner);
 ScriptsSidePanel.displayName = 'ScriptsSidePanel';


### PR DESCRIPTION
## Summary
Closes #800 (approximately — also covers the "鼠标侧键退回上一层" alternative by removing the need to navigate in/out entirely).

The terminal's scripts side panel used breadcrumb navigation, so crossing packages meant clicking out and back in. Replace that with a single tree view where every package row has a chevron to expand/collapse (same affordance as the SFTP tree), so snippets across multiple packages stay visible and reachable without drilling.

Behaviors:
- All discovered packages default to expanded — matches the user's expectation of seeing everything at once; user can collapse rows they don't care about.
- Search flattens to a list of matching snippets regardless of nesting, each annotated with its package path so the origin is still clear.
- Implicit ancestor packages (e.g. \`a/b/c\` implies \`a\` and \`a/b\`) are materialized so deeply nested snippets aren't orphaned if an intermediate package isn't listed explicitly.
- Depth-based left padding + chevron rotation mirror \`SftpPaneTreeView\` affordances.

## Test plan
- [x] \`tsc --noEmit\` clean on \`ScriptsSidePanel.tsx\`.
- [x] \`eslint components/ScriptsSidePanel.tsx\` clean.
- [x] Manual: open the terminal scripts side panel with multiple nested packages; confirm chevron expand/collapse works per row, snippet click runs in the focused terminal, context menu still offers Edit/Delete.
- [x] Manual: search; confirm matching snippets appear flattened with their package path visible as subtitle, and that clearing search restores the tree (with previous expand state).
- [x] Manual: orphan (no-package) snippets render at top level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)