### PR TITLE
Align snippet row icons with package row icons in tree

### DIFF
--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -379,8 +379,11 @@ const SnippetRow: React.FC<SnippetRowProps> = ({
               type="button"
               onClick={onClick}
               className="w-full flex items-center gap-1.5 pr-3 py-1.5 text-left hover:bg-accent/50 transition-colors overflow-hidden"
-              style={{ paddingLeft: 8 + depth * 14 + 14 }}
+              style={{ paddingLeft: 8 + depth * 14 }}
             >
+              {/* Hidden chevron column mirrors PackageRow's layout so the
+                  snippet icon lines up exactly with the package icon above. */}
+              <ChevronRight size={12} className="shrink-0 opacity-0" aria-hidden />
               <FileCode size={12} className="shrink-0 text-muted-foreground" />
               <span className="flex-1 min-w-0 truncate text-xs font-medium">{snippet.label}</span>
               {subtitle && (


### PR DESCRIPTION
## Summary
Follow-up to #801. Snippet rows used \`paddingLeft: 8 + depth*14 + 14\` to reserve room for the chevron column that package rows render, but the flex \`gap-1.5\` between chevron and icon wasn't accounted for, leaving the FileCode icon a few pixels to the left of the Package icon above it.

Mirror \`PackageRow\`'s flex layout literally by rendering an invisible \`ChevronRight\` placeholder on snippet rows — both rows now share identical column structure (padding → chevron → gap → icon → gap → label) so icons line up exactly.

## Test plan
- [x] \`tsc --noEmit\` + \`eslint\` clean.
- [ ] Manual: open the terminal scripts side panel with a mix of root-level (orphan) snippets, expandable packages, and collapsed packages; confirm all icons share the same column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)