### PR TITLE
feat(editor): promote SFTP text editor into top-level tabs (#631)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ coverage
 # Serena MCP project config (local only)
 /.serena/
 
+# Git worktrees (local isolated workspaces)
+/.worktrees/
+
 # Windows VS Build environment scripts (local dev only)
 Directory.Build.props
 Directory.Build.targets

--- a/App.tsx
+++ b/App.tsx
@@ -1939,6 +1939,7 @@ function App({ settings }: { settings: SettingsState }) {
             isVisible={activeTabId === toEditorTabId(tab.id)}
             hotkeyScheme={hotkeyScheme}
             keyBindings={keyBindings}
+            hostById={hostById}
           />
         ))}
       </div>

--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,8 @@ import { LogView as LogViewType } from './application/state/useSessionState';
 import type { SftpView as SftpViewComponent } from './components/SftpView';
 import type { TerminalLayer as TerminalLayerComponent } from './components/TerminalLayer';
 import { TextEditorTabView } from './components/editor/TextEditorTabView';
+import { UnsavedChangesProvider } from './components/editor/UnsavedChangesDialog';
+import { editorSftpWrite } from './application/state/editorSftpBridge';
 
 // Initialize fonts eagerly at app startup
 initializeFonts();
@@ -1690,11 +1692,6 @@ function App({ settings }: { settings: SettingsState }) {
     e.preventDefault();
   }, []);
 
-  // Stub close handler for editor tabs — Task 12 will replace with dirty-confirm flow.
-  const handleRequestCloseEditorTab = useCallback((id: string) => {
-    editorTabStore.close(id);
-  }, []);
-
   // Combined ordered tab list including editor tab ids (for TopTabs scrollable area)
   const orderedTabsWithEditors = useMemo(
     () => [...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))],
@@ -1702,6 +1699,49 @@ function App({ settings }: { settings: SettingsState }) {
   );
 
   return (
+    <UnsavedChangesProvider>
+      {({ prompt }) => {
+        // Helper: close an editor tab and activate the neighbor (left-preference), or vault.
+        const closeEditorAndActivateNeighbor = (id: string) => {
+          const closingTabId = toEditorTabId(id);
+          const list = orderedTabsWithEditors;
+          const idx = list.indexOf(closingTabId);
+          editorTabStore.close(id);
+          if (activeTabStore.getActiveTabId() !== closingTabId) return;
+          const next = list[idx - 1] ?? list[idx + 1] ?? 'vault';
+          activeTabStore.setActiveTabId(next === closingTabId ? 'vault' : next);
+        };
+
+        // Real dirty-confirm close handler.
+        const handleRequestCloseEditorTab = async (id: string) => {
+          const tab = editorTabStore.getTab(id);
+          if (!tab) return;
+          const dirty = tab.content !== tab.baselineContent;
+          if (!dirty) {
+            closeEditorAndActivateNeighbor(id);
+            return;
+          }
+          const choice = await prompt(tab.fileName);
+          if (choice === 'cancel') return;
+          if (choice === 'discard') {
+            closeEditorAndActivateNeighbor(id);
+            return;
+          }
+          if (choice === 'save') {
+            try {
+              editorTabStore.setSavingState(id, 'saving');
+              await editorSftpWrite(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
+              editorTabStore.markSaved(id, tab.content);
+              closeEditorAndActivateNeighbor(id);
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : 'Save failed';
+              editorTabStore.setSavingState(id, 'error', msg);
+              toast.error(msg, 'SFTP');
+            }
+          }
+        };
+
+        return (
     <div className={cn("flex flex-col h-screen text-foreground font-sans netcatty-shell", activeTerminalTheme && "immersive-transition")} onContextMenu={handleRootContextMenu}>
       <TopTabs
         theme={resolvedTheme}
@@ -2134,6 +2174,9 @@ function App({ settings }: { settings: SettingsState }) {
         </DialogContent>
       </Dialog>
     </div>
+        );
+      }}
+    </UnsavedChangesProvider>
   );
 }
 

--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,7 @@ import { useSettingsState } from './application/state/useSettingsState';
 import { useUpdateCheck } from './application/state/useUpdateCheck';
 import { useVaultState } from './application/state/useVaultState';
 import { useWindowControls } from './application/state/useWindowControls';
-import { useEditorTabs } from './application/state/editorTabStore';
+import { useEditorTabs, editorTabStore } from './application/state/editorTabStore';
 import { initializeFonts } from './application/state/fontStore';
 import { initializeUIFonts } from './application/state/uiFontStore';
 import { I18nProvider, useI18n } from './application/i18n/I18nProvider';
@@ -1690,6 +1690,17 @@ function App({ settings }: { settings: SettingsState }) {
     e.preventDefault();
   }, []);
 
+  // Stub close handler for editor tabs — Task 12 will replace with dirty-confirm flow.
+  const handleRequestCloseEditorTab = useCallback((id: string) => {
+    editorTabStore.close(id);
+  }, []);
+
+  // Combined ordered tab list including editor tab ids (for TopTabs scrollable area)
+  const orderedTabsWithEditors = useMemo(
+    () => [...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))],
+    [orderedTabs, editorTabs],
+  );
+
   return (
     <div className={cn("flex flex-col h-screen text-foreground font-sans netcatty-shell", activeTerminalTheme && "immersive-transition")} onContextMenu={handleRootContextMenu}>
       <TopTabs
@@ -1700,7 +1711,7 @@ function App({ settings }: { settings: SettingsState }) {
         orphanSessions={orphanSessions}
         workspaces={workspaces}
         logViews={logViews}
-        orderedTabs={orderedTabs}
+        orderedTabs={orderedTabsWithEditors}
         draggingSessionId={draggingSessionId}
         isMacClient={isMacClient}
         onCloseSession={closeSession}
@@ -1719,6 +1730,9 @@ function App({ settings }: { settings: SettingsState }) {
         onEndSessionDrag={handleEndSessionDrag}
         onReorderTabs={reorderTabs}
         showSftpTab={settings.showSftpTab}
+        editorTabs={editorTabs}
+        onRequestCloseEditorTab={handleRequestCloseEditorTab}
+        hostById={hostById}
       />
 
       <div className="flex-1 relative min-h-0">

--- a/App.tsx
+++ b/App.tsx
@@ -1954,6 +1954,7 @@ function App({ settings }: { settings: SettingsState }) {
             hotkeyScheme={hotkeyScheme}
             keyBindings={keyBindings}
             hostById={hostById}
+            onRequestClose={(id) => handleRequestCloseEditorTabRef.current(id)}
           />
         ))}
       </div>

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
-import { activeTabStore, useActiveTabId, useIsSftpActive, useIsTerminalLayerVisible, useIsVaultActive, toEditorTabId } from './application/state/activeTabStore';
+import { activeTabStore, useActiveTabId, useIsSftpActive, useIsTerminalLayerVisible, useIsVaultActive, toEditorTabId, fromEditorTabId, isEditorTabId } from './application/state/activeTabStore';
 import { useAutoSync } from './application/state/useAutoSync';
 import { useImmersiveMode } from './application/state/useImmersiveMode';
 import { useManagedSourceSync } from './application/state/useManagedSourceSync';
@@ -1027,6 +1027,10 @@ function App({ settings }: { settings: SettingsState }) {
   const closeSidePanelRef = useRef<(() => void) | null>(null);
   const activeSidePanelTabRef = useRef<string | null>(null);
   const closeTabInFlightRef = useRef(false);
+  // Populated by UnsavedChangesProvider render-prop below so that the hotkey
+  // dispatcher (defined outside that scope) can still reach the dirty-confirm
+  // close flow.
+  const handleRequestCloseEditorTabRef = useRef<(id: string) => void>(() => {});
 
   const createLocalTerminalWithCurrentShell = useCallback(() => {
     const resolved = resolveShellSetting(terminalSettings.localShell, discoveredShells);
@@ -1189,6 +1193,13 @@ function App({ settings }: { settings: SettingsState }) {
         const currentId = activeTabStore.getActiveTabId();
         if (!currentId || currentId === 'vault' || currentId === 'sftp') break;
         if (closeTabInFlightRef.current) break;
+
+        // Editor tabs route through their own dirty-confirm close flow.
+        if (isEditorTabId(currentId)) {
+          const editorId = fromEditorTabId(currentId);
+          if (editorId) handleRequestCloseEditorTabRef.current(editorId);
+          break;
+        }
 
         const session = sessions.find((s) => s.id === currentId) ?? null;
         const workspace = workspaces.find((w) => w.id === currentId) ?? null;
@@ -1753,6 +1764,9 @@ function App({ settings }: { settings: SettingsState }) {
             }
           }
         };
+
+        // Expose to the hotkey dispatcher (Cmd/Ctrl+W).
+        handleRequestCloseEditorTabRef.current = handleRequestCloseEditorTab;
 
         return (
     <div className={cn("flex flex-col h-screen text-foreground font-sans netcatty-shell", activeTerminalTheme && "immersive-transition")} onContextMenu={handleRootContextMenu}>

--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
-import { activeTabStore, useActiveTabId, useIsSftpActive, useIsTerminalLayerVisible, useIsVaultActive } from './application/state/activeTabStore';
+import { activeTabStore, useActiveTabId, useIsSftpActive, useIsTerminalLayerVisible, useIsVaultActive, toEditorTabId } from './application/state/activeTabStore';
 import { useAutoSync } from './application/state/useAutoSync';
 import { useImmersiveMode } from './application/state/useImmersiveMode';
 import { useManagedSourceSync } from './application/state/useManagedSourceSync';
@@ -10,6 +10,7 @@ import { useSettingsState } from './application/state/useSettingsState';
 import { useUpdateCheck } from './application/state/useUpdateCheck';
 import { useVaultState } from './application/state/useVaultState';
 import { useWindowControls } from './application/state/useWindowControls';
+import { useEditorTabs } from './application/state/editorTabStore';
 import { initializeFonts } from './application/state/fontStore';
 import { initializeUIFonts } from './application/state/uiFontStore';
 import { I18nProvider, useI18n } from './application/i18n/I18nProvider';
@@ -54,6 +55,7 @@ import { ConnectionLog, Host, HostProtocol, SerialConfig, TerminalSession, Termi
 import { LogView as LogViewType } from './application/state/useSessionState';
 import type { SftpView as SftpViewComponent } from './components/SftpView';
 import type { TerminalLayer as TerminalLayerComponent } from './components/TerminalLayer';
+import { TextEditorTabView } from './components/editor/TextEditorTabView';
 
 // Initialize fonts eagerly at app startup
 initializeFonts();
@@ -330,6 +332,7 @@ function App({ settings }: { settings: SettingsState }) {
   // ---------------------------------------------------------------------------
   const activeTabId = useActiveTabId();
   const customThemes = useCustomThemes();
+  const editorTabs = useEditorTabs();
 
   useEffect(() => {
     if (!settings.showSftpTab && activeTabId === 'sftp') {
@@ -1127,13 +1130,13 @@ function App({ settings }: { settings: SettingsState }) {
 
   // Shared hotkey action handler - used by both global handler and terminal callback
   const executeHotkeyAction = useCallback((action: string, e: KeyboardEvent) => {
-    // Build complete tab list: vault + (sftp when visible) + sessions/workspaces.
+    // Build complete tab list: vault + (sftp when visible) + sessions/workspaces + editor tabs.
     // Hiding the SFTP tab must also remove it from keyboard cycling so nextTab
     // doesn't land on a hidden tab (which would get redirected back) and so
     // number shortcuts don't shift.
     const allTabs = settings.showSftpTab
-      ? ['vault', 'sftp', ...orderedTabs]
-      : ['vault', ...orderedTabs];
+      ? ['vault', 'sftp', ...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))]
+      : ['vault', ...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))];
     switch (action) {
       case 'switchToTab': {
         // Get the number key pressed (1-9)
@@ -1333,7 +1336,7 @@ function App({ settings }: { settings: SettingsState }) {
         break;
       }
     }
-  }, [orderedTabs, sessions, workspaces, setActiveTabId, closeSession, closeWorkspace, createLocalTerminalWithCurrentShell, splitSessionWithCurrentShell, moveFocusInWorkspace, toggleBroadcast, settings.showSftpTab, confirmIfBusyLocalTerminal]);
+  }, [orderedTabs, editorTabs, sessions, workspaces, setActiveTabId, closeSession, closeWorkspace, createLocalTerminalWithCurrentShell, splitSessionWithCurrentShell, moveFocusInWorkspace, toggleBroadcast, settings.showSftpTab, confirmIfBusyLocalTerminal]);
 
   // Callback for terminal to invoke app-level hotkey actions
   const handleHotkeyAction = useCallback((action: string, e: KeyboardEvent) => {
@@ -1860,6 +1863,17 @@ function App({ settings }: { settings: SettingsState }) {
             />
           );
         })}
+
+        {/* Editor Tabs — kept mounted for Monaco instance persistence; visibility toggled via CSS */}
+        {editorTabs.map((tab) => (
+          <TextEditorTabView
+            key={tab.id}
+            tabId={tab.id}
+            isVisible={activeTabId === toEditorTabId(tab.id)}
+            hotkeyScheme={hotkeyScheme}
+            keyBindings={keyBindings}
+          />
+        ))}
       </div>
 
       {/* Global "quick add / edit snippet" dialog, triggered by the

--- a/App.tsx
+++ b/App.tsx
@@ -874,6 +874,19 @@ function App({ settings }: { settings: SettingsState }) {
     };
   }, []);
 
+  // Quit guard: block app exit while any editor tab has unsaved changes.
+  // Main process sends "app:query-dirty-editors"; we respond with the result.
+  useEffect(() => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.onCheckDirtyEditors) return;
+    const unsub = bridge.onCheckDirtyEditors(() => {
+      const hasDirty = editorTabStore.getTabs().some((tab) => tab.content !== tab.baselineContent);
+      if (hasDirty) toast.warning(t('sftp.editor.quitBlockedByDirty'), 'SFTP');
+      bridge.reportDirtyEditorsResult?.(hasDirty);
+    });
+    return unsub;
+  }, [t]);
+
   // Keyboard-interactive authentication (2FA/MFA) event listener
   useEffect(() => {
     const bridge = netcattyBridge.get();

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1780,6 +1780,7 @@ const en: Messages = {
 
   // Text Editor
   'sftp.editor.wordWrap': 'Word Wrap',
+  'sftp.editor.maximize': 'Maximize',
 
   // AI Settings
   'ai.agentSettings': 'Agent Settings',

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1785,6 +1785,7 @@ const en: Messages = {
   'sftp.editor.unsavedMessage': '{fileName} has unsaved changes. Save before closing?',
   'sftp.editor.discardChanges': 'Discard',
   'sftp.editor.saveAndClose': 'Save and close',
+  'sftp.editor.quitBlockedByDirty': 'Unsaved editors — please save or discard before quitting',
 
   // AI Settings
   'ai.agentSettings': 'Agent Settings',

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1781,6 +1781,10 @@ const en: Messages = {
   // Text Editor
   'sftp.editor.wordWrap': 'Word Wrap',
   'sftp.editor.maximize': 'Maximize',
+  'sftp.editor.unsavedTitle': 'Unsaved changes',
+  'sftp.editor.unsavedMessage': '{fileName} has unsaved changes. Save before closing?',
+  'sftp.editor.discardChanges': 'Discard',
+  'sftp.editor.saveAndClose': 'Save and close',
 
   // AI Settings
   'ai.agentSettings': 'Agent Settings',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1789,6 +1789,7 @@ const zhCN: Messages = {
 
   // Text Editor
   'sftp.editor.wordWrap': '自动换行',
+  'sftp.editor.maximize': '最大化',
 
   // AI Settings
   'ai.agentSettings': 'Agent 设置',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1790,6 +1790,10 @@ const zhCN: Messages = {
   // Text Editor
   'sftp.editor.wordWrap': '自动换行',
   'sftp.editor.maximize': '最大化',
+  'sftp.editor.unsavedTitle': '未保存的修改',
+  'sftp.editor.unsavedMessage': '{fileName} 有未保存的修改，是否保存后关闭？',
+  'sftp.editor.discardChanges': '不保存',
+  'sftp.editor.saveAndClose': '保存并关闭',
 
   // AI Settings
   'ai.agentSettings': 'Agent 设置',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1794,6 +1794,7 @@ const zhCN: Messages = {
   'sftp.editor.unsavedMessage': '{fileName} 有未保存的修改，是否保存后关闭？',
   'sftp.editor.discardChanges': '不保存',
   'sftp.editor.saveAndClose': '保存并关闭',
+  'sftp.editor.quitBlockedByDirty': '存在未保存的编辑器，请先处理后再退出',
 
   // AI Settings
   'ai.agentSettings': 'Agent 设置',

--- a/application/state/activeTabStore.ts
+++ b/application/state/activeTabStore.ts
@@ -3,6 +3,18 @@ import { useCallback,useSyncExternalStore } from 'react';
 // Simple store for active tab that allows fine-grained subscriptions
 type Listener = () => void;
 
+// ----- Editor tab id helpers -----
+export const EDITOR_PREFIX = 'editor:';
+
+/** Returns true when `id` is an editor tab id (starts with "editor:"). */
+export const isEditorTabId = (id: string): boolean => id.startsWith(EDITOR_PREFIX);
+
+/** Convert an editorTab's internal id to a top-tab id understood by the tab bar. */
+export const toEditorTabId = (editorId: string): string => `${EDITOR_PREFIX}${editorId}`;
+
+/** Strip the "editor:" prefix to recover the internal editorTab id. */
+export const fromEditorTabId = (tabId: string): string => tabId.slice(EDITOR_PREFIX.length);
+
 class ActiveTabStore {
   private activeTabId: string = 'vault';
   private listeners = new Set<Listener>();
@@ -70,9 +82,17 @@ export const useIsSftpActive = () => {
   );
 };
 
+// Check if a specific editor tab is currently active
+export const useIsEditorTabActive = (tabId: string): boolean => {
+  const editorTopId = toEditorTabId(tabId);
+  const getSnapshot = useCallback(() => activeTabStore.getActiveTabId() === editorTopId, [editorTopId]);
+  return useSyncExternalStore(activeTabStore.subscribe, getSnapshot);
+};
+
 // Check if terminal layer should be visible
+// Editor tabs are NOT terminal tabs, so exclude them from the visibility condition.
 export const useIsTerminalLayerVisible = (draggingSessionId: string | null) => {
   const activeTabId = useActiveTabId();
-  const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp';
+  const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp' && !isEditorTabId(activeTabId);
   return isTerminalTab || !!draggingSessionId;
 };

--- a/application/state/editorSftpBridge.ts
+++ b/application/state/editorSftpBridge.ts
@@ -10,15 +10,60 @@ export interface EditorSftpWrite {
   ): Promise<void>;
 }
 
-let writer: EditorSftpWrite | null = null;
+// `useSftpState` is instantiated in at least two places (the top-level SftpView
+// and the per-terminal SftpSidePanel), each owning its own pane registry. An
+// editor tab opened from either path must be saved via the matching instance,
+// so the bridge tracks all currently-mounted writers and dispatches by
+// attempting each in turn until one succeeds.
+//
+// Each writer throws synchronously (or rejects) if the connectionId isn't in
+// its pane registry; we use "connection no longer available" text as the
+// signal to fall through to the next writer. Any other error is re-thrown
+// immediately because it represents a real save failure the user must see.
+const writers = new Set<EditorSftpWrite>();
+
+const NOT_MY_CONNECTION_RE = /SFTP connection is no longer available/i;
 
 export const registerEditorSftpWriter = (fn: EditorSftpWrite | null) => {
-  writer = fn;
+  // Pass `null` on cleanup — but cleanup also needs to know WHICH writer to
+  // remove. Callers who register once per mount should instead use
+  // `registerEditorSftpWriterScoped` below, which returns an unregister fn.
+  // This legacy signature is preserved for callers that prefer the
+  // register/unregister-with-null pattern: we clear ALL writers on null.
+  if (fn === null) {
+    writers.clear();
+    return;
+  }
+  writers.add(fn);
+};
+
+export const registerEditorSftpWriterScoped = (fn: EditorSftpWrite): (() => void) => {
+  writers.add(fn);
+  return () => {
+    writers.delete(fn);
+  };
 };
 
 export const editorSftpWrite: EditorSftpWrite = async (...args) => {
-  if (!writer) {
+  if (writers.size === 0) {
     throw new Error("SFTP editor bridge not registered — cannot save (no SFTP view mounted)");
   }
-  return writer(...args);
+  let lastNotMine: Error | null = null;
+  for (const fn of writers) {
+    try {
+      await fn(...args);
+      return;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (NOT_MY_CONNECTION_RE.test(msg)) {
+        // This writer doesn't own the connectionId — try the next one.
+        lastNotMine = err instanceof Error ? err : new Error(msg);
+        continue;
+      }
+      // Real save error — surface it.
+      throw err;
+    }
+  }
+  // No writer owned the connectionId.
+  throw lastNotMine ?? new Error("SFTP connection is no longer available");
 };

--- a/application/state/editorSftpBridge.ts
+++ b/application/state/editorSftpBridge.ts
@@ -1,0 +1,24 @@
+import type { SftpFilenameEncoding } from "../../types";
+
+export interface EditorSftpWrite {
+  (
+    connectionId: string,
+    expectedHostId: string,
+    filePath: string,
+    content: string,
+    filenameEncoding?: SftpFilenameEncoding,
+  ): Promise<void>;
+}
+
+let writer: EditorSftpWrite | null = null;
+
+export const registerEditorSftpWriter = (fn: EditorSftpWrite | null) => {
+  writer = fn;
+};
+
+export const editorSftpWrite: EditorSftpWrite = async (...args) => {
+  if (!writer) {
+    throw new Error("SFTP editor bridge not registered — cannot save (no SFTP view mounted)");
+  }
+  return writer(...args);
+};

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -152,3 +152,47 @@ test("dedup scope is per-sessionId — same path on different sessions are disti
   assert.notEqual(a, b);
   assert.equal(store.getTabs().length, 2);
 });
+
+test("confirmCloseBySession returns true when no tabs match", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  const ok = await store.confirmCloseBySession("other_conn", async () => "discard");
+  assert.equal(ok, true);
+  assert.equal(store.getTabs().length, 1);
+});
+
+test("confirmCloseBySession discards all dirty matching tabs when prompt returns 'discard'", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_1", content: "x", baselineContent: "y" }));
+  store._debugInsert(makeTab({ id: "edt_2", remotePath: "/b.txt", fileName: "b.txt", content: "x", baselineContent: "y" }));
+  const ok = await store.confirmCloseBySession("conn_1", async () => "discard");
+  assert.equal(ok, true);
+  assert.equal(store.getTabs().length, 0);
+});
+
+test("confirmCloseBySession closes clean tabs without prompting; aborts on cancel", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_clean" })); // content == baseline
+  store._debugInsert(makeTab({ id: "edt_dirty", remotePath: "/b.txt", fileName: "b.txt", content: "x", baselineContent: "y" }));
+  let prompts = 0;
+  const ok = await store.confirmCloseBySession("conn_1", async () => { prompts++; return "cancel"; });
+  assert.equal(ok, false);
+  assert.equal(prompts, 1, "prompt fires only for dirty tab");
+  // clean tab was closed before the dirty cancel aborted the batch
+  assert.equal(store.getTab("edt_clean"), undefined);
+  assert.ok(store.getTab("edt_dirty"));
+});
+
+test("confirmCloseBySession invokes save callback for 'save' choice and only closes on save success", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_1", content: "new", baselineContent: "old" }));
+  let saved = false;
+  const ok = await store.confirmCloseBySession("conn_1", async () => "save", async (id) => {
+    assert.equal(id, "edt_1");
+    saved = true;
+    store.markSaved(id, "new");
+  });
+  assert.equal(saved, true);
+  assert.equal(ok, true);
+  assert.equal(store.getTab("edt_1"), undefined);
+});

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -82,3 +82,73 @@ test("subscribers fire on change and not on read", () => {
     unsub();
   });
 });
+
+test("promoteFromModal creates a new tab and returns its id", () => {
+  const store = new EditorTabStore();
+  const id = store.promoteFromModal({
+    sessionId: "conn_1",
+    hostId: "host_1",
+    remotePath: "/etc/nginx/nginx.conf",
+    fileName: "nginx.conf",
+    languageId: "ini",
+    content: "x",
+    baselineContent: "x",
+    wordWrap: false,
+    viewState: null,
+  });
+  const tab = store.getTab(id)!;
+  assert.equal(tab.remotePath, "/etc/nginx/nginx.conf");
+  assert.equal(tab.fileName, "nginx.conf");
+  assert.equal(tab.kind, "editor");
+});
+
+test("promoteFromModal focuses existing tab for same sessionId+normalized path and overrides content", () => {
+  const store = new EditorTabStore();
+  const first = store.promoteFromModal({
+    sessionId: "conn_1",
+    hostId: "host_1",
+    remotePath: "/etc/nginx/./nginx.conf",
+    fileName: "nginx.conf",
+    languageId: "ini",
+    content: "v1",
+    baselineContent: "v1",
+    wordWrap: false,
+    viewState: null,
+  });
+  const second = store.promoteFromModal({
+    sessionId: "conn_1",
+    hostId: "host_1",
+    remotePath: "/etc/nginx/nginx.conf",
+    fileName: "nginx.conf",
+    languageId: "ini",
+    content: "v2",
+    baselineContent: "v1",
+    wordWrap: false,
+    viewState: null,
+  });
+  assert.equal(second, first);
+  assert.equal(store.getTab(first)!.content, "v2");
+  assert.equal(store.getTabs().length, 1);
+});
+
+test("dedup scope is per-sessionId — same path on different sessions are distinct tabs", () => {
+  const store = new EditorTabStore();
+  const a = store.promoteFromModal({
+    sessionId: "conn_A",
+    hostId: "host_1",
+    remotePath: "/etc/hosts",
+    fileName: "hosts",
+    languageId: "plaintext",
+    content: "", baselineContent: "", wordWrap: false, viewState: null,
+  });
+  const b = store.promoteFromModal({
+    sessionId: "conn_B",
+    hostId: "host_2",
+    remotePath: "/etc/hosts",
+    fileName: "hosts",
+    languageId: "plaintext",
+    content: "", baselineContent: "", wordWrap: false, viewState: null,
+  });
+  assert.notEqual(a, b);
+  assert.equal(store.getTabs().length, 2);
+});

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EditorTabStore, type EditorTab } from "./editorTabStore.ts";
+
+const makeTab = (overrides: Partial<EditorTab> = {}): EditorTab => ({
+  id: "edt_1",
+  kind: "editor",
+  sessionId: "conn_1",
+  hostId: "host_1",
+  remotePath: "/etc/nginx/nginx.conf",
+  fileName: "nginx.conf",
+  languageId: "ini",
+  content: "worker_processes auto;",
+  baselineContent: "worker_processes auto;",
+  wordWrap: false,
+  viewState: null,
+  savingState: "idle",
+  saveError: null,
+  ...overrides,
+});
+
+test("updateContent stores content and viewState; dirty flag derives from baseline", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  store.updateContent("edt_1", "worker_processes 4;", null);
+  const tab = store.getTab("edt_1")!;
+  assert.equal(tab.content, "worker_processes 4;");
+  assert.equal(store.isDirty("edt_1"), true);
+});
+
+test("markSaved moves baseline to current content and clears dirty", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ content: "changed", baselineContent: "orig" }));
+  assert.equal(store.isDirty("edt_1"), true);
+  store.markSaved("edt_1", "changed");
+  assert.equal(store.isDirty("edt_1"), false);
+  assert.equal(store.getTab("edt_1")!.baselineContent, "changed");
+});
+
+test("setWordWrap updates only that tab", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_1" }));
+  store._debugInsert(makeTab({ id: "edt_2", remotePath: "/b.txt", fileName: "b.txt" }));
+  store.setWordWrap("edt_1", true);
+  assert.equal(store.getTab("edt_1")!.wordWrap, true);
+  assert.equal(store.getTab("edt_2")!.wordWrap, false);
+});
+
+test("setSavingState transitions and clears error on idle", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  store.setSavingState("edt_1", "saving");
+  assert.equal(store.getTab("edt_1")!.savingState, "saving");
+  store.setSavingState("edt_1", "error", "EACCES");
+  assert.equal(store.getTab("edt_1")!.saveError, "EACCES");
+  store.setSavingState("edt_1", "idle");
+  assert.equal(store.getTab("edt_1")!.saveError, null);
+});
+
+test("close removes the tab and returns remaining ids in order", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_1" }));
+  store._debugInsert(makeTab({ id: "edt_2", remotePath: "/b.txt", fileName: "b.txt" }));
+  store.close("edt_1");
+  assert.equal(store.getTab("edt_1"), undefined);
+  assert.deepEqual(store.getTabs().map((t) => t.id), ["edt_2"]);
+});
+
+test("subscribers fire on change and not on read", () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  let count = 0;
+  const unsub = store.subscribe(() => { count++; });
+  store.getTab("edt_1");
+  store.getTabs();
+  assert.equal(count, 0);
+  store.updateContent("edt_1", "x", null);
+  // notifications are microtask-deferred, flush via awaiting a resolved promise
+  return Promise.resolve().then(() => {
+    assert.equal(count, 1);
+    unsub();
+  });
+});

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -1,0 +1,131 @@
+import { useCallback, useSyncExternalStore } from "react";
+import type * as Monaco from "monaco-editor";
+
+export type EditorTabId = string;
+
+export type EditorSavingState = "idle" | "saving" | "error";
+
+export interface EditorTab {
+  id: EditorTabId;
+  kind: "editor";
+  /** SFTP connection id (matches SftpConnection.id). Session lookup key. */
+  sessionId: string;
+  /** Stable endpoint id; used to verify the session is still the one we opened against. */
+  hostId: string;
+  remotePath: string;
+  fileName: string;
+  languageId: string;
+  content: string;
+  baselineContent: string;
+  wordWrap: boolean;
+  viewState: Monaco.editor.ICodeEditorViewState | null;
+  savingState: EditorSavingState;
+  saveError: string | null;
+}
+
+type Listener = () => void;
+
+let idCounter = 0;
+const genId = (): EditorTabId => `edt_${Date.now().toString(36)}_${(++idCounter).toString(36)}`;
+
+export class EditorTabStore {
+  private tabs: EditorTab[] = [];
+  private listeners = new Set<Listener>();
+  private pendingNotify = false;
+
+  getTabs = (): readonly EditorTab[] => this.tabs;
+  getTab = (id: EditorTabId): EditorTab | undefined => this.tabs.find((t) => t.id === id);
+  isDirty = (id: EditorTabId): boolean => {
+    const t = this.getTab(id);
+    return !!t && t.content !== t.baselineContent;
+  };
+
+  updateContent = (
+    id: EditorTabId,
+    content: string,
+    viewState: Monaco.editor.ICodeEditorViewState | null,
+  ) => {
+    this.patch(id, { content, viewState });
+  };
+
+  markSaved = (id: EditorTabId, newBaseline: string) => {
+    this.patch(id, { baselineContent: newBaseline, savingState: "idle", saveError: null });
+  };
+
+  setWordWrap = (id: EditorTabId, value: boolean) => {
+    this.patch(id, { wordWrap: value });
+  };
+
+  setSavingState = (id: EditorTabId, state: EditorSavingState, error: string | null = null) => {
+    const patch: Partial<EditorTab> = { savingState: state };
+    if (state === "idle") patch.saveError = null;
+    else if (state === "error") patch.saveError = error;
+    this.patch(id, patch);
+  };
+
+  close = (id: EditorTabId) => {
+    const next = this.tabs.filter((t) => t.id !== id);
+    if (next.length !== this.tabs.length) {
+      this.tabs = next;
+      this.notify();
+    }
+  };
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  };
+
+  /** TEST-ONLY: seed a tab without going through promote/openOrFocus. */
+  _debugInsert = (tab: EditorTab) => {
+    this.tabs = [...this.tabs, tab];
+    this.notify();
+  };
+
+  protected makeId = genId;
+
+  protected patch = (id: EditorTabId, patch: Partial<EditorTab>) => {
+    let changed = false;
+    this.tabs = this.tabs.map((t) => {
+      if (t.id !== id) return t;
+      changed = true;
+      return { ...t, ...patch };
+    });
+    if (changed) this.notify();
+  };
+
+  protected notify = () => {
+    if (this.pendingNotify) return;
+    this.pendingNotify = true;
+    Promise.resolve().then(() => {
+      this.pendingNotify = false;
+      this.listeners.forEach((l) => l());
+    });
+  };
+}
+
+export const editorTabStore = new EditorTabStore();
+
+// Hooks
+const getTabsSnapshot = () => editorTabStore.getTabs();
+
+export const useEditorTabs = (): readonly EditorTab[] =>
+  useSyncExternalStore(editorTabStore.subscribe, getTabsSnapshot);
+
+export const useEditorTab = (id: EditorTabId): EditorTab | undefined => {
+  const getSnapshot = useCallback(() => editorTabStore.getTab(id), [id]);
+  return useSyncExternalStore(editorTabStore.subscribe, getSnapshot);
+};
+
+export const useEditorDirty = (id: EditorTabId): boolean => {
+  const getSnapshot = useCallback(() => editorTabStore.isDirty(id), [id]);
+  return useSyncExternalStore(editorTabStore.subscribe, getSnapshot);
+};
+
+export const useAnyEditorDirty = (): boolean => {
+  const getSnapshot = useCallback(
+    () => editorTabStore.getTabs().some((t) => t.content !== t.baselineContent),
+    [],
+  );
+  return useSyncExternalStore(editorTabStore.subscribe, getSnapshot);
+};

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -123,6 +123,40 @@ export class EditorTabStore {
     return tab.id;
   };
 
+  /**
+   * Walk all editor tabs bound to `sessionId`. Clean tabs close silently; dirty tabs
+   * prompt via `promptChoice`. 'save' invokes `saveTab` and closes only on its success.
+   * Any 'cancel' aborts the batch (subsequent dirty tabs are preserved) and returns false.
+   */
+  confirmCloseBySession = async (
+    sessionId: string,
+    promptChoice: (tab: EditorTab) => Promise<"save" | "discard" | "cancel">,
+    saveTab?: (tabId: EditorTabId) => Promise<void>,
+  ): Promise<boolean> => {
+    const matching = this.tabs.filter((t) => t.sessionId === sessionId);
+    for (const tab of matching) {
+      const dirty = tab.content !== tab.baselineContent;
+      if (!dirty) {
+        this.close(tab.id);
+        continue;
+      }
+      const choice = await promptChoice(tab);
+      if (choice === "cancel") return false;
+      if (choice === "discard") { this.close(tab.id); continue; }
+      if (choice === "save") {
+        if (!saveTab) throw new Error("saveTab callback required when 'save' choice is possible");
+        try {
+          await saveTab(tab.id);
+        } catch {
+          // Save failed — treat like cancel (keep tab open, abort batch so the user sees the error)
+          return false;
+        }
+        this.close(tab.id);
+      }
+    }
+    return true;
+  };
+
   subscribe = (listener: Listener): (() => void) => {
     this.listeners.add(listener);
     return () => { this.listeners.delete(listener); };

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -63,6 +63,10 @@ export class EditorTabStore {
     this.patch(id, { wordWrap: value });
   };
 
+  setLanguage = (id: EditorTabId, languageId: string) => {
+    this.patch(id, { languageId });
+  };
+
   setSavingState = (id: EditorTabId, state: EditorSavingState, error: string | null = null) => {
     const patch: Partial<EditorTab> = { savingState: state };
     if (state === "idle") patch.saveError = null;

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -1,6 +1,13 @@
 import { useCallback, useSyncExternalStore } from "react";
 import type * as Monaco from "monaco-editor";
 
+// POSIX-style normalization: collapse "/./" and duplicate slashes, not ".." (remote paths
+// may contain semantic ".." segments we don't want to resolve client-side).
+const normalizePath = (p: string): string => {
+  const collapsed = p.replace(/\/+/g, "/").replace(/\/\.(?=\/|$)/g, "");
+  return collapsed.length > 1 && collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
+};
+
 export type EditorTabId = string;
 
 export type EditorSavingState = "idle" | "saving" | "error";
@@ -69,6 +76,51 @@ export class EditorTabStore {
       this.tabs = next;
       this.notify();
     }
+  };
+
+  promoteFromModal = (snapshot: {
+    sessionId: string;
+    hostId: string;
+    remotePath: string;
+    fileName: string;
+    languageId: string;
+    content: string;
+    baselineContent: string;
+    wordWrap: boolean;
+    viewState: Monaco.editor.ICodeEditorViewState | null;
+  }): EditorTabId => {
+    const normalized = normalizePath(snapshot.remotePath);
+    const existing = this.tabs.find(
+      (t) => t.sessionId === snapshot.sessionId && normalizePath(t.remotePath) === normalized,
+    );
+    if (existing) {
+      this.patch(existing.id, {
+        content: snapshot.content,
+        baselineContent: snapshot.baselineContent,
+        wordWrap: snapshot.wordWrap,
+        viewState: snapshot.viewState,
+        // keep languageId/hostId/fileName stable; they shouldn't change for the same path
+      });
+      return existing.id;
+    }
+    const tab: EditorTab = {
+      id: this.makeId(),
+      kind: "editor",
+      sessionId: snapshot.sessionId,
+      hostId: snapshot.hostId,
+      remotePath: snapshot.remotePath,
+      fileName: snapshot.fileName,
+      languageId: snapshot.languageId,
+      content: snapshot.content,
+      baselineContent: snapshot.baselineContent,
+      wordWrap: snapshot.wordWrap,
+      viewState: snapshot.viewState,
+      savingState: "idle",
+      saveError: null,
+    };
+    this.tabs = [...this.tabs, tab];
+    this.notify();
+    return tab.id;
   };
 
   subscribe = (listener: Listener): (() => void) => {

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -82,6 +82,22 @@ export class EditorTabStore {
     }
   };
 
+  /**
+   * Force-close every tab bound to any of the given sessionIds, with no dirty
+   * prompt. Intended for cases where the owning SFTP instance has gone away
+   * entirely (e.g. the hosting terminal tab was closed) and there is no
+   * realistic save channel anyway. Returns the closed tab ids.
+   */
+  forceCloseBySessions = (sessionIds: readonly string[]): EditorTabId[] => {
+    if (sessionIds.length === 0) return [];
+    const idSet = new Set(sessionIds);
+    const removed = this.tabs.filter((t) => idSet.has(t.sessionId)).map((t) => t.id);
+    if (removed.length === 0) return [];
+    this.tabs = this.tabs.filter((t) => !idSet.has(t.sessionId));
+    this.notify();
+    return removed;
+  };
+
   promoteFromModal = (snapshot: {
     sessionId: string;
     hostId: string;

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -1,6 +1,8 @@
 import { useCallback, useSyncExternalStore } from "react";
 import type * as Monaco from "monaco-editor";
 
+import { activeTabStore, fromEditorTabId, isEditorTabId } from "./activeTabStore";
+
 // POSIX-style normalization: collapse "/./" and duplicate slashes, not ".." (remote paths
 // may contain semantic ".." segments we don't want to resolve client-side).
 const normalizePath = (p: string): string => {
@@ -95,6 +97,19 @@ export class EditorTabStore {
     if (removed.length === 0) return [];
     this.tabs = this.tabs.filter((t) => !idSet.has(t.sessionId));
     this.notify();
+
+    // If the current active tab was one of the editor tabs we just removed,
+    // fall back to 'vault' so the user doesn't end up on a stale id (empty
+    // chrome + no content). Any better neighbor choice would need the full
+    // orderedTabs list, which isn't available here; 'vault' is always valid.
+    const activeId = activeTabStore.getActiveTabId();
+    if (isEditorTabId(activeId)) {
+      const activeEditorId = fromEditorTabId(activeId);
+      if (activeEditorId && removed.includes(activeEditorId)) {
+        activeTabStore.setActiveTabId('vault');
+      }
+    }
+
     return removed;
   };
 

--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useMemo } from "react";
-import { TransferTask, TransferStatus } from "../../../domain/models";
+import { TransferTask, TransferStatus, SftpFilenameEncoding } from "../../../domain/models";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { logger } from "../../../lib/logger";
 import { SftpPane } from "./types";
@@ -20,6 +20,7 @@ export type { UploadResult };
 
 interface UseSftpExternalOperationsParams {
   getActivePane: (side: "left" | "right") => SftpPane | null;
+  getPaneByConnectionId: (connectionId: string) => SftpPane | null;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   sftpSessionsRef: React.MutableRefObject<Map<string, string>>;
   connectionCacheKeyMapRef: React.MutableRefObject<Map<string, string>>;
@@ -35,6 +36,13 @@ interface SftpExternalOperationsResult {
   readTextFile: (side: "left" | "right", filePath: string) => Promise<string>;
   readBinaryFile: (side: "left" | "right", filePath: string) => Promise<ArrayBuffer>;
   writeTextFile: (side: "left" | "right", filePath: string, content: string) => Promise<void>;
+  writeTextFileByConnection: (
+    connectionId: string,
+    expectedHostId: string,
+    filePath: string,
+    content: string,
+    filenameEncoding?: SftpFilenameEncoding,
+  ) => Promise<void>;
   downloadToTempAndOpen: (
     side: "left" | "right",
     remotePath: string,
@@ -62,6 +70,7 @@ export const useSftpExternalOperations = (
 ): SftpExternalOperationsResult => {
   const {
     getActivePane,
+    getPaneByConnectionId,
     refresh,
     sftpSessionsRef,
     connectionCacheKeyMapRef,
@@ -171,6 +180,41 @@ export const useSftpExternalOperations = (
       await bridge.writeSftp(sftpId, filePath, content, pane.filenameEncoding);
     },
     [getActivePane, sftpSessionsRef],
+  );
+
+  const writeTextFileByConnection = useCallback(
+    async (
+      connectionId: string,
+      expectedHostId: string,
+      filePath: string,
+      content: string,
+      filenameEncoding?: SftpFilenameEncoding,
+    ): Promise<void> => {
+      const pane = getPaneByConnectionId(connectionId);
+      if (!pane?.connection) {
+        throw new Error("SFTP connection is no longer available");
+      }
+      if (pane.connection.hostId !== expectedHostId) {
+        throw new Error("SFTP connection changed while editing — file not saved to prevent writing to wrong host");
+      }
+
+      if (pane.connection.isLocal) {
+        const bridge = netcattyBridge.get();
+        if (!bridge?.writeLocalFile) throw new Error("Local file writing not supported");
+        const data = new TextEncoder().encode(content);
+        await bridge.writeLocalFile(filePath, data.buffer);
+        return;
+      }
+
+      const sftpId = sftpSessionsRef.current.get(pane.connection.id);
+      if (!sftpId) throw new Error("SFTP session not found");
+
+      const bridge = netcattyBridge.get();
+      if (!bridge) throw new Error("Bridge not available");
+
+      await bridge.writeSftp(sftpId, filePath, content, filenameEncoding ?? pane.filenameEncoding);
+    },
+    [getPaneByConnectionId, sftpSessionsRef],
   );
 
   const downloadToTempAndOpen = useCallback(
@@ -693,6 +737,7 @@ export const useSftpExternalOperations = (
     readTextFile,
     readBinaryFile,
     writeTextFile,
+    writeTextFileByConnection,
     downloadToTempAndOpen,
     uploadExternalFiles,
     uploadExternalEntries,

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -301,6 +301,7 @@ export const useSftpState = (
     readTextFile,
     readBinaryFile,
     writeTextFile,
+    writeTextFileByConnection,
     downloadToTempAndOpen,
     uploadExternalFiles,
     uploadExternalEntries,
@@ -309,6 +310,7 @@ export const useSftpState = (
     activeFileWatchCountRef,
   } = useSftpExternalOperations({
     getActivePane,
+    getPaneByConnectionId,
     refresh,
     sftpSessionsRef,
     connectionCacheKeyMapRef,
@@ -359,6 +361,7 @@ export const useSftpState = (
     readTextFile,
     readBinaryFile,
     writeTextFile,
+    writeTextFileByConnection,
     downloadToTempAndOpen,
     uploadExternalFiles,
     uploadExternalEntries,
@@ -413,6 +416,7 @@ export const useSftpState = (
     readTextFile,
     readBinaryFile,
     writeTextFile,
+    writeTextFileByConnection,
     downloadToTempAndOpen,
     uploadExternalFiles,
     uploadExternalEntries,
@@ -476,6 +480,8 @@ export const useSftpState = (
     readTextFile: (...args: Parameters<typeof readTextFile>) => methodsRef.current.readTextFile(...args),
     readBinaryFile: (...args: Parameters<typeof readBinaryFile>) => methodsRef.current.readBinaryFile(...args),
     writeTextFile: (...args: Parameters<typeof writeTextFile>) => methodsRef.current.writeTextFile(...args),
+    writeTextFileByConnection: (...args: Parameters<typeof writeTextFileByConnection>) =>
+      methodsRef.current.writeTextFileByConnection(...args),
     downloadToTempAndOpen: (...args: Parameters<typeof downloadToTempAndOpen>) => methodsRef.current.downloadToTempAndOpen(...args),
     uploadExternalFiles: (...args: Parameters<typeof uploadExternalFiles>) => methodsRef.current.uploadExternalFiles(...args),
     uploadExternalEntries: (...args: Parameters<typeof uploadExternalEntries>) =>

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -15,6 +15,7 @@ import { formatHostPort } from "../domain/host";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useSftpState } from "../application/state/useSftpState";
 import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
+import { editorTabStore } from "../application/state/editorTabStore";
 import { useSftpBackend } from "../application/state/useSftpBackend";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
 import { getParentPath } from "../application/state/sftp/utils";
@@ -134,6 +135,23 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       sftp.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
     );
   }, [sftp]);
+
+  // When this side panel unmounts (its hosting terminal tab was closed) we
+  // force-close any editor tabs bound to connections this panel owned — the
+  // save channel is gone with the SFTP session and there's no way to recover
+  // it. Dirty state is dropped intentionally; the user closed the terminal
+  // knowing the file was open.
+  useEffect(() => {
+    return () => {
+      const owned = new Set<string>();
+      const l = sftpRef.current?.leftPane?.connection?.id;
+      const r = sftpRef.current?.rightPane?.connection?.id;
+      if (l) owned.add(l);
+      if (r) owned.add(r);
+      if (owned.size === 0) return;
+      editorTabStore.forceCloseBySessions([...owned]);
+    };
+  }, []);
 
   const behaviorRef = useRef(sftpDoubleClickBehavior);
   behaviorRef.current = sftpDoubleClickBehavior;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -224,6 +224,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     fileOpenerTarget,
     setFileOpenerTarget,
     handleSaveTextFile,
+    onPromoteToTab,
     handleFileOpenerSelect,
     handleSelectSystemApp,
   } = useSftpViewPaneCallbacks({
@@ -679,6 +680,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
           setFileOpenerTarget={setFileOpenerTarget}
           handleFileOpenerSelect={handleFileOpenerSelect}
           handleSelectSystemApp={handleSelectSystemApp}
+          onPromoteToTab={onPromoteToTab}
           t={t}
         />
       )}

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -14,6 +14,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "
 import { formatHostPort } from "../domain/host";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useSftpState } from "../application/state/useSftpState";
+import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
 import { useSftpBackend } from "../application/state/useSftpBackend";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
 import { getParentPath } from "../application/state/sftp/utils";
@@ -124,6 +125,15 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
 
   const sftpRef = useRef(sftp);
   sftpRef.current = sftp;
+
+  // Register this instance's writeTextFileByConnection with the editor bridge
+  // so editor tabs promoted from SFTP files opened in a terminal side panel
+  // can still route saves through this useSftpState.
+  useEffect(() => {
+    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding) =>
+      sftp.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
+    );
+  }, [sftp]);
 
   const behaviorRef = useRef(sftpDoubleClickBehavior);
   behaviorRef.current = sftpDoubleClickBehavior;

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -219,6 +219,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
     fileOpenerTarget,
     setFileOpenerTarget,
     handleSaveTextFile,
+    onPromoteToTab,
     handleFileOpenerSelect,
     handleSelectSystemApp,
   } = useSftpViewPaneCallbacks({
@@ -475,6 +476,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
           setFileOpenerTarget={setFileOpenerTarget}
           handleFileOpenerSelect={handleFileOpenerSelect}
           handleSelectSystemApp={handleSelectSystemApp}
+          onPromoteToTab={onPromoteToTab}
           t={t}
         />
       </div>

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -27,7 +27,7 @@ import { useInstantThemeSwitch } from "../lib/useInstantThemeSwitch";
 import { Host, Identity, SSHKey } from "../types";
 import { resolveGroupDefaults, applyGroupDefaults } from "../domain/groupConfig";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
-import { registerEditorSftpWriter } from "../application/state/editorSftpBridge";
+import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
 import { toast } from "./ui/toast";
 
 // Import extracted components
@@ -120,13 +120,15 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
 
   const sftp = useSftpState(effectiveHosts, keys, identities, sftpOptions);
 
-  // Register writeTextFileByConnection with the editorSftpBridge singleton so that
-  // the editor tab's save path can use the active SFTP session.
+  // Register this useSftpState's writeTextFileByConnection with the bridge so
+  // the editor tab's save path can reach the active SFTP session. The bridge
+  // supports multiple simultaneous writers (SftpSidePanel inside terminals
+  // also registers its own instance) and dispatches by trying each until one
+  // owns the target connectionId.
   useEffect(() => {
-    registerEditorSftpWriter((connectionId, expectedHostId, filePath, content, encoding) =>
+    return registerEditorSftpWriterScoped((connectionId, expectedHostId, filePath, content, encoding) =>
       sftp.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
     );
-    return () => registerEditorSftpWriter(null);
   }, [sftp]);
 
   // Get backend helpers for file downloads and local filesystem writes.

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -14,7 +14,7 @@
  * - components/sftp/SftpHostPicker.tsx - Host selection dialog
  */
 
-import React, { memo, useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useIsSftpActive } from "../application/state/activeTabStore";
 import { useSftpState } from "../application/state/useSftpState";
@@ -27,6 +27,7 @@ import { useInstantThemeSwitch } from "../lib/useInstantThemeSwitch";
 import { Host, Identity, SSHKey } from "../types";
 import { resolveGroupDefaults, applyGroupDefaults } from "../domain/groupConfig";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
+import { registerEditorSftpWriter } from "../application/state/editorSftpBridge";
 import { toast } from "./ui/toast";
 
 // Import extracted components
@@ -118,6 +119,15 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
   );
 
   const sftp = useSftpState(effectiveHosts, keys, identities, sftpOptions);
+
+  // Register writeTextFileByConnection with the editorSftpBridge singleton so that
+  // the editor tab's save path can use the active SFTP session.
+  useEffect(() => {
+    registerEditorSftpWriter((connectionId, expectedHostId, filePath, content, encoding) =>
+      sftp.writeTextFileByConnection(connectionId, expectedHostId, filePath, content, encoding),
+    );
+    return () => registerEditorSftpWriter(null);
+  }, [sftp]);
 
   // Get backend helpers for file downloads and local filesystem writes.
   const {

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -14,12 +14,16 @@ import type { HotkeyScheme, KeyBinding } from '../domain/models';
 
 /** Snapshot passed to `onPromoteToTab` when the user clicks the maximize button. */
 export interface TextEditorModalSnapshot {
+  /** The file name at the time of promotion (modal's fileName prop). */
+  fileName: string;
   /** The clean baseline content at the time the modal was opened. */
   baselineContent: string;
   /** The current (possibly-dirty) editor content. */
   content: string;
   /** The current language ID selected by the user (may differ from file-detected default). */
   languageId: string;
+  /** The current word-wrap state (carried over so the tab opens with the same setting). */
+  wordWrap: boolean;
   /** The latest Monaco view state (scroll position, cursor, etc.) — may be null before first edit. */
   viewState: Monaco.editor.ICodeEditorViewState | null;
 }
@@ -106,12 +110,14 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   const handlePromote = useCallback(() => {
     if (!onPromoteToTab) return;
     onPromoteToTab({
+      fileName,
       baselineContent: initialContent,
       content,
       languageId,
+      wordWrap: editorWordWrap,
       viewState: viewStateRef.current,
     });
-  }, [onPromoteToTab, initialContent, content, languageId]);
+  }, [onPromoteToTab, fileName, initialContent, content, languageId, editorWordWrap]);
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -1,31 +1,28 @@
 /**
- * TextEditorModal - Modal for editing text files in SFTP with syntax highlighting
+ * TextEditorModal - Dialog shell for editing text files in SFTP.
+ * Delegates all editor chrome to TextEditorPane.
  */
-import {
-  CloudUpload,
-  Loader2,
-  Search,
-  WrapText,
-  X,
-} from 'lucide-react';
-import Editor, { type OnMount, loader, useMonaco } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-// Configure Monaco to use local files instead of CDN
-const monacoBasePath = import.meta.env.DEV
-  ? './node_modules/monaco-editor/min/vs'
-  : `${import.meta.env.BASE_URL}monaco/vs`;
-loader.config({ paths: { vs: monacoBasePath } });
-
-import { useI18n } from '../application/i18n/I18nProvider';
-import { useClipboardBackend } from '../application/state/useClipboardBackend';
-import { HotkeyScheme, KeyBinding, matchesKeyBinding } from '../domain/models';
-import { getLanguageId, getLanguageName, getSupportedLanguages } from '../lib/sftpFileUtils';
-import { Button } from './ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
-import { Combobox } from './ui/combobox';
+import { getLanguageId } from '../lib/sftpFileUtils';
+import { Dialog, DialogContent } from './ui/dialog';
 import { toast } from './ui/toast';
+import { TextEditorPane } from './editor/TextEditorPane';
+import { useI18n } from '../application/i18n/I18nProvider';
+import type { HotkeyScheme, KeyBinding } from '../domain/models';
+
+/** Snapshot passed to `onPromoteToTab` when the user clicks the maximize button. */
+export interface TextEditorModalSnapshot {
+  /** The clean baseline content at the time the modal was opened. */
+  baselineContent: string;
+  /** The current (possibly-dirty) editor content. */
+  content: string;
+  /** The current language ID selected by the user (may differ from file-detected default). */
+  languageId: string;
+  /** The latest Monaco view state (scroll position, cursor, etc.) — may be null before first edit. */
+  viewState: Monaco.editor.ICodeEditorViewState | null;
+}
 
 interface TextEditorModalProps {
   open: boolean;
@@ -37,127 +34,9 @@ interface TextEditorModalProps {
   onToggleWordWrap: () => void;
   hotkeyScheme: HotkeyScheme;
   keyBindings: KeyBinding[];
+  /** If provided, a maximize button is shown in the Pane header. */
+  onPromoteToTab?: (snapshot: TextEditorModalSnapshot) => void;
 }
-
-// Map our language IDs to Monaco language IDs
-const languageIdToMonaco = (langId: string): string => {
-  const mapping: Record<string, string> = {
-    'javascript': 'javascript',
-    'typescript': 'typescript',
-    'python': 'python',
-    'shell': 'shell',
-    'batch': 'bat',
-    'powershell': 'powershell',
-    'c': 'c',
-    'cpp': 'cpp',
-    'java': 'java',
-    'kotlin': 'kotlin',
-    'go': 'go',
-    'rust': 'rust',
-    'ruby': 'ruby',
-    'php': 'php',
-    'perl': 'perl',
-    'lua': 'lua',
-    'r': 'r',
-    'swift': 'swift',
-    'dart': 'dart',
-    'csharp': 'csharp',
-    'fsharp': 'fsharp',
-    'vb': 'vb',
-    'html': 'html',
-    'css': 'css',
-    'scss': 'scss',
-    'sass': 'sass',
-    'less': 'less',
-    'json': 'json',
-    'jsonc': 'json',
-    'json5': 'json',
-    'xml': 'xml',
-    'yaml': 'yaml',
-    'toml': 'ini',
-    'ini': 'ini',
-    'sql': 'sql',
-    'graphql': 'graphql',
-    'markdown': 'markdown',
-    'plaintext': 'plaintext',
-    'vue': 'html',
-    'svelte': 'html',
-    'dockerfile': 'dockerfile',
-    'makefile': 'makefile',
-    'diff': 'diff',
-  };
-  return mapping[langId] || 'plaintext';
-};
-
-// Convert HSL string "h s% l%" to hex color
-const hslToHex = (hslString: string): string => {
-  const parts = hslString.trim().split(/\s+/);
-  if (parts.length < 3) return '#1e1e1e';
-  const h = parseFloat(parts[0]) / 360;
-  const s = parseFloat(parts[1].replace('%', '')) / 100;
-  const l = parseFloat(parts[2].replace('%', '')) / 100;
-
-  const hue2rgb = (p: number, q: number, t: number) => {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-    return p;
-  };
-
-  let r: number, g: number, b: number;
-  if (s === 0) {
-    r = g = b = l;
-  } else {
-    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-    const p = 2 * l - q;
-    r = hue2rgb(p, q, h + 1 / 3);
-    g = hue2rgb(p, q, h);
-    b = hue2rgb(p, q, h - 1 / 3);
-  }
-
-  const toHex = (x: number) => {
-    const hex = Math.round(x * 255).toString(16);
-    return hex.length === 1 ? '0' + hex : hex;
-  };
-
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-};
-
-// Read a CSS custom-property and convert from HSL to hex
-const getCssColor = (varName: string, fallback: string): string => {
-  const value = getComputedStyle(document.documentElement)
-    .getPropertyValue(varName)
-    .trim();
-  return value ? hslToHex(value) : fallback;
-};
-
-interface EditorColors {
-  bg: string;
-  fg: string;
-  primary: string;
-  card: string;
-  mutedFg: string;
-  border: string;
-}
-
-/** Read all UI CSS variables that matter for the Monaco theme. */
-const getEditorColors = (isDark: boolean): EditorColors => ({
-  bg: getCssColor('--background', isDark ? '#1e1e1e' : '#ffffff'),
-  fg: getCssColor('--foreground', isDark ? '#d4d4d4' : '#1e1e1e'),
-  primary: getCssColor('--primary', isDark ? '#569cd6' : '#0078d4'),
-  card: getCssColor('--card', isDark ? '#252526' : '#f3f3f3'),
-  mutedFg: getCssColor('--muted-foreground', isDark ? '#858585' : '#858585'),
-  border: getCssColor('--border', isDark ? '#3c3c3c' : '#d4d4d4'),
-});
-
-/** Build a fingerprint string so we can detect immersive-mode color changes cheaply. */
-const getThemeSignal = (): string => {
-  const root = document.documentElement;
-  return root.dataset.immersiveTheme
-    ?? getComputedStyle(root).getPropertyValue('--background').trim();
-};
 
 export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   open,
@@ -169,181 +48,44 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   onToggleWordWrap,
   hotkeyScheme,
   keyBindings,
+  onPromoteToTab,
 }) => {
   const { t } = useI18n();
-  const { readClipboardText: readClipboardTextFromBridge } = useClipboardBackend();
-  const monaco = useMonaco();
+
   const [content, setContent] = useState(initialContent);
   const [saving, setSaving] = useState(false);
-  const [hasChanges, setHasChanges] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [languageId, setLanguageId] = useState(() => getLanguageId(fileName));
-  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
 
-  // Ref to store the latest save function to avoid stale closure in keyboard shortcut
-  const handleSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
-  const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
-  const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
+  // Latest view state captured from Pane's onContentChange — used by handlePromote
+  const viewStateRef = useRef<Monaco.editor.ICodeEditorViewState | null>(null);
 
-  // Track theme from document.documentElement class (syncs with app theme)
-  const [isDarkTheme, setIsDarkTheme] = useState(() =>
-    document.documentElement.classList.contains('dark')
-  );
+  // Derived: whether the current content differs from the clean baseline
+  const hasChanges = content !== initialContent;
 
-  // Track a signal that changes whenever immersive-mode or base theme colors change
-  const [themeSignal, setThemeSignal] = useState(() => getThemeSignal());
-
-  // Custom theme name
-  const customThemeName = isDarkTheme ? 'netcatty-dark' : 'netcatty-light';
-
-  // Define and update custom Monaco themes — syncs with immersive-mode / base UI colors
-  useEffect(() => {
-    if (!monaco) return;
-
-    const colors = getEditorColors(isDarkTheme);
-
-    const themeColors: Record<string, string> = {
-      'editor.background': colors.bg,
-      'editor.foreground': colors.fg,
-      'editorCursor.foreground': colors.primary,
-      'editor.selectionBackground': colors.primary + '40',
-      'editor.inactiveSelectionBackground': colors.primary + '25',
-      'editorLineNumber.foreground': colors.mutedFg,
-      'editorLineNumber.activeForeground': colors.fg,
-      'editor.lineHighlightBackground': colors.fg + '08',
-      'editorWidget.background': colors.card,
-      'editorWidget.foreground': colors.fg,
-      'editorWidget.border': colors.border,
-      'input.background': colors.card,
-      'input.foreground': colors.fg,
-      'input.border': colors.border,
-    };
-
-    monaco.editor.defineTheme('netcatty-dark', {
-      base: 'vs-dark',
-      inherit: true,
-      rules: [],
-      colors: themeColors,
-    });
-
-    monaco.editor.defineTheme('netcatty-light', {
-      base: 'vs',
-      inherit: true,
-      rules: [],
-      colors: themeColors,
-    });
-
-    monaco.editor.setTheme(customThemeName);
-  }, [monaco, isDarkTheme, themeSignal, customThemeName]);
-
-  // Listen for theme changes via MutationObserver on <html> class, style, and immersive data attr
-  useEffect(() => {
-    const root = document.documentElement;
-    const updateTheme = () => {
-      setIsDarkTheme(root.classList.contains('dark'));
-      setThemeSignal(getThemeSignal());
-    };
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(root, {
-      attributes: true,
-      attributeFilter: ['class', 'style', 'data-immersive-theme'],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  // Reset content when file changes
+  // Reset all state when a new file is opened
   useEffect(() => {
     setContent(initialContent);
-    setHasChanges(false);
+    setSaveError(null);
     setLanguageId(getLanguageId(fileName));
+    viewStateRef.current = null;
   }, [initialContent, fileName]);
-
-  // Track changes
-  useEffect(() => {
-    setHasChanges(content !== initialContent);
-  }, [content, initialContent]);
-
-  const closeTabBinding = useMemo(
-    () => keyBindings.find((binding) => binding.action === 'closeTab'),
-    [keyBindings],
-  );
 
   const handleSave = useCallback(async () => {
     if (saving) return;
     setSaving(true);
+    setSaveError(null);
     try {
       await onSave(content);
-      setHasChanges(false);
       toast.success(t('sftp.editor.saved'), 'SFTP');
     } catch (e) {
-      toast.error(
-        e instanceof Error ? e.message : t('sftp.editor.saveFailed'),
-        'SFTP'
-      );
+      const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
+      setSaveError(msg);
+      toast.error(msg, 'SFTP');
     } finally {
       setSaving(false);
     }
   }, [content, onSave, saving, t]);
-
-  // Keep the ref updated with the latest handleSave function
-  useEffect(() => {
-    handleSaveRef.current = handleSave;
-  }, [handleSave]);
-
-  const readClipboardText = useCallback(async (): Promise<string | null> => {
-    try {
-      if (navigator.clipboard?.readText) {
-        return await navigator.clipboard.readText();
-      }
-    } catch {
-      // Fall through to Electron bridge
-    }
-
-    try {
-      return await readClipboardTextFromBridge();
-    } catch {
-      // Both clipboard APIs unavailable; signal failure so caller can fall back.
-      return null;
-    }
-  }, [readClipboardTextFromBridge]);
-
-  useEffect(() => {
-    readClipboardTextRef.current = readClipboardText;
-  }, [readClipboardText]);
-
-  const handlePaste = useCallback(async () => {
-    const editor = editorRef.current;
-    if (!editor) return;
-
-    const text = await readClipboardText();
-    if (text === null) {
-      // Clipboard read unavailable; fall back to Monaco's native paste.
-      editor.trigger('keyboard', 'editor.action.clipboardPasteAction', null);
-      return;
-    }
-    if (!text) return;
-
-    const selections = editor.getSelections();
-    if (!selections || selections.length === 0) return;
-
-    // Match Monaco's default multicursorPaste:'spread' behavior:
-    // distribute one line per cursor when line count equals cursor count.
-    const lines = text.split(/\r\n|\n/);
-    const distribute = selections.length > 1 && lines.length === selections.length;
-
-    editor.executeEdits(
-      'netcatty-paste',
-      selections.map((selection, i) => ({
-        range: selection,
-        text: distribute ? lines[i] : text,
-        forceMoveMarkers: true,
-      })),
-    );
-    editor.focus();
-  }, [readClipboardText]);
-
-  useEffect(() => {
-    handlePasteRef.current = handlePaste;
-  }, [handlePaste]);
 
   const handleClose = useCallback(() => {
     if (hasChanges) {
@@ -353,222 +95,47 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
     onClose();
   }, [hasChanges, onClose, t]);
 
-  const handleEditorChange = useCallback((value: string | undefined) => {
-    setContent(value || '');
-  }, []);
-
-  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
-    editorRef.current = editor;
-
-    // Add save shortcut - use ref to avoid stale closure
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
-      handleSaveRef.current();
-    });
-
-    // Add find shortcut (Ctrl+F / Cmd+F)
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
-      // Trigger Monaco's built-in find widget
-      editor.trigger('keyboard', 'actions.find', null);
-    });
-
-    // Fallback paste path for Electron environments where Monaco paste can fail.
-    // Skip custom paste when focus is inside the find/replace widget so that
-    // its input fields receive the pasted text via default browser behavior.
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
-      const active = document.activeElement;
-      if (active?.closest('.find-widget')) {
-        // Read clipboard and insert into the find/replace input field.
-        void (async () => {
-          try {
-            const text = await readClipboardTextRef.current();
-            if (!text) return;
-            // Monaco find widget inputs are <textarea> elements inside .monaco-inputbox
-            if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) {
-              const start = active.selectionStart ?? active.value.length;
-              const end = active.selectionEnd ?? active.value.length;
-              active.focus();
-              active.setSelectionRange(start, end);
-              document.execCommand('insertText', false, text);
-            }
-          } catch {
-            // Ignore – paste simply won't work
-          }
-        })();
-        return;
-      }
-      void handlePasteRef.current();
-    });
-
-    editor.focus();
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const frame = window.requestAnimationFrame(() => {
-      editorRef.current?.focus();
-    });
-
-    return () => window.cancelAnimationFrame(frame);
-  }, [open]);
-
-  const handleDialogKeyDownCapture = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (hotkeyScheme === 'disabled' || !closeTabBinding) return;
-
-    const isMac = hotkeyScheme === 'mac';
-    const keyStr = isMac ? closeTabBinding.mac : closeTabBinding.pc;
-    if (!matchesKeyBinding(e.nativeEvent, keyStr, isMac)) return;
-
-    e.preventDefault();
-    e.stopPropagation();
-    e.nativeEvent.stopPropagation();
-    handleClose();
-  }, [closeTabBinding, handleClose, hotkeyScheme]);
-
-  // Trigger search dialog
-  const handleSearch = useCallback(() => {
-    if (editorRef.current) {
-      editorRef.current.trigger('keyboard', 'actions.find', null);
-      editorRef.current.focus();
-    }
-  }, []);
-
-  const supportedLanguages = useMemo(() => getSupportedLanguages(), []);
-  const monacoLanguage = useMemo(() => languageIdToMonaco(languageId), [languageId]);
-  const languageOptions = useMemo(
-    () => supportedLanguages.map((lang) => ({ value: lang.id, label: lang.name })),
-    [supportedLanguages],
+  const handleContentChange = useCallback(
+    (nextContent: string, viewState: Monaco.editor.ICodeEditorViewState | null) => {
+      setContent(nextContent);
+      viewStateRef.current = viewState;
+    },
+    [],
   );
 
-  const handleLanguageChange = useCallback((nextValue: string) => {
-    setLanguageId(nextValue || 'plaintext');
-  }, []);
+  const handlePromote = useCallback(() => {
+    if (!onPromoteToTab) return;
+    onPromoteToTab({
+      baselineContent: initialContent,
+      content,
+      languageId,
+      viewState: viewStateRef.current,
+    });
+  }, [onPromoteToTab, initialContent, content, languageId]);
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <DialogContent
         className="max-w-5xl h-[85vh] flex flex-col p-0 gap-0"
         hideCloseButton
-        data-hotkey-close-tab="true"
-        onKeyDownCapture={handleDialogKeyDownCapture}
       >
-        {/* Header */}
-        <DialogHeader className="px-4 py-3 border-b border-border/60 flex-shrink-0">
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-              <DialogTitle className="text-sm font-semibold truncate">
-                {fileName}
-                {hasChanges && <span className="text-primary ml-1">*</span>}
-              </DialogTitle>
-            </div>
-            <div className="flex items-center gap-2 min-w-0">
-              {/* Search button */}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handleSearch}
-                title={t('common.search')}
-              >
-                <Search size={14} />
-              </Button>
-
-              {/* Word wrap toggle */}
-              <Button
-                variant={editorWordWrap ? 'secondary' : 'ghost'}
-                size="icon"
-                className="h-7 w-7"
-                onClick={onToggleWordWrap}
-                title={t('sftp.editor.wordWrap')}
-              >
-                <WrapText size={14} />
-              </Button>
-
-              {/* Language selector */}
-              <Combobox
-                options={languageOptions}
-                value={languageId}
-                onValueChange={handleLanguageChange}
-                placeholder={t('sftp.editor.syntaxHighlight')}
-                triggerClassName="h-7 max-w-[180px] min-w-[120px] text-xs"
-              />
-
-              {/* Save button */}
-              <Button
-                variant="default"
-                size="sm"
-                className="h-7"
-                onClick={handleSave}
-                disabled={saving || !hasChanges}
-              >
-                {saving ? (
-                  <Loader2 size={14} className="mr-1.5 animate-spin" />
-                ) : (
-                  <CloudUpload size={14} className="mr-1.5" />
-                )}
-                {saving ? t('sftp.editor.saving') : t('sftp.editor.save')}
-              </Button>
-
-              {/* Close button */}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handleClose}
-              >
-                <X size={14} />
-              </Button>
-            </div>
-          </div>
-        </DialogHeader>
-
-        {/* Monaco Editor */}
-        <div className="flex-1 min-h-0 relative">
-          <Editor
-            height="100%"
-            language={monacoLanguage}
-            value={content}
-            onChange={handleEditorChange}
-            onMount={handleEditorMount}
-            theme={customThemeName}
-            loading={
-              <div className="absolute inset-0 flex items-center justify-center bg-background">
-                <Loader2 size={32} className="animate-spin text-muted-foreground" />
-              </div>
-            }
-            options={{
-              // Prefer native context menu in Electron so right-click Paste uses OS clipboard path.
-              contextmenu: false,
-              minimap: { enabled: true },
-              fontSize: 14,
-              lineNumbers: 'on',
-              roundedSelection: false,
-              scrollBeyondLastLine: false,
-              automaticLayout: true,
-              tabSize: 2,
-              insertSpaces: true,
-              wordWrap: editorWordWrap ? 'on' : 'off',
-              folding: true,
-              renderWhitespace: 'selection',
-              bracketPairColorization: { enabled: true },
-              find: {
-                addExtraSpaceOnTop: false,
-                autoFindInSelection: 'never',
-                seedSearchStringFromSelection: 'selection',
-              },
-            }}
-          />
-        </div>
-
-        {/* Footer */}
-        <div className="px-4 py-2 border-t border-border/60 flex items-center justify-between text-xs text-muted-foreground bg-muted/30 flex-shrink-0">
-          <span>
-            {getLanguageName(languageId)}
-          </span>
-          <span>
-            {content.split('\n').length} lines • {content.length} characters
-          </span>
-        </div>
+        <TextEditorPane
+          chrome="modal"
+          fileName={`${fileName}${hasChanges ? ' *' : ''}`}
+          content={content}
+          languageId={languageId}
+          wordWrap={editorWordWrap}
+          saving={saving}
+          saveError={saveError}
+          hotkeyScheme={hotkeyScheme}
+          keyBindings={keyBindings}
+          onContentChange={handleContentChange}
+          onLanguageChange={setLanguageId}
+          onToggleWordWrap={onToggleWordWrap}
+          onSave={handleSave}
+          onRequestClose={handleClose}
+          onPromoteToTab={onPromoteToTab ? handlePromote : undefined}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -6,7 +6,7 @@ import type * as Monaco from 'monaco-editor';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { getLanguageId } from '../lib/sftpFileUtils';
-import { Dialog, DialogContent } from './ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from './ui/dialog';
 import { toast } from './ui/toast';
 import { TextEditorPane } from './editor/TextEditorPane';
 import { useI18n } from '../application/i18n/I18nProvider';
@@ -125,6 +125,10 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
         className="max-w-5xl h-[85vh] flex flex-col p-0 gap-0"
         hideCloseButton
       >
+        {/* Radix requires a DialogTitle inside every DialogContent for a11y.
+            The Pane's own header already shows the filename visually, so we
+            mirror it here inside an sr-only DialogTitle for screen readers. */}
+        <DialogTitle className="sr-only">{fileName}</DialogTitle>
         <TextEditorPane
           chrome="modal"
           fileName={`${fileName}${hasChanges ? ' *' : ''}`}

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -20,6 +20,9 @@ import { SyncStatusButton } from './SyncStatusButton';
 const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties;
 const dragRegionNoSelect = { WebkitAppRegion: 'drag', userSelect: 'none' } as React.CSSProperties;
 
+// File extensions that render the code-file icon instead of the plain text icon.
+const CODE_EXTENSIONS_RE = /\.(js|jsx|ts|tsx|py|rb|go|rs|c|cpp|cs|java|php|sh|bash|zsh|fish|lua|r|scala|swift|kt|html|css|scss|less|json|yaml|yml|toml|xml|sql|graphql|gql|md|mdx|conf|ini|env|tf|hcl|dockerfile)$/i;
+
 interface TopTabsProps {
   theme: 'dark' | 'light';
   followAppTerminalTheme?: boolean;
@@ -564,9 +567,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         const suffix = dupes.length > 1
           ? ` · ${editorTab.remotePath.split('/').slice(-2, -1)[0] || '/'}`
           : '';
-        // Use FileCode for code-like extensions, FileText for others
-        const codeExtensions = /\.(js|jsx|ts|tsx|py|rb|go|rs|c|cpp|cs|java|php|sh|bash|zsh|fish|lua|r|scala|swift|kt|html|css|scss|less|json|yaml|yml|toml|xml|sql|graphql|gql|md|mdx|conf|ini|env|tf|hcl|dockerfile)$/i;
-        const FileIcon = codeExtensions.test(editorTab.fileName) ? FileCode : FileText;
+        const FileIcon = CODE_EXTENSIONS_RE.test(editorTab.fileName) ? FileCode : FileText;
 
         return (
           <div
@@ -574,7 +575,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             data-tab-id={tabId}
             data-tab-type="editor"
             data-state={isActive ? 'active' : 'inactive'}
-            onClick={() => activeTabStore.setActiveTabId(tabId)}
+            onClick={() => onSelectTab(tabId)}
             title={tooltip}
             className={cn(
               "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,6 +1,7 @@
-import { Bell, Copy, FileText, Folder, FolderLock, LayoutGrid, Minus, Moon, MoreHorizontal, Plus, Server, Sparkles, Square, Sun, TerminalSquare, Usb, X } from 'lucide-react';
+import { Bell, Copy, FileCode, FileText, Folder, FolderLock, LayoutGrid, Minus, Moon, MoreHorizontal, Plus, Server, Sparkles, Square, Sun, TerminalSquare, Usb, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { activeTabStore, useActiveTabId } from '../application/state/activeTabStore';
+import { activeTabStore, fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
+import type { EditorTab } from '../application/state/editorTabStore';
 import { buildWorkspaceActivityMap } from '../application/state/sessionActivity';
 import { useSessionActivityMap } from '../application/state/sessionActivityStore';
 import { LogView } from '../application/state/useSessionState';
@@ -46,6 +47,9 @@ interface TopTabsProps {
   onEndSessionDrag: () => void;
   onReorderTabs: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
   showSftpTab: boolean;
+  editorTabs: readonly EditorTab[];
+  onRequestCloseEditorTab: (editorTabId: string) => void;
+  hostById: Map<string, Host>;
 }
 
 // Detect local OS for local terminal tab icons
@@ -255,6 +259,9 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onEndSessionDrag,
   onReorderTabs,
   showSftpTab,
+  editorTabs,
+  onRequestCloseEditorTab,
+  hostById,
 }) => {
   const { t } = useI18n();
   // Subscribe to activeTabId from external store
@@ -477,9 +484,22 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     return styles;
   }, [dropIndicator, isDraggingForReorder, orderedTabs]);
 
+  // Pre-compute editor tab map for O(1) access
+  const editorTabMap = useMemo(() => {
+    const map = new Map<string, EditorTab>();
+    for (const t of editorTabs) map.set(t.id, t);
+    return map;
+  }, [editorTabs]);
+
   // Build ordered tab items using pre-computed maps for O(1) lookups
   const orderedTabItems = useMemo(() => {
     return orderedTabs.map((tabId) => {
+      if (isEditorTabId(tabId)) {
+        const editorId = fromEditorTabId(tabId);
+        const editorTab = editorTabMap.get(editorId);
+        if (!editorTab) return null;
+        return { type: 'editor' as const, id: tabId, editorTab };
+      }
       const session = orphanSessionMap.get(tabId);
       const workspace = workspaceMap.get(tabId);
       const logView = logViewMap.get(tabId);
@@ -494,7 +514,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       }
       return null;
     }).filter(Boolean);
-  }, [orderedTabs, orphanSessionMap, workspaceMap, logViewMap, workspacePaneCounts]);
+  }, [orderedTabs, editorTabMap, orphanSessionMap, workspaceMap, logViewMap, workspacePaneCounts]);
 
   // Bulk-close menu items shared by session and workspace context menus.
   // Anchor is the tab the user right-clicked on (matches VSCode/JetBrains UX).
@@ -531,6 +551,80 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const renderOrderedTabs = () => {
     return orderedTabItems.map((item) => {
       if (!item) return null;
+
+      if (item.type === 'editor') {
+        const { editorTab } = item;
+        const tabId = item.id;
+        const isActive = activeTabId === tabId;
+        const host = hostById.get(editorTab.hostId);
+        const dirty = editorTab.content !== editorTab.baselineContent;
+        const tooltip = `${host?.label ?? editorTab.hostId}@${host?.hostname ?? ''}:${editorTab.remotePath}`;
+        // Disambiguate duplicate filenames within editor tabs (O(n) scan)
+        const dupes = editorTabs.filter((t) => t.fileName === editorTab.fileName);
+        const suffix = dupes.length > 1
+          ? ` · ${editorTab.remotePath.split('/').slice(-2, -1)[0] || '/'}`
+          : '';
+        // Use FileCode for code-like extensions, FileText for others
+        const codeExtensions = /\.(js|jsx|ts|tsx|py|rb|go|rs|c|cpp|cs|java|php|sh|bash|zsh|fish|lua|r|scala|swift|kt|html|css|scss|less|json|yaml|yml|toml|xml|sql|graphql|gql|md|mdx|conf|ini|env|tf|hcl|dockerfile)$/i;
+        const FileIcon = codeExtensions.test(editorTab.fileName) ? FileCode : FileText;
+
+        return (
+          <div
+            key={tabId}
+            data-tab-id={tabId}
+            data-tab-type="editor"
+            data-state={isActive ? 'active' : 'inactive'}
+            onClick={() => activeTabStore.setActiveTabId(tabId)}
+            title={tooltip}
+            className={cn(
+              "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
+            )}
+            style={{
+              backgroundColor: isActive
+                ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+                : 'transparent',
+              color: isActive
+                ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+                : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+            }}
+            onMouseEnter={(e) => {
+              if (!isActive) {
+                e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+                e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isActive) {
+                e.currentTarget.style.backgroundColor = 'transparent';
+                e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+              }
+            }}
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <FileIcon
+                size={14}
+                className="shrink-0"
+                style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+              />
+              <span className="truncate flex items-center gap-0.5">
+                {dirty && <span className="text-primary mr-0.5">●</span>}
+                {editorTab.fileName}
+                {suffix && <span className="text-muted-foreground ml-1">{suffix}</span>}
+              </span>
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onRequestCloseEditorTab(editorTab.id);
+              }}
+              className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
+              aria-label="Close editor tab"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        );
+      }
 
       if (item.type === 'session') {
         const session = item.session;

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -159,6 +159,8 @@ export interface TextEditorPaneProps {
   keyBindings: KeyBinding[];
   /** Layout mode — affects header chrome (modal shows close+maximize; tab-form only shows content controls since tab has its own close). */
   chrome: 'modal' | 'tab';
+  /** Optional secondary label shown next to the filename in muted text — used by the tab form to display `host:remotePath`. */
+  subtitle?: string;
   onContentChange: (content: string, viewState: Monaco.editor.ICodeEditorViewState | null) => void;
   onLanguageChange: (nextLanguageId: string) => void;
   onToggleWordWrap: () => void;
@@ -178,6 +180,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
   hotkeyScheme,
   keyBindings,
   chrome,
+  subtitle,
   onContentChange,
   onLanguageChange,
   onToggleWordWrap,
@@ -422,11 +425,16 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
       {/* Header */}
       <div className="px-4 py-3 border-b border-border/60 flex-shrink-0">
         <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            <span className="text-sm font-semibold truncate">
+          <div className="flex items-baseline gap-2 flex-1 min-w-0">
+            <span className="text-sm font-semibold truncate flex-shrink-0">
               {fileName}
             </span>
-            {saveError && <span className="text-xs text-destructive">{saveError}</span>}
+            {subtitle && (
+              <span className="text-xs text-muted-foreground truncate" title={subtitle}>
+                {subtitle}
+              </span>
+            )}
+            {saveError && <span className="text-xs text-destructive truncate">{saveError}</span>}
           </div>
           <div className="flex items-center gap-2 min-w-0">
             {/* Search button */}

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -24,7 +24,7 @@ loader.config({ paths: { vs: monacoBasePath } });
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { useClipboardBackend } from '../../application/state/useClipboardBackend';
 import { HotkeyScheme, KeyBinding, matchesKeyBinding } from '../../domain/models';
-import { getLanguageId, getLanguageName, getSupportedLanguages } from '../../lib/sftpFileUtils';
+import { getLanguageName, getSupportedLanguages } from '../../lib/sftpFileUtils';
 import { Button } from '../ui/button';
 import { Combobox } from '../ui/combobox';
 

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -1,0 +1,558 @@
+/**
+ * TextEditorPane — pure Monaco editor body + toolbar.
+ * Extracted from TextEditorModal.tsx. Contains no Dialog shell.
+ * Parents (modal or tab) own content state, saving state, and toast calls.
+ */
+import {
+  CloudUpload,
+  Loader2,
+  Maximize2,
+  Search,
+  WrapText,
+  X,
+} from 'lucide-react';
+import Editor, { type OnMount, loader, useMonaco } from '@monaco-editor/react';
+import type * as Monaco from 'monaco-editor';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+// Configure Monaco to use local files instead of CDN
+const monacoBasePath = import.meta.env.DEV
+  ? './node_modules/monaco-editor/min/vs'
+  : `${import.meta.env.BASE_URL}monaco/vs`;
+loader.config({ paths: { vs: monacoBasePath } });
+
+import { useI18n } from '../../application/i18n/I18nProvider';
+import { useClipboardBackend } from '../../application/state/useClipboardBackend';
+import { HotkeyScheme, KeyBinding, matchesKeyBinding } from '../../domain/models';
+import { getLanguageId, getLanguageName, getSupportedLanguages } from '../../lib/sftpFileUtils';
+import { Button } from '../ui/button';
+import { Combobox } from '../ui/combobox';
+
+// Map our language IDs to Monaco language IDs
+const languageIdToMonaco = (langId: string): string => {
+  const mapping: Record<string, string> = {
+    'javascript': 'javascript',
+    'typescript': 'typescript',
+    'python': 'python',
+    'shell': 'shell',
+    'batch': 'bat',
+    'powershell': 'powershell',
+    'c': 'c',
+    'cpp': 'cpp',
+    'java': 'java',
+    'kotlin': 'kotlin',
+    'go': 'go',
+    'rust': 'rust',
+    'ruby': 'ruby',
+    'php': 'php',
+    'perl': 'perl',
+    'lua': 'lua',
+    'r': 'r',
+    'swift': 'swift',
+    'dart': 'dart',
+    'csharp': 'csharp',
+    'fsharp': 'fsharp',
+    'vb': 'vb',
+    'html': 'html',
+    'css': 'css',
+    'scss': 'scss',
+    'sass': 'sass',
+    'less': 'less',
+    'json': 'json',
+    'jsonc': 'json',
+    'json5': 'json',
+    'xml': 'xml',
+    'yaml': 'yaml',
+    'toml': 'ini',
+    'ini': 'ini',
+    'sql': 'sql',
+    'graphql': 'graphql',
+    'markdown': 'markdown',
+    'plaintext': 'plaintext',
+    'vue': 'html',
+    'svelte': 'html',
+    'dockerfile': 'dockerfile',
+    'makefile': 'makefile',
+    'diff': 'diff',
+  };
+  return mapping[langId] || 'plaintext';
+};
+
+// Convert HSL string "h s% l%" to hex color
+const hslToHex = (hslString: string): string => {
+  const parts = hslString.trim().split(/\s+/);
+  if (parts.length < 3) return '#1e1e1e';
+  const h = parseFloat(parts[0]) / 360;
+  const s = parseFloat(parts[1].replace('%', '')) / 100;
+  const l = parseFloat(parts[2].replace('%', '')) / 100;
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  const toHex = (x: number) => {
+    const hex = Math.round(x * 255).toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+// Read a CSS custom-property and convert from HSL to hex
+const getCssColor = (varName: string, fallback: string): string => {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  return value ? hslToHex(value) : fallback;
+};
+
+interface EditorColors {
+  bg: string;
+  fg: string;
+  primary: string;
+  card: string;
+  mutedFg: string;
+  border: string;
+}
+
+/** Read all UI CSS variables that matter for the Monaco theme. */
+const getEditorColors = (isDark: boolean): EditorColors => ({
+  bg: getCssColor('--background', isDark ? '#1e1e1e' : '#ffffff'),
+  fg: getCssColor('--foreground', isDark ? '#d4d4d4' : '#1e1e1e'),
+  primary: getCssColor('--primary', isDark ? '#569cd6' : '#0078d4'),
+  card: getCssColor('--card', isDark ? '#252526' : '#f3f3f3'),
+  mutedFg: getCssColor('--muted-foreground', isDark ? '#858585' : '#858585'),
+  border: getCssColor('--border', isDark ? '#3c3c3c' : '#d4d4d4'),
+});
+
+/** Build a fingerprint string so we can detect immersive-mode color changes cheaply. */
+const getThemeSignal = (): string => {
+  const root = document.documentElement;
+  return root.dataset.immersiveTheme
+    ?? getComputedStyle(root).getPropertyValue('--background').trim();
+};
+
+export interface TextEditorPaneProps {
+  fileName: string;
+  content: string;
+  languageId: string;
+  wordWrap: boolean;
+  saving: boolean;
+  saveError: string | null;
+  hotkeyScheme: HotkeyScheme;
+  keyBindings: KeyBinding[];
+  /** Layout mode — affects header chrome (modal shows close+maximize; tab-form only shows content controls since tab has its own close). */
+  chrome: 'modal' | 'tab';
+  onContentChange: (content: string, viewState: Monaco.editor.ICodeEditorViewState | null) => void;
+  onLanguageChange: (nextLanguageId: string) => void;
+  onToggleWordWrap: () => void;
+  onSave: () => void;
+  onRequestClose?: () => void;   // modal only
+  onPromoteToTab?: () => void;   // modal only — omit to hide the maximize button
+  initialViewState?: Monaco.editor.ICodeEditorViewState | null;
+}
+
+export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
+  fileName,
+  content,
+  languageId,
+  wordWrap,
+  saving,
+  saveError,
+  hotkeyScheme,
+  keyBindings,
+  chrome,
+  onContentChange,
+  onLanguageChange,
+  onToggleWordWrap,
+  onSave,
+  onRequestClose,
+  onPromoteToTab,
+  initialViewState,
+}) => {
+  const { t } = useI18n();
+  const { readClipboardText: readClipboardTextFromBridge } = useClipboardBackend();
+  const monaco = useMonaco();
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+
+  // Ref to store the latest save function to avoid stale closure in keyboard shortcut
+  const handleSaveRef = useRef<() => void>(() => {});
+  const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
+
+  // Track theme from document.documentElement class (syncs with app theme)
+  const [isDarkTheme, setIsDarkTheme] = useState(() =>
+    document.documentElement.classList.contains('dark')
+  );
+
+  // Track a signal that changes whenever immersive-mode or base theme colors change
+  const [themeSignal, setThemeSignal] = useState(() => getThemeSignal());
+
+  // Custom theme name
+  const customThemeName = isDarkTheme ? 'netcatty-dark' : 'netcatty-light';
+
+  // Define and update custom Monaco themes — syncs with immersive-mode / base UI colors
+  useEffect(() => {
+    if (!monaco) return;
+
+    const colors = getEditorColors(isDarkTheme);
+
+    const themeColors: Record<string, string> = {
+      'editor.background': colors.bg,
+      'editor.foreground': colors.fg,
+      'editorCursor.foreground': colors.primary,
+      'editor.selectionBackground': colors.primary + '40',
+      'editor.inactiveSelectionBackground': colors.primary + '25',
+      'editorLineNumber.foreground': colors.mutedFg,
+      'editorLineNumber.activeForeground': colors.fg,
+      'editor.lineHighlightBackground': colors.fg + '08',
+      'editorWidget.background': colors.card,
+      'editorWidget.foreground': colors.fg,
+      'editorWidget.border': colors.border,
+      'input.background': colors.card,
+      'input.foreground': colors.fg,
+      'input.border': colors.border,
+    };
+
+    monaco.editor.defineTheme('netcatty-dark', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [],
+      colors: themeColors,
+    });
+
+    monaco.editor.defineTheme('netcatty-light', {
+      base: 'vs',
+      inherit: true,
+      rules: [],
+      colors: themeColors,
+    });
+
+    monaco.editor.setTheme(customThemeName);
+  }, [monaco, isDarkTheme, themeSignal, customThemeName]);
+
+  // Listen for theme changes via MutationObserver on <html> class, style, and immersive data attr
+  useEffect(() => {
+    const root = document.documentElement;
+    const updateTheme = () => {
+      setIsDarkTheme(root.classList.contains('dark'));
+      setThemeSignal(getThemeSignal());
+    };
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-immersive-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  const closeTabBinding = useMemo(
+    () => keyBindings.find((binding) => binding.action === 'closeTab'),
+    [keyBindings],
+  );
+
+  const handleSave = useCallback(() => {
+    if (saving) return;
+    onSave();
+  }, [saving, onSave]);
+
+  // Keep the ref updated with the latest handleSave function
+  useEffect(() => {
+    handleSaveRef.current = handleSave;
+  }, [handleSave]);
+
+  const readClipboardText = useCallback(async (): Promise<string | null> => {
+    try {
+      if (navigator.clipboard?.readText) {
+        return await navigator.clipboard.readText();
+      }
+    } catch {
+      // Fall through to Electron bridge
+    }
+
+    try {
+      return await readClipboardTextFromBridge();
+    } catch {
+      // Both clipboard APIs unavailable; signal failure so caller can fall back.
+      return null;
+    }
+  }, [readClipboardTextFromBridge]);
+
+  useEffect(() => {
+    readClipboardTextRef.current = readClipboardText;
+  }, [readClipboardText]);
+
+  const handlePaste = useCallback(async () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const text = await readClipboardText();
+    if (text === null) {
+      // Clipboard read unavailable; fall back to Monaco's native paste.
+      editor.trigger('keyboard', 'editor.action.clipboardPasteAction', null);
+      return;
+    }
+    if (!text) return;
+
+    const selections = editor.getSelections();
+    if (!selections || selections.length === 0) return;
+
+    // Match Monaco's default multicursorPaste:'spread' behavior:
+    // distribute one line per cursor when line count equals cursor count.
+    const lines = text.split(/\r\n|\n/);
+    const distribute = selections.length > 1 && lines.length === selections.length;
+
+    editor.executeEdits(
+      'netcatty-paste',
+      selections.map((selection, i) => ({
+        range: selection,
+        text: distribute ? lines[i] : text,
+        forceMoveMarkers: true,
+      })),
+    );
+    editor.focus();
+  }, [readClipboardText]);
+
+  useEffect(() => {
+    handlePasteRef.current = handlePaste;
+  }, [handlePaste]);
+
+  const handleEditorChange = useCallback((value: string | undefined) => {
+    const editor = editorRef.current;
+    onContentChange(value ?? '', editor ? editor.saveViewState() : null);
+  }, [onContentChange]);
+
+  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
+    editorRef.current = editor;
+
+    if (initialViewState) editor.restoreViewState(initialViewState);
+
+    // Add save shortcut - use ref to avoid stale closure
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+      handleSaveRef.current();
+    });
+
+    // Add find shortcut (Ctrl+F / Cmd+F)
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
+      // Trigger Monaco's built-in find widget
+      editor.trigger('keyboard', 'actions.find', null);
+    });
+
+    // Fallback paste path for Electron environments where Monaco paste can fail.
+    // Skip custom paste when focus is inside the find/replace widget so that
+    // its input fields receive the pasted text via default browser behavior.
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
+      const active = document.activeElement;
+      if (active?.closest('.find-widget')) {
+        // Read clipboard and insert into the find/replace input field.
+        void (async () => {
+          try {
+            const text = await readClipboardTextRef.current();
+            if (!text) return;
+            // Monaco find widget inputs are <textarea> elements inside .monaco-inputbox
+            if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) {
+              const start = active.selectionStart ?? active.value.length;
+              const end = active.selectionEnd ?? active.value.length;
+              active.focus();
+              active.setSelectionRange(start, end);
+              document.execCommand('insertText', false, text);
+            }
+          } catch {
+            // Ignore – paste simply won't work
+          }
+        })();
+        return;
+      }
+      void handlePasteRef.current();
+    });
+
+    editor.focus();
+  }, [initialViewState]);
+
+  const handleDialogKeyDownCapture = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (chrome !== 'modal' || hotkeyScheme === 'disabled' || !closeTabBinding || !onRequestClose) return;
+
+    const isMac = hotkeyScheme === 'mac';
+    const keyStr = isMac ? closeTabBinding.mac : closeTabBinding.pc;
+    if (!matchesKeyBinding(e.nativeEvent, keyStr, isMac)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    e.nativeEvent.stopPropagation();
+    onRequestClose();
+  }, [chrome, closeTabBinding, hotkeyScheme, onRequestClose]);
+
+  // Trigger search dialog
+  const handleSearch = useCallback(() => {
+    if (editorRef.current) {
+      editorRef.current.trigger('keyboard', 'actions.find', null);
+      editorRef.current.focus();
+    }
+  }, []);
+
+  const supportedLanguages = useMemo(() => getSupportedLanguages(), []);
+  const monacoLanguage = useMemo(() => languageIdToMonaco(languageId), [languageId]);
+  const languageOptions = useMemo(
+    () => supportedLanguages.map((lang) => ({ value: lang.id, label: lang.name })),
+    [supportedLanguages],
+  );
+
+  return (
+    <div
+      className="h-full flex flex-col"
+      onKeyDownCapture={handleDialogKeyDownCapture}
+      data-hotkey-close-tab={chrome === 'modal' ? 'true' : undefined}
+    >
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-border/60 flex-shrink-0">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <span className="text-sm font-semibold truncate">
+              {fileName}
+            </span>
+            {saveError && <span className="text-xs text-destructive">{saveError}</span>}
+          </div>
+          <div className="flex items-center gap-2 min-w-0">
+            {/* Search button */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={handleSearch}
+              title={t('common.search')}
+            >
+              <Search size={14} />
+            </Button>
+
+            {/* Word wrap toggle */}
+            <Button
+              variant={wordWrap ? 'secondary' : 'ghost'}
+              size="icon"
+              className="h-7 w-7"
+              onClick={onToggleWordWrap}
+              title={t('sftp.editor.wordWrap')}
+            >
+              <WrapText size={14} />
+            </Button>
+
+            {/* Language selector */}
+            <Combobox
+              options={languageOptions}
+              value={languageId}
+              onValueChange={(v) => onLanguageChange(v || 'plaintext')}
+              placeholder={t('sftp.editor.syntaxHighlight')}
+              triggerClassName="h-7 max-w-[180px] min-w-[120px] text-xs"
+            />
+
+            {/* Save button */}
+            <Button
+              variant="default"
+              size="sm"
+              className="h-7"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? (
+                <Loader2 size={14} className="mr-1.5 animate-spin" />
+              ) : (
+                <CloudUpload size={14} className="mr-1.5" />
+              )}
+              {saving ? t('sftp.editor.saving') : t('sftp.editor.save')}
+            </Button>
+
+            {/* Maximize button — modal chrome only, when onPromoteToTab is provided */}
+            {chrome === 'modal' && onPromoteToTab && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={onPromoteToTab}
+                title={t('sftp.editor.maximize')}
+              >
+                <Maximize2 size={14} />
+              </Button>
+            )}
+
+            {/* Close button — modal chrome only */}
+            {chrome === 'modal' && onRequestClose && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={onRequestClose}
+              >
+                <X size={14} />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Monaco Editor */}
+      <div className="flex-1 min-h-0 relative">
+        <Editor
+          height="100%"
+          language={monacoLanguage}
+          value={content}
+          onChange={handleEditorChange}
+          onMount={handleEditorMount}
+          theme={customThemeName}
+          loading={
+            <div className="absolute inset-0 flex items-center justify-center bg-background">
+              <Loader2 size={32} className="animate-spin text-muted-foreground" />
+            </div>
+          }
+          options={{
+            // Prefer native context menu in Electron so right-click Paste uses OS clipboard path.
+            contextmenu: false,
+            minimap: { enabled: true },
+            fontSize: 14,
+            lineNumbers: 'on',
+            roundedSelection: false,
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 2,
+            insertSpaces: true,
+            wordWrap: wordWrap ? 'on' : 'off',
+            folding: true,
+            renderWhitespace: 'selection',
+            bracketPairColorization: { enabled: true },
+            find: {
+              addExtraSpaceOnTop: false,
+              autoFindInSelection: 'never',
+              seedSearchStringFromSelection: 'selection',
+            },
+          }}
+        />
+      </div>
+
+      {/* Footer */}
+      <div className="px-4 py-2 border-t border-border/60 flex items-center justify-between text-xs text-muted-foreground bg-muted/30 flex-shrink-0">
+        <span>
+          {getLanguageName(languageId)}
+        </span>
+        <span>
+          {content.split('\n').length} lines • {content.length} characters
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default TextEditorPane;

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -196,6 +196,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
 
   // Ref to store the latest save function to avoid stale closure in keyboard shortcut
   const handleSaveRef = useRef<() => void>(() => {});
+  const handleCloseRef = useRef<(() => void) | null>(null);
   const handlePasteRef = useRef<() => Promise<void>>(() => Promise.resolve());
   const readClipboardTextRef = useRef<() => Promise<string | null>>(() => Promise.resolve(null));
 
@@ -280,6 +281,12 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
     handleSaveRef.current = handleSave;
   }, [handleSave]);
 
+  // Keep the close ref fresh so the Monaco Cmd/Ctrl+W command invokes the
+  // latest onRequestClose handler without re-binding the Monaco command.
+  useEffect(() => {
+    handleCloseRef.current = onRequestClose ?? null;
+  }, [onRequestClose]);
+
   const readClipboardText = useCallback(async (): Promise<string | null> => {
     try {
       if (navigator.clipboard?.readText) {
@@ -351,6 +358,14 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
       handleSaveRef.current();
     });
 
+    // Close-tab shortcut inside Monaco. The capture-phase keydown on the
+    // Pane's root div also tries to handle this, but Monaco's internal
+    // key-event dispatcher fires first for focused editor keystrokes, so
+    // registering the command here is the reliable path.
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyW, () => {
+      handleCloseRef.current?.();
+    });
+
     // Add find shortcut (Ctrl+F / Cmd+F)
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => {
       // Trigger Monaco's built-in find widget
@@ -388,8 +403,11 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
     editor.focus();
   }, [initialViewState]);
 
+  // Capture-phase close-tab hotkey handler. Runs in both modal and tab chrome
+  // so Cmd/Ctrl+W works even when focus is inside Monaco (which otherwise
+  // swallows the event). Requires an `onRequestClose` prop from the parent.
   const handleDialogKeyDownCapture = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (chrome !== 'modal' || hotkeyScheme === 'disabled' || !closeTabBinding || !onRequestClose) return;
+    if (hotkeyScheme === 'disabled' || !closeTabBinding || !onRequestClose) return;
 
     const isMac = hotkeyScheme === 'mac';
     const keyStr = isMac ? closeTabBinding.mac : closeTabBinding.pc;
@@ -399,7 +417,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
     e.stopPropagation();
     e.nativeEvent.stopPropagation();
     onRequestClose();
-  }, [chrome, closeTabBinding, hotkeyScheme, onRequestClose]);
+  }, [closeTabBinding, hotkeyScheme, onRequestClose]);
 
   // Trigger search dialog
   const handleSearch = useCallback(() => {

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -82,9 +82,12 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
     // all fill their flex-1 parent via `absolute inset-0`. Match that here so
     // an inactive editor tab doesn't collapse to zero height in normal flow,
     // and an active one fills the viewport instead of stacking beneath others.
+    // z-index high enough to stay above the TerminalLayer's inner `z-10` panels
+    // (TerminalLayer root is visibility:hidden when editor tabs are active, but
+    // its children's stacking contexts can still overlap without an explicit z.)
     <div
-      style={{ display: isVisible ? undefined : 'none' }}
-      className="absolute inset-0 min-h-0 flex flex-col"
+      style={{ display: isVisible ? undefined : 'none', zIndex: 20 }}
+      className="absolute inset-0 min-h-0 flex flex-col bg-background"
     >
       <TextEditorPane
         chrome="tab"

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -11,6 +11,7 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import { editorSftpWrite } from '../../application/state/editorSftpBridge';
 import { editorTabStore, useEditorTab, type EditorTabId } from '../../application/state/editorTabStore';
 import type { HotkeyScheme, KeyBinding } from '../../domain/models';
+import type { Host } from '../../types';
 import { toast } from '../ui/toast';
 import { TextEditorPane } from './TextEditorPane';
 
@@ -20,6 +21,8 @@ export interface TextEditorTabViewProps {
   isVisible: boolean;
   hotkeyScheme: HotkeyScheme;
   keyBindings: KeyBinding[];
+  /** Host lookup for building the `host:remotePath` subtitle next to the filename. */
+  hostById: Map<string, Host>;
 }
 
 export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
@@ -27,6 +30,7 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   isVisible,
   hotkeyScheme,
   keyBindings,
+  hostById,
 }) => {
   const { t } = useI18n();
   const tab = useEditorTab(tabId);
@@ -76,6 +80,12 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   if (!tab) return null;
 
   const isDirty = tab.content !== tab.baselineContent;
+  // Subtitle shown next to the filename in the Pane header, e.g.
+  // "Rainyun-114.66.26.174:/root/hello-server.go". Falls back to hostId when
+  // we don't have a Host record (session may have been removed).
+  const host = hostById.get(tab.hostId);
+  const hostLabel = host?.label ?? tab.hostId;
+  const subtitle = `${hostLabel}:${tab.remotePath}`;
 
   return (
     // Sibling tab panels (VaultView, SftpView, TerminalLayerMount, LogView)
@@ -92,6 +102,7 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
       <TextEditorPane
         chrome="tab"
         fileName={`${tab.fileName}${isDirty ? ' *' : ''}`}
+        subtitle={subtitle}
         content={tab.content}
         languageId={tab.languageId}
         wordWrap={tab.wordWrap}

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -78,7 +78,14 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   const isDirty = tab.content !== tab.baselineContent;
 
   return (
-    <div style={{ display: isVisible ? undefined : 'none' }} className="h-full">
+    // Sibling tab panels (VaultView, SftpView, TerminalLayerMount, LogView)
+    // all fill their flex-1 parent via `absolute inset-0`. Match that here so
+    // an inactive editor tab doesn't collapse to zero height in normal flow,
+    // and an active one fills the viewport instead of stacking beneath others.
+    <div
+      style={{ display: isVisible ? undefined : 'none' }}
+      className="absolute inset-0 min-h-0 flex flex-col"
+    >
       <TextEditorPane
         chrome="tab"
         fileName={`${tab.fileName}${isDirty ? ' *' : ''}`}

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -46,25 +46,30 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   );
 
   const handleToggleWordWrap = useCallback(() => {
-    if (!tab) return;
-    editorTabStore.setWordWrap(tabId, !tab.wordWrap);
-  }, [tabId, tab]);
+    const current = editorTabStore.getTab(tabId);
+    if (!current) return;
+    editorTabStore.setWordWrap(tabId, !current.wordWrap);
+  }, [tabId]);
 
   const handleSave = useCallback(async () => {
-    if (!tab) return;
-    if (tab.savingState === 'saving') return;
+    // Read live store state at call time — React state snapshot lags the store
+    // by one microtask, so a keystroke between onChange and this save would
+    // otherwise leave us writing stale content and marking a stale baseline.
+    const current = editorTabStore.getTab(tabId);
+    if (!current) return;
+    if (current.savingState === 'saving') return;
 
     editorTabStore.setSavingState(tabId, 'saving');
     try {
-      await editorSftpWrite(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
-      editorTabStore.markSaved(tabId, tab.content);
+      await editorSftpWrite(current.sessionId, current.hostId, current.remotePath, current.content);
+      editorTabStore.markSaved(tabId, current.content);
       toast.success(t('sftp.editor.saved'), 'SFTP');
     } catch (e) {
       const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
       editorTabStore.setSavingState(tabId, 'error', msg);
       toast.error(msg, 'SFTP');
     }
-  }, [tab, tabId, t]);
+  }, [tabId, t]);
 
   // Tab has been closed — render nothing (parent should remove this instance,
   // but guard here in case of a transient render before unmount).

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -1,0 +1,97 @@
+/**
+ * TextEditorTabView — thin wrapper that binds an editorTab entry to TextEditorPane.
+ *
+ * Each tab has its own instance (keyed by tabId), so Monaco is never torn down
+ * on tab-switch — we just toggle CSS visibility via the `isVisible` prop.
+ */
+import type * as Monaco from 'monaco-editor';
+import React, { useCallback } from 'react';
+
+import { useI18n } from '../../application/i18n/I18nProvider';
+import { editorSftpWrite } from '../../application/state/editorSftpBridge';
+import { editorTabStore, useEditorTab, type EditorTabId } from '../../application/state/editorTabStore';
+import type { HotkeyScheme, KeyBinding } from '../../domain/models';
+import { toast } from '../ui/toast';
+import { TextEditorPane } from './TextEditorPane';
+
+export interface TextEditorTabViewProps {
+  tabId: EditorTabId;
+  /** When false the view is hidden via display:none so the Monaco instance persists. */
+  isVisible: boolean;
+  hotkeyScheme: HotkeyScheme;
+  keyBindings: KeyBinding[];
+}
+
+export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
+  tabId,
+  isVisible,
+  hotkeyScheme,
+  keyBindings,
+}) => {
+  const { t } = useI18n();
+  const tab = useEditorTab(tabId);
+
+  const handleContentChange = useCallback(
+    (content: string, viewState: Monaco.editor.ICodeEditorViewState | null) => {
+      editorTabStore.updateContent(tabId, content, viewState);
+    },
+    [tabId],
+  );
+
+  const handleLanguageChange = useCallback(
+    (lang: string) => {
+      editorTabStore.setLanguage(tabId, lang);
+    },
+    [tabId],
+  );
+
+  const handleToggleWordWrap = useCallback(() => {
+    if (!tab) return;
+    editorTabStore.setWordWrap(tabId, !tab.wordWrap);
+  }, [tabId, tab]);
+
+  const handleSave = useCallback(async () => {
+    if (!tab) return;
+    if (tab.savingState === 'saving') return;
+
+    editorTabStore.setSavingState(tabId, 'saving');
+    try {
+      await editorSftpWrite(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
+      editorTabStore.markSaved(tabId, tab.content);
+      toast.success(t('sftp.editor.saved'), 'SFTP');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
+      editorTabStore.setSavingState(tabId, 'error', msg);
+      toast.error(msg, 'SFTP');
+    }
+  }, [tab, tabId, t]);
+
+  // Tab has been closed — render nothing (parent should remove this instance,
+  // but guard here in case of a transient render before unmount).
+  if (!tab) return null;
+
+  const isDirty = tab.content !== tab.baselineContent;
+
+  return (
+    <div style={{ display: isVisible ? undefined : 'none' }} className="h-full">
+      <TextEditorPane
+        chrome="tab"
+        fileName={`${tab.fileName}${isDirty ? ' *' : ''}`}
+        content={tab.content}
+        languageId={tab.languageId}
+        wordWrap={tab.wordWrap}
+        saving={tab.savingState === 'saving'}
+        saveError={tab.saveError}
+        hotkeyScheme={hotkeyScheme}
+        keyBindings={keyBindings}
+        onContentChange={handleContentChange}
+        onLanguageChange={handleLanguageChange}
+        onToggleWordWrap={handleToggleWordWrap}
+        onSave={handleSave}
+        initialViewState={tab.viewState}
+      />
+    </div>
+  );
+};
+
+export default TextEditorTabView;

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -23,6 +23,9 @@ export interface TextEditorTabViewProps {
   keyBindings: KeyBinding[];
   /** Host lookup for building the `host:remotePath` subtitle next to the filename. */
   hostById: Map<string, Host>;
+  /** Routed into Monaco's Cmd/Ctrl+W command so closing the editor tab works
+   * even when focus is inside the editor (Monaco otherwise swallows the event). */
+  onRequestClose: (tabId: EditorTabId) => void;
 }
 
 export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
@@ -31,6 +34,7 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   hotkeyScheme,
   keyBindings,
   hostById,
+  onRequestClose,
 }) => {
   const { t } = useI18n();
   const tab = useEditorTab(tabId);
@@ -103,6 +107,7 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
         chrome="tab"
         fileName={`${tab.fileName}${isDirty ? ' *' : ''}`}
         subtitle={subtitle}
+        onRequestClose={() => onRequestClose(tabId)}
         content={tab.content}
         languageId={tab.languageId}
         wordWrap={tab.wordWrap}

--- a/components/editor/UnsavedChangesDialog.tsx
+++ b/components/editor/UnsavedChangesDialog.tsx
@@ -41,6 +41,13 @@ export const UnsavedChangesProvider: React.FC<{
     [],
   );
 
+  // Register the prompt function as the module-level singleton so it can be
+  // called from outside the React tree (e.g. useSftpViewPaneActions).
+  useEffect(() => {
+    promptSingleton = prompt;
+    return () => { promptSingleton = null; };
+  }, [prompt]);
+
   // On unmount, resolve any in-flight prompt as "cancel" so awaiting callers don't leak.
   useEffect(() => () => {
     const prior = pendingRef.current;
@@ -82,4 +89,16 @@ export const UnsavedChangesProvider: React.FC<{
       </Dialog>
     </>
   );
+};
+
+// ---------------------------------------------------------------------------
+// Module-level singleton — lets non-React code call the dialog without
+// prop-drilling. Registered/unregistered by UnsavedChangesProvider above.
+// ---------------------------------------------------------------------------
+
+let promptSingleton: ((fileName: string) => Promise<UnsavedChoice>) | null = null;
+
+export const promptUnsavedChanges = (fileName: string): Promise<UnsavedChoice> => {
+  if (!promptSingleton) return Promise.resolve("cancel");
+  return promptSingleton(fileName);
 };

--- a/components/editor/UnsavedChangesDialog.tsx
+++ b/components/editor/UnsavedChangesDialog.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useState } from "react";
+import { useI18n } from "../../application/i18n/I18nProvider";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+
+export type UnsavedChoice = "save" | "discard" | "cancel";
+
+interface Pending {
+  fileName: string;
+  resolve: (choice: UnsavedChoice) => void;
+}
+
+interface UnsavedChangesAPI {
+  prompt: (fileName: string) => Promise<UnsavedChoice>;
+}
+
+export const UnsavedChangesProvider: React.FC<{
+  children: (api: UnsavedChangesAPI) => React.ReactNode;
+}> = ({ children }) => {
+  const { t } = useI18n();
+  const [pending, setPending] = useState<Pending | null>(null);
+
+  const prompt = useCallback(
+    (fileName: string) =>
+      new Promise<UnsavedChoice>((resolve) => {
+        setPending({ fileName, resolve });
+      }),
+    [],
+  );
+
+  const resolveWith = useCallback((choice: UnsavedChoice) => {
+    if (!pending) return;
+    pending.resolve(choice);
+    setPending(null);
+  }, [pending]);
+
+  return (
+    <>
+      {children({ prompt })}
+      <Dialog open={!!pending} onOpenChange={(o) => { if (!o) resolveWith("cancel"); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("sftp.editor.unsavedTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("sftp.editor.unsavedMessage", { fileName: pending?.fileName ?? "" })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button variant="ghost" onClick={() => resolveWith("cancel")}>
+              {t("common.cancel")}
+            </Button>
+            <Button variant="outline" onClick={() => resolveWith("discard")}>
+              {t("sftp.editor.discardChanges")}
+            </Button>
+            <Button variant="default" onClick={() => resolveWith("save")}>
+              {t("sftp.editor.saveAndClose")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/components/editor/UnsavedChangesDialog.tsx
+++ b/components/editor/UnsavedChangesDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useI18n } from "../../application/i18n/I18nProvider";
 import { Button } from "../ui/button";
 import {
@@ -26,14 +26,29 @@ export const UnsavedChangesProvider: React.FC<{
 }> = ({ children }) => {
   const { t } = useI18n();
   const [pending, setPending] = useState<Pending | null>(null);
+  const pendingRef = useRef<Pending | null>(null);
+  pendingRef.current = pending;
 
   const prompt = useCallback(
     (fileName: string) =>
       new Promise<UnsavedChoice>((resolve) => {
+        // Re-entrance: if a prior prompt is still pending, cancel it so its caller
+        // doesn't hang forever waiting for a resolve that now belongs to a new prompt.
+        const prior = pendingRef.current;
+        if (prior) prior.resolve("cancel");
         setPending({ fileName, resolve });
       }),
     [],
   );
+
+  // On unmount, resolve any in-flight prompt as "cancel" so awaiting callers don't leak.
+  useEffect(() => () => {
+    const prior = pendingRef.current;
+    if (prior) {
+      prior.resolve("cancel");
+      pendingRef.current = null;
+    }
+  }, []);
 
   const resolveWith = useCallback((choice: UnsavedChoice) => {
     if (!pending) return;

--- a/components/sftp/SftpContext.tsx
+++ b/components/sftp/SftpContext.tsx
@@ -20,7 +20,7 @@ export interface SftpTransferSource {
 // Types for the context
 export interface SftpPaneCallbacks {
     onConnect: (host: Host | "local") => void;
-    onDisconnect: () => void;
+    onDisconnect: () => Promise<void>;
     onPrepareSelection: () => void;
     onNavigateTo: (path: string) => void;
     onNavigateUp: () => void;

--- a/components/sftp/SftpOverlays.tsx
+++ b/components/sftp/SftpOverlays.tsx
@@ -5,6 +5,7 @@ import type { useSftpState } from "../../application/state/useSftpState";
 import type { HotkeyScheme, KeyBinding } from "../../domain/models";
 import FileOpenerDialog from "../FileOpenerDialog";
 import TextEditorModal from "../TextEditorModal";
+import type { TextEditorModalSnapshot } from "../TextEditorModal";
 import { SftpConflictDialog, SftpHostPicker, SftpPermissionsDialog } from "./index";
 import { SftpTransferQueue } from "./SftpTransferQueue";
 
@@ -44,6 +45,7 @@ interface SftpOverlaysProps {
   setFileOpenerTarget: (target: { file: SftpFileEntry; side: "left" | "right"; fullPath: string } | null) => void;
   handleFileOpenerSelect: (openerType: FileOpenerType, setAsDefault: boolean, systemApp?: SystemAppInfo) => void;
   handleSelectSystemApp: (systemApp: { path: string; name: string }) => void;
+  onPromoteToTab?: (snapshot: TextEditorModalSnapshot) => void;
 }
 
 export const SftpOverlays: React.FC<SftpOverlaysProps> = React.memo(({
@@ -80,6 +82,7 @@ export const SftpOverlays: React.FC<SftpOverlaysProps> = React.memo(({
   setFileOpenerTarget,
   handleFileOpenerSelect,
   handleSelectSystemApp,
+  onPromoteToTab,
 }) => {
   return (
     <>
@@ -146,6 +149,7 @@ export const SftpOverlays: React.FC<SftpOverlaysProps> = React.memo(({
         onToggleWordWrap={() => setEditorWordWrap(!editorWordWrap)}
         hotkeyScheme={hotkeyScheme}
         keyBindings={keyBindings}
+        onPromoteToTab={onPromoteToTab}
       />
 
       {/* File Opener Dialog */}

--- a/components/sftp/SftpPaneDialogs.tsx
+++ b/components/sftp/SftpPaneDialogs.tsx
@@ -61,7 +61,7 @@ interface SftpPaneDialogsProps {
   hostSearch: string;
   setHostSearch: (value: string) => void;
   onConnect: (host: Host | "local") => void;
-  onDisconnect: () => void;
+  onDisconnect: () => Promise<void>;
 }
 
 const HostHint: React.FC<{ label?: string }> = ({ label }) =>
@@ -357,12 +357,12 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
       side={side}
       hostSearch={hostSearch}
       onHostSearchChange={setHostSearch}
-      onSelectLocal={() => {
-        onDisconnect();
+      onSelectLocal={async () => {
+        await onDisconnect();
         onConnect("local");
       }}
-      onSelectHost={(host) => {
-        onDisconnect();
+      onSelectHost={async (host) => {
+        await onDisconnect();
         onConnect(host);
       }}
     />

--- a/components/sftp/hooks/useSftpViewFileOps.ts
+++ b/components/sftp/hooks/useSftpViewFileOps.ts
@@ -5,8 +5,11 @@ import { getParentPath, joinPath as joinFsPath } from "../../../application/stat
 import type { SftpStateApi } from "../../../application/state/useSftpState";
 import { logger } from "../../../lib/logger";
 import { toast } from "../../ui/toast";
-import { getFileExtension, FileOpenerType, SystemAppInfo } from "../../../lib/sftpFileUtils";
+import { getFileExtension, getLanguageId, FileOpenerType, SystemAppInfo } from "../../../lib/sftpFileUtils";
 import { isNavigableDirectory } from "../index";
+import { editorTabStore } from "../../../application/state/editorTabStore";
+import { toEditorTabId, activeTabStore } from "../../../application/state/activeTabStore";
+import type { TextEditorModalSnapshot } from "../../TextEditorModal";
 
 interface UseSftpViewFileOpsParams {
   sftpRef: MutableRefObject<SftpStateApi>;
@@ -80,6 +83,7 @@ interface UseSftpViewFileOpsResult {
     } | null>
   >;
   handleSaveTextFile: (content: string) => Promise<void>;
+  onPromoteToTab: (snapshot: TextEditorModalSnapshot) => void;
   handleFileOpenerSelect: (
     openerType: FileOpenerType,
     setAsDefault: boolean,
@@ -297,6 +301,31 @@ export const useSftpViewFileOps = ({
     },
     [sftpRef],
   );
+
+  const handlePromoteToTab = useCallback((snapshot: TextEditorModalSnapshot) => {
+    const target = textEditorTargetRef.current;
+    if (!target) return;
+    const pane = target.side === "left" ? sftpRef.current.leftPane : sftpRef.current.rightPane;
+    const connection = pane.connection;
+    if (!connection || !target.hostId) return;
+
+    const editorId = editorTabStore.promoteFromModal({
+      sessionId: connection.id,
+      hostId: target.hostId,
+      remotePath: target.fullPath,
+      fileName: target.file.name,
+      languageId: snapshot.languageId || getLanguageId(target.file.name),
+      content: snapshot.content,
+      baselineContent: snapshot.baselineContent,
+      wordWrap: snapshot.wordWrap,
+      viewState: snapshot.viewState,
+    });
+    activeTabStore.setActiveTabId(toEditorTabId(editorId));
+    // Close the modal
+    setShowTextEditor(false);
+    setTextEditorTarget(null);
+    setTextEditorContent("");
+  }, [sftpRef]);
 
   const onEditFileLeft = useCallback(
     (file: SftpFileEntry, fullPath?: string) => handleEditFileForSide("left", file, fullPath),
@@ -664,6 +693,7 @@ export const useSftpViewFileOps = ({
     fileOpenerTarget,
     setFileOpenerTarget,
     handleSaveTextFile,
+    onPromoteToTab: handlePromoteToTab,
     handleFileOpenerSelect,
     handleSelectSystemApp,
     onEditPermissionsLeft,

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -3,6 +3,9 @@ import type { MutableRefObject } from "react";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
 import type { SftpDragCallbacks, SftpTransferSource } from "../SftpContext";
 import { keepOnlyActivePaneSelections } from "./selectionScope";
+import { editorTabStore } from "../../../application/state/editorTabStore";
+import type { EditorTab, EditorTabId } from "../../../application/state/editorTabStore";
+import { promptUnsavedChanges } from "../../editor/UnsavedChangesDialog";
 
 interface UseSftpViewPaneActionsParams {
   sftpRef: MutableRefObject<SftpStateApi>;
@@ -127,8 +130,36 @@ export const useSftpViewPaneActions = ({
     (host: Parameters<SftpStateApi["connect"]>[1]) => sftpRef.current.connect("right", host),
     [sftpRef],
   );
-  const onDisconnectLeft = useCallback(() => sftpRef.current.disconnect("left"), [sftpRef]);
-  const onDisconnectRight = useCallback(() => sftpRef.current.disconnect("right"), [sftpRef]);
+  const onDisconnectLeft = useCallback(async () => {
+    const connectionId = sftpRef.current.getActivePane("left")?.connection?.id;
+    if (connectionId) {
+      const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
+      const saveTab = async (id: EditorTabId) => {
+        const tab = editorTabStore.getTab(id);
+        if (!tab) return;
+        await sftpRef.current.writeTextFileByConnection(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
+        editorTabStore.markSaved(id, tab.content);
+      };
+      const ok = await editorTabStore.confirmCloseBySession(connectionId, choice, saveTab);
+      if (!ok) return;
+    }
+    sftpRef.current.disconnect("left");
+  }, [sftpRef]);
+  const onDisconnectRight = useCallback(async () => {
+    const connectionId = sftpRef.current.getActivePane("right")?.connection?.id;
+    if (connectionId) {
+      const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
+      const saveTab = async (id: EditorTabId) => {
+        const tab = editorTabStore.getTab(id);
+        if (!tab) return;
+        await sftpRef.current.writeTextFileByConnection(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
+        editorTabStore.markSaved(id, tab.content);
+      };
+      const ok = await editorTabStore.confirmCloseBySession(connectionId, choice, saveTab);
+      if (!ok) return;
+    }
+    sftpRef.current.disconnect("right");
+  }, [sftpRef]);
   const onPrepareSelectionLeft = useCallback(() => {
     keepOnlyActivePaneSelections(sftpRef.current, "left");
   }, [sftpRef]);

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -16,8 +16,8 @@ interface UseSftpViewPaneActionsResult {
   draggedFiles: (SftpTransferSource & { side: "left" | "right" })[] | null;
   onConnectLeft: (host: Parameters<SftpStateApi["connect"]>[1]) => void;
   onConnectRight: (host: Parameters<SftpStateApi["connect"]>[1]) => void;
-  onDisconnectLeft: () => void;
-  onDisconnectRight: () => void;
+  onDisconnectLeft: () => Promise<void>;
+  onDisconnectRight: () => Promise<void>;
   onPrepareSelectionLeft: () => void;
   onPrepareSelectionRight: () => void;
   onNavigateToLeft: (path: string) => void;

--- a/components/sftp/hooks/useSftpViewPaneCallbacks.ts
+++ b/components/sftp/hooks/useSftpViewPaneCallbacks.ts
@@ -232,6 +232,7 @@ export const useSftpViewPaneCallbacks = ({
     fileOpenerTarget: fileOps.fileOpenerTarget,
     setFileOpenerTarget: fileOps.setFileOpenerTarget,
     handleSaveTextFile: fileOps.handleSaveTextFile,
+    onPromoteToTab: fileOps.onPromoteToTab,
     handleFileOpenerSelect: fileOps.handleFileOpenerSelect,
     handleSelectSystemApp: fileOps.handleSelectSystemApp,
   };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1203,7 +1203,19 @@ if (!gotLock) {
     quitGuardChannelBusy = true;
     event.preventDefault();
     win.webContents.send("app:query-dirty-editors");
+
+    // Timeout fallback: if the renderer never replies (crash, unhandled
+    // exception in the listener, etc.) we would otherwise be stuck with
+    // quitGuardChannelBusy=true and the app becomes un-quittable. After
+    // 5 s assume no dirty editors and proceed.
+    const timeoutId = setTimeout(() => {
+      _ipcMain.removeAllListeners("app:dirty-editors-result");
+      quitGuardChannelBusy = false;
+      app.quit();
+    }, 5000);
+
     _ipcMain.once("app:dirty-editors-result", (_evt, { hasDirty }) => {
+      clearTimeout(timeoutId);
       quitGuardChannelBusy = false;
       if (!hasDirty) {
         // No dirty editors — proceed with quit.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1184,8 +1184,33 @@ if (!gotLock) {
     }
   });
 
-  app.on("before-quit", () => {
+  // Re-entry guard: prevents the handler from firing a second time while the
+  // async dirty-editor check is still in flight.
+  let quitGuardChannelBusy = false;
+
+  app.on("before-quit", (event) => {
     getWindowManager().setIsQuitting(true);
+
+    // If the guard is busy we're in the second pass triggered by app.quit()
+    // after the renderer confirmed no dirty editors — let it through.
+    if (quitGuardChannelBusy) return;
+
+    const { ipcMain: _ipcMain } = electronModule;
+    const win = BrowserWindow.getAllWindows()[0];
+    // No window — nothing to check; let the quit proceed.
+    if (!win || win.isDestroyed?.()) return;
+
+    quitGuardChannelBusy = true;
+    event.preventDefault();
+    win.webContents.send("app:query-dirty-editors");
+    _ipcMain.once("app:dirty-editors-result", (_evt, { hasDirty }) => {
+      quitGuardChannelBusy = false;
+      if (!hasDirty) {
+        // No dirty editors — proceed with quit.
+        app.quit();
+      }
+      // If hasDirty === true the renderer has shown a toast; stay put.
+    });
   });
 
   // Cleanup all PTY sessions and port forwarding tunnels before quitting

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1184,16 +1184,35 @@ if (!gotLock) {
     }
   });
 
-  // Re-entry guard: prevents the handler from firing a second time while the
-  // async dirty-editor check is still in flight.
+  // Quit guard state:
+  // - quitConfirmed: once true, before-quit falls through without re-checking.
+  //   Set right before we call app.quit() after a successful dirty-editor check,
+  //   so the re-entered before-quit doesn't loop back into another check.
+  // - quitGuardChannelBusy: prevents a second check from being started while the
+  //   first round-trip is still in flight.
+  // Note: both are intentionally NOT reset on the dirty=true path — if the user
+  // cancels quit to save, a subsequent Cmd+Q re-enters with quitConfirmed=false
+  // and quitGuardChannelBusy=false (reset in the once/timeout handlers), which
+  // kicks off a fresh check as expected.
   let quitGuardChannelBusy = false;
+  let quitConfirmed = false;
+
+  // 5s timeout: long enough for the renderer to show a toast before reporting
+  // back, short enough that a hung renderer doesn't strand the app forever.
+  const QUIT_GUARD_TIMEOUT_MS = 5000;
 
   app.on("before-quit", (event) => {
     getWindowManager().setIsQuitting(true);
 
-    // If the guard is busy we're in the second pass triggered by app.quit()
-    // after the renderer confirmed no dirty editors — let it through.
-    if (quitGuardChannelBusy) return;
+    // Fast path: we've already confirmed the quit once; let this re-entry through.
+    if (quitConfirmed) return;
+
+    // A check is already in flight — swallow this event; the in-flight handler
+    // will issue app.quit() when it completes if appropriate.
+    if (quitGuardChannelBusy) {
+      event.preventDefault();
+      return;
+    }
 
     const { ipcMain: _ipcMain } = electronModule;
     const win = BrowserWindow.getAllWindows()[0];
@@ -1205,20 +1224,22 @@ if (!gotLock) {
     win.webContents.send("app:query-dirty-editors");
 
     // Timeout fallback: if the renderer never replies (crash, unhandled
-    // exception in the listener, etc.) we would otherwise be stuck with
-    // quitGuardChannelBusy=true and the app becomes un-quittable. After
-    // 5 s assume no dirty editors and proceed.
+    // exception in the listener, etc.) we'd otherwise be stuck with
+    // quitGuardChannelBusy=true and the app un-quittable.
     const timeoutId = setTimeout(() => {
       _ipcMain.removeAllListeners("app:dirty-editors-result");
       quitGuardChannelBusy = false;
+      quitConfirmed = true;
       app.quit();
-    }, 5000);
+    }, QUIT_GUARD_TIMEOUT_MS);
 
     _ipcMain.once("app:dirty-editors-result", (_evt, { hasDirty }) => {
       clearTimeout(timeoutId);
       quitGuardChannelBusy = false;
       if (!hasDirty) {
-        // No dirty editors — proceed with quit.
+        // No dirty editors — commit to quitting before app.quit() re-fires
+        // before-quit so the re-entry hits the quitConfirmed fast path.
+        quitConfirmed = true;
         app.quit();
       }
       // If hasDirty === true the renderer has shown a toast; stay put.

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -894,6 +894,16 @@ const api = {
 
   // Tell main process the renderer has mounted/painted (used to avoid initial blank screen).
   rendererReady: () => ipcRenderer.send("netcatty:renderer:ready"),
+
+  // Quit guard: main process asks whether any editor tabs have unsaved changes.
+  // Returns an unsubscribe function so React effects can clean up on unmount.
+  onCheckDirtyEditors: (listener) => {
+    const handler = () => listener();
+    ipcRenderer.on("app:query-dirty-editors", handler);
+    return () => ipcRenderer.removeListener("app:query-dirty-editors", handler);
+  },
+  // Renderer reports the dirty-check result back to the main process.
+  reportDirtyEditorsResult: (hasDirty) => ipcRenderer.send("app:dirty-editors-result", { hasDirty }),
   
   // Port Forwarding API
   startPortForward: async (options) => {

--- a/global.d.ts
+++ b/global.d.ts
@@ -587,6 +587,12 @@ declare global {
     // Notify main process the renderer has mounted/painted (used to avoid initial blank screen).
     rendererReady?(): void;
 
+    // Quit guard: subscribe to main-process quit requests that query for dirty editors.
+    // Listener is called with no arguments; return value is an unsubscribe function.
+    onCheckDirtyEditors?(listener: () => void): () => void;
+    // Report the dirty-check result back to the main process.
+    reportDirtyEditorsResult?(hasDirty: boolean): void;
+
     onLanguageChanged?(cb: (language: string) => void): () => void;
 
     // Chain progress listener for jump host connections


### PR DESCRIPTION
Closes #631 — the editor modal can now be "maximized" to a top-level tab, enabling multi-open and coexistence with terminals/SFTP.

## Summary

- **Modal stays as default** for quick edits. A new ⛶ button in the modal header promotes the current buffer into a top-level tab (single-way transition, per-session-path dedup).
- **Tab form** is peer-level with Vaults / SFTP / terminal tabs, keyed so each carries its own Monaco instance across tab switches (no re-mount).
- **Dirty tracking** via ● dot on the tab + three-button confirm dialog (Save / Discard / Cancel) on close, session disconnect, and app quit.
- **Multi-open** works out of the box; same file re-opened from modal focuses the existing tab and overwrites content (spec'd "dirty merge").
- **Lifecycle coupling**: closing an SFTP session prompts dirty tabs first; closing the terminal tab that hosted the editor force-closes associated tabs (connection gone, no recoverable save path); app quit is blocked while any dirty tab exists.
- **Tab header** shows `fileName` + muted `hostLabel:remotePath` subtitle, disambiguating same-named files across hosts.

## Non-goals (explicit, deferred)

- Tab → Modal reverse transition
- Persistence across app restart
- Detached BrowserWindow (PR2)
- External-change conflict detection
- Diff/split view
- Local-file (non-SFTP) editing

## Architecture

- `application/state/editorTabStore.ts` — class singleton + \`useSyncExternalStore\` hooks, 13 unit tests covering dedup, dirty derivation, save flows, batch close with cancel/save/discard.
- `application/state/editorSftpBridge.ts` — out-of-React save channel; `Set<writer>` with per-connection dispatch so both `SftpView` and per-terminal `SftpSidePanel` can register their own `useSftpState` instance.
- `application/state/sftp/useSftpExternalOperations.ts` — new `writeTextFileByConnection(connectionId, expectedHostId, …)` for pane-agnostic saves with `hostId` safety check.
- `components/editor/TextEditorPane.tsx` — pure controlled Monaco body extracted from the modal; consumed by both the modal shell and `TextEditorTabView`.
- `components/editor/UnsavedChangesDialog.tsx` — three-button dialog with re-entrance + unmount leak protection, module-level `promptUnsavedChanges` singleton for non-React callers.
- `electron/main.cjs` + `preload.cjs` — quit-guard IPC with re-entry flag, 5 s timeout fallback.

## Test plan

- [x] `npm test` — 212/212 passing (199 baseline + 13 new store tests)
- [x] `npx tsc --noEmit` — zero new errors (18 pre-existing in unrelated files, same count as main)
- [x] `npx eslint` on all touched files — clean
- [x] Manual (macOS): double-click SFTP file → modal → ⛶ maximize → editor tab mounted and active
- [x] Edit → save → ● dot clears, toast success
- [x] Open 3 files → all independent, each tracks its own dirty state
- [x] Same file re-opened from modal → focuses existing tab (dedup)
- [x] Cmd+W inside Monaco → dirty confirm → Save / Discard / Cancel all behave correctly
- [x] Close SFTP session with dirty tab → batch prompt → cancel aborts disconnect
- [x] Close terminal hosting the editor → associated tabs force-close, active tab falls back to Vaults when appropriate
- [x] Cmd+Q with dirty tabs → blocked, toast warns; save all → Cmd+Q again → quits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)