### PR TITLE
fix(ssh): include legacy HMACs for very old servers (closes #807)

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -7,6 +7,7 @@ const net = require("node:net");
 const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
+const crypto = require("node:crypto");
 const { exec } = require("node:child_process");
 const { Client: SSHClient, utils: sshUtils } = require("ssh2");
 const { NetcattyAgent } = require("./netcattyAgent.cjs");
@@ -251,6 +252,19 @@ const log = (msg, data) => {
   console.log("[SSH]", msg, data ? JSON.stringify(data, null, 2) : "");
 };
 
+// FIPS-enabled OpenSSL builds disable MD5. Feature-detect once so the legacy
+// algorithm list can skip hmac-md5 on those builds — ssh2 validates exact
+// algorithm lists strictly and would otherwise throw "Unsupported algorithm"
+// before the SSH handshake even starts.
+let _md5Supported = null;
+function md5Supported() {
+  if (_md5Supported === null) {
+    try { _md5Supported = crypto.getHashes().includes("md5"); }
+    catch { _md5Supported = false; }
+  }
+  return _md5Supported;
+}
+
 /**
  * Build SSH algorithm configuration.
  * When legacyEnabled is true, legacy algorithms are appended to each list
@@ -291,11 +305,22 @@ function buildAlgorithms(legacyEnabled) {
     // verification that depends on it fails with
     // "Handshake failed: signature verification failed" — which looks like
     // a host-key problem but is really a MAC negotiation mismatch.
+    //
+    // hmac-md5 is only appended when the local OpenSSL build actually
+    // supports MD5. FIPS-enabled Node builds disable MD5 entirely, and
+    // ssh2 strictly validates exact algorithm lists — listing an unavailable
+    // algorithm would throw "Unsupported algorithm" before any SSH
+    // negotiation, turning the legacy toggle into a hard failure for FIPS
+    // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
+    // stays unconditionally.
     algorithms.hmac = [
       'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com',
       'hmac-sha2-256', 'hmac-sha2-512',
-      'hmac-sha1', 'hmac-md5',
+      'hmac-sha1',
     ];
+    if (md5Supported()) {
+      algorithms.hmac.push('hmac-md5');
+    }
   }
 
   return algorithms;

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -285,6 +285,17 @@ function buildAlgorithms(legacyEnabled) {
       'rsa-sha2-512', 'rsa-sha2-256',
       'ssh-rsa', 'ssh-dss',
     ];
+    // Legacy HMACs — required by very old servers (e.g. FreeBSD 6.1 OpenSSH
+    // ~2006, issue #807). Without hmac-sha1/md5 in the offered list, the
+    // handshake exchange-hash MAC never agrees and the host-key signature
+    // verification that depends on it fails with
+    // "Handshake failed: signature verification failed" — which looks like
+    // a host-key problem but is really a MAC negotiation mismatch.
+    algorithms.hmac = [
+      'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com',
+      'hmac-sha2-256', 'hmac-sha2-512',
+      'hmac-sha1', 'hmac-md5',
+    ];
   }
 
   return algorithms;

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -313,9 +313,13 @@ function buildAlgorithms(legacyEnabled) {
     // negotiation, turning the legacy toggle into a hard failure for FIPS
     // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
     // stays unconditionally.
+    // hmac-sha1-etm@openssh.com is in ssh2's default MAC set — keep it so
+    // hosts that only accept EtM SHA-1 MACs don't regress to "no matching
+    // C->S MAC" when legacy mode replaces the default list.
     algorithms.hmac = [
       'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com',
       'hmac-sha2-256', 'hmac-sha2-512',
+      'hmac-sha1-etm@openssh.com',
       'hmac-sha1',
     ];
     if (md5Supported()) {


### PR DESCRIPTION
Closes #807.

## Root cause

`buildAlgorithms()` in `electron/bridges/sshBridge.cjs` handles the "allow legacy algorithms" toggle by appending legacy entries to **kex**, **cipher**, and **serverHostKey** — but never touches `algorithms.hmac` at all. So even with the toggle on, the ssh2 library's default (modern) HMAC list applied, which doesn't include `hmac-sha1` / `hmac-md5`.

Very old OpenSSH builds (FreeBSD 6.1, released 2006 — per the issue) can only speak `hmac-sha1` or `hmac-md5`. With the toggle on, kex and host-key negotiation succeeded but MAC negotiation settled on something the server couldn't actually produce. The wrong exchange-hash MAC then broke host-key signature verification, surfacing as:

> \`Handshake failed: signature verification failed\`

The message looks like a host-key algorithm problem, which is why the user's initial workaround (enabling `ssh-dss`/`ssh-rsa`) didn't help — the real mismatch was on the MAC layer.

## Fix

Add an explicit `algorithms.hmac` list to the legacy branch that keeps modern MACs in front and appends the two legacy ones:

\`\`\`js
algorithms.hmac = [
  'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com',
  'hmac-sha2-256', 'hmac-sha2-512',
  'hmac-sha1', 'hmac-md5',
];
\`\`\`

Modern servers still prefer SHA-2 (they appear first and server picks the first match from its own list). Only servers that literally cannot do SHA-2 will fall back to SHA-1/MD5 — the exact behavior the toggle promises.

## Test plan

- [x] `node -c electron/bridges/sshBridge.cjs` — syntax OK
- Needs verification from the issue reporter against FreeBSD 6.1 — the fix matches their local ssh command parameters (`MACs=+hmac-sha1,hmac-md5`).
- No regression risk on modern servers: HMAC list is additive, SHA-2 entries come first, so servers that can do SHA-2 still will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)