### PR TITLE
fix(autocomplete): stop prepending theme cwd ("~ ") to completed commands (closes #806)

### DIFF
--- a/components/terminal/autocomplete/promptDetector.ts
+++ b/components/terminal/autocomplete/promptDetector.ts
@@ -206,6 +206,46 @@ function findPromptBoundary(lineText: string): number {
 }
 
 /**
+ * Reconcile a buffer-parsed prompt with the user's own keystroke history.
+ *
+ * findPromptBoundary stops at the first `PROMPT_CHAR + space` it sees, so
+ * themes that render additional content after the prompt char — e.g.
+ * oh-my-zsh's robbyrussell prints "➜  ~ " where `~` is the cwd — get
+ * parsed as prompt="➜ " + userInput="~ lo". Every consumer downstream
+ * (history recording, suggestion matching, insertion) then treats the
+ * theme's cwd marker as part of the user's command, which pollutes
+ * history with entries like "~ sudo id" and makes Tab insertions prepend
+ * a phantom "~ " to the typed command (issue #806).
+ *
+ * Whenever we have an independent record of what the user actually typed
+ * since the last Enter (keystroke buffer), we can detect this case: the
+ * real input is always a suffix of the over-captured userInput. When it
+ * is, reattribute the leading garbage back to promptText so the rest of
+ * the pipeline sees the clean split.
+ */
+export function reconcilePromptWithTypedInput(
+  prompt: PromptDetectionResult,
+  typedInput: string,
+): PromptDetectionResult {
+  if (!prompt.isAtPrompt) return prompt;
+  if (!typedInput) return prompt;
+  if (prompt.userInput === typedInput) return prompt;
+  if (
+    prompt.userInput.length > typedInput.length &&
+    prompt.userInput.endsWith(typedInput)
+  ) {
+    const extra = prompt.userInput.slice(0, prompt.userInput.length - typedInput.length);
+    return {
+      isAtPrompt: true,
+      promptText: prompt.promptText + extra,
+      userInput: typedInput,
+      cursorOffset: typedInput.length,
+    };
+  }
+  return prompt;
+}
+
+/**
  * Simplified prompt detection: just check if we're likely at a prompt.
  */
 export function isLikelyAtPrompt(term: XTerm): boolean {

--- a/components/terminal/autocomplete/promptDetector.ts
+++ b/components/terminal/autocomplete/promptDetector.ts
@@ -38,6 +38,18 @@ const NO_PROMPT: PromptDetectionResult = {
   isAtPrompt: false, promptText: "", userInput: "", cursorOffset: 0,
 };
 
+export interface AlignedPromptResult {
+  /** The prompt view every consumer should use for parsing / suggestion lookup / line rewrites. */
+  prompt: PromptDetectionResult;
+  /**
+   * The keystroke buffer, but only when it's both marked reliable AND
+   * actually matches the tail of the raw detected userInput. Returns
+   * null otherwise — the single signal downstream uses to decide
+   * whether to record it as the executed command.
+   */
+  alignedTyped: string | null;
+}
+
 /**
  * Detect whether the terminal cursor is at a shell prompt and extract the current user input.
  */
@@ -243,6 +255,37 @@ export function reconcilePromptWithTypedInput(
     };
   }
   return prompt;
+}
+
+/**
+ * Unified entry point for any autocomplete code path that needs a prompt
+ * view. Every consumer (fetchSuggestions, insertSuggestion,
+ * handleSubDirSelect, Enter-record) goes through this one helper so the
+ * alignment policy lives in exactly one place — if another out-of-band
+ * line-rewrite path gets added later and forgets to notify the keystroke
+ * buffer, the worst that happens is reconcile no-ops and we degrade to
+ * pre-#806 behavior, not a worse pollution.
+ *
+ * Alignment rule: the keystroke buffer is usable only when it's marked
+ * reliable AND the raw detected userInput ends with it. Otherwise the
+ * buffer is ignored and the raw detector result passes through.
+ */
+export function getAlignedPrompt(
+  term: XTerm | null,
+  typedBuffer: string,
+  typedReliable: boolean,
+): AlignedPromptResult {
+  if (!term) return { prompt: NO_PROMPT, alignedTyped: null };
+  const raw = detectPrompt(term);
+  const aligned =
+    typedReliable &&
+    typedBuffer.length > 0 &&
+    raw.isAtPrompt &&
+    raw.userInput.endsWith(typedBuffer);
+  return {
+    prompt: aligned ? reconcilePromptWithTypedInput(raw, typedBuffer) : raw,
+    alignedTyped: aligned ? typedBuffer : null,
+  };
 }
 
 /**

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -687,6 +687,11 @@ export function useTerminalAutocomplete(
         if (nlIdx >= 0) {
           typedInputBufferRef.current = data.slice(nlIdx + 1);
           typedBufferReliableRef.current = true;
+          // The embedded newline flushed any previously-accepted
+          // suggestion too — clearing the cache here prevents the next
+          // Enter from falling into the lastAcceptedCommandRef fast path
+          // and recording that stale command.
+          lastAcceptedCommandRef.current = null;
           clearState();
           return;
         }

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -11,7 +11,7 @@
 import { startTransition, useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { GhostTextAddon } from "./GhostTextAddon";
-import { detectPrompt, type PromptDetectionResult } from "./promptDetector";
+import { detectPrompt, reconcilePromptWithTypedInput, type PromptDetectionResult } from "./promptDetector";
 import { getCompletions, parseCommandLine, type CompletionSuggestion } from "./completionEngine";
 import { recordCommand } from "./commandHistoryStore";
 import { preloadCommonSpecs } from "./figSpecLoader";
@@ -149,6 +149,17 @@ export function useTerminalAutocomplete(
   const lastAcceptedCommandRef = useRef<string | null>(null);
   /** Monotonic counter to invalidate stale async sub-dir fetches */
   const subDirFetchVersionRef = useRef(0);
+  /**
+   * Keystroke buffer mirroring what the user has typed since the last
+   * prompt boundary (Enter / Ctrl-C / Ctrl-U / cursor movement).
+   *
+   * detectPrompt parses the xterm buffer and can misattribute theme
+   * content — e.g. oh-my-zsh robbyrussell's "➜  ~ " — as user input.
+   * Keeping an independent keystroke log lets reconcilePromptWithTypedInput
+   * snap the detected userInput back to what was actually typed, which
+   * in turn keeps history recording and Tab insertion honest (#806).
+   */
+  const typedInputBufferRef = useRef<string>("");
 
   // Preload common specs on first mount (only if enabled)
   useEffect(() => {
@@ -444,7 +455,7 @@ export function useTerminalAutocomplete(
     // Capture version at start — if it changes during async work, discard results
     const version = ++fetchVersionRef.current;
 
-    const prompt = detectPrompt(term);
+    const prompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
     lastPromptRef.current = prompt;
 
     if (!prompt.isAtPrompt || prompt.userInput.length < settingsRef.current.minChars) {
@@ -485,7 +496,7 @@ export function useTerminalAutocomplete(
 
     // Discard stale results: if the user kept typing while getCompletions was running,
     // the current prompt input will have changed. Re-detect and compare.
-    const currentPrompt = detectPrompt(term);
+    const currentPrompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
     if (!currentPrompt.isAtPrompt || currentPrompt.userInput !== input) {
       return; // Input changed — these completions are stale
     }
@@ -568,25 +579,65 @@ export function useTerminalAutocomplete(
           if (lastAcceptedCommandRef.current) {
             recordCommand(lastAcceptedCommandRef.current, hostIdRef.current, hostOsRef.current);
           } else {
-            // Try real-time detection; fall back to cached prompt
-            const livePrompt = termRef.current ? detectPrompt(termRef.current) : null;
-            const prompt = (livePrompt?.isAtPrompt && livePrompt.userInput.trim())
-              ? livePrompt
-              : lastPromptRef.current;
-            if (prompt?.isAtPrompt && prompt.userInput.trim()) {
-              recordCommand(prompt.userInput.trim(), hostIdRef.current, hostOsRef.current);
+            // Require a live prompt before trusting either keystroke buffer
+            // or buffer-based detection — otherwise sudo password Enter
+            // would record the typed password as a command.
+            const livePrompt = termRef.current
+              ? reconcilePromptWithTypedInput(detectPrompt(termRef.current), typedInputBufferRef.current)
+              : null;
+            if (livePrompt?.isAtPrompt) {
+              // Typed buffer wins when present: it can't have been polluted
+              // by a theme that renders cwd after the prompt char (#806).
+              const typedCommand = typedInputBufferRef.current.trim();
+              if (typedCommand) {
+                recordCommand(typedCommand, hostIdRef.current, hostOsRef.current);
+              } else if (livePrompt.userInput.trim()) {
+                recordCommand(livePrompt.userInput.trim(), hostIdRef.current, hostOsRef.current);
+              }
+            } else if (lastPromptRef.current?.isAtPrompt && lastPromptRef.current.userInput.trim()) {
+              // Only fall back to the cached prompt when we have no live
+              // reading at all — guards against recording during interactive
+              // prompts where detectPrompt correctly bails out.
+              recordCommand(lastPromptRef.current.userInput.trim(), hostIdRef.current, hostOsRef.current);
             }
           }
           lastAcceptedCommandRef.current = null;
         }
+        typedInputBufferRef.current = "";
         clearState();
         return;
       }
 
       // Ctrl+C, Ctrl+U — clear
       if (data === "\x03" || data === "\x15") {
+        typedInputBufferRef.current = "";
         clearState();
         return;
+      }
+
+      // Backspace / DEL: drop the last typed char so the buffer stays aligned
+      // with what the shell actually holds.
+      if (data === "\x7f" || data === "\b") {
+        typedInputBufferRef.current = typedInputBufferRef.current.slice(0, -1);
+      } else if (data === "\x17") {
+        // Ctrl+W: word-erase — kill the trailing whitespace + word.
+        typedInputBufferRef.current = typedInputBufferRef.current.replace(/\s*\S+\s*$/, "");
+      } else if (data.startsWith("\x1b") && data !== "\x1b") {
+        // Cursor-movement / function keys — we lose track of where the
+        // cursor sits relative to our append-only buffer, so drop it
+        // and let detectPrompt take over until the next Enter.
+        typedInputBufferRef.current = "";
+      } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
+        typedInputBufferRef.current += data;
+      } else if (data.length > 1 && !data.startsWith("\x1b")) {
+        // Paste: treat as literal text.
+        typedInputBufferRef.current += data;
+      } else if (data.length === 1 && data.charCodeAt(0) < 32) {
+        // Any other single control char (Ctrl-A, Ctrl-E, Ctrl-B, Ctrl-F,
+        // Ctrl-R, etc.) moves the cursor or swaps the line in ways this
+        // append-only buffer can't follow. Drop it so we don't hand out
+        // stale reconciliation data until the next Enter.
+        typedInputBufferRef.current = "";
       }
 
       // Escape sequences (arrow keys, Home, End, etc.): clear stale suggestions
@@ -660,7 +711,9 @@ export function useTerminalAutocomplete(
           const ghostText = ghost.getGhostText();
           if (ghostText) {
             writeToTerminal(ghostText);
-            lastAcceptedCommandRef.current = ghost.getSuggestion();
+            const fullSuggestion = ghost.getSuggestion();
+            lastAcceptedCommandRef.current = fullSuggestion;
+            if (fullSuggestion) typedInputBufferRef.current = fullSuggestion;
             ghost.hide();
             clearState();
           }
@@ -675,6 +728,7 @@ export function useTerminalAutocomplete(
           const nextWord = ghost.getNextWord();
           if (nextWord) {
             writeToTerminal(nextWord);
+            typedInputBufferRef.current += nextWord;
             // Update ghost text to show remaining
             const fullSuggestion = ghost.getSuggestion();
             const currentInput = ghost.getGhostText().substring(nextWord.length);
@@ -847,7 +901,7 @@ export function useTerminalAutocomplete(
 
       // Always use real-time prompt detection — lastPromptRef may be stale
       // if the user typed more characters after suggestions were fetched
-      const prompt = detectPrompt(term);
+      const prompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
       if (!prompt.isAtPrompt) return;
 
       // If suggestion starts with the current input, insert only the remaining part.
@@ -869,6 +923,16 @@ export function useTerminalAutocomplete(
 
       if (payload) {
         writeToTerminal(payload);
+      }
+
+      // Keystroke buffer now reflects the accepted text (either extended by
+      // the insertion suffix, or wholesale replaced by the fuzzy-match path
+      // that emits Ctrl-U first). Re-aligning it here keeps the subsequent
+      // Enter-record honest.
+      if (execute) {
+        typedInputBufferRef.current = "";
+      } else {
+        typedInputBufferRef.current = suggestion.text;
       }
 
       // Track accepted command for accurate history recording on fast Enter

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -160,6 +160,19 @@ export function useTerminalAutocomplete(
    * in turn keeps history recording and Tab insertion honest (#806).
    */
   const typedInputBufferRef = useRef<string>("");
+  /**
+   * Whether typedInputBufferRef can be trusted as the full tail of the
+   * current command line. Cleared after any event this append-only buffer
+   * can't follow (history recall via ↑/Ctrl-P, cursor moves, reverse
+   * search, etc.). Reset to true on clean line boundaries — Enter,
+   * Ctrl-C, Ctrl-U — and after we explicitly re-align via
+   * insertSuggestion or a ghost-text accept.
+   *
+   * Without this flag, an Up-arrow-recall workflow would leave the buffer
+   * holding only the post-navigation suffix, and Enter would record that
+   * suffix as a command (pollutes history, misleads future completions).
+   */
+  const typedBufferReliableRef = useRef<boolean>(true);
 
   // Preload common specs on first mount (only if enabled)
   useEffect(() => {
@@ -455,7 +468,10 @@ export function useTerminalAutocomplete(
     // Capture version at start — if it changes during async work, discard results
     const version = ++fetchVersionRef.current;
 
-    const prompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
+    const prompt = reconcilePromptWithTypedInput(
+      detectPrompt(term),
+      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
+    );
     lastPromptRef.current = prompt;
 
     if (!prompt.isAtPrompt || prompt.userInput.length < settingsRef.current.minChars) {
@@ -496,7 +512,10 @@ export function useTerminalAutocomplete(
 
     // Discard stale results: if the user kept typing while getCompletions was running,
     // the current prompt input will have changed. Re-detect and compare.
-    const currentPrompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
+    const currentPrompt = reconcilePromptWithTypedInput(
+      detectPrompt(term),
+      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
+    );
     if (!currentPrompt.isAtPrompt || currentPrompt.userInput !== input) {
       return; // Input changed — these completions are stale
     }
@@ -582,13 +601,21 @@ export function useTerminalAutocomplete(
             // Require a live prompt before trusting either keystroke buffer
             // or buffer-based detection — otherwise sudo password Enter
             // would record the typed password as a command.
+            const bufferReliable = typedBufferReliableRef.current;
             const livePrompt = termRef.current
-              ? reconcilePromptWithTypedInput(detectPrompt(termRef.current), typedInputBufferRef.current)
+              ? reconcilePromptWithTypedInput(
+                  detectPrompt(termRef.current),
+                  bufferReliable ? typedInputBufferRef.current : "",
+                )
               : null;
             if (livePrompt?.isAtPrompt) {
-              // Typed buffer wins when present: it can't have been polluted
-              // by a theme that renders cwd after the prompt char (#806).
-              const typedCommand = typedInputBufferRef.current.trim();
+              // Only prefer the keystroke buffer when it's reliable. After
+              // Up-arrow / Ctrl-R / cursor moves the buffer may hold just a
+              // post-navigation suffix of the real line — recording that
+              // instead of the executed command would pollute history.
+              const typedCommand = bufferReliable
+                ? typedInputBufferRef.current.trim()
+                : "";
               if (typedCommand) {
                 recordCommand(typedCommand, hostIdRef.current, hostOsRef.current);
               } else if (livePrompt.userInput.trim()) {
@@ -604,13 +631,16 @@ export function useTerminalAutocomplete(
           lastAcceptedCommandRef.current = null;
         }
         typedInputBufferRef.current = "";
+        typedBufferReliableRef.current = true;
         clearState();
         return;
       }
 
-      // Ctrl+C, Ctrl+U — clear
+      // Ctrl+C, Ctrl+U — clear. These kill the zle line entirely, so the
+      // buffer is once again a true reflection of the (empty) line.
       if (data === "\x03" || data === "\x15") {
         typedInputBufferRef.current = "";
+        typedBufferReliableRef.current = true;
         clearState();
         return;
       }
@@ -624,9 +654,11 @@ export function useTerminalAutocomplete(
         typedInputBufferRef.current = typedInputBufferRef.current.replace(/\s*\S+\s*$/, "");
       } else if (data.startsWith("\x1b") && data !== "\x1b") {
         // Cursor-movement / function keys — we lose track of where the
-        // cursor sits relative to our append-only buffer, so drop it
-        // and let detectPrompt take over until the next Enter.
+        // cursor sits relative to our append-only buffer. Mark the
+        // buffer unreliable and drop it; detectPrompt takes over until
+        // the next Enter / Ctrl-C / Ctrl-U.
         typedInputBufferRef.current = "";
+        typedBufferReliableRef.current = false;
       } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
         typedInputBufferRef.current += data;
       } else if (data.length > 1 && !data.startsWith("\x1b")) {
@@ -634,10 +666,11 @@ export function useTerminalAutocomplete(
         typedInputBufferRef.current += data;
       } else if (data.length === 1 && data.charCodeAt(0) < 32) {
         // Any other single control char (Ctrl-A, Ctrl-E, Ctrl-B, Ctrl-F,
-        // Ctrl-R, etc.) moves the cursor or swaps the line in ways this
-        // append-only buffer can't follow. Drop it so we don't hand out
-        // stale reconciliation data until the next Enter.
+        // Ctrl-R, Ctrl-P, Ctrl-N, ...) moves the cursor or swaps the
+        // line in ways this append-only buffer can't follow. Same story
+        // as escape sequences above.
         typedInputBufferRef.current = "";
+        typedBufferReliableRef.current = false;
       }
 
       // Escape sequences (arrow keys, Home, End, etc.): clear stale suggestions
@@ -713,7 +746,10 @@ export function useTerminalAutocomplete(
             writeToTerminal(ghostText);
             const fullSuggestion = ghost.getSuggestion();
             lastAcceptedCommandRef.current = fullSuggestion;
-            if (fullSuggestion) typedInputBufferRef.current = fullSuggestion;
+            if (fullSuggestion) {
+              typedInputBufferRef.current = fullSuggestion;
+              typedBufferReliableRef.current = true;
+            }
             ghost.hide();
             clearState();
           }
@@ -728,7 +764,12 @@ export function useTerminalAutocomplete(
           const nextWord = ghost.getNextWord();
           if (nextWord) {
             writeToTerminal(nextWord);
-            typedInputBufferRef.current += nextWord;
+            // Only extend the buffer if it was already aligned with the
+            // line — otherwise we'd end up with just the appended word,
+            // which the next Enter would then record as the command.
+            if (typedBufferReliableRef.current) {
+              typedInputBufferRef.current += nextWord;
+            }
             // Update ghost text to show remaining
             const fullSuggestion = ghost.getSuggestion();
             const currentInput = ghost.getGhostText().substring(nextWord.length);
@@ -901,7 +942,10 @@ export function useTerminalAutocomplete(
 
       // Always use real-time prompt detection — lastPromptRef may be stale
       // if the user typed more characters after suggestions were fetched
-      const prompt = reconcilePromptWithTypedInput(detectPrompt(term), typedInputBufferRef.current);
+      const prompt = reconcilePromptWithTypedInput(
+        detectPrompt(term),
+        typedBufferReliableRef.current ? typedInputBufferRef.current : "",
+      );
       if (!prompt.isAtPrompt) return;
 
       // If suggestion starts with the current input, insert only the remaining part.
@@ -928,12 +972,14 @@ export function useTerminalAutocomplete(
       // Keystroke buffer now reflects the accepted text (either extended by
       // the insertion suffix, or wholesale replaced by the fuzzy-match path
       // that emits Ctrl-U first). Re-aligning it here keeps the subsequent
-      // Enter-record honest.
+      // Enter-record honest, and flips reliability back on since we know
+      // the line content exactly.
       if (execute) {
         typedInputBufferRef.current = "";
       } else {
         typedInputBufferRef.current = suggestion.text;
       }
+      typedBufferReliableRef.current = true;
 
       // Track accepted command for accurate history recording on fast Enter
       if (!execute) {

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -673,7 +673,23 @@ export function useTerminalAutocomplete(
       } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
         typedInputBufferRef.current += data;
       } else if (data.length > 1 && !data.startsWith("\x1b")) {
-        // Paste: treat as literal text.
+        // Paste chunk. Any \r / \n inside executes the preceding text as
+        // a command in the shell, so keeping the pre-newline portion in
+        // our buffer would leave stale content that a later Enter could
+        // record (Codex #814 P2). Drop everything up to and including
+        // the last terminator and keep only the tail as new content.
+        // Intermediate executed lines aren't synthesized back into
+        // recordCommand here — the onCommandExecuted path in
+        // createXTermRuntime still captures them independently.
+        const lastCR = data.lastIndexOf("\r");
+        const lastLF = data.lastIndexOf("\n");
+        const nlIdx = Math.max(lastCR, lastLF);
+        if (nlIdx >= 0) {
+          typedInputBufferRef.current = data.slice(nlIdx + 1);
+          typedBufferReliableRef.current = true;
+          clearState();
+          return;
+        }
         typedInputBufferRef.current += data;
       } else if (data.length === 1 && data.charCodeAt(0) < 32) {
         // Any other single control char (Ctrl-A, Ctrl-E, Ctrl-B, Ctrl-F,

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -420,8 +420,13 @@ export function useTerminalAutocomplete(
     const panel = s.subDirPanels[level];
     if (!panel) return;
 
-    // Get current prompt to know what command prefix to keep (e.g., "cd ")
-    const prompt = detectPrompt(term);
+    // Get current prompt to know what command prefix to keep (e.g., "cd ").
+    // Reconcile with the typed buffer so robbyrussell-style themes don't
+    // fold their cwd marker ("~ ") into the parsed command prefix (#806).
+    const prompt = reconcilePromptWithTypedInput(
+      detectPrompt(term),
+      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
+    );
     if (!prompt.isAtPrompt) return;
 
     // Find the command part (everything before the path argument)
@@ -447,7 +452,13 @@ export function useTerminalAutocomplete(
     const clearSeq = isWindows
       ? "\b".repeat(prompt.userInput.length)
       : "\x15";
-    writeToTerminal(clearSeq + cmdPrefix + replacementPath);
+    const newCommand = cmdPrefix + replacementPath;
+    writeToTerminal(clearSeq + newCommand);
+    // Sub-dir selection rewrote the whole command line; re-align the
+    // keystroke buffer so the next Enter records the executed command
+    // instead of whatever partial input we had before (P2 from #814).
+    typedInputBufferRef.current = newCommand;
+    typedBufferReliableRef.current = true;
     clearState();
 
     if (entry.type === "directory") {

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -665,6 +665,20 @@ export function useTerminalAutocomplete(
       } else if (data === "\x17") {
         // Ctrl+W: word-erase — kill the trailing whitespace + word.
         typedInputBufferRef.current = typedInputBufferRef.current.replace(/\s*\S+\s*$/, "");
+      } else if (data.startsWith("\x1b[200~")) {
+        // Bracketed paste: "\x1b[200~...\x1b[201~". The inner bytes are
+        // literal input, so newlines stay on the zle line instead of
+        // executing each segment — meaning we must preserve the whole
+        // content in the buffer, not just the post-final-newline tail
+        // (Codex #814 P2).
+        const endIdx = data.indexOf("\x1b[201~");
+        const content = endIdx >= 0
+          ? data.slice("\x1b[200~".length, endIdx)
+          : data.slice("\x1b[200~".length);
+        typedInputBufferRef.current += content;
+        typedBufferReliableRef.current = true;
+        clearState();
+        return;
       } else if (data.startsWith("\x1b") && data !== "\x1b") {
         // Cursor-movement / function keys — we lose track of where the
         // cursor sits relative to our append-only buffer. Mark the

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -663,12 +663,21 @@ export function useTerminalAutocomplete(
         // executing each segment — meaning we must preserve the whole
         // content in the buffer, not just the post-final-newline tail
         // (Codex #814 P2).
+        //
+        // Reliability is *inherited*, not reset: if the buffer was
+        // already aligned with the line (reliable=true), appending this
+        // paste keeps it aligned; if the buffer was unreliable (e.g.
+        // after ↑ recalled a history command so line ≠ buffer), the
+        // paste only extends the tail but the head is still whatever
+        // the shell had, so the buffer stays unreliable. Without this,
+        // a paste-after-recall flow would flip reliability back on and
+        // Enter would record just the pasted suffix as the command
+        // (Codex #814 P1 follow-up).
         const endIdx = data.indexOf("\x1b[201~");
         const content = endIdx >= 0
           ? data.slice("\x1b[200~".length, endIdx)
           : data.slice("\x1b[200~".length);
         typedInputBufferRef.current += content;
-        typedBufferReliableRef.current = true;
         clearState();
         return;
       } else if (data.startsWith("\x1b") && data !== "\x1b") {

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -11,7 +11,7 @@
 import { startTransition, useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { GhostTextAddon } from "./GhostTextAddon";
-import { detectPrompt, reconcilePromptWithTypedInput, type PromptDetectionResult } from "./promptDetector";
+import { getAlignedPrompt, type PromptDetectionResult } from "./promptDetector";
 import { getCompletions, parseCommandLine, type CompletionSuggestion } from "./completionEngine";
 import { recordCommand } from "./commandHistoryStore";
 import { preloadCommonSpecs } from "./figSpecLoader";
@@ -155,9 +155,10 @@ export function useTerminalAutocomplete(
    *
    * detectPrompt parses the xterm buffer and can misattribute theme
    * content — e.g. oh-my-zsh robbyrussell's "➜  ~ " — as user input.
-   * Keeping an independent keystroke log lets reconcilePromptWithTypedInput
-   * snap the detected userInput back to what was actually typed, which
-   * in turn keeps history recording and Tab insertion honest (#806).
+   * Keeping an independent keystroke log lets getAlignedPrompt snap the
+   * detected userInput back to what was actually typed (and only when
+   * the buffer matches the live line's tail), which in turn keeps
+   * history recording and Tab insertion honest (#806).
    */
   const typedInputBufferRef = useRef<string>("");
   /**
@@ -270,8 +271,12 @@ export function useTerminalAutocomplete(
       return;
     }
     const term = termRef.current;
-    const livePrompt = term ? detectPrompt(term) : null;
-    const activePrompt = livePrompt?.isAtPrompt ? livePrompt : lastPromptRef.current;
+    const { prompt: livePrompt } = getAlignedPrompt(
+      term,
+      typedInputBufferRef.current,
+      typedBufferReliableRef.current,
+    );
+    const activePrompt = livePrompt.isAtPrompt ? livePrompt : lastPromptRef.current;
     const activeWord = activePrompt?.isAtPrompt
       ? parseCommandLine(activePrompt.userInput).currentWord
       : parseCommandLine(item.text).currentWord;
@@ -421,12 +426,9 @@ export function useTerminalAutocomplete(
     if (!panel) return;
 
     // Get current prompt to know what command prefix to keep (e.g., "cd ").
-    // Reconcile with the typed buffer so robbyrussell-style themes don't
-    // fold their cwd marker ("~ ") into the parsed command prefix (#806).
-    const prompt = reconcilePromptWithTypedInput(
-      detectPrompt(term),
-      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
-    );
+    // getAlignedPrompt handles robbyrussell-style themes by trimming the
+    // cwd marker out of userInput when the typed buffer is aligned (#806).
+    const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
     if (!prompt.isAtPrompt) return;
 
     // Find the command part (everything before the path argument)
@@ -479,10 +481,7 @@ export function useTerminalAutocomplete(
     // Capture version at start — if it changes during async work, discard results
     const version = ++fetchVersionRef.current;
 
-    const prompt = reconcilePromptWithTypedInput(
-      detectPrompt(term),
-      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
-    );
+    const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
     lastPromptRef.current = prompt;
 
     if (!prompt.isAtPrompt || prompt.userInput.length < settingsRef.current.minChars) {
@@ -523,10 +522,7 @@ export function useTerminalAutocomplete(
 
     // Discard stale results: if the user kept typing while getCompletions was running,
     // the current prompt input will have changed. Re-detect and compare.
-    const currentPrompt = reconcilePromptWithTypedInput(
-      detectPrompt(term),
-      typedBufferReliableRef.current ? typedInputBufferRef.current : "",
-    );
+    const { prompt: currentPrompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
     if (!currentPrompt.isAtPrompt || currentPrompt.userInput !== input) {
       return; // Input changed — these completions are stale
     }
@@ -612,25 +608,21 @@ export function useTerminalAutocomplete(
             // Require a live prompt before trusting either keystroke buffer
             // or buffer-based detection — otherwise sudo password Enter
             // would record the typed password as a command.
-            const bufferReliable = typedBufferReliableRef.current;
-            const livePrompt = termRef.current
-              ? reconcilePromptWithTypedInput(
-                  detectPrompt(termRef.current),
-                  bufferReliable ? typedInputBufferRef.current : "",
-                )
-              : null;
-            if (livePrompt?.isAtPrompt) {
-              // Only prefer the keystroke buffer when it's reliable AND
-              // actually aligned with the live line. Non-keyboard inserts
-              // that bypass handleInput (hotkey / middle-click / context
-              // paste in createXTermRuntime) can leave the buffer holding
-              // only a stale prefix of what the shell now sees; trusting
-              // it here would record that prefix as the command (#814 P1).
-              const typedRaw = bufferReliable ? typedInputBufferRef.current : "";
-              const typedAligned =
-                typedRaw.length > 0 && livePrompt.userInput.endsWith(typedRaw);
-              if (typedAligned && typedRaw.trim()) {
-                recordCommand(typedRaw.trim(), hostIdRef.current, hostOsRef.current);
+            const { prompt: livePrompt, alignedTyped } = getAlignedPrompt(
+              termRef.current,
+              typedInputBufferRef.current,
+              typedBufferReliableRef.current,
+            );
+            if (livePrompt.isAtPrompt) {
+              // alignedTyped is only non-null when the buffer is reliable
+              // AND matches the live line's tail — that single signal
+              // covers both the robbyrussell "~ " case (#806) and the
+              // stale-buffer cases from out-of-band pastes / history
+              // recall (#814 P1/P2). When it's null we fall back to the
+              // reconciled livePrompt.userInput, which for paste-bypass
+              // scenarios lands on pre-PR behavior (no regression).
+              if (alignedTyped && alignedTyped.trim()) {
+                recordCommand(alignedTyped.trim(), hostIdRef.current, hostOsRef.current);
               } else if (livePrompt.userInput.trim()) {
                 recordCommand(livePrompt.userInput.trim(), hostIdRef.current, hostOsRef.current);
               }
@@ -989,11 +981,8 @@ export function useTerminalAutocomplete(
       if (!term) return;
 
       // Always use real-time prompt detection — lastPromptRef may be stale
-      // if the user typed more characters after suggestions were fetched
-      const prompt = reconcilePromptWithTypedInput(
-        detectPrompt(term),
-        typedBufferReliableRef.current ? typedInputBufferRef.current : "",
-      );
+      // if the user typed more characters after suggestions were fetched.
+      const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
       if (!prompt.isAtPrompt) return;
 
       // If suggestion starts with the current input, insert only the remaining part.

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -620,15 +620,17 @@ export function useTerminalAutocomplete(
                 )
               : null;
             if (livePrompt?.isAtPrompt) {
-              // Only prefer the keystroke buffer when it's reliable. After
-              // Up-arrow / Ctrl-R / cursor moves the buffer may hold just a
-              // post-navigation suffix of the real line — recording that
-              // instead of the executed command would pollute history.
-              const typedCommand = bufferReliable
-                ? typedInputBufferRef.current.trim()
-                : "";
-              if (typedCommand) {
-                recordCommand(typedCommand, hostIdRef.current, hostOsRef.current);
+              // Only prefer the keystroke buffer when it's reliable AND
+              // actually aligned with the live line. Non-keyboard inserts
+              // that bypass handleInput (hotkey / middle-click / context
+              // paste in createXTermRuntime) can leave the buffer holding
+              // only a stale prefix of what the shell now sees; trusting
+              // it here would record that prefix as the command (#814 P1).
+              const typedRaw = bufferReliable ? typedInputBufferRef.current : "";
+              const typedAligned =
+                typedRaw.length > 0 && livePrompt.userInput.endsWith(typedRaw);
+              if (typedAligned && typedRaw.trim()) {
+                recordCommand(typedRaw.trim(), hostIdRef.current, hostOsRef.current);
               } else if (livePrompt.userInput.trim()) {
                 recordCommand(livePrompt.userInput.trim(), hostIdRef.current, hostOsRef.current);
               }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -482,6 +482,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
             if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
               ctx.onBroadcastInputRef.current(snippetData, ctx.sessionId);
             }
+            // Let the autocomplete hook observe the raw (pre-wrap) bytes so
+            // its keystroke buffer tracks out-of-band writes too — otherwise
+            // a subsequent Enter would record a stale typed prefix (#814 P1).
+            ctx.onAutocompleteInput?.(snippetData);
             // Wrap for this terminal only, after broadcasting
             const snippetIsMultiLine = snippetData.includes("\n");
             if (snippetIsMultiLine && term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste) snippetData = wrapBracketedPaste(snippetData);
@@ -525,8 +529,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           navigator.clipboard.readText().then((text) => {
             const id = ctx.sessionRef.current;
             if (id) {
-              let data = normalizeLineEndings(text);
-              if (term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste) data = wrapBracketedPaste(data);
+              const rawData = normalizeLineEndings(text);
+              // Notify autocomplete with the raw bytes so its keystroke
+              // buffer stays aligned with what the shell is about to see.
+              ctx.onAutocompleteInput?.(rawData);
+              const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
+                ? wrapBracketedPaste(rawData)
+                : rawData;
               ctx.terminalBackend.writeToSession(id, data);
               scrollToBottomAfterPaste();
             }
@@ -537,8 +546,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           const selection = term.getSelection();
           const id = ctx.sessionRef.current;
           if (selection && id) {
-            let data = normalizeLineEndings(selection);
-            if (term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste) data = wrapBracketedPaste(data);
+            const rawData = normalizeLineEndings(selection);
+            ctx.onAutocompleteInput?.(rawData);
+            const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
+              ? wrapBracketedPaste(rawData)
+              : rawData;
             ctx.terminalBackend.writeToSession(id, data);
             scrollToBottomAfterPaste();
           }
@@ -572,8 +584,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       try {
         const text = await navigator.clipboard.readText();
         if (text && ctx.sessionRef.current) {
-          let data = normalizeLineEndings(text);
-          if (term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste) data = wrapBracketedPaste(data);
+          const rawData = normalizeLineEndings(text);
+          ctx.onAutocompleteInput?.(rawData);
+          const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
+            ? wrapBracketedPaste(rawData)
+            : rawData;
           ctx.terminalBackend.writeToSession(ctx.sessionRef.current, data);
           scrollToBottomAfterPaste();
         }

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -482,13 +482,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
             if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
               ctx.onBroadcastInputRef.current(snippetData, ctx.sessionId);
             }
-            // Let the autocomplete hook observe the raw (pre-wrap) bytes so
-            // its keystroke buffer tracks out-of-band writes too — otherwise
-            // a subsequent Enter would record a stale typed prefix (#814 P1).
-            ctx.onAutocompleteInput?.(snippetData);
             // Wrap for this terminal only, after broadcasting
             const snippetIsMultiLine = snippetData.includes("\n");
             if (snippetIsMultiLine && term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste) snippetData = wrapBracketedPaste(snippetData);
+            // Notify autocomplete with the final (possibly bracket-wrapped)
+            // bytes so its keystroke buffer can tell literal multi-line
+            // paste ("\x1b[200~...\x1b[201~") from the non-bracketed path
+            // where each \n executes an intermediate command (#814 P2).
+            ctx.onAutocompleteInput?.(snippetData);
             ctx.terminalBackend.writeToSession(id, snippetData);
             if (!snippet.noAutoRun && ctx.onCommandExecuted) {
               const cmd = snippet.command.trim();
@@ -530,12 +531,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
             const id = ctx.sessionRef.current;
             if (id) {
               const rawData = normalizeLineEndings(text);
-              // Notify autocomplete with the raw bytes so its keystroke
-              // buffer stays aligned with what the shell is about to see.
-              ctx.onAutocompleteInput?.(rawData);
               const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
                 ? wrapBracketedPaste(rawData)
                 : rawData;
+              // Notify autocomplete with the final bytes so bracketed
+              // pastes preserve their inner newlines as literal input.
+              ctx.onAutocompleteInput?.(data);
               ctx.terminalBackend.writeToSession(id, data);
               scrollToBottomAfterPaste();
             }
@@ -547,10 +548,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           const id = ctx.sessionRef.current;
           if (selection && id) {
             const rawData = normalizeLineEndings(selection);
-            ctx.onAutocompleteInput?.(rawData);
             const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
               ? wrapBracketedPaste(rawData)
               : rawData;
+            ctx.onAutocompleteInput?.(data);
             ctx.terminalBackend.writeToSession(id, data);
             scrollToBottomAfterPaste();
           }
@@ -585,10 +586,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         const text = await navigator.clipboard.readText();
         if (text && ctx.sessionRef.current) {
           const rawData = normalizeLineEndings(text);
-          ctx.onAutocompleteInput?.(rawData);
           const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
             ? wrapBracketedPaste(rawData)
             : rawData;
+          ctx.onAutocompleteInput?.(data);
           ctx.terminalBackend.writeToSession(ctx.sessionRef.current, data);
           scrollToBottomAfterPaste();
         }


### PR DESCRIPTION
Closes #806.

## The bug

Reporter connects to a zsh host running the oh-my-zsh **robbyrussell** theme (prompt: `➜  ~ `), runs `sudo id`, enters the password, then types a partial command and hits Tab. The accepted completion shows up on the command line with a phantom `~ ` prepended.

## Root cause

`findPromptBoundary` stops at the **first** `PROMPT_CHAR + space` it finds. Themes that put cwd/branch/VCS info after the prompt char trip it — `"➜  ~ sudo id"` parses as `promptText="➜ "` + `userInput="~ sudo id"`. That junk then rides through the rest of the autocomplete pipeline:

1. `recordCommand` logs entries like `"~ sudo id"` into history.
2. `fuzzyQueryHistory` later returns those polluted entries as suggestions.
3. `insertSuggestion` compares `suggestion.text` (`"~ ls"`) against the detector's `userInput` (`"~ lo"`), falls into the Ctrl-U + rewrite path, and the phantom `~ ` lands on the real command line.

Sudo is a red herring — it's what seeded the bad history fast enough for fuzzy matches to start winning. Without sudo the popup stays empty, so the rewrite path never fires and the user doesn't see the bug.

## Fix

Track what the user actually typed in an independent keystroke buffer (`typedInputBufferRef`) inside the autocomplete hook:

- Append every printable char / paste chunk.
- Pop on backspace, word-kill on `Ctrl+W`.
- Clear on Enter, `Ctrl+C`, `Ctrl+U`, and any escape sequence / unhandled control char (cursor moves we can't follow → invalidate).

New helper `reconcilePromptWithTypedInput(prompt, typed)` inspects the detector's output: if `userInput` ends with the typed buffer and is longer, the parser over-captured — move the excess back to `promptText` so `userInput` matches what was actually typed. Applied at every `detectPrompt` call site (`fetchSuggestions`, the stale-result recheck, `insertSuggestion`).

For Enter-record the typed buffer wins outright when present, but only after a live `detectPrompt` confirms we're at a shell prompt — otherwise a password-entry Enter would log the password as a command. `insertSuggestion` / ghost-text accept update the typed buffer to the accepted text so a subsequent Enter records the right command.

## Test plan

- [x] `npx tsc --noEmit` — error count unchanged (baseline 24).
- [x] `npx eslint` on both touched files — clean.
- Manual (needs verification):
  - [ ] zsh + robbyrussell: type `lo` + Tab with `ls` in history → result is `ls`, **no** `~ ` prepended. History records `ls`, not `~ ls`.
  - [ ] Same host: run `sudo id`, enter password, then type + Tab → completion clean.
  - [ ] Plain bash `user@host:~$ ` prompt — unchanged behavior (detector was already correct here, reconciler is a no-op).
  - [ ] Password entry Enter — does **not** log the password as a command (live `detectPrompt` still returns `isAtPrompt=false` on the `[sudo] password for user: ` line).
  - [ ] Use Ctrl-A / Ctrl-E to move the cursor, then Tab — buffer is invalidated, reconciler defers to the detector (no worse than current behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)