### PR TITLE
fix(terminal): preserve selection when typing Space or uppercase (#819)

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -419,10 +419,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   };
 
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-    if (e.type !== "keydown") {
-      return true;
-    }
-
     // Preserve mouse selection across keystrokes when enabled. xterm.js
     // unconditionally clears the selection on user input
     // (SelectionService.ts: coreService.onUserInput → clearSelection).
@@ -430,7 +426,17 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // processed the key + cleared. The microtask runs after both
     // synchronous listeners, so by then either the selection is gone (and
     // we restore) or it's still there (we no-op).
+    //
+    // Both keydown AND keypress must be hooked: xterm routes Space
+    // (keyCode 32 fails Keyboard.ts: `ev.keyCode >= 48`) and A–Z
+    // (CoreBrowserTerminal.ts:_keyDown A–Z IME HACK) through the
+    // `keypress` event, calling triggerDataEvent in _keyPress rather
+    // than _keyDown. For those keys, keydown's microtask drains before
+    // keypress fires, so hasSelection is still true → no-op. Attaching
+    // to keypress gives us a second microtask that drains after
+    // _keyPress clears the selection, so the restore runs.
     if (
+      (e.type === "keydown" || e.type === "keypress") &&
       ctx.terminalSettingsRef.current?.preserveSelectionOnInput &&
       term.hasSelection()
     ) {
@@ -453,6 +459,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           }
         });
       }
+    }
+
+    if (e.type !== "keydown") {
+      return true;
     }
 
     // Autocomplete key handler (must be checked before other handlers)


### PR DESCRIPTION
## Summary

- Extend PR #763's capture-and-restore to also hook the `keypress` event, not just `keydown`
- Fixes the two cases shideqin reported in #819 (and in the #755 follow-up comments) where **Space** and **Shift+letter / CapsLock+letter** still wipe the selection even with *Keep selection while typing* enabled

Closes #819
Follow-up to #755 / #763

## Why PR #763 missed these two keys

PR #763 captures the selection in the keydown handler and restores it in a `queueMicrotask`. That assumes the selection clear (`SelectionService.onUserInput` → `clearSelection`) happens **synchronously inside `_keyDown`**, so by the time the microtask drains `hasSelection()` is `false` and the restore runs.

But `@xterm/xterm/src/browser/CoreBrowserTerminal.ts` routes two key classes through the `keypress` event instead:

1. **Space** — `Keyboard.ts:357` gates on `ev.keyCode >= 48`, and space is `32`, so `result.key` stays `undefined`. `_keyDown:1066-1068` then does `if (!result.key) return true;` and never calls `triggerDataEvent`.
2. **A–Z** — `_keyDown:1070-1076` has an explicit IME HACK that returns `true` for any single-char key whose `charCodeAt(0)` is 65–90 (so both Shift+letter and CapsLock+letter), deferring to `keypress`.

For those keys:

| Step | Lowercase 'a' | Space / Uppercase 'A' |
| --- | --- | --- |
| keydown: capture + queueMicrotask | ✅ | ✅ |
| keydown: `triggerDataEvent` clears selection | ✅ synchronous | ❌ not called, returns `true` |
| keydown task ends, microtask drains | `hasSelection=false` → **restore runs** ✅ | `hasSelection=true` → **no-op** ❌ |
| keypress task fires `triggerDataEvent` | (never, preventDefault'd) | ✅ clears, **no restore scheduled** |

Result: with the setting on, typing `sz ` (where the space is the trigger) or any uppercase letter still drops the mouse selection.

## The fix

Attach the same capture-and-restore to `keypress` as well. The `keypress` handler's microtask drains *after* `_keyPress` calls `triggerDataEvent` (line 1175), so `hasSelection()` is `false` when the microtask runs and the restore actually happens.

- The keydown microtask still fires, but now harmlessly no-ops for the keypress path (selection is still intact when it drains) — no double-restore, no visible flicker
- All other handler logic (autocomplete, snippets, hotkey matching) still only runs on keydown; the `if (e.type !== \"keydown\") return true;` guard is just moved below the capture block
- \`isRestoringSelectionRef\` gate in \`Terminal.tsx\` is unchanged — it already covers both call sites since it's set/unset around \`term.select(...)\` itself

## Test plan

- [x] Setting off (default): no behavior change — typing still clears selection
- [x] Setting on: select text, type lowercase letter → selection stays (regression check for #755)
- [x] Setting on: select text, type **Space** → selection stays (new in #819)
- [x] Setting on: select text, type **Shift+letter** → selection stays (new in #819)
- [x] Setting on: select text with CapsLock, type letter → selection stays
- [x] Setting on: select text, type the `sz ` + middle-click-paste workflow → path pasted intact
- [x] Setting on + copy-on-select on: select X, copy Y in another app, type any key → clipboard still has Y (not re-overwritten by restore)
- [x] Setting on: click in empty area → selection clears (mouse path unaffected)
- [x] Setting on: terminal output scrolls past selected rows → selection drops naturally (no stuck restore)
- [x] Setting on: multi-line selection survives keystroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)