### PR TITLE
fix(cloud-sync): fall back to OS-assigned OAuth port when 45678 is busy (closes #823)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1518,6 +1518,7 @@ const en: Messages = {
   'cloudSync.conflict.keepLocal': 'Overwrite cloud (keep local)',
   'cloudSync.conflict.useCloud': 'Download cloud (overwrite local)',
   'cloudSync.connect.browserContinue': 'Complete authorization in browser',
+  'cloudSync.connect.browserCancelled': 'Previous browser authorization was cancelled',
   'cloudSync.connect.github.success': 'GitHub connected successfully',
   'cloudSync.connect.github.failedTitle': 'GitHub connection failed',
   'cloudSync.connect.github.timeout': 'GitHub connection timed out. Check your network or proxy settings.',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1123,6 +1123,7 @@ const zhCN: Messages = {
   'cloudSync.conflict.keepLocal': '覆盖云端（保留本地）',
   'cloudSync.conflict.useCloud': '下载云端（覆盖本地）',
   'cloudSync.connect.browserContinue': '请在浏览器中完成授权',
+  'cloudSync.connect.browserCancelled': '已取消上一个浏览器授权流程',
   'cloudSync.connect.github.success': 'GitHub 已连接',
   'cloudSync.connect.github.failedTitle': 'GitHub 连接失败',
   'cloudSync.connect.github.timeout': '连接 GitHub 超时，请检查网络或代理设置。',

--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -146,6 +146,7 @@ const getSnapshot = (): SyncManagerState => {
 export const useCloudSync = (): CloudSyncHook => {
   // Use useSyncExternalStore for real-time state sync across all components
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const activeOAuthSessionIdRef = useRef<string | null>(null);
 
   // Auto-unlock: if a master key exists, retrieve the persisted password (Electron safeStorage)
   // and unlock silently so users don't have to manage a LOCKED state in the UI.
@@ -262,7 +263,7 @@ export const useCloudSync = (): CloudSyncHook => {
     if (result.type !== 'device_code') {
       throw new Error('Unexpected auth type');
     }
-    return result.data as DeviceFlowState;
+    return result.data;
   }, []);
   
   const completeGitHubAuth = useCallback(async (
@@ -279,30 +280,29 @@ export const useCloudSync = (): CloudSyncHook => {
       const bridge = netcattyBridge.get();
       const prepare = bridge?.prepareOAuthCallback;
       const awaitCallback = bridge?.awaitOAuthCallback;
-      if (!prepare || !awaitCallback) {
+      const openExternal = bridge?.openExternal;
+      if (!prepare || !awaitCallback || !openExternal) {
         throw new Error('OAuth bridge is unavailable');
       }
 
       // Bind the loopback callback server first so we know which port to put
       // in the provider's redirect_uri (#823: 45678 may be in use).
-      const prepared = await prepare();
-      const redirectUri = prepared.redirectUri;
+      const { redirectUri, sessionId } = await prepare();
+      activeOAuthSessionIdRef.current = sessionId;
 
-      let authStarted = false;
       try {
         const result = await manager.startProviderAuth(provider, redirectUri);
         if (result.type !== 'url') {
           throw new Error('Unexpected auth type');
         }
-        authStarted = true;
-        const data = result.data as { url: string; redirectUri: string };
+        const data = result.data;
 
         const adapter = manager.getAdapter(provider) as
           | { getPKCEState?: () => string | null }
           | undefined;
         const expectedState = adapter?.getPKCEState?.() || undefined;
 
-        const callbackPromise = awaitCallback(expectedState);
+        const callbackPromise = awaitCallback(expectedState, sessionId);
 
         // Use system browser to avoid white-screen issues in popup windows (#563).
         // Race: if browser launch fails, surface the error immediately.
@@ -310,9 +310,9 @@ export const useCloudSync = (): CloudSyncHook => {
         const browserPromise = new Promise<never>((_resolve, reject) => {
           openTimer = setTimeout(async () => {
             try {
-              await bridge?.openExternal(data.url);
+              await openExternal(data.url);
             } catch (err) {
-              bridge?.cancelOAuthCallback?.();
+              bridge?.cancelOAuthCallback?.(sessionId);
               reject(
                 err instanceof Error
                   ? err
@@ -331,16 +331,20 @@ export const useCloudSync = (): CloudSyncHook => {
 
         return data.url;
       } catch (err) {
-        // If we bound a server but never reached awaitCallback (or it failed
-        // before resolving), release the port so the next attempt can bind.
-        if (!authStarted) {
-          try {
-            await bridge?.cancelOAuthCallback?.();
-          } catch {
-            // Best-effort cleanup
-          }
+        const ownsActiveSession = activeOAuthSessionIdRef.current === sessionId;
+        try {
+          await bridge?.cancelOAuthCallback?.(sessionId);
+        } catch {
+          // Best-effort cleanup
+        }
+        if (ownsActiveSession) {
+          manager.resetProviderStatus(provider);
         }
         throw err;
+      } finally {
+        if (activeOAuthSessionIdRef.current === sessionId) {
+          activeOAuthSessionIdRef.current = null;
+        }
       }
     },
     []
@@ -380,7 +384,7 @@ export const useCloudSync = (): CloudSyncHook => {
   
   const cancelOAuthConnect = useCallback(() => {
     const bridge = netcattyBridge.get();
-    bridge?.cancelOAuthCallback?.();
+    bridge?.cancelOAuthCallback?.(activeOAuthSessionIdRef.current ?? undefined);
   }, []);
 
   // ========== Settings ==========

--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -53,6 +53,7 @@ export interface CloudSyncHook {
   remoteVersion: number;
   remoteUpdatedAt: number;
   syncHistory: SyncHistoryEntry[];
+  pendingBrowserAuthProvider: 'google' | 'onedrive' | null;
   
   // Computed
   hasAnyConnectedProvider: boolean;
@@ -72,7 +73,9 @@ export interface CloudSyncHook {
     deviceCode: string,
     interval: number,
     expiresAt: number,
-    onPending?: () => void
+    onPending?: () => void,
+    signal?: AbortSignal,
+    authAttemptId?: number
   ) => Promise<void>;
   connectGoogle: () => Promise<string>;
   connectOneDrive: () => Promise<string>;
@@ -126,6 +129,47 @@ export interface CloudSyncHook {
   getShrinkBlockedFinding: () => Extract<ShrinkFinding, { suspicious: true }> | null;
 }
 
+type PendingBrowserAuthState = {
+  provider: 'google' | 'onedrive';
+  sessionId: string;
+  authAttemptId?: number;
+} | null;
+
+let pendingBrowserAuthState: PendingBrowserAuthState = null;
+const pendingBrowserAuthListeners = new Set<() => void>();
+let activeOAuthBrowserHandoff:
+  | { sessionId: string; cancel: () => void }
+  | null = null;
+const cancelledOAuthSessionIds = new Set<string>();
+
+const getPendingBrowserAuthState = (): PendingBrowserAuthState => pendingBrowserAuthState;
+
+const subscribePendingBrowserAuthState = (callback: () => void) => {
+  pendingBrowserAuthListeners.add(callback);
+  return () => pendingBrowserAuthListeners.delete(callback);
+};
+
+const setPendingBrowserAuthState = (next: PendingBrowserAuthState) => {
+  pendingBrowserAuthState = next;
+  pendingBrowserAuthListeners.forEach((callback) => callback());
+};
+
+const clearPendingBrowserAuthState = (
+  match?: { provider: 'google' | 'onedrive'; sessionId: string; authAttemptId?: number }
+) => {
+  if (!match) {
+    setPendingBrowserAuthState(null);
+    return;
+  }
+  if (
+    pendingBrowserAuthState &&
+    pendingBrowserAuthState.provider === match.provider &&
+    pendingBrowserAuthState.sessionId === match.sessionId
+  ) {
+    setPendingBrowserAuthState(null);
+  }
+};
+
 // ============================================================================
 // Hook Implementation
 // ============================================================================
@@ -146,7 +190,15 @@ const getSnapshot = (): SyncManagerState => {
 export const useCloudSync = (): CloudSyncHook => {
   // Use useSyncExternalStore for real-time state sync across all components
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const pendingBrowserAuth = useSyncExternalStore(
+    subscribePendingBrowserAuthState,
+    getPendingBrowserAuthState,
+    getPendingBrowserAuthState
+  );
   const activeOAuthSessionIdRef = useRef<string | null>(null);
+  const activeOAuthProviderRef = useRef<'google' | 'onedrive' | null>(null);
+  const activeGitHubAuthAbortRef = useRef<AbortController | null>(null);
+  const activeGitHubAuthAttemptIdRef = useRef<number | null>(null);
 
   // Auto-unlock: if a master key exists, retrieve the persisted password (Electron safeStorage)
   // and unlock silently so users don't have to manage a LOCKED state in the UI.
@@ -263,6 +315,7 @@ export const useCloudSync = (): CloudSyncHook => {
     if (result.type !== 'device_code') {
       throw new Error('Unexpected auth type');
     }
+    activeGitHubAuthAttemptIdRef.current = result.data.authAttemptId ?? null;
     return result.data;
   }, []);
   
@@ -270,9 +323,73 @@ export const useCloudSync = (): CloudSyncHook => {
     deviceCode: string,
     interval: number,
     expiresAt: number,
-    onPending?: () => void
+    onPending?: () => void,
+    signal?: AbortSignal,
+    authAttemptId?: number
   ): Promise<void> => {
-    await manager.completeGitHubAuth(deviceCode, interval, expiresAt, onPending);
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+
+    if (signal?.aborted) {
+      abort();
+    } else if (signal) {
+      signal.addEventListener('abort', abort, { once: true });
+    }
+
+    activeGitHubAuthAbortRef.current = controller;
+
+    try {
+      await manager.completeGitHubAuth(
+        deviceCode,
+        interval,
+        expiresAt,
+        onPending,
+        controller.signal,
+        authAttemptId
+      );
+    } finally {
+      if (signal) {
+        signal.removeEventListener('abort', abort);
+      }
+      if (activeGitHubAuthAbortRef.current === controller) {
+        activeGitHubAuthAbortRef.current = null;
+      }
+      if (activeGitHubAuthAttemptIdRef.current === (authAttemptId ?? null)) {
+        activeGitHubAuthAttemptIdRef.current = null;
+      }
+    }
+  }, []);
+
+  const cancelActivePKCEAuth = useCallback(async () => {
+    const pending = getPendingBrowserAuthState();
+    const sessionId = pending?.sessionId ?? activeOAuthSessionIdRef.current;
+    const provider = pending?.provider ?? activeOAuthProviderRef.current;
+    const authAttemptId = pending?.authAttemptId;
+    if (!sessionId || !provider) return;
+
+    cancelledOAuthSessionIds.add(sessionId);
+    if (activeOAuthBrowserHandoff?.sessionId === sessionId) {
+      activeOAuthBrowserHandoff.cancel();
+      activeOAuthBrowserHandoff = null;
+    }
+    manager.cancelProviderAuthAttempt(provider, authAttemptId);
+    activeOAuthSessionIdRef.current = null;
+    activeOAuthProviderRef.current = null;
+    clearPendingBrowserAuthState(
+      pending
+        ? {
+            provider: pending.provider,
+            sessionId: pending.sessionId,
+            authAttemptId: pending.authAttemptId,
+          }
+        : undefined
+    );
+
+    try {
+      await netcattyBridge.get()?.cancelOAuthCallback?.(sessionId);
+    } catch {
+      // Best-effort cleanup
+    }
   }, []);
   
   const runPKCEAuth = useCallback(
@@ -285,10 +402,17 @@ export const useCloudSync = (): CloudSyncHook => {
         throw new Error('OAuth bridge is unavailable');
       }
 
+      // Only one loopback OAuth flow can be active at a time. If the user
+      // starts another provider while a previous browser hop is still pending,
+      // cancel the stale one first so the new attempt owns the callback port.
+      await cancelActivePKCEAuth();
+
       // Bind the loopback callback server first so we know which port to put
       // in the provider's redirect_uri (#823: 45678 may be in use).
       const { redirectUri, sessionId } = await prepare();
       activeOAuthSessionIdRef.current = sessionId;
+      activeOAuthProviderRef.current = provider;
+      setPendingBrowserAuthState({ provider, sessionId });
 
       try {
         const result = await manager.startProviderAuth(provider, redirectUri);
@@ -296,6 +420,10 @@ export const useCloudSync = (): CloudSyncHook => {
           throw new Error('Unexpected auth type');
         }
         const data = result.data;
+
+        if (cancelledOAuthSessionIds.has(sessionId)) {
+          throw new Error('OAuth flow cancelled');
+        }
 
         const adapter = manager.getAdapter(provider) as
           | { getPKCEState?: () => string | null }
@@ -305,12 +433,19 @@ export const useCloudSync = (): CloudSyncHook => {
         const callbackPromise = awaitCallback(expectedState, sessionId);
 
         // Use system browser to avoid white-screen issues in popup windows (#563).
-        // Race: if browser launch fails, surface the error immediately.
+        // Once the browser has opened, let the rest of the PKCE handshake
+        // continue in the background so closing the browser later does not
+        // leave the whole settings page locked waiting on a timeout.
         let openTimer: ReturnType<typeof setTimeout> | null = null;
-        const browserPromise = new Promise<never>((_resolve, reject) => {
+        let browserOpened = false;
+        let rejectBrowserPromise: ((error: Error) => void) | null = null;
+        const browserPromise = new Promise<void>((resolve, reject) => {
+          rejectBrowserPromise = reject;
           openTimer = setTimeout(async () => {
             try {
               await openExternal(data.url);
+              browserOpened = true;
+              resolve();
             } catch (err) {
               bridge?.cancelOAuthCallback?.(sessionId);
               reject(
@@ -321,33 +456,123 @@ export const useCloudSync = (): CloudSyncHook => {
             }
           }, 100);
         });
+        activeOAuthBrowserHandoff = {
+          sessionId,
+          cancel: () => {
+          if (openTimer) {
+            clearTimeout(openTimer);
+            openTimer = null;
+          }
+          if (rejectBrowserPromise) {
+            rejectBrowserPromise(new Error('OAuth flow cancelled'));
+            rejectBrowserPromise = null;
+          }
+          },
+        };
 
         try {
-          const { code } = await Promise.race([callbackPromise, browserPromise]);
-          await manager.completePKCEAuth(provider, code, data.redirectUri);
+          await Promise.race([
+            browserPromise,
+            callbackPromise.then(
+              () => {
+                throw new Error('OAuth callback completed before browser handoff');
+              },
+              (error) => {
+                if (browserOpened) {
+                  return new Promise<void>(() => {});
+                }
+                throw error;
+              }
+            ),
+          ]);
         } finally {
           if (openTimer) clearTimeout(openTimer);
+          if (activeOAuthBrowserHandoff?.sessionId === sessionId) {
+            activeOAuthBrowserHandoff = null;
+          }
         }
+        setPendingBrowserAuthState({
+          provider,
+          sessionId,
+          authAttemptId: data.authAttemptId,
+        });
 
+        const completionPromise = (async () => {
+          try {
+            const { code } = await callbackPromise;
+            await manager.completePKCEAuth(provider, code, data.redirectUri, data.authAttemptId);
+          } catch (error) {
+            const ownsActiveSession =
+              activeOAuthSessionIdRef.current === sessionId &&
+              activeOAuthProviderRef.current === provider;
+            const message = error instanceof Error ? error.message : String(error);
+            const cancelledOrSuperseded =
+              message.includes('cancelled') || message.includes('auth superseded');
+            const timedOut = message.toLowerCase().includes('timeout');
+            if (ownsActiveSession && (cancelledOrSuperseded || timedOut)) {
+              activeOAuthSessionIdRef.current = null;
+              activeOAuthProviderRef.current = null;
+              cancelledOAuthSessionIds.delete(sessionId);
+              clearPendingBrowserAuthState({
+                provider,
+                sessionId,
+                authAttemptId: data.authAttemptId,
+              });
+              manager.resetProviderStatus(provider);
+            } else if (ownsActiveSession) {
+              activeOAuthSessionIdRef.current = null;
+              activeOAuthProviderRef.current = null;
+              cancelledOAuthSessionIds.delete(sessionId);
+              clearPendingBrowserAuthState({
+                provider,
+                sessionId,
+                authAttemptId: data.authAttemptId,
+              });
+              manager.setProviderError(provider, message);
+            }
+          } finally {
+            if (
+              activeOAuthSessionIdRef.current === sessionId &&
+              activeOAuthProviderRef.current === provider
+            ) {
+              activeOAuthSessionIdRef.current = null;
+              activeOAuthProviderRef.current = null;
+            }
+            cancelledOAuthSessionIds.delete(sessionId);
+            clearPendingBrowserAuthState({
+              provider,
+              sessionId,
+              authAttemptId: data.authAttemptId,
+            });
+          }
+        })();
+
+        // Release the transient "connecting" UI once the browser handoff has
+        // happened. The callback session remains active in the background and
+        // will mark the provider connected when the redirect completes.
+        manager.resetProviderStatus(provider);
+        manager.clearProviderError(provider);
+        void completionPromise;
         return data.url;
       } catch (err) {
-        const ownsActiveSession = activeOAuthSessionIdRef.current === sessionId;
+        const ownsActiveSession =
+          activeOAuthSessionIdRef.current === sessionId &&
+          activeOAuthProviderRef.current === provider;
         try {
           await bridge?.cancelOAuthCallback?.(sessionId);
         } catch {
           // Best-effort cleanup
         }
         if (ownsActiveSession) {
+          activeOAuthSessionIdRef.current = null;
+          activeOAuthProviderRef.current = null;
+          manager.cancelProviderAuthAttempt(provider);
           manager.resetProviderStatus(provider);
         }
         throw err;
-      } finally {
-        if (activeOAuthSessionIdRef.current === sessionId) {
-          activeOAuthSessionIdRef.current = null;
-        }
       }
     },
-    []
+    [cancelActivePKCEAuth]
   );
 
   const connectGoogle = useCallback(async (): Promise<string> => {
@@ -383,9 +608,16 @@ export const useCloudSync = (): CloudSyncHook => {
   }, []);
   
   const cancelOAuthConnect = useCallback(() => {
-    const bridge = netcattyBridge.get();
-    bridge?.cancelOAuthCallback?.(activeOAuthSessionIdRef.current ?? undefined);
-  }, []);
+    const githubAbort = activeGitHubAuthAbortRef.current;
+    if (githubAbort) {
+      manager.cancelProviderAuthAttempt('github', activeGitHubAuthAttemptIdRef.current ?? undefined);
+      activeGitHubAuthAttemptIdRef.current = null;
+      githubAbort.abort();
+      return;
+    }
+
+    void cancelActivePKCEAuth();
+  }, [cancelActivePKCEAuth]);
 
   // ========== Settings ==========
   
@@ -473,6 +705,7 @@ export const useCloudSync = (): CloudSyncHook => {
     remoteVersion: state.remoteVersion,
     remoteUpdatedAt: state.remoteUpdatedAt,
     syncHistory: state.syncHistory,
+    pendingBrowserAuthProvider: pendingBrowserAuth?.provider ?? null,
     
     // Computed
     hasAnyConnectedProvider,

--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -274,95 +274,86 @@ export const useCloudSync = (): CloudSyncHook => {
     await manager.completeGitHubAuth(deviceCode, interval, expiresAt, onPending);
   }, []);
   
-  const connectGoogle = useCallback(async (): Promise<string> => {
-    const result = await manager.startProviderAuth('google');
-    if (result.type !== 'url') {
-      throw new Error('Unexpected auth type');
-    }
-    const data = result.data as { url: string; redirectUri: string };
-
-    // Start OAuth callback server in Electron and wait for authorization
-    const bridge = netcattyBridge.get();
-    const startCallback = bridge?.startOAuthCallback;
-    if (startCallback) {
-      // Get state from adapter for CSRF protection
-      const adapter = manager.getAdapter('google') as { getPKCEState?: () => string | null } | undefined;
-      const expectedState = adapter?.getPKCEState?.() || undefined;
-
-      // Start callback server and open system browser
-      const callbackPromise = startCallback(expectedState);
-
-      // Use system browser to avoid white-screen issues in popup windows (#563)
-      // Race: if browser launch fails, surface the error immediately
-      let openTimer: ReturnType<typeof setTimeout> | null = null;
-      const browserPromise = new Promise<never>((_resolve, reject) => {
-        openTimer = setTimeout(async () => {
-          try {
-            await bridge?.openExternal(data.url);
-          } catch (err) {
-            bridge?.cancelOAuthCallback?.();
-            reject(err instanceof Error ? err : new Error('Failed to open browser for authentication'));
-          }
-        }, 100);
-      });
-
-      try {
-        const { code } = await Promise.race([callbackPromise, browserPromise]);
-
-        // Complete auth with the received code
-        await manager.completePKCEAuth('google', code, data.redirectUri);
-      } finally {
-        if (openTimer) clearTimeout(openTimer);
+  const runPKCEAuth = useCallback(
+    async (provider: 'google' | 'onedrive'): Promise<string> => {
+      const bridge = netcattyBridge.get();
+      const prepare = bridge?.prepareOAuthCallback;
+      const awaitCallback = bridge?.awaitOAuthCallback;
+      if (!prepare || !awaitCallback) {
+        throw new Error('OAuth bridge is unavailable');
       }
-    }
 
-    return data.url;
-  }, []);
+      // Bind the loopback callback server first so we know which port to put
+      // in the provider's redirect_uri (#823: 45678 may be in use).
+      const prepared = await prepare();
+      const redirectUri = prepared.redirectUri;
+
+      let authStarted = false;
+      try {
+        const result = await manager.startProviderAuth(provider, redirectUri);
+        if (result.type !== 'url') {
+          throw new Error('Unexpected auth type');
+        }
+        authStarted = true;
+        const data = result.data as { url: string; redirectUri: string };
+
+        const adapter = manager.getAdapter(provider) as
+          | { getPKCEState?: () => string | null }
+          | undefined;
+        const expectedState = adapter?.getPKCEState?.() || undefined;
+
+        const callbackPromise = awaitCallback(expectedState);
+
+        // Use system browser to avoid white-screen issues in popup windows (#563).
+        // Race: if browser launch fails, surface the error immediately.
+        let openTimer: ReturnType<typeof setTimeout> | null = null;
+        const browserPromise = new Promise<never>((_resolve, reject) => {
+          openTimer = setTimeout(async () => {
+            try {
+              await bridge?.openExternal(data.url);
+            } catch (err) {
+              bridge?.cancelOAuthCallback?.();
+              reject(
+                err instanceof Error
+                  ? err
+                  : new Error('Failed to open browser for authentication')
+              );
+            }
+          }, 100);
+        });
+
+        try {
+          const { code } = await Promise.race([callbackPromise, browserPromise]);
+          await manager.completePKCEAuth(provider, code, data.redirectUri);
+        } finally {
+          if (openTimer) clearTimeout(openTimer);
+        }
+
+        return data.url;
+      } catch (err) {
+        // If we bound a server but never reached awaitCallback (or it failed
+        // before resolving), release the port so the next attempt can bind.
+        if (!authStarted) {
+          try {
+            await bridge?.cancelOAuthCallback?.();
+          } catch {
+            // Best-effort cleanup
+          }
+        }
+        throw err;
+      }
+    },
+    []
+  );
+
+  const connectGoogle = useCallback(async (): Promise<string> => {
+    return runPKCEAuth('google');
+  }, [runPKCEAuth]);
 
   const connectOneDrive = useCallback(async (): Promise<string> => {
-    const result = await manager.startProviderAuth('onedrive');
-    if (result.type !== 'url') {
-      throw new Error('Unexpected auth type');
-    }
-    const data = result.data as { url: string; redirectUri: string };
+    return runPKCEAuth('onedrive');
+  }, [runPKCEAuth]);
 
-    // Start OAuth callback server in Electron and wait for authorization
-    const bridge = netcattyBridge.get();
-    const startCallback = bridge?.startOAuthCallback;
-    if (startCallback) {
-      // Get state from adapter for CSRF protection
-      const adapter = manager.getAdapter('onedrive') as { getPKCEState?: () => string | null } | undefined;
-      const expectedState = adapter?.getPKCEState?.() || undefined;
-
-      // Start callback server and open system browser
-      const callbackPromise = startCallback(expectedState);
-
-      // Use system browser to avoid white-screen issues in popup windows (#563)
-      let openTimer: ReturnType<typeof setTimeout> | null = null;
-      const browserPromise = new Promise<never>((_resolve, reject) => {
-        openTimer = setTimeout(async () => {
-          try {
-            await bridge?.openExternal(data.url);
-          } catch (err) {
-            bridge?.cancelOAuthCallback?.();
-            reject(err instanceof Error ? err : new Error('Failed to open browser for authentication'));
-          }
-        }, 100);
-      });
-
-      try {
-        const { code } = await Promise.race([callbackPromise, browserPromise]);
-
-        // Complete auth with the received code
-        await manager.completePKCEAuth('onedrive', code, data.redirectUri);
-      } finally {
-        if (openTimer) clearTimeout(openTimer);
-      }
-    }
-
-    return data.url;
-  }, []);
-  
   const completePKCEAuth = useCallback(async (
     provider: 'google' | 'onedrive',
     code: string,

--- a/components/CloudSyncSettings.tsx
+++ b/components/CloudSyncSettings.tsx
@@ -1152,6 +1152,40 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     } | null>(null);
     const [historyPreviewLoading, setHistoryPreviewLoading] = useState(false);
     const [historyError, setHistoryError] = useState<string | null>(null);
+    const [pendingConnectProvider, setPendingConnectProvider] = useState<CloudProvider | null>(null);
+    const pendingConnectProviderRef = useRef<CloudProvider | null>(null);
+
+    const hasConnectingProvider = (Object.values(sync.providers) as Array<{ status: string }>).some(
+        (provider) => provider.status === 'connecting'
+    );
+
+    const isConnectDisabled = (provider: CloudProvider): boolean => {
+        if (pendingConnectProvider && pendingConnectProvider !== provider) {
+            return true;
+        }
+        if (pendingConnectProvider === provider) {
+            return true;
+        }
+        if (hasConnectingProvider && sync.providers[provider].status !== 'connecting') {
+            return true;
+        }
+        return sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers[provider]);
+    };
+
+    const beginPendingConnect = (provider: CloudProvider): boolean => {
+        if (pendingConnectProviderRef.current) {
+            return false;
+        }
+        pendingConnectProviderRef.current = provider;
+        setPendingConnectProvider(provider);
+        return true;
+    };
+
+    const endPendingConnect = (provider: CloudProvider) => {
+        if (pendingConnectProviderRef.current !== provider) return;
+        pendingConnectProviderRef.current = null;
+        setPendingConnectProvider((current) => (current === provider ? null : current));
+    };
 
     // Change master key dialog
     const [showChangeKeyDialog, setShowChangeKeyDialog] = useState(false);
@@ -1275,6 +1309,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
 
     // Connect GitHub (disconnect others first - single provider only)
     const handleConnectGitHub = async () => {
+        if (!beginPendingConnect('github')) return;
         try {
             await disconnectOtherProviders('github');
             const deviceFlow = await sync.connectGitHub();
@@ -1300,42 +1335,46 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
             sync.resetProviderStatus('github');
             const message = getNetworkErrorMessage(error, t('common.unknownError'));
             toast.error(message, t('cloudSync.connect.github.failedTitle'));
+        } finally {
+            endPendingConnect('github');
         }
     };
 
     // Connect Google (disconnect others first - single provider only)
     const handleConnectGoogle = async () => {
+        if (!beginPendingConnect('google')) return;
         try {
             await disconnectOtherProviders('google');
             await sync.connectGoogle();
             // Note: Auth flow is handled automatically by oauthBridge
             toast.info(t('cloudSync.connect.browserContinue'));
         } catch (error) {
-            // Reset provider status so button is clickable again (without tearing down existing connections)
-            sync.resetProviderStatus('google');
             const msg = error instanceof Error ? error.message : t('common.unknownError');
             // Don't show toast for user-initiated cancellation (popup closed)
             if (!msg.includes('cancelled')) {
                 toast.error(msg, t('cloudSync.connect.google.failedTitle'));
             }
+        } finally {
+            endPendingConnect('google');
         }
     };
 
     // Connect OneDrive (disconnect others first - single provider only)
     const handleConnectOneDrive = async () => {
+        if (!beginPendingConnect('onedrive')) return;
         try {
             await disconnectOtherProviders('onedrive');
             await sync.connectOneDrive();
             // Note: Auth flow is handled automatically by oauthBridge
             toast.info(t('cloudSync.connect.browserContinue'));
         } catch (error) {
-            // Reset provider status so button is clickable again (without tearing down existing connections)
-            sync.resetProviderStatus('onedrive');
             const msg = error instanceof Error ? error.message : t('common.unknownError');
             // Don't show toast for user-initiated cancellation (popup closed)
             if (!msg.includes('cancelled')) {
                 toast.error(msg, t('cloudSync.connect.onedrive.failedTitle'));
             }
+        } finally {
+            endPendingConnect('onedrive');
         }
     };
 
@@ -1673,7 +1712,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         account={sync.providers.github.account}
                         lastSync={sync.providers.github.lastSync}
                         error={sync.providers.github.error}
-                        disabled={sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers.github)}
+                        disabled={isConnectDisabled('github')}
                         onConnect={handleConnectGitHub}
                         onDisconnect={() => sync.disconnectProvider('github')}
                         onSync={() => handleSync('github')}
@@ -1697,7 +1736,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         account={sync.providers.google.account}
                         lastSync={sync.providers.google.lastSync}
                         error={sync.providers.google.error}
-                        disabled={sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers.google)}
+                        disabled={isConnectDisabled('google')}
                         onConnect={handleConnectGoogle}
                         onCancelConnect={sync.cancelOAuthConnect}
                         onDisconnect={() => sync.disconnectProvider('google')}
@@ -1714,7 +1753,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         account={sync.providers.onedrive.account}
                         lastSync={sync.providers.onedrive.lastSync}
                         error={sync.providers.onedrive.error}
-                        disabled={sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers.onedrive)}
+                        disabled={isConnectDisabled('onedrive')}
                         onConnect={handleConnectOneDrive}
                         onCancelConnect={sync.cancelOAuthConnect}
                         onDisconnect={() => sync.disconnectProvider('onedrive')}
@@ -1731,7 +1770,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         account={sync.providers.webdav.account}
                         lastSync={sync.providers.webdav.lastSync}
                         error={sync.providers.webdav.error}
-                        disabled={sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers.webdav)}
+                        disabled={isConnectDisabled('webdav')}
                         onEdit={openWebdavDialog}
                         onConnect={openWebdavDialog}
                         onDisconnect={() => sync.disconnectProvider('webdav')}
@@ -1748,7 +1787,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         account={sync.providers.s3.account}
                         lastSync={sync.providers.s3.lastSync}
                         error={sync.providers.s3.error}
-                        disabled={sync.hasAnyConnectedProvider && !isProviderReadyForSync(sync.providers.s3)}
+                        disabled={isConnectDisabled('s3')}
                         onEdit={openS3Dialog}
                         onConnect={openS3Dialog}
                         onDisconnect={() => sync.disconnectProvider('s3')}

--- a/components/CloudSyncSettings.tsx
+++ b/components/CloudSyncSettings.tsx
@@ -433,7 +433,7 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
                         size="sm"
                         variant="outline"
                         onClick={onCancelConnect}
-                        className="gap-1"
+                        className="gap-1 min-w-[136px] justify-center"
                     >
                         <X size={14} />
                         {t('common.cancel')}
@@ -442,7 +442,7 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
                     <Button
                         size="sm"
                         onClick={() => { onConnect(); }}
-                        className="gap-1"
+                        className="gap-1 min-w-[136px] justify-center"
                         disabled={disabled || isConnecting}
                     >
                         {isConnecting ? <Loader2 size={14} className="animate-spin" /> : <Cloud size={14} />}
@@ -1121,6 +1121,10 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     };
 
     const disconnectOtherProviders = async (current: CloudProvider) => {
+        if (sync.pendingBrowserAuthProvider && sync.pendingBrowserAuthProvider !== current) {
+            toast.info(t('cloudSync.connect.browserCancelled'));
+        }
+        sync.cancelOAuthConnect();
         const providers: CloudProvider[] = ['github', 'google', 'onedrive', 'webdav', 's3'];
         for (const provider of providers) {
             if (provider === current) continue;
@@ -1135,6 +1139,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     const [gitHubUserCode, setGitHubUserCode] = useState('');
     const [gitHubVerificationUri, setGitHubVerificationUri] = useState('');
     const [isPollingGitHub, setIsPollingGitHub] = useState(false);
+    const activeGitHubAttemptIdRef = useRef<number | null>(null);
 
     // Conflict modal
     const [showConflictModal, setShowConflictModal] = useState(false);
@@ -1310,9 +1315,13 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     // Connect GitHub (disconnect others first - single provider only)
     const handleConnectGitHub = async () => {
         if (!beginPendingConnect('github')) return;
+        const cancelController = new AbortController();
+        let authAttemptId: number | null = null;
         try {
             await disconnectOtherProviders('github');
             const deviceFlow = await sync.connectGitHub();
+            authAttemptId = deviceFlow.authAttemptId ?? null;
+            activeGitHubAttemptIdRef.current = authAttemptId;
             setGitHubUserCode(deviceFlow.userCode);
             setGitHubVerificationUri(deviceFlow.verificationUri);
             setShowGitHubModal(true);
@@ -1322,21 +1331,32 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                 deviceFlow.deviceCode,
                 deviceFlow.interval,
                 deviceFlow.expiresAt,
-                () => { } // onPending callback
+                () => { }, // onPending callback
+                cancelController.signal,
+                authAttemptId ?? undefined
             );
 
-            setIsPollingGitHub(false);
-            setShowGitHubModal(false);
+            if (activeGitHubAttemptIdRef.current === authAttemptId) {
+                activeGitHubAttemptIdRef.current = null;
+                setIsPollingGitHub(false);
+                setShowGitHubModal(false);
+            }
             toast.success(t('cloudSync.connect.github.success'));
         } catch (error) {
-            setIsPollingGitHub(false);
-            setShowGitHubModal(false);
-            // Reset provider status so button is clickable again (without tearing down existing connections)
-            sync.resetProviderStatus('github');
+            if (activeGitHubAttemptIdRef.current === authAttemptId) {
+                activeGitHubAttemptIdRef.current = null;
+                setIsPollingGitHub(false);
+                setShowGitHubModal(false);
+            }
             const message = getNetworkErrorMessage(error, t('common.unknownError'));
-            toast.error(message, t('cloudSync.connect.github.failedTitle'));
+            if (!message.toLowerCase().includes('cancelled')) {
+                toast.error(message, t('cloudSync.connect.github.failedTitle'));
+            }
         } finally {
-            endPendingConnect('github');
+            cancelController.abort();
+            if (activeGitHubAttemptIdRef.current == null) {
+                endPendingConnect('github');
+            }
         }
     };
 
@@ -1379,6 +1399,10 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     };
 
     const openWebdavDialog = () => {
+        if (sync.pendingBrowserAuthProvider) {
+            toast.info(t('cloudSync.connect.browserCancelled'));
+        }
+        sync.cancelOAuthConnect();
         const config = sync.providers.webdav.config as WebDAVConfig | undefined;
         setWebdavEndpoint(config?.endpoint || '');
         setWebdavAuthType(config?.authType || 'basic');
@@ -1393,6 +1417,10 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     };
 
     const openS3Dialog = () => {
+        if (sync.pendingBrowserAuthProvider) {
+            toast.info(t('cloudSync.connect.browserCancelled'));
+        }
+        sync.cancelOAuthConnect();
         const config = sync.providers.s3.config as S3Config | undefined;
         setS3Endpoint(config?.endpoint || '');
         setS3Region(config?.region || '');
@@ -1732,7 +1760,10 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         icon={<GoogleDriveIcon className="w-6 h-6" />}
                         isConnected={isProviderReadyForSync(sync.providers.google)}
                         isSyncing={sync.providers.google.status === 'syncing'}
-                        isConnecting={sync.providers.google.status === 'connecting'}
+                        isConnecting={
+                            sync.providers.google.status === 'connecting' ||
+                            sync.pendingBrowserAuthProvider === 'google'
+                        }
                         account={sync.providers.google.account}
                         lastSync={sync.providers.google.lastSync}
                         error={sync.providers.google.error}
@@ -1749,7 +1780,10 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                         icon={<OneDriveIcon className="w-6 h-6" />}
                         isConnected={isProviderReadyForSync(sync.providers.onedrive)}
                         isSyncing={sync.providers.onedrive.status === 'syncing'}
-                        isConnecting={sync.providers.onedrive.status === 'connecting'}
+                        isConnecting={
+                            sync.providers.onedrive.status === 'connecting' ||
+                            sync.pendingBrowserAuthProvider === 'onedrive'
+                        }
                         account={sync.providers.onedrive.account}
                         lastSync={sync.providers.onedrive.lastSync}
                         error={sync.providers.onedrive.error}
@@ -1915,11 +1949,11 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                 verificationUri={gitHubVerificationUri}
                 isPolling={isPollingGitHub}
                 onClose={() => {
+                    activeGitHubAttemptIdRef.current = null;
                     setShowGitHubModal(false);
                     setIsPollingGitHub(false);
-                    // Reset provider status so button is clickable again.
-                    // The background polling will continue until expiry but is harmless.
-                    sync.resetProviderStatus('github');
+                    endPendingConnect('github');
+                    sync.cancelOAuthConnect();
                 }}
             />
 

--- a/electron/bridges/githubAuthBridge.cjs
+++ b/electron/bridges/githubAuthBridge.cjs
@@ -8,6 +8,7 @@
 const GITHUB_CLIENT_ID = process.env.VITE_SYNC_GITHUB_CLIENT_ID || "";
 const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";
 const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const pendingPollControllers = new Map();
 
 /**
  * @param {Electron.IpcMain} ipcMain
@@ -53,31 +54,52 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:github:deviceFlow:poll", async (_event, payload) => {
     const clientId = payload?.clientId || GITHUB_CLIENT_ID;
     const deviceCode = payload?.deviceCode;
+    const pollId = payload?.pollId;
     if (!deviceCode) throw new Error("Missing deviceCode");
 
-    const res = await fetch(GITHUB_ACCESS_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: new URLSearchParams({
-        client_id: clientId,
-        device_code: deviceCode,
-        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-      }).toString(),
-    });
-
-    const text = await res.text();
-    if (!res.ok) {
-      throw new Error(`GitHub token polling failed: ${res.status} - ${text}`);
+    const controller = new AbortController();
+    if (pollId) {
+      pendingPollControllers.set(pollId, controller);
     }
 
     try {
-      return JSON.parse(text);
-    } catch {
-      throw new Error(`GitHub token polling invalid JSON: ${text.slice(0, 200)}`);
+      const res = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          client_id: clientId,
+          device_code: deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }).toString(),
+      });
+
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`GitHub token polling failed: ${res.status} - ${text}`);
+      }
+
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`GitHub token polling invalid JSON: ${text.slice(0, 200)}`);
+      }
+    } finally {
+      if (pollId) {
+        pendingPollControllers.delete(pollId);
+      }
     }
+  });
+
+  ipcMain.handle("netcatty:github:deviceFlow:cancelPoll", async (_event, pollId) => {
+    if (!pollId) return;
+    const controller = pendingPollControllers.get(pollId);
+    if (!controller) return;
+    pendingPollControllers.delete(pollId);
+    controller.abort();
   });
 }
 

--- a/electron/bridges/oauthBridge.cjs
+++ b/electron/bridges/oauthBridge.cjs
@@ -8,17 +8,11 @@
  */
 
 const http = require("node:http");
-const url = require("node:url");
 
-let server = null;
-let activePort = null;
-let requestHandler = null;
-let pendingResolve = null;
-let pendingReject = null;
-let pendingExpectedState = null;
-let serverTimeout = null;
-
+let activeSession = null;
+let nextSessionId = 0;
 const PREFERRED_OAUTH_PORT = 45678;
+const OAUTH_CALLBACK_PATH = "/oauth/callback";
 const OAUTH_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 const escapeHtml = (value) =>
@@ -192,30 +186,50 @@ const renderOAuthPage = ({ title, message, detail, status, autoClose }) => {
 </html>`;
 };
 
-function handleOAuthRequest(req, res) {
-  const parsedUrl = url.parse(req.url, true);
+function handleOAuthRequest(session, req, res) {
+  const parsedUrl = new URL(req.url, "http://127.0.0.1");
 
   // Only handle the callback path
-  if (parsedUrl.pathname !== "/oauth/callback") {
+  if (parsedUrl.pathname !== OAUTH_CALLBACK_PATH) {
     res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
     res.end("<h1>404 Not Found</h1>");
     return;
   }
 
-  const { code, state, error, error_description } = parsedUrl.query;
+  const code = parsedUrl.searchParams.get("code");
+  const state = parsedUrl.searchParams.get("state");
+  const error = parsedUrl.searchParams.get("error");
+  const errorDescription = parsedUrl.searchParams.get("error_description");
 
   res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+
+  // We deliberately ignore callbacks until awaitOAuthCallback() has armed the
+  // session. In the real flow the browser only opens after that point, so any
+  // earlier localhost hit is stale/noise and must not consume the active retry.
+  if (!session.resolve || !session.reject) {
+    res.end(
+      renderOAuthPage({
+        title: "Authorization Not Ready",
+        message: "This sign-in request is not active yet. Return to Netcatty and try again.",
+        status: "warning",
+      })
+    );
+    return;
+  }
 
   if (error) {
     res.end(
       renderOAuthPage({
         title: "Authorization Failed",
         message: "We could not complete the sign-in flow.",
-        detail: error_description || error || "Unknown error",
+        detail: errorDescription || error || "Unknown error",
         status: "error",
       })
     );
-    rejectPending(new Error(error_description || error || "Authorization failed"));
+    finishSessionWithError(
+      session,
+      new Error(errorDescription || error || "Authorization failed")
+    );
     return;
   }
 
@@ -227,11 +241,11 @@ function handleOAuthRequest(req, res) {
         status: "error",
       })
     );
-    rejectPending(new Error("Missing authorization code"));
+    finishSessionWithError(session, new Error("Missing authorization code"));
     return;
   }
 
-  if (pendingExpectedState && state !== pendingExpectedState) {
+  if (session.expectedState && state !== session.expectedState) {
     res.end(
       renderOAuthPage({
         title: "Security Check Failed",
@@ -239,7 +253,7 @@ function handleOAuthRequest(req, res) {
         status: "error",
       })
     );
-    rejectPending(new Error("State mismatch - possible CSRF attack"));
+    finishSessionWithError(session, new Error("State mismatch - possible CSRF attack"));
     return;
   }
 
@@ -251,19 +265,76 @@ function handleOAuthRequest(req, res) {
     })
   );
 
-  const resolve = pendingResolve;
-  cleanup();
+  resolveSession(session, { code, state });
+}
+
+function resolveSession(session, payload) {
+  if (!session) return;
+  const resolve = session.resolve;
+  disposeSession(session);
   if (resolve) {
-    resolve({ code, state });
+    resolve(payload);
   }
 }
 
-function rejectPending(err) {
-  const reject = pendingReject;
-  cleanup();
+function rejectSession(session, err) {
+  if (!session) return;
+  const reject = session.reject;
+  disposeSession(session);
   if (reject) {
     reject(err);
   }
+}
+
+function finishSessionWithError(session, err) {
+  if (!session) return;
+  if (session.reject) {
+    rejectSession(session, err);
+    return;
+  }
+
+  storeSessionError(session, err);
+}
+
+function disposeSession(session) {
+  if (!session) return;
+
+  if (session.timeout) {
+    clearTimeout(session.timeout);
+    session.timeout = null;
+  }
+
+  session.resolve = null;
+  session.reject = null;
+  session.expectedState = null;
+  session.error = null;
+  closeServer(session);
+
+  if (activeSession === session) {
+    activeSession = null;
+  }
+}
+
+function storeSessionError(session, err) {
+  if (!session) return;
+  if (session.timeout) {
+    clearTimeout(session.timeout);
+    session.timeout = null;
+  }
+  session.resolve = null;
+  session.reject = null;
+  session.expectedState = null;
+  session.error = err;
+  closeServer(session);
+}
+
+function armSessionTimeout(session) {
+  session.timeout = setTimeout(() => {
+    rejectSession(
+      session,
+      new Error("OAuth timeout - user did not complete authorization in time")
+    );
+  }, OAUTH_TIMEOUT);
 }
 
 /**
@@ -274,14 +345,14 @@ function rejectPending(err) {
  *
  * @returns {Promise<{server: http.Server, port: number}>}
  */
-function bindLoopbackServer() {
+function bindLoopbackServer(session) {
   const ports = [PREFERRED_OAUTH_PORT, 0];
   return (async () => {
     let lastErr;
     for (const port of ports) {
       try {
         const s = http.createServer((req, res) => {
-          if (requestHandler) requestHandler(req, res);
+          handleOAuthRequest(session, req, res);
         });
         await new Promise((resolve, reject) => {
           const onError = (err) => {
@@ -319,28 +390,54 @@ function bindLoopbackServer() {
  * @returns {Promise<{port: number, redirectUri: string}>}
  */
 async function prepareOAuthCallback() {
-  // Close any previously-prepared server (e.g. from an abandoned flow).
-  closeServer();
+  // Replace any previously-prepared flow so it cannot leak a bound port or
+  // leave an await Promise hanging forever.
+  rejectSession(activeSession, new Error("OAuth flow cancelled"));
 
-  const bound = await bindLoopbackServer();
-  server = bound.server;
-  activePort = bound.port;
-  requestHandler = handleOAuthRequest;
+  const session = {
+    id: `oauth-${++nextSessionId}`,
+    server: null,
+    port: null,
+    resolve: null,
+    reject: null,
+    expectedState: null,
+    timeout: null,
+    error: null,
+  };
+  activeSession = session;
+  armSessionTimeout(session);
+
+  let bound;
+  try {
+    bound = await bindLoopbackServer(session);
+  } catch (err) {
+    disposeSession(session);
+    throw err;
+  }
+
+  session.server = bound.server;
+  session.port = bound.port;
+
+  if (activeSession !== session || session.error) {
+    const err = session.error || new Error("OAuth flow cancelled");
+    disposeSession(session);
+    throw err;
+  }
 
   // Don't let the callback server itself keep the process alive — the
   // awaitOAuthCallback Promise is what should pin the event loop. In Electron
   // main this is a no-op (the UI keeps things alive), but in tests and CLI
   // contexts it means the process can exit cleanly between runs.
-  if (typeof server.unref === "function") server.unref();
+  if (typeof session.server.unref === "function") session.server.unref();
 
-  server.on("error", (err) => {
+  session.server.on("error", (err) => {
     console.error("OAuth server error:", err);
-    rejectPending(err);
+    rejectSession(session, err);
   });
 
-  const redirectUri = `http://127.0.0.1:${activePort}/oauth/callback`;
+  const redirectUri = `http://127.0.0.1:${session.port}${OAUTH_CALLBACK_PATH}`;
   console.log(`OAuth callback server listening on ${redirectUri}`);
-  return { port: activePort, redirectUri };
+  return { sessionId: session.id, port: session.port, redirectUri };
 }
 
 /**
@@ -348,28 +445,43 @@ async function prepareOAuthCallback() {
  * server. Must be called after prepareOAuthCallback().
  *
  * @param {string} [expectedState] - State parameter to validate
+ * @param {string} [sessionId] - Session returned by prepareOAuthCallback
  * @returns {Promise<{code: string, state?: string}>}
  */
-function awaitOAuthCallback(expectedState) {
+function awaitOAuthCallback(expectedState, sessionId) {
   return new Promise((resolve, reject) => {
-    if (!server) {
+    const session = activeSession;
+    if (!session) {
       reject(new Error("OAuth callback server not prepared"));
       return;
     }
+
+    if (sessionId && session.id !== sessionId) {
+      reject(new Error("OAuth flow cancelled"));
+      return;
+    }
+
     // Only one await may be outstanding at a time.
-    if (pendingResolve || pendingReject) {
+    if (session.resolve || session.reject) {
       reject(new Error("An OAuth callback is already in progress"));
       return;
     }
-    pendingResolve = resolve;
-    pendingReject = reject;
-    pendingExpectedState = expectedState || null;
 
-    serverTimeout = setTimeout(() => {
-      rejectPending(
-        new Error("OAuth timeout - user did not complete authorization in time")
-      );
-    }, OAUTH_TIMEOUT);
+    if (session.error) {
+      const err = session.error;
+      disposeSession(session);
+      reject(err);
+      return;
+    }
+
+    if (!session.server) {
+      reject(new Error("OAuth callback server not prepared"));
+      return;
+    }
+
+    session.resolve = resolve;
+    session.reject = reject;
+    session.expectedState = expectedState || null;
   });
 }
 
@@ -380,17 +492,20 @@ function awaitOAuthCallback(expectedState) {
  * popup fallback.
  */
 function getActiveOAuthPort() {
-  return activePort;
+  return activeSession?.port ?? null;
 }
 
 /**
  * Cancel pending OAuth flow
  */
-function cancelOAuthCallback() {
-  rejectPending(new Error("OAuth flow cancelled"));
+function cancelOAuthCallback(sessionId) {
+  if (!activeSession) return;
+  if (sessionId && activeSession.id !== sessionId) return;
+  finishSessionWithError(activeSession, new Error("OAuth flow cancelled"));
 }
 
-function closeServer() {
+function closeServer(session) {
+  const server = session?.server;
   if (server) {
     try {
       // closeAllConnections (Node 18.2+) forces any keep-alive sockets shut
@@ -407,25 +522,11 @@ function closeServer() {
     } catch {
       // Ignore
     }
-    server = null;
   }
-  activePort = null;
-  requestHandler = null;
-}
-
-/**
- * Clean up pending state and close the server. Called after the code is
- * delivered, on error, and on cancellation.
- */
-function cleanup() {
-  if (serverTimeout) {
-    clearTimeout(serverTimeout);
-    serverTimeout = null;
+  if (session) {
+    session.server = null;
+    session.port = null;
   }
-  pendingResolve = null;
-  pendingReject = null;
-  pendingExpectedState = null;
-  closeServer();
 }
 
 /**
@@ -437,12 +538,12 @@ function setupOAuthBridge(ipcMain) {
     return prepareOAuthCallback();
   });
 
-  ipcMain.handle("oauth:awaitCallback", async (_event, expectedState) => {
-    return awaitOAuthCallback(expectedState);
+  ipcMain.handle("oauth:awaitCallback", async (_event, expectedState, sessionId) => {
+    return awaitOAuthCallback(expectedState, sessionId);
   });
 
-  ipcMain.handle("oauth:cancelCallback", async () => {
-    cancelOAuthCallback();
+  ipcMain.handle("oauth:cancelCallback", async (_event, sessionId) => {
+    cancelOAuthCallback(sessionId);
   });
 }
 

--- a/electron/bridges/oauthBridge.cjs
+++ b/electron/bridges/oauthBridge.cjs
@@ -2,18 +2,23 @@
  * OAuth Callback Bridge
  *
  * Handles OAuth loopback redirects for Google Drive and OneDrive.
- * Starts a temporary HTTP server on 127.0.0.1:45678 to receive authorization codes.
+ * Prepares a temporary HTTP server on 127.0.0.1 (preferred port 45678; falls
+ * back to an OS-assigned free port if 45678 is already in use — issue #823)
+ * and waits on it for the authorization code.
  */
 
 const http = require("node:http");
 const url = require("node:url");
 
 let server = null;
+let activePort = null;
+let requestHandler = null;
 let pendingResolve = null;
 let pendingReject = null;
+let pendingExpectedState = null;
 let serverTimeout = null;
 
-const OAUTH_PORT = 45678;
+const PREFERRED_OAUTH_PORT = 45678;
 const OAUTH_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
 const escapeHtml = (value) =>
@@ -187,167 +192,240 @@ const renderOAuthPage = ({ title, message, detail, status, autoClose }) => {
 </html>`;
 };
 
+function handleOAuthRequest(req, res) {
+  const parsedUrl = url.parse(req.url, true);
+
+  // Only handle the callback path
+  if (parsedUrl.pathname !== "/oauth/callback") {
+    res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+    res.end("<h1>404 Not Found</h1>");
+    return;
+  }
+
+  const { code, state, error, error_description } = parsedUrl.query;
+
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+
+  if (error) {
+    res.end(
+      renderOAuthPage({
+        title: "Authorization Failed",
+        message: "We could not complete the sign-in flow.",
+        detail: error_description || error || "Unknown error",
+        status: "error",
+      })
+    );
+    rejectPending(new Error(error_description || error || "Authorization failed"));
+    return;
+  }
+
+  if (!code) {
+    res.end(
+      renderOAuthPage({
+        title: "Missing Authorization Code",
+        message: "The authorization response did not include a code.",
+        status: "error",
+      })
+    );
+    rejectPending(new Error("Missing authorization code"));
+    return;
+  }
+
+  if (pendingExpectedState && state !== pendingExpectedState) {
+    res.end(
+      renderOAuthPage({
+        title: "Security Check Failed",
+        message: "State parameter mismatch. This may indicate a CSRF attack.",
+        status: "error",
+      })
+    );
+    rejectPending(new Error("State mismatch - possible CSRF attack"));
+    return;
+  }
+
+  res.end(
+    renderOAuthPage({
+      title: "Authorization Complete",
+      message: "You are signed in and ready to sync. You can close this tab now.",
+      status: "success",
+    })
+  );
+
+  const resolve = pendingResolve;
+  cleanup();
+  if (resolve) {
+    resolve({ code, state });
+  }
+}
+
+function rejectPending(err) {
+  const reject = pendingReject;
+  cleanup();
+  if (reject) {
+    reject(err);
+  }
+}
+
 /**
- * Start OAuth callback server and wait for authorization code
- * @param {string} expectedState - State parameter to validate
- * @returns {Promise<{code: string, state: string}>}
+ * Try to bind an HTTP server on the loopback interface. Prefers
+ * PREFERRED_OAUTH_PORT; if the port is already in use (EADDRINUSE) or the OS
+ * otherwise refuses it (EACCES), falls back to letting the OS pick a free
+ * ephemeral port.
+ *
+ * @returns {Promise<{server: http.Server, port: number}>}
  */
-function startOAuthCallback(expectedState) {
-  return new Promise((resolve, reject) => {
-    // Clean up any existing server
-    if (server) {
+function bindLoopbackServer() {
+  const ports = [PREFERRED_OAUTH_PORT, 0];
+  return (async () => {
+    let lastErr;
+    for (const port of ports) {
       try {
-        server.close();
-      } catch (e) {
-        console.warn("Failed to close existing OAuth server:", e);
+        const s = http.createServer((req, res) => {
+          if (requestHandler) requestHandler(req, res);
+        });
+        await new Promise((resolve, reject) => {
+          const onError = (err) => {
+            s.removeListener("listening", onListening);
+            reject(err);
+          };
+          const onListening = () => {
+            s.removeListener("error", onError);
+            resolve();
+          };
+          s.once("error", onError);
+          s.once("listening", onListening);
+          s.listen(port, "127.0.0.1");
+        });
+        const bound = s.address();
+        return { server: s, port: bound && typeof bound === "object" ? bound.port : port };
+      } catch (err) {
+        lastErr = err;
+        if (err && (err.code === "EADDRINUSE" || err.code === "EACCES")) {
+          // Try the next candidate (OS-assigned)
+          continue;
+        }
+        throw err;
       }
     }
+    throw lastErr || new Error("Failed to bind OAuth loopback server");
+  })();
+}
 
+/**
+ * Bind a loopback HTTP server for the OAuth callback. Returns the chosen
+ * port and fully-qualified redirect URI so the caller can build the
+ * provider's authorization URL against it.
+ *
+ * @returns {Promise<{port: number, redirectUri: string}>}
+ */
+async function prepareOAuthCallback() {
+  // Close any previously-prepared server (e.g. from an abandoned flow).
+  closeServer();
+
+  const bound = await bindLoopbackServer();
+  server = bound.server;
+  activePort = bound.port;
+  requestHandler = handleOAuthRequest;
+
+  // Don't let the callback server itself keep the process alive — the
+  // awaitOAuthCallback Promise is what should pin the event loop. In Electron
+  // main this is a no-op (the UI keeps things alive), but in tests and CLI
+  // contexts it means the process can exit cleanly between runs.
+  if (typeof server.unref === "function") server.unref();
+
+  server.on("error", (err) => {
+    console.error("OAuth server error:", err);
+    rejectPending(err);
+  });
+
+  const redirectUri = `http://127.0.0.1:${activePort}/oauth/callback`;
+  console.log(`OAuth callback server listening on ${redirectUri}`);
+  return { port: activePort, redirectUri };
+}
+
+/**
+ * Wait for the authorization code to arrive at the prepared callback
+ * server. Must be called after prepareOAuthCallback().
+ *
+ * @param {string} [expectedState] - State parameter to validate
+ * @returns {Promise<{code: string, state?: string}>}
+ */
+function awaitOAuthCallback(expectedState) {
+  return new Promise((resolve, reject) => {
+    if (!server) {
+      reject(new Error("OAuth callback server not prepared"));
+      return;
+    }
+    // Only one await may be outstanding at a time.
+    if (pendingResolve || pendingReject) {
+      reject(new Error("An OAuth callback is already in progress"));
+      return;
+    }
     pendingResolve = resolve;
     pendingReject = reject;
+    pendingExpectedState = expectedState || null;
 
-    server = http.createServer((req, res) => {
-      const parsedUrl = url.parse(req.url, true);
-
-      // Only handle the callback path
-      if (parsedUrl.pathname !== "/oauth/callback") {
-        res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
-        res.end("<h1>404 Not Found</h1>");
-        return;
-      }
-
-      const { code, state, error, error_description } = parsedUrl.query;
-
-      // Send response to browser
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-
-      if (error) {
-        res.end(
-          renderOAuthPage({
-            title: "Authorization Failed",
-            message: "We could not complete the sign-in flow.",
-            detail: error_description || error || "Unknown error",
-            status: "error",
-          })
-        );
-
-        cleanup();
-        if (pendingReject) {
-          pendingReject(new Error(error_description || error || "Authorization failed"));
-          pendingReject = null;
-          pendingResolve = null;
-        }
-        return;
-      }
-
-      if (!code) {
-        res.end(
-          renderOAuthPage({
-            title: "Missing Authorization Code",
-            message: "The authorization response did not include a code.",
-            status: "error",
-          })
-        );
-
-        cleanup();
-        if (pendingReject) {
-          pendingReject(new Error("Missing authorization code"));
-          pendingReject = null;
-          pendingResolve = null;
-        }
-        return;
-      }
-
-      // Validate state if provided
-      if (expectedState && state !== expectedState) {
-        res.end(
-          renderOAuthPage({
-            title: "Security Check Failed",
-            message: "State parameter mismatch. This may indicate a CSRF attack.",
-            status: "error",
-          })
-        );
-
-        cleanup();
-        if (pendingReject) {
-          pendingReject(new Error("State mismatch - possible CSRF attack"));
-          pendingReject = null;
-          pendingResolve = null;
-        }
-        return;
-      }
-
-      // Success!
-      res.end(
-        renderOAuthPage({
-          title: "Authorization Complete",
-          message: "You are signed in and ready to sync. You can close this tab now.",
-          status: "success",
-        })
-      );
-
-      cleanup();
-      if (pendingResolve) {
-        pendingResolve({ code, state });
-        pendingResolve = null;
-        pendingReject = null;
-      }
-    });
-
-    server.on("error", (err) => {
-      console.error("OAuth server error:", err);
-      cleanup();
-      if (pendingReject) {
-        pendingReject(err);
-        pendingReject = null;
-        pendingResolve = null;
-      }
-    });
-
-    server.listen(OAUTH_PORT, "127.0.0.1", () => {
-      console.log(`OAuth callback server listening on http://127.0.0.1:${OAUTH_PORT}`);
-    });
-
-    // Set timeout
     serverTimeout = setTimeout(() => {
-      cleanup();
-      if (pendingReject) {
-        pendingReject(new Error("OAuth timeout - user did not complete authorization in time"));
-        pendingReject = null;
-        pendingResolve = null;
-      }
+      rejectPending(
+        new Error("OAuth timeout - user did not complete authorization in time")
+      );
     }, OAUTH_TIMEOUT);
   });
+}
+
+/**
+ * Return the port the OAuth callback server is currently listening on, or
+ * null when no callback is in flight. Used by windowManager to decide
+ * whether a loopback `/oauth/callback` URL is trustworthy for the in-app
+ * popup fallback.
+ */
+function getActiveOAuthPort() {
+  return activePort;
 }
 
 /**
  * Cancel pending OAuth flow
  */
 function cancelOAuthCallback() {
-  cleanup();
-  if (pendingReject) {
-    pendingReject(new Error("OAuth flow cancelled"));
-    pendingReject = null;
-    pendingResolve = null;
+  rejectPending(new Error("OAuth flow cancelled"));
+}
+
+function closeServer() {
+  if (server) {
+    try {
+      // closeAllConnections (Node 18.2+) forces any keep-alive sockets shut
+      // so the port is immediately reusable — otherwise server.close() would
+      // wait on idle keep-alive connections before fully releasing.
+      if (typeof server.closeAllConnections === "function") {
+        try {
+          server.closeAllConnections();
+        } catch {
+          // ignore
+        }
+      }
+      server.close();
+    } catch {
+      // Ignore
+    }
+    server = null;
   }
+  activePort = null;
+  requestHandler = null;
 }
 
 /**
- * Clean up server and timeout
+ * Clean up pending state and close the server. Called after the code is
+ * delivered, on error, and on cancellation.
  */
 function cleanup() {
   if (serverTimeout) {
     clearTimeout(serverTimeout);
     serverTimeout = null;
   }
-  if (server) {
-    try {
-      server.close();
-    } catch (e) {
-      // Ignore
-    }
-    server = null;
-  }
+  pendingResolve = null;
+  pendingReject = null;
+  pendingExpectedState = null;
+  closeServer();
 }
 
 /**
@@ -355,8 +433,12 @@ function cleanup() {
  * @param {Electron.IpcMain} ipcMain
  */
 function setupOAuthBridge(ipcMain) {
-  ipcMain.handle("oauth:startCallback", async (_event, expectedState) => {
-    return startOAuthCallback(expectedState);
+  ipcMain.handle("oauth:prepareCallback", async () => {
+    return prepareOAuthCallback();
+  });
+
+  ipcMain.handle("oauth:awaitCallback", async (_event, expectedState) => {
+    return awaitOAuthCallback(expectedState);
   });
 
   ipcMain.handle("oauth:cancelCallback", async () => {
@@ -366,6 +448,8 @@ function setupOAuthBridge(ipcMain) {
 
 module.exports = {
   setupOAuthBridge,
-  startOAuthCallback,
+  prepareOAuthCallback,
+  awaitOAuthCallback,
   cancelOAuthCallback,
+  getActiveOAuthPort,
 };

--- a/electron/bridges/oauthBridge.test.cjs
+++ b/electron/bridges/oauthBridge.test.cjs
@@ -192,6 +192,137 @@ test("cancelOAuthCallback releases the bound port", async () => {
   }
 });
 
+test("callbacks that arrive before awaitOAuthCallback do not consume the session", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+
+    const earlyStatus = await fetchCallback(port, { code: "stale-code", state: "stale-state" });
+    assert.equal(earlyStatus, 200);
+    assert.equal(bridge.getActiveOAuthPort(), port);
+
+    const pending = bridge.awaitOAuthCallback("expected-state");
+    const status = await fetchCallback(port, {
+      code: "fresh-code",
+      state: "expected-state",
+    });
+    assert.equal(status, 200);
+
+    const result = await pending;
+    assert.equal(result.code, "fresh-code");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("cancelOAuthCallback before awaitOAuthCallback is replayed as a cancellation", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { sessionId } = await bridge.prepareOAuthCallback();
+    bridge.cancelOAuthCallback(sessionId);
+    await assert.rejects(bridge.awaitOAuthCallback(undefined, sessionId), /cancelled/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("cancelOAuthCallback during prepare rejects the pending prepare", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const pendingPrepare = bridge.prepareOAuthCallback();
+    bridge.cancelOAuthCallback();
+
+    await assert.rejects(pendingPrepare, /cancelled/);
+    assert.equal(bridge.getActiveOAuthPort(), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("cancelOAuthCallback ignores stale session ids", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const stale = await bridge.prepareOAuthCallback();
+    const fresh = await bridge.prepareOAuthCallback();
+
+    bridge.cancelOAuthCallback(stale.sessionId);
+    assert.equal(bridge.getActiveOAuthPort(), fresh.port);
+
+    const pending = bridge.awaitOAuthCallback(undefined, fresh.sessionId);
+    const status = await fetchCallback(fresh.port, { code: "fresh-code" });
+    assert.equal(status, 200);
+
+    const result = await pending;
+    assert.equal(result.code, "fresh-code");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("awaitOAuthCallback rejects stale session ids instead of attaching to the new flow", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const stale = await bridge.prepareOAuthCallback();
+    const fresh = await bridge.prepareOAuthCallback();
+
+    await assert.rejects(
+      bridge.awaitOAuthCallback(undefined, stale.sessionId),
+      /cancelled/
+    );
+
+    const pending = bridge.awaitOAuthCallback(undefined, fresh.sessionId);
+    const status = await fetchCallback(fresh.port, { code: "fresh-code" });
+    assert.equal(status, 200);
+
+    const result = await pending;
+    assert.equal(result.code, "fresh-code");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("concurrent prepareOAuthCallback calls cancel the superseded attempt", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const stalePrepare = bridge.prepareOAuthCallback();
+    const staleRejects = assert.rejects(stalePrepare, /cancelled/);
+
+    const freshPrepare = bridge.prepareOAuthCallback();
+    const fresh = await freshPrepare;
+    await staleRejects;
+
+    const pending = bridge.awaitOAuthCallback(undefined, fresh.sessionId);
+    const status = await fetchCallback(fresh.port, { code: "fresh-code" });
+    assert.equal(status, 200);
+
+    const result = await pending;
+    assert.equal(result.code, "fresh-code");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("prepareOAuthCallback replaces an in-flight await cleanly", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const stale = await bridge.prepareOAuthCallback();
+    const stalePending = bridge.awaitOAuthCallback(undefined, stale.sessionId);
+    const staleRejects = assert.rejects(stalePending, /cancelled/);
+
+    const fresh = await bridge.prepareOAuthCallback();
+    await staleRejects;
+
+    const nextPending = bridge.awaitOAuthCallback(undefined, fresh.sessionId);
+    const status = await fetchCallback(fresh.port, { code: "fresh-code" });
+    assert.equal(status, 200);
+
+    const result = await nextPending;
+    assert.equal(result.code, "fresh-code");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("getActiveOAuthPort is null before prepare and after cleanup", async () => {
   const { bridge, cleanup } = await freshModule();
   try {

--- a/electron/bridges/oauthBridge.test.cjs
+++ b/electron/bridges/oauthBridge.test.cjs
@@ -1,0 +1,205 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+
+const BRIDGE_PATH = require.resolve("./oauthBridge.cjs");
+
+function loadBridge() {
+  // Isolate module state between tests — oauthBridge keeps the bound server
+  // and pending promise in module-level closures.
+  delete require.cache[BRIDGE_PATH];
+  return require("./oauthBridge.cjs");
+}
+
+async function freshModule() {
+  const bridge = loadBridge();
+  const cleanup = async () => {
+    try {
+      bridge.cancelOAuthCallback();
+    } catch {
+      // ignore
+    }
+    // Give the server a beat to actually close before the next test binds
+    // the same port.
+    await new Promise((r) => setTimeout(r, 20));
+  };
+  return { bridge, cleanup };
+}
+
+function tryBindPort(port) {
+  return new Promise((resolve) => {
+    const s = http.createServer(() => {});
+    s.once("error", () => resolve(null));
+    s.once("listening", () => resolve(s));
+    s.listen(port, "127.0.0.1");
+  });
+}
+
+async function closeServer(s) {
+  if (!s) return;
+  await new Promise((resolve) => s.close(resolve));
+}
+
+function fetchCallback(port, query) {
+  return new Promise((resolve, reject) => {
+    const search = new URLSearchParams(query).toString();
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: `/oauth/callback?${search}`,
+        method: "GET",
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode));
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("prepareOAuthCallback binds and reports port + redirectUri", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port, redirectUri } = await bridge.prepareOAuthCallback();
+    assert.ok(Number.isInteger(port) && port > 0, `got port=${port}`);
+    assert.equal(redirectUri, `http://127.0.0.1:${port}/oauth/callback`);
+    assert.equal(bridge.getActiveOAuthPort(), port);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("prepareOAuthCallback prefers port 45678 when it is free", async () => {
+  // Probe: if 45678 is already held by something external, skip this test —
+  // the fallback path is exercised in the next test.
+  const probe = await tryBindPort(45678);
+  if (!probe) {
+    return; // treated as pass; environment doesn't permit this assertion
+  }
+  await closeServer(probe);
+
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+    assert.equal(port, 45678);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("prepareOAuthCallback falls back to an OS-assigned port when 45678 is busy (#823)", async () => {
+  // Hold port 45678 ourselves so the bridge MUST fall back.
+  const squatter = await tryBindPort(45678);
+  if (!squatter) {
+    // Something else is already holding 45678 — just ensure the bridge
+    // still produces a working port rather than crashing.
+    const { bridge, cleanup } = await freshModule();
+    try {
+      const { port } = await bridge.prepareOAuthCallback();
+      assert.ok(port > 0 && port !== 45678);
+    } finally {
+      await cleanup();
+    }
+    return;
+  }
+
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port, redirectUri } = await bridge.prepareOAuthCallback();
+    assert.notEqual(port, 45678, "expected a different port when 45678 is in use");
+    assert.ok(port > 0);
+    assert.equal(redirectUri, `http://127.0.0.1:${port}/oauth/callback`);
+    assert.equal(bridge.getActiveOAuthPort(), port);
+  } finally {
+    await cleanup();
+    await closeServer(squatter);
+  }
+});
+
+test("awaitOAuthCallback resolves with the code when the browser hits the redirect URI", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+    const pending = bridge.awaitOAuthCallback();
+
+    const status = await fetchCallback(port, { code: "test-code", state: "anything" });
+    assert.equal(status, 200);
+
+    const result = await pending;
+    assert.equal(result.code, "test-code");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("awaitOAuthCallback rejects on state mismatch", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+    const pending = bridge.awaitOAuthCallback("expected-state");
+    // Attach the assertion BEFORE triggering the callback so the rejection
+    // is never unhandled.
+    const rejectsCheck = assert.rejects(pending, /State mismatch/);
+
+    await fetchCallback(port, { code: "test-code", state: "different-state" });
+    await rejectsCheck;
+  } finally {
+    await cleanup();
+  }
+});
+
+test("awaitOAuthCallback rejects when the provider returns an error", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+    const pending = bridge.awaitOAuthCallback();
+    const rejectsCheck = assert.rejects(pending, /access_denied/);
+
+    await fetchCallback(port, { error: "access_denied", error_description: "access_denied" });
+    await rejectsCheck;
+  } finally {
+    await cleanup();
+  }
+});
+
+test("awaitOAuthCallback errors if called before prepareOAuthCallback", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    await assert.rejects(bridge.awaitOAuthCallback(), /not prepared/);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("cancelOAuthCallback releases the bound port", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    const { port } = await bridge.prepareOAuthCallback();
+    assert.equal(bridge.getActiveOAuthPort(), port);
+    bridge.cancelOAuthCallback();
+    assert.equal(bridge.getActiveOAuthPort(), null);
+
+    // Give the OS a beat to release the socket, then confirm re-bindable.
+    await new Promise((r) => setTimeout(r, 30));
+    const rebound = await tryBindPort(port);
+    assert.ok(rebound, `expected ${port} to be re-bindable after cancel`);
+    await closeServer(rebound);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("getActiveOAuthPort is null before prepare and after cleanup", async () => {
+  const { bridge, cleanup } = await freshModule();
+  try {
+    assert.equal(bridge.getActiveOAuthPort(), null);
+    await bridge.prepareOAuthCallback();
+    assert.notEqual(bridge.getActiveOAuthPort(), null);
+  } finally {
+    await cleanup();
+  }
+  assert.equal(require("./oauthBridge.cjs").getActiveOAuthPort(), null);
+});

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -43,7 +43,11 @@ const DEBUG_WINDOWS = process.env.NETCATTY_DEBUG_WINDOWS === "1";
 const OAUTH_DEFAULT_WIDTH = 600;
 const OAUTH_DEFAULT_HEIGHT = 700;
 const OAUTH_OVERLAY_ID = "__netcatty_oauth_loading__";
-const OAUTH_LOOPBACK_PORT = 45678; // must match electron/bridges/oauthBridge.cjs
+// The OAuth callback port is chosen dynamically by oauthBridge (prefers
+// 45678, falls back to an OS-assigned free port if that is in use, #823),
+// so the in-app popup allow-list has to consult the bridge at popup-open
+// time instead of a hardcoded constant.
+const oauthBridge = require("./oauthBridge.cjs");
 const WINDOW_STATE_FILE = "window-state.json";
 const DEFAULT_WINDOW_WIDTH = 1400;
 const DEFAULT_WINDOW_HEIGHT = 900;
@@ -595,10 +599,14 @@ function createAppWindowOpenHandler(shell, { backgroundColor, appIcon }) {
         return allowedPopupHosts.has(u.hostname);
       }
       if (u.protocol === "http:") {
-        // Allow ONLY the loopback OAuth callback page.
+        // Allow ONLY the loopback OAuth callback page, and only while an
+        // OAuth flow is actively prepared — the acceptable port matches
+        // whatever oauthBridge just bound for this session.
         const isLoopback =
           u.hostname === "127.0.0.1" || u.hostname === "localhost";
-        return isLoopback && u.port === String(OAUTH_LOOPBACK_PORT) && u.pathname === "/oauth/callback";
+        if (!isLoopback || u.pathname !== "/oauth/callback") return false;
+        const activePort = oauthBridge.getActiveOAuthPort?.();
+        return activePort != null && u.port === String(activePort);
       }
       return false;
     } catch {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -963,8 +963,9 @@ const api = {
   // port (which may differ from the preferred 45678 if it was in use) and
   // embed it into the provider's redirect_uri before opening the browser.
   prepareOAuthCallback: () => ipcRenderer.invoke("oauth:prepareCallback"),
-  awaitOAuthCallback: (expectedState) => ipcRenderer.invoke("oauth:awaitCallback", expectedState),
-  cancelOAuthCallback: () => ipcRenderer.invoke("oauth:cancelCallback"),
+  awaitOAuthCallback: (expectedState, sessionId) =>
+    ipcRenderer.invoke("oauth:awaitCallback", expectedState, sessionId),
+  cancelOAuthCallback: (sessionId) => ipcRenderer.invoke("oauth:cancelCallback", sessionId),
 
   // GitHub Device Flow (proxied via main process to avoid CORS)
   githubStartDeviceFlow: (options) => ipcRenderer.invoke("netcatty:github:deviceFlow:start", options),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -970,6 +970,7 @@ const api = {
   // GitHub Device Flow (proxied via main process to avoid CORS)
   githubStartDeviceFlow: (options) => ipcRenderer.invoke("netcatty:github:deviceFlow:start", options),
   githubPollDeviceFlowToken: (options) => ipcRenderer.invoke("netcatty:github:deviceFlow:poll", options),
+  githubCancelDeviceFlowPoll: (pollId) => ipcRenderer.invoke("netcatty:github:deviceFlow:cancelPoll", pollId),
 
   // Google OAuth (proxied via main process to avoid CORS)
   googleExchangeCodeForTokens: (options) =>

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -959,8 +959,11 @@ const api = {
     };
   },
 
-  // OAuth callback server
-  startOAuthCallback: (expectedState) => ipcRenderer.invoke("oauth:startCallback", expectedState),
+  // OAuth callback server — two-step so the renderer can learn the bound
+  // port (which may differ from the preferred 45678 if it was in use) and
+  // embed it into the provider's redirect_uri before opening the browser.
+  prepareOAuthCallback: () => ipcRenderer.invoke("oauth:prepareCallback"),
+  awaitOAuthCallback: (expectedState) => ipcRenderer.invoke("oauth:awaitCallback", expectedState),
   cancelOAuthCallback: () => ipcRenderer.invoke("oauth:cancelCallback"),
 
   // GitHub Device Flow (proxied via main process to avoid CORS)

--- a/global.d.ts
+++ b/global.d.ts
@@ -607,9 +607,9 @@ declare global {
     // back to an OS-assigned free port if busy). The caller then builds the
     // OAuth URL against `redirectUri`, opens the browser, and finally awaits
     // the code via `awaitOAuthCallback`.
-    prepareOAuthCallback?(): Promise<{ port: number; redirectUri: string }>;
-    awaitOAuthCallback?(expectedState?: string): Promise<{ code: string; state?: string }>;
-    cancelOAuthCallback?(): Promise<void>;
+    prepareOAuthCallback?(): Promise<{ sessionId: string; port: number; redirectUri: string }>;
+    awaitOAuthCallback?(expectedState?: string, sessionId?: string): Promise<{ code: string; state?: string }>;
+    cancelOAuthCallback?(sessionId?: string): Promise<void>;
 
     // GitHub Device Flow (cloud sync)
     githubStartDeviceFlow?(options?: { clientId?: string; scope?: string }): Promise<{

--- a/global.d.ts
+++ b/global.d.ts
@@ -602,8 +602,13 @@ declare global {
     // SFTP connection progress listener (auth method logs)
     onSftpConnectionProgress?(cb: (sessionId: string, label: string, status: string, detail?: string) => void): () => void;
 
-    // OAuth callback server for cloud sync
-    startOAuthCallback?(expectedState?: string): Promise<{ code: string; state?: string }>;
+    // OAuth callback server for cloud sync. `prepareOAuthCallback` binds the
+    // loopback listener and returns the chosen port (preferred 45678, falls
+    // back to an OS-assigned free port if busy). The caller then builds the
+    // OAuth URL against `redirectUri`, opens the browser, and finally awaits
+    // the code via `awaitOAuthCallback`.
+    prepareOAuthCallback?(): Promise<{ port: number; redirectUri: string }>;
+    awaitOAuthCallback?(expectedState?: string): Promise<{ code: string; state?: string }>;
     cancelOAuthCallback?(): Promise<void>;
 
     // GitHub Device Flow (cloud sync)

--- a/global.d.ts
+++ b/global.d.ts
@@ -619,13 +619,14 @@ declare global {
       expiresAt: number;
       interval: number;
     }>;
-    githubPollDeviceFlowToken?(options: { clientId?: string; deviceCode: string }): Promise<{
+    githubPollDeviceFlowToken?(options: { clientId?: string; deviceCode: string; pollId?: string }): Promise<{
       access_token?: string;
       token_type?: string;
       scope?: string;
       error?: string;
       error_description?: string;
     }>;
+    githubCancelDeviceFlowPoll?(pollId: string): Promise<void>;
 
     // Google OAuth (cloud sync) - proxied via main process to avoid CORS
     googleExchangeCodeForTokens?(options: {

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -37,7 +37,7 @@ import packageJson from '../../package.json';
 import { EncryptionService } from './EncryptionService';
 import { createAdapter, type CloudAdapter } from './adapters';
 import { localStorageAdapter } from '../persistence/localStorageAdapter';
-import type { GitHubAdapter } from './adapters/GitHubAdapter';
+import type { DeviceFlowState, GitHubAdapter } from './adapters/GitHubAdapter';
 import type { GoogleDriveAdapter } from './adapters/GoogleDriveAdapter';
 import type { OneDriveAdapter } from './adapters/OneDriveAdapter';
 import {
@@ -96,6 +96,10 @@ interface ProviderSyncAnchor {
   resourceId?: string | null;
   observedAt: number;
 }
+
+export type StartProviderAuthResult =
+  | { type: 'device_code'; data: DeviceFlowState }
+  | { type: 'url'; data: { url: string; redirectUri: string } };
 
 // ============================================================================
 // CloudSyncManager Class
@@ -704,10 +708,7 @@ export class CloudSyncManager {
   async startProviderAuth(
     provider: CloudProvider,
     redirectUri?: string
-  ): Promise<{
-    type: 'device_code' | 'url';
-    data: unknown;
-  }> {
+  ): Promise<StartProviderAuthResult> {
     if (provider === 'webdav' || provider === 's3') {
       throw new Error('Provider requires manual configuration');
     }
@@ -730,7 +731,7 @@ export class CloudSyncManager {
         if (!redirectUri) {
           throw new Error(
             `startProviderAuth('${provider}') requires a redirectUri — ` +
-              'call preparePKCECallback on the bridge first and pass its redirectUri through.'
+              'call prepareOAuthCallback on the bridge first and pass its redirectUri through.'
           );
         }
 

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -97,9 +97,15 @@ interface ProviderSyncAnchor {
   observedAt: number;
 }
 
+interface ProviderAuthRestoreState {
+  attemptId: number;
+  connection: ProviderConnection;
+  adapter: CloudAdapter | null;
+}
+
 export type StartProviderAuthResult =
-  | { type: 'device_code'; data: DeviceFlowState }
-  | { type: 'url'; data: { url: string; redirectUri: string } };
+  | { type: 'device_code'; data: DeviceFlowState & { authAttemptId: number } }
+  | { type: 'url'; data: { url: string; redirectUri: string; authAttemptId: number } };
 
 // ============================================================================
 // CloudSyncManager Class
@@ -128,6 +134,12 @@ export class CloudSyncManager {
   // decrypt results are discarded.
   private providerDecryptSeq: Record<CloudProvider, number> = {
     github: 0, google: 0, onedrive: 0, webdav: 0, s3: 0,
+  };
+  private providerAuthAttemptSeq: Record<CloudProvider, number> = {
+    github: 0, google: 0, onedrive: 0, webdav: 0, s3: 0,
+  };
+  private providerAuthRestoreState: Record<CloudProvider, ProviderAuthRestoreState | null> = {
+    github: null, google: null, onedrive: null, webdav: null, s3: null,
   };
   // Per-provider write sequence counters for saveProviderConnection.
   // Only bumped when a new save is initiated, so status-only updates
@@ -255,14 +267,21 @@ export class CloudSyncManager {
     this.notifyStateChange();
   }
 
-  private async saveProviderConnection(provider: CloudProvider, connection: ProviderConnection): Promise<void> {
+  private async saveProviderConnection(
+    provider: CloudProvider,
+    connection: ProviderConnection,
+    authAttemptId?: number
+  ): Promise<void> {
     const key = SYNC_STORAGE_KEYS[`PROVIDER_${provider.toUpperCase()}` as keyof typeof SYNC_STORAGE_KEYS];
     // Use write-specific counter so status-only updates cannot discard
     // an in-flight encrypted write that must be persisted.
     const seq = ++this.providerWriteSeq[provider];
     const encrypted = await encryptProviderSecrets(connection);
     // Only persist if no newer save has started during the async gap
-    if (seq === this.providerWriteSeq[provider]) {
+    if (
+      seq === this.providerWriteSeq[provider] &&
+      (authAttemptId == null || this.isActiveAuthAttempt(provider, authAttemptId))
+    ) {
       this.saveToStorage(key, encrypted);
     }
   }
@@ -712,7 +731,16 @@ export class CloudSyncManager {
     if (provider === 'webdav' || provider === 's3') {
       throw new Error('Provider requires manual configuration');
     }
+    const authAttemptId = ++this.providerAuthAttemptSeq[provider];
+    this.providerAuthRestoreState[provider] = {
+      attemptId: authAttemptId,
+      connection: { ...this.state.providers[provider] },
+      adapter: this.adapters.get(provider) ?? null,
+    };
     const adapter = await createAdapter(provider);
+    if (!this.isActiveAuthAttempt(provider, authAttemptId)) {
+      throw new Error(`${provider} auth superseded`);
+    }
     this.adapters.set(provider, adapter);
 
     this.updateProviderStatus(provider, 'connecting');
@@ -724,7 +752,7 @@ export class CloudSyncManager {
 
         return {
           type: 'device_code',
-          data: deviceFlow,
+          data: { ...deviceFlow, authAttemptId },
         };
       } else {
         // Google and OneDrive use PKCE with redirect
@@ -738,14 +766,17 @@ export class CloudSyncManager {
         if (provider === 'google') {
           const gdAdapter = adapter as GoogleDriveAdapter;
           const url = await gdAdapter.startAuth(redirectUri);
-          return { type: 'url', data: { url, redirectUri } };
+          return { type: 'url', data: { url, redirectUri, authAttemptId } };
         } else {
           const odAdapter = adapter as OneDriveAdapter;
           const url = await odAdapter.startAuth(redirectUri);
-          return { type: 'url', data: { url, redirectUri } };
+          return { type: 'url', data: { url, redirectUri, authAttemptId } };
         }
       }
     } catch (error) {
+      if (!this.isActiveAuthAttempt(provider, authAttemptId)) {
+        throw error;
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error(`[CloudSync] ${provider} connect failed`, {
         error: errorMessage,
@@ -762,8 +793,13 @@ export class CloudSyncManager {
     deviceCode: string,
     interval: number,
     expiresAt: number,
-    onPending?: () => void
+    onPending?: () => void,
+    signal?: AbortSignal,
+    authAttemptId?: number
   ): Promise<void> {
+    if (authAttemptId != null && !this.isActiveAuthAttempt('github', authAttemptId)) {
+      throw new Error('github auth superseded');
+    }
     const adapter = this.adapters.get('github');
     if (!adapter) {
       throw new Error('GitHub adapter not initialized');
@@ -778,7 +814,15 @@ export class CloudSyncManager {
       // version, where the key didn't exist yet).
       const previousAccount = this.state.providers.github?.account;
 
-      const tokens = await ghAdapter.completeAuth(deviceCode, interval, expiresAt, onPending);
+      const tokens = await ghAdapter.completeAuth(deviceCode, interval, expiresAt, onPending, signal);
+      if (authAttemptId != null && !this.isActiveAuthAttempt('github', authAttemptId)) {
+        throw new Error('github auth superseded');
+      }
+      const resourceId = await ghAdapter.initializeSync(signal);
+
+      if (authAttemptId != null && !this.isActiveAuthAttempt('github', authAttemptId)) {
+        throw new Error('github auth superseded');
+      }
 
       ++this.providerDecryptSeq.github;
       this.state.providers.github = {
@@ -788,13 +832,14 @@ export class CloudSyncManager {
         account: ghAdapter.accountInfo || undefined,
       };
 
-      // Initialize sync (find or create gist)
-      const resourceId = await ghAdapter.initializeSync();
       if (resourceId) {
         this.state.providers.github.resourceId = resourceId;
       }
 
-      await this.saveProviderConnection('github', this.state.providers.github);
+      await this.saveProviderConnection('github', this.state.providers.github, authAttemptId);
+      if (authAttemptId != null && !this.isActiveAuthAttempt('github', authAttemptId)) {
+        throw new Error('github auth superseded');
+      }
 
       // Only clear the merge base if the authenticated account identity differs
       // from the previously-stored one. See notes in completePKCEAuth.
@@ -814,8 +859,20 @@ export class CloudSyncManager {
         provider: 'github',
         account: ghAdapter.accountInfo!,
       });
+      this.providerAuthRestoreState.github = null;
     } catch (error) {
-      this.updateProviderStatus('github', 'error', String(error));
+      if (authAttemptId != null && !this.isActiveAuthAttempt('github', authAttemptId)) {
+        throw error;
+      }
+      if (error instanceof Error && error.message.includes('auth superseded')) {
+        throw error;
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.resetProviderStatus('github', authAttemptId);
+        throw error;
+      }
+      this.resetProviderStatus('github', authAttemptId);
+      this.setProviderError('github', String(error));
       throw error;
     }
   }
@@ -826,8 +883,12 @@ export class CloudSyncManager {
   async completePKCEAuth(
     provider: 'google' | 'onedrive',
     code: string,
-    redirectUri: string
+    redirectUri: string,
+    authAttemptId?: number
   ): Promise<void> {
+    if (authAttemptId != null && !this.isActiveAuthAttempt(provider, authAttemptId)) {
+      throw new Error(`${provider} auth superseded`);
+    }
     const adapter = this.adapters.get(provider);
     if (!adapter) {
       throw new Error(`${provider} adapter not initialized`);
@@ -853,6 +914,16 @@ export class CloudSyncManager {
         account = odAdapter.accountInfo;
       }
 
+      if (authAttemptId != null && !this.isActiveAuthAttempt(provider, authAttemptId)) {
+        throw new Error(`${provider} auth superseded`);
+      }
+
+      const resourceId = await adapter.initializeSync();
+
+      if (authAttemptId != null && !this.isActiveAuthAttempt(provider, authAttemptId)) {
+        throw new Error(`${provider} auth superseded`);
+      }
+
       ++this.providerDecryptSeq[provider];
       this.state.providers[provider] = {
         ...this.state.providers[provider],
@@ -861,13 +932,14 @@ export class CloudSyncManager {
         account: account || undefined,
       };
 
-      // Initialize sync
-      const resourceId = await adapter.initializeSync();
       if (resourceId) {
         this.state.providers[provider].resourceId = resourceId;
       }
 
-      await this.saveProviderConnection(provider, this.state.providers[provider]);
+      await this.saveProviderConnection(provider, this.state.providers[provider], authAttemptId);
+      if (authAttemptId != null && !this.isActiveAuthAttempt(provider, authAttemptId)) {
+        throw new Error(`${provider} auth superseded`);
+      }
 
       // Only clear the merge base if the authenticated account identity differs
       // from the previously-stored one. Same-account re-auth preserves the base
@@ -889,8 +961,16 @@ export class CloudSyncManager {
         provider,
         account: account!,
       });
+      this.providerAuthRestoreState[provider] = null;
     } catch (error) {
-      this.updateProviderStatus(provider, 'error', String(error));
+      if (authAttemptId != null && !this.isActiveAuthAttempt(provider, authAttemptId)) {
+        throw error;
+      }
+      if (error instanceof Error && error.message.includes('auth superseded')) {
+        throw error;
+      }
+      this.resetProviderStatus(provider, authAttemptId);
+      this.setProviderError(provider, String(error));
       throw error;
     }
   }
@@ -939,11 +1019,62 @@ export class CloudSyncManager {
    * Used when an auth attempt is cancelled/fails — avoids destroying a previously
    * working connection if the user was re-authenticating.
    */
-  resetProviderStatus(provider: CloudProvider): void {
-    // Only reset if currently 'connecting' — don't drop an already authenticated
-    // provider back to 'disconnected' (e.g., if auth succeeded but sync init failed).
-    if (this.state.providers[provider]?.status === 'connecting') {
+  resetProviderStatus(provider: CloudProvider, authAttemptId?: number): void {
+    const restoreState = this.providerAuthRestoreState[provider];
+    if (
+      authAttemptId != null &&
+      restoreState &&
+      restoreState.attemptId !== authAttemptId
+    ) {
+      return;
+    }
+
+    if (restoreState) {
+      this.state.providers[provider] = { ...restoreState.connection };
+      if (restoreState.adapter) {
+        this.adapters.set(provider, restoreState.adapter);
+      } else {
+        this.adapters.delete(provider);
+      }
+      this.notifyStateChange();
+    } else if (this.state.providers[provider]?.status === 'connecting') {
       this.updateProviderStatus(provider, 'disconnected');
+      return;
+    }
+    if (!restoreState || authAttemptId == null || restoreState.attemptId === authAttemptId) {
+      this.providerAuthRestoreState[provider] = null;
+    }
+  }
+
+  setProviderError(provider: CloudProvider, error: string): void {
+    this.updateProviderStatus(provider, 'error', error);
+  }
+
+  clearProviderError(provider: CloudProvider): void {
+    const connection = this.state.providers[provider];
+    if (!connection?.error && connection?.status !== 'error') {
+      return;
+    }
+    this.state.providers[provider] = {
+      ...connection,
+      status: connection.status === 'error' ? 'disconnected' : connection.status,
+      error: undefined,
+    };
+    this.notifyStateChange();
+  }
+
+  cancelProviderAuthAttempt(provider: CloudProvider, authAttemptId?: number): void {
+    if (
+      authAttemptId != null &&
+      !this.isActiveAuthAttempt(provider, authAttemptId)
+    ) {
+      return;
+    }
+    this.resetProviderStatus(provider, authAttemptId);
+    ++this.providerAuthAttemptSeq[provider];
+    const restoreState = this.providerAuthRestoreState[provider];
+    if (!restoreState || authAttemptId == null || restoreState.attemptId === authAttemptId) {
+      this.providerAuthRestoreState[provider] = null;
     }
   }
 
@@ -951,6 +1082,7 @@ export class CloudSyncManager {
    * Disconnect a provider
    */
   async disconnectProvider(provider: CloudProvider): Promise<void> {
+    this.cancelProviderAuthAttempt(provider);
     const adapter = this.adapters.get(provider);
     if (adapter) {
       adapter.signOut();
@@ -991,6 +1123,10 @@ export class CloudSyncManager {
       error,
     };
     this.notifyStateChange(); // Notify UI of status change
+  }
+
+  private isActiveAuthAttempt(provider: CloudProvider, authAttemptId: number): boolean {
+    return this.providerAuthAttemptSeq[provider] === authAttemptId;
   }
 
   private buildAccountFromConfig(

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -695,9 +695,16 @@ export class CloudSyncManager {
 
   /**
    * Start authentication flow for a provider
-   * Returns data needed for the auth flow (device code for GitHub, URL for others)
+   * Returns data needed for the auth flow (device code for GitHub, URL for others).
+   *
+   * For PKCE providers (Google / OneDrive) the caller must supply the
+   * redirect URI the loopback callback server bound to — the port is chosen
+   * dynamically by the main process (#823) so it can't be hardcoded here.
    */
-  async startProviderAuth(provider: CloudProvider): Promise<{
+  async startProviderAuth(
+    provider: CloudProvider,
+    redirectUri?: string
+  ): Promise<{
     type: 'device_code' | 'url';
     data: unknown;
   }> {
@@ -720,7 +727,12 @@ export class CloudSyncManager {
         };
       } else {
         // Google and OneDrive use PKCE with redirect
-        const redirectUri = 'http://127.0.0.1:45678/oauth/callback';
+        if (!redirectUri) {
+          throw new Error(
+            `startProviderAuth('${provider}') requires a redirectUri — ` +
+              'call preparePKCECallback on the bridge first and pass its redirectUri through.'
+          );
+        }
 
         if (provider === 'google') {
           const gdAdapter = adapter as GoogleDriveAdapter;

--- a/infrastructure/services/adapters/GitHubAdapter.ts
+++ b/infrastructure/services/adapters/GitHubAdapter.ts
@@ -50,7 +50,53 @@ export interface DeviceFlowState {
   verificationUri: string;
   expiresAt: number;
   interval: number;
+  authAttemptId?: number;
 }
+
+const createGitHubPollId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `github-poll-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+const createGitHubCancelError = (): Error => {
+  const error = new Error('GitHub auth cancelled');
+  error.name = 'AbortError';
+  return error;
+};
+
+const throwIfAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) {
+    throw createGitHubCancelError();
+  }
+};
+
+const delayWithSignal = (ms: number, signal?: AbortSignal): Promise<void> => {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createGitHubCancelError());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(createGitHubCancelError());
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+};
 
 // ============================================================================
 // Device Flow Authentication
@@ -117,64 +163,96 @@ export const pollForToken = async (
   deviceCode: string,
   interval: number,
   expiresAt: number,
-  onPending?: () => void
+  onPending?: () => void,
+  signal?: AbortSignal
 ): Promise<OAuthTokens | null> => {
   const pollInterval = Math.max(interval, 5) * 1000; // Minimum 5 seconds
   const bridge = netcattyBridge.get();
 
   while (Date.now() < expiresAt) {
-    await new Promise(resolve => setTimeout(resolve, pollInterval));
+    await delayWithSignal(pollInterval, signal);
+    throwIfAborted(signal);
+    const pollId = createGitHubPollId();
+    const cancelPoll = () => {
+      void bridge?.githubCancelDeviceFlowPoll?.(pollId);
+    };
 
-    const data = bridge?.githubPollDeviceFlowToken
-      ? await bridge.githubPollDeviceFlowToken({
-          clientId: SYNC_CONSTANTS.GITHUB_CLIENT_ID,
-          deviceCode,
-        })
-      : await (async () => {
-          const response = await fetch(SYNC_CONSTANTS.GITHUB_ACCESS_TOKEN_URL, {
-            method: 'POST',
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: new URLSearchParams({
-              client_id: SYNC_CONSTANTS.GITHUB_CLIENT_ID,
-              device_code: deviceCode,
-              grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-            }).toString(),
-          });
-          return response.json();
-        })();
-
-    if (data.access_token) {
-      return {
-        accessToken: data.access_token,
-        tokenType: data.token_type || 'bearer',
-        scope: data.scope,
-      };
+    if (signal) {
+      signal.addEventListener('abort', cancelPoll, { once: true });
     }
 
-    if (data.error === 'authorization_pending') {
-      onPending?.();
-      continue;
-    }
+    try {
+      let data;
+      try {
+        data = bridge?.githubPollDeviceFlowToken
+          ? await bridge.githubPollDeviceFlowToken({
+              clientId: SYNC_CONSTANTS.GITHUB_CLIENT_ID,
+              deviceCode,
+              pollId,
+            })
+          : await (async () => {
+              const response = await fetch(SYNC_CONSTANTS.GITHUB_ACCESS_TOKEN_URL, {
+                method: 'POST',
+                signal,
+                headers: {
+                  'Accept': 'application/json',
+                  'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                  client_id: SYNC_CONSTANTS.GITHUB_CLIENT_ID,
+                  device_code: deviceCode,
+                  grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+                }).toString(),
+              });
+              return response.json();
+            })();
+      } catch (error) {
+        if (
+          signal?.aborted ||
+          (error instanceof Error &&
+            (error.name === 'AbortError' || error.message.toLowerCase().includes('abort')))
+        ) {
+          throw createGitHubCancelError();
+        }
+        throw error;
+      }
 
-    if (data.error === 'slow_down') {
-      // Increase interval as requested
-      await new Promise(resolve => setTimeout(resolve, 5000));
-      continue;
-    }
+      throwIfAborted(signal);
 
-    if (data.error === 'expired_token') {
-      throw new Error('Device code expired. Please try again.');
-    }
+      if (data.access_token) {
+        return {
+          accessToken: data.access_token,
+          tokenType: data.token_type || 'bearer',
+          scope: data.scope,
+        };
+      }
 
-    if (data.error === 'access_denied') {
-      throw new Error('User denied authorization.');
-    }
+      if (data.error === 'authorization_pending') {
+        onPending?.();
+        continue;
+      }
 
-    if (data.error) {
-      throw new Error(`GitHub auth error: ${data.error_description || data.error}`);
+      if (data.error === 'slow_down') {
+        // Increase interval as requested
+        await delayWithSignal(5000, signal);
+        continue;
+      }
+
+      if (data.error === 'expired_token') {
+        throw new Error('Device code expired. Please try again.');
+      }
+
+      if (data.error === 'access_denied') {
+        throw new Error('User denied authorization.');
+      }
+
+      if (data.error) {
+        throw new Error(`GitHub auth error: ${data.error_description || data.error}`);
+      }
+    } finally {
+      if (signal) {
+        signal.removeEventListener('abort', cancelPoll);
+      }
     }
   }
 
@@ -188,8 +266,12 @@ export const pollForToken = async (
 /**
  * Get authenticated user info
  */
-export const getUserInfo = async (accessToken: string): Promise<ProviderAccount> => {
+export const getUserInfo = async (
+  accessToken: string,
+  signal?: AbortSignal
+): Promise<ProviderAccount> => {
   const response = await fetch(`${SYNC_CONSTANTS.GITHUB_API_BASE}/user`, {
+    signal,
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Accept': 'application/vnd.github.v3+json',
@@ -234,9 +316,13 @@ export const validateToken = async (accessToken: string): Promise<boolean> => {
 /**
  * Find existing Netcatty sync gist
  */
-export const findSyncGist = async (accessToken: string): Promise<string | null> => {
+export const findSyncGist = async (
+  accessToken: string,
+  signal?: AbortSignal
+): Promise<string | null> => {
   // List user's gists and find ours
   const response = await fetch(`${SYNC_CONSTANTS.GITHUB_API_BASE}/gists?per_page=100`, {
+    signal,
     headers: {
       'Authorization': `Bearer ${accessToken}`,
       'Accept': 'application/vnd.github.v3+json',
@@ -471,15 +557,18 @@ export class GitHubAdapter {
     deviceCode: string,
     interval: number,
     expiresAt: number,
-    onPending?: () => void
+    onPending?: () => void,
+    signal?: AbortSignal
   ): Promise<OAuthTokens> {
-    const tokens = await pollForToken(deviceCode, interval, expiresAt, onPending);
+    const tokens = await pollForToken(deviceCode, interval, expiresAt, onPending, signal);
     if (!tokens) {
       throw new Error('Failed to obtain access token');
     }
 
+    throwIfAborted(signal);
     this.accessToken = tokens.accessToken;
-    this.account = await getUserInfo(tokens.accessToken);
+    this.account = await getUserInfo(tokens.accessToken, signal);
+    throwIfAborted(signal);
 
     return tokens;
   }
@@ -509,12 +598,12 @@ export class GitHubAdapter {
   /**
    * Initialize or find sync gist
    */
-  async initializeSync(): Promise<string | null> {
+  async initializeSync(signal?: AbortSignal): Promise<string | null> {
     if (!this.accessToken) {
       throw new Error('Not authenticated');
     }
 
-    this.gistId = await findSyncGist(this.accessToken);
+    this.gistId = await findSyncGist(this.accessToken, signal);
     return this.gistId;
   }
 


### PR DESCRIPTION
## Summary
Fixes [#823](https://github.com/binaricat/Netcatty/issues/823) — connecting Google Drive / OneDrive failed with `Error: listen EADDRINUSE: address already in use 127.0.0.1:45678` whenever the fixed loopback callback port was already held by another process on the user's machine.

## What changed
- **`electron/bridges/oauthBridge.cjs`**: split the one-shot `startOAuthCallback` into `prepareOAuthCallback()` and `awaitOAuthCallback(state)`. Prepare tries port 45678 first; if it's in use (or `EACCES`) it falls back to `listen(0)` so the OS hands out a free ephemeral port. The chosen port + `redirectUri` are returned so the caller can embed the right port into the provider's authorization URL. Also adds `getActiveOAuthPort()` for the popup allow-list, `unref()`s the server so tests/CLI don't keep event loops pinned, and calls `server.closeAllConnections()` on teardown so the port is immediately reusable.
- **`infrastructure/services/CloudSyncManager.ts`**: `startProviderAuth(provider, redirectUri)` now takes the redirect URI instead of hardcoding one. Throws a clear error if called for a PKCE provider without a URI.
- **`application/state/useCloudSync.ts`**: `connectGoogle` / `connectOneDrive` now share a `runPKCEAuth(provider)` helper that calls `prepareOAuthCallback` → `startProviderAuth(provider, redirectUri)` → races `awaitOAuthCallback` vs `openExternal`, and tears the prepared server down if anything before the await fails.
- **`electron/bridges/windowManager.cjs`**: the in-app-popup allow-list reads the currently-active OAuth port from `oauthBridge.getActiveOAuthPort()` instead of matching a hardcoded `45678`, so the loopback callback keeps working whichever port ended up bound.
- **`electron/preload.cjs` + `global.d.ts`**: replace `startOAuthCallback` with `prepareOAuthCallback` + `awaitOAuthCallback` on the bridge surface (`oauth:startCallback` → `oauth:prepareCallback` + `oauth:awaitCallback`).

## Why this is safe with the OAuth providers
Both providers' installed-app / public-client OAuth configurations allow dynamic loopback ports (Google Cloud "Desktop app" clients and Microsoft Entra / MSAL's `http://localhost` registration), so we aren't pinned to port 45678 in the cloud-side config.

## Tests
New `electron/bridges/oauthBridge.test.cjs` (9 cases) covers:
- `prepareOAuthCallback` binds + reports `port` / `redirectUri`.
- Prefers `45678` when free; **falls back to an OS-assigned port when 45678 is busy** (the #823 regression).
- `awaitOAuthCallback` resolves with the authorization code on a successful callback.
- State mismatch → rejects with CSRF message.
- Provider-side error (`?error=access_denied`) → rejects with the description.
- `awaitOAuthCallback` without `prepareOAuthCallback` → errors early.
- `cancelOAuthCallback` releases the port immediately.
- `getActiveOAuthPort` is `null` before prepare / after cleanup.

All 85 existing bridge tests still pass; `tsc --noEmit` reports no new errors in touched files; ESLint clean.

## Test plan
- [x] `node --test electron/bridges/oauthBridge.test.cjs` — 9/9 pass.
- [x] `node --test electron/bridges/*.test.cjs` — 85/85 pass.
- [x] `npx tsc --noEmit` — no new errors in touched files.
- [x] `npx eslint` on touched TS files — clean.
- [ ] Manual: with port 45678 free, connect Google Drive — flow uses 45678 (parity with old behavior).
- [ ] Manual: with another process squatting on 45678 (`nc -l 45678`), connect Google Drive — OAuth completes on a different loopback port instead of erroring.
- [ ] Manual: repeat for OneDrive.