### PR TITLE
fix(cloud-sync): preserve adapter across browser handoff (closes #827)

### DIFF
--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -550,7 +550,10 @@ export const useCloudSync = (): CloudSyncHook => {
         // Release the transient "connecting" UI once the browser handoff has
         // happened. The callback session remains active in the background and
         // will mark the provider connected when the redirect completes.
-        manager.resetProviderStatus(provider);
+        // Do NOT use resetProviderStatus here — it would restore from the
+        // auth snapshot and delete the adapter we just created, making the
+        // eventual completePKCEAuth call fail with "adapter not initialized".
+        manager.clearConnectingStatus(provider);
         manager.clearProviderError(provider);
         void completionPromise;
         return data.url;

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1050,6 +1050,19 @@ export class CloudSyncManager {
     this.updateProviderStatus(provider, 'error', error);
   }
 
+  /**
+   * Release the transient 'connecting' UI state without disturbing the adapter
+   * or the auth restore snapshot. Used by PKCE flows after the browser handoff
+   * has succeeded, so the settings page isn't visually stuck at "connecting"
+   * while we wait for the redirect callback in the background.
+   */
+  clearConnectingStatus(provider: CloudProvider): void {
+    if (this.state.providers[provider]?.status !== 'connecting') {
+      return;
+    }
+    this.updateProviderStatus(provider, 'disconnected');
+  }
+
   clearProviderError(provider: CloudProvider): void {
     const connection = this.state.providers[provider];
     if (!connection?.error && connection?.status !== 'error') {


### PR DESCRIPTION
## Summary
- `resetProviderStatus` was hardened in a1866747 to restore the adapter from the auth snapshot on cancellation. But `useCloudSync.runPKCEAuth` also calls `resetProviderStatus` right after the browser handoff — *not* to cancel, just to release the transient "connecting" UI. For a first-time connect the snapshot's `adapter` is `null`, so that call deleted the freshly-created adapter, and the subsequent `completePKCEAuth` threw `google/onedrive adapter not initialized`. The error was then persisted onto provider state, so the red dot survives restarts until the provider is manually reset.
- Introduce `CloudSyncManager.clearConnectingStatus(provider)` for the "release connecting UI" intent (only transitions `connecting → disconnected`, no adapter/snapshot touching) and switch the PKCE flow to use it.
- Added a short comment at the call site explaining why `resetProviderStatus` must not be used there, so it doesn't get "simplified" back.

GitHub device flow is unaffected (it doesn't go through that code path).

## Test plan
- [ ] Fresh profile → connect Google Drive → finish OAuth → provider shows Connected, no "adapter not initialized" error.
- [ ] Same for OneDrive.
- [ ] Cancel mid-flow (close browser / click cancel) → provider returns to Disconnected without clobbering an already-connected account.
- [ ] Reconnect to the same Google/OneDrive account → merge base is preserved (no "first sync" zombie entries).
- [ ] GitHub device-flow connect still works end-to-end.

Fixes #827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)