### PR TITLE
fix(session-logs): render terminal control sequences in saved logs

### DIFF
--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -8,7 +8,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const {
   toLocalISOString,
-  terminalPlainTextToHtml,
+  wrapTerminalHtmlContent,
 } = require("./sessionLogsBridge.cjs");
 const { createTerminalTextRenderer } = require("./terminalLogSanitizer.cjs");
 
@@ -125,10 +125,9 @@ function flushBuffer(entry) {
 }
 
 function renderSnapshotContent(entry) {
-  const text = entry.renderer.toString();
   return entry.isHtml
-    ? terminalPlainTextToHtml(text, entry.hostLabel, entry.startTime)
-    : text;
+    ? wrapTerminalHtmlContent(entry.renderer.toHtmlContent(), entry.hostLabel, entry.startTime)
+    : entry.renderer.toString();
 }
 
 function scheduleSnapshot(entry) {

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -6,7 +6,11 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
-const { toLocalISOString, stripAnsi, terminalDataToHtml } = require("./sessionLogsBridge.cjs");
+const {
+  toLocalISOString,
+  terminalPlainTextToHtml,
+} = require("./sessionLogsBridge.cjs");
+const { createTerminalTextRenderer } = require("./terminalLogSanitizer.cjs");
 
 // Active log streams keyed by sessionId
 const activeStreams = new Map();
@@ -42,34 +46,45 @@ function startStream(sessionId, opts) {
 
     const date = new Date(startTime || Date.now());
     const dateStr = toLocalISOString(date);
-    // For html format, write raw data to a temp file during streaming,
-    // then convert on stopStream.
+    // Raw logs are written directly. Txt/html logs keep terminal parser state
+    // in memory and write the rendered file on each flush.
+    const isRaw = format === "raw";
     const isHtml = format === "html";
-    const ext = isHtml ? "log.tmp" : format === "raw" ? "log" : "txt";
+    const ext = isRaw ? "log" : isHtml ? "html" : "txt";
     const fileName = `${dateStr}.${ext}`;
     const filePath = path.join(hostDir, fileName);
 
-    const writeStream = fs.createWriteStream(filePath, { flags: "w", encoding: "utf8" });
+    const writeStream = isRaw
+      ? fs.createWriteStream(filePath, { flags: "w", encoding: "utf8" })
+      : null;
 
-    writeStream.on("error", (err) => {
-      console.error(`[SessionLogStream] Write error for ${sessionId}:`, err.message);
-      // Disable this stream on error to avoid cascading failures
-      const entry = activeStreams.get(sessionId);
-      if (entry) {
-        entry.disabled = true;
-      }
-    });
+    if (writeStream) {
+      writeStream.on("error", (err) => {
+        console.error(`[SessionLogStream] Write error for ${sessionId}:`, err.message);
+        // Disable this stream on error to avoid cascading failures
+        const entry = activeStreams.get(sessionId);
+        if (entry) {
+          entry.disabled = true;
+        }
+      });
+    }
 
     const entry = {
       writeStream,
       filePath,
       hostDir,
       format,
+      isRaw,
       isHtml,
+      renderer: isRaw ? null : createTerminalTextRenderer(),
       hostLabel: hostLabel || hostname || "unknown",
       startTime: startTime || Date.now(),
       buffer: "",
       flushTimer: null,
+      snapshotPromise: null,
+      snapshotRequested: false,
+      snapshotDirty: false,
+      closing: false,
       disabled: false,
     };
 
@@ -96,18 +111,54 @@ function flushBuffer(entry) {
     const data = entry.buffer;
     entry.buffer = "";
 
-    if (entry.isHtml) {
-      // For HTML format, write raw data during streaming; convert on close
-      entry.writeStream.write(data);
-    } else if (entry.format === "raw") {
+    if (entry.isRaw) {
       entry.writeStream.write(data);
     } else {
-      // txt format: strip ANSI codes
-      entry.writeStream.write(stripAnsi(data));
+      entry.renderer.feed(data);
+      entry.snapshotDirty = true;
+      scheduleSnapshot(entry);
     }
   } catch (err) {
     console.error("[SessionLogStream] Flush error:", err.message);
     entry.disabled = true;
+  }
+}
+
+function renderSnapshotContent(entry) {
+  const text = entry.renderer.toString();
+  return entry.isHtml
+    ? terminalPlainTextToHtml(text, entry.hostLabel, entry.startTime)
+    : text;
+}
+
+function scheduleSnapshot(entry) {
+  if (!entry || entry.disabled || entry.isRaw || entry.closing) return;
+  if (!entry.snapshotDirty) return;
+
+  if (entry.snapshotPromise) {
+    entry.snapshotRequested = true;
+    return;
+  }
+
+  entry.snapshotDirty = false;
+  entry.snapshotPromise = fs.promises
+    .writeFile(entry.filePath, renderSnapshotContent(entry), "utf8")
+    .catch((err) => {
+      console.error("[SessionLogStream] Snapshot write failed:", err.message);
+      entry.snapshotDirty = true;
+    })
+    .finally(() => {
+      entry.snapshotPromise = null;
+      if ((entry.snapshotRequested || entry.snapshotDirty) && !entry.closing) {
+        entry.snapshotRequested = false;
+        scheduleSnapshot(entry);
+      }
+    });
+}
+
+async function waitForSnapshotIdle(entry) {
+  while (entry.snapshotPromise) {
+    await entry.snapshotPromise;
   }
 }
 
@@ -139,6 +190,7 @@ async function stopStream(sessionId) {
   const entry = activeStreams.get(sessionId);
   if (!entry) return null;
   activeStreams.delete(sessionId);
+  entry.closing = true;
 
   // Stop periodic flush
   if (entry.flushTimer) {
@@ -148,33 +200,24 @@ async function stopStream(sessionId) {
 
   // Flush remaining buffer
   flushBuffer(entry);
+  await waitForSnapshotIdle(entry);
 
-  // Close the write stream and wait for it to finish
-  await new Promise((resolve) => {
-    entry.writeStream.end(resolve);
-  });
-
-  let finalPath = entry.filePath;
-
-  // For HTML format: read the temp raw file and convert to HTML
-  if (entry.isHtml && !entry.disabled) {
+  // Close the raw write stream and wait for it to finish.
+  if (entry.writeStream) {
+    await new Promise((resolve) => {
+      entry.writeStream.end(resolve);
+    });
+  } else if (!entry.disabled && entry.snapshotDirty) {
     try {
-      const rawData = await fs.promises.readFile(entry.filePath, "utf8");
-      const htmlContent = terminalDataToHtml(rawData, entry.hostLabel, entry.startTime);
-      const htmlPath = entry.filePath.replace(/\.log\.tmp$/, ".html");
-      await fs.promises.writeFile(htmlPath, htmlContent, "utf8");
-      // Remove temp file
-      try {
-        await fs.promises.unlink(entry.filePath);
-      } catch {
-        // Ignore cleanup errors
-      }
-      finalPath = htmlPath;
+      await fs.promises.writeFile(entry.filePath, renderSnapshotContent(entry), "utf8");
+      entry.snapshotDirty = false;
     } catch (err) {
-      console.error(`[SessionLogStream] HTML conversion failed for ${sessionId}:`, err.message);
-      // Keep the raw temp file as fallback
+      console.error(`[SessionLogStream] Final snapshot write failed for ${sessionId}:`, err.message);
+      entry.disabled = true;
     }
   }
+
+  const finalPath = entry.filePath;
 
   console.log(`[SessionLogStream] Stopped stream for ${sessionId} -> ${finalPath}`);
   return finalPath;

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -6,6 +6,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { dialog } = require("electron");
+const { terminalDataToPlainText } = require("./terminalLogSanitizer.cjs");
 
 /**
  * Get current Date to a local ISO-like string (YYYY-MM-DDTHH-MM-SS)
@@ -24,22 +25,6 @@ function toLocalISOString(date = new Date()) {
 }
 
 /**
- * Strip ANSI escape codes from text
- * Used for plain text export format
- */
-function stripAnsi(str) {
-  // eslint-disable-next-line no-control-regex
-  return str
-    // OSC: ESC ] ... BEL or ESC ] ... ESC \
-    .replace(/\x1B\][\s\S]*?(?:\x07|\x1B\\)/g, '')
-    // ANSI CSI / ESC sequences
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "")
-    // Remove remaining control chars except \n \r \t
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
-}
-
-/**
  * Escape HTML special characters to prevent XSS
  * Must be applied before converting ANSI codes to HTML spans
  */
@@ -52,75 +37,8 @@ function escapeHtml(str) {
     .replace(/'/g, "&#039;");
 }
 
-/**
- * Convert terminal data to HTML with colors preserved
- */
-function terminalDataToHtml(terminalData, hostLabel, timestamp) {
-  // Basic ANSI to HTML conversion for common codes
-  const ansiToHtml = (text) => {
-    const colorMap = {
-      "30": "color: #000",
-      "31": "color: #c00",
-      "32": "color: #0c0",
-      "33": "color: #cc0",
-      "34": "color: #00c",
-      "35": "color: #c0c",
-      "36": "color: #0cc",
-      "37": "color: #ccc",
-      "90": "color: #666",
-      "91": "color: #f66",
-      "92": "color: #6f6",
-      "93": "color: #ff6",
-      "94": "color: #66f",
-      "95": "color: #f6f",
-      "96": "color: #6ff",
-      "97": "color: #fff",
-      "40": "background: #000",
-      "41": "background: #c00",
-      "42": "background: #0c0",
-      "43": "background: #cc0",
-      "44": "background: #00c",
-      "45": "background: #c0c",
-      "46": "background: #0cc",
-      "47": "background: #ccc",
-      "1": "font-weight: bold",
-      "3": "font-style: italic",
-      "4": "text-decoration: underline",
-    };
-
-    // First, escape HTML in the text content (not the ANSI codes)
-    // We do this by splitting on ANSI sequences, escaping each text part, then rejoining
-    // eslint-disable-next-line no-control-regex
-    const ansiRegex = /(\x1B\[[0-9;]*m|\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]))/g;
-    const parts = text.split(ansiRegex);
-
-    let result = parts.map((part) => {
-      // Check if this part is an ANSI sequence
-      // eslint-disable-next-line no-control-regex
-      if (/^\x1B/.test(part)) {
-        // It's an ANSI sequence, convert to HTML span or remove
-        const match = part.match(/^\x1B\[([0-9;]*)m$/);
-        if (match) {
-          const codes = match[1];
-          if (codes === "0" || codes === "") {
-            return "</span>";
-          }
-          const styles = codes.split(";").map((c) => colorMap[c]).filter(Boolean);
-          if (styles.length > 0) {
-            return `<span style="${styles.join("; ")}">`;
-          }
-        }
-        // Other ANSI sequences are stripped
-        return "";
-      }
-      // It's regular text, escape HTML
-      return escapeHtml(part);
-    }).join("");
-
-    return result;
-  };
-
-  const htmlContent = ansiToHtml(terminalData);
+function terminalPlainTextToHtml(plainText, hostLabel, timestamp) {
+  const htmlContent = escapeHtml(plainText || "");
   const dateStr = new Date(timestamp).toLocaleString();
   const safeHostLabel = escapeHtml(hostLabel || "Unknown");
   const safeDateStr = escapeHtml(dateStr);
@@ -157,6 +75,13 @@ function terminalDataToHtml(terminalData, hostLabel, timestamp) {
   <div class="content">${htmlContent}</div>
 </body>
 </html>`;
+}
+
+/**
+ * Convert terminal data to HTML after applying terminal text controls.
+ */
+function terminalDataToHtml(terminalData, hostLabel, timestamp) {
+  return terminalPlainTextToHtml(terminalDataToPlainText(terminalData), hostLabel, timestamp);
 }
 
 /**
@@ -201,8 +126,8 @@ async function exportSessionLog(event, payload) {
     // Raw format preserves ANSI codes
     content = terminalData;
   } else {
-    // Plain text - strip ANSI codes
-    content = stripAnsi(terminalData);
+    // Plain text - apply terminal text controls and remove escape sequences
+    content = terminalDataToPlainText(terminalData);
   }
 
   await fs.promises.writeFile(result.filePath, content, "utf8");
@@ -258,7 +183,7 @@ async function autoSaveSessionLog(event, payload) {
     } else if (format === "raw") {
       content = terminalData;
     } else {
-      content = stripAnsi(terminalData);
+      content = terminalDataToPlainText(terminalData);
     }
 
     await fs.promises.writeFile(filePath, content, "utf8");
@@ -307,7 +232,7 @@ module.exports = {
   selectSessionLogsDir,
   autoSaveSessionLog,
   openSessionLogsDir,
-  stripAnsi,
   toLocalISOString,
   terminalDataToHtml,
+  terminalPlainTextToHtml,
 };

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -6,7 +6,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { dialog } = require("electron");
-const { terminalDataToPlainText } = require("./terminalLogSanitizer.cjs");
+const {
+  terminalDataToHtmlContent,
+  terminalDataToPlainText,
+} = require("./terminalLogSanitizer.cjs");
 
 /**
  * Get current Date to a local ISO-like string (YYYY-MM-DDTHH-MM-SS)
@@ -39,6 +42,10 @@ function escapeHtml(str) {
 
 function terminalPlainTextToHtml(plainText, hostLabel, timestamp) {
   const htmlContent = escapeHtml(plainText || "");
+  return wrapTerminalHtmlContent(htmlContent, hostLabel, timestamp);
+}
+
+function wrapTerminalHtmlContent(htmlContent, hostLabel, timestamp) {
   const dateStr = new Date(timestamp).toLocaleString();
   const safeHostLabel = escapeHtml(hostLabel || "Unknown");
   const safeDateStr = escapeHtml(dateStr);
@@ -72,16 +79,17 @@ function terminalPlainTextToHtml(plainText, hostLabel, timestamp) {
     Host: ${safeHostLabel}<br>
     Date: ${safeDateStr}
   </div>
-  <div class="content">${htmlContent}</div>
+  <div class="content">${htmlContent || ""}</div>
 </body>
 </html>`;
 }
 
 /**
- * Convert terminal data to HTML after applying terminal text controls.
+ * Convert terminal data to HTML after applying terminal text controls while
+ * preserving SGR styles such as color, bold, italic, and underline.
  */
 function terminalDataToHtml(terminalData, hostLabel, timestamp) {
-  return terminalPlainTextToHtml(terminalDataToPlainText(terminalData), hostLabel, timestamp);
+  return wrapTerminalHtmlContent(terminalDataToHtmlContent(terminalData), hostLabel, timestamp);
 }
 
 /**
@@ -235,4 +243,5 @@ module.exports = {
   toLocalISOString,
   terminalDataToHtml,
   terminalPlainTextToHtml,
+  wrapTerminalHtmlContent,
 };

--- a/electron/bridges/terminalLogSanitizer.cjs
+++ b/electron/bridges/terminalLogSanitizer.cjs
@@ -1,0 +1,238 @@
+/**
+ * Terminal log sanitizer.
+ *
+ * This is intentionally stateful: terminal output is a stream of cursor and
+ * erase operations, not plain text with decoration. The renderer below keeps a
+ * small virtual text buffer so plain-text and HTML logs reflect what common
+ * line-editing output actually leaves on screen.
+ */
+
+const CSI_FINAL_RE = /[@-~]/;
+
+class TerminalTextRenderer {
+  constructor() {
+    this.lines = [[]];
+    this.row = 0;
+    this.col = 0;
+    this.state = "normal";
+    this.escapeBuffer = "";
+  }
+
+  feed(input) {
+    if (!input) return;
+
+    for (const ch of input) {
+      this.#consume(ch);
+    }
+  }
+
+  finish() {
+    this.state = "normal";
+    this.escapeBuffer = "";
+    return this.toString();
+  }
+
+  toString() {
+    return this.lines
+      .map((line) => line.join("").replace(/[ \t]+$/g, ""))
+      .join("\n")
+      .replace(/\n+$/g, "");
+  }
+
+  #consume(ch) {
+    if (this.state === "esc") {
+      this.#consumeEsc(ch);
+      return;
+    }
+    if (this.state === "csi") {
+      this.escapeBuffer += ch;
+      if (CSI_FINAL_RE.test(ch)) {
+        this.#applyCsi(this.escapeBuffer);
+        this.state = "normal";
+        this.escapeBuffer = "";
+      }
+      return;
+    }
+    if (this.state === "osc") {
+      if (ch === "\x07") {
+        this.state = "normal";
+        this.escapeBuffer = "";
+        return;
+      }
+      if (ch === "\x1b") {
+        this.state = "oscEsc";
+      }
+      return;
+    }
+    if (this.state === "oscEsc") {
+      this.state = ch === "\\" ? "normal" : "osc";
+      return;
+    }
+
+    switch (ch) {
+      case "\x1b":
+        this.state = "esc";
+        this.escapeBuffer = "";
+        break;
+      case "\b":
+        this.col = Math.max(0, this.col - 1);
+        break;
+      case "\r":
+        this.col = 0;
+        break;
+      case "\n":
+        this.row += 1;
+        this.col = 0;
+        this.#ensureLine();
+        break;
+      case "\t":
+        this.#writeText(" ".repeat(8 - (this.col % 8)));
+        break;
+      default:
+        if (this.#isPrintable(ch)) this.#writeText(ch);
+        break;
+    }
+  }
+
+  #consumeEsc(ch) {
+    if (ch === "[") {
+      this.state = "csi";
+      this.escapeBuffer = "";
+      return;
+    }
+    if (ch === "]") {
+      this.state = "osc";
+      this.escapeBuffer = "";
+      return;
+    }
+    // Single-character ESC sequences are terminal controls. Ignore them for
+    // logs, but consume them so they never leak into txt/html output.
+    this.state = "normal";
+    this.escapeBuffer = "";
+  }
+
+  #applyCsi(sequence) {
+    const final = sequence.at(-1);
+    const params = sequence.slice(0, -1);
+    const values = params
+      .replace(/[?><=]/g, "")
+      .split(";")
+      .map((part) => {
+        if (part === "") return undefined;
+        const n = Number.parseInt(part, 10);
+        return Number.isFinite(n) ? n : undefined;
+      });
+    const n = values[0] || 1;
+
+    switch (final) {
+      case "A":
+        this.row = Math.max(0, this.row - n);
+        this.#ensureLine();
+        break;
+      case "B":
+      case "E":
+        this.row += n;
+        if (final === "E") this.col = 0;
+        this.#ensureLine();
+        break;
+      case "C":
+        this.col += n;
+        break;
+      case "D":
+        this.col = Math.max(0, this.col - n);
+        break;
+      case "F":
+        this.row = Math.max(0, this.row - n);
+        this.col = 0;
+        this.#ensureLine();
+        break;
+      case "G":
+        this.col = Math.max(0, n - 1);
+        break;
+      case "H":
+      case "f":
+        this.row = Math.max(0, (values[0] || 1) - 1);
+        this.col = Math.max(0, (values[1] || 1) - 1);
+        this.#ensureLine();
+        break;
+      case "J":
+        this.#eraseDisplay(values[0] || 0);
+        break;
+      case "K":
+        this.#eraseLine(values[0] || 0);
+        break;
+      default:
+        // SGR and unsupported CSI controls are intentionally ignored.
+        break;
+    }
+  }
+
+  #writeText(text) {
+    this.#ensureLine();
+    const line = this.lines[this.row];
+    while (line.length < this.col) line.push(" ");
+    for (const ch of text) {
+      line[this.col] = ch;
+      this.col += 1;
+    }
+  }
+
+  #eraseLine(mode) {
+    this.#ensureLine();
+    const line = this.lines[this.row];
+    if (mode === 1) {
+      for (let i = 0; i <= this.col && i < line.length; i += 1) line[i] = " ";
+      return;
+    }
+    if (mode === 2) {
+      this.lines[this.row] = [];
+      this.col = 0;
+      return;
+    }
+    line.length = Math.min(line.length, this.col);
+  }
+
+  #eraseDisplay(mode) {
+    this.#ensureLine();
+    if (mode === 2 || mode === 3) {
+      this.lines = [[]];
+      this.row = 0;
+      this.col = 0;
+      return;
+    }
+    if (mode === 1) {
+      this.lines = this.lines.slice(this.row);
+      this.row = 0;
+      this.#eraseLine(1);
+      return;
+    }
+    this.#eraseLine(0);
+    this.lines.length = this.row + 1;
+  }
+
+  #ensureLine() {
+    while (this.lines.length <= this.row) this.lines.push([]);
+  }
+
+  #isPrintable(ch) {
+    const code = ch.codePointAt(0);
+    if (code === undefined) return false;
+    return code >= 0x20 && code !== 0x7f;
+  }
+}
+
+function terminalDataToPlainText(terminalData) {
+  const renderer = new TerminalTextRenderer();
+  renderer.feed(terminalData || "");
+  return renderer.finish();
+}
+
+function createTerminalTextRenderer() {
+  return new TerminalTextRenderer();
+}
+
+module.exports = {
+  TerminalTextRenderer,
+  createTerminalTextRenderer,
+  terminalDataToPlainText,
+};

--- a/electron/bridges/terminalLogSanitizer.cjs
+++ b/electron/bridges/terminalLogSanitizer.cjs
@@ -8,6 +8,28 @@
  */
 
 const CSI_FINAL_RE = /[@-~]/;
+const DEFAULT_FOREGROUND = "#d4d4d4";
+const DEFAULT_BACKGROUND = "#1e1e1e";
+const BASIC_COLORS = [
+  "#000000",
+  "#cd3131",
+  "#0dbc79",
+  "#e5e510",
+  "#2472c8",
+  "#bc3fbc",
+  "#11a8cd",
+  "#e5e5e5",
+];
+const BRIGHT_COLORS = [
+  "#666666",
+  "#f14c4c",
+  "#23d18b",
+  "#f5f543",
+  "#3b8eea",
+  "#d670d6",
+  "#29b8db",
+  "#ffffff",
+];
 
 class TerminalTextRenderer {
   constructor() {
@@ -16,6 +38,7 @@ class TerminalTextRenderer {
     this.col = 0;
     this.state = "normal";
     this.escapeBuffer = "";
+    this.style = createDefaultStyle();
   }
 
   feed(input) {
@@ -34,7 +57,14 @@ class TerminalTextRenderer {
 
   toString() {
     return this.lines
-      .map((line) => line.join("").replace(/[ \t]+$/g, ""))
+      .map((line) => line.map((cell) => cell?.ch || " ").join("").replace(/[ \t]+$/g, ""))
+      .join("\n")
+      .replace(/\n+$/g, "");
+  }
+
+  toHtmlContent() {
+    return this.lines
+      .map((line) => renderLineHtml(line))
       .join("\n")
       .replace(/\n+$/g, "");
   }
@@ -161,18 +191,75 @@ class TerminalTextRenderer {
       case "K":
         this.#eraseLine(values[0] || 0);
         break;
-      default:
-        // SGR and unsupported CSI controls are intentionally ignored.
+      case "m":
+        this.#applySgr(values);
         break;
+      default:
+        // Unsupported CSI controls are intentionally ignored.
+        break;
+    }
+  }
+
+  #applySgr(values) {
+    const codes = values.length > 0 ? values : [0];
+
+    for (let i = 0; i < codes.length; i += 1) {
+      const code = codes[i] ?? 0;
+
+      if (code === 0) {
+        this.style = createDefaultStyle();
+      } else if (code === 1) {
+        this.style.bold = true;
+      } else if (code === 3) {
+        this.style.italic = true;
+      } else if (code === 4) {
+        this.style.underline = true;
+      } else if (code === 7) {
+        this.style.inverse = true;
+      } else if (code === 22) {
+        this.style.bold = false;
+      } else if (code === 23) {
+        this.style.italic = false;
+      } else if (code === 24) {
+        this.style.underline = false;
+      } else if (code === 27) {
+        this.style.inverse = false;
+      } else if (code >= 30 && code <= 37) {
+        this.style.fg = BASIC_COLORS[code - 30];
+      } else if (code === 39) {
+        this.style.fg = null;
+      } else if (code >= 40 && code <= 47) {
+        this.style.bg = BASIC_COLORS[code - 40];
+      } else if (code === 49) {
+        this.style.bg = null;
+      } else if (code >= 90 && code <= 97) {
+        this.style.fg = BRIGHT_COLORS[code - 90];
+      } else if (code >= 100 && code <= 107) {
+        this.style.bg = BRIGHT_COLORS[code - 100];
+      } else if ((code === 38 || code === 48) && codes[i + 1] === 5) {
+        const color = colorFromAnsi256(codes[i + 2]);
+        if (color) {
+          if (code === 38) this.style.fg = color;
+          else this.style.bg = color;
+        }
+        i += 2;
+      } else if ((code === 38 || code === 48) && codes[i + 1] === 2) {
+        const color = colorFromRgb(codes[i + 2], codes[i + 3], codes[i + 4]);
+        if (color) {
+          if (code === 38) this.style.fg = color;
+          else this.style.bg = color;
+        }
+        i += 4;
+      }
     }
   }
 
   #writeText(text) {
     this.#ensureLine();
     const line = this.lines[this.row];
-    while (line.length < this.col) line.push(" ");
+    while (line.length < this.col) line.push(createCell(" ", createDefaultStyle()));
     for (const ch of text) {
-      line[this.col] = ch;
+      line[this.col] = createCell(ch, this.style);
       this.col += 1;
     }
   }
@@ -181,12 +268,13 @@ class TerminalTextRenderer {
     this.#ensureLine();
     const line = this.lines[this.row];
     if (mode === 1) {
-      for (let i = 0; i <= this.col && i < line.length; i += 1) line[i] = " ";
+      for (let i = 0; i <= this.col && i < line.length; i += 1) {
+        line[i] = createCell(" ", createDefaultStyle());
+      }
       return;
     }
     if (mode === 2) {
       this.lines[this.row] = [];
-      this.col = 0;
       return;
     }
     line.length = Math.min(line.length, this.col);
@@ -227,6 +315,13 @@ function terminalDataToPlainText(terminalData) {
   return renderer.finish();
 }
 
+function terminalDataToHtmlContent(terminalData) {
+  const renderer = new TerminalTextRenderer();
+  renderer.feed(terminalData || "");
+  renderer.finish();
+  return renderer.toHtmlContent();
+}
+
 function createTerminalTextRenderer() {
   return new TerminalTextRenderer();
 }
@@ -234,5 +329,125 @@ function createTerminalTextRenderer() {
 module.exports = {
   TerminalTextRenderer,
   createTerminalTextRenderer,
+  terminalDataToHtmlContent,
   terminalDataToPlainText,
 };
+
+function createDefaultStyle() {
+  return {
+    fg: null,
+    bg: null,
+    bold: false,
+    italic: false,
+    underline: false,
+    inverse: false,
+  };
+}
+
+function createCell(ch, style) {
+  return {
+    ch,
+    style: { ...style },
+  };
+}
+
+function renderLineHtml(line) {
+  let html = "";
+  let runText = "";
+  let runStyle = null;
+
+  const flush = () => {
+    if (!runText) return;
+    const escaped = escapeHtml(runText);
+    const style = styleToCss(runStyle);
+    html += style ? `<span style="${style}">${escaped}</span>` : escaped;
+    runText = "";
+  };
+
+  const trimmedLength = getTrimmedLineLength(line);
+  for (let i = 0; i < trimmedLength; i += 1) {
+    const cell = line[i] || createCell(" ", createDefaultStyle());
+    if (!runStyle || !stylesEqual(runStyle, cell.style)) {
+      flush();
+      runStyle = cell.style;
+    }
+    runText += cell.ch;
+  }
+  flush();
+  return html;
+}
+
+function getTrimmedLineLength(line) {
+  let length = line.length;
+  while (length > 0) {
+    const cell = line[length - 1];
+    const ch = cell?.ch || " ";
+    if (ch !== " " && ch !== "\t") break;
+    if (styleToCss(cell?.style)) break;
+    length -= 1;
+  }
+  return length;
+}
+
+function styleToCss(style) {
+  if (!style) return "";
+  const declarations = [];
+  const fg = style.inverse ? (style.bg || DEFAULT_BACKGROUND) : style.fg;
+  const bg = style.inverse ? (style.fg || DEFAULT_FOREGROUND) : style.bg;
+  if (fg) declarations.push(`color: ${fg}`);
+  if (bg) declarations.push(`background-color: ${bg}`);
+  if (style.bold) declarations.push("font-weight: 700");
+  if (style.italic) declarations.push("font-style: italic");
+  if (style.underline) declarations.push("text-decoration: underline");
+  return declarations.join("; ");
+}
+
+function stylesEqual(a, b) {
+  return (
+    a.fg === b.fg &&
+    a.bg === b.bg &&
+    a.bold === b.bold &&
+    a.italic === b.italic &&
+    a.underline === b.underline &&
+    a.inverse === b.inverse
+  );
+}
+
+function colorFromAnsi256(value) {
+  if (!Number.isInteger(value) || value < 0 || value > 255) return null;
+  if (value < 8) return BASIC_COLORS[value];
+  if (value < 16) return BRIGHT_COLORS[value - 8];
+  if (value < 232) {
+    const n = value - 16;
+    const r = Math.floor(n / 36);
+    const g = Math.floor((n % 36) / 6);
+    const b = n % 6;
+    return colorFromRgb(colorCubeValue(r), colorCubeValue(g), colorCubeValue(b));
+  }
+  const level = 8 + (value - 232) * 10;
+  return colorFromRgb(level, level, level);
+}
+
+function colorCubeValue(n) {
+  return n === 0 ? 0 : 55 + n * 40;
+}
+
+function colorFromRgb(r, g, b) {
+  if (![r, g, b].every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) {
+    return null;
+  }
+  return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+}
+
+function hex2(value) {
+  return value.toString(16).padStart(2, "0");
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
Add a stateful terminal log sanitizer for txt/html session logs so saved output handles backspace, carriage-return overwrites, erase-line/display controls, and split CSI/OSC sequences correctly.

Stream txt/html auto-save through a persistent renderer and write rendered snapshots directly to the final log file, avoiding raw temp files and redundant full rewrites on session close. Keep raw log format unchanged.