### PR TITLE
[codex] Show SFTP toolbar button

### DIFF
--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { I18nProvider } from "../../application/i18n/I18nProvider.tsx";
+import type { Host } from "../../types.ts";
+import { TerminalToolbar } from "./TerminalToolbar.tsx";
+
+const sshHost: Host = {
+  id: "host-1",
+  label: "Host",
+  hostname: "example.com",
+  username: "root",
+  tags: [],
+  os: "linux",
+  protocol: "ssh",
+};
+
+const renderToolbar = (host: Host, status: "connecting" | "connected" | "disconnected" = "connected") =>
+  renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(TerminalToolbar, {
+        status,
+        host,
+        onOpenSFTP: () => {},
+        onOpenScripts: () => {},
+        onOpenTheme: () => {},
+      }),
+    ),
+  );
+
+test("keeps SFTP visible before the terminal overflow menu for SSH sessions", () => {
+  const markup = renderToolbar(sshHost);
+
+  const sftpIndex = markup.indexOf('aria-label="Open SFTP"');
+  const moreIndex = markup.indexOf('aria-label="More actions"');
+
+  assert.notEqual(sftpIndex, -1);
+  assert.notEqual(moreIndex, -1);
+  assert.ok(sftpIndex < moreIndex);
+});
+
+test("hides SFTP for local terminal sessions", () => {
+  const markup = renderToolbar({
+    ...sshHost,
+    id: "local-1",
+    protocol: "local",
+  });
+
+  assert.equal(markup.includes('aria-label="Open SFTP"'), false);
+});

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -1,6 +1,6 @@
 /**
  * Terminal Toolbar
- * Displays SFTP, Scripts, Theme, Highlight, Search buttons and close button in terminal status bar
+ * Displays high-frequency terminal actions and close button in the terminal status bar.
  */
 import { Check, ChevronRight, FolderInput, Languages, MoreVertical, X, Zap, Palette, Search, TextCursorInput } from 'lucide-react';
 import React, { useState } from 'react';
@@ -82,6 +82,26 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                 buttonClassName={buttonBase}
             />
 
+            {!hidesSftp && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="secondary"
+                            size="icon"
+                            className={cn(buttonBase, status !== 'connected' && "opacity-50")}
+                            aria-label={status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
+                            onClick={onOpenSFTP}
+                            disabled={status !== 'connected'}
+                        >
+                            <FolderInput size={12} />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        {status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
+                    </TooltipContent>
+                </Tooltip>
+            )}
+
             <Tooltip>
                 <TooltipTrigger asChild>
                     <Button
@@ -114,9 +134,9 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                 <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
             </Tooltip>
 
-            {/* Overflow menu — collapses the four opener-style actions
-                (SFTP / Encoding / Scripts / Terminal Settings) behind a
-                single ⋮ trigger so the toolbar doesn't feel crowded.
+            {/* Overflow menu — keeps lower-frequency opener-style actions
+                (Encoding / Scripts / Terminal Settings) behind a single
+                trigger so the toolbar doesn't feel crowded.
                 Highlight / Compose / Search stay visible because they
                 are toggled mid-session, not just once. */}
             <Popover
@@ -154,21 +174,6 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                         }
                     }}
                 >
-                    {!hidesSftp && (
-                        <PopoverClose asChild>
-                            <button
-                                type="button"
-                                className={cn(menuItemClass, status !== 'connected' && "opacity-50 pointer-events-none")}
-                                onClick={onOpenSFTP}
-                                disabled={status !== 'connected'}
-                            >
-                                <FolderInput size={12} className="shrink-0" />
-                                <span className="flex-1 text-left truncate">
-                                    {status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
-                                </span>
-                            </button>
-                        </PopoverClose>
-                    )}
                     <PopoverClose asChild>
                         <button type="button" className={menuItemClass} onClick={onOpenScripts}>
                             <Zap size={12} className="shrink-0" />


### PR DESCRIPTION
## Summary

- Move the SFTP opener out of the terminal overflow menu so it is directly visible in the terminal toolbar for SSH sessions.
- Keep SFTP hidden for local and serial terminals where it does not apply.
- Add a regression check that verifies SFTP stays visible before the overflow menu.

## Why

Issue #829 reports that the high-frequency SFTP action is hidden behind the three-dot menu. This makes a common workflow harder to discover and slower to use.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`

Closes #829