### PR TITLE
fix(quit): target main window for dirty-editor check on quit

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1225,9 +1225,16 @@ if (!gotLock) {
     }
 
     const { ipcMain: _ipcMain } = electronModule;
-    const win = BrowserWindow.getAllWindows()[0];
-    // No window — nothing to check; commit to quit directly.
-    if (!win || win.isDestroyed?.()) {
+    // Target the main window explicitly. Falling back to
+    // BrowserWindow.getAllWindows()[0] could pick the tray panel or settings
+    // window, whose renderers don't listen for app:query-dirty-editors and
+    // would force the 5s timeout fallback to run on every quit.
+    const win = getWindowManager().getMainWindow();
+    // No main window, or it's hidden (tray-panel "Quit" path) — there's no
+    // visible UI to surface a "save first" toast on, so skip the round-trip
+    // and quit directly. The renderer's dirty-editor check exists to warn the
+    // user; if they can't see the warning, it's just dead 5-second wait.
+    if (!win || win.isDestroyed?.() || !win.isVisible?.()) {
       commitQuit();
       return;
     }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1234,7 +1234,15 @@ if (!gotLock) {
     // visible UI to surface a "save first" toast on, so skip the round-trip
     // and quit directly. The renderer's dirty-editor check exists to warn the
     // user; if they can't see the warning, it's just dead 5-second wait.
-    if (!win || win.isDestroyed?.() || !win.isVisible?.()) {
+    //
+    // A minimized window is *not* hidden: the user has a taskbar/Dock entry
+    // and can restore in one click, so we still want to gate the quit on the
+    // dirty-editor check there. Some platforms report isVisible()=false on a
+    // minimized window (see globalShortcutBridge.cjs:478), so check both.
+    const isReachableByUser =
+      win && !win.isDestroyed?.() &&
+      (win.isVisible?.() || win.isMinimized?.());
+    if (!isReachableByUser) {
       commitQuit();
       return;
     }


### PR DESCRIPTION
解决在系统托盘退出应用等待5秒的问题