### PR TITLE
[codex] Fix PowerShell MCP command execution

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -86,6 +86,10 @@ function escapeCmdForNestedShell(text) {
   return String(text || "").replace(/"/g, '""').replace(/%/g, "%%");
 }
 
+// Matches PowerShell's default prompt only (e.g. `PS C:\Users\alice>`,
+// `PS>`). Custom prompt functions (oh-my-posh, starship, PSReadLine themes
+// that emit `❯`/`λ`/etc.) intentionally fall through — we'd rather miss
+// the override than wrap a fish/zsh prompt as PowerShell.
 function isPowerShellPrompt(prompt) {
   const lastLine = stripAnsi(String(prompt || ""))
     .replace(/\r/g, "")

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -104,15 +104,23 @@ function isPowerShellPrompt(prompt) {
   return isDefaultPowerShellPromptLine(lastLine);
 }
 
-// Prompt-driven override is intentionally narrow: only flip when the
-// session has no confirmed POSIX shell. This keeps the issue #841 fix
-// (SSH sessions, where shellKind is undefined) working while preventing
-// a malicious remote process from spoofing a `PS ...>` line on a real
-// POSIX shell to coerce a single mis-wrapped command.
+// Prompt-driven override is intentionally narrow: only flip to PowerShell
+// when the session has no confirmed shell type. This keeps the issue #841
+// fix working (SSH/Telnet sessions never set shellKind — see
+// sshBridge.cjs:1265) while preventing a malicious remote process from
+// spoofing a `PS ...>` line on a real bash/zsh/fish/cmd session to coerce
+// a single mis-wrapped command.
+//
+// Universe of shellKind values (see lib/localShell.cjs:23-33 and
+// terminalBridge.cjs:368, :932, :1074):
+//   "posix" | "powershell" | "cmd" | "fish" | "unknown" | "raw" | "" | undefined
+// Excluded on purpose:
+//   - "posix" / "fish" / "cmd": confirmed POSIX-family or cmd.exe — never override.
+//   - "powershell": already correct; no override needed (would be a no-op).
+//   - "raw": serial / network device — execViaRawPty bypasses buildWrappedCommand.
 const SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE = new Set([
   "",
   "unknown",
-  "powershell",
 ]);
 
 function resolveEffectiveShellKind(shellKind, expectedPrompt) {

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -86,6 +86,22 @@ function escapeCmdForNestedShell(text) {
   return String(text || "").replace(/"/g, '""').replace(/%/g, "%%");
 }
 
+function isPowerShellPrompt(prompt) {
+  const lastLine = stripAnsi(String(prompt || ""))
+    .replace(/\r/g, "")
+    .split("\n")
+    .pop()
+    ?.replace(/\s+$/, "") || "";
+  return /^PS(?:\s+.*)?>$/.test(lastLine);
+}
+
+function resolveEffectiveShellKind(shellKind, expectedPrompt) {
+  if (isPowerShellPrompt(expectedPrompt)) {
+    return "powershell";
+  }
+  return shellKind || "posix";
+}
+
 function buildWrappedCommand(command, shellKind, marker) {
   switch (shellKind) {
     case "powershell": {
@@ -305,7 +321,7 @@ function startPtyJob(ptyStream, command, options) {
   } = options || {};
 
   const marker = `__NCMCP_${Date.now().toString(36)}_${crypto.randomBytes(16).toString('hex')}__`;
-  const resolvedShellKind = shellKind || "posix";
+  const resolvedShellKind = resolveEffectiveShellKind(shellKind, expectedPrompt);
   const CANCEL_RETRY_MS = 5000;
   const CANCEL_WALL_TIMEOUT_MS = 30000;
 
@@ -1133,5 +1149,6 @@ module.exports = {
   execViaChannel,
   execViaRawPty,
   detectShellKind,
+  resolveEffectiveShellKind,
   stripAnsi,
 };

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -12,7 +12,7 @@
 const crypto = require("crypto");
 const { StringDecoder } = require("node:string_decoder");
 const iconv = require("iconv-lite");
-const { stripAnsi } = require("./shellUtils.cjs");
+const { stripAnsi, isDefaultPowerShellPromptLine } = require("./shellUtils.cjs");
 const { classifyLocalShellType } = require("../../../lib/localShell.cjs");
 
 // Build a stateful decoder for a full exec call. Serial data events can
@@ -89,21 +89,41 @@ function escapeCmdForNestedShell(text) {
 // Matches PowerShell's default prompt only (e.g. `PS C:\Users\alice>`,
 // `PS>`). Custom prompt functions (oh-my-posh, starship, PSReadLine themes
 // that emit `❯`/`λ`/etc.) intentionally fall through — we'd rather miss
-// the override than wrap a fish/zsh prompt as PowerShell.
+// the override than wrap a fish/zsh prompt as PowerShell. Pattern lives
+// in shellUtils.cjs so prompt extraction and wrapper selection share one
+// source of truth.
 function isPowerShellPrompt(prompt) {
+  // Treat `\r` as a line break too so a PSReadLine/ConPTY redraw like
+  // `PS C:\old>\rPS C:\new>` is matched against the redrawn last line,
+  // not the doubled string.
   const lastLine = stripAnsi(String(prompt || ""))
-    .replace(/\r/g, "")
+    .replace(/\r/g, "\n")
     .split("\n")
     .pop()
-    ?.replace(/\s+$/, "") || "";
-  return /^PS(?:\s+.*)?>$/.test(lastLine);
+    .replace(/\s+$/, "");
+  return isDefaultPowerShellPromptLine(lastLine);
 }
 
+// Prompt-driven override is intentionally narrow: only flip when the
+// session has no confirmed POSIX shell. This keeps the issue #841 fix
+// (SSH sessions, where shellKind is undefined) working while preventing
+// a malicious remote process from spoofing a `PS ...>` line on a real
+// POSIX shell to coerce a single mis-wrapped command.
+const SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE = new Set([
+  "",
+  "unknown",
+  "powershell",
+]);
+
 function resolveEffectiveShellKind(shellKind, expectedPrompt) {
-  if (isPowerShellPrompt(expectedPrompt)) {
+  const baseKind = shellKind || "";
+  if (
+    SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE.has(baseKind) &&
+    isPowerShellPrompt(expectedPrompt)
+  ) {
     return "powershell";
   }
-  return shellKind || "posix";
+  return baseKind || "posix";
 }
 
 function buildWrappedCommand(command, shellKind, marker) {

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -5,39 +5,76 @@ const {
   resolveEffectiveShellKind,
 } = require("./ptyExec.cjs");
 
-test("uses PowerShell wrapping when a POSIX session is now at a PowerShell prompt", () => {
+test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
+  // SSH sessions don't set shellKind (sshBridge never assigns one), which
+  // is exactly the issue #841 case the override targets.
+  assert.equal(
+    resolveEffectiveShellKind(undefined, "PS C:\\Users\\alice>"),
+    "powershell",
+  );
+});
+
+test("uses PowerShell wrapping when shellKind is 'unknown'", () => {
+  assert.equal(
+    resolveEffectiveShellKind("unknown", "PS C:\\Users\\alice>"),
+    "powershell",
+  );
+});
+
+test("does NOT override an explicit non-PowerShell shell kind even if the prompt looks like PowerShell", () => {
+  // Defends against a malicious remote process spoofing a `PS ...>` line
+  // on a real bash/zsh session to coerce a single mis-wrapped command.
   assert.equal(
     resolveEffectiveShellKind("posix", "PS C:\\Users\\alice>"),
-    "powershell",
+    "posix",
+  );
+  assert.equal(
+    resolveEffectiveShellKind("fish", "PS C:\\Users\\alice>"),
+    "fish",
+  );
+  assert.equal(
+    resolveEffectiveShellKind("cmd", "PS C:\\Users\\alice>"),
+    "cmd",
   );
 });
 
 test("recognizes a PowerShell prompt that has trailing whitespace", () => {
   assert.equal(
-    resolveEffectiveShellKind("posix", "PS C:\\Users\\alice>   "),
+    resolveEffectiveShellKind(undefined, "PS C:\\Users\\alice>   "),
     "powershell",
   );
 });
 
 test("recognizes a bare PowerShell prompt without a working directory", () => {
+  assert.equal(resolveEffectiveShellKind(undefined, "PS>"), "powershell");
+});
+
+test("recognizes PowerShell on Linux/macOS prompts (`PS /home/alice>`)", () => {
   assert.equal(
-    resolveEffectiveShellKind("posix", "PS>"),
+    resolveEffectiveShellKind(undefined, "PS /home/alice>"),
     "powershell",
   );
 });
 
 test("ignores ANSI-coloured PowerShell prompts when detecting the shell", () => {
   assert.equal(
-    resolveEffectiveShellKind("posix", "[32mPS C:\\Users\\alice>[0m"),
+    resolveEffectiveShellKind(undefined, "[32mPS C:\\Users\\alice>[0m"),
     "powershell",
   );
 });
 
-test("keeps the configured shell kind when the prompt is not PowerShell", () => {
+test("treats a CR-redrawn last line as the effective prompt, not the doubled string", () => {
+  // PSReadLine / ConPTY emit `\r` to repaint the current line. Without
+  // CR-as-newline normalization the regex would match a doubled prompt
+  // string that never round-trips through the live PTY tail.
   assert.equal(
-    resolveEffectiveShellKind("fish", "alice@macbook ~ %"),
-    "fish",
+    resolveEffectiveShellKind(undefined, "PS C:\\old>\rPS C:\\new>"),
+    "powershell",
   );
+});
+
+test("rejects spoofed `PS >` (literal space then `>`) — default PowerShell never emits this", () => {
+  assert.equal(resolveEffectiveShellKind(undefined, "PS >"), "posix");
 });
 
 test("falls back to posix when neither shell kind nor prompt is informative", () => {
@@ -46,6 +83,6 @@ test("falls back to posix when neither shell kind nor prompt is informative", ()
 });
 
 test("does not misclassify command output that happens to contain 'PS'", () => {
-  assert.equal(resolveEffectiveShellKind("posix", "PSO>"), "posix");
-  assert.equal(resolveEffectiveShellKind("posix", "ZIPS>"), "posix");
+  assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix");
+  assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix");
 });

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -12,9 +12,40 @@ test("uses PowerShell wrapping when a POSIX session is now at a PowerShell promp
   );
 });
 
+test("recognizes a PowerShell prompt that has trailing whitespace", () => {
+  assert.equal(
+    resolveEffectiveShellKind("posix", "PS C:\\Users\\alice>   "),
+    "powershell",
+  );
+});
+
+test("recognizes a bare PowerShell prompt without a working directory", () => {
+  assert.equal(
+    resolveEffectiveShellKind("posix", "PS>"),
+    "powershell",
+  );
+});
+
+test("ignores ANSI-coloured PowerShell prompts when detecting the shell", () => {
+  assert.equal(
+    resolveEffectiveShellKind("posix", "[32mPS C:\\Users\\alice>[0m"),
+    "powershell",
+  );
+});
+
 test("keeps the configured shell kind when the prompt is not PowerShell", () => {
   assert.equal(
     resolveEffectiveShellKind("fish", "alice@macbook ~ %"),
     "fish",
   );
+});
+
+test("falls back to posix when neither shell kind nor prompt is informative", () => {
+  assert.equal(resolveEffectiveShellKind(undefined, ""), "posix");
+  assert.equal(resolveEffectiveShellKind(null, undefined), "posix");
+});
+
+test("does not misclassify command output that happens to contain 'PS'", () => {
+  assert.equal(resolveEffectiveShellKind("posix", "PSO>"), "posix");
+  assert.equal(resolveEffectiveShellKind("posix", "ZIPS>"), "posix");
 });

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -23,7 +23,8 @@ test("uses PowerShell wrapping when shellKind is 'unknown'", () => {
 
 test("does NOT override an explicit non-PowerShell shell kind even if the prompt looks like PowerShell", () => {
   // Defends against a malicious remote process spoofing a `PS ...>` line
-  // on a real bash/zsh session to coerce a single mis-wrapped command.
+  // on a real bash/zsh/cmd/fish/raw session to coerce a single
+  // mis-wrapped command.
   assert.equal(
     resolveEffectiveShellKind("posix", "PS C:\\Users\\alice>"),
     "posix",
@@ -35,6 +36,26 @@ test("does NOT override an explicit non-PowerShell shell kind even if the prompt
   assert.equal(
     resolveEffectiveShellKind("cmd", "PS C:\\Users\\alice>"),
     "cmd",
+  );
+  assert.equal(
+    resolveEffectiveShellKind("raw", "PS C:\\Users\\alice>"),
+    "raw",
+  );
+});
+
+test("keeps powershell wrapping for an explicit powershell session even when nested into a non-PS shell", () => {
+  // After `wsl` or similar, a confirmed PowerShell session may show a
+  // posix prompt. We currently keep PowerShell wrapping (the user's
+  // configured shell is the source of truth). Reverse detection would
+  // be a separate feature; this test locks the current behavior so a
+  // future change is intentional.
+  assert.equal(
+    resolveEffectiveShellKind("powershell", "alice@host:~$"),
+    "powershell",
+  );
+  assert.equal(
+    resolveEffectiveShellKind("powershell", ""),
+    "powershell",
   );
 });
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1,0 +1,20 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  resolveEffectiveShellKind,
+} = require("./ptyExec.cjs");
+
+test("uses PowerShell wrapping when a POSIX session is now at a PowerShell prompt", () => {
+  assert.equal(
+    resolveEffectiveShellKind("posix", "PS C:\\Users\\alice>"),
+    "powershell",
+  );
+});
+
+test("keeps the configured shell kind when the prompt is not PowerShell", () => {
+  assert.equal(
+    resolveEffectiveShellKind("fish", "alice@macbook ~ %"),
+    "fish",
+  );
+});

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -32,6 +32,10 @@ function extractTrailingIdlePrompt(output) {
   const rightTrimmed = lastLine.replace(/\s+$/, "");
   if (!rightTrimmed) return "";
 
+  if (/^PS(?:\s+.*)?>$/.test(rightTrimmed)) {
+    return lastLine;
+  }
+
   if (/^[^\s@]+@[^\s:]+(?::[^\n\r]*)?[#$]$/.test(rightTrimmed)) {
     return lastLine;
   }

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -24,19 +24,30 @@ function stripAnsi(input) {
   return String(input || "").replace(ANSI_OSC_REGEX, "").replace(ANSI_ESCAPE_REGEX, "");
 }
 
+// Default PowerShell prompt (e.g. `PS C:\Users\alice>`, `PS>`,
+// `PS /home/alice>`). Anchored so command output that merely starts with
+// `PS` (e.g. `PSO>`) doesn't match. The `\S` after `\s+` rejects literal
+// `"PS >"` (which the default prompt never emits) so a script that prints
+// such a line can't trick prompt-driven shell-kind selection.
+const POWERSHELL_PROMPT_PATTERN = /^PS(?:\s+\S.*)?>$/;
+
+function isDefaultPowerShellPromptLine(line) {
+  return POWERSHELL_PROMPT_PATTERN.test(String(line || ""));
+}
+
 function extractTrailingIdlePrompt(output) {
-  const normalized = stripAnsi(output).replace(/\r/g, "");
+  // Treat `\r` as a line break, not as a stripped character: PSReadLine /
+  // ConPTY repaints emit bare `\r` to redraw the current line, and we
+  // want only the redrawn line to be considered, not the concatenation
+  // of every overwritten frame.
+  const normalized = stripAnsi(output).replace(/\r/g, "\n");
   if (!normalized || normalized.endsWith("\n")) return "";
 
   const lastLine = normalized.split("\n").pop() || "";
   const rightTrimmed = lastLine.replace(/\s+$/, "");
   if (!rightTrimmed) return "";
 
-  // Default PowerShell prompt (e.g. `PS C:\Users\alice>`). Custom prompt
-  // functions intentionally fall through. Keep this regex in sync with
-  // isPowerShellPrompt() in ptyExec.cjs — the wrapper selection there
-  // re-checks the same shape against the captured prompt.
-  if (/^PS(?:\s+.*)?>$/.test(rightTrimmed)) {
+  if (isDefaultPowerShellPromptLine(rightTrimmed)) {
     return lastLine;
   }
 
@@ -327,6 +338,7 @@ function serializeStreamChunk(chunk) {
 module.exports = {
   stripAnsi,
   extractTrailingIdlePrompt,
+  isDefaultPowerShellPromptLine,
   trackSessionIdlePrompt,
   isLocalhostHostname,
   extractFirstNonLocalhostUrl,

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -32,6 +32,10 @@ function extractTrailingIdlePrompt(output) {
   const rightTrimmed = lastLine.replace(/\s+$/, "");
   if (!rightTrimmed) return "";
 
+  // Default PowerShell prompt (e.g. `PS C:\Users\alice>`). Custom prompt
+  // functions intentionally fall through. Keep this regex in sync with
+  // isPowerShellPrompt() in ptyExec.cjs — the wrapper selection there
+  // re-checks the same shape against the captured prompt.
   if (/^PS(?:\s+.*)?>$/.test(rightTrimmed)) {
     return lastLine;
   }

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -1,0 +1,24 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  extractTrailingIdlePrompt,
+  trackSessionIdlePrompt,
+} = require("./shellUtils.cjs");
+
+test("extracts a trailing PowerShell idle prompt", () => {
+  assert.equal(
+    extractTrailingIdlePrompt("Microsoft Windows...\r\nPS C:\\Users\\alice>"),
+    "PS C:\\Users\\alice>",
+  );
+});
+
+test("tracks PowerShell idle prompt after SSH output", () => {
+  const session = {};
+
+  const prompt = trackSessionIdlePrompt(session, "Last login...\r\nPS C:\\Windows\\System32>");
+
+  assert.equal(prompt, "PS C:\\Windows\\System32>");
+  assert.equal(session.lastIdlePrompt, "PS C:\\Windows\\System32>");
+  assert.equal(typeof session.lastIdlePromptAt, "number");
+});

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -13,6 +13,28 @@ test("extracts a trailing PowerShell idle prompt", () => {
   );
 });
 
+test("preserves trailing whitespace on a captured PowerShell prompt", () => {
+  // The wrapper-selection logic trims this, but the suffix-match logic in
+  // hasExpectedPromptSuffix() compares against raw PTY bytes, so the trailing
+  // space PowerShell emits after `>` must round-trip unchanged.
+  assert.equal(
+    extractTrailingIdlePrompt("Microsoft Windows...\r\nPS C:\\Users\\alice> "),
+    "PS C:\\Users\\alice> ",
+  );
+});
+
+test("extracts a bare PowerShell prompt with no working directory", () => {
+  assert.equal(extractTrailingIdlePrompt("welcome\r\nPS>"), "PS>");
+});
+
+test("does not extract content that merely looks PowerShell-ish", () => {
+  // Any non-prompt output ending in `PSO>` or `ZIPS>` would have produced a
+  // trailing newline before the next prompt; this guards against the regex
+  // accidentally matching command output that just happens to contain "PS".
+  assert.equal(extractTrailingIdlePrompt("nope\r\nPSO>"), "");
+  assert.equal(extractTrailingIdlePrompt("nope\r\nZIPS>"), "");
+});
+
 test("tracks PowerShell idle prompt after SSH output", () => {
   const session = {};
 

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   extractTrailingIdlePrompt,
+  isDefaultPowerShellPromptLine,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
 
@@ -33,6 +34,34 @@ test("does not extract content that merely looks PowerShell-ish", () => {
   // accidentally matching command output that just happens to contain "PS".
   assert.equal(extractTrailingIdlePrompt("nope\r\nPSO>"), "");
   assert.equal(extractTrailingIdlePrompt("nope\r\nZIPS>"), "");
+});
+
+test("rejects `PS >` (literal `PS` + space + `>`) so spoofed scripts can't masquerade as a default prompt", () => {
+  // Default PowerShell never emits this shape; rejecting it makes the
+  // override harder to coerce via printed output.
+  assert.equal(extractTrailingIdlePrompt("welcome\r\nPS >"), "");
+});
+
+test("treats CR repaints as line breaks so only the redrawn line is captured", () => {
+  // PSReadLine / ConPTY emit bare `\r` to repaint the current line. The
+  // captured prompt must equal the visible last line, not the
+  // concatenation of every overwritten frame, so hasExpectedPromptSuffix
+  // can still match the live PTY tail later.
+  assert.equal(
+    extractTrailingIdlePrompt("PS C:\\old>\rPS C:\\new>"),
+    "PS C:\\new>",
+  );
+});
+
+test("isDefaultPowerShellPromptLine matches default shapes and rejects look-alikes", () => {
+  assert.equal(isDefaultPowerShellPromptLine("PS C:\\Users\\alice>"), true);
+  assert.equal(isDefaultPowerShellPromptLine("PS /home/alice>"), true);
+  assert.equal(isDefaultPowerShellPromptLine("PS>"), true);
+  assert.equal(isDefaultPowerShellPromptLine("PS >"), false);
+  assert.equal(isDefaultPowerShellPromptLine("PSO>"), false);
+  assert.equal(isDefaultPowerShellPromptLine("ZIPS>"), false);
+  assert.equal(isDefaultPowerShellPromptLine(""), false);
+  assert.equal(isDefaultPowerShellPromptLine(null), false);
 });
 
 test("tracks PowerShell idle prompt after SSH output", () => {


### PR DESCRIPTION
## Summary

Fixes #841 by making MCP terminal execution recognize when an interactive session has moved into PowerShell, such as after SSHing from a local macOS shell into a Windows host.

## What changed

- Track idle PowerShell prompts like `PS C:\...>`.
- Choose the PowerShell command wrapper when the current prompt indicates PowerShell, even if the original local session was POSIX.
- Add regression tests for prompt tracking and wrapper selection.

## Validation

- `node --test electron/bridges/ai/shellUtils.test.cjs electron/bridges/ai/ptyExec.test.cjs`
- `npm test`
- `npm run lint`