### PR TITLE
Drop stale lastIdlePrompt before forcing PowerShell wrapper

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -73,6 +73,32 @@ function trackSessionIdlePrompt(session, chunk) {
   return prompt;
 }
 
+// Return `session.lastIdlePrompt` only if the PTY's recent rolling tail
+// still ends with it. The cached prompt is updated only when
+// extractTrailingIdlePrompt recognizes a known shape (PowerShell or
+// `user@host[:path][#$]`); a remote shell switch into cmd.exe, an
+// oh-my-posh / starship / custom PS1, or any unrecognized prompt would
+// otherwise leave a stale value behind, which `resolveEffectiveShellKind`
+// would then keep using to coerce future commands into a PowerShell
+// wrapper. By re-checking the live tail we self-correct: if the visible
+// last line no longer matches the cached prompt, the prompt is treated
+// as expired and downstream wrapper selection / suffix matching falls
+// back to `shellKind` alone.
+function getFreshIdlePrompt(session) {
+  if (!session) return "";
+  const cached = session.lastIdlePrompt;
+  if (!cached) return "";
+
+  const tail = session._promptTrackTail;
+  if (typeof tail !== "string" || !tail) return "";
+
+  const normalizedTail = stripAnsi(tail).replace(/\r/g, "\n");
+  const normalizedCached = stripAnsi(cached).replace(/\r/g, "\n");
+  if (!normalizedCached) return "";
+
+  return normalizedTail.endsWith(normalizedCached) ? cached : "";
+}
+
 // ── URL helpers ──
 
 function isLocalhostHostname(hostname) {
@@ -338,6 +364,7 @@ function serializeStreamChunk(chunk) {
 module.exports = {
   stripAnsi,
   extractTrailingIdlePrompt,
+  getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
   trackSessionIdlePrompt,
   isLocalhostHostname,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   extractTrailingIdlePrompt,
+  getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
@@ -72,4 +73,68 @@ test("tracks PowerShell idle prompt after SSH output", () => {
   assert.equal(prompt, "PS C:\\Windows\\System32>");
   assert.equal(session.lastIdlePrompt, "PS C:\\Windows\\System32>");
   assert.equal(typeof session.lastIdlePromptAt, "number");
+});
+
+test("getFreshIdlePrompt returns the cached prompt when the live tail still ends with it", () => {
+  const session = {
+    lastIdlePrompt: "PS C:\\Users\\alice>",
+    _promptTrackTail: "Microsoft Windows...\r\nPS C:\\Users\\alice>",
+  };
+  assert.equal(getFreshIdlePrompt(session), "PS C:\\Users\\alice>");
+});
+
+test("getFreshIdlePrompt drops a stale prompt when the live tail has moved on (e.g. exited PowerShell)", () => {
+  // Simulates: SSH session entered PowerShell, captured `PS C:\>`, then
+  // user `exit`-ed back into a shell with a custom prompt the regex
+  // doesn't recognize. lastIdlePrompt is still the old PS line, but the
+  // visible tail now shows the new prompt — we must NOT keep handing
+  // the stale value to resolveEffectiveShellKind.
+  const session = {
+    lastIdlePrompt: "PS C:\\Users\\alice>",
+    _promptTrackTail: "PS C:\\Users\\alice>\r\nexit\r\nlogout\r\n❯ ",
+  };
+  assert.equal(getFreshIdlePrompt(session), "");
+});
+
+test("getFreshIdlePrompt drops a stale prompt when the live tail switched to cmd.exe", () => {
+  const session = {
+    lastIdlePrompt: "PS C:\\Users\\alice>",
+    _promptTrackTail: "PS C:\\Users\\alice>\r\ncmd\r\nMicrosoft Windows...\r\nC:\\Users\\alice>",
+  };
+  assert.equal(getFreshIdlePrompt(session), "");
+});
+
+test("getFreshIdlePrompt tolerates ANSI colour codes that wrap the prompt in either side", () => {
+  const session = {
+    lastIdlePrompt: "PS C:\\Users\\alice>",
+    _promptTrackTail: "stuff\r\n[32mPS C:\\Users\\alice>[0m",
+  };
+  assert.equal(getFreshIdlePrompt(session), "PS C:\\Users\\alice>");
+});
+
+test("getFreshIdlePrompt returns empty string when the session has no cached prompt or tail", () => {
+  assert.equal(getFreshIdlePrompt(null), "");
+  assert.equal(getFreshIdlePrompt(undefined), "");
+  assert.equal(getFreshIdlePrompt({}), "");
+  assert.equal(getFreshIdlePrompt({ lastIdlePrompt: "PS C:\\>" }), "");
+  assert.equal(
+    getFreshIdlePrompt({ lastIdlePrompt: "", _promptTrackTail: "anything" }),
+    "",
+  );
+});
+
+test("getFreshIdlePrompt and trackSessionIdlePrompt round-trip through a real PTY-like flow", () => {
+  // (1) Remote PowerShell prompt arrives — lastIdlePrompt is captured.
+  const session = {};
+  trackSessionIdlePrompt(session, "Microsoft Windows...\r\nPS C:\\Users\\alice>");
+  assert.equal(getFreshIdlePrompt(session), "PS C:\\Users\\alice>");
+
+  // (2) User runs `exit` and the shell now shows an unrecognized prompt.
+  // trackSessionIdlePrompt does not update lastIdlePrompt (the new shape
+  // doesn't match POSIX or PowerShell regexes), so the cache is stale.
+  trackSessionIdlePrompt(session, "\r\nexit\r\nlogout\r\n❯ ");
+  assert.equal(session.lastIdlePrompt, "PS C:\\Users\\alice>"); // unchanged
+  // The freshness check rescues us: the visible tail no longer ends
+  // with the cached PS line, so downstream wrapper selection sees "".
+  assert.equal(getFreshIdlePrompt(session), "");
 });

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -30,6 +30,7 @@ const {
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   getShellEnv,
+  getFreshIdlePrompt,
   invalidateShellEnvCache,
   serializeStreamChunk,
   toUnpackedAsarPath,
@@ -1322,7 +1323,7 @@ function registerHandlers(ipcMain) {
           timeoutMs,
           shellKind: session.shellKind,
           chatSessionId,
-          expectedPrompt: session.lastIdlePrompt || "",
+          expectedPrompt: getFreshIdlePrompt(session),
           typedInput: true,
           echoCommand: (rawCommand) => {
             const contents = electronModule?.webContents?.fromId?.(session.webContentsId);

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -12,7 +12,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { existsSync } = require("node:fs");
 
-const { toUnpackedAsarPath } = require("./ai/shellUtils.cjs");
+const { toUnpackedAsarPath, getFreshIdlePrompt } = require("./ai/shellUtils.cjs");
 const { execViaPty, startPtyJob, execViaChannel, execViaRawPty } = require("./ai/ptyExec.cjs");
 const { safeSend } = require("./ipcUtils.cjs");
 const { getCliDiscoveryFilePath } = require("../cli/discoveryPath.cjs");
@@ -1493,7 +1493,7 @@ function handleExec(params) {
       trackForCancellation: activePtyExecs,
       timeoutMs: commandTimeoutMs,
       shellKind: session.shellKind,
-      expectedPrompt: session.lastIdlePrompt || "",
+      expectedPrompt: getFreshIdlePrompt(session),
       typedInput: true,
       echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
       chatSessionId,
@@ -1581,7 +1581,7 @@ function handleJobStart(params) {
       timeoutMs,
       shellKind: session.shellKind,
       chatSessionId,
-      expectedPrompt: session.lastIdlePrompt || "",
+      expectedPrompt: getFreshIdlePrompt(session),
       typedInput: true,
       echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
       maxBufferedChars: MAX_BACKGROUND_JOB_OUTPUT_CHARS,


### PR DESCRIPTION
## Summary

Follow-up to #851 (addresses Codex review comment on commit `32bab2d4`).

After #851, `resolveEffectiveShellKind` flips an unknown-shell session to PowerShell based on `session.lastIdlePrompt`, but that field is only updated when `trackSessionIdlePrompt` recognizes a known prompt shape (default PowerShell or `user@host[:path][#$]`).

**Bug**: on an SSH/Telnet session that enters PowerShell and then leaves it for a shell whose prompt is unrecognized — cmd.exe (`C:\>`), oh-my-posh / starship / any custom PS1 — the cached `PS ...>` value persists. Every subsequent MCP command then keeps getting wrapped as PowerShell against a non-PowerShell shell. Nothing self-heals until the user reconnects.

## Fix

New helper `getFreshIdlePrompt(session)` in `shellUtils.cjs`: returns the cached prompt only when the rolling PTY tail (`session._promptTrackTail`) still ends with it. If the visible last line has moved on — even to a prompt shape we don't recognize — the cache is treated as expired and downstream wrapper selection / suffix matching falls back to `shellKind` alone (the correct behavior for the unknown-shell case).

Three call sites previously read `session.lastIdlePrompt || ""` and now use the helper:
- `aiBridge.cjs:1325` — Catty Agent foreground exec
- `mcpServerBridge.cjs:1496` — MCP `terminal_execute`
- `mcpServerBridge.cjs:1584` — MCP `terminal_start` background job

## Test plan

- [x] `node --test electron/bridges/ai/shellUtils.test.cjs electron/bridges/ai/ptyExec.test.cjs` (26/26 ✔)
- [x] `npm test` (293/293 ✔)
- [x] `npm run lint` (clean)
- [x] New unit tests cover: fresh-prompt round-trip, stale-after-exit-PowerShell, switch-to-cmd.exe, ANSI-coloured tail, null/empty session edge cases, end-to-end `trackSessionIdlePrompt` → `getFreshIdlePrompt` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)