### PR TITLE
Harden the dirty-editor quit guard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -892,7 +892,14 @@ function App({ settings }: { settings: SettingsState }) {
       } catch (err) {
         console.error('[App] dirty-editors check failed:', err);
       }
-      bridge.reportDirtyEditorsResult?.(hasDirty);
+      try {
+        bridge.reportDirtyEditorsResult?.(hasDirty);
+      } catch (err) {
+        // Reporting itself shouldn't throw, but if the IPC bridge is in a
+        // bad state we'd rather log than bubble out of the listener and
+        // disable the quit guard for the rest of the session.
+        console.error('[App] reportDirtyEditorsResult failed:', err);
+      }
     });
     return unsub;
   }, [t]);

--- a/App.tsx
+++ b/App.tsx
@@ -880,8 +880,18 @@ function App({ settings }: { settings: SettingsState }) {
     const bridge = netcattyBridge.get();
     if (!bridge?.onCheckDirtyEditors) return;
     const unsub = bridge.onCheckDirtyEditors(() => {
-      const hasDirty = editorTabStore.getTabs().some((tab) => tab.content !== tab.baselineContent);
-      if (hasDirty) toast.warning(t('sftp.editor.quitBlockedByDirty'), 'SFTP');
+      // Always report SOMETHING so the main process doesn't time out for
+      // 5 s on an unhandled exception. If we can't determine the state,
+      // fail open — losing unsaved work is bad, but stranding the user
+      // on a slow quit and then quitting anyway after the timeout is
+      // exactly the same outcome.
+      let hasDirty = false;
+      try {
+        hasDirty = editorTabStore.getTabs().some((tab) => tab.content !== tab.baselineContent);
+        if (hasDirty) toast.warning(t('sftp.editor.quitBlockedByDirty'), 'SFTP');
+      } catch (err) {
+        console.error('[App] dirty-editors check failed:', err);
+      }
       bridge.reportDirtyEditorsResult?.(hasDirty);
     });
     return unsub;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1318,28 +1318,68 @@ if (!gotLock) {
       return;
     }
 
+    // The renderer needs to be alive for the IPC roundtrip to make sense.
+    // A crashed renderer would silently drop the message and we'd wait
+    // 5 s for nothing — skip straight to quit (we can't ask the user
+    // anyway, the UI is gone).
+    const wc = win.webContents;
+    if (!wc || wc.isDestroyed?.() || wc.isCrashed?.()) {
+      commitQuit();
+      return;
+    }
+
     quitGuardChannelBusy = true;
     event.preventDefault();
-    win.webContents.send("app:query-dirty-editors");
+
+    // The response and the timeout race against each other; whichever
+    // one fires first wins. A naive `clearTimeout` is not enough — once
+    // the timer has already been queued for the next tick, clearTimeout
+    // is a no-op and the timeout callback runs even after the response
+    // arrived, which would commit the quit even on a `hasDirty=true`
+    // reply (i.e. silently override the user's "save first" intent).
+    let settled = false;
+    let timeoutId = null;
+    const settle = (decision) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      _ipcMain.removeListener("app:dirty-editors-result", onResult);
+      quitGuardChannelBusy = false;
+      if (decision === "commit") commitQuit();
+      // decision === "stay": renderer showed a toast for dirty editors.
+      // Do not touch isQuitting so tray / close-to-tray gating keeps working.
+    };
+    function onResult(evt, payload) {
+      // Defence in depth: this channel is queried with a specific
+      // webContents in mind. A reply from any other window (e.g. a
+      // misbehaving extension or a future bug that wires the channel
+      // elsewhere) is silently ignored so it can't decide the quit.
+      // We use `.on` (not `.once`) so a rogue reply doesn't consume
+      // the listener slot and let the real reply fall through.
+      if (evt?.sender && evt.sender !== wc) return;
+      const hasDirty = payload && payload.hasDirty === true;
+      settle(hasDirty ? "stay" : "commit");
+    }
+    _ipcMain.on("app:dirty-editors-result", onResult);
 
     // Timeout fallback: if the renderer never replies (crash, unhandled
     // exception in the listener, etc.) we'd otherwise be stuck with
     // quitGuardChannelBusy=true and the app un-quittable.
-    const timeoutId = setTimeout(() => {
-      _ipcMain.removeAllListeners("app:dirty-editors-result");
-      quitGuardChannelBusy = false;
-      commitQuit();
-    }, QUIT_GUARD_TIMEOUT_MS);
+    timeoutId = setTimeout(() => settle("commit"), QUIT_GUARD_TIMEOUT_MS);
 
-    _ipcMain.once("app:dirty-editors-result", (_evt, { hasDirty }) => {
-      clearTimeout(timeoutId);
-      quitGuardChannelBusy = false;
-      if (!hasDirty) {
-        commitQuit();
-      }
-      // If hasDirty === true the renderer has shown a toast; stay put. Do not
-      // touch isQuitting so tray/close-to-tray gating keeps working.
-    });
+    try {
+      wc.send("app:query-dirty-editors");
+    } catch (err) {
+      // `webContents.send` can throw if the renderer was destroyed
+      // between our `isCrashed?.()` check and this call (a real race
+      // when the GPU process is dying). Tear the listener/timer down
+      // synchronously so we don't strand quitGuardChannelBusy=true.
+      console.warn("[Main] Failed to query renderer for dirty editors:", err);
+      settle("commit");
+    }
   });
 
   // Cleanup all PTY sessions and port forwarding tunnels before quitting

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1358,8 +1358,10 @@ if (!gotLock) {
       // misbehaving extension or a future bug that wires the channel
       // elsewhere) is silently ignored so it can't decide the quit.
       // We use `.on` (not `.once`) so a rogue reply doesn't consume
-      // the listener slot and let the real reply fall through.
-      if (evt?.sender && evt.sender !== wc) return;
+      // the listener slot and let the real reply fall through. Reject
+      // strictly: a missing/falsy sender is anomalous in real IPC and
+      // is treated the same as a wrong-window reply.
+      if (evt?.sender !== wc) return;
       const hasDirty = payload && payload.hasDirty === true;
       settle(hasDirty ? "stay" : "commit");
     }


### PR DESCRIPTION
## Summary

Follow-up to #840 / #851 review pass. Three concrete failure modes that a multi-agent round-2 review turned up in `electron/main.cjs:1268-1343`:

1. **`webContents.send` is unguarded.** If the renderer is destroyed between the reachability check and the send (dying GPU process, etc.), the throw escapes the `before-quit` handler with `quitGuardChannelBusy = true` already set and no timeout scheduled yet — the app becomes un-quittable until restart.
2. **Timeout vs. response race silently commits quit on `hasDirty=true`.** Once `setTimeout` has already enqueued its callback for the next tick, `clearTimeout` is a no-op and the timeout still runs `commitQuit()`, overriding the user's "save first" intent.
3. **Reply listener accepted any sender.** A rogue or future-buggy `webContents` could decide the quit by sending the channel name first.

## Fix

- Funnel both paths through a `settle()` helper that only acts the first time it's called (handles race #2).
- Wrap the send in `try/catch`; on failure, tear the listener/timer down and `commitQuit()` synchronously (handles #1).
- Switch from `.once` to `.on` + explicit `removeListener` and validate `evt.sender === wc`, so a rogue early reply doesn't consume the slot or decide the quit (handles #3).
- Add `wc.isCrashed?.()` to the reachability gate so a known-dead renderer skips the round-trip and quits instantly.
- Renderer-side: wrap `editorTabStore.getTabs()` in `try/catch` so an unexpected throw reports `hasDirty=false` immediately instead of stranding the main process on the 5 s timeout.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 293/293 ✔
- [ ] Manually verify: CMD+Q with dirty editor → toast appears, app stays open
- [ ] Manually verify: CMD+Q with no dirty editors → app quits instantly
- [ ] Manually verify: tray "Quit" with main window hidden → app quits instantly (preserves #840 behaviour)
- [ ] Manually verify: rapid CMD+Q mash → app quits cleanly without ghost listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)