### PR TITLE
feat(ai-chat): expose data-role CSS hooks on chat messages

### DIFF
--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -9,27 +9,37 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: 'user' | 'assistant' | 'system' | 'tool';
 };
 
+// Public CSS hooks for user customization (Settings → Appearance → Custom CSS):
+//   .ai-chat-message[data-role="user"]      — outer row, user-authored
+//   .ai-chat-message[data-role="assistant"] — outer row, assistant reply
+//   .ai-chat-message-content[data-role=...] — inner bubble / content area
+// These attributes are part of the UI's stable contract; do not rename
+// without updating Custom CSS docs.
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      'group flex w-full max-w-[95%] flex-col gap-1.5',
+      'ai-chat-message group flex w-full max-w-[95%] flex-col gap-1.5',
       from === 'user' ? 'is-user ml-auto' : 'is-assistant',
       className,
     )}
+    data-role={from}
     {...props}
   />
 );
 
-export type MessageContentProps = HTMLAttributes<HTMLDivElement>;
+export type MessageContentProps = HTMLAttributes<HTMLDivElement> & {
+  from?: 'user' | 'assistant' | 'system' | 'tool';
+};
 
-export const MessageContent = ({ children, className, ...props }: MessageContentProps) => (
+export const MessageContent = ({ children, className, from, ...props }: MessageContentProps) => (
   <div
     className={cn(
-      'flex w-fit min-w-0 max-w-full flex-col gap-1.5 text-[13px] leading-relaxed',
+      'ai-chat-message-content flex w-fit min-w-0 max-w-full flex-col gap-1.5 text-[13px] leading-relaxed',
       'group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:border group-[.is-user]:border-border/50 group-[.is-user]:bg-muted/50 group-[.is-user]:px-2.5 group-[.is-user]:py-2',
       'group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground/90',
       className,
     )}
+    data-role={from}
     {...props}
   >
     {children}

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -196,7 +196,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({ messages, isStreaming
 
           return (
             <Message key={message.id} from={message.role}>
-              <MessageContent>
+              <MessageContent from={message.role}>
                 {/* Thinking block */}
                 {!isUser && message.thinking && (
                   <ThinkingBlock


### PR DESCRIPTION
## Summary

Closes #838.

Adds stable CSS hooks to the Catty Agent chat panel so users can distinguish their own messages from agent replies via the existing Settings → Appearance → Custom CSS field — without forking, and without forcing a specific colour scheme on everyone.

## What changed

`components/ai-elements/message.tsx`:
- Added `ai-chat-message` and `ai-chat-message-content` classnames on the row + content containers.
- Added `data-role="user|assistant|system|tool"` attribute on both, sourced from the existing `from` prop.
- Threaded `from` through `MessageContent` (single call site, updated in `ChatMessageList.tsx`).
- Documented the hook contract with a comment on the `Message` component.

## Why hooks instead of changing the default

The default theme intentionally stays minimal (bordered user bubble + plain assistant text). Different users want different visual distinctions; exposing hooks lets each user pick their own palette without us choosing one for everyone.

## Example usage

After merging, users can paste this into Settings → Appearance → Custom CSS:

```css
.ai-chat-message[data-role="user"] .ai-chat-message-content {
  background: rgba(91, 124, 250, 0.12);
  border-color: rgba(91, 124, 250, 0.4);
}
.ai-chat-message[data-role="assistant"] .ai-chat-message-content {
  background: rgba(0, 0, 0, 0.02);
}
```

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 293/293 ✔
- [ ] Manually verify in dev: the rendered DOM exposes `data-role` and `ai-chat-message*` classes on each chat row
- [ ] Manually verify: a custom CSS rule targeting `.ai-chat-message[data-role="user"]` actually applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)