### PR TITLE
fix: consume SFTP side panel initial location once

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -47,6 +47,7 @@ interface SftpSidePanelProps {
   /** The host to connect to (follows focused terminal) */
   activeHost: Host | null;
   initialLocation?: { hostId: string; path: string } | null;
+  onInitialLocationApplied?: (location: { hostId: string; path: string }) => void;
   showWorkspaceHostHeader?: boolean;
   isVisible?: boolean;
   renderOverlays?: boolean;
@@ -78,6 +79,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   sftpDefaultViewMode,
   activeHost,
   initialLocation,
+  onInitialLocationApplied,
   showWorkspaceHostHeader = false,
   isVisible = true,
   renderOverlays = true,
@@ -467,16 +469,18 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const locationKey = `${connectedKeyRef.current}:${initialLocation.path}`;
     if (lastAppliedInitialLocationKeyRef.current === locationKey) return;
 
+    lastAppliedInitialLocationKeyRef.current = locationKey;
+    onInitialLocationApplied?.(initialLocation);
+
     if (connection.currentPath === initialLocation.path) {
-      lastAppliedInitialLocationKeyRef.current = locationKey;
       return;
     }
 
-    lastAppliedInitialLocationKeyRef.current = locationKey;
     sftpRef.current.navigateTo("left", initialLocation.path);
   }, [
     activeHost,
     initialLocation,
+    onInitialLocationApplied,
     sftp.leftPane,
   ]);
 

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -794,6 +794,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     });
   }, []);
 
+  const handleSftpInitialLocationApplied = useCallback((tabId: string, location: { hostId: string; path: string }) => {
+    setSftpInitialLocationForTab(prev => {
+      const current = prev.get(tabId);
+      if (!current || current.hostId !== location.hostId || current.path !== location.path) {
+        return prev;
+      }
+      const next = new Map(prev);
+      next.delete(tabId);
+      return next;
+    });
+  }, []);
+
   // Focus-mode workspace sidebar resize handler. The sidebar is always
   // anchored to the left of the workspace area, so a rightward drag grows it.
   const handleFocusSidebarResizeStart = useCallback((e: React.MouseEvent) => {
@@ -2285,6 +2297,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
                               ? (sftpInitialLocationForTab.get(tabId) ?? null)
                               : null
                           }
+                          onInitialLocationApplied={(location) => handleSftpInitialLocationApplied(tabId, location)}
                           showWorkspaceHostHeader={isVisibleSftpPanel && !!activeWorkspace}
                           isVisible={isVisibleSftpPanel}
                           renderOverlays={isVisibleSftpPanel}


### PR DESCRIPTION
Clear the stored initial SFTP location after it has been applied by the terminal side panel. This prevents later pane state updates, such as clearing selection after closing the built-in editor, from reusing the stale initial location and navigating back to the startup directory.