### PR TITLE
[codex] Optimize snippets shortcut behavior

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import { resolveHostAuth } from './domain/sshAuth';
 import { resolveHostTerminalThemeId } from './domain/terminalAppearance';
 import { collectSessionIds } from './domain/workspace';
 import { resolveCloseIntent } from './application/state/resolveCloseIntent';
+import { resolveSnippetsShortcutIntent } from './application/state/resolveSnippetsShortcutIntent';
 import { TERMINAL_THEMES } from './infrastructure/config/terminalThemes';
 import { useCustomThemes } from './application/state/customThemeStore';
 import type { SyncPayload } from './domain/sync';
@@ -1042,6 +1043,7 @@ function App({ settings }: { settings: SettingsState }) {
   addConnectionLogRef.current = addConnectionLog;
 
   const closeSidePanelRef = useRef<(() => void) | null>(null);
+  const toggleScriptsSidePanelRef = useRef<(() => void) | null>(null);
   const activeSidePanelTabRef = useRef<string | null>(null);
   const closeTabInFlightRef = useRef(false);
   // Populated by UnsavedChangesProvider render-prop below so that the hotkey
@@ -1303,9 +1305,23 @@ function App({ settings }: { settings: SettingsState }) {
         setNavigateToSection('port');
         break;
       case 'snippets':
-        // Navigate to vault and open snippets section
-        setActiveTabId('vault');
-        setNavigateToSection('snippets');
+        {
+          const currentId = activeTabStore.getActiveTabId();
+          const intent = resolveSnippetsShortcutIntent({
+            activeTabId: currentId,
+            sessionForTab: sessions.find((s) => s.id === currentId) ?? null,
+            workspaceForTab: workspaces.find((w) => w.id === currentId) ?? null,
+            terminalScriptsToggleAvailable: !!toggleScriptsSidePanelRef.current,
+          });
+
+          if (intent.kind === 'toggleTerminalScripts') {
+            toggleScriptsSidePanelRef.current();
+            break;
+          }
+
+          setActiveTabId('vault');
+          setNavigateToSection('snippets');
+        }
         break;
       case 'broadcast': {
         // Toggle broadcast mode for the active workspace
@@ -1943,6 +1959,7 @@ function App({ settings }: { settings: SettingsState }) {
           sessionLogsDir={sessionLogsDir}
           sessionLogsFormat={sessionLogsFormat}
           closeSidePanelRef={closeSidePanelRef}
+          toggleScriptsSidePanelRef={toggleScriptsSidePanelRef}
           activeSidePanelTabRef={activeSidePanelTabRef}
         />
 

--- a/application/state/resolveSnippetsShortcutIntent.test.ts
+++ b/application/state/resolveSnippetsShortcutIntent.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveScriptsSidePanelShortcutIntent,
+  resolveSnippetsShortcutIntent,
+} from "./resolveSnippetsShortcutIntent.ts";
+
+test("active single terminal tab toggles the terminal scripts panel", () => {
+  const result = resolveSnippetsShortcutIntent({
+    activeTabId: "s1",
+    sessionForTab: { id: "s1" },
+    workspaceForTab: null,
+  });
+
+  assert.deepEqual(result, { kind: "toggleTerminalScripts" });
+});
+
+test("active workspace tab toggles the terminal scripts panel", () => {
+  const result = resolveSnippetsShortcutIntent({
+    activeTabId: "w1",
+    sessionForTab: null,
+    workspaceForTab: { id: "w1" },
+  });
+
+  assert.deepEqual(result, { kind: "toggleTerminalScripts" });
+});
+
+test("non-terminal tabs navigate to the vault snippets section", () => {
+  for (const activeTabId of ["vault", "sftp", "editor:notes", "log1", null]) {
+    const result = resolveSnippetsShortcutIntent({
+      activeTabId,
+      sessionForTab: null,
+      workspaceForTab: null,
+    });
+
+    assert.deepEqual(result, { kind: "openVaultSnippets" });
+  }
+});
+
+test("terminal tabs fall back to vault snippets when terminal toggle is unavailable", () => {
+  const result = resolveSnippetsShortcutIntent({
+    activeTabId: "s1",
+    sessionForTab: { id: "s1" },
+    workspaceForTab: null,
+    terminalScriptsToggleAvailable: false,
+  });
+
+  assert.deepEqual(result, { kind: "openVaultSnippets" });
+});
+
+test("scripts panel shortcut closes when scripts is already open", () => {
+  const result = resolveScriptsSidePanelShortcutIntent("scripts");
+
+  assert.deepEqual(result, { kind: "closeTerminalSidePanel" });
+});
+
+test("scripts panel shortcut opens scripts from closed or other panel states", () => {
+  for (const activePanel of [null, "sftp", "theme", "ai"]) {
+    const result = resolveScriptsSidePanelShortcutIntent(activePanel);
+
+    assert.deepEqual(result, { kind: "openTerminalScripts" });
+  }
+});

--- a/application/state/resolveSnippetsShortcutIntent.ts
+++ b/application/state/resolveSnippetsShortcutIntent.ts
@@ -1,0 +1,42 @@
+export type SnippetsShortcutIntent =
+  | { kind: 'toggleTerminalScripts' }
+  | { kind: 'openVaultSnippets' };
+
+export type ScriptsSidePanelShortcutIntent =
+  | { kind: 'closeTerminalSidePanel' }
+  | { kind: 'openTerminalScripts' };
+
+export interface ResolveSnippetsShortcutIntentInput {
+  activeTabId: string | null;
+  sessionForTab: { id: string } | null;
+  workspaceForTab: { id: string } | null;
+  terminalScriptsToggleAvailable?: boolean;
+}
+
+export function resolveSnippetsShortcutIntent(
+  input: ResolveSnippetsShortcutIntentInput,
+): SnippetsShortcutIntent {
+  const {
+    activeTabId,
+    sessionForTab,
+    workspaceForTab,
+    terminalScriptsToggleAvailable = true,
+  } = input;
+  if (!activeTabId) return { kind: 'openVaultSnippets' };
+
+  if ((sessionForTab || workspaceForTab) && terminalScriptsToggleAvailable) {
+    return { kind: 'toggleTerminalScripts' };
+  }
+
+  return { kind: 'openVaultSnippets' };
+}
+
+export function resolveScriptsSidePanelShortcutIntent(
+  activePanel: string | null,
+): ScriptsSidePanelShortcutIntent {
+  if (activePanel === 'scripts') {
+    return { kind: 'closeTerminalSidePanel' };
+  }
+
+  return { kind: 'openTerminalScripts' };
+}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -54,6 +54,7 @@ import { Input } from './ui/input';
 import { RippleButton } from './ui/ripple';
 import { ScrollArea } from './ui/scroll-area';
 import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate';
+import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
 
 type SidePanelTab = 'sftp' | 'scripts' | 'theme' | 'ai';
 
@@ -437,6 +438,7 @@ interface TerminalLayerProps {
   sessionLogsDir?: string;
   sessionLogsFormat?: string;
   closeSidePanelRef?: React.MutableRefObject<(() => void) | null>;
+  toggleScriptsSidePanelRef?: React.MutableRefObject<(() => void) | null>;
   activeSidePanelTabRef?: React.MutableRefObject<string | null>;
 }
 
@@ -493,6 +495,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   sessionLogsDir,
   sessionLogsFormat,
   closeSidePanelRef,
+  toggleScriptsSidePanelRef,
   activeSidePanelTabRef,
 }) => {
   // Subscribe to activeTabId from external store
@@ -1416,6 +1419,34 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const handleOpenScripts = useCallback(() => {
     handleSwitchSidePanelTab('scripts');
   }, [handleSwitchSidePanelTab]);
+
+  const handleToggleScriptsSidePanel = useCallback(() => {
+    const tabId = activeTabIdRef.current;
+    if (!tabId) return;
+
+    const intent = resolveScriptsSidePanelShortcutIntent(
+      sidePanelOpenTabsRef.current.get(tabId) ?? null,
+    );
+
+    if (intent.kind === 'closeTerminalSidePanel') {
+      handleCloseSidePanel();
+      return;
+    }
+
+    setSidePanelOpenTabs(prev => {
+      const next = new Map(prev);
+      next.set(tabId, 'scripts');
+      return next;
+    });
+  }, [handleCloseSidePanel]);
+
+  useEffect(() => {
+    if (!toggleScriptsSidePanelRef) return;
+    toggleScriptsSidePanelRef.current = handleToggleScriptsSidePanel;
+    return () => {
+      toggleScriptsSidePanelRef.current = null;
+    };
+  }, [toggleScriptsSidePanelRef, handleToggleScriptsSidePanel]);
 
   // Open theme side panel (called from Terminal toolbar)
   const handleOpenTheme = useCallback(() => {
@@ -2614,6 +2645,7 @@ const terminalLayerAreEqual = (prev: TerminalLayerProps, next: TerminalLayerProp
     prev.onToggleWorkspaceViewMode === next.onToggleWorkspaceViewMode &&
     prev.onSetWorkspaceFocusedSession === next.onSetWorkspaceFocusedSession &&
     prev.onSplitSession === next.onSplitSession &&
+    prev.toggleScriptsSidePanelRef === next.toggleScriptsSidePanelRef &&
     prev.identities === next.identities
   );
 };

--- a/components/VaultView.memo.test.tsx
+++ b/components/VaultView.memo.test.tsx
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { vaultViewAreEqual } from "./VaultView.tsx";
+
+test("VaultView re-renders when an external section navigation request changes", () => {
+  const baseProps = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    snippetPackages: [],
+    customGroups: [],
+    knownHosts: [],
+    shellHistory: [],
+    connectionLogs: [],
+    sessions: [],
+    managedSources: [],
+    groupConfigs: {},
+    terminalThemeId: "default",
+    terminalFontSize: 14,
+    navigateToSection: null,
+  };
+
+  assert.equal(
+    vaultViewAreEqual(
+      baseProps as never,
+      { ...baseProps, navigateToSection: "snippets" } as never,
+    ),
+    false,
+  );
+});

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -3199,7 +3199,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 };
 
 // Only re-render when data props change - isActive is now managed internally via store subscription
-const vaultViewAreEqual = (
+export const vaultViewAreEqual = (
   prev: VaultViewProps,
   next: VaultViewProps,
 ): boolean => {
@@ -3217,7 +3217,8 @@ const vaultViewAreEqual = (
     prev.managedSources === next.managedSources &&
     prev.groupConfigs === next.groupConfigs &&
     prev.terminalThemeId === next.terminalThemeId &&
-    prev.terminalFontSize === next.terminalFontSize;
+    prev.terminalFontSize === next.terminalFontSize &&
+    prev.navigateToSection === next.navigateToSection;
 
   return isEqual;
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs application/state/*.test.ts components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs application/state/*.test.ts components/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## What changed

- The Open Snippets shortcut now opens the terminal Scripts side panel when the active tab is a terminal or workspace.
- Pressing the shortcut again closes the Scripts side panel.
- Outside terminal tabs, the shortcut still opens Vaults directly on the Snippets section.

## Why

Fixes #839. The shortcut previously only switched to Vaults, which made the workflow slower when the user wanted scripts while working in a terminal.

## Validation

- `node --test --import tsx application/state/resolveSnippetsShortcutIntent.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`