### PR TITLE
[codex] Keep known hosts local during sync

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,7 +24,7 @@ import { resolveSnippetsShortcutIntent } from './application/state/resolveSnippe
 import { TERMINAL_THEMES } from './infrastructure/config/terminalThemes';
 import { useCustomThemes } from './application/state/customThemeStore';
 import type { SyncPayload } from './domain/sync';
-import { applySyncPayload, buildSyncPayload, hasMeaningfulSyncData } from './application/syncPayload';
+import { applySyncPayload, buildLocalVaultPayload, hasMeaningfulSyncData } from './application/syncPayload';
 import {
   applyProtectedSyncPayload,
   ensureVersionChangeBackup,
@@ -441,7 +441,7 @@ function App({ settings }: { settings: SettingsState }) {
       }
     }
 
-    return buildSyncPayload(
+    return buildLocalVaultPayload(
       {
         hosts,
         keys,
@@ -557,7 +557,6 @@ function App({ settings }: { settings: SettingsState }) {
     customGroups,
     snippetPackages,
     portForwardingRules: portForwardingRulesForSync,
-    knownHosts,
     groupConfigs,
     settingsVersion: settings.settingsVersion,
     startupReady: startupSyncSafetyReady,

--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -16,14 +16,13 @@ import {
   findSyncPayloadEncryptedCredentialPaths,
 } from '../../domain/credentials';
 import { isProviderReadyForSync, type CloudProvider, type SyncPayload } from '../../domain/sync';
-import { collectSyncableSettings, hasMeaningfulSyncData } from '../syncPayload';
+import { collectSyncableSettings, hasMeaningfulCloudSyncData } from '../syncPayload';
 import { readInterruptedVaultApply } from '../localVaultBackups';
 import {
   STORAGE_KEY_PORT_FORWARDING,
   STORAGE_KEY_VAULT_RESTORE_IN_PROGRESS_UNTIL,
 } from '../../infrastructure/config/storageKeys';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
-import { getEffectiveKnownHosts } from '../../infrastructure/syncHelpers';
 import { notify } from '../notification';
 
 interface AutoSyncConfig {
@@ -35,7 +34,6 @@ interface AutoSyncConfig {
   customGroups: SyncPayload['customGroups'];
   snippetPackages?: SyncPayload['snippetPackages'];
   portForwardingRules?: SyncPayload['portForwardingRules'];
-  knownHosts?: SyncPayload['knownHosts'];
   groupConfigs?: SyncPayload['groupConfigs'];
   /** Opaque token that changes whenever a synced setting changes. */
   settingsVersion?: number;
@@ -140,8 +138,6 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       }
     }
 
-    const effectiveKnownHosts = getEffectiveKnownHosts(config.knownHosts);
-
     return {
       hosts: config.hosts,
       keys: config.keys,
@@ -150,7 +146,6 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       customGroups: config.customGroups,
       snippetPackages: config.snippetPackages,
       portForwardingRules: effectivePFRules,
-      knownHosts: effectiveKnownHosts,
       groupConfigs: config.groupConfigs,
     };
   }, [
@@ -161,7 +156,6 @@ export const useAutoSync = (config: AutoSyncConfig) => {
     config.customGroups,
     config.snippetPackages,
     config.portForwardingRules,
-    config.knownHosts,
     config.groupConfigs,
   ]);
 
@@ -283,7 +277,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       // checkRemoteVersion below: if inspect transiently errors we still
       // let auto-sync run, trusting this guard to refuse if local is
       // truly empty rather than letting an empty state clobber remote.
-      if (!hasMeaningfulSyncData(payload)) {
+      if (!hasMeaningfulCloudSyncData(payload)) {
         if (trigger === 'auto') {
           console.warn('[AutoSync] Blocked: refusing to auto-sync an empty vault to cloud');
           return;
@@ -437,8 +431,8 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       const remoteFile = inspection.remoteFile;
       const remotePayload = inspection.payload;
       const localPayload = buildPayloadRef.current();
-      const localIsEmpty = !hasMeaningfulSyncData(localPayload);
-      const remoteHasData = hasMeaningfulSyncData(remotePayload);
+      const localIsEmpty = !hasMeaningfulCloudSyncData(localPayload);
+      const remoteHasData = hasMeaningfulCloudSyncData(remotePayload);
 
       // If local vault is empty but cloud has data, this almost certainly
       // means the user's data was lost (update, storage corruption, etc.).

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { SyncPayload } from "../domain/sync.ts";
+import type { KnownHost } from "../domain/models.ts";
+import type { SyncableVaultData } from "./syncPayload.ts";
+
+type LocalStorageMock = {
+  clear(): void;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function installLocalStorage(): LocalStorageMock {
+  const store = new Map<string, string>();
+  const localStorage: LocalStorageMock = {
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorage,
+    configurable: true,
+  });
+  return localStorage;
+}
+
+const localStorage = installLocalStorage();
+const {
+  applyLocalVaultPayload,
+  applySyncPayload,
+  buildLocalVaultPayload,
+  buildSyncPayload,
+  hasMeaningfulCloudSyncData,
+} = await import("./syncPayload.ts");
+
+const knownHost = (id = "kh-1"): KnownHost => ({
+  id,
+  hostname: `${id}.example.com`,
+  port: 22,
+  keyType: "ssh-ed25519",
+  fingerprint: `SHA256:${id}`,
+});
+
+const vault = (knownHosts: KnownHost[] = [knownHost()]): SyncableVaultData => ({
+  hosts: [],
+  keys: [],
+  identities: [],
+  snippets: [],
+  customGroups: [],
+  snippetPackages: [],
+  knownHosts,
+  groupConfigs: [],
+});
+
+test.beforeEach(() => {
+  localStorage.clear();
+});
+
+test("buildSyncPayload treats known hosts as local-only data", () => {
+  const payload = buildSyncPayload(vault([knownHost("kh-cloud")]));
+
+  assert.equal("knownHosts" in payload, false);
+});
+
+test("hasMeaningfulCloudSyncData ignores legacy cloud known hosts", () => {
+  assert.equal(
+    hasMeaningfulCloudSyncData({
+      hosts: [],
+      keys: [],
+      identities: [],
+      snippets: [],
+      customGroups: [],
+      knownHosts: [knownHost("kh-only")],
+      syncedAt: 1,
+    }),
+    false,
+  );
+});
+
+test("buildLocalVaultPayload preserves known hosts for local backups", () => {
+  const payload = buildLocalVaultPayload(vault([knownHost("kh-local")]));
+
+  assert.deepEqual(payload.knownHosts, [knownHost("kh-local")]);
+});
+
+test("applySyncPayload ignores legacy cloud known hosts", () => {
+  let imported: Record<string, unknown> | null = null;
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    knownHosts: [knownHost("kh-legacy")],
+    syncedAt: 1,
+  };
+
+  applySyncPayload(payload, {
+    importVaultData: (json) => {
+      imported = JSON.parse(json);
+    },
+  });
+
+  assert.ok(imported);
+  assert.equal("knownHosts" in imported, false);
+});
+
+test("applyLocalVaultPayload restores known hosts from local backups", () => {
+  let imported: Record<string, unknown> | null = null;
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    knownHosts: [knownHost("kh-backup")],
+    syncedAt: 1,
+  };
+
+  applyLocalVaultPayload(payload, {
+    importVaultData: (json) => {
+      imported = JSON.parse(json);
+    },
+  });
+
+  assert.ok(imported);
+  assert.deepEqual(imported.knownHosts, [knownHost("kh-backup")]);
+});

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -58,7 +58,7 @@ import {
 
 const CUSTOM_KEY_BINDINGS_SYNC_PAYLOAD_ORIGIN = 'sync-payload';
 
-/** All vault-owned data that participates in cloud sync. */
+/** Vault-owned data. Some fields are local-only and excluded from cloud sync. */
 export interface SyncableVaultData {
   hosts: Host[];
   keys: SSHKey[];
@@ -66,6 +66,7 @@ export interface SyncableVaultData {
   snippets: Snippet[];
   customGroups: string[];
   snippetPackages?: string[];
+  /** Local trust records. Kept in local backups, excluded from cloud sync. */
   knownHosts: KnownHost[];
   groupConfigs?: GroupConfig[];
 }
@@ -93,9 +94,31 @@ export function hasMeaningfulSyncData(payload: SyncPayload): boolean {
   );
 }
 
+/**
+ * Returns true when a payload contains cloud-sync data.
+ * Local-only trust records are intentionally ignored.
+ */
+export function hasMeaningfulCloudSyncData(payload: SyncPayload): boolean {
+  const hasEntities =
+    (payload.hosts?.length ?? 0) > 0 ||
+    (payload.keys?.length ?? 0) > 0 ||
+    (payload.snippets?.length ?? 0) > 0 ||
+    (payload.identities?.length ?? 0) > 0 ||
+    (payload.customGroups?.length ?? 0) > 0 ||
+    (payload.snippetPackages?.length ?? 0) > 0 ||
+    (payload.portForwardingRules?.length ?? 0) > 0 ||
+    (payload.groupConfigs?.length ?? 0) > 0;
+
+  if (hasEntities) return true;
+
+  return Boolean(
+    payload.settings && Object.values(payload.settings).some((value) => value !== undefined),
+  );
+}
+
 /** Callbacks used by `applySyncPayload` to import data into local state. */
 interface SyncPayloadImporters {
-  /** Import vault data (hosts, keys, identities, snippets, customGroups, snippetPackages, knownHosts). */
+  /** Import vault data. Cloud sync excludes local-only known hosts by default. */
   importVaultData: (jsonString: string) => void;
   /** Import port-forwarding rules (lives outside the vault hook). */
   importPortForwardingRules?: (rules: PortForwardingRule[]) => void;
@@ -317,11 +340,21 @@ export function buildSyncPayload(
     snippets: vault.snippets,
     customGroups: vault.customGroups,
     snippetPackages: vault.snippetPackages,
-    knownHosts: vault.knownHosts,
     groupConfigs: vault.groupConfigs,
     portForwardingRules,
     settings: collectSyncableSettings(),
     syncedAt: Date.now(),
+  };
+}
+
+/** Build a local backup/restore payload, including local-only trust records. */
+export function buildLocalVaultPayload(
+  vault: SyncableVaultData,
+  portForwardingRules?: PortForwardingRule[],
+): SyncPayload {
+  return {
+    ...buildSyncPayload(vault, portForwardingRules),
+    knownHosts: vault.knownHosts,
   };
 }
 
@@ -331,14 +364,13 @@ export function buildSyncPayload(
  * This ensures both vault data and port-forwarding rules are imported
  * consistently across windows.
  */
-export function applySyncPayload(
+function applyPayload(
   payload: SyncPayload,
   importers: SyncPayloadImporters,
+  options: { includeLocalOnlyData: boolean },
 ): void {
-  // Build the vault import object.  knownHosts is only included when the
-  // payload explicitly carries the field (even if it's []).  Legacy cloud
-  // snapshots may omit it entirely — in that case we leave the local
-  // known-hosts list untouched rather than destructively wiping it.
+  // Build the vault import object. Cloud sync intentionally ignores
+  // local-only trust records even if legacy cloud snapshots still carry them.
   const vaultImport: Record<string, unknown> = {
     hosts: payload.hosts,
     keys: payload.keys,
@@ -349,7 +381,7 @@ export function applySyncPayload(
   if (payload.snippetPackages !== undefined) {
     vaultImport.snippetPackages = payload.snippetPackages;
   }
-  if (payload.knownHosts !== undefined) {
+  if (options.includeLocalOnlyData && payload.knownHosts !== undefined) {
     vaultImport.knownHosts = payload.knownHosts;
   }
   if (Array.isArray(payload.groupConfigs)) {
@@ -373,4 +405,18 @@ export function applySyncPayload(
     if (payload.settings.sftpGlobalBookmarks != null) rehydrateGlobalBookmarks();
     importers.onSettingsApplied?.();
   }
+}
+
+export function applySyncPayload(
+  payload: SyncPayload,
+  importers: SyncPayloadImporters,
+): void {
+  applyPayload(payload, importers, { includeLocalOnlyData: false });
+}
+
+export function applyLocalVaultPayload(
+  payload: SyncPayload,
+  importers: SyncPayloadImporters,
+): void {
+  applyPayload(payload, importers, { includeLocalOnlyData: true });
 }

--- a/components/CloudSyncSettings.tsx
+++ b/components/CloudSyncSettings.tsx
@@ -638,6 +638,7 @@ const ConflictModal: React.FC<ConflictModalProps> = ({
 interface SyncDashboardProps {
     onBuildPayload: () => SyncPayload;
     onApplyPayload: (payload: SyncPayload) => void | Promise<void>;
+    onApplyLocalPayload?: (payload: SyncPayload) => void | Promise<void>;
     onClearLocalData?: () => void;
 }
 
@@ -1055,6 +1056,7 @@ const LocalBackupsPanel: React.FC<LocalBackupsPanelProps> = ({
 const SyncDashboard: React.FC<SyncDashboardProps> = ({
     onBuildPayload,
     onApplyPayload,
+    onApplyLocalPayload,
     onClearLocalData,
 }) => {
     const { t, resolvedLocale } = useI18n();
@@ -1916,7 +1918,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
 
                     <div ref={localBackupsRef}>
                         <LocalBackupsPanel
-                            onApplyPayload={onApplyPayload}
+                            onApplyPayload={onApplyLocalPayload ?? onApplyPayload}
                         />
                     </div>
 
@@ -2612,6 +2614,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
 interface CloudSyncSettingsProps {
     onBuildPayload: () => SyncPayload;
     onApplyPayload: (payload: SyncPayload) => void | Promise<void>;
+    onApplyLocalPayload?: (payload: SyncPayload) => void | Promise<void>;
     onClearLocalData?: () => void;
 }
 

--- a/components/settings/tabs/SettingsSyncTab.tsx
+++ b/components/settings/tabs/SettingsSyncTab.tsx
@@ -1,7 +1,12 @@
 import React, { useCallback } from "react";
 import type { PortForwardingRule } from "../../../domain/models";
 import type { SyncPayload } from "../../../domain/sync";
-import { buildSyncPayload, applySyncPayload } from "../../../application/syncPayload";
+import {
+  applyLocalVaultPayload,
+  buildLocalVaultPayload,
+  buildSyncPayload,
+  applySyncPayload,
+} from "../../../application/syncPayload";
 import { applyProtectedSyncPayload } from "../../../application/localVaultBackups";
 import type { SyncableVaultData } from "../../../application/syncPayload";
 import { useI18n } from "../../../application/i18n/I18nProvider";
@@ -29,7 +34,7 @@ export default function SettingsSyncTab(props: {
   } = props;
   const { t } = useI18n();
 
-  const onBuildPayload = useCallback((): SyncPayload => {
+  const getEffectivePortForwardingRules = useCallback((): PortForwardingRule[] => {
     // If hook state is empty but localStorage has data, the async store
     // initialization hasn't finished yet.  Read from localStorage directly
     // to avoid uploading empty arrays and overwriting the remote snapshot.
@@ -51,15 +56,26 @@ export default function SettingsSyncTab(props: {
       }
     }
 
+    return effectiveRules;
+  }, [portForwardingRules]);
+
+  const onBuildPayload = useCallback((): SyncPayload => {
+    return buildSyncPayload(vault, getEffectivePortForwardingRules());
+  }, [vault, getEffectivePortForwardingRules]);
+
+  const onBuildLocalPayload = useCallback((): SyncPayload => {
     const effectiveKnownHosts = getEffectiveKnownHosts(vault.knownHosts);
 
-    return buildSyncPayload({ ...vault, knownHosts: effectiveKnownHosts }, effectiveRules);
-  }, [vault, portForwardingRules]);
+    return buildLocalVaultPayload(
+      { ...vault, knownHosts: effectiveKnownHosts ?? [] },
+      getEffectivePortForwardingRules(),
+    );
+  }, [vault, getEffectivePortForwardingRules]);
 
   const onApplyPayload = useCallback(
     (payload: SyncPayload) =>
       applyProtectedSyncPayload({
-        buildPreApplyPayload: onBuildPayload,
+        buildPreApplyPayload: onBuildLocalPayload,
         applyPayload: () =>
           applySyncPayload(payload, {
             importVaultData: importDataFromString,
@@ -69,7 +85,23 @@ export default function SettingsSyncTab(props: {
         translateProtectiveBackupFailure: (message) =>
           t("cloudSync.localBackups.protectiveBackupFailed", { message }),
       }),
-    [importDataFromString, importPortForwardingRules, onBuildPayload, onSettingsApplied, t],
+    [importDataFromString, importPortForwardingRules, onBuildLocalPayload, onSettingsApplied, t],
+  );
+
+  const onApplyLocalPayload = useCallback(
+    (payload: SyncPayload) =>
+      applyProtectedSyncPayload({
+        buildPreApplyPayload: onBuildLocalPayload,
+        applyPayload: () =>
+          applyLocalVaultPayload(payload, {
+            importVaultData: importDataFromString,
+            importPortForwardingRules,
+            onSettingsApplied,
+          }),
+        translateProtectiveBackupFailure: (message) =>
+          t("cloudSync.localBackups.protectiveBackupFailed", { message }),
+      }),
+    [importDataFromString, importPortForwardingRules, onBuildLocalPayload, onSettingsApplied, t],
   );
 
   const clearAllLocalData = useCallback(() => {
@@ -82,6 +114,7 @@ export default function SettingsSyncTab(props: {
       <CloudSyncSettings
         onBuildPayload={onBuildPayload}
         onApplyPayload={onApplyPayload}
+        onApplyLocalPayload={onApplyLocalPayload}
         onClearLocalData={clearAllLocalData}
       />
     </SettingsTabContent>

--- a/domain/syncGuards.test.ts
+++ b/domain/syncGuards.test.ts
@@ -156,13 +156,11 @@ test("only non-hosts entity shrinks → reports that entity", () => {
   }
 });
 
-test("knownHosts shrink triggers (security-sensitive)", () => {
+test("knownHosts shrink is ignored because known hosts are local-only", () => {
   const kh = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `kh${i}`, hostname: `h${i}`, port: 22, keyType: "rsa", fingerprint: "x" })) as unknown as SyncPayload["knownHosts"];
   const base = payload({ knownHosts: kh(12) });
   const out = payload({ knownHosts: kh(2) });
-  const result = detectSuspiciousShrink(out, base);
-  assert.equal(result.suspicious, true);
-  if (result.suspicious) assert.equal(result.entityType, "knownHosts");
+  assert.deepEqual(detectSuspiciousShrink(out, base), { suspicious: false });
 });
 
 test("empty base (all zeros) — no shrink possible, returns not suspicious", () => {

--- a/domain/syncGuards.ts
+++ b/domain/syncGuards.ts
@@ -12,7 +12,6 @@ export type ShrinkFinding =
         | 'snippets'
         | 'customGroups'
         | 'snippetPackages'
-        | 'knownHosts'
         | 'portForwardingRules'
         | 'groupConfigs';
       baseCount: number;
@@ -32,7 +31,6 @@ const CHECKED_ENTITIES = [
   'snippets',
   'customGroups',
   'snippetPackages',
-  'knownHosts',
   'portForwardingRules',
   'groupConfigs',
 ] as const;

--- a/domain/syncMerge.test.ts
+++ b/domain/syncMerge.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeSyncPayloads } from "./syncMerge.ts";
+import type { SyncPayload } from "./sync.ts";
+
+function payload(overrides: Partial<SyncPayload> = {}): SyncPayload {
+  return {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    snippetPackages: [],
+    portForwardingRules: [],
+    groupConfigs: [],
+    settings: undefined,
+    syncedAt: 0,
+    ...overrides,
+  };
+}
+
+const knownHosts = (n: number): SyncPayload["knownHosts"] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `kh-${i}`,
+    hostname: `host-${i}.example.com`,
+    port: 22,
+    keyType: "ssh-ed25519",
+    fingerprint: `SHA256:${i}`,
+  })) as SyncPayload["knownHosts"];
+
+test("mergeSyncPayloads does not carry legacy known hosts forward", () => {
+  const result = mergeSyncPayloads(
+    payload({ knownHosts: knownHosts(2) }),
+    payload(),
+    payload({ knownHosts: knownHosts(3) }),
+  );
+
+  assert.equal("knownHosts" in result.payload, false);
+});

--- a/domain/syncMerge.ts
+++ b/domain/syncMerge.ts
@@ -347,7 +347,6 @@ export function mergeSyncPayloads(
     snippets: [],
     customGroups: [],
     snippetPackages: [],
-    knownHosts: [],
     portForwardingRules: [],
     settings: undefined,
     syncedAt: 0,
@@ -365,19 +364,6 @@ export function mergeSyncPayloads(
   const keys = mergeEntityArrays(b.keys ?? [], local.keys ?? [], remote.keys ?? []);
   const identities = mergeEntityArrays(b.identities ?? [], local.identities ?? [], remote.identities ?? []);
   const snippets = mergeEntityArrays(b.snippets ?? [], local.snippets ?? [], remote.snippets ?? []);
-  const knownHostsRaw = mergeEntityArrays(b.knownHosts ?? [], local.knownHosts ?? [], remote.knownHosts ?? []);
-  // Deduplicate known hosts by (hostname, port, keyType) since IDs are random per device
-  const knownHostSeen = new Set<string>();
-  const knownHosts = {
-    ...knownHostsRaw,
-    merged: knownHostsRaw.merged.filter((kh) => {
-      const entry = kh as unknown as { hostname: string; port: number; keyType: string };
-      const fp = `${entry.hostname}:${entry.port}:${entry.keyType}`;
-      if (knownHostSeen.has(fp)) return false;
-      knownHostSeen.add(fp);
-      return true;
-    }),
-  };
   const portForwardingRules = mergeEntityArrays(
     b.portForwardingRules ?? [],
     local.portForwardingRules ?? [],
@@ -394,7 +380,7 @@ export function mergeSyncPayloads(
 
   // Aggregate stats
   const entityResults: Pick<EntityMergeResult<unknown>, 'added' | 'deleted' | 'modified' | 'conflicts'>[] =
-    [hosts, keys, identities, snippets, knownHosts, portForwardingRules, groupConfigsResult];
+    [hosts, keys, identities, snippets, portForwardingRules, groupConfigsResult];
   for (const r of entityResults) {
     summary.added.local += r.added.local;
     summary.added.remote += r.added.remote;
@@ -437,7 +423,6 @@ export function mergeSyncPayloads(
     snippets: snippets.merged,
     customGroups,
     snippetPackages,
-    knownHosts: knownHosts.merged,
     portForwardingRules: portForwardingRules.merged,
     groupConfigs: unwrapGC(groupConfigsResult.merged),
     settings,

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -1425,7 +1425,6 @@ export class CloudSyncManager {
     customGroups: SyncPayload['customGroups'];
     snippetPackages?: SyncPayload['snippetPackages'];
     portForwardingRules?: SyncPayload['portForwardingRules'];
-    knownHosts?: SyncPayload['knownHosts'];
     settings?: SyncPayload['settings'];
   }): SyncPayload {
     return {

--- a/infrastructure/syncHelpers.ts
+++ b/infrastructure/syncHelpers.ts
@@ -3,11 +3,11 @@ import { STORAGE_KEY_KNOWN_HOSTS } from './config/storageKeys';
 import { localStorageAdapter } from './persistence/localStorageAdapter';
 
 /**
- * Get effective knownHosts for sync payload.
+ * Get effective knownHosts for local vault payloads.
  *
  * If the hook/state knownHosts is empty but localStorage has data,
- * read from localStorage to avoid uploading an empty array that
- * overwrites the cloud snapshot.
+ * read from localStorage so local backups do not miss entries while
+ * async store initialization is still settling.
  */
 export function getEffectiveKnownHosts(
   knownHostsFromState: KnownHost[] | undefined,


### PR DESCRIPTION
## Summary

- Stop including known hosts in cloud sync payloads.
- Ignore legacy cloud known-host data when applying or merging sync snapshots.
- Keep known hosts in local backup and restore flows.
- Add regression tests for cloud payloads, local backups, merge behavior, and shrink protection.

## Why

Known hosts are device-local trust records. Syncing them across machines can overwrite local state with records from another device, so cloud sync should leave them alone while still preserving them in local backups.

Related to #859.

## Validation

- `node --test --import tsx application/syncPayload.test.ts domain/syncMerge.test.ts domain/syncGuards.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`