### PR TITLE
Wire bundled mosh release flow

### DIFF
--- a/.github/scripts/generate-release-note.js
+++ b/.github/scripts/generate-release-note.js
@@ -56,8 +56,7 @@ const files = {
     x64: `Netcatty-${version}-mac-x64.dmg`
   },
   win: {
-    x64: `Netcatty-${version}-win-x64.exe`,
-    arm64: `Netcatty-${version}-win-arm64.exe`
+    x64: `Netcatty-${version}-win-x64.exe`
   },
   linux: {
     appimage: {
@@ -77,8 +76,7 @@ const files = {
 
 const badges = {
   win: {
-    setup_x64: `[![Setup x64](https://img.shields.io/badge/Setup-x64-0078D6?style=flat-square&logo=windows)](${baseUrl}/${files.win.x64})`,
-    setup_arm64: `[![Setup arm64](https://img.shields.io/badge/Setup-arm64-0078D6?style=flat-square&logo=windows)](${baseUrl}/${files.win.arm64})`
+    setup_x64: `[![Setup x64](https://img.shields.io/badge/Setup-x64-0078D6?style=flat-square&logo=windows)](${baseUrl}/${files.win.x64})`
   },
   mac: {
     apple_silicon: `[![DMG Apple Silicon](https://img.shields.io/badge/DMG-Apple_Silicon-000000?style=flat-square&logo=apple)](${baseUrl}/${files.mac.arm64})`,
@@ -99,7 +97,7 @@ const content = `
 
 | OS | Download |
 | :--- | :--- |
-| **Windows** | ${badges.win.setup_x64} ${badges.win.setup_arm64} |
+| **Windows** | ${badges.win.setup_x64} |
 | **macOS** | ${badges.mac.apple_silicon} ${badges.mac.intel} |
 | **Linux** | ${badges.linux.appimage_x64} ${badges.linux.deb_x64} ${badges.linux.rpm_x64} <br> ${badges.linux.appimage_arm64} ${badges.linux.deb_arm64} ${badges.linux.rpm_arm64} |
 `;

--- a/.github/workflows/build-mosh-binaries.yml
+++ b/.github/workflows/build-mosh-binaries.yml
@@ -207,6 +207,7 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts
@@ -251,3 +252,8 @@ jobs:
             All artifacts are GPL-3.0; see `resources/mosh/README.md` for source provenance.
           draft: false
           prerelease: false
+      - name: Set default bundled mosh-client release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+        run: gh variable set MOSH_BIN_RELEASE --body "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/build-mosh-binaries.yml
+++ b/.github/workflows/build-mosh-binaries.yml
@@ -207,7 +207,6 @@ jobs:
       || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
     permissions:
       contents: write
-      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts
@@ -252,8 +251,3 @@ jobs:
             All artifacts are GPL-3.0; see `resources/mosh/README.md` for source provenance.
           draft: false
           prerelease: false
-      - name: Set default bundled mosh-client release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.tag.outputs.name }}
-        run: gh variable set MOSH_BIN_RELEASE --body "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,11 @@ jobs:
             npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" "@zed-industries/codex-acp-win32-arm64@${CODEX_VER}" --no-save --force
           fi
 
-      - name: Require bundled mosh-client release
+      - name: Resolve bundled mosh-client release
         shell: bash
-        run: |
-          if [[ -z "${MOSH_BIN_RELEASE:-}" ]]; then
-            echo "::error::Set workflow input mosh_bin_release or repository variable MOSH_BIN_RELEASE before packaging."
-            exit 1
-          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/resolve-mosh-bin-release.cjs
 
       - name: Fetch bundled mosh-client
         shell: bash
@@ -167,12 +165,10 @@ jobs:
           npm_config_arch: x64
         run: bash scripts/ensure-node-pty-linux.sh prepare x64
 
-      - name: Require bundled mosh-client release
-        run: |
-          if [ -z "${MOSH_BIN_RELEASE:-}" ]; then
-            echo "::error::Set workflow input mosh_bin_release or repository variable MOSH_BIN_RELEASE before packaging."
-            exit 1
-          fi
+      - name: Resolve bundled mosh-client release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/resolve-mosh-bin-release.cjs
 
       - name: Fetch bundled mosh-client
         run: npm run fetch:mosh -- --platform=linux --arch=x64
@@ -248,12 +244,10 @@ jobs:
           npm_config_arch: arm64
         run: bash scripts/ensure-node-pty-linux.sh prepare arm64
 
-      - name: Require bundled mosh-client release
-        run: |
-          if [ -z "${MOSH_BIN_RELEASE:-}" ]; then
-            echo "::error::Set workflow input mosh_bin_release or repository variable MOSH_BIN_RELEASE before packaging."
-            exit 1
-          fi
+      - name: Resolve bundled mosh-client release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/resolve-mosh-bin-release.cjs
 
       - name: Fetch bundled mosh-client
         run: npm run fetch:mosh -- --platform=linux --arch=arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,10 @@ jobs:
             pack_script: pack:mac
           - name: windows
             os: windows-latest
-            pack_script: pack:win
+            # The mosh binary workflow currently produces win32-x64 only.
+            # Keep official packages aligned with bundled-mosh coverage
+            # until Cygwin arm64 is stable enough to build win32-arm64.
+            pack_script: pack:win-x64
     env:
       VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
@@ -53,16 +56,16 @@ jobs:
       - name: Install cross-platform native binaries
         shell: bash
         run: |
-          # npm ci only installs optional deps for the host platform, but
-          # electron-builder produces both arm64 and x64 binaries, so we
-          # need the native codex-acp binary for the other architecture too.
+          # npm ci only installs optional deps for the host platform.
+          # macOS packages still cover both arm64 and x64, so we need
+          # codex-acp for both architectures there.
           # Platform-specific codex-acp packages declare cpu/os constraints,
           # so --force is needed to install the non-host-arch binary.
           CODEX_VER=$(node -e "console.log(require('./node_modules/@zed-industries/codex-acp/package.json').version)")
           if [[ "${{ matrix.name }}" == "macos" ]]; then
             npm install "@zed-industries/codex-acp-darwin-x64@${CODEX_VER}" "@zed-industries/codex-acp-darwin-arm64@${CODEX_VER}" --no-save --force
           elif [[ "${{ matrix.name }}" == "windows" ]]; then
-            npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" "@zed-industries/codex-acp-win32-arm64@${CODEX_VER}" --no-save --force
+            npm install "@zed-industries/codex-acp-win32-x64@${CODEX_VER}" --no-save --force
           fi
 
       - name: Resolve bundled mosh-client release

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pack": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --publish=never",
     "pack:dir": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --dir --publish=never",
     "pack:win": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --win --x64 --publish=never && cross-env npm_config_arch=arm64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --win --arm64 --publish=never",
+    "pack:win-x64": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --win --x64 --publish=never",
     "pack:mac": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --mac --publish=never",
     "pack:linux": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --publish=never",
     "pack:linux-x64": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --x64 --publish=never",

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -27,9 +27,7 @@ directly (see `electron/bridges/moshHandshake.cjs` and
    default workflow.
 
 2. The release built by that workflow gets a tag like
-   `mosh-bin-1.4.0-1`, with `SHA256SUMS` attached. When the workflow
-   publishes a release, it also updates the repository variable
-   `MOSH_BIN_RELEASE` to that tag.
+   `mosh-bin-1.4.0-1`, with `SHA256SUMS` attached.
 
 3. Release packaging runs `scripts/resolve-mosh-bin-release.cjs` before
    `npm run fetch:mosh`. It uses an explicit workflow input first, then
@@ -39,6 +37,10 @@ directly (see `electron/bridges/moshHandshake.cjs` and
    set `MOSH_BIN_RELEASE` yourself before running the same fetch command.
    `electron-builder.config.cjs` then copies the matching binary into
    `Resources/mosh/mosh-client[.exe]`.
+
+   Official Windows package builds currently ship x64 only for bundled
+   Mosh coverage. Windows arm64 packaging should be re-enabled there
+   after the `build-mosh-binaries` workflow can produce `win32-arm64`.
 
 The directory is otherwise empty (binaries are gitignored).
 

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -27,12 +27,16 @@ directly (see `electron/bridges/moshHandshake.cjs` and
    default workflow.
 
 2. The release built by that workflow gets a tag like
-   `mosh-bin-1.4.0-1`, with `SHA256SUMS` attached.
+   `mosh-bin-1.4.0-1`, with `SHA256SUMS` attached. When the workflow
+   publishes a release, it also updates the repository variable
+   `MOSH_BIN_RELEASE` to that tag.
 
-3. Release packaging sets `MOSH_BIN_RELEASE=mosh-bin-1.4.0-1` and runs
-   `npm run fetch:mosh` to pull the binaries into
-   `resources/mosh/<platform-arch>/`. For local packaging, set
-   `MOSH_BIN_RELEASE` yourself before running the same fetch command.
+3. Release packaging runs `scripts/resolve-mosh-bin-release.cjs` before
+   `npm run fetch:mosh`. It uses an explicit workflow input first, then
+   the `MOSH_BIN_RELEASE` repository variable, then the latest
+   non-draft `mosh-bin-*` GitHub Release. The fetch step pulls the
+   binaries into `resources/mosh/<platform-arch>/`. For local packaging,
+   set `MOSH_BIN_RELEASE` yourself before running the same fetch command.
    `electron-builder.config.cjs` then copies the matching binary into
    `Resources/mosh/mosh-client[.exe]`.
 

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+//
+// Resolve the mosh-client binary release used by build-packages.
+//
+// Priority:
+//   1. MOSH_BIN_RELEASE from workflow input / repository variable.
+//   2. Latest non-draft, non-prerelease GitHub Release whose tag is
+//      mosh-bin-* in MOSH_BIN_OWNER/MOSH_BIN_REPO (or GITHUB_REPOSITORY).
+//
+// In GitHub Actions, the resolved tag is written back to $GITHUB_ENV so
+// later steps can run scripts/fetch-mosh-binaries.cjs without duplicating
+// release discovery logic.
+
+const fs = require("node:fs");
+const https = require("node:https");
+
+const TAG_RE = /^mosh-bin-[A-Za-z0-9._-]+$/;
+
+function log(msg) {
+  console.log(`[resolve-mosh-bin-release] ${msg}`);
+}
+
+function validateReleaseTag(tag) {
+  const value = String(tag || "").trim();
+  if (!TAG_RE.test(value)) {
+    throw new Error(`invalid mosh binary release tag: ${tag}`);
+  }
+  return value;
+}
+
+function parseRepository(env) {
+  const owner = env.MOSH_BIN_OWNER || (env.GITHUB_REPOSITORY || "").split("/")[0] || "binaricat";
+  const repo = env.MOSH_BIN_REPO || (env.GITHUB_REPOSITORY || "").split("/")[1] || "Netcatty";
+  return { owner, repo };
+}
+
+function releaseTimestamp(release) {
+  const raw = release.published_at || release.created_at || "";
+  const value = Date.parse(raw);
+  return Number.isNaN(value) ? 0 : value;
+}
+
+function pickLatestMoshBinRelease(releases) {
+  return releases
+    .map((release, index) => ({ release, index }))
+    .filter(({ release }) => {
+      return release
+        && TAG_RE.test(String(release.tag_name || ""))
+        && release.draft !== true
+        && release.prerelease !== true;
+    })
+    .sort((a, b) => {
+      const diff = releaseTimestamp(b.release) - releaseTimestamp(a.release);
+      return diff || a.index - b.index;
+    })[0]?.release.tag_name;
+}
+
+function requestJson(url, env, depth = 0) {
+  return new Promise((resolve, reject) => {
+    if (depth > 5) {
+      reject(new Error("too many redirects while looking up mosh binary releases"));
+      return;
+    }
+
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "netcatty-mosh-release-resolver",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    const token = env.GITHUB_TOKEN || env.GH_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    https.get(url, { headers }, (res) => {
+      const location = res.headers.location;
+      if (res.statusCode >= 300 && res.statusCode < 400 && location) {
+        res.resume();
+        resolve(requestJson(new URL(location, url).toString(), env, depth + 1));
+        return;
+      }
+
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8");
+        if (res.statusCode !== 200) {
+          reject(new Error(`GitHub API returned HTTP ${res.statusCode}: ${body.slice(0, 300)}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(body));
+        } catch (err) {
+          reject(new Error(`GitHub API returned invalid JSON: ${err.message}`));
+        }
+      });
+      res.on("error", reject);
+    }).on("error", reject);
+  });
+}
+
+async function loadReleases(env) {
+  if (env.MOSH_BIN_RELEASES_JSON) {
+    const parsed = JSON.parse(env.MOSH_BIN_RELEASES_JSON);
+    if (!Array.isArray(parsed)) {
+      throw new Error("MOSH_BIN_RELEASES_JSON must be a JSON array");
+    }
+    return parsed;
+  }
+
+  const { owner, repo } = parseRepository(env);
+  const apiBase = (env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "");
+  const url = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/releases?per_page=100`;
+  log(`looking up latest mosh-bin-* release in ${owner}/${repo}`);
+  return requestJson(url, env);
+}
+
+function exportRelease(release, env) {
+  if (env.GITHUB_ENV) {
+    fs.appendFileSync(env.GITHUB_ENV, `MOSH_BIN_RELEASE=${release}\n`, "utf8");
+  }
+}
+
+async function main(env = process.env) {
+  if (String(env.MOSH_BIN_RELEASE || "").trim()) {
+    const release = validateReleaseTag(env.MOSH_BIN_RELEASE);
+    exportRelease(release, env);
+    log(`using MOSH_BIN_RELEASE=${release}`);
+    return release;
+  }
+
+  const releases = await loadReleases(env);
+  const release = pickLatestMoshBinRelease(releases);
+  if (!release) {
+    throw new Error(
+      "could not find a non-draft mosh-bin-* release. Run build-mosh-binaries with release_tag (for example mosh-bin-1.4.0-1) before packaging.",
+    );
+  }
+
+  const validated = validateReleaseTag(release);
+  exportRelease(validated, env);
+  log(`resolved MOSH_BIN_RELEASE=${validated}`);
+  return validated;
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`[resolve-mosh-bin-release] FATAL ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  validateReleaseTag,
+  parseRepository,
+  pickLatestMoshBinRelease,
+  main,
+};

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -56,7 +56,18 @@ function pickLatestMoshBinRelease(releases) {
     })[0]?.release.tag_name;
 }
 
-function requestJson(url, env, depth = 0) {
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of String(linkHeader).split(",")) {
+    const match = part.match(/^\s*<([^>]+)>\s*;\s*(.+)\s*$/);
+    if (!match) continue;
+    const rel = match[2].split(";").some((attr) => attr.trim() === 'rel="next"');
+    if (rel) return match[1];
+  }
+  return null;
+}
+
+function requestJsonWithHeaders(url, env, depth = 0) {
   return new Promise((resolve, reject) => {
     if (depth > 5) {
       reject(new Error("too many redirects while looking up mosh binary releases"));
@@ -75,7 +86,7 @@ function requestJson(url, env, depth = 0) {
       const location = res.headers.location;
       if (res.statusCode >= 300 && res.statusCode < 400 && location) {
         res.resume();
-        resolve(requestJson(new URL(location, url).toString(), env, depth + 1));
+        resolve(requestJsonWithHeaders(new URL(location, url).toString(), env, depth + 1));
         return;
       }
 
@@ -88,7 +99,7 @@ function requestJson(url, env, depth = 0) {
           return;
         }
         try {
-          resolve(JSON.parse(body));
+          resolve({ json: JSON.parse(body), headers: res.headers });
         } catch (err) {
           reject(new Error(`GitHub API returned invalid JSON: ${err.message}`));
         }
@@ -98,7 +109,7 @@ function requestJson(url, env, depth = 0) {
   });
 }
 
-async function loadReleases(env) {
+async function loadReleases(env, request = requestJsonWithHeaders) {
   if (env.MOSH_BIN_RELEASES_JSON) {
     const parsed = JSON.parse(env.MOSH_BIN_RELEASES_JSON);
     if (!Array.isArray(parsed)) {
@@ -109,9 +120,24 @@ async function loadReleases(env) {
 
   const { owner, repo } = parseRepository(env);
   const apiBase = (env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "");
-  const url = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/releases?per_page=100`;
+  let url = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/releases?per_page=100`;
   log(`looking up latest mosh-bin-* release in ${owner}/${repo}`);
-  return requestJson(url, env);
+  const releases = [];
+  const seen = new Set();
+  while (url) {
+    if (seen.has(url)) {
+      throw new Error(`GitHub API pagination looped while looking up releases: ${url}`);
+    }
+    seen.add(url);
+
+    const { json, headers = {} } = await request(url, env);
+    if (!Array.isArray(json)) {
+      throw new Error("GitHub API releases response was not an array");
+    }
+    releases.push(...json);
+    url = parseNextLink(headers.link);
+  }
+  return releases;
 }
 
 function exportRelease(release, env) {
@@ -150,6 +176,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  loadReleases,
+  parseNextLink,
   validateReleaseTag,
   parseRepository,
   pickLatestMoshBinRelease,

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -1,0 +1,83 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  main,
+  parseRepository,
+  pickLatestMoshBinRelease,
+  validateReleaseTag,
+} = require("./resolve-mosh-bin-release.cjs");
+
+function makeTmp(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-resolve-mosh-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+test("validateReleaseTag accepts only mosh binary release tags", () => {
+  assert.equal(validateReleaseTag("mosh-bin-1.4.0-1"), "mosh-bin-1.4.0-1");
+  assert.throws(() => validateReleaseTag("v1.2.3"), /invalid mosh binary release tag/);
+  assert.throws(() => validateReleaseTag("mosh-bin-../bad"), /invalid mosh binary release tag/);
+});
+
+test("parseRepository falls back to Netcatty release repository", () => {
+  assert.deepEqual(parseRepository({}), { owner: "binaricat", repo: "Netcatty" });
+  assert.deepEqual(parseRepository({ GITHUB_REPOSITORY: "owner/project" }), { owner: "owner", repo: "project" });
+  assert.deepEqual(
+    parseRepository({ GITHUB_REPOSITORY: "owner/project", MOSH_BIN_OWNER: "bin", MOSH_BIN_REPO: "binaries" }),
+    { owner: "bin", repo: "binaries" },
+  );
+});
+
+test("pickLatestMoshBinRelease ignores non-packaging releases", () => {
+  const got = pickLatestMoshBinRelease([
+    { tag_name: "v1.0.0", published_at: "2026-03-01T00:00:00Z" },
+    { tag_name: "mosh-bin-1.4.0-3", draft: true, published_at: "2026-04-01T00:00:00Z" },
+    { tag_name: "mosh-bin-1.4.0-4", prerelease: true, published_at: "2026-04-02T00:00:00Z" },
+    { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-02-01T00:00:00Z" },
+    { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-03-01T00:00:00Z" },
+  ]);
+
+  assert.equal(got, "mosh-bin-1.4.0-2");
+});
+
+test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {
+  const githubEnv = path.join(makeTmp(t), "github-env");
+
+  const got = await main({
+    MOSH_BIN_RELEASE: "mosh-bin-1.4.0-1",
+    GITHUB_ENV: githubEnv,
+  });
+
+  assert.equal(got, "mosh-bin-1.4.0-1");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=mosh-bin-1.4.0-1\n");
+});
+
+test("main resolves the latest release from the release list and exports it", async (t) => {
+  const githubEnv = path.join(makeTmp(t), "github-env");
+  const got = await main({
+    GITHUB_ENV: githubEnv,
+    MOSH_BIN_RELEASES_JSON: JSON.stringify([
+      { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-01-01T00:00:00Z" },
+      { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-02-01T00:00:00Z" },
+    ]),
+  });
+
+  assert.equal(got, "mosh-bin-1.4.0-2");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=mosh-bin-1.4.0-2\n");
+});
+
+test("main fails when no usable release exists", async () => {
+  await assert.rejects(
+    main({
+      MOSH_BIN_RELEASES_JSON: JSON.stringify([
+        { tag_name: "v1.0.0", published_at: "2026-01-01T00:00:00Z" },
+        { tag_name: "mosh-bin-1.4.0-1", draft: true, published_at: "2026-02-01T00:00:00Z" },
+      ]),
+    }),
+    /could not find/,
+  );
+});

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -5,8 +5,10 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  loadReleases,
   main,
   parseRepository,
+  parseNextLink,
   pickLatestMoshBinRelease,
   validateReleaseTag,
 } = require("./resolve-mosh-bin-release.cjs");
@@ -42,6 +44,52 @@ test("pickLatestMoshBinRelease ignores non-packaging releases", () => {
   ]);
 
   assert.equal(got, "mosh-bin-1.4.0-2");
+});
+
+test("parseNextLink reads the next GitHub pagination URL", () => {
+  const link = [
+    '<https://api.github.com/repos/owner/repo/releases?per_page=100&page=1>; rel="prev"',
+    '<https://api.github.com/repos/owner/repo/releases?per_page=100&page=3>; rel="next"',
+    '<https://api.github.com/repos/owner/repo/releases?per_page=100&page=9>; rel="last"',
+  ].join(", ");
+
+  assert.equal(
+    parseNextLink(link),
+    "https://api.github.com/repos/owner/repo/releases?per_page=100&page=3",
+  );
+  assert.equal(parseNextLink('<https://api.github.com/repos/owner/repo/releases?page=1>; rel="last"'), null);
+});
+
+test("loadReleases follows GitHub pagination until the last page", async () => {
+  const requested = [];
+  const got = await loadReleases({ GITHUB_REPOSITORY: "owner/repo" }, async (url) => {
+    requested.push(url);
+    if (url.includes("page=2")) {
+      return {
+        json: [{ tag_name: "mosh-bin-1.4.0-1", published_at: "2026-01-01T00:00:00Z" }],
+        headers: {},
+      };
+    }
+    return {
+      json: [{ tag_name: "v1.0.0", published_at: "2026-01-01T00:00:00Z" }],
+      headers: {
+        link: '<https://api.github.com/repos/owner/repo/releases?per_page=100&page=2>; rel="next"',
+      },
+    };
+  });
+
+  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "mosh-bin-1.4.0-1"]);
+  assert.equal(requested.length, 2);
+});
+
+test("loadReleases rejects pagination loops", async () => {
+  await assert.rejects(
+    loadReleases({ GITHUB_REPOSITORY: "owner/repo" }, async (url) => ({
+      json: [],
+      headers: { link: `<${url}>; rel="next"` },
+    })),
+    /pagination looped/,
+  );
 });
 
 test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {


### PR DESCRIPTION
## Summary
- Resolve the bundled mosh-client binary release during package builds instead of requiring every run to provide one manually.
- Keep package builds self-contained by using an explicit input or repo variable first, then falling back to the latest non-draft mosh-bin-* release.
- Keep official Windows packaging aligned with current bundled Mosh coverage by shipping Windows x64 only until win32-arm64 mosh binaries exist.
- Document the flow and cover resolver behavior, including paginated GitHub Release lookup, with tests.

## Validation
- npm test
- npm run lint
- git diff --check
- Ruby YAML parse for build.yml, build-mosh-binaries.yml, and test.yml
- Release note generation check confirms Windows arm64 download links are not emitted
- Multi-agent review rounds: initial findings fixed, final narrow review clean

## Follow-up after merge
Run build-mosh-binaries once with release_tag like mosh-bin-1.4.0-1. After that, package builds should pick it up automatically from the latest mosh-bin-* release, or from MOSH_BIN_RELEASE if explicitly set.
