### PR TITLE
[codex] Preserve provider reasoning context

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -31,6 +31,14 @@ import type { NetcattyBridge, ExecutorContext } from '../../../infrastructure/ai
 import { runExternalAgentTurn } from '../../../infrastructure/ai/externalAgentAdapter';
 import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
 import { classifyError } from '../../../infrastructure/ai/errorClassifier';
+import {
+  extractProviderContinuationFromRawChunk,
+  mergeProviderContinuation,
+  normalizeProviderContinuationOptions,
+  type OpenAIChatAssistantFields,
+  type ProviderContinuation,
+  type ProviderContinuationOptions,
+} from '../../../infrastructure/ai/providerContinuation';
 
 // -------------------------------------------------------------------
 // Stream chunk type interfaces (Issue #13: replace unsafe casts)
@@ -47,6 +55,15 @@ interface TextDeltaChunk {
 interface ReasoningChunk {
   type: 'reasoning' | 'reasoning-start' | 'reasoning-delta';
   text?: string;
+  textDelta?: string;
+  delta?: string;
+  providerMetadata?: unknown;
+}
+
+/** Shape of a raw provider chunk from the Vercel AI SDK fullStream. */
+interface RawChunk {
+  type: 'raw';
+  rawValue: unknown;
 }
 
 /** Shape of a tool-call chunk from the Vercel AI SDK fullStream. */
@@ -105,6 +122,7 @@ type StreamChunk =
   | ToolCallChunk
   | ToolResultChunk
   | ErrorChunk
+  | RawChunk
   | { type: 'reasoning-end' | 'text-start' | 'text-end' | 'start' | 'finish' | 'start-step' | 'finish-step' | 'tool-approval-request' };
 
 /** Shape of the netcatty bridge exposed on `window` (panel-specific subset). */
@@ -152,6 +170,15 @@ export interface TerminalSessionInfo {
 export interface DefaultTargetSessionHint extends TerminalSessionInfo {
   source: 'scope-target' | 'only-connected-in-scope';
 }
+
+interface CattyProviderContinuationContext {
+  openAIChatAssistantFields: Array<OpenAIChatAssistantFields | undefined>;
+}
+
+type AssistantContentPart =
+  | { type: 'reasoning'; text: string; providerOptions?: ProviderContinuationOptions }
+  | { type: 'text'; text: string }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown };
 
 /** Typed accessor for the netcatty bridge on the window object. */
 export function getNetcattyBridge(): PanelBridge | undefined {
@@ -251,6 +278,7 @@ export interface UseAIChatStreamingReturn {
     signal: AbortSignal,
     currentAssistantMsgId: string,
     advancedParams?: ProviderAdvancedParams,
+    continuationContext?: CattyProviderContinuationContext,
   ) => Promise<void>;
   /** Send a message to the Catty agent (built-in). */
   sendToCattyAgent: (
@@ -389,6 +417,7 @@ export function useAIChatStreaming({
     signal: AbortSignal,
     currentAssistantMsgId: string,
     advancedParams?: ProviderAdvancedParams,
+    continuationContext?: CattyProviderContinuationContext,
   ): Promise<void> => {
     const result = streamText({
       model,
@@ -397,6 +426,7 @@ export function useAIChatStreaming({
       tools,
       stopWhen: stepCountIs(maxIterations),
       abortSignal: signal,
+      includeRawChunks: true,
       ...(advancedParams?.maxTokens != null && { maxOutputTokens: advancedParams.maxTokens }),
       ...(advancedParams?.temperature != null && { temperature: advancedParams.temperature }),
       ...(advancedParams?.topP != null && { topP: advancedParams.topP }),
@@ -412,6 +442,64 @@ export function useAIChatStreaming({
     // -- Text-delta batching: accumulate deltas and flush periodically --
     let pendingText = '';
     let rafId: number | null = null;
+    const openAIFieldIndexByMessageId = new Map<string, number>();
+
+    const ensureAssistantMessage = (): string => {
+      if (lastAddedRole !== 'tool') return activeMsgId;
+
+      const newId = generateId();
+      addMessageToSession(streamSessionId, {
+        id: newId,
+        role: 'assistant',
+        content: '',
+        timestamp: Date.now(),
+      });
+      activeMsgId = newId;
+      lastAddedRole = 'assistant';
+      return activeMsgId;
+    };
+
+    const mergeOpenAIChatFields = (
+      messageId: string,
+      fields: OpenAIChatAssistantFields | undefined,
+    ) => {
+      if (!fields || !continuationContext) return;
+
+      let fieldIndex = openAIFieldIndexByMessageId.get(messageId);
+      if (fieldIndex === undefined) {
+        fieldIndex = continuationContext.openAIChatAssistantFields.length;
+        continuationContext.openAIChatAssistantFields.push(undefined);
+        openAIFieldIndexByMessageId.set(messageId, fieldIndex);
+      }
+
+      const merged = mergeProviderContinuation(
+        { openAIChatAssistantFields: continuationContext.openAIChatAssistantFields[fieldIndex] },
+        { openAIChatAssistantFields: fields },
+      );
+      continuationContext.openAIChatAssistantFields[fieldIndex] = merged?.openAIChatAssistantFields;
+    };
+
+    const updateAssistantContinuation = (
+      messageId: string,
+      continuation: ProviderContinuation | undefined,
+      thinkingText = '',
+    ) => {
+      if (!continuation && !thinkingText) return;
+      mergeOpenAIChatFields(messageId, continuation?.openAIChatAssistantFields);
+      updateMessageById(streamSessionId, messageId, msg => {
+        const providerContinuation = mergeProviderContinuation(msg.providerContinuation, continuation);
+        return {
+          ...msg,
+          ...(providerContinuation ? { providerContinuation } : {}),
+          ...(thinkingText ? { thinking: (msg.thinking || '') + thinkingText } : {}),
+        };
+      });
+    };
+
+    const getOpenAIReasoningText = (continuation: ProviderContinuation | undefined): string => {
+      const reasoningContent = continuation?.openAIChatAssistantFields?.reasoning_content;
+      return typeof reasoningContent === 'string' ? reasoningContent : '';
+    };
 
     const flushText = () => {
       if (pendingText) {
@@ -469,25 +557,30 @@ export function useAIChatStreaming({
           cancelPendingFlush();
           flushText();
           const typedChunk = chunk as ReasoningChunk;
-          const rText = typedChunk.text;
-          if (rText) {
-            if (lastAddedRole === 'tool') {
-              const newId = generateId();
-              addMessageToSession(streamSessionId, {
-                id: newId,
-                role: 'assistant',
-                content: '',
-                thinking: rText,
-                timestamp: Date.now(),
-              });
-              activeMsgId = newId;
-              lastAddedRole = 'assistant';
-            } else {
-              updateMessageById(streamSessionId, activeMsgId, msg => ({
-                ...msg,
-                thinking: (msg.thinking || '') + rText,
-              }));
-            }
+          const rText = typedChunk.text ?? typedChunk.textDelta ?? typedChunk.delta ?? '';
+          const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
+          const continuation = rText || providerOptions
+            ? {
+                reasoningParts: [{
+                  text: rText,
+                  ...(providerOptions ? { providerOptions } : {}),
+                }],
+              } satisfies ProviderContinuation
+            : undefined;
+          if (continuation || rText) {
+            const messageId = ensureAssistantMessage();
+            updateAssistantContinuation(messageId, continuation, rText);
+          }
+          break;
+        }
+        case 'raw': {
+          const typedChunk = chunk as RawChunk;
+          const continuation = extractProviderContinuationFromRawChunk(typedChunk.rawValue);
+          if (continuation) {
+            cancelPendingFlush();
+            flushText();
+            const messageId = ensureAssistantMessage();
+            updateAssistantContinuation(messageId, continuation, getOpenAIReasoningText(continuation));
           }
           break;
         }
@@ -778,20 +871,9 @@ export function useAIChatStreaming({
       return;
     }
 
-    // Create model with placeholder API key — the main process injects the real
-    // decrypted key when the HTTP request is proxied through IPC, so plaintext
-    // keys never transit the renderer ↔ main IPC boundary.
-    let model;
-    try {
-      model = createModelFromConfig({
-        ...context.activeProvider,
-        defaultModel: context.activeModelId || context.activeProvider.defaultModel || '',
-      });
-    } catch (e) {
-      console.error('[Catty] Model creation failed:', e);
-      reportStreamError(sessionId, abortController.signal, `Model creation failed: ${e instanceof Error ? e.message : String(e)}`);
-      return;
-    }
+    const continuationContext: CattyProviderContinuationContext = {
+      openAIChatAssistantFields: [],
+    };
 
     try {
       // Issue #5: Build SDK messages including tool-call and tool-result messages
@@ -840,10 +922,17 @@ export function useAIChatStreaming({
           if (m.toolCalls?.length) {
             // Only include tool calls that have matching results
             const resolvedCalls = m.toolCalls.filter(tc => resolvedToolCallIds.has(tc.id));
-            const contentParts: Array<
-              { type: 'text'; text: string } |
-              { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
-            > = [];
+            const contentParts: AssistantContentPart[] = [];
+            if (resolvedCalls.length > 0) {
+              for (const part of m.providerContinuation?.reasoningParts ?? []) {
+                if (!part.text && !part.providerOptions) continue;
+                contentParts.push({
+                  type: 'reasoning' as const,
+                  text: part.text,
+                  ...(part.providerOptions ? { providerOptions: part.providerOptions } : {}),
+                });
+              }
+            }
             if (m.content) {
               contentParts.push({ type: 'text' as const, text: m.content });
             }
@@ -858,6 +947,9 @@ export function useAIChatStreaming({
             // If all tool calls were orphaned, just include the text content
             if (contentParts.length > 0) {
               sdkMessages.push({ role: 'assistant', content: contentParts.length === 1 && contentParts[0].type === 'text' ? (contentParts[0] as { type: 'text'; text: string }).text : contentParts });
+              if (resolvedCalls.length > 0) {
+                continuationContext.openAIChatAssistantFields.push(m.providerContinuation?.openAIChatAssistantFields);
+              }
             }
           } else if (m.content) {
             sdkMessages.push({ role: 'assistant', content: m.content });
@@ -890,7 +982,37 @@ export function useAIChatStreaming({
         sdkMessages.push({ role: 'user', content: trimmed });
       }
 
-      await processCattyStream(sessionId, model, systemPrompt, tools, sdkMessages, abortController.signal, assistantMsgId, context.activeProvider?.advancedParams);
+      // Create model with placeholder API key — the main process injects the real
+      // decrypted key when the HTTP request is proxied through IPC, so plaintext
+      // keys never transit the renderer ↔ main IPC boundary.
+      let model;
+      try {
+        model = createModelFromConfig(
+          {
+            ...context.activeProvider,
+            defaultModel: context.activeModelId || context.activeProvider.defaultModel || '',
+          },
+          {
+            getOpenAIChatAssistantFields: () => continuationContext.openAIChatAssistantFields,
+          },
+        );
+      } catch (e) {
+        console.error('[Catty] Model creation failed:', e);
+        reportStreamError(sessionId, abortController.signal, `Model creation failed: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+
+      await processCattyStream(
+        sessionId,
+        model,
+        systemPrompt,
+        tools,
+        sdkMessages,
+        abortController.signal,
+        assistantMsgId,
+        context.activeProvider?.advancedParams,
+        continuationContext,
+      );
     } catch (err) {
       console.error('[Catty] streamText error:', err);
       reportStreamError(sessionId, abortController.signal, err);

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -33,11 +33,14 @@ import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
 import { classifyError } from '../../../infrastructure/ai/errorClassifier';
 import {
   extractProviderContinuationFromRawChunk,
+  isProviderContinuationForSource,
   mergeProviderContinuation,
   normalizeProviderContinuationOptions,
+  withProviderContinuationSource,
   type OpenAIChatAssistantFields,
   type ProviderContinuation,
   type ProviderContinuationOptions,
+  type ProviderContinuationSource,
 } from '../../../infrastructure/ai/providerContinuation';
 
 // -------------------------------------------------------------------
@@ -49,6 +52,7 @@ interface TextDeltaChunk {
   type: 'text' | 'text-delta';
   text?: string;
   textDelta?: string;
+  providerMetadata?: unknown;
 }
 
 /** Shape of a reasoning chunk from the Vercel AI SDK fullStream. */
@@ -73,6 +77,7 @@ interface ToolCallChunk {
   toolName: string;
   input?: unknown;
   args?: unknown;
+  providerMetadata?: unknown;
 }
 
 /** Shape of a tool-result chunk from the Vercel AI SDK fullStream. */
@@ -172,13 +177,21 @@ export interface DefaultTargetSessionHint extends TerminalSessionInfo {
 }
 
 interface CattyProviderContinuationContext {
+  source: ProviderContinuationSource;
   openAIChatAssistantFields: Array<OpenAIChatAssistantFields | undefined>;
 }
 
 type AssistantContentPart =
   | { type: 'reasoning'; text: string; providerOptions?: ProviderContinuationOptions }
-  | { type: 'text'; text: string }
-  | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown };
+  | { type: 'text'; text: string; providerOptions?: ProviderContinuationOptions }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown; providerOptions?: ProviderContinuationOptions };
+
+function toAssistantModelContent(parts: AssistantContentPart[]): string | AssistantContentPart[] {
+  if (parts.length === 1 && parts[0].type === 'text' && !parts[0].providerOptions) {
+    return parts[0].text;
+  }
+  return parts;
+}
 
 /** Typed accessor for the netcatty bridge on the window object. */
 export function getNetcattyBridge(): PanelBridge | undefined {
@@ -459,18 +472,25 @@ export function useAIChatStreaming({
       return activeMsgId;
     };
 
-    const mergeOpenAIChatFields = (
-      messageId: string,
-      fields: OpenAIChatAssistantFields | undefined,
-    ) => {
-      if (!fields || !continuationContext) return;
-
+    const ensureOpenAIChatFieldSlot = (messageId: string): number | undefined => {
+      if (!continuationContext) return undefined;
       let fieldIndex = openAIFieldIndexByMessageId.get(messageId);
       if (fieldIndex === undefined) {
         fieldIndex = continuationContext.openAIChatAssistantFields.length;
         continuationContext.openAIChatAssistantFields.push(undefined);
         openAIFieldIndexByMessageId.set(messageId, fieldIndex);
       }
+      return fieldIndex;
+    };
+
+    const mergeOpenAIChatFields = (
+      messageId: string,
+      fields: OpenAIChatAssistantFields | undefined,
+    ) => {
+      if (!fields || !continuationContext) return;
+
+      const fieldIndex = ensureOpenAIChatFieldSlot(messageId);
+      if (fieldIndex === undefined) return;
 
       const merged = mergeProviderContinuation(
         { openAIChatAssistantFields: continuationContext.openAIChatAssistantFields[fieldIndex] },
@@ -485,9 +505,10 @@ export function useAIChatStreaming({
       thinkingText = '',
     ) => {
       if (!continuation && !thinkingText) return;
-      mergeOpenAIChatFields(messageId, continuation?.openAIChatAssistantFields);
+      const sourcedContinuation = withProviderContinuationSource(continuation, continuationContext?.source);
+      mergeOpenAIChatFields(messageId, sourcedContinuation?.openAIChatAssistantFields);
       updateMessageById(streamSessionId, messageId, msg => {
-        const providerContinuation = mergeProviderContinuation(msg.providerContinuation, continuation);
+        const providerContinuation = mergeProviderContinuation(msg.providerContinuation, sourcedContinuation);
         return {
           ...msg,
           ...(providerContinuation ? { providerContinuation } : {}),
@@ -543,6 +564,11 @@ export function useAIChatStreaming({
         case 'text-delta': {
           const typedChunk = chunk as TextDeltaChunk;
           const text = typedChunk.text ?? typedChunk.textDelta;
+          const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
+          if (providerOptions) {
+            const messageId = ensureAssistantMessage();
+            updateAssistantContinuation(messageId, { textProviderOptions: providerOptions });
+          }
           if (text) {
             pendingText += text;
             if (rafId === null) {
@@ -596,7 +622,10 @@ export function useAIChatStreaming({
           cancelPendingFlush();
           flushText();
           const typedChunk = chunk as ToolCallChunk;
-          updateMessageById(streamSessionId, activeMsgId, msg => ({
+          const messageId = ensureAssistantMessage();
+          ensureOpenAIChatFieldSlot(messageId);
+          const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
+          updateMessageById(streamSessionId, messageId, msg => ({
             ...msg,
             toolCalls: [...(msg.toolCalls || []), {
               id: typedChunk.toolCallId,
@@ -606,6 +635,13 @@ export function useAIChatStreaming({
             executionStatus: 'running',
             statusText: undefined,
           }));
+          if (providerOptions) {
+            updateAssistantContinuation(messageId, {
+              toolCallProviderOptionsById: {
+                [typedChunk.toolCallId]: providerOptions,
+              },
+            });
+          }
           break;
         }
         case 'tool-result': {
@@ -871,7 +907,13 @@ export function useAIChatStreaming({
       return;
     }
 
+    const activeModelId = context.activeModelId || context.activeProvider.defaultModel || '';
     const continuationContext: CattyProviderContinuationContext = {
+      source: {
+        providerConfigId: context.activeProvider.id,
+        providerType: context.activeProvider.providerId,
+        modelId: activeModelId,
+      },
       openAIChatAssistantFields: [],
     };
 
@@ -919,12 +961,18 @@ export function useAIChatStreaming({
             sdkMessages.push({ role: 'user', content: m.content });
           }
         } else if (m.role === 'assistant') {
+          const activeContinuation = isProviderContinuationForSource(
+            m.providerContinuation,
+            continuationContext.source,
+          )
+            ? m.providerContinuation
+            : undefined;
           if (m.toolCalls?.length) {
             // Only include tool calls that have matching results
             const resolvedCalls = m.toolCalls.filter(tc => resolvedToolCallIds.has(tc.id));
             const contentParts: AssistantContentPart[] = [];
             if (resolvedCalls.length > 0) {
-              for (const part of m.providerContinuation?.reasoningParts ?? []) {
+              for (const part of activeContinuation?.reasoningParts ?? []) {
                 if (!part.text && !part.providerOptions) continue;
                 contentParts.push({
                   type: 'reasoning' as const,
@@ -934,25 +982,48 @@ export function useAIChatStreaming({
               }
             }
             if (m.content) {
-              contentParts.push({ type: 'text' as const, text: m.content });
+              contentParts.push({
+                type: 'text' as const,
+                text: m.content,
+                ...(activeContinuation?.textProviderOptions ? { providerOptions: activeContinuation.textProviderOptions } : {}),
+              });
             }
             for (const tc of resolvedCalls) {
+              const providerOptions = activeContinuation?.toolCallProviderOptionsById?.[tc.id];
               contentParts.push({
                 type: 'tool-call' as const,
                 toolCallId: tc.id,
                 toolName: tc.name,
                 input: tc.arguments ?? {},
+                ...(providerOptions ? { providerOptions } : {}),
               });
             }
             // If all tool calls were orphaned, just include the text content
             if (contentParts.length > 0) {
-              sdkMessages.push({ role: 'assistant', content: contentParts.length === 1 && contentParts[0].type === 'text' ? (contentParts[0] as { type: 'text'; text: string }).text : contentParts });
+              sdkMessages.push({ role: 'assistant', content: toAssistantModelContent(contentParts) });
               if (resolvedCalls.length > 0) {
-                continuationContext.openAIChatAssistantFields.push(m.providerContinuation?.openAIChatAssistantFields);
+                continuationContext.openAIChatAssistantFields.push(activeContinuation?.openAIChatAssistantFields);
               }
             }
           } else if (m.content) {
-            sdkMessages.push({ role: 'assistant', content: m.content });
+            const contentParts: AssistantContentPart[] = [];
+            for (const part of activeContinuation?.reasoningParts ?? []) {
+              if (!part.text && !part.providerOptions) continue;
+              contentParts.push({
+                type: 'reasoning' as const,
+                text: part.text,
+                ...(part.providerOptions ? { providerOptions: part.providerOptions } : {}),
+              });
+            }
+            contentParts.push({
+              type: 'text' as const,
+              text: m.content,
+              ...(activeContinuation?.textProviderOptions ? { providerOptions: activeContinuation.textProviderOptions } : {}),
+            });
+            sdkMessages.push({
+              role: 'assistant',
+              content: toAssistantModelContent(contentParts),
+            });
           }
         } else if (m.role === 'tool' && m.toolResults?.length) {
           sdkMessages.push({
@@ -990,7 +1061,7 @@ export function useAIChatStreaming({
         model = createModelFromConfig(
           {
             ...context.activeProvider,
-            defaultModel: context.activeModelId || context.activeProvider.defaultModel || '',
+            defaultModel: activeModelId,
           },
           {
             getOpenAIChatAssistantFields: () => continuationContext.openAIChatAssistantFields,

--- a/infrastructure/ai/providerContinuation.test.ts
+++ b/infrastructure/ai/providerContinuation.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  applyOpenAIChatContinuationToBody,
+  extractProviderContinuationFromRawChunk,
+  mergeProviderContinuation,
+} from './providerContinuation';
+
+test('extracts OpenAI-compatible reasoning deltas from raw provider chunks', () => {
+  const first = extractProviderContinuationFromRawChunk({
+    choices: [
+      {
+        delta: {
+          reasoning_content: 'check ',
+        },
+      },
+    ],
+  });
+  const second = extractProviderContinuationFromRawChunk({
+    choices: [
+      {
+        delta: {
+          reasoning_content: 'tools',
+        },
+      },
+    ],
+  });
+
+  const merged = mergeProviderContinuation(first, second);
+
+  assert.equal(merged?.openAIChatAssistantFields?.reasoning_content, 'check tools');
+  assert.deepEqual(merged?.reasoningParts, [{ text: 'check tools' }]);
+});
+
+test('patches OpenAI-compatible assistant tool-call messages with saved continuation fields', () => {
+  const body = JSON.stringify({
+    model: 'deepseek-v4-flash',
+    stream: true,
+    messages: [
+      { role: 'system', content: 'system' },
+      { role: 'user', content: 'inspect the host' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'run_command', arguments: '{}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+    ],
+  });
+
+  const patched = JSON.parse(
+    applyOpenAIChatContinuationToBody(body, [
+      { reasoning_content: 'need shell context' },
+    ]),
+  );
+
+  assert.equal(patched.messages[2].reasoning_content, 'need shell context');
+});
+
+test('merges provider reasoning metadata into the reasoning part it belongs to', () => {
+  const merged = mergeProviderContinuation(
+    { reasoningParts: [{ text: 'consider options' }] },
+    { reasoningParts: [{ text: '', providerOptions: { anthropic: { signature: 'sig-1' } } }] },
+  );
+
+  assert.deepEqual(merged?.reasoningParts, [
+    {
+      text: 'consider options',
+      providerOptions: { anthropic: { signature: 'sig-1' } },
+    },
+  ]);
+});
+
+test('matches continuation fields only to assistant tool-call messages', () => {
+  const body = JSON.stringify({
+    stream: true,
+    messages: [
+      { role: 'assistant', content: 'plain answer' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'run_command', arguments: '{}' },
+          },
+        ],
+      },
+    ],
+  });
+
+  const patched = JSON.parse(
+    applyOpenAIChatContinuationToBody(body, [
+      { reasoning_content: 'tool reasoning' },
+    ]),
+  );
+
+  assert.equal(patched.messages[0].reasoning_content, undefined);
+  assert.equal(patched.messages[1].reasoning_content, 'tool reasoning');
+});
+
+test('keeps assistant tool-call continuation fields aligned with message order', () => {
+  const toolCall = (id: string) => ({
+    id,
+    type: 'function',
+    function: { name: 'run_command', arguments: '{}' },
+  });
+  const body = JSON.stringify({
+    stream: true,
+    messages: [
+      { role: 'assistant', content: '', tool_calls: [toolCall('call_1')] },
+      { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      { role: 'assistant', content: '', tool_calls: [toolCall('call_2')] },
+    ],
+  });
+
+  const patched = JSON.parse(
+    applyOpenAIChatContinuationToBody(body, [
+      undefined,
+      { reasoning_content: 'second reasoning' },
+    ]),
+  );
+
+  assert.equal(patched.messages[0].reasoning_content, undefined);
+  assert.equal(patched.messages[2].reasoning_content, 'second reasoning');
+});
+
+test('leaves invalid or unchanged OpenAI-compatible request bodies alone', () => {
+  assert.equal(applyOpenAIChatContinuationToBody('{', []), '{');
+
+  const body = JSON.stringify({ stream: true, messages: [{ role: 'user', content: 'hi' }] });
+  assert.equal(applyOpenAIChatContinuationToBody(body, [{ reasoning_content: 'unused' }]), body);
+});

--- a/infrastructure/ai/providerContinuation.test.ts
+++ b/infrastructure/ai/providerContinuation.test.ts
@@ -3,7 +3,10 @@ import test from 'node:test';
 import {
   applyOpenAIChatContinuationToBody,
   extractProviderContinuationFromRawChunk,
+  isProviderContinuationForSource,
   mergeProviderContinuation,
+  normalizeProviderContinuationOptions,
+  withProviderContinuationSource,
 } from './providerContinuation';
 
 test('extracts OpenAI-compatible reasoning deltas from raw provider chunks', () => {
@@ -75,6 +78,97 @@ test('merges provider reasoning metadata into the reasoning part it belongs to',
       providerOptions: { anthropic: { signature: 'sig-1' } },
     },
   ]);
+});
+
+test('normalizes provider metadata without unsafe object keys', () => {
+  const unsafeMetadata = JSON.parse('{"google":{"thoughtSignature":"sig-1","__proto__":{"polluted":true},"nested":{"constructor":{"bad":true},"value":"safe"}},"__proto__":{"ignored":true}}');
+  const normalized = normalizeProviderContinuationOptions(unsafeMetadata);
+
+  assert.deepEqual(normalized, {
+    google: {
+      thoughtSignature: 'sig-1',
+      nested: { value: 'safe' },
+    },
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(normalized?.google ?? {}, '__proto__'), false);
+});
+
+test('merges equivalent provider options without depending on key order', () => {
+  const merged = mergeProviderContinuation(
+    { reasoningParts: [{ text: 'one ', providerOptions: { google: { b: 2, a: 1 } } }] },
+    { reasoningParts: [{ text: 'two', providerOptions: { google: { a: 1, b: 2 } } }] },
+  );
+
+  assert.deepEqual(merged?.reasoningParts, [
+    {
+      text: 'one two',
+      providerOptions: { google: { b: 2, a: 1 } },
+    },
+  ]);
+});
+
+test('cleans nested unsafe provider option keys when merging saved data', () => {
+  const unsafeOptions = JSON.parse('{"google":{"nested":{"prototype":{"bad":true},"value":"safe"}}}');
+  const merged = mergeProviderContinuation(
+    { reasoningParts: [{ text: 'one ', providerOptions: unsafeOptions }] },
+    { reasoningParts: [{ text: 'two' }] },
+  );
+
+  assert.deepEqual(merged?.reasoningParts, [
+    {
+      text: 'one ',
+      providerOptions: { google: { nested: { value: 'safe' } } },
+    },
+    { text: 'two' },
+  ]);
+});
+
+test('tracks continuation source so provider switches do not replay hidden context', () => {
+  const source = { providerConfigId: 'deepseek-custom', providerType: 'custom', modelId: 'deepseek-v4-flash' };
+  const continuation = withProviderContinuationSource(
+    { openAIChatAssistantFields: { reasoning_content: 'think' } },
+    source,
+  );
+
+  assert.equal(isProviderContinuationForSource(continuation, source), true);
+  assert.equal(
+    isProviderContinuationForSource(continuation, {
+      providerConfigId: 'openai',
+      providerType: 'openai',
+      modelId: 'gpt-5',
+    }),
+    false,
+  );
+});
+
+test('drops old hidden context instead of relabeling it when sources differ', () => {
+  const deepseek = { providerConfigId: 'deepseek-custom', providerType: 'custom', modelId: 'deepseek-v4-flash' };
+  const openai = { providerConfigId: 'openai', providerType: 'openai', modelId: 'gpt-5' };
+  const merged = mergeProviderContinuation(
+    { source: deepseek, openAIChatAssistantFields: { reasoning_content: 'old' } },
+    { source: openai, reasoningParts: [{ text: 'new' }] },
+  );
+
+  assert.deepEqual(merged, {
+    source: openai,
+    reasoningParts: [{ text: 'new' }],
+  });
+});
+
+test('merges tool-call provider options by tool call id', () => {
+  const merged = mergeProviderContinuation(
+    { toolCallProviderOptionsById: { call_1: { google: { thoughtSignature: 'sig-1' } } } },
+    { toolCallProviderOptionsById: { call_1: { google: { extra: true } } } },
+  );
+
+  assert.deepEqual(merged?.toolCallProviderOptionsById, {
+    call_1: {
+      google: {
+        thoughtSignature: 'sig-1',
+        extra: true,
+      },
+    },
+  });
 });
 
 test('matches continuation fields only to assistant tool-call messages', () => {

--- a/infrastructure/ai/providerContinuation.ts
+++ b/infrastructure/ai/providerContinuation.ts
@@ -13,8 +13,17 @@ export interface ProviderContinuationReasoningPart {
   providerOptions?: ProviderContinuationOptions;
 }
 
+export interface ProviderContinuationSource {
+  providerConfigId: string;
+  providerType: string;
+  modelId?: string;
+}
+
 export interface ProviderContinuation {
+  source?: ProviderContinuationSource;
   reasoningParts?: ProviderContinuationReasoningPart[];
+  textProviderOptions?: ProviderContinuationOptions;
+  toolCallProviderOptionsById?: Record<string, ProviderContinuationOptions>;
   openAIChatAssistantFields?: Record<string, unknown>;
 }
 
@@ -22,6 +31,10 @@ export type OpenAIChatAssistantFields = Record<string, unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSafeObjectKey(key: string): boolean {
+  return key !== '__proto__' && key !== 'prototype' && key !== 'constructor';
 }
 
 function parseRawValue(rawValue: unknown): unknown {
@@ -49,6 +62,7 @@ function toContinuationJSONValue(value: unknown): ProviderContinuationJSONValue 
   if (isRecord(value)) {
     const converted: { [key: string]: ProviderContinuationJSONValue } = {};
     for (const [key, item] of Object.entries(value)) {
+      if (!isSafeObjectKey(key)) continue;
       const convertedItem = toContinuationJSONValue(item);
       if (convertedItem !== undefined) converted[key] = convertedItem;
     }
@@ -61,9 +75,11 @@ export function normalizeProviderContinuationOptions(value: unknown): ProviderCo
   if (!isRecord(value)) return undefined;
   const options: ProviderContinuationOptions = {};
   for (const [provider, providerOptions] of Object.entries(value)) {
+    if (!isSafeObjectKey(provider)) continue;
     if (!isRecord(providerOptions)) continue;
     const normalizedProviderOptions: Record<string, ProviderContinuationJSONValue> = {};
     for (const [key, optionValue] of Object.entries(providerOptions)) {
+      if (!isSafeObjectKey(key)) continue;
       const normalizedValue = toContinuationJSONValue(optionValue);
       if (normalizedValue !== undefined) normalizedProviderOptions[key] = normalizedValue;
     }
@@ -78,7 +94,14 @@ function cloneProviderOptions(options: ProviderContinuationOptions | undefined):
   if (!options) return undefined;
   const cloned: ProviderContinuationOptions = {};
   for (const [provider, providerOptions] of Object.entries(options)) {
-    cloned[provider] = { ...providerOptions };
+    if (!isSafeObjectKey(provider)) continue;
+    const safeProviderOptions: Record<string, ProviderContinuationJSONValue> = {};
+    for (const [key, value] of Object.entries(providerOptions)) {
+      if (!isSafeObjectKey(key)) continue;
+      const normalizedValue = toContinuationJSONValue(value);
+      if (normalizedValue !== undefined) safeProviderOptions[key] = normalizedValue;
+    }
+    if (Object.keys(safeProviderOptions).length) cloned[provider] = safeProviderOptions;
   }
   return cloned;
 }
@@ -97,9 +120,18 @@ function mergeProviderOptions(
   if (!current && !incoming) return undefined;
   const merged: ProviderContinuationOptions = cloneProviderOptions(current) ?? {};
   for (const [provider, providerOptions] of Object.entries(incoming ?? {})) {
+    if (!isSafeObjectKey(provider)) continue;
+    const safeIncoming: Record<string, ProviderContinuationJSONValue> = {};
+    for (const [key, value] of Object.entries(providerOptions)) {
+      if (!isSafeObjectKey(key)) continue;
+      const normalizedValue = toContinuationJSONValue(value);
+      if (normalizedValue !== undefined) safeIncoming[key] = normalizedValue;
+    }
+    const existing = isRecord(merged[provider]) ? merged[provider] : undefined;
+    if (!existing && !Object.keys(safeIncoming).length) continue;
     merged[provider] = {
-      ...(isRecord(merged[provider]) ? merged[provider] : {}),
-      ...providerOptions,
+      ...(existing ?? {}),
+      ...safeIncoming,
     };
   }
   return Object.keys(merged).length ? merged : undefined;
@@ -110,19 +142,46 @@ function mergeAssistantFields(
   incoming: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   if (!current && !incoming) return undefined;
-  const merged: Record<string, unknown> = { ...(current ?? {}) };
+  const merged: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(current ?? {})) {
+    if (!isSafeObjectKey(key)) continue;
+    merged[key] = value;
+  }
   for (const [key, value] of Object.entries(incoming ?? {})) {
+    if (!isSafeObjectKey(key)) continue;
     if (value === undefined) continue;
+    const safeValue = typeof value === 'string' ? value : toContinuationJSONValue(value);
+    if (safeValue === undefined) continue;
     const previous = merged[key];
-    merged[key] = typeof previous === 'string' && typeof value === 'string'
-      ? previous + value
-      : value;
+    merged[key] = typeof previous === 'string' && typeof safeValue === 'string'
+      ? previous + safeValue
+      : safeValue;
   }
   return Object.keys(merged).length ? merged : undefined;
 }
 
+function isSameProviderContinuationSource(
+  current: ProviderContinuationSource | undefined,
+  incoming: ProviderContinuationSource | undefined,
+): boolean {
+  if (!current || !incoming) return false;
+  return current.providerConfigId === incoming.providerConfigId
+    && current.providerType === incoming.providerType
+    && current.modelId === incoming.modelId;
+}
+
+function stableJSONValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableJSONValue);
+  if (!isRecord(value)) return value;
+  const stable: Record<string, unknown> = {};
+  for (const key of Object.keys(value).filter(isSafeObjectKey).sort()) {
+    stable[key] = stableJSONValue(value[key]);
+  }
+  return stable;
+}
+
 function providerOptionsKey(options: ProviderContinuationOptions | undefined): string {
-  return JSON.stringify(options ?? {});
+  return JSON.stringify(stableJSONValue(options ?? {}));
 }
 
 function canMergeReasoningPart(
@@ -163,17 +222,68 @@ export function mergeProviderContinuation(
   current?: ProviderContinuation | null,
   incoming?: ProviderContinuation | null,
 ): ProviderContinuation | undefined {
-  const reasoningParts = appendReasoningParts(current?.reasoningParts, incoming?.reasoningParts);
+  const base = current?.source && incoming?.source && !isSameProviderContinuationSource(current.source, incoming.source)
+    ? undefined
+    : current;
+  const reasoningParts = appendReasoningParts(base?.reasoningParts, incoming?.reasoningParts);
+  const textProviderOptions = mergeProviderOptions(base?.textProviderOptions, incoming?.textProviderOptions);
+  const toolCallProviderOptionsById = mergeToolCallProviderOptions(
+    base?.toolCallProviderOptionsById,
+    incoming?.toolCallProviderOptionsById,
+  );
   const openAIChatAssistantFields = mergeAssistantFields(
-    current?.openAIChatAssistantFields,
+    base?.openAIChatAssistantFields,
     incoming?.openAIChatAssistantFields,
   );
+  const source = incoming?.source ?? base?.source;
 
-  if (!reasoningParts && !openAIChatAssistantFields) return undefined;
+  if (!reasoningParts && !textProviderOptions && !toolCallProviderOptionsById && !openAIChatAssistantFields) {
+    return undefined;
+  }
   return {
+    ...(source ? { source } : {}),
     ...(reasoningParts ? { reasoningParts } : {}),
+    ...(textProviderOptions ? { textProviderOptions } : {}),
+    ...(toolCallProviderOptionsById ? { toolCallProviderOptionsById } : {}),
     ...(openAIChatAssistantFields ? { openAIChatAssistantFields } : {}),
   };
+}
+
+function mergeToolCallProviderOptions(
+  current: Record<string, ProviderContinuationOptions> | undefined,
+  incoming: Record<string, ProviderContinuationOptions> | undefined,
+): Record<string, ProviderContinuationOptions> | undefined {
+  if (!current && !incoming) return undefined;
+  const merged: Record<string, ProviderContinuationOptions> = {};
+  for (const [toolCallId, providerOptions] of Object.entries(current ?? {})) {
+    if (!isSafeObjectKey(toolCallId)) continue;
+    const cloned = cloneProviderOptions(providerOptions);
+    if (cloned) merged[toolCallId] = cloned;
+  }
+  for (const [toolCallId, providerOptions] of Object.entries(incoming ?? {})) {
+    if (!isSafeObjectKey(toolCallId)) continue;
+    const next = mergeProviderOptions(merged[toolCallId], providerOptions);
+    if (next) merged[toolCallId] = next;
+  }
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+export function withProviderContinuationSource(
+  continuation: ProviderContinuation | undefined,
+  source: ProviderContinuationSource | undefined,
+): ProviderContinuation | undefined {
+  if (!continuation) return undefined;
+  return source ? { ...continuation, source } : continuation;
+}
+
+export function isProviderContinuationForSource(
+  continuation: ProviderContinuation | undefined,
+  source: ProviderContinuationSource | undefined,
+): boolean {
+  if (!continuation?.source || !source) return false;
+  return continuation.source.providerConfigId === source.providerConfigId
+    && continuation.source.providerType === source.providerType
+    && continuation.source.modelId === source.modelId;
 }
 
 export function extractProviderContinuationFromRawChunk(rawValue: unknown): ProviderContinuation | undefined {
@@ -205,8 +315,11 @@ function hasToolCalls(message: Record<string, unknown>): boolean {
 function compactAssistantFields(fields: OpenAIChatAssistantFields | undefined): OpenAIChatAssistantFields | undefined {
   const compacted: OpenAIChatAssistantFields = {};
   for (const [key, value] of Object.entries(fields ?? {})) {
+    if (!isSafeObjectKey(key)) continue;
     if (value === undefined || value === null || value === '') continue;
-    compacted[key] = value;
+    const safeValue = typeof value === 'string' ? value : toContinuationJSONValue(value);
+    if (safeValue === undefined || safeValue === null || safeValue === '') continue;
+    compacted[key] = safeValue;
   }
   return Object.keys(compacted).length ? compacted : undefined;
 }

--- a/infrastructure/ai/providerContinuation.ts
+++ b/infrastructure/ai/providerContinuation.ts
@@ -1,0 +1,249 @@
+export type ProviderContinuationJSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ProviderContinuationJSONValue[]
+  | { [key: string]: ProviderContinuationJSONValue };
+
+export type ProviderContinuationOptions = Record<string, Record<string, ProviderContinuationJSONValue>>;
+
+export interface ProviderContinuationReasoningPart {
+  text: string;
+  providerOptions?: ProviderContinuationOptions;
+}
+
+export interface ProviderContinuation {
+  reasoningParts?: ProviderContinuationReasoningPart[];
+  openAIChatAssistantFields?: Record<string, unknown>;
+}
+
+export type OpenAIChatAssistantFields = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseRawValue(rawValue: unknown): unknown {
+  if (typeof rawValue !== 'string') return rawValue;
+  try {
+    return JSON.parse(rawValue);
+  } catch {
+    return rawValue;
+  }
+}
+
+function toContinuationJSONValue(value: unknown): ProviderContinuationJSONValue | undefined {
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const values: ProviderContinuationJSONValue[] = [];
+    for (const item of value) {
+      const converted = toContinuationJSONValue(item);
+      if (converted !== undefined) values.push(converted);
+    }
+    return values;
+  }
+  if (isRecord(value)) {
+    const converted: { [key: string]: ProviderContinuationJSONValue } = {};
+    for (const [key, item] of Object.entries(value)) {
+      const convertedItem = toContinuationJSONValue(item);
+      if (convertedItem !== undefined) converted[key] = convertedItem;
+    }
+    return converted;
+  }
+  return undefined;
+}
+
+export function normalizeProviderContinuationOptions(value: unknown): ProviderContinuationOptions | undefined {
+  if (!isRecord(value)) return undefined;
+  const options: ProviderContinuationOptions = {};
+  for (const [provider, providerOptions] of Object.entries(value)) {
+    if (!isRecord(providerOptions)) continue;
+    const normalizedProviderOptions: Record<string, ProviderContinuationJSONValue> = {};
+    for (const [key, optionValue] of Object.entries(providerOptions)) {
+      const normalizedValue = toContinuationJSONValue(optionValue);
+      if (normalizedValue !== undefined) normalizedProviderOptions[key] = normalizedValue;
+    }
+    if (Object.keys(normalizedProviderOptions).length) {
+      options[provider] = normalizedProviderOptions;
+    }
+  }
+  return Object.keys(options).length ? options : undefined;
+}
+
+function cloneProviderOptions(options: ProviderContinuationOptions | undefined): ProviderContinuationOptions | undefined {
+  if (!options) return undefined;
+  const cloned: ProviderContinuationOptions = {};
+  for (const [provider, providerOptions] of Object.entries(options)) {
+    cloned[provider] = { ...providerOptions };
+  }
+  return cloned;
+}
+
+function cloneReasoningPart(part: ProviderContinuationReasoningPart): ProviderContinuationReasoningPart {
+  return {
+    text: part.text,
+    ...(part.providerOptions ? { providerOptions: cloneProviderOptions(part.providerOptions) } : {}),
+  };
+}
+
+function mergeProviderOptions(
+  current: ProviderContinuationOptions | undefined,
+  incoming: ProviderContinuationOptions | undefined,
+): ProviderContinuationOptions | undefined {
+  if (!current && !incoming) return undefined;
+  const merged: ProviderContinuationOptions = cloneProviderOptions(current) ?? {};
+  for (const [provider, providerOptions] of Object.entries(incoming ?? {})) {
+    merged[provider] = {
+      ...(isRecord(merged[provider]) ? merged[provider] : {}),
+      ...providerOptions,
+    };
+  }
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function mergeAssistantFields(
+  current: Record<string, unknown> | undefined,
+  incoming: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!current && !incoming) return undefined;
+  const merged: Record<string, unknown> = { ...(current ?? {}) };
+  for (const [key, value] of Object.entries(incoming ?? {})) {
+    if (value === undefined) continue;
+    const previous = merged[key];
+    merged[key] = typeof previous === 'string' && typeof value === 'string'
+      ? previous + value
+      : value;
+  }
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function providerOptionsKey(options: ProviderContinuationOptions | undefined): string {
+  return JSON.stringify(options ?? {});
+}
+
+function canMergeReasoningPart(
+  current: ProviderContinuationReasoningPart,
+  incoming: ProviderContinuationReasoningPart,
+): boolean {
+  if (!incoming.text) return true;
+  return providerOptionsKey(current.providerOptions) === providerOptionsKey(incoming.providerOptions);
+}
+
+function appendReasoningParts(
+  current: ProviderContinuationReasoningPart[] | undefined,
+  incoming: ProviderContinuationReasoningPart[] | undefined,
+): ProviderContinuationReasoningPart[] | undefined {
+  const merged = (current ?? []).map(cloneReasoningPart);
+
+  for (const part of incoming ?? []) {
+    if (!part.text && !part.providerOptions) continue;
+    const normalizedPart = cloneReasoningPart(part);
+    const last = merged.at(-1);
+    if (last && canMergeReasoningPart(last, normalizedPart)) {
+      last.text += normalizedPart.text;
+      const providerOptions = mergeProviderOptions(last.providerOptions, normalizedPart.providerOptions);
+      if (providerOptions) {
+        last.providerOptions = providerOptions;
+      } else {
+        delete last.providerOptions;
+      }
+      continue;
+    }
+    merged.push(normalizedPart);
+  }
+
+  return merged.length ? merged : undefined;
+}
+
+export function mergeProviderContinuation(
+  current?: ProviderContinuation | null,
+  incoming?: ProviderContinuation | null,
+): ProviderContinuation | undefined {
+  const reasoningParts = appendReasoningParts(current?.reasoningParts, incoming?.reasoningParts);
+  const openAIChatAssistantFields = mergeAssistantFields(
+    current?.openAIChatAssistantFields,
+    incoming?.openAIChatAssistantFields,
+  );
+
+  if (!reasoningParts && !openAIChatAssistantFields) return undefined;
+  return {
+    ...(reasoningParts ? { reasoningParts } : {}),
+    ...(openAIChatAssistantFields ? { openAIChatAssistantFields } : {}),
+  };
+}
+
+export function extractProviderContinuationFromRawChunk(rawValue: unknown): ProviderContinuation | undefined {
+  const parsed = parseRawValue(rawValue);
+  if (!isRecord(parsed) || !Array.isArray(parsed.choices)) return undefined;
+
+  let reasoningContent = '';
+  for (const choice of parsed.choices) {
+    if (!isRecord(choice)) continue;
+    const delta = isRecord(choice.delta) ? choice.delta : undefined;
+    const message = isRecord(choice.message) ? choice.message : undefined;
+    const rawReasoning = delta?.reasoning_content ?? message?.reasoning_content;
+    if (typeof rawReasoning === 'string' && rawReasoning) {
+      reasoningContent += rawReasoning;
+    }
+  }
+
+  if (!reasoningContent) return undefined;
+  return {
+    reasoningParts: [{ text: reasoningContent }],
+    openAIChatAssistantFields: { reasoning_content: reasoningContent },
+  };
+}
+
+function hasToolCalls(message: Record<string, unknown>): boolean {
+  return Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+}
+
+function compactAssistantFields(fields: OpenAIChatAssistantFields | undefined): OpenAIChatAssistantFields | undefined {
+  const compacted: OpenAIChatAssistantFields = {};
+  for (const [key, value] of Object.entries(fields ?? {})) {
+    if (value === undefined || value === null || value === '') continue;
+    compacted[key] = value;
+  }
+  return Object.keys(compacted).length ? compacted : undefined;
+}
+
+export function applyOpenAIChatContinuationToBody(
+  body: string,
+  assistantFieldsByToolCallMessage: Array<OpenAIChatAssistantFields | undefined>,
+): string {
+  if (!assistantFieldsByToolCallMessage.length) return body;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) return body;
+
+  let fieldIndex = 0;
+  let changed = false;
+  const messages = parsed.messages.map((message) => {
+    if (!isRecord(message) || message.role !== 'assistant' || !hasToolCalls(message)) {
+      return message;
+    }
+
+    const fields = compactAssistantFields(assistantFieldsByToolCallMessage[fieldIndex]);
+    fieldIndex += 1;
+    if (!fields) return message;
+
+    changed = true;
+    return {
+      ...message,
+      ...mergeAssistantFields(message, fields),
+    };
+  });
+
+  if (!changed) return body;
+  return JSON.stringify({ ...parsed, messages });
+}

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -2,6 +2,14 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { ProviderConfig } from '../types';
+import {
+  applyOpenAIChatContinuationToBody,
+  type OpenAIChatAssistantFields,
+} from '../providerContinuation';
+
+export interface ProviderRequestContext {
+  getOpenAIChatAssistantFields?: () => Array<OpenAIChatAssistantFields | undefined>;
+}
 
 /**
  * Bridge API subset used for SDK fetch adapter.
@@ -100,7 +108,10 @@ function toSafeStatusText(message: string, fallback: string): string {
   return byteStringSafe.slice(0, 120) || fallback;
 }
 
-export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.fetch {
+export function createBridgeFetchForSDK(
+  providerId?: string,
+  requestContext?: ProviderRequestContext,
+): typeof globalThis.fetch {
   return async (
     input: string | URL | Request,
     init?: RequestInit,
@@ -132,6 +143,12 @@ export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.
     const headers = extractHeaders(resolvedInit?.headers);
     const body =
       resolvedInit?.body != null ? String(resolvedInit.body) : undefined;
+    const requestBody = body != null
+      ? applyOpenAIChatContinuationToBody(
+          body,
+          requestContext?.getOpenAIChatAssistantFields?.() ?? [],
+        )
+      : undefined;
 
     // Streaming path
     if (isStreamingRequest(resolvedInit)) {
@@ -186,7 +203,7 @@ export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.
         requestId,
         url,
         headers,
-        body || '',
+        requestBody || '',
         providerId,
       );
 
@@ -231,7 +248,7 @@ export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.
     }
 
     // Non-streaming path
-    const result = await bridge.aiFetch(url, method, headers, body, providerId);
+    const result = await bridge.aiFetch(url, method, headers, requestBody, providerId);
 
     return new Response(result.data, {
       status: result.status,
@@ -249,10 +266,13 @@ export function createBridgeFetchForSDK(providerId?: string): typeof globalThis.
  * process replaces the placeholder with the real decrypted key before
  * making the HTTP request.
  */
-export function createModelFromConfig(config: ProviderConfig) {
+export function createModelFromConfig(
+  config: ProviderConfig,
+  requestContext?: ProviderRequestContext,
+) {
   // Use placeholder API key — the main process will inject the real key
   const safeApiKey = config.apiKey ? API_KEY_PLACEHOLDER : undefined;
-  const customFetch = createBridgeFetchForSDK(config.id);
+  const customFetch = createBridgeFetchForSDK(config.id, requestContext);
   const modelId = config.defaultModel || '';
 
   switch (config.providerId) {

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -1,4 +1,6 @@
 // AI Provider types
+import type { ProviderContinuation } from './providerContinuation';
+
 export type AIProviderId = 'openai' | 'anthropic' | 'google' | 'ollama' | 'openrouter' | 'custom';
 
 export interface ProviderAdvancedParams {
@@ -69,6 +71,7 @@ export interface ChatMessage {
   images?: ChatMessageAttachment[];
   thinking?: string;
   thinkingDurationMs?: number;
+  providerContinuation?: ProviderContinuation;
   toolCalls?: ToolCall[];
   toolResults?: ToolResult[];
   timestamp: number;


### PR DESCRIPTION
## What changed

- Preserve provider continuation data from reasoning/thinking streams and raw provider chunks.
- Reattach OpenAI-compatible reasoning context to assistant tool-call messages when sending follow-up tool results.
- Add tests for extraction, merging, request patching, and message-order alignment.

## Why

Fixes #876 by handling providers that require hidden reasoning context to be passed back during tool-use turns, without hard-coding the behavior to one model.

## Validation

- npm run lint
- npm test
- npm run build
