### PR TITLE
Fix Codex ACP model selection

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -24,6 +24,7 @@ import type {
   AIPanelView,
   AIPermissionMode,
   AIToolIntegrationMode,
+  AgentModelPreset,
   AISession,
   AISessionScope,
   ChatMessage,
@@ -69,6 +70,17 @@ import { buildAcpHistoryMessagesForBridge } from './ai/acpHistory';
 import { clearAllPendingApprovals } from '../infrastructure/ai/shared/approvalGate';
 import { useConversationExport } from './ai/hooks/useConversationExport';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
+
+function modelPresetMatchesId(preset: AgentModelPreset, modelId: string): boolean {
+  if (preset.thinkingLevels?.length) {
+    return preset.thinkingLevels.some((level) => `${preset.id}/${level}` === modelId);
+  }
+  return preset.id === modelId;
+}
+
+function modelPresetsContainId(presets: AgentModelPreset[], modelId: string): boolean {
+  return presets.some((preset) => modelPresetMatchesId(preset, modelId));
+}
 
 function isCopilotAgentConfig(agent?: ExternalAgentConfig): boolean {
   if (!agent) return false;
@@ -231,7 +243,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   const scopeKey = `${scopeType}:${scopeTargetId ?? ''}`;
 
   const [showHistory, setShowHistory] = useState(false);
-  const [runtimeAgentModelPresets, setRuntimeAgentModelPresets] = useState<Record<string, ReturnType<typeof getAgentModelPresets>>>({});
+  const [runtimeAgentModelPresets, setRuntimeAgentModelPresets] = useState<Record<string, AgentModelPreset[]>>({});
   const [userSkillOptions, setUserSkillOptions] = useState<UserSkillOption[]>([]);
   const { openSettingsWindow } = useWindowControls();
   const terminalSessionsRef = useRef(terminalSessions);
@@ -608,12 +620,10 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
 
   useEffect(() => {
     if (!currentAgentConfig?.acpCommand) return;
-    // Codex has its own path via aiCodexGetIntegration (reads config.toml).
-    // Everyone else that speaks ACP can be asked for their available models
-    // directly — in particular, Claude Code through claude-agent-acp
-    // advertises the real catalog (including Bedrock/Vertex model ids when
-    // the user configured those) instead of the hardcoded CLAUDE_MODEL_PRESETS.
-    if (!isCopilotExternalAgent && !isClaudeManagedAgent) return;
+    // ACP agents can expose their runtime model catalog during session setup.
+    // Codex also exposes model/reasoning selectors through ACP config options,
+    // which keeps the picker aligned with the user's installed CLI version.
+    if (!isCopilotExternalAgent && !isClaudeManagedAgent && !isCodexManagedAgent) return;
 
     const bridge = getNetcattyBridge();
     if (!bridge?.aiAcpListModels) return;
@@ -640,13 +650,13 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
         });
         return;
       }
-      const knownModelIds = new Set(result.models.map((model) => model.id));
+      const runtimePresets = result.models ?? [];
       setRuntimeAgentModelPresets((prev) => ({
         ...prev,
-        [currentAgentId]: result.models ?? [],
+        [currentAgentId]: runtimePresets,
       }));
       const storedModelId = agentModelMapRef.current[currentAgentId];
-      if (result.currentModelId && (!storedModelId || !knownModelIds.has(storedModelId))) {
+      if (result.currentModelId && (!storedModelId || !modelPresetsContainId(runtimePresets, storedModelId))) {
         setAgentModel(currentAgentId, result.currentModelId);
       }
     }).catch((err) => {
@@ -658,7 +668,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [currentAgentConfig, currentAgentId, isCopilotExternalAgent, isClaudeManagedAgent, setAgentModel]);
+  }, [currentAgentConfig, currentAgentId, isCopilotExternalAgent, isClaudeManagedAgent, isCodexManagedAgent, setAgentModel]);
 
   // When Codex is backed by a ~/.codex/config.toml custom provider, the
   // stock CODEX_MODEL_PRESETS catalog is invalid for that endpoint.
@@ -668,7 +678,11 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
   const hasCodexCustomConfig = codexCustomConfigResolved && isCodexManagedAgent;
 
   const agentModelPresets = useMemo(() => {
+    const runtimePresets = runtimeAgentModelPresets[currentAgentId];
     if (hasCodexCustomConfig) {
+      if (runtimePresets) {
+        return runtimePresets;
+      }
       // Config.toml with a pinned model → show just that model.
       if (codexConfigModel) {
         return [{ id: codexConfigModel, name: codexConfigModel }];
@@ -678,13 +692,13 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
       // wouldn't work. Empty list disables the picker.
       return [];
     }
-    return runtimeAgentModelPresets[currentAgentId] ?? getAgentModelPresets(currentAgentConfig?.command);
+    return runtimePresets ?? getAgentModelPresets(currentAgentConfig?.command);
   }, [currentAgentConfig?.command, currentAgentId, runtimeAgentModelPresets, hasCodexCustomConfig, codexConfigModel]);
 
   // Per-agent model: recall last selection or use first preset as default
   const selectedAgentModel = useMemo(() => {
     const stored = agentModelMap[currentAgentId];
-    if (stored && agentModelPresets.some(p => stored === p.id || stored.startsWith(p.id + '/'))) {
+    if (stored && modelPresetsContainId(agentModelPresets, stored)) {
       return stored;
     }
     // Default to first preset; for models with thinking levels, use the default level

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -142,7 +142,7 @@ export interface PanelBridge extends NetcattyBridge {
     cwd?: string,
     providerId?: string,
     chatSessionId?: string,
-  ) => Promise<{ ok: boolean; models?: Array<{ id: string; name: string; description?: string }>; currentModelId?: string | null; error?: string }>;
+  ) => Promise<{ ok: boolean; models?: Array<{ id: string; name: string; description?: string; thinkingLevels?: string[] }>; currentModelId?: string | null; error?: string }>;
   aiAcpCleanup?: (chatSessionId: string) => Promise<{ ok: boolean }>;
   aiUserSkillsGetStatus?: () => Promise<{
     ok: boolean;

--- a/electron/bridges/ai/acpModels.cjs
+++ b/electron/bridges/ai/acpModels.cjs
@@ -1,0 +1,130 @@
+function toNonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeConfigOptionValue(value) {
+  const id = toNonEmptyString(value?.value ?? value?.id);
+  if (!id) return null;
+  return {
+    id,
+    name: toNonEmptyString(value?.name ?? value?.displayName) || id,
+    description: toNonEmptyString(value?.description) || undefined,
+  };
+}
+
+function flattenConfigOptionValues(values) {
+  if (!Array.isArray(values)) return [];
+  const flattened = [];
+  for (const value of values) {
+    const nestedValues = Array.isArray(value?.options)
+      ? value.options
+      : Array.isArray(value?.items)
+        ? value.items
+        : Array.isArray(value?.children)
+          ? value.children
+          : null;
+    if (nestedValues) {
+      flattened.push(...flattenConfigOptionValues(nestedValues));
+      continue;
+    }
+    const normalized = normalizeConfigOptionValue(value);
+    if (normalized) {
+      flattened.push(normalized);
+    }
+  }
+  return flattened;
+}
+
+function findConfigOption(configOptions, category, fallbackIds = []) {
+  if (!Array.isArray(configOptions)) return null;
+  return configOptions.find((option) => {
+    const optionCategory = toNonEmptyString(option?.category);
+    const optionId = toNonEmptyString(option?.id);
+    return optionCategory === category || (optionId && fallbackIds.includes(optionId));
+  }) || null;
+}
+
+function normalizeConfigOptionsModels(sessionInfo) {
+  const configOptions = Array.isArray(sessionInfo?.configOptions)
+    ? sessionInfo.configOptions
+    : [];
+  const modelOption = findConfigOption(configOptions, "model", ["model"]);
+  const reasoningOption = findConfigOption(configOptions, "thought_level", [
+    "reasoning_effort",
+    "reasoning",
+    "thought_level",
+  ]);
+
+  const modelValues = flattenConfigOptionValues(modelOption?.options);
+  if (modelValues.length === 0) return null;
+
+  const configuredThinkingLevels = flattenConfigOptionValues(reasoningOption?.options)
+    .map((option) => option.id);
+  const availableModelIds = Array.isArray(sessionInfo?.models?.availableModels)
+    ? sessionInfo.models.availableModels
+        .map((modelInfo) => toNonEmptyString(modelInfo?.modelId ?? modelInfo?.id))
+        .filter(Boolean)
+    : [];
+  const availableModelIdSet = new Set(availableModelIds);
+  const thinkingLevelsByModelId = new Map();
+  for (const model of modelValues) {
+    const validThinkingLevels = configuredThinkingLevels.length > 0
+      ? configuredThinkingLevels.filter((level) => availableModelIdSet.has(`${model.id}/${level}`))
+      : availableModelIds
+          .filter((modelId) => modelId.startsWith(`${model.id}/`))
+          .map((modelId) => modelId.slice(model.id.length + 1))
+          .filter(Boolean);
+    if (validThinkingLevels.length > 0) {
+      thinkingLevelsByModelId.set(model.id, validThinkingLevels);
+    }
+  }
+
+  const currentFromModels = toNonEmptyString(sessionInfo?.models?.currentModelId);
+  const currentModel = toNonEmptyString(modelOption?.currentValue);
+  const currentThinking = toNonEmptyString(reasoningOption?.currentValue);
+  let currentModelId = currentFromModels;
+  if (currentModel) {
+    if (currentThinking && availableModelIdSet.has(`${currentModel}/${currentThinking}`)) {
+      currentModelId = `${currentModel}/${currentThinking}`;
+    } else if (!currentModelId || (currentModelId !== currentModel && !currentModelId.startsWith(`${currentModel}/`))) {
+      currentModelId = currentModel;
+    }
+  }
+
+  return {
+    currentModelId: currentModelId || null,
+    models: modelValues.map((model) => {
+      const modelThinkingLevels = thinkingLevelsByModelId.get(model.id);
+      return {
+        ...model,
+        ...(modelThinkingLevels ? { thinkingLevels: modelThinkingLevels } : {}),
+      };
+    }),
+  };
+}
+
+function normalizeLegacySessionModels(sessionInfo) {
+  const availableModels = Array.isArray(sessionInfo?.models?.availableModels)
+    ? sessionInfo.models.availableModels
+    : [];
+  return {
+    currentModelId: toNonEmptyString(sessionInfo?.models?.currentModelId),
+    models: availableModels.map((modelInfo) => {
+      const id = toNonEmptyString(modelInfo?.modelId ?? modelInfo?.id);
+      if (!id) return null;
+      return {
+        id,
+        name: toNonEmptyString(modelInfo?.name ?? modelInfo?.displayName) || id,
+        description: toNonEmptyString(modelInfo?.description) || undefined,
+      };
+    }).filter(Boolean),
+  };
+}
+
+function normalizeAcpSessionModels(sessionInfo) {
+  return normalizeConfigOptionsModels(sessionInfo) || normalizeLegacySessionModels(sessionInfo);
+}
+
+module.exports = {
+  normalizeAcpSessionModels,
+};

--- a/electron/bridges/ai/acpModels.test.cjs
+++ b/electron/bridges/ai/acpModels.test.cjs
@@ -1,0 +1,158 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { normalizeAcpSessionModels } = require("./acpModels.cjs");
+
+test("normalizeAcpSessionModels uses ACP config options for model and reasoning selectors", () => {
+  const result = normalizeAcpSessionModels({
+    models: {
+      currentModelId: "gpt-5.5/xhigh",
+      availableModels: [
+        { modelId: "gpt-5.5/low", name: "GPT 5.5 Low" },
+        { modelId: "gpt-5.5/medium", name: "GPT 5.5 Medium" },
+        { modelId: "gpt-5.5/high", name: "GPT 5.5 High" },
+        { modelId: "gpt-5.5/xhigh", name: "GPT 5.5 Extra High" },
+        { modelId: "gpt-5.1-codex-mini/medium", name: "Codex Mini Medium" },
+        { modelId: "gpt-5.1-codex-mini/high", name: "Codex Mini High" },
+      ],
+    },
+    configOptions: [
+      {
+        id: "model",
+        category: "model",
+        currentValue: "gpt-5.5",
+        options: [
+          { value: "gpt-5.5", name: "GPT 5.5" },
+          { value: "gpt-5.1-codex-mini", name: "Codex Mini", description: "Fast" },
+        ],
+      },
+      {
+        id: "reasoning_effort",
+        category: "thought_level",
+        currentValue: "xhigh",
+        options: [
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+          { value: "xhigh", name: "Extra High" },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.currentModelId, "gpt-5.5/xhigh");
+  assert.deepEqual(result.models, [
+    {
+      id: "gpt-5.5",
+      name: "GPT 5.5",
+      description: undefined,
+      thinkingLevels: ["low", "medium", "high", "xhigh"],
+    },
+    {
+      id: "gpt-5.1-codex-mini",
+      name: "Codex Mini",
+      description: "Fast",
+      thinkingLevels: ["medium", "high"],
+    },
+  ]);
+});
+
+test("normalizeAcpSessionModels flattens grouped ACP config option values", () => {
+  const result = normalizeAcpSessionModels({
+    models: {
+      currentModelId: "gpt-5.4/high",
+      availableModels: [
+        { modelId: "gpt-5.4/high", name: "GPT 5.4 High" },
+      ],
+    },
+    configOptions: [
+      {
+        id: "model",
+        category: "model",
+        currentValue: "gpt-5.4",
+        options: [
+          {
+            name: "Frontier",
+            options: [
+              { value: "gpt-5.4", name: "GPT 5.4" },
+            ],
+          },
+        ],
+      },
+      {
+        id: "reasoning_effort",
+        category: "thought_level",
+        currentValue: "high",
+        options: [
+          {
+            name: "Reasoning",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "high", name: "High" },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.currentModelId, "gpt-5.4/high");
+  assert.deepEqual(result.models, [
+    {
+      id: "gpt-5.4",
+      name: "GPT 5.4",
+      description: undefined,
+      thinkingLevels: ["high"],
+    },
+  ]);
+});
+
+test("normalizeAcpSessionModels infers thinking levels from available model ids", () => {
+  const result = normalizeAcpSessionModels({
+    models: {
+      currentModelId: "gpt-5.4/high",
+      availableModels: [
+        { modelId: "gpt-5.4/low", name: "GPT 5.4 Low" },
+        { modelId: "gpt-5.4/high", name: "GPT 5.4 High" },
+      ],
+    },
+    configOptions: [
+      {
+        id: "model",
+        category: "model",
+        currentValue: "gpt-5.4",
+        options: [
+          { value: "gpt-5.4", name: "GPT 5.4" },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.currentModelId, "gpt-5.4/high");
+  assert.deepEqual(result.models, [
+    {
+      id: "gpt-5.4",
+      name: "GPT 5.4",
+      description: undefined,
+      thinkingLevels: ["low", "high"],
+    },
+  ]);
+});
+
+test("normalizeAcpSessionModels falls back to legacy ACP models when config options are absent", () => {
+  const result = normalizeAcpSessionModels({
+    models: {
+      currentModelId: "claude-opus-4-5",
+      availableModels: [
+        { modelId: "claude-opus-4-5", displayName: "Opus 4.5" },
+        { modelId: "claude-sonnet-4-5", name: "Sonnet 4.5" },
+      ],
+    },
+  });
+
+  assert.equal(result.currentModelId, "claude-opus-4-5");
+  assert.deepEqual(result.models, [
+    { id: "claude-opus-4-5", name: "Opus 4.5", description: undefined },
+    { id: "claude-sonnet-4-5", name: "Sonnet 4.5", description: undefined },
+  ]);
+});

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -54,6 +54,7 @@ const {
   getCodexValidationCache,
   setCodexValidationCache,
 } = require("./ai/codexHelpers.cjs");
+const { normalizeAcpSessionModels } = require("./ai/acpModels.cjs");
 
 const DEBUG_MCP = process.env.NETCATTY_MCP_DEBUG === "1";
 const NETCATTY_TOOL_SKILL_PATH = toUnpackedAsarPath(
@@ -2269,15 +2270,13 @@ function registerHandlers(ipcMain) {
       });
 
       const sessionInfo = await provider.initSession();
-      const availableModels = Array.isArray(sessionInfo?.models?.availableModels)
-        ? sessionInfo.models.availableModels
-        : [];
+      const modelCatalog = normalizeAcpSessionModels(sessionInfo);
 
       if (isCopilotAgent) {
         logAcpDebug(agentLabel, "Fetched session models", {
           chatSessionId: chatSessionId || null,
-          currentModelId: sessionInfo?.models?.currentModelId || null,
-          availableModelIds: availableModels.map((modelInfo) => modelInfo?.modelId).filter(Boolean),
+          currentModelId: modelCatalog.currentModelId || null,
+          availableModelIds: modelCatalog.models.map((modelInfo) => modelInfo.id),
           copilotHome: copilotConfigInfo?.copilotHome || null,
           copilotMcpConfigPath: copilotConfigInfo?.configPath || null,
         });
@@ -2285,12 +2284,8 @@ function registerHandlers(ipcMain) {
 
       return {
         ok: true,
-        currentModelId: sessionInfo?.models?.currentModelId || null,
-        models: availableModels.map((modelInfo) => ({
-          id: modelInfo?.modelId,
-          name: modelInfo?.name || modelInfo?.displayName || modelInfo?.modelId,
-          description: modelInfo?.description || undefined,
-        })).filter((modelInfo) => Boolean(modelInfo.id)),
+        currentModelId: modelCatalog.currentModelId || null,
+        models: modelCatalog.models,
       };
     } catch (err) {
       console.error("[ACP] Failed to list models:", err?.message || err);

--- a/global.d.ts
+++ b/global.d.ts
@@ -936,6 +936,7 @@ declare global {
     aiCloseAgentStdin?(agentId: string): Promise<{ ok: boolean; error?: string }>;
     aiKillAgent?(agentId: string): Promise<{ ok: boolean; error?: string }>;
     aiAcpStream?(requestId: string, chatSessionId: string, acpCommand: string, acpArgs: string[], prompt: string, cwd?: string, providerId?: string, model?: string, existingSessionId?: string, historyMessages?: Array<{ role: 'user' | 'assistant'; content: string }>, images?: Array<{ base64Data: string; mediaType: string; filename?: string }>, toolIntegrationMode?: 'mcp' | 'skills', defaultTargetSession?: { sessionId: string; hostname: string; label: string; os?: string; username?: string; protocol?: string; shellType?: string; deviceType?: string; connected: boolean; source: 'scope-target' | 'only-connected-in-scope' }, userSkillsContext?: string): Promise<{ ok: boolean; error?: string }>;
+    aiAcpListModels?(acpCommand: string, acpArgs?: string[], cwd?: string, providerId?: string, chatSessionId?: string): Promise<{ ok: boolean; models?: Array<{ id: string; name: string; description?: string; thinkingLevels?: string[] }>; currentModelId?: string | null; error?: string }>;
     aiAcpCancel?(requestId: string, chatSessionId?: string): Promise<{ ok: boolean; error?: string }>;
     aiAcpCleanup?(chatSessionId: string): Promise<{ ok: boolean }>;
     onAiAcpEvent?(requestId: string, cb: (event: Record<string, unknown>) => void): () => void;


### PR DESCRIPTION
## Summary
- load Codex ACP model options dynamically instead of relying on the static preset list
- support ACP config option model/reasoning selectors when building the picker
- keep custom Codex configs from falling back to stale hardcoded models

Fixes #875

## Tests
- node --test electron/bridges/ai/acpModels.test.cjs
- npm run lint
- npm test
- npm run build