### PR TITLE
Improve ACP agent error diagnostics

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -66,6 +66,7 @@ import {
   type DefaultTargetSessionHint,
 } from './ai/hooks/useAIChatStreaming';
 import { buildAcpHistoryMessagesForBridge } from './ai/acpHistory';
+import { canSendWithAgent, findEnabledExternalAgent } from './ai/agentSendEligibility';
 import { clearAllPendingApprovals } from '../infrastructure/ai/shared/approvalGate';
 import { useConversationExport } from './ai/hooks/useConversationExport';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
@@ -698,6 +699,12 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     return undefined;
   }, [currentAgentId, agentModelMap, agentModelPresets]);
 
+  const inputAgentId = activeSession?.agentId ?? currentDraft?.agentId ?? currentAgentId;
+  const canSendCurrentAgent = useMemo(
+    () => canSendWithAgent(inputAgentId, externalAgents),
+    [inputAgentId, externalAgents],
+  );
+
   const handleAgentModelSelect = useCallback((modelId: string) => {
     setAgentModel(currentAgentId, modelId);
   }, [currentAgentId, setAgentModel]);
@@ -800,6 +807,10 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     // immediately after the first send path starts; `isStreaming` alone does
     // not protect the initial draft->session transition.
     if (!trimmed || isStreaming) return;
+    const sendAgentId = currentSessionView?.agentId ?? draft?.agentId ?? currentAgentId;
+    const agentConfig = sendAgentId !== 'catty' ? findEnabledExternalAgent(externalAgents, sendAgentId) : undefined;
+    if (sendAgentId !== 'catty' && !agentConfig) return;
+
     const selectedSkillSlugs = draft?.selectedUserSkillSlugs ?? [];
     const attachments = (draft?.attachments ?? []).map((file) => ({
       base64Data: file.base64Data,
@@ -816,8 +827,6 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
     try {
       let sessionId = currentSessionView?.id ?? null;
       let currentSession = currentSessionView ?? null;
-      const sendAgentId = currentSessionView?.agentId ?? draft?.agentId ?? currentAgentId;
-
       if (isDraftMode) {
         const scope: AISessionScope = { type: scopeType, targetId: scopeTargetId, hostIds: scopeHostIds };
         const createdSession = createSession(scope, sendAgentId);
@@ -857,7 +866,6 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
       setStreamingForScope(sessionId, true);
 
       // Create assistant message placeholder with a tracked ID
-      const agentConfig = isExternalAgent ? externalAgents.find((agent) => agent.id === sendAgentId) : undefined;
       const assistantMsgId = generateId();
       addMessageToSession(sessionId, {
         id: assistantMsgId, role: 'assistant', content: '', timestamp: Date.now(),
@@ -1088,6 +1096,7 @@ const AIChatSidePanelInner: React.FC<AIChatSidePanelProps> = ({
             onSend={handleSend}
             onStop={handleStop}
             isStreaming={isStreaming}
+            disabled={!canSendCurrentAgent}
             providerName={providerDisplayName}
             modelName={modelDisplayName}
             agentName={currentAgentId === 'catty' ? 'Catty Agent' : externalAgents.find(a => a.id === currentAgentId)?.name}

--- a/components/ai/agentSendEligibility.test.ts
+++ b/components/ai/agentSendEligibility.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { canSendWithAgent, findEnabledExternalAgent } from './agentSendEligibility';
+import type { ExternalAgentConfig } from '../../infrastructure/ai/types';
+
+const agents: ExternalAgentConfig[] = [
+  {
+    id: 'enabled-agent',
+    name: 'Enabled Agent',
+    command: '/usr/local/bin/enabled-agent',
+    enabled: true,
+  },
+  {
+    id: 'disabled-agent',
+    name: 'Disabled Agent',
+    command: '/usr/local/bin/disabled-agent',
+    enabled: false,
+  },
+];
+
+test('canSendWithAgent allows Catty and enabled external agents', () => {
+  assert.equal(canSendWithAgent('catty', agents), true);
+  assert.equal(canSendWithAgent('enabled-agent', agents), true);
+});
+
+test('canSendWithAgent blocks missing or disabled external agents', () => {
+  assert.equal(canSendWithAgent('disabled-agent', agents), false);
+  assert.equal(canSendWithAgent('missing-agent', agents), false);
+});
+
+test('findEnabledExternalAgent ignores disabled external agents', () => {
+  assert.equal(findEnabledExternalAgent(agents, 'enabled-agent')?.name, 'Enabled Agent');
+  assert.equal(findEnabledExternalAgent(agents, 'disabled-agent'), undefined);
+});

--- a/components/ai/agentSendEligibility.ts
+++ b/components/ai/agentSendEligibility.ts
@@ -1,0 +1,15 @@
+import type { ExternalAgentConfig } from "../../infrastructure/ai/types";
+
+export function findEnabledExternalAgent(
+  agents: ExternalAgentConfig[],
+  agentId: string,
+): ExternalAgentConfig | undefined {
+  return agents.find((agent) => agent.id === agentId && agent.enabled);
+}
+
+export function canSendWithAgent(
+  agentId: string,
+  agents: ExternalAgentConfig[],
+): boolean {
+  return agentId === "catty" || Boolean(findEnabledExternalAgent(agents, agentId));
+}

--- a/components/ai/managedAgentState.test.ts
+++ b/components/ai/managedAgentState.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildManagedAgentState } from '../settings/tabs/ai/managedAgentState';
+import type { ExternalAgentConfig } from '../../infrastructure/ai/types';
+
+test('buildManagedAgentState removes stale managed agents when path detection fails', () => {
+  const agents: ExternalAgentConfig[] = [
+    {
+      id: 'discovered_codex',
+      name: 'Codex CLI',
+      command: '/usr/local/bin/codex',
+      enabled: true,
+      acpCommand: 'codex-acp',
+      acpArgs: [],
+    },
+    {
+      id: 'custom-agent',
+      name: 'Custom Agent',
+      command: '/usr/local/bin/custom-agent',
+      enabled: true,
+    },
+  ];
+
+  const state = buildManagedAgentState(
+    agents,
+    'discovered_codex',
+    'codex',
+    { path: '/usr/local/bin/codex', version: null, available: false },
+  );
+
+  assert.deepEqual(
+    state.agents.map((agent) => agent.id),
+    ['custom-agent'],
+  );
+  assert.equal(state.defaultAgentId, 'catty');
+});
+
+test('buildManagedAgentState keeps unrelated defaults when removing stale managed agents', () => {
+  const agents: ExternalAgentConfig[] = [
+    {
+      id: 'discovered_claude',
+      name: 'Claude Code',
+      command: '/usr/local/bin/claude',
+      enabled: true,
+      acpCommand: 'claude-agent-acp',
+      acpArgs: [],
+    },
+    {
+      id: 'custom-agent',
+      name: 'Custom Agent',
+      command: '/usr/local/bin/custom-agent',
+      enabled: true,
+    },
+  ];
+
+  const state = buildManagedAgentState(
+    agents,
+    'custom-agent',
+    'claude',
+    { path: '/usr/local/bin/claude', version: null, available: false },
+  );
+
+  assert.deepEqual(
+    state.agents.map((agent) => agent.id),
+    ['custom-agent'],
+  );
+  assert.equal(state.defaultAgentId, 'custom-agent');
+});
+
+test('buildManagedAgentState does not remove user-created matching agents', () => {
+  const agents: ExternalAgentConfig[] = [
+    {
+      id: 'my-claude-wrapper',
+      name: 'My Claude Wrapper',
+      command: '/usr/local/bin/claude',
+      enabled: true,
+      acpCommand: 'claude-agent-acp',
+      acpArgs: [],
+    },
+  ];
+
+  const state = buildManagedAgentState(
+    agents,
+    'my-claude-wrapper',
+    'claude',
+    { path: '/usr/local/bin/claude', version: null, available: false },
+  );
+
+  assert.deepEqual(state.agents, agents);
+  assert.equal(state.defaultAgentId, 'my-claude-wrapper');
+});
+
+test('buildManagedAgentState only rewrites settings-managed discovered agents', () => {
+  const agents: ExternalAgentConfig[] = [
+    {
+      id: 'my-codex-wrapper',
+      name: 'My Codex Wrapper',
+      command: '/usr/local/bin/codex',
+      enabled: true,
+      acpCommand: 'codex-acp',
+      acpArgs: [],
+    },
+  ];
+
+  const state = buildManagedAgentState(
+    agents,
+    'my-codex-wrapper',
+    'codex',
+    { path: '/opt/netcatty/codex-acp', version: 'Bundled ACP', available: true },
+  );
+
+  assert.deepEqual(
+    state.agents.map((agent) => agent.id),
+    ['my-codex-wrapper', 'discovered_codex'],
+  );
+  assert.equal(state.agents[0], agents[0]);
+  assert.equal(state.defaultAgentId, 'my-codex-wrapper');
+});

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -17,11 +17,7 @@ import type {
   ProviderConfig,
   WebSearchConfig,
 } from "../../../infrastructure/ai/types";
-import {
-  getManagedAgentStoredPath,
-  matchesManagedAgentConfig,
-  type ManagedAgentKey,
-} from "../../../infrastructure/ai/managedAgents";
+import type { ManagedAgentKey } from "../../../infrastructure/ai/managedAgents";
 import { PROVIDER_PRESETS } from "../../../infrastructure/ai/types";
 import { useI18n } from "../../../application/i18n/I18nProvider";
 import { TabsContent } from "../../ui/tabs";
@@ -36,7 +32,6 @@ import type {
   UserSkillsStatusResult,
 } from "./ai/types";
 import {
-  AGENT_DEFAULTS,
   getBridge,
   normalizeCodexBridgeError,
 } from "./ai/types";
@@ -48,6 +43,11 @@ import { ClaudeCodeCard } from "./ai/ClaudeCodeCard";
 import { CopilotCliCard } from "./ai/CopilotCliCard";
 import { SafetySettings } from "./ai/SafetySettings";
 import { WebSearchSettings } from "./ai/WebSearchSettings";
+import {
+  areExternalAgentListsEqual,
+  buildManagedAgentState,
+  getInitialManagedAgentPaths,
+} from "./ai/managedAgentState";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -78,54 +78,6 @@ interface SettingsAITabProps {
   setMaxIterations: (value: number) => void;
   webSearchConfig: WebSearchConfig | null;
   setWebSearchConfig: (config: WebSearchConfig | null) => void;
-}
-
-function areExternalAgentListsEqual(
-  left: ExternalAgentConfig[],
-  right: ExternalAgentConfig[],
-): boolean {
-  if (left.length !== right.length) return false;
-  return left.every((agent, index) => JSON.stringify(agent) === JSON.stringify(right[index]));
-}
-
-function buildManagedAgentState(
-  prevAgents: ExternalAgentConfig[],
-  defaultAgentId: string,
-  agentKey: ManagedAgentKey,
-  pathInfo: AgentPathInfo | null,
-): { agents: ExternalAgentConfig[]; defaultAgentId: string } {
-  const managedId = `discovered_${agentKey}`;
-  const managedAgents = prevAgents.filter((agent) => matchesManagedAgentConfig(agent, agentKey));
-  const otherAgents = prevAgents.filter((agent) => !matchesManagedAgentConfig(agent, agentKey));
-  const storedPath = getManagedAgentStoredPath(prevAgents, agentKey);
-
-  if (!pathInfo?.available || !pathInfo.path) {
-    return {
-      agents: storedPath ? prevAgents : otherAgents,
-      defaultAgentId: storedPath
-        ? defaultAgentId
-        : managedAgents.some((agent) => agent.id === defaultAgentId)
-          ? "catty"
-          : defaultAgentId,
-    };
-  }
-
-  const existingManaged = managedAgents.find((agent) => agent.id === managedId);
-  const defaults = AGENT_DEFAULTS[agentKey];
-  const nextManagedAgent: ExternalAgentConfig = {
-    ...existingManaged,
-    ...defaults,
-    id: managedId,
-    command: pathInfo.path,
-    enabled: managedAgents.length === 0 ? true : managedAgents.some((agent) => agent.enabled),
-  };
-
-  return {
-    agents: [...otherAgents, nextManagedAgent],
-    defaultAgentId: managedAgents.some((agent) => agent.id === defaultAgentId)
-      ? managedId
-      : defaultAgentId,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -179,11 +131,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     copilot: string;
   } | null>(null);
   if (!initialManagedPathsRef.current) {
-    initialManagedPathsRef.current = {
-      codex: getManagedAgentStoredPath(externalAgents, "codex") ?? "",
-      claude: getManagedAgentStoredPath(externalAgents, "claude") ?? "",
-      copilot: getManagedAgentStoredPath(externalAgents, "copilot") ?? "",
-    };
+    initialManagedPathsRef.current = getInitialManagedAgentPaths(externalAgents);
   }
 
   const [copilotPathInfo, setCopilotPathInfo] = useState<AgentPathInfo | null>(null);

--- a/components/settings/tabs/ai/managedAgentState.ts
+++ b/components/settings/tabs/ai/managedAgentState.ts
@@ -1,0 +1,72 @@
+import type { ExternalAgentConfig } from "../../../../infrastructure/ai/types";
+import {
+  type ManagedAgentKey,
+} from "../../../../infrastructure/ai/managedAgents";
+import type { AgentPathInfo } from "./types";
+import { AGENT_DEFAULTS } from "./types";
+
+function isPathLikeCommand(command: string | undefined): boolean {
+  const normalized = String(command || "").trim();
+  return normalized.includes("/") || normalized.includes("\\");
+}
+
+function getAutoManagedAgentStoredPath(
+  agents: ExternalAgentConfig[],
+  agentKey: ManagedAgentKey,
+): string | null {
+  const managed = agents.find((agent) => agent.id === `discovered_${agentKey}`);
+  return isPathLikeCommand(managed?.command) ? managed?.command ?? null : null;
+}
+
+export function areExternalAgentListsEqual(
+  left: ExternalAgentConfig[],
+  right: ExternalAgentConfig[],
+): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((agent, index) => JSON.stringify(agent) === JSON.stringify(right[index]));
+}
+
+export function buildManagedAgentState(
+  prevAgents: ExternalAgentConfig[],
+  defaultAgentId: string,
+  agentKey: ManagedAgentKey,
+  pathInfo: AgentPathInfo | null,
+): { agents: ExternalAgentConfig[]; defaultAgentId: string } {
+  const managedId = `discovered_${agentKey}`;
+  const managedAgents = prevAgents.filter((agent) => agent.id === managedId);
+  const otherAgents = prevAgents.filter((agent) => agent.id !== managedId);
+
+  if (!pathInfo?.available || !pathInfo.path) {
+    return {
+      agents: otherAgents,
+      defaultAgentId: managedAgents.some((agent) => agent.id === defaultAgentId)
+        ? "catty"
+        : defaultAgentId,
+    };
+  }
+
+  const existingManaged = managedAgents.find((agent) => agent.id === managedId);
+  const defaults = AGENT_DEFAULTS[agentKey];
+  const nextManagedAgent: ExternalAgentConfig = {
+    ...existingManaged,
+    ...defaults,
+    id: managedId,
+    command: pathInfo.path,
+    enabled: managedAgents.length === 0 ? true : managedAgents.some((agent) => agent.enabled),
+  };
+
+  return {
+    agents: [...otherAgents, nextManagedAgent],
+    defaultAgentId: managedAgents.some((agent) => agent.id === defaultAgentId)
+      ? managedId
+      : defaultAgentId,
+  };
+}
+
+export function getInitialManagedAgentPaths(agents: ExternalAgentConfig[]) {
+  return {
+    codex: getAutoManagedAgentStoredPath(agents, "codex") ?? "",
+    claude: getAutoManagedAgentStoredPath(agents, "claude") ?? "",
+    copilot: getAutoManagedAgentStoredPath(agents, "copilot") ?? "",
+  };
+}

--- a/electron/bridges/ai/codexHelpers.cjs
+++ b/electron/bridges/ai/codexHelpers.cjs
@@ -353,16 +353,57 @@ function normalizeCodexIntegrationState(rawOutput) {
 
 // ── Error helpers ──
 
+function safeJsonStringify(value) {
+  const seen = new WeakSet();
+  try {
+    return JSON.stringify(value, (_key, nestedValue) => {
+      if (typeof nestedValue !== "object" || nestedValue === null) {
+        return nestedValue;
+      }
+      if (seen.has(nestedValue)) {
+        return "[Circular]";
+      }
+      seen.add(nestedValue);
+      return nestedValue;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function stringifyErrorValue(value, seen = new WeakSet()) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof Error) return value.message || value.name || String(value);
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular error]";
+  seen.add(value);
+
+  const candidates = [
+    value?.data?.message,
+    value?.data?.error,
+    value?.errorText,
+    value?.message,
+    value?.error,
+    value?.cause,
+    value?.data,
+  ];
+  for (const candidate of candidates) {
+    const message = stringifyErrorValue(candidate, seen).trim();
+    if (message && message !== "{}") {
+      return message;
+    }
+  }
+
+  return safeJsonStringify(value) || String(value);
+}
+
 function extractCodexError(error) {
-  const message =
-    error?.data?.message ||
-    error?.errorText ||
-    error?.message ||
-    error?.error ||
-    String(error);
-  const code = error?.data?.code || error?.code;
+  const message = stringifyErrorValue(error) || "Unknown Codex error";
+  const code = error?.data?.code || error?.code || error?.error?.code || error?.data?.error?.code;
   return {
-    message: typeof message === "string" ? message : String(message),
+    message,
     code: typeof code === "string" ? code : undefined,
   };
 }

--- a/electron/bridges/ai/codexHelpers.test.cjs
+++ b/electron/bridges/ai/codexHelpers.test.cjs
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { extractCodexError } = require("./codexHelpers.cjs");
+
+test("extractCodexError preserves nested error object messages", () => {
+  const normalized = extractCodexError({
+    error: {
+      code: "model_not_found",
+      message: "Model gpt-test is not available",
+    },
+  });
+
+  assert.deepEqual(normalized, {
+    message: "Model gpt-test is not available",
+    code: "model_not_found",
+  });
+});
+
+test("extractCodexError stringifies unknown object errors instead of [object Object]", () => {
+  const normalized = extractCodexError({
+    status: 400,
+    detail: "Bad request",
+  });
+
+  assert.equal(normalized.message, '{"status":400,"detail":"Bad request"}');
+  assert.equal(normalized.code, undefined);
+});
+
+test("extractCodexError handles circular structured errors", () => {
+  const error = { status: 500 };
+  error.self = error;
+
+  const normalized = extractCodexError(error);
+
+  assert.equal(normalized.message, '{"status":500,"self":"[Circular]"}');
+});

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -202,6 +202,15 @@ function toUnpackedAsarPath(filePath) {
   return filePath;
 }
 
+function isPlausibleCliVersionOutput(value) {
+  const line = stripAnsi(String(value || "")).trim().split(/\r?\n/)[0]?.trim() || "";
+  if (!line) return false;
+  if (/^(?:file|node):\/\//i.test(line)) return false;
+  if (/^\s*at\s+/i.test(line)) return false;
+  if (/\b(?:Error|TypeError|ReferenceError|SyntaxError|ERR_[A-Z_]+)\b/.test(line)) return false;
+  return /(?:^|[^\d])v?\d+(?:\.\d+){1,3}(?:[-+][0-9A-Za-z.-]+)?(?:$|[^\d])/.test(line);
+}
+
 // ── Shell environment (cached) ──
 
 let _cachedShellEnv = null;
@@ -374,6 +383,7 @@ module.exports = {
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   toUnpackedAsarPath,
+  isPlausibleCliVersionOutput,
   getShellEnv,
   invalidateShellEnvCache,
   serializeStreamChunk,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -5,6 +5,7 @@ const {
   extractTrailingIdlePrompt,
   getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
+  isPlausibleCliVersionOutput,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
 
@@ -63,6 +64,16 @@ test("isDefaultPowerShellPromptLine matches default shapes and rejects look-alik
   assert.equal(isDefaultPowerShellPromptLine("ZIPS>"), false);
   assert.equal(isDefaultPowerShellPromptLine(""), false);
   assert.equal(isDefaultPowerShellPromptLine(null), false);
+});
+
+test("isPlausibleCliVersionOutput rejects stack traces and file URLs", () => {
+  assert.equal(isPlausibleCliVersionOutput("2.1.123 (Claude Code)"), true);
+  assert.equal(isPlausibleCliVersionOutput("codex-cli 0.125.0"), true);
+  assert.equal(isPlausibleCliVersionOutput("file:///opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/cli.js:95"), false);
+  assert.equal(isPlausibleCliVersionOutput("TypeError: Cannot read properties of undefined"), false);
+  assert.equal(isPlausibleCliVersionOutput("    at runCli (cli.js:10:1)"), false);
+  assert.equal(isPlausibleCliVersionOutput("permission denied"), false);
+  assert.equal(isPlausibleCliVersionOutput("Usage: claude [options]"), false);
 });
 
 test("tracks PowerShell idle prompt after SSH output", () => {

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -29,6 +29,7 @@ const {
   shouldUseShellForCommand,
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
+  isPlausibleCliVersionOutput,
   getShellEnv,
   getFreshIdlePrompt,
   invalidateShellEnvCache,
@@ -1428,6 +1429,67 @@ function registerHandlers(ipcMain) {
     });
   }
 
+  function getCommandOutput(result) {
+    return [result?.stdout, result?.stderr]
+      .filter((chunk) => typeof chunk === "string" && chunk.length > 0)
+      .join("\n")
+      .trim();
+  }
+
+  function getFirstCommandOutputLine(result) {
+    return getCommandOutput(result).split(/\r?\n/)[0] || "";
+  }
+
+  async function probeCliVersion(probeCmd, probeArgs, env) {
+    try {
+      const result = await runCommand(probeCmd, probeArgs, { env });
+      return {
+        launched: true,
+        exitCode: result.exitCode,
+        output: getCommandOutput(result),
+        version: getFirstCommandOutputLine(result),
+      };
+    } catch {
+      return {
+        launched: false,
+        exitCode: null,
+        output: "",
+        version: "",
+      };
+    }
+  }
+
+  function isCodexAcpFallbackPath(command, usesAcpFallback, resolvedPath) {
+    return (
+      command === "codex" &&
+      usesAcpFallback &&
+      path.basename(resolvedPath || "").toLowerCase().startsWith("codex-acp")
+    );
+  }
+
+  function isCodexAcpFallbackProbeUsable(command, usesAcpFallback, resolvedPath, probe) {
+    if (!isCodexAcpFallbackPath(command, usesAcpFallback, resolvedPath) || !probe?.launched) {
+      return false;
+    }
+    const output = String(probe.output || "").toLowerCase();
+    const hasCodexAcpUsage = /\busage:\s*codex-acp(?:\.exe)?\s+\[options\]/.test(output);
+    const rejectedVersionFlag =
+      /(unexpected|unrecognized|unknown)\s+(argument|option|flag)\s+['"]?--version['"]?/.test(output) ||
+      /['"]?--version['"]?\s+(found|is\s+)?(unexpected|unrecognized|unknown)/.test(output);
+    return hasCodexAcpUsage && rejectedVersionFlag;
+  }
+
+  function isClaudeAcpFallbackProbeUsable(command, usesAcpFallback, probe) {
+    return command === "claude" && usesAcpFallback && probe?.launched && probe.exitCode === 0;
+  }
+
+  function isAcpFallbackProbeUsable(command, usesAcpFallback, resolvedPath, probe) {
+    return (
+      isCodexAcpFallbackProbeUsable(command, usesAcpFallback, resolvedPath, probe) ||
+      isClaudeAcpFallbackProbeUsable(command, usesAcpFallback, probe)
+    );
+  }
+
   async function runCodexCli(args, options) {
     const shellEnv = await getShellEnv();
     const codexCliPath = resolveCliFromPath("codex", shellEnv) || "codex";
@@ -1676,11 +1738,17 @@ function registerHandlers(ipcMain) {
       // resolveCodexAcpBinaryPath returns a plain string.
       let versionCommand = null;
       let versionPrependArgs = [];
-      if (!resolvedPath && agent.resolveAcp) {
+      let usesAcpFallback = false;
+      const tryResolveAcpFallback = () => {
+        if (!agent.resolveAcp) return false;
         const result = agent.resolveAcp(shellEnv, electronModule);
         if (typeof result === "string") {
           if (result && result !== agent.acpCommand && existsSync(result)) {
             resolvedPath = result;
+            versionCommand = null;
+            versionPrependArgs = [];
+            usesAcpFallback = true;
+            return true;
           }
         } else if (result?.command) {
           // On Windows the command may be `node` with the script in prependArgs.
@@ -1690,39 +1758,62 @@ function registerHandlers(ipcMain) {
           const displayPath = scriptPath || result.command;
           if (displayPath !== agent.acpCommand && existsSync(displayPath)) {
             resolvedPath = displayPath;
+            usesAcpFallback = true;
             if (scriptPath) {
               versionCommand = result.command;
               versionPrependArgs = result.prependArgs;
+            } else {
+              versionCommand = null;
+              versionPrependArgs = [];
             }
+            return true;
           }
         }
+        return false;
+      };
+      if (!resolvedPath) {
+        tryResolveAcpFallback();
       }
 
       if (!resolvedPath || seenPaths.has(resolvedPath)) {
         continue;
       }
 
-      let version = "";
-      try {
-        // When the agent is invoked via Node (Windows), probe version with
-        // the full command (e.g. `node /path/to/dist/index.js --version`).
-        const probeCmd = versionCommand || resolvedPath;
-        const probeArgs = [...versionPrependArgs, "--version"];
-        const result = await runCommand(probeCmd, probeArgs, { env: shellEnv });
-        version = (result.stdout || result.stderr || "").trim().split("\n")[0];
-      } catch {
-        // --version failed: not a valid CLI executable (e.g. .app bundle)
-        continue;
+      // When the agent is invoked via Node (Windows), probe version with
+      // the full command (e.g. `node /path/to/dist/index.js --version`).
+      let probe = await probeCliVersion(versionCommand || resolvedPath, [...versionPrependArgs, "--version"], shellEnv);
+      let version = probe.version;
+      let hasPlausibleVersion = probe.exitCode === 0 && isPlausibleCliVersionOutput(version);
+      let hasUsableAcpFallback = isAcpFallbackProbeUsable(
+        agent.command,
+        usesAcpFallback,
+        resolvedPath,
+        probe,
+      );
+
+      if (!hasPlausibleVersion && !hasUsableAcpFallback && !usesAcpFallback && agent.command === "codex") {
+        const previousPath = resolvedPath;
+        if (tryResolveAcpFallback() && resolvedPath !== previousPath && !seenPaths.has(resolvedPath)) {
+          probe = await probeCliVersion(versionCommand || resolvedPath, [...versionPrependArgs, "--version"], shellEnv);
+          version = probe.version;
+          hasPlausibleVersion = probe.exitCode === 0 && isPlausibleCliVersionOutput(version);
+          hasUsableAcpFallback = isAcpFallbackProbeUsable(
+            agent.command,
+            usesAcpFallback,
+            resolvedPath,
+            probe,
+          );
+        }
       }
 
-      if (!version) continue;
+      if (!hasPlausibleVersion && !hasUsableAcpFallback) continue;
 
       const { resolveAcp: _unused, ...agentInfo } = agent;
       agents.push({
         ...agentInfo,
         acpCommand: agent.command === "copilot" ? resolvedPath : agentInfo.acpCommand,
         path: resolvedPath,
-        version,
+        version: hasPlausibleVersion ? version : "Bundled ACP",
         available: true,
       });
       seenPaths.add(resolvedPath);
@@ -1736,6 +1827,50 @@ function registerHandlers(ipcMain) {
     if (!validateSenderOrSettings(event)) return { ok: false, error: "Unauthorized IPC sender" };
     const shellEnv = await getShellEnv();
     let resolvedPath = null;
+    let versionCommand = null;
+    let versionPrependArgs = [];
+    let usesAcpFallback = false;
+    const getBundledAcpFallback = () => {
+      if (command === "codex") {
+        const acpPath = resolveCodexAcpBinaryPath(shellEnv, electronModule);
+        if (acpPath && acpPath !== "codex-acp" && existsSync(acpPath)) {
+          return {
+            displayPath: acpPath,
+            command: null,
+            prependArgs: [],
+          };
+        }
+        return null;
+      }
+      if (command === "claude") {
+        const acpPath = resolveClaudeAcpBinaryPath(shellEnv, electronModule);
+        const scriptPath = acpPath?.prependArgs?.[0];
+        const displayPath = scriptPath || acpPath?.command;
+        if (displayPath && displayPath !== "claude-agent-acp" && existsSync(displayPath)) {
+          return {
+            displayPath,
+            command: scriptPath ? acpPath.command : null,
+            prependArgs: scriptPath ? acpPath.prependArgs : [],
+          };
+        }
+      }
+      return null;
+    };
+    const resolveBundledAcpFallback = () => {
+      const fallback = getBundledAcpFallback();
+      if (!fallback) return false;
+      if (resolvedPath === fallback.displayPath) {
+        versionCommand = fallback.command;
+        versionPrependArgs = fallback.prependArgs;
+        usesAcpFallback = true;
+        return true;
+      }
+      resolvedPath = fallback.displayPath;
+      versionCommand = fallback.command;
+      versionPrependArgs = fallback.prependArgs;
+      usesAcpFallback = true;
+      return true;
+    };
 
     if (customPath) {
       // Normalize Windows shim paths like `codex` -> `codex.cmd` when present.
@@ -1745,25 +1880,38 @@ function registerHandlers(ipcMain) {
     } else {
       resolvedPath = resolveCliFromPath(command, shellEnv);
     }
+    if (!resolvedPath) {
+      resolveBundledAcpFallback();
+    } else {
+      const fallback = getBundledAcpFallback();
+      if (fallback && resolvedPath === fallback.displayPath) {
+        versionCommand = fallback.command;
+        versionPrependArgs = fallback.prependArgs;
+        usesAcpFallback = true;
+      }
+    }
 
     if (!resolvedPath) {
       return { path: null, version: null, available: false };
     }
 
-    let version = "";
-    try {
-      const result = await runCommand(resolvedPath, ["--version"], { env: shellEnv });
-      version = (result.stdout || result.stderr || "").trim().split("\n")[0];
-    } catch {
-      // --version failed: not a valid CLI executable
+    let probe = await probeCliVersion(versionCommand || resolvedPath, [...versionPrependArgs, "--version"], shellEnv);
+    let version = probe.version;
+    let hasPlausibleVersion = probe.exitCode === 0 && isPlausibleCliVersionOutput(version);
+    let hasUsableAcpFallback = isAcpFallbackProbeUsable(command, usesAcpFallback, resolvedPath, probe);
+    if (!hasPlausibleVersion && !hasUsableAcpFallback && !usesAcpFallback && command === "codex") {
+      if (resolveBundledAcpFallback()) {
+        probe = await probeCliVersion(versionCommand || resolvedPath, [...versionPrependArgs, "--version"], shellEnv);
+        version = probe.version;
+        hasPlausibleVersion = probe.exitCode === 0 && isPlausibleCliVersionOutput(version);
+        hasUsableAcpFallback = isAcpFallbackProbeUsable(command, usesAcpFallback, resolvedPath, probe);
+      }
+    }
+    if (!hasPlausibleVersion && !hasUsableAcpFallback) {
       return { path: resolvedPath, version: null, available: false };
     }
 
-    if (!version) {
-      return { path: resolvedPath, version: null, available: false };
-    }
-
-    return { path: resolvedPath, version, available: true };
+    return { path: resolvedPath, version: hasPlausibleVersion ? version : "Bundled ACP", available: true };
   });
 
   ipcMain.handle("netcatty:ai:codex:get-integration", async (event, options) => {
@@ -2293,8 +2441,9 @@ function registerHandlers(ipcMain) {
         })).filter((modelInfo) => Boolean(modelInfo.id)),
       };
     } catch (err) {
-      console.error("[ACP] Failed to list models:", err?.message || err);
-      return { ok: false, error: err?.message || String(err) };
+      const normalized = extractCodexError(err);
+      console.error("[ACP] Failed to list models:", normalized.message);
+      return { ok: false, error: normalized.message };
     } finally {
       try {
         cleanupAcpProviderInstance(provider, chatSessionId || "transient-model-list");

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -1,6 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const Module = require("node:module");
+const os = require("node:os");
+const path = require("node:path");
 
 function createIpcMainStub() {
   const handlers = new Map();
@@ -25,6 +28,40 @@ function createEmptyStreamResult() {
       },
     },
   };
+}
+
+function writeFakeCodexAcpUsage(filePath) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(
+      filePath,
+      "@echo off\r\necho error: unexpected argument '--version' found\r\necho.\r\necho Usage: codex-acp [OPTIONS]\r\nexit /b 2\r\n",
+      "utf8",
+    );
+    return;
+  }
+  fs.writeFileSync(
+    filePath,
+    "#!/bin/sh\necho \"error: unexpected argument '--version' found\"\necho\necho 'Usage: codex-acp [OPTIONS]'\nexit 2\n",
+    "utf8",
+  );
+  fs.chmodSync(filePath, 0o755);
+}
+
+function writeFakeCodexAcpLoaderError(filePath) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(
+      filePath,
+      "@echo off\r\necho codex-acp: error while loading shared libraries: libssl.so: cannot open shared object file\r\nexit /b 127\r\n",
+      "utf8",
+    );
+    return;
+  }
+  fs.writeFileSync(
+    filePath,
+    "#!/bin/sh\necho 'codex-acp: error while loading shared libraries: libssl.so: cannot open shared object file'\nexit 127\n",
+    "utf8",
+  );
+  fs.chmodSync(filePath, 0o755);
 }
 
 function loadBridgeWithMocks(options = {}) {
@@ -74,10 +111,23 @@ function loadBridgeWithMocks(options = {}) {
     },
     "./ai/shellUtils.cjs": {
       stripAnsi: (value) => value,
-      normalizeCliPathForPlatform: (value) => value,
+      normalizeCliPathForPlatform: (...args) =>
+        typeof options.normalizeCliPathForPlatform === "function"
+          ? options.normalizeCliPathForPlatform(...args)
+          : args[0],
       shouldUseShellForCommand: () => false,
-      resolveCliFromPath: () => null,
-      resolveClaudeAcpBinaryPath: () => null,
+      isPlausibleCliVersionOutput: (value) =>
+        typeof options.isPlausibleCliVersionOutput === "function"
+          ? options.isPlausibleCliVersionOutput(value)
+          : true,
+      resolveCliFromPath: (...args) =>
+        typeof options.resolveCliFromPath === "function"
+          ? options.resolveCliFromPath(...args)
+          : null,
+      resolveClaudeAcpBinaryPath: (...args) =>
+        typeof options.resolveClaudeAcpBinaryPath === "function"
+          ? options.resolveClaudeAcpBinaryPath(...args)
+          : null,
       getShellEnv: async () => ({}),
       invalidateShellEnvCache() {},
       serializeStreamChunk: (chunk) => chunk,
@@ -85,7 +135,10 @@ function loadBridgeWithMocks(options = {}) {
     },
     "./ai/codexHelpers.cjs": {
       codexLoginSessions: new Map(),
-      resolveCodexAcpBinaryPath: () => null,
+      resolveCodexAcpBinaryPath: (...args) =>
+        typeof options.resolveCodexAcpBinaryPath === "function"
+          ? options.resolveCodexAcpBinaryPath(...args)
+          : null,
       appendCodexLoginOutput() {},
       toCodexLoginSessionResponse: () => ({}),
       getActiveCodexLoginSession: () => null,
@@ -198,6 +251,582 @@ function loadBridgeWithMocks(options = {}) {
     throw error;
   }
 }
+
+test("discovers bundled Codex ACP fallback when --version prints usage", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpUsage(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].command, "codex");
+    assert.equal(agents[0].path, codexAcpPath);
+    assert.equal(agents[0].version, "Bundled ACP");
+    assert.equal(agents[0].available, true);
+  } finally {
+    restore();
+  }
+});
+
+test("discovers bundled Codex ACP fallback when PATH Codex shim is broken", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-broken-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexPath = path.join(tempDir, process.platform === "win32" ? "codex.cmd" : "codex");
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  if (process.platform === "win32") {
+    fs.writeFileSync(codexPath, "@echo off\r\necho TypeError: Cannot read properties of undefined\r\n", "utf8");
+    writeFakeCodexAcpUsage(codexAcpPath);
+  } else {
+    fs.writeFileSync(codexPath, "#!/bin/sh\necho 'TypeError: Cannot read properties of undefined'\n", "utf8");
+    fs.chmodSync(codexPath, 0o755);
+    writeFakeCodexAcpUsage(codexAcpPath);
+  }
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCliFromPath: (command) => (command === "codex" ? codexPath : null),
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].command, "codex");
+    assert.equal(agents[0].path, codexAcpPath);
+    assert.equal(agents[0].version, "Bundled ACP");
+    assert.equal(agents[0].available, true);
+  } finally {
+    restore();
+  }
+});
+
+test("discovers bundled Codex ACP fallback when PATH Codex exits nonzero", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-exit-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexPath = path.join(tempDir, process.platform === "win32" ? "codex.cmd" : "codex");
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  if (process.platform === "win32") {
+    fs.writeFileSync(codexPath, "@echo off\r\necho codex-cli 1.0.0\r\nexit /b 1\r\n", "utf8");
+    writeFakeCodexAcpUsage(codexAcpPath);
+  } else {
+    fs.writeFileSync(codexPath, "#!/bin/sh\necho 'codex-cli 1.0.0'\nexit 1\n", "utf8");
+    fs.chmodSync(codexPath, 0o755);
+    writeFakeCodexAcpUsage(codexAcpPath);
+  }
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: (value) => String(value).startsWith("codex-cli"),
+    resolveCliFromPath: (command) => (command === "codex" ? codexPath : null),
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].command, "codex");
+    assert.equal(agents[0].path, codexAcpPath);
+    assert.equal(agents[0].version, "Bundled ACP");
+    assert.equal(agents[0].available, true);
+  } finally {
+    restore();
+  }
+});
+
+test("does not discover bundled Codex ACP fallback when the fallback cannot run", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-bad-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  fs.mkdirSync(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("does not discover bundled Codex ACP fallback when the fallback prints a loader error", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-loader-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpLoaderError(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli accepts bundled Codex ACP fallback when --version prints usage", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-resolve-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpUsage(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli accepts stored bundled Codex ACP path", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-stored-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpUsage(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    normalizeCliPathForPlatform: () => codexAcpPath,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler(
+      { sender: { id: 1 } },
+      { command: "codex", customPath: codexAcpPath },
+    );
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli falls back to bundled Codex ACP when a stored path is stale", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-stale-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpUsage(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    normalizeCliPathForPlatform: () => null,
+    resolveCliFromPath: () => null,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler(
+      { sender: { id: 1 } },
+      { command: "codex", customPath: "/stale/bin/codex" },
+    );
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli falls back to bundled Codex ACP when PATH Codex shim is broken", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-resolve-broken-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexPath = path.join(tempDir, process.platform === "win32" ? "codex.cmd" : "codex");
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  if (process.platform === "win32") {
+    fs.writeFileSync(codexPath, "@echo off\r\necho TypeError: Cannot read properties of undefined\r\n", "utf8");
+    writeFakeCodexAcpUsage(codexAcpPath);
+  } else {
+    fs.writeFileSync(codexPath, "#!/bin/sh\necho 'TypeError: Cannot read properties of undefined'\n", "utf8");
+    fs.chmodSync(codexPath, 0o755);
+    writeFakeCodexAcpUsage(codexAcpPath);
+  }
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCliFromPath: (command) => (command === "codex" ? codexPath : null),
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli falls back to bundled Codex ACP when PATH Codex exits nonzero", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-resolve-exit-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexPath = path.join(tempDir, process.platform === "win32" ? "codex.cmd" : "codex");
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  if (process.platform === "win32") {
+    fs.writeFileSync(codexPath, "@echo off\r\necho codex-cli 1.0.0\r\nexit /b 1\r\n", "utf8");
+    writeFakeCodexAcpUsage(codexAcpPath);
+  } else {
+    fs.writeFileSync(codexPath, "#!/bin/sh\necho 'codex-cli 1.0.0'\nexit 1\n", "utf8");
+    fs.chmodSync(codexPath, 0o755);
+    writeFakeCodexAcpUsage(codexAcpPath);
+  }
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: (value) => String(value).startsWith("codex-cli"),
+    resolveCliFromPath: (command) => (command === "codex" ? codexPath : null),
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli rejects bundled Codex ACP fallback when the fallback cannot run", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-resolve-bad-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  fs.mkdirSync(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: null,
+      available: false,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli rejects bundled Codex ACP fallback when the fallback prints a loader error", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-acp-resolve-loader-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexAcpPath = path.join(tempDir, process.platform === "win32" ? "codex-acp.cmd" : "codex-acp");
+  writeFakeCodexAcpLoaderError(codexAcpPath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: () => false,
+    resolveCodexAcpBinaryPath: () => codexAcpPath,
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexAcpPath,
+      version: null,
+      available: false,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("discovers bundled Claude ACP fallback when the version probe is silent", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-acp-discover-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const scriptPath = path.join(tempDir, "index.js");
+  fs.writeFileSync(scriptPath, "process.exit(0);\n", "utf8");
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: (value) => String(value || "").trim().length > 0,
+    resolveClaudeAcpBinaryPath: () => ({
+      command: process.execPath,
+      prependArgs: [scriptPath],
+    }),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const discoverHandler = ipcMain.handlers.get("netcatty:ai:agents:discover");
+    assert.equal(typeof discoverHandler, "function");
+
+    const agents = await discoverHandler({ sender: { id: 1 } });
+
+    assert.equal(agents.length, 1);
+    assert.equal(agents[0].command, "claude");
+    assert.equal(agents[0].path, scriptPath);
+    assert.equal(agents[0].version, "Bundled ACP");
+    assert.equal(agents[0].available, true);
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli accepts stored bundled Claude ACP script path via its launcher", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-acp-stored-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const scriptPath = path.join(tempDir, "index.js");
+  fs.writeFileSync(scriptPath, "process.exit(0);\n", "utf8");
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    isPlausibleCliVersionOutput: (value) => String(value || "").trim().length > 0,
+    normalizeCliPathForPlatform: () => scriptPath,
+    resolveClaudeAcpBinaryPath: () => ({
+      command: process.execPath,
+      prependArgs: [scriptPath],
+    }),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "claude", customPath: scriptPath });
+
+    assert.deepEqual(result, {
+      path: scriptPath,
+      version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
 
 test("replays fallback history only after creating a fresh ACP session when the recovered turn fails", async () => {
   const { bridge, streamCalls, providerCreationArgs, restore } = loadBridgeWithMocks();

--- a/infrastructure/ai/acpAgentAdapter.test.ts
+++ b/infrastructure/ai/acpAgentAdapter.test.ts
@@ -1,0 +1,161 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatAcpErrorForDisplay, runAcpAgentTurn } from './acpAgentAdapter';
+import type { AcpAgentCallbacks } from './acpAgentAdapter';
+import type { ExternalAgentConfig } from './types';
+
+function createCallbacks(errors: string[]): AcpAgentCallbacks {
+  return {
+    onTextDelta: () => {},
+    onThinkingDelta: () => {},
+    onThinkingDone: () => {},
+    onToolCall: () => {},
+    onToolResult: () => {},
+    onError: (error) => errors.push(error),
+    onDone: () => {},
+  };
+}
+
+const acpConfig: ExternalAgentConfig = {
+  id: 'agent',
+  name: 'Agent',
+  command: 'agent',
+  enabled: true,
+  acpCommand: 'agent-acp',
+  acpArgs: [],
+};
+
+test('formatAcpErrorForDisplay preserves nested ACP error messages', () => {
+  assert.equal(
+    formatAcpErrorForDisplay({
+      error: {
+        code: 'invalid_model',
+        message: 'Model is not available',
+      },
+    }),
+    'Model is not available',
+  );
+});
+
+test('formatAcpErrorForDisplay stringifies unknown objects instead of [object Object]', () => {
+  assert.equal(
+    formatAcpErrorForDisplay({ status: 502, detail: 'Proxy failed' }),
+    '{"status":502,"detail":"Proxy failed"}',
+  );
+});
+
+test('formatAcpErrorForDisplay handles circular errors', () => {
+  const error: Record<string, unknown> = { status: 500 };
+  error.self = error;
+
+  assert.equal(
+    formatAcpErrorForDisplay(error),
+    '{"status":500,"self":"[Circular]"}',
+  );
+});
+
+test('runAcpAgentTurn formats structured startup errors', async () => {
+  const errors: string[] = [];
+  const bridge: Record<string, (...args: unknown[]) => unknown> = {
+    aiAcpStream: async () => ({
+      ok: false,
+      error: {
+        error: {
+          code: 'invalid_model',
+          message: 'Model is not available',
+        },
+      },
+    }),
+    aiAcpCancel: async () => ({ ok: true }),
+    onAiAcpEvent: () => () => {},
+    onAiAcpDone: () => () => {},
+    onAiAcpError: () => () => {},
+  };
+
+  await runAcpAgentTurn(
+    bridge,
+    'request-1',
+    'chat-1',
+    acpConfig,
+    'hello',
+    createCallbacks(errors),
+  );
+
+  assert.deepEqual(errors, ['Model is not available']);
+});
+
+test('runAcpAgentTurn formats structured async error events', async () => {
+  const errors: string[] = [];
+  let onError: ((error: unknown) => void) | null = null;
+  const bridge: Record<string, (...args: unknown[]) => unknown> = {
+    aiAcpStream: async () => {
+      queueMicrotask(() => {
+        onError?.({
+          data: {
+            error: {
+              message: 'Proxy failed',
+            },
+          },
+        });
+      });
+      return { ok: true };
+    },
+    aiAcpCancel: async () => ({ ok: true }),
+    onAiAcpEvent: () => () => {},
+    onAiAcpDone: () => () => {},
+    onAiAcpError: (_requestId: unknown, cb: unknown) => {
+      onError = cb as (error: unknown) => void;
+      return () => {};
+    },
+  };
+
+  await runAcpAgentTurn(
+    bridge,
+    'request-2',
+    'chat-1',
+    acpConfig,
+    'hello',
+    createCallbacks(errors),
+  );
+
+  assert.deepEqual(errors, ['Proxy failed']);
+});
+
+test('runAcpAgentTurn formats structured stream error events', async () => {
+  const errors: string[] = [];
+  let onEvent: ((event: unknown) => void) | null = null;
+  const bridge: Record<string, (...args: unknown[]) => unknown> = {
+    aiAcpStream: async () => {
+      queueMicrotask(() => {
+        onEvent?.({
+          type: 'error',
+          error: {
+            error: {
+              message: 'Stream failed',
+            },
+          },
+        });
+      });
+      return { ok: true };
+    },
+    aiAcpCancel: async () => ({ ok: true }),
+    onAiAcpEvent: (_requestId: unknown, cb: unknown) => {
+      onEvent = cb as (event: unknown) => void;
+      return () => {};
+    },
+    onAiAcpDone: () => () => {},
+    onAiAcpError: () => () => {},
+  };
+
+  await runAcpAgentTurn(
+    bridge,
+    'request-3',
+    'chat-1',
+    acpConfig,
+    'hello',
+    createCallbacks(errors),
+  );
+
+  assert.deepEqual(errors, ['Stream failed']);
+});

--- a/infrastructure/ai/acpAgentAdapter.ts
+++ b/infrastructure/ai/acpAgentAdapter.ts
@@ -49,11 +49,11 @@ interface AcpBridge {
     toolIntegrationMode?: AIToolIntegrationMode,
     defaultTargetSession?: DefaultTargetSessionHint,
     userSkillsContext?: string,
-  ): Promise<{ ok: boolean; error?: string }>;
+  ): Promise<{ ok: boolean; error?: unknown }>;
   aiAcpCancel(requestId: string, chatSessionId?: string): Promise<{ ok: boolean }>;
   onAiAcpEvent(requestId: string, cb: (event: StreamEvent) => void): () => void;
   onAiAcpDone(requestId: string, cb: () => void): () => void;
-  onAiAcpError(requestId: string, cb: (error: string) => void): () => void;
+  onAiAcpError(requestId: string, cb: (error: unknown) => void): () => void;
 }
 
 interface StreamEvent {
@@ -71,6 +71,61 @@ export interface FileAttachment {
   mediaType: string;
   filename?: string;
   filePath?: string;
+}
+
+function safeJsonStringify(value: unknown): string | null {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, nestedValue: unknown) => {
+      if (typeof nestedValue !== 'object' || nestedValue === null) {
+        return nestedValue;
+      }
+      if (seen.has(nestedValue)) {
+        return '[Circular]';
+      }
+      seen.add(nestedValue);
+      return nestedValue;
+    });
+  } catch {
+    return null;
+  }
+}
+
+function formatAcpErrorValue(error: unknown, seen = new WeakSet<object>()): string {
+  if (error == null) return '';
+  if (typeof error === 'string') return error;
+  if (typeof error === 'number' || typeof error === 'boolean') return String(error);
+  if (error instanceof Error) return error.message || error.name || '';
+  if (typeof error !== 'object') return String(error);
+  if (seen.has(error)) return '[Circular error]';
+  seen.add(error);
+
+  const record = error as Record<string, unknown>;
+  const data = record.data as Record<string, unknown> | undefined;
+  const nestedError = record.error as Record<string, unknown> | undefined;
+  const candidates: unknown[] = [
+    data?.message,
+    data?.error,
+    record.errorText,
+    record.message,
+    record.error,
+    record.cause,
+    nestedError?.message,
+    record.data,
+  ];
+
+  for (const candidate of candidates) {
+    const message = formatAcpErrorValue(candidate, seen).trim();
+    if (message && message !== '{}') {
+      return message;
+    }
+  }
+
+  return safeJsonStringify(error) || String(error);
+}
+
+export function formatAcpErrorForDisplay(error: unknown): string {
+  return formatAcpErrorValue(error).trim() || 'Unknown error';
 }
 
 export async function runAcpAgentTurn(
@@ -98,15 +153,11 @@ export async function runAcpAgentTurn(
   }
 
   const cleanupFns: (() => void)[] = [];
-
-  // Set up event listeners before starting stream
-  const unsubEvent = acpBridge.onAiAcpEvent(requestId, (event: StreamEvent) => {
-    handleStreamEvent(event, callbacks);
-  });
-  cleanupFns.push(unsubEvent);
-
   let settled = false;
-  let resolveDone!: () => void;
+  let resolveDone: () => void = () => {};
+  const donePromise = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
   const settle = (fn?: () => void) => {
     if (settled) return false;
     settled = true;
@@ -115,22 +166,28 @@ export async function runAcpAgentTurn(
     return true;
   };
 
-  const donePromise = new Promise<void>((resolve) => {
-    resolveDone = resolve;
-    const unsubDone = acpBridge.onAiAcpDone(requestId, () => {
-      settle(() => {
-        callbacks.onDone();
-      });
-    });
-    cleanupFns.push(unsubDone);
-
-    const unsubError = acpBridge.onAiAcpError(requestId, (error: string) => {
-      settle(() => {
-        callbacks.onError(error);
-      });
-    });
-    cleanupFns.push(unsubError);
+  // Set up event listeners before starting stream
+  const unsubEvent = acpBridge.onAiAcpEvent(requestId, (event: StreamEvent) => {
+    const streamFailed = handleStreamEvent(event, callbacks);
+    if (streamFailed) {
+      settle();
+    }
   });
+  cleanupFns.push(unsubEvent);
+
+  const unsubDone = acpBridge.onAiAcpDone(requestId, () => {
+    settle(() => {
+      callbacks.onDone();
+    });
+  });
+  cleanupFns.push(unsubDone);
+
+  const unsubError = acpBridge.onAiAcpError(requestId, (error: unknown) => {
+    settle(() => {
+      callbacks.onError(formatAcpErrorForDisplay(error));
+    });
+  });
+  cleanupFns.push(unsubError);
 
   // Handle abort
   if (signal) {
@@ -167,12 +224,16 @@ export async function runAcpAgentTurn(
   ).then((result) => {
     if (result?.ok === false) {
       settle(() => {
-        callbacks.onError(result.error || 'Failed to start ACP stream');
+        callbacks.onError(
+          result.error == null
+            ? 'Failed to start ACP stream'
+            : formatAcpErrorForDisplay(result.error),
+        );
       });
     }
-  }).catch((err: Error) => {
+  }).catch((err: unknown) => {
     settle(() => {
-      callbacks.onError(err.message);
+      callbacks.onError(formatAcpErrorForDisplay(err));
     });
   }).finally(() => {
     if (settled) {
@@ -195,32 +256,32 @@ function cleanup(fns: (() => void)[]) {
  * Handle a single stream event from the AI SDK fullStream.
  * Events come from `streamText().fullStream` in the main process.
  */
-function handleStreamEvent(event: StreamEvent, callbacks: AcpAgentCallbacks) {
+function handleStreamEvent(event: StreamEvent, callbacks: AcpAgentCallbacks): boolean {
   switch (event.type) {
     case 'text-delta': {
       const text = (event.textDelta as string) || (event.delta as string) || '';
       if (text) callbacks.onTextDelta(text);
-      break;
+      return false;
     }
     case 'reasoning-start': {
       // Reasoning block started — nothing to render yet
-      break;
+      return false;
     }
     case 'reasoning-delta': {
       const text = (event.delta as string) || '';
       if (text) callbacks.onThinkingDelta(text);
-      break;
+      return false;
     }
     case 'reasoning-end': {
       callbacks.onThinkingDone();
-      break;
+      return false;
     }
     case 'tool-call': {
       const toolName = (event.toolName as string) || 'unknown';
       const input = (event.input as Record<string, unknown>) || {};
       const toolCallId = (event.toolCallId as string) || undefined;
       callbacks.onToolCall(toolName, input, toolCallId);
-      break;
+      return false;
     }
     case 'tool-result': {
       const toolCallId = (event.toolCallId as string) || '';
@@ -230,22 +291,24 @@ function handleStreamEvent(event: StreamEvent, callbacks: AcpAgentCallbacks) {
         ? output
         : JSON.stringify(output);
       callbacks.onToolResult(toolCallId, result, toolName);
-      break;
+      return false;
     }
     case 'status': {
       const msg = (event.message as string) || '';
       if (msg) callbacks.onStatus?.(msg);
-      break;
+      return false;
     }
     case 'session-id': {
       const sessionId = (event.sessionId as string) || '';
       if (sessionId) callbacks.onSessionId?.(sessionId);
-      break;
+      return false;
     }
     case 'error': {
-      callbacks.onError(String(event.error || 'Unknown error'));
-      break;
+      callbacks.onError(formatAcpErrorForDisplay(event.error));
+      return true;
     }
     // step-start, step-finish, etc. — ignore silently
+    default:
+      return false;
   }
 }


### PR DESCRIPTION
Fixes #844

Summary:
- Keep ACP/Codex structured error messages readable instead of showing [object Object].
- Treat CLI stack traces, file URLs, and non-version output as failed version probes so broken agent binaries do not appear available.
- Remove stale settings-managed agents when detection fails, while preserving user-created agent configs.
- Keep the bundled Codex ACP fallback discoverable, including when a previously stored Codex path is stale.
- Block disabled/missing agents before a send creates chat messages.
- Add regression coverage for nested/circular error objects, startup/callback/stream error display, stale managed agents, disabled agents, and bundled Codex ACP discovery.

Verification:
- node --test --import tsx electron/bridges/aiBridge.test.cjs infrastructure/ai/acpAgentAdapter.test.ts components/ai/managedAgentState.test.ts components/ai/agentSendEligibility.test.ts
- npm run lint
- npm test
- npm run build
- git diff --check