### PR TITLE
[codex] Use dedicated mosh binary repository

### DIFF
--- a/.github/workflows/build-mosh-binaries.yml
+++ b/.github/workflows/build-mosh-binaries.yml
@@ -4,10 +4,9 @@ name: build-mosh-binaries
 #  - Pushes that touch the mosh build pipeline + PRs run the matrix
 #    so we can validate workflow / script changes without tagging.
 #    Artifacts upload as workflow artifacts only; *no* release.
-#  - Tag push matching `mosh-bin-<version>-<rev>` (e.g.
-#    `mosh-bin-1.4.0-1`) runs the matrix and publishes a Release with
-#    the binaries + SHA256SUMS.
-#  - Manual `workflow_dispatch` → opt-in publish via `release_tag`.
+#  - Manual `workflow_dispatch` with `release_tag` publishes the
+#    binaries + SHA256SUMS to the dedicated binary repository
+#    (`binaricat/Netcatty-mosh-bin` by default).
 #
 # `paths` keeps unrelated commits (UI, bridges, etc) from rebuilding
 # mosh on every push — this workflow is expensive (~30min Cygwin leg).
@@ -22,11 +21,13 @@ on:
         description: "Optional release tag to attach binaries to (e.g. mosh-bin-1.4.0-1). Empty = artifacts only."
         type: string
         default: ""
+      release_repo:
+        description: "Repository that stores mosh-client binary releases."
+        type: string
+        default: "binaricat/Netcatty-mosh-bin"
   push:
     branches:
       - "**"
-    tags:
-      - "mosh-bin-*"
     paths:
       - ".gitattributes"
       - ".github/workflows/build-mosh-binaries.yml"
@@ -45,11 +46,10 @@ on:
       - "scripts/fetch-mosh-binaries.cjs"
       - "scripts/mosh-extra-resources.cjs"
 
-# Cancel superseded branch / PR builds; tag builds use a unique group
-# so a follow-up commit doesn't kill the in-progress release.
+# Cancel superseded branch / PR builds.
 concurrency:
   group: build-mosh-binaries-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: true
 
 env:
   MOSH_REF: ${{ inputs.mosh_ref || 'mosh-1.4.0' }}
@@ -188,7 +188,7 @@ jobs:
   # ------------------------------------------------------------------
 
   # ------------------------------------------------------------------
-  # Aggregate + (optional) GitHub Release.
+  # Aggregate + optional release to the dedicated binary repository.
   # ------------------------------------------------------------------
   release:
     name: release
@@ -198,15 +198,9 @@ jobs:
       - build-macos-universal
       - build-windows-x64
     runs-on: ubuntu-latest
-    # Release only on a `mosh-bin-*` tag push or an explicit
-    # workflow_dispatch with `release_tag` provided. Branch pushes /
-    # PRs (even on a branch literally called `mosh-bin-foo`) can't
-    # match `refs/tags/mosh-bin-*`, so they never publish.
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/mosh-bin-'))
-      || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+    if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Download artifacts
@@ -228,26 +222,32 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            tag="${GITHUB_REF_NAME}"
-          else
-            tag="${RELEASE_TAG}"
-          fi
+          tag="${RELEASE_TAG}"
           if [[ ! "$tag" =~ ^mosh-bin-[A-Za-z0-9._-]+$ ]]; then
             echo "Invalid mosh binary release tag: $tag" >&2
             exit 1
           fi
           printf 'name=%s\n' "$tag" >> "$GITHUB_OUTPUT"
       - name: Create / update release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.name }}
-          name: ${{ steps.tag.outputs.name }}
-          files: release/*
-          body: |
-            Pre-built `mosh-client` binaries consumed by `scripts/fetch-mosh-binaries.cjs`
-            during `npm run pack`. Built from `mobile-shell/mosh` upstream ref `${{ env.MOSH_REF }}`.
-
-            All artifacts are GPL-3.0; see `resources/mosh/README.md` for source provenance.
-          draft: false
-          prerelease: false
+        env:
+          GH_TOKEN: ${{ secrets.MOSH_BIN_RELEASE_TOKEN }}
+          RELEASE_REPO: ${{ inputs.release_repo }}
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::MOSH_BIN_RELEASE_TOKEN is required to publish into ${RELEASE_REPO}."
+            exit 1
+          fi
+          {
+            printf '%s\n' 'Pre-built `mosh-client` binaries consumed by `scripts/fetch-mosh-binaries.cjs` during `npm run pack`.'
+            printf 'Built from `mobile-shell/mosh` upstream ref `%s`.\n\n' "${MOSH_REF}"
+            printf 'Source workflow: %s/%s/actions/runs/%s\n' "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}"
+            printf 'Source commit: `%s`\n\n' "${GITHUB_SHA}"
+            printf '%s\n' 'All artifacts are GPL-3.0; see `resources/mosh/README.md` for source provenance.'
+          } > release-notes.md
+          gh release delete "${RELEASE_TAG}" --repo "${RELEASE_REPO}" --cleanup-tag --yes || true
+          gh release create "${RELEASE_TAG}" release/* \
+            --repo "${RELEASE_REPO}" \
+            --title "${RELEASE_TAG}" \
+            --notes-file release-notes.md

--- a/.github/workflows/build-mosh-binaries.yml
+++ b/.github/workflows/build-mosh-binaries.yml
@@ -246,8 +246,17 @@ jobs:
             printf 'Source commit: `%s`\n\n' "${GITHUB_SHA}"
             printf '%s\n' 'All artifacts are GPL-3.0; see `resources/mosh/README.md` for source provenance.'
           } > release-notes.md
-          gh release delete "${RELEASE_TAG}" --repo "${RELEASE_REPO}" --cleanup-tag --yes || true
-          gh release create "${RELEASE_TAG}" release/* \
-            --repo "${RELEASE_REPO}" \
-            --title "${RELEASE_TAG}" \
-            --notes-file release-notes.md
+          if gh release view "${RELEASE_TAG}" --repo "${RELEASE_REPO}" >/dev/null 2>&1; then
+            gh release edit "${RELEASE_TAG}" \
+              --repo "${RELEASE_REPO}" \
+              --title "${RELEASE_TAG}" \
+              --notes-file release-notes.md
+            gh release upload "${RELEASE_TAG}" release/* \
+              --repo "${RELEASE_REPO}" \
+              --clobber
+          else
+            gh release create "${RELEASE_TAG}" release/* \
+              --repo "${RELEASE_REPO}" \
+              --title "${RELEASE_TAG}" \
+              --notes-file release-notes.md
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,8 @@ build_with_vs2022.bat
 # Bundled mosh-client binaries fetched at pack time by
 # scripts/fetch-mosh-binaries.cjs. resources/mosh/README.md is
 # committed; the actual binaries (and on Windows the Cygwin DLL
-# bundle that ships alongside mosh-client.exe) are pulled from a
-# release tag, never committed.
+# bundle that ships alongside mosh-client.exe) are pulled from the
+# dedicated mosh binary repository, never committed.
 /resources/mosh/*/mosh-client
 /resources/mosh/*/mosh-client.exe
 /resources/mosh/*/mosh-client-*-dlls/

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -81,3 +81,77 @@ test("startMosh does not pass legacy configured mosh client paths to the backend
   assert.equal(capturedOptions.hostname, "example.test");
   assert.equal(capturedOptions.port, 2200);
 });
+
+test("startMosh passes the saved password to the mosh backend", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "mosh-session";
+    },
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "alice",
+      password: "saved-secret",
+      port: 2200,
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startMosh(term as never);
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.username, "alice");
+  assert.equal(capturedOptions.password, "saved-secret");
+});

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -754,11 +754,28 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
 
     try {
+      const pendingAuth = ctx.pendingAuthRef.current;
+      const resolvedAuth = resolveHostAuth({
+        host: ctx.host,
+        keys: ctx.keys,
+        identities: ctx.identities,
+        override: pendingAuth
+          ? {
+            authMethod: pendingAuth.authMethod,
+            username: pendingAuth.username,
+            password: pendingAuth.password,
+            keyId: pendingAuth.keyId,
+            passphrase: pendingAuth.passphrase,
+          }
+          : null,
+      });
+      const effectivePassword = sanitizeCredentialValue(resolvedAuth.password);
       const moshEnv = buildTermEnv(ctx.host, ctx.terminalSettings);
       const id = await ctx.terminalBackend.startMoshSession({
         sessionId: ctx.sessionId,
         hostname: ctx.host.hostname,
-        username: ctx.host.username || "root",
+        username: resolvedAuth.username || "root",
+        password: effectivePassword,
         port: ctx.host.port || 22,
         moshServerPath: ctx.host.moshServerPath,
         agentForwarding: ctx.host.agentForwarding,

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { resolveBareMoshClient } = require("./terminalBridge.cjs");
+const { addBundledMoshDllPath, resolveBareMoshClient } = require("./terminalBridge.cjs");
 
 function makeTmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-mosh-resolve-"));
@@ -86,6 +86,38 @@ test("mosh runtime does not fall back to system mosh or mosh-client", () => {
   assert.equal(source.includes('resolvePosixExecutable("mosh"'), false);
   assert.equal(source.includes('findExecutable("mosh"'), false);
   assert.equal(source.includes("brew install mosh"), false);
+});
+
+test("Windows dev mosh-client prepends the bundled DLL directory", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client.exe");
+  const dllDir = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client-win32-x64-dlls");
+  writeExecutable(client);
+  fs.mkdirSync(dllDir, { recursive: true });
+  fs.writeFileSync(path.join(dllDir, "cygwin1.dll"), "dll");
+
+  const env = { Path: "C:\\Windows\\System32" };
+  addBundledMoshDllPath(env, client, { platform: "win32", arch: "x64" });
+
+  assert.equal(env.Path.split(";")[0], dllDir);
+});
+
+test("Windows dev mosh-client updates the PATH key used by child process env", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client.exe");
+  const dllDir = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client-win32-x64-dlls");
+  writeExecutable(client);
+  fs.mkdirSync(dllDir, { recursive: true });
+  fs.writeFileSync(path.join(dllDir, "cygwin1.dll"), "dll");
+
+  const env = {
+    Path: "C:\\Windows\\System32",
+    PATH: "C:\\Tools",
+  };
+  addBundledMoshDllPath(env, client, { platform: "win32", arch: "x64" });
+
+  assert.equal(env.PATH.split(";")[0], dllDir);
+  assert.equal(Object.prototype.hasOwnProperty.call(env, "Path"), false);
 });
 
 test("removed Mosh client detection APIs are not exposed to the renderer", () => {

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -16,26 +16,36 @@ function writeExecutable(filePath) {
   fs.chmodSync(filePath, 0o755);
 }
 
-test("resolveBareMoshClient honors an explicit path with a mosh-client basename", () => {
+test("resolveBareMoshClient ignores explicit local mosh-client paths", () => {
   const tmp = makeTmp();
   const p = path.join(tmp, "mosh-client");
   writeExecutable(p);
-  assert.equal(resolveBareMoshClient({ moshClientPath: p }), p);
+  assert.equal(resolveBareMoshClient({ moshClientPath: p }, { projectRoot: tmp, resourcesPath: path.join(tmp, "missing") }), null);
 });
 
-test("resolveBareMoshClient ignores an explicit path whose basename is `mosh` (the wrapper)", () => {
+test("resolveBareMoshClient resolves only the bundled client", () => {
   const tmp = makeTmp();
-  const p = path.join(tmp, "mosh");
-  writeExecutable(p);
-  // No bundled mosh available in this test (no resources/mosh/<x>/),
-  // so the fallback is undefined → null/undefined return.
-  const got = resolveBareMoshClient({ moshClientPath: p });
-  assert.notEqual(got, p, "explicit `mosh` wrapper path should not be treated as a bare client");
+  const bundled = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  writeExecutable(bundled);
+
+  assert.equal(
+    resolveBareMoshClient({}, {
+      platform: "linux",
+      arch: "x64",
+      projectRoot: tmp,
+      resourcesPath: path.join(tmp, "missing"),
+    }),
+    bundled,
+  );
 });
 
 test("resolveBareMoshClient rejects relative explicit paths", () => {
-  const got = resolveBareMoshClient({ moshClientPath: "./mosh-client" });
-  assert.notEqual(got, "./mosh-client");
+  const tmp = makeTmp();
+  const got = resolveBareMoshClient({ moshClientPath: "./mosh-client" }, {
+    projectRoot: tmp,
+    resourcesPath: path.join(tmp, "missing"),
+  });
+  assert.equal(got, null);
 });
 
 test("resolveBareMoshClient ignores a non-executable explicit path", () => {
@@ -43,22 +53,39 @@ test("resolveBareMoshClient ignores a non-executable explicit path", () => {
   const p = path.join(tmp, "mosh-client");
   fs.writeFileSync(p, "");
   fs.chmodSync(p, 0o644);
-  const got = resolveBareMoshClient({ moshClientPath: p });
-  assert.notEqual(got, p);
+  const got = resolveBareMoshClient({ moshClientPath: p }, {
+    projectRoot: tmp,
+    resourcesPath: path.join(tmp, "missing"),
+  });
+  assert.equal(got, null);
 });
 
-test("resolveBareMoshClient honors caller PATH overrides", () => {
+test("resolveBareMoshClient ignores mosh-client on PATH", () => {
   const tmp = makeTmp();
   const p = path.join(tmp, "mosh-client");
   writeExecutable(p);
 
-  assert.equal(resolveBareMoshClient({}, { pathOverride: tmp }), p);
+  assert.equal(resolveBareMoshClient({}, {
+    pathOverride: tmp,
+    projectRoot: tmp,
+    resourcesPath: path.join(tmp, "missing"),
+  }), null);
 });
 
 test("mosh fallback messages do not point users to the removed Mosh settings field", () => {
   const source = fs.readFileSync(path.join(__dirname, "terminalBridge.cjs"), "utf8");
 
   assert.equal(source.includes("Settings → Terminal → Mosh"), false);
+});
+
+test("mosh runtime does not fall back to system mosh or mosh-client", () => {
+  const source = fs.readFileSync(path.join(__dirname, "terminalBridge.cjs"), "utf8");
+
+  assert.equal(source.includes('resolvePosixExecutable("mosh-client"'), false);
+  assert.equal(source.includes('findExecutable("mosh-client"'), false);
+  assert.equal(source.includes('resolvePosixExecutable("mosh"'), false);
+  assert.equal(source.includes('findExecutable("mosh"'), false);
+  assert.equal(source.includes("brew install mosh"), false);
 });
 
 test("removed Mosh client detection APIs are not exposed to the renderer", () => {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -792,6 +792,70 @@ function resolveBareMoshClient(_options, opts = {}) {
   return bundledMoshClient(opts);
 }
 
+function getEnvPathKey(env) {
+  const pathKeys = Object.keys(env).filter((key) => key.toLowerCase() === "path");
+  if (pathKeys.length === 0) return "PATH";
+  return pathKeys.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))[0];
+}
+
+function getEnvPathDelimiter(opts = {}) {
+  return (opts.platform || process.platform) === "win32" ? ";" : path.delimiter;
+}
+
+function normalizeEnvPathPart(part, opts = {}) {
+  const pathApi = (opts.platform || process.platform) === "win32" ? path.win32 : path;
+  return pathApi.normalize(part).toLowerCase();
+}
+
+function prependEnvPath(env, dir, opts = {}) {
+  if (!dir) return env;
+  const pathKey = getEnvPathKey(env);
+  const duplicatePathKeys = Object.keys(env)
+    .filter((key) => key.toLowerCase() === "path" && key !== pathKey);
+  for (const key of duplicatePathKeys) {
+    delete env[key];
+  }
+  const current = env[pathKey] || "";
+  const delimiter = getEnvPathDelimiter(opts);
+  const parts = String(current).split(delimiter).filter(Boolean);
+  const normalizedDir = normalizeEnvPathPart(dir, opts);
+  if (!parts.some((part) => normalizeEnvPathPart(part, opts) === normalizedDir)) {
+    env[pathKey] = current ? `${dir}${delimiter}${current}` : dir;
+  }
+  return env;
+}
+
+function findBundledMoshDllDir(bareClient, opts = {}) {
+  const platform = opts.platform || process.platform;
+  if (platform !== "win32" || !bareClient) return null;
+
+  const clientDir = path.dirname(bareClient);
+  const arch = opts.arch || process.arch;
+  const preferred = path.join(clientDir, `mosh-client-win32-${arch}-dlls`);
+  if (fs.existsSync(preferred) && fs.statSync(preferred).isDirectory()) {
+    return preferred;
+  }
+
+  try {
+    const match = fs.readdirSync(clientDir)
+      .map((name) => path.join(clientDir, name))
+      .find((candidate) => {
+        const name = path.basename(candidate);
+        return /^mosh-client-win32-.+-dlls$/.test(name)
+          && fs.existsSync(candidate)
+          && fs.statSync(candidate).isDirectory();
+      });
+    return match || null;
+  } catch {
+    return null;
+  }
+}
+
+function addBundledMoshDllPath(env, bareClient, opts = {}) {
+  const dllDir = findBundledMoshDllDir(bareClient, opts);
+  return dllDir ? prependEnvPath(env, dllDir, opts) : env;
+}
+
 function createMoshSshPasswordResponder(sshPty, password) {
   if (typeof password !== "string" || password.length === 0) {
     return () => {};
@@ -988,6 +1052,7 @@ function swapToMoshClient(session, options, ctx) {
     key: parsed.key,
     lang,
   });
+  addBundledMoshDllPath(env, bareClient);
   if (options.agentForwarding && process.env.SSH_AUTH_SOCK) {
     env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
   }
@@ -1561,6 +1626,7 @@ module.exports = {
   startMoshSession,
   bundledMoshClient,
   resolveBareMoshClient,
+  addBundledMoshDllPath,
   startSerialSession,
   listSerialPorts,
   writeToSession,

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -792,6 +792,27 @@ function resolveBareMoshClient(_options, opts = {}) {
   return bundledMoshClient(opts);
 }
 
+function createMoshSshPasswordResponder(sshPty, password) {
+  if (typeof password !== "string" || password.length === 0) {
+    return () => {};
+  }
+
+  let answered = false;
+  let tail = "";
+
+  return (chunk) => {
+    if (answered) return;
+    const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk || "");
+    if (!text) return;
+
+    tail = (tail + text).slice(-512);
+    if (!/(^|[\r\n]).*password:\s*$/i.test(tail)) return;
+
+    answered = true;
+    sshPty.write(`${password}\r`);
+  };
+}
+
 /**
  * Phase-2 / Phase-3b path: run the SSH bootstrap ourselves *inside the
  * user's terminal PTY* so password / 2FA / known-hosts prompts render
@@ -882,6 +903,7 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
   session.flushPendingData = flush;
 
   const sniffer = moshHandshake.createMoshConnectSniffer();
+  const respondToPasswordPrompt = createMoshSshPasswordResponder(sshPty, options.password);
 
   // Forward bytes from the ssh PTY to the renderer, redacting the
   // MOSH CONNECT magic line. ZMODEM is intentionally not enabled
@@ -892,6 +914,7 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
     if (visible && (visible.length || (typeof visible === "string" && visible))) {
       const str = Buffer.isBuffer(visible) ? visible.toString("utf8") : visible;
       if (str.length > 0) {
+        respondToPasswordPrompt(str);
         bufferData(str);
         sessionLogStreamManager.appendData(sessionId, str);
       }

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -784,38 +784,12 @@ async function startTelnetSession(event, options) {
 }
 
 /**
- * Resolve a usable bare `mosh-client` binary (i.e. not the Perl
- * wrapper) from, in order:
- *   1. options.moshClientPath when its basename matches `mosh-client[.exe]`
- *   2. resources/mosh/<…>/ via bundledMoshClient()
- *   3. PATH lookup for `mosh-client`
+ * Resolve Netcatty's bundled bare `mosh-client` binary.
  *
  * Returns the absolute path or null.
  */
-function resolveBareMoshClient(options, opts = {}) {
-  const explicit = typeof options.moshClientPath === "string" ? options.moshClientPath.trim() : "";
-  if (explicit) {
-    const expanded = expandHomePath(explicit);
-    if (path.isAbsolute(expanded) && isExecutableFile(expanded)) {
-      const base = path.basename(expanded).toLowerCase();
-      if (base === "mosh-client" || base === "mosh-client.exe") {
-        return path.resolve(expanded);
-      }
-    }
-    return null;
-  }
-
-  const bundled = bundledMoshClient();
-  if (bundled) return bundled;
-
-  if (process.platform === "win32") {
-    const onPath = findExecutable("mosh-client", { pathOverride: opts.pathOverride });
-    if (onPath && onPath !== "mosh-client" && fs.existsSync(onPath)) return onPath;
-  } else {
-    const onPath = resolvePosixExecutable("mosh-client", { pathOverride: opts.pathOverride });
-    if (onPath) return onPath;
-  }
-  return null;
+function resolveBareMoshClient(_options, opts = {}) {
+  return bundledMoshClient(opts);
 }
 
 /**
@@ -1071,14 +1045,11 @@ function resolveLangFromCharsetForMosh(charset) {
 /**
  * Start a Mosh session.
  *
- * Phase 2 (preferred): when a bare `mosh-client` binary is available
- * and `ssh` is on the system, drive the handshake in Node and spawn
- * mosh-client directly — no Perl wrapper, works on Windows.
- *
- * Phase 1 fallback (legacy): delegate to the system `mosh` wrapper,
- * preserved so users with custom mosh setups don't regress.
+ * Netcatty only uses its bundled `mosh-client` binary here. System
+ * `mosh` / `mosh-client` installs are intentionally ignored so dev,
+ * CI, and release builds exercise the same binary.
  */
-async function startMoshSession(event, options) {
+async function startMoshSession(event, options, opts = {}) {
   const optionsEnv = options.env || {};
   // Program discovery must consider the same PATH the spawned PTY will
   // receive, including host-level terminal environment overrides.
@@ -1086,261 +1057,27 @@ async function startMoshSession(event, options) {
     ? optionsEnv.PATH
     : process.env.PATH;
 
-  // Phase 2 path — try first.
-  const bareClient = resolveBareMoshClient(options, { pathOverride: mergedPathForResolution });
-  if (bareClient) {
-    const sshExe = moshHandshake.resolveSshExecutable({
-      findExecutable: (name) => (
-        process.platform === "win32"
-          ? findExecutable(name, { pathOverride: mergedPathForResolution })
-          : resolvePosixExecutable(name, { pathOverride: mergedPathForResolution })
-      ),
-      fileExists: (p) => isExecutableFile(p) || fs.existsSync(p),
-    });
-    if (sshExe) {
-      return startMoshSessionViaHandshake(event, options, { bareClient, sshExe });
-    }
+  const bareClient = resolveBareMoshClient(options, opts.moshClientLookup || {});
+  if (!bareClient) {
+    throw new Error(
+      "Bundled mosh-client not found. Run `npm run fetch:mosh:dev` for local dev, " +
+      "or ensure release packaging downloads the mosh binary release before building.",
+    );
   }
 
-  // Phase 1 legacy: system `mosh` Perl wrapper.
-  const sessionId = options.sessionId || randomUUID();
-
-  const cols = options.cols || 80;
-  const rows = options.rows || 24;
-
-  // Resolve the mosh client to an absolute path before spawning. Bare names
-  // rely on the spawn-time PATH search, which on macOS GUI apps is reduced to
-  // `/usr/bin:/bin:/usr/sbin:/sbin` and silently fails for Homebrew installs
-  // (see issue #842). On Windows keep the existing behaviour.
-  //
-  let moshCmd;
-  let resolvedMoshDir = null;
-  // 1. Honor caller-supplied moshClientPath (legacy/internal override).
-  //    Strict failure: a missing/non-executable file produces a clear error
-  //    instead of silently falling back, so users notice typos / stale paths.
-  const explicitClient = typeof options.moshClientPath === "string" ? options.moshClientPath.trim() : "";
-  if (explicitClient) {
-    const expanded = expandHomePath(explicitClient);
-    // Reject relative paths up front. validatePath in the renderer is shared
-    // with localShell and resolves bare names through PATH (so "mosh.exe"
-    // would look valid in the UI), but here moshClientPath is taken as a
-    // literal filesystem path and any non-absolute value would be resolved
-    // against the app's cwd and silently fail.
-    if (!path.isAbsolute(expanded)) {
-      throw new Error(
-        `Mosh client path must be absolute: "${explicitClient}". Leave the override empty to use Netcatty's bundled client, or provide an absolute path.`,
-      );
-    }
-    if (!isExecutableFile(expanded)) {
-      throw new Error(
-        `Configured Mosh client not usable: ${explicitClient}. Leave the override empty to use Netcatty's bundled client, or provide another executable.`,
-      );
-    }
-    moshCmd = path.resolve(expanded);
-    // Always remember the directory so we can extend PATH and locate
-    // mosh-client / ssh helpers regardless of platform — Windows
-    // installs outside %PATH% otherwise can't resolve siblings even
-    // though the wrapper itself runs.
-    resolvedMoshDir = path.dirname(moshCmd);
-  } else if (process.platform === "win32") {
-    // Windows fallback when the Phase-2 handshake can't fire (no
-    // bundled mosh-client on disk and no `ssh` resolvable). Most
-    // packaged Windows installs *do* hit the Phase-2 path because
-    // OpenSSH ships in-box and mosh-client is bundled, so this branch
-    // is hit primarily by dev builds without bundled binaries.
-    const winResolved = findExecutable("mosh");
-    if (winResolved && winResolved !== "mosh" && fs.existsSync(winResolved)) {
-      moshCmd = winResolved;
-      resolvedMoshDir = path.dirname(winResolved);
-    } else {
-      throw new Error(
-        "Mosh prerequisites not detected on Windows. The packaged build " +
-        "ships a bundled mosh-client and uses the in-box OpenSSH client; " +
-        "this dev build is missing one of them. Either install a `mosh` " +
-        "wrapper (Cygwin / WSL) on PATH, or run a packaged build that " +
-        "includes resources/mosh/win32-x64/mosh-client.exe.",
-      );
-    }
-  } else {
-    const resolved = resolvePosixExecutable("mosh", { pathOverride: mergedPathForResolution });
-    if (!resolved) {
-      const installHint =
-        process.platform === "darwin"
-          ? "macOS: brew install mosh"
-          : "Linux: sudo apt install mosh / sudo dnf install mosh / sudo pacman -S mosh";
-      throw new Error(
-        `Mosh wrapper not found on PATH. Install it (${installHint}) or place the 'mosh' binary somewhere on PATH such as /opt/homebrew/bin or /usr/local/bin.`,
-      );
-    }
-    moshCmd = resolved;
-    resolvedMoshDir = path.dirname(resolved);
+  const sshExe = moshHandshake.resolveSshExecutable({
+    findExecutable: (name) => (
+      process.platform === "win32"
+        ? findExecutable(name, { pathOverride: mergedPathForResolution })
+        : resolvePosixExecutable(name, { pathOverride: mergedPathForResolution })
+    ),
+    fileExists: (p) => isExecutableFile(p) || fs.existsSync(p),
+  });
+  if (!sshExe) {
+    throw new Error("OpenSSH client not found. Netcatty needs ssh to start the remote mosh-server handshake.");
   }
 
-  const args = [];
-
-  if (options.port && options.port !== 22) {
-    args.push('--ssh=ssh -p ' + options.port);
-  }
-
-  if (options.moshServerPath) {
-    args.push('--server=' + options.moshServerPath);
-  }
-
-  const userHost = options.username
-    ? `${options.username}@${options.hostname}`
-    : options.hostname;
-  args.push(userHost);
-
-  const resolveLangFromCharset = (charset) => {
-    if (!charset) return 'en_US.UTF-8';
-    const trimmed = String(charset).trim();
-    if (/^utf-?8$/i.test(trimmed) || /^utf8$/i.test(trimmed)) {
-      return 'en_US.UTF-8';
-    }
-    return trimmed;
-  };
-
-  const env = {
-    ...process.env,
-    ...optionsEnv,
-    TERM: 'xterm-256color',
-    LANG: resolveLangFromCharset(options.charset),
-  };
-
-  // The mosh wrapper is a Perl script that exec's `mosh-client` (and `ssh`)
-  // by name, so it needs them on PATH. Prepend the resolved mosh's directory
-  // to the env PATH (typical layout: mosh + mosh-client live side by side).
-  // Also point MOSH_CLIENT at the absolute mosh-client when present, so the
-  // wrapper picks it up even if PATH is overridden downstream.
-  if (resolvedMoshDir) {
-    const sep = path.delimiter; // ":" on POSIX, ";" on Win32
-    const existingPath = env.PATH || "";
-    const onPath = existingPath
-      .split(sep)
-      .some((p) => p && path.normalize(p) === path.normalize(resolvedMoshDir));
-    if (!onPath) {
-      env.PATH = existingPath ? `${resolvedMoshDir}${sep}${existingPath}` : resolvedMoshDir;
-    }
-    if (!env.MOSH_CLIENT) {
-      const clientCandidates =
-        process.platform === "win32"
-          ? ["mosh-client.exe", "mosh-client.bat", "mosh-client.cmd", "mosh-client"]
-          : ["mosh-client"];
-      for (const name of clientCandidates) {
-        const candidate = path.join(resolvedMoshDir, name);
-        if (isExecutableFile(candidate)) {
-          env.MOSH_CLIENT = candidate;
-          break;
-        }
-      }
-    }
-  }
-
-  // Prefer the bundled mosh-client over whatever the system mosh wrapper
-  // would otherwise resolve via PATH. We've vendored a known-good build
-  // (see scripts/build-mosh/, .github/workflows/build-mosh-binaries.yml)
-  // so distro skew on libssl / libprotobuf / libncurses can't break a
-  // connection.
-  if (!explicitClient && !env.MOSH_CLIENT) {
-    const bundled = bundledMoshClient();
-    if (bundled) env.MOSH_CLIENT = bundled;
-  }
-
-  if (options.agentForwarding && process.env.SSH_AUTH_SOCK) {
-    env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
-  }
-
-  try {
-    const proc = pty.spawn(moshCmd, args, {
-      cols,
-      rows,
-      env,
-      cwd: os.homedir(),
-      encoding: null, // Return Buffer for ZMODEM binary support
-    });
-
-    const session = {
-      proc,
-      pty: proc,
-      type: 'mosh',
-      protocol: 'mosh',
-      webContentsId: event.sender.id,
-      hostname: options.hostname || '',
-      username: options.username || '',
-      label: options.label || options.hostname || 'Mosh Session',
-      shellKind: 'posix',
-      shellExecutable: 'remote-shell',
-      flushPendingData: null,
-      lastIdlePrompt: "",
-      lastIdlePromptAt: 0,
-      _promptTrackTail: "",
-    };
-    sessions.set(sessionId, session);
-
-    // Start real-time session log stream if configured
-    if (options.sessionLog?.enabled && options.sessionLog?.directory) {
-      sessionLogStreamManager.startStream(sessionId, {
-        hostLabel: options.label || options.hostname,
-        hostname: options.hostname,
-        directory: options.sessionLog.directory,
-        format: options.sessionLog.format || "txt",
-        startTime: Date.now(),
-      });
-    }
-
-    const { bufferData: bufferMoshData, flush: flushMosh } = createPtyBuffer((data) => {
-      const contents = electronModule.webContents.fromId(session.webContentsId);
-      contents?.send("netcatty:data", { sessionId, data });
-    });
-    session.flushPendingData = flushMosh;
-
-    if (process.platform !== "win32") {
-      const moshDecoder = new StringDecoder("utf8");
-      const moshZmodemSentry = createZmodemSentry({
-        sessionId,
-        onData(buf) {
-          const str = moshDecoder.write(buf);
-          if (!str) return;
-          trackSessionIdlePrompt(session, str);
-          bufferMoshData(str);
-          sessionLogStreamManager.appendData(sessionId, str);
-        },
-        writeToRemote(buf) {
-          try { return proc.write(buf); } catch { return true; }
-        },
-        getWebContents() {
-          return electronModule.webContents.fromId(session.webContentsId);
-        },
-        label: "Mosh",
-      });
-      session.zmodemSentry = moshZmodemSentry;
-
-      proc.onData((data) => {
-        moshZmodemSentry.consume(data);
-      });
-    } else {
-      proc.onData((data) => {
-        trackSessionIdlePrompt(session, data);
-        bufferMoshData(data);
-        sessionLogStreamManager.appendData(sessionId, data);
-      });
-    }
-
-    proc.onExit((evt) => {
-      flushMosh();
-      sessionLogStreamManager.stopStream(sessionId);
-      ptyProcessTree.unregisterPid(sessionId);
-      sessions.delete(sessionId);
-      const contents = electronModule.webContents.fromId(session.webContentsId);
-      // Mosh non-zero exit typically means connection/auth failure — show error UI
-      contents?.send("netcatty:exit", { sessionId, ...evt, reason: evt.exitCode === 0 ? "exited" : "error" });
-    });
-
-    return { sessionId };
-  } catch (err) {
-    console.error("[Mosh] Failed to start mosh session:", err.message);
-    throw err;
-  }
+  return startMoshSessionViaHandshake(event, options, { bareClient, sshExe });
 }
 
 /**
@@ -1718,10 +1455,8 @@ function validatePath(event, payload) {
  * root so the helper is testable without packaging the app.
  *
  * Note this returns the network-protocol `mosh-client`, not the `mosh`
- * wrapper script. POSIX platforms still rely on a system `mosh` Perl
- * wrapper to orchestrate the SSH bootstrap; the bundled binary is wired
- * into that wrapper via `MOSH_CLIENT=<bundled>` so users get a known-good
- * client instead of whatever the distro happens to ship.
+ * wrapper script. Netcatty drives the SSH bootstrap itself and then
+ * launches this bundled client directly.
  */
 function bundledMoshClient(opts = {}) {
   const isWin = (opts.platform || process.platform) === "win32";

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -83,7 +83,7 @@ function makeHarness(t) {
 
   const binDir = path.join(tmp, "bin");
   const sshPath = path.join(binDir, "ssh");
-  const moshClientPath = path.join(binDir, "mosh-client");
+  const moshClientPath = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
   writeExecutable(sshPath);
   writeExecutable(moshClientPath);
 
@@ -115,29 +115,36 @@ function makeHarness(t) {
       sessionId: "mosh-test-session",
       hostname: "example.com",
       username: "alice",
-      moshClientPath,
       cols: 80,
       rows: 24,
     },
     event: { sender: { id: 42 } },
+    lookupOpts: {
+      platform: "linux",
+      arch: "x64",
+      projectRoot: tmp,
+      resourcesPath: path.join(tmp, "missing"),
+    },
   };
 }
 
 test("startMoshSession handshake path returns the same shape as the legacy path", async (t) => {
   const h = makeHarness(t);
-  const result = await h.bridge.startMoshSession(h.event, h.options);
+  const result = await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
   assert.deepEqual(result, { sessionId: "mosh-test-session" });
 });
 
-test("startMoshSession handshake path honors configured PATH during discovery", async (t) => {
+test("startMoshSession uses bundled mosh-client even when PATH contains another client", async (t) => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-mosh-session-path-"));
   t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
 
   const binDir = path.join(tmp, "bin");
   const sshPath = path.join(binDir, "ssh");
-  const moshClientPath = path.join(binDir, "mosh-client");
+  const pathMoshClient = path.join(binDir, "mosh-client");
+  const bundledMoshClient = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
   writeExecutable(sshPath);
-  writeExecutable(moshClientPath);
+  writeExecutable(pathMoshClient);
+  writeExecutable(bundledMoshClient);
 
   const oldPath = process.env.PATH;
   process.env.PATH = "";
@@ -168,6 +175,14 @@ test("startMoshSession handshake path honors configured PATH during discovery", 
       rows: 24,
       env: { PATH: binDir },
     },
+    {
+      moshClientLookup: {
+        platform: "linux",
+        arch: "x64",
+        projectRoot: tmp,
+        resourcesPath: path.join(tmp, "missing"),
+      },
+    },
   );
 
   assert.deepEqual(result, { sessionId: "mosh-path-session" });
@@ -176,12 +191,12 @@ test("startMoshSession handshake path honors configured PATH during discovery", 
   spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
   spawns[0].emitExit({ exitCode: 0, signal: 0 });
 
-  assert.equal(spawns[1].command, moshClientPath);
+  assert.equal(spawns[1].command, bundledMoshClient);
 });
 
 test("startMoshSession handshake path sends the existing exit event on failure", async (t) => {
   const h = makeHarness(t);
-  await h.bridge.startMoshSession(h.event, h.options);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
 
   h.spawns[0].emitExit({ exitCode: 255, signal: 0 });
 
@@ -193,7 +208,7 @@ test("startMoshSession handshake path sends the existing exit event on failure",
 
 test("startMoshSession handshake path sends the existing exit event after mosh-client exits", async (t) => {
   const h = makeHarness(t);
-  await h.bridge.startMoshSession(h.event, h.options);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
 
   h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
   h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
@@ -205,4 +220,48 @@ test("startMoshSession handshake path sends the existing exit event after mosh-c
   assert.ok(exit);
   assert.equal(exit.payload.sessionId, "mosh-test-session");
   assert.equal(exit.payload.reason, "exited");
+});
+
+test("startMoshSession fails when bundled mosh-client is missing even if PATH has mosh-client", async (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-mosh-session-missing-"));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const binDir = path.join(tmp, "bin");
+  writeExecutable(path.join(binDir, "ssh"));
+  writeExecutable(path.join(binDir, "mosh-client"));
+
+  const spawns = [];
+  const bridge = loadBridgeWithFakePty(spawns);
+  bridge.init({
+    sessions: new Map(),
+    electronModule: {
+      webContents: {
+        fromId() {
+          return { send() {} };
+        },
+      },
+    },
+  });
+
+  await assert.rejects(
+    bridge.startMoshSession(
+      { sender: { id: 42 } },
+      {
+        sessionId: "mosh-missing-bundled",
+        hostname: "example.com",
+        username: "alice",
+        env: { PATH: binDir },
+      },
+      {
+        moshClientLookup: {
+          platform: "linux",
+          arch: "x64",
+          projectRoot: tmp,
+          resourcesPath: path.join(tmp, "missing"),
+        },
+      },
+    ),
+    /Bundled mosh-client not found/,
+  );
+  assert.equal(spawns.length, 0);
 });

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -206,6 +206,19 @@ test("startMoshSession handshake path sends the existing exit event on failure",
   assert.equal(exit.payload.reason, "error");
 });
 
+test("startMoshSession writes the saved password when ssh prompts for one", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    { ...h.options, password: "saved-secret" },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  h.spawns[0].emitData("(alice@example.com) Password:");
+
+  assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
+});
+
 test("startMoshSession handshake path sends the existing exit event after mosh-client exits", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });

--- a/global.d.ts
+++ b/global.d.ts
@@ -177,6 +177,7 @@ declare global {
       sessionId?: string;
       hostname: string;
       username?: string;
+      password?: string;
       port?: number;
       moshServerPath?: string;
       moshClientPath?: string;

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "netcatty-tool-cli": "./electron/cli/netcatty-tool-cli.cjs"
   },
   "scripts": {
-    "dev": "npm run lint && concurrently -k \"vite\" \"npm:dev:electron\"",
+    "dev": "npm run fetch:mosh:dev && npm run lint && concurrently -k \"vite\" \"npm:dev:electron\"",
     "dev:electron": "wait-on http-get://localhost:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 node electron/launch.cjs",
     "prebuild": "node scripts/copy-monaco.cjs",
     "fetch:mosh": "node scripts/fetch-mosh-binaries.cjs",
+    "fetch:mosh:dev": "node scripts/fetch-mosh-binaries.cjs --host --resolve-release",
     "build": "vite build",
     "preview": "vite preview",
     "start": "node electron/launch.cjs",

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -8,8 +8,8 @@ directly (see `electron/bridges/moshHandshake.cjs` and
 
 ## How binaries land here
 
-1. `.github/workflows/build-mosh-binaries.yml` builds `mosh-client` on a
-   `workflow_dispatch` or `mosh-bin-*` tag push. It uses
+1. `.github/workflows/build-mosh-binaries.yml` builds `mosh-client` on
+   relevant pushes/PRs, or on a manual `workflow_dispatch`. It uses
    `scripts/build-mosh/{build-linux,build-macos,build-windows}.sh` to
    produce one binary per target from upstream `mobile-shell/mosh`
    source:
@@ -26,17 +26,21 @@ directly (see `electron/bridges/moshHandshake.cjs` and
    the FluentTerminal-pinned binary; it's no longer wired into the
    default workflow.
 
-2. The release built by that workflow gets a tag like
-   `mosh-bin-1.4.0-1`, with `SHA256SUMS` attached.
+2. When manually dispatched with `release_tag`, that workflow publishes
+   the binaries to the dedicated `binaricat/Netcatty-mosh-bin`
+   repository. The release gets a tag like `mosh-bin-1.4.0-1`, with
+   `SHA256SUMS` attached.
 
 3. Release packaging runs `scripts/resolve-mosh-bin-release.cjs` before
    `npm run fetch:mosh`. It uses an explicit workflow input first, then
    the `MOSH_BIN_RELEASE` repository variable, then the latest
-   non-draft `mosh-bin-*` GitHub Release. The fetch step pulls the
-   binaries into `resources/mosh/<platform-arch>/`. For local packaging,
-   set `MOSH_BIN_RELEASE` yourself before running the same fetch command.
-   `electron-builder.config.cjs` then copies the matching binary into
-   `Resources/mosh/mosh-client[.exe]`.
+   non-draft `mosh-bin-*` GitHub Release from the dedicated binary
+   repository. The fetch step pulls the binaries into
+   `resources/mosh/<platform-arch>/`. For local packaging, set
+   `MOSH_BIN_RELEASE` yourself before running the same fetch command.
+   Override `MOSH_BIN_OWNER` / `MOSH_BIN_REPO` only when testing a
+   different binary repository. `electron-builder.config.cjs` then
+   copies the matching binary into `Resources/mosh/mosh-client[.exe]`.
 
    Official Windows package builds currently ship x64 only for bundled
    Mosh coverage. Windows arm64 packaging should be re-enabled there

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -42,6 +42,13 @@ directly (see `electron/bridges/moshHandshake.cjs` and
    different binary repository. `electron-builder.config.cjs` then
    copies the matching binary into `Resources/mosh/mosh-client[.exe]`.
 
+   Local dev uses the same binary path: `npm run dev` runs
+   `npm run fetch:mosh:dev` first, which downloads the host platform's
+   bundled `mosh-client` into this gitignored directory. Netcatty does
+   not fall back to a system-installed `mosh` or `mosh-client`; if the
+   bundled binary is missing, Mosh startup fails loudly instead of using
+   whatever happens to be installed on the developer machine.
+
    Official Windows package builds currently ship x64 only for bundled
    Mosh coverage. Windows arm64 packaging should be re-enabled there
    after the `build-mosh-binaries` workflow can produce `win32-arm64`.
@@ -88,11 +95,9 @@ For macOS the build needs an Xcode toolchain; see
   to a freshly-spawned `mosh-client` PTY when `MOSH CONNECT` is
   detected. Keystrokes that arrive after the swap go to mosh-client
   because `writeToSession` reads `session.proc` lazily.
-- Preferred whenever a bare `mosh-client` (bundled / explicit /
-  system) and `ssh` (in-box OpenSSH on Win10 1809+, system everywhere
-  else) are both detectable. The legacy path through the system
-  `mosh` Perl wrapper is preserved as a fallback so existing setups
-  don't regress.
+- Mosh startup requires Netcatty's bundled `mosh-client` and a usable
+  `ssh` client for the remote bootstrap. System-installed `mosh` /
+  `mosh-client` binaries are intentionally ignored.
 - Windows binary built in-CI from upstream source via Cygwin GCC; ships
   alongside `cygwin1.dll` + transitive deps so it runs on a stock
   Windows machine without a Cygwin install.

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -10,6 +10,7 @@
 // Usage:
 //   node scripts/fetch-mosh-binaries.cjs                # all platforms
 //   node scripts/fetch-mosh-binaries.cjs --platform=darwin --arch=universal
+//   node scripts/fetch-mosh-binaries.cjs --host --resolve-release
 //
 // Env knobs:
 //   MOSH_BIN_RELEASE  — release tag in ${MOSH_BIN_OWNER}/${MOSH_BIN_REPO}.
@@ -30,6 +31,7 @@ const https = require("node:https");
 const os = require("node:os");
 const crypto = require("node:crypto");
 const { execFileSync } = require("node:child_process");
+const { main: resolveMoshBinRelease } = require("./resolve-mosh-bin-release.cjs");
 
 const ROOT = path.resolve(__dirname, "..");
 const DEFAULT_RES_DIR = path.join(ROOT, "resources", "mosh");
@@ -142,6 +144,15 @@ function parseMoshBinRepository(env) {
   };
 }
 
+function resolveHostTarget(opts = {}) {
+  const platform = opts.platform || process.platform;
+  const arch = opts.arch || process.arch;
+  if (platform === "darwin") return { platform: "darwin", arch: "universal" };
+  if (platform === "linux" && (arch === "x64" || arch === "arm64")) return { platform, arch };
+  if (platform === "win32" && arch === "x64") return { platform, arch };
+  throw new Error(`No bundled mosh-client target for ${platform}-${arch}`);
+}
+
 function assertExtractedTreeSafe(root) {
   const stack = [root];
   while (stack.length > 0) {
@@ -243,7 +254,10 @@ async function fetchOne(target, sums, opts) {
 }
 
 async function main(argv = process.argv.slice(2), env = process.env) {
-  const release = env.MOSH_BIN_RELEASE;
+  let release = env.MOSH_BIN_RELEASE;
+  if (!release && argv.includes("--resolve-release")) {
+    release = await resolveMoshBinRelease(env);
+  }
   if (!release) {
     log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. mosh-bin-1.4.0-1) to bundle mosh-client into the package.");
     return 0;
@@ -254,8 +268,9 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     `https://github.com/${owner}/${repo}/releases/download/${encodeURIComponent(release)}`;
   const resDir = path.resolve(env.MOSH_BIN_RES_DIR || DEFAULT_RES_DIR);
   const allowUnverified = env.MOSH_BIN_ALLOW_UNVERIFIED === "true";
-  const platformFilter = (argv.find((a) => a.startsWith("--platform=")) || "").split("=")[1];
-  const archFilter = (argv.find((a) => a.startsWith("--arch=")) || "").split("=")[1];
+  const hostTarget = argv.includes("--host") ? resolveHostTarget() : null;
+  const platformFilter = hostTarget?.platform || (argv.find((a) => a.startsWith("--platform=")) || "").split("=")[1];
+  const archFilter = hostTarget?.arch || (argv.find((a) => a.startsWith("--arch=")) || "").split("=")[1];
 
   log(`release=${release} owner=${owner} repo=${repo}`);
   const sums = await fetchSums(baseUrl, { allowUnverified });
@@ -282,6 +297,7 @@ if (require.main === module) {
 module.exports = {
   TARGETS,
   parseMoshBinRepository,
+  resolveHostTarget,
   parseSums,
   validateTarEntries,
   assertExtractedTreeSafe,

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -254,6 +254,18 @@ async function fetchOne(target, sums, opts) {
 }
 
 async function main(argv = process.argv.slice(2), env = process.env) {
+  const platformArg = (argv.find((a) => a.startsWith("--platform=")) || "").split("=")[1];
+  const archArg = (argv.find((a) => a.startsWith("--arch=")) || "").split("=")[1];
+  let hostTarget = null;
+  if (argv.includes("--host")) {
+    try {
+      hostTarget = resolveHostTarget({ platform: platformArg || process.platform, arch: archArg || process.arch });
+    } catch (err) {
+      warn(`${err.message} - skipping host mosh-client fetch.`);
+      return 0;
+    }
+  }
+
   let release = env.MOSH_BIN_RELEASE;
   if (!release && argv.includes("--resolve-release")) {
     release = await resolveMoshBinRelease(env);
@@ -268,9 +280,8 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     `https://github.com/${owner}/${repo}/releases/download/${encodeURIComponent(release)}`;
   const resDir = path.resolve(env.MOSH_BIN_RES_DIR || DEFAULT_RES_DIR);
   const allowUnverified = env.MOSH_BIN_ALLOW_UNVERIFIED === "true";
-  const hostTarget = argv.includes("--host") ? resolveHostTarget() : null;
-  const platformFilter = hostTarget?.platform || (argv.find((a) => a.startsWith("--platform=")) || "").split("=")[1];
-  const archFilter = hostTarget?.arch || (argv.find((a) => a.startsWith("--arch=")) || "").split("=")[1];
+  const platformFilter = hostTarget?.platform || platformArg;
+  const archFilter = hostTarget?.arch || archArg;
 
   log(`release=${release} owner=${owner} repo=${repo}`);
   const sums = await fetchSums(baseUrl, { allowUnverified });

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -15,10 +15,9 @@
 //   MOSH_BIN_RELEASE  — release tag in ${MOSH_BIN_OWNER}/${MOSH_BIN_REPO}.
 //                       Skip the whole step if unset (printed as a notice
 //                       so the build doesn't silently miss the bundling).
-//   MOSH_BIN_OWNER    — default 'binaricat'
-//   MOSH_BIN_REPO     — default 'Netcatty' (binaries attached to a
-//                       dedicated tag in the netcatty repo to keep
-//                       provenance auditable).
+//   MOSH_BIN_OWNER    — defaults to the GITHUB_REPOSITORY owner, or 'binaricat'
+//   MOSH_BIN_REPO     — default 'Netcatty-mosh-bin' (a dedicated binary
+//                       repository so the client repo stays source-only).
 //   MOSH_BIN_BASE_URL — full override (e.g. for staging / local mirror).
 //   MOSH_BIN_RES_DIR  — override output dir for tests.
 //   MOSH_BIN_ALLOW_UNVERIFIED=true — explicit local escape hatch for mirrors
@@ -135,6 +134,14 @@ function chmodExecutable(filePath) {
   }
 }
 
+function parseMoshBinRepository(env) {
+  const githubOwner = (env.GITHUB_REPOSITORY || "").split("/")[0];
+  return {
+    owner: env.MOSH_BIN_OWNER || githubOwner || "binaricat",
+    repo: env.MOSH_BIN_REPO || "Netcatty-mosh-bin",
+  };
+}
+
 function assertExtractedTreeSafe(root) {
   const stack = [root];
   while (stack.length > 0) {
@@ -242,8 +249,7 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     return 0;
   }
 
-  const owner = env.MOSH_BIN_OWNER || "binaricat";
-  const repo = env.MOSH_BIN_REPO || "Netcatty";
+  const { owner, repo } = parseMoshBinRepository(env);
   const baseUrl = env.MOSH_BIN_BASE_URL ||
     `https://github.com/${owner}/${repo}/releases/download/${encodeURIComponent(release)}`;
   const resDir = path.resolve(env.MOSH_BIN_RES_DIR || DEFAULT_RES_DIR);
@@ -275,6 +281,7 @@ if (require.main === module) {
 
 module.exports = {
   TARGETS,
+  parseMoshBinRepository,
   parseSums,
   validateTarEntries,
   assertExtractedTreeSafe,

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -10,7 +10,7 @@ const crypto = require("node:crypto");
 
 const script = path.resolve(__dirname, "fetch-mosh-binaries.cjs");
 const execFileAsync = promisify(execFile);
-const { parseMoshBinRepository } = require("./fetch-mosh-binaries.cjs");
+const { parseMoshBinRepository, resolveHostTarget } = require("./fetch-mosh-binaries.cjs");
 
 function makeTmp(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-fetch-mosh-"));
@@ -44,6 +44,30 @@ test("fetch-mosh-binaries defaults to the dedicated mosh binary repository", () 
     parseMoshBinRepository({ GITHUB_REPOSITORY: "owner/project", MOSH_BIN_OWNER: "bin", MOSH_BIN_REPO: "binaries" }),
     { owner: "bin", repo: "binaries" },
   );
+});
+
+test("resolveHostTarget maps the local platform to the bundled target", () => {
+  assert.deepEqual(resolveHostTarget({ platform: "darwin", arch: "arm64" }), {
+    platform: "darwin",
+    arch: "universal",
+  });
+  assert.deepEqual(resolveHostTarget({ platform: "darwin", arch: "x64" }), {
+    platform: "darwin",
+    arch: "universal",
+  });
+  assert.deepEqual(resolveHostTarget({ platform: "linux", arch: "x64" }), {
+    platform: "linux",
+    arch: "x64",
+  });
+  assert.deepEqual(resolveHostTarget({ platform: "linux", arch: "arm64" }), {
+    platform: "linux",
+    arch: "arm64",
+  });
+  assert.deepEqual(resolveHostTarget({ platform: "win32", arch: "x64" }), {
+    platform: "win32",
+    arch: "x64",
+  });
+  assert.throws(() => resolveHostTarget({ platform: "freebsd", arch: "x64" }), /No bundled mosh-client target/);
 });
 
 async function serveAssets(t, assets) {

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -70,6 +70,54 @@ test("resolveHostTarget maps the local platform to the bundled target", () => {
   assert.throws(() => resolveHostTarget({ platform: "freebsd", arch: "x64" }), /No bundled mosh-client target/);
 });
 
+test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const baseUrl = await serveAssets(t, {
+    SHA256SUMS: "",
+  });
+
+  const { stderr } = await execFileAsync(
+    process.execPath,
+    [script, "--host", "--platform=win32", "--arch=arm64"],
+    {
+      env: {
+        ...process.env,
+        MOSH_BIN_RELEASE: "test",
+        MOSH_BIN_BASE_URL: baseUrl,
+        MOSH_BIN_RES_DIR: resDir,
+        CI: "true",
+      },
+      stdio: "pipe",
+    },
+  );
+
+  assert.match(stderr, /No bundled mosh-client target for win32-arm64/);
+  assert.equal(fs.existsSync(resDir), false);
+});
+
+test("fetch-mosh-binaries host mode skips unsupported targets before resolving release", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    [script, "--host", "--resolve-release", "--platform=win32", "--arch=arm64"],
+    {
+      env: {
+        ...process.env,
+        MOSH_BIN_RELEASE: "",
+        MOSH_BIN_RELEASES_JSON: "[]",
+        MOSH_BIN_RES_DIR: resDir,
+        CI: "true",
+      },
+      stdio: "pipe",
+    },
+  );
+
+  assert.match(stderr, /No bundled mosh-client target for win32-arm64/);
+  assert.doesNotMatch(stdout, /MOSH_BIN_RELEASE is unset/);
+  assert.equal(fs.existsSync(resDir), false);
+});
+
 async function serveAssets(t, assets) {
   const server = http.createServer((req, res) => {
     const name = decodeURIComponent(req.url.split("/").pop());

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -10,6 +10,7 @@ const crypto = require("node:crypto");
 
 const script = path.resolve(__dirname, "fetch-mosh-binaries.cjs");
 const execFileAsync = promisify(execFile);
+const { parseMoshBinRepository } = require("./fetch-mosh-binaries.cjs");
 
 function makeTmp(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-fetch-mosh-"));
@@ -32,6 +33,18 @@ function makeTarGz(t, entries) {
   execFileSync("tar", ["-czf", tarPath, "-C", dir, "."], { stdio: "pipe" });
   return fs.readFileSync(tarPath);
 }
+
+test("fetch-mosh-binaries defaults to the dedicated mosh binary repository", () => {
+  assert.deepEqual(parseMoshBinRepository({}), { owner: "binaricat", repo: "Netcatty-mosh-bin" });
+  assert.deepEqual(parseMoshBinRepository({ GITHUB_REPOSITORY: "owner/project" }), {
+    owner: "owner",
+    repo: "Netcatty-mosh-bin",
+  });
+  assert.deepEqual(
+    parseMoshBinRepository({ GITHUB_REPOSITORY: "owner/project", MOSH_BIN_OWNER: "bin", MOSH_BIN_REPO: "binaries" }),
+    { owner: "bin", repo: "binaries" },
+  );
+});
 
 async function serveAssets(t, assets) {
   const server = http.createServer((req, res) => {

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -6,7 +6,8 @@
 // Priority:
 //   1. MOSH_BIN_RELEASE from workflow input / repository variable.
 //   2. Latest non-draft, non-prerelease GitHub Release whose tag is
-//      mosh-bin-* in MOSH_BIN_OWNER/MOSH_BIN_REPO (or GITHUB_REPOSITORY).
+//      mosh-bin-* in MOSH_BIN_OWNER/MOSH_BIN_REPO. By default this is a
+//      dedicated sibling binary repository named Netcatty-mosh-bin.
 //
 // In GitHub Actions, the resolved tag is written back to $GITHUB_ENV so
 // later steps can run scripts/fetch-mosh-binaries.cjs without duplicating
@@ -31,7 +32,7 @@ function validateReleaseTag(tag) {
 
 function parseRepository(env) {
   const owner = env.MOSH_BIN_OWNER || (env.GITHUB_REPOSITORY || "").split("/")[0] || "binaricat";
-  const repo = env.MOSH_BIN_REPO || (env.GITHUB_REPOSITORY || "").split("/")[1] || "Netcatty";
+  const repo = env.MOSH_BIN_REPO || "Netcatty-mosh-bin";
   return { owner, repo };
 }
 
@@ -158,7 +159,7 @@ async function main(env = process.env) {
   const release = pickLatestMoshBinRelease(releases);
   if (!release) {
     throw new Error(
-      "could not find a non-draft mosh-bin-* release. Run build-mosh-binaries with release_tag (for example mosh-bin-1.4.0-1) before packaging.",
+      "could not find a non-draft mosh-bin-* release in the mosh binary repository. Publish build-mosh-binaries artifacts with release_tag (for example mosh-bin-1.4.0-1) before packaging.",
     );
   }
 

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -25,9 +25,12 @@ test("validateReleaseTag accepts only mosh binary release tags", () => {
   assert.throws(() => validateReleaseTag("mosh-bin-../bad"), /invalid mosh binary release tag/);
 });
 
-test("parseRepository falls back to Netcatty release repository", () => {
-  assert.deepEqual(parseRepository({}), { owner: "binaricat", repo: "Netcatty" });
-  assert.deepEqual(parseRepository({ GITHUB_REPOSITORY: "owner/project" }), { owner: "owner", repo: "project" });
+test("parseRepository falls back to the dedicated mosh binary repository", () => {
+  assert.deepEqual(parseRepository({}), { owner: "binaricat", repo: "Netcatty-mosh-bin" });
+  assert.deepEqual(parseRepository({ GITHUB_REPOSITORY: "owner/project" }), {
+    owner: "owner",
+    repo: "Netcatty-mosh-bin",
+  });
   assert.deepEqual(
     parseRepository({ GITHUB_REPOSITORY: "owner/project", MOSH_BIN_OWNER: "bin", MOSH_BIN_REPO: "binaries" }),
     { owner: "bin", repo: "binaries" },


### PR DESCRIPTION
## What changed

- Point bundled mosh-client release resolution and downloads at the dedicated `binaricat/Netcatty-mosh-bin` repository by default.
- Stop `build-mosh-binaries` from publishing `mosh-bin-*` releases back into the client repo; manual publishing now targets the dedicated binary repo.
- Make local dev use the bundled mosh-client by default: `npm run dev` now fetches the host platform binary before startup.
- Remove runtime fallback to system-installed `mosh` / `mosh-client`; Netcatty now requires the bundled client and fails loudly if it is missing.
- Update docs and tests so locally downloaded binaries remain ignored and temporary.

## Validation

- `node --test electron/bridges/terminalBridge.bareMoshClient.test.cjs electron/bridges/terminalBridge.moshHandshakeSession.test.cjs scripts/fetch-mosh-binaries.test.cjs`
- `npm run fetch:mosh:dev` and `resources/mosh/darwin-universal/mosh-client --version`
- checked that `resources/mosh/darwin-universal/mosh-client` is gitignored
- `npm test`
- `npm run lint`
- `npm run build`
