### PR TITLE
Fix DeepSeek reasoning replay for tool loops

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -33,6 +33,7 @@ import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
 import { classifyError } from '../../../infrastructure/ai/errorClassifier';
 import {
   extractProviderContinuationFromRawChunk,
+  getOpenAIChatAssistantFieldsForHistoryMessage,
   isProviderContinuationForSource,
   mergeProviderContinuation,
   normalizeProviderContinuationOptions,
@@ -456,6 +457,8 @@ export function useAIChatStreaming({
     let pendingText = '';
     let rafId: number | null = null;
     const openAIFieldIndexByMessageId = new Map<string, number>();
+    let nextPreseededOpenAIFieldIndex = continuationContext?.openAIChatAssistantFields.length ?? 0;
+    const preseededOpenAIFieldSlots = new Set<number>();
 
     const ensureAssistantMessage = (): string => {
       if (lastAddedRole !== 'tool') return activeMsgId;
@@ -476,8 +479,14 @@ export function useAIChatStreaming({
       if (!continuationContext) return undefined;
       let fieldIndex = openAIFieldIndexByMessageId.get(messageId);
       if (fieldIndex === undefined) {
-        fieldIndex = continuationContext.openAIChatAssistantFields.length;
-        continuationContext.openAIChatAssistantFields.push(undefined);
+        if (nextPreseededOpenAIFieldIndex < continuationContext.openAIChatAssistantFields.length) {
+          fieldIndex = nextPreseededOpenAIFieldIndex;
+          nextPreseededOpenAIFieldIndex += 1;
+          preseededOpenAIFieldSlots.add(fieldIndex);
+        } else {
+          fieldIndex = continuationContext.openAIChatAssistantFields.length;
+          continuationContext.openAIChatAssistantFields.push(undefined);
+        }
         openAIFieldIndexByMessageId.set(messageId, fieldIndex);
       }
       return fieldIndex;
@@ -491,6 +500,7 @@ export function useAIChatStreaming({
 
       const fieldIndex = ensureOpenAIChatFieldSlot(messageId);
       if (fieldIndex === undefined) return;
+      if (preseededOpenAIFieldSlots.has(fieldIndex)) return;
 
       const merged = mergeProviderContinuation(
         { openAIChatAssistantFields: continuationContext.openAIChatAssistantFields[fieldIndex] },
@@ -942,7 +952,9 @@ export function useAIChatStreaming({
       };
 
       const sdkMessages: Array<ModelMessage> = [];
+      let previousHistoryMessageWasToolResult = false;
       for (const m of allMessages) {
+        const currentMessageFollowsToolResult = previousHistoryMessageWasToolResult;
         if (m.role === 'user') {
           // Build multimodal content when attachments are present (fallback to legacy `images` field)
           const messageAttachments = m.attachments ?? m.images;
@@ -967,6 +979,10 @@ export function useAIChatStreaming({
           )
             ? m.providerContinuation
             : undefined;
+          const openAIChatAssistantFields = getOpenAIChatAssistantFieldsForHistoryMessage(
+            m,
+            continuationContext.source,
+          );
           if (m.toolCalls?.length) {
             // Only include tool calls that have matching results
             const resolvedCalls = m.toolCalls.filter(tc => resolvedToolCallIds.has(tc.id));
@@ -1002,7 +1018,7 @@ export function useAIChatStreaming({
             if (contentParts.length > 0) {
               sdkMessages.push({ role: 'assistant', content: toAssistantModelContent(contentParts) });
               if (resolvedCalls.length > 0) {
-                continuationContext.openAIChatAssistantFields.push(activeContinuation?.openAIChatAssistantFields);
+                continuationContext.openAIChatAssistantFields.push(openAIChatAssistantFields);
               }
             }
           } else if (m.content) {
@@ -1024,6 +1040,9 @@ export function useAIChatStreaming({
               role: 'assistant',
               content: toAssistantModelContent(contentParts),
             });
+            if (currentMessageFollowsToolResult) {
+              continuationContext.openAIChatAssistantFields.push(openAIChatAssistantFields);
+            }
           }
         } else if (m.role === 'tool' && m.toolResults?.length) {
           sdkMessages.push({
@@ -1036,6 +1055,7 @@ export function useAIChatStreaming({
             })),
           });
         }
+        previousHistoryMessageWasToolResult = m.role === 'tool' && !!m.toolResults?.length;
       }
       // Build the current user message — include attachments as multimodal content
       if (attachments?.length) {

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -456,10 +456,6 @@ export function useAIChatStreaming({
     // -- Text-delta batching: accumulate deltas and flush periodically --
     let pendingText = '';
     let rafId: number | null = null;
-    const openAIFieldIndexByMessageId = new Map<string, number>();
-    let nextPreseededOpenAIFieldIndex = continuationContext?.openAIChatAssistantFields.length ?? 0;
-    const preseededOpenAIFieldSlots = new Set<number>();
-
     const ensureAssistantMessage = (): string => {
       if (lastAddedRole !== 'tool') return activeMsgId;
 
@@ -475,40 +471,6 @@ export function useAIChatStreaming({
       return activeMsgId;
     };
 
-    const ensureOpenAIChatFieldSlot = (messageId: string): number | undefined => {
-      if (!continuationContext) return undefined;
-      let fieldIndex = openAIFieldIndexByMessageId.get(messageId);
-      if (fieldIndex === undefined) {
-        if (nextPreseededOpenAIFieldIndex < continuationContext.openAIChatAssistantFields.length) {
-          fieldIndex = nextPreseededOpenAIFieldIndex;
-          nextPreseededOpenAIFieldIndex += 1;
-          preseededOpenAIFieldSlots.add(fieldIndex);
-        } else {
-          fieldIndex = continuationContext.openAIChatAssistantFields.length;
-          continuationContext.openAIChatAssistantFields.push(undefined);
-        }
-        openAIFieldIndexByMessageId.set(messageId, fieldIndex);
-      }
-      return fieldIndex;
-    };
-
-    const mergeOpenAIChatFields = (
-      messageId: string,
-      fields: OpenAIChatAssistantFields | undefined,
-    ) => {
-      if (!fields || !continuationContext) return;
-
-      const fieldIndex = ensureOpenAIChatFieldSlot(messageId);
-      if (fieldIndex === undefined) return;
-      if (preseededOpenAIFieldSlots.has(fieldIndex)) return;
-
-      const merged = mergeProviderContinuation(
-        { openAIChatAssistantFields: continuationContext.openAIChatAssistantFields[fieldIndex] },
-        { openAIChatAssistantFields: fields },
-      );
-      continuationContext.openAIChatAssistantFields[fieldIndex] = merged?.openAIChatAssistantFields;
-    };
-
     const updateAssistantContinuation = (
       messageId: string,
       continuation: ProviderContinuation | undefined,
@@ -516,7 +478,6 @@ export function useAIChatStreaming({
     ) => {
       if (!continuation && !thinkingText) return;
       const sourcedContinuation = withProviderContinuationSource(continuation, continuationContext?.source);
-      mergeOpenAIChatFields(messageId, sourcedContinuation?.openAIChatAssistantFields);
       updateMessageById(streamSessionId, messageId, msg => {
         const providerContinuation = mergeProviderContinuation(msg.providerContinuation, sourcedContinuation);
         return {
@@ -633,7 +594,6 @@ export function useAIChatStreaming({
           flushText();
           const typedChunk = chunk as ToolCallChunk;
           const messageId = ensureAssistantMessage();
-          ensureOpenAIChatFieldSlot(messageId);
           const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
           updateMessageById(streamSessionId, messageId, msg => ({
             ...msg,

--- a/infrastructure/ai/providerContinuation.test.ts
+++ b/infrastructure/ai/providerContinuation.test.ts
@@ -3,9 +3,11 @@ import test from 'node:test';
 import {
   applyOpenAIChatContinuationToBody,
   extractProviderContinuationFromRawChunk,
+  getOpenAIChatAssistantFieldsForHistoryMessage,
   isProviderContinuationForSource,
   mergeProviderContinuation,
   normalizeProviderContinuationOptions,
+  rawOpenAIChatChunkHasToolCalls,
   withProviderContinuationSource,
 } from './providerContinuation';
 
@@ -64,6 +66,106 @@ test('patches OpenAI-compatible assistant tool-call messages with saved continua
   );
 
   assert.equal(patched.messages[2].reasoning_content, 'need shell context');
+});
+
+test('patches the final assistant message after a tool result with saved continuation fields', () => {
+  const body = JSON.stringify({
+    model: 'deepseek-v4-flash',
+    stream: true,
+    messages: [
+      { role: 'user', content: 'inspect the host' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'run_command', arguments: '{}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      { role: 'assistant', content: 'host is healthy' },
+      { role: 'user', content: 'continue' },
+    ],
+  });
+
+  const patched = JSON.parse(
+    applyOpenAIChatContinuationToBody(body, [
+      { reasoning_content: 'need shell context' },
+      { reasoning_content: 'summarize result' },
+    ]),
+  );
+
+  assert.equal(patched.messages[1].reasoning_content, 'need shell context');
+  assert.equal(patched.messages[3].reasoning_content, 'summarize result');
+});
+
+test('rebuilds OpenAI-compatible continuation fields from saved thinking for legacy history', () => {
+  const source = { providerConfigId: 'deepseek-custom', providerType: 'custom', modelId: 'deepseek-v4-flash' };
+
+  assert.deepEqual(
+    getOpenAIChatAssistantFieldsForHistoryMessage(
+      {
+        thinking: 'legacy visible reasoning',
+        providerId: 'custom',
+        model: 'deepseek-v4-flash',
+      },
+      source,
+    ),
+    { reasoning_content: 'legacy visible reasoning' },
+  );
+});
+
+test('does not rebuild continuation fields from thinking when provider or model differs', () => {
+  const source = { providerConfigId: 'deepseek-custom', providerType: 'custom', modelId: 'deepseek-v4-flash' };
+
+  assert.equal(
+    getOpenAIChatAssistantFieldsForHistoryMessage(
+      {
+        thinking: 'other provider reasoning',
+        providerId: 'openai',
+        model: 'deepseek-v4-flash',
+      },
+      source,
+    ),
+    undefined,
+  );
+  assert.equal(
+    getOpenAIChatAssistantFieldsForHistoryMessage(
+      {
+        thinking: 'other model reasoning',
+        providerId: 'custom',
+        model: 'another-model',
+      },
+      source,
+    ),
+    undefined,
+  );
+});
+
+test('detects OpenAI-compatible tool calls in raw chunks', () => {
+  assert.equal(rawOpenAIChatChunkHasToolCalls({
+    choices: [
+      {
+        delta: {
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'run_command', arguments: '{}' },
+            },
+          ],
+        },
+      },
+    ],
+  }), true);
+
+  assert.equal(rawOpenAIChatChunkHasToolCalls({
+    choices: [{ delta: { reasoning_content: 'think' } }],
+  }), false);
+  assert.equal(rawOpenAIChatChunkHasToolCalls('[DONE]'), false);
 });
 
 test('merges provider reasoning metadata into the reasoning part it belongs to', () => {
@@ -171,7 +273,7 @@ test('merges tool-call provider options by tool call id', () => {
   });
 });
 
-test('matches continuation fields only to assistant tool-call messages', () => {
+test('skips plain assistant messages that are not part of a tool loop', () => {
   const body = JSON.stringify({
     stream: true,
     messages: [

--- a/infrastructure/ai/providerContinuation.test.ts
+++ b/infrastructure/ai/providerContinuation.test.ts
@@ -143,6 +143,26 @@ test('does not rebuild continuation fields from thinking when provider or model 
     ),
     undefined,
   );
+  assert.equal(
+    getOpenAIChatAssistantFieldsForHistoryMessage(
+      {
+        thinking: 'missing provider metadata',
+        model: 'deepseek-v4-flash',
+      },
+      source,
+    ),
+    undefined,
+  );
+  assert.equal(
+    getOpenAIChatAssistantFieldsForHistoryMessage(
+      {
+        thinking: 'missing model metadata',
+        providerId: 'custom',
+      },
+      source,
+    ),
+    undefined,
+  );
 });
 
 test('detects OpenAI-compatible tool calls in raw chunks', () => {

--- a/infrastructure/ai/providerContinuation.ts
+++ b/infrastructure/ai/providerContinuation.ts
@@ -29,6 +29,13 @@ export interface ProviderContinuation {
 
 export type OpenAIChatAssistantFields = Record<string, unknown>;
 
+export interface ProviderContinuationHistoryMessage {
+  providerContinuation?: ProviderContinuation;
+  thinking?: string;
+  model?: string;
+  providerId?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -286,6 +293,25 @@ export function isProviderContinuationForSource(
     && continuation.source.modelId === source.modelId;
 }
 
+export function getOpenAIChatAssistantFieldsForHistoryMessage(
+  message: ProviderContinuationHistoryMessage,
+  source: ProviderContinuationSource | undefined,
+): OpenAIChatAssistantFields | undefined {
+  const activeContinuation = isProviderContinuationForSource(message.providerContinuation, source)
+    ? message.providerContinuation
+    : undefined;
+  if (activeContinuation?.openAIChatAssistantFields) {
+    return activeContinuation.openAIChatAssistantFields;
+  }
+
+  if (!source) return undefined;
+  if (message.providerId && message.providerId !== source.providerType) return undefined;
+  if (message.model && message.model !== source.modelId) return undefined;
+
+  const thinking = typeof message.thinking === 'string' ? message.thinking.trim() : '';
+  return thinking ? { reasoning_content: thinking } : undefined;
+}
+
 export function extractProviderContinuationFromRawChunk(rawValue: unknown): ProviderContinuation | undefined {
   const parsed = parseRawValue(rawValue);
   if (!isRecord(parsed) || !Array.isArray(parsed.choices)) return undefined;
@@ -308,6 +334,21 @@ export function extractProviderContinuationFromRawChunk(rawValue: unknown): Prov
   };
 }
 
+export function rawOpenAIChatChunkHasToolCalls(rawValue: unknown): boolean {
+  const parsed = parseRawValue(rawValue);
+  if (!isRecord(parsed) || !Array.isArray(parsed.choices)) return false;
+
+  for (const choice of parsed.choices) {
+    if (!isRecord(choice)) continue;
+    const delta = isRecord(choice.delta) ? choice.delta : undefined;
+    const message = isRecord(choice.message) ? choice.message : undefined;
+    if (delta && hasToolCalls(delta)) return true;
+    if (message && hasToolCalls(message)) return true;
+  }
+
+  return false;
+}
+
 function hasToolCalls(message: Record<string, unknown>): boolean {
   return Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
 }
@@ -326,9 +367,9 @@ function compactAssistantFields(fields: OpenAIChatAssistantFields | undefined): 
 
 export function applyOpenAIChatContinuationToBody(
   body: string,
-  assistantFieldsByToolCallMessage: Array<OpenAIChatAssistantFields | undefined>,
+  assistantFieldsByContinuationMessage: Array<OpenAIChatAssistantFields | undefined>,
 ): string {
-  if (!assistantFieldsByToolCallMessage.length) return body;
+  if (!assistantFieldsByContinuationMessage.length) return body;
 
   let parsed: unknown;
   try {
@@ -341,12 +382,19 @@ export function applyOpenAIChatContinuationToBody(
 
   let fieldIndex = 0;
   let changed = false;
+  let previousMessageWasTool = false;
   const messages = parsed.messages.map((message) => {
-    if (!isRecord(message) || message.role !== 'assistant' || !hasToolCalls(message)) {
+    const isToolMessage = isRecord(message) && message.role === 'tool';
+    const needsContinuationFields = isRecord(message)
+      && message.role === 'assistant'
+      && (hasToolCalls(message) || previousMessageWasTool);
+    previousMessageWasTool = isToolMessage;
+
+    if (!needsContinuationFields) {
       return message;
     }
 
-    const fields = compactAssistantFields(assistantFieldsByToolCallMessage[fieldIndex]);
+    const fields = compactAssistantFields(assistantFieldsByContinuationMessage[fieldIndex]);
     fieldIndex += 1;
     if (!fields) return message;
 

--- a/infrastructure/ai/providerContinuation.ts
+++ b/infrastructure/ai/providerContinuation.ts
@@ -305,8 +305,8 @@ export function getOpenAIChatAssistantFieldsForHistoryMessage(
   }
 
   if (!source) return undefined;
-  if (message.providerId && message.providerId !== source.providerType) return undefined;
-  if (message.model && message.model !== source.modelId) return undefined;
+  if (message.providerId !== source.providerType) return undefined;
+  if (source.modelId && message.model !== source.modelId) return undefined;
 
   const thinking = typeof message.thinking === 'string' ? message.thinking.trim() : '';
   return thinking ? { reasoning_content: thinking } : undefined;

--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -84,6 +84,205 @@ test('captures OpenAI-compatible reasoning_content before the tool follow-up req
   assert.equal(messages[1].reasoning_content, 'need shell context');
 });
 
+test('does not duplicate reasoning_content when tool calls stream across chunks', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const assistantFields: Array<OpenAIChatAssistantFields | undefined> = [];
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        if (sentBodies.length === 1) {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { reasoning_content: 'need shell context' } }] }));
+          emit(JSON.stringify({
+            choices: [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'terminal_exec', arguments: '' },
+                }],
+              },
+            }],
+          }));
+          emit(JSON.stringify({
+            choices: [{
+              index: 0,
+              delta: {
+                tool_calls: [{
+                  index: 0,
+                  function: { arguments: '{}' },
+                }],
+              },
+            }],
+          }));
+        }
+        endHandlers.get(requestId)?.();
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const fetch = createBridgeFetchForSDK('deepseek-custom', {
+    getOpenAIChatAssistantFields: () => assistantFields,
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [{ role: 'user', content: 'inspect the host' }],
+    }),
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [
+        { role: 'user', content: 'inspect the host' },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'terminal_exec', arguments: '{}' },
+          }],
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      ],
+    }),
+  });
+
+  const followUpBody = sentBodies[1];
+  const messages = followUpBody.messages as Array<Record<string, unknown>>;
+  assert.equal(messages[1].reasoning_content, 'need shell context');
+});
+
+test('keeps captured reasoning_content aligned across consecutive tool calls', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const assistantFields: Array<OpenAIChatAssistantFields | undefined> = [];
+  const toolCall = (id: string) => ({
+    id,
+    type: 'function',
+    function: { name: 'terminal_exec', arguments: '{}' },
+  });
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const emit = dataHandlers.get(requestId);
+        assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+        if (sentBodies.length === 1) {
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { reasoning_content: 'first tool reasoning' } }] }));
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { tool_calls: [toolCall('call_1')] } }] }));
+        } else if (sentBodies.length === 2) {
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { reasoning_content: 'second tool reasoning' } }] }));
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { tool_calls: [toolCall('call_2')] } }] }));
+        }
+        endHandlers.get(requestId)?.();
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const fetch = createBridgeFetchForSDK('deepseek-custom', {
+    getOpenAIChatAssistantFields: () => assistantFields,
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [{ role: 'user', content: 'inspect the host' }],
+    }),
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [
+        { role: 'user', content: 'inspect the host' },
+        { role: 'assistant', content: '', tool_calls: [toolCall('call_1')] },
+        { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      ],
+    }),
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [
+        { role: 'user', content: 'inspect the host' },
+        { role: 'assistant', content: '', tool_calls: [toolCall('call_1')] },
+        { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+        { role: 'assistant', content: '', tool_calls: [toolCall('call_2')] },
+        { role: 'tool', tool_call_id: 'call_2', content: '{"ok":true}' },
+      ],
+    }),
+  });
+
+  const secondRequestMessages = sentBodies[1].messages as Array<Record<string, unknown>>;
+  const thirdRequestMessages = sentBodies[2].messages as Array<Record<string, unknown>>;
+  assert.equal(secondRequestMessages[1].reasoning_content, 'first tool reasoning');
+  assert.equal(thirdRequestMessages[1].reasoning_content, 'first tool reasoning');
+  assert.equal(thirdRequestMessages[3].reasoning_content, 'second tool reasoning');
+});
+
 test('replays reasoning_content through the SDK tool loop', async (t) => {
   const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
   t.after(() => {

--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+import { createBridgeFetchForSDK, createModelFromConfig } from './sdk/providers';
+import type { OpenAIChatAssistantFields } from './providerContinuation';
+
+test('captures OpenAI-compatible reasoning_content before the tool follow-up request', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const assistantFields: Array<OpenAIChatAssistantFields | undefined> = [];
+
+  const toolCall = {
+    id: 'call_1',
+    type: 'function',
+    function: { name: 'terminal_exec', arguments: '{}' },
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        if (sentBodies.length === 1) {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { reasoning_content: 'need shell ' } }] }));
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { reasoning_content: 'context' } }] }));
+          emit(JSON.stringify({ choices: [{ index: 0, delta: { tool_calls: [toolCall] } }] }));
+        }
+        endHandlers.get(requestId)?.();
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const fetch = createBridgeFetchForSDK('deepseek-custom', {
+    getOpenAIChatAssistantFields: () => assistantFields,
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [{ role: 'user', content: 'inspect the host' }],
+    }),
+  });
+
+  await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [
+        { role: 'user', content: 'inspect the host' },
+        { role: 'assistant', content: '', tool_calls: [toolCall] },
+        { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      ],
+    }),
+  });
+
+  const followUpBody = sentBodies[1];
+  const messages = followUpBody.messages as Array<Record<string, unknown>>;
+  assert.equal(messages[1].reasoning_content, 'need shell context');
+});
+
+test('replays reasoning_content through the SDK tool loop', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const assistantFields: Array<OpenAIChatAssistantFields | undefined> = [];
+  const toolCall = {
+    index: 0,
+    id: 'call_1',
+    type: 'function',
+    function: { name: 'terminal_exec', arguments: '{}' },
+  };
+
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      id: 'chatcmpl-test',
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'deepseek-v4-flash',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, { reasoning_content: 'need disk ' });
+            emitChatChunk(emit, { reasoning_content: 'context' });
+            emitChatChunk(emit, { tool_calls: [toolCall] });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { reasoning_content: 'read result' });
+            emitChatChunk(emit, { content: 'disk usage is 81%' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const model = createModelFromConfig(
+    {
+      id: 'deepseek-custom',
+      providerId: 'custom',
+      name: 'DeepSeek',
+      apiKey: 'test-key',
+      baseURL: 'https://api.deepseek.com',
+      defaultModel: 'deepseek-v4-flash',
+      enabled: true,
+    },
+    { getOpenAIChatAssistantFields: () => assistantFields },
+  );
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect disk' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({}),
+        execute: async () => ({ ok: true }),
+      }),
+    },
+    stopWhen: stepCountIs(2),
+    includeRawChunks: true,
+  });
+
+  for await (const _chunk of result.fullStream) {
+    // Drain the stream so the SDK completes the tool loop.
+  }
+
+  const followUpBody = sentBodies[1];
+  const messages = followUpBody.messages as Array<Record<string, unknown>>;
+  assert.equal(messages[1].reasoning_content, 'need disk context');
+});

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -90,27 +90,27 @@ function createOpenAIChatStreamFieldCapture(
     return streamFieldIndex;
   };
 
+  const flushPendingFields = (fieldIndex: number) => {
+    if (!pendingFields) return;
+    assistantFields[fieldIndex] = mergeOpenAIChatAssistantFields(
+      assistantFields[fieldIndex],
+      pendingFields,
+    );
+    pendingFields = undefined;
+  };
+
   return (data: string) => {
     const continuation = extractProviderContinuationFromRawChunk(data);
     const fields = continuation?.openAIChatAssistantFields;
     if (fields) {
       pendingFields = mergeOpenAIChatAssistantFields(pendingFields, fields);
       if (streamFieldIndex !== undefined) {
-        assistantFields[streamFieldIndex] = mergeOpenAIChatAssistantFields(
-          assistantFields[streamFieldIndex],
-          fields,
-        );
+        flushPendingFields(streamFieldIndex);
       }
     }
 
     if (rawOpenAIChatChunkHasToolCalls(data)) {
-      const fieldIndex = ensureStreamFieldSlot();
-      if (pendingFields) {
-        assistantFields[fieldIndex] = mergeOpenAIChatAssistantFields(
-          assistantFields[fieldIndex],
-          pendingFields,
-        );
-      }
+      flushPendingFields(ensureStreamFieldSlot());
     }
   };
 }

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -4,6 +4,9 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { ProviderConfig } from '../types';
 import {
   applyOpenAIChatContinuationToBody,
+  extractProviderContinuationFromRawChunk,
+  mergeProviderContinuation,
+  rawOpenAIChatChunkHasToolCalls,
   type OpenAIChatAssistantFields,
 } from '../providerContinuation';
 
@@ -59,6 +62,57 @@ function isStreamingRequest(init?: RequestInit): boolean {
   } catch {
     return false;
   }
+}
+
+function mergeOpenAIChatAssistantFields(
+  current: OpenAIChatAssistantFields | undefined,
+  incoming: OpenAIChatAssistantFields | undefined,
+): OpenAIChatAssistantFields | undefined {
+  return mergeProviderContinuation(
+    { openAIChatAssistantFields: current },
+    { openAIChatAssistantFields: incoming },
+  )?.openAIChatAssistantFields;
+}
+
+function createOpenAIChatStreamFieldCapture(
+  requestContext?: ProviderRequestContext,
+): (data: string) => void {
+  const assistantFields = requestContext?.getOpenAIChatAssistantFields?.();
+  if (!assistantFields) return () => undefined;
+
+  let streamFieldIndex: number | undefined;
+  let pendingFields: OpenAIChatAssistantFields | undefined;
+
+  const ensureStreamFieldSlot = (): number => {
+    if (streamFieldIndex !== undefined) return streamFieldIndex;
+    streamFieldIndex = assistantFields.length;
+    assistantFields.push(undefined);
+    return streamFieldIndex;
+  };
+
+  return (data: string) => {
+    const continuation = extractProviderContinuationFromRawChunk(data);
+    const fields = continuation?.openAIChatAssistantFields;
+    if (fields) {
+      pendingFields = mergeOpenAIChatAssistantFields(pendingFields, fields);
+      if (streamFieldIndex !== undefined) {
+        assistantFields[streamFieldIndex] = mergeOpenAIChatAssistantFields(
+          assistantFields[streamFieldIndex],
+          fields,
+        );
+      }
+    }
+
+    if (rawOpenAIChatChunkHasToolCalls(data)) {
+      const fieldIndex = ensureStreamFieldSlot();
+      if (pendingFields) {
+        assistantFields[fieldIndex] = mergeOpenAIChatAssistantFields(
+          assistantFields[fieldIndex],
+          pendingFields,
+        );
+      }
+    }
+  };
 }
 
 /**
@@ -153,6 +207,7 @@ export function createBridgeFetchForSDK(
     // Streaming path
     if (isStreamingRequest(resolvedInit)) {
       const requestId = `sdk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const captureOpenAIChatFields = createOpenAIChatStreamFieldCapture(requestContext);
 
       // Set up IPC event listeners BEFORE starting the stream to avoid
       // missing early events.
@@ -161,6 +216,7 @@ export function createBridgeFetchForSDK(
       let cleanedUp = false;
 
       const unsubData = bridge.onAiStreamData(requestId, (data: string) => {
+        captureOpenAIChatFields(data);
         // Re-wrap as SSE so the SDK can parse it
         streamController?.enqueue(encoder.encode(`data: ${data}\n\n`));
       });


### PR DESCRIPTION
## Summary
- capture OpenAI-compatible reasoning fields before tool follow-up requests
- replay saved reasoning fields for tool-call assistant messages and the final assistant message after tool results
- add coverage for immediate tool follow-ups and next-turn replay after tool use

## Verification
- node --test --import tsx infrastructure/ai/providerContinuation.test.ts infrastructure/ai/providersBridgeFetch.test.ts
- node --test --import tsx components/ai/*.test.ts infrastructure/ai/*.test.ts
- npm run lint
- npm run build
- npm test