### PR TITLE
[codex] Tighten AI chat spacing

### DIFF
--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -35,7 +35,7 @@ export const MessageContent = ({ children, className, from, ...props }: MessageC
   <div
     className={cn(
       'ai-chat-message-content flex w-fit min-w-0 max-w-full flex-col gap-1.5 text-[13px] leading-relaxed',
-      'group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:border group-[.is-user]:border-border/50 group-[.is-user]:bg-muted/50 group-[.is-user]:px-2.5 group-[.is-user]:py-2',
+      'group-[.is-user]:ml-auto group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:border group-[.is-user]:border-border/50 group-[.is-user]:bg-muted/50 group-[.is-user]:px-2.5 group-[.is-user]:py-[7px]',
       'group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground/90',
       className,
     )}

--- a/components/ai/ChatMessageList.tsx
+++ b/components/ai/ChatMessageList.tsx
@@ -233,7 +233,7 @@ const ChatMessageList: React.FC<ChatMessageListProps> = ({ messages, isStreaming
 
                 {message.content && (
                   isUser
-                    ? <div className="whitespace-pre-wrap break-words text-[13px]">{message.content}</div>
+                    ? <div className="whitespace-pre-wrap break-words text-[13px] leading-[1.45]">{message.content}</div>
                     : <MessageResponse isAnimating={isThisStreaming}>
                         {message.content}
                       </MessageResponse>

--- a/index.css
+++ b/index.css
@@ -516,11 +516,12 @@ body {
 }
 
 /* Streamdown table overrides */
-[data-streamdown="table-wrapper"] {
+.ai-chat-message-content[data-role="assistant"] [data-streamdown="table-wrapper"] {
   gap: 4px !important;
   padding: 4px 8px 8px !important;
 }
 
-[data-streamdown="table-wrapper"] > div:first-child:has(button) button {
+.ai-chat-message-content[data-role="assistant"] [data-streamdown="table-wrapper"] > div:first-child > button,
+.ai-chat-message-content[data-role="assistant"] [data-streamdown="table-wrapper"] > div:first-child > div > button {
   padding: 3px !important;
 }

--- a/index.css
+++ b/index.css
@@ -514,3 +514,13 @@ body {
   line-height: 1.5 !important;
   white-space: pre !important;
 }
+
+/* Streamdown table overrides */
+[data-streamdown="table-wrapper"] {
+  gap: 4px !important;
+  padding: 4px 8px 8px !important;
+}
+
+[data-streamdown="table-wrapper"] > div:first-child:has(button) button {
+  padding: 3px !important;
+}


### PR DESCRIPTION
## Summary
- Tighten Streamdown table toolbar spacing in AI chat responses
- Make user message bubbles use symmetric vertical padding and a tighter line height

## Validation
- npm run lint
- npm run build
- Electron visual style measurement for table toolbar and user bubble spacing
- npm test