### PR TITLE
[codex] Fix SFTP editor saved state

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -58,7 +58,7 @@ import type { SftpView as SftpViewComponent } from './components/SftpView';
 import type { TerminalLayer as TerminalLayerComponent } from './components/TerminalLayer';
 import { TextEditorTabView } from './components/editor/TextEditorTabView';
 import { UnsavedChangesProvider } from './components/editor/UnsavedChangesDialog';
-import { editorSftpWrite } from './application/state/editorSftpBridge';
+import { releaseEditorTabSaveCoordinator, saveEditorTab } from './application/state/editorTabSave';
 
 // Initialize fonts eagerly at app startup
 initializeFonts();
@@ -1769,6 +1769,7 @@ function App({ settings }: { settings: SettingsState }) {
           const closingTabId = toEditorTabId(id);
           const list = orderedTabsWithEditors;
           const idx = list.indexOf(closingTabId);
+          releaseEditorTabSaveCoordinator(id);
           editorTabStore.close(id);
           if (activeTabStore.getActiveTabId() !== closingTabId) return;
           const next = list[idx - 1] ?? list[idx + 1] ?? 'vault';
@@ -1791,16 +1792,15 @@ function App({ settings }: { settings: SettingsState }) {
             return;
           }
           if (choice === 'save') {
-            try {
-              editorTabStore.setSavingState(id, 'saving');
-              await editorSftpWrite(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
-              editorTabStore.markSaved(id, tab.content);
-              closeEditorAndActivateNeighbor(id);
-            } catch (e) {
-              const msg = e instanceof Error ? e.message : 'Save failed';
-              editorTabStore.setSavingState(id, 'error', msg);
+            const ok = await saveEditorTab(id);
+            if (!ok) {
+              const msg = editorTabStore.getTab(id)?.saveError ?? 'Save failed';
               toast.error(msg, 'SFTP');
+              return;
             }
+            const latest = editorTabStore.getTab(id);
+            if (!latest || latest.content !== latest.baselineContent) return;
+            closeEditorAndActivateNeighbor(id);
           }
         };
 

--- a/application/state/editorTabSave.test.ts
+++ b/application/state/editorTabSave.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EditorTabStore, type EditorTab } from "./editorTabStore.ts";
+import { createEditorTabSaveService } from "./editorTabSave.ts";
+
+const deferred = <T = void>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeTab = (overrides: Partial<EditorTab> = {}): EditorTab => ({
+  id: "edt_1",
+  kind: "editor",
+  sessionId: "conn_1",
+  hostId: "host_1",
+  remotePath: "/tmp/file.txt",
+  fileName: "file.txt",
+  languageId: "plaintext",
+  content: "v1",
+  baselineContent: "old",
+  wordWrap: false,
+  viewState: null,
+  savingState: "idle",
+  saveError: null,
+  ...overrides,
+});
+
+test("editor tab save service joins duplicate saves for the same content", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  const pending = deferred();
+  const writes: string[] = [];
+  const service = createEditorTabSaveService({
+    store,
+    write: async (_sessionId, _hostId, _remotePath, content) => {
+      writes.push(content);
+      await pending.promise;
+    },
+  });
+
+  const first = service.saveTab("edt_1");
+  const second = service.saveTab("edt_1", "v1");
+
+  assert.deepEqual(writes, ["v1"]);
+  pending.resolve();
+
+  assert.equal(await first, true);
+  assert.equal(await second, true);
+  assert.deepEqual(writes, ["v1"]);
+  assert.equal(store.getTab("edt_1")?.baselineContent, "v1");
+  assert.equal(store.getTab("edt_1")?.savingState, "idle");
+});
+
+test("editor tab save service queues newer tab content after an in-flight save", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab());
+  const firstSave = deferred();
+  const secondSave = deferred();
+  const writes: string[] = [];
+  const service = createEditorTabSaveService({
+    store,
+    write: async (_sessionId, _hostId, _remotePath, content) => {
+      writes.push(content);
+      await (content === "v1" ? firstSave.promise : secondSave.promise);
+    },
+  });
+
+  const first = service.saveTab("edt_1");
+  store.updateContent("edt_1", "v2", null);
+  const second = service.saveTab("edt_1");
+
+  assert.deepEqual(writes, ["v1"]);
+  firstSave.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(writes, ["v1", "v2"]);
+  secondSave.resolve();
+
+  assert.equal(await first, true);
+  assert.equal(await second, true);
+  assert.equal(store.getTab("edt_1")?.baselineContent, "v2");
+  assert.equal(store.getTab("edt_1")?.content, "v2");
+});

--- a/application/state/editorTabSave.ts
+++ b/application/state/editorTabSave.ts
@@ -1,0 +1,72 @@
+import { editorSftpWrite, type EditorSftpWrite } from "./editorSftpBridge";
+import { editorTabStore, type EditorTabId, type EditorTabStore } from "./editorTabStore";
+import {
+  createTextEditorSaveCoordinator,
+  type TextEditorSaveCoordinator,
+} from "./textEditorSaveCoordinator";
+
+interface EditorTabSaveServiceDeps {
+  store: EditorTabStore;
+  write: EditorSftpWrite;
+}
+
+export interface EditorTabSaveService {
+  saveTab(id: EditorTabId, contentOverride?: string): Promise<boolean>;
+  releaseTab(id: EditorTabId): void;
+}
+
+const formatSaveError = (error: unknown): string =>
+  error instanceof Error ? error.message : "Save failed";
+
+export const createEditorTabSaveService = ({
+  store,
+  write,
+}: EditorTabSaveServiceDeps): EditorTabSaveService => {
+  const coordinators = new Map<EditorTabId, TextEditorSaveCoordinator>();
+
+  const getCoordinator = (id: EditorTabId): TextEditorSaveCoordinator => {
+    const existing = coordinators.get(id);
+    if (existing) return existing;
+
+    const coordinator = createTextEditorSaveCoordinator({
+      onSave: async (content) => {
+        const tab = store.getTab(id);
+        if (!tab) throw new Error("Editor tab closed before save completed");
+        await write(tab.sessionId, tab.hostId, tab.remotePath, content);
+      },
+      onSaveStart: () => {
+        store.setSavingState(id, "saving");
+      },
+      onSaveSuccess: (content) => {
+        store.markSaved(id, content);
+      },
+      onSaveError: (error) => {
+        store.setSavingState(id, "error", formatSaveError(error));
+      },
+    });
+
+    coordinators.set(id, coordinator);
+    return coordinator;
+  };
+
+  return {
+    saveTab: async (id, contentOverride) => {
+      const tab = store.getTab(id);
+      if (!tab) return false;
+      return getCoordinator(id).save(contentOverride ?? tab.content);
+    },
+    releaseTab: (id) => {
+      const coordinator = coordinators.get(id);
+      coordinator?.reset();
+      coordinators.delete(id);
+    },
+  };
+};
+
+const editorTabSaveService = createEditorTabSaveService({
+  store: editorTabStore,
+  write: editorSftpWrite,
+});
+
+export const saveEditorTab = editorTabSaveService.saveTab;
+export const releaseEditorTabSaveCoordinator = editorTabSaveService.releaseTab;

--- a/application/state/editorTabStore.test.ts
+++ b/application/state/editorTabStore.test.ts
@@ -196,3 +196,24 @@ test("confirmCloseBySession invokes save callback for 'save' choice and only clo
   assert.equal(ok, true);
   assert.equal(store.getTab("edt_1"), undefined);
 });
+
+test("confirmCloseBySession reports every closed editor tab to cleanup callback", async () => {
+  const store = new EditorTabStore();
+  store._debugInsert(makeTab({ id: "edt_clean" }));
+  store._debugInsert(makeTab({ id: "edt_dirty", remotePath: "/b.txt", fileName: "b.txt", content: "new", baselineContent: "old" }));
+  const closed: string[] = [];
+
+  const ok = await store.confirmCloseBySession(
+    "conn_1",
+    async () => "save",
+    async (id) => {
+      const tab = store.getTab(id)!;
+      store.markSaved(id, tab.content);
+    },
+    (id) => closed.push(id),
+  );
+
+  assert.equal(ok, true);
+  assert.deepEqual(closed, ["edt_clean", "edt_dirty"]);
+  assert.equal(store.getTabs().length, 0);
+});

--- a/application/state/editorTabStore.ts
+++ b/application/state/editorTabStore.ts
@@ -167,17 +167,23 @@ export class EditorTabStore {
     sessionId: string,
     promptChoice: (tab: EditorTab) => Promise<"save" | "discard" | "cancel">,
     saveTab?: (tabId: EditorTabId) => Promise<void>,
+    onCloseTab?: (tabId: EditorTabId) => void,
   ): Promise<boolean> => {
     const matching = this.tabs.filter((t) => t.sessionId === sessionId);
     for (const tab of matching) {
       const dirty = tab.content !== tab.baselineContent;
       if (!dirty) {
+        onCloseTab?.(tab.id);
         this.close(tab.id);
         continue;
       }
       const choice = await promptChoice(tab);
       if (choice === "cancel") return false;
-      if (choice === "discard") { this.close(tab.id); continue; }
+      if (choice === "discard") {
+        onCloseTab?.(tab.id);
+        this.close(tab.id);
+        continue;
+      }
       if (choice === "save") {
         if (!saveTab) throw new Error("saveTab callback required when 'save' choice is possible");
         try {
@@ -186,6 +192,7 @@ export class EditorTabStore {
           // Save failed — treat like cancel (keep tab open, abort batch so the user sees the error)
           return false;
         }
+        onCloseTab?.(tab.id);
         this.close(tab.id);
       }
     }

--- a/application/state/textEditorSaveCoordinator.test.ts
+++ b/application/state/textEditorSaveCoordinator.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createTextEditorSaveCoordinator } from "./textEditorSaveCoordinator.ts";
+
+const deferred = <T = void>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+test("text editor save coordinator joins duplicate saves already in flight", async () => {
+  const pending = deferred();
+  const saved: string[] = [];
+  const savingStates: boolean[] = [];
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async (content) => {
+      saved.push(content);
+      await pending.promise;
+    },
+    onSavingChange: (saving) => savingStates.push(saving),
+  });
+
+  const first = coordinator.save("remote text");
+  const second = coordinator.save("remote text");
+
+  assert.deepEqual(saved, ["remote text"]);
+  pending.resolve();
+
+  assert.equal(await first, true);
+  assert.equal(await second, true);
+  assert.deepEqual(saved, ["remote text"]);
+  assert.deepEqual(savingStates, [true, false]);
+});
+
+test("text editor save coordinator saves newer content after an in-flight save finishes", async () => {
+  const firstSave = deferred();
+  const secondSave = deferred();
+  const saved: string[] = [];
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async (content) => {
+      saved.push(content);
+      await (content === "v1" ? firstSave.promise : secondSave.promise);
+    },
+  });
+
+  const first = coordinator.save("v1");
+  const second = coordinator.save("v2");
+
+  assert.deepEqual(saved, ["v1"]);
+  firstSave.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(saved, ["v1", "v2"]);
+  secondSave.resolve();
+
+  assert.equal(await first, true);
+  assert.equal(await second, true);
+});
+
+test("text editor save coordinator returns false to duplicate callers when the in-flight save fails", async () => {
+  const pending = deferred();
+  const errors: string[] = [];
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async () => {
+      await pending.promise;
+      throw new Error("denied");
+    },
+    onSaveError: (error) => {
+      errors.push(error instanceof Error ? error.message : String(error));
+    },
+  });
+
+  const first = coordinator.save("content");
+  const second = coordinator.save("content");
+
+  pending.resolve();
+
+  assert.equal(await first, false);
+  assert.equal(await second, false);
+  assert.deepEqual(errors, ["denied"]);
+});
+
+test("text editor save coordinator reset prevents an old in-flight save from updating the next file", async () => {
+  const pending = deferred();
+  const successes: string[] = [];
+  const errors: string[] = [];
+  const savingStates: boolean[] = [];
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async () => {
+      await pending.promise;
+    },
+    onSaveSuccess: (content) => successes.push(content),
+    onSaveError: (error) => errors.push(error instanceof Error ? error.message : String(error)),
+    onSavingChange: (saving) => savingStates.push(saving),
+  });
+
+  const save = coordinator.save("old file");
+  coordinator.reset();
+  pending.resolve();
+
+  assert.equal(await save, false);
+  assert.deepEqual(successes, []);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(savingStates, [true, false]);
+});
+
+test("text editor save coordinator reset cancels queued stale saves", async () => {
+  const firstSave = deferred();
+  const saved: string[] = [];
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async (content) => {
+      saved.push(content);
+      await firstSave.promise;
+    },
+  });
+
+  const first = coordinator.save("old v1");
+  const queued = coordinator.save("old v2");
+  coordinator.reset();
+  firstSave.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(await first, false);
+  assert.equal(await queued, false);
+  assert.deepEqual(saved, ["old v1"]);
+});

--- a/application/state/textEditorSaveCoordinator.ts
+++ b/application/state/textEditorSaveCoordinator.ts
@@ -1,0 +1,90 @@
+export interface TextEditorSaveCoordinator {
+  save(content: string): Promise<boolean>;
+  isSaving(): boolean;
+  reset(): void;
+}
+
+export interface TextEditorSaveCoordinatorOptions {
+  onSave: (content: string) => Promise<void>;
+  onSaveStart?: (content: string) => void;
+  onSaveSuccess?: (content: string) => void;
+  onSaveError?: (error: unknown) => void;
+  onSavingChange?: (saving: boolean) => void;
+}
+
+interface InFlightSave {
+  content: string;
+  promise: Promise<boolean>;
+}
+
+export const createTextEditorSaveCoordinator = (
+  options: TextEditorSaveCoordinatorOptions,
+): TextEditorSaveCoordinator => {
+  let inFlight: InFlightSave | null = null;
+  let generation = 0;
+
+  const notifySavingChange = () => {
+    options.onSavingChange?.(inFlight !== null);
+  };
+
+  const startSave = (content: string): Promise<boolean> => {
+    const saveGeneration = generation;
+    options.onSaveStart?.(content);
+
+    const promise = (async () => {
+      try {
+        await options.onSave(content);
+        if (saveGeneration !== generation) {
+          return false;
+        }
+        if (saveGeneration === generation) {
+          options.onSaveSuccess?.(content);
+        }
+        return true;
+      } catch (error) {
+        if (saveGeneration !== generation) {
+          return false;
+        }
+        if (saveGeneration === generation) {
+          options.onSaveError?.(error);
+        }
+        return false;
+      }
+    })();
+
+    const entry = { content, promise };
+    inFlight = entry;
+    notifySavingChange();
+    void promise.finally(() => {
+      if (inFlight === entry) {
+        inFlight = null;
+        notifySavingChange();
+      }
+    });
+    return promise;
+  };
+
+  const save = async (content: string): Promise<boolean> => {
+    const current = inFlight;
+    if (current) {
+      const waitGeneration = generation;
+      const ok = await current.promise;
+      if (waitGeneration !== generation) return false;
+      if (!ok || current.content === content) return ok;
+      return save(content);
+    }
+    return startSave(content);
+  };
+
+  return {
+    save,
+    isSaving: () => inFlight !== null,
+    reset: () => {
+      generation += 1;
+      if (inFlight) {
+        inFlight = null;
+        notifySavingChange();
+      }
+    },
+  };
+};

--- a/application/state/windowInputFocus.ts
+++ b/application/state/windowInputFocus.ts
@@ -1,0 +1,25 @@
+import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
+
+export const requestWindowInputFocus = (): void => {
+  try {
+    const result = netcattyBridge.get()?.windowFocus?.();
+    void result?.catch?.(() => undefined);
+  } catch {
+    // Browser preview or a disposed Electron bridge.
+  }
+};
+
+export const scheduleWindowInputFocus = (): void => {
+  const scheduleFrame: (callback: () => void) => unknown =
+    typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame
+      : (callback) => {
+        callback();
+        return undefined;
+      };
+
+  scheduleFrame(() => {
+    requestWindowInputFocus();
+    setTimeout(requestWindowInputFocus, 50);
+  });
+};

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -16,6 +16,7 @@ import { useI18n } from "../application/i18n/I18nProvider";
 import { useSftpState } from "../application/state/useSftpState";
 import { registerEditorSftpWriterScoped } from "../application/state/editorSftpBridge";
 import { editorTabStore } from "../application/state/editorTabStore";
+import { releaseEditorTabSaveCoordinator } from "../application/state/editorTabSave";
 import { useSftpBackend } from "../application/state/useSftpBackend";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
 import { getParentPath } from "../application/state/sftp/utils";
@@ -167,7 +168,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         if (id) owned.add(id);
       }
       if (owned.size === 0) return;
-      editorTabStore.forceCloseBySessions([...owned]);
+      const closed = editorTabStore.forceCloseBySessions([...owned]);
+      closed.forEach(releaseEditorTabSaveCoordinator);
     };
   }, []);
 

--- a/components/TextEditorModal.test.tsx
+++ b/components/TextEditorModal.test.tsx
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createTextEditorModalSnapshot } from "./TextEditorModal.tsx";
+import { createTextEditorSaveCoordinator } from "../application/state/textEditorSaveCoordinator.ts";
+
+test("promotion snapshot uses the latest saved baseline after a save", async () => {
+  let baselineContent = "old";
+  let content = "saved";
+  const coordinator = createTextEditorSaveCoordinator({
+    onSave: async () => {},
+    onSaveSuccess: (savedContent) => {
+      baselineContent = savedContent;
+    },
+  });
+
+  await coordinator.save(content);
+
+  const snapshot = createTextEditorModalSnapshot({
+    fileName: "file.txt",
+    getBaselineContent: () => baselineContent,
+    getContent: () => content,
+    languageId: "plaintext",
+    wordWrap: false,
+    getViewState: () => null,
+    isSaving: () => false,
+  });
+
+  assert.equal(snapshot?.baselineContent, "saved");
+  assert.equal(snapshot?.content, "saved");
+});
+
+test("promotion snapshot is blocked while saving", () => {
+  const snapshot = createTextEditorModalSnapshot({
+    fileName: "file.txt",
+    getBaselineContent: () => "old",
+    getContent: () => "new",
+    languageId: "plaintext",
+    wordWrap: false,
+    getViewState: () => null,
+    isSaving: () => true,
+  });
+
+  assert.equal(snapshot, null);
+});

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -11,6 +11,7 @@ import { toast } from './ui/toast';
 import { TextEditorPane } from './editor/TextEditorPane';
 import { promptUnsavedChanges } from './editor/UnsavedChangesDialog';
 import { useI18n } from '../application/i18n/I18nProvider';
+import { scheduleWindowInputFocus } from '../application/state/windowInputFocus';
 import type { HotkeyScheme, KeyBinding } from '../domain/models';
 
 /** Snapshot passed to `onPromoteToTab` when the user clicks the maximize button. */
@@ -126,6 +127,7 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
         }
       }
       onClose();
+      scheduleWindowInputFocus();
     })().finally(() => {
       closePromptRef.current = null;
     });
@@ -149,6 +151,10 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
     if (!open) {
       closePromptRef.current = null;
     }
+  }, [open]);
+
+  useEffect(() => {
+    if (open) scheduleWindowInputFocus();
   }, [open]);
 
   const handleContentChange = useCallback(

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -9,6 +9,7 @@ import { getLanguageId } from '../lib/sftpFileUtils';
 import { Dialog, DialogContent, DialogTitle } from './ui/dialog';
 import { toast } from './ui/toast';
 import { TextEditorPane } from './editor/TextEditorPane';
+import { promptUnsavedChanges } from './editor/UnsavedChangesDialog';
 import { useI18n } from '../application/i18n/I18nProvider';
 import type { HotkeyScheme, KeyBinding } from '../domain/models';
 
@@ -16,7 +17,7 @@ import type { HotkeyScheme, KeyBinding } from '../domain/models';
 export interface TextEditorModalSnapshot {
   /** The file name at the time of promotion (modal's fileName prop). */
   fileName: string;
-  /** The clean baseline content at the time the modal was opened. */
+  /** The clean baseline content at the time of promotion. */
   baselineContent: string;
   /** The current (possibly-dirty) editor content. */
   content: string;
@@ -57,51 +58,103 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   const { t } = useI18n();
 
   const [content, setContent] = useState(initialContent);
+  const [baselineContent, setBaselineContent] = useState(initialContent);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [languageId, setLanguageId] = useState(() => getLanguageId(fileName));
+  const contentRef = useRef(initialContent);
+  const baselineContentRef = useRef(initialContent);
+  const savingRef = useRef(false);
+  const closePromptRef = useRef<Promise<void> | null>(null);
 
   // Latest view state captured from Pane's onContentChange — used by handlePromote
   const viewStateRef = useRef<Monaco.editor.ICodeEditorViewState | null>(null);
 
   // Derived: whether the current content differs from the clean baseline
-  const hasChanges = content !== initialContent;
+  const hasChanges = content !== baselineContent;
 
   // Reset all state when a new file is opened
   useEffect(() => {
     setContent(initialContent);
+    setBaselineContent(initialContent);
     setSaveError(null);
+    setSaving(false);
     setLanguageId(getLanguageId(fileName));
+    contentRef.current = initialContent;
+    baselineContentRef.current = initialContent;
+    savingRef.current = false;
+    closePromptRef.current = null;
     viewStateRef.current = null;
   }, [initialContent, fileName]);
 
-  const handleSave = useCallback(async () => {
-    if (saving) return;
+  const saveContent = useCallback(async (contentToSave = contentRef.current): Promise<boolean> => {
+    if (savingRef.current) return false;
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     try {
-      await onSave(content);
+      await onSave(contentToSave);
+      setBaselineContent(contentToSave);
+      baselineContentRef.current = contentToSave;
       toast.success(t('sftp.editor.saved'), 'SFTP');
+      return true;
     } catch (e) {
       const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
       setSaveError(msg);
       toast.error(msg, 'SFTP');
+      return false;
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
-  }, [content, onSave, saving, t]);
+  }, [onSave, t]);
+
+  const handleSave = useCallback(async () => {
+    await saveContent();
+  }, [saveContent]);
 
   const handleClose = useCallback(() => {
-    if (hasChanges) {
-      const confirmed = confirm(t('sftp.editor.unsavedChanges'));
-      if (!confirmed) return;
+    if (closePromptRef.current) return;
+
+    const closeTask = (async () => {
+      if (contentRef.current !== baselineContentRef.current) {
+        const choice = await promptUnsavedChanges(fileName);
+        if (choice === 'cancel') return;
+        if (choice === 'save') {
+          const saved = await saveContent();
+          if (!saved) return;
+        }
+      }
+      onClose();
+    })().finally(() => {
+      closePromptRef.current = null;
+    });
+
+    closePromptRef.current = closeTask;
+  }, [fileName, onClose, saveContent]);
+
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  useEffect(() => {
+    baselineContentRef.current = baselineContent;
+  }, [baselineContent]);
+
+  useEffect(() => {
+    savingRef.current = saving;
+  }, [saving]);
+
+  useEffect(() => {
+    if (!open) {
+      closePromptRef.current = null;
     }
-    onClose();
-  }, [hasChanges, onClose, t]);
+  }, [open]);
 
   const handleContentChange = useCallback(
     (nextContent: string, viewState: Monaco.editor.ICodeEditorViewState | null) => {
       setContent(nextContent);
+      contentRef.current = nextContent;
       viewStateRef.current = viewState;
     },
     [],
@@ -111,13 +164,13 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
     if (!onPromoteToTab) return;
     onPromoteToTab({
       fileName,
-      baselineContent: initialContent,
+      baselineContent,
       content,
       languageId,
       wordWrap: editorWordWrap,
       viewState: viewStateRef.current,
     });
-  }, [onPromoteToTab, fileName, initialContent, content, languageId, editorWordWrap]);
+  }, [onPromoteToTab, fileName, baselineContent, content, languageId, editorWordWrap]);
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>

--- a/components/TextEditorModal.tsx
+++ b/components/TextEditorModal.tsx
@@ -12,6 +12,10 @@ import { TextEditorPane } from './editor/TextEditorPane';
 import { promptUnsavedChanges } from './editor/UnsavedChangesDialog';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { scheduleWindowInputFocus } from '../application/state/windowInputFocus';
+import {
+  createTextEditorSaveCoordinator,
+  type TextEditorSaveCoordinator,
+} from '../application/state/textEditorSaveCoordinator';
 import type { HotkeyScheme, KeyBinding } from '../domain/models';
 
 /** Snapshot passed to `onPromoteToTab` when the user clicks the maximize button. */
@@ -29,6 +33,31 @@ export interface TextEditorModalSnapshot {
   /** The latest Monaco view state (scroll position, cursor, etc.) — may be null before first edit. */
   viewState: Monaco.editor.ICodeEditorViewState | null;
 }
+
+export interface TextEditorModalSnapshotSource {
+  fileName: string;
+  getBaselineContent: () => string;
+  getContent: () => string;
+  languageId: string;
+  wordWrap: boolean;
+  getViewState: () => Monaco.editor.ICodeEditorViewState | null;
+  isSaving: () => boolean;
+}
+
+export const createTextEditorModalSnapshot = (
+  source: TextEditorModalSnapshotSource,
+): TextEditorModalSnapshot | null => {
+  if (source.isSaving()) return null;
+  return {
+    fileName: source.fileName,
+    baselineContent: source.getBaselineContent(),
+    content: source.getContent(),
+    languageId: source.languageId,
+    wordWrap: source.wordWrap,
+    viewState: source.getViewState(),
+  };
+};
+
 
 interface TextEditorModalProps {
   open: boolean;
@@ -67,6 +96,9 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   const baselineContentRef = useRef(initialContent);
   const savingRef = useRef(false);
   const closePromptRef = useRef<Promise<void> | null>(null);
+  const onSaveRef = useRef(onSave);
+  const tRef = useRef(t);
+  const saveCoordinatorRef = useRef<TextEditorSaveCoordinator | null>(null);
 
   // Latest view state captured from Pane's onContentChange — used by handlePromote
   const viewStateRef = useRef<Monaco.editor.ICodeEditorViewState | null>(null);
@@ -74,8 +106,42 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   // Derived: whether the current content differs from the clean baseline
   const hasChanges = content !== baselineContent;
 
+  if (!saveCoordinatorRef.current) {
+    saveCoordinatorRef.current = createTextEditorSaveCoordinator({
+      onSave: (contentToSave) => onSaveRef.current(contentToSave),
+      onSaveStart: () => {
+        setSaveError(null);
+      },
+      onSaveSuccess: (savedContent) => {
+        setBaselineContent(savedContent);
+        baselineContentRef.current = savedContent;
+        toast.success(tRef.current('sftp.editor.saved'), 'SFTP');
+      },
+      onSaveError: (error) => {
+        const msg = error instanceof Error
+          ? error.message
+          : tRef.current('sftp.editor.saveFailed');
+        setSaveError(msg);
+        toast.error(msg, 'SFTP');
+      },
+      onSavingChange: (nextSaving) => {
+        savingRef.current = nextSaving;
+        setSaving(nextSaving);
+      },
+    });
+  }
+
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
+
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
   // Reset all state when a new file is opened
   useEffect(() => {
+    saveCoordinatorRef.current?.reset();
     setContent(initialContent);
     setBaselineContent(initialContent);
     setSaveError(null);
@@ -89,26 +155,8 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
   }, [initialContent, fileName]);
 
   const saveContent = useCallback(async (contentToSave = contentRef.current): Promise<boolean> => {
-    if (savingRef.current) return false;
-    savingRef.current = true;
-    setSaving(true);
-    setSaveError(null);
-    try {
-      await onSave(contentToSave);
-      setBaselineContent(contentToSave);
-      baselineContentRef.current = contentToSave;
-      toast.success(t('sftp.editor.saved'), 'SFTP');
-      return true;
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
-      setSaveError(msg);
-      toast.error(msg, 'SFTP');
-      return false;
-    } finally {
-      savingRef.current = false;
-      setSaving(false);
-    }
-  }, [onSave, t]);
+    return saveCoordinatorRef.current?.save(contentToSave) ?? false;
+  }, []);
 
   const handleSave = useCallback(async () => {
     await saveContent();
@@ -124,6 +172,7 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
         if (choice === 'save') {
           const saved = await saveContent();
           if (!saved) return;
+          if (contentRef.current !== baselineContentRef.current) return;
         }
       }
       onClose();
@@ -168,15 +217,17 @@ export const TextEditorModal: React.FC<TextEditorModalProps> = ({
 
   const handlePromote = useCallback(() => {
     if (!onPromoteToTab) return;
-    onPromoteToTab({
+    const snapshot = createTextEditorModalSnapshot({
       fileName,
-      baselineContent,
-      content,
+      getBaselineContent: () => baselineContentRef.current,
+      getContent: () => contentRef.current,
       languageId,
       wordWrap: editorWordWrap,
-      viewState: viewStateRef.current,
+      getViewState: () => viewStateRef.current,
+      isSaving: () => savingRef.current,
     });
-  }, [onPromoteToTab, fileName, baselineContent, content, languageId, editorWordWrap]);
+    if (snapshot) onPromoteToTab(snapshot);
+  }, [onPromoteToTab, fileName, languageId, editorWordWrap]);
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>

--- a/components/editor/TextEditorPane.test.tsx
+++ b/components/editor/TextEditorPane.test.tsx
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  canPromoteTextEditor,
+  isTextEditorReadOnly,
+  TextEditorPromoteButton,
+} from "./TextEditorPane.tsx";
+
+test("disables promoting a modal editor to a tab while a save is running", () => {
+  assert.equal(canPromoteTextEditor({ saving: true }), false);
+  assert.equal(canPromoteTextEditor({ saving: false }), true);
+  assert.equal(isTextEditorReadOnly({ saving: true }), true);
+  assert.equal(isTextEditorReadOnly({ saving: false }), false);
+});
+
+test("renders the promote button disabled while a save is running", () => {
+  const savingMarkup = renderToStaticMarkup(
+    React.createElement(TextEditorPromoteButton, {
+      saving: true,
+      onPromoteToTab: () => {},
+      title: "Maximize",
+    }),
+  );
+  const idleMarkup = renderToStaticMarkup(
+    React.createElement(TextEditorPromoteButton, {
+      saving: false,
+      onPromoteToTab: () => {},
+      title: "Maximize",
+    }),
+  );
+
+  assert.match(savingMarkup, /disabled=""/);
+  assert.doesNotMatch(idleMarkup, /disabled=""/);
+});

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -16,9 +16,10 @@ import type * as Monaco from 'monaco-editor';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 // Configure Monaco to use local files instead of CDN
-const monacoBasePath = import.meta.env.DEV
+const viteEnv = import.meta.env ?? { BASE_URL: "/" };
+const monacoBasePath = viteEnv.DEV
   ? './node_modules/monaco-editor/min/vs'
-  : `${import.meta.env.BASE_URL}monaco/vs`;
+  : `${viteEnv.BASE_URL}monaco/vs`;
 loader.config({ paths: { vs: monacoBasePath } });
 
 import { useI18n } from '../../application/i18n/I18nProvider';
@@ -116,6 +117,9 @@ const hslToHex = (hslString: string): string => {
 
 // Read a CSS custom-property and convert from HSL to hex
 const getCssColor = (varName: string, fallback: string): string => {
+  if (typeof document === 'undefined' || typeof getComputedStyle === 'undefined') {
+    return fallback;
+  }
   const value = getComputedStyle(document.documentElement)
     .getPropertyValue(varName)
     .trim();
@@ -143,6 +147,9 @@ const getEditorColors = (isDark: boolean): EditorColors => ({
 
 /** Build a fingerprint string so we can detect immersive-mode color changes cheaply. */
 const getThemeSignal = (): string => {
+  if (typeof document === 'undefined' || typeof getComputedStyle === 'undefined') {
+    return '';
+  }
   const root = document.documentElement;
   return root.dataset.immersiveTheme
     ?? getComputedStyle(root).getPropertyValue('--background').trim();
@@ -169,6 +176,27 @@ export interface TextEditorPaneProps {
   onPromoteToTab?: () => void;   // modal only — omit to hide the maximize button
   initialViewState?: Monaco.editor.ICodeEditorViewState | null;
 }
+
+export const isTextEditorReadOnly = ({ saving }: { saving: boolean }): boolean => saving;
+
+export const canPromoteTextEditor = ({ saving }: { saving: boolean }): boolean => !saving;
+
+export const TextEditorPromoteButton: React.FC<{
+  saving: boolean;
+  onPromoteToTab: () => void;
+  title: string;
+}> = ({ saving, onPromoteToTab, title }) => (
+  <Button
+    variant="ghost"
+    size="icon"
+    className="h-7 w-7"
+    onClick={onPromoteToTab}
+    disabled={!canPromoteTextEditor({ saving })}
+    title={title}
+  >
+    <Maximize2 size={14} />
+  </Button>
+);
 
 export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
   fileName,
@@ -202,7 +230,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
 
   // Track theme from document.documentElement class (syncs with app theme)
   const [isDarkTheme, setIsDarkTheme] = useState(() =>
-    document.documentElement.classList.contains('dark')
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark')
   );
 
   // Track a signal that changes whenever immersive-mode or base theme colors change
@@ -253,6 +281,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
 
   // Listen for theme changes via MutationObserver on <html> class, style, and immersive data attr
   useEffect(() => {
+    if (typeof document === 'undefined' || typeof MutationObserver === 'undefined') return;
     const root = document.documentElement;
     const updateTheme = () => {
       setIsDarkTheme(root.classList.contains('dark'));
@@ -309,6 +338,7 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
   }, [readClipboardText]);
 
   const handlePaste = useCallback(async () => {
+    if (saving) return;
     const editor = editorRef.current;
     if (!editor) return;
 
@@ -337,16 +367,17 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
       })),
     );
     editor.focus();
-  }, [readClipboardText]);
+  }, [readClipboardText, saving]);
 
   useEffect(() => {
     handlePasteRef.current = handlePaste;
   }, [handlePaste]);
 
   const handleEditorChange = useCallback((value: string | undefined) => {
+    if (saving) return;
     const editor = editorRef.current;
     onContentChange(value ?? '', editor ? editor.saveViewState() : null);
-  }, [onContentChange]);
+  }, [onContentChange, saving]);
 
   const handleEditorMount: OnMount = useCallback((editor, monaco) => {
     editorRef.current = editor;
@@ -504,15 +535,11 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
 
             {/* Maximize button — modal chrome only, when onPromoteToTab is provided */}
             {chrome === 'modal' && onPromoteToTab && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={onPromoteToTab}
+              <TextEditorPromoteButton
+                saving={saving}
+                onPromoteToTab={onPromoteToTab}
                 title={t('sftp.editor.maximize')}
-              >
-                <Maximize2 size={14} />
-              </Button>
+              />
             )}
 
             {/* Close button — modal chrome only */}
@@ -556,6 +583,8 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
             tabSize: 2,
             insertSpaces: true,
             wordWrap: wordWrap ? 'on' : 'off',
+            readOnly: isTextEditorReadOnly({ saving }),
+            domReadOnly: isTextEditorReadOnly({ saving }),
             folding: true,
             renderWhitespace: 'selection',
             bracketPairColorization: { enabled: true },

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -8,7 +8,7 @@ import type * as Monaco from 'monaco-editor';
 import React, { useCallback } from 'react';
 
 import { useI18n } from '../../application/i18n/I18nProvider';
-import { editorSftpWrite } from '../../application/state/editorSftpBridge';
+import { saveEditorTab } from '../../application/state/editorTabSave';
 import { editorTabStore, useEditorTab, type EditorTabId } from '../../application/state/editorTabStore';
 import type { HotkeyScheme, KeyBinding } from '../../domain/models';
 import type { Host } from '../../types';
@@ -60,21 +60,11 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   }, [tabId]);
 
   const handleSave = useCallback(async () => {
-    // Read live store state at call time — React state snapshot lags the store
-    // by one microtask, so a keystroke between onChange and this save would
-    // otherwise leave us writing stale content and marking a stale baseline.
-    const current = editorTabStore.getTab(tabId);
-    if (!current) return;
-    if (current.savingState === 'saving') return;
-
-    editorTabStore.setSavingState(tabId, 'saving');
-    try {
-      await editorSftpWrite(current.sessionId, current.hostId, current.remotePath, current.content);
-      editorTabStore.markSaved(tabId, current.content);
+    const ok = await saveEditorTab(tabId);
+    if (ok) {
       toast.success(t('sftp.editor.saved'), 'SFTP');
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : t('sftp.editor.saveFailed');
-      editorTabStore.setSavingState(tabId, 'error', msg);
+    } else {
+      const msg = editorTabStore.getTab(tabId)?.saveError ?? t('sftp.editor.saveFailed');
       toast.error(msg, 'SFTP');
     }
   }, [tabId, t]);

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -5,6 +5,7 @@ import type { SftpDragCallbacks, SftpTransferSource } from "../SftpContext";
 import { keepOnlyActivePaneSelections } from "./selectionScope";
 import { editorTabStore } from "../../../application/state/editorTabStore";
 import type { EditorTab, EditorTabId } from "../../../application/state/editorTabStore";
+import { releaseEditorTabSaveCoordinator, saveEditorTab } from "../../../application/state/editorTabSave";
 import { promptUnsavedChanges } from "../../editor/UnsavedChangesDialog";
 
 interface UseSftpViewPaneActionsParams {
@@ -139,12 +140,18 @@ export const useSftpViewPaneActions = ({
     if (connectionId) {
       const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
       const saveTab = async (id: EditorTabId) => {
+        const ok = await saveEditorTab(id);
         const tab = editorTabStore.getTab(id);
-        if (!tab) return;
-        await sftpRef.current.writeTextFileByConnection(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
-        editorTabStore.markSaved(id, tab.content);
+        if (!ok || (tab && tab.content !== tab.baselineContent)) {
+          throw new Error(tab?.saveError ?? "Save failed");
+        }
       };
-      const ok = await editorTabStore.confirmCloseBySession(connectionId, choice, saveTab);
+      const ok = await editorTabStore.confirmCloseBySession(
+        connectionId,
+        choice,
+        saveTab,
+        releaseEditorTabSaveCoordinator,
+      );
       if (!ok) return false;
     }
     sftpRef.current.disconnect("left");
@@ -155,12 +162,18 @@ export const useSftpViewPaneActions = ({
     if (connectionId) {
       const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
       const saveTab = async (id: EditorTabId) => {
+        const ok = await saveEditorTab(id);
         const tab = editorTabStore.getTab(id);
-        if (!tab) return;
-        await sftpRef.current.writeTextFileByConnection(tab.sessionId, tab.hostId, tab.remotePath, tab.content);
-        editorTabStore.markSaved(id, tab.content);
+        if (!ok || (tab && tab.content !== tab.baselineContent)) {
+          throw new Error(tab?.saveError ?? "Save failed");
+        }
       };
-      const ok = await editorTabStore.confirmCloseBySession(connectionId, choice, saveTab);
+      const ok = await editorTabStore.confirmCloseBySession(
+        connectionId,
+        choice,
+        saveTab,
+        releaseEditorTabSaveCoordinator,
+      );
       if (!ok) return false;
     }
     sftpRef.current.disconnect("right");

--- a/components/sftp/hooks/useSftpViewTabs.ts
+++ b/components/sftp/hooks/useSftpViewTabs.ts
@@ -2,6 +2,10 @@ import React, { useCallback, useMemo, useState } from "react";
 import type { MutableRefObject } from "react";
 import type { Host } from "../../../types";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
+import { editorTabStore } from "../../../application/state/editorTabStore";
+import type { EditorTab, EditorTabId } from "../../../application/state/editorTabStore";
+import { releaseEditorTabSaveCoordinator, saveEditorTab } from "../../../application/state/editorTabSave";
+import { promptUnsavedChanges } from "../../editor/UnsavedChangesDialog";
 
 interface UseSftpViewTabsParams {
   sftp: SftpStateApi;
@@ -23,8 +27,8 @@ interface UseSftpViewTabsResult {
   setHostSearchRight: React.Dispatch<React.SetStateAction<string>>;
   handleAddTabLeft: () => string;
   handleAddTabRight: () => string;
-  handleCloseTabLeft: (tabId: string) => void;
-  handleCloseTabRight: (tabId: string) => void;
+  handleCloseTabLeft: (tabId: string) => Promise<void>;
+  handleCloseTabRight: (tabId: string) => Promise<void>;
   handleSelectTabLeft: (tabId: string) => void;
   handleSelectTabRight: (tabId: string) => void;
   handleReorderTabsLeft: (draggedId: string, targetId: string, position: "before" | "after") => void;
@@ -53,13 +57,41 @@ export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSf
     return tabId;
   }, [sftpRef]);
 
-  const handleCloseTabLeft = useCallback((tabId: string) => {
-    sftpRef.current.closeTab("left", tabId);
-  }, [sftpRef]);
+  const confirmCloseEditorTabsByConnection = useCallback(async (connectionId: string): Promise<boolean> => {
+    const choice = (tab: EditorTab) => promptUnsavedChanges(tab.fileName);
+    const saveTab = async (id: EditorTabId) => {
+      const ok = await saveEditorTab(id);
+      const tab = editorTabStore.getTab(id);
+      if (!ok || (tab && tab.content !== tab.baselineContent)) {
+        throw new Error(tab?.saveError ?? "Save failed");
+      }
+    };
+    return editorTabStore.confirmCloseBySession(
+      connectionId,
+      choice,
+      saveTab,
+      releaseEditorTabSaveCoordinator,
+    );
+  }, []);
 
-  const handleCloseTabRight = useCallback((tabId: string) => {
-    sftpRef.current.closeTab("right", tabId);
-  }, [sftpRef]);
+  const handleCloseSftpTab = useCallback(async (side: "left" | "right", tabId: string) => {
+    const sideTabs = side === "left" ? sftpRef.current.leftTabs : sftpRef.current.rightTabs;
+    const pane = sideTabs.tabs.find((tab) => tab.id === tabId);
+    const connectionId = pane?.connection?.id;
+    if (connectionId) {
+      const ok = await confirmCloseEditorTabsByConnection(connectionId);
+      if (!ok) return;
+    }
+    sftpRef.current.closeTab(side, tabId);
+  }, [confirmCloseEditorTabsByConnection, sftpRef]);
+
+  const handleCloseTabLeft = useCallback((tabId: string) => (
+    handleCloseSftpTab("left", tabId)
+  ), [handleCloseSftpTab]);
+
+  const handleCloseTabRight = useCallback((tabId: string) => (
+    handleCloseSftpTab("right", tabId)
+  ), [handleCloseSftpTab]);
 
   const handleSelectTabLeft = useCallback((tabId: string) => {
     sftpRef.current.selectTab("left", tabId);

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1279,10 +1279,19 @@ function restoreWindowInputFocus(win, options = {}) {
   if (platform === "win32") {
     try {
       win.setAlwaysOnTop(true);
-      win.focus();
-      win.setAlwaysOnTop(false);
     } catch {
       // ignore
+    }
+    try {
+      win.focus();
+    } catch {
+      // ignore
+    } finally {
+      try {
+        win.setAlwaysOnTop(false);
+      } catch {
+        // ignore
+      }
     }
   } else {
     try {
@@ -1771,6 +1780,7 @@ module.exports = {
   getMainWindow,
   getSettingsWindow,
   isWindowUsable,
+  registerWindowHandlers,
   restoreWindowInputFocus,
   waitForRendererReady,
   setIsQuitting,

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1263,14 +1263,20 @@ async function createWindow(electronModule, options) {
  * calling `webContents.focus()` covers (2) so the renderer marks the page as
  * focused regardless of whether the OS granted foreground.
  */
-function showAndFocusWindow(win) {
-  if (!win || win.isDestroyed()) return;
-  try {
-    win.show();
-  } catch {
-    // ignore
+function restoreWindowInputFocus(win, options = {}) {
+  if (!win || win.isDestroyed()) return false;
+  const shouldShow = options.show === true;
+  const platform = options.platform || process.platform;
+
+  if (shouldShow) {
+    try {
+      win.show();
+    } catch {
+      // ignore
+    }
   }
-  if (process.platform === "win32") {
+
+  if (platform === "win32") {
     try {
       win.setAlwaysOnTop(true);
       win.focus();
@@ -1285,6 +1291,7 @@ function showAndFocusWindow(win) {
       // ignore
     }
   }
+
   try {
     if (win.webContents && !win.webContents.isDestroyed()) {
       win.webContents.focus();
@@ -1292,6 +1299,11 @@ function showAndFocusWindow(win) {
   } catch {
     // ignore
   }
+  return true;
+}
+
+function showAndFocusWindow(win) {
+  restoreWindowInputFocus(win, { show: true });
 }
 
 async function openSettingsWindow(electronModule, options, { showOnLoad = true } = {}) {
@@ -1576,6 +1588,11 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
     return false;
   });
 
+  ipcMain.handle("netcatty:window:focus", (event) => {
+    const win = getWindowForIpcEvent(event);
+    return restoreWindowInputFocus(win);
+  });
+
   ipcMain.handle("netcatty:setTheme", (_event, theme) => {
     currentTheme = theme;
     nativeTheme.themeSource = theme;
@@ -1754,6 +1771,7 @@ module.exports = {
   getMainWindow,
   getSettingsWindow,
   isWindowUsable,
+  restoreWindowInputFocus,
   waitForRendererReady,
   setIsQuitting,
   openFallbackBrowser,

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { isWindowUsable, restoreWindowInputFocus } = require("./windowManager.cjs");
+const { isWindowUsable, registerWindowHandlers, restoreWindowInputFocus } = require("./windowManager.cjs");
 
 function createWindowStub({ destroyed = false, webContents } = {}) {
   return {
@@ -102,6 +102,40 @@ test("restoreWindowInputFocus focuses the window and renderer on Windows without
   ]);
 });
 
+test("restoreWindowInputFocus clears Windows always-on-top even if window focus throws", () => {
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    focus() {
+      calls.push("focus");
+      throw new Error("focus failed");
+    },
+    setAlwaysOnTop(value) {
+      calls.push(`alwaysOnTop:${value}`);
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      focus() {
+        calls.push("webContents.focus");
+      },
+    },
+  };
+
+  const restored = restoreWindowInputFocus(win, { platform: "win32" });
+
+  assert.equal(restored, true);
+  assert.deepEqual(calls, [
+    "alwaysOnTop:true",
+    "focus",
+    "alwaysOnTop:false",
+    "webContents.focus",
+  ]);
+});
+
 test("restoreWindowInputFocus can show the window when requested", () => {
   const calls = [];
   const win = {
@@ -128,4 +162,48 @@ test("restoreWindowInputFocus can show the window when requested", () => {
 
   assert.equal(restored, true);
   assert.deepEqual(calls, ["show", "focus", "webContents.focus"]);
+});
+
+test("window focus IPC handler focuses the sender owner window", async () => {
+  const handlers = new Map();
+  const ipcMain = {
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+    on(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    focus() {
+      calls.push("focus");
+    },
+    webContents: {
+      id: 101,
+      isDestroyed() {
+        return false;
+      },
+      focus() {
+        calls.push("webContents.focus");
+      },
+    },
+  };
+
+  registerWindowHandlers(ipcMain, { themeSource: "light" });
+
+  const result = await handlers.get("netcatty:window:focus")({
+    sender: {
+      id: 202,
+      getOwnerBrowserWindow() {
+        return win;
+      },
+    },
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, ["focus", "webContents.focus"]);
 });

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { isWindowUsable } = require("./windowManager.cjs");
+const { isWindowUsable, restoreWindowInputFocus } = require("./windowManager.cjs");
 
 function createWindowStub({ destroyed = false, webContents } = {}) {
   return {
@@ -64,4 +64,68 @@ test("isWindowUsable can require a visible window", () => {
 
   assert.equal(isWindowUsable(hiddenWin, { requireVisible: true }), false);
   assert.equal(isWindowUsable(hiddenWin, { requireVisible: false }), true);
+});
+
+test("restoreWindowInputFocus focuses the window and renderer on Windows without showing hidden windows", () => {
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    show() {
+      calls.push("show");
+    },
+    focus() {
+      calls.push("focus");
+    },
+    setAlwaysOnTop(value) {
+      calls.push(`alwaysOnTop:${value}`);
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      focus() {
+        calls.push("webContents.focus");
+      },
+    },
+  };
+
+  const restored = restoreWindowInputFocus(win, { platform: "win32" });
+
+  assert.equal(restored, true);
+  assert.deepEqual(calls, [
+    "alwaysOnTop:true",
+    "focus",
+    "alwaysOnTop:false",
+    "webContents.focus",
+  ]);
+});
+
+test("restoreWindowInputFocus can show the window when requested", () => {
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    show() {
+      calls.push("show");
+    },
+    focus() {
+      calls.push("focus");
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      focus() {
+        calls.push("webContents.focus");
+      },
+    },
+  };
+
+  const restored = restoreWindowInputFocus(win, { platform: "darwin", show: true });
+
+  assert.equal(restored, true);
+  assert.deepEqual(calls, ["show", "focus", "webContents.focus"]);
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -816,6 +816,7 @@ const api = {
   windowClose: () => ipcRenderer.invoke("netcatty:window:close"),
   windowIsMaximized: () => ipcRenderer.invoke("netcatty:window:isMaximized"),
   windowIsFullscreen: () => ipcRenderer.invoke("netcatty:window:isFullscreen"),
+  windowFocus: () => ipcRenderer.invoke("netcatty:window:focus"),
   onWindowFullScreenChanged: (cb) => {
     fullscreenChangeListeners.add(cb);
     return () => fullscreenChangeListeners.delete(cb);

--- a/global.d.ts
+++ b/global.d.ts
@@ -465,6 +465,7 @@ declare global {
     windowClose?(): Promise<void>;
     windowIsMaximized?(): Promise<boolean>;
     windowIsFullscreen?(): Promise<boolean>;
+    windowFocus?(): Promise<boolean>;
     onWindowFullScreenChanged?(cb: (isFullscreen: boolean) => void): () => void;
 
     // Settings window

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/state/*.test.ts components/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/state/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## Summary
- update the SFTP built-in editor so a successful save becomes the clean baseline
- replace the native unsaved-changes prompt with the app dialog used by editor tabs
- keep promoted editor tabs aligned with the latest saved baseline
- restore the app window input focus around the built-in editor so Windows input fields do not get stuck in a visually focused but non-typing state

## Why
Fixes #884. Also addresses the main triggers described in #886: false unsaved-change prompts after saving, and intermittent inability to type in the built-in editor or SFTP path field after editor workflows.

## Validation
- node --test electron/bridges/windowManagerReadiness.test.cjs
- npm test
- npm run lint
- npm run build