### PR TITLE
Fix Linux/macOS mosh terminfo lookup (#890)

### DIFF
--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -125,6 +125,61 @@ test("Windows dev mosh-client updates the PATH key used by child process env", (
   assert.equal(Object.prototype.hasOwnProperty.call(env, "Path"), false);
 });
 
+test("Linux mosh-client points ncurses at standard distro terminfo paths", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  writeExecutable(client);
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  assert.equal(env.TERMINFO, undefined);
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.ok(dirs.includes("/etc/terminfo"));
+  assert.ok(dirs.includes("/lib/terminfo"));
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+});
+
+test("Linux mosh-client prepends a sibling bundled terminfo dir when present", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  const terminfo = path.join(tmp, "resources", "mosh", "linux-x64", "terminfo");
+  writeExecutable(client);
+  fs.mkdirSync(path.join(terminfo, "x"), { recursive: true });
+  fs.writeFileSync(path.join(terminfo, "x", "xterm-256color"), "terminfo");
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.equal(dirs[0], terminfo);
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+});
+
+test("Linux mosh-client does not overwrite a caller-supplied TERMINFO_DIRS", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  writeExecutable(client);
+
+  const env = { TERMINFO_DIRS: "/home/user/.terminfo:/usr/share/terminfo" };
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  assert.equal(env.TERMINFO_DIRS, "/home/user/.terminfo:/usr/share/terminfo");
+});
+
+test("Darwin mosh-client uses macOS-aware terminfo search paths", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "darwin-universal", "mosh-client");
+  writeExecutable(client);
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "darwin" });
+
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+  assert.ok(dirs.includes("/opt/homebrew/share/terminfo"));
+});
+
 test("Windows mosh-client points ncurses at bundled terminfo", () => {
   const tmp = makeTmp();
   const client = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client.exe");

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -857,9 +857,7 @@ function addBundledMoshDllPath(env, bareClient, opts = {}) {
 }
 
 function findBundledMoshTerminfoDir(bareClient, opts = {}) {
-  const platform = opts.platform || process.platform;
-  if (platform !== "win32" || !bareClient) return null;
-
+  if (!bareClient) return null;
   const terminfoDir = path.join(path.dirname(bareClient), "terminfo");
   const hasXterm256 =
     fs.existsSync(path.join(terminfoDir, "x", "xterm-256color")) ||
@@ -867,11 +865,49 @@ function findBundledMoshTerminfoDir(bareClient, opts = {}) {
   return hasXterm256 ? terminfoDir : null;
 }
 
+// Standard locations where distros / package managers install the compiled
+// terminfo database. Our bundled mosh-client links a privately-built ncurses
+// whose compiled-in default points at the build-time prefix (a temp dir),
+// so without these hints `setupterm()` fails with
+// "Terminfo database could not be found." See issue #890.
+const LINUX_SYSTEM_TERMINFO_DIRS = [
+  "/etc/terminfo",
+  "/lib/terminfo",
+  "/usr/share/terminfo",
+  "/usr/lib/terminfo",
+];
+
+const DARWIN_SYSTEM_TERMINFO_DIRS = [
+  "/usr/share/terminfo",
+  "/opt/homebrew/share/terminfo",
+  "/usr/local/share/terminfo",
+  "/opt/local/share/terminfo",
+];
+
 function addBundledMoshTerminfoEnv(env, bareClient, opts = {}) {
+  const platform = opts.platform || process.platform;
   const terminfoDir = findBundledMoshTerminfoDir(bareClient, opts);
-  if (!terminfoDir) return env;
-  env.TERMINFO = terminfoDir;
-  env.TERMINFO_DIRS = terminfoDir;
+
+  if (platform === "win32") {
+    if (!terminfoDir) return env;
+    env.TERMINFO = terminfoDir;
+    env.TERMINFO_DIRS = terminfoDir;
+    return env;
+  }
+
+  // POSIX: leave any caller-/user-set value alone (e.g. exported in the
+  // launching shell). Otherwise fall back to a search list that includes
+  // the bundled dir (when present) and the standard distro paths.
+  if (typeof env.TERMINFO_DIRS === "string" && env.TERMINFO_DIRS.length > 0) {
+    return env;
+  }
+  const systemDirs = platform === "darwin" ? DARWIN_SYSTEM_TERMINFO_DIRS : LINUX_SYSTEM_TERMINFO_DIRS;
+  const dirs = [];
+  if (terminfoDir) dirs.push(terminfoDir);
+  for (const dir of systemDirs) {
+    if (!dirs.includes(dir)) dirs.push(dir);
+  }
+  env.TERMINFO_DIRS = dirs.join(":");
   return env;
 }
 


### PR DESCRIPTION
## Summary
- Fixes #890. After 1.1.1 switched from the system `mosh` to a bundled, statically-linked `mosh-client`, the embedded ncurses' compiled-in default terminfo path points at the build-time `--prefix=$WORK/prefix` — a temp dir that no longer exists on the user's machine. On a clean Ubuntu 26.04 install `setupterm("xterm-256color")` then fails with `Error: Terminfo database could not be found.`
- The Windows fix in #889 only set `TERMINFO`/`TERMINFO_DIRS` on `win32`. This PR extends `addBundledMoshTerminfoEnv` to POSIX: on Linux it points `TERMINFO_DIRS` at the standard distro paths (`/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo`); on macOS it adds Homebrew / MacPorts locations.
- A sibling `terminfo/` directory next to the binary (future-proofing for a Linux bundle) is prepended when present, and any caller-supplied `TERMINFO_DIRS` is respected.

## Why mac wasn't already broken
macOS users tend to have one of: a system `/usr/share/terminfo`, a `~/.terminfo`, or a shell-exported `TERMINFO_DIRS` that ncurses' first three search steps hit before reaching the broken compiled-in fallback. Linux users on a fresh `.deb` install don't have those, so the fallback fires immediately. After this change all three POSIX targets behave deterministically.

## Test plan
- [x] `node --test electron/bridges/terminalBridge.bareMoshClient.test.cjs` (16/16, including 4 new cases for Linux defaults, bundled-dir prepend, caller override, and Darwin paths)
- [x] `node --test electron/bridges/terminalBridge.bundledMosh.test.cjs electron/bridges/terminalBridge.moshHandshakeSession.test.cjs electron/bridges/moshHandshake.test.cjs` (39/39)
- [ ] Manual: install the resulting `.deb` on Ubuntu 26.04 (and a stripped container without `ncurses-base` if available), connect via mosh, verify the session attaches without the terminfo error
- [ ] Manual: macOS smoke test that bundled mosh still connects (no regression on the already-working path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)