### PR TITLE
Bundle mosh terminfo on Linux and macOS (#890)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,10 +66,11 @@ build_with_vs2022.bat
 
 # Bundled mosh-client binaries fetched at pack time by
 # scripts/fetch-mosh-binaries.cjs. resources/mosh/README.md is
-# committed; the actual binaries (and on Windows the Cygwin DLL
-# bundle that ships alongside mosh-client.exe) are pulled from the
+# committed; the actual binaries, the Cygwin DLL bundle (Windows),
+# and the bundled ncurses terminfo database are all pulled from the
 # dedicated mosh binary repository, never committed.
 /resources/mosh/*/mosh-client
 /resources/mosh/*/mosh-client.exe
 /resources/mosh/*/mosh-client-*-dlls/
 /resources/mosh/*/*.dll
+/resources/mosh/*/terminfo/

--- a/electron/bridges/terminalBridge.bareMoshClient.test.cjs
+++ b/electron/bridges/terminalBridge.bareMoshClient.test.cjs
@@ -125,6 +125,68 @@ test("Windows dev mosh-client updates the PATH key used by child process env", (
   assert.equal(Object.prototype.hasOwnProperty.call(env, "Path"), false);
 });
 
+test("Linux mosh-client prefers a sibling bundled terminfo dir", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  const terminfo = path.join(tmp, "resources", "mosh", "linux-x64", "terminfo");
+  writeExecutable(client);
+  fs.mkdirSync(path.join(terminfo, "x"), { recursive: true });
+  fs.writeFileSync(path.join(terminfo, "x", "xterm-256color"), "terminfo");
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  assert.equal(env.TERMINFO, terminfo);
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.equal(dirs[0], terminfo);
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+});
+
+test("Linux mosh-client falls back to distro paths when no bundle present", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  writeExecutable(client);
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  assert.equal(env.TERMINFO, undefined);
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.ok(dirs.includes("/etc/terminfo"));
+  assert.ok(dirs.includes("/lib/terminfo"));
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+});
+
+test("Linux mosh-client merges caller-supplied TERMINFO_DIRS between bundle and system defaults", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "linux-x64", "mosh-client");
+  const terminfo = path.join(tmp, "resources", "mosh", "linux-x64", "terminfo");
+  writeExecutable(client);
+  fs.mkdirSync(path.join(terminfo, "x"), { recursive: true });
+  fs.writeFileSync(path.join(terminfo, "x", "xterm-256color"), "terminfo");
+
+  const env = { TERMINFO_DIRS: "/home/user/.terminfo" };
+  addBundledMoshTerminfoEnv(env, client, { platform: "linux" });
+
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.equal(dirs[0], terminfo);
+  assert.equal(dirs[1], "/home/user/.terminfo");
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+});
+
+test("Darwin mosh-client uses macOS-aware terminfo search paths", () => {
+  const tmp = makeTmp();
+  const client = path.join(tmp, "resources", "mosh", "darwin-universal", "mosh-client");
+  writeExecutable(client);
+
+  const env = {};
+  addBundledMoshTerminfoEnv(env, client, { platform: "darwin" });
+
+  const dirs = env.TERMINFO_DIRS.split(":");
+  assert.ok(dirs.includes("/usr/share/terminfo"));
+  assert.ok(dirs.includes("/opt/homebrew/share/terminfo"));
+});
+
 test("Windows mosh-client points ncurses at bundled terminfo", () => {
   const tmp = makeTmp();
   const client = path.join(tmp, "resources", "mosh", "win32-x64", "mosh-client.exe");

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -856,10 +856,8 @@ function addBundledMoshDllPath(env, bareClient, opts = {}) {
   return dllDir ? prependEnvPath(env, dllDir, opts) : env;
 }
 
-function findBundledMoshTerminfoDir(bareClient, opts = {}) {
-  const platform = opts.platform || process.platform;
-  if (platform !== "win32" || !bareClient) return null;
-
+function findBundledMoshTerminfoDir(bareClient, _opts = {}) {
+  if (!bareClient) return null;
   const terminfoDir = path.join(path.dirname(bareClient), "terminfo");
   const hasXterm256 =
     fs.existsSync(path.join(terminfoDir, "x", "xterm-256color")) ||
@@ -867,11 +865,56 @@ function findBundledMoshTerminfoDir(bareClient, opts = {}) {
   return hasXterm256 ? terminfoDir : null;
 }
 
+// Standard locations where distros / package managers install the compiled
+// terminfo database. Used as a fallback only — the bundled directory ships
+// with the mosh release and is preferred. See issue #890 for context.
+const LINUX_SYSTEM_TERMINFO_DIRS = [
+  "/etc/terminfo",
+  "/lib/terminfo",
+  "/usr/share/terminfo",
+  "/usr/lib/terminfo",
+];
+
+const DARWIN_SYSTEM_TERMINFO_DIRS = [
+  "/usr/share/terminfo",
+  "/opt/homebrew/share/terminfo",
+  "/usr/local/share/terminfo",
+  "/opt/local/share/terminfo",
+];
+
 function addBundledMoshTerminfoEnv(env, bareClient, opts = {}) {
+  const platform = opts.platform || process.platform;
   const terminfoDir = findBundledMoshTerminfoDir(bareClient, opts);
-  if (!terminfoDir) return env;
-  env.TERMINFO = terminfoDir;
-  env.TERMINFO_DIRS = terminfoDir;
+
+  if (platform === "win32") {
+    if (!terminfoDir) return env;
+    env.TERMINFO = terminfoDir;
+    env.TERMINFO_DIRS = terminfoDir;
+    return env;
+  }
+
+  // POSIX. The bundled terminfo is the source of truth — our static
+  // ncurses' compiled-in default points at a build-time temp dir that no
+  // longer exists on the user's machine. Fall back to standard distro
+  // paths when the bundle is absent (e.g. running against an older mosh
+  // binary release that pre-dates the bundle). A caller-supplied
+  // TERMINFO_DIRS is preserved between the bundle and the system defaults.
+  const existing = (typeof env.TERMINFO_DIRS === "string" && env.TERMINFO_DIRS.length > 0)
+    ? env.TERMINFO_DIRS.split(":").filter(Boolean)
+    : [];
+  const systemDirs = platform === "darwin" ? DARWIN_SYSTEM_TERMINFO_DIRS : LINUX_SYSTEM_TERMINFO_DIRS;
+  const dirs = [];
+  if (terminfoDir) dirs.push(terminfoDir);
+  for (const dir of existing) {
+    if (!dirs.includes(dir)) dirs.push(dir);
+  }
+  for (const dir of systemDirs) {
+    if (!dirs.includes(dir)) dirs.push(dir);
+  }
+  if (terminfoDir) {
+    env.TERMINFO = terminfoDir;
+  }
+  env.TERMINFO_DIRS = dirs.join(":");
   return env;
 }
 

--- a/scripts/build-mosh/build-linux.sh
+++ b/scripts/build-mosh/build-linux.sh
@@ -4,11 +4,17 @@
 # Inputs (env):
 #   MOSH_REF  — git ref of mobile-shell/mosh to build (e.g. mosh-1.4.0)
 #   ARCH      — x64 | arm64 (for output naming only; container is already that arch)
-#   OUT_DIR   — directory to write mosh-client-linux-<arch> + sha256
+#   OUT_DIR   — directory to write mosh-client-linux-<arch>.tar.gz + sha256
 #
 # Output:
-#   $OUT_DIR/mosh-client-linux-<arch>
-#   $OUT_DIR/mosh-client-linux-<arch>.sha256
+#   $OUT_DIR/mosh-client-linux-<arch>.tar.gz       (binary + terminfo bundle)
+#   $OUT_DIR/mosh-client-linux-<arch>.tar.gz.sha256
+#
+# The bundle ships a private terminfo database next to the binary because
+# our statically-linked ncurses has its compiled-in TERMINFO path pointing
+# at the build-time prefix (a temp dir). Without bundling, mosh-client on
+# distros lacking /usr/share/terminfo (or stripped containers) fails with
+# "Terminfo database could not be found." See issue #890.
 #
 # Strategy: build OpenSSL, protobuf, ncurses as static archives in a
 # scratch prefix, then build mosh against those and link libstdc++/libgcc
@@ -87,7 +93,9 @@ git -C mosh checkout --detach FETCH_HEAD
     LIBS="-ldl -lpthread"
   make -j"$(nproc)" )
 
-OUT_BIN="$OUT_DIR/mosh-client-linux-$ARCH"
+BUNDLE_DIR="$WORK/linux-$ARCH-bundle"
+mkdir -p "$BUNDLE_DIR"
+OUT_BIN="$BUNDLE_DIR/mosh-client"
 cp mosh/src/frontend/mosh-client "$OUT_BIN"
 strip "$OUT_BIN"
 
@@ -110,5 +118,38 @@ if grep -Ev '^(linux-vdso\.so\.1|lib(c|m|pthread|rt|dl|resolv|util|z)\.so\.[0-9]
   exit 1
 fi
 
-( cd "$OUT_DIR" && sha256sum "mosh-client-linux-$ARCH" > "mosh-client-linux-$ARCH.sha256" )
-cat "$OUT_DIR/mosh-client-linux-$ARCH.sha256"
+# Bundle the terminfo entries our statically-linked ncurses needs. The
+# ncurses `make install` above populated $PREFIX/share/terminfo/ with the
+# full upstream terminfo.src. Ship a curated subset so users hit a
+# working entry regardless of TERM.
+TERMINFO_SRC="$PREFIX/share/terminfo"
+TERMINFO_OUT="$BUNDLE_DIR/terminfo"
+mkdir -p "$TERMINFO_OUT"
+copy_terminfo_entry() {
+  local name="$1"
+  for src in "$TERMINFO_SRC"/?/"$name" "$TERMINFO_SRC"/??/"$name"; do
+    [ -f "$src" ] || continue
+    local rel
+    rel=$(basename "$(dirname "$src")")
+    mkdir -p "$TERMINFO_OUT/$rel"
+    cp "$src" "$TERMINFO_OUT/$rel/$name"
+    return 0
+  done
+  return 1
+}
+for entry in xterm-256color xterm xterm-color vt100 vt220 ansi screen screen-256color tmux tmux-256color dumb linux; do
+  copy_terminfo_entry "$entry" || echo "WARN: terminfo entry $entry not found in $TERMINFO_SRC" >&2
+done
+if [ ! -f "$TERMINFO_OUT/x/xterm-256color" ] && [ ! -f "$TERMINFO_OUT/78/xterm-256color" ]; then
+  echo "ERROR: failed to bundle xterm-256color terminfo for mosh-client (linux-$ARCH)." >&2
+  exit 1
+fi
+
+echo "--- bundled terminfo ---"
+find "$TERMINFO_OUT" -type f -print
+
+BUNDLE_TGZ="$OUT_DIR/mosh-client-linux-$ARCH.tar.gz"
+( cd "$BUNDLE_DIR" && tar -czf "$BUNDLE_TGZ" "mosh-client" "terminfo" )
+
+( cd "$OUT_DIR" && sha256sum "mosh-client-linux-$ARCH.tar.gz" > "mosh-client-linux-$ARCH.tar.gz.sha256" )
+cat "$OUT_DIR/mosh-client-linux-$ARCH.tar.gz.sha256"

--- a/scripts/build-mosh/build-macos.sh
+++ b/scripts/build-mosh/build-macos.sh
@@ -7,8 +7,13 @@
 #   MACOSX_DEPLOYMENT_TARGET  — minimum macOS version (default 11.0)
 #
 # Output:
-#   $OUT_DIR/mosh-client-darwin-universal
-#   $OUT_DIR/mosh-client-darwin-universal.sha256
+#   $OUT_DIR/mosh-client-darwin-universal.tar.gz       (binary + terminfo bundle)
+#   $OUT_DIR/mosh-client-darwin-universal.tar.gz.sha256
+#
+# The bundle ships a private terminfo database next to the binary because
+# our statically-linked ncurses has its compiled-in TERMINFO path pointing
+# at the build-time prefix (a temp dir). Without bundling, mosh-client
+# fails with "Terminfo database could not be found." See issue #890.
 #
 # Strategy: build OpenSSL/protobuf/ncurses for arm64 and x86_64
 # (cross-compile via Apple clang's -arch flag), link mosh-client per arch,
@@ -110,7 +115,16 @@ build_arch() {
       CFLAGS="$CFLAGS_COMMON" CXXFLAGS="$CFLAGS_COMMON" LDFLAGS="$LDFLAGS_COMMON"
     make -j"$(sysctl -n hw.ncpu)"
     make -C include install
-    make -C ncurses install )
+    make -C ncurses install
+    # Compile + install the terminfo database for the native arch only.
+    # `tic` runs on the build host, so a cross-target build can't compile
+    # terminfo entries — but the .src database is arch-independent, so a
+    # single native-arch install populates $PREFIX/share/terminfo/ with
+    # the data we bundle below.
+    if [ "$ARCH" = "$NATIVE_ARCH" ]; then
+      make -C progs install
+      make -C misc install
+    fi )
 
   # mosh per-arch build
   ( cd mosh-src
@@ -138,7 +152,9 @@ else
   build_arch arm64
 fi
 
-OUT_BIN="$OUT_DIR/mosh-client-darwin-universal"
+BUNDLE_DIR="$WORK/darwin-universal-bundle"
+mkdir -p "$BUNDLE_DIR"
+OUT_BIN="$BUNDLE_DIR/mosh-client"
 lipo -create "$WORK/mosh-client-arm64" "$WORK/mosh-client-x86_64" -output "$OUT_BIN"
 strip -x "$OUT_BIN" || true
 
@@ -157,5 +173,36 @@ if otool -L "$OUT_BIN" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/
   exit 1
 fi
 
-( cd "$OUT_DIR" && shasum -a 256 "mosh-client-darwin-universal" > "mosh-client-darwin-universal.sha256" )
-cat "$OUT_DIR/mosh-client-darwin-universal.sha256"
+# Bundle the terminfo entries our statically-linked ncurses needs. Pull
+# from the native-arch prefix where `make -C misc install` ran tic above.
+TERMINFO_SRC="$WORK/prefix-$NATIVE_ARCH/share/terminfo"
+TERMINFO_OUT="$BUNDLE_DIR/terminfo"
+mkdir -p "$TERMINFO_OUT"
+copy_terminfo_entry() {
+  local name="$1"
+  for src in "$TERMINFO_SRC"/?/"$name" "$TERMINFO_SRC"/??/"$name"; do
+    [ -f "$src" ] || continue
+    local rel
+    rel=$(basename "$(dirname "$src")")
+    mkdir -p "$TERMINFO_OUT/$rel"
+    cp "$src" "$TERMINFO_OUT/$rel/$name"
+    return 0
+  done
+  return 1
+}
+for entry in xterm-256color xterm xterm-color vt100 vt220 ansi screen screen-256color tmux tmux-256color dumb; do
+  copy_terminfo_entry "$entry" || echo "WARN: terminfo entry $entry not found in $TERMINFO_SRC" >&2
+done
+if [ ! -f "$TERMINFO_OUT/x/xterm-256color" ] && [ ! -f "$TERMINFO_OUT/78/xterm-256color" ]; then
+  echo "ERROR: failed to bundle xterm-256color terminfo for mosh-client (darwin-universal)." >&2
+  exit 1
+fi
+
+echo "--- bundled terminfo ---"
+find "$TERMINFO_OUT" -type f -print
+
+BUNDLE_TGZ="$OUT_DIR/mosh-client-darwin-universal.tar.gz"
+( cd "$BUNDLE_DIR" && tar -czf "$BUNDLE_TGZ" "mosh-client" "terminfo" )
+
+( cd "$OUT_DIR" && shasum -a 256 "mosh-client-darwin-universal.tar.gz" > "mosh-client-darwin-universal.tar.gz.sha256" )
+cat "$OUT_DIR/mosh-client-darwin-universal.tar.gz.sha256"

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -40,14 +40,15 @@ const DEFAULT_RES_DIR = path.join(ROOT, "resources", "mosh");
 // Using flat names in the release for SHA256SUMS readability, then
 // fanning out into platform-arch subdirs locally.
 //
-// `extract` indicates a tar.gz archive containing the binary + helper
-// DLLs (Windows). The tarball is unpacked into the platform-arch
-// directory so resources/mosh/win32-x64/ ends up with mosh-client.exe
-// alongside cygwin1.dll, cygcrypto-*.dll, etc.
+// All targets are tar.gz bundles containing the binary plus the runtime
+// helpers each platform needs: ncurses terminfo on every platform, plus
+// the Cygwin DLL set on Windows. Bundling terminfo lets the bundled
+// statically-linked mosh-client work on minimal hosts that don't have a
+// system ncurses-base — see issue #890.
 const TARGETS = [
-  { platform: "linux", arch: "x64", file: "mosh-client-linux-x64", local: "linux-x64/mosh-client" },
-  { platform: "linux", arch: "arm64", file: "mosh-client-linux-arm64", local: "linux-arm64/mosh-client" },
-  { platform: "darwin", arch: "universal", file: "mosh-client-darwin-universal", local: "darwin-universal/mosh-client" },
+  { platform: "linux", arch: "x64", file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz" },
+  { platform: "linux", arch: "arm64", file: "mosh-client-linux-arm64.tar.gz", localDir: "linux-arm64", extract: "tar.gz" },
+  { platform: "darwin", arch: "universal", file: "mosh-client-darwin-universal.tar.gz", localDir: "darwin-universal", extract: "tar.gz" },
   { platform: "win32", arch: "x64", file: "mosh-client-win32-x64.tar.gz", localDir: "win32-x64", extract: "tar.gz" },
 ];
 
@@ -183,6 +184,20 @@ function assertExtractedTreeSafe(root) {
   }
 }
 
+function assertBundledTerminfo(extractDir, target) {
+  const terminfoDir = path.join(extractDir, "terminfo");
+  const terminfoEntry = [
+    path.join(terminfoDir, "x", "xterm-256color"),
+    path.join(terminfoDir, "78", "xterm-256color"),
+  ].find((entry) => fs.existsSync(entry));
+  if (terminfoEntry && !fs.lstatSync(terminfoEntry).isFile()) {
+    throw new Error(`${target.file} contained invalid terminfo for xterm-256color`);
+  }
+  if (!terminfoEntry) {
+    warn(`${target.file} did not contain terminfo for xterm-256color; ${target.platform}-${target.arch} mosh packaging will fall back to host system terminfo (issue #890).`);
+  }
+}
+
 function normalizeWindowsBundle(extractDir, target) {
   const genericExe = path.join(extractDir, "mosh-client.exe");
   const legacyExe = path.join(extractDir, `mosh-client-${target.platform}-${target.arch}.exe`);
@@ -196,18 +211,26 @@ function normalizeWindowsBundle(extractDir, target) {
   if (!fs.existsSync(dllDir) || !fs.statSync(dllDir).isDirectory()) {
     throw new Error(`${target.file} did not contain ${path.basename(dllDir)}/`);
   }
-  const terminfoDir = path.join(extractDir, "terminfo");
-  const terminfoEntry = [
-    path.join(terminfoDir, "x", "xterm-256color"),
-    path.join(terminfoDir, "78", "xterm-256color"),
-  ].find((entry) => fs.existsSync(entry));
-  if (terminfoEntry && !fs.lstatSync(terminfoEntry).isFile()) {
-    throw new Error(`${target.file} contained invalid terminfo for xterm-256color`);
-  }
-  if (!terminfoEntry) {
-    warn(`${target.file} did not contain terminfo for xterm-256color; Windows mosh packaging will need a refreshed mosh binary release.`);
-  }
+  assertBundledTerminfo(extractDir, target);
   chmodExecutable(genericExe);
+}
+
+function normalizePosixBundle(extractDir, target) {
+  const binary = path.join(extractDir, "mosh-client");
+  const legacyBinary = path.join(extractDir, `mosh-client-${target.platform}-${target.arch}`);
+  if (!fs.existsSync(binary) && fs.existsSync(legacyBinary)) {
+    fs.renameSync(legacyBinary, binary);
+  }
+  if (!fs.existsSync(binary) || !fs.lstatSync(binary).isFile()) {
+    throw new Error(`${target.file} did not contain mosh-client`);
+  }
+  assertBundledTerminfo(extractDir, target);
+  chmodExecutable(binary);
+}
+
+function normalizeBundle(extractDir, target) {
+  if (target.platform === "win32") return normalizeWindowsBundle(extractDir, target);
+  return normalizePosixBundle(extractDir, target);
 }
 
 function replaceDir(srcDir, destDir) {
@@ -237,9 +260,7 @@ function unpackTarGz(buf, target, { resDir }) {
       stdio: "inherit",
     });
     assertExtractedTreeSafe(extractDir);
-    if (target.platform === "win32") {
-      normalizeWindowsBundle(extractDir, target);
-    }
+    normalizeBundle(extractDir, target);
     replaceDir(extractDir, destDir);
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -45,12 +45,43 @@ const DEFAULT_RES_DIR = path.join(ROOT, "resources", "mosh");
 // the Cygwin DLL set on Windows. Bundling terminfo lets the bundled
 // statically-linked mosh-client work on minimal hosts that don't have a
 // system ncurses-base — see issue #890.
+//
+// `legacy` describes the pre-bundle artifact name some published mosh
+// binary releases still ship (Linux/Darwin used flat files before the
+// bundle layout). When SHA256SUMS lists only the legacy name we fall
+// back to it so existing releases keep working until a new tag is
+// republished with the bundle layout.
 const TARGETS = [
-  { platform: "linux", arch: "x64", file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz" },
-  { platform: "linux", arch: "arm64", file: "mosh-client-linux-arm64.tar.gz", localDir: "linux-arm64", extract: "tar.gz" },
-  { platform: "darwin", arch: "universal", file: "mosh-client-darwin-universal.tar.gz", localDir: "darwin-universal", extract: "tar.gz" },
+  {
+    platform: "linux", arch: "x64",
+    file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz",
+    legacy: { file: "mosh-client-linux-x64", local: "linux-x64/mosh-client" },
+  },
+  {
+    platform: "linux", arch: "arm64",
+    file: "mosh-client-linux-arm64.tar.gz", localDir: "linux-arm64", extract: "tar.gz",
+    legacy: { file: "mosh-client-linux-arm64", local: "linux-arm64/mosh-client" },
+  },
+  {
+    platform: "darwin", arch: "universal",
+    file: "mosh-client-darwin-universal.tar.gz", localDir: "darwin-universal", extract: "tar.gz",
+    legacy: { file: "mosh-client-darwin-universal", local: "darwin-universal/mosh-client" },
+  },
   { platform: "win32", arch: "x64", file: "mosh-client-win32-x64.tar.gz", localDir: "win32-x64", extract: "tar.gz" },
 ];
+
+function selectReleaseAsset(target, sums) {
+  const primary = { file: target.file, extract: target.extract, local: target.local, localDir: target.localDir };
+  if (!target.legacy) return primary;
+  // SHA256SUMS unavailable (allowUnverified mirror) — keep the primary
+  // and let download / extraction errors surface naturally.
+  if (sums.size === 0) return primary;
+  if (sums.has(target.file)) return primary;
+  if (sums.has(target.legacy.file)) {
+    return { file: target.legacy.file, local: target.legacy.local };
+  }
+  return primary;
+}
 
 function log(msg) { console.log(`[fetch-mosh-binaries] ${msg}`); }
 function warn(msg) { console.warn(`[fetch-mosh-binaries] WARN ${msg}`); }
@@ -270,33 +301,37 @@ function unpackTarGz(buf, target, { resDir }) {
 
 async function fetchOne(target, sums, opts) {
   const { baseUrl, resDir, allowUnverified = false } = opts;
-  const url = `${baseUrl}/${target.file}`;
+  const asset = selectReleaseAsset(target, sums);
+  if (asset.file !== target.file) {
+    log(`using legacy asset ${asset.file} (release predates the bundled tar.gz layout for ${target.platform}-${target.arch})`);
+  }
+  const url = `${baseUrl}/${asset.file}`;
   let buf;
   try {
     buf = await follow(url);
   } catch (err) {
-    throw new Error(`download failed for ${target.file}: ${err.message}`);
+    throw new Error(`download failed for ${asset.file}: ${err.message}`);
   }
 
-  const expected = sums.get(target.file);
+  const expected = sums.get(asset.file);
   const actual = crypto.createHash("sha256").update(buf).digest("hex");
   if (expected && expected !== actual) {
-    throw new Error(`SHA256 mismatch for ${target.file}: expected ${expected}, got ${actual}`);
+    throw new Error(`SHA256 mismatch for ${asset.file}: expected ${expected}, got ${actual}`);
   }
   if (!expected) {
     if (!allowUnverified) {
-      throw new Error(`no SHA256 entry for ${target.file}`);
+      throw new Error(`no SHA256 entry for ${asset.file}`);
     }
-    warn(`no SHA256 entry for ${target.file} - accepting actual ${actual}`);
+    warn(`no SHA256 entry for ${asset.file} - accepting actual ${actual}`);
   }
 
-  if (target.extract === "tar.gz") {
+  if (asset.extract === "tar.gz") {
     const destDir = unpackTarGz(buf, target, { resDir });
-    log(`unpacked ${target.file} into ${path.relative(ROOT, destDir)}/ (sha256=${actual})`);
+    log(`unpacked ${asset.file} into ${path.relative(ROOT, destDir)}/ (sha256=${actual})`);
     return true;
   }
 
-  const dest = path.join(resDir, target.local);
+  const dest = path.join(resDir, asset.local);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.writeFileSync(dest, buf);
   if (target.platform !== "win32") fs.chmodSync(dest, 0o755);
@@ -363,6 +398,7 @@ module.exports = {
   resolveHostTarget,
   resolveTarArchiveInvocation,
   parseSums,
+  selectReleaseAsset,
   validateTarEntries,
   assertExtractedTreeSafe,
   unpackTarGz,

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -288,6 +288,108 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the requested asset", asyn
   );
 });
 
+test("fetch-mosh-binaries unpacks the Linux tarball with bundled terminfo", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const tar = makeTarGz(t, {
+    "mosh-client": "binary",
+    "terminfo/x/xterm-256color": "terminfo",
+  });
+  const baseUrl = await serveAssets(t, {
+    "mosh-client-linux-x64.tar.gz": tar,
+    SHA256SUMS: `${sha256(tar)}  mosh-client-linux-x64.tar.gz\n`,
+  });
+
+  await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
+    env: {
+      ...process.env,
+      MOSH_BIN_RELEASE: "test",
+      MOSH_BIN_BASE_URL: baseUrl,
+      MOSH_BIN_RES_DIR: resDir,
+      CI: "true",
+    },
+    stdio: "pipe",
+  });
+
+  assert.equal(fs.existsSync(path.join(resDir, "linux-x64", "mosh-client")), true);
+  assert.equal(fs.existsSync(path.join(resDir, "linux-x64", "terminfo", "x", "xterm-256color")), true);
+});
+
+test("fetch-mosh-binaries warns when the Linux tarball lacks terminfo", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const tar = makeTarGz(t, {
+    "mosh-client": "binary",
+  });
+  const baseUrl = await serveAssets(t, {
+    "mosh-client-linux-x64.tar.gz": tar,
+    SHA256SUMS: `${sha256(tar)}  mosh-client-linux-x64.tar.gz\n`,
+  });
+
+  const { stderr } = await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
+    env: {
+      ...process.env,
+      MOSH_BIN_RELEASE: "test",
+      MOSH_BIN_BASE_URL: baseUrl,
+      MOSH_BIN_RES_DIR: resDir,
+      CI: "true",
+    },
+    stdio: "pipe",
+  });
+
+  assert.match(stderr, /did not contain terminfo for xterm-256color/);
+  assert.equal(fs.existsSync(path.join(resDir, "linux-x64", "mosh-client")), true);
+});
+
+test("fetch-mosh-binaries unpacks the Darwin tarball with bundled terminfo", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const tar = makeTarGz(t, {
+    "mosh-client": "binary",
+    "terminfo/x/xterm-256color": "terminfo",
+  });
+  const baseUrl = await serveAssets(t, {
+    "mosh-client-darwin-universal.tar.gz": tar,
+    SHA256SUMS: `${sha256(tar)}  mosh-client-darwin-universal.tar.gz\n`,
+  });
+
+  await execFileAsync(process.execPath, [script, "--platform=darwin", "--arch=universal"], {
+    env: {
+      ...process.env,
+      MOSH_BIN_RELEASE: "test",
+      MOSH_BIN_BASE_URL: baseUrl,
+      MOSH_BIN_RES_DIR: resDir,
+      CI: "true",
+    },
+    stdio: "pipe",
+  });
+
+  assert.equal(fs.existsSync(path.join(resDir, "darwin-universal", "mosh-client")), true);
+  assert.equal(fs.existsSync(path.join(resDir, "darwin-universal", "terminfo", "x", "xterm-256color")), true);
+});
+
+test("fetch-mosh-binaries rejects a Linux tarball without mosh-client", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const tar = makeTarGz(t, {
+    "terminfo/x/xterm-256color": "terminfo",
+  });
+  const baseUrl = await serveAssets(t, {
+    "mosh-client-linux-x64.tar.gz": tar,
+    SHA256SUMS: `${sha256(tar)}  mosh-client-linux-x64.tar.gz\n`,
+  });
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
+      env: {
+        ...process.env,
+        MOSH_BIN_RELEASE: "test",
+        MOSH_BIN_BASE_URL: baseUrl,
+        MOSH_BIN_RES_DIR: resDir,
+        CI: "true",
+      },
+      stdio: "pipe",
+    }),
+    /did not contain mosh-client/,
+  );
+});
+
 test("fetch-mosh-binaries rejects symlinks inside Windows tarballs", { skip: process.platform === "win32" }, async (t) => {
   const srcDir = makeTmp(t);
   fs.writeFileSync(path.join(srcDir, "outside.exe"), "outside");

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -15,6 +15,7 @@ const {
   replaceDir,
   resolveHostTarget,
   resolveTarArchiveInvocation,
+  selectReleaseAsset,
 } = require("./fetch-mosh-binaries.cjs");
 
 function makeTmp(t) {
@@ -286,6 +287,65 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the requested asset", asyn
       stdio: "pipe",
     }),
   );
+});
+
+test("selectReleaseAsset prefers the bundled tarball when listed in SHA256SUMS", () => {
+  const target = {
+    platform: "linux", arch: "x64",
+    file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz",
+    legacy: { file: "mosh-client-linux-x64", local: "linux-x64/mosh-client" },
+  };
+  const sums = new Map([
+    ["mosh-client-linux-x64.tar.gz", "abc"],
+    ["mosh-client-linux-x64", "def"],
+  ]);
+  assert.equal(selectReleaseAsset(target, sums).file, "mosh-client-linux-x64.tar.gz");
+});
+
+test("selectReleaseAsset falls back to the legacy flat asset when only it is published", () => {
+  const target = {
+    platform: "linux", arch: "x64",
+    file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz",
+    legacy: { file: "mosh-client-linux-x64", local: "linux-x64/mosh-client" },
+  };
+  const sums = new Map([["mosh-client-linux-x64", "def"]]);
+  const asset = selectReleaseAsset(target, sums);
+  assert.equal(asset.file, "mosh-client-linux-x64");
+  assert.equal(asset.local, "linux-x64/mosh-client");
+  assert.equal(asset.extract, undefined);
+});
+
+test("selectReleaseAsset stays on the primary when SHA256SUMS is empty (unverified mirror)", () => {
+  const target = {
+    platform: "linux", arch: "x64",
+    file: "mosh-client-linux-x64.tar.gz", localDir: "linux-x64", extract: "tar.gz",
+    legacy: { file: "mosh-client-linux-x64", local: "linux-x64/mosh-client" },
+  };
+  assert.equal(selectReleaseAsset(target, new Map()).file, "mosh-client-linux-x64.tar.gz");
+});
+
+test("fetch-mosh-binaries falls back to the legacy flat asset for older releases", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+  const flat = Buffer.from("legacy-binary");
+  const baseUrl = await serveAssets(t, {
+    "mosh-client-linux-x64": flat,
+    SHA256SUMS: `${sha256(flat)}  mosh-client-linux-x64\n`,
+  });
+
+  await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
+    env: {
+      ...process.env,
+      MOSH_BIN_RELEASE: "test",
+      MOSH_BIN_BASE_URL: baseUrl,
+      MOSH_BIN_RES_DIR: resDir,
+      CI: "true",
+    },
+    stdio: "pipe",
+  });
+
+  assert.equal(fs.existsSync(path.join(resDir, "linux-x64", "mosh-client")), true);
+  assert.equal(fs.readFileSync(path.join(resDir, "linux-x64", "mosh-client"), "utf8"), "legacy-binary");
+  assert.equal(fs.existsSync(path.join(resDir, "linux-x64", "terminfo")), false);
 });
 
 test("fetch-mosh-binaries unpacks the Linux tarball with bundled terminfo", async (t) => {

--- a/scripts/mosh-extra-resources.cjs
+++ b/scripts/mosh-extra-resources.cjs
@@ -32,16 +32,28 @@ function moshExtraResources(platform) {
   if (platform === "darwin") {
     const file = path.join(moshRoot, "darwin-universal", "mosh-client");
     if (!hasFile(file)) return [];
-    return [
+    const resources = [
       { from: "resources/mosh/darwin-universal/", to: "mosh/", filter: ["mosh-client"] },
     ];
+    const terminfoDir = path.join(moshRoot, "darwin-universal", "terminfo");
+    if (hasDir(terminfoDir)) {
+      resources.push({ from: "resources/mosh/darwin-universal/terminfo/", to: "mosh/terminfo/", filter: ["**/*"] });
+    }
+    return resources;
   }
 
   if (platform === "linux") {
     const arch = requestedArch();
     const file = path.join(moshRoot, `linux-${arch}`, "mosh-client");
     if (!hasFile(file)) return [];
-    return [{ from: `resources/mosh/linux-${arch}/`, to: "mosh/", filter: ["mosh-client"] }];
+    const resources = [
+      { from: `resources/mosh/linux-${arch}/`, to: "mosh/", filter: ["mosh-client"] },
+    ];
+    const terminfoDir = path.join(moshRoot, `linux-${arch}`, "terminfo");
+    if (hasDir(terminfoDir)) {
+      resources.push({ from: `resources/mosh/linux-${arch}/terminfo/`, to: "mosh/terminfo/", filter: ["**/*"] });
+    }
+    return resources;
   }
 
   if (platform === "win32") {

--- a/scripts/mosh-extra-resources.test.cjs
+++ b/scripts/mosh-extra-resources.test.cjs
@@ -29,7 +29,7 @@ function writeFile(filePath) {
   fs.writeFileSync(filePath, "x");
 }
 
-test("moshExtraResources returns concrete Linux arch paths", (t) => {
+test("moshExtraResources returns concrete Linux arch paths (legacy bundle without terminfo)", (t) => {
   const root = makeTmp(t);
   withCwdAndArch(t, root, "x64");
   writeFile(path.join(root, "resources", "mosh", "linux-x64", "mosh-client"));
@@ -37,6 +37,32 @@ test("moshExtraResources returns concrete Linux arch paths", (t) => {
   const got = moshExtraResources("linux");
   assert.deepEqual(got, [
     { from: "resources/mosh/linux-x64/", to: "mosh/", filter: ["mosh-client"] },
+  ]);
+});
+
+test("moshExtraResources packages bundled terminfo on Linux when present", (t) => {
+  const root = makeTmp(t);
+  withCwdAndArch(t, root, "arm64");
+  writeFile(path.join(root, "resources", "mosh", "linux-arm64", "mosh-client"));
+  writeFile(path.join(root, "resources", "mosh", "linux-arm64", "terminfo", "x", "xterm-256color"));
+
+  const got = moshExtraResources("linux");
+  assert.deepEqual(got, [
+    { from: "resources/mosh/linux-arm64/", to: "mosh/", filter: ["mosh-client"] },
+    { from: "resources/mosh/linux-arm64/terminfo/", to: "mosh/terminfo/", filter: ["**/*"] },
+  ]);
+});
+
+test("moshExtraResources packages bundled terminfo on Darwin when present", (t) => {
+  const root = makeTmp(t);
+  withCwdAndArch(t, root, "x64");
+  writeFile(path.join(root, "resources", "mosh", "darwin-universal", "mosh-client"));
+  writeFile(path.join(root, "resources", "mosh", "darwin-universal", "terminfo", "x", "xterm-256color"));
+
+  const got = moshExtraResources("darwin");
+  assert.deepEqual(got, [
+    { from: "resources/mosh/darwin-universal/", to: "mosh/", filter: ["mosh-client"] },
+    { from: "resources/mosh/darwin-universal/terminfo/", to: "mosh/terminfo/", filter: ["**/*"] },
   ]);
 });
 


### PR DESCRIPTION
Closes #890. Supersedes #893 (the runtime-only patch).

## Why a deeper fix
The bundled `mosh-client` we ship since 1.1.1 is statically linked against an ncurses we built ourselves in CI with `--prefix=$WORK/prefix` — a temp dir gone after the build. ncurses' compiled-in default terminfo path therefore points at a directory that doesn't exist on the user's machine, and `setupterm("xterm-256color")` fails with the exact message in the issue. Mac happened to work because users typically have something in `/usr/share/terminfo`, `~/.terminfo`, or an exported `TERMINFO_DIRS` that satisfies an earlier ncurses search step. Linux on a clean .deb does not. #893 papers over this by pointing `TERMINFO_DIRS` at standard distro paths at spawn time — that fixes #890 today but still relies on the host having `ncurses-base`. This PR makes the binary fully self-sufficient by shipping the database alongside it (mirroring the Windows fix in #889).

## Changes
- `scripts/build-mosh/build-linux.sh` and `build-macos.sh`: copy a curated set of compiled terminfo entries (`xterm-256color`, `xterm`, `vt100`, `screen-256color`, `tmux-256color`, …) out of `$PREFIX/share/terminfo/` and tar them up next to the binary as `mosh-client-<plat>-<arch>.tar.gz`. macOS does the install on the native arch only because `tic` has to run on the build host.
- `scripts/fetch-mosh-binaries.cjs`: Linux + Darwin `TARGETS` switch to `.tar.gz` extracts; bundle-normalize logic split into `normalizeWindowsBundle` / `normalizePosixBundle` and a shared `assertBundledTerminfo` helper.
- `scripts/mosh-extra-resources.cjs`: include the sibling `terminfo/` dir in `extraResources` for Linux + Darwin when present.
- `electron/bridges/terminalBridge.cjs`: `addBundledMoshTerminfoEnv` prefers the bundled dir on POSIX, then merges any caller-supplied `TERMINFO_DIRS`, then falls back to standard distro paths so an older mosh release without the bundle still works.

## Rollout
Requires re-running `build-mosh-binaries.yml` (`workflow_dispatch` with a new `release_tag`, e.g. `mosh-bin-1.4.0-2`) to publish the new bundle layout. `resolve-mosh-bin-release.cjs` auto-discovers the latest non-draft `mosh-bin-*` tag, so no code change is needed to bump it after the rebuild.

Until the new mosh release is published, packaged builds keep working: `fetch-mosh-binaries` will warn about missing terminfo on the old artifacts but still write the binary, and `terminalBridge` falls back to the system terminfo paths the runtime-only patch added — so this PR does not regress in the gap between merge and rebuild.

## Test plan
- [x] `node --test electron/bridges/terminalBridge.bareMoshClient.test.cjs scripts/mosh-extra-resources.test.cjs scripts/fetch-mosh-binaries.test.cjs` (36/36 incl. new Linux/Darwin tar.gz extract, packaging, and runtime-env cases)
- [x] `node --test electron/bridges/terminalBridge.bundledMosh.test.cjs electron/bridges/terminalBridge.moshHandshakeSession.test.cjs electron/bridges/moshHandshake.test.cjs` (39/39)
- [x] `bash -n scripts/build-mosh/build-linux.sh scripts/build-mosh/build-macos.sh`
- [ ] Manual: `workflow_dispatch` on `build-mosh-binaries.yml` with `release_tag=mosh-bin-1.4.0-2`, then a packaged Netcatty .deb on Ubuntu 26.04 (and a stripped container without `ncurses-base`) connects via mosh without the terminfo error
- [ ] Manual: macOS smoke test that bundled mosh still connects (no regression on the already-working path)
- [ ] Manual: Windows smoke test (the win32 branch is untouched but the shared `normalizeBundle`/`assertBundledTerminfo` helpers run on the same path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)