### PR TITLE
fix: handle Windows agent paths with spaces

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -168,6 +168,29 @@ function shouldUseShellForCommand(command) {
   return normalized.endsWith(".cmd") || normalized.endsWith(".bat");
 }
 
+function quoteWindowsShellArg(value) {
+  const arg = String(value ?? "");
+  if (!arg) return "\"\"";
+  return `"${arg.replace(/"/g, '\\"')}"`;
+}
+
+function buildWindowsShellCommandLine(command, args) {
+  return [command, ...(args || [])].map(quoteWindowsShellArg).join(" ");
+}
+
+function prepareCommandForSpawn(command, args) {
+  const spawnArgs = Array.isArray(args) ? args : [];
+  if (!shouldUseShellForCommand(command)) {
+    return { command, args: spawnArgs, shell: false };
+  }
+
+  return {
+    command: buildWindowsShellCommandLine(command, spawnArgs),
+    args: [],
+    shell: true,
+  };
+}
+
 function resolveCliFromPath(command, shellEnv) {
   // Validate command: only allow valid binary names (alphanumeric, hyphens, underscores, dots)
   if (!command || !/^[a-zA-Z0-9._-]+$/.test(command)) {
@@ -380,6 +403,9 @@ module.exports = {
   extractFirstNonLocalhostUrl,
   normalizeCliPathForPlatform,
   shouldUseShellForCommand,
+  quoteWindowsShellArg,
+  buildWindowsShellCommandLine,
+  prepareCommandForSpawn,
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   toUnpackedAsarPath,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -2,10 +2,12 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  buildWindowsShellCommandLine,
   extractTrailingIdlePrompt,
   getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
   isPlausibleCliVersionOutput,
+  prepareCommandForSpawn,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
 
@@ -74,6 +76,30 @@ test("isPlausibleCliVersionOutput rejects stack traces and file URLs", () => {
   assert.equal(isPlausibleCliVersionOutput("    at runCli (cli.js:10:1)"), false);
   assert.equal(isPlausibleCliVersionOutput("permission denied"), false);
   assert.equal(isPlausibleCliVersionOutput("Usage: claude [options]"), false);
+});
+
+test("buildWindowsShellCommandLine quotes command paths and args with spaces", () => {
+  assert.equal(
+    buildWindowsShellCommandLine("C:\\Program Files\\Codex\\codex.cmd", ["login", "status"]),
+    "\"C:\\Program Files\\Codex\\codex.cmd\" \"login\" \"status\"",
+  );
+});
+
+test("prepareCommandForSpawn wraps Windows cmd shims as a single shell command", () => {
+  const result = prepareCommandForSpawn("C:\\Program Files\\Codex\\codex.cmd", ["--version"]);
+  if (process.platform === "win32") {
+    assert.deepEqual(result, {
+      command: "\"C:\\Program Files\\Codex\\codex.cmd\" \"--version\"",
+      args: [],
+      shell: true,
+    });
+  } else {
+    assert.deepEqual(result, {
+      command: "C:\\Program Files\\Codex\\codex.cmd",
+      args: ["--version"],
+      shell: false,
+    });
+  }
 });
 
 test("tracks PowerShell idle prompt after SSH output", () => {

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -26,7 +26,7 @@ const {
 const {
   stripAnsi,
   normalizeCliPathForPlatform,
-  shouldUseShellForCommand,
+  prepareCommandForSpawn,
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   isPlausibleCliVersionOutput,
@@ -1392,11 +1392,12 @@ function registerHandlers(ipcMain) {
 
   async function runCommand(command, args, options) {
     return await new Promise((resolve, reject) => {
-      const child = spawn(command, args || [], {
+      const spawnSpec = prepareCommandForSpawn(command, args || []);
+      const child = spawn(spawnSpec.command, spawnSpec.args, {
         stdio: ["ignore", "pipe", "pipe"],
         cwd: options?.cwd || undefined,
         env: options?.env || process.env,
-        shell: shouldUseShellForCommand(command),
+        shell: spawnSpec.shell,
         windowsHide: true,
       });
 
@@ -2006,10 +2007,11 @@ function registerHandlers(ipcMain) {
       const shellEnv = await getShellEnv();
       const codexCliPath = resolveCliFromPath("codex", shellEnv) || "codex";
       const sessionId = `codex_login_${randomUUID()}`;
-      const child = spawn(codexCliPath, ["login"], {
+      const spawnSpec = prepareCommandForSpawn(codexCliPath, ["login"]);
+      const child = spawn(spawnSpec.command, spawnSpec.args, {
         stdio: ["ignore", "pipe", "pipe"],
         env: shellEnv,
-        shell: shouldUseShellForCommand(codexCliPath),
+        shell: spawnSpec.shell,
         windowsHide: true,
       });
 

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const Module = require("node:module");
 const os = require("node:os");
 const path = require("node:path");
+const { prepareCommandForSpawn } = require("./ai/shellUtils.cjs");
 
 function createIpcMainStub() {
   const handlers = new Map();
@@ -116,6 +117,10 @@ function loadBridgeWithMocks(options = {}) {
           ? options.normalizeCliPathForPlatform(...args)
           : args[0],
       shouldUseShellForCommand: () => false,
+      prepareCommandForSpawn: (...args) =>
+        typeof options.prepareCommandForSpawn === "function"
+          ? options.prepareCommandForSpawn(...args)
+          : prepareCommandForSpawn(...args),
       isPlausibleCliVersionOutput: (value) =>
         typeof options.isPlausibleCliVersionOutput === "function"
           ? options.isPlausibleCliVersionOutput(value)
@@ -525,6 +530,128 @@ test("resolve-cli accepts stored bundled Codex ACP path", async (t) => {
     assert.deepEqual(result, {
       path: codexAcpPath,
       version: "Bundled ACP",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli probes Windows cmd paths with spaces", { skip: process.platform !== "win32" }, async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty codex resolve "));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const codexPath = path.join(tempDir, "codex.cmd");
+  fs.writeFileSync(
+    codexPath,
+    "@echo off\r\necho codex-cli 1.2.3\r\n",
+    "utf8",
+  );
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    prepareCommandForSpawn,
+    resolveCliFromPath: (command) => (command === "codex" ? codexPath : null),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "codex", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: codexPath,
+      version: "codex-cli 1.2.3",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli probes Windows Claude cmd paths with spaces", { skip: process.platform !== "win32" }, async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty claude resolve "));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const claudePath = path.join(tempDir, "claude.cmd");
+  fs.writeFileSync(
+    claudePath,
+    "@echo off\r\necho 2.1.123 (Claude Code)\r\n",
+    "utf8",
+  );
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    prepareCommandForSpawn,
+    resolveCliFromPath: (command) => (command === "claude" ? claudePath : null),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "claude", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: claudePath,
+      version: "2.1.123 (Claude Code)",
+      available: true,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("resolve-cli probes Windows Claude exe paths with spaces", { skip: process.platform !== "win32" }, async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty claude exe resolve "));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const claudePath = path.join(tempDir, "claude.exe");
+  fs.copyFileSync(process.execPath, claudePath);
+
+  const { bridge, restore } = loadBridgeWithMocks({
+    prepareCommandForSpawn,
+    resolveCliFromPath: (command) => (command === "claude" ? claudePath : null),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const resolveHandler = ipcMain.handlers.get("netcatty:ai:resolve-cli");
+    assert.equal(typeof resolveHandler, "function");
+
+    const result = await resolveHandler({ sender: { id: 1 } }, { command: "claude", customPath: "" });
+
+    assert.deepEqual(result, {
+      path: claudePath,
+      version: process.version,
       available: true,
     });
   } finally {


### PR DESCRIPTION
When the executable file is installed in a directory containing spaces, the Codex and Claude path/version detection do not work.