### PR TITLE
Fix Windows mosh binary fallback selection

### DIFF
--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -104,10 +104,11 @@ function selectReleaseAsset(target, sums, opts = {}) {
   const primary = { file: target.file, extract: target.extract, local: target.local, localDir: target.localDir };
   if (!target.legacy) return primary;
   if (target.preferLegacy && !opts.forceWindowsCygwin) {
-    if (sums.has(target.legacy.file)) {
-      return { file: target.legacy.file, local: target.legacy.local };
+    const legacy = applyReleaseAssetOverrides(target.legacy, opts);
+    if (sums.get(target.legacy.file) === legacy.sha256) {
+      return { file: target.legacy.file, local: target.legacy.local, sha256: legacy.sha256 };
     }
-    return applyReleaseAssetOverrides(target.legacy, opts);
+    return legacy;
   }
   // SHA256SUMS unavailable (allowUnverified mirror) — keep the primary
   // and let download / extraction errors surface naturally.

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -360,12 +360,33 @@ test("selectReleaseAsset uses the released Windows standalone asset when publish
     },
     preferLegacy: true,
   };
-  const asset = selectReleaseAsset(target, new Map([["mosh-client-win32-x64.exe", "def"]]));
+  const asset = selectReleaseAsset(target, new Map([["mosh-client-win32-x64.exe", "abc"]]));
 
   assert.equal(asset.file, "mosh-client-win32-x64.exe");
   assert.equal(asset.local, "win32-x64/mosh-client.exe");
   assert.equal(asset.url, undefined);
-  assert.equal(asset.sha256, undefined);
+  assert.equal(asset.sha256, "abc");
+});
+
+test("selectReleaseAsset ignores a released Windows asset when its checksum is not the pinned standalone", () => {
+  const target = {
+    platform: "win32", arch: "x64",
+    file: "mosh-client-win32-x64.tar.gz", localDir: "win32-x64", extract: "tar.gz",
+    legacy: {
+      id: "windows-fluentterminal-standalone",
+      file: "mosh-client-win32-x64.exe",
+      local: "win32-x64/mosh-client.exe",
+      url: "https://example.test/mosh-client.exe",
+      sha256: "abc",
+    },
+    preferLegacy: true,
+  };
+  const asset = selectReleaseAsset(target, new Map([["mosh-client-win32-x64.exe", "def"]]));
+
+  assert.equal(asset.file, "mosh-client-win32-x64.exe");
+  assert.equal(asset.local, "win32-x64/mosh-client.exe");
+  assert.equal(asset.url, "https://example.test/mosh-client.exe");
+  assert.equal(asset.sha256, "abc");
 });
 
 test("fetch-mosh-binaries downloads the pinned Windows standalone client", async (t) => {


### PR DESCRIPTION
## Summary
- only trust the released Windows standalone mosh-client asset when its SHA matches the pinned standalone checksum
- fall back to the pinned FluentTerminal URL when a same-named release asset is actually the old Cygwin/dynamic binary
- add coverage for mismatched Windows release asset checksums

## Tests
- `node --test scripts\fetch-mosh-binaries.test.cjs scripts\mosh-extra-resources.test.cjs`
- `git diff --check HEAD~1..HEAD`

## Notes
The failing runtime exit code `-1073741515` is Windows `0xC0000135`, which means the local `mosh-client.exe` failed to load a required DLL. The remote `mosh-server detached` line means SSH auth and remote server startup succeeded; the failure is local Windows client startup.