### PR TITLE
Strip LC_* before mosh ssh handshake

### DIFF
--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -1130,6 +1130,13 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
   });
 
   const sshEnv = { ...process.env, ...optionsEnv, TERM: "xterm-256color" };
+  // macOS Terminal/iTerm export LC_CTYPE=UTF-8 (a bare value, not a real
+  // locale name). System ssh_config has `SendEnv LC_*`, so without scrubbing
+  // these the remote shell tries to setlocale("UTF-8") and prints a warning
+  // on every connection. mosh-server sets the locale it needs separately.
+  for (const key of Object.keys(sshEnv)) {
+    if (key.startsWith("LC_")) delete sshEnv[key];
+  }
   if (options.agentForwarding && process.env.SSH_AUTH_SOCK) {
     sshEnv.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;
   }


### PR DESCRIPTION
## Summary
- macOS Terminal/iTerm export `LC_CTYPE=UTF-8` (a bare value, not a real locale name). System `ssh_config` has `SendEnv LC_*`, so when netcatty spawns the system `ssh` for mosh handshake, that value leaks to the remote and every login prints:
  ```
  -bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
  ```
- Tried `-o "SendEnv -LC_*"` first but OpenSSH processes `-o` **before** the system config, so the `-` removal happens against an empty list and the system `SendEnv LC_*` re-adds it.
- Fix: scrub all `LC_*` keys from the env passed to the spawned `ssh` child in \`startMoshSessionViaHandshake\`. mosh-server already sets the locale it needs via the \`LC_ALL=...\` prefix.

## Test plan
- [x] mosh-connect to a Debian/Ubuntu host that does not have \`UTF-8\` (or \`en_US.UTF-8\`) locale generated; confirm bash no longer prints the \`setlocale\` warning at login.
- [x] Confirm UTF-8 characters render correctly in the mosh session (Chinese filenames, emoji, etc).
- [x] \`node --test electron/bridges/moshHandshake.test.cjs\` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)