### PR TITLE
[codex] Improve Telnet credential login

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -63,9 +63,9 @@ export const useTerminalBackend = () => {
     return bridge.execCommand(options);
   }, []);
 
-  const writeToSession = useCallback((sessionId: string, data: string) => {
+  const writeToSession = useCallback((sessionId: string, data: string, options?: { automated?: boolean }) => {
     const bridge = netcattyBridge.get();
-    bridge?.writeToSession?.(sessionId, data);
+    bridge?.writeToSession?.(sessionId, data, options);
   }, []);
 
   const resizeSession = useCallback((sessionId: string, cols: number, rows: number) => {
@@ -94,6 +94,16 @@ export const useTerminalBackend = () => {
     const bridge = netcattyBridge.get();
     if (!bridge?.onSessionExit) throw new Error("onSessionExit unavailable");
     return bridge.onSessionExit(sessionId, cb);
+  }, []);
+
+  const onTelnetAutoLoginComplete = useCallback((sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.onTelnetAutoLoginComplete?.(sessionId, cb);
+  }, []);
+
+  const onTelnetAutoLoginCancelled = useCallback((sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.onTelnetAutoLoginCancelled?.(sessionId, cb);
   }, []);
 
   const onChainProgress = useCallback((cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void) => {
@@ -175,6 +185,8 @@ export const useTerminalBackend = () => {
     setSessionEncoding,
     onSessionData,
     onSessionExit,
+    onTelnetAutoLoginComplete,
+    onTelnetAutoLoginCancelled,
     onChainProgress,
     openExternal,
   };

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -21,13 +21,13 @@ const hostWithMissingProxyProfile: Host = {
   createdAt: 1,
 };
 
-const renderHostDetails = () =>
+const renderHostDetails = (initialData: Host = hostWithMissingProxyProfile) =>
   renderToStaticMarkup(
     React.createElement(
       I18nProvider,
       { locale: "en" },
       React.createElement(HostDetailsPanel, {
-        initialData: hostWithMissingProxyProfile,
+        initialData,
         availableKeys: [],
         identities: [],
         proxyProfiles: [],
@@ -48,4 +48,23 @@ test("HostDetailsPanel shows a missing saved proxy without undefined fields", ()
 
   assert.match(markup, /Missing saved proxy/);
   assert.doesNotMatch(markup, /undefined:undefined/);
+});
+
+test("HostDetailsPanel keeps explicitly cleared telnet credentials empty", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    protocol: "telnet",
+    telnetEnabled: true,
+    telnetPort: 23,
+    username: "root",
+    password: "ssh-password",
+    telnetUsername: "",
+    telnetPassword: "",
+    proxyProfileId: undefined,
+  });
+
+  assert.match(markup, /placeholder="Telnet Username"[^>]*value=""/);
+  assert.match(markup, /placeholder="Telnet Password"[^>]*value=""/);
+  assert.doesNotMatch(markup, /placeholder="Telnet Username"[^>]*value="root"/);
+  assert.doesNotMatch(markup, /placeholder="Telnet Password"[^>]*value="ssh-password"/);
 });

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -68,3 +68,17 @@ test("HostDetailsPanel keeps explicitly cleared telnet credentials empty", () =>
   assert.doesNotMatch(markup, /placeholder="Telnet Username"[^>]*value="root"/);
   assert.doesNotMatch(markup, /placeholder="Telnet Password"[^>]*value="ssh-password"/);
 });
+
+test("HostDetailsPanel gives the telnet port field the same roomy layout as SSH", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    protocol: "telnet",
+    telnetEnabled: true,
+    telnetPort: 2325,
+    proxyProfileId: undefined,
+  });
+
+  assert.match(markup, /Telnet on[\s\S]*ml-auto w-1\/2 min-w-0 flex items-center gap-2 justify-end/);
+  assert.match(markup, /class="[^"]*h-8 flex-1 min-w-0 text-center[^"]*"[^>]*value="2325"/);
+  assert.doesNotMatch(markup, /class="[^"]*w-16[^"]*"[^>]*value="2325"/);
+});

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { I18nProvider } from "../application/i18n/I18nProvider.tsx";
 import type { Host } from "../types.ts";
-import HostDetailsPanel from "./HostDetailsPanel.tsx";
+import HostDetailsPanel, { parseOptionalPortInput } from "./HostDetailsPanel.tsx";
 
 const hostWithMissingProxyProfile: Host = {
   id: "host-1",
@@ -43,6 +43,18 @@ const renderHostDetails = (initialData: Host = hostWithMissingProxyProfile) =>
     ),
   );
 
+const findInputByValue = (markup: string, value: string) => {
+  const match = markup.match(new RegExp(`<input(?=[^>]*value="${value}")[^>]*>`));
+  assert.ok(match, `expected input with value ${value}`);
+  return match[0];
+};
+
+const classTokens = (markup: string) => {
+  const classMatch = markup.match(/class="([^"]*)"/);
+  assert.ok(classMatch, "expected class attribute");
+  return new Set(classMatch[1].split(/\s+/).filter(Boolean));
+};
+
 test("HostDetailsPanel shows a missing saved proxy without undefined fields", () => {
   const markup = renderHostDetails();
 
@@ -78,7 +90,150 @@ test("HostDetailsPanel gives the telnet port field the same roomy layout as SSH"
     proxyProfileId: undefined,
   });
 
-  assert.match(markup, /Telnet on[\s\S]*ml-auto w-1\/2 min-w-0 flex items-center gap-2 justify-end/);
-  assert.match(markup, /class="[^"]*h-8 flex-1 min-w-0 text-center[^"]*"[^>]*value="2325"/);
-  assert.doesNotMatch(markup, /class="[^"]*w-16[^"]*"[^>]*value="2325"/);
+  const telnetMarkup = markup.slice(markup.indexOf("Telnet on"));
+  const wrapperMatch = telnetMarkup.match(/<div class="([^"]*w-1\/2[^"]*)"/);
+  assert.ok(wrapperMatch, "expected telnet port wrapper");
+  const wrapperClasses = new Set(wrapperMatch[1].split(/\s+/).filter(Boolean));
+  assert.ok(wrapperClasses.has("ml-auto"));
+  assert.ok(wrapperClasses.has("w-1/2"));
+  assert.ok(wrapperClasses.has("min-w-0"));
+  assert.ok(wrapperClasses.has("justify-end"));
+  const telnetPortInput = findInputByValue(markup, "2325");
+  const inputClasses = classTokens(telnetPortInput);
+  assert.ok(inputClasses.has("flex-1"));
+  assert.ok(inputClasses.has("min-w-0"));
+  assert.ok(inputClasses.has("text-center"));
+  assert.equal(inputClasses.has("w-16"), false);
+});
+
+test("HostDetailsPanel displays inherited telnet port before falling back to 23", () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(HostDetailsPanel, {
+        initialData: {
+          ...hostWithMissingProxyProfile,
+          protocol: "telnet",
+          telnetEnabled: true,
+          telnetPort: undefined,
+          port: undefined,
+          group: "network",
+          proxyProfileId: undefined,
+        },
+        availableKeys: [],
+        identities: [],
+        proxyProfiles: [],
+        groups: ["network"],
+        managedSources: [],
+        allTags: [],
+        allHosts: [],
+        terminalThemeId: "default",
+        terminalFontSize: 14,
+        groupConfigs: [{ path: "network", telnetPort: 2325 }],
+        onSave: () => {},
+        onCancel: () => {},
+      }),
+    ),
+  );
+
+  assert.match(findInputByValue(markup, "2325"), /type="number"/);
+});
+
+test("HostDetailsPanel uses group telnet port instead of ssh port for optional telnet", () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(HostDetailsPanel, {
+        initialData: {
+          ...hostWithMissingProxyProfile,
+          protocol: "ssh",
+          telnetEnabled: true,
+          telnetPort: undefined,
+          port: 2222,
+          group: "network",
+          proxyProfileId: undefined,
+        },
+        availableKeys: [],
+        identities: [],
+        proxyProfiles: [],
+        groups: ["network"],
+        managedSources: [],
+        allTags: [],
+        allHosts: [],
+        terminalThemeId: "default",
+        terminalFontSize: 14,
+        groupConfigs: [{ path: "network", telnetPort: 2325 }],
+        onSave: () => {},
+        onCancel: () => {},
+      }),
+    ),
+  );
+
+  const telnetMarkup = markup.slice(markup.indexOf("Telnet on"));
+  assert.match(findInputByValue(telnetMarkup, "2325"), /type="number"/);
+  assert.doesNotMatch(telnetMarkup, /value="2222"/);
+});
+
+test("HostDetailsPanel displays inherited telnet credentials", () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: "en" },
+      React.createElement(HostDetailsPanel, {
+        initialData: {
+          ...hostWithMissingProxyProfile,
+          protocol: "telnet",
+          telnetEnabled: true,
+          telnetUsername: undefined,
+          telnetPassword: undefined,
+          username: "ssh-user",
+          password: "ssh-password",
+          group: "network",
+          proxyProfileId: undefined,
+        },
+        availableKeys: [],
+        identities: [],
+        proxyProfiles: [],
+        groups: ["network"],
+        managedSources: [],
+        allTags: [],
+        allHosts: [],
+        terminalThemeId: "default",
+        terminalFontSize: 14,
+        groupConfigs: [{
+          path: "network",
+          telnetUsername: "group-telnet-user",
+          telnetPassword: "group-telnet-password",
+        }],
+        onSave: () => {},
+        onCancel: () => {},
+      }),
+    ),
+  );
+
+  assert.match(markup, /placeholder="Telnet Username"[^>]*value="group-telnet-user"/);
+  assert.match(markup, /placeholder="Telnet Password"[^>]*value="group-telnet-password"/);
+  assert.doesNotMatch(markup, /placeholder="Telnet Username"[^>]*value="ssh-user"/);
+  assert.doesNotMatch(markup, /placeholder="Telnet Password"[^>]*value="ssh-password"/);
+});
+
+test("parseOptionalPortInput clears empty port values", () => {
+  assert.equal(parseOptionalPortInput(""), undefined);
+  assert.equal(parseOptionalPortInput("2325"), 2325);
+});
+
+test("HostDetailsPanel does not offer to disable telnet when telnet is the primary protocol", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    protocol: "telnet",
+    telnetEnabled: true,
+    telnetPort: 23,
+    proxyProfileId: undefined,
+  });
+  const telnetHeader = markup.match(/Telnet on[\s\S]*?Credentials/);
+
+  assert.ok(telnetHeader);
+  assert.doesNotMatch(telnetHeader[0], /hover:text-destructive/);
 });

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -1925,15 +1925,17 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         {form.telnetEnabled || form.protocol === "telnet" ? (
           <Card className="p-3 space-y-3 bg-card border-border/80">
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-2 py-1">
+              <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
                 <span className="text-xs text-muted-foreground">{t("hostDetails.telnetOn")}</span>
-                <Input
-                  type="number"
-                  value={form.telnetPort || 23}
-                  onChange={(e) => update("telnetPort", Number(e.target.value))}
-                  className="h-8 w-16 text-center"
-                />
-                <span className="text-xs text-muted-foreground">{t("hostDetails.port")}</span>
+                <div className="ml-auto w-1/2 min-w-0 flex items-center gap-2 justify-end">
+                  <Input
+                    type="number"
+                    value={form.telnetPort || 23}
+                    onChange={(e) => update("telnetPort", Number(e.target.value))}
+                    className="h-8 flex-1 min-w-0 text-center"
+                  />
+                  <span className="text-xs text-muted-foreground">{t("hostDetails.port")}</span>
+                </div>
               </div>
               <Button
                 variant="ghost"

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -1949,7 +1949,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
             <p className="text-xs font-semibold">{t("hostDetails.telnet.credentials")}</p>
             <Input
               placeholder={t("hostDetails.telnet.username")}
-              value={form.telnetUsername || form.username || ""}
+              value={form.telnetUsername ?? form.username ?? ""}
               onChange={(e) =>
                 update("telnetUsername" as keyof Host, e.target.value)
               }
@@ -1958,7 +1958,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
             <Input
               placeholder={t("hostDetails.telnet.password")}
               type="password"
-              value={form.telnetPassword || form.password || ""}
+              value={form.telnetPassword ?? form.password ?? ""}
               onChange={(e) =>
                 update("telnetPassword" as keyof Host, e.target.value)
               }

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -35,6 +35,7 @@ import { resolveGroupDefaults, resolveGroupTerminalThemeId } from "../domain/gro
 import {
   getEffectiveHostDistro,
   LINUX_DISTRO_OPTIONS,
+  normalizePrimaryTelnetState,
   NETWORK_DEVICE_OPTIONS,
 } from "../domain/host";
 import { isCompleteProxyConfig, normalizeManualProxyConfig } from "../domain/proxyProfiles";
@@ -90,6 +91,44 @@ type SubPanel =
   | "theme-select"
   | "telnet-theme-select";
 
+export const parseOptionalPortInput = (value: string): number | undefined =>
+  value ? Number(value) : undefined;
+
+const resolveDetailsTelnetPort = (
+  host: Host,
+  groupDefaults?: Partial<GroupConfig>,
+): number => {
+  if (host.telnetPort !== undefined && host.telnetPort !== null) return host.telnetPort;
+  if (groupDefaults?.telnetPort !== undefined && groupDefaults.telnetPort !== null) {
+    return groupDefaults.telnetPort;
+  }
+  if (host.protocol === "telnet") {
+    if (host.port !== undefined && host.port !== null) return host.port;
+    if (groupDefaults?.port !== undefined && groupDefaults.port !== null) return groupDefaults.port;
+  }
+  return 23;
+};
+
+const resolveDetailsTelnetUsername = (
+  host: Host,
+  groupDefaults?: Partial<GroupConfig>,
+): string =>
+  host.telnetUsername !== undefined
+    ? host.telnetUsername
+    : groupDefaults?.telnetUsername !== undefined
+      ? groupDefaults.telnetUsername
+      : host.username ?? groupDefaults?.username ?? "";
+
+const resolveDetailsTelnetPassword = (
+  host: Host,
+  groupDefaults?: Partial<GroupConfig>,
+): string =>
+  host.telnetPassword !== undefined
+    ? host.telnetPassword
+    : groupDefaults?.telnetPassword !== undefined
+      ? groupDefaults.telnetPassword
+      : host.password ?? groupDefaults?.password ?? "";
+
 const LINUX_DISTRO_OPTION_IDS = [
   ...LINUX_DISTRO_OPTIONS,
   ...NETWORK_DEVICE_OPTIONS,
@@ -140,7 +179,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   const { checkSshAgent } = useApplicationBackend();
   const [form, setForm] = useState<Host>(
     () =>
-      initialData ||
+      (initialData ? normalizePrimaryTelnetState(initialData) : null) ||
       ({
         id: crypto.randomUUID(),
         label: "",
@@ -200,14 +239,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
 
   useEffect(() => {
     if (initialData) {
-      // Ensure telnetEnabled is set when protocol is telnet
-      const updatedData = { ...initialData };
-      if (initialData.protocol === "telnet" && !initialData.telnetEnabled) {
-        updatedData.telnetEnabled = true;
-        updatedData.telnetPort =
-          initialData.telnetPort || initialData.port || 23;
-      }
-      setForm(updatedData);
+      setForm(normalizePrimaryTelnetState(initialData));
       setGroupInputValue(initialData.group || "");
       // Reset password visibility when host changes for privacy
       setShowPassword(false);
@@ -244,6 +276,9 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   );
   const effectiveTelnetThemeId =
     form.protocols?.find((p) => p.protocol === "telnet")?.theme || effectiveThemeId;
+  const effectiveTelnetPort = resolveDetailsTelnetPort(form, effectiveGroupDefaults);
+  const effectiveTelnetUsername = resolveDetailsTelnetUsername(form, effectiveGroupDefaults);
+  const effectiveTelnetPassword = resolveDetailsTelnetPassword(form, effectiveGroupDefaults);
   const distroOptions = useMemo(
     () =>
       LINUX_DISTRO_OPTION_IDS.map((value) => ({
@@ -424,17 +459,22 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
     }
 
     const { proxyConfig: _draftProxyConfig, ...formWithoutProxyDraft } = form;
-    const cleaned: Host = {
+    const finalPort =
+      form.protocol === "telnet"
+        ? form.port
+        : form.port ?? (groupDefaults?.port ? undefined : 22);
+    let cleaned: Host = {
       ...formWithoutProxyDraft,
       ...(normalizedProxyConfig && { proxyConfig: normalizedProxyConfig }),
       label: finalLabel,
       group: finalGroup,
       tags: form.tags || [],
-      port: form.port ?? (groupDefaults?.port ? undefined : 22),
+      port: finalPort,
       // Clear password if savePassword is explicitly set to false
       password: form.savePassword === false ? undefined : form.password,
       managedSourceId: finalManagedSourceId,
     };
+    cleaned = normalizePrimaryTelnetState(cleaned);
     const preserveLegacyTheme = initialData?.theme != null && cleaned.themeOverride !== false;
     const preserveLegacyFontFamily = initialData?.fontFamily != null && cleaned.fontFamilyOverride !== false;
     const preserveLegacyFontSize = initialData?.fontSize != null && cleaned.fontSizeOverride !== false;
@@ -687,7 +727,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
               ...(form.protocols || []),
               {
                 protocol: "telnet" as const,
-                port: form.telnetPort || 23,
+                port: effectiveTelnetPort,
                 enabled: true,
                 theme: themeId,
               },
@@ -1928,41 +1968,43 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
               <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
                 <span className="text-xs text-muted-foreground">{t("hostDetails.telnetOn")}</span>
                 <div className="ml-auto w-1/2 min-w-0 flex items-center gap-2 justify-end">
-                  <Input
-                    type="number"
-                    value={form.telnetPort || 23}
-                    onChange={(e) => update("telnetPort", Number(e.target.value))}
-                    className="h-8 flex-1 min-w-0 text-center"
-                  />
+	                  <Input
+	                    type="number"
+	                    value={effectiveTelnetPort}
+	                    onChange={(e) => update("telnetPort", parseOptionalPortInput(e.target.value))}
+	                    className="h-8 flex-1 min-w-0 text-center"
+	                  />
                   <span className="text-xs text-muted-foreground">{t("hostDetails.port")}</span>
                 </div>
               </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                onClick={() => update("telnetEnabled", false)}
-              >
-                <X size={14} />
-              </Button>
+              {form.protocol !== "telnet" && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                  onClick={() => update("telnetEnabled", false)}
+                >
+                  <X size={14} />
+                </Button>
+              )}
             </div>
 
             {/* Telnet Credentials */}
             <p className="text-xs font-semibold">{t("hostDetails.telnet.credentials")}</p>
-            <Input
-              placeholder={t("hostDetails.telnet.username")}
-              value={form.telnetUsername ?? form.username ?? ""}
-              onChange={(e) =>
-                update("telnetUsername" as keyof Host, e.target.value)
-              }
+	            <Input
+	              placeholder={t("hostDetails.telnet.username")}
+	              value={effectiveTelnetUsername}
+	              onChange={(e) =>
+	                update("telnetUsername" as keyof Host, e.target.value)
+	              }
               className="h-10"
             />
             <Input
-              placeholder={t("hostDetails.telnet.password")}
-              type="password"
-              value={form.telnetPassword ?? form.password ?? ""}
-              onChange={(e) =>
-                update("telnetPassword" as keyof Host, e.target.value)
+	              placeholder={t("hostDetails.telnet.password")}
+	              type="password"
+	              value={effectiveTelnetPassword}
+	              onChange={(e) =>
+	                update("telnetPassword" as keyof Host, e.target.value)
               }
               className="h-10"
             />
@@ -2011,7 +2053,6 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
             className="w-full h-10 justify-start gap-2 border border-dashed border-border/60"
             onClick={() => {
               update("telnetEnabled", true);
-              update("telnetPort", 23);
             }}
           >
             <Plus size={14} />

--- a/components/HostTreeView.test.tsx
+++ b/components/HostTreeView.test.tsx
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { GroupConfig, Host } from "../types.ts";
+import { getHostTreeDisplayDetails } from "./HostTreeView.tsx";
+
+const baseHost: Host = {
+  id: "host-1",
+  label: "Router",
+  hostname: "router.example.com",
+  username: "ssh-user",
+  port: 2222,
+  protocol: "telnet",
+  tags: [],
+  os: "linux",
+  createdAt: 1,
+};
+
+test("HostTreeView display details include inherited telnet defaults", () => {
+  const host: Host = {
+    ...baseHost,
+    group: "network",
+    username: "ssh-user",
+    port: 2222,
+    telnetUsername: undefined,
+    telnetPort: undefined,
+  };
+  const groupConfigs: GroupConfig[] = [{
+    path: "network",
+    telnetUsername: "group-telnet-user",
+    telnetPort: 2325,
+  }];
+
+  assert.deepEqual(getHostTreeDisplayDetails(host, groupConfigs), {
+    protocol: "telnet",
+    username: "group-telnet-user",
+    port: 2325,
+  });
+});
+
+test("HostTreeView display details keep explicit cleared telnet username", () => {
+  const host: Host = {
+    ...baseHost,
+    group: "network",
+    telnetUsername: "",
+  };
+  const groupConfigs: GroupConfig[] = [{
+    path: "network",
+    telnetUsername: "group-telnet-user",
+    telnetPort: 2325,
+  }];
+
+  assert.deepEqual(getHostTreeDisplayDetails(host, groupConfigs), {
+    protocol: "telnet",
+    username: "",
+    port: 2325,
+  });
+});

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -2,10 +2,11 @@ import { CheckSquare, ChevronRight, Edit2, FileSymlink, Folder, FolderOpen, Moni
 import React, { useMemo } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { useTreeExpandedState } from '../application/state/useTreeExpandedState';
-import { sanitizeHost } from '../domain/host';
+import { applyGroupDefaults, resolveGroupDefaults } from '../domain/groupConfig';
+import { resolveTelnetPort, resolveTelnetUsername, sanitizeHost } from '../domain/host';
 import { STORAGE_KEY_VAULT_HOSTS_TREE_EXPANDED } from '../infrastructure/config/storageKeys';
 import { cn } from '../lib/utils';
-import { GroupNode, Host } from '../types';
+import { GroupConfig, GroupNode, Host } from '../types';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './ui/collapsible';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from './ui/context-menu';
 import { DistroAvatar } from './DistroAvatar';
@@ -38,6 +39,7 @@ interface HostTreeViewProps {
   toggleHostSelection?: (hostId: string) => void;
   getDropTargetClasses?: (target: string) => string;
   setDragOverDropTarget?: (target: string | null) => void;
+  groupConfigs?: GroupConfig[];
 }
 
 interface TreeNodeProps {
@@ -65,6 +67,7 @@ interface TreeNodeProps {
   toggleHostSelection?: (hostId: string) => void;
   getDropTargetClasses?: (target: string) => string;
   setDragOverDropTarget?: (target: string | null) => void;
+  groupConfigs: GroupConfig[];
 }
 
 
@@ -93,6 +96,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   toggleHostSelection,
   getDropTargetClasses,
   setDragOverDropTarget,
+  groupConfigs,
 }) => {
   const { t } = useI18n();
   const isExpanded = expandedPaths.has(node.path);
@@ -255,13 +259,14 @@ const TreeNode: React.FC<TreeNodeProps> = ({
               managedGroupPaths={managedGroupPaths}
               onUnmanageGroup={onUnmanageGroup}
 
-              isMultiSelectMode={isMultiSelectMode}
-              selectedHostIds={selectedHostIds}
-              toggleHostSelection={toggleHostSelection}
-              getDropTargetClasses={getDropTargetClasses}
-              setDragOverDropTarget={setDragOverDropTarget}
-            />
-          ))}
+	              isMultiSelectMode={isMultiSelectMode}
+	              selectedHostIds={selectedHostIds}
+	              toggleHostSelection={toggleHostSelection}
+	              getDropTargetClasses={getDropTargetClasses}
+	              setDragOverDropTarget={setDragOverDropTarget}
+	              groupConfigs={groupConfigs}
+	            />
+	          ))}
 
           {/* Hosts in this group */}
           {sortedHosts.map((host) => (
@@ -276,11 +281,12 @@ const TreeNode: React.FC<TreeNodeProps> = ({
               onCopyCredentials={onCopyCredentials}
               moveHostToGroup={moveHostToGroup}
 
-              isMultiSelectMode={isMultiSelectMode}
-              selectedHostIds={selectedHostIds}
-              toggleHostSelection={toggleHostSelection}
-            />
-          ))}
+	              isMultiSelectMode={isMultiSelectMode}
+	              selectedHostIds={selectedHostIds}
+	              toggleHostSelection={toggleHostSelection}
+	              groupConfigs={groupConfigs}
+	            />
+	          ))}
         </CollapsibleContent>
       </Collapsible>
     </div>
@@ -300,7 +306,27 @@ interface HostTreeItemProps {
   isMultiSelectMode?: boolean;
   selectedHostIds?: Set<string>;
   toggleHostSelection?: (hostId: string) => void;
+  groupConfigs: GroupConfig[];
 }
+
+export const getHostTreeDisplayDetails = (
+  host: Host,
+  groupConfigs: GroupConfig[] = [],
+) => {
+  const displayHost = host.group
+    ? applyGroupDefaults(host, resolveGroupDefaults(host.group, groupConfigs))
+    : host;
+  const isTelnet = displayHost.protocol === 'telnet';
+  return {
+    protocol: displayHost.protocol,
+    username: isTelnet
+      ? (resolveTelnetUsername(displayHost) || '')
+      : (displayHost.username?.trim() || ''),
+    port: isTelnet
+      ? resolveTelnetPort(displayHost)
+      : (displayHost.port ?? 22),
+  };
+};
 
 const HostTreeItem: React.FC<HostTreeItemProps> = ({
   host,
@@ -315,18 +341,19 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
   isMultiSelectMode,
   selectedHostIds,
   toggleHostSelection,
+  groupConfigs,
 }) => {
   const { t } = useI18n();
   const paddingLeft = `${depth * 20 + 12}px`;
   const safeHost = sanitizeHost(host);
   const tags = host.tags || [];
-  const isTelnet = host.protocol === 'telnet';
-  const displayUsername = isTelnet
-    ? (host.telnetUsername?.trim() || host.username?.trim() || '')
-    : (host.username?.trim() || '');
-  const displayPort = isTelnet
-    ? (host.telnetPort ?? host.port ?? 23)
-    : (host.port ?? 22);
+  const displayDetails = useMemo(
+    () => getHostTreeDisplayDetails(host, groupConfigs),
+    [groupConfigs, host],
+  );
+  const displayProtocol = displayDetails.protocol;
+  const displayUsername = displayDetails.username;
+  const displayPort = displayDetails.port;
   const isSelected = isMultiSelectMode && selectedHostIds?.has(host.id);
 
   return (
@@ -371,11 +398,11 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
             </div>
           </div>
           <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-            {host.protocol && host.protocol !== 'ssh' && (
-              <span className="text-xs px-1.5 py-0.5 bg-primary/10 text-primary rounded">
-                {host.protocol.toUpperCase()}
-              </span>
-            )}
+	            {displayProtocol && displayProtocol !== 'ssh' && (
+	              <span className="text-xs px-1.5 py-0.5 bg-primary/10 text-primary rounded">
+	                {displayProtocol.toUpperCase()}
+	              </span>
+	            )}
             {tags.length > 0 && (
               <span className="text-xs opacity-60">
                 {tags.slice(0, 2).join(', ')}
@@ -445,6 +472,7 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
   toggleHostSelection,
   getDropTargetClasses,
   setDragOverDropTarget,
+  groupConfigs = [],
 }) => {
   const { t } = useI18n();
 
@@ -568,9 +596,10 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
           isMultiSelectMode={isMultiSelectMode}
           selectedHostIds={selectedHostIds}
           toggleHostSelection={toggleHostSelection}
-          getDropTargetClasses={getDropTargetClasses}
-          setDragOverDropTarget={setDragOverDropTarget}
-        />
+	          getDropTargetClasses={getDropTargetClasses}
+	          setDragOverDropTarget={setDragOverDropTarget}
+	          groupConfigs={groupConfigs}
+	        />
       ))}
 
       {/* Ungrouped hosts at root level */}
@@ -586,9 +615,10 @@ export const HostTreeView: React.FC<HostTreeViewProps> = ({
           onCopyCredentials={onCopyCredentials}
           moveHostToGroup={moveHostToGroup}
           isMultiSelectMode={isMultiSelectMode}
-          selectedHostIds={selectedHostIds}
-          toggleHostSelection={toggleHostSelection}
-        />
+	          selectedHostIds={selectedHostIds}
+	          toggleHostSelection={toggleHostSelection}
+	          groupConfigs={groupConfigs}
+	        />
       ))}
       
       {/* Empty state */}

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -36,8 +36,16 @@ import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
 import { useTreeExpandedState } from "../application/state/useTreeExpandedState";
+import { sanitizeCredentialValue } from "../domain/credentials";
 import { resolveGroupDefaults, applyGroupDefaults } from "../domain/groupConfig";
-import { getEffectiveHostDistro, sanitizeHost, upsertHostById } from "../domain/host";
+import {
+  getEffectiveHostDistro,
+  resolveTelnetPassword,
+  resolveTelnetPort,
+  resolveTelnetUsername,
+  sanitizeHost,
+  upsertHostById,
+} from "../domain/host";
 import { importVaultHostsFromText, exportHostsToCsvWithStats } from "../domain/vaultImport";
 import type { VaultImportFormat } from "../domain/vaultImport";
 import {
@@ -493,9 +501,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     const isTelnet = effective.protocol === "telnet";
 
     const defaultPort = isTelnet ? 23 : 22;
-    const effectivePort = isTelnet
-      ? (effective.telnetPort ?? effective.port ?? 23)
-      : (effective.port ?? 22);
+    const effectivePort = isTelnet ? resolveTelnetPort(effective) : (effective.port ?? 22);
 
     // Bracket IPv6 addresses when appending non-default port
     let address: string;
@@ -514,12 +520,13 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       : undefined;
 
     const username = isTelnet
-      ? (effective.telnetUsername?.trim() || effective.username?.trim())
+      ? resolveTelnetUsername(effective)
       : (identity?.username?.trim() || effective.username?.trim());
 
-    const password = isTelnet
-      ? (effective.telnetPassword || effective.password)
+    const rawPassword = isTelnet
+      ? resolveTelnetPassword(effective)
       : (identity?.password || effective.password);
+    const password = sanitizeCredentialValue(rawPassword);
 
     if (!password) {
       toast.warning(t('vault.hosts.copyCredentials.toast.noPassword'));
@@ -2525,11 +2532,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                       isMultiSelectMode={isMultiSelectMode}
                       selectedHostIds={selectedHostIds}
                       toggleHostSelection={toggleHostSelection}
-                      getDropTargetClasses={(path) =>
-                        getDropTargetClasses({ kind: "group", path })
-                      }
-                      setDragOverDropTarget={setGroupDragOverDropTarget}
-                    />
+	                      getDropTargetClasses={(path) =>
+	                        getDropTargetClasses({ kind: "group", path })
+	                      }
+	                      setDragOverDropTarget={setGroupDragOverDropTarget}
+	                      groupConfigs={groupConfigs}
+	                    />
                   ) : sortMode === "group" && groupedDisplayHosts ? (
                     <div className="space-y-6">
                         {groupedDisplayHosts.map((group) => (

--- a/components/terminal/TerminalConnectionDialog.tsx
+++ b/components/terminal/TerminalConnectionDialog.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { cn } from '../../lib/utils';
 import { Host, SSHKey } from '../../types';
-import { formatHostPort } from '../../domain/host';
+import { formatHostPort, resolveTelnetPort } from '../../domain/host';
 import { DistroAvatar } from '../DistroAvatar';
 import { Button } from '../ui/button';
 import { TerminalAuthDialog, TerminalAuthDialogProps } from './TerminalAuthDialog';
@@ -48,7 +48,7 @@ const getProtocolInfo = (host: Host): { i18nKey: string; showPort: boolean; port
             return { i18nKey: 'terminal.connection.protocol.local', showPort: false, port: 0 };
         case 'telnet':
             // Telnet uses telnetPort, not port (which is SSH port)
-            return { i18nKey: 'terminal.connection.protocol.telnet', showPort: true, port: host.telnetPort ?? host.port ?? 23 };
+            return { i18nKey: 'terminal.connection.protocol.telnet', showPort: true, port: resolveTelnetPort(host) };
         case 'mosh':
             return { i18nKey: 'terminal.connection.protocol.mosh', showPort: true, port: host.port || 22 };
         case 'serial':

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import { createTerminalSessionStarters, getMissingChainHostIds } from "./createTerminalSessionStarters";
 
 const noop = () => undefined;
+const ENCRYPTED_CREDENTIAL_PLACEHOLDER = "enc:v1:djEwAAAA";
 
 test("getMissingChainHostIds reports unresolved jump hosts", () => {
   assert.deepEqual(
@@ -67,7 +68,7 @@ test("startMosh does not pass legacy configured mosh client paths to the backend
     hasConnectedRef: { current: false },
     hasRunStartupCommandRef: { current: false },
     disposeDataRef: { current: null },
-    disposeExitRef: { current: null },
+    disposeExitRef: { current: null as (() => void) | null },
     fitAddonRef: { current: null },
     serializeAddonRef: { current: null },
     pendingAuthRef: { current: null },
@@ -142,7 +143,7 @@ test("startMosh passes the saved password to the mosh backend", async () => {
     hasConnectedRef: { current: false },
     hasRunStartupCommandRef: { current: false },
     disposeDataRef: { current: null },
-    disposeExitRef: { current: null },
+    disposeExitRef: { current: null as (() => void) | null },
     fitAddonRef: { current: null },
     serializeAddonRef: { current: null },
     pendingAuthRef: { current: null },
@@ -786,6 +787,547 @@ test("startTelnet passes saved telnet credentials without falling back after exp
   assert.equal(capturedOptions.username, "");
   assert.equal(capturedOptions.password, "telnet-password");
   assert.equal(capturedOptions.port, 2323);
+});
+
+test("startTelnet preserves an explicitly cleared telnet password", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      password: "ssh-password",
+      telnetUsername: "telnet-user",
+      telnetPassword: "",
+      telnetPort: 2323,
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.username, "telnet-user");
+  assert.equal(capturedOptions.password, "");
+});
+
+test("startTelnet rejects unreadable saved telnet passwords before connecting", async () => {
+  let started = false;
+  let error = "";
+  let needsAuth = true;
+  let retryMessage: string | null = "previous";
+  let status = "";
+  const writes: string[] = [];
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async () => {
+      started = true;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      password: "ssh-password",
+      telnetUsername: "telnet-user",
+      telnetPassword: ENCRYPTED_CREDENTIAL_PLACEHOLDER,
+      telnetPort: 2323,
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: (next: string) => { status = next; },
+    setStatus: noop,
+    setError: (message: string) => { error = message; },
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setAuthRetryMessage: (message: string | null) => { retryMessage = message; },
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: (data: string) => { writes.push(data); },
+    writeln: (data: string) => { writes.push(data); },
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+
+  assert.equal(started, false);
+  assert.equal(needsAuth, false);
+  assert.equal(retryMessage, null);
+  assert.equal(status, "disconnected");
+  assert.match(error, /Saved credentials cannot be decrypted/);
+  assert.match(writes.join("\n"), /Saved credentials cannot be decrypted/);
+});
+
+test("startTelnet waits for auto-login before running the startup command", async () => {
+  const writtenCommands: string[] = [];
+  const executedCommands: string[] = [];
+  let capturedOptions: Record<string, unknown> | null = null;
+  let autoLoginComplete: ((evt: { sessionId: string }) => void) | null = null;
+  let disposedAutoLoginCancelListener = false;
+  let resolveCommand: (() => void) | null = null;
+  const commandWritten = new Promise<void>((resolve) => {
+    resolveCommand = resolve;
+  });
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onTelnetAutoLoginComplete: (sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+      assert.equal(sessionId, "session-1");
+      autoLoginComplete = cb;
+      return noop;
+    },
+    onTelnetAutoLoginCancelled: () => () => {
+      disposedAutoLoginCancelListener = true;
+    },
+    onChainProgress: () => noop,
+    writeToSession: (_sessionId: string, data: string) => {
+      writtenCommands.push(data);
+      resolveCommand?.();
+    },
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      telnetUsername: "telnet-user",
+      telnetPassword: "",
+      telnetPort: 2323,
+      startupCommand: "show version",
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+    onCommandExecuted: (command: string) => {
+      executedCommands.push(command);
+    },
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+  assert.ok(capturedOptions);
+  assert.ok(autoLoginComplete);
+
+  await new Promise((resolve) => setTimeout(resolve, 700));
+  assert.deepEqual(writtenCommands, []);
+  assert.deepEqual(executedCommands, []);
+
+  autoLoginComplete({ sessionId: "session-1" });
+
+  await Promise.race([
+    commandWritten,
+    new Promise((_, reject) => setTimeout(() => reject(new Error("Timed out waiting for startup command")), 1000)),
+  ]);
+
+  assert.deepEqual(writtenCommands, ["show version\r"]);
+  assert.deepEqual(executedCommands, ["show version"]);
+  assert.equal(disposedAutoLoginCancelListener, true);
+});
+
+test("startTelnet cancels pending startup command when user takes over", async () => {
+  const writtenCommands: string[] = [];
+  let capturedOptions: Record<string, unknown> | null = null;
+  let autoLoginComplete: ((evt: { sessionId: string }) => void) | null = null;
+  let autoLoginCancelled: ((evt: { sessionId: string }) => void) | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onTelnetAutoLoginComplete: (_sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+      autoLoginComplete = cb;
+      return noop;
+    },
+    onTelnetAutoLoginCancelled: (_sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+      autoLoginCancelled = cb;
+      return noop;
+    },
+    onChainProgress: () => noop,
+    writeToSession: (_sessionId: string, data: string) => {
+      writtenCommands.push(data);
+    },
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      telnetUsername: "telnet-user",
+      telnetPassword: "secret",
+      startupCommand: "show version",
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+  assert.ok(capturedOptions);
+  assert.ok(autoLoginComplete);
+  assert.ok(autoLoginCancelled);
+
+  autoLoginComplete({ sessionId: "session-1" });
+  autoLoginCancelled({ sessionId: "session-1" });
+  await new Promise((resolve) => setTimeout(resolve, 700));
+
+  assert.deepEqual(writtenCommands, []);
+});
+
+test("startTelnet does not run startup command if auto-login never completes", async () => {
+  const writtenCommands: string[] = [];
+  const executedCommands: string[] = [];
+  let capturedOptions: Record<string, unknown> | null = null;
+  let autoLoginComplete: ((evt: { sessionId: string }) => void) | null = null;
+  let disposedAutoLoginListener = false;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onTelnetAutoLoginComplete: (_sessionId: string, cb: (evt: { sessionId: string }) => void) => {
+      autoLoginComplete = cb;
+      return () => {
+        disposedAutoLoginListener = true;
+      };
+    },
+    onChainProgress: () => noop,
+    writeToSession: (_sessionId: string, data: string) => {
+      writtenCommands.push(data);
+    },
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      telnetUsername: "telnet-user",
+      telnetPassword: "",
+      telnetPort: 2323,
+      startupCommand: "show version",
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+    onCommandExecuted: (command: string) => {
+      executedCommands.push(command);
+    },
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+  assert.ok(capturedOptions);
+  assert.ok(autoLoginComplete);
+
+  await new Promise((resolve) => setTimeout(resolve, 700));
+
+  assert.deepEqual(writtenCommands, []);
+  assert.deepEqual(executedCommands, []);
+
+  ctx.disposeExitRef.current?.();
+  assert.equal(disposedAutoLoginListener, true);
+});
+
+test("startTelnet does not run startup command during manual login", async () => {
+  const writtenCommands: string[] = [];
+  let capturedOptions: Record<string, unknown> | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: (_sessionId: string, data: string) => {
+      writtenCommands.push(data);
+    },
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: undefined,
+      password: undefined,
+      telnetUsername: undefined,
+      telnetPassword: undefined,
+      port: 2222,
+      startupCommand: "show version",
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+  await new Promise((resolve) => setTimeout(resolve, 700));
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.port, 23);
+  assert.deepEqual(writtenCommands, []);
 });
 
 test("startTelnet rejects configured proxies instead of connecting directly", async () => {

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -711,6 +711,83 @@ test("startTelnet rejects missing saved proxy profiles", async () => {
   assert.match(error, /Saved proxy/);
 });
 
+test("startTelnet passes saved telnet credentials without falling back after explicit clears", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      password: "ssh-password",
+      telnetUsername: "",
+      telnetPassword: "telnet-password",
+      telnetPort: 2323,
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.username, "");
+  assert.equal(capturedOptions.password, "telnet-password");
+  assert.equal(capturedOptions.port, 2323);
+});
+
 test("startTelnet rejects configured proxies instead of connecting directly", async () => {
   let started = false;
   let error = "";

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -781,10 +781,20 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
 
     try {
       const telnetEnv = buildTermEnv(ctx.host, ctx.terminalSettings);
+      const telnetUsername =
+        ctx.host.telnetUsername !== undefined
+          ? ctx.host.telnetUsername.trim()
+          : ctx.host.username?.trim();
+      const telnetPassword =
+        ctx.host.telnetPassword !== undefined
+          ? ctx.host.telnetPassword
+          : ctx.host.password;
       const id = await ctx.terminalBackend.startTelnetSession({
         sessionId: ctx.sessionId,
         hostname: ctx.host.hostname,
         port: ctx.host.telnetPort || ctx.host.port || 23,
+        username: telnetUsername,
+        password: telnetPassword,
         cols: term.cols,
         rows: term.rows,
         charset: ctx.host.charset,

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -10,7 +10,12 @@ import {
   sanitizeCredentialValue,
 } from "../../../domain/credentials";
 import { resolveHostAuth } from "../../../domain/sshAuth";
-import { detectVendorFromSshVersion } from "../../../domain/host";
+import {
+  detectVendorFromSshVersion,
+  resolveTelnetPassword,
+  resolveTelnetPort,
+  resolveTelnetUsername,
+} from "../../../domain/host";
 
 /**
  * Per-connection token for stale-timer detection. The renderer reuses the
@@ -68,10 +73,18 @@ type TerminalBackendApi = {
     sessionId: string,
     cb: (evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void,
   ) => () => void;
+  onTelnetAutoLoginComplete?: (
+    sessionId: string,
+    cb: (evt: { sessionId: string }) => void,
+  ) => (() => void) | undefined;
+  onTelnetAutoLoginCancelled?: (
+    sessionId: string,
+    cb: (evt: { sessionId: string }) => void,
+  ) => (() => void) | undefined;
   onChainProgress: (
     cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void,
   ) => (() => void) | undefined;
-  writeToSession: (sessionId: string, data: string) => void;
+  writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   resizeSession: (sessionId: string, cols: number, rows: number) => void;
 };
 
@@ -209,6 +222,7 @@ const attachSessionToTerminal = (
   opts?: {
     onExitMessage?: (evt: { exitCode?: number; signal?: number; error?: string; reason?: string }) => string;
     onConnected?: () => void;
+    onExit?: (evt: { exitCode?: number; signal?: number; error?: string; reason?: string }) => void;
     // For serial: convert lone LF to CRLF to avoid "staircase effect"
     convertLfToCrlf?: boolean;
   },
@@ -263,8 +277,36 @@ const attachSessionToTerminal = (
     // (previously they would see the old token still in the map and pass).
     connectionTokensBySessionId.delete(ctx.sessionId);
 
+    opts?.onExit?.(evt);
     ctx.onSessionExit?.(ctx.sessionId, evt);
   });
+};
+
+const scheduleStartupCommand = (
+  ctx: TerminalSessionStartersContext,
+  id: string,
+  onSettled?: () => void,
+): (() => void) | undefined => {
+  const commandToRun = ctx.startupCommand || ctx.host.startupCommand;
+  if (!commandToRun || ctx.hasRunStartupCommandRef.current) return undefined;
+
+  ctx.hasRunStartupCommandRef.current = true;
+  const scheduledSessionId = id;
+  const timeoutId = setTimeout(() => {
+    if (!ctx.sessionRef.current || ctx.sessionRef.current !== scheduledSessionId) {
+      onSettled?.();
+      return;
+    }
+    const suffix = ctx.noAutoRun ? "" : "\r";
+    ctx.terminalBackend.writeToSession(ctx.sessionRef.current, `${commandToRun}${suffix}`, {
+      automated: true,
+    });
+    onSettled?.();
+    if (!ctx.noAutoRun && ctx.onCommandExecuted) {
+      ctx.onCommandExecuted(commandToRun, ctx.host.id, ctx.host.label, ctx.sessionId);
+    }
+  }, 600);
+  return () => clearTimeout(timeoutId);
 };
 
 const runDistroDetection = async (
@@ -698,21 +740,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           `\r\n[session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
       });
 
-      const commandToRun = ctx.startupCommand || ctx.host.startupCommand;
-      if (commandToRun && !ctx.hasRunStartupCommandRef.current) {
-        ctx.hasRunStartupCommandRef.current = true;
-        const scheduledSessionId = id;
-        setTimeout(() => {
-          // Guard against stale timers: if the session changed (e.g. user
-          // clicked Start Over quickly), skip to avoid double execution
-          if (!ctx.sessionRef.current || ctx.sessionRef.current !== scheduledSessionId) return;
-          const suffix = ctx.noAutoRun ? '' : '\r';
-          ctx.terminalBackend.writeToSession(ctx.sessionRef.current, `${commandToRun}${suffix}`);
-          if (!ctx.noAutoRun && ctx.onCommandExecuted) {
-            ctx.onCommandExecuted(commandToRun, ctx.host.id, ctx.host.label, ctx.sessionId);
-          }
-        }, 600);
-      }
+      scheduleStartupCommand(ctx, id);
 
       // Run OS detection only after successful connection. Mint a fresh
       // token for this specific connection attempt and register it as
@@ -779,20 +807,68 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       return;
     }
 
+    let disposeAutoLoginComplete: (() => void) | undefined;
+    let disposeAutoLoginCancelled: (() => void) | undefined;
+    let cancelPendingStartupCommand: (() => void) | undefined;
+    const disposeAutoLoginListener = () => {
+      disposeAutoLoginComplete?.();
+      disposeAutoLoginComplete = undefined;
+    };
+    const disposeAutoLoginCancelListener = () => {
+      disposeAutoLoginCancelled?.();
+      disposeAutoLoginCancelled = undefined;
+    };
+    const cleanupTelnetStartupWait = () => {
+      disposeAutoLoginListener();
+      disposeAutoLoginCancelListener();
+      cancelPendingStartupCommand?.();
+      cancelPendingStartupCommand = undefined;
+    };
     try {
       const telnetEnv = buildTermEnv(ctx.host, ctx.terminalSettings);
-      const telnetUsername =
-        ctx.host.telnetUsername !== undefined
-          ? ctx.host.telnetUsername.trim()
-          : ctx.host.username?.trim();
-      const telnetPassword =
-        ctx.host.telnetPassword !== undefined
-          ? ctx.host.telnetPassword
-          : ctx.host.password;
+      const telnetUsername = resolveTelnetUsername(ctx.host);
+      const rawTelnetPassword = resolveTelnetPassword(ctx.host);
+      const telnetPassword = sanitizeCredentialValue(rawTelnetPassword);
+      const hasTelnetPasswordForAutoLogin = rawTelnetPassword !== undefined;
+      if (isEncryptedCredentialPlaceholder(rawTelnetPassword)) {
+        const message = tr(
+          "terminal.auth.credentialsUnavailable",
+          "Saved credentials cannot be decrypted on this device. Please re-enter and save them again.",
+        );
+        ctx.setNeedsAuth(false);
+        ctx.setAuthRetryMessage(null);
+        ctx.setError(message);
+        term.writeln(`\r\n[${message}]`);
+        ctx.updateStatus("disconnected");
+        return;
+      }
+      const commandToRun = ctx.startupCommand || ctx.host.startupCommand;
+      const waitsForAutoLogin = Boolean(
+        commandToRun &&
+        (telnetUsername || hasTelnetPasswordForAutoLogin) &&
+        ctx.terminalBackend.onTelnetAutoLoginComplete,
+      );
+      let telnetSessionId = ctx.sessionId;
+      if (waitsForAutoLogin) {
+        disposeAutoLoginComplete = ctx.terminalBackend.onTelnetAutoLoginComplete?.(
+          ctx.sessionId,
+          () => {
+            disposeAutoLoginListener();
+            cancelPendingStartupCommand = scheduleStartupCommand(ctx, telnetSessionId, () => {
+              cancelPendingStartupCommand = undefined;
+              disposeAutoLoginCancelListener();
+            });
+          },
+        );
+        disposeAutoLoginCancelled = ctx.terminalBackend.onTelnetAutoLoginCancelled?.(
+          ctx.sessionId,
+          cleanupTelnetStartupWait,
+        );
+      }
       const id = await ctx.terminalBackend.startTelnetSession({
         sessionId: ctx.sessionId,
         hostname: ctx.host.hostname,
-        port: ctx.host.telnetPort || ctx.host.port || 23,
+        port: resolveTelnetPort(ctx.host),
         username: telnetUsername,
         password: telnetPassword,
         cols: term.cols,
@@ -801,12 +877,23 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         env: telnetEnv,
         sessionLog: ctx.sessionLog?.enabled ? ctx.sessionLog : undefined,
       });
+      telnetSessionId = id;
 
-      attachSessionToTerminal(ctx, term, id, {
-        onExitMessage: (evt) =>
-          `\r\n[Telnet session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
-      });
-    } catch (err) {
+	      attachSessionToTerminal(ctx, term, id, {
+	        onExitMessage: (evt) =>
+	          `\r\n[Telnet session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
+	        onExit: cleanupTelnetStartupWait,
+	      });
+	      const disposeTelnetExit = ctx.disposeExitRef.current;
+	      ctx.disposeExitRef.current = () => {
+	        cleanupTelnetStartupWait();
+	        disposeTelnetExit?.();
+	      };
+	      if (waitsForAutoLogin) {
+	        return;
+	      }
+	    } catch (err) {
+	      cleanupTelnetStartupWait();
       const message = err instanceof Error ? err.message : String(err);
       ctx.setError(message);
       term.writeln(`\r\n[Failed to start Telnet: ${message}]`);
@@ -925,19 +1012,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           `\r\n[Mosh session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
       });
 
-      const commandToRun = ctx.startupCommand || ctx.host.startupCommand;
-      if (commandToRun && !ctx.hasRunStartupCommandRef.current) {
-        ctx.hasRunStartupCommandRef.current = true;
-        const scheduledSessionId = id;
-        setTimeout(() => {
-          if (!ctx.sessionRef.current || ctx.sessionRef.current !== scheduledSessionId) return;
-          const suffix = ctx.noAutoRun ? '' : '\r';
-          ctx.terminalBackend.writeToSession(ctx.sessionRef.current, `${commandToRun}${suffix}`);
-          if (!ctx.noAutoRun && ctx.onCommandExecuted) {
-            ctx.onCommandExecuted(commandToRun, ctx.host.id, ctx.host.label, ctx.sessionId);
-          }
-        }, 600);
-      }
+      scheduleStartupCommand(ctx, id);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.setError(message);

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { applyGroupDefaults, resolveGroupDefaults } from "./groupConfig.ts";
+import { resolveTelnetPassword, resolveTelnetUsername } from "./host.ts";
 import type { GroupConfig, Host } from "./models.ts";
 
 const host = (overrides: Partial<Host> = {}): Host => ({
@@ -129,4 +130,55 @@ test("resolveGroupDefaults keeps missing child proxy profiles instead of using p
 
   assert.equal(resolved.proxyProfileId, "missing-proxy");
   assert.equal(resolved.proxyConfig, undefined);
+});
+
+test("applyGroupDefaults preserves explicitly cleared telnet credentials", () => {
+  const result = applyGroupDefaults(
+    host({
+      username: "ssh-user",
+      password: "ssh-password",
+      telnetUsername: "",
+      telnetPassword: "",
+    }),
+    {
+      telnetUsername: "group-telnet-user",
+      telnetPassword: "group-telnet-password",
+    },
+  );
+
+  assert.equal(result.telnetUsername, "");
+  assert.equal(result.telnetPassword, "");
+  assert.equal(resolveTelnetUsername(result), "");
+  assert.equal(resolveTelnetPassword(result), "");
+});
+
+test("applyGroupDefaults still inherits telnet credentials when host fields are unset", () => {
+  const result = applyGroupDefaults(
+    host({
+      username: "ssh-user",
+      password: "ssh-password",
+    }),
+    {
+      telnetUsername: "group-telnet-user",
+      telnetPassword: "group-telnet-password",
+    },
+  );
+
+  assert.equal(result.telnetUsername, "group-telnet-user");
+  assert.equal(result.telnetPassword, "group-telnet-password");
+  assert.equal(resolveTelnetUsername(result), "group-telnet-user");
+  assert.equal(resolveTelnetPassword(result), "group-telnet-password");
+});
+
+test("applyGroupDefaults continues to inherit empty ssh username from the group", () => {
+  const result = applyGroupDefaults(
+    host({
+      username: "",
+    }),
+    {
+      username: "group-ssh-user",
+    },
+  );
+
+  assert.equal(result.username, "group-ssh-user");
 });

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -82,6 +82,11 @@ const INHERITABLE_KEYS: (keyof GroupConfig)[] = [
   'backspaceBehavior',
 ];
 
+const EMPTY_STRING_OVERRIDES_GROUP_DEFAULT = new Set<keyof GroupConfig>([
+  'telnetUsername',
+  'telnetPassword',
+]);
+
 /**
  * Apply group defaults to a host. Only fills in fields the host doesn't already have.
  * Returns a new host object — does NOT mutate the original.
@@ -101,7 +106,12 @@ export function applyGroupDefaults(
     if (key === 'proxyConfig' && (host.proxyProfileId !== undefined || hostHasUsableProxyProfile)) continue;
     const hostValue = (effective as unknown as Record<string, unknown>)[key];
     const groupValue = (groupDefaults as unknown as Record<string, unknown>)[key];
-    if ((hostValue === undefined || hostValue === '' || hostValue === null) && groupValue !== undefined) {
+    const emptyStringIsOverride = EMPTY_STRING_OVERRIDES_GROUP_DEFAULT.has(key);
+    const shouldInherit =
+      hostValue === undefined ||
+      hostValue === null ||
+      (hostValue === '' && !emptyStringIsOverride);
+    if (shouldInherit && groupValue !== undefined) {
       (effective as unknown as Record<string, unknown>)[key] = groupValue;
     }
   }

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -2,7 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { Host } from "./models.ts";
-import { upsertHostById } from "./host.ts";
+import {
+  normalizePrimaryTelnetState,
+  resolveTelnetPort,
+  resolveTelnetPassword,
+  resolveTelnetUsername,
+  upsertHostById,
+} from "./host.ts";
 
 const makeHost = (overrides: Partial<Host> = {}): Host => ({
   id: "host-1",
@@ -48,4 +54,79 @@ test("upsertHostById appends a duplicated host with a fresh id", () => {
   });
 
   assert.deepEqual(upsertHostById([existing], duplicate), [existing, duplicate]);
+});
+
+test("telnet credential helpers preserve explicitly cleared values", () => {
+  const host = makeHost({
+    username: "ssh-user",
+    password: "ssh-password",
+    telnetUsername: "",
+    telnetPassword: "",
+  });
+
+  assert.equal(resolveTelnetUsername(host), "");
+  assert.equal(resolveTelnetPassword(host), "");
+});
+
+test("telnet credential helpers fall back only when telnet fields are unset", () => {
+  const host = makeHost({
+    username: " ssh-user ",
+    password: "ssh-password",
+    telnetUsername: undefined,
+    telnetPassword: undefined,
+  });
+
+  assert.equal(resolveTelnetUsername(host), "ssh-user");
+  assert.equal(resolveTelnetPassword(host), "ssh-password");
+});
+
+test("normalizePrimaryTelnetState enables primary telnet without materializing a port", () => {
+  const result = normalizePrimaryTelnetState(makeHost({
+    protocol: "telnet",
+    telnetEnabled: false,
+    telnetPort: undefined,
+    port: undefined,
+  }));
+
+  assert.equal(result.telnetEnabled, true);
+  assert.equal(result.telnetPort, undefined);
+  assert.equal(result.port, undefined);
+});
+
+test("normalizePrimaryTelnetState leaves optional telnet hosts unchanged", () => {
+  const result = normalizePrimaryTelnetState(makeHost({
+    protocol: "ssh",
+    telnetEnabled: false,
+    telnetPort: undefined,
+  }));
+
+  assert.equal(result.telnetEnabled, false);
+  assert.equal(result.telnetPort, undefined);
+});
+
+test("normalizePrimaryTelnetState preserves an explicit telnet port", () => {
+  const result = normalizePrimaryTelnetState(makeHost({
+    protocol: "telnet",
+    telnetEnabled: false,
+    telnetPort: 2325,
+  }));
+
+  assert.equal(result.telnetEnabled, true);
+  assert.equal(result.telnetPort, 2325);
+});
+
+test("resolveTelnetPort ignores ssh ports for optional telnet", () => {
+  assert.equal(resolveTelnetPort(makeHost({
+    protocol: "ssh",
+    port: 2222,
+    telnetPort: undefined,
+  })), 23);
+});
+
+test("resolveTelnetPort uses primary telnet port fallback", () => {
+  assert.equal(resolveTelnetPort(makeHost({
+    protocol: "telnet",
+    port: 2325,
+    telnetPort: undefined,
+  })), 2325);
 });

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -153,6 +153,35 @@ export const formatHostPort = (hostname: string, port?: number | null): string =
   return `${display}:${port}`;
 };
 
+export const resolveTelnetUsername = (
+  host: Pick<Host, 'telnetUsername' | 'username'>,
+): string | undefined =>
+  host.telnetUsername !== undefined
+    ? host.telnetUsername.trim()
+    : host.username?.trim();
+
+export const resolveTelnetPassword = (
+  host: Pick<Host, 'telnetPassword' | 'password'>,
+): string | undefined =>
+  host.telnetPassword !== undefined
+    ? host.telnetPassword
+    : host.password;
+
+export const resolveTelnetPort = (
+  host: Pick<Host, 'protocol' | 'telnetPort' | 'port'>,
+): number => {
+  if (host.telnetPort !== undefined && host.telnetPort !== null) return host.telnetPort;
+  if (host.protocol === 'telnet' && host.port !== undefined && host.port !== null) {
+    return host.port;
+  }
+  return 23;
+};
+
+export const normalizePrimaryTelnetState = (host: Host): Host =>
+  host.protocol === 'telnet' && !host.telnetEnabled
+    ? { ...host, telnetEnabled: true }
+    : host;
+
 export const upsertHostById = (hosts: Host[], host: Host): Host[] => {
   const hostExists = hosts.some((entry) => entry.id === host.id);
   return hostExists

--- a/electron/bridges/telnetAutoLogin.cjs
+++ b/electron/bridges/telnetAutoLogin.cjs
@@ -3,9 +3,9 @@ const TAIL_LIMIT = 2048;
 
 const ANSI_PATTERN = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g;
 const LAST_LOGIN_PATTERN = /(?:^|[\s([])(?:last|previous)\s+login\s*[:>]\s*$/i;
-const USERNAME_PROMPT_PATTERN = /(?:^|[\s([])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:>]\s*$/i;
-const PASSWORD_PROMPT_PATTERN = /(?:^|[\s([])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:>]\s*$/i;
-const CONTINUE_PROMPT_PATTERN = /\b(?:press|hit)\s+(?:return|enter|any\s+key|space)\b.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
+const USERNAME_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:>]\s*$/i;
+const PASSWORD_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:>]\s*$/i;
+const CONTINUE_PROMPT_PATTERN = /(?:press|hit)\s+(?:return|enter|any\s+key|space)\b.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
 
 function stripAnsi(text) {
   return String(text || "").replace(ANSI_PATTERN, "");

--- a/electron/bridges/telnetAutoLogin.cjs
+++ b/electron/bridges/telnetAutoLogin.cjs
@@ -1,0 +1,110 @@
+const DEFAULT_TIMEOUT_MS = 60_000;
+const TAIL_LIMIT = 2048;
+
+const ANSI_PATTERN = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g;
+const LAST_LOGIN_PATTERN = /(?:^|[\s([])(?:last|previous)\s+login\s*[:>]\s*$/i;
+const USERNAME_PROMPT_PATTERN = /(?:^|[\s([])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:>]\s*$/i;
+const PASSWORD_PROMPT_PATTERN = /(?:^|[\s([])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:>]\s*$/i;
+const CONTINUE_PROMPT_PATTERN = /\b(?:press|hit)\s+(?:return|enter|any\s+key|space)\b.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
+
+function stripAnsi(text) {
+  return String(text || "").replace(ANSI_PATTERN, "");
+}
+
+function normalizePromptTail(text) {
+  return stripAnsi(text)
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+\n/g, "\n");
+}
+
+function lastPromptLine(text) {
+  const normalized = normalizePromptTail(text);
+  const lines = normalized.split("\n");
+  return (lines[lines.length - 1] || "").slice(-320);
+}
+
+function isContinuePrompt(text) {
+  const line = lastPromptLine(text);
+  return CONTINUE_PROMPT_PATTERN.test(line);
+}
+
+function isUsernamePrompt(text) {
+  const line = lastPromptLine(text);
+  return !LAST_LOGIN_PATTERN.test(line) && USERNAME_PROMPT_PATTERN.test(line);
+}
+
+function isPasswordPrompt(text) {
+  return PASSWORD_PROMPT_PATTERN.test(lastPromptLine(text));
+}
+
+function normalizeUsername(username) {
+  return typeof username === "string" ? username.trim() : "";
+}
+
+function normalizePassword(password) {
+  return typeof password === "string" ? password : "";
+}
+
+function createTelnetAutoLogin(options = {}) {
+  const username = normalizeUsername(options.username);
+  const password = normalizePassword(options.password);
+  const hasCredentials = username.length > 0 || password.length > 0;
+  const write = typeof options.write === "function" ? options.write : () => {};
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  let tail = "";
+  let sentWake = false;
+  let sentUsername = false;
+  let sentPassword = false;
+  let disabled = !hasCredentials;
+  const startedAt = now();
+
+  const isExpired = () => timeoutMs >= 0 && now() - startedAt > timeoutMs;
+  const stopIfFinished = () => {
+    if (sentPassword || (sentUsername && !password)) disabled = true;
+  };
+  const sendLine = (value) => {
+    write(`${value}\r`);
+  };
+
+  return {
+    handleText(text) {
+      if (disabled || isExpired()) {
+        disabled = true;
+        return;
+      }
+
+      tail = `${tail}${text || ""}`.slice(-TAIL_LIMIT);
+
+      if (!sentWake && isContinuePrompt(tail)) {
+        sentWake = true;
+        sendLine("");
+        return;
+      }
+
+      if (!sentUsername && username && isUsernamePrompt(tail)) {
+        sentUsername = true;
+        sendLine(username);
+        stopIfFinished();
+        return;
+      }
+
+      if (!sentPassword && password && isPasswordPrompt(tail)) {
+        sentPassword = true;
+        sendLine(password);
+        stopIfFinished();
+      }
+    },
+    handleUserInput() {
+      disabled = true;
+    },
+  };
+}
+
+module.exports = {
+  createTelnetAutoLogin,
+  isContinuePrompt,
+  isPasswordPrompt,
+  isUsernamePrompt,
+};

--- a/electron/bridges/telnetAutoLogin.cjs
+++ b/electron/bridges/telnetAutoLogin.cjs
@@ -5,7 +5,8 @@ const ANSI_PATTERN = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1
 const LAST_LOGIN_PATTERN = /(?:^|[\s([])(?:last|previous)\s+login\s*[:>]\s*$/i;
 const USERNAME_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:>]\s*$/i;
 const PASSWORD_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:>]\s*$/i;
-const CONTINUE_PROMPT_PATTERN = /(?:press|hit)\s+(?:return|enter|any\s+key|space)\b.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
+const CONTINUE_PROMPT_PATTERN = /(?:press|hit)\s+(?:[<\[(]?\s*)?(?:return|enter|any\s+key|space)\b(?:\s*[>\])])?.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
+const COMMAND_PROMPT_PATTERN = /[$#>]\s*$/;
 
 function stripAnsi(text) {
   return String(text || "").replace(ANSI_PATTERN, "");
@@ -23,6 +24,12 @@ function lastPromptLine(text) {
   return (lines[lines.length - 1] || "").slice(-320);
 }
 
+function promptLines(text) {
+  return normalizePromptTail(text)
+    .split("\n")
+    .map((line) => line.slice(-320));
+}
+
 function isContinuePrompt(text) {
   const line = lastPromptLine(text);
   return CONTINUE_PROMPT_PATTERN.test(line);
@@ -37,6 +44,27 @@ function isPasswordPrompt(text) {
   return PASSWORD_PROMPT_PATTERN.test(lastPromptLine(text));
 }
 
+function isCommandPrompt(text) {
+  const line = lastPromptLine(text).trimEnd();
+  if (!line || line.length > 200) return false;
+  if (LAST_LOGIN_PATTERN.test(line)) return false;
+  if (USERNAME_PROMPT_PATTERN.test(line)) return false;
+  if (PASSWORD_PROMPT_PATTERN.test(line)) return false;
+  if (CONTINUE_PROMPT_PATTERN.test(line)) return false;
+  return COMMAND_PROMPT_PATTERN.test(line);
+}
+
+function hasUsernamePromptBeforePassword(text) {
+  const lines = promptLines(text);
+  const lastPasswordIndex = lines.findLastIndex((line) =>
+    PASSWORD_PROMPT_PATTERN.test(line),
+  );
+  if (lastPasswordIndex < 0) return false;
+  return lines
+    .slice(0, lastPasswordIndex)
+    .some((line) => !LAST_LOGIN_PATTERN.test(line) && USERNAME_PROMPT_PATTERN.test(line));
+}
+
 function normalizeUsername(username) {
   return typeof username === "string" ? username.trim() : "";
 }
@@ -48,8 +76,11 @@ function normalizePassword(password) {
 function createTelnetAutoLogin(options = {}) {
   const username = normalizeUsername(options.username);
   const password = normalizePassword(options.password);
-  const hasCredentials = username.length > 0 || password.length > 0;
+  const hasPassword = typeof options.password === "string";
+  const hasCredentials = username.length > 0 || hasPassword;
   const write = typeof options.write === "function" ? options.write : () => {};
+  const onComplete = typeof options.onComplete === "function" ? options.onComplete : () => {};
+  const onUserInput = typeof options.onUserInput === "function" ? options.onUserInput : () => {};
   const now = typeof options.now === "function" ? options.now : Date.now;
   const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS;
 
@@ -58,14 +89,30 @@ function createTelnetAutoLogin(options = {}) {
   let sentUsername = false;
   let sentPassword = false;
   let disabled = !hasCredentials;
+  let completed = false;
+  let userInputNotified = false;
   const startedAt = now();
 
   const isExpired = () => timeoutMs >= 0 && now() - startedAt > timeoutMs;
-  const stopIfFinished = () => {
-    if (sentPassword || (sentUsername && !password)) disabled = true;
+  const complete = () => {
+    if (completed) return;
+    completed = true;
+    onComplete();
+  };
+  const hasSentCredentials = () => sentPassword || sentUsername;
+  const completeIfReady = () => {
+    if (hasSentCredentials() && isCommandPrompt(tail)) {
+      disabled = true;
+      complete();
+    }
   };
   const sendLine = (value) => {
     write(`${value}\r`);
+  };
+  const notifyUserInput = () => {
+    if (userInputNotified) return;
+    userInputNotified = true;
+    onUserInput();
   };
 
   return {
@@ -76,6 +123,8 @@ function createTelnetAutoLogin(options = {}) {
       }
 
       tail = `${tail}${text || ""}`.slice(-TAIL_LIMIT);
+      completeIfReady();
+      if (disabled) return;
 
       if (!sentWake && isContinuePrompt(tail)) {
         sentWake = true;
@@ -83,27 +132,32 @@ function createTelnetAutoLogin(options = {}) {
         return;
       }
 
-      if (!sentUsername && username && isUsernamePrompt(tail)) {
+      if (
+        !sentUsername &&
+        (username || hasPassword) &&
+        (isUsernamePrompt(tail) || hasUsernamePromptBeforePassword(tail))
+      ) {
         sentUsername = true;
         sendLine(username);
-        stopIfFinished();
-        return;
+        completeIfReady();
       }
 
-      if (!sentPassword && password && isPasswordPrompt(tail)) {
+      if (!disabled && !sentPassword && hasPassword && isPasswordPrompt(tail)) {
         sentPassword = true;
         sendLine(password);
-        stopIfFinished();
+        completeIfReady();
       }
     },
     handleUserInput() {
       disabled = true;
+      notifyUserInput();
     },
   };
 }
 
 module.exports = {
   createTelnetAutoLogin,
+  isCommandPrompt,
   isContinuePrompt,
   isPasswordPrompt,
   isUsernamePrompt,

--- a/electron/bridges/telnetAutoLogin.test.cjs
+++ b/electron/bridges/telnetAutoLogin.test.cjs
@@ -46,6 +46,36 @@ test("telnet auto-login wakes devices that ask for return before login", () => {
   assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
 });
 
+test("telnet auto-login handles prompts concatenated after wake banners", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Press RETURN to get started.");
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
+});
+
+test("telnet auto-login handles wake banners concatenated with preceding text", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Netcatty local Telnet test servicePress RETURN to get started.");
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
+});
+
 test("telnet auto-login stops when the user starts typing manually", () => {
   const writes = [];
   const autoLogin = createTelnetAutoLogin({

--- a/electron/bridges/telnetAutoLogin.test.cjs
+++ b/electron/bridges/telnetAutoLogin.test.cjs
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
+
+test("telnet auto-login sends saved username and password for split prompts", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("\x1b[32mUser");
+  autoLogin.handleText("name:\x1b[0m ");
+  autoLogin.handleText("\r\nPass");
+  autoLogin.handleText("word: ");
+
+  assert.deepEqual(writes, ["admin\r", "secret\r"]);
+});
+
+test("telnet auto-login supports password-only prompts", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    password: "line-password",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Password: ");
+
+  assert.deepEqual(writes, ["line-password\r"]);
+});
+
+test("telnet auto-login wakes devices that ask for return before login", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Press RETURN to get started.");
+  autoLogin.handleText("\r\nrouter login: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
+});
+
+test("telnet auto-login stops when the user starts typing manually", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleUserInput();
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("Password: ");
+
+  assert.deepEqual(writes, []);
+});
+
+test("telnet auto-login avoids common non-prompt login text", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Last login:");
+
+  assert.deepEqual(writes, []);
+});

--- a/electron/bridges/telnetAutoLogin.test.cjs
+++ b/electron/bridges/telnetAutoLogin.test.cjs
@@ -19,6 +19,77 @@ test("telnet auto-login sends saved username and password for split prompts", ()
   assert.deepEqual(writes, ["admin\r", "secret\r"]);
 });
 
+test("telnet auto-login completes only after a command prompt appears", () => {
+  const writes = [];
+  let completeCount = 0;
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+    onComplete: () => { completeCount += 1; },
+  });
+
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["admin\r", "secret\r"]);
+  assert.equal(completeCount, 0);
+
+  autoLogin.handleText("\r\nWelcome\r\nrouter# ");
+  autoLogin.handleText("\r\nrouter# ");
+
+  assert.equal(completeCount, 1);
+});
+
+test("telnet auto-login does not complete username-only login until the prompt appears", () => {
+  const writes = [];
+  let completed = false;
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    write: (data) => writes.push(data),
+    onComplete: () => { completed = true; },
+  });
+
+  autoLogin.handleText("Username: ");
+
+  assert.deepEqual(writes, ["admin\r"]);
+  assert.equal(completed, false);
+
+  autoLogin.handleText("\r\nrouter> ");
+
+  assert.equal(completed, true);
+});
+
+test("telnet auto-login completes when a password-ready host only asks for username", () => {
+  const writes = [];
+  let completed = false;
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+    onComplete: () => { completed = true; },
+  });
+
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nrouter# ");
+
+  assert.deepEqual(writes, ["admin\r"]);
+  assert.equal(completed, true);
+});
+
+test("telnet auto-login sends username before password when prompts arrive together", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Username: \r\nPassword: ");
+
+  assert.deepEqual(writes, ["admin\r", "secret\r"]);
+});
+
 test("telnet auto-login supports password-only prompts", () => {
   const writes = [];
   const autoLogin = createTelnetAutoLogin({
@@ -31,6 +102,34 @@ test("telnet auto-login supports password-only prompts", () => {
   assert.deepEqual(writes, ["line-password\r"]);
 });
 
+test("telnet auto-login sends a blank username before a saved password", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "",
+    password: "line-password",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "line-password\r"]);
+});
+
+test("telnet auto-login sends an intentionally blank password", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Username: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["admin\r", "\r"]);
+});
+
 test("telnet auto-login wakes devices that ask for return before login", () => {
   const writes = [];
   const autoLogin = createTelnetAutoLogin({
@@ -41,6 +140,36 @@ test("telnet auto-login wakes devices that ask for return before login", () => {
 
   autoLogin.handleText("Press RETURN to get started.");
   autoLogin.handleText("\r\nrouter login: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
+});
+
+test("telnet auto-login wakes devices that ask for bracketed enter", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Press <ENTER> to continue");
+  autoLogin.handleText("\r\nUsername: ");
+  autoLogin.handleText("\r\nPassword: ");
+
+  assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
+});
+
+test("telnet auto-login wakes devices that ask for square-bracketed enter", () => {
+  const writes = [];
+  const autoLogin = createTelnetAutoLogin({
+    username: "admin",
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autoLogin.handleText("Press [Enter] to continue");
+  autoLogin.handleText("\r\nUsername: ");
   autoLogin.handleText("\r\nPassword: ");
 
   assert.deepEqual(writes, ["\r", "admin\r", "secret\r"]);
@@ -78,17 +207,21 @@ test("telnet auto-login handles wake banners concatenated with preceding text", 
 
 test("telnet auto-login stops when the user starts typing manually", () => {
   const writes = [];
+  let cancelCount = 0;
   const autoLogin = createTelnetAutoLogin({
     username: "admin",
     password: "secret",
     write: (data) => writes.push(data),
+    onUserInput: () => { cancelCount += 1; },
   });
 
+  autoLogin.handleUserInput();
   autoLogin.handleUserInput();
   autoLogin.handleText("Username: ");
   autoLogin.handleText("Password: ");
 
   assert.deepEqual(writes, []);
+  assert.equal(cancelCount, 1);
 });
 
 test("telnet auto-login avoids common non-prompt login text", () => {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -527,6 +527,14 @@ async function startTelnetSession(event, options) {
       write(data) {
         if (!socket.destroyed) socket.write(data);
       },
+      onComplete() {
+        const contents = electronModule.webContents.fromId(event.sender.id);
+        contents?.send("netcatty:telnet:auto-login-complete", { sessionId });
+      },
+      onUserInput() {
+        const contents = electronModule.webContents.fromId(event.sender.id);
+        contents?.send("netcatty:telnet:auto-login-cancelled", { sessionId });
+      },
     });
 
     // Telnet protocol constants
@@ -1565,7 +1573,7 @@ function writeToSession(event, payload) {
   }
 
   try {
-    if (session.type === 'telnet-native') {
+    if (session.type === 'telnet-native' && !payload.automated) {
       session.autoLogin?.handleUserInput();
     }
 

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -23,6 +23,7 @@ const { createZmodemSentry } = require("./zmodemHelper.cjs");
 const { discoverShells } = require("./shellDiscovery.cjs");
 const moshHandshake = require("./moshHandshake.cjs");
 const tempDirBridge = require("./tempDirBridge.cjs");
+const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -520,6 +521,13 @@ async function startTelnetSession(event, options) {
   return new Promise((resolve, reject) => {
     const socket = new net.Socket();
     let connected = false;
+    const telnetAutoLogin = createTelnetAutoLogin({
+      username: options.username,
+      password: options.password,
+      write(data) {
+        if (!socket.destroyed) socket.write(data);
+      },
+    });
 
     // Telnet protocol constants
     const TELNET = {
@@ -663,6 +671,7 @@ async function startTelnetSession(event, options) {
         _promptTrackTail: "",
         encoding: initialTelnetEncoding,
         decoderRef: telnetDecoderRef,
+        autoLogin: telnetAutoLogin,
       };
       session.flushPendingData = flushTelnet;
       sessions.set(sessionId, session);
@@ -700,6 +709,7 @@ async function startTelnetSession(event, options) {
         if (!decoded) return;
         const session = sessions.get(sessionId);
         if (session) trackSessionIdlePrompt(session, decoded);
+        telnetAutoLogin.handleText(decoded);
         bufferTelnetData(decoded);
         sessionLogStreamManager.appendData(sessionId, decoded);
       },
@@ -1555,6 +1565,10 @@ function writeToSession(event, payload) {
   }
 
   try {
+    if (session.type === 'telnet-native') {
+      session.autoLogin?.handleUserInput();
+    }
+
     if (session.stream) {
       session.stream.write(payload.data);
     } else if (session.proc) {

--- a/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
+++ b/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
@@ -36,10 +36,15 @@ test("startTelnetSession answers login prompts with saved credentials", async ()
   const received = [];
   const server = net.createServer((socket) => {
     socket.setEncoding("utf8");
-    socket.write("Username: ");
+    let promptedForUsername = false;
+    socket.write("Device bannerPress RETURN to get started.");
     socket.on("data", (chunk) => {
       received.push(chunk);
       const joined = received.join("");
+      if (!promptedForUsername && joined.includes("\r")) {
+        promptedForUsername = true;
+        socket.write("Username: ");
+      }
       if (joined.includes("admin\r") && !joined.includes("secret\r")) {
         socket.write("\r\nPassword: ");
       }
@@ -78,8 +83,8 @@ test("startTelnetSession answers login prompts with saved credentials", async ()
     );
 
     assert.equal(result.sessionId, "telnet-auto-login-test");
-    await waitFor(() => received.join("").includes("admin\rsecret\r"));
-    assert.equal(received.join(""), "admin\rsecret\r");
+    await waitFor(() => received.join("").includes("\radmin\rsecret\r"));
+    assert.equal(received.join(""), "\radmin\rsecret\r");
   } finally {
     terminalBridge.cleanupAllSessions();
     await new Promise((resolve) => server.close(resolve));

--- a/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
+++ b/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
@@ -34,9 +34,18 @@ function waitFor(predicate, timeoutMs = 1000) {
 
 test("startTelnetSession answers login prompts with saved credentials", async () => {
   const received = [];
+  const sockets = new Set();
+  const serverErrors = [];
   const server = net.createServer((socket) => {
+    sockets.add(socket);
     socket.setEncoding("utf8");
     let promptedForUsername = false;
+    socket.on("error", (err) => {
+      if (err.code !== "ECONNRESET") serverErrors.push(err);
+    });
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
     socket.write("Device bannerPress RETURN to get started.");
     socket.on("data", (chunk) => {
       received.push(chunk);
@@ -49,7 +58,7 @@ test("startTelnetSession answers login prompts with saved credentials", async ()
         socket.write("\r\nPassword: ");
       }
       if (joined.includes("secret\r")) {
-        socket.end("\r\nWelcome\r\n");
+        socket.end("\r\nWelcome\r\nrouter# ");
       }
     });
   });
@@ -85,8 +94,145 @@ test("startTelnetSession answers login prompts with saved credentials", async ()
     assert.equal(result.sessionId, "telnet-auto-login-test");
     await waitFor(() => received.join("").includes("\radmin\rsecret\r"));
     assert.equal(received.join(""), "\radmin\rsecret\r");
+    assert.ok(sentEvents.some((evt) =>
+      evt.channel === "netcatty:telnet:auto-login-complete" &&
+      evt.payload?.sessionId === "telnet-auto-login-test",
+    ));
+    assert.deepEqual(serverErrors, []);
   } finally {
     terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("automated Telnet writes do not cancel auto-login", async () => {
+  const received = [];
+  const sockets = new Set();
+  let clientSocket = null;
+  const server = net.createServer((socket) => {
+    clientSocket = socket;
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+    socket.on("data", (chunk) => {
+      received.push(chunk);
+      const joined = received.join("");
+      if (joined.includes("admin\r") && !joined.includes("secret\r")) {
+        socket.write("\r\nPassword: ");
+      }
+      if (joined.includes("secret\r")) {
+        socket.end("\r\nWelcome\r\n");
+      }
+    });
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({
+          send() {},
+        }),
+      },
+    },
+  });
+
+  try {
+    await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-automated-write-test",
+        hostname: "127.0.0.1",
+        port,
+        username: "admin",
+        password: "secret",
+      },
+    );
+    await waitFor(() => clientSocket);
+
+    terminalBridge.writeToSession(
+      {},
+      {
+        sessionId: "telnet-automated-write-test",
+        data: "show version\r",
+        automated: true,
+      },
+    );
+
+    clientSocket.write("Username: ");
+
+    await waitFor(() => received.join("").includes("admin\rsecret\r"));
+    assert.equal(received.join(""), "show version\radmin\rsecret\r");
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("manual Telnet writes cancel auto-login", async () => {
+  const sockets = new Set();
+  let clientSocket = null;
+  const server = net.createServer((socket) => {
+    clientSocket = socket;
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  const sentEvents = [];
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({
+          send(channel, payload) {
+            sentEvents.push({ channel, payload });
+          },
+        }),
+      },
+    },
+  });
+
+  try {
+    await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-manual-write-test",
+        hostname: "127.0.0.1",
+        port,
+        username: "admin",
+        password: "secret",
+      },
+    );
+    await waitFor(() => clientSocket);
+
+    terminalBridge.writeToSession(
+      {},
+      {
+        sessionId: "telnet-manual-write-test",
+        data: "a",
+      },
+    );
+
+    await waitFor(() => sentEvents.some((evt) =>
+      evt.channel === "netcatty:telnet:auto-login-cancelled" &&
+      evt.payload?.sessionId === "telnet-manual-write-test",
+    ));
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
     await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
+++ b/electron/bridges/terminalBridge.telnetAutoLogin.test.cjs
@@ -1,0 +1,87 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const net = require("node:net");
+
+const terminalBridge = require("./terminalBridge.cjs");
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve(server.address().port);
+    });
+  });
+}
+
+function waitFor(predicate, timeoutMs = 1000) {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error("Timed out waiting for telnet auto-login"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+test("startTelnetSession answers login prompts with saved credentials", async () => {
+  const received = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.write("Username: ");
+    socket.on("data", (chunk) => {
+      received.push(chunk);
+      const joined = received.join("");
+      if (joined.includes("admin\r") && !joined.includes("secret\r")) {
+        socket.write("\r\nPassword: ");
+      }
+      if (joined.includes("secret\r")) {
+        socket.end("\r\nWelcome\r\n");
+      }
+    });
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  const sentEvents = [];
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({
+          send(channel, payload) {
+            sentEvents.push({ channel, payload });
+          },
+        }),
+      },
+    },
+  });
+
+  try {
+    const result = await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-auto-login-test",
+        hostname: "127.0.0.1",
+        port,
+        username: "admin",
+        password: "secret",
+      },
+    );
+
+    assert.equal(result.sessionId, "telnet-auto-login-test");
+    await waitFor(() => received.join("").includes("admin\rsecret\r"));
+    assert.equal(received.join(""), "admin\rsecret\r");
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -12,6 +12,8 @@ const chainProgressListeners = new Map();
 const zmodemListeners = new Map();
 const sftpConnectionProgressListeners = new Set();
 const authFailedListeners = new Map();
+const telnetAutoLoginCompleteListeners = new Map();
+const telnetAutoLoginCancelledListeners = new Map();
 const languageChangeListeners = new Set();
 const fullscreenChangeListeners = new Set();
 const keyboardInteractiveListeners = new Set();
@@ -177,6 +179,8 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
   }
   dataListeners.delete(payload.sessionId);
   exitListeners.delete(payload.sessionId);
+  telnetAutoLoginCompleteListeners.delete(payload.sessionId);
+  telnetAutoLoginCancelledListeners.delete(payload.sessionId);
   zmodemListeners.delete(payload.sessionId);
   const pendingTimer = _mcpFlushTimers.get(payload.sessionId);
   if (pendingTimer) {
@@ -244,6 +248,30 @@ ipcRenderer.on("netcatty:auth:failed", (_event, payload) => {
       }
     });
   }
+});
+
+ipcRenderer.on("netcatty:telnet:auto-login-complete", (_event, payload) => {
+  const set = telnetAutoLoginCompleteListeners.get(payload.sessionId);
+  if (!set) return;
+  set.forEach((cb) => {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error("Telnet auto-login callback failed", err);
+    }
+  });
+});
+
+ipcRenderer.on("netcatty:telnet:auto-login-cancelled", (_event, payload) => {
+  const set = telnetAutoLoginCancelledListeners.get(payload.sessionId);
+  if (!set) return;
+  set.forEach((cb) => {
+    try {
+      cb(payload);
+    } catch (err) {
+      console.error("Telnet auto-login cancellation callback failed", err);
+    }
+  });
 });
 
 // Keyboard-interactive authentication events (2FA/MFA)
@@ -566,8 +594,12 @@ const api = {
   validatePath: async (path, type) => {
     return ipcRenderer.invoke("netcatty:local:validatePath", { path, type });
   },
-  writeToSession: (sessionId, data) => {
-    ipcRenderer.send("netcatty:write", { sessionId, data });
+  writeToSession: (sessionId, data, options) => {
+    ipcRenderer.send("netcatty:write", {
+      sessionId,
+      data,
+      automated: Boolean(options?.automated),
+    });
   },
   execCommand: async (options) => {
     return ipcRenderer.invoke("netcatty:ssh:exec", options);
@@ -624,6 +656,20 @@ const api = {
     if (!exitListeners.has(sessionId)) exitListeners.set(sessionId, new Set());
     exitListeners.get(sessionId).add(cb);
     return () => exitListeners.get(sessionId)?.delete(cb);
+  },
+  onTelnetAutoLoginComplete: (sessionId, cb) => {
+    if (!telnetAutoLoginCompleteListeners.has(sessionId)) {
+      telnetAutoLoginCompleteListeners.set(sessionId, new Set());
+    }
+    telnetAutoLoginCompleteListeners.get(sessionId).add(cb);
+    return () => telnetAutoLoginCompleteListeners.get(sessionId)?.delete(cb);
+  },
+  onTelnetAutoLoginCancelled: (sessionId, cb) => {
+    if (!telnetAutoLoginCancelledListeners.has(sessionId)) {
+      telnetAutoLoginCancelledListeners.set(sessionId, new Set());
+    }
+    telnetAutoLoginCancelledListeners.get(sessionId).add(cb);
+    return () => telnetAutoLoginCancelledListeners.get(sessionId)?.delete(cb);
   },
   onAuthFailed: (sessionId, cb) => {
     if (!authFailedListeners.has(sessionId)) authFailedListeners.set(sessionId, new Set());

--- a/global.d.ts
+++ b/global.d.ts
@@ -167,6 +167,8 @@ declare global {
       sessionId?: string;
       hostname: string;
       port?: number;
+      username?: string;
+      password?: string;
       cols?: number;
       rows?: number;
       charset?: string;

--- a/global.d.ts
+++ b/global.d.ts
@@ -304,7 +304,7 @@ declare global {
       };
     }>;
     setSessionEncoding?(sessionId: string, encoding: string): Promise<{ ok: boolean; encoding: string }>;
-    writeToSession(sessionId: string, data: string): void;
+    writeToSession(sessionId: string, data: string, options?: { automated?: boolean }): void;
     resizeSession(sessionId: string, cols: number, rows: number): void;
     closeSession(sessionId: string): void;
     // ZMODEM file transfer
@@ -328,6 +328,14 @@ declare global {
     onSessionExit(
       sessionId: string,
       cb: (evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void
+    ): () => void;
+    onTelnetAutoLoginComplete?(
+      sessionId: string,
+      cb: (evt: { sessionId: string }) => void
+    ): () => void;
+    onTelnetAutoLoginCancelled?(
+      sessionId: string,
+      cb: (evt: { sessionId: string }) => void
     ): () => void;
     onAuthFailed?(
       sessionId: string,


### PR DESCRIPTION
## Summary
- Pass saved Telnet credentials into Telnet sessions.
- Auto-answer common username and password prompts once, including split prompts and press-return banners.
- Keep explicitly cleared Telnet credential fields empty instead of falling back to SSH credentials.

Fixes #907.

## Validation
- npm run lint
- npm test
- npm run build