### PR TITLE
Restart session log stream on reconnect

### DIFF
--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -23,8 +23,19 @@ const MAX_BUFFER_SIZE = 64 * 1024;
 /**
  * Start a log stream for a session.
  * Creates the log file and opens a write stream.
+ *
+ * Returns a unique token identifying the started stream. Callers should pass
+ * this token to stopStream() so a late close handler from a previous
+ * incarnation of the same sessionId (e.g. SSH conn.once('close') firing
+ * after the user clicked "Restart" and a new stream is already running)
+ * cannot accidentally tear down the fresh stream. Without the token check,
+ * the same sessionId being recycled across reconnects would let stale stop
+ * calls kill the new log file. See issue #916.
+ *
  * @param {string} sessionId
  * @param {{ hostLabel: string, hostname: string, directory: string, format: string, startTime?: number }} opts
+ * @returns {symbol|null} Token identifying this stream, or null if no
+ *   stream was started (e.g. missing directory).
  */
 function startStream(sessionId, opts) {
   if (activeStreams.has(sessionId)) {
@@ -35,7 +46,7 @@ function startStream(sessionId, opts) {
   const { hostLabel, hostname, directory, format, startTime } = opts;
   if (!directory) {
     console.warn("[SessionLogStream] No directory specified, skipping");
-    return;
+    return null;
   }
 
   try {
@@ -69,6 +80,7 @@ function startStream(sessionId, opts) {
       });
     }
 
+    const startToken = Symbol("session-log-stream");
     const entry = {
       writeStream,
       filePath,
@@ -86,6 +98,7 @@ function startStream(sessionId, opts) {
       snapshotDirty: false,
       closing: false,
       disabled: false,
+      startToken,
     };
 
     // Start periodic flush
@@ -95,8 +108,10 @@ function startStream(sessionId, opts) {
 
     activeStreams.set(sessionId, entry);
     console.log(`[SessionLogStream] Started stream for ${sessionId} -> ${filePath}`);
+    return startToken;
   } catch (err) {
     console.error(`[SessionLogStream] Failed to start stream for ${sessionId}:`, err.message);
+    return null;
   }
 }
 
@@ -184,12 +199,28 @@ function appendData(sessionId, dataChunk) {
 /**
  * Stop the log stream for a session.
  * Flushes remaining data, closes the write stream, and finalizes the file.
+ *
+ * If `expectedToken` is provided, the stop is only honoured when it matches
+ * the active stream's start token. This protects against stale close
+ * handlers from a previous incarnation of the same sessionId (e.g. an SSH
+ * connection's `conn.once('close')` firing after the user has already
+ * clicked "Restart" and a fresh stream has been started). Without this
+ * guard, the stale handler would silently destroy the new session's log.
+ * See issue #916.
+ *
  * @param {string} sessionId
- * @returns {Promise<string|null>} The final file path, or null if no stream was active
+ * @param {symbol} [expectedToken] - Token returned by startStream()
+ * @returns {Promise<string|null>} The final file path, or null if no
+ *   matching stream was active.
  */
-async function stopStream(sessionId) {
+async function stopStream(sessionId, expectedToken) {
   const entry = activeStreams.get(sessionId);
   if (!entry) return null;
+  if (expectedToken && entry.startToken !== expectedToken) {
+    // Stale stop call from a previous session that reused this sessionId.
+    // The current stream belongs to a fresh incarnation; leave it alone.
+    return null;
+  }
   activeStreams.delete(sessionId);
   entry.closing = true;
 

--- a/electron/bridges/sessionLogStreamManager.test.cjs
+++ b/electron/bridges/sessionLogStreamManager.test.cjs
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const {
   appendData,
+  hasStream,
   startStream,
   stopStream,
 } = require("./sessionLogStreamManager.cjs");
@@ -51,6 +52,89 @@ test("txt stream finalization commits pending ED2 cleared screens", async () => 
     assert.equal(fs.readFileSync(filePath, "utf8"), "before tui\n\nframe one\n\nframe two");
   } finally {
     await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStream returns a token; stopStream with stale token leaves the active stream alone (issue #916)", async () => {
+  // Reproduces the bug shape where the user clicks "Restart" after a
+  // session disconnect. The renderer reuses the same sessionId, so the
+  // bridges call startStream(sessionId, ...) again. If a stale close
+  // handler from the previous incarnation later fires
+  // stopStream(sessionId), it must NOT clobber the freshly-started stream.
+  const directory = path.join(TEMP_ROOT, `stream-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    // First connection.
+    const firstToken = startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    assert.ok(firstToken, "first startStream should return a token");
+    appendData(sessionId, "first-session\n");
+    const firstPath = await stopStream(sessionId, firstToken);
+    assert.ok(firstPath, "first stopStream should return its file path");
+
+    // User clicks "Restart" - same sessionId, fresh stream.
+    const secondToken = startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 10),
+    });
+    assert.ok(secondToken, "second startStream should return a token");
+    assert.notEqual(firstToken, secondToken, "tokens must be unique across starts");
+    appendData(sessionId, "second-session-before-stale\n");
+
+    // SIMULATE THE BUG: a stale close handler from the previous SSH
+    // connection finally fires and calls stopStream with the OLD token.
+    // The current implementation must ignore it.
+    const staleResult = await stopStream(sessionId, firstToken);
+    assert.equal(staleResult, null, "stale stopStream must be a no-op");
+    assert.equal(hasStream(sessionId), true, "second stream must still be active after stale stop");
+
+    // More output for the new session — must reach the file.
+    appendData(sessionId, "second-session-after-stale\n");
+    const secondPath = await stopStream(sessionId, secondToken);
+    assert.ok(secondPath, "second stopStream should return its file path");
+    assert.notEqual(firstPath, secondPath, "second connection should write to a new file");
+
+    // Both files exist and contain the expected output.
+    assert.equal(fs.readFileSync(firstPath, "utf8"), "first-session\n");
+    assert.equal(
+      fs.readFileSync(secondPath, "utf8"),
+      "second-session-before-stale\nsecond-session-after-stale\n",
+    );
+  } finally {
+    // Belt-and-suspenders cleanup; both streams are normally already stopped.
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("stopStream without a token still tears down the current stream (back-compat)", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    appendData(sessionId, "data\n");
+    const finalPath = await stopStream(sessionId);
+    assert.ok(finalPath);
+    assert.equal(fs.readFileSync(finalPath, "utf8"), "data\n");
+    assert.equal(hasStream(sessionId), false);
+  } finally {
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -709,6 +709,12 @@ async function startSSHSession(event, options) {
     const conn = new SSHClient();
     let chainConnections = [];
     let connectionSocket = null;
+    // Token returned by sessionLogStreamManager.startStream when (and if)
+    // a real-time log stream is opened. Captured here so every close /
+    // error / timeout handler below can pass it back to stopStream and
+    // avoid tearing down a stream that a subsequent reconnect on the same
+    // sessionId may have already started (issue #916).
+    let logStreamToken = null;
 
     // Determine if we have jump hosts
     const jumpHosts = options.jumpHosts || [];
@@ -1291,7 +1297,7 @@ async function startSSHSession(event, options) {
 
             // Start real-time session log stream if configured
             if (options.sessionLog?.enabled && options.sessionLog?.directory) {
-              sessionLogStreamManager.startStream(sessionId, {
+              logStreamToken = sessionLogStreamManager.startStream(sessionId, {
                 hostLabel: options.hostLabel || options.hostname || '',
                 hostname: options.hostname || '',
                 directory: options.sessionLog.directory,
@@ -1385,7 +1391,7 @@ async function startSSHSession(event, options) {
                 clearTimeout(flushTimeout);
               }
               flushBuffer();
-              sessionLogStreamManager.stopStream(sessionId);
+              sessionLogStreamManager.stopStream(sessionId, logStreamToken);
               if (detachX11Forwarding) {
                 detachX11Forwarding();
                 detachX11Forwarding = null;
@@ -1471,7 +1477,7 @@ async function startSSHSession(event, options) {
 
         sendProgress(totalHops, totalHops, options.hostname, 'error', err.message);
         safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
-        sessionLogStreamManager.stopStream(sessionId);
+        sessionLogStreamManager.stopStream(sessionId, logStreamToken);
         if (detachX11Forwarding) {
           detachX11Forwarding();
           detachX11Forwarding = null;
@@ -1496,7 +1502,7 @@ async function startSSHSession(event, options) {
         const contents = event.sender;
         sendProgress(totalHops, totalHops, options.hostname, 'error', err.message);
         safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "timeout" });
-        sessionLogStreamManager.stopStream(sessionId);
+        sessionLogStreamManager.stopStream(sessionId, logStreamToken);
         sessions.get(sessionId)?.zmodemSentry?.cancel();
         sessions.delete(sessionId);
         sessionEncodings.delete(sessionId);
@@ -1527,7 +1533,7 @@ async function startSSHSession(event, options) {
             safeSend(contents, "netcatty:exit", { sessionId, exitCode: 0, reason: "closed" });
           }
         }
-        sessionLogStreamManager.stopStream(sessionId);
+        sessionLogStreamManager.stopStream(sessionId, logStreamToken);
         sessions.get(sessionId)?.zmodemSentry?.cancel();
         sessions.delete(sessionId);
         sessionEncodings.delete(sessionId);

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -437,9 +437,14 @@ function startLocalSession(event, payload) {
   sessions.set(sessionId, session);
   ptyProcessTree.registerPid(sessionId, proc.pid);
 
-  // Start real-time session log stream if configured
+  // Start real-time session log stream if configured. The token returned
+  // by startStream is captured so the corresponding stopStream below only
+  // tears down THIS stream — a stale exit event from a previous session
+  // that reused this sessionId would no-op instead of killing a freshly
+  // started stream after a "Restart" reconnect (issue #916).
+  let logStreamToken = null;
   if (payload?.sessionLog?.enabled && payload?.sessionLog?.directory) {
-    sessionLogStreamManager.startStream(sessionId, {
+    logStreamToken = sessionLogStreamManager.startStream(sessionId, {
       hostLabel: "Local",
       hostname: "localhost",
       directory: payload.sessionLog.directory,
@@ -491,7 +496,7 @@ function startLocalSession(event, payload) {
 
   proc.onExit((evt) => {
     flushLocal();
-    sessionLogStreamManager.stopStream(sessionId);
+    sessionLogStreamManager.stopStream(sessionId, logStreamToken);
     ptyProcessTree.unregisterPid(sessionId);
     sessions.delete(sessionId);
     const contents = electronModule.webContents.fromId(session.webContentsId);
@@ -521,6 +526,11 @@ async function startTelnetSession(event, options) {
   return new Promise((resolve, reject) => {
     const socket = new net.Socket();
     let connected = false;
+    // Token for the log stream we open on this connection. Captured here so
+    // the close/error handlers below can pass it back to stopStream and
+    // avoid tearing down a fresh stream that a subsequent reconnect on the
+    // same sessionId may have started (issue #916).
+    let logStreamToken = null;
     const telnetAutoLogin = createTelnetAutoLogin({
       username: options.username,
       password: options.password,
@@ -686,7 +696,7 @@ async function startTelnetSession(event, options) {
 
       // Start real-time session log stream if configured
       if (options.sessionLog?.enabled && options.sessionLog?.directory) {
-        sessionLogStreamManager.startStream(sessionId, {
+        logStreamToken = sessionLogStreamManager.startStream(sessionId, {
           hostLabel: options.label || hostname,
           hostname,
           directory: options.sessionLog.directory,
@@ -773,7 +783,7 @@ async function startTelnetSession(event, options) {
         reject(new Error(`Failed to connect: ${err.message}`));
       } else {
         flushTelnet();
-        sessionLogStreamManager.stopStream(sessionId);
+        sessionLogStreamManager.stopStream(sessionId, logStreamToken);
         const session = sessions.get(sessionId);
         if (session) {
           session.zmodemSentry?.cancel();
@@ -790,7 +800,7 @@ async function startTelnetSession(event, options) {
       clearTimeout(connectTimeout);
 
       flushTelnet();
-      sessionLogStreamManager.stopStream(sessionId);
+      sessionLogStreamManager.stopStream(sessionId, logStreamToken);
       const session = sessions.get(sessionId);
       if (session) {
         session.zmodemSentry?.cancel();
@@ -1196,8 +1206,9 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
   };
   sessions.set(sessionId, session);
 
+  let logStreamToken = null;
   if (options.sessionLog?.enabled && options.sessionLog?.directory) {
-    sessionLogStreamManager.startStream(sessionId, {
+    logStreamToken = sessionLogStreamManager.startStream(sessionId, {
       hostLabel: options.label || options.hostname,
       hostname: options.hostname,
       directory: options.sessionLog.directory,
@@ -1205,6 +1216,10 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
       startTime: Date.now(),
     });
   }
+  // Expose the token so swapToMoshClient can keep using it after the
+  // handshake hand-off; the new mc-pty's exit handler will also rely on
+  // it to scope its stopStream call.
+  session.logStreamToken = logStreamToken;
 
   const { bufferData, flush } = createPtyBuffer((data) => {
     const contents = electronModule.webContents.fromId(session.webContentsId);
@@ -1255,7 +1270,7 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
         });
       } catch (err) {
         flush();
-        sessionLogStreamManager.stopStream(sessionId);
+        sessionLogStreamManager.stopStream(sessionId, logStreamToken);
         const contents = electronModule.webContents.fromId(session.webContentsId);
         contents?.send("netcatty:exit", {
           sessionId,
@@ -1272,7 +1287,7 @@ async function startMoshSessionViaHandshake(event, options, { bareClient, sshExe
     // key warning, etc). Just surface a session-exit with the code so
     // the renderer can label the session "disconnected".
     flush();
-    sessionLogStreamManager.stopStream(sessionId);
+    sessionLogStreamManager.stopStream(sessionId, logStreamToken);
     const contents = electronModule.webContents.fromId(session.webContentsId);
     contents?.send("netcatty:exit", {
       sessionId,
@@ -1359,7 +1374,7 @@ function swapToMoshClient(session, options, ctx) {
       return;
     }
     flush();
-    sessionLogStreamManager.stopStream(sessionId);
+    sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
     const contents = electronModule.webContents.fromId(session.webContentsId);
     contents?.send("netcatty:exit", {
       sessionId,
@@ -1454,6 +1469,11 @@ async function startSerialSession(event, options) {
   console.log(`[Serial] Starting connection to ${portPath} at ${baudRate} baud`);
 
   return new Promise((resolve, reject) => {
+    // Token for the log stream we open on this connection. Captured here so
+    // the close/error handlers can pass it to stopStream and avoid
+    // tearing down a freshly started stream after a "Restart" reconnect on
+    // the same sessionId (issue #916).
+    let logStreamToken = null;
     try {
       const serialPort = new SerialPort({
         path: portPath,
@@ -1495,7 +1515,7 @@ async function startSerialSession(event, options) {
 
         // Start real-time session log stream if configured
         if (options.sessionLog?.enabled && options.sessionLog?.directory) {
-          sessionLogStreamManager.startStream(sessionId, {
+          logStreamToken = sessionLogStreamManager.startStream(sessionId, {
             hostLabel: options.label || portPath,
             hostname: portPath,
             directory: options.sessionLog.directory,
@@ -1531,7 +1551,7 @@ async function startSerialSession(event, options) {
         serialPort.on('error', (err) => {
           console.error(`[Serial] Port error: ${err.message}`);
           session.zmodemSentry?.cancel();
-          sessionLogStreamManager.stopStream(sessionId);
+          sessionLogStreamManager.stopStream(sessionId, logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
           contents?.send("netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
           ptyProcessTree.unregisterPid(sessionId);
@@ -1541,7 +1561,7 @@ async function startSerialSession(event, options) {
         serialPort.on('close', () => {
           console.log(`[Serial] Port closed`);
           session.zmodemSentry?.cancel();
-          sessionLogStreamManager.stopStream(sessionId);
+          sessionLogStreamManager.stopStream(sessionId, logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
           contents?.send("netcatty:exit", { sessionId, exitCode: 0, reason: "closed" });
           ptyProcessTree.unregisterPid(sessionId);


### PR DESCRIPTION
Fixes #916.

## Root cause

The renderer reuses the same `sessionId` across reconnects within a tab. When the user clicks "Restart" after a disconnect, the bridges call `sessionLogStreamManager.startStream(sessionId, ...)` again to open a fresh log file. The previous connection's close handlers, however, are still attached to the old transport (SSH `stream.on('close')` and `conn.once('close')`, serial `'close'`, telnet `'close'`, mosh PTY `onExit`, plus their error/timeout siblings) and they all fire asynchronously after the new stream may already be active. Each one calls `stopStream(sessionId)` unconditionally — and `stopStream` keys only on `sessionId`, so a stale handler from the OLD connection silently tears down the NEW stream. After that, every `appendData` call for the reconnected session is dropped because no entry exists in `activeStreams`. The first connection's file ends up with the captured-up-to-disconnect content; the reconnected session's log is empty (or nonexistent).

## Fix

`startStream` now returns a unique token (a `Symbol`) identifying the stream it just opened. `stopStream(sessionId, expectedToken)` checks the token against the currently active stream and no-ops if they do not match — so a late close handler from a previous incarnation cannot kill a stream a later reconnect started. All call sites in `terminalBridge.cjs` (local, telnet, serial, mosh handshake / swap) and `sshBridge.cjs` (shell `close`, `error`, `timeout`, transport `close`) capture the returned token and pass it to their corresponding `stopStream`. `cleanupAll` continues to work without a token (used only on app quit).

## Semantics chosen

Each reconnect produces its own timestamped log file. The streaming manager already builds a fresh filename from `startTime` on every `startStream` call, so this maps cleanly with no additional plumbing and matches the existing "auto-save-on-close" semantics (one file per connection). Concatenating into a single file would have required appending to a known-prior path and migrating the `'w'` flag to `'a'` (and reading back the renderer state for txt/html), all for a strictly less informative result.

## Files changed

- `electron/bridges/sessionLogStreamManager.cjs` — token issuance + guarded `stopStream`.
- `electron/bridges/sessionLogStreamManager.test.cjs` — new tests for the race scenario and back-compat.
- `electron/bridges/terminalBridge.cjs` — local / telnet / serial / mosh handshake & swap pass tokens.
- `electron/bridges/sshBridge.cjs` — SSH `stream`/`conn` handlers pass the token.

## Test plan

- [x] `npm run lint`
- [x] `node --test --import tsx electron/bridges/sessionLogStreamManager.test.cjs` (4 tests; new race scenario asserts the stale `stopStream` does not kill the fresh stream and both sessions' files contain their data)
- [x] `node --test --import tsx components/terminal/runtime/*.test.ts` (23 tests, unchanged)
- [x] `node --test --import tsx electron/bridges/*.test.cjs` (224 pass / 3 skipped, unchanged)
- [ ] Manual smoke: connect via SSH with session logs enabled, exit/disconnect remote, click "Restart"; confirm a second `<host>/<timestamp>.txt` appears alongside the first and contains the reconnected session's IO.
- [ ] Manual smoke: same flow over Telnet and Serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)