### PR TITLE
Support Shift+Enter

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -37,6 +37,16 @@ import {
   isEraseScrollbackSequence,
   preserveTerminalViewportInScrollback,
 } from "../clearTerminalViewport";
+import {
+  buildKittyKeyboardModeQueryResponse,
+  createKittyKeyboardModeState,
+  encodeKittyControlKey,
+  popKittyKeyboardModeFlags,
+  pushKittyKeyboardModeFlags,
+  setKittyKeyboardAlternateScreenActive,
+  setKittyKeyboardModeFlags,
+  type KittyKeyboardModeApplyMode,
+} from "./kittyKeyboardProtocol";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import type {
   Host,
@@ -205,6 +215,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const wordSeparator = settings?.wordSeparators ?? " ()[]{}'\"";
   const keywordHighlightRules = settings?.keywordHighlightRules ?? [];
   const keywordHighlightEnabled = settings?.keywordHighlightEnabled ?? false;
+  const kittyKeyboardMode = createKittyKeyboardModeState();
 
   const resolvedFontWeightBold = (() => {
     if (typeof document === "undefined" || !document.fonts?.check) {
@@ -514,6 +525,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       }
     }
 
+    const kittyControlSequence = encodeKittyControlKey(kittyKeyboardMode, e);
+    if (kittyControlSequence) {
+      const id = ctx.sessionRef.current;
+      if (id) {
+        e.preventDefault();
+        e.stopPropagation();
+        ctx.onAutocompleteInput?.(kittyControlSequence);
+        ctx.terminalBackend.writeToSession(id, kittyControlSequence);
+        if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
+          ctx.onBroadcastInputRef.current(kittyControlSequence, ctx.sessionId);
+        }
+        scrollToBottomAfterInput(kittyControlSequence);
+        return false;
+      }
+    }
+
     const currentBindings = ctx.keyBindingsRef.current;
     if (currentScheme === "disabled" || currentBindings.length === 0) {
       return true;
@@ -733,6 +760,86 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     return !wipeAllowed;
   });
 
+  const readParam = (
+    params: readonly (number | number[])[],
+    index: number,
+    fallback: number,
+  ): number => {
+    const value = params[index];
+    if (Array.isArray(value)) return typeof value[0] === "number" ? value[0] : fallback;
+    return typeof value === "number" && value > 0 ? value : fallback;
+  };
+
+  const writeKittyKeyboardReply = (payload: string) => {
+    const id = ctx.sessionRef.current;
+    if (!id) return;
+    ctx.terminalBackend.writeToSession(id, payload);
+  };
+
+  const kittyKeyboardQueryDisposable = term.parser.registerCsiHandler(
+    { prefix: "?", final: "u" },
+    () => {
+      writeKittyKeyboardReply(buildKittyKeyboardModeQueryResponse(kittyKeyboardMode));
+      return true;
+    },
+  );
+
+  const kittyKeyboardSetDisposable = term.parser.registerCsiHandler(
+    { prefix: "=", final: "u" },
+    (params) => {
+      const flags = readParam(params, 0, 0);
+      const mode = readParam(params, 1, 1) as KittyKeyboardModeApplyMode;
+      setKittyKeyboardModeFlags(kittyKeyboardMode, flags, mode === 2 || mode === 3 ? mode : 1);
+      return true;
+    },
+  );
+
+  const kittyKeyboardPushDisposable = term.parser.registerCsiHandler(
+    { prefix: ">", final: "u" },
+    (params) => {
+      pushKittyKeyboardModeFlags(kittyKeyboardMode, readParam(params, 0, 0));
+      return true;
+    },
+  );
+
+  const kittyKeyboardPopDisposable = term.parser.registerCsiHandler(
+    { prefix: "<", final: "u" },
+    (params) => {
+      popKittyKeyboardModeFlags(kittyKeyboardMode, readParam(params, 0, 1));
+      return true;
+    },
+  );
+
+  const alternateScreenSetDisposable = term.parser.registerCsiHandler(
+    { prefix: "?", final: "h" },
+    (params) => {
+      const switchesToAlternateScreen = params.some((param) =>
+        Array.isArray(param)
+          ? param.includes(47) || param.includes(1047) || param.includes(1049)
+          : param === 47 || param === 1047 || param === 1049,
+      );
+      if (switchesToAlternateScreen) {
+        setKittyKeyboardAlternateScreenActive(kittyKeyboardMode, true);
+      }
+      return false;
+    },
+  );
+
+  const alternateScreenResetDisposable = term.parser.registerCsiHandler(
+    { prefix: "?", final: "l" },
+    (params) => {
+      const switchesToMainScreen = params.some((param) =>
+        Array.isArray(param)
+          ? param.includes(47) || param.includes(1047) || param.includes(1049)
+          : param === 47 || param === 1047 || param === 1049,
+      );
+      if (switchesToMainScreen) {
+        setKittyKeyboardAlternateScreenActive(kittyKeyboardMode, false);
+      }
+      return false;
+    },
+  );
+
   // Register OSC 7 handler using xterm.js parser
   // OSC 7 is the standard way for shells to report the current working directory
   const osc7Disposable = term.parser.registerOscHandler(7, (data) => {
@@ -858,6 +965,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       cleanupMiddleClick?.();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();
+      kittyKeyboardQueryDisposable.dispose();
+      kittyKeyboardSetDisposable.dispose();
+      kittyKeyboardPushDisposable.dispose();
+      kittyKeyboardPopDisposable.dispose();
+      alternateScreenSetDisposable.dispose();
+      alternateScreenResetDisposable.dispose();
       osc7Disposable.dispose();
       osc52Disposable.dispose();
       cursorPreferenceDisposable?.dispose();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -38,15 +38,10 @@ import {
   preserveTerminalViewportInScrollback,
 } from "../clearTerminalViewport";
 import {
-  buildKittyKeyboardModeQueryResponse,
   createKittyKeyboardModeState,
   encodeKittyControlKey,
-  popKittyKeyboardModeFlags,
-  pushKittyKeyboardModeFlags,
-  setKittyKeyboardAlternateScreenActive,
-  setKittyKeyboardModeFlags,
-  type KittyKeyboardModeApplyMode,
 } from "./kittyKeyboardProtocol";
+import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import type {
   Host,
@@ -525,6 +520,74 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       }
     }
 
+    const currentBindings = ctx.keyBindingsRef.current;
+    if (currentScheme !== "disabled" && currentBindings.length > 0) {
+      const matched = checkAppShortcut(e, currentBindings, isMac);
+      if (matched) {
+        const { action } = matched;
+
+        if (appLevelActions.has(action)) {
+          return true; // Let app-level handler process it
+        }
+
+        if (terminalActions.has(action)) {
+          e.preventDefault();
+          e.stopPropagation();
+          switch (action) {
+            case "copy": {
+              const selection = term.getSelection();
+              if (selection) navigator.clipboard.writeText(selection);
+              break;
+            }
+            case "paste": {
+              navigator.clipboard.readText().then((text) => {
+                const id = ctx.sessionRef.current;
+                if (id) {
+                  const rawData = normalizeLineEndings(text);
+                  const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
+                    ? wrapBracketedPaste(rawData)
+                    : rawData;
+                  // Notify autocomplete with the final bytes so bracketed
+                  // pastes preserve their inner newlines as literal input.
+                  ctx.onAutocompleteInput?.(data);
+                  ctx.terminalBackend.writeToSession(id, data);
+                  scrollToBottomAfterPaste();
+                }
+              });
+              break;
+            }
+            case "pasteSelection": {
+              const selection = term.getSelection();
+              const id = ctx.sessionRef.current;
+              if (selection && id) {
+                const rawData = normalizeLineEndings(selection);
+                const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
+                  ? wrapBracketedPaste(rawData)
+                  : rawData;
+                ctx.onAutocompleteInput?.(data);
+                ctx.terminalBackend.writeToSession(id, data);
+                scrollToBottomAfterPaste();
+              }
+              break;
+            }
+            case "selectAll": {
+              term.selectAll();
+              break;
+            }
+            case "clearBuffer": {
+              clearTerminalViewport(term);
+              break;
+            }
+            case "searchTerminal": {
+              ctx.setIsSearchOpen(true);
+              break;
+            }
+          }
+          return false;
+        }
+      }
+    }
+
     const kittyControlSequence = encodeKittyControlKey(kittyKeyboardMode, e);
     if (kittyControlSequence) {
       const id = ctx.sessionRef.current;
@@ -539,76 +602,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         scrollToBottomAfterInput(kittyControlSequence);
         return false;
       }
-    }
-
-    const currentBindings = ctx.keyBindingsRef.current;
-    if (currentScheme === "disabled" || currentBindings.length === 0) {
-      return true;
-    }
-
-    const matched = checkAppShortcut(e, currentBindings, isMac);
-    if (!matched) return true;
-
-    const { action } = matched;
-
-    if (appLevelActions.has(action)) {
-      return true; // Let app-level handler process it
-    }
-
-    if (terminalActions.has(action)) {
-      e.preventDefault();
-      e.stopPropagation();
-      switch (action) {
-        case "copy": {
-          const selection = term.getSelection();
-          if (selection) navigator.clipboard.writeText(selection);
-          break;
-        }
-        case "paste": {
-          navigator.clipboard.readText().then((text) => {
-            const id = ctx.sessionRef.current;
-            if (id) {
-              const rawData = normalizeLineEndings(text);
-              const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
-                ? wrapBracketedPaste(rawData)
-                : rawData;
-              // Notify autocomplete with the final bytes so bracketed
-              // pastes preserve their inner newlines as literal input.
-              ctx.onAutocompleteInput?.(data);
-              ctx.terminalBackend.writeToSession(id, data);
-              scrollToBottomAfterPaste();
-            }
-          });
-          break;
-        }
-        case "pasteSelection": {
-          const selection = term.getSelection();
-          const id = ctx.sessionRef.current;
-          if (selection && id) {
-            const rawData = normalizeLineEndings(selection);
-            const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
-              ? wrapBracketedPaste(rawData)
-              : rawData;
-            ctx.onAutocompleteInput?.(data);
-            ctx.terminalBackend.writeToSession(id, data);
-            scrollToBottomAfterPaste();
-          }
-          break;
-        }
-        case "selectAll": {
-          term.selectAll();
-          break;
-        }
-        case "clearBuffer": {
-          clearTerminalViewport(term);
-          break;
-        }
-        case "searchTerminal": {
-          ctx.setIsSearchOpen(true);
-          break;
-        }
-      }
-      return false;
     }
 
     return true;
@@ -760,84 +753,16 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     return !wipeAllowed;
   });
 
-  const readParam = (
-    params: readonly (number | number[])[],
-    index: number,
-    fallback: number,
-  ): number => {
-    const value = params[index];
-    if (Array.isArray(value)) return typeof value[0] === "number" ? value[0] : fallback;
-    return typeof value === "number" && value > 0 ? value : fallback;
-  };
-
   const writeKittyKeyboardReply = (payload: string) => {
     const id = ctx.sessionRef.current;
     if (!id) return;
     ctx.terminalBackend.writeToSession(id, payload);
   };
 
-  const kittyKeyboardQueryDisposable = term.parser.registerCsiHandler(
-    { prefix: "?", final: "u" },
-    () => {
-      writeKittyKeyboardReply(buildKittyKeyboardModeQueryResponse(kittyKeyboardMode));
-      return true;
-    },
-  );
-
-  const kittyKeyboardSetDisposable = term.parser.registerCsiHandler(
-    { prefix: "=", final: "u" },
-    (params) => {
-      const flags = readParam(params, 0, 0);
-      const mode = readParam(params, 1, 1) as KittyKeyboardModeApplyMode;
-      setKittyKeyboardModeFlags(kittyKeyboardMode, flags, mode === 2 || mode === 3 ? mode : 1);
-      return true;
-    },
-  );
-
-  const kittyKeyboardPushDisposable = term.parser.registerCsiHandler(
-    { prefix: ">", final: "u" },
-    (params) => {
-      pushKittyKeyboardModeFlags(kittyKeyboardMode, readParam(params, 0, 0));
-      return true;
-    },
-  );
-
-  const kittyKeyboardPopDisposable = term.parser.registerCsiHandler(
-    { prefix: "<", final: "u" },
-    (params) => {
-      popKittyKeyboardModeFlags(kittyKeyboardMode, readParam(params, 0, 1));
-      return true;
-    },
-  );
-
-  const alternateScreenSetDisposable = term.parser.registerCsiHandler(
-    { prefix: "?", final: "h" },
-    (params) => {
-      const switchesToAlternateScreen = params.some((param) =>
-        Array.isArray(param)
-          ? param.includes(47) || param.includes(1047) || param.includes(1049)
-          : param === 47 || param === 1047 || param === 1049,
-      );
-      if (switchesToAlternateScreen) {
-        setKittyKeyboardAlternateScreenActive(kittyKeyboardMode, true);
-      }
-      return false;
-    },
-  );
-
-  const alternateScreenResetDisposable = term.parser.registerCsiHandler(
-    { prefix: "?", final: "l" },
-    (params) => {
-      const switchesToMainScreen = params.some((param) =>
-        Array.isArray(param)
-          ? param.includes(47) || param.includes(1047) || param.includes(1049)
-          : param === 47 || param === 1047 || param === 1049,
-      );
-      if (switchesToMainScreen) {
-        setKittyKeyboardAlternateScreenActive(kittyKeyboardMode, false);
-      }
-      return false;
-    },
+  const kittyKeyboardDisposable = installKittyKeyboardProtocolHandlers(
+    term.parser,
+    kittyKeyboardMode,
+    writeKittyKeyboardReply,
   );
 
   // Register OSC 7 handler using xterm.js parser
@@ -965,12 +890,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       cleanupMiddleClick?.();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();
-      kittyKeyboardQueryDisposable.dispose();
-      kittyKeyboardSetDisposable.dispose();
-      kittyKeyboardPushDisposable.dispose();
-      kittyKeyboardPopDisposable.dispose();
-      alternateScreenSetDisposable.dispose();
-      alternateScreenResetDisposable.dispose();
+      kittyKeyboardDisposable.dispose();
       osc7Disposable.dispose();
       osc52Disposable.dispose();
       cursorPreferenceDisposable?.dispose();

--- a/components/terminal/runtime/kittyKeyboardProtocol.test.ts
+++ b/components/terminal/runtime/kittyKeyboardProtocol.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildKittyKeyboardModeQueryResponse,
+  createKittyKeyboardModeState,
+  encodeKittyControlKey,
+  popKittyKeyboardModeFlags,
+  pushKittyKeyboardModeFlags,
+  setKittyKeyboardAlternateScreenActive,
+  setKittyKeyboardModeFlags,
+} from "./kittyKeyboardProtocol";
+
+test("kitty keyboard query reports the active screen flags", () => {
+  const state = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(state, 1, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+
+  setKittyKeyboardAlternateScreenActive(state, true);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
+});
+
+test("kitty keyboard set mode respects replace, union, and subtract semantics", () => {
+  const state = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(state, 1, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+
+  setKittyKeyboardModeFlags(state, 8, 2);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?9u");
+
+  setKittyKeyboardModeFlags(state, 8, 3);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+});
+
+test("kitty keyboard mode stacks are independent for main and alternate screen", () => {
+  const state = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(state, 1, 1);
+  pushKittyKeyboardModeFlags(state, 0);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
+
+  setKittyKeyboardAlternateScreenActive(state, true);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
+  setKittyKeyboardModeFlags(state, 1, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+
+  popKittyKeyboardModeFlags(state, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
+
+  setKittyKeyboardAlternateScreenActive(state, false);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
+  popKittyKeyboardModeFlags(state, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+});
+
+test("kitty control key encoding keeps bare enter legacy but disambiguates modified enter", () => {
+  const state = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(state, 1, 1);
+
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Enter" }),
+    null,
+  );
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Enter", shiftKey: true }),
+    "\u001b[13;2u",
+  );
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Escape" }),
+    "\u001b[27u",
+  );
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Backspace", ctrlKey: true, altKey: true }),
+    "\u001b[127;7u",
+  );
+});
+
+test("kitty report-all mode enables the supported modified control key subset", () => {
+  const state = createKittyKeyboardModeState();
+  setKittyKeyboardModeFlags(state, 8, 1);
+
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?8u");
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Enter", shiftKey: true }),
+    "\u001b[13;2u",
+  );
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Tab", shiftKey: true }),
+    "\u001b[9;2u",
+  );
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Enter" }),
+    null,
+  );
+});

--- a/components/terminal/runtime/kittyKeyboardProtocol.test.ts
+++ b/components/terminal/runtime/kittyKeyboardProtocol.test.ts
@@ -10,6 +10,58 @@ import {
   setKittyKeyboardAlternateScreenActive,
   setKittyKeyboardModeFlags,
 } from "./kittyKeyboardProtocol";
+import {
+  installKittyKeyboardProtocolHandlers,
+  readKittyKeyboardCsiParam,
+  type KittyKeyboardCsiParams,
+} from "./kittyKeyboardRuntime";
+
+type CsiHandlerId = {
+  prefix?: string;
+  intermediates?: string;
+  final: string;
+};
+
+type CsiHandler = (params: KittyKeyboardCsiParams) => boolean;
+
+const csiKey = (id: CsiHandlerId): string => (
+  `${id.prefix ?? ""}|${id.intermediates ?? ""}|${id.final}`
+);
+
+const createFakeCsiParser = () => {
+  const handlers = new Map<string, CsiHandler[]>();
+
+  return {
+    parser: {
+      registerCsiHandler(id: CsiHandlerId, callback: CsiHandler) {
+        const key = csiKey(id);
+        const list = handlers.get(key) ?? [];
+        list.push(callback);
+        handlers.set(key, list);
+        return {
+          dispose: () => {
+            const current = handlers.get(key);
+            if (!current) return;
+            const index = current.indexOf(callback);
+            if (index >= 0) current.splice(index, 1);
+            if (current.length === 0) handlers.delete(key);
+          },
+        };
+      },
+    },
+    dispatch(id: CsiHandlerId, params: KittyKeyboardCsiParams = []) {
+      const list = handlers.get(csiKey(id));
+      assert.ok(list?.length, `missing CSI handler for ${csiKey(id)}`);
+      for (let index = list.length - 1; index >= 0; index -= 1) {
+        if (list[index](params)) return true;
+      }
+      return false;
+    },
+    hasHandler(id: CsiHandlerId) {
+      return handlers.has(csiKey(id));
+    },
+  };
+};
 
 test("kitty keyboard query reports the active screen flags", () => {
   const state = createKittyKeyboardModeState();
@@ -30,6 +82,16 @@ test("kitty keyboard set mode respects replace, union, and subtract semantics", 
 
   setKittyKeyboardModeFlags(state, 8, 3);
   assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?1u");
+});
+
+test("kitty keyboard mode ignores unsupported progressive enhancement flags", () => {
+  const state = createKittyKeyboardModeState();
+
+  setKittyKeyboardModeFlags(state, 1 | 2 | 4 | 8 | 16, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?9u");
+
+  setKittyKeyboardModeFlags(state, 2 | 4 | 16, 1);
+  assert.equal(buildKittyKeyboardModeQueryResponse(state), "\u001b[?0u");
 });
 
 test("kitty keyboard mode stacks are independent for main and alternate screen", () => {
@@ -72,6 +134,94 @@ test("kitty control key encoding keeps bare enter legacy but disambiguates modif
     encodeKittyControlKey(state, { key: "Backspace", ctrlKey: true, altKey: true }),
     "\u001b[127;7u",
   );
+});
+
+test("kitty keyboard CSI param reader applies fallbacks for odd params", () => {
+  assert.equal(readKittyKeyboardCsiParam([], 0, 7), 7);
+  assert.equal(readKittyKeyboardCsiParam([0], 0, 7), 7);
+  assert.equal(readKittyKeyboardCsiParam([-1], 0, 7), 7);
+  assert.equal(readKittyKeyboardCsiParam([[8, 9]], 0, 7), 8);
+  assert.equal(readKittyKeyboardCsiParam([1], 1, 7), 7);
+});
+
+test("kitty keyboard CSI handlers negotiate mode and enable Shift+Enter encoding", () => {
+  const state = createKittyKeyboardModeState();
+  const fake = createFakeCsiParser();
+  const replies: string[] = [];
+  const disposable = installKittyKeyboardProtocolHandlers(
+    fake.parser,
+    state,
+    (payload) => replies.push(payload),
+  );
+
+  assert.equal(fake.dispatch({ prefix: "?", final: "u" }), true);
+  assert.deepEqual(replies, ["\u001b[?0u"]);
+
+  assert.equal(fake.dispatch({ prefix: "=", final: "u" }, [1]), true);
+  assert.equal(
+    encodeKittyControlKey(state, { key: "Enter", shiftKey: true }),
+    "\u001b[13;2u",
+  );
+  assert.equal(encodeKittyControlKey(state, { key: "Enter" }), null);
+
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?1u");
+
+  disposable.dispose();
+  assert.equal(fake.hasHandler({ prefix: "?", final: "u" }), false);
+  assert.equal(fake.hasHandler({ prefix: "=", final: "u" }), false);
+  assert.equal(fake.hasHandler({ prefix: ">", final: "u" }), false);
+  assert.equal(fake.hasHandler({ prefix: "<", final: "u" }), false);
+  assert.equal(fake.hasHandler({ prefix: "?", final: "h" }), false);
+  assert.equal(fake.hasHandler({ prefix: "?", final: "l" }), false);
+});
+
+test("kitty keyboard CSI handlers handle invalid modes and stack defaults", () => {
+  const state = createKittyKeyboardModeState();
+  const fake = createFakeCsiParser();
+  const replies: string[] = [];
+  installKittyKeyboardProtocolHandlers(fake.parser, state, (payload) => replies.push(payload));
+
+  fake.dispatch({ prefix: "=", final: "u" }, [8]);
+  fake.dispatch({ prefix: "=", final: "u" }, [1, 99]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?1u");
+
+  fake.dispatch({ prefix: "=", final: "u" }, [8, 2]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?9u");
+
+  fake.dispatch({ prefix: "=", final: "u" }, [8, 3]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?1u");
+
+  fake.dispatch({ prefix: ">", final: "u" }, [1 | 2 | 4 | 8 | 16]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?9u");
+
+  fake.dispatch({ prefix: "<", final: "u" }, [0]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?1u");
+});
+
+test("kitty keyboard CSI handlers keep main and alternate screen state separate", () => {
+  const state = createKittyKeyboardModeState();
+  const fake = createFakeCsiParser();
+  const replies: string[] = [];
+  installKittyKeyboardProtocolHandlers(fake.parser, state, (payload) => replies.push(payload));
+
+  fake.dispatch({ prefix: "=", final: "u" }, [1]);
+  assert.equal(fake.dispatch({ prefix: "?", final: "h" }, [[1049]]), false);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?0u");
+
+  fake.dispatch({ prefix: "=", final: "u" }, [8]);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?8u");
+
+  assert.equal(fake.dispatch({ prefix: "?", final: "l" }, [1049]), false);
+  fake.dispatch({ prefix: "?", final: "u" });
+  assert.equal(replies.at(-1), "\u001b[?1u");
 });
 
 test("kitty report-all mode enables the supported modified control key subset", () => {

--- a/components/terminal/runtime/kittyKeyboardProtocol.ts
+++ b/components/terminal/runtime/kittyKeyboardProtocol.ts
@@ -1,0 +1,165 @@
+export const KITTY_KEYBOARD_DISAMBIGUATE_ESC_CODES = 0b1;
+export const KITTY_KEYBOARD_REPORT_ALL_KEYS_AS_ESC_CODES = 0b1000;
+export const KITTY_SUPPORTED_KEYBOARD_FLAGS =
+  KITTY_KEYBOARD_DISAMBIGUATE_ESC_CODES |
+  KITTY_KEYBOARD_REPORT_ALL_KEYS_AS_ESC_CODES;
+
+const MAX_KEYBOARD_MODE_STACK_DEPTH = 32;
+
+export type KittyKeyboardModeState = {
+  mainFlags: number;
+  alternateFlags: number;
+  mainStack: number[];
+  alternateStack: number[];
+  alternateScreenActive: boolean;
+};
+
+export type KittyKeyboardModeApplyMode = 1 | 2 | 3;
+
+export type KittyKeyboardControlEvent = {
+  key: string;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+};
+
+const CONTROL_KEY_CODES: Record<string, number> = {
+  Escape: 27,
+  Tab: 9,
+  Enter: 13,
+  Backspace: 127,
+};
+
+const sanitizeFlags = (flags: number): number => {
+  return flags & KITTY_SUPPORTED_KEYBOARD_FLAGS;
+};
+
+const clampPositiveInteger = (value: number, fallback: number): number => {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+};
+
+export const createKittyKeyboardModeState = (): KittyKeyboardModeState => ({
+  mainFlags: 0,
+  alternateFlags: 0,
+  mainStack: [],
+  alternateStack: [],
+  alternateScreenActive: false,
+});
+
+export const getKittyKeyboardModeFlags = (state: KittyKeyboardModeState): number => {
+  return state.alternateScreenActive ? state.alternateFlags : state.mainFlags;
+};
+
+export const setKittyKeyboardAlternateScreenActive = (
+  state: KittyKeyboardModeState,
+  active: boolean,
+): void => {
+  state.alternateScreenActive = active;
+};
+
+export const setKittyKeyboardModeFlags = (
+  state: KittyKeyboardModeState,
+  flags: number,
+  mode: KittyKeyboardModeApplyMode = 1,
+): number => {
+  const sanitized = sanitizeFlags(flags);
+  const current = getKittyKeyboardModeFlags(state);
+
+  let next = current;
+  switch (mode) {
+    case 1:
+      next = sanitized;
+      break;
+    case 2:
+      next = current | sanitized;
+      break;
+    case 3:
+      next = current & ~sanitized;
+      break;
+  }
+
+  if (state.alternateScreenActive) {
+    state.alternateFlags = next;
+  } else {
+    state.mainFlags = next;
+  }
+
+  return next;
+};
+
+export const pushKittyKeyboardModeFlags = (
+  state: KittyKeyboardModeState,
+  flags = 0,
+): number => {
+  const stack = state.alternateScreenActive ? state.alternateStack : state.mainStack;
+  stack.push(getKittyKeyboardModeFlags(state));
+  if (stack.length > MAX_KEYBOARD_MODE_STACK_DEPTH) {
+    stack.shift();
+  }
+  return setKittyKeyboardModeFlags(state, flags, 1);
+};
+
+export const popKittyKeyboardModeFlags = (
+  state: KittyKeyboardModeState,
+  count = 1,
+): number => {
+  const stack = state.alternateScreenActive ? state.alternateStack : state.mainStack;
+  const total = clampPositiveInteger(count, 1);
+
+  let next = 0;
+  for (let i = 0; i < total; i += 1) {
+    next = stack.pop() ?? 0;
+  }
+
+  if (state.alternateScreenActive) {
+    state.alternateFlags = next;
+  } else {
+    state.mainFlags = next;
+  }
+
+  return next;
+};
+
+export const buildKittyKeyboardModeQueryResponse = (
+  state: KittyKeyboardModeState,
+): string => {
+  return `\u001b[?${getKittyKeyboardModeFlags(state)}u`;
+};
+
+const getKittyModifierBits = (event: KittyKeyboardControlEvent): number => {
+  let bits = 0;
+  if (event.shiftKey) bits |= 0b1;
+  if (event.altKey) bits |= 0b10;
+  if (event.ctrlKey) bits |= 0b100;
+  if (event.metaKey) bits |= 0b1000;
+  return bits;
+};
+
+export const encodeKittyControlKey = (
+  state: KittyKeyboardModeState,
+  event: KittyKeyboardControlEvent,
+): string | null => {
+  const activeFlags = getKittyKeyboardModeFlags(state);
+  const controlKeyEncodingFlags =
+    KITTY_KEYBOARD_DISAMBIGUATE_ESC_CODES |
+    KITTY_KEYBOARD_REPORT_ALL_KEYS_AS_ESC_CODES;
+
+  if ((activeFlags & controlKeyEncodingFlags) === 0) {
+    return null;
+  }
+
+  const keyCode = CONTROL_KEY_CODES[event.key];
+  if (!keyCode) return null;
+
+  const modifiers = getKittyModifierBits(event);
+
+  // Keep bare Enter/Tab/Backspace on legacy bytes so the terminal remains
+  // usable after a crashed app, but still allow modified forms like
+  // Shift+Enter for tool UIs that need a distinct key event.
+  if (event.key !== "Escape" && modifiers === 0) {
+    return null;
+  }
+
+  return `\u001b[${keyCode}${modifiers ? `;${modifiers + 1}` : ""}u`;
+};

--- a/components/terminal/runtime/kittyKeyboardRuntime.ts
+++ b/components/terminal/runtime/kittyKeyboardRuntime.ts
@@ -1,0 +1,116 @@
+import type { IDisposable } from "@xterm/xterm";
+
+import {
+  buildKittyKeyboardModeQueryResponse,
+  popKittyKeyboardModeFlags,
+  pushKittyKeyboardModeFlags,
+  setKittyKeyboardAlternateScreenActive,
+  setKittyKeyboardModeFlags,
+  type KittyKeyboardModeApplyMode,
+  type KittyKeyboardModeState,
+} from "./kittyKeyboardProtocol";
+
+export type KittyKeyboardCsiParams = readonly (number | number[])[];
+
+type CsiHandlerId = {
+  prefix?: string;
+  intermediates?: string;
+  final: string;
+};
+
+type KittyKeyboardParser = {
+  registerCsiHandler: (
+    id: CsiHandlerId,
+    callback: (params: KittyKeyboardCsiParams) => boolean,
+  ) => IDisposable;
+};
+
+export const readKittyKeyboardCsiParam = (
+  params: KittyKeyboardCsiParams,
+  index: number,
+  fallback: number,
+): number => {
+  const value = params[index];
+  if (Array.isArray(value)) return typeof value[0] === "number" ? value[0] : fallback;
+  return typeof value === "number" && value > 0 ? value : fallback;
+};
+
+const normalizeKittyKeyboardApplyMode = (mode: number): KittyKeyboardModeApplyMode => {
+  return mode === 2 || mode === 3 ? mode : 1;
+};
+
+const paramsIncludeAny = (
+  params: KittyKeyboardCsiParams,
+  targets: readonly number[],
+): boolean => {
+  return params.some((param) => (
+    Array.isArray(param)
+      ? param.some((value) => targets.includes(value))
+      : targets.includes(param)
+  ));
+};
+
+export const installKittyKeyboardProtocolHandlers = (
+  parser: KittyKeyboardParser,
+  state: KittyKeyboardModeState,
+  writeReply: (payload: string) => void,
+): IDisposable => {
+  const disposables = [
+    parser.registerCsiHandler(
+      { prefix: "?", final: "u" },
+      () => {
+        writeReply(buildKittyKeyboardModeQueryResponse(state));
+        return true;
+      },
+    ),
+    parser.registerCsiHandler(
+      { prefix: "=", final: "u" },
+      (params) => {
+        const flags = readKittyKeyboardCsiParam(params, 0, 0);
+        const mode = normalizeKittyKeyboardApplyMode(readKittyKeyboardCsiParam(params, 1, 1));
+        setKittyKeyboardModeFlags(state, flags, mode);
+        return true;
+      },
+    ),
+    parser.registerCsiHandler(
+      { prefix: ">", final: "u" },
+      (params) => {
+        pushKittyKeyboardModeFlags(state, readKittyKeyboardCsiParam(params, 0, 0));
+        return true;
+      },
+    ),
+    parser.registerCsiHandler(
+      { prefix: "<", final: "u" },
+      (params) => {
+        popKittyKeyboardModeFlags(state, readKittyKeyboardCsiParam(params, 0, 1));
+        return true;
+      },
+    ),
+    parser.registerCsiHandler(
+      { prefix: "?", final: "h" },
+      (params) => {
+        if (paramsIncludeAny(params, [47, 1047, 1049])) {
+          setKittyKeyboardAlternateScreenActive(state, true);
+        }
+        return false;
+      },
+    ),
+    parser.registerCsiHandler(
+      { prefix: "?", final: "l" },
+      (params) => {
+        if (paramsIncludeAny(params, [47, 1047, 1049])) {
+          setKittyKeyboardAlternateScreenActive(state, false);
+        }
+        return false;
+      },
+    ),
+  ];
+
+  return {
+    dispose: () => {
+      for (const disposable of disposables) {
+        disposable.dispose();
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Summary

This change implements a small, targeted subset of the [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) to preserve a distinct `Shift+Enter` key event in the terminal runtime.

It does **not** implement the full protocol. The goal here is narrower: enable the negotiation and control-key encoding needed for `Shift+Enter` and a few related keys, while leaving room to expand this into fuller kitty keyboard protocol support later.

## What changed

- add kitty keyboard mode state tracking for the main and alternate screen
- handle kitty keyboard mode query, set, push, and pop CSI sequences
- encode a limited subset of kitty-style control-key `CSI u` sequences when the mode is enabled
- keep bare Enter/Tab/Backspace on legacy bytes while allowing modified forms to be disambiguated
- add tests for keyboard mode state transitions and control-key encoding

## Scope

This PR implements part of the kitty keyboard protocol, specifically the pieces needed for:
- `Shift+Enter`
- modified `Tab`
- modified `Backspace`
- `Escape`

It is not intended to claim full kitty keyboard protocol support. Instead, it establishes the runtime state and parser hooks needed to build toward more complete support in follow-up work.

## Why

Some terminal-driven tools rely on `Shift+Enter` being distinguishable from a plain Enter press. Netcatty previously forwarded only the legacy control bytes, so modified Enter could not be represented separately.

Using a limited subset of the kitty keyboard protocol lets Netcatty support this behavior now, without changing the legacy behavior for plain Enter and similar keys, and gives us a clear base for implementing fuller protocol coverage later.

