### PR TITLE
Sync AI/UI settings and fix multi-display settings window placement

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -16,13 +16,20 @@ import {
   findSyncPayloadEncryptedCredentialPaths,
 } from '../../domain/credentials';
 import { isProviderReadyForSync, type CloudProvider, type SyncPayload } from '../../domain/sync';
-import { collectSyncableSettings, hasMeaningfulCloudSyncData } from '../syncPayload';
+import {
+  SYNCABLE_SETTING_STORAGE_KEYS,
+  collectSyncableSettings,
+  hasMeaningfulCloudSyncData,
+} from '../syncPayload';
 import { readInterruptedVaultApply } from '../localVaultBackups';
 import {
   STORAGE_KEY_PORT_FORWARDING,
   STORAGE_KEY_VAULT_RESTORE_IN_PROGRESS_UNTIL,
 } from '../../infrastructure/config/storageKeys';
-import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
+import {
+  LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+  localStorageAdapter,
+} from '../../infrastructure/persistence/localStorageAdapter';
 import { notify } from '../notification';
 
 interface AutoSyncConfig {
@@ -47,6 +54,7 @@ interface AutoSyncConfig {
 // Get manager singleton for direct state access
 const manager = getCloudSyncManager();
 const AUTO_SYNC_PROVIDER_ORDER: CloudProvider[] = ['github', 'google', 'onedrive', 'webdav', 's3'];
+const SYNCABLE_SETTING_STORAGE_KEY_SET = new Set<string>(SYNCABLE_SETTING_STORAGE_KEYS);
 
 // Cross-window restore barrier: stored as an epoch-ms deadline. Any value
 // in the future means a restore is applying in some window and auto-sync
@@ -122,6 +130,29 @@ export const useAutoSync = (config: AutoSyncConfig) => {
     const handler = () => setBookmarksVersion((v) => v + 1);
     window.addEventListener('sftp-bookmarks-changed', handler);
     return () => window.removeEventListener('sftp-bookmarks-changed', handler);
+  }, []);
+
+  const [syncableSettingsStorageVersion, setSyncableSettingsStorageVersion] = useState(0);
+  useEffect(() => {
+    const bumpIfSyncableSetting = (key: string | null | undefined) => {
+      if (!key || !SYNCABLE_SETTING_STORAGE_KEY_SET.has(key)) return;
+      setSyncableSettingsStorageVersion((v) => v + 1);
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      bumpIfSyncableSetting(event.key);
+    };
+    const handleLocalStorageAdapterChanged = (event: Event) => {
+      const key = (event as CustomEvent<{ key?: string }>).detail?.key;
+      bumpIfSyncableSetting(key);
+    };
+
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleLocalStorageAdapterChanged);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleLocalStorageAdapterChanged);
+    };
   }, []);
 
   const getSyncSnapshot = useCallback(() => {
@@ -639,7 +670,17 @@ export const useAutoSync = (config: AutoSyncConfig) => {
         clearTimeout(syncTimeoutRef.current);
       }
     };
-  }, [sync.hasAnyConnectedProvider, sync.autoSyncEnabled, sync.isUnlocked, sync.isSyncing, getDataHash, syncNow, config.settingsVersion, bookmarksVersion]);
+  }, [
+    sync.hasAnyConnectedProvider,
+    sync.autoSyncEnabled,
+    sync.isUnlocked,
+    sync.isSyncing,
+    getDataHash,
+    syncNow,
+    config.settingsVersion,
+    bookmarksVersion,
+    syncableSettingsStorageVersion,
+  ]);
   
   // Check remote version on startup/unlock, then retry with backoff
   // while the inspect keeps failing. Without the timer-based retry,

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -229,6 +229,151 @@ test("applySyncPayload restores AI configuration settings", async () => {
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!), webSearch);
 });
 
+test("applySyncPayload preserves local AI provider apiKeys when synced payload omits them", async () => {
+  const localProviders = [
+    {
+      id: "openai-main",
+      providerId: "openai",
+      name: "OpenAI",
+      apiKey: "enc:v1:djEwLOCAL",
+      enabled: true,
+    },
+    {
+      id: "anthropic-main",
+      providerId: "anthropic",
+      name: "Anthropic",
+      apiKey: "enc:v1:djEwANTHROPIC",
+      enabled: true,
+    },
+  ];
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify(localProviders));
+
+  // Synced payload mirrors what `collectSyncableSettings` produces on another device:
+  // metadata is preserved but encrypted device-bound apiKeys are stripped.
+  const syncedProviders = [
+    { id: "openai-main", providerId: "openai", name: "OpenAI (renamed)", enabled: true },
+    { id: "anthropic-main", providerId: "anthropic", name: "Anthropic", enabled: false },
+  ];
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: { ai: { providers: syncedProviders } },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const stored = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PROVIDERS)!);
+  assert.deepEqual(stored, [
+    {
+      id: "openai-main",
+      providerId: "openai",
+      name: "OpenAI (renamed)",
+      apiKey: "enc:v1:djEwLOCAL",
+      enabled: true,
+    },
+    {
+      id: "anthropic-main",
+      providerId: "anthropic",
+      name: "Anthropic",
+      apiKey: "enc:v1:djEwANTHROPIC",
+      enabled: false,
+    },
+  ]);
+});
+
+test("applySyncPayload prefers explicit synced apiKey over local apiKey", async () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify([
+    { id: "openai-main", providerId: "openai", name: "OpenAI", apiKey: "enc:v1:djEwLOCAL", enabled: true },
+  ]));
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        providers: [
+          { id: "openai-main", providerId: "openai", name: "OpenAI", apiKey: "plaintext-from-other-device", enabled: true },
+        ],
+      },
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const stored = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PROVIDERS)!);
+  assert.equal(stored[0].apiKey, "plaintext-from-other-device");
+});
+
+test("applySyncPayload preserves local web-search apiKey when synced config omits it", async () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify({
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwWEB",
+    enabled: true,
+    maxResults: 7,
+  }));
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        webSearchConfig: { providerId: "tavily", enabled: false, maxResults: 12 },
+      },
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const stored = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!);
+  assert.deepEqual(stored, {
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwWEB",
+    enabled: false,
+    maxResults: 12,
+  });
+});
+
+test("applySyncPayload drops local web-search apiKey when synced config switches provider", async () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify({
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwWEB",
+    enabled: true,
+  }));
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        webSearchConfig: { providerId: "exa", enabled: true },
+      },
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const stored = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!);
+  assert.equal("apiKey" in stored, false);
+  assert.equal(stored.providerId, "exa");
+});
+
 test("buildSyncPayload includes syncable terminal options from settings", () => {
   localStorage.setItem(storageKeys.STORAGE_KEY_TERM_FOLLOW_APP_THEME, "true");
   localStorage.setItem(storageKeys.STORAGE_KEY_TERM_SETTINGS, JSON.stringify({

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -103,13 +103,6 @@ test("buildSyncPayload includes AI configuration settings", () => {
     defaultModel: "gpt-test",
     enabled: true,
   }];
-  const externalAgents = [{
-    id: "codex",
-    name: "Codex",
-    command: "codex",
-    enabled: true,
-    acpCommand: "codex-acp",
-  }];
   const webSearch = {
     providerId: "tavily",
     apiKey: "enc:v1:web",
@@ -122,7 +115,6 @@ test("buildSyncPayload includes AI configuration settings", () => {
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_ACTIVE_MODEL, "gpt-test");
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_PERMISSION_MODE, "autonomous");
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_TOOL_INTEGRATION_MODE, "skills");
-  localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS, JSON.stringify(externalAgents));
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_DEFAULT_AGENT, "codex");
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_COMMAND_BLOCKLIST, JSON.stringify(["rm -rf"]));
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_COMMAND_TIMEOUT, "120");
@@ -138,7 +130,6 @@ test("buildSyncPayload includes AI configuration settings", () => {
     activeModelId: "gpt-test",
     globalPermissionMode: "autonomous",
     toolIntegrationMode: "skills",
-    externalAgents,
     defaultAgentId: "codex",
     commandBlocklist: ["rm -rf"],
     commandTimeout: 120,
@@ -146,6 +137,16 @@ test("buildSyncPayload includes AI configuration settings", () => {
     agentModelMap: { codex: "gpt-test" },
     webSearchConfig: webSearch,
   });
+});
+
+test("buildSyncPayload excludes externalAgents (device-local OS-bound config)", () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS, JSON.stringify([
+    { id: "codex", name: "Codex", command: "/opt/homebrew/bin/codex", enabled: true },
+  ]));
+
+  const payload = buildSyncPayload(vault([]));
+
+  assert.equal("ai" in (payload.settings ?? {}), false);
 });
 
 test("buildSyncPayload omits device-bound encrypted AI API keys", () => {
@@ -176,12 +177,6 @@ test("applySyncPayload restores AI configuration settings", async () => {
     apiKey: "enc:v1:test",
     enabled: true,
   }];
-  const externalAgents = [{
-    id: "claude",
-    name: "Claude",
-    command: "claude",
-    enabled: true,
-  }];
   const webSearch = {
     providerId: "exa",
     apiKey: "enc:v1:web",
@@ -201,7 +196,6 @@ test("applySyncPayload restores AI configuration settings", async () => {
         activeModelId: "claude-test",
         globalPermissionMode: "observer",
         toolIntegrationMode: "mcp",
-        externalAgents,
         defaultAgentId: "claude",
         commandBlocklist: ["shutdown"],
         commandTimeout: 30,
@@ -220,13 +214,43 @@ test("applySyncPayload restores AI configuration settings", async () => {
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_ACTIVE_MODEL), "claude-test");
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PERMISSION_MODE), "observer");
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_TOOL_INTEGRATION_MODE), "mcp");
-  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS)!), externalAgents);
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_DEFAULT_AGENT), "claude");
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_COMMAND_BLOCKLIST)!), ["shutdown"]);
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_COMMAND_TIMEOUT), "30");
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_MAX_ITERATIONS), "5");
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_AGENT_MODEL_MAP)!), { claude: "claude-test" });
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!), webSearch);
+});
+
+test("applySyncPayload preserves local externalAgents and ignores legacy payload field", async () => {
+  const localAgents = [
+    { id: "codex", name: "Codex", command: "/usr/local/bin/codex", enabled: true },
+  ];
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS, JSON.stringify(localAgents));
+
+  const payload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        // Legacy snapshot still carries externalAgents; current code must ignore it.
+        externalAgents: [
+          { id: "claude", name: "Claude", command: "C:\\Tools\\claude.exe", enabled: true },
+        ],
+      },
+    },
+    syncedAt: 1,
+  } as unknown as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  assert.deepEqual(
+    JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS)!),
+    localAgents,
+  );
 });
 
 test("applySyncPayload preserves local AI provider apiKeys when synced payload omits them", async () => {

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -43,6 +43,7 @@ const {
   buildSyncPayload,
   hasMeaningfulCloudSyncData,
 } = await import("./syncPayload.ts");
+const storageKeys = await import("../infrastructure/config/storageKeys.ts");
 
 const knownHost = (id = "kh-1"): KnownHost => ({
   id,
@@ -91,6 +92,164 @@ test("buildSyncPayload includes reusable proxy profiles", () => {
   } as SyncableVaultData & { proxyProfiles: typeof proxyProfiles });
 
   assert.deepEqual(payload.proxyProfiles, proxyProfiles);
+});
+
+test("buildSyncPayload includes AI configuration settings", () => {
+  const providers = [{
+    id: "openai-main",
+    providerId: "openai",
+    name: "OpenAI",
+    apiKey: "enc:v1:test",
+    defaultModel: "gpt-test",
+    enabled: true,
+  }];
+  const externalAgents = [{
+    id: "codex",
+    name: "Codex",
+    command: "codex",
+    enabled: true,
+    acpCommand: "codex-acp",
+  }];
+  const webSearch = {
+    providerId: "tavily",
+    apiKey: "enc:v1:web",
+    enabled: true,
+    maxResults: 7,
+  };
+
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify(providers));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_ACTIVE_PROVIDER, "openai-main");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_ACTIVE_MODEL, "gpt-test");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PERMISSION_MODE, "autonomous");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_TOOL_INTEGRATION_MODE, "skills");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS, JSON.stringify(externalAgents));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_DEFAULT_AGENT, "codex");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_COMMAND_BLOCKLIST, JSON.stringify(["rm -rf"]));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_COMMAND_TIMEOUT, "120");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_MAX_ITERATIONS, "10");
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_AGENT_MODEL_MAP, JSON.stringify({ codex: "gpt-test" }));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify(webSearch));
+
+  const payload = buildSyncPayload(vault([]));
+
+  assert.deepEqual(payload.settings?.ai, {
+    providers,
+    activeProviderId: "openai-main",
+    activeModelId: "gpt-test",
+    globalPermissionMode: "autonomous",
+    toolIntegrationMode: "skills",
+    externalAgents,
+    defaultAgentId: "codex",
+    commandBlocklist: ["rm -rf"],
+    commandTimeout: 120,
+    maxIterations: 10,
+    agentModelMap: { codex: "gpt-test" },
+    webSearchConfig: webSearch,
+  });
+});
+
+test("buildSyncPayload omits device-bound encrypted AI API keys", () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify([{
+    id: "openai-main",
+    providerId: "openai",
+    name: "OpenAI",
+    apiKey: "enc:v1:djEwAAAA",
+    enabled: true,
+  }]));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify({
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwAAAA",
+    enabled: true,
+  }));
+
+  const payload = buildSyncPayload(vault([]));
+
+  assert.equal("apiKey" in (payload.settings?.ai?.providers?.[0] ?? {}), false);
+  assert.equal("apiKey" in (payload.settings?.ai?.webSearchConfig ?? {}), false);
+});
+
+test("applySyncPayload restores AI configuration settings", async () => {
+  const providers = [{
+    id: "anthropic-main",
+    providerId: "anthropic",
+    name: "Anthropic",
+    apiKey: "enc:v1:test",
+    enabled: true,
+  }];
+  const externalAgents = [{
+    id: "claude",
+    name: "Claude",
+    command: "claude",
+    enabled: true,
+  }];
+  const webSearch = {
+    providerId: "exa",
+    apiKey: "enc:v1:web",
+    enabled: true,
+  };
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        providers,
+        activeProviderId: "anthropic-main",
+        activeModelId: "claude-test",
+        globalPermissionMode: "observer",
+        toolIntegrationMode: "mcp",
+        externalAgents,
+        defaultAgentId: "claude",
+        commandBlocklist: ["shutdown"],
+        commandTimeout: 30,
+        maxIterations: 5,
+        agentModelMap: { claude: "claude-test" },
+        webSearchConfig: webSearch,
+      },
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PROVIDERS)!), providers);
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_ACTIVE_PROVIDER), "anthropic-main");
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_ACTIVE_MODEL), "claude-test");
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PERMISSION_MODE), "observer");
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_TOOL_INTEGRATION_MODE), "mcp");
+  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS)!), externalAgents);
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_DEFAULT_AGENT), "claude");
+  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_COMMAND_BLOCKLIST)!), ["shutdown"]);
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_COMMAND_TIMEOUT), "30");
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_MAX_ITERATIONS), "5");
+  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_AGENT_MODEL_MAP)!), { claude: "claude-test" });
+  assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!), webSearch);
+});
+
+test("buildSyncPayload includes syncable terminal options from settings", () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_TERM_FOLLOW_APP_THEME, "true");
+  localStorage.setItem(storageKeys.STORAGE_KEY_TERM_SETTINGS, JSON.stringify({
+    terminalEmulationType: "vt100",
+    altAsMeta: true,
+    showServerStats: false,
+    serverStatsRefreshInterval: 12,
+    rendererType: "dom",
+    localShell: "/bin/zsh",
+  }));
+
+  const payload = buildSyncPayload(vault([]));
+
+  assert.equal(payload.settings?.followAppTerminalTheme, true);
+  assert.deepEqual(payload.settings?.terminalSettings, {
+    terminalEmulationType: "vt100",
+    altAsMeta: true,
+    showServerStats: false,
+    serverStatsRefreshInterval: 12,
+    rendererType: "dom",
+  });
 });
 
 test("hasMeaningfulCloudSyncData ignores legacy cloud known hosts", () => {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -231,6 +231,47 @@ const stripDeviceBoundApiKey = <T extends Record<string, unknown>>(value: T): T 
 };
 
 /**
+ * `collectSyncableSettings` strips device-bound encrypted apiKeys before upload,
+ * so an incoming providers array typically has no apiKey for providers that
+ * already exist locally. Re-attach the local apiKey by id; without this merge,
+ * applying any synced settings change would silently wipe credentials on the
+ * receiving device.
+ */
+const mergeAiProvidersPreservingLocalApiKeys = (
+  incoming: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> => {
+  const local = readArraySetting(STORAGE_KEY_AI_PROVIDERS) ?? [];
+  const localById = new Map<string, Record<string, unknown>>();
+  for (const provider of local) {
+    if (typeof provider?.id === 'string') localById.set(provider.id, provider);
+  }
+  return incoming.map((provider) => {
+    if (provider.apiKey != null) return provider;
+    const id = typeof provider.id === 'string' ? provider.id : undefined;
+    const localProvider = id != null ? localById.get(id) : undefined;
+    if (localProvider && typeof localProvider.apiKey === 'string') {
+      return { ...provider, apiKey: localProvider.apiKey };
+    }
+    return provider;
+  });
+};
+
+/**
+ * Same rationale as `mergeAiProvidersPreservingLocalApiKeys`. Only restores the
+ * local apiKey when the incoming config still points at the same providerId —
+ * switching providers must not silently leak a key meant for a different one.
+ */
+const mergeWebSearchConfigPreservingLocalApiKey = (
+  incoming: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (incoming.apiKey != null) return incoming;
+  const local = readRecordSetting(STORAGE_KEY_AI_WEB_SEARCH);
+  if (!local || typeof local.apiKey !== 'string') return incoming;
+  if (local.providerId !== incoming.providerId) return incoming;
+  return { ...incoming, apiKey: local.apiKey };
+};
+
+/**
  * Collect all syncable settings from localStorage.
  */
 export function collectSyncableSettings(): SyncPayload['settings'] {
@@ -457,7 +498,12 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
 
   const ai = settings.ai;
   if (ai) {
-    if (ai.providers != null) localStorageAdapter.write(STORAGE_KEY_AI_PROVIDERS, ai.providers);
+    if (ai.providers != null) {
+      localStorageAdapter.write(
+        STORAGE_KEY_AI_PROVIDERS,
+        mergeAiProvidersPreservingLocalApiKeys(ai.providers),
+      );
+    }
     if (ai.activeProviderId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_ACTIVE_PROVIDER, ai.activeProviderId);
     if (ai.activeModelId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_ACTIVE_MODEL, ai.activeModelId);
     if (ai.globalPermissionMode != null) localStorageAdapter.writeString(STORAGE_KEY_AI_PERMISSION_MODE, ai.globalPermissionMode);
@@ -473,7 +519,10 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
       if (ai.webSearchConfig === null) {
         localStorageAdapter.remove(STORAGE_KEY_AI_WEB_SEARCH);
       } else {
-        localStorageAdapter.write(STORAGE_KEY_AI_WEB_SEARCH, ai.webSearchConfig);
+        localStorageAdapter.write(
+          STORAGE_KEY_AI_WEB_SEARCH,
+          mergeWebSearchConfigPreservingLocalApiKey(ai.webSearchConfig),
+        );
       }
     }
   }

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -61,7 +61,6 @@ import {
   STORAGE_KEY_AI_PERMISSION_MODE,
   STORAGE_KEY_AI_TOOL_INTEGRATION_MODE,
   STORAGE_KEY_AI_HOST_PERMISSIONS,
-  STORAGE_KEY_AI_EXTERNAL_AGENTS,
   STORAGE_KEY_AI_DEFAULT_AGENT,
   STORAGE_KEY_AI_COMMAND_BLOCKLIST,
   STORAGE_KEY_AI_COMMAND_TIMEOUT,
@@ -201,7 +200,6 @@ export const SYNCABLE_SETTING_STORAGE_KEYS = [
   STORAGE_KEY_AI_PERMISSION_MODE,
   STORAGE_KEY_AI_TOOL_INTEGRATION_MODE,
   STORAGE_KEY_AI_HOST_PERMISSIONS,
-  STORAGE_KEY_AI_EXTERNAL_AGENTS,
   STORAGE_KEY_AI_DEFAULT_AGENT,
   STORAGE_KEY_AI_COMMAND_BLOCKLIST,
   STORAGE_KEY_AI_COMMAND_TIMEOUT,
@@ -387,8 +385,7 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   }
   const hostPermissions = readArraySetting(STORAGE_KEY_AI_HOST_PERMISSIONS);
   if (hostPermissions) ai.hostPermissions = hostPermissions;
-  const externalAgents = readArraySetting(STORAGE_KEY_AI_EXTERNAL_AGENTS);
-  if (externalAgents) ai.externalAgents = externalAgents;
+  // externalAgents intentionally not collected: command/args/env are device-local.
   const defaultAgentId = localStorageAdapter.readString(STORAGE_KEY_AI_DEFAULT_AGENT);
   if (defaultAgentId != null) ai.defaultAgentId = defaultAgentId;
   const commandBlocklist = localStorageAdapter.read<string[]>(STORAGE_KEY_AI_COMMAND_BLOCKLIST);
@@ -509,7 +506,8 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
     if (ai.globalPermissionMode != null) localStorageAdapter.writeString(STORAGE_KEY_AI_PERMISSION_MODE, ai.globalPermissionMode);
     if (ai.toolIntegrationMode != null) localStorageAdapter.writeString(STORAGE_KEY_AI_TOOL_INTEGRATION_MODE, ai.toolIntegrationMode);
     if (ai.hostPermissions != null) localStorageAdapter.write(STORAGE_KEY_AI_HOST_PERMISSIONS, ai.hostPermissions);
-    if (ai.externalAgents != null) localStorageAdapter.write(STORAGE_KEY_AI_EXTERNAL_AGENTS, ai.externalAgents);
+    // externalAgents intentionally not applied: device-local. Legacy snapshots
+    // that still carry an `externalAgents` field are silently ignored.
     if (ai.defaultAgentId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_DEFAULT_AGENT, ai.defaultAgentId);
     if (ai.commandBlocklist != null) localStorageAdapter.write(STORAGE_KEY_AI_COMMAND_BLOCKLIST, ai.commandBlocklist);
     if (ai.commandTimeout != null) localStorageAdapter.writeNumber(STORAGE_KEY_AI_COMMAND_TIMEOUT, ai.commandTimeout);

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -24,6 +24,7 @@ import {
   parseCustomKeyBindingsStorageRecord,
   serializeCustomKeyBindingsStorageRecord,
 } from '../domain/customKeyBindings';
+import { isEncryptedCredentialPlaceholder } from '../domain/credentials';
 import { localStorageAdapter } from '../infrastructure/persistence/localStorageAdapter';
 import { rehydrateGlobalBookmarks } from '../components/sftp/hooks/useGlobalSftpBookmarks';
 import {
@@ -36,6 +37,7 @@ import {
   STORAGE_KEY_UI_LANGUAGE,
   STORAGE_KEY_CUSTOM_CSS,
   STORAGE_KEY_TERM_THEME,
+  STORAGE_KEY_TERM_FOLLOW_APP_THEME,
   STORAGE_KEY_TERM_FONT_FAMILY,
   STORAGE_KEY_TERM_FONT_SIZE,
   STORAGE_KEY_TERM_SETTINGS,
@@ -46,11 +48,26 @@ import {
   STORAGE_KEY_SFTP_SHOW_HIDDEN_FILES,
   STORAGE_KEY_SFTP_USE_COMPRESSED_UPLOAD,
   STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR,
+  STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE,
   STORAGE_KEY_SFTP_GLOBAL_BOOKMARKS,
   STORAGE_KEY_CUSTOM_THEMES,
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
+  STORAGE_KEY_AI_PROVIDERS,
+  STORAGE_KEY_AI_ACTIVE_PROVIDER,
+  STORAGE_KEY_AI_ACTIVE_MODEL,
+  STORAGE_KEY_AI_PERMISSION_MODE,
+  STORAGE_KEY_AI_TOOL_INTEGRATION_MODE,
+  STORAGE_KEY_AI_HOST_PERMISSIONS,
+  STORAGE_KEY_AI_EXTERNAL_AGENTS,
+  STORAGE_KEY_AI_DEFAULT_AGENT,
+  STORAGE_KEY_AI_COMMAND_BLOCKLIST,
+  STORAGE_KEY_AI_COMMAND_TIMEOUT,
+  STORAGE_KEY_AI_MAX_ITERATIONS,
+  STORAGE_KEY_AI_AGENT_MODEL_MAP,
+  STORAGE_KEY_AI_WEB_SEARCH,
 } from '../infrastructure/config/storageKeys';
 
 // ---------------------------------------------------------------------------
@@ -136,17 +153,82 @@ interface SyncPayloadImporters {
 
 /** Terminal settings keys that are safe to sync (platform-agnostic). */
 const SYNCABLE_TERMINAL_KEYS = [
-  'scrollback', 'drawBoldInBrightColors', 'fontLigatures', 'fontWeight', 'fontWeightBold',
+  'scrollback', 'drawBoldInBrightColors', 'terminalEmulationType',
+  'fontLigatures', 'fontWeight', 'fontWeightBold', 'fallbackFont',
   'linePadding', 'cursorShape', 'cursorBlink', 'minimumContrastRatio',
-  'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
+  'altAsMeta', 'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
   'smoothScrolling',
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'disableBracketedPaste', 'clearWipesScrollback',
-  'preserveSelectionOnInput', 'osc52Clipboard',
+  'preserveSelectionOnInput', 'osc52Clipboard', 'showServerStats',
+  'serverStatsRefreshInterval', 'rendererType',
   'autocompleteEnabled', 'autocompleteGhostText', 'autocompletePopupMenu',
   'autocompleteDebounceMs', 'autocompleteMinChars', 'autocompleteMaxSuggestions',
 ] as const;
+
+export const SYNCABLE_SETTING_STORAGE_KEYS = [
+  STORAGE_KEY_THEME,
+  STORAGE_KEY_UI_THEME_LIGHT,
+  STORAGE_KEY_UI_THEME_DARK,
+  STORAGE_KEY_ACCENT_MODE,
+  STORAGE_KEY_COLOR,
+  STORAGE_KEY_UI_FONT_FAMILY,
+  STORAGE_KEY_UI_LANGUAGE,
+  STORAGE_KEY_CUSTOM_CSS,
+  STORAGE_KEY_TERM_THEME,
+  STORAGE_KEY_TERM_FOLLOW_APP_THEME,
+  STORAGE_KEY_TERM_FONT_FAMILY,
+  STORAGE_KEY_TERM_FONT_SIZE,
+  STORAGE_KEY_TERM_SETTINGS,
+  STORAGE_KEY_CUSTOM_THEMES,
+  STORAGE_KEY_CUSTOM_KEY_BINDINGS,
+  STORAGE_KEY_EDITOR_WORD_WRAP,
+  STORAGE_KEY_SFTP_DOUBLE_CLICK_BEHAVIOR,
+  STORAGE_KEY_SFTP_AUTO_SYNC,
+  STORAGE_KEY_SFTP_SHOW_HIDDEN_FILES,
+  STORAGE_KEY_SFTP_USE_COMPRESSED_UPLOAD,
+  STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR,
+  STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE,
+  STORAGE_KEY_SFTP_GLOBAL_BOOKMARKS,
+  STORAGE_KEY_SHOW_RECENT_HOSTS,
+  STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
+  STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
+  STORAGE_KEY_AI_PROVIDERS,
+  STORAGE_KEY_AI_ACTIVE_PROVIDER,
+  STORAGE_KEY_AI_ACTIVE_MODEL,
+  STORAGE_KEY_AI_PERMISSION_MODE,
+  STORAGE_KEY_AI_TOOL_INTEGRATION_MODE,
+  STORAGE_KEY_AI_HOST_PERMISSIONS,
+  STORAGE_KEY_AI_EXTERNAL_AGENTS,
+  STORAGE_KEY_AI_DEFAULT_AGENT,
+  STORAGE_KEY_AI_COMMAND_BLOCKLIST,
+  STORAGE_KEY_AI_COMMAND_TIMEOUT,
+  STORAGE_KEY_AI_MAX_ITERATIONS,
+  STORAGE_KEY_AI_AGENT_MODEL_MAP,
+  STORAGE_KEY_AI_WEB_SEARCH,
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const readArraySetting = <T = Record<string, unknown>>(key: string): T[] | null => {
+  const value = localStorageAdapter.read<T[]>(key);
+  return Array.isArray(value) ? value : null;
+};
+
+const readRecordSetting = <T extends Record<string, unknown> = Record<string, unknown>>(key: string): T | null => {
+  const value = localStorageAdapter.read<T>(key);
+  return isRecord(value) ? value as T : null;
+};
+
+const stripDeviceBoundApiKey = <T extends Record<string, unknown>>(value: T): T => {
+  if (!isEncryptedCredentialPlaceholder(value.apiKey as string | undefined)) return value;
+  const next = { ...value };
+  delete next.apiKey;
+  return next;
+};
 
 /**
  * Collect all syncable settings from localStorage.
@@ -175,6 +257,10 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   // Terminal
   const termTheme = localStorageAdapter.readString(STORAGE_KEY_TERM_THEME);
   if (termTheme) settings.terminalTheme = termTheme;
+  const followAppTermTheme = localStorageAdapter.readString(STORAGE_KEY_TERM_FOLLOW_APP_THEME);
+  if (followAppTermTheme === 'true' || followAppTermTheme === 'false') {
+    settings.followAppTerminalTheme = followAppTermTheme === 'true';
+  }
   const termFont = localStorageAdapter.readString(STORAGE_KEY_TERM_FONT_FAMILY);
   if (termFont) settings.terminalFontFamily = termFont;
   const termSize = localStorageAdapter.readNumber(STORAGE_KEY_TERM_FONT_SIZE);
@@ -224,6 +310,8 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   if (compress === 'true' || compress === 'false') settings.sftpUseCompressedUpload = compress === 'true';
   const autoOpenSidebar = localStorageAdapter.readString(STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR);
   if (autoOpenSidebar === 'true' || autoOpenSidebar === 'false') settings.sftpAutoOpenSidebar = autoOpenSidebar === 'true';
+  const defaultViewMode = localStorageAdapter.readString(STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE);
+  if (defaultViewMode === 'list' || defaultViewMode === 'tree') settings.sftpDefaultViewMode = defaultViewMode;
 
   // SFTP Bookmarks (global only — local bookmarks are device-specific)
   const globalBookmarks = localStorageAdapter.read<SftpBookmark[]>(STORAGE_KEY_SFTP_GLOBAL_BOOKMARKS);
@@ -236,6 +324,43 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   if (showOnlyUngroupedHostsInRoot != null) settings.showOnlyUngroupedHostsInRoot = showOnlyUngroupedHostsInRoot;
   const showSftpTab = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_SFTP_TAB);
   if (showSftpTab != null) settings.showSftpTab = showSftpTab;
+  const workspaceFocusStyle = localStorageAdapter.readString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE);
+  if (workspaceFocusStyle === 'dim' || workspaceFocusStyle === 'border') {
+    settings.workspaceFocusStyle = workspaceFocusStyle;
+  }
+
+  const ai: NonNullable<SyncPayload['settings']>['ai'] = {};
+  const providers = readArraySetting(STORAGE_KEY_AI_PROVIDERS);
+  if (providers) ai.providers = providers.map(stripDeviceBoundApiKey);
+  const activeProviderId = localStorageAdapter.readString(STORAGE_KEY_AI_ACTIVE_PROVIDER);
+  if (activeProviderId != null) ai.activeProviderId = activeProviderId;
+  const activeModelId = localStorageAdapter.readString(STORAGE_KEY_AI_ACTIVE_MODEL);
+  if (activeModelId != null) ai.activeModelId = activeModelId;
+  const permissionMode = localStorageAdapter.readString(STORAGE_KEY_AI_PERMISSION_MODE);
+  if (permissionMode === 'observer' || permissionMode === 'confirm' || permissionMode === 'autonomous') {
+    ai.globalPermissionMode = permissionMode;
+  }
+  const toolIntegrationMode = localStorageAdapter.readString(STORAGE_KEY_AI_TOOL_INTEGRATION_MODE);
+  if (toolIntegrationMode === 'mcp' || toolIntegrationMode === 'skills') {
+    ai.toolIntegrationMode = toolIntegrationMode;
+  }
+  const hostPermissions = readArraySetting(STORAGE_KEY_AI_HOST_PERMISSIONS);
+  if (hostPermissions) ai.hostPermissions = hostPermissions;
+  const externalAgents = readArraySetting(STORAGE_KEY_AI_EXTERNAL_AGENTS);
+  if (externalAgents) ai.externalAgents = externalAgents;
+  const defaultAgentId = localStorageAdapter.readString(STORAGE_KEY_AI_DEFAULT_AGENT);
+  if (defaultAgentId != null) ai.defaultAgentId = defaultAgentId;
+  const commandBlocklist = localStorageAdapter.read<string[]>(STORAGE_KEY_AI_COMMAND_BLOCKLIST);
+  if (Array.isArray(commandBlocklist)) ai.commandBlocklist = commandBlocklist;
+  const commandTimeout = localStorageAdapter.readNumber(STORAGE_KEY_AI_COMMAND_TIMEOUT);
+  if (commandTimeout != null && Number.isFinite(commandTimeout)) ai.commandTimeout = commandTimeout;
+  const maxIterations = localStorageAdapter.readNumber(STORAGE_KEY_AI_MAX_ITERATIONS);
+  if (maxIterations != null && Number.isFinite(maxIterations)) ai.maxIterations = maxIterations;
+  const agentModelMap = readRecordSetting<Record<string, string>>(STORAGE_KEY_AI_AGENT_MODEL_MAP);
+  if (agentModelMap) ai.agentModelMap = agentModelMap;
+  const webSearchConfig = readRecordSetting(STORAGE_KEY_AI_WEB_SEARCH);
+  if (webSearchConfig) ai.webSearchConfig = stripDeviceBoundApiKey(webSearchConfig);
+  if (Object.keys(ai).length > 0) settings.ai = ai;
 
   return Object.keys(settings).length > 0 ? settings : undefined;
 }
@@ -257,6 +382,9 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
 
   // Terminal
   if (settings.terminalTheme != null) localStorageAdapter.writeString(STORAGE_KEY_TERM_THEME, settings.terminalTheme);
+  if (settings.followAppTerminalTheme != null) {
+    localStorageAdapter.writeString(STORAGE_KEY_TERM_FOLLOW_APP_THEME, String(settings.followAppTerminalTheme));
+  }
   if (settings.terminalFontFamily != null) localStorageAdapter.writeString(STORAGE_KEY_TERM_FONT_FAMILY, settings.terminalFontFamily);
   if (settings.terminalFontSize != null) localStorageAdapter.writeString(STORAGE_KEY_TERM_FONT_SIZE, String(settings.terminalFontSize));
 
@@ -305,6 +433,9 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
   if (settings.sftpShowHiddenFiles != null) localStorageAdapter.writeString(STORAGE_KEY_SFTP_SHOW_HIDDEN_FILES, String(settings.sftpShowHiddenFiles));
   if (settings.sftpUseCompressedUpload != null) localStorageAdapter.writeString(STORAGE_KEY_SFTP_USE_COMPRESSED_UPLOAD, String(settings.sftpUseCompressedUpload));
   if (settings.sftpAutoOpenSidebar != null) localStorageAdapter.writeString(STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR, String(settings.sftpAutoOpenSidebar));
+  if (settings.sftpDefaultViewMode != null) {
+    localStorageAdapter.writeString(STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE, settings.sftpDefaultViewMode);
+  }
 
   // SFTP Bookmarks (global only)
   if (settings.sftpGlobalBookmarks != null) localStorageAdapter.write(STORAGE_KEY_SFTP_GLOBAL_BOOKMARKS, settings.sftpGlobalBookmarks);
@@ -319,6 +450,32 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
   }
   if (settings.showSftpTab != null) {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_SFTP_TAB, settings.showSftpTab);
+  }
+  if (settings.workspaceFocusStyle != null) {
+    localStorageAdapter.writeString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE, settings.workspaceFocusStyle);
+  }
+
+  const ai = settings.ai;
+  if (ai) {
+    if (ai.providers != null) localStorageAdapter.write(STORAGE_KEY_AI_PROVIDERS, ai.providers);
+    if (ai.activeProviderId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_ACTIVE_PROVIDER, ai.activeProviderId);
+    if (ai.activeModelId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_ACTIVE_MODEL, ai.activeModelId);
+    if (ai.globalPermissionMode != null) localStorageAdapter.writeString(STORAGE_KEY_AI_PERMISSION_MODE, ai.globalPermissionMode);
+    if (ai.toolIntegrationMode != null) localStorageAdapter.writeString(STORAGE_KEY_AI_TOOL_INTEGRATION_MODE, ai.toolIntegrationMode);
+    if (ai.hostPermissions != null) localStorageAdapter.write(STORAGE_KEY_AI_HOST_PERMISSIONS, ai.hostPermissions);
+    if (ai.externalAgents != null) localStorageAdapter.write(STORAGE_KEY_AI_EXTERNAL_AGENTS, ai.externalAgents);
+    if (ai.defaultAgentId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_DEFAULT_AGENT, ai.defaultAgentId);
+    if (ai.commandBlocklist != null) localStorageAdapter.write(STORAGE_KEY_AI_COMMAND_BLOCKLIST, ai.commandBlocklist);
+    if (ai.commandTimeout != null) localStorageAdapter.writeNumber(STORAGE_KEY_AI_COMMAND_TIMEOUT, ai.commandTimeout);
+    if (ai.maxIterations != null) localStorageAdapter.writeNumber(STORAGE_KEY_AI_MAX_ITERATIONS, ai.maxIterations);
+    if (ai.agentModelMap != null) localStorageAdapter.write(STORAGE_KEY_AI_AGENT_MODEL_MAP, ai.agentModelMap);
+    if (ai.webSearchConfig !== undefined) {
+      if (ai.webSearchConfig === null) {
+        localStorageAdapter.remove(STORAGE_KEY_AI_WEB_SEARCH);
+      } else {
+        localStorageAdapter.write(STORAGE_KEY_AI_WEB_SEARCH, ai.webSearchConfig);
+      }
+    }
   }
 }
 

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -226,7 +226,8 @@ export interface SyncPayload {
       globalPermissionMode?: 'observer' | 'confirm' | 'autonomous';
       toolIntegrationMode?: 'mcp' | 'skills';
       hostPermissions?: Array<Record<string, unknown>>;
-      externalAgents?: Array<Record<string, unknown>>;
+      // externalAgents intentionally omitted: command/args/env are device-local
+      // (binary paths, OS-specific values) and don't survive cross-device sync.
       defaultAgentId?: string;
       commandBlocklist?: string[];
       commandTimeout?: number;

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -191,6 +191,7 @@ export interface SyncPayload {
     customCSS?: string;
     // Terminal
     terminalTheme?: string;
+    followAppTerminalTheme?: boolean;
     terminalFontFamily?: string;
     terminalFontSize?: number;
     terminalSettings?: Record<string, unknown>;
@@ -205,6 +206,7 @@ export interface SyncPayload {
     sftpShowHiddenFiles?: boolean;
     sftpUseCompressedUpload?: boolean;
     sftpAutoOpenSidebar?: boolean;
+    sftpDefaultViewMode?: 'list' | 'tree';
     sftpGlobalBookmarks?: import('./models').SftpBookmark[];
     // Immersive mode
     immersiveMode?: boolean;
@@ -214,6 +216,24 @@ export interface SyncPayload {
     showOnlyUngroupedHostsInRoot?: boolean;
     // Top tabs: show standalone SFTP view tab
     showSftpTab?: boolean;
+    // Workspace focus indicator style
+    workspaceFocusStyle?: 'dim' | 'border';
+    // AI configuration
+    ai?: {
+      providers?: Array<Record<string, unknown>>;
+      activeProviderId?: string;
+      activeModelId?: string;
+      globalPermissionMode?: 'observer' | 'confirm' | 'autonomous';
+      toolIntegrationMode?: 'mcp' | 'skills';
+      hostPermissions?: Array<Record<string, unknown>>;
+      externalAgents?: Array<Record<string, unknown>>;
+      defaultAgentId?: string;
+      commandBlocklist?: string[];
+      commandTimeout?: number;
+      maxIterations?: number;
+      agentModelMap?: Record<string, string>;
+      webSearchConfig?: Record<string, unknown> | null;
+    };
   };
 
   // Sync metadata

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1315,12 +1315,58 @@ function showAndFocusWindow(win) {
   restoreWindowInputFocus(win, { show: true });
 }
 
+function isLiveWindow(win) {
+  return Boolean(win && typeof win.isDestroyed === "function" && !win.isDestroyed());
+}
+
+function resolveSettingsWindowBounds(
+  electronModule,
+  { sourceWindow, settingsWidth, settingsHeight } = {},
+) {
+  const { screen } = electronModule || {};
+  if (!screen || !isLiveWindow(sourceWindow)) return {};
+
+  try {
+    const sourceBounds = sourceWindow.getBounds();
+    const display = screen.getDisplayMatching(sourceBounds);
+    const { x: dx, y: dy, width: dw, height: dh } = display.workArea;
+    return {
+      x: Math.round(dx + (dw - settingsWidth) / 2),
+      y: Math.round(dy + (dh - settingsHeight) / 2),
+    };
+  } catch {
+    return {};
+  }
+}
+
+function centerSettingsWindowOnSourceDisplay(win, electronModule, sourceWindow) {
+  if (!isLiveWindow(win)) return;
+  let bounds = { width: 980, height: 720 };
+  try {
+    bounds = win.getBounds();
+  } catch {
+    // keep defaults
+  }
+  const nextPosition = resolveSettingsWindowBounds(electronModule, {
+    sourceWindow,
+    settingsWidth: bounds.width,
+    settingsHeight: bounds.height,
+  });
+  if (nextPosition.x === undefined || nextPosition.y === undefined) return;
+  try {
+    win.setPosition(nextPosition.x, nextPosition.y);
+  } catch {
+    // ignore
+  }
+}
+
 async function openSettingsWindow(electronModule, options, { showOnLoad = true } = {}) {
   const { BrowserWindow, shell } = electronModule;
-  const { preload, devServerUrl, isDev, appIcon, isMac, electronDir } = options;
+  const { preload, devServerUrl, isDev, appIcon, isMac, electronDir, sourceWindow } = options;
 
   // If settings window already exists, show and focus it
   if (settingsWindow && !settingsWindow.isDestroyed()) {
+    centerSettingsWindowOnSourceDisplay(settingsWindow, electronModule, sourceWindow || mainWindow);
     showAndFocusWindow(settingsWindow);
     return settingsWindow;
   }
@@ -1334,15 +1380,11 @@ async function openSettingsWindow(electronModule, options, { showOnLoad = true }
   // Center the settings window on the same display as the main window
   const settingsWidth = 980;
   const settingsHeight = 720;
-  let settingsX, settingsY;
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    const { screen } = electronModule;
-    const mainBounds = mainWindow.getBounds();
-    const display = screen.getDisplayMatching(mainBounds);
-    const { x: dx, y: dy, width: dw, height: dh } = display.workArea;
-    settingsX = Math.round(dx + (dw - settingsWidth) / 2);
-    settingsY = Math.round(dy + (dh - settingsHeight) / 2);
-  }
+  const { x: settingsX, y: settingsY } = resolveSettingsWindowBounds(electronModule, {
+    sourceWindow: sourceWindow || mainWindow,
+    settingsWidth,
+    settingsHeight,
+  });
 
   const win = new BrowserWindow({
     title: "netcatty Settings",
@@ -1786,5 +1828,6 @@ module.exports = {
   setIsQuitting,
   openFallbackBrowser,
   tryOpenExternalWithFallback,
+  resolveSettingsWindowBounds,
   THEME_COLORS,
 };

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -1,7 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { isWindowUsable, registerWindowHandlers, restoreWindowInputFocus } = require("./windowManager.cjs");
+const {
+  isWindowUsable,
+  registerWindowHandlers,
+  resolveSettingsWindowBounds,
+  restoreWindowInputFocus,
+} = require("./windowManager.cjs");
 
 function createWindowStub({ destroyed = false, webContents } = {}) {
   return {
@@ -206,4 +211,32 @@ test("window focus IPC handler focuses the sender owner window", async () => {
 
   assert.equal(result, true);
   assert.deepEqual(calls, ["focus", "webContents.focus"]);
+});
+
+test("resolveSettingsWindowBounds centers settings on the requesting window display", () => {
+  const sourceWindow = {
+    getBounds() {
+      return { x: 2100, y: 80, width: 900, height: 700 };
+    },
+    isDestroyed() {
+      return false;
+    },
+  };
+  const electronModule = {
+    screen: {
+      getDisplayMatching(bounds) {
+        assert.deepEqual(bounds, { x: 2100, y: 80, width: 900, height: 700 });
+        return { workArea: { x: 1920, y: 0, width: 1440, height: 900 } };
+      },
+    },
+  };
+
+  assert.deepEqual(
+    resolveSettingsWindowBounds(electronModule, {
+      sourceWindow,
+      settingsWidth: 980,
+      settingsHeight: 720,
+    }),
+    { x: 2150, y: 90 },
+  );
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -576,7 +576,7 @@ const registerBridges = (win) => {
   });
 
   // Settings window handler
-  ipcMain.handle("netcatty:settings:open", async () => {
+  ipcMain.handle("netcatty:settings:open", async (event) => {
     try {
       await getWindowManager().openSettingsWindow(electronModule, {
         preload,
@@ -585,6 +585,7 @@ const registerBridges = (win) => {
         appIcon,
         isMac,
         electronDir,
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
       });
       return true;
     } catch (err) {

--- a/infrastructure/persistence/localStorageAdapter.ts
+++ b/infrastructure/persistence/localStorageAdapter.ts
@@ -7,6 +7,24 @@ const safeParse = <T>(value: string | null): T | null => {
   }
 };
 
+export const LOCAL_STORAGE_ADAPTER_CHANGED_EVENT = 'netcatty:local-storage-adapter-changed';
+
+function emitLocalStorageAdapterChanged(key: string): void {
+  try {
+    const target = globalThis as typeof globalThis & {
+      dispatchEvent?: (event: Event) => boolean;
+      CustomEvent?: typeof CustomEvent;
+    };
+    if (typeof target.dispatchEvent !== 'function' || typeof target.CustomEvent !== 'function') return;
+    target.dispatchEvent(new target.CustomEvent<{ key: string }>(
+      LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+      { detail: { key } },
+    ));
+  } catch {
+    // ignore
+  }
+}
+
 /**
  * Safely write to localStorage, catching QuotaExceededError.
  * Returns true if the write succeeded, false if storage quota was exceeded.
@@ -14,6 +32,7 @@ const safeParse = <T>(value: string | null): T | null => {
 function safeSetItem(key: string, value: string): boolean {
   try {
     localStorage.setItem(key, value);
+    emitLocalStorageAdapterChanged(key);
     return true;
   } catch (err) {
     if (
@@ -63,5 +82,6 @@ export const localStorageAdapter = {
   },
   remove(key: string) {
     localStorage.removeItem(key);
+    emitLocalStorageAdapterChanged(key);
   },
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## Summary
- Extend cloud sync to cover AI provider/agent/permission/tool config, command policy, web search, workspace focus style, terminal follow-app theme, SFTP default view, and additional terminal options. Device-bound encrypted apiKey placeholders are stripped from providers and webSearchConfig before upload.
- Auto-sync now reacts to syncable localStorage changes through a new adapter-level event so settings edits trigger sync without an explicit settingsVersion bump.
- Center the Settings window on the display of the window that requested it (fixes #920) instead of always anchoring to the main window.

## Test plan
- [ ] `npm test` (covers new syncPayload and windowManager readiness tests)
- [ ] Open Settings from a window on a secondary display and confirm placement
- [ ] Edit AI/UI settings, confirm auto-sync triggers, and verify a second device receives them without local apiKeys being uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)