### PR TITLE
Fix WebDAV Basic Auth for non-ASCII passwords (Hetzner #891)

### DIFF
--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -48,6 +48,15 @@ const buildError = (message, details) => {
   return err;
 };
 
+// Per RFC 7617, Basic Auth credentials must be UTF-8 encoded before base64.
+// The upstream `webdav` package routes through `base-64`, which encodes as
+// Latin1 — silently corrupting non-ASCII characters (e.g. `ö`, `ä`) and
+// causing 401s against servers that follow the spec, like Hetzner Storage
+// Box (#891). We build the header ourselves to avoid that path.
+const buildBasicAuthHeader = (username, password) =>
+  "Basic " +
+  Buffer.from(`${username || ""}:${password || ""}`, "utf8").toString("base64");
+
 const buildWebdavClient = (config) => {
   if (!config) throw new Error("Missing WebDAV config");
   const endpoint = normalizeEndpoint(config.endpoint);
@@ -74,9 +83,10 @@ const buildWebdavClient = (config) => {
     });
   }
   return createClient(endpoint, {
-    authType: AuthType.Password,
-    username: config.username || "",
-    password: config.password || "",
+    authType: AuthType.None,
+    headers: {
+      Authorization: buildBasicAuthHeader(config.username, config.password),
+    },
     ...extraOpts,
   });
 };
@@ -286,4 +296,7 @@ const registerHandlers = (ipcMain) => {
 
 module.exports = {
   registerHandlers,
+  // Exposed for tests
+  handleWebdavInitialize,
+  buildBasicAuthHeader,
 };

--- a/electron/bridges/cloudSyncBridge.webdavBasicAuth.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavBasicAuth.test.cjs
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+
+const {
+  buildBasicAuthHeader,
+  handleWebdavInitialize,
+} = require("./cloudSyncBridge.cjs");
+
+// Per RFC 7617, Basic Auth credentials are UTF-8 encoded before base64.
+// The upstream `webdav` npm package (via `base-64`) encodes them as Latin1
+// instead, which silently corrupts non-ASCII characters like German umlauts
+// (ö, ä) — exactly the case reported by Hetzner Storage Box users (#891).
+//
+// `ö` (U+00F6):
+//   Latin1 → 1 byte:  F6
+//   UTF-8  → 2 bytes: C3 B6
+const PASSWORD_WITH_UMLAUT = "6?G:ö9yZöäMF+H3";
+const USERNAME = "uHetzner1";
+
+test("buildBasicAuthHeader UTF-8 encodes credentials (RFC 7617)", () => {
+  const header = buildBasicAuthHeader("user", "ö");
+  // UTF-8 base64 of "user:ö" = "user" + ":" + 0xC3 0xB6
+  assert.equal(header, "Basic dXNlcjrDtg==");
+});
+
+test("buildBasicAuthHeader stays compatible with pure-ASCII credentials", () => {
+  // For ASCII, UTF-8 and Latin1 are byte-identical, so the header is unchanged.
+  const header = buildBasicAuthHeader("user", "password");
+  assert.equal(header, "Basic dXNlcjpwYXNzd29yZA==");
+});
+
+function startUtf8BasicAuthServer({ username, password }) {
+  const expected =
+    "Basic " +
+    Buffer.from(`${username}:${password}`, "utf8").toString("base64");
+
+  const server = http.createServer((req, res) => {
+    const got = req.headers["authorization"];
+    if (got !== expected) {
+      res.writeHead(401, {
+        "WWW-Authenticate": 'Basic realm="test", charset="UTF-8"',
+      });
+      res.end("Unauthorized");
+      return;
+    }
+    // Minimal but parseable PROPFIND response so client.exists() resolves true.
+    res.writeHead(207, { "Content-Type": "application/xml; charset=utf-8" });
+    res.end(
+      `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>${req.url}</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>netcatty-vault.json</D:displayname>
+        <D:getlastmodified>Sat, 10 May 2026 00:00:00 GMT</D:getlastmodified>
+        <D:getcontentlength>0</D:getcontentlength>
+        <D:resourcetype/>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`,
+    );
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, endpoint: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+test("handleWebdavInitialize sends UTF-8 Basic Auth (Hetzner umlaut password #891)", async () => {
+  const { server, endpoint } = await startUtf8BasicAuthServer({
+    username: USERNAME,
+    password: PASSWORD_WITH_UMLAUT,
+  });
+  try {
+    const result = await handleWebdavInitialize({
+      endpoint,
+      authType: "password",
+      username: USERNAME,
+      password: PASSWORD_WITH_UMLAUT,
+    });
+    assert.equal(result.resourceId, "/netcatty-vault.json");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});


### PR DESCRIPTION
## Summary

- Build the WebDAV `Authorization: Basic …` header ourselves with **UTF-8** encoding (RFC 7617). The upstream `webdav` package routes through `base-64`, which Latin1-encodes the credentials, so passwords containing non-ASCII characters (e.g. `ö`, `ä`) silently turn into a different byte sequence on the wire and the server returns 401. ASCII-only passwords are byte-identical, so existing setups are unaffected.
- Digest and token auth modes are untouched.
- Adds an integration test that spins up a local HTTP server enforcing UTF-8 Basic Auth with the umlaut-containing password from the issue, plus a unit test pinning the encoding contract.

Fixes #891

## Test plan

- [x] New test reproduces the original 401 against the unfixed code (verified RED before the fix).
- [x] All 3 new tests pass after the fix.
- [x] Full suite: 706 tests passing, 0 failures.
- [ ] Manual smoke against a real Hetzner Storage Box with an umlaut password (left for the reporter — happy to ping them on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)