### PR TITLE
Fix ghost text duplicating glyphs after Tab completion (#906)

### DIFF
--- a/components/terminal/GhostTextAddon.test.ts
+++ b/components/terminal/GhostTextAddon.test.ts
@@ -323,3 +323,130 @@ test("hides ghost immediately when input no longer matches suggestion", () => {
     restoreDocument();
   }
 });
+
+test("applyKeystroke: printable char trims ghost tail when buffer is unreliable (issue #906)", () => {
+  // Repro for issue #906: after Tab passes to shell and the typed-buffer
+  // is flagged unreliable, the ghost addon's currentInput is the only
+  // source of truth for what the user has typed since the last show().
+  // Without applyKeystroke, line 798's reliability gate prevents
+  // adjustToInput from firing and the ghost retains its show-time tail
+  // — when the next keystroke advances the cursor, the stale tail
+  // overlaps the just-typed glyph (e.g., typing 't' after 'systemctl s'
+  // makes the screen read 'systemctl sttop firewalld').
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    addon.show("systemctl stop firewalld", "systemctl s");
+    const ghost = ghostElement();
+    assert.ok(ghost);
+    assert.equal(ghost.textContent, "top firewalld");
+
+    addon.applyKeystroke("t");
+
+    // Ghost tail must shrink by exactly one char so when the shell
+    // echoes 't', the next visible glyph after the cursor is 'o', not
+    // 't' (which would render as 'sttop').
+    assert.equal(ghost.textContent, "op firewalld");
+    assert.equal(addon.isActive(), true);
+  } finally {
+    restoreDocument();
+  }
+});
+
+test("applyKeystroke: backspace re-grows ghost tail by one char", () => {
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    addon.show("docker", "doc");
+    const ghost = ghostElement();
+    assert.ok(ghost);
+    assert.equal(ghost.textContent, "ker");
+
+    addon.applyKeystroke("\x7f");
+
+    assert.equal(ghost.textContent, "cker");
+  } finally {
+    restoreDocument();
+  }
+});
+
+test("applyKeystroke: Ctrl+W word-erases trailing word from currentInput", () => {
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    // Mid-suggestion: user has typed two words; Ctrl+W should drop the
+    // tail word and let the ghost regrow to cover what was erased.
+    addon.show("git commit -m wip", "git com");
+    const ghost = ghostElement();
+    assert.ok(ghost);
+    assert.equal(ghost.textContent, "mit -m wip");
+
+    addon.applyKeystroke("\x17");
+
+    // The same /\s*\S+\s*$/ regex used by handleInput consumes the
+    // leading whitespace too, so "git com" → "git"; the ghost regrows
+    // to cover the now-uncovered leading space + remainder.
+    assert.equal(ghost.textContent, " commit -m wip");
+  } finally {
+    restoreDocument();
+  }
+});
+
+test("applyKeystroke: hides ghost when next char diverges from suggestion", () => {
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    addon.show("docker", "do");
+    const ghost = ghostElement();
+    assert.ok(ghost);
+
+    // 'x' breaks the prefix invariant — ghost must hide immediately so
+    // a → -accept after this point can't pull a stale tail onto a line
+    // that no longer matches the suggestion.
+    addon.applyKeystroke("x");
+
+    assert.equal(ghost.style.display, "none");
+    assert.equal(addon.isActive(), false);
+  } finally {
+    restoreDocument();
+  }
+});
+
+test("applyKeystroke: ignores non-typing data (escape sequences, control codes)", () => {
+  // Escape sequences and other control codes are routed through
+  // clearState() in handleInput, not propagated to the ghost — but we
+  // want applyKeystroke to be a safe no-op if accidentally called with
+  // them (defense in depth).
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    addon.show("docker", "do");
+    const ghost = ghostElement();
+    assert.ok(ghost);
+    const tailBefore = ghost.textContent;
+
+    addon.applyKeystroke("\x1b[A"); // up-arrow escape sequence
+    addon.applyKeystroke("\x01");    // Ctrl+A
+    addon.applyKeystroke("");         // empty
+
+    assert.equal(ghost.textContent, tailBefore);
+    assert.equal(addon.isActive(), true);
+  } finally {
+    restoreDocument();
+  }
+});

--- a/components/terminal/autocomplete/GhostTextAddon.ts
+++ b/components/terminal/autocomplete/GhostTextAddon.ts
@@ -213,6 +213,40 @@ export class GhostTextAddon implements IDisposable {
     this.ghostElement.style.display = "block";
   }
 
+  /**
+   * Apply a single keystroke's effect to the ghost without consulting the
+   * outer typed-input buffer. Used when that buffer's reliability flag is
+   * off (post-Tab, history recall, cursor moves) — without this hook the
+   * gate at handleInput's adjustToInput call would freeze the ghost at
+   * the previous show()'s tail, and a subsequent → -accept would paste
+   * that stale tail on top of the chars typed in the meantime
+   * (sttop/dduplicate-glyph bug, issue #906).
+   *
+   * Only forwards events the ghost can locally re-derive: a printable
+   * char appends, Backspace/DEL slices off one char, Ctrl-W performs
+   * the same trailing-word erase as zsh/bash. Anything else (escape
+   * sequences, other control codes) is treated as a no-op — those
+   * paths already clearState() in handleInput, so by the time the user
+   * could trigger an accept, the ghost is gone.
+   */
+  applyKeystroke(data: string): void {
+    if (this.disposed || !this.currentSuggestion || !data) return;
+    let nextInput: string;
+    if (data === "\x7f" || data === "\b") {
+      if (this.currentInput.length === 0) return;
+      nextInput = this.currentInput.slice(0, -1);
+    } else if (data === "\x17") {
+      const erased = this.currentInput.replace(/\s*\S+\s*$/, "");
+      if (erased === this.currentInput) return;
+      nextInput = erased;
+    } else if (data.length === 1 && data.charCodeAt(0) >= 32) {
+      nextInput = this.currentInput + data;
+    } else {
+      return;
+    }
+    this.adjustToInput(nextInput);
+  }
+
   getSuggestion(): string {
     return this.currentSuggestion;
   }

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -789,14 +789,26 @@ export function useTerminalAutocomplete(
       // immediately. Without this the ghost keeps the tail it captured at
       // show() time; a fast "type + press →" sequence then pastes the
       // pre-update tail on top of the new input ("doc" + "cker ls" →
-      // "doccker ls"). Only safe to call when the buffer is reliable —
-      // otherwise its content doesn't correspond to the live line and
-      // adjustToInput would make the ghost lie. Also skip when the user
-      // has turned showGhostText off mid-session: otherwise a ghost that
-      // was active before the toggle would keep moving around under a
-      // setting the user just said to disable (Codex #815 P2).
-      if (typedBufferReliableRef.current && settingsRef.current.showGhostText) {
-        ghostAddonRef.current?.adjustToInput(typedInputBufferRef.current);
+      // "doccker ls"). Skip when the user has turned showGhostText off
+      // mid-session: otherwise a ghost that was active before the toggle
+      // would keep moving around under a setting the user just said to
+      // disable (Codex #815 P2).
+      //
+      // Reliable buffer: feed adjustToInput the full post-mutation buffer
+      // so multi-char pastes refresh the ghost as one batch. Unreliable
+      // buffer (post Tab / cursor-move / history recall): the buffer
+      // is just the suffix typed since unreliability began, so feeding
+      // it to adjustToInput would fail the prefix invariant and hide
+      // the ghost. Instead let the addon evolve its own currentInput
+      // off the keystroke directly (issue #906) — that input was seeded
+      // by the last show() with the live xterm reading, which is the
+      // only post-Tab source-of-truth we have.
+      if (settingsRef.current.showGhostText) {
+        if (typedBufferReliableRef.current) {
+          ghostAddonRef.current?.adjustToInput(typedInputBufferRef.current);
+        } else {
+          ghostAddonRef.current?.applyKeystroke(data);
+        }
       }
 
       // Fast typing suppression: if typing faster than threshold, skip this debounce cycle


### PR DESCRIPTION
Closes #906.

## Summary
- The reliability gate at `handleInput`'s `adjustToInput` call froze the ghost at its last `show()`-time tail in any path where the typed buffer becomes unreliable (Tab pass-through to shell, history recall, cursor moves). When the user kept typing into that gap, the next render advanced the cursor past the ghost's anchor while the ghost text stayed put — and a → -accept then pasted the stale tail on top of the just-typed glyphs.
- Added `GhostTextAddon.applyKeystroke` so the ghost can evolve its own `currentInput` off raw keystrokes (printable / Backspace / Ctrl-W), seeded by whatever the last `show()` captured from the live xterm reading.
- `handleInput` now keeps the existing `adjustToInput` on the reliable path (preserves multi-char paste re-alignment) and routes single-keystroke events through `applyKeystroke` on the unreliable path, fixing the visual misalignment and the duplication-on-accept in one shot.

## Reproduction (issue #906)
1. Enable autocomplete + inline suggestion in terminal settings.
2. Have `systemctl stop firewalld` in shell history.
3. Type `s`, then Tab (shell completes to `systemctl `), then keep typing `s` `t`.
4. Before fix: screen shows `systemctl sttop firewalld` — duplicated `t` because ghost text `top firewalld` was left at its show-time anchor while the cursor advanced past it. Pressing → applies the stale tail and pollutes the command.
5. After fix: ghost shrinks to `op firewalld` after the `t` keystroke; → -accept produces a clean `systemctl stop firewalld`.

## Why prior PR #815 wasn't enough
PR #815 added `adjustToInput` on every keystroke, but only behind the `typedBufferReliableRef` gate. Tab pass-through (and any cursor-move / history-recall path) clears that flag, leaving the ghost frozen between debounced `fetchSuggestions` cycles. The fix here lifts the gate without requiring a reliable buffer — the ghost's own `currentInput` cache, seeded by `show()` from the live xterm reading, is the source of truth.

## Test plan
- [x] `node --test --import tsx components/terminal/GhostTextAddon.test.ts` — 5 new tests cover the issue #906 scenario, Backspace re-grow, Ctrl-W word-erase, divergent-keystroke hide, and no-op for control sequences.
- [x] Full repo test suite: 728 pass, 0 fail (pre-existing 3 skipped).
- [x] No new TypeScript errors in changed files; lint clean.
- [ ] Manual SSH smoke test: connect to a Linux server, repro the issue #906 sequence (history → Ctrl+C → re-type with Tab → continue typing), confirm ghost stays aligned and → -accept produces a clean command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)