### PR TITLE
Stabilize useTerminalBackend return identity

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
 
 export const useTerminalBackend = () => {
@@ -177,36 +177,79 @@ export const useTerminalBackend = () => {
     return bridge.getServerStats(sessionId);
   }, []);
 
-  return {
-    backendAvailable,
-    telnetAvailable,
-    moshAvailable,
-    localAvailable,
-    serialAvailable,
-    execAvailable,
-    openExternalAvailable,
-    startSSHSession,
-    startTelnetSession,
-    startMoshSession,
-    startLocalSession,
-    startSerialSession,
-    listSerialPorts,
-    execCommand,
-    getSessionPwd,
-    getSessionRemoteInfo,
-    getSessionDistroInfo,
-    getServerStats,
-    writeToSession,
-    resizeSession,
-    closeSession,
-    setSessionEncoding,
-    onSessionData,
-    onSessionExit,
-    onTelnetAutoLoginComplete,
-    onTelnetAutoLoginCancelled,
-    onChainProgress,
-    onHostKeyVerification,
-    respondHostKeyVerification,
-    openExternal,
-  };
+  // Memoize the returned object so its identity is stable across the
+  // hook's lifetime. Each method above is already useCallback([])-stable,
+  // so listing them as deps means useMemo recomputes once and then
+  // caches forever. Without this, every render produced a fresh object
+  // literal — making `terminalBackend` an unstable reference that
+  // forced consumers' useEffects (`}, [..., terminalBackend])`) to
+  // rerun on every parent render and forced lint to flag any deeper
+  // property dep (`}, [terminalBackend.onHostKeyVerification])`) it
+  // couldn't statically prove safe.
+  return useMemo(
+    () => ({
+      backendAvailable,
+      telnetAvailable,
+      moshAvailable,
+      localAvailable,
+      serialAvailable,
+      execAvailable,
+      openExternalAvailable,
+      startSSHSession,
+      startTelnetSession,
+      startMoshSession,
+      startLocalSession,
+      startSerialSession,
+      listSerialPorts,
+      execCommand,
+      getSessionPwd,
+      getSessionRemoteInfo,
+      getSessionDistroInfo,
+      getServerStats,
+      writeToSession,
+      resizeSession,
+      closeSession,
+      setSessionEncoding,
+      onSessionData,
+      onSessionExit,
+      onTelnetAutoLoginComplete,
+      onTelnetAutoLoginCancelled,
+      onChainProgress,
+      onHostKeyVerification,
+      respondHostKeyVerification,
+      openExternal,
+    }),
+    [
+      backendAvailable,
+      telnetAvailable,
+      moshAvailable,
+      localAvailable,
+      serialAvailable,
+      execAvailable,
+      openExternalAvailable,
+      startSSHSession,
+      startTelnetSession,
+      startMoshSession,
+      startLocalSession,
+      startSerialSession,
+      listSerialPorts,
+      execCommand,
+      getSessionPwd,
+      getSessionRemoteInfo,
+      getSessionDistroInfo,
+      getServerStats,
+      writeToSession,
+      resizeSession,
+      closeSession,
+      setSessionEncoding,
+      onSessionData,
+      onSessionExit,
+      onTelnetAutoLoginComplete,
+      onTelnetAutoLoginCancelled,
+      onChainProgress,
+      onHostKeyVerification,
+      respondHostKeyVerification,
+      openExternal,
+    ],
+  );
 };

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -683,7 +683,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     return () => {
       dispose?.();
     };
-  }, [sessionId, terminalBackend.onHostKeyVerification]);
+  }, [sessionId, terminalBackend]);
 
   const handleTopOverlayMouseDownCapture = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;


### PR DESCRIPTION
## Summary
- `useTerminalBackend()` returned a fresh object literal on every render. The 26 methods inside were already `useCallback([])`-stable, but the wrapping object was not — so every consumer's effect with `terminalBackend` in its deps re-ran on every parent render even when nothing semantic had changed (Terminal.tsx alone had three such sites: cwd polling at L547, the session-lifecycle hook at L788, the programmatic-input writer at L1462).
- ESLint flagged the one site that depended on a property access (\`terminalBackend.onHostKeyVerification\`, Terminal.tsx:686) because it can't statically prove a deep-property dep is safe.

## Fix
- Wrap the return in \`useMemo\` with every stable callback listed as a dep. Recomputation happens once and the identity is cached for the hook's lifetime.
- Update the host-key-verification effect to depend on \`terminalBackend\` (now stable) so the warning is cleared at the root rather than patched locally.

## Why this is the right shape
All 26 methods were already individually \`useCallback([])\`-wrapped — the only thing missing was a stable container. Listing them in the \`useMemo\` deps array (rather than \`[]\`) keeps ESLint honest and protects against a future contributor swapping out a callback for an inline function without realizing it would defeat the memo.

## Test plan
- [x] \`npm run lint\` — previously emitted 1 warning at Terminal.tsx:686, now clean.
- [x] \`npm test\` — 728 pass, 0 fail (3 pre-existing skipped).
- [x] \`npx tsc --noEmit -p .\` shows no new errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)