### PR TITLE
Fix #941: restore right-click paste in mouse-tracking TUIs

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1394,10 +1394,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (!el) return;
 
     const handleContextMenuCapture = (e: MouseEvent) => {
-      if (mouseTrackingRef.current) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
+      if (!mouseTrackingRef.current) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      // stopImmediatePropagation blocks the event from reaching React's
+      // bubble-phase root listener, so the onContextMenu handler in
+      // TerminalContextMenu (which dispatches paste / select-word) never
+      // fires inside a mouse-tracking TUI. Without dispatching the user's
+      // chosen action here, right-click paste silently stops working in
+      // opencode, tmux with `mouse on`, vim with `set mouse=a`, etc. (#941).
+      // Middle-click still works because its auxclick listener lives in
+      // createXTermRuntime and isn't gated by mouseTracking.
+      const behavior = terminalSettingsRef.current?.rightClickBehavior;
+      if (behavior === 'paste') {
+        void terminalContextActionsRef.current?.onPaste?.();
+      } else if (behavior === 'select-word') {
+        terminalContextActionsRef.current?.onSelectWord?.();
       }
+      // 'context-menu' is intentionally not handled — Radix opens the
+      // menu via its own pointerdown listener, which our capture handler
+      // does not intercept.
     };
 
     const handleMouseUpCapture = (e: MouseEvent) => {
@@ -1494,6 +1511,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     disableBracketedPasteRef,
     scrollOnPasteRef,
   });
+  // Kept fresh on every render so the mouseTracking capture handler at
+  // handleContextMenuCapture (which is bound once per sessionId) can
+  // still invoke the latest paste / select-word callbacks without
+  // re-binding on every action identity change. See #941.
+  const terminalContextActionsRef = useRef(terminalContextActions);
+  terminalContextActionsRef.current = terminalContextActions;
 
   const handleSetTerminalEncoding = (encoding: 'utf-8' | 'gb18030') => {
     setTerminalEncoding(encoding);


### PR DESCRIPTION
## Summary

[#941](https://github.com/binaricat/Netcatty/issues/941) reports: with right-click behavior set to "Paste", right-clicking inside `opencode` (and other mouse-tracking TUI apps like `tmux mouse on` or `vim mouse=a`) silently does nothing. Menu mode and middle-click paste both still work.

## Root cause

`components/Terminal.tsx:1392-1414` attaches a capture-phase `contextmenu` listener on the terminal container. When SGR mouse tracking is active, it calls `e.stopImmediatePropagation()` to bypass xterm.js's built-in right-click handler (`textarea.select()`, which steals focus and dismisses tmux/vim popup menus).

The unintended side effect: React's `onContextMenu` delegation is bubble-phase on the React root, so killing propagation at capture phase also kills React's handler. `TerminalContextMenu.handleRightClick` — which is where `rightClickBehavior === 'paste'` dispatches `onPaste` — never runs.

Menu mode keeps working because Radix's `ContextMenuTrigger` opens via `pointerdown`, not contextmenu. Middle-click keeps working because its `auxclick` listener in `createXTermRuntime` is unrelated to contextmenu.

## Fix

Have the capture handler dispatch the user's chosen right-click action when it intercepts the event:

```ts
const handleContextMenuCapture = (e: MouseEvent) => {
  if (!mouseTrackingRef.current) return;
  e.preventDefault();
  e.stopImmediatePropagation();

  const behavior = terminalSettingsRef.current?.rightClickBehavior;
  if (behavior === 'paste') {
    void terminalContextActionsRef.current?.onPaste?.();
  } else if (behavior === 'select-word') {
    terminalContextActionsRef.current?.onSelectWord?.();
  }
  // 'context-menu' is handled by Radix's own pointerdown listener.
};
```

`terminalSettingsRef` already exists in this file; this commit adds the symmetric `terminalContextActionsRef` so the once-bound capture handler can call the current action without re-binding on every action-identity change.

## tmux popup compatibility

The capture handler still calls `stopImmediatePropagation` first, so xterm.js's `textarea.select()` still doesn't fire — the original "tmux popup menus don't get dismissed" protection stays intact. We only repurpose the now-blocked event to invoke the user's setting.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 784 pass / 0 fail
- [x] `npm run build` — clean
- [ ] **Manual**: open `opencode` (or any mouse-tracking TUI), set right-click behavior to "Paste", right-click → should paste from clipboard
- [ ] **Manual**: same setup, set right-click behavior to "Context menu" → right-click should still open Radix menu (Radix uses pointerdown, unaffected)
- [ ] **Manual**: tmux with `set -g mouse on` + popup menu — right-click should still bring up tmux's popup without our `textarea.select()` dismissing it

Closes #941.