### PR TITLE
[codex] Fix issue 957 long paste display

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1506,9 +1506,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const terminalContextActions = useTerminalContextActions({
     termRef,
     sessionRef,
-    terminalBackend,
     onHasSelectionChange: setHasSelection,
-    disableBracketedPasteRef,
     scrollOnPasteRef,
   });
   // Kept fresh on every render so the mouseTracking capture handler at

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -2,26 +2,18 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback } from "react";
 import type { RefObject } from "react";
 import { logger } from "../../../lib/logger";
-import { normalizeLineEndings, wrapBracketedPaste } from "../../../lib/utils";
+import { pasteTextIntoTerminal } from "../runtime/terminalUserPaste";
 import { clearTerminalViewport } from "../clearTerminalViewport";
-
-type TerminalBackendWriteApi = {
-  writeToSession: (sessionId: string, data: string) => void;
-};
 
 export const useTerminalContextActions = ({
   termRef,
   sessionRef,
-  terminalBackend,
   onHasSelectionChange,
-  disableBracketedPasteRef,
   scrollOnPasteRef,
 }: {
   termRef: RefObject<XTerm | null>;
   sessionRef: RefObject<string | null>;
-  terminalBackend: TerminalBackendWriteApi;
   onHasSelectionChange?: (hasSelection: boolean) => void;
-  disableBracketedPasteRef?: RefObject<boolean>;
   scrollOnPasteRef?: RefObject<boolean>;
 }) => {
   const onCopy = useCallback(() => {
@@ -39,40 +31,24 @@ export const useTerminalContextActions = ({
     try {
       const text = await navigator.clipboard.readText();
       if (text && sessionRef.current) {
-        let data = normalizeLineEndings(text);
-        if (term.modes.bracketedPasteMode && !disableBracketedPasteRef?.current) data = wrapBracketedPaste(data);
-        terminalBackend.writeToSession(sessionRef.current, data);
-        if (scrollOnPasteRef?.current) {
-          term.scrollToBottom();
-          if (typeof requestAnimationFrame === "function") {
-            requestAnimationFrame(() => {
-              term.scrollToBottom();
-            });
-          }
-        }
+        pasteTextIntoTerminal(term, text, {
+          scrollOnPaste: scrollOnPasteRef?.current ?? false,
+        });
       }
     } catch (err) {
       logger.warn("Failed to paste from clipboard", err);
     }
-  }, [sessionRef, termRef, terminalBackend, disableBracketedPasteRef, scrollOnPasteRef]);
+  }, [sessionRef, termRef, scrollOnPasteRef]);
 
   const onPasteSelection = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
     const selection = term.getSelection();
     if (!selection || !sessionRef.current) return;
-    let data = normalizeLineEndings(selection);
-    if (term.modes.bracketedPasteMode && !disableBracketedPasteRef?.current) data = wrapBracketedPaste(data);
-    terminalBackend.writeToSession(sessionRef.current, data);
-    if (scrollOnPasteRef?.current) {
-      term.scrollToBottom();
-      if (typeof requestAnimationFrame === "function") {
-        requestAnimationFrame(() => {
-          term.scrollToBottom();
-        });
-      }
-    }
-  }, [sessionRef, termRef, terminalBackend, disableBracketedPasteRef, scrollOnPasteRef]);
+    pasteTextIntoTerminal(term, selection, {
+      scrollOnPaste: scrollOnPasteRef?.current ?? false,
+    });
+  }, [sessionRef, termRef, scrollOnPasteRef]);
 
   const onSelectAll = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -17,6 +17,10 @@ import {
   resolveTelnetPort,
   resolveTelnetUsername,
 } from "../../../domain/host";
+import {
+  clearPasteResidualAfterTerminalWrite,
+  prepareTerminalDataForUserPasteDisplay,
+} from "./terminalUserPaste";
 
 /**
  * Per-connection token for stale-timer detection. The renderer reuses the
@@ -206,13 +210,17 @@ const writeSessionData = (
   term: XTerm,
   data: string,
 ) => {
+  const displayData = prepareTerminalDataForUserPasteDisplay(term, data);
   const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
   if (!shouldScrollOnTerminalOutput(settings)) {
-    term.write(data);
+    term.write(displayData, () => {
+      clearPasteResidualAfterTerminalWrite(term);
+    });
     return;
   }
 
-  term.write(data, () => {
+  term.write(displayData, () => {
+    clearPasteResidualAfterTerminalWrite(term);
     handleTerminalOutputAutoScroll(ctx, term);
   });
 };

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -44,7 +44,10 @@ import {
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { handleSerialLineModeInput } from "./serialLineInput";
-import { pasteTextIntoTerminal } from "./terminalUserPaste";
+import {
+  pasteTextIntoTerminal,
+  shouldSuppressTerminalInputScrollForUserPaste,
+} from "./terminalUserPaste";
 import type {
   Host,
   KeyBinding,
@@ -651,7 +654,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         ctx.onBroadcastInputRef.current(broadcastData, ctx.sessionId);
       }
 
-      scrollToBottomAfterInput(data);
+      if (!shouldSuppressTerminalInputScrollForUserPaste(term, data)) {
+        scrollToBottomAfterInput(data);
+      }
 
       // Notify autocomplete of input
       ctx.onAutocompleteInput?.(data);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -43,6 +43,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
+import { pasteTextIntoTerminal } from "./terminalUserPaste";
 import type {
   Host,
   KeyBinding,
@@ -405,19 +406,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   const appLevelActions = getAppLevelActions();
   const terminalActions = getTerminalPassthroughActions();
-  const scrollViewportToBottom = () => {
-    term.scrollToBottom();
-    if (typeof requestAnimationFrame === "function") {
-      requestAnimationFrame(() => {
-        term.scrollToBottom();
-      });
-    }
-  };
-  const scrollToBottomAfterPaste = () => {
-    if (shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current)) {
-      scrollViewportToBottom();
-    }
-  };
   const scrollToBottomAfterInput = (data: string) => {
     if (shouldScrollOnTerminalInput(ctx.terminalSettingsRef.current, data)) {
       term.scrollToBottom();
@@ -542,15 +530,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               navigator.clipboard.readText().then((text) => {
                 const id = ctx.sessionRef.current;
                 if (id) {
-                  const rawData = normalizeLineEndings(text);
-                  const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
-                    ? wrapBracketedPaste(rawData)
-                    : rawData;
-                  // Notify autocomplete with the final bytes so bracketed
-                  // pastes preserve their inner newlines as literal input.
-                  ctx.onAutocompleteInput?.(data);
-                  ctx.terminalBackend.writeToSession(id, data);
-                  scrollToBottomAfterPaste();
+                  pasteTextIntoTerminal(term, text, {
+                    scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+                  });
                 }
               });
               break;
@@ -559,13 +541,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               const selection = term.getSelection();
               const id = ctx.sessionRef.current;
               if (selection && id) {
-                const rawData = normalizeLineEndings(selection);
-                const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
-                  ? wrapBracketedPaste(rawData)
-                  : rawData;
-                ctx.onAutocompleteInput?.(data);
-                ctx.terminalBackend.writeToSession(id, data);
-                scrollToBottomAfterPaste();
+                pasteTextIntoTerminal(term, selection, {
+                  scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+                });
               }
               break;
             }
@@ -615,13 +593,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       try {
         const text = await navigator.clipboard.readText();
         if (text && ctx.sessionRef.current) {
-          const rawData = normalizeLineEndings(text);
-          const data = term.modes.bracketedPasteMode && !ctx.terminalSettingsRef.current?.disableBracketedPaste
-            ? wrapBracketedPaste(rawData)
-            : rawData;
-          ctx.onAutocompleteInput?.(data);
-          ctx.terminalBackend.writeToSession(ctx.sessionRef.current, data);
-          scrollToBottomAfterPaste();
+          pasteTextIntoTerminal(term, text, {
+            scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+          });
         }
       } catch (err) {
         logger.warn("[Terminal] Failed to paste from clipboard:", err);

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -43,6 +43,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
+import { handleSerialLineModeInput } from "./serialLineInput";
 import { pasteTextIntoTerminal } from "./terminalUserPaste";
 import type {
   Host,
@@ -615,45 +616,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (id) {
       // Serial line mode: buffer input and send on Enter
       if (ctx.host.protocol === "serial" && ctx.serialLineMode && ctx.serialLineBufferRef) {
-        if (data === "\r") {
-          // Enter key: send buffered line + CR
-          const line = ctx.serialLineBufferRef.current + "\r";
-          ctx.terminalBackend.writeToSession(id, line);
-          ctx.serialLineBufferRef.current = "";
-          // Local echo newline if enabled
-          if (ctx.serialLocalEcho) {
-            term.write("\r\n");
-          }
-        } else if (data === "\x7f" || data === "\b") {
-          // Backspace: remove last character from buffer
-          if (ctx.serialLineBufferRef.current.length > 0) {
-            ctx.serialLineBufferRef.current = ctx.serialLineBufferRef.current.slice(0, -1);
-            if (ctx.serialLocalEcho) {
-              term.write("\b \b");
-            }
-          }
-        } else if (data === "\x03") {
-          // Ctrl+C: clear buffer and send Ctrl+C
-          ctx.serialLineBufferRef.current = "";
-          ctx.terminalBackend.writeToSession(id, data);
-          if (ctx.serialLocalEcho) {
-            term.write("^C\r\n");
-          }
-        } else if (data === "\x15") {
-          // Ctrl+U: clear line buffer
-          if (ctx.serialLocalEcho && ctx.serialLineBufferRef.current.length > 0) {
-            // Erase the displayed line
-            const len = ctx.serialLineBufferRef.current.length;
-            term.write("\b \b".repeat(len));
-          }
-          ctx.serialLineBufferRef.current = "";
-        } else if (data.charCodeAt(0) >= 32 || data.length > 1) {
-          // Regular characters: add to buffer
-          ctx.serialLineBufferRef.current += data;
-          if (ctx.serialLocalEcho) {
-            term.write(data);
-          }
-        }
+        handleSerialLineModeInput(data, {
+          bufferRef: ctx.serialLineBufferRef,
+          localEcho: ctx.serialLocalEcho,
+          writeToSession: (nextData) => ctx.terminalBackend.writeToSession(id, nextData),
+          writeToTerminal: (nextData) => term.write(nextData),
+        });
       } else {
         // Character mode (default): send immediately
         // When backspaceBehavior is configured, remap the Backspace key output

--- a/components/terminal/runtime/serialLineInput.test.ts
+++ b/components/terminal/runtime/serialLineInput.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleSerialLineModeInput } from "./serialLineInput";
+
+test("serial line mode sends completed lines from a multi-line paste chunk", () => {
+  const writes: string[] = [];
+  const echoes: string[] = [];
+  const bufferRef = { current: "" };
+
+  handleSerialLineModeInput("show version\rshow clock", {
+    bufferRef,
+    writeToSession: (data) => writes.push(data),
+    writeToTerminal: (data) => echoes.push(data),
+  });
+
+  assert.deepEqual(writes, ["show version\r"]);
+  assert.equal(bufferRef.current, "show clock");
+  assert.deepEqual(echoes, []);
+});
+
+test("serial line mode sends every completed line when pasted text ends with enter", () => {
+  const writes: string[] = [];
+  const echoes: string[] = [];
+  const bufferRef = { current: "" };
+
+  handleSerialLineModeInput("show version\rshow clock\r", {
+    bufferRef,
+    localEcho: true,
+    writeToSession: (data) => writes.push(data),
+    writeToTerminal: (data) => echoes.push(data),
+  });
+
+  assert.deepEqual(writes, ["show version\r", "show clock\r"]);
+  assert.equal(bufferRef.current, "");
+  assert.deepEqual(echoes, ["show version", "\r\n", "show clock", "\r\n"]);
+});

--- a/components/terminal/runtime/serialLineInput.ts
+++ b/components/terminal/runtime/serialLineInput.ts
@@ -1,0 +1,86 @@
+type StringRef = {
+  current: string;
+};
+
+type SerialLineModeInputOptions = {
+  bufferRef: StringRef;
+  localEcho?: boolean;
+  writeToSession: (data: string) => void;
+  writeToTerminal: (data: string) => void;
+};
+
+const submitLine = ({
+  bufferRef,
+  localEcho,
+  writeToSession,
+  writeToTerminal,
+}: SerialLineModeInputOptions) => {
+  const line = `${bufferRef.current}\r`;
+  writeToSession(line);
+  bufferRef.current = "";
+  if (localEcho) writeToTerminal("\r\n");
+};
+
+const appendText = (
+  text: string,
+  { bufferRef, localEcho, writeToTerminal }: SerialLineModeInputOptions,
+) => {
+  if (!text) return;
+  bufferRef.current += text;
+  if (localEcho) writeToTerminal(text);
+};
+
+const clearLine = ({
+  bufferRef,
+  localEcho,
+  writeToTerminal,
+}: SerialLineModeInputOptions) => {
+  if (localEcho && bufferRef.current.length > 0) {
+    writeToTerminal("\b \b".repeat(bufferRef.current.length));
+  }
+  bufferRef.current = "";
+};
+
+export function handleSerialLineModeInput(
+  data: string,
+  options: SerialLineModeInputOptions,
+): void {
+  if (data === "\r" || data === "\n") {
+    submitLine(options);
+    return;
+  }
+
+  if (data === "\x7f" || data === "\b") {
+    if (options.bufferRef.current.length > 0) {
+      options.bufferRef.current = options.bufferRef.current.slice(0, -1);
+      if (options.localEcho) options.writeToTerminal("\b \b");
+    }
+    return;
+  }
+
+  if (data === "\x03") {
+    options.bufferRef.current = "";
+    options.writeToSession(data);
+    if (options.localEcho) options.writeToTerminal("^C\r\n");
+    return;
+  }
+
+  if (data === "\x15") {
+    clearLine(options);
+    return;
+  }
+
+  const normalizedData = data.replace(/\r\n/g, "\r").replace(/\n/g, "\r");
+  if (normalizedData.includes("\r")) {
+    const parts = normalizedData.split("\r");
+    parts.forEach((part, index) => {
+      appendText(part, options);
+      if (index < parts.length - 1) submitLine(options);
+    });
+    return;
+  }
+
+  if (data.charCodeAt(0) >= 32 || data.length > 1) {
+    appendText(data, options);
+  }
+}

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearPasteResidualAfterTerminalWrite,
+  pasteTextIntoTerminal,
+  prepareTerminalDataForUserPasteDisplay,
+} from "./terminalUserPaste";
+
+test("user paste delegates raw clipboard text to xterm paste handling", () => {
+  const pasted: string[] = [];
+  const term = {
+    paste: (text: string) => pasted.push(text),
+    scrollToBottom: () => {
+      throw new Error("scrollToBottom should not run when scrollOnPaste is false");
+    },
+  };
+
+  const text = "line one\r\nline two\nline three";
+
+  pasteTextIntoTerminal(term, text, { scrollOnPaste: false });
+
+  assert.deepEqual(pasted, [text]);
+});
+
+test("user paste preserves the existing scroll-on-paste behavior", () => {
+  const calls: string[] = [];
+  const term = {
+    paste: () => calls.push("paste"),
+    scrollToBottom: () => calls.push("scroll"),
+  };
+
+  pasteTextIntoTerminal(term, "echo ok", {
+    scrollOnPaste: true,
+    requestAnimationFrame: (callback) => {
+      calls.push("raf");
+      callback();
+    },
+  });
+
+  assert.deepEqual(calls, ["paste", "scroll", "raf", "scroll"]);
+});
+
+test("long multi-line paste strips readline active-region highlighting from echo", () => {
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: () => {},
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(
+    prepareTerminalDataForUserPasteDisplay(term, "\x1b[7mthird line\x1b[27m"),
+    "third line",
+  );
+});
+
+test("long multi-line paste clears cursor-right residue after terminal echo", () => {
+  const writes: string[] = [];
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: (data: string) => writes.push(data),
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  clearPasteResidualAfterTerminalWrite(term);
+
+  assert.deepEqual(writes, ["\x1b[K"]);
+});

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -56,9 +56,49 @@ test("long multi-line paste strips readline active-region highlighting from echo
   });
 
   assert.equal(
-    prepareTerminalDataForUserPasteDisplay(term, "\x1b[7mthird line\x1b[27m"),
-    "third line",
+    prepareTerminalDataForUserPasteDisplay(term, "\x1b[7mline 3 with enough content\x1b[27m"),
+    "line 3 with enough content",
   );
+});
+
+test("long multi-line paste preserves unrelated reverse-video output", () => {
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: () => {},
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(
+    prepareTerminalDataForUserPasteDisplay(term, "\x1b[7munrelated ncurses status\x1b[27m"),
+    "\x1b[7munrelated ncurses status\x1b[27m",
+  );
+});
+
+test("long multi-line paste does not clear cursor-right residue before terminal echo", () => {
+  const writes: string[] = [];
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: (data: string) => writes.push(data),
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  clearPasteResidualAfterTerminalWrite(term);
+
+  assert.deepEqual(writes, []);
 });
 
 test("long multi-line paste clears cursor-right residue after terminal echo", () => {
@@ -75,6 +115,7 @@ test("long multi-line paste clears cursor-right residue after terminal echo", ()
   pasteTextIntoTerminal(term, longPaste, {
     scrollOnPaste: false,
   });
+  prepareTerminalDataForUserPasteDisplay(term, "\x1b[7mline 3 with enough content\x1b[27m");
 
   clearPasteResidualAfterTerminalWrite(term);
 

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -81,6 +81,53 @@ test("long multi-line paste preserves unrelated reverse-video output", () => {
   );
 });
 
+test("long multi-line paste strips only matched paste echo segments in mixed output", () => {
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: () => {},
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(
+    prepareTerminalDataForUserPasteDisplay(
+      term,
+      "mode \x1b[7mINSERT\x1b[27m \x1b[7mline 3 with enough content\x1b[27m done",
+    ),
+    "mode \x1b[7mINSERT\x1b[27m line 3 with enough content done",
+  );
+});
+
+test("long multi-line paste strips matched paste echo when active-region spans chunks", () => {
+  const term = {
+    cols: 20,
+    rows: 4,
+    paste: () => {},
+    scrollToBottom: () => {},
+    write: () => {},
+  };
+
+  const longPaste = Array.from({ length: 20 }, (_, index) => `line ${index} with enough content`).join("\n");
+  pasteTextIntoTerminal(term, longPaste, {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(
+    prepareTerminalDataForUserPasteDisplay(term, "\x1b[7mline 3 with enough"),
+    "line 3 with enough",
+  );
+  assert.equal(
+    prepareTerminalDataForUserPasteDisplay(term, " content\x1b[27m"),
+    " content",
+  );
+});
+
 test("long multi-line paste does not clear cursor-right residue before terminal echo", () => {
   const writes: string[] = [];
   const term = {

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -5,6 +5,7 @@ import {
   clearPasteResidualAfterTerminalWrite,
   pasteTextIntoTerminal,
   prepareTerminalDataForUserPasteDisplay,
+  shouldSuppressTerminalInputScrollForUserPaste,
 } from "./terminalUserPaste";
 
 test("user paste delegates raw clipboard text to xterm paste handling", () => {
@@ -39,6 +40,65 @@ test("user paste preserves the existing scroll-on-paste behavior", () => {
   });
 
   assert.deepEqual(calls, ["paste", "scroll", "raf", "scroll"]);
+});
+
+test("user paste with scroll disabled suppresses input auto-scroll for raw paste data", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "line one\rline two"), true);
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "x"), false);
+});
+
+test("user paste with scroll disabled suppresses input auto-scroll for bracketed paste data", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(
+    shouldSuppressTerminalInputScrollForUserPaste(term, "\x1b[200~line one\rline two\x1b[201~"),
+    true,
+  );
+});
+
+test("user paste with scroll enabled keeps input auto-scroll available", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: true,
+    requestAnimationFrame: () => {},
+  });
+
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "line one\rline two"), false);
+});
+
+test("user paste with scroll disabled suppresses split input chunks", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+  });
+
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "line one\r"), true);
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "line two"), true);
+  assert.equal(shouldSuppressTerminalInputScrollForUserPaste(term, "line two"), false);
 });
 
 test("long multi-line paste strips readline active-region highlighting from echo", () => {

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -12,12 +12,14 @@ type PasteDisplayState = {
   expiresAt: number;
   clearPending: number;
   pasteEchoFragments: string[];
+  inPasteEchoActiveRegion: boolean;
 };
 
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
 const LONG_PASTE_MIN_LENGTH = 200;
 const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
-const READLINE_ACTIVE_REGION_MARKERS = ["\x1b[7m", "\x1b[27m"] as const;
+const READLINE_ACTIVE_REGION_START = "\x1b[7m";
+const READLINE_ACTIVE_REGION_END = "\x1b[27m";
 const MIN_PASTE_ECHO_FRAGMENT_LENGTH = 6;
 const ESC = "\x1b";
 const BEL = "\x07";
@@ -27,14 +29,12 @@ const getNow = () => Date.now();
 const isStateActive = (state: PasteDisplayState | undefined): state is PasteDisplayState =>
   !!state && state.expiresAt > getNow();
 
-const hasReadlineActiveRegion = (data: string): boolean =>
-  READLINE_ACTIVE_REGION_MARKERS.some((marker) => data.includes(marker));
-
 const stripReadlineActiveRegion = (data: string): string =>
-  READLINE_ACTIVE_REGION_MARKERS.reduce(
-    (nextData, marker) => nextData.split(marker).join(""),
-    data,
-  );
+  data
+    .split(READLINE_ACTIVE_REGION_START)
+    .join("")
+    .split(READLINE_ACTIVE_REGION_END)
+    .join("");
 
 const isCsiFinalByte = (char: string): boolean => {
   const code = char.charCodeAt(0);
@@ -120,6 +120,66 @@ const isExpectedPasteEcho = (data: string, state: PasteDisplayState): boolean =>
   );
 };
 
+const stripMatchedReadlineActiveRegion = (
+  data: string,
+  state: PasteDisplayState,
+): { data: string; matched: boolean } => {
+  let index = 0;
+  let matched = false;
+  let nextData = "";
+
+  while (index < data.length) {
+    if (state.inPasteEchoActiveRegion) {
+      const endIndex = data.indexOf(READLINE_ACTIVE_REGION_END, index);
+      if (endIndex === -1) {
+        nextData += data.slice(index);
+        matched = true;
+        break;
+      }
+
+      nextData += data.slice(index, endIndex);
+      index = endIndex + READLINE_ACTIVE_REGION_END.length;
+      state.inPasteEchoActiveRegion = false;
+      matched = true;
+      continue;
+    }
+
+    const startIndex = data.indexOf(READLINE_ACTIVE_REGION_START, index);
+    if (startIndex === -1) {
+      nextData += data.slice(index);
+      break;
+    }
+
+    nextData += data.slice(index, startIndex);
+    const contentStart = startIndex + READLINE_ACTIVE_REGION_START.length;
+    const endIndex = data.indexOf(READLINE_ACTIVE_REGION_END, contentStart);
+
+    if (endIndex === -1) {
+      const highlightedContent = data.slice(contentStart);
+      if (isExpectedPasteEcho(highlightedContent, state)) {
+        nextData += highlightedContent;
+        state.inPasteEchoActiveRegion = true;
+        matched = true;
+      } else {
+        nextData += data.slice(startIndex);
+      }
+      break;
+    }
+
+    const highlightedContent = data.slice(contentStart, endIndex);
+    if (isExpectedPasteEcho(highlightedContent, state)) {
+      nextData += highlightedContent;
+      matched = true;
+    } else {
+      nextData += data.slice(startIndex, endIndex + READLINE_ACTIVE_REGION_END.length);
+    }
+
+    index = endIndex + READLINE_ACTIVE_REGION_END.length;
+  }
+
+  return { data: nextData, matched };
+};
+
 const estimateRows = (text: string, cols: number): number => {
   const width = Math.max(1, cols);
   return text
@@ -151,6 +211,7 @@ export function pasteTextIntoTerminal(
       expiresAt: getNow() + PASTE_DISPLAY_FIX_WINDOW_MS,
       clearPending: 0,
       pasteEchoFragments: getPasteEchoFragments(text),
+      inPasteEchoActiveRegion: false,
     });
   }
 
@@ -176,12 +237,13 @@ export function prepareTerminalDataForUserPasteDisplay(term: object, data: strin
   const state = pasteDisplayStates.get(term);
   if (!isStateActive(state)) return data;
 
-  const isPasteEcho = isExpectedPasteEcho(data, state);
-  if (hasReadlineActiveRegion(data) && isPasteEcho) {
+  const strippedActiveRegion = stripMatchedReadlineActiveRegion(data, state);
+  if (strippedActiveRegion.matched) {
     state.clearPending = Math.max(state.clearPending, 3);
-    return stripReadlineActiveRegion(data);
+    return strippedActiveRegion.data;
   }
 
+  const isPasteEcho = isExpectedPasteEcho(data, state);
   if (isPasteEcho && (data.length > LONG_PASTE_MIN_LENGTH || data.includes("\r"))) {
     state.clearPending = Math.max(state.clearPending, 1);
   }

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -1,0 +1,111 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+type PasteTarget = Pick<XTerm, "paste" | "scrollToBottom"> &
+  Partial<Pick<XTerm, "cols" | "rows" | "write">>;
+
+type PasteOptions = {
+  scrollOnPaste?: boolean;
+  requestAnimationFrame?: (callback: () => void) => unknown;
+};
+
+type PasteDisplayState = {
+  expiresAt: number;
+  clearPending: number;
+};
+
+const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
+const LONG_PASTE_MIN_LENGTH = 200;
+const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
+const READLINE_ACTIVE_REGION_MARKERS = ["\x1b[7m", "\x1b[27m"] as const;
+
+const getNow = () => Date.now();
+
+const isStateActive = (state: PasteDisplayState | undefined): state is PasteDisplayState =>
+  !!state && state.expiresAt > getNow();
+
+const hasReadlineActiveRegion = (data: string): boolean =>
+  READLINE_ACTIVE_REGION_MARKERS.some((marker) => data.includes(marker));
+
+const stripReadlineActiveRegion = (data: string): string =>
+  READLINE_ACTIVE_REGION_MARKERS.reduce(
+    (nextData, marker) => nextData.split(marker).join(""),
+    data,
+  );
+
+const estimateRows = (text: string, cols: number): number => {
+  const width = Math.max(1, cols);
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .reduce((rows, line) => rows + Math.max(1, Math.ceil(line.length / width)), 0);
+};
+
+const shouldApplyPasteDisplayFix = (term: PasteTarget, text: string): boolean => {
+  if (text.length < LONG_PASTE_MIN_LENGTH) return false;
+
+  const lineCount = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n").length;
+  const rows = typeof term.rows === "number" && term.rows > 0 ? term.rows : 24;
+  const cols = typeof term.cols === "number" && term.cols > 0 ? term.cols : 80;
+
+  return lineCount >= rows - 1 || estimateRows(text, cols) >= rows - 1;
+};
+
+export function pasteTextIntoTerminal(
+  term: PasteTarget,
+  text: string,
+  options: PasteOptions = {},
+): void {
+  if (!text) return;
+
+  if (shouldApplyPasteDisplayFix(term, text)) {
+    pasteDisplayStates.set(term, {
+      expiresAt: getNow() + PASTE_DISPLAY_FIX_WINDOW_MS,
+      clearPending: 1,
+    });
+  }
+
+  term.paste(text);
+
+  if (!options.scrollOnPaste) return;
+
+  term.scrollToBottom();
+  const scheduleFrame =
+    options.requestAnimationFrame ??
+    (typeof globalThis.requestAnimationFrame === "function"
+      ? globalThis.requestAnimationFrame.bind(globalThis)
+      : undefined);
+
+  if (scheduleFrame) {
+    scheduleFrame(() => {
+      term.scrollToBottom();
+    });
+  }
+}
+
+export function prepareTerminalDataForUserPasteDisplay(term: object, data: string): string {
+  const state = pasteDisplayStates.get(term);
+  if (!isStateActive(state)) return data;
+
+  if (hasReadlineActiveRegion(data)) {
+    state.clearPending = Math.max(state.clearPending, 3);
+    return stripReadlineActiveRegion(data);
+  }
+
+  if (data.length > LONG_PASTE_MIN_LENGTH || data.includes("\r")) {
+    state.clearPending = Math.max(state.clearPending, 1);
+  }
+  return data;
+}
+
+export function clearPasteResidualAfterTerminalWrite(term: object): void {
+  const state = pasteDisplayStates.get(term);
+  if (!isStateActive(state)) return;
+  if (state.clearPending <= 0) return;
+  if (typeof (term as Partial<Pick<XTerm, "write">>).write !== "function") return;
+
+  // Readline can leave stale cells to the right of the cursor after very long
+  // bracketed paste redraws; clear them locally without sending bytes upstream.
+  state.clearPending -= 1;
+  (term as Pick<XTerm, "write">).write("\x1b[K");
+}

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -15,18 +15,27 @@ type PasteDisplayState = {
   inPasteEchoActiveRegion: boolean;
 };
 
+type PasteInputScrollState = {
+  expiresAt: number;
+  remainingDataVariants: string[];
+};
+
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
+const pasteInputScrollStates = new WeakMap<object, PasteInputScrollState>();
 const LONG_PASTE_MIN_LENGTH = 200;
 const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
+const PASTE_INPUT_SCROLL_WINDOW_MS = 4000;
 const READLINE_ACTIVE_REGION_START = "\x1b[7m";
 const READLINE_ACTIVE_REGION_END = "\x1b[27m";
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 const MIN_PASTE_ECHO_FRAGMENT_LENGTH = 6;
 const ESC = "\x1b";
 const BEL = "\x07";
 
 const getNow = () => Date.now();
 
-const isStateActive = (state: PasteDisplayState | undefined): state is PasteDisplayState =>
+const isStateActive = <T extends { expiresAt: number }>(state: T | undefined): state is T =>
   !!state && state.expiresAt > getNow();
 
 const stripReadlineActiveRegion = (data: string): string =>
@@ -106,6 +115,18 @@ const getPasteEchoFragments = (text: string): string[] =>
         .filter((line) => line.length >= MIN_PASTE_ECHO_FRAGMENT_LENGTH),
     ),
   );
+
+const preparePasteTextForXterm = (text: string): string => text.replace(/\r?\n/g, "\r");
+
+const getPasteInputDataVariants = (text: string): string[] => {
+  const preparedText = preparePasteTextForXterm(text);
+  return Array.from(
+    new Set([
+      preparedText,
+      `${BRACKETED_PASTE_START}${preparedText}${BRACKETED_PASTE_END}`,
+    ]),
+  ).filter((candidate) => candidate.length > 0);
+};
 
 const isExpectedPasteEcho = (data: string, state: PasteDisplayState): boolean => {
   if (state.pasteEchoFragments.length === 0) return false;
@@ -215,6 +236,15 @@ export function pasteTextIntoTerminal(
     });
   }
 
+  if (options.scrollOnPaste === false) {
+    pasteInputScrollStates.set(term, {
+      expiresAt: getNow() + PASTE_INPUT_SCROLL_WINDOW_MS,
+      remainingDataVariants: getPasteInputDataVariants(text),
+    });
+  } else {
+    pasteInputScrollStates.delete(term);
+  }
+
   term.paste(text);
 
   if (!options.scrollOnPaste) return;
@@ -231,6 +261,28 @@ export function pasteTextIntoTerminal(
       term.scrollToBottom();
     });
   }
+}
+
+export function shouldSuppressTerminalInputScrollForUserPaste(term: object, data: string): boolean {
+  const state = pasteInputScrollStates.get(term);
+  if (!isStateActive(state)) {
+    pasteInputScrollStates.delete(term);
+    return false;
+  }
+
+  const matchingIndex = state.remainingDataVariants.findIndex((candidate) => {
+    if (candidate === data) return true;
+    return candidate.startsWith(data);
+  });
+  if (matchingIndex === -1) return false;
+
+  const candidate = state.remainingDataVariants[matchingIndex];
+  if (candidate.length > data.length) {
+    state.remainingDataVariants[matchingIndex] = candidate.slice(data.length);
+  } else {
+    pasteInputScrollStates.delete(term);
+  }
+  return true;
 }
 
 export function prepareTerminalDataForUserPasteDisplay(term: object, data: string): string {

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -11,12 +11,16 @@ type PasteOptions = {
 type PasteDisplayState = {
   expiresAt: number;
   clearPending: number;
+  pasteEchoFragments: string[];
 };
 
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
 const LONG_PASTE_MIN_LENGTH = 200;
 const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
 const READLINE_ACTIVE_REGION_MARKERS = ["\x1b[7m", "\x1b[27m"] as const;
+const MIN_PASTE_ECHO_FRAGMENT_LENGTH = 6;
+const ESC = "\x1b";
+const BEL = "\x07";
 
 const getNow = () => Date.now();
 
@@ -31,6 +35,90 @@ const stripReadlineActiveRegion = (data: string): string =>
     (nextData, marker) => nextData.split(marker).join(""),
     data,
   );
+
+const isCsiFinalByte = (char: string): boolean => {
+  const code = char.charCodeAt(0);
+  return code >= 0x40 && code <= 0x7e;
+};
+
+const stripAnsiEscapeSequences = (data: string): string => {
+  let plainText = "";
+
+  for (let index = 0; index < data.length; index += 1) {
+    const char = data[index];
+    if (char !== ESC) {
+      plainText += char;
+      continue;
+    }
+
+    const nextChar = data[index + 1];
+    if (nextChar === "[") {
+      index += 2;
+      while (index < data.length && !isCsiFinalByte(data[index])) {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (nextChar === "]") {
+      index += 2;
+      while (index < data.length) {
+        if (data[index] === BEL) break;
+        if (data[index] === ESC && data[index + 1] === "\\") {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (nextChar) {
+      index += 1;
+    }
+  }
+
+  return plainText;
+};
+
+const stripNonLineBreakControls = (data: string): string => {
+  let plainText = "";
+  for (const char of data) {
+    const code = char.charCodeAt(0);
+    if (char === "\n" || (code >= 0x20 && code !== 0x7f)) {
+      plainText += char;
+    }
+  }
+  return plainText;
+};
+
+const getPlainTerminalText = (data: string): string =>
+  stripNonLineBreakControls(
+    stripAnsiEscapeSequences(data).replace(/\r\n/g, "\n").replace(/\r/g, "\n"),
+  );
+
+const getPasteEchoFragments = (text: string): string[] =>
+  Array.from(
+    new Set(
+      getPlainTerminalText(text)
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length >= MIN_PASTE_ECHO_FRAGMENT_LENGTH),
+    ),
+  );
+
+const isExpectedPasteEcho = (data: string, state: PasteDisplayState): boolean => {
+  if (state.pasteEchoFragments.length === 0) return false;
+
+  const candidateLines = getPlainTerminalText(stripReadlineActiveRegion(data))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length >= MIN_PASTE_ECHO_FRAGMENT_LENGTH);
+
+  return candidateLines.some((line) =>
+    state.pasteEchoFragments.some((fragment) => fragment.includes(line) || line.includes(fragment)),
+  );
+};
 
 const estimateRows = (text: string, cols: number): number => {
   const width = Math.max(1, cols);
@@ -61,7 +149,8 @@ export function pasteTextIntoTerminal(
   if (shouldApplyPasteDisplayFix(term, text)) {
     pasteDisplayStates.set(term, {
       expiresAt: getNow() + PASTE_DISPLAY_FIX_WINDOW_MS,
-      clearPending: 1,
+      clearPending: 0,
+      pasteEchoFragments: getPasteEchoFragments(text),
     });
   }
 
@@ -87,12 +176,13 @@ export function prepareTerminalDataForUserPasteDisplay(term: object, data: strin
   const state = pasteDisplayStates.get(term);
   if (!isStateActive(state)) return data;
 
-  if (hasReadlineActiveRegion(data)) {
+  const isPasteEcho = isExpectedPasteEcho(data, state);
+  if (hasReadlineActiveRegion(data) && isPasteEcho) {
     state.clearPending = Math.max(state.clearPending, 3);
     return stripReadlineActiveRegion(data);
   }
 
-  if (data.length > LONG_PASTE_MIN_LENGTH || data.includes("\r")) {
+  if (isPasteEcho && (data.length > LONG_PASTE_MIN_LENGTH || data.includes("\r"))) {
     state.clearPending = Math.max(state.clearPending, 1);
   }
   return data;


### PR DESCRIPTION
## Summary
- Fixes the Debian bash long-paste display artifacts where stale text remains after the cursor.
- Removes the pasted command echo highlight that looks like a terminal selection.
- Routes user paste actions through a shared path so context-menu, keyboard, and middle-click paste behave consistently.
- Preserves serial line mode behavior when a paste arrives as one multi-line input chunk.

## Validation
- Reproduced the reported docker command in an 80-column Debian-style bash shell before and after the fix.
- `node --test --import tsx components/terminal/runtime/terminalUserPaste.test.ts`
- `node --test --import tsx components/terminal/runtime/serialLineInput.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`

Addresses the long-paste display part of #957.