### PR TITLE
Fix #957: persist SSH known-host trust across app restarts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -300,6 +300,16 @@ function App({ settings }: { settings: SettingsState }) {
   keysRef.current = keys;
   const knownHostsRef = useRef(knownHosts);
   knownHostsRef.current = knownHosts;
+  // Bridge the gap while useVaultState hydrates: its async init awaits
+  // hosts/keys/identities/proxyProfiles decryption before reading knownHosts,
+  // so the state is briefly [] at boot even when localStorage has entries.
+  // Any SSH connect during that window (manual click or restored session)
+  // would otherwise see no trusted hosts and prompt for fingerprint
+  // re-confirmation. Mirrors the same fallback already used by sync payloads.
+  const effectiveKnownHosts = useMemo(
+    () => getEffectiveKnownHosts(knownHosts) ?? [],
+    [knownHosts],
+  );
 
   const {
     sessions,
@@ -1996,7 +2006,7 @@ function App({ settings }: { settings: SettingsState }) {
             snippets={snippets}
             snippetPackages={snippetPackages}
             customGroups={customGroups}
-            knownHosts={knownHosts}
+            knownHosts={effectiveKnownHosts}
             shellHistory={shellHistory}
             connectionLogs={connectionLogs}
             managedSources={managedSources}
@@ -2069,7 +2079,7 @@ function App({ settings }: { settings: SettingsState }) {
           snippetPackages={snippetPackages}
           sessions={sessions}
           workspaces={workspaces}
-          knownHosts={knownHosts}
+          knownHosts={effectiveKnownHosts}
           draggingSessionId={draggingSessionId}
           terminalTheme={currentTerminalTheme}
           followAppTerminalTheme={followAppTerminalTheme}


### PR DESCRIPTION
## Summary

Fixes the "remembered host fingerprints stop working after restarting netcatty" symptom reported in #957.

## Root cause

Commit [`bce33f34`](https://github.com/binaricat/Netcatty/commit/bce33f34) "Fix SSH known host verification" (shipped in 1.1.3) introduced a `hostVerifier` in the main process that decides whether a host is trusted by reading the `options.knownHosts` array passed in from the renderer.

The renderer's `knownHosts` comes from the React state owned by `useVaultState`, and that state is hydrated **asynchronously**: the init flow in [useVaultState.ts:404](https://github.com/binaricat/Netcatty/blob/main/application/state/useVaultState.ts#L404) `await`s the decryption of hosts / keys / identities / proxyProfiles before it finally reads `knownHosts` at [line 509](https://github.com/binaricat/Netcatty/blob/main/application/state/useVaultState.ts#L509). For users with several encrypted keys, the full hydration can easily take a few hundred milliseconds.

Until that finishes the React state is still `[]`, and `App.tsx` lines 1999 / 2072 pass that state straight through to `VaultView` / `TerminalLayerMount`, which eventually reaches [sshBridge.cjs:762](https://github.com/binaricat/Netcatty/blob/main/electron/bridges/sshBridge.cjs#L762) `createHostVerifier({ knownHosts: options.knownHosts })`. If the user clicks connect before hydration completes (manually, or via auto-restored sessions), the verifier sees an empty array, classifies every host as `"unknown"`, and prompts. The user's "accept" is correctly written to localStorage, but next restart the same race fires again — giving the impression that the fingerprint was never saved.

## Fix

The project already had a [`getEffectiveKnownHosts`](https://github.com/binaricat/Netcatty/blob/main/infrastructure/syncHelpers.ts) helper. Its docstring spells out the exact situation:

> If the hook/state knownHosts is empty but localStorage has data, read from localStorage so local backups do not miss entries while async store initialization is still settling.

The sync-payload code path already used it ([App.tsx:479](https://github.com/binaricat/Netcatty/blob/main/App.tsx#L479)), but the SSH-connect path was missed. This PR wires the same helper into the `knownHosts` prop that `VaultView` and `TerminalLayerMount` receive.

Wrapped in `useMemo` keyed on the `knownHosts` state so that:
- once hydration completes, the memo returns the state itself (stable reference, downstream `React.memo` equality checks keep working)
- before hydration, the memo returns the localStorage fallback with a stable reference within the same render cycle

## Test plan

- [x] `npx tsc --noEmit` — no new errors in changed files (other pre-existing repo-wide TS errors are unrelated to this PR)
- [x] Ran the hostKey / knownHosts-related test suites — 51 tests pass:
  - `electron/bridges/hostKeyVerifier.test.cjs`
  - `components/terminal/hostKeyVerification.test.ts`
  - `components/terminal/runtime/createTerminalSessionStarters.test.ts`
  - `components/TerminalLayer.memo.test.tsx`
  - `domain/knownHosts.test.ts`
- [ ] Manual regression: on a machine where the fingerprint was already accepted, restart netcatty and reconnect — the confirmation dialog should **no longer** appear
- [ ] Manual regression: first-time connections to unknown hosts still prompt as expected; after accepting, restart immediately and reconnect — the dialog should not reappear

## Related

- Closes the "fingerprint not persisted" half of #957
- The "long command display" half of the same issue was already fixed in #959 — out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
