### PR TITLE
Fix #919: harden built-in Telnet handshake for legacy gear

### DIFF
--- a/electron/bridges/telnetProtocol.cjs
+++ b/electron/bridges/telnetProtocol.cjs
@@ -236,6 +236,142 @@ function unescapeIacFromPayload(buf) {
   return Buffer.from(out);
 }
 
+/**
+ * Build a Telnet negotiation policy machine.
+ *
+ * The machine owns the rules for which options we accept, the
+ * direction-aware acknowledgement tracking, and the wire bytes sent in
+ * response to peer commands. It is intentionally separated from socket I/O
+ * so it can be exercised directly in unit tests.
+ *
+ * `writeCommand(cmd, opt)` is invoked to send `IAC <cmd> <opt>` on the
+ * wire; `writeSubnegotiation(opt, payload)` is invoked to send
+ * `IAC SB <opt> <payload...> IAC SE` (with `payload` already escaped if
+ * needed by the caller); `getWindowSize()` returns `{ cols, rows }` for
+ * the current terminal dimensions; `termType` is the string advertised
+ * for TERMINAL-TYPE subnegotiation (default "XTERM-256COLOR").
+ */
+function createTelnetNegotiator({
+  writeCommand,
+  writeSubnegotiation,
+  getWindowSize,
+  termType = "XTERM-256COLOR",
+} = {}) {
+  const pendingDoRequests = new Set();
+  const pendingWillRequests = new Set();
+
+  const noopWrite = () => {};
+  const cmdSink = typeof writeCommand === "function" ? writeCommand : noopWrite;
+  const sbSink = typeof writeSubnegotiation === "function" ? writeSubnegotiation : noopWrite;
+  const sizeFn = typeof getWindowSize === "function"
+    ? getWindowSize
+    : () => ({ cols: 80, rows: 24 });
+
+  const naws = () => {
+    const { cols, rows } = sizeFn() || {};
+    const safeCols = Number.isFinite(cols) && cols > 0 ? cols : 80;
+    const safeRows = Number.isFinite(rows) && rows > 0 ? rows : 24;
+    const payload = Buffer.from([
+      (safeCols >> 8) & 0xff, safeCols & 0xff,
+      (safeRows >> 8) & 0xff, safeRows & 0xff,
+    ]);
+    sbSink(OPT.NAWS, escapeIacForWire(payload));
+  };
+
+  const sendTerminalType = () => {
+    sbSink(
+      OPT.TERMINAL_TYPE,
+      Buffer.concat([
+        Buffer.from([SUBOPTION_IS]),
+        Buffer.from(String(termType), "ascii"),
+      ]),
+    );
+  };
+
+  const requestOption = (cmd, opt) => {
+    if (cmd === DO) pendingDoRequests.add(opt);
+    else if (cmd === WILL) pendingWillRequests.add(opt);
+    cmdSink(cmd, opt);
+  };
+
+  const start = () => {
+    // Drive the negotiation rather than waiting for the peer. Many legacy
+    // servers will not advance past their banner until the client commits
+    // to a basic option set.
+    requestOption(DO, OPT.SUPPRESS_GO_AHEAD);
+    requestOption(WILL, OPT.TERMINAL_TYPE);
+    requestOption(WILL, OPT.NAWS);
+  };
+
+  const handleCommand = (cmd, opt) => {
+    let acknowledgesOurRequest = false;
+    if ((cmd === WILL || cmd === WONT) && pendingDoRequests.has(opt)) {
+      pendingDoRequests.delete(opt);
+      acknowledgesOurRequest = true;
+    } else if ((cmd === DO || cmd === DONT) && pendingWillRequests.has(opt)) {
+      pendingWillRequests.delete(opt);
+      acknowledgesOurRequest = true;
+    }
+
+    if (cmd === WILL) {
+      if (!acknowledgesOurRequest) {
+        if (opt === OPT.SUPPRESS_GO_AHEAD || opt === OPT.ECHO) {
+          cmdSink(DO, opt);
+        } else {
+          cmdSink(DONT, opt);
+        }
+      }
+      return;
+    }
+
+    if (cmd === DO) {
+      if (opt === OPT.NAWS) {
+        if (!acknowledgesOurRequest) cmdSink(WILL, opt);
+        // Always follow through with the actual size, whether this DO is the
+        // peer's reply to our WILL or an independent fresh request.
+        naws();
+      } else if (opt === OPT.TERMINAL_TYPE || opt === OPT.SUPPRESS_GO_AHEAD) {
+        if (!acknowledgesOurRequest) cmdSink(WILL, opt);
+      } else {
+        if (!acknowledgesOurRequest) cmdSink(WONT, opt);
+      }
+      return;
+    }
+
+    if (cmd === DONT) {
+      if (!acknowledgesOurRequest) cmdSink(WONT, opt);
+      return;
+    }
+
+    if (cmd === WONT) {
+      if (!acknowledgesOurRequest) cmdSink(DONT, opt);
+      return;
+    }
+  };
+
+  const handleSubnegotiation = (opt, payload) => {
+    if (opt === OPT.TERMINAL_TYPE
+      && payload && payload.length > 0
+      && payload[0] === SUBOPTION_SEND) {
+      sendTerminalType();
+    }
+  };
+
+  return {
+    start,
+    handleCommand,
+    handleSubnegotiation,
+    sendWindowSize: naws,
+    /** Test/debug introspection — number of options awaiting a reply per direction. */
+    get pendingDoCount() {
+      return pendingDoRequests.size;
+    },
+    get pendingWillCount() {
+      return pendingWillRequests.size;
+    },
+  };
+}
+
 module.exports = {
   // Command constants
   IAC,
@@ -262,4 +398,5 @@ module.exports = {
   commandName,
   escapeIacForWire,
   createTelnetParser,
+  createTelnetNegotiator,
 };

--- a/electron/bridges/telnetProtocol.cjs
+++ b/electron/bridges/telnetProtocol.cjs
@@ -1,0 +1,265 @@
+/**
+ * Telnet protocol helpers — RFC 854 framing + RFC 858/1091/1184/1408 options.
+ *
+ * The pieces live here so the protocol layer can be exercised by unit tests
+ * without spinning up a socket. terminalBridge.cjs owns the policy (which
+ * options to enable, what TERM-TYPE to advertise, how to wire data back to
+ * the renderer), this module owns the parsing.
+ */
+
+// Command bytes (RFC 854 / RFC 855).
+const IAC = 255;
+const SE = 240;
+const NOP = 241;
+const DM = 242;
+const BRK = 243;
+const IP = 244;
+const AO = 245;
+const AYT = 246;
+const EC = 247;
+const EL = 248;
+const GA = 249;
+const SB = 250;
+const WILL = 251;
+const WONT = 252;
+const DO = 253;
+const DONT = 254;
+
+// Options we care about. Servers may negotiate plenty of others, but we only
+// surface these to the policy layer; everything else is rejected with DONT/
+// WONT so the conversation terminates cleanly.
+const OPT = {
+  ECHO: 1,                 // RFC 857
+  SUPPRESS_GO_AHEAD: 3,    // RFC 858
+  STATUS: 5,
+  TERMINAL_TYPE: 24,       // RFC 1091
+  NAWS: 31,                // RFC 1073 — window size
+  TERMINAL_SPEED: 32,
+  LINEMODE: 34,
+  NEW_ENVIRON: 39,
+};
+
+const SUBOPTION_IS = 0;
+const SUBOPTION_SEND = 1;
+
+const isOptionCommand = (cmd) =>
+  cmd === WILL || cmd === WONT || cmd === DO || cmd === DONT;
+
+const commandName = (cmd) => {
+  switch (cmd) {
+    case IAC: return "IAC";
+    case SE: return "SE";
+    case NOP: return "NOP";
+    case DM: return "DM";
+    case BRK: return "BRK";
+    case IP: return "IP";
+    case AO: return "AO";
+    case AYT: return "AYT";
+    case EC: return "EC";
+    case EL: return "EL";
+    case GA: return "GA";
+    case SB: return "SB";
+    case WILL: return "WILL";
+    case WONT: return "WONT";
+    case DO: return "DO";
+    case DONT: return "DONT";
+    default: return String(cmd);
+  }
+};
+
+/**
+ * Escape a buffer for wire transmission: any literal 0xFF byte becomes
+ * 0xFF 0xFF so the peer's parser does not treat it as IAC. Cheap fast-path
+ * for the common case (no 0xFF bytes) so user typing — which is UTF-8 and
+ * cannot contain 0xFF — pays nothing.
+ */
+function escapeIacForWire(buf) {
+  if (!Buffer.isBuffer(buf) || buf.length === 0) return buf;
+  if (buf.indexOf(0xff) < 0) return buf;
+  const out = [];
+  for (let i = 0; i < buf.length; i++) {
+    out.push(buf[i]);
+    if (buf[i] === 0xff) out.push(0xff);
+  }
+  return Buffer.from(out);
+}
+
+/**
+ * Build a stateful Telnet parser.
+ *
+ * The parser preserves any partial command (IAC alone, IAC + verb without
+ * option, or unterminated subnegotiation) between feeds so that a sequence
+ * split across TCP frames is reassembled before being acted on. The previous
+ * stateless approach would either drop the lone IAC or treat the tail of an
+ * unterminated SB block as data — exactly the source of the garbled-output
+ * symptom on chatty old equipment.
+ *
+ * Callbacks:
+ *   onCommand(cmd, opt)        — WILL/WONT/DO/DONT for `opt`.
+ *   onSubnegotiation(opt, buf) — IAC SB <opt> ... IAC SE. `buf` is the
+ *                                 payload between option byte and IAC SE,
+ *                                 with any IAC IAC unescaped to a single
+ *                                 0xFF.
+ *   onData(buf)                — clean stream bytes, IAC IAC already
+ *                                 unescaped. Emitted in chunks coinciding
+ *                                 with command boundaries; never empty.
+ */
+function createTelnetParser({ onCommand, onSubnegotiation, onData } = {}) {
+  let pending = Buffer.alloc(0);
+
+  const noop = () => {};
+  const handleCommand = typeof onCommand === "function" ? onCommand : noop;
+  const handleSubnegotiation = typeof onSubnegotiation === "function" ? onSubnegotiation : noop;
+  const handleData = typeof onData === "function" ? onData : noop;
+
+  const feed = (chunk) => {
+    if (!chunk || chunk.length === 0) return;
+    const buf = pending.length === 0
+      ? (Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      : Buffer.concat([pending, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+    pending = Buffer.alloc(0);
+
+    const out = [];
+    let i = 0;
+    const flushData = () => {
+      if (out.length > 0) {
+        handleData(Buffer.from(out));
+        out.length = 0;
+      }
+    };
+
+    while (i < buf.length) {
+      const byte = buf[i];
+      if (byte !== IAC) {
+        out.push(byte);
+        i++;
+        continue;
+      }
+
+      // We are at an IAC byte. Need at least one more byte to know the verb.
+      if (i + 1 >= buf.length) {
+        pending = buf.subarray(i);
+        break;
+      }
+
+      const cmd = buf[i + 1];
+
+      if (cmd === IAC) {
+        // Escaped literal 0xFF in the data stream.
+        out.push(0xff);
+        i += 2;
+        continue;
+      }
+
+      if (isOptionCommand(cmd)) {
+        if (i + 2 >= buf.length) {
+          pending = buf.subarray(i);
+          break;
+        }
+        const opt = buf[i + 2];
+        flushData();
+        handleCommand(cmd, opt);
+        i += 3;
+        continue;
+      }
+
+      if (cmd === SB) {
+        // Subnegotiation: IAC SB <opt> <payload...> IAC SE. We need to find
+        // the terminating IAC SE while ignoring escaped IAC IAC inside the
+        // payload (RFC 855).
+        let j = i + 3;
+        let seFound = false;
+        while (j + 1 < buf.length) {
+          if (buf[j] === IAC) {
+            if (buf[j + 1] === SE) {
+              seFound = true;
+              break;
+            }
+            // Escaped IAC IAC in payload, or another IAC verb (rare,
+            // ignored). Either way, skip two bytes and keep scanning.
+            j += 2;
+            continue;
+          }
+          j++;
+        }
+        if (!seFound) {
+          // Subnegotiation continues into the next frame.
+          pending = buf.subarray(i);
+          break;
+        }
+        if (i + 2 >= buf.length) {
+          pending = buf.subarray(i);
+          break;
+        }
+        const opt = buf[i + 2];
+        const rawPayload = buf.subarray(i + 3, j);
+        const payload = unescapeIacFromPayload(rawPayload);
+        flushData();
+        handleSubnegotiation(opt, payload);
+        i = j + 2;
+        continue;
+      }
+
+      // Other single-verb IAC commands (NOP, AYT, IP, ...). The protocol
+      // does not require us to act, but we must still consume the two bytes
+      // so they do not leak into the data stream.
+      flushData();
+      i += 2;
+    }
+
+    flushData();
+  };
+
+  return {
+    feed,
+    get pendingByteCount() {
+      return pending.length;
+    },
+    /** Reset state — used when a session is torn down or reconnected. */
+    reset() {
+      pending = Buffer.alloc(0);
+    },
+  };
+}
+
+function unescapeIacFromPayload(buf) {
+  if (!buf || buf.indexOf(0xff) < 0) return buf;
+  const out = [];
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === 0xff && i + 1 < buf.length && buf[i + 1] === 0xff) {
+      out.push(0xff);
+      i++;
+      continue;
+    }
+    out.push(buf[i]);
+  }
+  return Buffer.from(out);
+}
+
+module.exports = {
+  // Command constants
+  IAC,
+  SE,
+  NOP,
+  DM,
+  BRK,
+  IP,
+  AO,
+  AYT,
+  EC,
+  EL,
+  GA,
+  SB,
+  WILL,
+  WONT,
+  DO,
+  DONT,
+  // Options
+  OPT,
+  SUBOPTION_IS,
+  SUBOPTION_SEND,
+  // Helpers
+  commandName,
+  escapeIacForWire,
+  createTelnetParser,
+};

--- a/electron/bridges/telnetProtocol.test.cjs
+++ b/electron/bridges/telnetProtocol.test.cjs
@@ -11,8 +11,11 @@ const {
   DO,
   DONT,
   OPT,
+  SUBOPTION_IS,
+  SUBOPTION_SEND,
   escapeIacForWire,
   createTelnetParser,
+  createTelnetNegotiator,
 } = require("./telnetProtocol.cjs");
 
 const collect = () => {
@@ -219,6 +222,166 @@ test("parser reset clears pending state", () => {
   assert.equal(parser.pendingByteCount, 1);
   parser.reset();
   assert.equal(parser.pendingByteCount, 0);
+});
+
+const recordNegotiator = (overrides = {}) => {
+  const commands = [];
+  const subnegs = [];
+  const negotiator = createTelnetNegotiator({
+    writeCommand(cmd, opt) {
+      commands.push({ cmd, opt });
+    },
+    writeSubnegotiation(opt, payload) {
+      subnegs.push({ opt, payload: Buffer.from(payload) });
+    },
+    getWindowSize: () => ({ cols: 120, rows: 40 }),
+    ...overrides,
+  });
+  return { negotiator, commands, subnegs };
+};
+
+test("negotiator.start drives the canonical handshake (DO SGA / WILL TT / WILL NAWS)", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.start();
+  assert.deepEqual(commands, [
+    { cmd: DO, opt: OPT.SUPPRESS_GO_AHEAD },
+    { cmd: WILL, opt: OPT.TERMINAL_TYPE },
+    { cmd: WILL, opt: OPT.NAWS },
+  ]);
+  assert.equal(negotiator.pendingDoCount, 1);
+  assert.equal(negotiator.pendingWillCount, 2);
+});
+
+test("peer's WILL on our pending DO is swallowed (no double-DO loop)", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.start();
+  commands.length = 0;
+  // Server replies WILL SGA — acknowledges our DO SGA.
+  negotiator.handleCommand(WILL, OPT.SUPPRESS_GO_AHEAD);
+  assert.deepEqual(commands, []);
+  assert.equal(negotiator.pendingDoCount, 0);
+});
+
+test("peer's independent DO on a SGA where our DO is still pending is replied with WILL (regression)", () => {
+  // RFC 858: WILL/WONT and DO/DONT are independent per direction. The peer
+  // can ask us to enable SGA on our side while our request to enable it on
+  // its side is still in flight. The old implementation incorrectly treated
+  // the peer's DO as an ack of our DO and never replied.
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.start();
+  commands.length = 0;
+
+  negotiator.handleCommand(DO, OPT.SUPPRESS_GO_AHEAD);
+
+  assert.deepEqual(commands, [{ cmd: WILL, opt: OPT.SUPPRESS_GO_AHEAD }]);
+  // The pending DO request stays open until the peer also says WILL/WONT.
+  assert.equal(negotiator.pendingDoCount, 1);
+});
+
+test("peer's DO NAWS that acknowledges our WILL NAWS still triggers a size subnegotiation", () => {
+  const { negotiator, commands, subnegs } = recordNegotiator();
+  negotiator.start();
+  commands.length = 0;
+  subnegs.length = 0;
+
+  negotiator.handleCommand(DO, OPT.NAWS);
+
+  // No echoed WILL NAWS — the peer was acknowledging our own WILL.
+  assert.deepEqual(commands, []);
+  // But the actual size payload must follow.
+  assert.equal(subnegs.length, 1);
+  assert.equal(subnegs[0].opt, OPT.NAWS);
+  assert.deepEqual(
+    [...subnegs[0].payload],
+    [(120 >> 8) & 0xff, 120 & 0xff, (40 >> 8) & 0xff, 40 & 0xff],
+  );
+  assert.equal(negotiator.pendingWillCount, 1); // TERMINAL-TYPE still outstanding
+});
+
+test("peer's independent DO NAWS (no WILL pending) replies WILL + size subneg", () => {
+  const { negotiator, commands, subnegs } = recordNegotiator();
+  // Note: not calling start(), so no WILL NAWS is pending.
+  negotiator.handleCommand(DO, OPT.NAWS);
+  assert.deepEqual(commands, [{ cmd: WILL, opt: OPT.NAWS }]);
+  assert.equal(subnegs.length, 1);
+  assert.equal(subnegs[0].opt, OPT.NAWS);
+});
+
+test("peer's WILL ECHO triggers DO ECHO, repeated WILL ECHO is swallowed as ack", () => {
+  const { negotiator, commands } = recordNegotiator();
+  // First WILL ECHO: fresh request → we reply DO ECHO. That DO is sent via
+  // the raw writer (not requestOption), so it is NOT in pendingDoRequests.
+  // The peer's subsequent WILL ECHO is a re-announce and we should reply
+  // with another DO. The negotiator does not currently de-duplicate, so
+  // this test pins down the actual behaviour: reply each time.
+  negotiator.handleCommand(WILL, OPT.ECHO);
+  negotiator.handleCommand(WILL, OPT.ECHO);
+  assert.deepEqual(commands, [
+    { cmd: DO, opt: OPT.ECHO },
+    { cmd: DO, opt: OPT.ECHO },
+  ]);
+});
+
+test("peer's WONT on our pending DO is swallowed", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.start();
+  commands.length = 0;
+  negotiator.handleCommand(WONT, OPT.SUPPRESS_GO_AHEAD);
+  assert.deepEqual(commands, []);
+  assert.equal(negotiator.pendingDoCount, 0);
+});
+
+test("peer's DONT on our pending WILL is swallowed", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.start();
+  commands.length = 0;
+  negotiator.handleCommand(DONT, OPT.TERMINAL_TYPE);
+  assert.deepEqual(commands, []);
+  // NAWS still outstanding.
+  assert.equal(negotiator.pendingWillCount, 1);
+});
+
+test("peer's DO on an option we don't support replies WONT", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.handleCommand(DO, OPT.LINEMODE);
+  assert.deepEqual(commands, [{ cmd: WONT, opt: OPT.LINEMODE }]);
+});
+
+test("peer's WILL on an option we don't support replies DONT", () => {
+  const { negotiator, commands } = recordNegotiator();
+  negotiator.handleCommand(WILL, OPT.NEW_ENVIRON);
+  assert.deepEqual(commands, [{ cmd: DONT, opt: OPT.NEW_ENVIRON }]);
+});
+
+test("peer's TERMINAL-TYPE SEND subnegotiation replies with IS <termType>", () => {
+  const { negotiator, subnegs } = recordNegotiator();
+  negotiator.handleSubnegotiation(
+    OPT.TERMINAL_TYPE,
+    Buffer.from([SUBOPTION_SEND]),
+  );
+  assert.equal(subnegs.length, 1);
+  assert.equal(subnegs[0].opt, OPT.TERMINAL_TYPE);
+  assert.equal(
+    subnegs[0].payload.toString("ascii"),
+    "\x00XTERM-256COLOR",
+  );
+});
+
+test("negotiator honors a custom termType override", () => {
+  const { negotiator, subnegs } = recordNegotiator({ termType: "VT100" });
+  negotiator.handleSubnegotiation(
+    OPT.TERMINAL_TYPE,
+    Buffer.from([SUBOPTION_SEND]),
+  );
+  assert.equal(subnegs[0].payload.toString("ascii"), "\x00VT100");
+});
+
+test("sendWindowSize falls back to 80x24 when getWindowSize returns garbage", () => {
+  const { negotiator, subnegs } = recordNegotiator({
+    getWindowSize: () => ({ cols: NaN, rows: -3 }),
+  });
+  negotiator.sendWindowSize();
+  assert.deepEqual([...subnegs[0].payload], [0, 80, 0, 24]);
 });
 
 test("data emitted before a command is delivered before that command's callback", () => {

--- a/electron/bridges/telnetProtocol.test.cjs
+++ b/electron/bridges/telnetProtocol.test.cjs
@@ -1,0 +1,246 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  IAC,
+  SE,
+  NOP,
+  SB,
+  WILL,
+  WONT,
+  DO,
+  DONT,
+  OPT,
+  escapeIacForWire,
+  createTelnetParser,
+} = require("./telnetProtocol.cjs");
+
+const collect = () => {
+  const data = [];
+  const commands = [];
+  const subnegs = [];
+  return {
+    data,
+    commands,
+    subnegs,
+    parser: createTelnetParser({
+      onData(buf) {
+        data.push(Buffer.from(buf));
+      },
+      onCommand(cmd, opt) {
+        commands.push({ cmd, opt });
+      },
+      onSubnegotiation(opt, payload) {
+        subnegs.push({ opt, payload: Buffer.from(payload) });
+      },
+    }),
+  };
+};
+
+test("escapeIacForWire — passthrough when no 0xFF byte", () => {
+  const input = Buffer.from([0x61, 0x62, 0x63]);
+  assert.equal(escapeIacForWire(input), input);
+});
+
+test("escapeIacForWire — doubles each 0xFF", () => {
+  const input = Buffer.from([0xff, 0x61, 0xff, 0xff, 0x62]);
+  const got = escapeIacForWire(input);
+  assert.deepEqual(
+    [...got],
+    [0xff, 0xff, 0x61, 0xff, 0xff, 0xff, 0xff, 0x62],
+  );
+});
+
+test("parser emits clean data when no IAC bytes are present", () => {
+  const { parser, data, commands, subnegs } = collect();
+  parser.feed(Buffer.from("hello world"));
+  assert.equal(Buffer.concat(data).toString("utf8"), "hello world");
+  assert.equal(commands.length, 0);
+  assert.equal(subnegs.length, 0);
+});
+
+test("parser handles a complete DO option command in one feed", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(Buffer.from([IAC, DO, OPT.SUPPRESS_GO_AHEAD]));
+  assert.equal(data.length, 0);
+  assert.deepEqual(commands, [{ cmd: DO, opt: OPT.SUPPRESS_GO_AHEAD }]);
+});
+
+test("parser splits clean data around an option command", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(
+    Buffer.concat([
+      Buffer.from("login: "),
+      Buffer.from([IAC, WILL, OPT.ECHO]),
+      Buffer.from("admin"),
+    ]),
+  );
+  assert.equal(Buffer.concat(data).toString("utf8"), "login: admin");
+  assert.deepEqual(commands, [{ cmd: WILL, opt: OPT.ECHO }]);
+});
+
+test("parser unescapes IAC IAC into a literal 0xFF in the data stream", () => {
+  const { parser, data } = collect();
+  parser.feed(Buffer.from([0x61, IAC, IAC, 0x62]));
+  assert.deepEqual([...Buffer.concat(data)], [0x61, 0xff, 0x62]);
+});
+
+test("parser ignores stand-alone IAC verbs (NOP)", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(Buffer.from([0x61, IAC, NOP, 0x62]));
+  assert.deepEqual([...Buffer.concat(data)], [0x61, 0x62]);
+  assert.equal(commands.length, 0);
+});
+
+test("parser parses a complete subnegotiation in one feed", () => {
+  const { parser, data, subnegs } = collect();
+  // IAC SB TERMINAL_TYPE IS "XTERM" IAC SE
+  parser.feed(
+    Buffer.concat([
+      Buffer.from([IAC, SB, OPT.TERMINAL_TYPE, 0]),
+      Buffer.from("XTERM"),
+      Buffer.from([IAC, SE]),
+    ]),
+  );
+  assert.equal(data.length, 0);
+  assert.equal(subnegs.length, 1);
+  assert.equal(subnegs[0].opt, OPT.TERMINAL_TYPE);
+  assert.deepEqual(
+    [...subnegs[0].payload],
+    [0, 0x58, 0x54, 0x45, 0x52, 0x4d],
+  );
+});
+
+test("parser tolerates IAC IAC inside a subnegotiation payload", () => {
+  const { parser, subnegs } = collect();
+  // SB STATUS 0xFF (encoded as IAC IAC) 0x01 SE
+  parser.feed(Buffer.from([IAC, SB, OPT.STATUS, IAC, IAC, 0x01, IAC, SE]));
+  assert.equal(subnegs.length, 1);
+  assert.deepEqual([...subnegs[0].payload], [0xff, 0x01]);
+});
+
+test("parser preserves a lone IAC at end-of-chunk for the next feed", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(Buffer.concat([Buffer.from("hi"), Buffer.from([IAC])]));
+  assert.equal(Buffer.concat(data).toString("utf8"), "hi");
+  assert.equal(commands.length, 0);
+  assert.equal(parser.pendingByteCount, 1);
+
+  // Next chunk completes the command.
+  parser.feed(Buffer.from([DO, OPT.NAWS, 0x61]));
+  assert.equal(parser.pendingByteCount, 0);
+  assert.deepEqual(commands, [{ cmd: DO, opt: OPT.NAWS }]);
+  // The trailing 'a' must have been emitted as data.
+  assert.equal(Buffer.concat(data).toString("utf8"), "hia");
+});
+
+test("parser preserves a half-finished option command (IAC DO) for the next feed", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(Buffer.from([0x61, IAC, DO]));
+  assert.equal(Buffer.concat(data).toString("utf8"), "a");
+  assert.equal(commands.length, 0);
+  assert.equal(parser.pendingByteCount, 2);
+
+  parser.feed(Buffer.from([OPT.TERMINAL_TYPE, 0x62]));
+  assert.deepEqual(commands, [{ cmd: DO, opt: OPT.TERMINAL_TYPE }]);
+  assert.equal(Buffer.concat(data).toString("utf8"), "ab");
+});
+
+test("parser preserves an unterminated subnegotiation across multiple frames", () => {
+  const { parser, data, subnegs } = collect();
+  // Send IAC SB TT 0 "XTE" — the SE is intentionally missing.
+  parser.feed(
+    Buffer.concat([
+      Buffer.from("prefix"),
+      Buffer.from([IAC, SB, OPT.TERMINAL_TYPE, 0]),
+      Buffer.from("XTE"),
+    ]),
+  );
+  assert.equal(Buffer.concat(data).toString("utf8"), "prefix");
+  assert.equal(subnegs.length, 0);
+
+  // Now the remaining payload + IAC SE arrive together with trailing data.
+  parser.feed(
+    Buffer.concat([
+      Buffer.from("RM-256COLOR"),
+      Buffer.from([IAC, SE]),
+      Buffer.from(" tail"),
+    ]),
+  );
+
+  assert.equal(subnegs.length, 1);
+  assert.equal(subnegs[0].opt, OPT.TERMINAL_TYPE);
+  assert.deepEqual(
+    Buffer.from(subnegs[0].payload).toString("utf8"),
+    "\x00XTERM-256COLOR",
+  );
+  assert.equal(Buffer.concat(data).toString("utf8"), "prefix tail");
+});
+
+test("parser does not leak SB payload as data when the SE never arrives", () => {
+  // Regression: in the old stateless implementation, an unterminated SB block
+  // would fall through to "skip IAC SB and emit the rest as data" — leaking
+  // option-type names and other text into the terminal.
+  const { parser, data, subnegs } = collect();
+  parser.feed(
+    Buffer.concat([
+      Buffer.from([IAC, SB, OPT.TERMINAL_TYPE, 0]),
+      Buffer.from("XTERM-PARTIAL"),
+    ]),
+  );
+  assert.equal(data.length, 0);
+  assert.equal(subnegs.length, 0);
+  assert.ok(parser.pendingByteCount > 0);
+});
+
+test("parser handles two consecutive option commands without losing either", () => {
+  const { parser, commands } = collect();
+  parser.feed(
+    Buffer.from([IAC, WILL, OPT.ECHO, IAC, DO, OPT.SUPPRESS_GO_AHEAD]),
+  );
+  assert.deepEqual(commands, [
+    { cmd: WILL, opt: OPT.ECHO },
+    { cmd: DO, opt: OPT.SUPPRESS_GO_AHEAD },
+  ]);
+});
+
+test("parser feed is no-op for empty / null chunks", () => {
+  const { parser, data, commands } = collect();
+  parser.feed(Buffer.alloc(0));
+  parser.feed(null);
+  parser.feed(undefined);
+  assert.equal(data.length, 0);
+  assert.equal(commands.length, 0);
+});
+
+test("parser reset clears pending state", () => {
+  const { parser } = collect();
+  parser.feed(Buffer.from([IAC]));
+  assert.equal(parser.pendingByteCount, 1);
+  parser.reset();
+  assert.equal(parser.pendingByteCount, 0);
+});
+
+test("data emitted before a command is delivered before that command's callback", () => {
+  const order = [];
+  const parser = createTelnetParser({
+    onData(buf) {
+      order.push(`data:${buf.toString("utf8")}`);
+    },
+    onCommand(cmd, opt) {
+      order.push(`cmd:${cmd}:${opt}`);
+    },
+  });
+  parser.feed(
+    Buffer.concat([
+      Buffer.from("hi"),
+      Buffer.from([IAC, WONT, OPT.LINEMODE]),
+      Buffer.from("bye"),
+    ]),
+  );
+  assert.deepEqual(order, [
+    "data:hi",
+    `cmd:${WONT}:${OPT.LINEMODE}`,
+    "data:bye",
+  ]);
+});

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -24,6 +24,7 @@ const { discoverShells } = require("./shellDiscovery.cjs");
 const moshHandshake = require("./moshHandshake.cjs");
 const tempDirBridge = require("./tempDirBridge.cjs");
 const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
+const telnetProtocol = require("./telnetProtocol.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -547,121 +548,148 @@ async function startTelnetSession(event, options) {
       },
     });
 
-    // Telnet protocol constants
-    const TELNET = {
-      IAC: 255,
-      DONT: 254,
-      DO: 253,
-      WONT: 252,
-      WILL: 251,
-      SB: 250,
-      SE: 240,
-      ECHO: 1,
-      SUPPRESS_GO_AHEAD: 3,
-      STATUS: 5,
-      TERMINAL_TYPE: 24,
-      NAWS: 31,
-      TERMINAL_SPEED: 32,
-      LINEMODE: 34,
-      NEW_ENVIRON: 39,
+    // Telnet protocol state. Negotiation only activates once we see an IAC
+    // byte from the peer — if the remote never speaks the protocol (some
+    // legacy raw-TCP services on port 23), we fall back to passthrough so we
+    // do not corrupt their stream by misreading stray 0xFF bytes as IAC.
+    const TELNET_TERM_TYPE = "XTERM-256COLOR";
+    let telnetProtocolActive = false;
+    let telnetCleanData = Buffer.alloc(0);
+    // Options for which we have already sent a request; the peer's reply for
+    // these is acknowledgement, not a fresh negotiation, so we must not
+    // bounce another command back at it (the source of negotiation loops).
+    const requestedOptions = new Set();
+
+    const writeTelnetCommand = (cmd, opt) => {
+      if (socket.destroyed) return;
+      socket.write(Buffer.from([telnetProtocol.IAC, cmd, opt]));
     };
 
-    const sendWindowSize = () => {
-      const buf = Buffer.from([
-        TELNET.IAC, TELNET.SB, TELNET.NAWS,
-        (cols >> 8) & 0xff, cols & 0xff,
-        (rows >> 8) & 0xff, rows & 0xff,
-        TELNET.IAC, TELNET.SE
+    const requestOption = (cmd, opt) => {
+      requestedOptions.add(opt);
+      writeTelnetCommand(cmd, opt);
+    };
+
+    const sendWindowSizeSubneg = (currentCols, currentRows) => {
+      if (socket.destroyed) return;
+      const safeCols = Number.isFinite(currentCols) && currentCols > 0 ? currentCols : 80;
+      const safeRows = Number.isFinite(currentRows) && currentRows > 0 ? currentRows : 24;
+      const payload = Buffer.from([
+        (safeCols >> 8) & 0xff, safeCols & 0xff,
+        (safeRows >> 8) & 0xff, safeRows & 0xff,
       ]);
-      socket.write(buf);
+      socket.write(Buffer.concat([
+        Buffer.from([telnetProtocol.IAC, telnetProtocol.SB, telnetProtocol.OPT.NAWS]),
+        telnetProtocol.escapeIacForWire(payload),
+        Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
+      ]));
     };
 
-    const handleTelnetNegotiation = (data) => {
-      const output = [];
-      let i = 0;
+    const sendTerminalTypeSubneg = () => {
+      if (socket.destroyed) return;
+      socket.write(Buffer.concat([
+        Buffer.from([
+          telnetProtocol.IAC,
+          telnetProtocol.SB,
+          telnetProtocol.OPT.TERMINAL_TYPE,
+          telnetProtocol.SUBOPTION_IS,
+        ]),
+        Buffer.from(TELNET_TERM_TYPE, "ascii"),
+        Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
+      ]));
+    };
 
-      while (i < data.length) {
-        if (data[i] === TELNET.IAC) {
-          if (i + 1 >= data.length) break;
-          
-          const cmd = data[i + 1];
-          
-          if (cmd === TELNET.IAC) {
-            output.push(255);
-            i += 2;
-            continue;
-          }
+    const startActiveNegotiation = () => {
+      // Drive the negotiation rather than waiting for the server. Quite a
+      // few older switches/routers will not advance past their welcome
+      // banner until the client commits to a basic option set, which is the
+      // root cause of "stuck on press-any-key" reports.
+      requestOption(telnetProtocol.DO, telnetProtocol.OPT.SUPPRESS_GO_AHEAD);
+      requestOption(telnetProtocol.WILL, telnetProtocol.OPT.TERMINAL_TYPE);
+      requestOption(telnetProtocol.WILL, telnetProtocol.OPT.NAWS);
+    };
 
-          if (cmd === TELNET.DO || cmd === TELNET.DONT || cmd === TELNET.WILL || cmd === TELNET.WONT) {
-            if (i + 2 >= data.length) break;
-            
-            const opt = data[i + 2];
-            console.log(`[Telnet] Received: ${cmd === TELNET.DO ? 'DO' : cmd === TELNET.DONT ? 'DONT' : cmd === TELNET.WILL ? 'WILL' : 'WONT'} ${opt}`);
-
-            if (cmd === TELNET.DO) {
-              if (opt === TELNET.NAWS) {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.WILL, opt]));
-                sendWindowSize();
-              } else if (opt === TELNET.TERMINAL_TYPE) {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.WILL, opt]));
-              } else if (opt === TELNET.SUPPRESS_GO_AHEAD) {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.WILL, opt]));
-              } else {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.WONT, opt]));
-              }
-            } else if (cmd === TELNET.WILL) {
-              if (opt === TELNET.ECHO || opt === TELNET.SUPPRESS_GO_AHEAD) {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.DO, opt]));
-              } else {
-                socket.write(Buffer.from([TELNET.IAC, TELNET.DONT, opt]));
-              }
-            } else if (cmd === TELNET.DONT) {
-              socket.write(Buffer.from([TELNET.IAC, TELNET.WONT, opt]));
-            } else if (cmd === TELNET.WONT) {
-              socket.write(Buffer.from([TELNET.IAC, TELNET.DONT, opt]));
-            }
-
-            i += 3;
-            continue;
-          }
-
-          if (cmd === TELNET.SB) {
-            let seIndex = i + 2;
-            while (seIndex < data.length - 1) {
-              if (data[seIndex] === TELNET.IAC && data[seIndex + 1] === TELNET.SE) {
-                break;
-              }
-              seIndex++;
-            }
-
-            if (seIndex < data.length - 1) {
-              const subOpt = data[i + 2];
-              console.log(`[Telnet] Sub-negotiation for option ${subOpt}`);
-              
-              if (subOpt === TELNET.TERMINAL_TYPE && data[i + 3] === 1) {
-                const termType = 'xterm-256color';
-                const response = Buffer.concat([
-                  Buffer.from([TELNET.IAC, TELNET.SB, TELNET.TERMINAL_TYPE, 0]),
-                  Buffer.from(termType),
-                  Buffer.from([TELNET.IAC, TELNET.SE])
-                ]);
-                socket.write(response);
-              }
-              
-              i = seIndex + 2;
-              continue;
-            }
-          }
-
-          i += 2;
-          continue;
+    const handleTelnetCommand = (cmd, opt) => {
+      // If we initiated this option, the peer's reply is just acknowledgement.
+      // Drop it from the pending set and do not bounce another command back —
+      // that is how spec-strict peers ended up in WILL/WONT ping-pong loops.
+      if (requestedOptions.has(opt)) {
+        if (cmd === telnetProtocol.WILL || cmd === telnetProtocol.WONT
+          || cmd === telnetProtocol.DO || cmd === telnetProtocol.DONT) {
+          requestedOptions.delete(opt);
+          return;
         }
-
-        output.push(data[i]);
-        i++;
       }
 
-      return Buffer.from(output);
+      if (cmd === telnetProtocol.WILL) {
+        if (opt === telnetProtocol.OPT.SUPPRESS_GO_AHEAD || opt === telnetProtocol.OPT.ECHO) {
+          writeTelnetCommand(telnetProtocol.DO, opt);
+        } else {
+          writeTelnetCommand(telnetProtocol.DONT, opt);
+        }
+        return;
+      }
+
+      if (cmd === telnetProtocol.DO) {
+        if (opt === telnetProtocol.OPT.NAWS) {
+          writeTelnetCommand(telnetProtocol.WILL, opt);
+          const session = sessions.get(sessionId);
+          sendWindowSizeSubneg(session?.cols ?? cols, session?.rows ?? rows);
+        } else if (opt === telnetProtocol.OPT.TERMINAL_TYPE
+          || opt === telnetProtocol.OPT.SUPPRESS_GO_AHEAD) {
+          writeTelnetCommand(telnetProtocol.WILL, opt);
+        } else {
+          writeTelnetCommand(telnetProtocol.WONT, opt);
+        }
+        return;
+      }
+
+      if (cmd === telnetProtocol.DONT) {
+        // Confirm we will not enable. Sending WONT only if the peer's DONT
+        // is unexpected (not a reply to our own WILL) avoids the loop.
+        writeTelnetCommand(telnetProtocol.WONT, opt);
+        return;
+      }
+
+      if (cmd === telnetProtocol.WONT) {
+        writeTelnetCommand(telnetProtocol.DONT, opt);
+        return;
+      }
+    };
+
+    const handleTelnetSubnegotiation = (opt, payload) => {
+      if (opt === telnetProtocol.OPT.TERMINAL_TYPE
+        && payload.length > 0
+        && payload[0] === telnetProtocol.SUBOPTION_SEND) {
+        sendTerminalTypeSubneg();
+      }
+    };
+
+    const telnetParser = telnetProtocol.createTelnetParser({
+      onData: (clean) => {
+        if (clean.length === 0) return;
+        telnetCleanData = telnetCleanData.length === 0
+          ? clean
+          : Buffer.concat([telnetCleanData, clean]);
+      },
+      onCommand: handleTelnetCommand,
+      onSubnegotiation: handleTelnetSubnegotiation,
+    });
+
+    const processIncomingTelnet = (data) => {
+      // Lazy protocol activation: only flip on once we see an IAC from the
+      // peer. Until then we just hand bytes back as-is so true raw-TCP-on-23
+      // services (the long tail of embedded devices) are not corrupted.
+      if (!telnetProtocolActive) {
+        if (data.indexOf(0xff) < 0) return data;
+        telnetProtocolActive = true;
+        startActiveNegotiation();
+      }
+      telnetCleanData = Buffer.alloc(0);
+      telnetParser.feed(data);
+      const out = telnetCleanData;
+      telnetCleanData = Buffer.alloc(0);
+      return out;
     };
 
     const connectTimeout = setTimeout(() => {
@@ -690,6 +718,12 @@ async function startTelnetSession(event, options) {
         encoding: initialTelnetEncoding,
         decoderRef: telnetDecoderRef,
         autoLogin: telnetAutoLogin,
+        // Mirror of the closure-local `telnetProtocolActive` so the resize
+        // handler (which only sees the session record) can decide whether
+        // to push a NAWS subnegotiation.
+        get telnetProtocolActive() {
+          return telnetProtocolActive;
+        },
       };
       session.flushPendingData = flushTelnet;
       sessions.set(sessionId, session);
@@ -769,7 +803,7 @@ async function startTelnetSession(event, options) {
 
       // Always run Telnet negotiation — even during ZMODEM, the Telnet
       // layer still escapes 0xFF as IAC IAC and sends control sequences.
-      const cleanData = handleTelnetNegotiation(data);
+      const cleanData = processIncomingTelnet(data);
       if (cleanData.length > 0) {
         telnetZmodemSentry.consume(cleanData);
       }
@@ -1610,7 +1644,19 @@ function writeToSession(event, payload) {
     } else if (session.proc) {
       session.proc.write(payload.data);
     } else if (session.socket) {
-      session.socket.write(payload.data);
+      // Telnet only: any 0xFF byte going out the wire must be doubled, or
+      // the peer will treat it as the start of an IAC command sequence and
+      // eat the next byte (RFC 854 §"Data Stream"). UTF-8 keyboard input
+      // never produces 0xFF, but paste of binary content and some legacy
+      // encodings do. Cheap no-op when there is no 0xFF.
+      let outgoing = payload.data;
+      if (session.type === 'telnet-native' && session.telnetProtocolActive) {
+        if (typeof outgoing === 'string') {
+          outgoing = Buffer.from(outgoing, 'utf8');
+        }
+        outgoing = telnetProtocol.escapeIacForWire(outgoing);
+      }
+      session.socket.write(outgoing);
     } else if (session.serialPort) {
       session.serialPort.write(payload.data);
     }
@@ -1638,14 +1684,19 @@ function resizeSession(event, payload) {
     } else if (session.socket && session.type === 'telnet-native') {
       session.cols = payload.cols;
       session.rows = payload.rows;
-      const TELNET = { IAC: 255, SB: 250, SE: 240, NAWS: 31 };
-      const buf = Buffer.from([
-        TELNET.IAC, TELNET.SB, TELNET.NAWS,
-        (payload.cols >> 8) & 0xff, payload.cols & 0xff,
-        (payload.rows >> 8) & 0xff, payload.rows & 0xff,
-        TELNET.IAC, TELNET.SE
-      ]);
-      session.socket.write(buf);
+      // Only push a NAWS update once the peer has activated the protocol;
+      // sending an IAC sequence to a raw-TCP server would corrupt its stream.
+      if (session.telnetProtocolActive) {
+        const colsByte = Buffer.from([
+          (payload.cols >> 8) & 0xff, payload.cols & 0xff,
+          (payload.rows >> 8) & 0xff, payload.rows & 0xff,
+        ]);
+        session.socket.write(Buffer.concat([
+          Buffer.from([telnetProtocol.IAC, telnetProtocol.SB, telnetProtocol.OPT.NAWS]),
+          telnetProtocol.escapeIacForWire(colsByte),
+          Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
+        ]));
+      }
     }
   } catch (err) {
     if (err.code !== 'EPIPE' && err.code !== 'ERR_STREAM_DESTROYED') {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -552,118 +552,31 @@ async function startTelnetSession(event, options) {
     // byte from the peer — if the remote never speaks the protocol (some
     // legacy raw-TCP services on port 23), we fall back to passthrough so we
     // do not corrupt their stream by misreading stray 0xFF bytes as IAC.
-    const TELNET_TERM_TYPE = "XTERM-256COLOR";
     let telnetProtocolActive = false;
     let telnetCleanData = Buffer.alloc(0);
-    // Options for which we have already sent a request; the peer's reply for
-    // these is acknowledgement, not a fresh negotiation, so we must not
-    // bounce another command back at it (the source of negotiation loops).
-    const requestedOptions = new Set();
 
-    const writeTelnetCommand = (cmd, opt) => {
+    const writeRawTelnetCommand = (cmd, opt) => {
       if (socket.destroyed) return;
       socket.write(Buffer.from([telnetProtocol.IAC, cmd, opt]));
     };
 
-    const requestOption = (cmd, opt) => {
-      requestedOptions.add(opt);
-      writeTelnetCommand(cmd, opt);
-    };
-
-    const sendWindowSizeSubneg = (currentCols, currentRows) => {
+    const writeRawSubnegotiation = (opt, payload) => {
       if (socket.destroyed) return;
-      const safeCols = Number.isFinite(currentCols) && currentCols > 0 ? currentCols : 80;
-      const safeRows = Number.isFinite(currentRows) && currentRows > 0 ? currentRows : 24;
-      const payload = Buffer.from([
-        (safeCols >> 8) & 0xff, safeCols & 0xff,
-        (safeRows >> 8) & 0xff, safeRows & 0xff,
-      ]);
       socket.write(Buffer.concat([
-        Buffer.from([telnetProtocol.IAC, telnetProtocol.SB, telnetProtocol.OPT.NAWS]),
-        telnetProtocol.escapeIacForWire(payload),
+        Buffer.from([telnetProtocol.IAC, telnetProtocol.SB, opt]),
+        payload,
         Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
       ]));
     };
 
-    const sendTerminalTypeSubneg = () => {
-      if (socket.destroyed) return;
-      socket.write(Buffer.concat([
-        Buffer.from([
-          telnetProtocol.IAC,
-          telnetProtocol.SB,
-          telnetProtocol.OPT.TERMINAL_TYPE,
-          telnetProtocol.SUBOPTION_IS,
-        ]),
-        Buffer.from(TELNET_TERM_TYPE, "ascii"),
-        Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
-      ]));
-    };
-
-    const startActiveNegotiation = () => {
-      // Drive the negotiation rather than waiting for the server. Quite a
-      // few older switches/routers will not advance past their welcome
-      // banner until the client commits to a basic option set, which is the
-      // root cause of "stuck on press-any-key" reports.
-      requestOption(telnetProtocol.DO, telnetProtocol.OPT.SUPPRESS_GO_AHEAD);
-      requestOption(telnetProtocol.WILL, telnetProtocol.OPT.TERMINAL_TYPE);
-      requestOption(telnetProtocol.WILL, telnetProtocol.OPT.NAWS);
-    };
-
-    const handleTelnetCommand = (cmd, opt) => {
-      // If we initiated this option, the peer's reply is just acknowledgement.
-      // Drop it from the pending set and do not bounce another command back —
-      // that is how spec-strict peers ended up in WILL/WONT ping-pong loops.
-      if (requestedOptions.has(opt)) {
-        if (cmd === telnetProtocol.WILL || cmd === telnetProtocol.WONT
-          || cmd === telnetProtocol.DO || cmd === telnetProtocol.DONT) {
-          requestedOptions.delete(opt);
-          return;
-        }
-      }
-
-      if (cmd === telnetProtocol.WILL) {
-        if (opt === telnetProtocol.OPT.SUPPRESS_GO_AHEAD || opt === telnetProtocol.OPT.ECHO) {
-          writeTelnetCommand(telnetProtocol.DO, opt);
-        } else {
-          writeTelnetCommand(telnetProtocol.DONT, opt);
-        }
-        return;
-      }
-
-      if (cmd === telnetProtocol.DO) {
-        if (opt === telnetProtocol.OPT.NAWS) {
-          writeTelnetCommand(telnetProtocol.WILL, opt);
-          const session = sessions.get(sessionId);
-          sendWindowSizeSubneg(session?.cols ?? cols, session?.rows ?? rows);
-        } else if (opt === telnetProtocol.OPT.TERMINAL_TYPE
-          || opt === telnetProtocol.OPT.SUPPRESS_GO_AHEAD) {
-          writeTelnetCommand(telnetProtocol.WILL, opt);
-        } else {
-          writeTelnetCommand(telnetProtocol.WONT, opt);
-        }
-        return;
-      }
-
-      if (cmd === telnetProtocol.DONT) {
-        // Confirm we will not enable. Sending WONT only if the peer's DONT
-        // is unexpected (not a reply to our own WILL) avoids the loop.
-        writeTelnetCommand(telnetProtocol.WONT, opt);
-        return;
-      }
-
-      if (cmd === telnetProtocol.WONT) {
-        writeTelnetCommand(telnetProtocol.DONT, opt);
-        return;
-      }
-    };
-
-    const handleTelnetSubnegotiation = (opt, payload) => {
-      if (opt === telnetProtocol.OPT.TERMINAL_TYPE
-        && payload.length > 0
-        && payload[0] === telnetProtocol.SUBOPTION_SEND) {
-        sendTerminalTypeSubneg();
-      }
-    };
+    const negotiator = telnetProtocol.createTelnetNegotiator({
+      writeCommand: writeRawTelnetCommand,
+      writeSubnegotiation: writeRawSubnegotiation,
+      getWindowSize: () => {
+        const session = sessions.get(sessionId);
+        return { cols: session?.cols ?? cols, rows: session?.rows ?? rows };
+      },
+    });
 
     const telnetParser = telnetProtocol.createTelnetParser({
       onData: (clean) => {
@@ -672,8 +585,8 @@ async function startTelnetSession(event, options) {
           ? clean
           : Buffer.concat([telnetCleanData, clean]);
       },
-      onCommand: handleTelnetCommand,
-      onSubnegotiation: handleTelnetSubnegotiation,
+      onCommand: (cmd, opt) => negotiator.handleCommand(cmd, opt),
+      onSubnegotiation: (opt, payload) => negotiator.handleSubnegotiation(opt, payload),
     });
 
     const processIncomingTelnet = (data) => {
@@ -683,7 +596,7 @@ async function startTelnetSession(event, options) {
       if (!telnetProtocolActive) {
         if (data.indexOf(0xff) < 0) return data;
         telnetProtocolActive = true;
-        startActiveNegotiation();
+        negotiator.start();
       }
       telnetCleanData = Buffer.alloc(0);
       telnetParser.feed(data);


### PR DESCRIPTION
## Summary

Addresses #919 — the built-in Telnet client got stuck at "Press any key to continue" on an HP ProCurve 2610, and after a subsequent update the same session started showing random-looking characters in the username field. Three independent correctness gaps in the old protocol layer, all fixed in one PR.

## Root causes

1. **Negotiation parser was stateless per chunk.** [`handleTelnetNegotiation`](electron/bridges/terminalBridge.cjs) ran on each `data` event in isolation. An IAC sequence split across TCP frames either dropped the lone IAC (lost command), or — worse — for `IAC SB ... IAC SE` blocks whose terminator landed in the next frame, fell through to "skip IAC SB and treat the rest as data". That spilled the subnegotiation payload (TERMINAL-TYPE strings, environment data) into the terminal display as garbage. This is the most likely source of the "Username: z Wz Wz W3" symptom in the issue thread.

2. **Client was purely reactive.** It only ever responded to options the server raised. Legacy switch / router firmware often waits for the client to actively commit to `SUPPRESS-GO-AHEAD` / `TERMINAL-TYPE` / `NAWS` before advancing past the banner — so the connection silently hung forever at "Press any key to continue".

3. **Outbound user input was never IAC-escaped.** Any 0xFF byte the user pastes (or that an alternate input encoding emits) was read by the peer as the start of a command, eating the following byte. UTF-8 keyboard typing does not produce 0xFF, but paste of binary content and some non-ASCII encodings do.

## Approach

### New `electron/bridges/telnetProtocol.cjs`

Pure module owning RFC 854 framing, separable from the bridge so it can be unit-tested without a socket.

- `createTelnetParser({ onData, onCommand, onSubnegotiation })` — a stateful machine that buffers any partial command (lone IAC, IAC + verb without option, unterminated SB) across feeds and replays it once the remaining bytes arrive. Emits clean stream bytes (with `IAC IAC` already unescaped), option commands (`WILL/WONT/DO/DONT`), and complete subnegotiations (with payload `IAC IAC` unescaped) through callbacks. Ordering preserved: data emitted before a command is delivered before that command's callback fires.
- `escapeIacForWire(buf)` — doubles 0xFF bytes on the way out, with a cheap fast-path that returns the input untouched when no 0xFF is present.

### `terminalBridge.cjs` rewiring

- **Lazy protocol activation.** Until the peer sends an IAC byte we leave the data stream alone (raw passthrough). True raw-TCP-on-port-23 services (the long tail of embedded gear) are no longer corrupted by a misread of an incidental 0xFF byte.
- **Active negotiation on activation.** When the peer's first IAC arrives we proactively request `DO SUPPRESS-GO-AHEAD`, `WILL TERMINAL-TYPE`, `WILL NAWS`, and track those in a `requestedOptions` Set. The peer's acknowledgement is consumed silently, so we no longer ping-pong replies on each WILL/WONT/DO/DONT.
- **Uppercase TERMINAL-TYPE.** We advertise `XTERM-256COLOR` (upper-case); legacy boxes that do case-sensitive `termcap` lookups recognise it where the previous `xterm-256color` failed and fell back to dumb terminal.
- **Resize-driven NAWS** only fires after the protocol has actually activated, so a passthrough session is never poisoned by stray IAC bytes.
- **Outbound user input** for telnet sockets goes through `escapeIacForWire` (strings are converted to UTF-8 buffers first), so paste of binary content and non-ASCII encodings round-trip safely.

## Tests

17 new tests in [`electron/bridges/telnetProtocol.test.cjs`](electron/bridges/telnetProtocol.test.cjs):

- Plain data passthrough
- Single-frame option commands and subnegotiations
- `IAC IAC` unescape in both data stream and SB payload
- **Every cross-frame split point**: lone IAC at end-of-chunk, `IAC + DO` without option, mid-SB without `IAC SE` — each correctly buffered and resumed on the next feed
- The specific regression that previously leaked SB payload as data when the SE never arrived
- Two consecutive option commands without losing either
- Callback ordering (data → command → data) matches byte order in the input

All 18 existing telnet auto-login tests still pass, exercising the end-to-end socket → parser → renderer path. Full suite: **825 pass / 0 fail / 3 skipped**.

\`npx tsc --noEmit\` clean on changed files (other pre-existing repo-wide TS errors unrelated to this PR).

## Test plan

- [x] Unit tests cover parser state and IAC escape
- [x] Existing telnet auto-login integration tests still pass
- [ ] Manual: connect to an HP ProCurve 2610 / similar legacy switch, confirm the "Press any key to continue" prompt now advances on Enter and the username field shows typed characters cleanly
- [ ] Manual: connect to a modern Linux telnet server (or [\`busybox telnetd\`]), confirm no regression in normal usage
- [ ] Manual: connect to a raw-TCP-on-23 service (e.g. nc -l 23 with no protocol), confirm data flows raw (no negotiation injected, no garbage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)