### PR TITLE
Place per-host statusbar tooltips below their triggers

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1895,7 +1895,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
                       <Copy size={10} />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
+                  <TooltipContent side="bottom">{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
                 </Tooltip>
               )}
             </div>
@@ -2234,7 +2234,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
                       <Radio size={12} />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>
+                  <TooltipContent side="bottom">
                     {isBroadcastEnabled
                       ? t("terminal.toolbar.broadcastDisable")
                       : t("terminal.toolbar.broadcastEnable")}
@@ -2254,7 +2254,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
                       <Maximize2 size={12} />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{t("terminal.toolbar.focusMode")}</TooltipContent>
+                  <TooltipContent side="bottom">{t("terminal.toolbar.focusMode")}</TooltipContent>
                 </Tooltip>
               )}
               {renderControls({ showClose: inWorkspace })}


### PR DESCRIPTION
## Summary

Per the bug report screenshot: hovering the **copy host address** button on the per-host statusbar paints its tooltip on top of the tab title above it (the tooltip "Copy host address (114.66.26.174)" covers "Rainyun-114.66.26.174" in the tab bar).

Root cause: the statusbar sits directly beneath the top tab bar, and `TooltipContent` defaults to `side="top"`. The same bar has two other migrated tooltips with the same problem — **broadcast** and **focus mode**.

## Fix

Pass `side="bottom"` to those three `TooltipContent`s so they drop downward. This matches the existing `HoverCardContent` panels used for the CPU / Memory / Disk / Network stats buttons on the same bar, which already use `side="bottom"`.

[components/Terminal.tsx](components/Terminal.tsx): 3 lines changed.

## Test plan

- [ ] Manual: hover the copy-host-address icon in the per-host statusbar — tooltip appears below the icon, not over the tab title
- [ ] Manual: same check for the broadcast and focus-mode icons in workspace mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)