### PR TITLE
Bring Duplicate / Copy Credentials to Pinned + Recently Connected menus

### DIFF
--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -2233,6 +2233,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                 <ContextMenuItem onClick={() => handleEditHost(host)}>
                                   <Edit2 className="mr-2 h-4 w-4" /> {t('action.edit')}
                                 </ContextMenuItem>
+                                <ContextMenuItem onClick={() => handleDuplicateHost(host)}>
+                                  <Copy className="mr-2 h-4 w-4" /> {t('action.duplicate')}
+                                </ContextMenuItem>
+                                <ContextMenuItem onClick={() => handleCopyCredentials(host)}>
+                                  <ClipboardCopy className="mr-2 h-4 w-4" /> {t('vault.hosts.copyCredentials')}
+                                </ContextMenuItem>
                                 <ContextMenuItem onClick={() => toggleHostPinned(host.id)}>
                                   <Pin className="mr-2 h-4 w-4" /> {t('vault.hosts.unpin')}
                                 </ContextMenuItem>
@@ -2331,6 +2337,12 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
                                 </ContextMenuItem>
                                 <ContextMenuItem onClick={() => handleEditHost(host)}>
                                   <Edit2 className="mr-2 h-4 w-4" /> {t('action.edit')}
+                                </ContextMenuItem>
+                                <ContextMenuItem onClick={() => handleDuplicateHost(host)}>
+                                  <Copy className="mr-2 h-4 w-4" /> {t('action.duplicate')}
+                                </ContextMenuItem>
+                                <ContextMenuItem onClick={() => handleCopyCredentials(host)}>
+                                  <ClipboardCopy className="mr-2 h-4 w-4" /> {t('vault.hosts.copyCredentials')}
                                 </ContextMenuItem>
                                 <ContextMenuItem onClick={() => toggleHostPinned(host.id)}>
                                   <Pin className="mr-2 h-4 w-4" /> {host.pinned ? t('vault.hosts.unpin') : t('vault.hosts.pinToTop')}


### PR DESCRIPTION
## Summary

Right-clicking a host card in the **Pinned** or **Recently Connected** section only offered Connect / Edit / Pin-Unpin / Delete. Right-clicking the same host in the main **All hosts** list also exposes **Duplicate** and **Copy Credentials**. Reported with a screenshot highlighting the two missing items.

The handlers (`handleDuplicateHost`, `handleCopyCredentials`) and i18n keys are already wired up — the two short menus simply didn't include the items.

## Fix

Add `Duplicate` and `Copy Credentials` entries to both [VaultView.tsx](components/VaultView.tsx) context menus (Pinned section and Recently Connected section), in the same order as the All-hosts menu so the three menus stay visually identical.

12 lines added, no behavior change for existing items.

## Test plan

- [ ] Right-click a host card in the **Pinned** section — menu now shows: Connect / Edit / **Duplicate** / **Copy Credentials** / Unpin / Delete
- [ ] Right-click a host card in the **Recently Connected** section — same six items (the Pin/Unpin label depends on whether the host is pinned)
- [ ] Both new entries trigger the same toast / behavior as in the All-hosts list

🤖 Generated with [Claude Code](https://claude.com/claude-code)