### PR TITLE
Use shadcn Button for the settings gear in the top tab bar

### DIFF
--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1098,16 +1098,18 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           </Tooltip>
         </div>
         {/* Settings gear button - sits to the left of WindowControls on win/linux, at the right edge on mac */}
-        <div className="self-stretch flex items-stretch">
+        <div className="self-stretch flex items-center px-2 app-drag" style={dragRegionStyle}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                onClick={onOpenSettings}
-                className="h-full w-10 flex items-center justify-center transition-all duration-150 app-no-drag hover:bg-accent"
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 app-no-drag"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+                onClick={onOpenSettings}
               >
                 <Settings size={16} />
-              </button>
+              </Button>
             </TooltipTrigger>
             <TooltipContent>{t('topTabs.openSettings')}</TooltipContent>
           </Tooltip>


### PR DESCRIPTION
## Summary

Follow-up to #966. That PR added `hover:bg-accent` to the existing raw `<button>` element for the settings gear, but the element is `h-full w-10` — so the hover fill flooded the entire title-bar height as a giant vertical accent strip. Reported with a screenshot.

## Fix

Replace the raw `<button>` with the same shadcn `Button variant=\"ghost\" size=\"icon\" h-6 w-6` that every other icon on the same row already uses. Wrap it in a centered container that keeps the title-bar height for window-control alignment:

- Wrapper carries `app-drag` (with `dragRegionStyle`) so the empty space around the icon still drags the window
- Button itself stays `app-no-drag` so clicks land on it

[components/TopTabs.tsx](components/TopTabs.tsx): 7 lines changed.

## Test plan

- [ ] Manual: hover the gear icon — small rounded accent fill on the icon only, matching the AI / theme-toggle / sync icons to its left
- [ ] Manual: drag the area around the icon — window still drags
- [ ] Manual: click the icon — Settings opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)