### PR TITLE
Fix #972: stop false "fingerprint changed" warnings on every SSH connect

### DIFF
--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { normalizeDistroId, sanitizeHost } from "../../domain/host";
 import { sanitizeGroupConfig } from "../../domain/groupConfig";
+import { normalizeKnownHosts } from "../../domain/knownHosts";
 import {
   ConnectionLog,
   GroupConfig,
@@ -505,11 +506,22 @@ export const useVaultState = () => {
         if (savedGroups) setCustomGroups(savedGroups);
         if (savedSnippetPackages) setSnippetPackages(savedSnippetPackages);
 
-        // Load known hosts
+        // Load known hosts. Records imported from `~/.ssh/known_hosts` and
+        // records saved by older builds may be missing the `fingerprint` /
+        // `keyType` fields the verifier compares against; backfill them now
+        // so the next SSH connect can match without falling into the brittle
+        // re-derivation path that caused the repeated "fingerprint changed"
+        // warnings in #972.
         const savedKnownHosts = localStorageAdapter.read<KnownHost[]>(
           STORAGE_KEY_KNOWN_HOSTS,
         );
-        if (savedKnownHosts) setKnownHosts(savedKnownHosts);
+        if (savedKnownHosts) {
+          const normalized = normalizeKnownHosts(savedKnownHosts);
+          setKnownHosts(normalized);
+          if (normalized !== savedKnownHosts) {
+            localStorageAdapter.write(STORAGE_KEY_KNOWN_HOSTS, normalized);
+          }
+        }
 
         // Load shell history
         const savedShellHistory = localStorageAdapter.read<ShellHistoryEntry[]>(
@@ -638,7 +650,7 @@ export const useVaultState = () => {
 
       if (key === STORAGE_KEY_KNOWN_HOSTS) {
         const next = safeParse<KnownHost[]>(event.newValue) ?? [];
-        setKnownHosts(next);
+        setKnownHosts(normalizeKnownHosts(next));
         return;
       }
 

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -22,6 +22,7 @@ import React, {
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useKnownHostsBackend } from "../application/state/useKnownHostsBackend";
 import { useStoredViewMode, ViewMode } from "../application/state/useStoredViewMode";
+import { fingerprintFromPublicKey } from "../domain/knownHosts";
 import { STORAGE_KEY_VAULT_KNOWN_HOSTS_VIEW_MODE } from "../infrastructure/config/storageKeys";
 import { logger } from "../lib/logger";
 import { cn } from "../lib/utils";
@@ -80,12 +81,20 @@ const parseKnownHostsFile = (content: string): KnownHost[] => {
         hostname = "(hashed)";
       }
 
+      const fullPublicKey = `${keyType} ${publicKey}`;
+      // Compute the fingerprint up front so the SSH host verifier can match
+      // against this record directly instead of re-deriving on every connect —
+      // the re-derivation path is where the false "fingerprint changed"
+      // warnings in #972 originated.
+      const fingerprint = fingerprintFromPublicKey(fullPublicKey);
+
       parsed.push({
         id: `kh-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
         hostname,
         port,
         keyType,
-        publicKey: `${keyType} ${publicKey}`,
+        publicKey: fullPublicKey,
+        fingerprint: fingerprint || undefined,
         discoveredAt: Date.now(),
       });
     } catch {

--- a/domain/knownHosts.test.ts
+++ b/domain/knownHosts.test.ts
@@ -1,8 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 
 import type { KnownHost } from "./models";
-import { upsertKnownHost } from "./knownHosts";
+import {
+  fingerprintFromPublicKey,
+  normalizeKnownHost,
+  normalizeKnownHosts,
+  upsertKnownHost,
+} from "./knownHosts";
 
 const knownHost = (overrides: Partial<KnownHost> = {}): KnownHost => ({
   id: "kh-existing",
@@ -96,4 +102,159 @@ test("upsertKnownHost appends genuinely new host keys", () => {
   const result = upsertKnownHost([existing], incoming);
 
   assert.deepEqual(result, [existing, incoming]);
+});
+
+// --- Fingerprint derivation -------------------------------------------------
+
+const makeRawPublicKey = (keyType: string, body = "trusted imported host key") => {
+  const type = Buffer.from(keyType);
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(type.length, 0);
+  return Buffer.concat([length, type, Buffer.from(body)]);
+};
+
+test("fingerprintFromPublicKey matches Node's SHA-256 over a base64-decoded OpenSSH line", () => {
+  const rawKey = makeRawPublicKey("ssh-ed25519");
+  const base64Body = rawKey.toString("base64");
+  const expected = crypto.createHash("sha256").update(rawKey).digest("base64").replace(/=+$/g, "");
+
+  assert.equal(fingerprintFromPublicKey(`ssh-ed25519 ${base64Body}`), expected);
+  assert.equal(
+    fingerprintFromPublicKey(`ssh-ed25519 ${base64Body} comment-tail`),
+    expected,
+    "trailing comment is ignored",
+  );
+});
+
+test("fingerprintFromPublicKey strips a SHA256: prefix and trailing padding", () => {
+  assert.equal(fingerprintFromPublicKey("SHA256:abc123=="), "abc123");
+  assert.equal(fingerprintFromPublicKey("sha256:abc123"), "abc123");
+});
+
+test("fingerprintFromPublicKey returns empty string on missing input", () => {
+  assert.equal(fingerprintFromPublicKey(undefined), "");
+  assert.equal(fingerprintFromPublicKey(null), "");
+  assert.equal(fingerprintFromPublicKey(""), "");
+});
+
+// --- Migration --------------------------------------------------------------
+
+test("normalizeKnownHost backfills fingerprint when only publicKey is stored", () => {
+  const rawKey = makeRawPublicKey("ssh-ed25519");
+  const base64Body = rawKey.toString("base64");
+  const expected = crypto.createHash("sha256").update(rawKey).digest("base64").replace(/=+$/g, "");
+
+  const stored: KnownHost = {
+    id: "kh-1",
+    hostname: "vps-1.example.com",
+    port: 22,
+    keyType: "ssh-ed25519",
+    publicKey: `ssh-ed25519 ${base64Body}`,
+    discoveredAt: 1,
+  };
+
+  const migrated = normalizeKnownHost(stored);
+  assert.notEqual(migrated, stored, "should return a new object when fingerprint is added");
+  assert.equal(migrated.fingerprint, expected);
+  assert.equal(migrated.keyType, "ssh-ed25519");
+});
+
+test("normalizeKnownHost backfills keyType from an OpenSSH-format publicKey", () => {
+  const rawKey = makeRawPublicKey("ssh-rsa");
+  const base64Body = rawKey.toString("base64");
+
+  const stored: KnownHost = {
+    id: "kh-1",
+    hostname: "vps-1.example.com",
+    port: 22,
+    keyType: "",
+    publicKey: `ssh-rsa ${base64Body}`,
+    discoveredAt: 1,
+  };
+
+  const migrated = normalizeKnownHost(stored);
+  assert.equal(migrated.keyType, "ssh-rsa");
+});
+
+test("normalizeKnownHost returns the same reference when nothing needs backfilling", () => {
+  const rawKey = makeRawPublicKey("ssh-ed25519");
+  const fp = crypto.createHash("sha256").update(rawKey).digest("base64").replace(/=+$/g, "");
+
+  const stored: KnownHost = {
+    id: "kh-1",
+    hostname: "vps-1.example.com",
+    port: 22,
+    keyType: "ssh-ed25519",
+    publicKey: `ssh-ed25519 ${rawKey.toString("base64")}`,
+    fingerprint: fp,
+    discoveredAt: 1,
+  };
+
+  assert.equal(normalizeKnownHost(stored), stored);
+});
+
+test("normalizeKnownHost is a no-op when publicKey is opaque and nothing else is known", () => {
+  const stored: KnownHost = {
+    id: "kh-1",
+    hostname: "vps-1.example.com",
+    port: 22,
+    keyType: "unknown",
+    publicKey: "SHA256:already-just-a-fingerprint",
+    discoveredAt: 1,
+  };
+
+  const migrated = normalizeKnownHost(stored);
+  // The SHA256: prefix becomes the fingerprint; keyType stays as "unknown" since
+  // we cannot recover it from a bare fingerprint.
+  assert.equal(migrated.fingerprint, "already-just-a-fingerprint");
+  assert.equal(migrated.keyType, "unknown");
+});
+
+test("normalizeKnownHosts returns the same array reference when nothing needs migration", () => {
+  const rawKey = makeRawPublicKey("ssh-ed25519");
+  const fp = crypto.createHash("sha256").update(rawKey).digest("base64").replace(/=+$/g, "");
+
+  const list: KnownHost[] = [{
+    id: "kh-1",
+    hostname: "vps-1.example.com",
+    port: 22,
+    keyType: "ssh-ed25519",
+    publicKey: `ssh-ed25519 ${rawKey.toString("base64")}`,
+    fingerprint: fp,
+    discoveredAt: 1,
+  }];
+
+  assert.equal(normalizeKnownHosts(list), list);
+});
+
+test("normalizeKnownHosts migrates each entry that needs backfilling", () => {
+  const rawKeyA = makeRawPublicKey("ssh-ed25519", "host-a-key");
+  const rawKeyB = makeRawPublicKey("ssh-rsa", "host-b-key");
+  const fpA = crypto.createHash("sha256").update(rawKeyA).digest("base64").replace(/=+$/g, "");
+  const fpB = crypto.createHash("sha256").update(rawKeyB).digest("base64").replace(/=+$/g, "");
+
+  const list: KnownHost[] = [
+    {
+      id: "kh-1",
+      hostname: "vps-1.example.com",
+      port: 22,
+      keyType: "ssh-ed25519",
+      publicKey: `ssh-ed25519 ${rawKeyA.toString("base64")}`,
+      discoveredAt: 1,
+    },
+    {
+      id: "kh-2",
+      hostname: "vps-2.example.com",
+      port: 22,
+      keyType: "",
+      publicKey: `ssh-rsa ${rawKeyB.toString("base64")}`,
+      discoveredAt: 2,
+    },
+  ];
+
+  const migrated = normalizeKnownHosts(list);
+  assert.notEqual(migrated, list);
+  assert.equal(migrated[0].fingerprint, fpA);
+  assert.equal(migrated[1].fingerprint, fpB);
+  assert.equal(migrated[1].keyType, "ssh-rsa");
 });

--- a/domain/knownHosts.ts
+++ b/domain/knownHosts.ts
@@ -36,3 +36,157 @@ export const upsertKnownHost = (
     ...knownHosts.slice(index + 1),
   ];
 };
+
+const SSH_KEY_TYPE_PREFIX = /^(?:ssh-|ecdsa-|sk-)/;
+
+const stripPadding = (value: string) => value.replace(/=+$/g, "");
+
+// Pure-JS SHA-256 used to migrate stored knownHosts records on hydration.
+// crypto.subtle is async and would force the migration through useEffect; for
+// a one-shot read-and-rewrite of a typically-small list, the sync path keeps
+// the call sites simple. Runs at most a handful of times per app start.
+const sha256Bytes = (data: Uint8Array): Uint8Array => {
+  const K = new Uint32Array([
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ]);
+  const length = data.length;
+  const bitLength = BigInt(length) * 8n;
+  const padded = new Uint8Array(((length + 9 + 63) >> 6) << 6);
+  padded.set(data);
+  padded[length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setBigUint64(padded.length - 8, bitLength, false);
+
+  const H = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const W = new Uint32Array(64);
+
+  for (let chunk = 0; chunk < padded.length; chunk += 64) {
+    for (let i = 0; i < 16; i += 1) W[i] = view.getUint32(chunk + i * 4, false);
+    for (let i = 16; i < 64; i += 1) {
+      const s0 = ((W[i - 15] >>> 7) | (W[i - 15] << 25)) ^ ((W[i - 15] >>> 18) | (W[i - 15] << 14)) ^ (W[i - 15] >>> 3);
+      const s1 = ((W[i - 2] >>> 17) | (W[i - 2] << 15)) ^ ((W[i - 2] >>> 19) | (W[i - 2] << 13)) ^ (W[i - 2] >>> 10);
+      W[i] = (W[i - 16] + s0 + W[i - 7] + s1) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = H;
+    for (let i = 0; i < 64; i += 1) {
+      const S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + W[i]) >>> 0;
+      const S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+      const mj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + mj) >>> 0;
+      h = g; g = f; f = e; e = (d + temp1) >>> 0;
+      d = c; c = b; b = a; a = (temp1 + temp2) >>> 0;
+    }
+    H[0] = (H[0] + a) >>> 0; H[1] = (H[1] + b) >>> 0; H[2] = (H[2] + c) >>> 0; H[3] = (H[3] + d) >>> 0;
+    H[4] = (H[4] + e) >>> 0; H[5] = (H[5] + f) >>> 0; H[6] = (H[6] + g) >>> 0; H[7] = (H[7] + h) >>> 0;
+  }
+
+  const out = new Uint8Array(32);
+  const outView = new DataView(out.buffer);
+  for (let i = 0; i < 8; i += 1) outView.setUint32(i * 4, H[i], false);
+  return out;
+};
+
+const base64Decode = (value: string): Uint8Array | null => {
+  try {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+};
+
+const base64Encode = (bytes: Uint8Array): string => {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += 1) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+};
+
+/**
+ * Compute the SHA-256 base64 fingerprint (no padding, no SHA256: prefix) from
+ * a stored `publicKey` field. Mirrors `fingerprintFromPublicKey` in
+ * electron/bridges/hostKeyVerifier.cjs so renderer-side migration produces the
+ * same value the verifier compares against at connect time.
+ */
+export const fingerprintFromPublicKey = (publicKey: string | undefined | null): string => {
+  if (typeof publicKey !== "string") return "";
+  const trimmed = publicKey.trim();
+  if (!trimmed) return "";
+
+  if (/^SHA256:/i.test(trimmed)) {
+    return stripPadding(trimmed.replace(/^SHA256:/i, ""));
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length >= 2 && SSH_KEY_TYPE_PREFIX.test(parts[0])) {
+    const bytes = base64Decode(parts[1]);
+    if (bytes) return stripPadding(base64Encode(sha256Bytes(bytes)));
+  }
+
+  return stripPadding(trimmed);
+};
+
+const extractKeyTypeFromPublicKey = (publicKey: string | undefined | null): string => {
+  if (typeof publicKey !== "string") return "";
+  const first = publicKey.trim().split(/\s+/)[0] ?? "";
+  return SSH_KEY_TYPE_PREFIX.test(first) ? first : "";
+};
+
+/**
+ * Backfill missing `fingerprint` / `keyType` on a stored record so the host
+ * verifier can match it without falling back to the brittle re-derivation
+ * path. Returns the same reference when nothing changes so callers can skip
+ * persistence writes and React re-renders.
+ */
+export const normalizeKnownHost = (knownHost: KnownHost): KnownHost => {
+  const hasFingerprint = typeof knownHost.fingerprint === "string" && knownHost.fingerprint.length > 0;
+  const hasKeyType = typeof knownHost.keyType === "string"
+    && knownHost.keyType.length > 0
+    && knownHost.keyType !== "unknown";
+
+  if (hasFingerprint && hasKeyType) return knownHost;
+
+  const derivedFingerprint = hasFingerprint
+    ? knownHost.fingerprint!
+    : fingerprintFromPublicKey(knownHost.publicKey);
+  const derivedKeyType = hasKeyType
+    ? knownHost.keyType
+    : extractKeyTypeFromPublicKey(knownHost.publicKey);
+
+  const fingerprintChanged = derivedFingerprint && derivedFingerprint !== knownHost.fingerprint;
+  const keyTypeChanged = derivedKeyType && derivedKeyType !== knownHost.keyType;
+  if (!fingerprintChanged && !keyTypeChanged) return knownHost;
+
+  return {
+    ...knownHost,
+    fingerprint: fingerprintChanged ? derivedFingerprint : knownHost.fingerprint,
+    keyType: keyTypeChanged ? derivedKeyType : knownHost.keyType,
+  };
+};
+
+/**
+ * Normalize a whole list. Returns the same array reference when no entries
+ * needed migration so referential-equality consumers (React.memo, prop
+ * comparisons in TerminalLayer) don't re-render on every hydration.
+ */
+export const normalizeKnownHosts = (knownHosts: KnownHost[]): KnownHost[] => {
+  let changed = false;
+  const next = knownHosts.map((entry) => {
+    const normalized = normalizeKnownHost(entry);
+    if (normalized !== entry) changed = true;
+    return normalized;
+  });
+  return changed ? next : knownHosts;
+};

--- a/electron/bridges/hostKeyVerifier.cjs
+++ b/electron/bridges/hostKeyVerifier.cjs
@@ -81,6 +81,17 @@ const getKnownHostFingerprint = (knownHost) => {
     || fingerprintFromPublicKey(knownHost?.publicKey);
 };
 
+// Classification rules, in order:
+//   1. Any record for (host, port) whose fingerprint matches the live key →
+//      trusted. Fingerprint is the ground truth; key type is metadata.
+//   2. A record matching (host, port, keyType) *exactly* with a non-matching
+//      fingerprint → changed. Only this case is a real "key rotated" alarm —
+//      the user already trusted this exact algorithm on this host and the
+//      server now presents a different key of the same type.
+//   3. Otherwise → unknown. This includes the case where the server presents
+//      a key of an algorithm we have no record for, even if the host has
+//      records for other algorithms. Tabby and OpenSSH both treat that as a
+//      first-time prompt rather than a mismatch warning (#972).
 const classifyHostKey = ({ knownHosts = [], hostname, port = 22, keyType, fingerprint }) => {
   const normalizedFingerprint = normalizeFingerprint(fingerprint);
   const candidates = Array.isArray(knownHosts)
@@ -104,26 +115,17 @@ const classifyHostKey = ({ knownHosts = [], hostname, port = 22, keyType, finger
   }
 
   const normalizedKeyType = typeof keyType === "string" ? keyType.trim() : "";
-  const hasSpecificIncomingType = normalizedKeyType && normalizedKeyType !== "unknown";
-  let sameTypeMismatch;
-  if (hasSpecificIncomingType) {
-    sameTypeMismatch = comparableCandidates.find((entry) => entry.knownHost.keyType === normalizedKeyType);
-    if (!sameTypeMismatch && comparableCandidates.length === 1) {
-      const onlyCandidate = comparableCandidates[0];
-      if (!onlyCandidate.knownHost.keyType || onlyCandidate.knownHost.keyType === "unknown") {
-        sameTypeMismatch = onlyCandidate;
-      }
+  if (normalizedKeyType && normalizedKeyType !== "unknown") {
+    const sameTypeMismatch = comparableCandidates.find(
+      (entry) => entry.knownHost.keyType === normalizedKeyType,
+    );
+    if (sameTypeMismatch) {
+      return {
+        status: "changed",
+        knownHost: sameTypeMismatch.knownHost,
+        expectedFingerprint: sameTypeMismatch.fingerprint,
+      };
     }
-  } else if (comparableCandidates.length === 1) {
-    sameTypeMismatch = comparableCandidates[0];
-  }
-
-  if (sameTypeMismatch) {
-    return {
-      status: "changed",
-      knownHost: sameTypeMismatch.knownHost,
-      expectedFingerprint: sameTypeMismatch.fingerprint,
-    };
   }
 
   return { status: "unknown" };

--- a/electron/bridges/hostKeyVerifier.test.cjs
+++ b/electron/bridges/hostKeyVerifier.test.cjs
@@ -117,7 +117,11 @@ test("classifyHostKey treats the same hostname on a different port as unknown", 
   assert.equal(result.status, "unknown");
 });
 
-test("classifyHostKey treats unknown incoming key types as comparable for changed hosts", () => {
+test("classifyHostKey reports unknown when only the incoming key type is unknown", () => {
+  // Without a confident key type from ssh2 we cannot tell whether this is a
+  // rotation of the stored key or a brand-new algorithm; force the user back
+  // through the first-time-trust path rather than scaring them with a
+  // "fingerprint changed" warning (#972).
   const result = classifyHostKey({
     knownHosts: [{
       id: "kh-1",
@@ -133,10 +137,13 @@ test("classifyHostKey treats unknown incoming key types as comparable for change
     fingerprint: "new-key",
   });
 
-  assert.equal(result.status, "changed");
+  assert.equal(result.status, "unknown");
 });
 
-test("classifyHostKey treats stored unknown key types as comparable for changed hosts", () => {
+test("classifyHostKey reports unknown when the stored record has no key type", () => {
+  // Legacy / imported records sometimes have an empty or "unknown" keyType.
+  // Promoting those to "changed" on every connect was the root cause of #972;
+  // treat them as not-comparable so the user re-confirms cleanly.
   const result = classifyHostKey({
     knownHosts: [{
       id: "kh-1",
@@ -152,7 +159,30 @@ test("classifyHostKey treats stored unknown key types as comparable for changed 
     fingerprint: "new-key",
   });
 
-  assert.equal(result.status, "changed");
+  assert.equal(result.status, "unknown");
+});
+
+test("classifyHostKey reports unknown when the server presents a different key type than any stored record", () => {
+  // Server with ssh-rsa stored; presents ssh-ed25519 this time. OpenSSH treats
+  // this as a new key offering, not a rotation; we match that behavior so a
+  // host with multiple algorithms doesn't spam mismatch warnings on every
+  // algorithm renegotiation.
+  const result = classifyHostKey({
+    knownHosts: [{
+      id: "kh-rsa",
+      hostname: "switch.local",
+      port: 22,
+      keyType: "ssh-rsa",
+      publicKey: "SHA256:rsa-key",
+      discoveredAt: 1,
+    }],
+    hostname: "switch.local",
+    port: 22,
+    keyType: "ssh-ed25519",
+    fingerprint: "new-key",
+  });
+
+  assert.equal(result.status, "unknown");
 });
 
 test("classifyHostKey prefers exact key type mismatches when a host has multiple keys", () => {
@@ -304,7 +334,10 @@ test("createHostVerifier prompts for unknown host keys and waits for user respon
 });
 
 test("createHostVerifier includes existing known host details when a key changes", async () => {
-  const rawKey = Buffer.from("changed server key");
+  // A well-formed wire blob so `describeHostKey` can recover keyType =
+  // "ssh-ed25519"; that triggers the strict (host, port, type) mismatch
+  // branch with a stored record of the same type but different fingerprint.
+  const rawKey = makeRawPublicKey("ssh-ed25519", "changed server key");
   const sent = [];
   const sender = {
     id: 1,
@@ -322,6 +355,7 @@ test("createHostVerifier includes existing known host details when a key changes
       port: 22,
       keyType: "ssh-ed25519",
       publicKey: "SHA256:old-key",
+      fingerprint: "old-key",
       discoveredAt: 1,
     }],
   });


### PR DESCRIPTION
## Summary

Users hitting #972 are getting "fingerprint changed" warnings on every SSH connect across many hosts, with no actual key rotation. Three independent paths in the host-key verifier all contributed to the false positives — this PR closes all three and brings the matching behavior in line with Tabby (`tabby-ssh/src/session/ssh.ts`) and OpenSSH.

- **Imported records had no `fingerprint` field.** `~/.ssh/known_hosts` scans (and older verifier saves) wrote only `publicKey`, leaving the verifier to re-derive the fingerprint at every connect through a brittle path that can diverge from ssh2's wire-format SHA-256. `KnownHostsManager.parseKnownHostsFile` now computes and stores the fingerprint up front, and `useVaultState` runs a one-shot migration on hydration to backfill any legacy records already in localStorage.
- **`classifyHostKey` had a loose "single candidate with unknown/empty keyType → changed" heuristic.** Any imported record whose `keyType` parse failed would be promoted to a rotation warning the first time the server presented a real algorithm. Removed entirely.
- **Multi-algorithm hosts were misclassified.** A host with a stored ssh-rsa record was reported as `changed` when the server presented a fresh ssh-ed25519, even though we had no record for that algorithm. Now reports `unknown` (matching Tabby and OpenSSH), so the user gets a clean first-time prompt instead of a scary mismatch warning.

The new classify rules, in order: fingerprint match (regardless of keyType) → trusted; strict `(host, port, keyType)` match with a different fingerprint → changed; otherwise → unknown.

## Test plan

- [x] `domain/knownHosts.test.ts` — pure-JS SHA-256 matches Node's `crypto`, migration backfills fingerprint + keyType, returns same reference when nothing to do
- [x] `electron/bridges/hostKeyVerifier.test.cjs` — two tests that previously asserted the loose heuristic now assert the safer `unknown` outcome; added coverage for the multi-algorithm first-encounter case
- [x] `npm test` — 848 pass, 0 fail
- [x] `npx tsc --noEmit` — no new errors on touched files
- [ ] Manual: connect to a host that previously triggered the false warning; confirm migration runs at startup and the host is `trusted` without a prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)