### PR TITLE
Fix #969: auto-fill saved password into PAM-style keyboard-interactive prompts

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -717,12 +717,44 @@ function buildAuthHandler(options) {
   };
 }
 
-// Latin-script + CJK keywords for "this prompt is asking for a password
-// rather than an OTP". Deliberately narrow: shapes like "Passcode:" (Duo),
-// "Verification code:", "Token:", "Code:" must NOT match here, because
-// auto-filling the saved password into one of those burns an auth attempt
-// on the server side and risks tripping `pam_faillock` / `pam_tally2`
-// lockout policies. See the #969 PR review.
+// OTP / MFA / token vocabulary. Matched FIRST — any hit here disqualifies the
+// challenge from auto-fill even if it also contains a "password" keyword.
+// Catches phrases like "One-time password", "动态密码", "动态口令",
+// "一次性密码", "Verification code", "Duo passcode", "two-factor", etc.
+// — all single-prompt shapes that look like password fields on the surface
+// but actually want an OTP. Submitting the saved password into any of these
+// burns an auth attempt and risks `pam_faillock` / `pam_tally2` lockout.
+// (#969 PR review, second round.)
+const OTP_PROMPT_PATTERN = new RegExp(
+  [
+    "one[\\s-]?time",
+    "\\botp\\b",
+    "verification",
+    "passcode",
+    "\\btoken\\b",
+    "2fa",
+    "two[\\s-]?factor",
+    "multi[\\s-]?factor",
+    "\\bmfa\\b",
+    "second\\s+factor",
+    "duo",
+    // CJK — no word boundaries; substring match is intentional
+    "动态",
+    "一次性",
+    "验证码",
+    "验证信息",
+    "令牌",
+    "双因素",
+    "多因素",
+    "短信验证",
+    "手机验证",
+  ].join("|"),
+  "i",
+);
+
+// Latin-script + CJK keywords for "this prompt is asking for a reusable
+// password". Only consulted AFTER OTP_PROMPT_PATTERN clears, so phrases like
+// "One-time password" or "动态密码" never reach this step.
 //
 // Custom-localized prompts that don't match these keywords fall through to
 // the modal, which is the same behavior as before the auto-fill optimization
@@ -739,11 +771,10 @@ const PASSWORD_PROMPT_PATTERN = /passw(or)?d|密\s*码|口\s*令/i;
  *
  * Conservative criteria, matching OpenSSH and Tabby behavior:
  *   - exactly one prompt (multi-prompt is almost certainly real 2FA / MFA)
- *   - the prompt has `echo === false` (so it isn't asking for a username,
- *     OTP code, or other low-secret value with visible echo)
- *   - the prompt text contains a known password keyword — Latin "password"
- *     or CJK "密码" / "口令" — so we don't blindly answer OTP / Duo /
- *     hardware-token challenges with the wrong value
+ *   - the prompt has `echo === false`
+ *   - the prompt text does NOT contain any OTP / MFA vocabulary
+ *   - the prompt text DOES contain a recognized password keyword (Latin
+ *     "password" / "passwd", CJK "密码" / "口令")
  *   - we have a non-empty saved password
  *
  * Anything else falls through to the modal so the user can answer in person.
@@ -754,6 +785,7 @@ function isAutoFillablePasswordChallenge(prompts, password) {
   const prompt = prompts[0];
   if (!prompt || prompt.echo !== false) return false;
   const promptText = typeof prompt.prompt === "string" ? prompt.prompt : "";
+  if (OTP_PROMPT_PATTERN.test(promptText)) return false;
   return PASSWORD_PROMPT_PATTERN.test(promptText);
 }
 

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -717,6 +717,18 @@ function buildAuthHandler(options) {
   };
 }
 
+// Latin-script + CJK keywords for "this prompt is asking for a password
+// rather than an OTP". Deliberately narrow: shapes like "Passcode:" (Duo),
+// "Verification code:", "Token:", "Code:" must NOT match here, because
+// auto-filling the saved password into one of those burns an auth attempt
+// on the server side and risks tripping `pam_faillock` / `pam_tally2`
+// lockout policies. See the #969 PR review.
+//
+// Custom-localized prompts that don't match these keywords fall through to
+// the modal, which is the same behavior as before the auto-fill optimization
+// — strictly no worse than the old "always prompt" baseline.
+const PASSWORD_PROMPT_PATTERN = /passw(or)?d|密\s*码|口\s*令/i;
+
 /**
  * Decide whether a keyboard-interactive challenge is "just a PAM-wrapped
  * password prompt" that we can answer with the saved host password without
@@ -729,6 +741,9 @@ function buildAuthHandler(options) {
  *   - exactly one prompt (multi-prompt is almost certainly real 2FA / MFA)
  *   - the prompt has `echo === false` (so it isn't asking for a username,
  *     OTP code, or other low-secret value with visible echo)
+ *   - the prompt text contains a known password keyword — Latin "password"
+ *     or CJK "密码" / "口令" — so we don't blindly answer OTP / Duo /
+ *     hardware-token challenges with the wrong value
  *   - we have a non-empty saved password
  *
  * Anything else falls through to the modal so the user can answer in person.
@@ -737,7 +752,9 @@ function isAutoFillablePasswordChallenge(prompts, password) {
   if (typeof password !== "string" || password.length === 0) return false;
   if (!Array.isArray(prompts) || prompts.length !== 1) return false;
   const prompt = prompts[0];
-  return Boolean(prompt) && prompt.echo === false;
+  if (!prompt || prompt.echo !== false) return false;
+  const promptText = typeof prompt.prompt === "string" ? prompt.prompt : "";
+  return PASSWORD_PROMPT_PATTERN.test(promptText);
 }
 
 /**

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -718,17 +718,63 @@ function buildAuthHandler(options) {
 }
 
 /**
+ * Decide whether a keyboard-interactive challenge is "just a PAM-wrapped
+ * password prompt" that we can answer with the saved host password without
+ * bothering the user. PAM-based Linux servers commonly advertise only
+ * `keyboard-interactive` (not `password`), so without this shortcut every
+ * connection pops a second password dialog even when the host already has a
+ * saved credential — see #969.
+ *
+ * Conservative criteria, matching OpenSSH and Tabby behavior:
+ *   - exactly one prompt (multi-prompt is almost certainly real 2FA / MFA)
+ *   - the prompt has `echo === false` (so it isn't asking for a username,
+ *     OTP code, or other low-secret value with visible echo)
+ *   - we have a non-empty saved password
+ *
+ * Anything else falls through to the modal so the user can answer in person.
+ */
+function isAutoFillablePasswordChallenge(prompts, password) {
+  if (typeof password !== "string" || password.length === 0) return false;
+  if (!Array.isArray(prompts) || prompts.length !== 1) return false;
+  const prompt = prompts[0];
+  return Boolean(prompt) && prompt.echo === false;
+}
+
+/**
  * Create a keyboard-interactive event handler
  * @param {Object} options
  * @param {Object} options.sender - Electron webContents sender
  * @param {string} options.sessionId - Session/connection ID
  * @param {string} options.hostname - Host being connected to
- * @param {string} [options.password] - Saved password for fill button
+ * @param {string} [options.password] - Saved password; used both as the
+ *   one-click fill button payload and as the auto-fill for the single-
+ *   password-prompt fast path (#969).
  * @param {string} [options.logPrefix] - Log prefix for debugging
+ * @param {Function} [options.onAutoFill] - Called when the saved password is
+ *   auto-filled into the challenge (no modal shown). Lets callers emit a
+ *   different progress message than the user-prompt flow.
+ * @param {Function} [options.onPromptShown] - Called right before the modal
+ *   IPC is sent to the renderer.
+ * @param {Function} [options.onUserResponded] - Called when the renderer
+ *   sends a response back (after the modal closed).
  * @returns {Function} - Event handler for 'keyboard-interactive' event
  */
 function createKeyboardInteractiveHandler(options) {
-  const { sender, sessionId, hostname, password, logPrefix = "[SSH]" } = options;
+  const {
+    sender,
+    sessionId,
+    hostname,
+    password,
+    logPrefix = "[SSH]",
+    onAutoFill,
+    onPromptShown,
+    onUserResponded,
+  } = options;
+  // ssh2 may re-invoke the keyboard-interactive event on auth failure with a
+  // fresh challenge. If our first auto-fill attempt was wrong, falling back
+  // to the modal on the retry lets the user correct it — and prevents a
+  // tight loop where we keep submitting the same wrong password.
+  let autoFilledOnce = false;
 
   return (name, instructions, instructionsLang, prompts, finish) => {
     console.log(`${logPrefix} ${hostname} keyboard-interactive auth requested`, {
@@ -744,10 +790,19 @@ function createKeyboardInteractiveHandler(options) {
       return;
     }
 
+    if (!autoFilledOnce && isAutoFillablePasswordChallenge(prompts, password)) {
+      autoFilledOnce = true;
+      console.log(`${logPrefix} Auto-filling saved password into single keyboard-interactive prompt`);
+      try { onAutoFill?.(); } catch (err) { console.warn(`${logPrefix} onAutoFill callback threw`, err); }
+      finish([password]);
+      return;
+    }
+
     // Forward prompts to user via IPC
     const requestId = keyboardInteractiveHandler.generateRequestId('ssh');
     keyboardInteractiveHandler.storeRequest(requestId, (userResponses) => {
       console.log(`${logPrefix} Received user responses, finishing keyboard-interactive`);
+      try { onUserResponded?.(); } catch (err) { console.warn(`${logPrefix} onUserResponded callback threw`, err); }
       finish(userResponses);
     }, sender.id, sessionId);
 
@@ -757,6 +812,7 @@ function createKeyboardInteractiveHandler(options) {
     }));
 
     console.log(`${logPrefix} Showing modal for ${promptsData.length} prompts`);
+    try { onPromptShown?.(); } catch (err) { console.warn(`${logPrefix} onPromptShown callback threw`, err); }
 
     safeSend(sender, "netcatty:keyboard-interactive", {
       requestId,
@@ -861,6 +917,7 @@ module.exports = {
   getAvailableAgentSocket,
   buildAuthHandler,
   createKeyboardInteractiveHandler,
+  isAutoFillablePasswordChallenge,
   applyAuthToConnOpts,
   safeSend,
   requestPassphrasesForEncryptedKeys,

--- a/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
+++ b/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
@@ -1,0 +1,189 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createKeyboardInteractiveHandler,
+  isAutoFillablePasswordChallenge,
+} = require("./sshAuthHelper.cjs");
+const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
+
+const createSender = () => {
+  const sent = [];
+  return {
+    sent,
+    sender: {
+      id: 42,
+      isDestroyed: () => false,
+      send: (channel, payload) => sent.push({ channel, payload }),
+    },
+  };
+};
+
+// Settles any modal requests that the handler queued via storeRequest so the
+// 5-minute TTL timer doesn't keep the test process alive.
+const drainPendingRequests = (sent) => {
+  for (const event of sent) {
+    if (event.channel !== "netcatty:keyboard-interactive") continue;
+    const requestId = event.payload?.requestId;
+    if (requestId) {
+      keyboardInteractiveHandler.handleResponse(null, { requestId, cancelled: true });
+    }
+  }
+};
+
+const passwordPrompt = { prompt: "Password:", echo: false };
+const verificationCodePrompt = { prompt: "Verification code:", echo: true };
+
+// --- isAutoFillablePasswordChallenge ---------------------------------------
+
+test("isAutoFillablePasswordChallenge accepts a single hidden-echo prompt with a saved password", () => {
+  assert.equal(isAutoFillablePasswordChallenge([passwordPrompt], "hunter2"), true);
+});
+
+test("isAutoFillablePasswordChallenge rejects multi-prompt challenges (likely 2FA)", () => {
+  assert.equal(
+    isAutoFillablePasswordChallenge([passwordPrompt, verificationCodePrompt], "hunter2"),
+    false,
+  );
+});
+
+test("isAutoFillablePasswordChallenge rejects echo=true prompts (could be username / OTP)", () => {
+  assert.equal(isAutoFillablePasswordChallenge([verificationCodePrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects when no saved password is available", () => {
+  assert.equal(isAutoFillablePasswordChallenge([passwordPrompt], ""), false);
+  assert.equal(isAutoFillablePasswordChallenge([passwordPrompt], undefined), false);
+  assert.equal(isAutoFillablePasswordChallenge([passwordPrompt], null), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects empty / non-array prompts", () => {
+  assert.equal(isAutoFillablePasswordChallenge([], "hunter2"), false);
+  assert.equal(isAutoFillablePasswordChallenge(undefined, "hunter2"), false);
+});
+
+// --- createKeyboardInteractiveHandler --------------------------------------
+
+test("createKeyboardInteractiveHandler auto-fills the saved password for a single password prompt", () => {
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+  const promptEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: "hunter2",
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+    onPromptShown: () => promptEvents.push("prompt-shown"),
+  });
+
+  const finishCalls = [];
+  handler("", "", "", [passwordPrompt], (responses) => finishCalls.push(responses));
+
+  // The handler answered without sending any IPC and without showing a prompt.
+  assert.deepEqual(sent, []);
+  assert.deepEqual(promptEvents, []);
+  assert.deepEqual(autoFillEvents, ["auto-fill"]);
+  assert.deepEqual(finishCalls, [["hunter2"]]);
+});
+
+test("createKeyboardInteractiveHandler falls back to the modal on the retry after a failed auto-fill", () => {
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+  const promptEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: "wrong-password",
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+    onPromptShown: () => promptEvents.push("prompt-shown"),
+  });
+
+  const finishCalls = [];
+  // First call — auto-fill fires, no modal shown.
+  handler("", "", "", [passwordPrompt], (responses) => finishCalls.push({ first: responses }));
+  // ssh2 re-invokes after auth failure — this time the user must see the modal.
+  handler("", "", "", [passwordPrompt], (responses) => finishCalls.push({ second: responses }));
+
+  assert.deepEqual(autoFillEvents, ["auto-fill"]);
+  assert.deepEqual(promptEvents, ["prompt-shown"]);
+  assert.deepEqual(finishCalls, [{ first: ["wrong-password"] }]);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].channel, "netcatty:keyboard-interactive");
+
+  drainPendingRequests(sent);
+});
+
+test("createKeyboardInteractiveHandler shows the modal when the challenge is real 2FA (multiple prompts)", () => {
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+  const promptEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: "hunter2",
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+    onPromptShown: () => promptEvents.push("prompt-shown"),
+  });
+
+  handler("Two-factor", "", "", [passwordPrompt, verificationCodePrompt], () => {});
+
+  assert.deepEqual(autoFillEvents, []);
+  assert.deepEqual(promptEvents, ["prompt-shown"]);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].payload.prompts.length, 2);
+
+  drainPendingRequests(sent);
+});
+
+test("createKeyboardInteractiveHandler does not auto-fill when no saved password is configured", () => {
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+  const promptEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: undefined,
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+    onPromptShown: () => promptEvents.push("prompt-shown"),
+  });
+
+  handler("", "", "", [passwordPrompt], () => {});
+
+  assert.deepEqual(autoFillEvents, []);
+  assert.deepEqual(promptEvents, ["prompt-shown"]);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].payload.savedPassword, null);
+
+  drainPendingRequests(sent);
+});
+
+test("createKeyboardInteractiveHandler short-circuits when the server sends zero prompts", () => {
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+  const promptEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: "hunter2",
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+    onPromptShown: () => promptEvents.push("prompt-shown"),
+  });
+
+  const finishCalls = [];
+  handler("", "", "", [], (responses) => finishCalls.push(responses));
+
+  assert.deepEqual(autoFillEvents, []);
+  assert.deepEqual(promptEvents, []);
+  assert.deepEqual(sent, []);
+  assert.deepEqual(finishCalls, [[]]);
+});

--- a/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
+++ b/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
@@ -32,11 +32,18 @@ const drainPendingRequests = (sent) => {
 };
 
 const passwordPrompt = { prompt: "Password:", echo: false };
+const linuxPasswordPrompt = { prompt: "[sudo] password for alice:", echo: false };
 const verificationCodePrompt = { prompt: "Verification code:", echo: true };
 const otpPrompt = { prompt: "Verification code:", echo: false }; // Google Auth / TOTP
 const duoPrompt = { prompt: "Duo two-factor login\nPasscode or option (1-1):", echo: false };
 const cjkPasswordPrompt = { prompt: "密码：", echo: false };
 const customizedAuthPrompt = { prompt: "Please authenticate:", echo: false };
+// OTP prompts that DO mention the word "password" or "口令" — the literal
+// keyword should not be enough to trigger auto-fill (#969 PR review round 2).
+const oneTimePasswordPrompt = { prompt: "Enter your one-time password:", echo: false };
+const cjkDynamicPasswordPrompt = { prompt: "动态密码：", echo: false };
+const cjkDynamicTokenPrompt = { prompt: "动态口令：", echo: false };
+const cjkOneTimePasswordPrompt = { prompt: "一次性密码：", echo: false };
 
 // --- isAutoFillablePasswordChallenge ---------------------------------------
 
@@ -90,6 +97,27 @@ test("isAutoFillablePasswordChallenge falls through to the modal for unrecognize
   // — the user sees the modal as before. No regression from the old
   // always-prompt baseline.
   assert.equal(isAutoFillablePasswordChallenge([customizedAuthPrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects 'One-time password' even though it contains the word 'password'", () => {
+  // PR review round 2: the OTP vocabulary check must run before the password
+  // keyword check, otherwise "password" in "One-time password" triggers a
+  // false-positive auto-fill that burns a 2FA attempt.
+  assert.equal(isAutoFillablePasswordChallenge([oneTimePasswordPrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects Chinese OTP prompts ('动态密码', '动态口令', '一次性密码')", () => {
+  // The Chinese "动态密码" / "动态口令" / "一次性密码" idioms specifically
+  // mean OTP. Mustn't auto-fill the reusable password into them.
+  assert.equal(isAutoFillablePasswordChallenge([cjkDynamicPasswordPrompt], "hunter2"), false);
+  assert.equal(isAutoFillablePasswordChallenge([cjkDynamicTokenPrompt], "hunter2"), false);
+  assert.equal(isAutoFillablePasswordChallenge([cjkOneTimePasswordPrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge accepts a sudo-style password prompt", () => {
+  // Regression guard: the OTP deny-list should not over-block normal Linux
+  // PAM prompts that legitimately mention a username after "password".
+  assert.equal(isAutoFillablePasswordChallenge([linuxPasswordPrompt], "hunter2"), true);
 });
 
 // --- createKeyboardInteractiveHandler --------------------------------------

--- a/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
+++ b/electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
@@ -33,6 +33,10 @@ const drainPendingRequests = (sent) => {
 
 const passwordPrompt = { prompt: "Password:", echo: false };
 const verificationCodePrompt = { prompt: "Verification code:", echo: true };
+const otpPrompt = { prompt: "Verification code:", echo: false }; // Google Auth / TOTP
+const duoPrompt = { prompt: "Duo two-factor login\nPasscode or option (1-1):", echo: false };
+const cjkPasswordPrompt = { prompt: "密码：", echo: false };
+const customizedAuthPrompt = { prompt: "Please authenticate:", echo: false };
 
 // --- isAutoFillablePasswordChallenge ---------------------------------------
 
@@ -60,6 +64,32 @@ test("isAutoFillablePasswordChallenge rejects when no saved password is availabl
 test("isAutoFillablePasswordChallenge rejects empty / non-array prompts", () => {
   assert.equal(isAutoFillablePasswordChallenge([], "hunter2"), false);
   assert.equal(isAutoFillablePasswordChallenge(undefined, "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects OTP-style hidden prompts (Google Authenticator, TOTP)", () => {
+  // Single prompt, echo=false, but the text says "Verification code" — that's
+  // a 2FA challenge, not a password. Submitting the saved password here would
+  // burn an auth attempt on the server. (#969 PR review)
+  assert.equal(isAutoFillablePasswordChallenge([otpPrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge rejects Duo-style passcode prompts", () => {
+  // "Passcode" is the term Duo uses for the OTP, not a reusable password.
+  // Treat it as a 2FA challenge.
+  assert.equal(isAutoFillablePasswordChallenge([duoPrompt], "hunter2"), false);
+});
+
+test("isAutoFillablePasswordChallenge accepts CJK password prompts", () => {
+  // PAM on Chinese-locale Linux often renders "密码：" — the user still
+  // expects the saved password to work.
+  assert.equal(isAutoFillablePasswordChallenge([cjkPasswordPrompt], "hunter2"), true);
+});
+
+test("isAutoFillablePasswordChallenge falls through to the modal for unrecognized prompt text", () => {
+  // Custom prompts that don't mention a known keyword stay on the safe side
+  // — the user sees the modal as before. No regression from the old
+  // always-prompt baseline.
+  assert.equal(isAutoFillablePasswordChallenge([customizedAuthPrompt], "hunter2"), false);
 });
 
 // --- createKeyboardInteractiveHandler --------------------------------------
@@ -161,6 +191,29 @@ test("createKeyboardInteractiveHandler does not auto-fill when no saved password
   assert.deepEqual(promptEvents, ["prompt-shown"]);
   assert.equal(sent.length, 1);
   assert.equal(sent[0].payload.savedPassword, null);
+
+  drainPendingRequests(sent);
+});
+
+test("createKeyboardInteractiveHandler shows the modal for OTP-style hidden prompts even with a saved password", () => {
+  // Regression guard for the #969 PR review: a single hidden-echo prompt
+  // that doesn't mention "password" must not auto-submit the saved value.
+  const { sender, sent } = createSender();
+  const autoFillEvents = [];
+
+  const handler = createKeyboardInteractiveHandler({
+    sender,
+    sessionId: "session-1",
+    hostname: "vps-1.example.com",
+    password: "hunter2",
+    onAutoFill: () => autoFillEvents.push("auto-fill"),
+  });
+
+  handler("", "", "", [otpPrompt], () => {});
+
+  assert.deepEqual(autoFillEvents, []);
+  assert.equal(sent.length, 1, "modal IPC should fire instead of auto-fill");
+  assert.equal(sent[0].channel, "netcatty:keyboard-interactive");
 
   drainPendingRequests(sent);
 });

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -633,23 +633,22 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
           reject(new Error(errMsg));
         });
         // Handle keyboard-interactive authentication for jump hosts (2FA/MFA)
-        const chainKiHandler = createKeyboardInteractiveHandler({
+        conn.on('keyboard-interactive', createKeyboardInteractiveHandler({
           sender,
           sessionId,
           hostname: hopLabel,
           password: jump.password,
           logPrefix: `[Chain] Hop ${i + 1}/${totalHops}`,
-        });
-        conn.on('keyboard-interactive', (name, instructions, lang, prompts, finish) => {
-          if (prompts && prompts.length > 0) {
-            sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'waiting for user input...');
-          }
-          const wrappedFinish = (...args) => {
-            sendProgress(i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'user responded');
-            finish(...args);
-          };
-          chainKiHandler(name, instructions, lang, prompts, wrappedFinish);
-        });
+          onAutoFill: () => sendProgress(
+            i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'using saved password',
+          ),
+          onPromptShown: () => sendProgress(
+            i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'waiting for user input...',
+          ),
+          onUserResponded: () => sendProgress(
+            i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'user responded',
+          ),
+        }));
         console.log(`[Chain] Hop ${i + 1}/${totalHops}: Connecting to ${hopLabel}...`);
         conn.connect(connOpts);
       });
@@ -1565,51 +1564,26 @@ async function startSSHSession(event, options) {
         }
       });
 
-      // Handle keyboard-interactive authentication (2FA/MFA)
-      conn.on("keyboard-interactive", (name, instructions, instructionsLang, prompts, finish) => {
-        console.log(`${logPrefix} ${options.hostname} keyboard-interactive auth requested`, {
-          name,
-          instructions,
-          promptCount: prompts?.length || 0,
-          prompts: prompts?.map(p => ({ prompt: p.prompt, echo: p.echo })),
-        });
-
-        // If there are no prompts, just call finish with empty array
-        if (!prompts || prompts.length === 0) {
-          console.log(`${logPrefix} No prompts, finishing keyboard-interactive`);
-          finish([]);
-          return;
-        }
-
-        sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'waiting for user input...');
-
-        // Forward ALL prompts to user - no auto-fill to avoid semantic detection issues
-        // (Prompt text is admin-customizable and may not contain expected keywords)
-        const requestId = keyboardInteractiveHandler.generateRequestId('ssh');
-
-        keyboardInteractiveHandler.storeRequest(requestId, (userResponses) => {
-          console.log(`${logPrefix} Received user responses, finishing keyboard-interactive`);
-          sendProgress(totalHops, totalHops, options.hostname, 'auth-attempt', 'user responded');
-          finish(userResponses);
-        }, sender.id, sessionId);
-
-        const promptsData = prompts.map((p) => ({
-          prompt: p.prompt,
-          echo: p.echo,
-        }));
-
-        console.log(`${logPrefix} Showing modal for ${promptsData.length} prompts`);
-
-        safeSend(sender, "netcatty:keyboard-interactive", {
-          requestId,
-          sessionId,
-          name: name || "",
-          instructions: instructions || "",
-          prompts: promptsData,
-          hostname: options.hostname,
-          savedPassword: options.password || null, // Pass saved password for optional fill button
-        });
-      });
+      // Handle keyboard-interactive authentication (2FA/MFA). Uses the shared
+      // factory so PAM-wrapped single-password prompts get auto-filled from
+      // the saved host password (#969) — same path the chain/SFTP/port-
+      // forwarding bridges go through.
+      conn.on("keyboard-interactive", createKeyboardInteractiveHandler({
+        sender,
+        sessionId,
+        hostname: options.hostname,
+        password: options.password,
+        logPrefix,
+        onAutoFill: () => sendProgress(
+          totalHops, totalHops, options.hostname, 'auth-attempt', 'using saved password',
+        ),
+        onPromptShown: () => sendProgress(
+          totalHops, totalHops, options.hostname, 'auth-attempt', 'waiting for user input...',
+        ),
+        onUserResponded: () => sendProgress(
+          totalHops, totalHops, options.hostname, 'auth-attempt', 'user responded',
+        ),
+      }));
 
 
       // Enable keyboard-interactive authentication in authHandler


### PR DESCRIPTION
## Summary

Servers running stock PAM Linux configurations (most distros) only advertise `keyboard-interactive` as their auth method, not `password` — so even when the host has a saved password, Netcatty was popping a modal asking the user to type it again, every connect.

\`createKeyboardInteractiveHandler\` now recognizes the classic "PAM-wrapped password" challenge — exactly one prompt with \`echo === false\` and a non-empty saved password — and answers it directly without showing the modal. Matches OpenSSH / Tabby behavior. Real multi-prompt or echo-visible challenges (2FA, OTP, security questions) still go through the modal, and a wrong-password auto-fill on the first attempt falls back to the modal on the retry so the user can correct it.

Also consolidated \`startSSHSession\`'s inline keyboard-interactive handler — which duplicated ~45 lines of the factory logic without the fix — to use the factory with new progress callbacks (\`onAutoFill\`, \`onPromptShown\`, \`onUserResponded\`). The chain / SFTP / port-forwarding bridges already went through the factory and pick up the auto-fill for free.

## Test plan

- [x] New tests in \`sshAuthHelper.kbdInteractive.test.cjs\`: auto-fill fires for single password prompt, falls back to modal on retry, modal-only path for multi-prompt / echo-visible / no-password / zero-prompt
- [x] \`npm test\` — 858 pass, 0 fail
- [x] \`npx tsc --noEmit\` — no new errors on touched files
- [ ] Manual: connect to a PAM-based Linux server with saved password; first connect should go straight in without a second password modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)