### PR TITLE
Fix #938: Homebrew tap auto-bump on stable release

### DIFF
--- a/.github/scripts/bump-homebrew-cask.sh
+++ b/.github/scripts/bump-homebrew-cask.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# bump-homebrew-cask.sh — push a new version of the Netcatty cask to the
+# binaricat/homebrew-netcatty tap.
+#
+# Called from the release pipeline (`build.yml` → `homebrew-tap` job) after
+# the GitHub Release has been published with the signed + notarized DMGs.
+# Computes SHA-256 of the arm64 and x64 DMGs, rewrites the cask file, and
+# pushes the bump back to the tap repository using HOMEBREW_TAP_TOKEN.
+#
+# Required env vars:
+#   VERSION              — semver without leading "v" (e.g. 1.1.6)
+#   HOMEBREW_TAP_TOKEN   — PAT with contents:write on the tap repo
+#
+# Optional env vars:
+#   TAP_REPO             — default: binaricat/homebrew-netcatty
+#   ARTIFACTS_DIR        — default: artifacts
+#   CASK_PATH            — default: Casks/netcatty.rb
+set -euo pipefail
+
+: "${VERSION:?VERSION env var required (no leading v)}"
+: "${HOMEBREW_TAP_TOKEN:?HOMEBREW_TAP_TOKEN env var required}"
+
+TAP_REPO="${TAP_REPO:-binaricat/homebrew-netcatty}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts}"
+CASK_PATH="${CASK_PATH:-Casks/netcatty.rb}"
+
+ARM_DMG="${ARTIFACTS_DIR}/Netcatty-${VERSION}-mac-arm64.dmg"
+X64_DMG="${ARTIFACTS_DIR}/Netcatty-${VERSION}-mac-x64.dmg"
+
+for f in "$ARM_DMG" "$X64_DMG"; do
+  if [[ ! -f "$f" ]]; then
+    echo "::error::Required DMG artifact not found: $f"
+    exit 1
+  fi
+done
+
+ARM_SHA=$(shasum -a 256 "$ARM_DMG" | awk '{print $1}')
+X64_SHA=$(shasum -a 256 "$X64_DMG" | awk '{print $1}')
+
+echo "Computed checksums:"
+echo "  arm64: ${ARM_SHA}"
+echo "  x64  : ${X64_SHA}"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+git clone --depth 1 \
+  "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" \
+  "$TMP/tap"
+cd "$TMP/tap"
+
+if [[ ! -f "$CASK_PATH" ]]; then
+  echo "::error::Cask file not found in tap: $CASK_PATH"
+  exit 1
+fi
+
+# Patch the cask in place. The three lines we touch are anchored well enough
+# that we don't need anything fancier than sed:
+#   - the `version "X.Y.Z"` line (single line, anchored to start)
+#   - the `sha256 arm:   "..."` line
+#   - the `       intel: "..."` line (anchor on "intel:" at start, after the
+#     leading whitespace, so we don't accidentally match the `arch arm:
+#     "...", intel: "..."` line earlier in the file)
+sed -i -E 's|^(\s*version)\s+"[^"]+"|\1 "'"$VERSION"'"|' "$CASK_PATH"
+sed -i -E 's|(sha256\s+arm:\s+)"[^"]+"|\1"'"$ARM_SHA"'"|' "$CASK_PATH"
+sed -i -E 's|^(\s*intel:\s+)"[^"]+"|\1"'"$X64_SHA"'"|' "$CASK_PATH"
+
+# Sanity-check: parsed file should still be valid Ruby. Catches a broken
+# substitution before we push.
+if command -v ruby >/dev/null 2>&1; then
+  ruby -c "$CASK_PATH" >/dev/null
+fi
+
+if git diff --quiet; then
+  echo "Cask already at ${VERSION} with matching checksums — nothing to push."
+  exit 0
+fi
+
+echo "Cask diff:"
+git --no-pager diff "$CASK_PATH"
+
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git add "$CASK_PATH"
+git commit -m "Bump netcatty to ${VERSION}"
+git push origin HEAD:main
+
+echo "Pushed bump for ${VERSION} to ${TAP_REPO}."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -604,3 +604,33 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: false
           token: ${{ secrets.RELEASE_TOKEN }}
+
+  homebrew-tap:
+    name: bump homebrew tap
+    runs-on: ubuntu-latest
+    needs: release
+    # Only stable release tags update the Cask. Prerelease tags
+    # (e.g. v1.2.0-rc.1) are skipped so brew users stay on stable.
+    if: |
+      startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref_name, '-')
+      && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_release))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: netcatty-macos
+          path: artifacts/
+
+      - name: Bump Cask in binaricat/homebrew-netcatty
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          ARTIFACTS_DIR: artifacts
+        run: |
+          # Strip the leading "v" — Cask version is plain semver.
+          VERSION="${GITHUB_REF_NAME#v}"
+          export VERSION
+          bash .github/scripts/bump-homebrew-cask.sh


### PR DESCRIPTION
## Summary

Closes #938.

Sets up a public Homebrew tap at [binaricat/homebrew-netcatty](https://github.com/binaricat/homebrew-netcatty) and wires the release pipeline to push a fresh Cask on every stable release tag. After this lands, macOS users can install Netcatty with:

\`\`\`bash
brew install binaricat/netcatty/netcatty
\`\`\`

\`brew upgrade\` picks up new releases automatically — the Cask URL points at the same Developer ID signed + Apple notarized DMGs already published to this repo's GitHub Releases, so it's literally the same bits.

## What's in this PR

- **\`.github/scripts/bump-homebrew-cask.sh\`** — computes SHA-256 of the arm64 + x64 DMGs that the existing release job already downloaded, sed-patches the version + sha256 lines in the Cask, validates the result parses as Ruby, and pushes the bump. Idempotent on re-run when checksums already match.
- **\`.github/workflows/build.yml\`** — new \`homebrew-tap\` job runs after the existing \`release\` job, on the same stable-tag gate that release uses. Prerelease tags (\`v1.2.0-rc.1\` etc.) are intentionally skipped so brew users stay on stable.

## What's already done outside this PR

- Tap repo [binaricat/homebrew-netcatty](https://github.com/binaricat/homebrew-netcatty) is created and seeded with the v1.1.5 Cask (manual computation of checksums), so the tap works today.
- \`brew audit --new --cask\` passes clean on the seeded Cask.
- \`brew install --cask --dry-run binaricat/netcatty/netcatty\` resolves end-to-end.

## What @binaricat needs to do before this is fully wired

Add a repo secret called \`HOMEBREW_TAP_TOKEN\` with a fine-grained PAT scoped to \`contents:write\` on \`binaricat/homebrew-netcatty\`. Until that secret exists the new job will fail fast at the env-var check with no side effects (no push attempted, no half-bumped Cask).

## Test plan

- [x] \`brew audit --new --cask binaricat/netcatty/netcatty\` — clean
- [x] \`brew tap binaricat/netcatty && brew install --cask --dry-run binaricat/netcatty/netcatty\` — resolves
- [x] sed transforms verified in an Ubuntu 24.04 container (matches CI env) — patches version, arm sha256, intel sha256 without touching the unrelated \`arch arm: ..., intel: ...\` line
- [ ] Real end-to-end: next stable tag push should auto-bump the tap. Will verify on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)