### PR TITLE
Support drag reorder in workspace focus sidebar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -346,6 +346,7 @@ function App({ settings }: { settings: SettingsState }) {
     splitSession,
     toggleWorkspaceViewMode,
     setWorkspaceFocusedSession,
+    reorderWorkspaceSessions,
     moveFocusInWorkspace,
     runSnippet,
     orphanSessions,
@@ -2114,6 +2115,7 @@ function App({ settings }: { settings: SettingsState }) {
           onSetDraggingSessionId={setDraggingSessionId}
           onToggleWorkspaceViewMode={toggleWorkspaceViewMode}
           onSetWorkspaceFocusedSession={setWorkspaceFocusedSession}
+          onReorderWorkspaceSessions={reorderWorkspaceSessions}
           onSplitSession={splitSessionWithCurrentShell}
           isBroadcastEnabled={isBroadcastEnabled}
           onToggleBroadcast={toggleBroadcast}

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -9,6 +9,7 @@ FocusDirection,
 getNextFocusSessionId,
 insertPaneIntoWorkspace,
 pruneWorkspaceNode,
+reorderWorkspaceFocusSessionOrder,
 SplitDirection,
 SplitHint,
 updateWorkspaceSplitSizes,
@@ -759,6 +760,27 @@ export const useSessionState = () => {
     }));
   }, []);
 
+  const reorderWorkspaceSessions = useCallback((
+    workspaceId: string,
+    draggedSessionId: string,
+    targetSessionId: string,
+    position: 'before' | 'after' = 'before',
+  ) => {
+    setWorkspaces(prev => prev.map(ws => {
+      if (ws.id !== workspaceId) return ws;
+      return {
+        ...ws,
+        focusSessionOrder: reorderWorkspaceFocusSessionOrder(
+          ws.root,
+          ws.focusSessionOrder,
+          draggedSessionId,
+          targetSessionId,
+          position,
+        ),
+      };
+    }));
+  }, []);
+
   // Move focus between panes in a workspace
   const moveFocusInWorkspace = useCallback((workspaceId: string, direction: FocusDirection): boolean => {
     const workspace = workspaces.find(w => w.id === workspaceId);
@@ -1049,6 +1071,7 @@ export const useSessionState = () => {
     splitSession,
     toggleWorkspaceViewMode,
     setWorkspaceFocusedSession,
+    reorderWorkspaceSessions,
     moveFocusInWorkspace,
     runSnippet,
     orphanSessions,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -8,8 +8,7 @@ import {
 } from '../application/state/sessionActivity';
 import { sessionActivityStore } from '../application/state/sessionActivityStore';
 import { useTerminalBackend } from '../application/state/useTerminalBackend';
-import { collectSessionIds } from '../domain/workspace';
-import { SplitDirection } from '../domain/workspace';
+import { collectSessionIds, resolveWorkspaceFocusSessionOrder, SplitDirection } from '../domain/workspace';
 import { KeyBinding, TerminalSettings } from '../domain/models';
 import {
   clearHostFontFamilyOverride,
@@ -55,7 +54,6 @@ import { TERMINAL_THEMES } from '../infrastructure/config/terminalThemes';
 import { useCustomThemes } from '../application/state/customThemeStore';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
-import { RippleButton } from './ui/ripple';
 import { ScrollArea } from './ui/scroll-area';
 import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate';
 import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
@@ -427,6 +425,7 @@ interface TerminalLayerProps {
   onSetDraggingSessionId: (id: string | null) => void;
   onToggleWorkspaceViewMode?: (workspaceId: string) => void;
   onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
+  onReorderWorkspaceSessions?: (workspaceId: string, draggedSessionId: string, targetSessionId: string, position: 'before' | 'after') => void;
   onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
   // Broadcast mode
   isBroadcastEnabled?: (workspaceId: string) => boolean;
@@ -490,6 +489,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   onSetDraggingSessionId,
   onToggleWorkspaceViewMode,
   onSetWorkspaceFocusedSession,
+  onReorderWorkspaceSessions,
   onSplitSession,
   isBroadcastEnabled,
   onToggleBroadcast,
@@ -625,6 +625,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const [dropHint, setDropHint] = useState<SplitHint>(null);
   // Focus-mode sidebar: client-side filter for the terminal list.
   const [focusSidebarSearch, setFocusSidebarSearch] = useState('');
+  const [focusSidebarDragSessionId, setFocusSidebarDragSessionId] = useState<string | null>(null);
+  const [focusSidebarDropIndicator, setFocusSidebarDropIndicator] = useState<{
+    sessionId: string;
+    position: 'before' | 'after';
+  } | null>(null);
   const [themePreview, setThemePreview] = useState<{ targetSessionId: string | null; themeId: string | null }>({
     targetSessionId: null,
     themeId: null,
@@ -2031,16 +2036,117 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     };
   }, [focusedSessionId, isFocusMode, activeWorkspace, isTerminalLayerVisible]);
 
-  // Get sessions for the active workspace in focus mode
-  const workspaceSessionIds = useMemo(() => {
-    if (!activeWorkspace) return [];
-    return collectSessionIds(activeWorkspace.root);
-  }, [activeWorkspace]);
-
   const workspaceSessions = useMemo(() => {
-    const idSet = new Set(workspaceSessionIds);
-    return sessions.filter(s => idSet.has(s.id));
-  }, [sessions, workspaceSessionIds]);
+    if (!activeWorkspace) return [];
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+    return resolveWorkspaceFocusSessionOrder(activeWorkspace.root, activeWorkspace.focusSessionOrder)
+      .map((sessionId) => sessionMap.get(sessionId))
+      .filter((session): session is TerminalSession => Boolean(session));
+  }, [activeWorkspace, sessions]);
+
+  const handleFocusSidebarDragStart = useCallback((e: React.DragEvent, sessionId: string) => {
+    e.stopPropagation();
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('workspace-focus-session-id', sessionId);
+    setFocusSidebarDragSessionId(sessionId);
+  }, []);
+
+  const handleFocusSidebarDragOver = useCallback((e: React.DragEvent, targetSessionId: string) => {
+    const draggedSessionId = e.dataTransfer.getData('workspace-focus-session-id') || focusSidebarDragSessionId;
+    if (!activeWorkspace || !draggedSessionId || draggedSessionId === targetSessionId) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const position = e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
+    setFocusSidebarDropIndicator({ sessionId: targetSessionId, position });
+  }, [activeWorkspace, focusSidebarDragSessionId]);
+
+  const getFocusSidebarContainerDropTarget = useCallback((
+    container: HTMLElement,
+    clientY: number,
+    draggedSessionId: string,
+  ): { sessionId: string; position: 'before' | 'after' } | null => {
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-workspace-focus-session-id]'),
+    );
+    if (rows.length === 0) return null;
+
+    for (const row of rows) {
+      const sessionId = row.dataset.workspaceFocusSessionId;
+      if (!sessionId || sessionId === draggedSessionId) continue;
+
+      const rect = row.getBoundingClientRect();
+      if (clientY < rect.top) return { sessionId, position: 'before' };
+      if (clientY <= rect.bottom) {
+        return {
+          sessionId,
+          position: clientY < rect.top + rect.height / 2 ? 'before' : 'after',
+        };
+      }
+    }
+
+    const lastRow = [...rows].reverse().find((row) => (
+      row.dataset.workspaceFocusSessionId
+      && row.dataset.workspaceFocusSessionId !== draggedSessionId
+    ));
+    const lastSessionId = lastRow?.dataset.workspaceFocusSessionId;
+    return lastSessionId ? { sessionId: lastSessionId, position: 'after' } : null;
+  }, []);
+
+  const handleFocusSidebarContainerDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    const draggedSessionId = e.dataTransfer.getData('workspace-focus-session-id') || focusSidebarDragSessionId;
+    if (!activeWorkspace || !draggedSessionId) return;
+
+    const target = getFocusSidebarContainerDropTarget(e.currentTarget, e.clientY, draggedSessionId);
+    if (!target) return;
+
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setFocusSidebarDropIndicator(target);
+  }, [activeWorkspace, focusSidebarDragSessionId, getFocusSidebarContainerDropTarget]);
+
+  const handleFocusSidebarContainerDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    const draggedSessionId = e.dataTransfer.getData('workspace-focus-session-id') || focusSidebarDragSessionId;
+    if (!activeWorkspace || !draggedSessionId) return;
+
+    const target = focusSidebarDropIndicator
+      ?? getFocusSidebarContainerDropTarget(e.currentTarget, e.clientY, draggedSessionId);
+    if (!target || target.sessionId === draggedSessionId) return;
+
+    e.preventDefault();
+    onReorderWorkspaceSessions?.(activeWorkspace.id, draggedSessionId, target.sessionId, target.position);
+    setFocusSidebarDragSessionId(null);
+    setFocusSidebarDropIndicator(null);
+  }, [
+    activeWorkspace,
+    focusSidebarDragSessionId,
+    focusSidebarDropIndicator,
+    getFocusSidebarContainerDropTarget,
+    onReorderWorkspaceSessions,
+  ]);
+
+  const handleFocusSidebarDrop = useCallback((e: React.DragEvent, targetSessionId: string) => {
+    const draggedSessionId = e.dataTransfer.getData('workspace-focus-session-id') || focusSidebarDragSessionId;
+    if (!activeWorkspace || !draggedSessionId || draggedSessionId === targetSessionId) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const position = focusSidebarDropIndicator?.sessionId === targetSessionId
+      ? focusSidebarDropIndicator.position
+      : e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
+    onReorderWorkspaceSessions?.(activeWorkspace.id, draggedSessionId, targetSessionId, position);
+    setFocusSidebarDragSessionId(null);
+    setFocusSidebarDropIndicator(null);
+  }, [activeWorkspace, focusSidebarDragSessionId, focusSidebarDropIndicator, onReorderWorkspaceSessions]);
+
+  const handleFocusSidebarDragEnd = useCallback(() => {
+    setFocusSidebarDragSessionId(null);
+    setFocusSidebarDropIndicator(null);
+  }, []);
 
   // Render focus mode sidebar
   const renderFocusModeSidebar = () => {
@@ -2135,7 +2241,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
         {/* Session list */}
         <ScrollArea className="flex-1">
-          <div className="p-2 space-y-1">
+          <div
+            className="p-2 space-y-1"
+            onDragOver={handleFocusSidebarContainerDragOver}
+            onDrop={handleFocusSidebarContainerDrop}
+          >
             {workspaceSessions.filter((session) => {
               const term = focusSidebarSearch.trim().toLowerCase();
               if (!term) return true;
@@ -2156,18 +2266,41 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
               const restBg = isSelected ? selectedBg : 'transparent';
               const hoverBg = isSelected ? selectedHoverBg : unselectedHoverBg;
               const rowFg = isSelected ? termFg : unselectedFg;
+              const dropPosition = focusSidebarDropIndicator?.sessionId === session.id
+                ? focusSidebarDropIndicator.position
+                : null;
+              const isDragging = focusSidebarDragSessionId === session.id;
 
               return (
-                <RippleButton
+                <div
                   key={session.id}
-                  variant="ghost"
+                  data-workspace-focus-session-id={session.id}
+                  draggable
+                  role="button"
+                  tabIndex={0}
                   // Row colors are terminal-theme derived (see renderFocusModeSidebar
                   // top). `hover:text-inherit` pins text against ghost variant's
                   // hover:text-accent-foreground default; hover bg is swapped
                   // via inline style so we stay on terminal-theme alpha rather
                   // than Tailwind's app-theme foreground color.
-                  className="w-full h-auto justify-start gap-2 px-2 py-1.5 font-normal hover:text-inherit"
-                  style={{ backgroundColor: restBg, color: rowFg }}
+                  className={cn(
+                    "relative flex w-full select-none items-center justify-start gap-2 rounded-md px-2 py-1.5 text-sm font-normal outline-none transition-colors hover:text-inherit focus-visible:ring-1 cursor-grab active:cursor-grabbing",
+                    isDragging && "opacity-50",
+                  )}
+                  style={{
+                    backgroundColor: restBg,
+                    color: rowFg,
+                    boxShadow: dropPosition
+                      ? `inset 0 ${dropPosition === 'before' ? '2px' : '-2px'} 0 ${termFg}`
+                      : undefined,
+                  }}
+                  onDragStart={(e) => handleFocusSidebarDragStart(e, session.id)}
+                  onDragOver={(e) => handleFocusSidebarDragOver(e, session.id)}
+                  onDragLeave={(e) => {
+                    e.stopPropagation();
+                  }}
+                  onDrop={(e) => handleFocusSidebarDrop(e, session.id)}
+                  onDragEnd={handleFocusSidebarDragEnd}
                   onMouseEnter={(e) => {
                     e.currentTarget.style.backgroundColor = hoverBg;
                   }}
@@ -2175,6 +2308,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
                     e.currentTarget.style.backgroundColor = restBg;
                   }}
                   onClick={() => onSetWorkspaceFocusedSession?.(activeWorkspace.id, session.id)}
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return;
+                    e.preventDefault();
+                    onSetWorkspaceFocusedSession?.(activeWorkspace.id, session.id);
+                  }}
                 >
                   <div className="relative flex-shrink-0">
                     {host ? (
@@ -2195,7 +2333,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
                       {session.username}@{session.hostname}
                     </div>
                   </div>
-                </RippleButton>
+                </div>
               );
             })}
           </div>

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -32,6 +32,7 @@ export const terminalLayerAreEqual = (
   prev.onAddKnownHost === next.onAddKnownHost &&
   prev.onToggleWorkspaceViewMode === next.onToggleWorkspaceViewMode &&
   prev.onSetWorkspaceFocusedSession === next.onSetWorkspaceFocusedSession &&
+  prev.onReorderWorkspaceSessions === next.onReorderWorkspaceSessions &&
   prev.onSplitSession === next.onSplitSession &&
   prev.toggleScriptsSidePanelRef === next.toggleScriptsSidePanelRef &&
   prev.identities === next.identities

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -810,6 +810,7 @@ export interface Workspace {
   root: WorkspaceNode;
   viewMode?: WorkspaceViewMode; // 'split' = tiled view (default), 'focus' = left list + single terminal
   focusedSessionId?: string; // Which session is focused when in focus mode
+  focusSessionOrder?: string[]; // User-defined session order for the focus-mode sidebar
   snippetId?: string; // If this workspace was created from running a snippet
 }
 

--- a/domain/workspace.test.ts
+++ b/domain/workspace.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { WorkspaceNode } from "./models.ts";
+import {
+  reorderWorkspaceFocusSessionOrder,
+  resolveWorkspaceFocusSessionOrder,
+} from "./workspace.ts";
+
+const root: WorkspaceNode = {
+  id: "split-1",
+  type: "split",
+  direction: "vertical",
+  children: [
+    { id: "pane-1", type: "pane", sessionId: "s1" },
+    { id: "pane-2", type: "pane", sessionId: "s2" },
+    { id: "pane-3", type: "pane", sessionId: "s3" },
+  ],
+};
+
+test("resolveWorkspaceFocusSessionOrder follows tree order when no saved order exists", () => {
+  assert.deepEqual(resolveWorkspaceFocusSessionOrder(root), ["s1", "s2", "s3"]);
+});
+
+test("resolveWorkspaceFocusSessionOrder drops stale ids and appends new panes", () => {
+  assert.deepEqual(
+    resolveWorkspaceFocusSessionOrder(root, ["stale", "s3", "s1"]),
+    ["s3", "s1", "s2"],
+  );
+});
+
+test("reorderWorkspaceFocusSessionOrder moves a session before a target", () => {
+  assert.deepEqual(
+    reorderWorkspaceFocusSessionOrder(root, undefined, "s3", "s1", "before"),
+    ["s3", "s1", "s2"],
+  );
+});
+
+test("reorderWorkspaceFocusSessionOrder moves a session after a target", () => {
+  assert.deepEqual(
+    reorderWorkspaceFocusSessionOrder(root, ["s1", "s2", "s3"], "s1", "s3", "after"),
+    ["s2", "s3", "s1"],
+  );
+});

--- a/domain/workspace.ts
+++ b/domain/workspace.ts
@@ -144,6 +144,7 @@ export const createWorkspaceFromSessions = (
     id: `ws-${crypto.randomUUID()}`,
     title: 'Workspace',
     focusedSessionId: baseSessionId, // Initialize with the base session focused
+    focusSessionOrder: [baseSessionId, joiningSessionId],
     root: {
       id: crypto.randomUUID(),
       type: 'split',
@@ -171,6 +172,47 @@ export const updateWorkspaceSplitSizes = (
   return patch(root);
 };
 
+export const resolveWorkspaceFocusSessionOrder = (
+  root: WorkspaceNode,
+  savedOrder?: string[],
+): string[] => {
+  const sessionIds = collectSessionIds(root);
+  if (!savedOrder?.length) return sessionIds;
+
+  const sessionIdSet = new Set(sessionIds);
+  const ordered = savedOrder.filter((id, index) => (
+    sessionIdSet.has(id) && savedOrder.indexOf(id) === index
+  ));
+  const orderedSet = new Set(ordered);
+  return [...ordered, ...sessionIds.filter((id) => !orderedSet.has(id))];
+};
+
+export const reorderWorkspaceFocusSessionOrder = (
+  root: WorkspaceNode,
+  savedOrder: string[] | undefined,
+  draggedSessionId: string,
+  targetSessionId: string,
+  position: 'before' | 'after' = 'before',
+): string[] => {
+  if (draggedSessionId === targetSessionId) {
+    return resolveWorkspaceFocusSessionOrder(root, savedOrder);
+  }
+
+  const currentOrder = resolveWorkspaceFocusSessionOrder(root, savedOrder);
+  const draggedIndex = currentOrder.indexOf(draggedSessionId);
+  const targetIndex = currentOrder.indexOf(targetSessionId);
+
+  if (draggedIndex === -1 || targetIndex === -1) return currentOrder;
+
+  currentOrder.splice(draggedIndex, 1);
+  let insertIndex = targetIndex;
+  if (draggedIndex < targetIndex) insertIndex -= 1;
+  if (position === 'after') insertIndex += 1;
+  currentOrder.splice(insertIndex, 0, draggedSessionId);
+
+  return currentOrder;
+};
+
 /**
  * Create a workspace from multiple session IDs.
  * Used for snippet runner - creates a workspace with all sessions in a horizontal split.
@@ -195,6 +237,7 @@ export const createWorkspaceFromSessionIds = (
       viewMode: options.viewMode,
       snippetId: options.snippetId,
       focusedSessionId: sessionIds[0],
+      focusSessionOrder: [sessionIds[0]],
       root: {
         id: crypto.randomUUID(),
         type: 'pane',
@@ -216,6 +259,7 @@ export const createWorkspaceFromSessionIds = (
     viewMode: options.viewMode,
     snippetId: options.snippetId,
     focusedSessionId: sessionIds[0],
+    focusSessionOrder: sessionIds,
     root: {
       id: crypto.randomUUID(),
       type: 'split',


### PR DESCRIPTION
 ## Summary

  This change lets users reorder terminals in the Workspace focus-mode sidebar by dragging rows in the host/session list.

  The Workspace focus-mode sidebar is useful for switching between multiple hosts, but its order previously followed internal session order and could not be adjusted by the user. Allowing drag reorder makes the sidebar more practical for larger workspaces where users want to group related hosts or put the most frequently used sessions near the top.

  The workspace layout itself is unchanged. This only controls the focus sidebar order, so users can arrange the left-side list independently while keeping the existing workspace panes and focus behavior intact.

  ## What changed

  * add a persisted `focusSessionOrder` field on workspace state
  * add domain helpers to resolve and update focus sidebar ordering while dropping stale session ids
  * wire workspace session reordering through `useSessionState`
  * render focus-mode sidebar sessions using the saved order instead of raw session array order
  * support drag-and-drop reordering across rows and the gaps between rows
  * add tests for focus sidebar order resolution and reorder behavior
