### PR TITLE
Fix remote path completion cwd (#900)

### DIFF
--- a/components/terminal/autocomplete/completionEngine.ts
+++ b/components/terminal/autocomplete/completionEngine.ts
@@ -238,6 +238,7 @@ export async function getCompletions(
     ? await getPathSuggestions(ctx, {
       sessionId: options.sessionId,
       protocol: options.protocol,
+      os: options.os,
       cwd: options.cwd,
       foldersOnly: pathCheck.foldersOnly,
     })

--- a/components/terminal/autocomplete/remotePathCompleter.ts
+++ b/components/terminal/autocomplete/remotePathCompleter.ts
@@ -13,6 +13,10 @@ export interface DirEntry {
   type: "file" | "directory" | "symlink";
 }
 
+interface ResolvePathOptions {
+  preferRelativeCwd?: boolean;
+}
+
 /** Bridge interface for directory listing */
 interface PathBridge {
   listAutocompleteRemoteDir?: (
@@ -130,18 +134,20 @@ export function shouldDoPathCompletion(
 export function resolvePathComponents(
   currentWord: string,
   cwd: string | undefined,
+  options: ResolvePathOptions = {},
 ): { dirToList: string; filterPrefix: string; pathPrefix: string; quoteSuffix: string } {
   const quotePrefix = getLeadingQuote(currentWord);
   const quoteSuffix = getTrailingMatchingQuote(currentWord, quotePrefix);
   const unquotedWord = stripWrappingQuotes(currentWord);
+  const preferRelativeCwd = options.preferRelativeCwd === true;
 
   // Handle empty input — list CWD
   if (!unquotedWord || unquotedWord === "." || unquotedWord === "~" || unquotedWord === "..") {
     const dir = unquotedWord === "~"
       ? "~"
       : unquotedWord === ".."
-        ? resolveDirLookup("../", cwd)
-        : (cwd || ".");
+        ? resolveDirLookup("../", cwd, preferRelativeCwd)
+        : resolveDirLookup("", cwd, preferRelativeCwd);
     const visiblePrefix = unquotedWord ? `${quotePrefix}${unquotedWord}/` : quotePrefix;
     return { dirToList: dir, filterPrefix: "", pathPrefix: visiblePrefix, quoteSuffix };
   }
@@ -155,22 +161,26 @@ export function resolvePathComponents(
     const decodedDirPart = decodeShellPathFragment(dirPart);
     const decodedFilterPart = decodeShellPathFragment(filterPart);
 
-    const dirToList = resolveDirLookup(decodedDirPart, cwd);
+    const dirToList = resolveDirLookup(decodedDirPart, cwd, preferRelativeCwd);
 
     return { dirToList, filterPrefix: decodedFilterPart, pathPrefix: quotePrefix + dirPart, quoteSuffix };
   }
 
   // No slash — filter CWD entries by the typed prefix
   return {
-    dirToList: cwd || ".",
+    dirToList: resolveDirLookup("", cwd, preferRelativeCwd),
     filterPrefix: decodeShellPathFragment(unquotedWord),
     pathPrefix: quotePrefix,
     quoteSuffix,
   };
 }
 
-export function normalizePathTokenForLookup(token: string, cwd?: string): string {
-  const { dirToList, filterPrefix } = resolvePathComponents(token, cwd);
+export function normalizePathTokenForLookup(
+  token: string,
+  cwd?: string,
+  options: ResolvePathOptions = {},
+): string {
+  const { dirToList, filterPrefix } = resolvePathComponents(token, cwd, options);
   if (!filterPrefix) return dirToList;
 
   if (!dirToList || dirToList === ".") {
@@ -189,16 +199,20 @@ export async function getPathSuggestions(
   options: {
     sessionId?: string;
     protocol?: string;
+    os?: "linux" | "windows" | "macos";
     cwd?: string;
     foldersOnly: boolean;
   },
 ): Promise<{ name: string; type: DirEntry["type"] }[]> {
-  const { sessionId, protocol, cwd, foldersOnly } = options;
-  const { dirToList, filterPrefix } = resolvePathComponents(ctx.currentWord, cwd);
+  const { sessionId, protocol, os, cwd, foldersOnly } = options;
+  const { dirToList, filterPrefix } = resolvePathComponents(ctx.currentWord, cwd, {
+    preferRelativeCwd: shouldUseRemoteShellCwd(protocol, sessionId, os),
+  });
 
   const entries = await listDirectoryEntries(dirToList, {
     sessionId,
     protocol,
+    os,
     foldersOnly,
     filterPrefix,
     limit: 100,
@@ -215,6 +229,7 @@ export async function listDirectoryEntries(
   options: {
     sessionId?: string;
     protocol?: string;
+    os?: "linux" | "windows" | "macos";
     foldersOnly: boolean;
     filterPrefix?: string;
     limit?: number;
@@ -223,6 +238,7 @@ export async function listDirectoryEntries(
   const {
     sessionId,
     protocol,
+    os,
     foldersOnly,
     filterPrefix = "",
     limit = 100,
@@ -232,28 +248,32 @@ export async function listDirectoryEntries(
   const baseKey = `${protocol || "auto"}:${sessionId || "local"}:${dirPath}:${foldersOnly}`;
   const fullCacheKey = `${baseKey}:all`;
   const filteredCacheKey = `${baseKey}:prefix:${normalizedPrefix}:${maxEntries}`;
+  const bypassCache = shouldBypassCache(protocol, sessionId, os, dirPath);
 
   // Full directory cache can satisfy both full and filtered lookups.
-  const fullCached = fullDirCache.get(fullCacheKey);
-  if (isFresh(fullCached)) {
-    return filterEntries(fullCached.entries, normalizedPrefix, maxEntries);
-  }
-
-  if (normalizedPrefix) {
-    const filteredCached = filteredDirCache.get(filteredCacheKey);
-    if (isFresh(filteredCached)) {
-      return filteredCached.entries;
+  if (!bypassCache) {
+    const fullCached = fullDirCache.get(fullCacheKey);
+    if (isFresh(fullCached)) {
+      return filterEntries(fullCached.entries, normalizedPrefix, maxEntries);
     }
-  }
 
-  const inFlightFull = inFlightRequests.get(fullCacheKey);
-  if (inFlightFull) {
-    return filterEntries(await inFlightFull, normalizedPrefix, maxEntries);
+    if (normalizedPrefix) {
+      const filteredCached = filteredDirCache.get(filteredCacheKey);
+      if (isFresh(filteredCached)) {
+        return filteredCached.entries;
+      }
+    }
+
+    const inFlightFull = inFlightRequests.get(fullCacheKey);
+    if (inFlightFull) {
+      return filterEntries(await inFlightFull, normalizedPrefix, maxEntries);
+    }
+
+    const inFlight = inFlightRequests.get(normalizedPrefix ? filteredCacheKey : fullCacheKey);
+    if (inFlight) return inFlight;
   }
 
   const requestKey = normalizedPrefix ? filteredCacheKey : fullCacheKey;
-  const inFlight = inFlightRequests.get(requestKey);
-  if (inFlight) return inFlight;
 
   // Make IPC call
   const promise = (async (): Promise<DirEntry[]> => {
@@ -284,6 +304,9 @@ export async function listDirectoryEntries(
 
       if (result.success) {
         const timestamp = Date.now();
+        if (bypassCache) {
+          return result.entries;
+        }
         if (normalizedPrefix) {
           filteredDirCache.set(requestKey, { entries: result.entries, timestamp });
           evictOldest(filteredDirCache, MAX_FILTERED_CACHE_SIZE);
@@ -299,11 +322,15 @@ export async function listDirectoryEntries(
     } catch {
       return [];
     } finally {
-      inFlightRequests.delete(requestKey);
+      if (!bypassCache) {
+        inFlightRequests.delete(requestKey);
+      }
     }
   })();
 
-  inFlightRequests.set(requestKey, promise);
+  if (!bypassCache) {
+    inFlightRequests.set(requestKey, promise);
+  }
   return promise;
 }
 
@@ -312,12 +339,31 @@ function clampLimit(limit: number): number {
   return Math.max(1, Math.min(200, Math.floor(limit)));
 }
 
-function resolveDirLookup(pathToken: string, cwd: string | undefined): string {
-  if (!pathToken) return cwd || ".";
+function resolveDirLookup(pathToken: string, cwd: string | undefined, preferRelativeCwd = false): string {
+  if (!pathToken) return preferRelativeCwd ? "." : (cwd || ".");
   if (pathToken.startsWith("/")) return normalizePosixLikePath(pathToken);
   if (pathToken === "~" || pathToken.startsWith("~/")) return normalizePosixLikePath(pathToken);
+  if (preferRelativeCwd) return normalizePosixLikePath(pathToken);
   if (cwd) return normalizePosixLikePath(`${cwd}/${pathToken}`);
   return normalizePosixLikePath(pathToken);
+}
+
+function shouldUseRemoteShellCwd(
+  protocol: string | undefined,
+  sessionId: string | undefined,
+  os?: "linux" | "windows" | "macos",
+): boolean {
+  return Boolean(sessionId && protocol !== "local" && os === "linux");
+}
+
+function shouldBypassCache(
+  protocol: string | undefined,
+  sessionId: string | undefined,
+  os: "linux" | "windows" | "macos" | undefined,
+  dirPath: string,
+): boolean {
+  if (!shouldUseRemoteShellCwd(protocol, sessionId, os)) return false;
+  return !dirPath.startsWith("/") && dirPath !== "~" && !dirPath.startsWith("~/");
 }
 
 function normalizePosixLikePath(input: string): string {

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -275,6 +275,7 @@ export function useTerminalAutocomplete(
     return listDirectoryEntries(dirPath, {
       sessionId: sessionIdRef.current,
       protocol: protocolRef.current,
+      os: hostOsRef.current,
       foldersOnly: false,
       limit: 50,
     });
@@ -308,7 +309,11 @@ export function useTerminalAutocomplete(
       getCwdRef.current?.(),
       hostOsRef.current,
     );
-    const dirPath = normalizePathTokenForLookup(parseCommandLine(item.text).currentWord, cwd);
+    const dirPath = normalizePathTokenForLookup(parseCommandLine(item.text).currentWord, cwd, {
+      preferRelativeCwd: Boolean(
+        sessionIdRef.current && protocolRef.current !== "local" && hostOsRef.current === "linux",
+      ),
+    });
     if (!dirPath) return;
 
     const requestVersion = ++subDirFetchVersionRef.current;

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -52,8 +52,14 @@ const storySpec: FigSpec = {
     },
   ],
 };
-const bridgeState: { localEntries: MockDirEntry[] } = {
+const bridgeState: {
+  localEntries: MockDirEntry[];
+  remoteEntriesByPath: Map<string, MockDirEntry[]>;
+  remoteCalls: string[];
+} = {
   localEntries: [],
+  remoteEntriesByPath: new Map(),
+  remoteCalls: [],
 };
 
 Object.defineProperty(globalThis, "window", {
@@ -74,6 +80,22 @@ Object.defineProperty(globalThis, "window", {
           .slice(0, limit ?? bridgeState.localEntries.length);
         return { success: true, entries };
       },
+      listAutocompleteRemoteDir: async (
+        _sessionId: string,
+        path: string,
+        foldersOnly: boolean,
+        filterPrefix?: string,
+        limit?: number,
+      ) => {
+        bridgeState.remoteCalls.push(path);
+        const prefix = (filterPrefix ?? "").toLowerCase();
+        const remoteEntries = bridgeState.remoteEntriesByPath.get(path) ?? [];
+        const entries = remoteEntries
+          .filter((entry) => !foldersOnly || entry.type === "directory")
+          .filter((entry) => !prefix || entry.name.toLowerCase().startsWith(prefix))
+          .slice(0, limit ?? remoteEntries.length);
+        return { success: true, entries };
+      },
     },
   },
   configurable: true,
@@ -86,6 +108,8 @@ test.beforeEach(() => {
   localStorage.clear();
   clearHistory();
   bridgeState.localEntries = [{ name: "package.json", type: "file" }];
+  bridgeState.remoteEntriesByPath = new Map();
+  bridgeState.remoteCalls = [];
 });
 
 test("getCompletions prioritizes spec-driven path suggestions over history", async () => {
@@ -120,4 +144,45 @@ test("getCompletions does not treat generator-only spec args as path contexts", 
   assert.equal(completions[0]?.source, "history");
   assert.equal(completions[0]?.text, "story pick package-choice");
   assert.equal(completions.some((entry) => entry.source === "path"), false);
+});
+
+test("getCompletions uses the remote shell cwd for relative path arguments instead of stale home", async () => {
+  bridgeState.remoteEntriesByPath.set("~", [{ name: "home-only.txt", type: "file" }]);
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "worktree.txt", type: "file" }]);
+
+  const completions = await getCompletions("cat wo", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+    cwd: "~",
+  });
+
+  assert.deepEqual(bridgeState.remoteCalls, ["."]);
+  assert.equal(completions[0]?.source, "path");
+  assert.equal(completions[0]?.text, "cat worktree.txt");
+  assert.equal(completions.some((entry) => entry.text.includes("~")), false);
+});
+
+test("getCompletions does not reuse cached remote relative listings after cwd changes", async () => {
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "home-only.txt", type: "file" }]);
+
+  await getCompletions("cat ", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "worktree.txt", type: "file" }]);
+
+  const completions = await getCompletions("cat wo", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+
+  assert.equal(bridgeState.remoteCalls.length, 2);
+  assert.equal(completions[0]?.text, "cat worktree.txt");
 });


### PR DESCRIPTION
## Summary
- Use the detected remote working directory when completing relative paths.
- Avoid reusing stale cached listings after the remote cwd changes.
- Keep remote path completions from adding an unnecessary home-prefix marker.

Fixes #900

## Verification
- npm test