### PR TITLE
Keep terminal tab after remote disconnect (#977)

### DIFF
--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveTerminalSessionExitIntent } from "./resolveTerminalSessionExitIntent.ts";
+
+test("backend exited events keep the tab and mark it disconnected", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "exited", exitCode: 0 }),
+    { kind: "markDisconnected" },
+  );
+});
+
+test("backend timeout events keep the tab and mark it disconnected", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "timeout", error: "idle timeout" }),
+    { kind: "markDisconnected" },
+  );
+});

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -1,0 +1,17 @@
+export type TerminalSessionExitEvent = {
+  exitCode?: number;
+  signal?: number;
+  error?: string;
+  reason?: "exited" | "error" | "timeout" | "closed";
+};
+
+export type TerminalSessionExitIntent =
+  | { kind: "markDisconnected" };
+
+export function resolveTerminalSessionExitIntent(
+  _evt: TerminalSessionExitEvent,
+): TerminalSessionExitIntent {
+  // Backend exits can be remote idle timeouts, shell termination, or transport closes.
+  // Explicit user closes bypass this policy and call the close-session path directly.
+  return { kind: "markDisconnected" };
+}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1,6 +1,7 @@
 import { Circle, Columns2, FolderTree, MessageSquare, PanelLeft, PanelRight, Palette, Plus, Search, Server, X, Zap } from 'lucide-react';
 import React, { createContext, memo, startTransition, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useActiveTabId } from '../application/state/activeTabStore';
+import { resolveTerminalSessionExitIntent, type TerminalSessionExitEvent } from '../application/state/resolveTerminalSessionExitIntent';
 import {
   getSessionActivityIdsToClear,
   getValidSessionActivityIds,
@@ -573,16 +574,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
   }, [onUpdateSessionStatus]);
 
-  const handleSessionExit = useCallback((sessionId: string, evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => {
-    // Auto-close the tab/session when the user actively exited (e.g. typed `exit`)
-    // reason === "exited" means the remote process/shell exited normally (stream-level close),
-    // as opposed to network errors, timeouts, or connection-level drops
-    if (evt.reason === "exited") {
-      onCloseSession(sessionId);
-    } else {
+  const handleSessionExit = useCallback((sessionId: string, evt: TerminalSessionExitEvent) => {
+    const intent = resolveTerminalSessionExitIntent(evt);
+    if (intent.kind === "markDisconnected") {
       onUpdateSessionStatus(sessionId, 'disconnected');
     }
-  }, [onUpdateSessionStatus, onCloseSession]);
+  }, [onUpdateSessionStatus]);
 
   const handleOsDetected = useCallback((hostId: string, distro: string) => {
     onUpdateHostDistro(hostId, distro);


### PR DESCRIPTION
## Summary
- Keep backend exit and timeout events visible as disconnected tabs.
- Leave explicit user-close and cancellation flows unchanged.
- Add tests for the exit decision behavior.

Fixes #977

## Verification
- npm test