### PR TITLE
Add terminal reconnect context action (#945)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1323,6 +1323,7 @@ const en: Messages = {
   'terminal.menu.paste': 'Paste',
   'terminal.menu.pasteSelection': 'Paste Selection',
   'terminal.menu.selectAll': 'Select All',
+  'terminal.menu.reconnect': 'Reconnect',
   'terminal.menu.splitHorizontal': 'Split Horizontal',
   'terminal.menu.splitVertical': 'Split Vertical',
   'terminal.menu.clearBuffer': 'Clear Buffer',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -900,6 +900,7 @@ const zhCN: Messages = {
   'terminal.menu.paste': '粘贴',
   'terminal.menu.pasteSelection': '粘贴选中文本',
   'terminal.menu.selectAll': '全选',
+  'terminal.menu.reconnect': '重新连接',
   'terminal.menu.splitHorizontal': '水平分屏',
   'terminal.menu.splitVertical': '垂直分屏',
   'terminal.menu.clearBuffer': '清空缓冲区',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1396,6 +1396,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     const handleContextMenuCapture = (e: MouseEvent) => {
       if (!mouseTrackingRef.current) return;
+      if (statusRef.current !== 'connected') return;
       e.preventDefault();
       e.stopImmediatePropagation();
 
@@ -1419,7 +1420,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     };
 
     const handleMouseUpCapture = (e: MouseEvent) => {
-      if (e.button === 2 && mouseTrackingRef.current) {
+      if (e.button === 2 && mouseTrackingRef.current && statusRef.current === 'connected') {
         e.stopImmediatePropagation();
       }
     };
@@ -1820,6 +1821,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       onSelectWord={terminalContextActions.onSelectWord}
       onSplitHorizontal={onSplitHorizontal}
       onSplitVertical={onSplitVertical}
+      isReconnectable={status === "disconnected"}
+      onReconnect={handleRetry}
       onClose={inWorkspace ? () => onCloseSession?.(sessionId) : undefined}
     >
       <div

--- a/components/terminal/TerminalContextMenu.test.ts
+++ b/components/terminal/TerminalContextMenu.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import en from "../../application/i18n/locales/en.ts";
+import zhCN from "../../application/i18n/locales/zh-CN.ts";
+import * as terminalContextMenu from "./TerminalContextMenu.tsx";
+
+const shouldShowReconnectAction = (
+  terminalContextMenu as {
+    shouldShowReconnectAction?: (options: {
+      isReconnectable?: boolean;
+      onReconnect?: () => void;
+    }) => boolean;
+  }
+).shouldShowReconnectAction;
+const shouldSuppressMouseTrackingContextMenu = (
+  terminalContextMenu as {
+    shouldSuppressMouseTrackingContextMenu?: (options: {
+      isAlternateScreen?: boolean;
+      showReconnectAction?: boolean;
+    }) => boolean;
+  }
+).shouldSuppressMouseTrackingContextMenu;
+
+test("shows reconnect only for reconnectable terminals with a handler", () => {
+  assert.equal(typeof shouldShowReconnectAction, "function");
+  if (typeof shouldShowReconnectAction !== "function") return;
+
+  assert.equal(
+    shouldShowReconnectAction({
+      isReconnectable: true,
+      onReconnect: () => {},
+    }),
+    true,
+  );
+  assert.equal(
+    shouldShowReconnectAction({
+      isReconnectable: false,
+      onReconnect: () => {},
+    }),
+    false,
+  );
+  assert.equal(shouldShowReconnectAction({ isReconnectable: true }), false);
+});
+
+test("localizes the reconnect context menu label", () => {
+  assert.equal(en["terminal.menu.reconnect"], "Reconnect");
+  assert.equal(zhCN["terminal.menu.reconnect"], "重新连接");
+});
+
+test("allows reconnect menu while stale mouse tracking is still active", () => {
+  assert.equal(typeof shouldSuppressMouseTrackingContextMenu, "function");
+  if (typeof shouldSuppressMouseTrackingContextMenu !== "function") return;
+
+  assert.equal(
+    shouldSuppressMouseTrackingContextMenu({
+      isAlternateScreen: true,
+      showReconnectAction: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldSuppressMouseTrackingContextMenu({
+      isAlternateScreen: true,
+      showReconnectAction: false,
+    }),
+    true,
+  );
+});

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -5,6 +5,7 @@
 import {
   ClipboardPaste,
   Copy,
+  RefreshCcw,
   SplitSquareHorizontal,
   SplitSquareVertical,
   Terminal as TerminalIcon,
@@ -36,9 +37,27 @@ export interface TerminalContextMenuProps {
   onClear?: () => void;
   onSplitHorizontal?: () => void;
   onSplitVertical?: () => void;
+  isReconnectable?: boolean;
+  onReconnect?: () => void;
   onClose?: () => void;
   onSelectWord?: () => void;
 }
+
+export const shouldShowReconnectAction = ({
+  isReconnectable,
+  onReconnect,
+}: {
+  isReconnectable?: boolean;
+  onReconnect?: () => void;
+}): boolean => Boolean(isReconnectable && onReconnect);
+
+export const shouldSuppressMouseTrackingContextMenu = ({
+  isAlternateScreen,
+  showReconnectAction,
+}: {
+  isAlternateScreen?: boolean;
+  showReconnectAction?: boolean;
+}): boolean => Boolean(isAlternateScreen && !showReconnectAction);
 
 export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   children,
@@ -54,6 +73,8 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   onClear,
   onSplitHorizontal,
   onSplitVertical,
+  isReconnectable,
+  onReconnect,
   onClose,
   onSelectWord,
 }) => {
@@ -88,6 +109,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   const splitHShortcut = getShortcut('split-horizontal');
   const splitVShortcut = getShortcut('split-vertical');
   const clearShortcut = getShortcut('clear-buffer');
+  const showReconnectAction = shouldShowReconnectAction({ isReconnectable, onReconnect });
 
   // Handle right-click: intercept for paste/select-word unless Shift is held
   // or rightClickBehavior is 'context-menu'. The ContextMenuTrigger stays always
@@ -95,8 +117,9 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
   const handleRightClick = useCallback(
     (e: React.MouseEvent) => {
       // In alternate screen (tmux, vim, etc.), let the terminal application
-      // handle right-click natively to avoid conflicting menus
-      if (isAlternateScreen) {
+      // handle right-click natively to avoid conflicting menus. Reconnect is
+      // still available after disconnect, even if mouse tracking was left on.
+      if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction })) {
         e.preventDefault();
         return;
       }
@@ -120,7 +143,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         onSelectWord?.();
       }
     },
-    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen],
+    [rightClickBehavior, onPaste, onSelectWord, isAlternateScreen, showReconnectAction],
   );
 
   // Always use ContextMenu wrapper to maintain consistent React tree structure
@@ -133,7 +156,7 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
       >
         {children}
       </ContextMenuTrigger>
-      {!isAlternateScreen && (
+      {!shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction }) && (
         <ContextMenuContent className="w-56">
           <ContextMenuItem onClick={onCopy} disabled={!hasSelection}>
             <Copy size={14} className="mr-2" />
@@ -157,6 +180,16 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
             {t('terminal.menu.selectAll')}
             <ContextMenuShortcut>{selectAllShortcut}</ContextMenuShortcut>
           </ContextMenuItem>
+
+          {showReconnectAction && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem onClick={onReconnect}>
+                <RefreshCcw size={14} className="mr-2" />
+                {t('terminal.menu.reconnect')}
+              </ContextMenuItem>
+            </>
+          )}
 
           <ContextMenuSeparator />
 


### PR DESCRIPTION
## Summary
- Add a reconnect action to the terminal context menu for disconnected sessions.
- Keep the action available even when stale mouse-tracking state would otherwise hide the menu.
- Add localization and focused coverage for the reconnect menu state.

Fixes #945

## Verification
- npm test