### PR TITLE
Broadcast pasted terminal input (#927)

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1509,6 +1509,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sessionRef,
     onHasSelectionChange: setHasSelection,
     scrollOnPasteRef,
+    isBroadcastEnabledRef,
+    onBroadcastInputRef,
   });
   // Kept fresh on every render so the mouseTracking capture handler at
   // handleContextMenuCapture (which is bound once per sessionId) can

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1506,6 +1506,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const terminalContextActions = useTerminalContextActions({
     termRef,
+    sourceSessionId: sessionId,
     sessionRef,
     onHasSelectionChange: setHasSelection,
     scrollOnPasteRef,

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -5,17 +5,47 @@ import { logger } from "../../../lib/logger";
 import { pasteTextIntoTerminal } from "../runtime/terminalUserPaste";
 import { clearTerminalViewport } from "../clearTerminalViewport";
 
+type BroadcastPasteRefs = {
+  sessionRef: RefObject<string | null>;
+  isBroadcastEnabledRef?: RefObject<boolean | undefined>;
+  onBroadcastInputRef?: RefObject<((data: string, sourceSessionId: string) => void) | undefined>;
+};
+
+export const broadcastTerminalPasteData = (
+  data: string,
+  { sessionRef, isBroadcastEnabledRef, onBroadcastInputRef }: BroadcastPasteRefs,
+): boolean => {
+  const sessionId = sessionRef.current;
+  if (sessionId && isBroadcastEnabledRef?.current && onBroadcastInputRef?.current) {
+    onBroadcastInputRef.current(data, sessionId);
+    return true;
+  }
+  return false;
+};
+
 export const useTerminalContextActions = ({
   termRef,
   sessionRef,
   onHasSelectionChange,
   scrollOnPasteRef,
+  isBroadcastEnabledRef,
+  onBroadcastInputRef,
 }: {
   termRef: RefObject<XTerm | null>;
   sessionRef: RefObject<string | null>;
   onHasSelectionChange?: (hasSelection: boolean) => void;
   scrollOnPasteRef?: RefObject<boolean>;
+  isBroadcastEnabledRef?: RefObject<boolean | undefined>;
+  onBroadcastInputRef?: RefObject<((data: string, sourceSessionId: string) => void) | undefined>;
 }) => {
+  const broadcastUserPasteData = useCallback((data: string) => {
+    return broadcastTerminalPasteData(data, {
+      sessionRef,
+      isBroadcastEnabledRef,
+      onBroadcastInputRef,
+    });
+  }, [isBroadcastEnabledRef, onBroadcastInputRef, sessionRef]);
+
   const onCopy = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
@@ -33,12 +63,13 @@ export const useTerminalContextActions = ({
       if (text && sessionRef.current) {
         pasteTextIntoTerminal(term, text, {
           scrollOnPaste: scrollOnPasteRef?.current ?? false,
+          onPasteData: broadcastUserPasteData,
         });
       }
     } catch (err) {
       logger.warn("Failed to paste from clipboard", err);
     }
-  }, [sessionRef, termRef, scrollOnPasteRef]);
+  }, [broadcastUserPasteData, sessionRef, termRef, scrollOnPasteRef]);
 
   const onPasteSelection = useCallback(() => {
     const term = termRef.current;
@@ -47,8 +78,9 @@ export const useTerminalContextActions = ({
     if (!selection || !sessionRef.current) return;
     pasteTextIntoTerminal(term, selection, {
       scrollOnPaste: scrollOnPasteRef?.current ?? false,
+      onPasteData: broadcastUserPasteData,
     });
-  }, [sessionRef, termRef, scrollOnPasteRef]);
+  }, [broadcastUserPasteData, sessionRef, termRef, scrollOnPasteRef]);
 
   const onSelectAll = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -6,6 +6,7 @@ import { pasteTextIntoTerminal } from "../runtime/terminalUserPaste";
 import { clearTerminalViewport } from "../clearTerminalViewport";
 
 type BroadcastPasteRefs = {
+  sourceSessionId: string;
   sessionRef: RefObject<string | null>;
   isBroadcastEnabledRef?: RefObject<boolean | undefined>;
   onBroadcastInputRef?: RefObject<((data: string, sourceSessionId: string) => void) | undefined>;
@@ -13,11 +14,10 @@ type BroadcastPasteRefs = {
 
 export const broadcastTerminalPasteData = (
   data: string,
-  { sessionRef, isBroadcastEnabledRef, onBroadcastInputRef }: BroadcastPasteRefs,
+  { sourceSessionId, sessionRef, isBroadcastEnabledRef, onBroadcastInputRef }: BroadcastPasteRefs,
 ): boolean => {
-  const sessionId = sessionRef.current;
-  if (sessionId && isBroadcastEnabledRef?.current && onBroadcastInputRef?.current) {
-    onBroadcastInputRef.current(data, sessionId);
+  if (sessionRef.current && isBroadcastEnabledRef?.current && onBroadcastInputRef?.current) {
+    onBroadcastInputRef.current(data, sourceSessionId);
     return true;
   }
   return false;
@@ -25,6 +25,7 @@ export const broadcastTerminalPasteData = (
 
 export const useTerminalContextActions = ({
   termRef,
+  sourceSessionId,
   sessionRef,
   onHasSelectionChange,
   scrollOnPasteRef,
@@ -32,6 +33,7 @@ export const useTerminalContextActions = ({
   onBroadcastInputRef,
 }: {
   termRef: RefObject<XTerm | null>;
+  sourceSessionId: string;
   sessionRef: RefObject<string | null>;
   onHasSelectionChange?: (hasSelection: boolean) => void;
   scrollOnPasteRef?: RefObject<boolean>;
@@ -40,11 +42,12 @@ export const useTerminalContextActions = ({
 }) => {
   const broadcastUserPasteData = useCallback((data: string) => {
     return broadcastTerminalPasteData(data, {
+      sourceSessionId,
       sessionRef,
       isBroadcastEnabledRef,
       onBroadcastInputRef,
     });
-  }, [isBroadcastEnabledRef, onBroadcastInputRef, sessionRef]);
+  }, [isBroadcastEnabledRef, onBroadcastInputRef, sessionRef, sourceSessionId]);
 
   const onCopy = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -46,6 +46,7 @@ import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
   pasteTextIntoTerminal,
+  shouldSuppressTerminalBroadcastForUserPaste,
   shouldSuppressTerminalInputScrollForUserPaste,
 } from "./terminalUserPaste";
 import type {
@@ -410,6 +411,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   const appLevelActions = getAppLevelActions();
   const terminalActions = getTerminalPassthroughActions();
+  const broadcastUserPasteData = (data: string) => {
+    if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
+      ctx.onBroadcastInputRef.current(data, ctx.sessionId);
+      return true;
+    }
+    return false;
+  };
   const scrollToBottomAfterInput = (data: string) => {
     if (shouldScrollOnTerminalInput(ctx.terminalSettingsRef.current, data)) {
       term.scrollToBottom();
@@ -536,6 +544,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
                 if (id) {
                   pasteTextIntoTerminal(term, text, {
                     scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+                    onPasteData: broadcastUserPasteData,
                   });
                 }
               });
@@ -547,6 +556,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               if (selection && id) {
                 pasteTextIntoTerminal(term, selection, {
                   scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+                  onPasteData: broadcastUserPasteData,
                 });
               }
               break;
@@ -599,6 +609,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         if (text && ctx.sessionRef.current) {
           pasteTextIntoTerminal(term, text, {
             scrollOnPaste: shouldScrollOnTerminalPaste(ctx.terminalSettingsRef.current),
+            onPasteData: broadcastUserPasteData,
           });
         }
       } catch (err) {
@@ -651,7 +662,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
         // Use remapped data so broadcast peers also receive the correct byte
         const broadcastData = (data === "\x7f" && ctx.host.backspaceBehavior === "ctrl-h") ? "\x08" : data;
-        ctx.onBroadcastInputRef.current(broadcastData, ctx.sessionId);
+        if (!shouldSuppressTerminalBroadcastForUserPaste(term, broadcastData)) {
+          ctx.onBroadcastInputRef.current(broadcastData, ctx.sessionId);
+        }
       }
 
       if (!shouldSuppressTerminalInputScrollForUserPaste(term, data)) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -46,7 +46,7 @@ import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
   pasteTextIntoTerminal,
-  shouldSuppressTerminalBroadcastForUserPaste,
+  shouldBroadcastTerminalUserInput,
   shouldSuppressTerminalInputScrollForUserPaste,
 } from "./terminalUserPaste";
 import type {
@@ -659,12 +659,14 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         }
       }
 
-      if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
-        // Use remapped data so broadcast peers also receive the correct byte
-        const broadcastData = (data === "\x7f" && ctx.host.backspaceBehavior === "ctrl-h") ? "\x08" : data;
-        if (!shouldSuppressTerminalBroadcastForUserPaste(term, broadcastData)) {
-          ctx.onBroadcastInputRef.current(broadcastData, ctx.sessionId);
-        }
+      const onBroadcastInput = ctx.onBroadcastInputRef.current;
+      // Use remapped data so broadcast peers also receive the correct byte
+      const broadcastData = (data === "\x7f" && ctx.host.backspaceBehavior === "ctrl-h") ? "\x08" : data;
+      if (shouldBroadcastTerminalUserInput(term, broadcastData, {
+        isBroadcastEnabled: ctx.isBroadcastEnabledRef.current,
+        hasBroadcastInputHandler: !!onBroadcastInput,
+      })) {
+        onBroadcastInput?.(broadcastData, ctx.sessionId);
       }
 
       if (!shouldSuppressTerminalInputScrollForUserPaste(term, data)) {

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -5,6 +5,7 @@ import {
   clearPasteResidualAfterTerminalWrite,
   pasteTextIntoTerminal,
   prepareTerminalDataForUserPasteDisplay,
+  shouldSuppressTerminalBroadcastForUserPaste,
   shouldSuppressTerminalInputScrollForUserPaste,
 } from "./terminalUserPaste";
 
@@ -22,6 +23,104 @@ test("user paste delegates raw clipboard text to xterm paste handling", () => {
   pasteTextIntoTerminal(term, text, { scrollOnPaste: false });
 
   assert.deepEqual(pasted, [text]);
+});
+
+test("user paste reports prepared terminal input for broadcast targets", () => {
+  const pasted: string[] = [];
+  const broadcastData: string[] = [];
+  const term = {
+    paste: (text: string) => pasted.push(text),
+    scrollToBottom: () => {},
+  };
+
+  const text = "line one\r\nline two\nline three";
+
+  const options = {
+    scrollOnPaste: false,
+    onPasteData: (data: string) => broadcastData.push(data),
+  };
+
+  pasteTextIntoTerminal(term, text, options);
+
+  assert.deepEqual(pasted, [text]);
+  assert.deepEqual(broadcastData, ["line one\rline two\rline three"]);
+});
+
+test("user paste reports bracketed terminal input for broadcast targets when bracketed paste is active", () => {
+  const broadcastData: string[] = [];
+  const term = {
+    modes: { bracketedPasteMode: true },
+    options: { ignoreBracketedPasteMode: false },
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+    onPasteData: (data: string) => broadcastData.push(data),
+  });
+
+  assert.deepEqual(broadcastData, ["\x1b[200~line one\rline two\x1b[201~"]);
+});
+
+test("user paste reports plain terminal input for broadcast targets when bracketed paste is ignored", () => {
+  const broadcastData: string[] = [];
+  const term = {
+    modes: { bracketedPasteMode: true },
+    options: { ignoreBracketedPasteMode: true },
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+    onPasteData: (data: string) => broadcastData.push(data),
+  });
+
+  assert.deepEqual(broadcastData, ["line one\rline two"]);
+});
+
+test("user paste broadcast data is consumed so xterm onData does not rebroadcast it", () => {
+  const term = {
+    modes: { bracketedPasteMode: true },
+    options: { ignoreBracketedPasteMode: false },
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one\nline two", {
+    scrollOnPaste: false,
+    onPasteData: () => true,
+  });
+
+  assert.equal(
+    shouldSuppressTerminalBroadcastForUserPaste(
+      term,
+      "\x1b[200~line one\rline two\x1b[201~",
+    ),
+    true,
+  );
+  assert.equal(
+    shouldSuppressTerminalBroadcastForUserPaste(
+      term,
+      "\x1b[200~line one\rline two\x1b[201~",
+    ),
+    false,
+  );
+});
+
+test("user paste does not suppress later broadcast when paste callback did not broadcast", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one", {
+    scrollOnPaste: false,
+    onPasteData: () => false,
+  });
+
+  assert.equal(shouldSuppressTerminalBroadcastForUserPaste(term, "line one"), false);
 });
 
 test("user paste preserves the existing scroll-on-paste behavior", () => {

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -5,6 +5,7 @@ import {
   clearPasteResidualAfterTerminalWrite,
   pasteTextIntoTerminal,
   prepareTerminalDataForUserPasteDisplay,
+  shouldBroadcastTerminalUserInput,
   shouldSuppressTerminalBroadcastForUserPaste,
   shouldSuppressTerminalInputScrollForUserPaste,
 } from "./terminalUserPaste";
@@ -121,6 +122,33 @@ test("user paste does not suppress later broadcast when paste callback did not b
   });
 
   assert.equal(shouldSuppressTerminalBroadcastForUserPaste(term, "line one"), false);
+});
+
+test("broadcast gate consumes paste state even when broadcast is disabled before onData", () => {
+  const term = {
+    paste: () => {},
+    scrollToBottom: () => {},
+  };
+
+  pasteTextIntoTerminal(term, "line one", {
+    scrollOnPaste: false,
+    onPasteData: () => true,
+  });
+
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "line one", {
+      isBroadcastEnabled: false,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "line one", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    true,
+  );
 });
 
 test("user paste preserves the existing scroll-on-paste behavior", () => {

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -12,6 +12,11 @@ type PasteOptions = {
   onPasteData?: (data: string) => boolean | void;
 };
 
+type BroadcastUserInputOptions = {
+  isBroadcastEnabled?: boolean;
+  hasBroadcastInputHandler?: boolean;
+};
+
 type PasteDisplayState = {
   expiresAt: number;
   clearPending: number;
@@ -297,6 +302,15 @@ export function shouldSuppressTerminalInputScrollForUserPaste(term: object, data
 
 export function shouldSuppressTerminalBroadcastForUserPaste(term: object, data: string): boolean {
   return consumePasteInputState(pasteBroadcastStates, term, data);
+}
+
+export function shouldBroadcastTerminalUserInput(
+  term: object,
+  data: string,
+  options: BroadcastUserInputOptions,
+): boolean {
+  const isSuppressedUserPaste = shouldSuppressTerminalBroadcastForUserPaste(term, data);
+  return !isSuppressedUserPaste && !!options.isBroadcastEnabled && !!options.hasBroadcastInputHandler;
 }
 
 function consumePasteInputState(

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -1,11 +1,15 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 type PasteTarget = Pick<XTerm, "paste" | "scrollToBottom"> &
-  Partial<Pick<XTerm, "cols" | "rows" | "write">>;
+  Partial<Pick<XTerm, "cols" | "rows" | "write">> & {
+    modes?: { bracketedPasteMode?: boolean };
+    options?: { ignoreBracketedPasteMode?: boolean };
+  };
 
 type PasteOptions = {
   scrollOnPaste?: boolean;
   requestAnimationFrame?: (callback: () => void) => unknown;
+  onPasteData?: (data: string) => boolean | void;
 };
 
 type PasteDisplayState = {
@@ -22,6 +26,7 @@ type PasteInputScrollState = {
 
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
 const pasteInputScrollStates = new WeakMap<object, PasteInputScrollState>();
+const pasteBroadcastStates = new WeakMap<object, PasteInputScrollState>();
 const LONG_PASTE_MIN_LENGTH = 200;
 const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
 const PASTE_INPUT_SCROLL_WINDOW_MS = 4000;
@@ -126,6 +131,14 @@ const getPasteInputDataVariants = (text: string): string[] => {
       `${BRACKETED_PASTE_START}${preparedText}${BRACKETED_PASTE_END}`,
     ]),
   ).filter((candidate) => candidate.length > 0);
+};
+
+const getPasteInputData = (term: PasteTarget, text: string): string => {
+  const preparedText = preparePasteTextForXterm(text);
+  if (term.modes?.bracketedPasteMode && !term.options?.ignoreBracketedPasteMode) {
+    return `${BRACKETED_PASTE_START}${preparedText}${BRACKETED_PASTE_END}`;
+  }
+  return preparedText;
 };
 
 const isExpectedPasteEcho = (data: string, state: PasteDisplayState): boolean => {
@@ -245,6 +258,21 @@ export function pasteTextIntoTerminal(
     pasteInputScrollStates.delete(term);
   }
 
+  if (options.onPasteData) {
+    const pasteData = getPasteInputData(term, text);
+    const didBroadcast = options.onPasteData(pasteData) === true;
+    if (didBroadcast) {
+      pasteBroadcastStates.set(term, {
+        expiresAt: getNow() + PASTE_INPUT_SCROLL_WINDOW_MS,
+        remainingDataVariants: [pasteData],
+      });
+    } else {
+      pasteBroadcastStates.delete(term);
+    }
+  } else {
+    pasteBroadcastStates.delete(term);
+  }
+
   term.paste(text);
 
   if (!options.scrollOnPaste) return;
@@ -264,9 +292,21 @@ export function pasteTextIntoTerminal(
 }
 
 export function shouldSuppressTerminalInputScrollForUserPaste(term: object, data: string): boolean {
-  const state = pasteInputScrollStates.get(term);
+  return consumePasteInputState(pasteInputScrollStates, term, data);
+}
+
+export function shouldSuppressTerminalBroadcastForUserPaste(term: object, data: string): boolean {
+  return consumePasteInputState(pasteBroadcastStates, term, data);
+}
+
+function consumePasteInputState(
+  states: WeakMap<object, PasteInputScrollState>,
+  term: object,
+  data: string,
+): boolean {
+  const state = states.get(term);
   if (!isStateActive(state)) {
-    pasteInputScrollStates.delete(term);
+    states.delete(term);
     return false;
   }
 
@@ -280,7 +320,7 @@ export function shouldSuppressTerminalInputScrollForUserPaste(term: object, data
   if (candidate.length > data.length) {
     state.remainingDataVariants[matchingIndex] = candidate.slice(data.length);
   } else {
-    pasteInputScrollStates.delete(term);
+    states.delete(term);
   }
   return true;
 }

--- a/components/terminal/useTerminalContextActions.test.ts
+++ b/components/terminal/useTerminalContextActions.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { broadcastTerminalPasteData } from "./hooks/useTerminalContextActions";
+
+test("terminal context paste reports whether it broadcast to peers", () => {
+  const broadcasted: Array<{ data: string; sessionId: string }> = [];
+
+  const didBroadcast = broadcastTerminalPasteData("line one", {
+    sessionRef: { current: "session-1" },
+    isBroadcastEnabledRef: { current: true },
+    onBroadcastInputRef: {
+      current: (data, sourceSessionId) => {
+        broadcasted.push({ data, sessionId: sourceSessionId });
+      },
+    },
+  });
+
+  assert.equal(didBroadcast, true);
+  assert.deepEqual(broadcasted, [{ data: "line one", sessionId: "session-1" }]);
+});
+
+test("terminal context paste reports false when broadcast is disabled", () => {
+  const didBroadcast = broadcastTerminalPasteData("line one", {
+    sessionRef: { current: "session-1" },
+    isBroadcastEnabledRef: { current: false },
+    onBroadcastInputRef: {
+      current: () => {
+        throw new Error("broadcast should not run");
+      },
+    },
+  });
+
+  assert.equal(didBroadcast, false);
+});

--- a/components/terminal/useTerminalContextActions.test.ts
+++ b/components/terminal/useTerminalContextActions.test.ts
@@ -7,7 +7,8 @@ test("terminal context paste reports whether it broadcast to peers", () => {
   const broadcasted: Array<{ data: string; sessionId: string }> = [];
 
   const didBroadcast = broadcastTerminalPasteData("line one", {
-    sessionRef: { current: "session-1" },
+    sourceSessionId: "workspace-session-1",
+    sessionRef: { current: "backend-session-1" },
     isBroadcastEnabledRef: { current: true },
     onBroadcastInputRef: {
       current: (data, sourceSessionId) => {
@@ -17,11 +18,12 @@ test("terminal context paste reports whether it broadcast to peers", () => {
   });
 
   assert.equal(didBroadcast, true);
-  assert.deepEqual(broadcasted, [{ data: "line one", sessionId: "session-1" }]);
+  assert.deepEqual(broadcasted, [{ data: "line one", sessionId: "workspace-session-1" }]);
 });
 
 test("terminal context paste reports false when broadcast is disabled", () => {
   const didBroadcast = broadcastTerminalPasteData("line one", {
+    sourceSessionId: "workspace-session-1",
     sessionRef: { current: "session-1" },
     isBroadcastEnabledRef: { current: false },
     onBroadcastInputRef: {


### PR DESCRIPTION
## Summary
- Broadcast user paste data when workspace broadcast mode is enabled.
- Prevent pasted data from being rebroadcast by the source terminal.
- Cover keyboard, middle-click, and context-menu paste paths, including broadcast-off boundaries.

Fixes #927

## Verification
- npm test