### PR TITLE
Fix Mosh saved password prompt matching

### DIFF
--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -938,7 +938,10 @@ function createMoshSshPasswordResponder(sshPty, password, passphrase) {
 
 function getLatestMoshPromptLine(text) {
   const lines = String(text || "").split(/[\r\n]+/);
-  return lines[lines.length - 1] || "";
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lines[index].trim().length > 0) return lines[index];
+  }
+  return "";
 }
 
 function isMoshAutoFillablePasswordPrompt(text, password) {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -25,6 +25,7 @@ const moshHandshake = require("./moshHandshake.cjs");
 const tempDirBridge = require("./tempDirBridge.cjs");
 const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
 const telnetProtocol = require("./telnetProtocol.cjs");
+const { isAutoFillablePasswordChallenge } = require("./sshAuthHelper.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -928,12 +929,22 @@ function createMoshSshPasswordResponder(sshPty, password, passphrase) {
       return;
     }
 
-    if (typeof password !== "string" || password.length === 0 || answeredPassword) return;
-    if (!/(^|[\r\n]).*password:\s*$/i.test(tail)) return;
+    if (answeredPassword || !isMoshAutoFillablePasswordPrompt(tail, password)) return;
 
     answeredPassword = true;
     sshPty.write(`${password}\r`);
   };
+}
+
+function getLatestMoshPromptLine(text) {
+  const lines = String(text || "").split(/[\r\n]+/);
+  return lines[lines.length - 1] || "";
+}
+
+function isMoshAutoFillablePasswordPrompt(text, password) {
+  const prompt = getLatestMoshPromptLine(text);
+  if (!/[:：]\s*$/.test(prompt)) return false;
+  return isAutoFillablePasswordChallenge([{ prompt, echo: false }], password);
 }
 
 function normalizeMoshIdentityPath(keyPath) {

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -232,6 +232,19 @@ test("startMoshSession writes the saved password for localized password prompts"
   assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
 });
 
+test("startMoshSession writes the saved password when the prompt chunk ends with newline", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    { ...h.options, password: "saved-secret" },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  h.spawns[0].emitData("Password:\r\n");
+
+  assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
+});
+
 test("startMoshSession does not write saved password into OTP prompts", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -219,6 +219,32 @@ test("startMoshSession writes the saved password when ssh prompts for one", asyn
   assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
 });
 
+test("startMoshSession writes the saved password for localized password prompts", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    { ...h.options, password: "saved-secret" },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  h.spawns[0].emitData("密码：");
+
+  assert.deepEqual(h.spawns[0].writes, ["saved-secret\r"]);
+});
+
+test("startMoshSession does not write saved password into OTP prompts", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    { ...h.options, password: "saved-secret" },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  h.spawns[0].emitData("One-time password:");
+
+  assert.deepEqual(h.spawns[0].writes, []);
+});
+
 test("startMoshSession passes vault private keys to ssh via a temp identity file", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(


### PR DESCRIPTION
## Summary

- align Mosh saved-password prompt detection with the SSH keyboard-interactive rules
- support localized password prompts
- keep OTP/MFA prompts such as "One-time password:" from receiving the saved password
- add Mosh handshake tests for both cases

Fixes #989.

## Validation

- node --test electron/bridges/terminalBridge.moshHandshakeSession.test.cjs electron/bridges/terminalBridge.bareMoshClient.test.cjs electron/bridges/sshAuthHelper.kbdInteractive.test.cjs
- npx eslint electron/bridges/terminalBridge.cjs electron/bridges/terminalBridge.moshHandshakeSession.test.cjs (project config ignores these CJS files; no errors)
- npm test