### PR TITLE
[codex] Fix browser loading of shared rule files

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -33,6 +33,7 @@ module.exports = {
         'dist/**/*',
         'electron/**/*',
         'lib/**/*.cjs',
+        'lib/**/*.json',
         '!electron/.dev-config.json',
         'skills/**/*',
         'public/**/*',

--- a/infrastructure/ai/commandBlocklist.test.ts
+++ b/infrastructure/ai/commandBlocklist.test.ts
@@ -6,10 +6,12 @@ import { checkCommandSafety } from "./cattyAgent/safety";
 import { DEFAULT_COMMAND_BLOCKLIST } from "./types";
 
 const require = createRequire(import.meta.url);
-const defaultCommandBlocklist = require("../../lib/commandBlocklist.cjs") as string[];
+const defaultCommandBlocklist = require("../../lib/commandBlocklist.json") as string[];
+const cjsCommandBlocklist = require("../../lib/commandBlocklist.cjs") as string[];
 
-test("AI command blocklist uses the shared CommonJS source", () => {
-  assert.deepEqual(DEFAULT_COMMAND_BLOCKLIST, Array.from(defaultCommandBlocklist));
+test("AI command blocklist uses the shared JSON source", () => {
+  assert.deepEqual(DEFAULT_COMMAND_BLOCKLIST, defaultCommandBlocklist);
+  assert.deepEqual(Array.from(cjsCommandBlocklist), defaultCommandBlocklist);
 });
 
 test("shared default command blocklist covers bypass-style shell execution", () => {

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -1,11 +1,6 @@
 // AI Provider types
-import * as commandBlocklistModule from '../../lib/commandBlocklist.cjs';
+import defaultCommandBlocklist from '../../lib/commandBlocklist.json';
 import type { ProviderContinuation } from './providerContinuation';
-
-const commandBlocklistSource = commandBlocklistModule as unknown as {
-  DEFAULT_COMMAND_BLOCKLIST?: string[];
-  default?: string[];
-};
 
 export type AIProviderId = 'openai' | 'anthropic' | 'google' | 'ollama' | 'openrouter' | 'custom';
 
@@ -255,7 +250,7 @@ export interface AISettings {
 }
 
 export const DEFAULT_COMMAND_BLOCKLIST = [
-  ...(commandBlocklistSource.DEFAULT_COMMAND_BLOCKLIST ?? commandBlocklistSource.default ?? []),
+  ...defaultCommandBlocklist,
 ];
 
 export const DEFAULT_AI_SETTINGS: AISettings = {

--- a/lib/commandBlocklist.cjs
+++ b/lib/commandBlocklist.cjs
@@ -1,24 +1,6 @@
 "use strict";
 
-const DEFAULT_COMMAND_BLOCKLIST = [
-  // rm with recursive+force in any order/form targeting root
-  "\\brm\\s+(-[a-zA-Z]*r[a-zA-Z]*\\s+(-[a-zA-Z]*f[a-zA-Z]*\\s+)?|-[a-zA-Z]*f[a-zA-Z]*\\s+(-[a-zA-Z]*r[a-zA-Z]*\\s+)?|--recursive\\s+|--force\\s+){1,}",
-  "\\bmkfs\\.",
-  "\\bdd\\s+if=.*\\s+of=/dev/",
-  "\\b(shutdown|reboot|poweroff|halt)\\b",
-  ":\\(\\)\\{\\s*:\\|:\\&\\s*\\};:",
-  ">\\s*/dev/sd",
-  "\\bchmod\\s+(-[a-zA-Z]*R[a-zA-Z]*|--recursive)\\s+777\\s+/",
-  "\\bmv\\s+/\\s",
-  ":\\s*>\\s*/etc/",
-  "\\bcurl\\s+.*\\|\\s*\\bsudo\\s+\\bbash\\b",
-  "\\bwget\\s+.*\\|\\s*\\bsudo\\s+\\bbash\\b",
-  // Common bypass techniques (defense-in-depth, not a security boundary)
-  "base64.*\\|.*(?:ba)?sh",
-  "\\beval\\b",
-  "\\$\\(",
-  "`.+`",
-];
+const DEFAULT_COMMAND_BLOCKLIST = [...require("./commandBlocklist.json")];
 
 module.exports = DEFAULT_COMMAND_BLOCKLIST;
 module.exports.DEFAULT_COMMAND_BLOCKLIST = DEFAULT_COMMAND_BLOCKLIST;

--- a/lib/commandBlocklist.json
+++ b/lib/commandBlocklist.json
@@ -1,0 +1,17 @@
+[
+  "\\brm\\s+(-[a-zA-Z]*r[a-zA-Z]*\\s+(-[a-zA-Z]*f[a-zA-Z]*\\s+)?|-[a-zA-Z]*f[a-zA-Z]*\\s+(-[a-zA-Z]*r[a-zA-Z]*\\s+)?|--recursive\\s+|--force\\s+){1,}",
+  "\\bmkfs\\.",
+  "\\bdd\\s+if=.*\\s+of=/dev/",
+  "\\b(shutdown|reboot|poweroff|halt)\\b",
+  ":\\(\\)\\{\\s*:\\|:\\&\\s*\\};:",
+  ">\\s*/dev/sd",
+  "\\bchmod\\s+(-[a-zA-Z]*R[a-zA-Z]*|--recursive)\\s+777\\s+/",
+  "\\bmv\\s+/\\s",
+  ":\\s*>\\s*/etc/",
+  "\\bcurl\\s+.*\\|\\s*\\bsudo\\s+\\bbash\\b",
+  "\\bwget\\s+.*\\|\\s*\\bsudo\\s+\\bbash\\b",
+  "base64.*\\|.*(?:ba)?sh",
+  "\\beval\\b",
+  "\\$\\(",
+  "`.+`"
+]

--- a/lib/localShell.cjs
+++ b/lib/localShell.cjs
@@ -1,10 +1,12 @@
 "use strict";
 
-const POWERSHELL_SHELLS = new Set(["powershell", "powershell.exe", "pwsh", "pwsh.exe"]);
-const CMD_SHELLS = new Set(["cmd", "cmd.exe"]);
-const FISH_SHELLS = new Set(["fish"]);
-const POSIX_SHELLS = new Set(["sh", "bash", "zsh", "ksh", "dash", "ash", "bash.exe"]);
-const WSL_SHELLS = new Set(["wsl", "wsl.exe"]);
+const localShellRules = require("./localShellRules.json");
+
+const POWERSHELL_SHELLS = new Set(localShellRules.powershellShells);
+const CMD_SHELLS = new Set(localShellRules.cmdShells);
+const FISH_SHELLS = new Set(localShellRules.fishShells);
+const POSIX_SHELLS = new Set(localShellRules.posixShells);
+const WSL_SHELLS = new Set(localShellRules.wslShells);
 
 function getExecutableBaseName(filePath) {
   const normalized = String(filePath || "").trim();

--- a/lib/localShell.ts
+++ b/lib/localShell.ts
@@ -1,18 +1,41 @@
-import * as localShellCore from "./localShell.cjs";
+import localShellRules from "./localShellRules.json";
 
 export type LocalShellType = "posix" | "fish" | "powershell" | "cmd" | "unknown";
 export type LocalOs = "linux" | "macos" | "windows";
 
-type LocalShellCore = {
-  detectLocalOs: (platformLike?: string) => LocalOs;
-  classifyLocalShellType: (
-    shellPath: string | undefined,
-    platformLike?: string,
-  ) => LocalShellType;
-};
+const POWERSHELL_SHELLS = new Set(localShellRules.powershellShells);
+const CMD_SHELLS = new Set(localShellRules.cmdShells);
+const FISH_SHELLS = new Set(localShellRules.fishShells);
+const POSIX_SHELLS = new Set(localShellRules.posixShells);
+const WSL_SHELLS = new Set(localShellRules.wslShells);
 
-const core = localShellCore as unknown as LocalShellCore;
+function getExecutableBaseName(filePath: string | undefined) {
+  const normalized = String(filePath || "").trim();
+  if (!normalized) return "";
+  const parts = normalized.split(/[\\/]/);
+  return (parts[parts.length - 1] || "").toLowerCase();
+}
 
-export const detectLocalOs = core.detectLocalOs;
+export function detectLocalOs(platformLike?: string): LocalOs {
+  const platform = String(platformLike || "").toLowerCase();
+  if (platform.includes("mac")) return "macos";
+  if (platform.includes("win")) return "windows";
+  if (platform.includes("darwin")) return "macos";
+  return "linux";
+}
 
-export const classifyLocalShellType = core.classifyLocalShellType;
+export function classifyLocalShellType(
+  shellPath: string | undefined,
+  platformLike?: string,
+): LocalShellType {
+  const shellName = getExecutableBaseName(shellPath);
+  if (POWERSHELL_SHELLS.has(shellName)) return "powershell";
+  if (CMD_SHELLS.has(shellName)) return "cmd";
+  if (FISH_SHELLS.has(shellName)) return "fish";
+  if (POSIX_SHELLS.has(shellName)) return "posix";
+  if (WSL_SHELLS.has(shellName)) return "posix";
+  if (!shellName) {
+    return detectLocalOs(platformLike) === "windows" ? "powershell" : "posix";
+  }
+  return "unknown";
+}

--- a/lib/localShellRules.json
+++ b/lib/localShellRules.json
@@ -1,0 +1,7 @@
+{
+  "powershellShells": ["powershell", "powershell.exe", "pwsh", "pwsh.exe"],
+  "cmdShells": ["cmd", "cmd.exe"],
+  "fishShells": ["fish"],
+  "posixShells": ["sh", "bash", "zsh", "ksh", "dash", "ash", "bash.exe"],
+  "wslShells": ["wsl", "wsl.exe"]
+}


### PR DESCRIPTION
## Summary
- Restore the two browser crash fixes that were pushed after PR #1001 had already merged.
- Move shared local-shell and command-blocklist rules into data files that both the app window and the backend bridges can load safely.
- Keep the backend bridge entry points working for existing callers.

## Validation
- node --test --import tsx lib/localShell.test.ts
- node --test --import tsx infrastructure/ai/commandBlocklist.test.ts
- npm run lint
- npm run build
- npm test