### PR TITLE
[codex] Optimize terminal tab switching

### DIFF
--- a/application/state/activeTabStore.ts
+++ b/application/state/activeTabStore.ts
@@ -1,4 +1,4 @@
-import { useCallback,useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 // Simple store for active tab that allows fine-grained subscriptions
 type Listener = () => void;
@@ -92,7 +92,11 @@ export const useIsEditorTabActive = (tabId: string): boolean => {
 // Check if terminal layer should be visible
 // Editor tabs are NOT terminal tabs, so exclude them from the visibility condition.
 export const useIsTerminalLayerVisible = (draggingSessionId: string | null) => {
-  const activeTabId = useActiveTabId();
-  const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp' && !isEditorTabId(activeTabId);
-  return isTerminalTab || !!draggingSessionId;
+  const getSnapshot = useCallback(() => {
+    const activeTabId = activeTabStore.getActiveTabId();
+    const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp' && !isEditorTabId(activeTabId);
+    return isTerminalTab || !!draggingSessionId;
+  }, [draggingSessionId]);
+
+  return useSyncExternalStore(activeTabStore.subscribe, getSnapshot);
 };

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1,5 +1,5 @@
 import { Circle, Columns2, FolderTree, MessageSquare, PanelLeft, PanelRight, Palette, Plus, Search, Server, X, Zap } from 'lucide-react';
-import React, { Suspense, createContext, lazy, memo, startTransition, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import React, { Suspense, createContext, lazy, memo, startTransition, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { activeTabStore, useActiveTabId } from '../application/state/activeTabStore';
 import { resolveTerminalSessionExitIntent, type TerminalSessionExitEvent } from '../application/state/resolveTerminalSessionExitIntent';
 import {
@@ -59,6 +59,7 @@ import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate
 import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { getTerminalPaneSnapshot, parseTerminalPaneSnapshot } from './terminalPaneVisibility';
+import { getScopedTopTabsThemeId } from './terminalTopTabsTheme';
 
 type SidePanelTab = 'sftp' | 'scripts' | 'theme' | 'ai';
 
@@ -149,22 +150,32 @@ const clearTerminalPreviewVars = (sessionId: string | null) => {
   pane.style.removeProperty('--terminal-preview-toolbar-btn-active');
 };
 
+const setStylePropertyIfChanged = (element: HTMLElement, property: string, value: string) => {
+  if (element.style.getPropertyValue(property) === value) return;
+  element.style.setProperty(property, value);
+};
+
+const removeStylePropertyIfSet = (element: HTMLElement, property: string) => {
+  if (!element.style.getPropertyValue(property)) return;
+  element.style.removeProperty(property);
+};
+
 const clearTopTabsPreviewVars = () => {
   if (typeof document === 'undefined') return;
   const tabsRoot = document.querySelector<HTMLElement>('[data-top-tabs-root]');
   if (!tabsRoot) return;
-  tabsRoot.style.removeProperty('--top-tabs-bg');
-  tabsRoot.style.removeProperty('--top-tabs-fg');
-  tabsRoot.style.removeProperty('--top-tabs-muted');
-  tabsRoot.style.removeProperty('--top-tabs-active-bg');
-  tabsRoot.style.removeProperty('--top-tabs-accent');
-  tabsRoot.style.removeProperty('--background');
-  tabsRoot.style.removeProperty('--foreground');
-  tabsRoot.style.removeProperty('--accent');
-  tabsRoot.style.removeProperty('--primary');
-  tabsRoot.style.removeProperty('--secondary');
-  tabsRoot.style.removeProperty('--border');
-  tabsRoot.style.removeProperty('--muted-foreground');
+  removeStylePropertyIfSet(tabsRoot, '--top-tabs-bg');
+  removeStylePropertyIfSet(tabsRoot, '--top-tabs-fg');
+  removeStylePropertyIfSet(tabsRoot, '--top-tabs-muted');
+  removeStylePropertyIfSet(tabsRoot, '--top-tabs-active-bg');
+  removeStylePropertyIfSet(tabsRoot, '--top-tabs-accent');
+  removeStylePropertyIfSet(tabsRoot, '--background');
+  removeStylePropertyIfSet(tabsRoot, '--foreground');
+  removeStylePropertyIfSet(tabsRoot, '--accent');
+  removeStylePropertyIfSet(tabsRoot, '--primary');
+  removeStylePropertyIfSet(tabsRoot, '--secondary');
+  removeStylePropertyIfSet(tabsRoot, '--border');
+  removeStylePropertyIfSet(tabsRoot, '--muted-foreground');
 };
 
 const filterTabsMap = <T,>(source: Map<string, T>, validIds: Set<string>): Map<string, T> => {
@@ -2005,9 +2016,33 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const focusedFontWeightOverridden = hasHostFontWeightOverride(focusedHost);
   const visibleFocusedThemeId = followAppTerminalTheme ? terminalTheme.id : focusedThemeId;
   const previewedOrVisibleThemeId = activeThemePreviewId ?? visibleFocusedThemeId;
-  const activeTopTabsThemeId = activeSidePanelTab === 'theme' && previewTargetSessionId
-    ? previewedOrVisibleThemeId
-    : (isVisible ? visibleFocusedThemeId : null);
+  const activeTopTabsThemeId = useMemo(
+    () =>
+      getScopedTopTabsThemeId({
+        activeSidePanelTab,
+        activeThemePreviewId,
+        activeWorkspace,
+        followAppTerminalTheme,
+        isVisible,
+        previewTargetSessionId,
+        previewedOrVisibleThemeId,
+        resolveSessionThemeId: (sessionId) => {
+          const host = sessionHostsMap.get(sessionId) ?? null;
+          return followAppTerminalTheme ? terminalTheme.id : resolveHostTerminalThemeId(host, terminalTheme.id);
+        },
+      }),
+    [
+      activeSidePanelTab,
+      activeThemePreviewId,
+      activeWorkspace,
+      followAppTerminalTheme,
+      isVisible,
+      previewTargetSessionId,
+      previewedOrVisibleThemeId,
+      sessionHostsMap,
+      terminalTheme.id,
+    ],
+  );
   const appliedPreviewSessionRef = useRef<string | null>(null);
   const customThemes = useCustomThemes();
   const applyTerminalPreviewVars = useCallback((sessionId: string | null, themeId: string | null) => {
@@ -2052,18 +2087,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const border = adjustLightnessToken(bg, isDark ? 12 : -10);
     const mutedFg = adjustSaturationToken(adjustLightnessToken(fg, isDark ? -20 : 20), 0.5);
 
-    tabsRoot.style.setProperty('--background', bg);
-    tabsRoot.style.setProperty('--foreground', fg);
-    tabsRoot.style.setProperty('--accent', accent);
-    tabsRoot.style.setProperty('--primary', accent);
-    tabsRoot.style.setProperty('--secondary', secondary);
-    tabsRoot.style.setProperty('--border', border);
-    tabsRoot.style.setProperty('--muted-foreground', mutedFg);
-    tabsRoot.style.setProperty('--top-tabs-bg', 'hsl(var(--secondary))');
-    tabsRoot.style.setProperty('--top-tabs-fg', 'hsl(var(--foreground))');
-    tabsRoot.style.setProperty('--top-tabs-muted', 'hsl(var(--muted-foreground))');
-    tabsRoot.style.setProperty('--top-tabs-active-bg', 'hsl(var(--background))');
-    tabsRoot.style.setProperty('--top-tabs-accent', 'hsl(var(--accent))');
+    setStylePropertyIfChanged(tabsRoot, '--background', bg);
+    setStylePropertyIfChanged(tabsRoot, '--foreground', fg);
+    setStylePropertyIfChanged(tabsRoot, '--accent', accent);
+    setStylePropertyIfChanged(tabsRoot, '--primary', accent);
+    setStylePropertyIfChanged(tabsRoot, '--secondary', secondary);
+    setStylePropertyIfChanged(tabsRoot, '--border', border);
+    setStylePropertyIfChanged(tabsRoot, '--muted-foreground', mutedFg);
+    setStylePropertyIfChanged(tabsRoot, '--top-tabs-bg', 'hsl(var(--secondary))');
+    setStylePropertyIfChanged(tabsRoot, '--top-tabs-fg', 'hsl(var(--foreground))');
+    setStylePropertyIfChanged(tabsRoot, '--top-tabs-muted', 'hsl(var(--muted-foreground))');
+    setStylePropertyIfChanged(tabsRoot, '--top-tabs-active-bg', 'hsl(var(--background))');
+    setStylePropertyIfChanged(tabsRoot, '--top-tabs-accent', 'hsl(var(--accent))');
   }, [accentMode, customAccent, customThemes]);
 
   useEffect(() => {
@@ -2092,7 +2127,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
   }, [applyTerminalPreviewVars, themePreview]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (activeTopTabsThemeId) {
       applyTopTabsPreviewVars(activeTopTabsThemeId);
       return;

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1,6 +1,6 @@
 import { Circle, Columns2, FolderTree, MessageSquare, PanelLeft, PanelRight, Palette, Plus, Search, Server, X, Zap } from 'lucide-react';
-import React, { Suspense, createContext, lazy, memo, startTransition, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useActiveTabId } from '../application/state/activeTabStore';
+import React, { Suspense, createContext, lazy, memo, startTransition, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { activeTabStore, useActiveTabId } from '../application/state/activeTabStore';
 import { resolveTerminalSessionExitIntent, type TerminalSessionExitEvent } from '../application/state/resolveTerminalSessionExitIntent';
 import {
   getSessionActivityIdsToClear,
@@ -58,6 +58,7 @@ import { ScrollArea } from './ui/scroll-area';
 import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate';
 import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
 import { terminalLayerAreEqual } from './terminalLayerMemo';
+import { getTerminalPaneSnapshot, parseTerminalPaneSnapshot } from './terminalPaneVisibility';
 
 type SidePanelTab = 'sftp' | 'scripts' | 'theme' | 'ai';
 
@@ -457,6 +458,365 @@ interface TerminalLayerProps {
   activeSidePanelTabRef?: React.MutableRefObject<string | null>;
 }
 
+interface TerminalPaneProps {
+  session: TerminalSession;
+  host: Host;
+  chainHosts?: Host[];
+  workspaceById: Map<string, Workspace>;
+  workspaceRectsById: Map<string, Record<string, WorkspaceRect>>;
+  isTerminalLayerVisible: boolean;
+  workspaceFocusHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  workspaceBroadcastHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  splitHorizontalHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  splitVerticalHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  themePreview: { targetSessionId: string | null; themeId: string | null };
+  keys: SSHKey[];
+  identities: Identity[];
+  snippets: Snippet[];
+  knownHosts: KnownHost[];
+  terminalFontFamilyId: string;
+  fontSize: number;
+  terminalTheme: TerminalTheme;
+  followAppTerminalTheme?: boolean;
+  accentMode?: 'theme' | 'custom';
+  customAccent?: string;
+  terminalSettings?: TerminalSettings;
+  hotkeyScheme?: 'disabled' | 'mac' | 'pc';
+  keyBindings?: KeyBinding[];
+  isResizing: boolean;
+  isComposeBarOpen: boolean;
+  sessionLog?: { enabled: true; directory: string; format: string };
+  onHotkeyAction?: (action: string, event: KeyboardEvent) => void;
+  onOpenSftp: (
+    host: Host,
+    initialPath?: string,
+    pendingUploadEntries?: DropEntry[],
+    sourceSessionId?: string,
+  ) => void;
+  onOpenScripts: () => void;
+  onOpenTheme: () => void;
+  onCloseSession: (sessionId: string) => void;
+  onStatusChange: (sessionId: string, status: TerminalSession['status']) => void;
+  onSessionExit: (sessionId: string, evt: TerminalSessionExitEvent) => void;
+  onTerminalDataCapture?: (sessionId: string, data: string) => void;
+  onOsDetected: (hostId: string, distro: string) => void;
+  onUpdateHost: (host: Host) => void;
+  onAddKnownHost?: (knownHost: KnownHost) => void;
+  onCommandExecuted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
+  onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
+  onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
+  isBroadcastEnabled?: (workspaceId: string) => boolean;
+  onBroadcastInput: (data: string, sourceSessionId: string) => void;
+  onToggleWorkspaceComposeBar: () => void;
+  onSnippetExecutorChange: (
+    sessionId: string,
+    executor: SnippetExecutor | null,
+  ) => void;
+}
+
+const getPaneThemePreviewId = (props: TerminalPaneProps): string | null => (
+  props.session.id === props.themePreview.targetSessionId
+    ? props.themePreview.themeId
+    : null
+);
+
+const terminalPanePropsAreEqual = (
+  prev: TerminalPaneProps,
+  next: TerminalPaneProps,
+): boolean => (
+  prev.session === next.session &&
+  prev.host === next.host &&
+  prev.chainHosts === next.chainHosts &&
+  prev.workspaceById === next.workspaceById &&
+  prev.workspaceRectsById === next.workspaceRectsById &&
+  prev.isTerminalLayerVisible === next.isTerminalLayerVisible &&
+  prev.workspaceFocusHandlersRef === next.workspaceFocusHandlersRef &&
+  prev.workspaceBroadcastHandlersRef === next.workspaceBroadcastHandlersRef &&
+  prev.splitHorizontalHandlersRef === next.splitHorizontalHandlersRef &&
+  prev.splitVerticalHandlersRef === next.splitVerticalHandlersRef &&
+  getPaneThemePreviewId(prev) === getPaneThemePreviewId(next) &&
+  prev.keys === next.keys &&
+  prev.identities === next.identities &&
+  prev.snippets === next.snippets &&
+  prev.knownHosts === next.knownHosts &&
+  prev.terminalFontFamilyId === next.terminalFontFamilyId &&
+  prev.fontSize === next.fontSize &&
+  prev.terminalTheme === next.terminalTheme &&
+  prev.followAppTerminalTheme === next.followAppTerminalTheme &&
+  prev.accentMode === next.accentMode &&
+  prev.customAccent === next.customAccent &&
+  prev.terminalSettings === next.terminalSettings &&
+  prev.hotkeyScheme === next.hotkeyScheme &&
+  prev.keyBindings === next.keyBindings &&
+  prev.isResizing === next.isResizing &&
+  prev.isComposeBarOpen === next.isComposeBarOpen &&
+  prev.sessionLog === next.sessionLog &&
+  prev.onHotkeyAction === next.onHotkeyAction &&
+  prev.onOpenSftp === next.onOpenSftp &&
+  prev.onOpenScripts === next.onOpenScripts &&
+  prev.onOpenTheme === next.onOpenTheme &&
+  prev.onCloseSession === next.onCloseSession &&
+  prev.onStatusChange === next.onStatusChange &&
+  prev.onSessionExit === next.onSessionExit &&
+  prev.onTerminalDataCapture === next.onTerminalDataCapture &&
+  prev.onOsDetected === next.onOsDetected &&
+  prev.onUpdateHost === next.onUpdateHost &&
+  prev.onAddKnownHost === next.onAddKnownHost &&
+  prev.onCommandExecuted === next.onCommandExecuted &&
+  prev.onSetWorkspaceFocusedSession === next.onSetWorkspaceFocusedSession &&
+  prev.onSplitSession === next.onSplitSession &&
+  prev.isBroadcastEnabled === next.isBroadcastEnabled &&
+  prev.onBroadcastInput === next.onBroadcastInput &&
+  prev.onToggleWorkspaceComposeBar === next.onToggleWorkspaceComposeBar &&
+  prev.onSnippetExecutorChange === next.onSnippetExecutorChange
+);
+
+const TerminalPane: React.FC<TerminalPaneProps> = memo(({
+  session,
+  host,
+  chainHosts,
+  workspaceById,
+  workspaceRectsById,
+  isTerminalLayerVisible,
+  workspaceFocusHandlersRef,
+  workspaceBroadcastHandlersRef,
+  splitHorizontalHandlersRef,
+  splitVerticalHandlersRef,
+  themePreview,
+  keys,
+  identities,
+  snippets,
+  knownHosts,
+  terminalFontFamilyId,
+  fontSize,
+  terminalTheme,
+  followAppTerminalTheme,
+  accentMode,
+  customAccent,
+  terminalSettings,
+  hotkeyScheme,
+  keyBindings,
+  isResizing,
+  isComposeBarOpen,
+  sessionLog,
+  onHotkeyAction,
+  onOpenSftp,
+  onOpenScripts,
+  onOpenTheme,
+  onCloseSession,
+  onStatusChange,
+  onSessionExit,
+  onTerminalDataCapture,
+  onOsDetected,
+  onUpdateHost,
+  onAddKnownHost,
+  onCommandExecuted,
+  onSetWorkspaceFocusedSession,
+  onSplitSession,
+  isBroadcastEnabled,
+  onBroadcastInput,
+  onToggleWorkspaceComposeBar,
+  onSnippetExecutorChange,
+}) => {
+  const getPaneSnapshot = useCallback(
+    () => getTerminalPaneSnapshot({
+      activeTabId: activeTabStore.getActiveTabId(),
+      sessionId: session.id,
+      sessionWorkspaceId: session.workspaceId,
+      workspaceById,
+      isTerminalLayerVisible,
+    }),
+    [isTerminalLayerVisible, session.id, session.workspaceId, workspaceById],
+  );
+  const paneSnapshot = useSyncExternalStore(activeTabStore.subscribe, getPaneSnapshot);
+  const paneState = parseTerminalPaneSnapshot(paneSnapshot);
+  const activeWorkspaceId = paneState.workspaceId;
+  const isVisible = paneState.isVisible;
+  const inActiveWorkspace = !!activeWorkspaceId;
+  const isFocusMode = paneState.mode === 'focus';
+  const isSplitViewVisible = paneState.mode === 'split';
+  const isFocusedPane = inActiveWorkspace && !isFocusMode && session.id === paneState.focusedSessionId;
+  const rect = activeWorkspaceId && isSplitViewVisible
+    ? workspaceRectsById.get(activeWorkspaceId)?.[session.id] ?? null
+    : null;
+  const layoutStyle = rect
+    ? {
+      left: `${rect.x}px`,
+      top: `${rect.y}px`,
+      width: `${rect.w}px`,
+      height: `${rect.h}px`,
+    }
+    : { left: 0, top: 0, width: '100%', height: '100%' };
+  const style: React.CSSProperties = { ...layoutStyle };
+
+  if (!isVisible) {
+    style.visibility = 'hidden';
+    style.pointerEvents = 'none';
+    // Preserve xterm state while keeping hidden terminals out of layout.
+    style.left = '-9999px';
+    style.top = '-9999px';
+  }
+
+  const workspaceFocusHandler = activeWorkspaceId
+    ? workspaceFocusHandlersRef.current.get(activeWorkspaceId)
+    : undefined;
+  const workspaceBroadcastHandler = activeWorkspaceId
+    ? workspaceBroadcastHandlersRef.current.get(activeWorkspaceId)
+    : undefined;
+  const splitHorizontalHandler = splitHorizontalHandlersRef.current.get(session.id);
+  const splitVerticalHandler = splitVerticalHandlersRef.current.get(session.id);
+  const broadcastEnabled = activeWorkspaceId ? !!isBroadcastEnabled?.(activeWorkspaceId) : false;
+  const themePreviewId = session.id === themePreview.targetSessionId
+    ? themePreview.themeId ?? undefined
+    : undefined;
+
+  const handlePaneClick = useCallback(() => {
+    if (activeWorkspaceId && !isFocusMode) {
+      onSetWorkspaceFocusedSession?.(activeWorkspaceId, session.id);
+    }
+  }, [activeWorkspaceId, isFocusMode, onSetWorkspaceFocusedSession, session.id]);
+
+  return (
+    <div
+      data-session-id={session.id}
+      className={cn(
+        "absolute bg-background",
+        inActiveWorkspace && "workspace-pane",
+        isVisible && "z-10",
+      )}
+      style={style}
+      tabIndex={-1}
+      onClick={handlePaneClick}
+    >
+      <Terminal
+        host={host}
+        keys={keys}
+        identities={identities}
+        snippets={snippets}
+        chainHosts={chainHosts}
+        themePreviewId={themePreviewId}
+        knownHosts={knownHosts}
+        isVisible={isVisible}
+        inWorkspace={inActiveWorkspace}
+        isResizing={isResizing}
+        isFocusMode={isFocusMode}
+        isFocused={isFocusedPane}
+        fontFamilyId={terminalFontFamilyId}
+        fontSize={fontSize}
+        terminalTheme={terminalTheme}
+        followAppTerminalTheme={followAppTerminalTheme}
+        accentMode={accentMode}
+        customAccent={customAccent}
+        terminalSettings={terminalSettings}
+        sessionId={session.id}
+        startupCommand={session.startupCommand}
+        noAutoRun={session.noAutoRun}
+        serialConfig={session.serialConfig}
+        hotkeyScheme={hotkeyScheme}
+        keyBindings={keyBindings}
+        onHotkeyAction={onHotkeyAction}
+        onOpenSftp={onOpenSftp}
+        onOpenScripts={onOpenScripts}
+        onOpenTheme={onOpenTheme}
+        onCloseSession={onCloseSession}
+        onStatusChange={onStatusChange}
+        onSessionExit={onSessionExit}
+        onTerminalDataCapture={onTerminalDataCapture}
+        onOsDetected={onOsDetected}
+        onUpdateHost={onUpdateHost}
+        onAddKnownHost={onAddKnownHost}
+        onCommandExecuted={onCommandExecuted}
+        onExpandToFocus={inActiveWorkspace && !isFocusMode ? workspaceFocusHandler : undefined}
+        onSplitHorizontal={onSplitSession ? splitHorizontalHandler : undefined}
+        onSplitVertical={onSplitSession ? splitVerticalHandler : undefined}
+        isBroadcastEnabled={broadcastEnabled}
+        onToggleBroadcast={inActiveWorkspace ? workspaceBroadcastHandler : undefined}
+        onToggleComposeBar={inActiveWorkspace ? onToggleWorkspaceComposeBar : undefined}
+        isWorkspaceComposeBarOpen={inActiveWorkspace ? isComposeBarOpen : undefined}
+        onBroadcastInput={broadcastEnabled ? onBroadcastInput : undefined}
+        onSnippetExecutorChange={onSnippetExecutorChange}
+        sessionLog={sessionLog}
+      />
+    </div>
+  );
+}, terminalPanePropsAreEqual);
+TerminalPane.displayName = 'TerminalPane';
+
+interface TerminalPanesHostProps {
+  sessions: TerminalSession[];
+  sessionHostsMap: Map<string, Host>;
+  sessionChainHostsMap: Map<string, Host[]>;
+  workspaceById: Map<string, Workspace>;
+  workspaceRectsById: Map<string, Record<string, WorkspaceRect>>;
+  isTerminalLayerVisible: boolean;
+  workspaceFocusHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  workspaceBroadcastHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  splitHorizontalHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  splitVerticalHandlersRef: React.MutableRefObject<Map<string, () => void>>;
+  themePreview: { targetSessionId: string | null; themeId: string | null };
+  keys: SSHKey[];
+  identities: Identity[];
+  snippets: Snippet[];
+  knownHosts: KnownHost[];
+  terminalFontFamilyId: string;
+  fontSize: number;
+  terminalTheme: TerminalTheme;
+  followAppTerminalTheme?: boolean;
+  accentMode?: 'theme' | 'custom';
+  customAccent?: string;
+  terminalSettings?: TerminalSettings;
+  hotkeyScheme?: 'disabled' | 'mac' | 'pc';
+  keyBindings?: KeyBinding[];
+  isResizing: boolean;
+  isComposeBarOpen: boolean;
+  sessionLog?: { enabled: true; directory: string; format: string };
+  onHotkeyAction?: (action: string, event: KeyboardEvent) => void;
+  onOpenSftp: TerminalPaneProps['onOpenSftp'];
+  onOpenScripts: () => void;
+  onOpenTheme: () => void;
+  onCloseSession: (sessionId: string) => void;
+  onStatusChange: (sessionId: string, status: TerminalSession['status']) => void;
+  onSessionExit: (sessionId: string, evt: TerminalSessionExitEvent) => void;
+  onTerminalDataCapture?: (sessionId: string, data: string) => void;
+  onOsDetected: (hostId: string, distro: string) => void;
+  onUpdateHost: (host: Host) => void;
+  onAddKnownHost?: (knownHost: KnownHost) => void;
+  onCommandExecuted?: (command: string, hostId: string, hostLabel: string, sessionId: string) => void;
+  onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
+  onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
+  isBroadcastEnabled?: (workspaceId: string) => boolean;
+  onBroadcastInput: (data: string, sourceSessionId: string) => void;
+  onToggleWorkspaceComposeBar: () => void;
+  onSnippetExecutorChange: (
+    sessionId: string,
+    executor: SnippetExecutor | null,
+  ) => void;
+}
+
+const TerminalPanesHost: React.FC<TerminalPanesHostProps> = memo(({
+  sessions,
+  sessionHostsMap,
+  sessionChainHostsMap,
+  ...sharedProps
+}) => (
+  <>
+    {sessions.map((session) => {
+      const host = sessionHostsMap.get(session.id);
+      if (!host) return null;
+      return (
+        <TerminalPane
+          key={session.id}
+          session={session}
+          host={host}
+          chainHosts={sessionChainHostsMap.get(session.id)}
+          {...sharedProps}
+        />
+      );
+    })}
+  </>
+));
+TerminalPanesHost.displayName = 'TerminalPanesHost';
+
 const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   hosts,
   groupConfigs,
@@ -649,23 +1009,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     startClient: { x: number; y: number };
   } | null>(null);
 
-  const activeWorkspace = useMemo(() => workspaces.find(w => w.id === activeTabId), [workspaces, activeTabId]);
+  const workspaceById = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+    [workspaces],
+  );
+  const activeWorkspace = useMemo(() => activeTabId ? workspaceById.get(activeTabId) : undefined, [workspaceById, activeTabId]);
   const activeSession = useMemo(() => sessions.find(s => s.id === activeTabId), [sessions, activeTabId]);
-
-  // Handle broadcast input - write to all other sessions in the same workspace
-  const handleBroadcastInput = useCallback((data: string, sourceSessionId: string) => {
-    if (!activeWorkspace) return;
-
-    // Get all session IDs in this workspace
-    const workspaceSessionIds = sessions
-      .filter(s => s.workspaceId === activeWorkspace.id && s.id !== sourceSessionId)
-      .map(s => s.id);
-
-    // Write to all other sessions
-    for (const targetSessionId of workspaceSessionIds) {
-      terminalBackend.writeToSession(targetSessionId, data);
-    }
-  }, [activeWorkspace, sessions, terminalBackend]);
 
   // Workspace-level compose bar state
   const [isComposeBarOpen, setIsComposeBarOpen] = useState(false);
@@ -673,6 +1022,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   activeTabIdRef.current = activeTabId;
   const activeWorkspaceRef = useRef(activeWorkspace);
   activeWorkspaceRef.current = activeWorkspace;
+  const activeSessionRef = useRef(activeSession);
+  activeSessionRef.current = activeSession;
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
   const workspacesRef = useRef(workspaces);
@@ -681,6 +1032,19 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   hostsRef.current = hosts;
   const onSetWorkspaceFocusedSessionRef = useRef(onSetWorkspaceFocusedSession);
   onSetWorkspaceFocusedSessionRef.current = onSetWorkspaceFocusedSession;
+
+  // Handle broadcast input - write to all other sessions in the source workspace.
+  const handleBroadcastInput = useCallback((data: string, sourceSessionId: string) => {
+    const sourceSession = sessionsRef.current.find((session) => session.id === sourceSessionId);
+    const workspaceId = sourceSession?.workspaceId;
+    if (!workspaceId) return;
+
+    for (const session of sessionsRef.current) {
+      if (session.workspaceId === workspaceId && session.id !== sourceSessionId) {
+        terminalBackend.writeToSession(session.id, data);
+      }
+    }
+  }, [terminalBackend]);
 
   // Side panel state - per-tab tracking of which sub-panel is active
   // Maps tab IDs to the active sub-panel type (sftp/scripts/theme), absent = closed
@@ -992,6 +1356,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
     return map;
   }, [sessions, sessionHostsMap, hostMap, groupConfigs, proxyProfileIdSet, proxyProfiles]);
+  const sessionHostsMapRef = useRef(sessionHostsMap);
+  sessionHostsMapRef.current = sessionHostsMap;
 
   const validAIScopeTargetIds = useMemo(() => {
     const ids = new Set<string>();
@@ -1115,15 +1481,33 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     return rects;
   }, []);
 
+  const workspaceRectsById = useMemo(
+    () => {
+      const map = new Map<string, Record<string, WorkspaceRect>>();
+      for (const workspace of workspaces) {
+        map.set(workspace.id, computeWorkspaceRects(workspace, workspaceArea));
+      }
+      return map;
+    },
+    [computeWorkspaceRects, workspaceArea, workspaces],
+  );
   const activeWorkspaceRects = useMemo<Record<string, WorkspaceRect>>(
-    () => computeWorkspaceRects(activeWorkspace, workspaceArea),
-    [activeWorkspace, workspaceArea, computeWorkspaceRects]
+    () => activeWorkspace ? workspaceRectsById.get(activeWorkspace.id) ?? {} : {},
+    [activeWorkspace, workspaceRectsById]
   );
 
   useEffect(() => {
     if (!workspaceInnerRef.current) return;
     const el = workspaceInnerRef.current;
-    const updateSize = () => setWorkspaceArea({ width: el.clientWidth, height: el.clientHeight });
+    const updateSize = () => {
+      const width = el.clientWidth;
+      const height = el.clientHeight;
+      setWorkspaceArea((prev) => (
+        prev.width === width && prev.height === height
+          ? prev
+          : { width, height }
+      ));
+    };
     updateSize();
     const observer = new ResizeObserver(() => updateSize());
     observer.observe(el);
@@ -1310,6 +1694,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   // Check if active workspace is in focus mode
   const isFocusMode = activeWorkspace?.viewMode === 'focus';
   const focusedSessionId = activeWorkspace?.focusedSessionId;
+  const focusedSessionIdRef = useRef(focusedSessionId);
+  focusedSessionIdRef.current = focusedSessionId;
 
   // Resolve the SFTP host for the current tab.
   // Uses the stored host from when the user opened SFTP, but updates when
@@ -1434,24 +1820,29 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
   // Switch side panel to a specific tab (or toggle if already on that tab)
   const handleSwitchSidePanelTab = useCallback((tab: SidePanelTab) => {
-    if (!activeTabId) return;
-    const currentPanel = sidePanelOpenTabsRef.current.get(activeTabId);
+    const tabId = activeTabIdRef.current;
+    if (!tabId) return;
+    const currentPanel = sidePanelOpenTabsRef.current.get(tabId);
 
     // If already on this tab, do nothing — user must click X to close
     if (currentPanel === tab) return;
 
     // If switching to SFTP and no host is stored yet, resolve it
-    if (tab === 'sftp' && !sftpHostForTabRef.current.has(activeTabId)) {
+    if (tab === 'sftp' && !sftpHostForTabRef.current.has(tabId)) {
       let host: Host | null = null;
-      if (activeWorkspace && focusedSessionId) {
-        host = sessionHostsMap.get(focusedSessionId) ?? null;
-      } else if (activeSession) {
-        host = sessionHostsMap.get(activeSession.id) ?? null;
+      const currentWorkspace = activeWorkspaceRef.current;
+      const currentFocusedSessionId = focusedSessionIdRef.current;
+      const currentActiveSession = activeSessionRef.current;
+      const currentSessionHosts = sessionHostsMapRef.current;
+      if (currentWorkspace && currentFocusedSessionId) {
+        host = currentSessionHosts.get(currentFocusedSessionId) ?? null;
+      } else if (currentActiveSession) {
+        host = currentSessionHosts.get(currentActiveSession.id) ?? null;
       }
       if (!host) return;
       setSftpHostForTab(prev => {
         const next = new Map(prev);
-        next.set(activeTabId, host);
+        next.set(tabId, host);
         return next;
       });
     }
@@ -1462,10 +1853,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     setSidePanelOpenTabs(prev => {
       const next = new Map(prev);
-      next.set(activeTabId, tab);
+      next.set(tabId, tab);
       return next;
     });
-  }, [activeTabId, activeWorkspace, focusedSessionId, activeSession, sessionHostsMap]);
+  }, []);
 
   // Toggle SFTP from activity bar header
   const handleToggleSftpFromBar = useCallback(() => {
@@ -1856,7 +2247,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const sessionById = new Map<string, TerminalSession>(sessions.map((session) => [session.id, session]));
     const workspaceById = new Map<string, Workspace>(workspaces.map((workspace) => [workspace.id, workspace]));
     const tabIds = new Set<string>(mountedAiTabIds);
-    if (activeTabId) tabIds.add(activeTabId);
 
     const contexts = new Map<string, AIPanelContext>();
 
@@ -1901,7 +2291,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     }
 
     return contexts;
-  }, [sessions, workspaces, mountedAiTabIds, activeTabId, sessionHostsMap]);
+  }, [sessions, workspaces, mountedAiTabIds, sessionHostsMap]);
 
   const resolveAIExecutorContext = useCallback((scope: {
     type: 'terminal' | 'workspace';
@@ -2673,123 +3063,53 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
               )}
             </div>
           )}
-          {sessions.map(session => {
-            // Use pre-computed host to avoid creating new objects on every render
-            const host = sessionHostsMap.get(session.id)!;
-            const inActiveWorkspace = !!activeWorkspace && session.workspaceId === activeWorkspace.id;
-            const isActiveSolo = activeTabId === session.id && !activeWorkspace && isTerminalLayerVisible;
-
-            // In focus mode, only the focused session is visible
-            const isFocusedInWorkspace = isFocusMode && inActiveWorkspace && session.id === focusedSessionId;
-            const isSplitViewVisible = !isFocusMode && inActiveWorkspace;
-
-            const isVisible = ((isFocusedInWorkspace || isSplitViewVisible || isActiveSolo) && isTerminalLayerVisible);
-
-            // In focus mode, use full area; in split mode, use computed rects
-            const rect = (isSplitViewVisible && !isFocusMode) ? activeWorkspaceRects[session.id] : null;
-
-            const layoutStyle = rect
-              ? {
-                left: `${rect.x}px`,
-                top: `${rect.y}px`,
-                width: `${rect.w}px`,
-                height: `${rect.h}px`,
-              }
-              : { left: 0, top: 0, width: '100%', height: '100%' };
-
-            const style: React.CSSProperties = { ...layoutStyle };
-
-            if (!isVisible) {
-              style.visibility = 'hidden';
-              style.pointerEvents = 'none';
-              // Use absolute offscreen position instead of display:none to preserve
-              // xterm canvas state in memory and avoid full re-render on tab switch.
-              style.left = '-9999px';
-              style.top = '-9999px';
-            }
-
-            // Check if this pane is the focused one in the workspace
-            const isFocusedPane = inActiveWorkspace && !isFocusMode && session.id === focusedSessionId;
-            const workspaceFocusHandler = activeWorkspace
-              ? workspaceFocusHandlersRef.current.get(activeWorkspace.id)
-              : undefined;
-            const workspaceBroadcastHandler = activeWorkspace
-              ? workspaceBroadcastHandlersRef.current.get(activeWorkspace.id)
-              : undefined;
-            const splitHorizontalHandler = splitHorizontalHandlersRef.current.get(session.id);
-            const splitVerticalHandler = splitVerticalHandlersRef.current.get(session.id);
-
-            return (
-              <div
-                key={session.id}
-                data-session-id={session.id}
-                className={cn(
-                  "absolute bg-background",
-                  inActiveWorkspace && "workspace-pane",
-                  isVisible && "z-10",
-                  // Focus indicator is handled by CSS .workspace-pane:not(:focus-within)
-                )}
-                style={style}
-                tabIndex={-1}
-                onClick={() => {
-                  // Set focused session when clicking on a pane in split view
-                  if (inActiveWorkspace && !isFocusMode && activeWorkspace) {
-                    onSetWorkspaceFocusedSession?.(activeWorkspace.id, session.id);
-                  }
-                }}
-              >
-                <Terminal
-                  host={host}
-                  keys={keys}
-                  identities={identities}
-                  snippets={snippets}
-                  chainHosts={sessionChainHostsMap.get(session.id)}
-                  themePreviewId={session.id === previewTargetSessionId ? activeThemePreviewId ?? undefined : undefined}
-                  knownHosts={knownHosts}
-                  isVisible={isVisible}
-                  inWorkspace={inActiveWorkspace}
-                  isResizing={!!resizing}
-                  isFocusMode={isFocusMode}
-                  isFocused={isFocusedPane}
-                  fontFamilyId={terminalFontFamilyId}
-                  fontSize={fontSize}
-                  terminalTheme={terminalTheme}
-                  followAppTerminalTheme={followAppTerminalTheme}
-                  accentMode={accentMode}
-                  customAccent={customAccent}
-                  terminalSettings={terminalSettings}
-                  sessionId={session.id}
-                  startupCommand={session.startupCommand}
-                  noAutoRun={session.noAutoRun}
-                  serialConfig={session.serialConfig}
-                  hotkeyScheme={hotkeyScheme}
-                  keyBindings={keyBindings}
-                  onHotkeyAction={onHotkeyAction}
-                  onOpenSftp={handleOpenSftp}
-                  onOpenScripts={handleOpenScripts}
-                  onOpenTheme={handleOpenTheme}
-                  onCloseSession={handleCloseSession}
-                  onStatusChange={handleStatusChange}
-                  onSessionExit={handleSessionExit}
-                  onTerminalDataCapture={handleTerminalDataCapture}
-                  onOsDetected={handleOsDetected}
-                  onUpdateHost={handleUpdateHost}
-                  onAddKnownHost={handleAddKnownHost}
-                  onCommandExecuted={handleCommandExecuted}
-                  onExpandToFocus={inActiveWorkspace && !isFocusMode ? workspaceFocusHandler : undefined}
-                  onSplitHorizontal={onSplitSession ? splitHorizontalHandler : undefined}
-                  onSplitVertical={onSplitSession ? splitVerticalHandler : undefined}
-                  isBroadcastEnabled={inActiveWorkspace && activeWorkspace ? isBroadcastEnabled?.(activeWorkspace.id) : false}
-                  onToggleBroadcast={inActiveWorkspace ? workspaceBroadcastHandler : undefined}
-                  onToggleComposeBar={inActiveWorkspace ? handleToggleWorkspaceComposeBar : undefined}
-                  isWorkspaceComposeBarOpen={inActiveWorkspace ? isComposeBarOpen : undefined}
-                  onBroadcastInput={inActiveWorkspace && activeWorkspace && isBroadcastEnabled?.(activeWorkspace.id) ? handleBroadcastInput : undefined}
-                  onSnippetExecutorChange={handleSnippetExecutorChange}
-                  sessionLog={sessionLogConfig}
-                />
-              </div>
-            );
-          })}
+          <TerminalPanesHost
+            sessions={sessions}
+            sessionHostsMap={sessionHostsMap}
+            sessionChainHostsMap={sessionChainHostsMap}
+            workspaceById={workspaceById}
+            workspaceRectsById={workspaceRectsById}
+            isTerminalLayerVisible={isTerminalLayerVisible}
+            workspaceFocusHandlersRef={workspaceFocusHandlersRef}
+            workspaceBroadcastHandlersRef={workspaceBroadcastHandlersRef}
+            splitHorizontalHandlersRef={splitHorizontalHandlersRef}
+            splitVerticalHandlersRef={splitVerticalHandlersRef}
+            themePreview={themePreview}
+            keys={keys}
+            identities={identities}
+            snippets={snippets}
+            knownHosts={knownHosts}
+            terminalFontFamilyId={terminalFontFamilyId}
+            fontSize={fontSize}
+            terminalTheme={terminalTheme}
+            followAppTerminalTheme={followAppTerminalTheme}
+            accentMode={accentMode}
+            customAccent={customAccent}
+            terminalSettings={terminalSettings}
+            hotkeyScheme={hotkeyScheme}
+            keyBindings={keyBindings}
+            isResizing={!!resizing}
+            isComposeBarOpen={isComposeBarOpen}
+            sessionLog={sessionLogConfig}
+            onHotkeyAction={onHotkeyAction}
+            onOpenSftp={handleOpenSftp}
+            onOpenScripts={handleOpenScripts}
+            onOpenTheme={handleOpenTheme}
+            onCloseSession={handleCloseSession}
+            onStatusChange={handleStatusChange}
+            onSessionExit={handleSessionExit}
+            onTerminalDataCapture={handleTerminalDataCapture}
+            onOsDetected={handleOsDetected}
+            onUpdateHost={handleUpdateHost}
+            onAddKnownHost={handleAddKnownHost}
+            onCommandExecuted={handleCommandExecuted}
+            onSetWorkspaceFocusedSession={onSetWorkspaceFocusedSession}
+            onSplitSession={onSplitSession}
+            isBroadcastEnabled={isBroadcastEnabled}
+            onBroadcastInput={handleBroadcastInput}
+            onToggleWorkspaceComposeBar={handleToggleWorkspaceComposeBar}
+            onSnippetExecutorChange={handleSnippetExecutorChange}
+          />
           {/* Only show resizers in split view mode, not in focus mode */}
           {!isFocusMode && activeResizers.map(handle => {
             const isVertical = handle.direction === 'vertical';

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -1,6 +1,6 @@
 import { Bell, Copy, FileCode, FileText, Folder, FolderLock, LayoutGrid, Minus, Moon, MoreHorizontal, Plus, Server, Settings, Sparkles, Square, Sun, TerminalSquare, Usb, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { activeTabStore, fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
+import { activeTabStore, fromEditorTabId, isEditorTabId, useActiveTabId, useIsTabActive } from '../application/state/activeTabStore';
 import type { EditorTab } from '../application/state/editorTabStore';
 import { buildWorkspaceActivityMap } from '../application/state/sessionActivity';
 import { useSessionActivityMap } from '../application/state/sessionActivityStore';
@@ -20,6 +20,7 @@ import { SyncStatusButton } from './SyncStatusButton';
 // Helper styles for Electron drag regions (use type assertion to include non-standard WebkitAppRegion)
 const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties;
 const dragRegionNoSelect = { WebkitAppRegion: 'drag', userSelect: 'none' } as React.CSSProperties;
+const emptyTabStyle: React.CSSProperties = {};
 
 // File extensions that render the code-file icon instead of the plain text icon.
 const CODE_EXTENSIONS_RE = /\.(js|jsx|ts|tsx|py|rb|go|rs|c|cpp|cs|java|php|sh|bash|zsh|fish|lua|r|scala|swift|kt|html|css|scss|less|json|yaml|yml|toml|xml|sql|graphql|gql|md|mdx|conf|ini|env|tf|hcl|dockerfile)$/i;
@@ -231,6 +232,512 @@ const WindowControls: React.FC = memo(() => {
 });
 WindowControls.displayName = 'WindowControls';
 
+type TranslateFn = ReturnType<typeof useI18n>['t'];
+type RenderBulkCloseItems = (anchorId: string) => React.ReactNode;
+
+interface ActiveTabAutoScrollerProps {
+  tabsContainerRef: React.RefObject<HTMLDivElement | null>;
+  updateScrollState: () => void;
+}
+
+const ActiveTabAutoScroller: React.FC<ActiveTabAutoScrollerProps> = memo(({
+  tabsContainerRef,
+  updateScrollState,
+}) => {
+  const activeTabId = useActiveTabId();
+
+  useLayoutEffect(() => {
+    if (!activeTabId || activeTabId === 'vault' || activeTabId === 'sftp') return;
+    const container = tabsContainerRef.current;
+    if (!container) return;
+
+    const activeTabElement = container.querySelector(`[data-tab-id="${activeTabId}"]`) as HTMLElement | null;
+    if (activeTabElement) {
+      const containerRect = container.getBoundingClientRect();
+      const tabRect = activeTabElement.getBoundingClientRect();
+
+      if (tabRect.left < containerRect.left) {
+        container.scrollLeft -= (containerRect.left - tabRect.left + 8);
+      } else if (tabRect.right > containerRect.right) {
+        container.scrollLeft += (tabRect.right - containerRect.right + 8);
+      }
+    }
+
+    setTimeout(updateScrollState, 100);
+  }, [activeTabId, tabsContainerRef, updateScrollState]);
+
+  return null;
+});
+ActiveTabAutoScroller.displayName = 'ActiveTabAutoScroller';
+
+interface RootTopTabProps {
+  tabId: 'vault' | 'sftp';
+  label: string;
+  icon: React.ReactNode;
+  className?: string;
+}
+
+const RootTopTab: React.FC<RootTopTabProps> = memo(({ tabId, label, icon, className }) => {
+  const isActive = useIsTabActive(tabId);
+  const handleClick = useCallback(() => {
+    activeTabStore.setActiveTabId(tabId);
+  }, [tabId]);
+
+  return (
+    <div
+      data-tab-id={tabId}
+      data-tab-type="root"
+      data-state={isActive ? 'active' : 'inactive'}
+      onClick={handleClick}
+      className={cn(
+        "netcatty-tab relative h-7 px-3 overflow-hidden text-xs font-semibold cursor-pointer flex items-center gap-2 app-no-drag",
+        className,
+      )}
+      style={{
+        backgroundColor: isActive
+          ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+          : 'transparent',
+        color: isActive
+          ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+          : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+          e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'transparent';
+          e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+        }
+      }}
+    >
+      {icon} {label}
+    </div>
+  );
+});
+RootTopTab.displayName = 'RootTopTab';
+
+interface EditorTopTabProps {
+  tabId: string;
+  editorTab: EditorTab;
+  host: Host | undefined;
+  suffix: string;
+  onRequestCloseEditorTab: (editorTabId: string) => void;
+}
+
+const EditorTopTab: React.FC<EditorTopTabProps> = memo(({
+  tabId,
+  editorTab,
+  host,
+  suffix,
+  onRequestCloseEditorTab,
+}) => {
+  const isActive = useIsTabActive(tabId);
+  const dirty = editorTab.content !== editorTab.baselineContent;
+  const tooltip = `${host?.label ?? editorTab.hostId}@${host?.hostname ?? ''}:${editorTab.remotePath}`;
+  const FileIcon = CODE_EXTENSIONS_RE.test(editorTab.fileName) ? FileCode : FileText;
+  const handleClick = useCallback(() => {
+    activeTabStore.setActiveTabId(tabId);
+  }, [tabId]);
+  const handleClose = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRequestCloseEditorTab(editorTab.id);
+  }, [editorTab.id, onRequestCloseEditorTab]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          data-tab-id={tabId}
+          data-tab-type="editor"
+          data-state={isActive ? 'active' : 'inactive'}
+          onClick={handleClick}
+          className="netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0"
+          style={{
+            backgroundColor: isActive
+              ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+              : 'transparent',
+            color: isActive
+              ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+              : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+          }}
+          onMouseEnter={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+              e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'transparent';
+              e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+            }
+          }}
+        >
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <FileIcon
+              size={14}
+              className="shrink-0"
+              style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+            />
+            <span className="truncate flex items-center gap-0.5">
+              {dirty && <span className="text-primary mr-0.5">●</span>}
+              {editorTab.fileName}
+              {suffix && <span className="text-muted-foreground ml-1">{suffix}</span>}
+            </span>
+          </div>
+          <button
+            onClick={handleClose}
+            className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
+            aria-label="Close editor tab"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+});
+EditorTopTab.displayName = 'EditorTopTab';
+
+interface SessionTopTabProps {
+  session: TerminalSession;
+  host: Host | undefined;
+  hasActivity: boolean;
+  isBeingDragged: boolean;
+  isDraggingForReorder: boolean;
+  shiftStyle: React.CSSProperties;
+  showDropIndicatorBefore: boolean;
+  showDropIndicatorAfter: boolean;
+  onTabDragStart: (e: React.DragEvent, tabId: string) => void;
+  onTabDragEnd: () => void;
+  onTabDragOver: (e: React.DragEvent, tabId: string) => void;
+  onTabDragLeave: (e: React.DragEvent) => void;
+  onTabDrop: (e: React.DragEvent, targetTabId: string) => void;
+  onCloseSession: (sessionId: string, e?: React.MouseEvent) => void;
+  onRenameSession: (sessionId: string) => void;
+  onCopySession: (sessionId: string) => void;
+  renderBulkCloseItems: RenderBulkCloseItems;
+  t: TranslateFn;
+}
+
+const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
+  session,
+  host,
+  hasActivity,
+  isBeingDragged,
+  isDraggingForReorder,
+  shiftStyle,
+  showDropIndicatorBefore,
+  showDropIndicatorAfter,
+  onTabDragStart,
+  onTabDragEnd,
+  onTabDragOver,
+  onTabDragLeave,
+  onTabDrop,
+  onCloseSession,
+  onRenameSession,
+  onCopySession,
+  renderBulkCloseItems,
+  t,
+}) => {
+  const isActive = useIsTabActive(session.id);
+  const handleClick = useCallback(() => {
+    activeTabStore.setActiveTabId(session.id);
+  }, [session.id]);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          data-tab-id={session.id}
+          data-tab-type="session"
+          data-state={isActive ? 'active' : 'inactive'}
+          onClick={handleClick}
+          draggable
+          onDragStart={(e) => onTabDragStart(e, session.id)}
+          onDragEnd={onTabDragEnd}
+          onDragOver={(e) => onTabDragOver(e, session.id)}
+          onDragLeave={onTabDragLeave}
+          onDrop={(e) => onTabDrop(e, session.id)}
+          className={cn(
+            "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
+            "transition-transform duration-150",
+            isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : ""
+          )}
+          style={{
+            ...shiftStyle,
+            backgroundColor: isActive
+              ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+              : 'transparent',
+            color: isActive
+              ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+              : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+          }}
+          onMouseEnter={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+              e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'transparent';
+              e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+            }
+          }}
+        >
+          {showDropIndicatorBefore && isDraggingForReorder && (
+            <div
+              className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+            />
+          )}
+          {showDropIndicatorAfter && isDraggingForReorder && (
+            <div
+              className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+            />
+          )}
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <SessionTabIcon host={host} isActive={isActive} protocol={session.protocol} shellIcon={session.localShellIcon} />
+            <span className="truncate">{session.hostLabel}</span>
+            <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
+          </div>
+          <button
+            onClick={(e) => onCloseSession(session.id, e)}
+            className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
+            aria-label={t('tabs.closeSessionAria')}
+          >
+            <X size={12} />
+          </button>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onRenameSession(session.id)}>
+          {t('common.rename')}
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => onCopySession(session.id)}>
+          {t('tabs.copyTab')}
+        </ContextMenuItem>
+        <ContextMenuItem className="text-destructive" onClick={() => onCloseSession(session.id)}>
+          {t('common.close')}
+        </ContextMenuItem>
+        {renderBulkCloseItems(session.id)}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+});
+SessionTopTab.displayName = 'SessionTopTab';
+
+interface WorkspaceTopTabProps {
+  workspace: Workspace;
+  paneCount: number;
+  hasActivity: boolean;
+  isBeingDragged: boolean;
+  isDraggingForReorder: boolean;
+  shiftStyle: React.CSSProperties;
+  showDropIndicatorBefore: boolean;
+  showDropIndicatorAfter: boolean;
+  onTabDragStart: (e: React.DragEvent, tabId: string) => void;
+  onTabDragEnd: () => void;
+  onTabDragOver: (e: React.DragEvent, tabId: string) => void;
+  onTabDragLeave: (e: React.DragEvent) => void;
+  onTabDrop: (e: React.DragEvent, targetTabId: string) => void;
+  onRenameWorkspace: (workspaceId: string) => void;
+  onCloseWorkspace: (workspaceId: string) => void;
+  renderBulkCloseItems: RenderBulkCloseItems;
+  t: TranslateFn;
+}
+
+const WorkspaceTopTab: React.FC<WorkspaceTopTabProps> = memo(({
+  workspace,
+  paneCount,
+  hasActivity,
+  isBeingDragged,
+  isDraggingForReorder,
+  shiftStyle,
+  showDropIndicatorBefore,
+  showDropIndicatorAfter,
+  onTabDragStart,
+  onTabDragEnd,
+  onTabDragOver,
+  onTabDragLeave,
+  onTabDrop,
+  onRenameWorkspace,
+  onCloseWorkspace,
+  renderBulkCloseItems,
+  t,
+}) => {
+  const isActive = useIsTabActive(workspace.id);
+  const handleClick = useCallback(() => {
+    activeTabStore.setActiveTabId(workspace.id);
+  }, [workspace.id]);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          data-tab-id={workspace.id}
+          data-tab-type="workspace"
+          data-state={isActive ? 'active' : 'inactive'}
+          onClick={handleClick}
+          draggable
+          onDragStart={(e) => onTabDragStart(e, workspace.id)}
+          onDragEnd={onTabDragEnd}
+          onDragOver={(e) => onTabDragOver(e, workspace.id)}
+          onDragLeave={onTabDragLeave}
+          onDrop={(e) => onTabDrop(e, workspace.id)}
+          className={cn(
+            "netcatty-tab relative h-7 pl-3 pr-2 min-w-[150px] max-w-[260px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
+            "transition-transform duration-150",
+            isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : ""
+          )}
+          style={{
+            ...shiftStyle,
+            backgroundColor: isActive
+              ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+              : 'transparent',
+            color: isActive
+              ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+              : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+          }}
+          onMouseEnter={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+              e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (!isActive) {
+              e.currentTarget.style.backgroundColor = 'transparent';
+              e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+            }
+          }}
+        >
+          {showDropIndicatorBefore && isDraggingForReorder && (
+            <div
+              className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+            />
+          )}
+          {showDropIndicatorAfter && isDraggingForReorder && (
+            <div
+              className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+            />
+          )}
+          <div className="flex items-center gap-2 truncate">
+            <LayoutGrid
+              size={14}
+              className="shrink-0"
+              style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+            />
+            <span className="truncate">{workspace.title}</span>
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            {hasActivity && sessionStatusDot('connected', true)}
+            <div
+              className="text-[10px] px-1.5 py-0.5 rounded-full min-w-[22px] text-center"
+              style={{
+                border: '1px solid color-mix(in srgb, var(--top-tabs-fg, hsl(var(--foreground))) 18%, transparent)',
+                backgroundColor: 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 60%, transparent)',
+              }}
+            >
+              {paneCount}
+            </div>
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => onRenameWorkspace(workspace.id)}>
+          {t('common.rename')}
+        </ContextMenuItem>
+        <ContextMenuItem className="text-destructive" onClick={() => onCloseWorkspace(workspace.id)}>
+          {t('common.close')}
+        </ContextMenuItem>
+        {renderBulkCloseItems(workspace.id)}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+});
+WorkspaceTopTab.displayName = 'WorkspaceTopTab';
+
+interface LogViewTopTabProps {
+  logView: LogView;
+  onCloseLogView: (logViewId: string) => void;
+  t: TranslateFn;
+}
+
+const LogViewTopTab: React.FC<LogViewTopTabProps> = memo(({
+  logView,
+  onCloseLogView,
+  t,
+}) => {
+  const isActive = useIsTabActive(logView.id);
+  const isLocal = logView.log.protocol === 'local' || logView.log.hostname === 'localhost';
+  const handleClick = useCallback(() => {
+    activeTabStore.setActiveTabId(logView.id);
+  }, [logView.id]);
+  const handleClose = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onCloseLogView(logView.id);
+  }, [logView.id, onCloseLogView]);
+
+  return (
+    <div
+      data-tab-id={logView.id}
+      data-tab-type="logView"
+      data-state={isActive ? 'active' : 'inactive'}
+      onClick={handleClick}
+      className="netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0"
+      style={{
+        backgroundColor: isActive
+          ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+          : 'transparent',
+        color: isActive
+          ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+          : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+          e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'transparent';
+          e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+        }
+      }}
+    >
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <FileText
+          size={14}
+          className="shrink-0"
+          style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+        />
+        <span className="truncate">
+          {t('tabs.logPrefix')} {isLocal ? t('tabs.logLocal') : logView.log.hostname}
+        </span>
+      </div>
+      <button
+        onClick={handleClose}
+        className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
+        aria-label={t('tabs.closeLogViewAria')}
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+});
+LogViewTopTab.displayName = 'LogViewTopTab';
+
 const TopTabsInner: React.FC<TopTabsProps> = ({
   theme,
   followAppTerminalTheme = false,
@@ -263,13 +770,8 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   hostById,
 }) => {
   const { t } = useI18n();
-  // Subscribe to activeTabId from external store
   const { maximize, isFullscreen, onFullscreenChanged } = useWindowControls();
-  const activeTabId = useActiveTabId();
   const sessionActivityMap = useSessionActivityMap();
-  const isVaultActive = activeTabId === 'vault';
-  const isSftpActive = activeTabId === 'sftp';
-  const onSelectTab = activeTabStore.setActiveTabId;
 
   // Tab reorder drag state
   const [dropIndicator, setDropIndicator] = useState<{ tabId: string; position: 'before' | 'after' } | null>(null);
@@ -333,29 +835,6 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       };
     }
   }, [updateScrollState, orderedTabs]);
-
-  // Scroll to active tab when it changes
-  useLayoutEffect(() => {
-    if (!activeTabId || activeTabId === 'vault' || activeTabId === 'sftp') return;
-    const container = tabsContainerRef.current;
-    if (!container) return;
-
-    // Find the active tab element
-    const activeTabElement = container.querySelector(`[data-tab-id="${activeTabId}"]`) as HTMLElement | null;
-    if (activeTabElement) {
-      const containerRect = container.getBoundingClientRect();
-      const tabRect = activeTabElement.getBoundingClientRect();
-
-      // Check if tab is outside visible area
-      if (tabRect.left < containerRect.left) {
-        container.scrollLeft -= (containerRect.left - tabRect.left + 8);
-      } else if (tabRect.right > containerRect.right) {
-        container.scrollLeft += (tabRect.right - containerRect.right + 8);
-      }
-    }
-    // Update scroll indicators after scroll
-    setTimeout(updateScrollState, 100);
-  }, [activeTabId, updateScrollState]);
 
   // Pre-compute lookup maps for O(1) access instead of O(n) find operations
   const orphanSessionMap = useMemo(() => {
@@ -525,7 +1004,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
 
   // Bulk-close menu items shared by session and workspace context menus.
   // Anchor is the tab the user right-clicked on (matches VSCode/JetBrains UX).
-  const renderBulkCloseItems = (anchorId: string) => {
+  const renderBulkCloseItems = useCallback((anchorId: string) => {
     const anchorIdx = orderedTabs.indexOf(anchorId);
     const othersIds = orderedTabs.filter((id) => id !== anchorId);
     const rightIds = anchorIdx >= 0 ? orderedTabs.slice(anchorIdx + 1) : [];
@@ -552,7 +1031,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         </ContextMenuItem>
       </>
     );
-  };
+  }, [onCloseTabsBatch, orderedTabs, t]);
 
   // Render the tabs
   const renderOrderedTabs = () => {
@@ -562,74 +1041,21 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       if (item.type === 'editor') {
         const { editorTab } = item;
         const tabId = item.id;
-        const isActive = activeTabId === tabId;
         const host = hostById.get(editorTab.hostId);
-        const dirty = editorTab.content !== editorTab.baselineContent;
-        const tooltip = `${host?.label ?? editorTab.hostId}@${host?.hostname ?? ''}:${editorTab.remotePath}`;
         // Disambiguate duplicate filenames using the memoed counts map.
         const suffix = (editorTabFileNameCounts.get(editorTab.fileName) ?? 0) > 1
           ? ` · ${editorTab.remotePath.split('/').slice(-2, -1)[0] || '/'}`
           : '';
-        const FileIcon = CODE_EXTENSIONS_RE.test(editorTab.fileName) ? FileCode : FileText;
 
         return (
-          <Tooltip key={tabId}>
-            <TooltipTrigger asChild>
-              <div
-                data-tab-id={tabId}
-                data-tab-type="editor"
-                data-state={isActive ? 'active' : 'inactive'}
-                onClick={() => onSelectTab(tabId)}
-                className={cn(
-                  "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
-                )}
-                style={{
-                  backgroundColor: isActive
-                    ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                    : 'transparent',
-                  color: isActive
-                    ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                    : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-                }}
-                onMouseEnter={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                    e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.backgroundColor = 'transparent';
-                    e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-                  }
-                }}
-              >
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <FileIcon
-                    size={14}
-                    className="shrink-0"
-                    style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
-                  />
-                  <span className="truncate flex items-center gap-0.5">
-                    {dirty && <span className="text-primary mr-0.5">●</span>}
-                    {editorTab.fileName}
-                    {suffix && <span className="text-muted-foreground ml-1">{suffix}</span>}
-                  </span>
-                </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRequestCloseEditorTab(editorTab.id);
-                  }}
-                  className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
-                  aria-label="Close editor tab"
-                >
-                  <X size={12} />
-                </button>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>{tooltip}</TooltipContent>
-          </Tooltip>
+          <EditorTopTab
+            key={tabId}
+            tabId={tabId}
+            editorTab={editorTab}
+            host={host}
+            suffix={suffix}
+            onRequestCloseEditorTab={onRequestCloseEditorTab}
+          />
         );
       }
 
@@ -637,92 +1063,32 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         const session = item.session;
         const hasActivity = !!sessionActivityMap[session.id];
         const isBeingDragged = draggingSessionId === session.id;
-        const shiftStyle = tabShiftStyles[session.id] || {};
+        const shiftStyle = tabShiftStyles[session.id] || emptyTabStyle;
         const showDropIndicatorBefore = dropIndicator?.tabId === session.id && dropIndicator.position === 'before';
         const showDropIndicatorAfter = dropIndicator?.tabId === session.id && dropIndicator.position === 'after';
 
         return (
-          <ContextMenu key={session.id}>
-            <ContextMenuTrigger asChild>
-              <div
-                data-tab-id={session.id}
-                data-tab-type="session"
-                data-state={activeTabId === session.id ? 'active' : 'inactive'}
-                onClick={() => onSelectTab(session.id)}
-                draggable
-                onDragStart={(e) => handleTabDragStart(e, session.id)}
-                onDragEnd={handleTabDragEnd}
-                onDragOver={(e) => handleTabDragOver(e, session.id)}
-                onDragLeave={handleTabDragLeave}
-                onDrop={(e) => handleTabDrop(e, session.id)}
-                className={cn(
-                  "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
-                  "transition-transform duration-150",
-                  isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : ""
-                )}
-                style={{
-                  ...shiftStyle,
-                  backgroundColor: activeTabId === session.id
-                    ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                    : 'transparent',
-                  color: activeTabId === session.id
-                    ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                    : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-                }}
-                onMouseEnter={(e) => {
-                  if (activeTabId !== session.id) {
-                    e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                    e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (activeTabId !== session.id) {
-                    e.currentTarget.style.backgroundColor = 'transparent';
-                    e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-                  }
-                }}
-              >
-                {/* Drop indicator line - before */}
-                {showDropIndicatorBefore && isDraggingForReorder && (
-                  <div
-                    className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-                    style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-                  />
-                )}
-                {/* Drop indicator line - after */}
-                {showDropIndicatorAfter && isDraggingForReorder && (
-                  <div
-                    className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-                    style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-                  />
-                )}
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <SessionTabIcon host={hostMap.get(session.hostId)} isActive={activeTabId === session.id} protocol={session.protocol} shellIcon={session.localShellIcon} />
-                  <span className="truncate">{session.hostLabel}</span>
-                  <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
-                </div>
-                <button
-                  onClick={(e) => onCloseSession(session.id, e)}
-                  className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
-                  aria-label={t('tabs.closeSessionAria')}
-                >
-                  <X size={12} />
-                </button>
-              </div>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem onClick={() => onRenameSession(session.id)}>
-                {t('common.rename')}
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => onCopySession(session.id)}>
-                {t('tabs.copyTab')}
-              </ContextMenuItem>
-              <ContextMenuItem className="text-destructive" onClick={() => onCloseSession(session.id)}>
-                {t('common.close')}
-              </ContextMenuItem>
-              {renderBulkCloseItems(session.id)}
-            </ContextMenuContent>
-          </ContextMenu>
+          <SessionTopTab
+            key={session.id}
+            session={session}
+            host={hostMap.get(session.hostId)}
+            hasActivity={hasActivity}
+            isBeingDragged={isBeingDragged}
+            isDraggingForReorder={isDraggingForReorder}
+            shiftStyle={shiftStyle}
+            showDropIndicatorBefore={showDropIndicatorBefore}
+            showDropIndicatorAfter={showDropIndicatorAfter}
+            onTabDragStart={handleTabDragStart}
+            onTabDragEnd={handleTabDragEnd}
+            onTabDragOver={handleTabDragOver}
+            onTabDragLeave={handleTabDragLeave}
+            onTabDrop={handleTabDrop}
+            onCloseSession={onCloseSession}
+            onRenameSession={onRenameSession}
+            onCopySession={onCopySession}
+            renderBulkCloseItems={renderBulkCloseItems}
+            t={t}
+          />
         );
       }
 
@@ -730,159 +1096,45 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         const workspace = item.workspace;
         const paneCount = item.paneCount;
         const hasActivity = !!workspaceActivityMap.get(workspace.id);
-        const isActive = activeTabId === workspace.id;
         const isBeingDragged = draggingSessionId === workspace.id;
-        const shiftStyle = tabShiftStyles[workspace.id] || {};
+        const shiftStyle = tabShiftStyles[workspace.id] || emptyTabStyle;
         const showDropIndicatorBefore = dropIndicator?.tabId === workspace.id && dropIndicator.position === 'before';
         const showDropIndicatorAfter = dropIndicator?.tabId === workspace.id && dropIndicator.position === 'after';
 
         return (
-          <ContextMenu key={workspace.id}>
-            <ContextMenuTrigger asChild>
-              <div
-                data-tab-id={workspace.id}
-                data-tab-type="workspace"
-                data-state={isActive ? 'active' : 'inactive'}
-                onClick={() => onSelectTab(workspace.id)}
-                draggable
-                onDragStart={(e) => handleTabDragStart(e, workspace.id)}
-                onDragEnd={handleTabDragEnd}
-                onDragOver={(e) => handleTabDragOver(e, workspace.id)}
-                onDragLeave={handleTabDragLeave}
-                onDrop={(e) => handleTabDrop(e, workspace.id)}
-                className={cn(
-                  "netcatty-tab relative h-7 pl-3 pr-2 min-w-[150px] max-w-[260px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
-                  "transition-transform duration-150",
-                  isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : ""
-                )}
-                style={{
-                  ...shiftStyle,
-                  backgroundColor: isActive
-                    ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                    : 'transparent',
-                  color: isActive
-                    ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                    : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-                }}
-                onMouseEnter={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                    e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!isActive) {
-                    e.currentTarget.style.backgroundColor = 'transparent';
-                    e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-                  }
-                }}
-              >
-                {/* Drop indicator line - before */}
-                {showDropIndicatorBefore && isDraggingForReorder && (
-                  <div
-                    className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-                    style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-                  />
-                )}
-                {/* Drop indicator line - after */}
-                {showDropIndicatorAfter && isDraggingForReorder && (
-                  <div
-                    className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-                    style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-                  />
-                )}
-                <div className="flex items-center gap-2 truncate">
-                  <LayoutGrid
-                    size={14}
-                    className="shrink-0"
-                    style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
-                  />
-                  <span className="truncate">{workspace.title}</span>
-                </div>
-                <div className="flex items-center gap-1.5 shrink-0">
-                  {hasActivity && sessionStatusDot('connected', true)}
-                  <div
-                    className="text-[10px] px-1.5 py-0.5 rounded-full min-w-[22px] text-center"
-                    style={{
-                      border: '1px solid color-mix(in srgb, var(--top-tabs-fg, hsl(var(--foreground))) 18%, transparent)',
-                      backgroundColor: 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 60%, transparent)',
-                    }}
-                  >
-                    {paneCount}
-                  </div>
-                </div>
-              </div>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem onClick={() => onRenameWorkspace(workspace.id)}>
-                {t('common.rename')}
-              </ContextMenuItem>
-              <ContextMenuItem className="text-destructive" onClick={() => onCloseWorkspace(workspace.id)}>
-                {t('common.close')}
-              </ContextMenuItem>
-              {renderBulkCloseItems(workspace.id)}
-            </ContextMenuContent>
-          </ContextMenu>
+          <WorkspaceTopTab
+            key={workspace.id}
+            workspace={workspace}
+            paneCount={paneCount}
+            hasActivity={hasActivity}
+            isBeingDragged={isBeingDragged}
+            isDraggingForReorder={isDraggingForReorder}
+            shiftStyle={shiftStyle}
+            showDropIndicatorBefore={showDropIndicatorBefore}
+            showDropIndicatorAfter={showDropIndicatorAfter}
+            onTabDragStart={handleTabDragStart}
+            onTabDragEnd={handleTabDragEnd}
+            onTabDragOver={handleTabDragOver}
+            onTabDragLeave={handleTabDragLeave}
+            onTabDrop={handleTabDrop}
+            onRenameWorkspace={onRenameWorkspace}
+            onCloseWorkspace={onCloseWorkspace}
+            renderBulkCloseItems={renderBulkCloseItems}
+            t={t}
+          />
         );
       }
 
       if (item.type === 'logView') {
         const logView = item.logView;
-        const isActive = activeTabId === logView.id;
-        const isLocal = logView.log.protocol === 'local' || logView.log.hostname === 'localhost';
 
         return (
-          <div
+          <LogViewTopTab
             key={logView.id}
-            data-tab-id={logView.id}
-            data-tab-type="logView"
-            data-state={isActive ? 'active' : 'inactive'}
-            onClick={() => onSelectTab(logView.id)}
-            className={cn(
-              "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
-            )}
-            style={{
-              backgroundColor: isActive
-                ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                : 'transparent',
-              color: isActive
-                ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-            }}
-            onMouseEnter={(e) => {
-              if (!isActive) {
-                e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-              }
-            }}
-            onMouseLeave={(e) => {
-              if (!isActive) {
-                e.currentTarget.style.backgroundColor = 'transparent';
-                e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-              }
-            }}
-          >
-            <div className="flex items-center gap-2 min-w-0 flex-1">
-              <FileText
-                size={14}
-                className="shrink-0"
-                style={{ color: isActive ? 'var(--top-tabs-accent, hsl(var(--accent)))' : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
-              />
-              <span className="truncate">
-                {t('tabs.logPrefix')} {isLocal ? t('tabs.logLocal') : logView.log.hostname}
-              </span>
-            </div>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onCloseLogView(logView.id);
-              }}
-              className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
-              aria-label={t('tabs.closeLogViewAria')}
-            >
-              <X size={12} />
-            </button>
-          </div>
+            logView={logView}
+            onCloseLogView={onCloseLogView}
+            t={t}
+          />
         );
       }
 
@@ -911,6 +1163,10 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       }}
       onDoubleClick={handleTitleBarDoubleClick}
     >
+      <ActiveTabAutoScroller
+        tabsContainerRef={tabsContainerRef}
+        updateScrollState={updateScrollState}
+      />
       {/* Always-on drag stripe so the window can be moved even when tabs fill the bar */}
       <div className="absolute inset-x-0 top-0 h-1 app-drag pointer-events-auto z-10" style={dragRegionStyle} aria-hidden />
       <div
@@ -919,69 +1175,19 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       >
         {/* Fixed left tabs: Vaults and SFTP */}
         <div className="flex items-end gap-0 flex-shrink-0 app-drag">
-          <div
-            data-tab-id="vault"
-            data-tab-type="root"
-            data-state={isVaultActive ? 'active' : 'inactive'}
-            onClick={() => onSelectTab('vault')}
-            className={cn(
-              "netcatty-tab relative h-7 px-3 rounded text-xs font-semibold cursor-pointer flex items-center gap-2 app-no-drag",
-            )}
-            style={{
-              backgroundColor: isVaultActive
-                ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                : 'transparent',
-              color: isVaultActive
-                ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-            }}
-            onMouseEnter={(e) => {
-              if (!isVaultActive) {
-                e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-              }
-            }}
-            onMouseLeave={(e) => {
-              if (!isVaultActive) {
-                e.currentTarget.style.backgroundColor = 'transparent';
-                e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-              }
-            }}
-          >
-            <FolderLock size={14} /> Vaults
-          </div>
+          <RootTopTab
+            tabId="vault"
+            label="Vaults"
+            icon={<FolderLock size={14} />}
+            className="rounded"
+          />
           {showSftpTab && (
-            <div
-              data-tab-id="sftp"
-              data-tab-type="root"
-              data-state={isSftpActive ? 'active' : 'inactive'}
-              onClick={() => onSelectTab('sftp')}
-              className={cn(
-                "netcatty-tab relative h-7 px-3 rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center gap-2 app-no-drag",
-              )}
-              style={{
-                backgroundColor: isSftpActive
-                  ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-                  : 'transparent',
-                color: isSftpActive
-                  ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-                  : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-              }}
-              onMouseEnter={(e) => {
-                if (!isSftpActive) {
-                  e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-                  e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!isSftpActive) {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                  e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-                }
-              }}
-            >
-              <Folder size={14} /> SFTP
-            </div>
+            <RootTopTab
+              tabId="sftp"
+              label="SFTP"
+              icon={<Folder size={14} />}
+              className="rounded-t-md"
+            />
           )}
         </div>
 

--- a/components/terminalPaneVisibility.test.tsx
+++ b/components/terminalPaneVisibility.test.tsx
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getTerminalPaneSnapshot, HIDDEN_TERMINAL_PANE_SNAPSHOT } from "./terminalPaneVisibility";
+import type { Workspace } from "../types";
+
+const createWorkspace = (
+  id: string,
+  sessionIds: string[],
+  options: Partial<Pick<Workspace, "viewMode" | "focusedSessionId">> = {},
+): Workspace => ({
+  id,
+  title: id,
+  root: {
+    id: `${id}-root`,
+    type: "split",
+    direction: "vertical",
+    children: sessionIds.map((sessionId) => ({
+      id: `${id}-${sessionId}`,
+      type: "pane",
+      sessionId,
+    })),
+  },
+  viewMode: options.viewMode ?? "split",
+  focusedSessionId: options.focusedSessionId,
+});
+
+test("terminal pane snapshot stays hidden for panes outside both workspace tabs", () => {
+  const workspaceById = new Map<string, Workspace>([
+    ["ws-a", createWorkspace("ws-a", ["a-1", "a-2"], { focusedSessionId: "a-1" })],
+    ["ws-b", createWorkspace("ws-b", ["b-1", "b-2"], { focusedSessionId: "b-1" })],
+    ["ws-c", createWorkspace("ws-c", ["c-1"])],
+  ]);
+
+  const before = getTerminalPaneSnapshot({
+    activeTabId: "ws-a",
+    sessionId: "c-1",
+    sessionWorkspaceId: "ws-c",
+    workspaceById,
+    isTerminalLayerVisible: true,
+  });
+  const after = getTerminalPaneSnapshot({
+    activeTabId: "ws-b",
+    sessionId: "c-1",
+    sessionWorkspaceId: "ws-c",
+    workspaceById,
+    isTerminalLayerVisible: true,
+  });
+
+  assert.equal(before, HIDDEN_TERMINAL_PANE_SNAPSHOT);
+  assert.equal(after, before);
+});
+
+test("terminal pane snapshot distinguishes solo, split workspace, and focus workspace visibility", () => {
+  const workspaceById = new Map<string, Workspace>([
+    ["ws-split", createWorkspace("ws-split", ["s-1", "s-2"], { focusedSessionId: "s-1" })],
+    ["ws-focus", createWorkspace("ws-focus", ["f-1", "f-2"], {
+      viewMode: "focus",
+      focusedSessionId: "f-2",
+    })],
+  ]);
+
+  assert.equal(
+    getTerminalPaneSnapshot({
+      activeTabId: "solo-1",
+      sessionId: "solo-1",
+      workspaceById,
+      isTerminalLayerVisible: true,
+    }),
+    "solo|solo-1",
+  );
+  assert.equal(
+    getTerminalPaneSnapshot({
+      activeTabId: "ws-split",
+      sessionId: "s-2",
+      sessionWorkspaceId: "ws-split",
+      workspaceById,
+      isTerminalLayerVisible: true,
+    }),
+    "workspace|split|ws-split|s-1",
+  );
+  assert.equal(
+    getTerminalPaneSnapshot({
+      activeTabId: "ws-focus",
+      sessionId: "f-1",
+      sessionWorkspaceId: "ws-focus",
+      workspaceById,
+      isTerminalLayerVisible: true,
+    }),
+    HIDDEN_TERMINAL_PANE_SNAPSHOT,
+  );
+  assert.equal(
+    getTerminalPaneSnapshot({
+      activeTabId: "ws-focus",
+      sessionId: "f-2",
+      sessionWorkspaceId: "ws-focus",
+      workspaceById,
+      isTerminalLayerVisible: true,
+    }),
+    "workspace|focus|ws-focus|f-2",
+  );
+});

--- a/components/terminalPaneVisibility.ts
+++ b/components/terminalPaneVisibility.ts
@@ -1,0 +1,82 @@
+import type { Workspace } from "../types";
+
+export const HIDDEN_TERMINAL_PANE_SNAPSHOT = "hidden";
+
+export type TerminalPaneSnapshot =
+  | typeof HIDDEN_TERMINAL_PANE_SNAPSHOT
+  | `solo|${string}`
+  | `workspace|split|${string}|${string}`
+  | `workspace|focus|${string}|${string}`;
+
+interface GetTerminalPaneSnapshotOptions {
+  activeTabId: string | null;
+  sessionId: string;
+  sessionWorkspaceId?: string;
+  workspaceById: Map<string, Workspace>;
+  isTerminalLayerVisible: boolean;
+}
+
+export function getTerminalPaneSnapshot({
+  activeTabId,
+  sessionId,
+  sessionWorkspaceId,
+  workspaceById,
+  isTerminalLayerVisible,
+}: GetTerminalPaneSnapshotOptions): TerminalPaneSnapshot {
+  if (!isTerminalLayerVisible || !activeTabId) {
+    return HIDDEN_TERMINAL_PANE_SNAPSHOT;
+  }
+
+  const activeWorkspace = workspaceById.get(activeTabId);
+  if (activeWorkspace) {
+    if (sessionWorkspaceId !== activeWorkspace.id) {
+      return HIDDEN_TERMINAL_PANE_SNAPSHOT;
+    }
+
+    const focusedSessionId = activeWorkspace.focusedSessionId ?? "";
+    if (activeWorkspace.viewMode === "focus") {
+      return sessionId === focusedSessionId
+        ? `workspace|focus|${activeWorkspace.id}|${focusedSessionId}`
+        : HIDDEN_TERMINAL_PANE_SNAPSHOT;
+    }
+
+    return `workspace|split|${activeWorkspace.id}|${focusedSessionId}`;
+  }
+
+  return activeTabId === sessionId
+    ? `solo|${sessionId}`
+    : HIDDEN_TERMINAL_PANE_SNAPSHOT;
+}
+
+export function parseTerminalPaneSnapshot(snapshot: TerminalPaneSnapshot): {
+  isVisible: boolean;
+  mode: "hidden" | "solo" | "split" | "focus";
+  workspaceId: string | null;
+  focusedSessionId: string | null;
+} {
+  if (snapshot === HIDDEN_TERMINAL_PANE_SNAPSHOT) {
+    return {
+      isVisible: false,
+      mode: "hidden",
+      workspaceId: null,
+      focusedSessionId: null,
+    };
+  }
+
+  const parts = snapshot.split("|");
+  if (parts[0] === "solo") {
+    return {
+      isVisible: true,
+      mode: "solo",
+      workspaceId: null,
+      focusedSessionId: null,
+    };
+  }
+
+  return {
+    isVisible: true,
+    mode: parts[1] === "focus" ? "focus" : "split",
+    workspaceId: parts[2] || null,
+    focusedSessionId: parts[3] || null,
+  };
+}

--- a/components/terminalTopTabsTheme.test.ts
+++ b/components/terminalTopTabsTheme.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Workspace } from "../types";
+import { getScopedTopTabsThemeId } from "./terminalTopTabsTheme.ts";
+
+const workspace = (sessionIds: string[], viewMode?: Workspace["viewMode"]): Workspace => ({
+  id: "workspace-1",
+  title: "Workspace",
+  viewMode,
+  focusedSessionId: sessionIds[0],
+  root: {
+    id: "split-1",
+    type: "split",
+    direction: "vertical",
+    children: sessionIds.map((sessionId) => ({
+      id: `pane-${sessionId}`,
+      type: "pane",
+      sessionId,
+    })),
+  },
+});
+
+const resolveThemeFrom = (themes: Record<string, string>) => (sessionId: string) => themes[sessionId] ?? null;
+
+test("top tabs use root immersive theme for normal single-session tab switching", () => {
+  assert.equal(
+    getScopedTopTabsThemeId({
+      activeSidePanelTab: null,
+      activeThemePreviewId: null,
+      activeWorkspace: undefined,
+      followAppTerminalTheme: false,
+      isVisible: true,
+      previewTargetSessionId: "s1",
+      previewedOrVisibleThemeId: "tokyo-night",
+      resolveSessionThemeId: resolveThemeFrom({ s1: "tokyo-night" }),
+    }),
+    null,
+  );
+});
+
+test("top tabs are scoped while previewing a terminal theme", () => {
+  assert.equal(
+    getScopedTopTabsThemeId({
+      activeSidePanelTab: "theme",
+      activeThemePreviewId: "catppuccin",
+      activeWorkspace: undefined,
+      followAppTerminalTheme: false,
+      isVisible: true,
+      previewTargetSessionId: "s1",
+      previewedOrVisibleThemeId: "catppuccin",
+      resolveSessionThemeId: resolveThemeFrom({ s1: "tokyo-night" }),
+    }),
+    "catppuccin",
+  );
+});
+
+test("top tabs use root immersive theme for same-theme workspace splits", () => {
+  assert.equal(
+    getScopedTopTabsThemeId({
+      activeSidePanelTab: null,
+      activeThemePreviewId: null,
+      activeWorkspace: workspace(["s1", "s2"]),
+      followAppTerminalTheme: false,
+      isVisible: true,
+      previewTargetSessionId: "s1",
+      previewedOrVisibleThemeId: "tokyo-night",
+      resolveSessionThemeId: resolveThemeFrom({ s1: "tokyo-night", s2: "tokyo-night" }),
+    }),
+    null,
+  );
+});
+
+test("top tabs are scoped for mixed-theme workspace splits", () => {
+  assert.equal(
+    getScopedTopTabsThemeId({
+      activeSidePanelTab: null,
+      activeThemePreviewId: null,
+      activeWorkspace: workspace(["s1", "s2"]),
+      followAppTerminalTheme: false,
+      isVisible: true,
+      previewTargetSessionId: "s1",
+      previewedOrVisibleThemeId: "tokyo-night",
+      resolveSessionThemeId: resolveThemeFrom({ s1: "tokyo-night", s2: "solarized-light" }),
+    }),
+    "tokyo-night",
+  );
+});
+
+test("top tabs avoid scoped theme when following the application theme", () => {
+  assert.equal(
+    getScopedTopTabsThemeId({
+      activeSidePanelTab: null,
+      activeThemePreviewId: null,
+      activeWorkspace: workspace(["s1", "s2"]),
+      followAppTerminalTheme: true,
+      isVisible: true,
+      previewTargetSessionId: "s1",
+      previewedOrVisibleThemeId: "app-theme",
+      resolveSessionThemeId: resolveThemeFrom({ s1: "tokyo-night", s2: "solarized-light" }),
+    }),
+    null,
+  );
+});

--- a/components/terminalTopTabsTheme.ts
+++ b/components/terminalTopTabsTheme.ts
@@ -1,0 +1,52 @@
+import { collectSessionIds } from "../domain/workspace";
+import type { Workspace } from "../types";
+
+export type TopTabsSidePanelTab = "sftp" | "scripts" | "theme" | "ai" | null;
+
+type ScopedTopTabsThemeInput = {
+  activeSidePanelTab: TopTabsSidePanelTab;
+  activeThemePreviewId: string | null;
+  activeWorkspace: Workspace | null | undefined;
+  followAppTerminalTheme: boolean;
+  isVisible: boolean;
+  previewTargetSessionId: string | null;
+  previewedOrVisibleThemeId: string;
+  resolveSessionThemeId: (sessionId: string) => string | null;
+};
+
+export function getScopedTopTabsThemeId({
+  activeSidePanelTab,
+  activeThemePreviewId,
+  activeWorkspace,
+  followAppTerminalTheme,
+  isVisible,
+  previewTargetSessionId,
+  previewedOrVisibleThemeId,
+  resolveSessionThemeId,
+}: ScopedTopTabsThemeInput): string | null {
+  if (activeSidePanelTab === "theme" && previewTargetSessionId && activeThemePreviewId) {
+    return activeThemePreviewId;
+  }
+
+  if (!isVisible || followAppTerminalTheme || !activeWorkspace || activeWorkspace.viewMode === "focus") {
+    return null;
+  }
+
+  const sessionIds = collectSessionIds(activeWorkspace.root);
+  if (sessionIds.length < 2) return null;
+
+  let firstThemeId: string | null = null;
+  for (const sessionId of sessionIds) {
+    const themeId = resolveSessionThemeId(sessionId);
+    if (!themeId) continue;
+    if (firstThemeId == null) {
+      firstThemeId = themeId;
+      continue;
+    }
+    if (themeId !== firstThemeId) {
+      return previewedOrVisibleThemeId;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Reduce terminal tab-switch work by letting each terminal pane subscribe to its own visibility snapshot.
- Keep terminal-layer visibility and pane callbacks stable across terminal/workspace tab switches.
- Split top tabs into memoized tab items so only affected tabs update when the active tab changes.

## Validation
- npm run lint
- npm run build
- npm test