### PR TITLE
[codex] Handle missing streamed tool call ids

### DIFF
--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -385,3 +385,109 @@ test('replays reasoning_content through the SDK tool loop', async (t) => {
   const messages = followUpBody.messages as Array<Record<string, unknown>>;
   assert.equal(messages[1].reasoning_content, 'need disk context');
 });
+
+test('continues OpenAI-compatible tool streams when the introductory tool chunk omits id', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      id: 'chatcmpl-glm-test',
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'glm-5.1',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                type: 'function',
+                function: { name: 'terminal_exec', arguments: '' },
+              }],
+            });
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                function: { arguments: '{}' },
+              }],
+            });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { content: 'tool completed' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const model = createModelFromConfig({
+    id: 'glm-custom',
+    providerId: 'custom',
+    name: 'GLM',
+    apiKey: 'test-key',
+    baseURL: 'https://tokenhub.tencentmaas.com/plan/v3',
+    defaultModel: 'glm-5.1',
+    enabled: true,
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect the host' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({}),
+        execute: async () => ({ ok: true }),
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  let text = '';
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    }
+  }
+
+  assert.equal(text, 'tool completed');
+  const followUpMessages = sentBodies[1].messages as Array<Record<string, unknown>>;
+  const assistantMessage = followUpMessages[1] as { tool_calls?: Array<{ id?: string }> };
+  const toolMessage = followUpMessages[2] as { tool_call_id?: string };
+  assert.ok(assistantMessage.tool_calls?.[0]?.id?.startsWith('call_netcatty_'));
+  assert.equal(toolMessage.tool_call_id, assistantMessage.tool_calls?.[0]?.id);
+});

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -115,6 +115,87 @@ function createOpenAIChatStreamFieldCapture(
   };
 }
 
+function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) => string {
+  const toolCallIdsByChoiceAndIndex = new Map<string, string>();
+  const requestIdToken = requestId.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+  return (data: string): string => {
+    if (!data || data.trim() === '[DONE]') return data;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return data;
+    }
+
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as Record<string, unknown>).choices)) {
+      return data;
+    }
+
+    let changed = false;
+    const normalizedChoices = ((parsed as Record<string, unknown>).choices as unknown[]).map((choice, choicePosition) => {
+      if (!choice || typeof choice !== 'object') return choice;
+      const choiceRecord = choice as Record<string, unknown>;
+      const delta = choiceRecord.delta;
+      if (!delta || typeof delta !== 'object') return choice;
+
+      const deltaRecord = delta as Record<string, unknown>;
+      if (!Array.isArray(deltaRecord.tool_calls)) return choice;
+
+      const choiceIndex = typeof choiceRecord.index === 'number' ? choiceRecord.index : choicePosition;
+      let deltaChanged = false;
+      const normalizedToolCalls = deltaRecord.tool_calls.map((toolCall, toolCallPosition) => {
+        if (!toolCall || typeof toolCall !== 'object') return toolCall;
+        const toolCallRecord = toolCall as Record<string, unknown>;
+        const toolCallIndex = typeof toolCallRecord.index === 'number' ? toolCallRecord.index : toolCallPosition;
+        const key = `${choiceIndex}:${toolCallIndex}`;
+        const existingId = toolCallIdsByChoiceAndIndex.get(key);
+
+        if (typeof toolCallRecord.id === 'string' && toolCallRecord.id) {
+          toolCallIdsByChoiceAndIndex.set(key, toolCallRecord.id);
+          return toolCall;
+        }
+
+        if (existingId || !hasFunctionName(toolCallRecord)) {
+          return toolCall;
+        }
+
+        const syntheticId = `call_netcatty_${requestIdToken}_${choiceIndex}_${toolCallIndex}`;
+        toolCallIdsByChoiceAndIndex.set(key, syntheticId);
+        changed = true;
+        deltaChanged = true;
+        return { ...toolCallRecord, id: syntheticId };
+      });
+
+      if (!deltaChanged) return choice;
+      return {
+        ...choiceRecord,
+        delta: {
+          ...deltaRecord,
+          tool_calls: normalizedToolCalls,
+        },
+      };
+    });
+
+    if (!changed) return data;
+    return JSON.stringify({
+      ...(parsed as Record<string, unknown>),
+      choices: normalizedChoices,
+    });
+  };
+}
+
+function hasFunctionName(toolCall: Record<string, unknown>): boolean {
+  const fn = toolCall.function;
+  return Boolean(
+    fn &&
+    typeof fn === 'object' &&
+    typeof (fn as Record<string, unknown>).name === 'string' &&
+    (fn as Record<string, unknown>).name,
+  );
+}
+
 /**
  * Extract headers as a plain Record<string, string> from various header formats.
  */
@@ -208,6 +289,7 @@ export function createBridgeFetchForSDK(
     if (isStreamingRequest(resolvedInit)) {
       const requestId = `sdk_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
       const captureOpenAIChatFields = createOpenAIChatStreamFieldCapture(requestContext);
+      const normalizeOpenAIChatToolCalls = createOpenAIChatToolCallNormalizer(requestId);
 
       // Set up IPC event listeners BEFORE starting the stream to avoid
       // missing early events.
@@ -216,9 +298,10 @@ export function createBridgeFetchForSDK(
       let cleanedUp = false;
 
       const unsubData = bridge.onAiStreamData(requestId, (data: string) => {
-        captureOpenAIChatFields(data);
+        const normalizedData = normalizeOpenAIChatToolCalls(data);
+        captureOpenAIChatFields(normalizedData);
         // Re-wrap as SSE so the SDK can parse it
-        streamController?.enqueue(encoder.encode(`data: ${data}\n\n`));
+        streamController?.enqueue(encoder.encode(`data: ${normalizedData}\n\n`));
       });
       const unsubEnd = bridge.onAiStreamEnd(requestId, () => {
         try { streamController?.close(); } catch { /* already closed */ }


### PR DESCRIPTION
## Summary

- Normalize OpenAI-compatible streaming tool-call chunks before handing them to the AI SDK.
- Add a stable temporary tool-call id only when a provider introduces a function tool call without an id.
- Cover the GLM-style missing-id stream with an SDK loop regression test.

## Root Cause

Some OpenAI-compatible providers can stream a function tool-call chunk with `function.name` and `function.arguments` but no `tool_calls[].id`. The AI SDK treats that chunk as a new tool call and rejects it before Netcatty can continue the conversation.

## Impact

Standard OpenAI-style streams are left unchanged. Providers with looser streaming tool-call output can continue through the tool loop instead of stopping the chat with `Expected 'id' to be a string.`

Fixes #1004.

## Verification

- `node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts` failed before the fix with `Expected 'id' to be a string.`
- `node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts`
- `node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts infrastructure/ai/providerContinuation.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`