### PR TITLE
[codex] Fix session log capture after reconnect

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -29,6 +29,7 @@ import { materializeHostProxyProfile } from './domain/proxyProfiles';
 import { resolveHostAuth } from './domain/sshAuth';
 import { isEncryptedCredentialPlaceholder } from './domain/credentials';
 import { applyCustomAccentToTerminalTheme, resolveHostTerminalThemeId } from './domain/terminalAppearance';
+import { selectConnectionLogForTerminalDataCapture } from './domain/connectionLog';
 import { collectSessionIds } from './domain/workspace';
 import { resolveCloseIntent } from './application/state/resolveCloseIntent';
 import { resolveSnippetsShortcutIntent } from './application/state/resolveSnippetsShortcutIntent';
@@ -1756,15 +1757,10 @@ function App({ settings }: { settings: SettingsState }) {
     if (IS_DEV) console.log('[handleTerminalDataCapture] Session', session);
     if (IS_DEV) console.log('[handleTerminalDataCapture] All logs:', connectionLogs.map(l => ({ id: l.id, sessionId: l.sessionId, hostname: l.hostname, endTime: l.endTime, hasTerminalData: !!l.terminalData })));
 
-    // Prefer the persisted sessionId because the session may already have been
-    // removed from state by the time the terminal unmount cleanup runs.
-    const matchingLog = connectionLogs
-      .filter((log) => {
-        if (log.endTime || log.terminalData) return false;
-        if (log.sessionId) return log.sessionId === sessionId;
-        return !!session && log.hostname === session.hostname;
-      })
-      .sort((a, b) => b.startTime - a.startTime)[0];
+    const matchingLog = selectConnectionLogForTerminalDataCapture(
+      connectionLogs,
+      { sessionId, hostname: session?.hostname },
+    );
 
     if (IS_DEV) console.log('[handleTerminalDataCapture] Matching log', matchingLog);
 

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ConnectionLog } from "./models.ts";
+import { selectConnectionLogForTerminalDataCapture } from "./connectionLog.ts";
+
+const baseLog: ConnectionLog = {
+  id: "log-base",
+  sessionId: "session-1",
+  hostId: "host-1",
+  hostLabel: "Example",
+  hostname: "example.com",
+  username: "user",
+  protocol: "ssh",
+  startTime: 1000,
+  localUsername: "local",
+  localHostname: "machine",
+  saved: false,
+};
+
+test("selectConnectionLogForTerminalDataCapture picks the active log for a normal session exit", () => {
+  const matchingLog = { ...baseLog, id: "active", startTime: 2000 };
+  const staleLog = {
+    ...baseLog,
+    id: "stale",
+    sessionId: "session-2",
+    startTime: 3000,
+  };
+
+  assert.equal(
+    selectConnectionLogForTerminalDataCapture(
+      [staleLog, matchingLog],
+      { sessionId: "session-1", hostname: "example.com" },
+    )?.id,
+    "active",
+  );
+});
+
+test("selectConnectionLogForTerminalDataCapture reuses the latest log for repeated captures after reconnect", () => {
+  const firstCapture = {
+    ...baseLog,
+    id: "first-capture",
+    startTime: 2000,
+    endTime: 2500,
+    terminalData: "first disconnect",
+  };
+  const olderSameSession = {
+    ...baseLog,
+    id: "older-same-session",
+    startTime: 1500,
+    endTime: 1800,
+    terminalData: "older data",
+  };
+  const otherSession = {
+    ...baseLog,
+    id: "other-session",
+    sessionId: "session-2",
+    startTime: 3000,
+  };
+
+  assert.equal(
+    selectConnectionLogForTerminalDataCapture(
+      [otherSession, olderSameSession, firstCapture],
+      { sessionId: "session-1", hostname: "example.com" },
+    )?.id,
+    "first-capture",
+  );
+});

--- a/domain/connectionLog.ts
+++ b/domain/connectionLog.ts
@@ -1,0 +1,25 @@
+import type { ConnectionLog } from "./models.ts";
+
+interface TerminalDataCaptureTarget {
+  sessionId: string;
+  hostname?: string;
+}
+
+export const selectConnectionLogForTerminalDataCapture = (
+  connectionLogs: ConnectionLog[],
+  target: TerminalDataCaptureTarget,
+): ConnectionLog | undefined => {
+  const matchingOpenLog = connectionLogs
+    .filter((log) => {
+      if (log.endTime || log.terminalData) return false;
+      if (log.sessionId) return log.sessionId === target.sessionId;
+      return !!target.hostname && log.hostname === target.hostname;
+    })
+    .sort((a, b) => b.startTime - a.startTime)[0];
+
+  if (matchingOpenLog) return matchingOpenLog;
+
+  return connectionLogs
+    .filter((log) => log.sessionId === target.sessionId)
+    .sort((a, b) => b.startTime - a.startTime)[0];
+};


### PR DESCRIPTION
## What changed

- Select the correct connection log entry when terminal data arrives after a reconnect.
- Add a focused regression test for reconnecting with the same terminal session id.

## Why

After a reconnect, the renderer keeps the same terminal session id, but the old log entry was already closed. Terminal output from the new connection could then be ignored instead of being appended to the new log.

Fixes #1011

## Validation

- `npm run lint`
- `git diff --check`
- `npm test`