### PR TITLE
[codex] Filter terminal cursor replies from broadcast input

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -45,6 +45,7 @@ import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
+  markExpectedTerminalCursorPositionReport,
   pasteTextIntoTerminal,
   shouldBroadcastTerminalUserInput,
   shouldSuppressTerminalInputScrollForUserPaste,
@@ -156,6 +157,15 @@ const detectPlatform = (): XTermPlatform => {
 
   return "darwin";
 };
+
+const csiParamsInclude = (
+  params: readonly (number | number[])[],
+  target: number,
+): boolean => params.some((param) => (
+  Array.isArray(param)
+    ? param.includes(target)
+    : param === target
+));
 
 /**
  * Extract the primary font family from a CSS font-family string that may
@@ -721,6 +731,18 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     return !wipeAllowed;
   });
 
+  const markCursorPositionReportRequest = (params: readonly (number | number[])[]): boolean => {
+    if (csiParamsInclude(params, 6)) {
+      markExpectedTerminalCursorPositionReport(term);
+    }
+    return false;
+  };
+
+  const cursorPositionReportRequestDisposables = [
+    term.parser.registerCsiHandler({ final: "n" }, markCursorPositionReportRequest),
+    term.parser.registerCsiHandler({ prefix: "?", final: "n" }, markCursorPositionReportRequest),
+  ];
+
   const writeKittyKeyboardReply = (payload: string) => {
     const id = ctx.sessionRef.current;
     if (!id) return;
@@ -858,6 +880,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       cleanupMiddleClick?.();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();
+      for (const disposable of cursorPositionReportRequestDisposables) {
+        disposable.dispose();
+      }
       kittyKeyboardDisposable.dispose();
       osc7Disposable.dispose();
       osc52Disposable.dispose();

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   clearPasteResidualAfterTerminalWrite,
+  markExpectedTerminalCursorPositionReport,
   pasteTextIntoTerminal,
   prepareTerminalDataForUserPasteDisplay,
   shouldBroadcastTerminalUserInput,
@@ -144,6 +145,60 @@ test("broadcast gate consumes paste state even when broadcast is disabled before
   );
   assert.equal(
     shouldBroadcastTerminalUserInput(term, "line one", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    true,
+  );
+});
+
+test("broadcast gate suppresses expected terminal cursor position report replies", () => {
+  const term = {};
+
+  markExpectedTerminalCursorPositionReport(term);
+
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[1;1R", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[1;1R", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    true,
+  );
+});
+
+test("broadcast gate preserves normal input while a cursor position report is pending", () => {
+  const term = {};
+
+  markExpectedTerminalCursorPositionReport(term);
+
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "ls\r", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[24;80R", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+});
+
+test("broadcast gate preserves keyboard sequences that look like cursor reports without a terminal request", () => {
+  const term = {};
+
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[1;2R", {
       isBroadcastEnabled: true,
       hasBroadcastInputHandler: true,
     }),

--- a/components/terminal/runtime/terminalUserPaste.test.ts
+++ b/components/terminal/runtime/terminalUserPaste.test.ts
@@ -173,6 +173,41 @@ test("broadcast gate suppresses expected terminal cursor position report replies
   );
 });
 
+test("broadcast gate suppresses cursor position report replies split across chunks", () => {
+  const term = {};
+
+  markExpectedTerminalCursorPositionReport(term);
+
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "24;", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "80R", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldBroadcastTerminalUserInput(term, "\x1b[24;80R", {
+      isBroadcastEnabled: true,
+      hasBroadcastInputHandler: true,
+    }),
+    true,
+  );
+});
+
 test("broadcast gate preserves normal input while a cursor position report is pending", () => {
   const term = {};
 

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -32,6 +32,7 @@ type PasteInputScrollState = {
 type TerminalProtocolReplyState = {
   expiresAt: number;
   pendingCursorPositionReports: number;
+  cursorPositionReportFragment: string;
 };
 
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
@@ -49,7 +50,6 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const MIN_PASTE_ECHO_FRAGMENT_LENGTH = 6;
 const ESC = "\x1b";
 const BEL = "\x07";
-const CURSOR_POSITION_REPORT_REPLY_BODY_PATTERN = /^\??\d+;\d+R$/;
 
 const getNow = () => Date.now();
 
@@ -124,9 +124,44 @@ const getPlainTerminalText = (data: string): string =>
     stripAnsiEscapeSequences(data).replace(/\r\n/g, "\n").replace(/\r/g, "\n"),
   );
 
-const isCursorPositionReportReply = (data: string): boolean =>
-  data.startsWith(`${ESC}[`) &&
-  CURSOR_POSITION_REPORT_REPLY_BODY_PATTERN.test(data.slice(2));
+type CursorPositionReportMatch =
+  | { type: "complete"; length: number }
+  | { type: "prefix" }
+  | { type: "none" };
+
+const isAsciiDigit = (char: string): boolean => char >= "0" && char <= "9";
+
+const matchCursorPositionReportFromStart = (data: string): CursorPositionReportMatch => {
+  if (!data.startsWith(ESC)) return { type: "none" };
+  if (data.length === 1) return { type: "prefix" };
+  if (data[1] !== "[") return { type: "none" };
+  if (data.length === 2) return { type: "prefix" };
+
+  let index = 2;
+  if (data[index] === "?") {
+    index += 1;
+    if (index === data.length) return { type: "prefix" };
+  }
+
+  let rowDigits = 0;
+  while (index < data.length && isAsciiDigit(data[index])) {
+    rowDigits += 1;
+    index += 1;
+  }
+  if (index === data.length) return { type: "prefix" };
+  if (rowDigits === 0 || data[index] !== ";") return { type: "none" };
+
+  index += 1;
+  let columnDigits = 0;
+  while (index < data.length && isAsciiDigit(data[index])) {
+    columnDigits += 1;
+    index += 1;
+  }
+  if (index === data.length) return { type: "prefix" };
+  if (columnDigits === 0 || data[index] !== "R") return { type: "none" };
+
+  return { type: "complete", length: index + 1 };
+};
 
 const getPasteEchoFragments = (text: string): string[] =>
   Array.from(
@@ -323,11 +358,13 @@ export function markExpectedTerminalCursorPositionReport(term: object): void {
     : {
         expiresAt: 0,
         pendingCursorPositionReports: 0,
+        cursorPositionReportFragment: "",
       };
 
   terminalProtocolReplyStates.set(term, {
     expiresAt: getNow() + TERMINAL_PROTOCOL_REPLY_WINDOW_MS,
     pendingCursorPositionReports: activeState.pendingCursorPositionReports + 1,
+    cursorPositionReportFragment: activeState.cursorPositionReportFragment,
   });
 }
 
@@ -338,14 +375,38 @@ function shouldSuppressTerminalProtocolReplyBroadcast(term: object, data: string
     return false;
   }
 
-  if (
-    state.pendingCursorPositionReports <= 0 ||
-    !isCursorPositionReportReply(data)
-  ) {
+  if (state.pendingCursorPositionReports <= 0 || data.length === 0) {
     return false;
   }
 
-  state.pendingCursorPositionReports -= 1;
+  let remainingData = `${state.cursorPositionReportFragment}${data}`;
+  let consumedCursorPositionReports = 0;
+
+  while (remainingData.length > 0) {
+    const match = matchCursorPositionReportFromStart(remainingData);
+    if (match.type === "none") {
+      state.cursorPositionReportFragment = "";
+      return false;
+    }
+
+    if (match.type === "prefix") {
+      if (consumedCursorPositionReports >= state.pendingCursorPositionReports) {
+        return false;
+      }
+      state.pendingCursorPositionReports -= consumedCursorPositionReports;
+      state.cursorPositionReportFragment = remainingData;
+      return true;
+    }
+
+    consumedCursorPositionReports += 1;
+    if (consumedCursorPositionReports > state.pendingCursorPositionReports) {
+      return false;
+    }
+    remainingData = remainingData.slice(match.length);
+  }
+
+  state.pendingCursorPositionReports -= consumedCursorPositionReports;
+  state.cursorPositionReportFragment = "";
   if (state.pendingCursorPositionReports <= 0) {
     terminalProtocolReplyStates.delete(term);
   }

--- a/components/terminal/runtime/terminalUserPaste.ts
+++ b/components/terminal/runtime/terminalUserPaste.ts
@@ -29,12 +29,19 @@ type PasteInputScrollState = {
   remainingDataVariants: string[];
 };
 
+type TerminalProtocolReplyState = {
+  expiresAt: number;
+  pendingCursorPositionReports: number;
+};
+
 const pasteDisplayStates = new WeakMap<object, PasteDisplayState>();
 const pasteInputScrollStates = new WeakMap<object, PasteInputScrollState>();
 const pasteBroadcastStates = new WeakMap<object, PasteInputScrollState>();
+const terminalProtocolReplyStates = new WeakMap<object, TerminalProtocolReplyState>();
 const LONG_PASTE_MIN_LENGTH = 200;
 const PASTE_DISPLAY_FIX_WINDOW_MS = 4000;
 const PASTE_INPUT_SCROLL_WINDOW_MS = 4000;
+const TERMINAL_PROTOCOL_REPLY_WINDOW_MS = 4000;
 const READLINE_ACTIVE_REGION_START = "\x1b[7m";
 const READLINE_ACTIVE_REGION_END = "\x1b[27m";
 const BRACKETED_PASTE_START = "\x1b[200~";
@@ -42,6 +49,7 @@ const BRACKETED_PASTE_END = "\x1b[201~";
 const MIN_PASTE_ECHO_FRAGMENT_LENGTH = 6;
 const ESC = "\x1b";
 const BEL = "\x07";
+const CURSOR_POSITION_REPORT_REPLY_BODY_PATTERN = /^\??\d+;\d+R$/;
 
 const getNow = () => Date.now();
 
@@ -115,6 +123,10 @@ const getPlainTerminalText = (data: string): string =>
   stripNonLineBreakControls(
     stripAnsiEscapeSequences(data).replace(/\r\n/g, "\n").replace(/\r/g, "\n"),
   );
+
+const isCursorPositionReportReply = (data: string): boolean =>
+  data.startsWith(`${ESC}[`) &&
+  CURSOR_POSITION_REPORT_REPLY_BODY_PATTERN.test(data.slice(2));
 
 const getPasteEchoFragments = (text: string): string[] =>
   Array.from(
@@ -304,13 +316,55 @@ export function shouldSuppressTerminalBroadcastForUserPaste(term: object, data: 
   return consumePasteInputState(pasteBroadcastStates, term, data);
 }
 
+export function markExpectedTerminalCursorPositionReport(term: object): void {
+  const currentState = terminalProtocolReplyStates.get(term);
+  const activeState = isStateActive(currentState)
+    ? currentState
+    : {
+        expiresAt: 0,
+        pendingCursorPositionReports: 0,
+      };
+
+  terminalProtocolReplyStates.set(term, {
+    expiresAt: getNow() + TERMINAL_PROTOCOL_REPLY_WINDOW_MS,
+    pendingCursorPositionReports: activeState.pendingCursorPositionReports + 1,
+  });
+}
+
+function shouldSuppressTerminalProtocolReplyBroadcast(term: object, data: string): boolean {
+  const state = terminalProtocolReplyStates.get(term);
+  if (!isStateActive(state)) {
+    terminalProtocolReplyStates.delete(term);
+    return false;
+  }
+
+  if (
+    state.pendingCursorPositionReports <= 0 ||
+    !isCursorPositionReportReply(data)
+  ) {
+    return false;
+  }
+
+  state.pendingCursorPositionReports -= 1;
+  if (state.pendingCursorPositionReports <= 0) {
+    terminalProtocolReplyStates.delete(term);
+  }
+  return true;
+}
+
 export function shouldBroadcastTerminalUserInput(
   term: object,
   data: string,
   options: BroadcastUserInputOptions,
 ): boolean {
   const isSuppressedUserPaste = shouldSuppressTerminalBroadcastForUserPaste(term, data);
-  return !isSuppressedUserPaste && !!options.isBroadcastEnabled && !!options.hasBroadcastInputHandler;
+  const isSuppressedTerminalProtocolReply = shouldSuppressTerminalProtocolReplyBroadcast(term, data);
+  return (
+    !isSuppressedUserPaste &&
+    !isSuppressedTerminalProtocolReply &&
+    !!options.isBroadcastEnabled &&
+    !!options.hasBroadcastInputHandler
+  );
 }
 
 function consumePasteInputState(


### PR DESCRIPTION
## What changed

- Detect terminal cursor-position replies produced by terminal probes.
- Stop those replies from being sent to other broadcast targets.
- Keep normal user input and paste behavior unchanged.

## Why

Some shells and tools ask the terminal for its cursor position. The terminal answers with a sequence such as `ESC[row;colR`; broadcast mode treated that answer as user input and forwarded pieces of it to other sessions, which showed up as stray text like `1R`.

Fixes #1015

## Validation

- `npm run lint`
- `git diff --check`
- `npm test`