### PR TITLE
[codex] Guard unsupported legacy SSH groups

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -36,6 +36,10 @@ const {
   preparePrivateKeyForAuth,
   loadFirstIdentityFileForAuth,
 } = require("./sshAuthHelper.cjs");
+const {
+  buildSftpAlgorithms,
+  _resetAlgorithmSupportCacheForTests,
+} = require("./sshAlgorithms.cjs");
 
 // SFTP clients storage - shared reference passed from main
 let sftpClients = null;
@@ -480,44 +484,6 @@ const ensureRemoteDirForSession = async (sftpId, dirPath, requestedEncoding) => 
   await ensureRemoteDirInternal(sftp, normalizedPath, encoding);
   return true;
 };
-
-/**
- * Build SSH algorithm configuration for SFTP connections.
- * When legacyEnabled is true, legacy algorithms are appended for older device compatibility.
- */
-function buildSftpAlgorithms(legacyEnabled) {
-  const algorithms = {
-    cipher: [
-      'aes128-gcm@openssh.com', 'aes256-gcm@openssh.com',
-      'aes128-ctr', 'aes192-ctr', 'aes256-ctr',
-    ],
-    kex: [
-      'curve25519-sha256', 'curve25519-sha256@libssh.org',
-      'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521',
-      'diffie-hellman-group14-sha256',
-      'diffie-hellman-group16-sha512', 'diffie-hellman-group18-sha512',
-      'diffie-hellman-group-exchange-sha256',
-    ],
-    compress: ['none'],
-  };
-
-  if (legacyEnabled) {
-    algorithms.kex.push(
-      'diffie-hellman-group14-sha1',
-      'diffie-hellman-group1-sha1',
-    );
-    algorithms.cipher.push(
-      'aes128-cbc', 'aes256-cbc', '3des-cbc',
-    );
-    algorithms.serverHostKey = [
-      'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521',
-      'rsa-sha2-512', 'rsa-sha2-256',
-      'ssh-rsa', 'ssh-dss',
-    ];
-  }
-
-  return algorithms;
-}
 
 const { safeSend } = require("./ipcUtils.cjs");
 
@@ -2471,6 +2437,8 @@ module.exports = {
   init,
   registerHandlers,
   getSftpClients,
+  buildSftpAlgorithms,
+  _resetAlgorithmSupportCacheForTests,
   requireSftpChannel,
   encodePathForSession,
   ensureRemoteDirForSession,

--- a/electron/bridges/sshAlgorithms.cjs
+++ b/electron/bridges/sshAlgorithms.cjs
@@ -12,7 +12,7 @@ let _md5Supported = null;
 const dhGroupSupport = new Map();
 
 // FIPS-enabled OpenSSL builds disable MD5. Feature-detect once so the legacy
-// algorithm list can skip hmac-md5 on those builds — ssh2 validates exact
+// algorithm list can skip hmac-md5 on those builds; ssh2 validates exact
 // algorithm lists strictly and would otherwise throw "Unsupported algorithm"
 // before the SSH handshake even starts.
 function md5Supported() {
@@ -74,6 +74,35 @@ function applyLegacyAlgorithms(algorithms) {
   ];
 }
 
+function applyLegacyHmacAlgorithms(algorithms) {
+  // Legacy HMACs: required by very old servers (e.g. FreeBSD 6.1 OpenSSH
+  // ~2006, issue #807). Without hmac-sha1/md5 in the offered list, the
+  // handshake exchange-hash MAC never agrees and the host-key signature
+  // verification that depends on it fails with
+  // "Handshake failed: signature verification failed", which looks like
+  // a host-key problem but is really a MAC negotiation mismatch.
+  //
+  // hmac-md5 is only appended when the local OpenSSL build actually
+  // supports MD5. FIPS-enabled Node builds disable MD5 entirely, and
+  // ssh2 strictly validates exact algorithm lists. Listing an unavailable
+  // algorithm would throw "Unsupported algorithm" before any SSH
+  // negotiation, turning the legacy toggle into a hard failure for FIPS
+  // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
+  // stays unconditionally.
+  // hmac-sha1-etm@openssh.com is in ssh2's default MAC set. Keep it so
+  // hosts that only accept EtM SHA-1 MACs don't regress to "no matching
+  // C->S MAC" when legacy mode replaces the default list.
+  algorithms.hmac = [
+    "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com",
+    "hmac-sha2-256", "hmac-sha2-512",
+    "hmac-sha1-etm@openssh.com",
+    "hmac-sha1",
+  ];
+  if (md5Supported()) {
+    algorithms.hmac.push("hmac-md5");
+  }
+}
+
 /**
  * Build SSH algorithm configuration.
  * When legacyEnabled is true, legacy algorithms are appended to each list
@@ -84,32 +113,7 @@ function buildAlgorithms(legacyEnabled) {
 
   if (legacyEnabled) {
     applyLegacyAlgorithms(algorithms);
-    // Legacy HMACs — required by very old servers (e.g. FreeBSD 6.1 OpenSSH
-    // ~2006, issue #807). Without hmac-sha1/md5 in the offered list, the
-    // handshake exchange-hash MAC never agrees and the host-key signature
-    // verification that depends on it fails with
-    // "Handshake failed: signature verification failed" — which looks like
-    // a host-key problem but is really a MAC negotiation mismatch.
-    //
-    // hmac-md5 is only appended when the local OpenSSL build actually
-    // supports MD5. FIPS-enabled Node builds disable MD5 entirely, and
-    // ssh2 strictly validates exact algorithm lists — listing an unavailable
-    // algorithm would throw "Unsupported algorithm" before any SSH
-    // negotiation, turning the legacy toggle into a hard failure for FIPS
-    // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
-    // stays unconditionally.
-    // hmac-sha1-etm@openssh.com is in ssh2's default MAC set — keep it so
-    // hosts that only accept EtM SHA-1 MACs don't regress to "no matching
-    // C->S MAC" when legacy mode replaces the default list.
-    algorithms.hmac = [
-      "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com",
-      "hmac-sha2-256", "hmac-sha2-512",
-      "hmac-sha1-etm@openssh.com",
-      "hmac-sha1",
-    ];
-    if (md5Supported()) {
-      algorithms.hmac.push("hmac-md5");
-    }
+    applyLegacyHmacAlgorithms(algorithms);
   }
 
   return algorithms;
@@ -124,6 +128,7 @@ function buildSftpAlgorithms(legacyEnabled) {
 
   if (legacyEnabled) {
     applyLegacyAlgorithms(algorithms);
+    applyLegacyHmacAlgorithms(algorithms);
   }
 
   return algorithms;

--- a/electron/bridges/sshAlgorithms.cjs
+++ b/electron/bridges/sshAlgorithms.cjs
@@ -1,0 +1,141 @@
+const crypto = require("node:crypto");
+
+const FIXED_DH_GROUP_BY_KEX = Object.freeze({
+  "diffie-hellman-group1-sha1": "modp2",
+  "diffie-hellman-group14-sha1": "modp14",
+  "diffie-hellman-group14-sha256": "modp14",
+  "diffie-hellman-group16-sha512": "modp16",
+  "diffie-hellman-group18-sha512": "modp18",
+});
+
+let _md5Supported = null;
+const dhGroupSupport = new Map();
+
+// FIPS-enabled OpenSSL builds disable MD5. Feature-detect once so the legacy
+// algorithm list can skip hmac-md5 on those builds — ssh2 validates exact
+// algorithm lists strictly and would otherwise throw "Unsupported algorithm"
+// before the SSH handshake even starts.
+function md5Supported() {
+  if (_md5Supported === null) {
+    try { _md5Supported = crypto.getHashes().includes("md5"); }
+    catch { _md5Supported = false; }
+  }
+  return _md5Supported;
+}
+
+function fixedDhGroupSupported(groupName) {
+  if (!dhGroupSupport.has(groupName)) {
+    try {
+      crypto.createDiffieHellmanGroup(groupName);
+      dhGroupSupport.set(groupName, true);
+    } catch {
+      dhGroupSupport.set(groupName, false);
+    }
+  }
+  return dhGroupSupport.get(groupName);
+}
+
+function filterSupportedFixedDhKex(kexAlgorithms) {
+  return kexAlgorithms.filter((kexName) => {
+    const groupName = FIXED_DH_GROUP_BY_KEX[kexName];
+    return !groupName || fixedDhGroupSupported(groupName);
+  });
+}
+
+function buildBaseAlgorithms() {
+  return {
+    cipher: [
+      "aes128-gcm@openssh.com", "aes256-gcm@openssh.com",
+      "aes128-ctr", "aes192-ctr", "aes256-ctr",
+    ],
+    kex: filterSupportedFixedDhKex([
+      "curve25519-sha256", "curve25519-sha256@libssh.org",
+      "ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
+      "diffie-hellman-group14-sha256",
+      "diffie-hellman-group16-sha512", "diffie-hellman-group18-sha512",
+      "diffie-hellman-group-exchange-sha256",
+    ]),
+    compress: ["none"],
+  };
+}
+
+function applyLegacyAlgorithms(algorithms) {
+  algorithms.kex.push(...filterSupportedFixedDhKex([
+    "diffie-hellman-group14-sha1",
+    "diffie-hellman-group1-sha1",
+  ]));
+  algorithms.cipher.push(
+    "aes128-cbc", "aes256-cbc", "3des-cbc",
+  );
+  algorithms.serverHostKey = [
+    "ssh-ed25519", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521",
+    "rsa-sha2-512", "rsa-sha2-256",
+    "ssh-rsa", "ssh-dss",
+  ];
+}
+
+/**
+ * Build SSH algorithm configuration.
+ * When legacyEnabled is true, legacy algorithms are appended to each list
+ * (lower priority than modern ones) for compatibility with older network equipment.
+ */
+function buildAlgorithms(legacyEnabled) {
+  const algorithms = buildBaseAlgorithms();
+
+  if (legacyEnabled) {
+    applyLegacyAlgorithms(algorithms);
+    // Legacy HMACs — required by very old servers (e.g. FreeBSD 6.1 OpenSSH
+    // ~2006, issue #807). Without hmac-sha1/md5 in the offered list, the
+    // handshake exchange-hash MAC never agrees and the host-key signature
+    // verification that depends on it fails with
+    // "Handshake failed: signature verification failed" — which looks like
+    // a host-key problem but is really a MAC negotiation mismatch.
+    //
+    // hmac-md5 is only appended when the local OpenSSL build actually
+    // supports MD5. FIPS-enabled Node builds disable MD5 entirely, and
+    // ssh2 strictly validates exact algorithm lists — listing an unavailable
+    // algorithm would throw "Unsupported algorithm" before any SSH
+    // negotiation, turning the legacy toggle into a hard failure for FIPS
+    // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
+    // stays unconditionally.
+    // hmac-sha1-etm@openssh.com is in ssh2's default MAC set — keep it so
+    // hosts that only accept EtM SHA-1 MACs don't regress to "no matching
+    // C->S MAC" when legacy mode replaces the default list.
+    algorithms.hmac = [
+      "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com",
+      "hmac-sha2-256", "hmac-sha2-512",
+      "hmac-sha1-etm@openssh.com",
+      "hmac-sha1",
+    ];
+    if (md5Supported()) {
+      algorithms.hmac.push("hmac-md5");
+    }
+  }
+
+  return algorithms;
+}
+
+/**
+ * Build SSH algorithm configuration for SFTP connections.
+ * When legacyEnabled is true, legacy algorithms are appended for older device compatibility.
+ */
+function buildSftpAlgorithms(legacyEnabled) {
+  const algorithms = buildBaseAlgorithms();
+
+  if (legacyEnabled) {
+    applyLegacyAlgorithms(algorithms);
+  }
+
+  return algorithms;
+}
+
+function _resetAlgorithmSupportCacheForTests() {
+  _md5Supported = null;
+  dhGroupSupport.clear();
+}
+
+module.exports = {
+  buildAlgorithms,
+  buildSftpAlgorithms,
+  _resetAlgorithmSupportCacheForTests,
+};

--- a/electron/bridges/sshAlgorithms.test.cjs
+++ b/electron/bridges/sshAlgorithms.test.cjs
@@ -13,34 +13,51 @@ const FIXED_DH_GROUP_BY_KEX = new Map([
   ["diffie-hellman-group18-sha512", "modp18"],
 ]);
 
+const BASE_FIXED_DH_KEX = [
+  "diffie-hellman-group14-sha256",
+  "diffie-hellman-group16-sha512",
+  "diffie-hellman-group18-sha512",
+];
+
+const LEGACY_FIXED_DH_KEX = [
+  "diffie-hellman-group14-sha1",
+  "diffie-hellman-group1-sha1",
+];
+
 function resetSupportCache() {
   sshBridge._resetAlgorithmSupportCacheForTests?.();
   sftpBridge._resetAlgorithmSupportCacheForTests?.();
 }
 
-function withUnsupportedDhGroups(unsupportedGroups, callback) {
+function withAlgorithmRuntime({ unsupportedGroups = new Set(), hashes = ["sha1", "sha256", "sha512", "md5"] }, callback) {
   const originalCreateGroup = crypto.createDiffieHellmanGroup;
-  crypto.createDiffieHellmanGroup = (name, ...args) => {
+  const originalGetHashes = crypto.getHashes;
+
+  crypto.createDiffieHellmanGroup = (name) => {
     if (unsupportedGroups.has(name)) {
       throw new Error("Unknown DH group");
     }
-    return originalCreateGroup.call(crypto, name, ...args);
+    return {};
   };
+  crypto.getHashes = () => hashes;
 
   resetSupportCache();
   try {
     return callback();
   } finally {
     crypto.createDiffieHellmanGroup = originalCreateGroup;
+    crypto.getHashes = originalGetHashes;
     resetSupportCache();
   }
 }
 
-function assertNoUnsupportedFixedDhKex(algorithms, unsupportedGroups) {
+function assertFixedDhKexSupport(algorithms, expectedKexNames, unsupportedGroups) {
+  const expectedKex = new Set(expectedKexNames);
+
   for (const [kexName, groupName] of FIXED_DH_GROUP_BY_KEX) {
     assert.equal(
       algorithms.kex.includes(kexName),
-      !unsupportedGroups.has(groupName),
+      expectedKex.has(kexName) && !unsupportedGroups.has(groupName),
       `${kexName} should match ${groupName} runtime support`,
     );
   }
@@ -53,13 +70,41 @@ for (const [label, buildAlgorithms] of [
   test(`${label} algorithms skip fixed DH groups unsupported by the runtime`, () => {
     assert.equal(typeof buildAlgorithms, "function");
 
-    withUnsupportedDhGroups(new Set(["modp16", "modp18"]), () => {
-      const algorithms = buildAlgorithms(true);
+    withAlgorithmRuntime({ unsupportedGroups: new Set(["modp16", "modp18"]) }, () => {
+      const modernAlgorithms = buildAlgorithms(false);
+      const legacyAlgorithms = buildAlgorithms(true);
 
-      assertNoUnsupportedFixedDhKex(algorithms, new Set(["modp16", "modp18"]));
-      assert.ok(algorithms.kex.includes("diffie-hellman-group-exchange-sha256"));
-      assert.ok(algorithms.kex.includes("diffie-hellman-group14-sha1"));
-      assert.ok(algorithms.kex.includes("diffie-hellman-group1-sha1"));
+      assertFixedDhKexSupport(modernAlgorithms, BASE_FIXED_DH_KEX, new Set(["modp16", "modp18"]));
+      assertFixedDhKexSupport(
+        legacyAlgorithms,
+        [...BASE_FIXED_DH_KEX, ...LEGACY_FIXED_DH_KEX],
+        new Set(["modp16", "modp18"]),
+      );
+      assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group-exchange-sha256"));
+      assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group14-sha1"));
+      assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group1-sha1"));
     });
   });
 }
+
+test("SFTP legacy HMAC algorithms match SSH legacy compatibility", () => {
+  withAlgorithmRuntime({}, () => {
+    const sshAlgorithms = sshBridge.buildAlgorithms(true);
+    const sftpAlgorithms = sftpBridge.buildSftpAlgorithms(true);
+
+    assert.deepEqual(sftpAlgorithms.hmac, sshAlgorithms.hmac);
+    assert.ok(sftpAlgorithms.hmac.includes("hmac-md5"));
+  });
+});
+
+test("legacy HMAC algorithms skip MD5 when the runtime disables it", () => {
+  withAlgorithmRuntime({ hashes: ["sha1", "sha256", "sha512"] }, () => {
+    for (const algorithms of [
+      sshBridge.buildAlgorithms(true),
+      sftpBridge.buildSftpAlgorithms(true),
+    ]) {
+      assert.ok(algorithms.hmac.includes("hmac-sha1"));
+      assert.equal(algorithms.hmac.includes("hmac-md5"), false);
+    }
+  });
+});

--- a/electron/bridges/sshAlgorithms.test.cjs
+++ b/electron/bridges/sshAlgorithms.test.cjs
@@ -1,0 +1,65 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+
+const sshBridge = require("./sshBridge.cjs");
+const sftpBridge = require("./sftpBridge.cjs");
+
+const FIXED_DH_GROUP_BY_KEX = new Map([
+  ["diffie-hellman-group1-sha1", "modp2"],
+  ["diffie-hellman-group14-sha1", "modp14"],
+  ["diffie-hellman-group14-sha256", "modp14"],
+  ["diffie-hellman-group16-sha512", "modp16"],
+  ["diffie-hellman-group18-sha512", "modp18"],
+]);
+
+function resetSupportCache() {
+  sshBridge._resetAlgorithmSupportCacheForTests?.();
+  sftpBridge._resetAlgorithmSupportCacheForTests?.();
+}
+
+function withUnsupportedDhGroups(unsupportedGroups, callback) {
+  const originalCreateGroup = crypto.createDiffieHellmanGroup;
+  crypto.createDiffieHellmanGroup = (name, ...args) => {
+    if (unsupportedGroups.has(name)) {
+      throw new Error("Unknown DH group");
+    }
+    return originalCreateGroup.call(crypto, name, ...args);
+  };
+
+  resetSupportCache();
+  try {
+    return callback();
+  } finally {
+    crypto.createDiffieHellmanGroup = originalCreateGroup;
+    resetSupportCache();
+  }
+}
+
+function assertNoUnsupportedFixedDhKex(algorithms, unsupportedGroups) {
+  for (const [kexName, groupName] of FIXED_DH_GROUP_BY_KEX) {
+    assert.equal(
+      algorithms.kex.includes(kexName),
+      !unsupportedGroups.has(groupName),
+      `${kexName} should match ${groupName} runtime support`,
+    );
+  }
+}
+
+for (const [label, buildAlgorithms] of [
+  ["SSH", sshBridge.buildAlgorithms],
+  ["SFTP", sftpBridge.buildSftpAlgorithms],
+]) {
+  test(`${label} algorithms skip fixed DH groups unsupported by the runtime`, () => {
+    assert.equal(typeof buildAlgorithms, "function");
+
+    withUnsupportedDhGroups(new Set(["modp16", "modp18"]), () => {
+      const algorithms = buildAlgorithms(true);
+
+      assertNoUnsupportedFixedDhKex(algorithms, new Set(["modp16", "modp18"]));
+      assert.ok(algorithms.kex.includes("diffie-hellman-group-exchange-sha256"));
+      assert.ok(algorithms.kex.includes("diffie-hellman-group14-sha1"));
+      assert.ok(algorithms.kex.includes("diffie-hellman-group1-sha1"));
+    });
+  });
+}

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -35,6 +35,10 @@ const {
 const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
 const { trackSessionIdlePrompt } = require("./ai/shellUtils.cjs");
 const { createZmodemSentry } = require("./zmodemHelper.cjs");
+const {
+  buildAlgorithms,
+  _resetAlgorithmSupportCacheForTests,
+} = require("./sshAlgorithms.cjs");
 
 // Default SSH key names in priority order (preferred keys tried first)
 const PREFERRED_KEY_NAMES = ["id_ed25519", "id_ecdsa", "id_rsa"];
@@ -262,84 +266,6 @@ const log = (msg, data) => {
   try { fs.appendFileSync(logFile, line); } catch { }
   console.log("[SSH]", msg, data ? JSON.stringify(data, null, 2) : "");
 };
-
-// FIPS-enabled OpenSSL builds disable MD5. Feature-detect once so the legacy
-// algorithm list can skip hmac-md5 on those builds — ssh2 validates exact
-// algorithm lists strictly and would otherwise throw "Unsupported algorithm"
-// before the SSH handshake even starts.
-let _md5Supported = null;
-function md5Supported() {
-  if (_md5Supported === null) {
-    try { _md5Supported = crypto.getHashes().includes("md5"); }
-    catch { _md5Supported = false; }
-  }
-  return _md5Supported;
-}
-
-/**
- * Build SSH algorithm configuration.
- * When legacyEnabled is true, legacy algorithms are appended to each list
- * (lower priority than modern ones) for compatibility with older network equipment.
- */
-function buildAlgorithms(legacyEnabled) {
-  const algorithms = {
-    cipher: [
-      'aes128-gcm@openssh.com', 'aes256-gcm@openssh.com',
-      'aes128-ctr', 'aes192-ctr', 'aes256-ctr',
-    ],
-    kex: [
-      'curve25519-sha256', 'curve25519-sha256@libssh.org',
-      'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521',
-      'diffie-hellman-group14-sha256',
-      'diffie-hellman-group16-sha512', 'diffie-hellman-group18-sha512',
-      'diffie-hellman-group-exchange-sha256',
-    ],
-    compress: ['none'],
-  };
-
-  if (legacyEnabled) {
-    algorithms.kex.push(
-      'diffie-hellman-group14-sha1',
-      'diffie-hellman-group1-sha1',
-    );
-    algorithms.cipher.push(
-      'aes128-cbc', 'aes256-cbc', '3des-cbc',
-    );
-    algorithms.serverHostKey = [
-      'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521',
-      'rsa-sha2-512', 'rsa-sha2-256',
-      'ssh-rsa', 'ssh-dss',
-    ];
-    // Legacy HMACs — required by very old servers (e.g. FreeBSD 6.1 OpenSSH
-    // ~2006, issue #807). Without hmac-sha1/md5 in the offered list, the
-    // handshake exchange-hash MAC never agrees and the host-key signature
-    // verification that depends on it fails with
-    // "Handshake failed: signature verification failed" — which looks like
-    // a host-key problem but is really a MAC negotiation mismatch.
-    //
-    // hmac-md5 is only appended when the local OpenSSL build actually
-    // supports MD5. FIPS-enabled Node builds disable MD5 entirely, and
-    // ssh2 strictly validates exact algorithm lists — listing an unavailable
-    // algorithm would throw "Unsupported algorithm" before any SSH
-    // negotiation, turning the legacy toggle into a hard failure for FIPS
-    // users. hmac-sha1 is allowed for HMAC even under FIPS 140-2 so it
-    // stays unconditionally.
-    // hmac-sha1-etm@openssh.com is in ssh2's default MAC set — keep it so
-    // hosts that only accept EtM SHA-1 MACs don't regress to "no matching
-    // C->S MAC" when legacy mode replaces the default list.
-    algorithms.hmac = [
-      'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com',
-      'hmac-sha2-256', 'hmac-sha2-512',
-      'hmac-sha1-etm@openssh.com',
-      'hmac-sha1',
-    ];
-    if (md5Supported()) {
-      algorithms.hmac.push('hmac-md5');
-    }
-  }
-
-  return algorithms;
-}
 
 // Session storage - shared reference passed from main
 let sessions = null;
@@ -2712,4 +2638,5 @@ module.exports = {
   registerHandlers,
   connectThroughChain,
   buildAlgorithms,
+  _resetAlgorithmSupportCacheForTests,
 };


### PR DESCRIPTION
## What changed

- Share SSH/SFTP algorithm selection through one helper.
- Check whether the current runtime supports each fixed DH group before offering it.
- Preserve the legacy groups that are actually available for old devices.

## Why

Some Electron/OpenSSL runtimes do not support every fixed DH group that was being offered. If a server negotiated one of those unsupported groups, the connection could fail immediately with `Unknown DH group`.

Fixes #1018

## Validation

- `npm run lint`
- `git diff --check`
- `npm test`