### PR TITLE
[codex] Use terminal cwd when opening SFTP

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -69,7 +69,7 @@ import { useTerminalAuthState } from "./terminal/hooks/useTerminalAuthState";
 import { useServerStats } from "./terminal/hooks/useServerStats";
 import { extractDropEntries, getPathForFile, DropEntry } from "../lib/sftpFileUtils";
 import { useTerminalAutocomplete, AutocompletePopup } from "./terminal/autocomplete";
-import { resolvePreferredTerminalCwd } from "./terminal/sftpCwd";
+import { createTerminalCwdTracker, resolvePreferredTerminalCwd } from "./terminal/sftpCwd";
 
 const MAX_CONNECTION_LOG_DATA_CHARS = 1_000_000;
 
@@ -284,6 +284,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const serializeAddonRef = useRef<SerializeAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const xtermRuntimeRef = useRef<XTermRuntime | null>(null);
+  const terminalCwdTracker = useMemo(() => createTerminalCwdTracker(), []);
   const knownCwdRef = useRef<string | undefined>(undefined);
   const disposeDataRef = useRef<(() => void) | null>(null);
   const disposeExitRef = useRef<(() => void) | null>(null);
@@ -551,7 +552,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     } : undefined,
     onAcceptText: (text) => autocompleteAcceptTextRef.current?.(text),
     protocol: host.protocol,
-    getCwd: () => knownCwdRef.current ?? xtermRuntimeRef.current?.currentCwd,
+    getCwd: () => terminalCwdTracker.getRendererCwd() ?? knownCwdRef.current,
   });
 
   // Wire up autocomplete handler refs so createXTermRuntime can use them
@@ -562,18 +563,23 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const resolveSftpInitialPath = useCallback(async (): Promise<string | undefined> => {
     const cwd = await resolvePreferredTerminalCwd({
-      rendererCwd: xtermRuntimeRef.current?.currentCwd,
+      rendererCwd: terminalCwdTracker.getRendererCwd(),
       sessionId: sessionRef.current,
       getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
     });
     return cwd ?? undefined;
-  }, [terminalBackend]);
+  }, [terminalBackend, terminalCwdTracker]);
 
-  useEffect(() => {
+  const clearTerminalCwd = useCallback(() => {
+    terminalCwdTracker.clearRendererCwd();
     knownCwdRef.current = undefined;
     onTerminalCwdChange?.(sessionId, null);
-    return () => onTerminalCwdChange?.(sessionId, null);
-  }, [sessionId, host.id, onTerminalCwdChange]);
+  }, [onTerminalCwdChange, sessionId, terminalCwdTracker]);
+
+  useEffect(() => {
+    clearTerminalCwd();
+    return clearTerminalCwd;
+  }, [clearTerminalCwd, host.id]);
 
   useEffect(() => {
     if (host.protocol === "local" || host.protocol === "serial" || host.protocol === "telnet") {
@@ -586,7 +592,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (!sessionRef.current) return;
       try {
         const result = await terminalBackend.getSessionPwd(sessionRef.current);
-        if (!cancelled && result.success && result.cwd) {
+        if (!cancelled && !terminalCwdTracker.getRendererCwd() && result.success && result.cwd) {
           knownCwdRef.current = result.cwd;
         }
       } catch {
@@ -598,7 +604,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [host.protocol, status, terminalBackend]);
+  }, [host.protocol, status, terminalBackend, terminalCwdTracker]);
 
   useEffect(() => {
     if (!isVisible) {
@@ -878,6 +884,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     setChainProgress,
     t,
     onSessionAttached: (id: string) => {
+      clearTerminalCwd();
       // SSH: always sync. Its backend starts in utf-8 regardless of
       // host.charset, so the push is what keeps the UI state aligned
       // across reconnects — including localhost SSH targets, hence
@@ -901,7 +908,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         setSessionEncoding(id, terminalEncodingRef.current);
       }
     },
-    onSessionExit,
+    onSessionExit: (closedSessionId, evt) => {
+      clearTerminalCwd();
+      onSessionExit?.(closedSessionId, evt);
+    },
     onTerminalDataCapture: handleTerminalDataCaptureOnce,
     onTerminalLogData: captureTerminalLogData,
     onOsDetected,
@@ -955,6 +965,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           serialLineBufferRef,
           onTerminalLogData: captureTerminalLogData,
           onCwdChange: (cwd: string) => {
+            terminalCwdTracker.setRendererCwd(cwd);
             knownCwdRef.current = cwd;
             onTerminalCwdChange?.(sessionId, cwd);
           },

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -69,6 +69,7 @@ import { useTerminalAuthState } from "./terminal/hooks/useTerminalAuthState";
 import { useServerStats } from "./terminal/hooks/useServerStats";
 import { extractDropEntries, getPathForFile, DropEntry } from "../lib/sftpFileUtils";
 import { useTerminalAutocomplete, AutocompletePopup } from "./terminal/autocomplete";
+import { resolvePreferredTerminalCwd } from "./terminal/sftpCwd";
 
 const MAX_CONNECTION_LOG_DATA_CHARS = 1_000_000;
 
@@ -171,6 +172,7 @@ interface TerminalProps {
     pendingUploadEntries?: DropEntry[],
     sourceSessionId?: string,
   ) => void;
+  onTerminalCwdChange?: (sessionId: string, cwd: string | null) => void;
   onOpenScripts?: () => void;
   onOpenTheme?: () => void;
   isBroadcastEnabled?: boolean;
@@ -261,6 +263,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   onSplitHorizontal,
   onSplitVertical,
   onOpenSftp,
+  onTerminalCwdChange,
   onOpenScripts,
   onOpenTheme,
   isBroadcastEnabled,
@@ -557,9 +560,20 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   autocompleteRepositionRef.current = autocomplete.repositionPopup;
   const autocompleteClosePopup = autocomplete.closePopup;
 
+  const resolveSftpInitialPath = useCallback(async (): Promise<string | undefined> => {
+    const cwd = await resolvePreferredTerminalCwd({
+      rendererCwd: xtermRuntimeRef.current?.currentCwd,
+      sessionId: sessionRef.current,
+      getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
+    });
+    return cwd ?? undefined;
+  }, [terminalBackend]);
+
   useEffect(() => {
     knownCwdRef.current = undefined;
-  }, [sessionId, host.id]);
+    onTerminalCwdChange?.(sessionId, null);
+    return () => onTerminalCwdChange?.(sessionId, null);
+  }, [sessionId, host.id, onTerminalCwdChange]);
 
   useEffect(() => {
     if (host.protocol === "local" || host.protocol === "serial" || host.protocol === "telnet") {
@@ -942,6 +956,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           onTerminalLogData: captureTerminalLogData,
           onCwdChange: (cwd: string) => {
             knownCwdRef.current = cwd;
+            onTerminalCwdChange?.(sessionId, cwd);
           },
           onOsc52ReadRequest: handleOsc52ReadRequest,
           // Autocomplete integration
@@ -1580,17 +1595,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const handleOpenSFTP = async () => {
     if (onOpenSftp) {
       // Delegate to parent (TerminalLayer) for shared SFTP side panel
-      let initialPath: string | undefined = undefined;
-      if (sessionRef.current) {
-        try {
-          const result = await terminalBackend.getSessionPwd(sessionRef.current);
-          if (result.success && result.cwd) {
-            initialPath = result.cwd;
-          }
-        } catch {
-          // Silently fail
-        }
-      }
+      const initialPath = await resolveSftpInitialPath();
       onOpenSftp(host, initialPath, undefined, sessionId);
       return;
     }
@@ -1803,17 +1808,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       } else {
         // Remote terminal: Trigger SFTP upload via parent
         if (onOpenSftp) {
-          let initialPath: string | undefined = undefined;
-          if (sessionRef.current) {
-            try {
-              const result = await terminalBackend.getSessionPwd(sessionRef.current);
-              if (result.success && result.cwd) {
-                initialPath = result.cwd;
-              }
-            } catch {
-              // Silently fail
-            }
-          }
+          const initialPath = await resolveSftpInitialPath();
           onOpenSftp(host, initialPath, dropEntries, sessionId);
         }
       }

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -60,6 +60,7 @@ import { resolveScriptsSidePanelShortcutIntent } from '../application/state/reso
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { getTerminalPaneSnapshot, parseTerminalPaneSnapshot } from './terminalPaneVisibility';
 import { getScopedTopTabsThemeId } from './terminalTopTabsTheme';
+import { resolvePreferredTerminalCwd } from './terminal/sftpCwd';
 
 type SidePanelTab = 'sftp' | 'scripts' | 'theme' | 'ai';
 
@@ -504,6 +505,7 @@ interface TerminalPaneProps {
     pendingUploadEntries?: DropEntry[],
     sourceSessionId?: string,
   ) => void;
+  onTerminalCwdChange: (sessionId: string, cwd: string | null) => void;
   onOpenScripts: () => void;
   onOpenTheme: () => void;
   onCloseSession: (sessionId: string) => void;
@@ -564,6 +566,7 @@ const terminalPanePropsAreEqual = (
   prev.sessionLog === next.sessionLog &&
   prev.onHotkeyAction === next.onHotkeyAction &&
   prev.onOpenSftp === next.onOpenSftp &&
+  prev.onTerminalCwdChange === next.onTerminalCwdChange &&
   prev.onOpenScripts === next.onOpenScripts &&
   prev.onOpenTheme === next.onOpenTheme &&
   prev.onCloseSession === next.onCloseSession &&
@@ -612,6 +615,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   sessionLog,
   onHotkeyAction,
   onOpenSftp,
+  onTerminalCwdChange,
   onOpenScripts,
   onOpenTheme,
   onCloseSession,
@@ -727,6 +731,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
         keyBindings={keyBindings}
         onHotkeyAction={onHotkeyAction}
         onOpenSftp={onOpenSftp}
+        onTerminalCwdChange={onTerminalCwdChange}
         onOpenScripts={onOpenScripts}
         onOpenTheme={onOpenTheme}
         onCloseSession={onCloseSession}
@@ -783,6 +788,7 @@ interface TerminalPanesHostProps {
   sessionLog?: { enabled: true; directory: string; format: string };
   onHotkeyAction?: (action: string, event: KeyboardEvent) => void;
   onOpenSftp: TerminalPaneProps['onOpenSftp'];
+  onTerminalCwdChange: TerminalPaneProps['onTerminalCwdChange'];
   onOpenScripts: () => void;
   onOpenTheme: () => void;
   onCloseSession: (sessionId: string) => void;
@@ -894,6 +900,24 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const isVaultActive = activeTabId === 'vault';
   const isSftpActive = activeTabId === 'sftp';
   const isVisible = (!isVaultActive && !isSftpActive) || !!draggingSessionId;
+  const terminalRendererCwdBySessionRef = useRef<Map<string, string>>(new Map());
+
+  const handleTerminalCwdChange = useCallback((sessionId: string, cwd: string | null) => {
+    if (cwd && cwd.trim().length > 0) {
+      terminalRendererCwdBySessionRef.current.set(sessionId, cwd);
+    } else {
+      terminalRendererCwdBySessionRef.current.delete(sessionId);
+    }
+  }, []);
+
+  useEffect(() => {
+    const liveSessionIds = new Set(sessions.map((session) => session.id));
+    for (const sessionId of terminalRendererCwdBySessionRef.current.keys()) {
+      if (!liveSessionIds.has(sessionId)) {
+        terminalRendererCwdBySessionRef.current.delete(sessionId);
+      }
+    }
+  }, [sessions]);
 
   // Stable callback references for Terminal components
   const handleCloseSession = useCallback((sessionId: string) => {
@@ -1772,13 +1796,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   // Get the focused terminal's current working directory
   const getTerminalCwd = useCallback(async (): Promise<string | null> => {
     const sessionId = getActiveTerminalSessionId();
-    if (!sessionId) return null;
-    try {
-      const result = await terminalBackend.getSessionPwd(sessionId);
-      return result.success && result.cwd ? result.cwd : null;
-    } catch {
-      return null;
-    }
+    return resolvePreferredTerminalCwd({
+      rendererCwd: sessionId ? terminalRendererCwdBySessionRef.current.get(sessionId) : undefined,
+      sessionId,
+      getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
+    });
   }, [getActiveTerminalSessionId, terminalBackend]);
 
   const refocusTerminalSession = useCallback((sessionId?: string | null) => {
@@ -3128,6 +3150,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
             sessionLog={sessionLogConfig}
             onHotkeyAction={onHotkeyAction}
             onOpenSftp={handleOpenSftp}
+            onTerminalCwdChange={handleTerminalCwdChange}
             onOpenScripts={handleOpenScripts}
             onOpenTheme={handleOpenTheme}
             onCloseSession={handleCloseSession}

--- a/components/terminal/sftpCwd.test.ts
+++ b/components/terminal/sftpCwd.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolvePreferredTerminalCwd } from "./sftpCwd";
+import {
+  createTerminalCwdTracker,
+  resolvePreferredTerminalCwd,
+} from "./sftpCwd";
 
 test("resolvePreferredTerminalCwd returns the renderer cwd without probing the backend", async () => {
   let backendCalls = 0;
@@ -40,4 +43,19 @@ test("resolvePreferredTerminalCwd returns null when neither source has a cwd", a
   });
 
   assert.equal(cwd, null);
+});
+
+test("terminal cwd tracker clears stale renderer cwd before falling back to backend pwd", async () => {
+  const tracker = createTerminalCwdTracker();
+
+  tracker.setRendererCwd("/srv/old-session");
+  tracker.clearRendererCwd();
+
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: tracker.getRendererCwd(),
+    sessionId: "session-1",
+    getSessionPwd: async () => ({ success: true, cwd: "/home/fresh-session" }),
+  });
+
+  assert.equal(cwd, "/home/fresh-session");
 });

--- a/components/terminal/sftpCwd.test.ts
+++ b/components/terminal/sftpCwd.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolvePreferredTerminalCwd } from "./sftpCwd";
+
+test("resolvePreferredTerminalCwd returns the renderer cwd without probing the backend", async () => {
+  let backendCalls = 0;
+
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: "/srv/app/current",
+    sessionId: "session-1",
+    getSessionPwd: async () => {
+      backendCalls += 1;
+      return { success: true, cwd: "/root" };
+    },
+  });
+
+  assert.equal(cwd, "/srv/app/current");
+  assert.equal(backendCalls, 0);
+});
+
+test("resolvePreferredTerminalCwd falls back to backend pwd when no renderer cwd is known", async () => {
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: undefined,
+    sessionId: "session-1",
+    getSessionPwd: async (sessionId) => {
+      assert.equal(sessionId, "session-1");
+      return { success: true, cwd: "/home/alice" };
+    },
+  });
+
+  assert.equal(cwd, "/home/alice");
+});
+
+test("resolvePreferredTerminalCwd returns null when neither source has a cwd", async () => {
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: "",
+    sessionId: "session-1",
+    getSessionPwd: async () => ({ success: false }),
+  });
+
+  assert.equal(cwd, null);
+});

--- a/components/terminal/sftpCwd.ts
+++ b/components/terminal/sftpCwd.ts
@@ -1,0 +1,32 @@
+type SessionPwdResult = {
+  success: boolean;
+  cwd?: string | null;
+};
+
+type ResolvePreferredTerminalCwdOptions = {
+  rendererCwd?: string | null;
+  sessionId?: string | null;
+  getSessionPwd: (sessionId: string) => Promise<SessionPwdResult>;
+};
+
+const normalizeCwd = (cwd?: string | null): string | null => {
+  if (typeof cwd !== "string" || cwd.trim().length === 0) return null;
+  return cwd;
+};
+
+export const resolvePreferredTerminalCwd = async ({
+  rendererCwd,
+  sessionId,
+  getSessionPwd,
+}: ResolvePreferredTerminalCwdOptions): Promise<string | null> => {
+  const knownCwd = normalizeCwd(rendererCwd);
+  if (knownCwd) return knownCwd;
+  if (!sessionId) return null;
+
+  try {
+    const result = await getSessionPwd(sessionId);
+    return result.success ? normalizeCwd(result.cwd) : null;
+  } catch {
+    return null;
+  }
+};

--- a/components/terminal/sftpCwd.ts
+++ b/components/terminal/sftpCwd.ts
@@ -14,6 +14,27 @@ const normalizeCwd = (cwd?: string | null): string | null => {
   return cwd;
 };
 
+export type TerminalCwdTracker = {
+  getRendererCwd: () => string | undefined;
+  setRendererCwd: (cwd?: string | null) => string | undefined;
+  clearRendererCwd: () => void;
+};
+
+export const createTerminalCwdTracker = (): TerminalCwdTracker => {
+  let rendererCwd: string | undefined;
+
+  return {
+    getRendererCwd: () => rendererCwd,
+    setRendererCwd: (cwd) => {
+      rendererCwd = normalizeCwd(cwd) ?? undefined;
+      return rendererCwd;
+    },
+    clearRendererCwd: () => {
+      rendererCwd = undefined;
+    },
+  };
+};
+
 export const resolvePreferredTerminalCwd = async ({
   rendererCwd,
   sessionId,


### PR DESCRIPTION
## What changed

- Track the terminal's current directory for SFTP entry points.
- Prefer the renderer-known terminal directory before asking the backend for a fallback path.
- Add regression coverage for the path selection behavior.

## Why

The terminal already knew the current working directory, but SFTP was asking the backend for it again. On some hosts that backend answer could fall back to the home/root directory, so "locate terminal directory" opened the wrong place.

Fixes #1019

## Validation

- `npm run lint`
- `git diff --check`
- `npm test`