### PR TITLE
[codex] Prevent terminal host preference pollution

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,7 +30,7 @@ import { resolveHostAuth } from './domain/sshAuth';
 import { isEncryptedCredentialPlaceholder } from './domain/credentials';
 import {
   applyCustomAccentToTerminalTheme,
-  mergeTerminalHostAppearanceUpdate,
+  mergeTerminalHostUpdate,
   resolveHostTerminalThemeId,
 } from './domain/terminalAppearance';
 import { selectConnectionLogForTerminalDataCapture } from './domain/connectionLog';
@@ -1733,7 +1733,7 @@ function App({ settings }: { settings: SettingsState }) {
 
   const handleUpdateHostFromTerminal = useCallback((host: Host) => {
     updateHosts(hosts.map((h) => (
-      h.id === host.id ? mergeTerminalHostAppearanceUpdate(h, host) : h
+      h.id === host.id ? mergeTerminalHostUpdate(h, host) : h
     )));
   }, [hosts, updateHosts]);
 

--- a/App.tsx
+++ b/App.tsx
@@ -28,7 +28,11 @@ import { upsertKnownHost } from './domain/knownHosts';
 import { materializeHostProxyProfile } from './domain/proxyProfiles';
 import { resolveHostAuth } from './domain/sshAuth';
 import { isEncryptedCredentialPlaceholder } from './domain/credentials';
-import { applyCustomAccentToTerminalTheme, resolveHostTerminalThemeId } from './domain/terminalAppearance';
+import {
+  applyCustomAccentToTerminalTheme,
+  mergeTerminalHostAppearanceUpdate,
+  resolveHostTerminalThemeId,
+} from './domain/terminalAppearance';
 import { selectConnectionLogForTerminalDataCapture } from './domain/connectionLog';
 import { collectSessionIds } from './domain/workspace';
 import { resolveCloseIntent } from './application/state/resolveCloseIntent';
@@ -1728,7 +1732,9 @@ function App({ settings }: { settings: SettingsState }) {
   }, [updateSessionStatus, updateHostLastConnected]);
 
   const handleUpdateHostFromTerminal = useCallback((host: Host) => {
-    updateHosts(hosts.map((h) => (h.id === host.id ? host : h)));
+    updateHosts(hosts.map((h) => (
+      h.id === host.id ? mergeTerminalHostAppearanceUpdate(h, host) : h
+    )));
   }, [hosts, updateHosts]);
 
   // Wrapper to create serial session with logging

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -2242,14 +2242,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         onUpdateTerminalFontFamilyId?.(fontFamilyId);
         return;
       }
-      onUpdateHost({ ...focusedHost, fontFamily: fontFamilyId, fontFamilyOverride: true });
+      if (rawFocusedHost) {
+        onUpdateHost({ ...rawFocusedHost, fontFamily: fontFamilyId, fontFamilyOverride: true });
+      }
     });
-  }, [focusedHost, focusedFontFamilyId, isFocusedHostEphemeral, onUpdateTerminalFontFamilyId, onUpdateHost]);
+  }, [focusedHost, focusedFontFamilyId, isFocusedHostEphemeral, onUpdateTerminalFontFamilyId, onUpdateHost, rawFocusedHost]);
 
   const handleFontFamilyResetForFocusedSession = useCallback(() => {
-    if (!focusedHost || isFocusedHostEphemeral) return;
-    onUpdateHost(clearHostFontFamilyOverride(focusedHost));
-  }, [focusedHost, isFocusedHostEphemeral, onUpdateHost]);
+    if (!focusedHost || isFocusedHostEphemeral || !rawFocusedHost) return;
+    onUpdateHost(clearHostFontFamilyOverride(rawFocusedHost));
+  }, [focusedHost, isFocusedHostEphemeral, onUpdateHost, rawFocusedHost]);
 
   const handleFontSizeChangeForFocusedSession = useCallback((newFontSize: number) => {
     if (!focusedHost || newFontSize === focusedFontSize) return;
@@ -2258,14 +2260,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         onUpdateTerminalFontSize?.(newFontSize);
         return;
       }
-      onUpdateHost({ ...focusedHost, fontSize: newFontSize, fontSizeOverride: true });
+      if (rawFocusedHost) {
+        onUpdateHost({ ...rawFocusedHost, fontSize: newFontSize, fontSizeOverride: true });
+      }
     });
-  }, [focusedHost, focusedFontSize, isFocusedHostEphemeral, onUpdateTerminalFontSize, onUpdateHost]);
+  }, [focusedHost, focusedFontSize, isFocusedHostEphemeral, onUpdateTerminalFontSize, onUpdateHost, rawFocusedHost]);
 
   const handleFontSizeResetForFocusedSession = useCallback(() => {
-    if (!focusedHost || isFocusedHostEphemeral) return;
-    onUpdateHost(clearHostFontSizeOverride(focusedHost));
-  }, [focusedHost, isFocusedHostEphemeral, onUpdateHost]);
+    if (!focusedHost || isFocusedHostEphemeral || !rawFocusedHost) return;
+    onUpdateHost(clearHostFontSizeOverride(rawFocusedHost));
+  }, [focusedHost, isFocusedHostEphemeral, onUpdateHost, rawFocusedHost]);
 
   const handleFontWeightChangeForFocusedSession = useCallback((newFontWeight: number) => {
     if (!focusedHost || newFontWeight === focusedFontWeight) return;

--- a/domain/terminalAppearance.test.ts
+++ b/domain/terminalAppearance.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   applyCustomAccentToTerminalTheme,
-  mergeTerminalHostAppearanceUpdate,
+  mergeTerminalHostUpdate,
 } from "./terminalAppearance";
 import type { Host, TerminalTheme } from "./models";
 
@@ -65,7 +65,7 @@ const savedHost: Host = {
   telnetPort: 23,
 };
 
-test("terminal appearance updates preserve saved connection protocol and port", () => {
+test("terminal updates preserve saved connection protocol and port", () => {
   const telnetSessionHost: Host = {
     ...savedHost,
     protocol: "telnet",
@@ -75,7 +75,7 @@ test("terminal appearance updates preserve saved connection protocol and port", 
     fontFamilyOverride: true,
   };
 
-  const merged = mergeTerminalHostAppearanceUpdate(savedHost, telnetSessionHost);
+  const merged = mergeTerminalHostUpdate(savedHost, telnetSessionHost);
 
   assert.equal(merged.protocol, "ssh");
   assert.equal(merged.port, 22);
@@ -84,6 +84,46 @@ test("terminal appearance updates preserve saved connection protocol and port", 
   assert.equal(merged.telnetPort, 23);
   assert.equal(merged.fontFamily, "jetbrains-mono");
   assert.equal(merged.fontFamilyOverride, true);
+});
+
+test("terminal updates still persist credentials entered during connection", () => {
+  const credentialUpdate: Host = {
+    ...savedHost,
+    protocol: "telnet",
+    port: 23,
+    moshEnabled: false,
+    username: "deploy",
+    authMethod: "password",
+    password: "secret",
+  };
+
+  const merged = mergeTerminalHostUpdate(savedHost, credentialUpdate);
+
+  assert.equal(merged.protocol, "ssh");
+  assert.equal(merged.port, 22);
+  assert.equal(merged.moshEnabled, true);
+  assert.equal(merged.username, "deploy");
+  assert.equal(merged.authMethod, "password");
+  assert.equal(merged.password, "secret");
+});
+
+test("terminal updates still persist SFTP bookmarks", () => {
+  const bookmarkUpdate: Host = {
+    ...savedHost,
+    protocol: "telnet",
+    port: 23,
+    moshEnabled: false,
+    sftpBookmarks: [{ id: "bookmark-1", path: "/srv/www", label: "/srv/www" }],
+  };
+
+  const merged = mergeTerminalHostUpdate(savedHost, bookmarkUpdate);
+
+  assert.equal(merged.protocol, "ssh");
+  assert.equal(merged.port, 22);
+  assert.equal(merged.moshEnabled, true);
+  assert.deepEqual(merged.sftpBookmarks, [
+    { id: "bookmark-1", path: "/srv/www", label: "/srv/www" },
+  ]);
 });
 
 test("terminal appearance reset clears only appearance fields", () => {
@@ -101,7 +141,7 @@ test("terminal appearance reset clears only appearance fields", () => {
     fontSizeOverride: false,
   };
 
-  const merged = mergeTerminalHostAppearanceUpdate(hostWithAppearance, resetUpdate);
+  const merged = mergeTerminalHostUpdate(hostWithAppearance, resetUpdate);
 
   assert.equal(merged.protocol, "ssh");
   assert.equal(merged.port, 22);

--- a/domain/terminalAppearance.test.ts
+++ b/domain/terminalAppearance.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { applyCustomAccentToTerminalTheme } from "./terminalAppearance";
-import type { TerminalTheme } from "./models";
+import {
+  applyCustomAccentToTerminalTheme,
+  mergeTerminalHostAppearanceUpdate,
+} from "./terminalAppearance";
+import type { Host, TerminalTheme } from "./models";
 
 const baseTheme: TerminalTheme = {
   id: "ui-snow",
@@ -45,4 +48,64 @@ test("applies a custom accent to terminal cursor and selection colors", () => {
 test("keeps terminal theme unchanged without a valid custom accent", () => {
   assert.equal(applyCustomAccentToTerminalTheme(baseTheme, "theme", "160 70% 40%"), baseTheme);
   assert.equal(applyCustomAccentToTerminalTheme(baseTheme, "custom", "not-a-color"), baseTheme);
+});
+
+const savedHost: Host = {
+  id: "host-1",
+  label: "Core switch",
+  hostname: "10.0.0.2",
+  username: "admin",
+  port: 22,
+  os: "linux",
+  group: "",
+  tags: [],
+  protocol: "ssh",
+  moshEnabled: true,
+  telnetEnabled: true,
+  telnetPort: 23,
+};
+
+test("terminal appearance updates preserve saved connection protocol and port", () => {
+  const telnetSessionHost: Host = {
+    ...savedHost,
+    protocol: "telnet",
+    port: 23,
+    moshEnabled: false,
+    fontFamily: "jetbrains-mono",
+    fontFamilyOverride: true,
+  };
+
+  const merged = mergeTerminalHostAppearanceUpdate(savedHost, telnetSessionHost);
+
+  assert.equal(merged.protocol, "ssh");
+  assert.equal(merged.port, 22);
+  assert.equal(merged.moshEnabled, true);
+  assert.equal(merged.telnetEnabled, true);
+  assert.equal(merged.telnetPort, 23);
+  assert.equal(merged.fontFamily, "jetbrains-mono");
+  assert.equal(merged.fontFamilyOverride, true);
+});
+
+test("terminal appearance reset clears only appearance fields", () => {
+  const hostWithAppearance: Host = {
+    ...savedHost,
+    fontSize: 16,
+    fontSizeOverride: true,
+  };
+  const resetUpdate: Host = {
+    ...hostWithAppearance,
+    protocol: "telnet",
+    port: 23,
+    moshEnabled: false,
+    fontSize: undefined,
+    fontSizeOverride: false,
+  };
+
+  const merged = mergeTerminalHostAppearanceUpdate(hostWithAppearance, resetUpdate);
+
+  assert.equal(merged.protocol, "ssh");
+  assert.equal(merged.port, 22);
+  assert.equal(merged.moshEnabled, true);
+  assert.equal(merged.fontSize, undefined);
+  assert.equal(merged.fontSizeOverride, false);
 });

--- a/domain/terminalAppearance.ts
+++ b/domain/terminalAppearance.ts
@@ -1,18 +1,5 @@
 import { Host, TerminalTheme } from './models';
 
-const TERMINAL_HOST_APPEARANCE_UPDATE_KEYS = [
-  'theme',
-  'themeOverride',
-  'fontFamily',
-  'fontFamilyOverride',
-  'fontSize',
-  'fontSizeOverride',
-  'fontWeight',
-  'fontWeightOverride',
-  'keywordHighlightRules',
-  'keywordHighlightEnabled',
-] as const satisfies readonly (keyof Host)[];
-
 const hasLegacyStringValue = (value: string | undefined): boolean =>
   typeof value === 'string' && value.trim().length > 0;
 
@@ -51,19 +38,21 @@ export const clearHostFontSizeOverride = (host: Host): Host => ({
   fontSizeOverride: false,
 });
 
-export const mergeTerminalHostAppearanceUpdate = (
+export const mergeTerminalHostUpdate = (
   savedHost: Host,
   terminalHostUpdate: Host,
 ): Host => {
-  const nextHost: Host = { ...savedHost };
-  const mutableNextHost = nextHost as unknown as Record<string, unknown>;
-  const updateRecord = terminalHostUpdate as unknown as Record<string, unknown>;
+  const nextHost: Host = {
+    ...terminalHostUpdate,
+    id: savedHost.id,
+    protocol: savedHost.protocol,
+    port: savedHost.port,
+    moshEnabled: savedHost.moshEnabled,
+  };
 
-  for (const key of TERMINAL_HOST_APPEARANCE_UPDATE_KEYS) {
-    if (Object.prototype.hasOwnProperty.call(updateRecord, key)) {
-      mutableNextHost[key] = updateRecord[key];
-    }
-  }
+  if (!Object.prototype.hasOwnProperty.call(savedHost, 'protocol')) delete nextHost.protocol;
+  if (!Object.prototype.hasOwnProperty.call(savedHost, 'port')) delete nextHost.port;
+  if (!Object.prototype.hasOwnProperty.call(savedHost, 'moshEnabled')) delete nextHost.moshEnabled;
 
   return nextHost;
 };

--- a/domain/terminalAppearance.ts
+++ b/domain/terminalAppearance.ts
@@ -1,5 +1,18 @@
 import { Host, TerminalTheme } from './models';
 
+const TERMINAL_HOST_APPEARANCE_UPDATE_KEYS = [
+  'theme',
+  'themeOverride',
+  'fontFamily',
+  'fontFamilyOverride',
+  'fontSize',
+  'fontSizeOverride',
+  'fontWeight',
+  'fontWeightOverride',
+  'keywordHighlightRules',
+  'keywordHighlightEnabled',
+] as const satisfies readonly (keyof Host)[];
+
 const hasLegacyStringValue = (value: string | undefined): boolean =>
   typeof value === 'string' && value.trim().length > 0;
 
@@ -37,6 +50,23 @@ export const clearHostFontSizeOverride = (host: Host): Host => ({
   fontSize: undefined,
   fontSizeOverride: false,
 });
+
+export const mergeTerminalHostAppearanceUpdate = (
+  savedHost: Host,
+  terminalHostUpdate: Host,
+): Host => {
+  const nextHost: Host = { ...savedHost };
+  const mutableNextHost = nextHost as unknown as Record<string, unknown>;
+  const updateRecord = terminalHostUpdate as unknown as Record<string, unknown>;
+
+  for (const key of TERMINAL_HOST_APPEARANCE_UPDATE_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(updateRecord, key)) {
+      mutableNextHost[key] = updateRecord[key];
+    }
+  }
+
+  return nextHost;
+};
 
 export const resolveHostTerminalThemeId = (host: Host | null | undefined, defaultThemeId: string): string =>
   hasHostThemeOverride(host) && host?.theme ? host.theme : defaultThemeId;


### PR DESCRIPTION
## What changed
- Prevent terminal-side host preference updates from replacing saved connection settings.
- Use the saved host as the source for terminal font family and font size updates.
- Add regression coverage for Telnet session values not overwriting saved SSH port/protocol.

## Why
Selecting Telnet for a multi-protocol host creates a session-time host with protocol/port set for Telnet. Terminal preference changes could save that session-time host back into the vault, turning the saved SSH host into a Telnet/port-23 host.

Fixes #1012

## Validation
- `node --test --import tsx domain/terminalAppearance.test.ts`
- `npm run lint`
- `git diff --check`
- `npm test`
