### PR TITLE
[codex] Fix broadcast hotkey refresh

### DIFF
--- a/components/TerminalLayer.memo.test.tsx
+++ b/components/TerminalLayer.memo.test.tsx
@@ -35,6 +35,8 @@ const baseProps = {
   onAddKnownHost: () => {},
   onToggleWorkspaceViewMode: () => {},
   onSetWorkspaceFocusedSession: () => {},
+  isBroadcastEnabled: () => false,
+  onToggleBroadcast: () => {},
   onSplitSession: () => {},
   toggleScriptsSidePanelRef: { current: null },
 };
@@ -92,6 +94,26 @@ test("TerminalLayer re-renders when proxy profiles change", () => {
           createdAt: 1,
         }],
       } as never,
+    ),
+    false,
+  );
+});
+
+test("TerminalLayer re-renders when broadcast state changes", () => {
+  assert.equal(
+    terminalLayerAreEqual(
+      baseProps as never,
+      { ...baseProps, isBroadcastEnabled: () => true } as never,
+    ),
+    false,
+  );
+});
+
+test("TerminalLayer re-renders when broadcast toggle handler changes", () => {
+  assert.equal(
+    terminalLayerAreEqual(
+      baseProps as never,
+      { ...baseProps, onToggleBroadcast: () => {} } as never,
     ),
     false,
   );

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -34,6 +34,8 @@ export const terminalLayerAreEqual = (
   prev.onSetWorkspaceFocusedSession === next.onSetWorkspaceFocusedSession &&
   prev.onReorderWorkspaceSessions === next.onReorderWorkspaceSessions &&
   prev.onSplitSession === next.onSplitSession &&
+  prev.isBroadcastEnabled === next.isBroadcastEnabled &&
+  prev.onToggleBroadcast === next.onToggleBroadcast &&
   prev.toggleScriptsSidePanelRef === next.toggleScriptsSidePanelRef &&
   prev.identities === next.identities
 );


### PR DESCRIPTION
## What changed
- Re-render the terminal layer when broadcast state or its toggle handler changes.
- Add regression coverage so broadcast-related memo props cannot be skipped again.

## Why
Issue #1016 reports that the broadcast mode shortcut stopped working reliably in 1.1.7 while the toolbar button still worked. The shortcut did toggle state, but the terminal layer could skip the refresh that propagates the new broadcast state to terminals.

Fixes #1016.

## Validation
- `node --test --import tsx components/TerminalLayer.memo.test.tsx`
- `npm test -- components/TerminalLayer.memo.test.tsx`
- `npm run lint`
- `npm run build`