### PR TITLE
[codex] Add legacy group-exchange SHA-1 SSH support

### DIFF
--- a/electron/bridges/sshAlgorithms.cjs
+++ b/electron/bridges/sshAlgorithms.cjs
@@ -61,6 +61,7 @@ function buildBaseAlgorithms() {
 
 function applyLegacyAlgorithms(algorithms) {
   algorithms.kex.push(...filterSupportedFixedDhKex([
+    "diffie-hellman-group-exchange-sha1",
     "diffie-hellman-group14-sha1",
     "diffie-hellman-group1-sha1",
   ]));

--- a/electron/bridges/sshAlgorithms.test.cjs
+++ b/electron/bridges/sshAlgorithms.test.cjs
@@ -81,6 +81,7 @@ for (const [label, buildAlgorithms] of [
         new Set(["modp16", "modp18"]),
       );
       assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group-exchange-sha256"));
+      assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group-exchange-sha1"));
       assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group14-sha1"));
       assert.ok(legacyAlgorithms.kex.includes("diffie-hellman-group1-sha1"));
     });


### PR DESCRIPTION
## Summary
- Include diffie-hellman-group-exchange-sha1 when legacy SSH algorithms are enabled.
- Add regression coverage for SSH and SFTP legacy algorithm lists.

Fixes #1027

## Test Plan
- node --test --import tsx electron/bridges/sshAlgorithms.test.cjs
- npm test
- npm run lint