### PR TITLE
Fix #1035: support diffie-hellman-group1-sha1 under BoringSSL

### DIFF
--- a/electron/bridges/boringSslDhCompat.cjs
+++ b/electron/bridges/boringSslDhCompat.cjs
@@ -1,0 +1,83 @@
+/**
+ * BoringSSL Diffie-Hellman group compatibility shim.
+ *
+ * Electron ships with BoringSSL, which no longer exposes some standard MODP
+ * groups through the *named* `crypto.createDiffieHellmanGroup()` API — notably
+ * the 1024-bit Oakley Group 2 ("modp2") that backs the SSH
+ * `diffie-hellman-group1-sha1` key exchange. ssh2 calls
+ * `createDiffieHellmanGroup('modp2')` for that kex, so on Electron it throws
+ * "Unknown DH group" and legacy network devices that only speak group1-sha1
+ * cannot be reached (issue #1035).
+ *
+ * The underlying DH math still works on BoringSSL via `createDiffieHellman()`
+ * with an explicit prime, so this shim wraps `createDiffieHellmanGroup` to fall
+ * back to the well-known prime constants when (and only when) the runtime can't
+ * resolve a group by name. On OpenSSL builds the original call succeeds and the
+ * fallback is never used, so behavior is unchanged there.
+ *
+ * IMPORTANT: ssh2 destructures `createDiffieHellmanGroup` at module load, so this
+ * must be installed BEFORE ssh2 (or any bridge that requires it) is loaded.
+ */
+const crypto = require("node:crypto");
+
+// Standard MODP groups (RFC 2409 / RFC 3526), generator 2. These primes are
+// public constants and are byte-identical to Node's built-in groups, so the
+// fallback produces the exact same key exchange the named group would have.
+// Only groups that a runtime might drop yet ssh2 still requests need to live
+// here; modp14/16/18 remain available on BoringSSL so they are intentionally
+// omitted.
+const MODP_GROUP_PRIMES = {
+  // Oakley Group 2 — RFC 2409, 1024-bit. ssh2: diffie-hellman-group1-sha1.
+  modp2:
+    "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
+    "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
+    "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
+    "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED" +
+    "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381" +
+    "FFFFFFFFFFFFFFFF",
+};
+const MODP_GENERATOR = Buffer.from([0x02]);
+
+function createGroupFromPrime(name) {
+  const primeHex = MODP_GROUP_PRIMES[name];
+  if (!primeHex) return null;
+  return crypto.createDiffieHellman(Buffer.from(primeHex, "hex"), MODP_GENERATOR);
+}
+
+/**
+ * Wrap `target.createDiffieHellmanGroup` so missing named groups fall back to an
+ * explicit-prime DiffieHellman. Idempotent. Returns true if it installed the
+ * shim, false if it was already installed (or there was nothing to wrap).
+ * @param {{ createDiffieHellmanGroup?: Function }} [target] defaults to the crypto module
+ */
+function installBoringSslDhCompat(target = crypto) {
+  const original = target.createDiffieHellmanGroup;
+  if (typeof original !== "function" || original.__boringSslDhCompat) {
+    return false;
+  }
+
+  const wrapped = function createDiffieHellmanGroup(name) {
+    try {
+      return original(name);
+    } catch (err) {
+      const fallback = createGroupFromPrime(name);
+      if (!fallback) throw err;
+      return fallback;
+    }
+  };
+  wrapped.__boringSslDhCompat = true;
+
+  try {
+    target.createDiffieHellmanGroup = wrapped;
+  } catch {
+    // The property may be read-only on some runtimes; force it via defineProperty.
+    Object.defineProperty(target, "createDiffieHellmanGroup", {
+      value: wrapped,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return true;
+}
+
+module.exports = { installBoringSslDhCompat, createGroupFromPrime, MODP_GROUP_PRIMES };

--- a/electron/bridges/boringSslDhCompat.test.cjs
+++ b/electron/bridges/boringSslDhCompat.test.cjs
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+
+const {
+  installBoringSslDhCompat,
+  MODP_GROUP_PRIMES,
+} = require("./boringSslDhCompat.cjs");
+
+test("falls back to an explicit-prime DH when the runtime lacks a named group", () => {
+  // Simulate BoringSSL: the named lookup throws "Unknown DH group".
+  const target = {
+    createDiffieHellmanGroup(name) {
+      throw new Error(`Unknown DH group: ${name}`);
+    },
+  };
+  assert.equal(installBoringSslDhCompat(target), true);
+
+  const dh = target.createDiffieHellmanGroup("modp2");
+  // The fallback group uses the exact RFC 2409 group1 prime.
+  assert.equal(dh.getPrime("hex").toUpperCase(), MODP_GROUP_PRIMES.modp2);
+
+  // And it performs a real, correct DH exchange.
+  const peer = crypto.createDiffieHellman(
+    Buffer.from(MODP_GROUP_PRIMES.modp2, "hex"),
+    Buffer.from([2]),
+  );
+  const ourPublic = dh.generateKeys();
+  const peerPublic = peer.generateKeys();
+  assert.ok(dh.computeSecret(peerPublic).equals(peer.computeSecret(ourPublic)));
+});
+
+test("uses the runtime's group when the name resolves (no fallback)", () => {
+  let calls = 0;
+  const sentinel = Symbol("native-group");
+  const target = {
+    createDiffieHellmanGroup() {
+      calls += 1;
+      return sentinel;
+    },
+  };
+  installBoringSslDhCompat(target);
+
+  assert.equal(target.createDiffieHellmanGroup("modp2"), sentinel);
+  assert.equal(calls, 1);
+});
+
+test("rethrows the original error for groups it cannot back", () => {
+  const target = {
+    createDiffieHellmanGroup() {
+      throw new Error("Unknown DH group");
+    },
+  };
+  installBoringSslDhCompat(target);
+
+  assert.throws(() => target.createDiffieHellmanGroup("modp-nonexistent"), /Unknown DH group/);
+});
+
+test("install is idempotent", () => {
+  const target = {
+    createDiffieHellmanGroup() {
+      return null;
+    },
+  };
+  assert.equal(installBoringSslDhCompat(target), true);
+  assert.equal(installBoringSslDhCompat(target), false);
+});
+
+test("on this (OpenSSL) runtime the real modp2 still works through the shim", () => {
+  // Sanity check against the actual crypto module: installing must not break the
+  // normal path where the runtime resolves the group by name.
+  const localCrypto = require("node:crypto");
+  installBoringSslDhCompat(localCrypto);
+  const dh = localCrypto.createDiffieHellmanGroup("modp2");
+  assert.equal(dh.getPrime("hex").toUpperCase(), MODP_GROUP_PRIMES.modp2);
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -93,6 +93,12 @@ function createLazyModule(modulePath) {
   };
 }
 
+// Restore standard DH groups that Electron's BoringSSL dropped from the named
+// createDiffieHellmanGroup() API (e.g. modp2 / diffie-hellman-group1-sha1), so
+// legacy network devices stay reachable (#1035). MUST run before any module that
+// requires ssh2 — ssh2 destructures createDiffieHellmanGroup at load time.
+require("./bridges/boringSslDhCompat.cjs").installBoringSslDhCompat();
+
 // Import bridge modules
 const sshBridge = require("./bridges/sshBridge.cjs");
 const sftpBridge = require("./bridges/sftpBridge.cjs");


### PR DESCRIPTION
## Summary
Connecting to legacy network devices that require `diffie-hellman-group1-sha1` failed with `Error: Unknown DH group`. Root cause: Electron ships **BoringSSL**, which dropped the 1024-bit Oakley Group 2 (`modp2`) from the *named* `crypto.createDiffieHellmanGroup()` API. ssh2 calls `createDiffieHellmanGroup('modp2')` for that kex, so it threw before the handshake.

The underlying DH math still works on BoringSSL via `createDiffieHellman()` with an explicit prime (verified: 1024-bit group1 key exchange completes and shared secrets match). This PR adds a small compatibility shim:

- `electron/bridges/boringSslDhCompat.cjs` wraps `createDiffieHellmanGroup` and falls back to the well-known RFC 2409 prime (byte-identical to Node's built-in) **only** when the runtime can't resolve a group by name. On OpenSSL the original succeeds and the fallback is never used.
- Installed in `main.cjs` **before** any ssh2-using bridge loads (ssh2 destructures `createDiffieHellmanGroup` at module load, so ordering matters).
- Composes with the existing legacy-group probe: once `modp2` resolves again, `group1-sha1` is re-offered, so affected devices actually connect. Still gated behind the per-host legacy-algorithms toggle (group1-sha1 is weak by modern standards).

`ssh-rsa` and `aes128-cbc` from the same issue are already handled by the legacy-algorithm path and work on BoringSSL — only the DH group was missing.

Fixes #1035.

## Test plan
- [x] `npm run lint`
- [x] New unit tests `electron/bridges/boringSslDhCompat.test.cjs` (fallback correctness, native passthrough, rethrow for unbacked groups, idempotent install) — pass
- [x] Verified under Electron's BoringSSL runtime (`ELECTRON_RUN_AS_NODE=1`): `modp2` goes from "Unknown DH group" → working 1024-bit DH, including via ssh2's destructure-at-load pattern; `modp14` untouched; unknown groups still throw
- [x] Full SSH test suite (18 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)