### PR TITLE
Fix #1040: unique macOS Mach-O LC_UUID for Local Network privacy

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -7,6 +7,11 @@ module.exports = {
     appId: 'com.netcatty.app',
     productName: 'Netcatty',
     artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
+    // Give the macOS build a unique Mach-O LC_UUID before signing, so macOS
+    // Local Network privacy treats Netcatty distinctly from every other
+    // Electron app (which all share Electron's prebuilt LC_UUID) — see #1040
+    // and scripts/afterPackMacUuid.cjs. No-op on Windows/Linux.
+    afterPack: './scripts/afterPackMacUuid.cjs',
     // Platform-split icons (#813):
     //   - public/icon.png keeps Apple's HIG grid margin so the rendered
     //     squircle sits at ~88% of the PNG canvas. macOS needs this —

--- a/scripts/afterPackMacUuid.cjs
+++ b/scripts/afterPackMacUuid.cjs
@@ -1,0 +1,147 @@
+/**
+ * electron-builder afterPack hook — give the macOS app a unique Mach-O LC_UUID.
+ *
+ * macOS keys the "Local Network" privacy permission on the main executable's
+ * Mach-O LC_UUID (see Apple TN3179). Electron's prebuilt binary is linked with
+ * LLD, which derives the UUID from a content hash, so EVERY app built from the
+ * same Electron version ships the *same* LC_UUID — even with a different bundle
+ * id. That collision makes the Local Network grant unreliable: macOS may apply
+ * another Electron app's decision to ours, so a user who toggles the permission
+ * on still gets `EHOSTUNREACH` when connecting to LAN/VMware host-only addresses
+ * (issue #1040).
+ *
+ * This hook rewrites the LC_UUID of the packaged main executable to a value
+ * derived deterministically from the appId — stable across builds (so users
+ * don't have to re-grant on every update) but distinct from every other app.
+ * It runs in `afterPack`, i.e. BEFORE electron-builder code-signs, so the
+ * signature/notarization covers the patched binary.
+ */
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const LC_UUID = 0x1b;
+const MH_MAGIC_64 = 0xfeedfacf; // thin 64-bit, little-endian on disk
+const MH_CIGAM_64 = 0xcffaedfe; // thin 64-bit, byte-swapped
+const FAT_MAGIC = 0xcafebabe; // fat, big-endian
+const FAT_MAGIC_64 = 0xcafebabf;
+const MACH_HEADER_64_SIZE = 32;
+
+/**
+ * Deterministic, app-specific 16-byte UUID. Stable across builds (so the
+ * Local Network grant survives updates) yet unique per appId.
+ * @param {string} appId
+ * @returns {Buffer}
+ */
+function deriveUuid(appId) {
+  const hash = crypto.createHash("sha1").update(`netcatty-local-network|${appId}`).digest();
+  const uuid = Buffer.from(hash.subarray(0, 16));
+  uuid[6] = (uuid[6] & 0x0f) | 0x50; // version 5
+  uuid[8] = (uuid[8] & 0x3f) | 0x80; // RFC 4122 variant
+  return uuid;
+}
+
+function formatUuid(buf) {
+  const h = buf.toString("hex").toUpperCase();
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+/**
+ * Patch every LC_UUID load command inside a single thin Mach-O slice.
+ * @returns {string[]} the old UUIDs that were replaced (hex)
+ */
+function patchThinSlice(buf, sliceOffset, uuid) {
+  const magic = buf.readUInt32LE(sliceOffset);
+  if (magic !== MH_MAGIC_64 && magic !== MH_CIGAM_64) return [];
+  const swapped = magic === MH_CIGAM_64;
+  const readU32 = (o) => (swapped ? buf.readUInt32BE(o) : buf.readUInt32LE(o));
+
+  const ncmds = readU32(sliceOffset + 16);
+  let off = sliceOffset + MACH_HEADER_64_SIZE;
+  const replaced = [];
+  for (let i = 0; i < ncmds; i += 1) {
+    const cmd = readU32(off);
+    const cmdsize = readU32(off + 4);
+    if (cmdsize <= 0) break;
+    if (cmd === LC_UUID) {
+      replaced.push(buf.subarray(off + 8, off + 24).toString("hex"));
+      uuid.copy(buf, off + 8); // uuid[16] follows cmd(4) + cmdsize(4)
+    }
+    off += cmdsize;
+  }
+  return replaced;
+}
+
+/**
+ * Rewrite all LC_UUID load commands in a Mach-O buffer (thin or fat) in place.
+ * @returns {{ patched: number, oldUuids: string[] }}
+ */
+function patchMachOBuffer(buf, uuid) {
+  const magicBE = buf.readUInt32BE(0);
+  const oldUuids = [];
+
+  if (magicBE === FAT_MAGIC || magicBE === FAT_MAGIC_64) {
+    const is64 = magicBE === FAT_MAGIC_64;
+    const archSize = is64 ? 32 : 20;
+    const nfat = buf.readUInt32BE(4);
+    for (let i = 0; i < nfat; i += 1) {
+      const archOff = 8 + i * archSize;
+      const sliceOffset = is64
+        ? Number(buf.readBigUInt64BE(archOff + 8))
+        : buf.readUInt32BE(archOff + 8);
+      oldUuids.push(...patchThinSlice(buf, sliceOffset, uuid));
+    }
+  } else {
+    oldUuids.push(...patchThinSlice(buf, 0, uuid));
+  }
+
+  return { patched: oldUuids.length, oldUuids };
+}
+
+function patchMachOFile(file, uuid) {
+  const buf = fs.readFileSync(file);
+  const result = patchMachOBuffer(buf, uuid);
+  if (result.patched > 0) fs.writeFileSync(file, buf);
+  return result;
+}
+
+/** @param {import('electron-builder').AfterPackContext} context */
+async function afterPack(context) {
+  if (context.electronPlatformName !== "darwin") return;
+
+  const appId = context.packager.appInfo.id || "com.netcatty.app";
+  const productFilename = context.packager.appInfo.productFilename;
+  const exePath = path.join(
+    context.appOutDir,
+    `${productFilename}.app`,
+    "Contents",
+    "MacOS",
+    productFilename,
+  );
+
+  if (!fs.existsSync(exePath)) {
+    throw new Error(`[afterPack] macOS executable not found: ${exePath}`);
+  }
+
+  const uuid = deriveUuid(appId);
+  const { patched, oldUuids } = patchMachOFile(exePath, uuid);
+
+  if (patched === 0) {
+    throw new Error(
+      `[afterPack] No LC_UUID load command found in ${exePath} — Local Network UUID fix did not apply`,
+    );
+  }
+
+  console.log(
+    `[afterPack] Mach-O LC_UUID rewritten for Local Network privacy (#1040): ` +
+      `${oldUuids.map((h) => formatUuid(Buffer.from(h, "hex"))).join(", ")} -> ${formatUuid(uuid)} ` +
+      `(${patched} slice(s), appId=${appId})`,
+  );
+}
+
+module.exports = afterPack;
+module.exports.default = afterPack;
+module.exports.deriveUuid = deriveUuid;
+module.exports.formatUuid = formatUuid;
+module.exports.patchMachOBuffer = patchMachOBuffer;
+module.exports.patchMachOFile = patchMachOFile;

--- a/scripts/afterPackMacUuid.test.cjs
+++ b/scripts/afterPackMacUuid.test.cjs
@@ -1,0 +1,117 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  deriveUuid,
+  patchMachOBuffer,
+} = require("./afterPackMacUuid.cjs");
+
+const LC_UUID = 0x1b;
+const LC_OTHER = 0x19;
+const MH_MAGIC_64 = 0xfeedfacf;
+
+// Build a minimal thin little-endian 64-bit Mach-O with two load commands:
+// one dummy command and one LC_UUID carrying `uuidBytes`.
+function buildThinMachO(uuidBytes) {
+  const header = Buffer.alloc(32);
+  header.writeUInt32LE(MH_MAGIC_64, 0); // magic
+  header.writeUInt32LE(0x0100000c, 4); // cputype arm64 (value irrelevant)
+  header.writeUInt32LE(0, 8); // cpusubtype
+  header.writeUInt32LE(2, 12); // filetype
+  header.writeUInt32LE(2, 16); // ncmds
+  header.writeUInt32LE(16 + 24, 20); // sizeofcmds
+  header.writeUInt32LE(0, 24); // flags
+  header.writeUInt32LE(0, 28); // reserved
+
+  const dummy = Buffer.alloc(16);
+  dummy.writeUInt32LE(LC_OTHER, 0); // cmd
+  dummy.writeUInt32LE(16, 4); // cmdsize
+  dummy.fill(0xab, 8); // payload sentinel
+
+  const uuidCmd = Buffer.alloc(24);
+  uuidCmd.writeUInt32LE(LC_UUID, 0); // cmd
+  uuidCmd.writeUInt32LE(24, 4); // cmdsize
+  uuidBytes.copy(uuidCmd, 8);
+
+  return Buffer.concat([header, dummy, uuidCmd]);
+}
+
+// Wrap one or more thin slices in a big-endian 32-bit fat binary.
+function buildFatMachO(slices) {
+  const headerSize = 8 + slices.length * 20;
+  const header = Buffer.alloc(headerSize);
+  header.writeUInt32BE(0xcafebabe, 0); // FAT_MAGIC
+  header.writeUInt32BE(slices.length, 4);
+
+  let offset = headerSize;
+  const offsets = [];
+  for (let i = 0; i < slices.length; i += 1) {
+    const archOff = 8 + i * 20;
+    header.writeUInt32BE(0x0100000c, archOff); // cputype
+    header.writeUInt32BE(0, archOff + 4); // cpusubtype
+    header.writeUInt32BE(offset, archOff + 8); // offset
+    header.writeUInt32BE(slices[i].length, archOff + 12); // size
+    header.writeUInt32BE(0, archOff + 16); // align
+    offsets.push(offset);
+    offset += slices[i].length;
+  }
+
+  return Buffer.concat([header, ...slices]);
+}
+
+test("deriveUuid is deterministic and 16 bytes", () => {
+  const a = deriveUuid("com.netcatty.app");
+  const b = deriveUuid("com.netcatty.app");
+  assert.equal(a.length, 16);
+  assert.ok(a.equals(b));
+});
+
+test("deriveUuid differs per appId and sets version/variant bits", () => {
+  const a = deriveUuid("com.netcatty.app");
+  const b = deriveUuid("com.example.other");
+  assert.ok(!a.equals(b));
+  assert.equal(a[6] & 0xf0, 0x50); // version 5
+  assert.equal(a[8] & 0xc0, 0x80); // RFC 4122 variant
+});
+
+test("patchMachOBuffer rewrites LC_UUID in a thin Mach-O and leaves the rest intact", () => {
+  const original = Buffer.alloc(16, 0x11);
+  const buf = buildThinMachO(original);
+  const uuid = deriveUuid("com.netcatty.app");
+
+  const { patched, oldUuids } = patchMachOBuffer(buf, uuid);
+
+  assert.equal(patched, 1);
+  assert.equal(oldUuids[0], original.toString("hex"));
+  // LC_UUID payload is now our derived uuid (uuid command starts at byte 48).
+  assert.ok(buf.subarray(48 + 8, 48 + 24).equals(uuid));
+  // Header magic + the dummy command's payload are untouched.
+  assert.equal(buf.readUInt32LE(0), MH_MAGIC_64);
+  assert.equal(buf.readUInt32LE(32), LC_OTHER);
+  assert.ok(buf.subarray(32 + 8, 32 + 16).equals(Buffer.alloc(8, 0xab)));
+});
+
+test("patchMachOBuffer patches every slice of a fat binary", () => {
+  const slice1 = buildThinMachO(Buffer.alloc(16, 0x22));
+  const slice2 = buildThinMachO(Buffer.alloc(16, 0x33));
+  const fat = buildFatMachO([slice1, slice2]);
+  const uuid = deriveUuid("com.netcatty.app");
+
+  const { patched } = patchMachOBuffer(fat, uuid);
+
+  assert.equal(patched, 2);
+});
+
+test("patchMachOBuffer reports zero when there is no LC_UUID", () => {
+  // A thin Mach-O whose single command is not LC_UUID.
+  const header = Buffer.alloc(32);
+  header.writeUInt32LE(MH_MAGIC_64, 0);
+  header.writeUInt32LE(1, 16); // ncmds
+  const cmd = Buffer.alloc(16);
+  cmd.writeUInt32LE(LC_OTHER, 0);
+  cmd.writeUInt32LE(16, 4);
+  const buf = Buffer.concat([header, cmd]);
+
+  const { patched } = patchMachOBuffer(buf, deriveUuid("com.netcatty.app"));
+  assert.equal(patched, 0);
+});


### PR DESCRIPTION
## Summary
On macOS, the **Local Network** privacy permission is keyed on the main executable's Mach-O `LC_UUID` (Apple [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)). Electron's prebuilt binary is linked with LLD, which derives the UUID from a content hash, so **every app built from the same Electron version ships the same `LC_UUID`** — even with a different bundle id (confirmed locally: our Electron binary is `4C4C44AE-5555-3144-A1C7-458EAD24ED10`). This collision makes the grant unreliable: a user who enables Local Network for Netcatty can still get `connect EHOSTUNREACH` to LAN / VMware host-only addresses, while loopback-forwarded connections work (#1040). Related upstream report: electron-builder [#9158](https://github.com/electron-userland/electron-builder/issues/9158).

Fix: add an electron-builder `afterPack` hook (`scripts/afterPackMacUuid.cjs`) that rewrites the packaged macOS executable's `LC_UUID` to a value derived deterministically from the appId — **stable across builds** (so the grant survives updates, unlike today where it changes on every Electron bump) but **distinct from every other app**. It runs in `afterPack`, i.e. before electron-builder code-signs, so signature/notarization cover the patched binary. No-op on Windows/Linux.

## Verification
- Ran the patcher on a copy of Electron's real binary: `LC_UUID` changes to the derived value, file stays a valid Mach-O, and the value is deterministic across runs.
- Unit tests for the Mach-O patcher (thin + fat slices, no-LC_UUID case) and the UUID derivation (deterministic, per-appId, version/variant bits).
- `npm run lint` clean.

## Notes / caveats
- Existing macOS users will need to re-grant Local Network once on the first build that includes this (their old grant was attached to the colliding UUID); after that it's stable across updates.
- `LC_UUID` change means crash reports won't symbolicate against Electron's official dSYMs — acceptable for this app.
- The end-to-end effect (does it unblock direct LAN connect on macOS 26) needs confirmation on a signed build by the reporter; the macOS CI build job validates that packaging + signing still succeed with the hook.

## Test plan
- [x] `npm run lint`
- [x] `node --test scripts/afterPackMacUuid.test.cjs` (5/5)
- [x] Real-binary smoke test (copy of Electron binary)
- [ ] macOS CI build (`build-macos`) succeeds with the afterPack hook
- [ ] Reporter confirms direct LAN connect works on a signed build

Fixes #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)