### PR TITLE
Fix #1013: stop ghost text from drawing over untracked echoed input

### DIFF
--- a/components/terminal/GhostTextAddon.test.ts
+++ b/components/terminal/GhostTextAddon.test.ts
@@ -450,3 +450,32 @@ test("applyKeystroke: ignores non-typing data (escape sequences, control codes)"
     restoreDocument();
   }
 });
+
+test("hides the ghost on render when the device echoed untracked input (#1013)", () => {
+  const restoreDocument = installFakeDocument();
+  const { term, ghostElement, fireRender } = createFakeTerm();
+  const addon = new GhostTextAddon();
+
+  try {
+    addon.activate(term as never);
+    // We believe only "network in" is typed; suggestion is the full command.
+    addon.show("network interface show", "network in");
+    assert.equal(addon.isActive(), true);
+
+    // The real line shows MORE than we tracked: a bastion host echoed the
+    // next char ("t") that our client-side buffer never recorded.
+    const line = "ecOS# network int";
+    const active = term.buffer.active as Record<string, unknown>;
+    active.baseY = 0;
+    active.cursorX = line.length;
+    active.getLine = () => ({ translateToString: () => line });
+
+    fireRender();
+
+    assert.equal(addon.isActive(), false);
+    assert.equal(ghostElement()?.style.display, "none");
+  } finally {
+    addon.dispose();
+    restoreDocument();
+  }
+});

--- a/components/terminal/autocomplete/GhostTextAddon.ts
+++ b/components/terminal/autocomplete/GhostTextAddon.ts
@@ -9,6 +9,7 @@
 
 import type { Terminal as XTerm, IDisposable } from "@xterm/xterm";
 import { getXTermCellDimensions, invalidateCellDimensionCache } from "./xtermUtils";
+import { lineHasUntrackedTrailingInput } from "./ghostTextConsistency";
 
 /**
  * Minimal East-Asian-Width-style classifier: returns 2 for wide glyphs
@@ -112,9 +113,16 @@ export class GhostTextAddon implements IDisposable {
 
     this.disposables.push(
       term.onRender(() => {
-        if (this.isVisible()) {
-          this.updatePosition();
+        if (!this.isVisible()) return;
+        // Fail-safe: if the device echoed input we didn't track (some bastion
+        // hosts / network OS, #1013), hide rather than draw the ghost over
+        // already-typed text. Done here (post-echo render) rather than in
+        // show()/adjustToInput so it never fights the keystroke-time path.
+        if (this.realLineHasUntrackedInput()) {
+          this.hide();
+          return;
         }
+        this.updatePosition();
       }),
     );
 
@@ -289,6 +297,23 @@ export class GhostTextAddon implements IDisposable {
 
     // Include leading whitespace + the word up to (and including) the separator
     return ghost.substring(0, leadingSpace + 1 + wordEnd + 1);
+  }
+
+  /**
+   * True when the real terminal line has more input than we tracked, so
+   * rendering the ghost would paint over already-typed characters. See
+   * ./ghostTextConsistency and issue #1013. Returns false on hosts/inputs
+   * we can't judge (non-ASCII, echo still catching up), so the ghost only
+   * gets suppressed when corruption is actually imminent.
+   */
+  private realLineHasUntrackedInput(): boolean {
+    if (!this.term || !this.currentInput) return false;
+    const buf = this.term.buffer.active;
+    if (typeof buf?.getLine !== "function") return false;
+    const line = buf.getLine(buf.baseY + buf.cursorY);
+    if (!line || typeof line.translateToString !== "function") return false;
+    const beforeCursor = line.translateToString(false).slice(0, buf.cursorX);
+    return lineHasUntrackedTrailingInput(this.currentInput, beforeCursor);
   }
 
   private updatePosition(): void {

--- a/components/terminal/autocomplete/ghostTextConsistency.ts
+++ b/components/terminal/autocomplete/ghostTextConsistency.ts
@@ -1,0 +1,42 @@
+/**
+ * Fail-safe consistency check for inline (ghost-text) suggestions.
+ *
+ * Ghost text renders `suggestion.substring(trackedInput.length)` after the
+ * cursor, where `trackedInput` is what the client thinks the user has typed.
+ * On hosts with non-standard echo (hardware bastion hosts / network OS such as
+ * `ecOS#`, issue #1013, previously #756 / #906) that tracked value drifts out
+ * of sync with what is actually on the terminal line, and the ghost ends up
+ * painted over characters the user already typed (`int` + ghost `terface` →
+ * `intterface`).
+ *
+ * This detects the one direction that produces visible corruption: the real
+ * line being AHEAD of the tracked input (it contains the tracked input
+ * followed by more, untracked characters). SSH echo latency is the opposite
+ * case — the line is a prefix-behind of the tracked input — and is
+ * intentionally NOT flagged, so the ghost stays responsive on slow links.
+ *
+ * Returns true when the caller should hide the ghost.
+ */
+export function lineHasUntrackedTrailingInput(
+  trackedInput: string,
+  lineBeforeCursor: string,
+): boolean {
+  // Single chars match too loosely to judge reliably; let them through.
+  if (trackedInput.length < 2) return false;
+  // Column↔string mapping is only unambiguous for narrow (ASCII) input, so the
+  // existing wide-char (CJK / emoji) handling is left untouched.
+  if (!/^[\x20-\x7e]+$/.test(trackedInput)) return false;
+
+  // Use the last occurrence so a prompt or command that repeats the same token
+  // earlier on the line doesn't shadow the freshly-typed input.
+  const idx = lineBeforeCursor.lastIndexOf(trackedInput);
+  if (idx < 0) {
+    // Tracked input isn't on screen yet — the echo is still catching up
+    // (latency). Keep the ghost; reality being behind never corrupts.
+    return false;
+  }
+
+  // Non-whitespace characters between the tracked input and the cursor mean the
+  // device echoed input we never tracked → the ghost would overlap real text.
+  return lineBeforeCursor.slice(idx + trackedInput.length).trimEnd().length > 0;
+}

--- a/components/terminal/ghostTextConsistency.test.ts
+++ b/components/terminal/ghostTextConsistency.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { lineHasUntrackedTrailingInput } from "./autocomplete/ghostTextConsistency.ts";
+
+test("keeps the ghost when the line matches the tracked input (in sync)", () => {
+  assert.equal(lineHasUntrackedTrailingInput("network int", "ecOS# network int"), false);
+});
+
+test("hides the ghost when the device echoed untracked trailing input (#1013)", () => {
+  // Tracked is one char behind what the device actually shows.
+  assert.equal(lineHasUntrackedTrailingInput("network in", "ecOS# network int"), true);
+});
+
+test("keeps the ghost during echo latency (line is behind the tracked input)", () => {
+  // The tracked input hasn't been fully echoed yet — reality being behind
+  // never corrupts, so the ghost must stay.
+  assert.equal(lineHasUntrackedTrailingInput("network int", "ecOS# network in"), false);
+});
+
+test("ignores trailing whitespace after the tracked input", () => {
+  assert.equal(lineHasUntrackedTrailingInput("git", "$ git "), false);
+});
+
+test("hides when untracked non-space input follows the tracked input", () => {
+  assert.equal(lineHasUntrackedTrailingInput("git", "$ git push"), true);
+});
+
+test("uses the last occurrence so a repeated token earlier on the line is ignored", () => {
+  // Prompt contains 'int'; the real typed 'int' is the one at the end.
+  assert.equal(lineHasUntrackedTrailingInput("int", "user@int-host:~$ int"), false);
+  assert.equal(lineHasUntrackedTrailingInput("int", "user@int-host:~$ intf"), true);
+});
+
+test("skips non-ASCII input (wide-char column mapping is ambiguous)", () => {
+  assert.equal(lineHasUntrackedTrailingInput("网络", "$ 网络口"), false);
+});
+
+test("skips single-character input", () => {
+  assert.equal(lineHasUntrackedTrailingInput("l", "$ lx"), false);
+});
+
+test("returns false when the tracked input isn't on the line yet (latency)", () => {
+  assert.equal(lineHasUntrackedTrailingInput("systemctl", "$ sys"), false);
+});


### PR DESCRIPTION
## Summary
Recurring bug (#1013, previously #756 / #906): on hosts with non-standard echo — hardware bastion hosts / network OS such as `ecOS#` — inline (ghost-text) suggestions get painted over characters the user already typed, e.g. `network int` + ghost `terface` rendered as `network intterface`.

Root cause: ghost text renders `suggestion.substring(trackedInput.length)` after the cursor, where `trackedInput` is a **client-side reconstruction** of the command line (buffer heuristics in `promptDetector.ts` + keystroke prediction, used to mask SSH echo latency). On devices that echo differently than a normal shell, that reconstruction drifts out of sync with what's actually on screen, and the ghost overlaps real text. Each prior fix patched a specific heuristic case; a new odd device finds a new gap — hence the recurrence.

This is **option A** from the discussion on the issue: rather than chase more heuristics (which can't be exhaustive), make the *corruption* impossible.

## Approach (fail-safe, not "always correct")
Add a consistency check that runs on each **post-echo render**: if the real terminal line before the cursor contains the tracked input followed by **more untracked, non-whitespace characters** (reality is AHEAD of what we tracked), hide the ghost instead of drawing over real text.

The key insight that makes this safe: 
- **SSH echo latency** = the on-screen line is a *prefix-behind* of the tracked input → never flagged → ghost stays responsive on slow links.
- **The bug** = the on-screen line is *ahead of / divergent from* the tracked input → flagged → ghost hides.

The check is ASCII-only (wide-char column↔string mapping is ambiguous, so CJK editing is untouched) and fail-open (degenerate/unknown cases keep the ghost). It runs on the render path only, never during `show()`/keystroke handling, so it can't fight the latency-prediction path.

Net effect: the recurring "ghost shows already-typed characters" turns into "ghost simply doesn't show" on devices we can't track reliably. It can only ever suppress a ghost that would otherwise corrupt — it never changes correct behaviour.

## Notes
- Pure decision logic is isolated in `ghostTextConsistency.ts` and unit-tested; `GhostTextAddon` calls it from its `onRender` handler.
- This does **not** make the ghost *correct* on every device (not achievable without device-specific echo knowledge) — it eliminates the visible corruption. Network-device auto-disable (option B) and a per-host toggle (option C) remain as possible follow-ups.
- Best verified against the actual bastion host from #1013.

## Test plan
- [x] `npm run lint`
- [x] New unit tests `components/terminal/ghostTextConsistency.test.ts` (in-sync / ahead / latency / trailing space / repeated token / non-ASCII / single char)
- [x] New integration test in `GhostTextAddon.test.ts` (ghost hides on render when the buffer line has untracked input)
- [x] Full terminal suite (273 tests) passes
- [ ] Reporter confirms on the real device (#1013)

Fixes #1013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)