### PR TITLE
[codex] fix Huawei VRP SSH detection

### DIFF
--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import type { Host } from "./models.ts";
 import {
+  detectVendorFromSshVersion,
   normalizePrimaryTelnetState,
   resolveHostKeepalive,
   resolveTelnetPort,
@@ -156,6 +157,11 @@ test("sanitizeHost keeps a still-valid fontFamily untouched", () => {
   const after = sanitizeHost(before);
   assert.equal(after.fontFamily, "fira-code");
   assert.equal(after.fontFamilyOverride, true);
+});
+
+test("detectVendorFromSshVersion recognizes legacy Huawei VRP dash banner", () => {
+  assert.equal(detectVendorFromSshVersion("-"), "huawei");
+  assert.equal(detectVendorFromSshVersion("SSH-2.0--"), "huawei");
 });
 
 const GLOBAL_KEEPALIVE = { keepaliveInterval: 30, keepaliveCountMax: 10 };

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -78,7 +78,7 @@ export const normalizeDistroId = (value?: string) => {
  * plain `OpenSSH_*` with no distinct vendor marker.
  */
 export const detectVendorFromSshVersion = (softwareVersion?: string): '' | NetworkDeviceVendor => {
-  const s = (softwareVersion || '').trim();
+  const s = (softwareVersion || '').trim().replace(/^SSH-(?:2\.0|1\.99)-/i, '');
   if (!s) return '';
 
   // Cisco family — IOS, IOS XA, Wireless LAN Controller
@@ -97,6 +97,7 @@ export const detectVendorFromSshVersion = (softwareVersion?: string): '' | Netwo
   if (/^NetScreen\b/.test(s)) return 'juniper';
 
   // Huawei VRP and related products
+  if (s === '-') return 'huawei';
   if (/^HUAWEI[-_]/i.test(s)) return 'huawei';
   if (/^VRP-/i.test(s)) return 'huawei';
 


### PR DESCRIPTION
## Summary
- Detect legacy Huawei VRP SSH banners that appear as a dash-only software string.
- Treat those sessions as Huawei network devices so Netcatty skips Linux-only background probing after login.
- Add a regression test for both the raw software token and full SSH identification form.

## Root Cause
Some older Huawei switches expose an unusual SSH identification value. Netcatty did not classify it as a network device, so after the interactive shell opened it tried the Linux distro probe on the same SSH connection. That extra probe can trip these devices and lead to a connection reset right after login.

## Validation
- `node --test --import tsx domain/host.test.ts`
- `node --test --import tsx domain/*.test.ts`
- `node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.test.ts`
- `npm run lint -- domain/host.ts domain/host.test.ts`
- `npm test`