### PR TITLE
fix #1049: clear WebGL texture atlas to recover from garbled terminal

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1241,6 +1241,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         termRef.current.options.ignoreBracketedPasteMode = terminalSettings.disableBracketedPaste ?? false;
       }
 
+      // Changing the font can leave the WebGL renderer drawing stale glyphs from
+      // the old metrics (xterm.js #3280), surfacing as garbled text (issue #1049).
+      // Clear the texture atlas so glyphs re-rasterize with the new font.
+      xtermRuntimeRef.current?.clearTextureAtlas();
+
       if (isVisibleRef.current) {
         setTimeout(() => safeFit({ force: true, requireVisible: true }), 50);
       } else {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -43,6 +43,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
+import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
   markExpectedTerminalCursorPositionReport,
@@ -79,6 +80,13 @@ export type XTermRuntime = {
   /** Current working directory detected via OSC 7 */
   currentCwd: string | undefined;
   keywordHighlighter: KeywordHighlighter;
+  /**
+   * Clear the WebGL renderer's glyph texture atlas so glyphs re-rasterize on the
+   * next frame. No-op when the DOM renderer is active. Used to recover from the
+   * persistent "garbled / 花屏" corruption (issue #1049) that the WebGL atlas can
+   * fall into after font changes or device pixel ratio changes.
+   */
+  clearTextureAtlas: () => void;
 };
 
 export type CreateXTermRuntimeContext = {
@@ -385,6 +393,45 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   scopedWindow.__xtermRendererPreference = performanceConfig.preferDOMRenderer
     ? "dom"
     : "webgl";
+
+  // The WebGL renderer caches rasterized glyphs in a texture atlas. Heavy TUIs
+  // (claude code / gemini cli / opencode and other full-screen agents), font
+  // changes, and device pixel ratio changes can leave that atlas in a corrupted
+  // state that persists for the life of the terminal — the "garbled / 花屏"
+  // report in issue #1049 where only opening a brand-new terminal helps. Clearing
+  // the atlas forces glyphs to re-rasterize at the correct scale on the next
+  // frame. No-op for the DOM renderer.
+  const clearWebglTextureAtlas = () => {
+    if (!webglAddon) return;
+    try {
+      webglAddon.clearTextureAtlas();
+    } catch (err) {
+      logger.warn("[XTerm] clearTextureAtlas failed", err);
+    }
+  };
+
+  // Recover the renderer when the device pixel ratio changes (moving the window
+  // between monitors with different DPI, or changing OS display scaling — a
+  // common Windows trigger). matchMedia change does not fire a normal resize, so
+  // this is needed in addition to the resize handling below.
+  let stopDprWatch: () => void = () => {};
+  if (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function"
+  ) {
+    stopDprWatch = watchDevicePixelRatio({
+      getDevicePixelRatio: () => window.devicePixelRatio || 1,
+      matchMedia: (query) => window.matchMedia(query),
+      onChange: () => {
+        clearWebglTextureAtlas();
+        try {
+          fitAddon.fit();
+        } catch (err) {
+          logger.warn("[XTerm] fit after devicePixelRatio change failed", err);
+        }
+      },
+    });
+  }
 
   const webLinksAddon = new WebLinksAddon((event, uri) => {
     const currentLinkModifier = ctx.terminalSettingsRef.current?.linkModifier ?? "none";
@@ -858,6 +905,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   let resizeTimeout: NodeJS.Timeout | null = null;
   const resizeDebounceMs = XTERM_PERFORMANCE_CONFIG.resize.debounceMs;
   term.onResize(({ cols, rows }) => {
+    // A reflow can leave stale glyphs in the WebGL atlas; clear it so the new
+    // dimensions re-rasterize cleanly (issue #1049).
+    clearWebglTextureAtlas();
     const id = ctx.sessionRef.current;
     if (!id) return;
     if (resizeTimeout) clearTimeout(resizeTimeout);
@@ -876,8 +926,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     serializeAddon,
     searchAddon,
     keywordHighlighter,
+    clearTextureAtlas: clearWebglTextureAtlas,
     dispose: () => {
       cleanupMiddleClick?.();
+      stopDprWatch();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();
       for (const disposable of cursorPositionReportRequestDisposables) {

--- a/components/terminal/runtime/rendererDprWatch.test.ts
+++ b/components/terminal/runtime/rendererDprWatch.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  type MediaQueryListLike,
+  watchDevicePixelRatio,
+} from "./rendererDprWatch";
+
+class FakeMediaQueryList implements MediaQueryListLike {
+  readonly query: string;
+  modernListeners: Array<() => void> = [];
+  legacyListeners: Array<() => void> = [];
+  private readonly supportsModern: boolean;
+
+  constructor(query: string, supportsModern = true) {
+    this.query = query;
+    this.supportsModern = supportsModern;
+    if (!supportsModern) {
+      // Strip the modern API to emulate legacy environments.
+      this.addEventListener = undefined;
+      this.removeEventListener = undefined;
+    }
+  }
+
+  addEventListener? = (_type: "change", listener: () => void) => {
+    this.modernListeners.push(listener);
+  };
+
+  removeEventListener? = (_type: "change", listener: () => void) => {
+    this.modernListeners = this.modernListeners.filter((l) => l !== listener);
+  };
+
+  addListener = (listener: () => void) => {
+    this.legacyListeners.push(listener);
+  };
+
+  removeListener = (listener: () => void) => {
+    this.legacyListeners = this.legacyListeners.filter((l) => l !== listener);
+  };
+
+  trigger() {
+    for (const l of [...this.modernListeners, ...this.legacyListeners]) l();
+  }
+
+  get listenerCount() {
+    return this.modernListeners.length + this.legacyListeners.length;
+  }
+}
+
+function makeEnv(initialDpr: number, supportsModern = true) {
+  let dpr = initialDpr;
+  const created: FakeMediaQueryList[] = [];
+  return {
+    created,
+    getDevicePixelRatio: () => dpr,
+    matchMedia: (query: string) => {
+      const mql = new FakeMediaQueryList(query, supportsModern);
+      created.push(mql);
+      return mql;
+    },
+    setDpr: (value: number) => {
+      dpr = value;
+    },
+  };
+}
+
+test("registers a change listener for the current devicePixelRatio", () => {
+  const env = makeEnv(1);
+  watchDevicePixelRatio({
+    getDevicePixelRatio: env.getDevicePixelRatio,
+    matchMedia: env.matchMedia,
+    onChange: () => {},
+  });
+
+  assert.equal(env.created.length, 1);
+  assert.equal(env.created[0].query, "(resolution: 1dppx)");
+  assert.equal(env.created[0].listenerCount, 1);
+});
+
+test("invokes onChange when the media query reports a change", () => {
+  const env = makeEnv(1);
+  let calls = 0;
+  watchDevicePixelRatio({
+    getDevicePixelRatio: env.getDevicePixelRatio,
+    matchMedia: env.matchMedia,
+    onChange: () => {
+      calls += 1;
+    },
+  });
+
+  env.setDpr(2);
+  env.created[0].trigger();
+
+  assert.equal(calls, 1);
+});
+
+test("re-registers for the new ratio so subsequent changes still fire", () => {
+  const env = makeEnv(1);
+  let calls = 0;
+  watchDevicePixelRatio({
+    getDevicePixelRatio: env.getDevicePixelRatio,
+    matchMedia: env.matchMedia,
+    onChange: () => {
+      calls += 1;
+    },
+  });
+
+  env.setDpr(2);
+  env.created[0].trigger();
+
+  assert.equal(env.created.length, 2);
+  assert.equal(env.created[1].query, "(resolution: 2dppx)");
+  // The stale listener must be detached so it cannot double-fire.
+  assert.equal(env.created[0].listenerCount, 0);
+
+  env.setDpr(3);
+  env.created[1].trigger();
+
+  assert.equal(calls, 2);
+});
+
+test("cleanup stops further onChange callbacks", () => {
+  const env = makeEnv(1);
+  let calls = 0;
+  const stop = watchDevicePixelRatio({
+    getDevicePixelRatio: env.getDevicePixelRatio,
+    matchMedia: env.matchMedia,
+    onChange: () => {
+      calls += 1;
+    },
+  });
+
+  stop();
+
+  assert.equal(env.created[0].listenerCount, 0);
+  env.created[0].trigger();
+  assert.equal(calls, 0);
+});
+
+test("falls back to addListener/removeListener when addEventListener is unavailable", () => {
+  const env = makeEnv(1, /* supportsModern */ false);
+  let calls = 0;
+  const stop = watchDevicePixelRatio({
+    getDevicePixelRatio: env.getDevicePixelRatio,
+    matchMedia: env.matchMedia,
+    onChange: () => {
+      calls += 1;
+    },
+  });
+
+  assert.equal(env.created[0].legacyListeners.length, 1);
+  env.created[0].trigger();
+  assert.equal(calls, 1);
+
+  stop();
+  // After cleanup the most recently registered query has no listeners.
+  const latest = env.created[env.created.length - 1];
+  assert.equal(latest.listenerCount, 0);
+});

--- a/components/terminal/runtime/rendererDprWatch.ts
+++ b/components/terminal/runtime/rendererDprWatch.ts
@@ -1,0 +1,72 @@
+/**
+ * Watches for devicePixelRatio changes (e.g. moving the window between monitors
+ * with different DPI, or changing the OS display scaling on Windows) and invokes
+ * a callback so the renderer can be repaired.
+ *
+ * The WebGL renderer caches rasterized glyphs in a texture atlas keyed to the
+ * device pixel ratio at creation time. When the ratio changes the cached glyphs
+ * are drawn at the wrong scale, producing the persistent "garbled / 花屏"
+ * corruption reported in issue #1049 that only goes away when a brand-new
+ * terminal is opened. xterm.js recommends calling `clearTextureAtlas()` on DPR
+ * change so glyphs re-rasterize at the new scale.
+ *
+ * `matchMedia('(resolution: Ndppx)')` only matches a single ratio, so after each
+ * change we must re-register the listener against the new ratio.
+ */
+export interface MediaQueryListLike {
+  addEventListener?: (type: "change", listener: () => void) => void;
+  removeEventListener?: (type: "change", listener: () => void) => void;
+  // Legacy API (older Safari / Electron) where addEventListener is unavailable.
+  addListener?: (listener: () => void) => void;
+  removeListener?: (listener: () => void) => void;
+}
+
+export interface WatchDevicePixelRatioOptions {
+  getDevicePixelRatio: () => number;
+  matchMedia: (query: string) => MediaQueryListLike;
+  onChange: () => void;
+}
+
+/**
+ * Start watching for devicePixelRatio changes. Returns a cleanup function that
+ * removes the active listener.
+ */
+export function watchDevicePixelRatio(
+  options: WatchDevicePixelRatioOptions,
+): () => void {
+  const { getDevicePixelRatio, matchMedia, onChange } = options;
+  let current: { mql: MediaQueryListLike; listener: () => void } | null = null;
+
+  const detach = () => {
+    if (!current) return;
+    const { mql, listener } = current;
+    if (mql.removeEventListener) {
+      mql.removeEventListener("change", listener);
+    } else if (mql.removeListener) {
+      mql.removeListener(listener);
+    }
+    current = null;
+  };
+
+  const attach = () => {
+    const dpr = getDevicePixelRatio();
+    const mql = matchMedia(`(resolution: ${dpr}dppx)`);
+    const listener = () => {
+      // A media query only matches the ratio it was created with, so detach the
+      // stale listener and re-register against the new ratio before notifying.
+      detach();
+      attach();
+      onChange();
+    };
+    if (mql.addEventListener) {
+      mql.addEventListener("change", listener);
+    } else if (mql.addListener) {
+      mql.addListener(listener);
+    }
+    current = { mql, listener };
+  };
+
+  attach();
+
+  return detach;
+}


### PR DESCRIPTION
## Problem

Issue #1049: terminal output becomes garbled and **stays** garbled — closing and reopening the *same* terminal does nothing, only opening a brand-new terminal recovers. Reported on **Windows 11** while running heavy AI CLI agents (claude code / opencode / gemini cli) over SSH.

The "only a new terminal fixes it" signature means the corruption lives in the **renderer instance**, not in the data from the server (so it's not an encoding/UTF-8 problem). xterm.js's WebGL renderer caches rasterized glyphs in a **texture atlas**. Two things push that atlas into a corrupted-for-life state:

1. **devicePixelRatio changes** — moving the window between monitors with different DPI, or changing OS display scaling (very common on Windows). The cached glyphs are then drawn at the wrong scale. xterm.js's documented recommendation is to call `clearTextureAtlas()` on DPR change.
2. **Font changes** while a session is live (xterm.js [#3280](https://github.com/xtermjs/xterm.js/issues/3280) — renderer keeps drawing stale glyphs from the old metrics).

Heavy full-screen TUIs (the AI agents) make this much more likely because they hammer the atlas with spinners, box-drawing, emoji, and constant redraws.

## Fix

Clear the texture atlas so glyphs re-rasterize at the correct scale, instead of forcing the user to reopen the terminal. All paths are **no-ops under the DOM renderer**.

- **`rendererDprWatch.ts`** (new, TDD'd): `watchDevicePixelRatio()` registers a `matchMedia('(resolution: Ndppx)')` listener and **re-registers** across each DPI change (a media query only matches the ratio it was created with), with a legacy `addListener`/`removeListener` fallback. Returns a cleanup fn.
- **`createXTermRuntime.ts`**:
  - on devicePixelRatio change → clear atlas + refit (covers the Windows scaling / multi-monitor trigger; `matchMedia` change does not fire a normal resize, so this is needed on top of resize handling);
  - clear atlas on reflow (`term.onResize`);
  - expose `clearTextureAtlas()` on `XTermRuntime`; tear the watcher down on `dispose`.
- **`Terminal.tsx`**: call `clearTextureAtlas()` after the font/appearance effect applies font options.

## Verification

- `node --test` runtime suite: **135 pass / 0 fail** (incl. 5 new `rendererDprWatch` tests, written test-first / red→green).
- `tsc --noEmit`: **40 errors on both this branch and `origin/main`** → 0 new type errors introduced (all pre-existing, in unrelated files).
- `eslint` on all changed files: clean (exit 0).
- `vite build`: exit 0.

## Notes / follow-ups (not in this PR)

- Suggested the reporter switch **Settings → Terminal → Renderer = DOM** as an immediate workaround / confirmation.
- Lower-priority follow-ups from triage left out to keep this focused: a user-facing "repair garble" shortcut, and improving `onContextLoss` to fully fall back/recreate rather than just dispose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)