### PR TITLE
fix #1043: skip pwd probe on network devices to keep Huawei VRP sessions alive

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -29,7 +29,7 @@ import {
   applyCustomAccentToTerminalTheme,
   resolveHostTerminalThemeId,
 } from "../domain/terminalAppearance";
-import { classifyDistroId } from "../domain/host";
+import { classifyDistroId, shouldProbeSessionCwd } from "../domain/host";
 import { resolveHostAuth } from "../domain/sshAuth";
 import { useTerminalBackend } from "../application/state/useTerminalBackend";
 // SFTPModal removed - SFTP is now handled by SftpSidePanel in TerminalLayer
@@ -585,6 +585,21 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     return clearTerminalCwd;
   }, [clearTerminalCwd, host.id]);
 
+  // Classify the host's device family from the *detected* distro and the
+  // explicit deviceType only. This intentionally bypasses
+  // getEffectiveHostDistro(): the manual distro override (`distroMode:
+  // 'manual'` + `manualDistro`) is a purely cosmetic icon choice, and a
+  // user who pinned e.g. an "ubuntu" icon on what is actually a Cisco /
+  // Huawei host must not silently re-enable POSIX-shell probes against it.
+  // Several features gate on this — the working-directory probe below, the
+  // /etc/os-release probe, and the periodic server-stats poll (#674) —
+  // because each opens an extra exec channel that strict network-device
+  // CLIs reject or log as a new AAA session, and on Huawei VRP closes the
+  // whole session (#1043).
+  const detectedDeviceClass = classifyDistroId(host.distro);
+  const isNetworkDevice =
+    host.deviceType === 'network' || detectedDeviceClass === 'network-device';
+
   useEffect(() => {
     if (host.protocol === "local" || host.protocol === "serial" || host.protocol === "telnet") {
       return;
@@ -593,9 +608,20 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     let cancelled = false;
     const timer = setTimeout(async () => {
-      if (!sessionRef.current) return;
+      const id = sessionRef.current;
+      if (!id) return;
       try {
-        const result = await terminalBackend.getSessionPwd(sessionRef.current);
+        // The pwd probe opens an extra POSIX-shell exec channel, which strict
+        // network-device CLIs like Huawei VRP answer by closing the whole
+        // session (#1043). Skip it for known network devices; for a brand-new
+        // host (distro not classified yet on the first connect) consult the
+        // SSH banner, which is captured for free at handshake time.
+        const info = await terminalBackend.getSessionRemoteInfo?.(id);
+        if (cancelled || id !== sessionRef.current) return;
+        if (!shouldProbeSessionCwd({ isNetworkDevice, remoteSshVersion: info?.remoteSshVersion })) {
+          return;
+        }
+        const result = await terminalBackend.getSessionPwd(id);
         if (!cancelled && !terminalCwdTracker.getRendererCwd() && result.success && result.cwd) {
           knownCwdRef.current = result.cwd;
         }
@@ -608,7 +634,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [host.protocol, status, terminalBackend, terminalCwdTracker]);
+  }, [host.protocol, status, terminalBackend, terminalCwdTracker, isNetworkDevice]);
 
   useEffect(() => {
     if (!isVisible) {
@@ -620,25 +646,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const isLocalConnection = host.protocol === "local";
   const isSerialConnection = host.protocol === "serial";
 
-  // Server stats (CPU, Memory, Disk) — only for Linux/macOS, and never
-  // for hosts classified as network devices (either via explicit
-  // deviceType='network' or via SSH banner detection that populated
-  // host.distro with a network-vendor ID). See #674: polling the stats
-  // command on Cisco / Huawei / Juniper etc. generates one AAA session
-  // log entry per poll because each exec channel is counted as a new
-  // session on those devices.
-  //
-  // IMPORTANT: this gating must NOT go through getEffectiveHostDistro()
-  // because that honors the manual distro override (`distroMode: 'manual'`
-  // + `manualDistro`) which is purely a cosmetic icon choice. A user who
-  // pinned an "ubuntu" icon on what is actually a Cisco host would
-  // otherwise silently re-enable the polling loop and re-introduce the
-  // AAA log flood this patch is meant to eliminate. The display icon can
-  // still be overridden (see DistroAvatar) — gating uses the raw detected
-  // `host.distro` and the explicit `host.deviceType` only.
-  const detectedDeviceClass = classifyDistroId(host.distro);
-  const isNetworkDevice =
-    host.deviceType === 'network' || detectedDeviceClass === 'network-device';
+  // Server stats (CPU, Memory, Disk) — only for Linux/macOS, never for
+  // network devices. See isNetworkDevice above for why the gating uses the
+  // raw detected distro / explicit deviceType (not getEffectiveHostDistro);
+  // #674 covers the AAA-log-flood motivation for stats specifically.
   const isSupportedOs =
     !isNetworkDevice &&
     (host.os === 'linux' || host.os === 'macos' || detectedDeviceClass === 'linux-like');

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -10,6 +10,7 @@ import {
   resolveTelnetPassword,
   resolveTelnetUsername,
   sanitizeHost,
+  shouldProbeSessionCwd,
   upsertHostById,
 } from "./host.ts";
 
@@ -162,6 +163,34 @@ test("sanitizeHost keeps a still-valid fontFamily untouched", () => {
 test("detectVendorFromSshVersion recognizes legacy Huawei VRP dash banner", () => {
   assert.equal(detectVendorFromSshVersion("-"), "huawei");
   assert.equal(detectVendorFromSshVersion("SSH-2.0--"), "huawei");
+});
+
+test("shouldProbeSessionCwd allows the probe on a plain Linux host", () => {
+  assert.equal(
+    shouldProbeSessionCwd({ isNetworkDevice: false, remoteSshVersion: "OpenSSH_9.6" }),
+    true,
+  );
+});
+
+test("shouldProbeSessionCwd skips the probe on an already-classified network device", () => {
+  // Reconnect / manual deviceType='network': host.distro already says network.
+  assert.equal(
+    shouldProbeSessionCwd({ isNetworkDevice: true, remoteSshVersion: "OpenSSH_9.6" }),
+    false,
+  );
+});
+
+test("shouldProbeSessionCwd skips the probe when the SSH banner reveals a network vendor", () => {
+  // First connect to a brand-new Huawei VRP: host.distro not persisted yet, so
+  // isNetworkDevice is still false — the banner is the only signal (#1043).
+  assert.equal(
+    shouldProbeSessionCwd({ isNetworkDevice: false, remoteSshVersion: "-" }),
+    false,
+  );
+  assert.equal(
+    shouldProbeSessionCwd({ isNetworkDevice: false, remoteSshVersion: "SSH-1.99--" }),
+    false,
+  );
 });
 
 const GLOBAL_KEEPALIVE = { keepaliveInterval: 30, keepaliveCountMax: 10 };

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -136,6 +136,24 @@ export const classifyDistroId = (distroId?: string): DeviceClass => {
   return 'other';
 };
 
+/**
+ * Decide whether it is safe to run the post-connect `pwd` probe that
+ * discovers the session's working directory. The probe opens an extra exec
+ * channel running a POSIX-shell script; strict network-device CLIs such as
+ * Huawei VRP respond by closing the whole SSH session (#1043), so it must be
+ * skipped for them.
+ *
+ * `isNetworkDevice` covers hosts we already classified (a reconnect, or an
+ * explicit `deviceType: 'network'`). On a brand-new host that field is not
+ * populated yet, so we also inspect the SSH server identification banner —
+ * captured for free at handshake — which identifies most vendors directly.
+ */
+export const shouldProbeSessionCwd = (opts: {
+  isNetworkDevice: boolean;
+  remoteSshVersion?: string;
+}): boolean =>
+  !opts.isNetworkDevice && !detectVendorFromSshVersion(opts.remoteSshVersion);
+
 export const getEffectiveHostDistro = (
   host?: Pick<Host, 'distro' | 'manualDistro' | 'distroMode'> | null,
 ) => {


### PR DESCRIPTION
## Problem

Connecting to an old Huawei VRP switch shows the prompt and then immediately drops to `[session closed (code 1)]` (#1043).

Root cause is a **timing** issue, not #1046 failing:

- 150ms after connect, `Terminal.tsx` calls `getSessionPwd()` to discover the working directory. It is implemented by opening an **extra exec channel running `exec sh -c <POSIX script>`** (`sshBridge.cjs`).
- Strict network-device CLIs like Huawei VRP don't support that extra POSIX-shell exec channel and close the **whole** SSH session in response.
- The vendor detection that would mark the host as a network device runs at **600ms** (`createTerminalSessionStarters.ts`), which is *after* the 150ms probe. So on a first connect — before `host.distro` is persisted — #1046's banner detection never gets the chance to gate the probe.

## Fix

Gate the pwd probe with a new pure helper `shouldProbeSessionCwd()`, reusing the same `isNetworkDevice` pattern that already protects the server-stats poll (#674):

1. **`isNetworkDevice`** — skips known/reconnected devices and the explicit `deviceType: 'network'` override.
2. **SSH banner check** — on a brand-new host (`host.distro` empty), read the banner via `getSessionRemoteInfo` (captured for free at handshake) and classify it with `detectVendorFromSshVersion`. Huawei VRP's `-` / `SSH-1.99--` banner is recognized as `huawei` (added in #1046).

Plain Linux/OpenSSH hosts are unaffected — the probe still runs for them.

`legacyAlgorithms` is **intentionally not** used as a gating signal (despite the issue suggestion): legitimate old Linux/OpenSSH hosts also require legacy algorithms but fully support the probe, so gating on it would needlessly disable CWD tracking for them. Banner + device class is more precise.

## Tests

- New unit tests for `shouldProbeSessionCwd` in `domain/host.test.ts` (Linux allowed, known network device skipped, banner-detected vendor skipped).
- Full suite: **1119 passing / 0 failing**.
- No new typecheck/lint errors.

## Caveat

I don't have a Huawei VRP device, so this is verified by unit tests + code analysis, not on real hardware. Real-device confirmation still needs the issue reporter.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)