### PR TITLE
Fix S3 checksum compatibility

### DIFF
--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -98,6 +98,8 @@ const buildS3Client = (config) =>
     region: config.region,
     endpoint: normalizeEndpoint(config.endpoint),
     forcePathStyle: config.forcePathStyle ?? true,
+    requestChecksumCalculation: "WHEN_REQUIRED",
+    responseChecksumValidation: "WHEN_REQUIRED",
     credentials: {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,
@@ -299,4 +301,5 @@ module.exports = {
   // Exposed for tests
   handleWebdavInitialize,
   buildBasicAuthHeader,
+  buildS3Client,
 };

--- a/electron/bridges/cloudSyncBridge.s3Checksum.test.cjs
+++ b/electron/bridges/cloudSyncBridge.s3Checksum.test.cjs
@@ -1,0 +1,25 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildS3Client,
+} = require("./cloudSyncBridge.cjs");
+
+const config = {
+  endpoint: "https://s3.example.com",
+  region: "us-east-1",
+  bucket: "netcatty-test",
+  accessKeyId: "access",
+  secretAccessKey: "secret",
+  forcePathStyle: true,
+};
+
+test("S3 client only sends request checksums when required", async () => {
+  const client = buildS3Client(config);
+  assert.equal(await client.config.requestChecksumCalculation(), "WHEN_REQUIRED");
+});
+
+test("S3 client only validates response checksums when required", async () => {
+  const client = buildS3Client(config);
+  assert.equal(await client.config.responseChecksumValidation(), "WHEN_REQUIRED");
+});

--- a/infrastructure/services/adapters/S3Adapter.ts
+++ b/infrastructure/services/adapters/S3Adapter.ts
@@ -194,6 +194,8 @@ export class S3Adapter {
       region: config.region,
       endpoint: config.endpoint,
       forcePathStyle: config.forcePathStyle ?? true,
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
       credentials: {
         accessKeyId: config.accessKeyId,
         secretAccessKey: config.secretAccessKey,


### PR DESCRIPTION
## Summary
- Avoid optional AWS SDK checksum headers for S3 sync uploads/downloads unless the provider requires them
- Apply the same S3 client behavior in both Electron sync and the renderer adapter path
- Add a regression test for the Electron S3 client checksum mode

Fixes #1051

## Verification
- npm run lint -- --quiet
- npm run build
- npm test