### PR TITLE
Fix terminal exit auto close

### DIFF
--- a/application/state/resolveTerminalSessionExitIntent.test.ts
+++ b/application/state/resolveTerminalSessionExitIntent.test.ts
@@ -3,16 +3,30 @@ import assert from "node:assert/strict";
 
 import { resolveTerminalSessionExitIntent } from "./resolveTerminalSessionExitIntent.ts";
 
-test("backend exited events keep the tab and mark it disconnected", () => {
+test("normal backend exited events close the session tab", () => {
   assert.deepEqual(
     resolveTerminalSessionExitIntent({ reason: "exited", exitCode: 0 }),
-    { kind: "markDisconnected" },
+    { kind: "closeSession" },
   );
 });
 
 test("backend timeout events keep the tab and mark it disconnected", () => {
   assert.deepEqual(
     resolveTerminalSessionExitIntent({ reason: "timeout", error: "idle timeout" }),
+    { kind: "markDisconnected" },
+  );
+});
+
+test("backend error events keep the tab and mark it disconnected", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "error", error: "connection reset" }),
+    { kind: "markDisconnected" },
+  );
+});
+
+test("backend closed events keep the tab and mark it disconnected", () => {
+  assert.deepEqual(
+    resolveTerminalSessionExitIntent({ reason: "closed", exitCode: 0 }),
     { kind: "markDisconnected" },
   );
 });

--- a/application/state/resolveTerminalSessionExitIntent.ts
+++ b/application/state/resolveTerminalSessionExitIntent.ts
@@ -6,12 +6,17 @@ export type TerminalSessionExitEvent = {
 };
 
 export type TerminalSessionExitIntent =
+  | { kind: "closeSession" }
   | { kind: "markDisconnected" };
 
 export function resolveTerminalSessionExitIntent(
-  _evt: TerminalSessionExitEvent,
+  evt: TerminalSessionExitEvent,
 ): TerminalSessionExitIntent {
-  // Backend exits can be remote idle timeouts, shell termination, or transport closes.
-  // Explicit user closes bypass this policy and call the close-session path directly.
+  if (evt.reason === "exited") {
+    return { kind: "closeSession" };
+  }
+
+  // Timeouts, transport errors, and channel closes should keep the tab visible
+  // so the user can inspect output and reconnect.
   return { kind: "markDisconnected" };
 }

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -978,10 +978,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
   const handleSessionExit = useCallback((sessionId: string, evt: TerminalSessionExitEvent) => {
     const intent = resolveTerminalSessionExitIntent(evt);
-    if (intent.kind === "markDisconnected") {
+    if (intent.kind === "closeSession") {
+      onCloseSession(sessionId);
+    } else {
       onUpdateSessionStatus(sessionId, 'disconnected');
     }
-  }, [onUpdateSessionStatus]);
+  }, [onCloseSession, onUpdateSessionStatus]);
 
   const handleOsDetected = useCallback((hostId: string, distro: string) => {
     onUpdateHostDistro(hostId, distro);


### PR DESCRIPTION
## Summary
- Restore auto-closing terminal tabs when the backend reports a normal shell/process exit
- Keep timeout, transport error, and channel close events as disconnected tabs for inspection/reconnect
- Add regression coverage for each exit intent branch

Fixes #1048

## Verification
- node --test --import tsx application/state/resolveTerminalSessionExitIntent.test.ts
- npm run lint -- --quiet
- npm run build
- npm test