### PR TITLE
feat #1005: Termius-style live-preview popup autocomplete (free the Tab key)

### DIFF
--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -95,16 +95,22 @@ const DirExpandIndicator: React.FC<{ visible: boolean; color: string }> = ({ vis
 const KeyCap: React.FC<{ label: string; color: string; bg: string }> = ({ label, color, bg }) => (
   <span
     style={{
-      fontSize: "10px",
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      boxSizing: "border-box",
+      height: "16px",
+      minWidth: "16px",
+      padding: "0 4px",
+      fontSize: "11px",
       lineHeight: 1,
-      padding: "2px 4px",
-      borderRadius: "3px",
-      border: `1px solid ${color}`,
-      color,
-      backgroundColor: bg,
+      borderRadius: "4px",
+      border: `1px solid color-mix(in srgb, ${color} 35%, transparent)`,
+      color: `color-mix(in srgb, ${color} 80%, ${bg})`,
+      backgroundColor: `color-mix(in srgb, ${color} 12%, ${bg})`,
       flexShrink: 0,
-      minWidth: "14px",
-      textAlign: "center",
+      fontFamily:
+        'ui-sans-serif, -apple-system, "Segoe UI", system-ui, sans-serif',
     }}
   >
     {label}
@@ -388,7 +394,7 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
                   {suggestion.source === "path" && suggestion.fileType === "directory" && (
                     <KeyCap label="→" color={dimTextColor} bg={popupBg} />
                   )}
-                  <KeyCap label="↵" color={dimTextColor} bg={popupBg} />
+                  <KeyCap label="⏎" color={dimTextColor} bg={popupBg} />
                 </span>
               )}
             </div>

--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -91,6 +91,26 @@ const DirExpandIndicator: React.FC<{ visible: boolean; color: string }> = ({ vis
   <span style={{ fontSize: "10px", color, opacity: visible ? 0.6 : 0, flexShrink: 0, marginLeft: "2px" }}>›</span>
 );
 
+/** Small key-cap badge shown on the selected row to hint the actionable key. */
+const KeyCap: React.FC<{ label: string; color: string; bg: string }> = ({ label, color, bg }) => (
+  <span
+    style={{
+      fontSize: "10px",
+      lineHeight: 1,
+      padding: "2px 4px",
+      borderRadius: "3px",
+      border: `1px solid ${color}`,
+      color,
+      backgroundColor: bg,
+      flexShrink: 0,
+      minWidth: "14px",
+      textAlign: "center",
+    }}
+  >
+    {label}
+  </span>
+);
+
 const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   suggestions,
   selectedIndex,
@@ -360,6 +380,16 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
               {/* Expand indicator for directories */}
               {suggestion.source === "path" && suggestion.fileType === "directory" && (
                 <DirExpandIndicator visible={isSelected || isHovered} color={dimTextColor} />
+              )}
+
+              {/* Key hint on the selected row: → expands directories, ↵ runs. */}
+              {isSelected && (
+                <span style={{ display: "flex", gap: "3px", marginLeft: "4px", flexShrink: 0 }}>
+                  {suggestion.source === "path" && suggestion.fileType === "directory" && (
+                    <KeyCap label="→" color={dimTextColor} bg={popupBg} />
+                  )}
+                  <KeyCap label="↵" color={dimTextColor} bg={popupBg} />
+                </span>
               )}
             </div>
           );

--- a/components/terminal/autocomplete/livePreviewSequence.test.ts
+++ b/components/terminal/autocomplete/livePreviewSequence.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computeLivePreviewWrite } from "./livePreviewSequence.ts";
+
+test("appends only the tail when the candidate continues the current line", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "do", candidate: "docker", os: "linux" }),
+    "cker",
+  );
+});
+
+test("returns empty when the line already equals the candidate", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "docker", candidate: "docker", os: "linux" }),
+    "",
+  );
+});
+
+test("clears with Ctrl-U then writes the full candidate on a non-prefix change", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "docker", candidate: "df", os: "linux" }),
+    "\x15df",
+  );
+});
+
+test("clears when switching to a shorter prefix candidate", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "docker-compose", candidate: "docker", os: "linux" }),
+    "\x15docker",
+  );
+});
+
+test("reverting to the typed baseline clears then rewrites the baseline", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "docker", candidate: "do", os: "linux" }),
+    "\x15do",
+  );
+});
+
+test("Windows uses backspaces sized to the current line, not Ctrl-U", () => {
+  assert.equal(
+    computeLivePreviewWrite({ currentLine: "abc", candidate: "xy", os: "windows" }),
+    "\b\b\bxy",
+  );
+});

--- a/components/terminal/autocomplete/livePreviewSequence.ts
+++ b/components/terminal/autocomplete/livePreviewSequence.ts
@@ -1,0 +1,24 @@
+/**
+ * Compute the keystrokes to send so the terminal input line becomes exactly
+ * `candidate`, given what is currently on the line. Drives the popup
+ * autocomplete live-preview (#1005): moving the selection renders the chosen
+ * suggestion into the command line, and switching / reverting rewrites it.
+ *
+ * - Forward prefix (candidate continues the line): append only the new tail.
+ * - Otherwise: clear the current input, then write the full candidate. POSIX
+ *   shells use Ctrl-U (kill-line); Windows (cmd/PowerShell) uses backspaces
+ *   sized to the current line length.
+ */
+export function computeLivePreviewWrite(input: {
+  currentLine: string;
+  candidate: string;
+  os: string;
+}): string {
+  const { currentLine, candidate, os } = input;
+  if (candidate === currentLine) return "";
+  if (candidate.startsWith(currentLine)) {
+    return candidate.slice(currentLine.length);
+  }
+  const clear = os === "windows" ? "\b".repeat(currentLine.length) : "\x15";
+  return clear + candidate;
+}

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -541,6 +541,41 @@ export function useTerminalAutocomplete(
     });
   }, [termRef]);
 
+  /**
+   * Render the full path for a sub-dir entry into the line WITHOUT finalizing
+   * (no clearState). Used for live-preview while navigating sub-dir panels (#1005).
+   */
+  const renderSubDirPath = useCallback((level: number, entry: SubDirEntry) => {
+    const s = stateRef.current;
+    const term = termRef.current;
+    if (!term) return;
+    const panel = s.subDirPanels[level];
+    if (!panel) return;
+    const { prompt } = getAlignedPrompt(
+      term, typedInputBufferRef.current, typedBufferReliableRef.current,
+    );
+    if (!prompt.isAtPrompt) return;
+    const parsed = parseCommandLine(prompt.userInput);
+    const cmdPrefix = parsed.tokens.slice(0, parsed.wordIndex).join(" ")
+      + (parsed.wordIndex > 0 ? " " : "");
+    const currentToken = parsed.currentWord;
+    const quotePrefix = currentToken.startsWith('"') || currentToken.startsWith("'")
+      ? currentToken[0] : "";
+    const quoteSuffix = quotePrefix && currentToken.endsWith(quotePrefix) ? quotePrefix : "";
+    const suffix = entry.type === "directory" ? "/" : "";
+    const entryName = quotePrefix || !/[\\$'"|!<>;#~` ]/.test(entry.name)
+      ? entry.name : shellEscape(entry.name);
+    const newCommand = cmdPrefix + `${quotePrefix}${panel.dirPath}${entryName}${suffix}${quoteSuffix}`;
+    const seq = computeLivePreviewWrite({
+      currentLine: prompt.userInput, candidate: newCommand, os: hostOsRef.current,
+    });
+    if (seq) writeToTerminal(seq);
+    typedInputBufferRef.current = newCommand;
+    typedBufferReliableRef.current = true;
+    previewActiveRef.current = true;
+    lastAcceptedCommandRef.current = newCommand;
+  }, [termRef, writeToTerminal]);
+
   /** Handle selecting a file/directory from any sub-dir panel.
    *  Builds the full path from the panel stack and replaces the current input. */
   const handleSubDirSelect = useCallback((level: number, entry: SubDirEntry) => {
@@ -1096,8 +1131,10 @@ export function useTerminalAutocomplete(
               panels[focusLevel] = { ...p, selectedIndex: newIdx };
               return { ...prev, subDirPanels: panels.slice(0, focusLevel + 1) };
             });
-            // Auto-expand next level if the newly selected item is a directory
+            // Live-render the highlighted entry's full path into the line (#1005).
             const newEntry = focusedPanel.entries[newIdx];
+            if (newEntry) renderSubDirPath(focusLevel, newEntry);
+            // Auto-expand next level if the newly selected item is a directory
             if (newEntry?.type === "directory") {
               expandSubDir(focusLevel, newEntry);
             }

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -24,6 +24,7 @@ import { preloadCommonSpecs } from "./figSpecLoader";
 import { getXTermCellDimensions } from "./xtermUtils";
 import { listDirectoryEntries, normalizePathTokenForLookup } from "./remotePathCompleter";
 import { decideGhostSuggestion } from "./ghostSuggestionPolicy";
+import { computeLivePreviewWrite } from "./livePreviewSequence";
 
 export interface AutocompleteSettings {
   enabled: boolean;
@@ -253,6 +254,10 @@ export function useTerminalAutocomplete(
   const fetchVersionRef = useRef(0);
   /** Last accepted suggestion text — for accurate history recording on fast Enter after accept */
   const lastAcceptedCommandRef = useRef<string | null>(null);
+  /** The user's typed input that produced the current popup suggestions (live-preview baseline). */
+  const previewBaselineRef = useRef<string>("");
+  /** Whether a popup candidate is currently rendered into the command line (#1005). */
+  const previewActiveRef = useRef(false);
   /** Monotonic counter to invalidate stale async sub-dir fetches */
   const subDirFetchVersionRef = useRef(0);
   /**
@@ -666,6 +671,9 @@ export function useTerminalAutocomplete(
 
     // Popup
     if (settingsRef.current.showPopupMenu && completions.length > 0) {
+      // Live-preview baseline: the typed input these suggestions completed.
+      previewBaselineRef.current = input;
+      previewActiveRef.current = false;
       const { position, cursorLineTop, cursorLineBottom, expandUpward } = calculatePopupPosition(term, completions.length);
       startTransition(() => {
         setState((prev) => {
@@ -1144,25 +1152,24 @@ export function useTerminalAutocomplete(
           return true;
         }
 
-        // Main panel navigation
-        if (e.key === "ArrowUp") {
+        // Main panel navigation. The cycle includes a -1 "no selection" slot so
+        // ↑ off the top / ↓ off the bottom reverts to the typed baseline. Moving
+        // the selection live-renders the candidate into the command line (#1005).
+        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
           e.preventDefault();
+          const n = s.suggestions.length;
+          const cur = s.selectedIndex;
+          const next =
+            e.key === "ArrowDown"
+              ? (cur >= n - 1 ? -1 : cur + 1)
+              : (cur <= -1 ? n - 1 : cur - 1);
           setState((prev) => ({
             ...prev,
-            selectedIndex: prev.selectedIndex <= 0 ? prev.suggestions.length - 1 : prev.selectedIndex - 1,
+            selectedIndex: next,
             subDirPanels: [], subDirFocusLevel: -1,
           }));
-          fetchSubDirForIndex(s.selectedIndex <= 0 ? s.suggestions.length - 1 : s.selectedIndex - 1);
-          return false;
-        }
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          setState((prev) => ({
-            ...prev,
-            selectedIndex: prev.selectedIndex >= prev.suggestions.length - 1 ? 0 : prev.selectedIndex + 1,
-            subDirPanels: [], subDirFocusLevel: -1,
-          }));
-          fetchSubDirForIndex(s.selectedIndex >= s.suggestions.length - 1 ? 0 : s.selectedIndex + 1);
+          renderPreviewSelection(next);
+          if (next >= 0) fetchSubDirForIndex(next);
           return false;
         }
 
@@ -1195,6 +1202,36 @@ export function useTerminalAutocomplete(
     // eslint-disable-next-line react-hooks/exhaustive-deps -- insertSuggestion uses refs, stable identity
     [writeToTerminal],
   );
+
+  /**
+   * Render the suggestion at `index` straight into the command line (Termius
+   * live-preview, #1005). `index < 0` restores the user's typed baseline.
+   */
+  const renderPreviewSelection = useCallback((index: number) => {
+    const s = stateRef.current;
+    const term = termRef.current;
+    if (!term) return;
+    const baseline = previewBaselineRef.current;
+    const candidate =
+      index >= 0 && s.suggestions[index] ? s.suggestions[index].text : baseline;
+    const { prompt } = getAlignedPrompt(
+      term,
+      typedInputBufferRef.current,
+      typedBufferReliableRef.current,
+    );
+    if (!prompt.isAtPrompt) return;
+    const seq = computeLivePreviewWrite({
+      currentLine: prompt.userInput,
+      candidate,
+      os: hostOsRef.current,
+    });
+    if (seq) writeToTerminal(seq);
+    typedInputBufferRef.current = candidate;
+    typedBufferReliableRef.current = true;
+    const isPreview = index >= 0 && candidate !== baseline;
+    previewActiveRef.current = isPreview;
+    lastAcceptedCommandRef.current = isPreview ? candidate : null;
+  }, [termRef, writeToTerminal]);
 
   /**
    * Insert a suggestion into the terminal.

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -1212,17 +1212,12 @@ export function useTerminalAutocomplete(
         }
 
         // Enter on popup. The selected candidate is already rendered into the
-        // line by live-preview, so let Enter reach the shell; just record the
-        // command for history and suppress handleInput's duplicate record.
+        // line by live-preview, so let Enter reach the shell. Don't record here:
+        // handleInput's Enter path records the *actual* line — it uses
+        // lastAcceptedCommandRef (set on select) but falls back to the live
+        // buffer when the user edited the previewed command (typing nulls that
+        // ref), so recording stays accurate in both cases.
         if (e.key === "Enter") {
-          if (s.selectedIndex >= 0 && previewActiveRef.current) {
-            const selected = s.suggestions[s.selectedIndex];
-            if (selected) {
-              recordCommand(selected.text, hostIdRef.current, hostOsRef.current);
-              suppressNextEnterRecordRef.current = true;
-              setTimeout(() => { suppressNextEnterRecordRef.current = false; }, 100);
-            }
-          }
           clearState();
           previewActiveRef.current = false;
           return true;

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -1063,10 +1063,11 @@ export function useTerminalAutocomplete(
       // which is otherwise shadowed by our single-Tab ghost accept.
       if (e.key === "Tab" && !e.ctrlKey && !e.metaKey && !e.altKey && s.subDirFocusLevel < 0) {
         if (s.popupVisible && s.suggestions.length > 0) {
-          e.preventDefault();
-          const selected = s.suggestions[Math.max(0, s.selectedIndex)];
-          if (selected) insertSuggestion(selected, false);
-          return false;
+          // #1005: don't intercept Tab. Keep whatever is currently rendered on
+          // the line and let Tab reach the shell for native completion.
+          clearState();
+          previewActiveRef.current = false;
+          return true;
         }
         // Hide stale ghost text before Tab reaches the shell — the shell's
         // completion will rewrite the line and the old ghost would mislead.
@@ -1173,17 +1174,21 @@ export function useTerminalAutocomplete(
           return false;
         }
 
-        // Enter on popup
+        // Enter on popup. The selected candidate is already rendered into the
+        // line by live-preview, so let Enter reach the shell; just record the
+        // command for history and suppress handleInput's duplicate record.
         if (e.key === "Enter") {
-          if (s.selectedIndex >= 0) {
+          if (s.selectedIndex >= 0 && previewActiveRef.current) {
             const selected = s.suggestions[s.selectedIndex];
             if (selected) {
-              e.preventDefault();
-              insertSuggestion(selected, true);
-              return false;
+              recordCommand(selected.text, hostIdRef.current, hostOsRef.current);
+              suppressNextEnterRecordRef.current = true;
+              setTimeout(() => { suppressNextEnterRecordRef.current = false; }, 100);
             }
           }
           clearState();
+          previewActiveRef.current = false;
+          return true;
         }
       }
 
@@ -1192,8 +1197,12 @@ export function useTerminalAutocomplete(
       // when only ghost text is showing (ghost text is passive/non-intrusive)
       if (e.key === "Escape" && s.popupVisible) {
         e.preventDefault();
+        if (previewActiveRef.current) {
+          renderPreviewSelection(-1); // restore the typed baseline
+        }
         ghost?.hide();
         clearState();
+        previewActiveRef.current = false;
         return false;
       }
 

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -919,6 +919,10 @@ export function useTerminalAutocomplete(
       // User is typing more — invalidate accepted command fallback since the
       // command is being edited further (e.g., accepted "git status" then added " --short")
       lastAcceptedCommandRef.current = null;
+      // The previewed candidate is now edited, so the line is the user's own
+      // text. Drop preview-active so Escape dismisses the popup without
+      // reverting these edits back to the stale baseline (#1005).
+      previewActiveRef.current = false;
 
       // Re-align any visible ghost text to the freshly-updated buffer
       // immediately. Without this the ghost keeps the tail it captured at

--- a/components/terminal/livePreviewSequence.test.ts
+++ b/components/terminal/livePreviewSequence.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { computeLivePreviewWrite } from "./livePreviewSequence.ts";
+import { computeLivePreviewWrite } from "./autocomplete/livePreviewSequence.ts";
 
 test("appends only the tail when the candidate continues the current line", () => {
   assert.equal(


### PR DESCRIPTION
## Problem

In popup-menu autocomplete mode, Netcatty intercepts **Tab** to accept the highlighted suggestion. But Tab is the native completion key in every mainstream shell (bash/zsh/fish), so our interception shadows and conflicts with the shell's own completion. Reporter (#1005) asked to use a non-Tab key, like the inline ghost suggestion does.

## Approach (Termius-style live preview)

Instead of an explicit "accept" key, **moving the selection renders the candidate straight into the command line**, so there's no separate confirm step:

- Popup opens with **no selection**; the line shows only what you typed (already the existing default).
- **↑ / ↓** move the selection and live-render the chosen candidate into the line. The cycle includes a "no selection" slot, so arrowing off either end reverts to your typed text.
- **Enter** executes the already-rendered line.
- **Tab** is no longer intercepted — it closes the popup, keeps the rendered text, and passes through to the shell for native completion. (This is the core fix.)
- **Esc** reverts the preview to your typed text and closes.
- **→** keeps its existing role of expanding a directory suggestion's sub-panel — no accept conflict, since selection itself is the accept. Sub-panel ↑/↓ live-render the full path too.

### Key hint

The selected row now shows a key-cap hint: `↵` (run) on every selected item, plus `→` (expand) on directory items.

## Implementation

- `livePreviewSequence.ts` — pure `computeLivePreviewWrite({ currentLine, candidate, os })` that returns the keystrokes to morph the line into the candidate (append tail for prefix continuations; Ctrl-U / backspaces + full write otherwise). Fully unit-tested.
- `useTerminalAutocomplete.ts` — baseline/preview refs, `renderPreviewSelection` / `renderSubDirPath`, ↑/↓ live-render, Tab freed, Enter executes, Esc reverts.
- `AutocompletePopup.tsx` — selected-row key-cap hint.

Inline ghost-text mode is untouched (it already uses → to accept; mutually exclusive with popup mode).

## Test plan

- [x] Unit tests for `computeLivePreviewWrite` (prefix / fuzzy / shorter-prefix / revert / Windows backspaces)
- [x] Full suite green (1137 passing)
- [ ] **Manual smoke test (please verify with `npm run dev`, popup mode on):**
  - Type `doc` → popup opens, nothing selected, line unchanged
  - ↓/↑ swap candidates live; ↑ off the top reverts to `doc`
  - Enter runs the rendered command (no duplicated text, history recorded)
  - Tab closes popup, keeps text, shell's own completion runs
  - Esc restores `doc`
  - Path completion: dir shows `→`+`↵`, non-dir shows `↵`; → expands; sub-panel ↑/↓ render full path
  - Sanity-check on a remote SSH host (latency) for flicker

> Note: the live-render rewrites the real shell input line on each navigation; this area had recent echo/ghost regressions (#1013/#1042), so the manual remote check matters before merge.

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)