### PR TITLE
fix #1063: force WebGL redraw on tab show to recover from garbled multi-tab terminals

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1269,6 +1269,18 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (!isVisible) return;
     const timer = setTimeout(() => {
       safeFit({ requireVisible: true });
+      // Recover the WebGL renderer now that this tab is visible again. Hidden
+      // panes stay mounted off-screen (visibility:hidden) so each keeps a live
+      // WebGL context; creating another terminal's context — or the GPU dropping
+      // a non-composited off-screen canvas — can leave this terminal's drawing
+      // buffer corrupted ("花屏", issue #1063). Because a hidden pane keeps its
+      // dimensions, becoming visible triggers no resize and therefore no redraw,
+      // so the corruption persists until the user resizes the window. Force the
+      // same recovery a resize performs: clear the texture atlas (no-op on the
+      // DOM renderer) and synchronously repaint every row.
+      xtermRuntimeRef.current?.clearTextureAtlas();
+      const visibleTerm = termRef.current;
+      if (visibleTerm) forceSyncRenderAfterResize(visibleTerm);
       if (pendingOutputScrollRef.current) {
         termRef.current?.scrollToBottom();
         if (typeof requestAnimationFrame === "function") {


### PR DESCRIPTION
## Problem

Closes #1063. With the **WebGL** renderer, opening multiple tabs leaves all but the just-opened tab garbled: opening 2 tabs garbles the 1st, opening 3 garbles the 1st and 2nd. The DOM renderer is unaffected; Auto is intermittent. Reproduces on **both Windows and macOS**. Re-dragging (resizing) the window restores the garbled tab.

## Root cause

Hidden tabs are not unmounted — they stay mounted off-screen via `visibility:hidden` + `left/top:-9999px` (`TerminalLayer.tsx`), keeping their dimensions at 100%. So every open tab holds a **live WebGL context** simultaneously. Creating another terminal's WebGL context — or the GPU dropping a non-composited off-screen canvas — corrupts the hidden terminals' drawing buffers. The DOM renderer is immune because it renders to real DOM nodes.

- **Why resize recovers it:** window drag → `ResizeObserver` → dimensions change → `term.resize` → `forceSyncRenderAfterResize` (full repaint) + `onResize` → `clearTextureAtlas`.
- **Why a tab switch did not:** the visibility effect in `Terminal.tsx` only calls `safeFit`, which early-returns when the pane's dimensions are unchanged (a hidden pane keeps its size). So becoming visible triggered no resize and therefore no redraw — the corruption persisted.

## Fix

When a tab becomes visible, perform the same recovery a resize does: clear the texture atlas (`clearTextureAtlas`, already a no-op on the DOM renderer) and force a synchronous full repaint (`forceSyncRenderAfterResize`). Both primitives are already used in the resize path, so this follows existing conventions.

Verified against the xterm core source that `RenderService._renderRows(0, end)` calls `renderer.renderRows` directly — an unconditional draw, independent of dimension changes or dirty-row tracking — so the repaint fires even though the dimensions are unchanged on a tab switch.

## Testing

- `tsc --noEmit`: no new type errors (baseline 40 → 40; the 3 pre-existing `Terminal.tsx` theme-typing errors are unrelated).
- This is a GPU/compositing behavior; the pixel-level "garbling is gone" still needs visual confirmation on a real GPU with the WebGL renderer (set Settings → Terminal → Renderer = WebGL, open 3 terminals, switch back to the first two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)