### PR TITLE
fix #1062: treat SSH shell TMOUT auto-logout as a timeout, not a normal exit

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -65,15 +65,23 @@ function extractTrailingIdlePrompt(output) {
 // exit code alone (verified: bash auto-logout exits 0). The banner is the only
 // reliable discriminator, letting the SSH bridge keep the tab open for
 // reconnect instead of auto-closing it (#1062, regression of #977).
-const IDLE_AUTO_LOGOUT_PATTERN = /timed out waiting for input|auto-?logout/i;
+const IDLE_AUTO_LOGOUT_PATTERN = /(?:timed out waiting for input:\s*)?auto-?logout$/i;
 
 function looksLikeIdleAutoLogout(outputTail) {
   if (typeof outputTail !== "string" || !outputTail) return false;
-  // The banner is the last thing the shell prints before exiting, so only
-  // inspect the tail end — unrelated earlier output (e.g. a file that happened
-  // to contain "auto-logout") must not be mistaken for a timeout.
-  const end = stripAnsi(outputTail).slice(-256);
-  return IDLE_AUTO_LOGOUT_PATTERN.test(end);
+  // The shell prints this banner on its own line as the very last thing before
+  // it exits, so anchor on the final non-empty line rather than a loose
+  // substring. Otherwise unrelated output that merely mentions "auto-logout"
+  // (e.g. `grep auto-logout /etc/profile`) followed by an intentional `exit`
+  // would be misclassified as a timeout and wrongly keep the tab open.
+  const lines = stripAnsi(outputTail.slice(-512)).replace(/\r/g, "\n").split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    // Drop control bytes (e.g. the BEL bash rings before the banner) and trim.
+    const line = lines[i].replace(/[\x00-\x1f\x7f]/g, "").trim();
+    if (!line) continue;
+    return IDLE_AUTO_LOGOUT_PATTERN.test(line);
+  }
+  return false;
 }
 
 function trackSessionIdlePrompt(session, chunk) {

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -58,6 +58,24 @@ function extractTrailingIdlePrompt(output) {
   return "";
 }
 
+// bash and csh/tcsh print a banner to the terminal right before exiting due to
+// the shell's TMOUT idle-timeout setting ("timed out waiting for input:
+// auto-logout" / "auto-logout"). That exit is a clean shell exit — numeric
+// code, no signal — so it is indistinguishable from a user-typed `exit` by
+// exit code alone (verified: bash auto-logout exits 0). The banner is the only
+// reliable discriminator, letting the SSH bridge keep the tab open for
+// reconnect instead of auto-closing it (#1062, regression of #977).
+const IDLE_AUTO_LOGOUT_PATTERN = /timed out waiting for input|auto-?logout/i;
+
+function looksLikeIdleAutoLogout(outputTail) {
+  if (typeof outputTail !== "string" || !outputTail) return false;
+  // The banner is the last thing the shell prints before exiting, so only
+  // inspect the tail end — unrelated earlier output (e.g. a file that happened
+  // to contain "auto-logout") must not be mistaken for a timeout.
+  const end = stripAnsi(outputTail).slice(-256);
+  return IDLE_AUTO_LOGOUT_PATTERN.test(end);
+}
+
 function trackSessionIdlePrompt(session, chunk) {
   if (!session || typeof chunk !== "string" || !chunk) return "";
 
@@ -399,6 +417,7 @@ module.exports = {
   getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
   trackSessionIdlePrompt,
+  looksLikeIdleAutoLogout,
   isLocalhostHostname,
   extractFirstNonLocalhostUrl,
   normalizeCliPathForPlatform,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -211,6 +211,27 @@ test("looksLikeIdleAutoLogout ignores the banner when it is not at the tail", ()
   assert.equal(looksLikeIdleAutoLogout(tail), false);
 });
 
+test("looksLikeIdleAutoLogout ignores auto-logout in command output before an intentional exit", () => {
+  // Investigating TMOUT: the user greps the profile (output mentions
+  // "auto-logout"), reads it, then exits on purpose. The banner is not the
+  // final line, so the tab must still auto-close. Guards against matching an
+  // unanchored substring anywhere in the recent output.
+  const tail =
+    "root@h:~# grep -i auto-logout /etc/profile\r\n" +
+    "# bash TMOUT auto-logout setting\r\nTMOUT=300\r\n" +
+    "root@h:~# exit\r\nlogout\r\n";
+  assert.equal(looksLikeIdleAutoLogout(tail), false);
+});
+
+test("looksLikeIdleAutoLogout matches the real-server banner shape (prompt + banner on one line)", () => {
+  // The banner can share a line with the trailing prompt after ANSI/control
+  // bytes are stripped (observed over real SSH); anchoring on the line end
+  // must still match.
+  const tail =
+    "\x1b]0;root@VM:~\x07root@VM:~# \x1b[?2004l\x07timed out waiting for input: auto-logout\n";
+  assert.equal(looksLikeIdleAutoLogout(tail), true);
+});
+
 test("looksLikeIdleAutoLogout returns false for empty / non-string input", () => {
   assert.equal(looksLikeIdleAutoLogout(""), false);
   assert.equal(looksLikeIdleAutoLogout(undefined), false);

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -7,6 +7,7 @@ const {
   getFreshIdlePrompt,
   isDefaultPowerShellPromptLine,
   isPlausibleCliVersionOutput,
+  looksLikeIdleAutoLogout,
   prepareCommandForSpawn,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
@@ -174,4 +175,44 @@ test("getFreshIdlePrompt and trackSessionIdlePrompt round-trip through a real PT
   // The freshness check rescues us: the visible tail no longer ends
   // with the cached PS line, so downstream wrapper selection sees "".
   assert.equal(getFreshIdlePrompt(session), "");
+});
+
+test("looksLikeIdleAutoLogout detects the bash TMOUT banner at the tail", () => {
+  // bash prints this immediately before a TMOUT auto-logout exit. The exit
+  // itself is a clean shell exit (code 0, no signal), so the banner is the
+  // only reliable discriminator from a user-typed `exit` (#1062 / #977).
+  assert.equal(
+    looksLikeIdleAutoLogout("user@host:~$ \x07timed out waiting for input: auto-logout\r\n"),
+    true,
+  );
+});
+
+test("looksLikeIdleAutoLogout detects the csh/tcsh auto-logout banner", () => {
+  assert.equal(looksLikeIdleAutoLogout("\r\nauto-logout\r\n"), true);
+});
+
+test("looksLikeIdleAutoLogout sees through ANSI escapes around the banner", () => {
+  assert.equal(
+    looksLikeIdleAutoLogout("\x1b[0m\x1b[33mtimed out waiting for input: auto-logout\x1b[0m\r\n"),
+    true,
+  );
+});
+
+test("looksLikeIdleAutoLogout ignores a plain (non-timeout) logout", () => {
+  // A normal login-shell exit prints "logout" — without the "auto-" prefix —
+  // and must still auto-close the tab.
+  assert.equal(looksLikeIdleAutoLogout("user@host:~$ logout\r\n"), false);
+});
+
+test("looksLikeIdleAutoLogout ignores the banner when it is not at the tail", () => {
+  // "auto-logout" scrolled past long ago; the user then ran more commands and
+  // exited normally. Only the tail end is inspected, so this is not a timeout.
+  const tail = "auto-logout\n" + "x".repeat(400) + "\nuser@host:~$ logout\r\n";
+  assert.equal(looksLikeIdleAutoLogout(tail), false);
+});
+
+test("looksLikeIdleAutoLogout returns false for empty / non-string input", () => {
+  assert.equal(looksLikeIdleAutoLogout(""), false);
+  assert.equal(looksLikeIdleAutoLogout(undefined), false);
+  assert.equal(looksLikeIdleAutoLogout(null), false);
 });

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -33,7 +33,7 @@ const {
   isPassphraseCancelledError,
 } = require("./sshAuthHelper.cjs");
 const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
-const { trackSessionIdlePrompt } = require("./ai/shellUtils.cjs");
+const { trackSessionIdlePrompt, looksLikeIdleAutoLogout } = require("./ai/shellUtils.cjs");
 const { createZmodemSentry } = require("./zmodemHelper.cjs");
 const {
   buildAlgorithms,
@@ -1386,7 +1386,14 @@ async function startSSHSession(event, options) {
                 if (transportError) {
                   safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: transportError, reason: "error" });
                 } else {
-                  safeSend(contents, "netcatty:exit", { sessionId, exitCode: streamExitCode, reason: streamExited ? "exited" : "closed" });
+                  // A shell TMOUT auto-logout is a clean exit (numeric code, no
+                  // signal) — identical to a user-typed `exit` by code/signal —
+                  // so detect it via the banner the shell prints just before
+                  // exiting and report it as a timeout. That keeps the tab open
+                  // for reconnect instead of auto-closing it (#1062 / #977).
+                  const idleTimedOut = streamExited && looksLikeIdleAutoLogout(session?._promptTrackTail);
+                  const reason = idleTimedOut ? "timeout" : (streamExited ? "exited" : "closed");
+                  safeSend(contents, "netcatty:exit", { sessionId, exitCode: streamExitCode, reason });
                 }
                 sessions.get(sessionId)?.zmodemSentry?.cancel();
                 sessions.delete(sessionId);


### PR DESCRIPTION
## Problem

Closes #1062 (regression of #977). With `export TMOUT=120` on a server, the SSH session auto-logs-out on idle, but netcatty **closes the tab** instead of showing the reconnect dialog.

## Root cause

A shell-level `TMOUT` auto-logout makes bash/csh **exit cleanly** — numeric exit code, no signal — which is indistinguishable from a user-typed `exit` at the SSH protocol level. PR #1057 keyed the close-vs-keep decision on `streamExited` (`typeof code === "number" && !signal`), so TMOUT exits were reported as `reason: "exited"` → `closeSession` → tab auto-closed. The original code comment assumed "idle timeout" arrives as a signal kill, but that only applies to the SSH server's `ClientAliveInterval`, not the shell's `TMOUT`.

## Fix

Since exit code/signal can't distinguish a TMOUT auto-logout from an intentional exit, detect the banner the shell prints right before exiting (`timed out waiting for input: auto-logout` / `auto-logout`) in the session's existing rolling output tail (`_promptTrackTail`) and report `reason: "timeout"` instead. That routes to the **existing** `markDisconnected` path (keep tab + reconnect). A normal `exit`/`logout` (no `auto-` prefix) still auto-closes the tab, so PR #1057's behavior is preserved.

- New `looksLikeIdleAutoLogout()` helper in `shellUtils.cjs` (inspects only the tail end + strips ANSI to avoid false positives).
- zsh's TMOUT raises SIGALRM (a signal) → already took the keep-tab/reconnect path; unaffected.

## Testing

- TDD: 6 new unit tests in `shellUtils.test.cjs` (red → green); related bridge/exit-intent suites pass.
- **Verified against a real server** (Ubuntu/bash) by reproducing the bridge's exact `ssh2` + PTY path: bash TMOUT exits `code 0 / no signal`, the `auto-logout` banner arrives before `close`, the real detector matches, and the computed `reason` is `"timeout"` ✅.

```
exit code   : 0   signal: undefined
streamExited: true
tail        : "...# export TMOUT=5 ... timed out waiting for input: auto-logout\n"
detector    : true
=> reason    : timeout  ✅ (keep tab + reconnect)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)