### PR TITLE
fix #1065: resolve terminal cwd through su/sudo for the SFTP locate

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2012,23 +2012,41 @@ async function getSessionPwd(event, payload) {
     // so sh keeps the same PID and $PPID = sshd. Starting another shell
     // without exec would make $PPID point at the intermediate shell instead.
     const posixScript = `SELF=$$
-find_child_shell() {
-  mode=$2
-  ps -e -o pid=,ppid=,stat=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" -v mode="$mode" '
-    $1 != self && $2 == pp && $4 ~ /^(ba|z|fi|k|da)?sh$/ {
-      if (index($3, "+") > 0) { print $1; found=1; exit }
-      if (mode != "foreground" && pid == "") pid=$1
-    }
-    END { if (!found && mode != "foreground" && pid != "") print pid }
+# Find an interactive shell child of this exec channel's sshd ($PPID).
+find_login_shell() {
+  ps -e -o pid=,ppid=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
+    $1 != self && $2 == pp && $3 ~ /^-?(ba|z|fi|k|da|a)?sh$/ { print $1; exit }
   '
 }
-pid=$(find_child_shell "$PPID" any)
-while [ -n "$pid" ]; do
-  child=$(find_child_shell "$pid" foreground)
-  [ -n "$child" ] || break
-  pid="$child"
-done
-if [ -n "$pid" ]; then
+# From the login shell, pick the DEEPEST foreground shell in its process
+# subtree. "Foreground" = the controlling tty's foreground process group ("+"
+# in stat), i.e. the shell the user is actually typing in. Walking the whole
+# subtree (rather than only direct shell children) lets us follow through
+# non-shell foreground parents like su / sudo, so we read the cwd of the
+# su'd / sudo'd shell instead of stopping at the login shell (#1065). Falls
+# back to the login shell when no foreground shell is found.
+find_active_shell() {
+  ps -e -o pid=,ppid=,stat=,comm= 2>/dev/null | awk -v start="$1" '
+    { pp[$1]=$2; st[$1]=$3; cm[$1]=$4; ord[NR]=$1 }
+    function isshell(c) { return c ~ /^-?(ba|z|fi|k|da|a)?sh$/ }
+    function depth(p,   d) { d=0; while (p != "" && d < 64) { if (p == start) return d; p=pp[p]; d++ } return -1 }
+    END {
+      best=-1; bp="";
+      for (i=1; i<=NR; i++) {
+        p=ord[i];
+        if (!isshell(cm[p])) continue;
+        if (index(st[p], "+") == 0) continue;
+        d=depth(p); if (d < 0) continue;
+        if (d > best) { best=d; bp=p }
+      }
+      print (bp != "" ? bp : start)
+    }
+  '
+}
+login=$(find_login_shell "$PPID")
+if [ -n "$login" ]; then
+  pid=$(find_active_shell "$login")
+  [ -n "$pid" ] || pid="$login"
   cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
   [ -n "$cwd" ] && printf '%s\\n' "$cwd" && exit 0
 fi

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2012,10 +2012,19 @@ async function getSessionPwd(event, payload) {
     // so sh keeps the same PID and $PPID = sshd. Starting another shell
     // without exec would make $PPID point at the intermediate shell instead.
     const posixScript = `SELF=$$
-# Find an interactive shell child of this exec channel's sshd ($PPID).
+# Find the interactive shell child of this exec channel's sshd ($PPID).
+# Prefer the one attached to a controlling tty (the user's shell): probe exec
+# channels like this one have no tty ("?"), and ps output is unsorted, so
+# without the tty preference a concurrent probe's shell could be picked when
+# several exist under the same sshd (#1065 review). Falls back to any shell
+# child if none has a tty.
 find_login_shell() {
-  ps -e -o pid=,ppid=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
-    $1 != self && $2 == pp && $3 ~ /^-?(ba|z|fi|k|da|a)?sh$/ { print $1; exit }
+  ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
+    $1 != self && $2 == pp && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ {
+      if ($3 != "?") { print $1; found=1; exit }
+      if (any == "") any=$1
+    }
+    END { if (!found && any != "") print any }
   '
 }
 # From the login shell, pick the DEEPEST foreground shell in its process

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2048,6 +2048,13 @@ if [ -n "$login" ]; then
   pid=$(find_active_shell "$login")
   [ -n "$pid" ] || pid="$login"
   cwd=$(readlink /proc/$pid/cwd 2>/dev/null)
+  # /proc/<pid>/cwd is only readable for same-uid processes (ptrace perms), so
+  # this unprivileged exec channel cannot read a su'd / sudo'd shell owned by
+  # another user. Fall back to the same-uid login shell's cwd before giving up
+  # to the home directory (#1065 review).
+  if [ -z "$cwd" ] && [ "$pid" != "$login" ]; then
+    cwd=$(readlink /proc/$login/cwd 2>/dev/null)
+  fi
   [ -n "$cwd" ] && printf '%s\\n' "$cwd" && exit 0
 fi
 emit_home() {


### PR DESCRIPTION
## Problem

Closes #1065. The SFTP sidebar's "locate to terminal's current directory" keeps showing the login user's home (e.g. `/root`) and stops tracking after the user switches accounts: e.g. login as root → `su <user>` → `cd` elsewhere, or `sudo -s` / `su` in the other direction.

## Root cause

`getSessionPwd` (`electron/bridges/sshBridge.cjs`) resolves the terminal's cwd by walking the remote process tree from a sibling exec channel: it finds the interactive shell under the connection's sshd, follows the foreground child shells down, and reads `/proc/<pid>/cwd`. But the walk only followed children whose `comm` is a **shell name** (`bash`/`zsh`/`fish`/...). `su` and `sudo` are named `su`/`sudo`, so the walk **stopped at the login shell** and read its cwd.

Real process tree (`root → su t1065 → bash`, cwd `/tmp`):

```
sshd
└─ bash   (root login shell)        ← walk stopped here → /root
   └─ su   stat=S
      └─ bash  stat=S+  cwd=/tmp     ← the shell the user is actually in
```

The active shell lives **under** `su`/`sudo` as the controlling tty's foreground process group (`+` in `stat`). (OSC 7 cwd reporting doesn't help here — it isn't emitted by default over plain SSH, and a su'd shell doesn't emit it, so `getSessionPwd` is the active path.)

## Fix

Rewrite the walk to select the **deepest foreground shell** (`+` in `stat`) within the login shell's entire process subtree. This transparently follows through non-shell foreground parents like `su`/`sudo` to the active shell, and falls back to the login shell when no foreground shell is found (so the no-su path is unchanged).

## Testing

This is a remote POSIX/awk script (needs a real Linux process tree + `/proc`), so it was verified against a **real server** by reproducing the exact `ssh2` + sibling-exec path the bridge uses:

- `root → su t1065 → cd /tmp`: **before → `/root`, after → `/tmp`** ✅
- no-su control (`cd /var`): **before → `/var`, after → `/var`** (no regression) ✅
- `node --test components/terminal/sftpCwd.test.ts` passes (resolution layer unchanged).

## Known limitation (out of scope)

If a user has OSC 7 cwd reporting enabled in their shell **and** then `su`'s, the cached OSC 7 value (`rendererCwd`) can still be preferred over this probe, since the su'd shell stops emitting OSC 7. That's a separate, narrower edge; this PR fixes the dominant cause (the process-tree walk) that affects standard SSH sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)