### PR TITLE
feat #1064: prompt to overwrite when rz upload hits a remote filename conflict

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -2092,6 +2092,11 @@ const en: Messages = {
   'zmodem.uploading': 'Uploading',
   'zmodem.downloading': 'Downloading',
   'zmodem.cancelTransfer': 'Cancel transfer (Ctrl+C)',
+  'zmodem.overwrite.title': 'Remote file already exists',
+  'zmodem.overwrite.applyToRest': 'Apply to remaining conflicts',
+  'zmodem.overwrite.overwrite': 'Overwrite',
+  'zmodem.overwrite.skip': 'Skip',
+  'zmodem.overwrite.cancel': 'Cancel',
   'settings.shortcuts.resetToDefault': 'Reset to default',
 };
 

--- a/application/i18n/locales/ru.ts
+++ b/application/i18n/locales/ru.ts
@@ -2124,6 +2124,11 @@ const ru: Messages = {
   'zmodem.uploading': 'Загрузка',
   'zmodem.downloading': 'Скачивание',
   'zmodem.cancelTransfer': 'Отменить передачу (Ctrl+C)',
+  'zmodem.overwrite.title': 'Remote file already exists',
+  'zmodem.overwrite.applyToRest': 'Apply to remaining conflicts',
+  'zmodem.overwrite.overwrite': 'Overwrite',
+  'zmodem.overwrite.skip': 'Skip',
+  'zmodem.overwrite.cancel': 'Cancel',
   'settings.shortcuts.resetToDefault': 'Сбросить по умолчанию',
 };
 

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -2101,6 +2101,11 @@ const zhCN: Messages = {
   'zmodem.uploading': '上传中',
   'zmodem.downloading': '下载中',
   'zmodem.cancelTransfer': '取消传输 (Ctrl+C)',
+  'zmodem.overwrite.title': '远端已存在同名文件',
+  'zmodem.overwrite.applyToRest': '应用到其余冲突文件',
+  'zmodem.overwrite.overwrite': '覆盖',
+  'zmodem.overwrite.skip': '跳过',
+  'zmodem.overwrite.cancel': '取消',
   'settings.shortcuts.resetToDefault': '重置为默认',
 };
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -49,6 +49,7 @@ import { TerminalToolbar } from "./terminal/TerminalToolbar";
 import { TerminalComposeBar } from "./terminal/TerminalComposeBar";
 import { TerminalContextMenu } from "./terminal/TerminalContextMenu";
 import { TerminalSearchBar } from "./terminal/TerminalSearchBar";
+import { ZmodemOverwriteDialog } from "./terminal/ZmodemOverwriteDialog";
 import { ZmodemProgressIndicator } from "./terminal/ZmodemProgressIndicator";
 import { createReplaySafeTerminalLogSanitizer } from "./terminal/replaySafeTerminalLog";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
@@ -2492,6 +2493,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
                 onCancel={zmodem.cancel}
               />
             </div>
+          )}
+          {/* ZMODEM overwrite conflict dialog */}
+          {zmodem.overwriteRequest && (
+            <ZmodemOverwriteDialog
+              filename={zmodem.overwriteRequest.filename}
+              onRespond={zmodem.respondOverwrite}
+            />
           )}
         </div>
 

--- a/components/terminal/ZmodemOverwriteDialog.tsx
+++ b/components/terminal/ZmodemOverwriteDialog.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "../ui/dialog";
+import { Button } from "../ui/button";
+
+interface Props {
+  filename: string;
+  onRespond: (action: "overwrite" | "skip" | "cancel", applyToRest: boolean) => void;
+}
+
+export const ZmodemOverwriteDialog: React.FC<Props> = ({ filename, onRespond }) => {
+  const [applyToRest, setApplyToRest] = useState(false);
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onRespond("cancel", false); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>远端已存在同名文件</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground break-all">{filename}</p>
+        <label className="flex items-center gap-2 text-sm mt-2">
+          <input type="checkbox" checked={applyToRest} onChange={(e) => setApplyToRest(e.target.checked)} />
+          应用到其余冲突文件
+        </label>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onRespond("cancel", applyToRest)}>取消</Button>
+          <Button variant="outline" onClick={() => onRespond("skip", applyToRest)}>跳过</Button>
+          <Button onClick={() => onRespond("overwrite", applyToRest)}>覆盖</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/terminal/ZmodemOverwriteDialog.tsx
+++ b/components/terminal/ZmodemOverwriteDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useI18n } from "../../application/i18n/I18nProvider";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "../ui/dialog";
 import { Button } from "../ui/button";
 
@@ -8,22 +9,23 @@ interface Props {
 }
 
 export const ZmodemOverwriteDialog: React.FC<Props> = ({ filename, onRespond }) => {
+  const { t } = useI18n();
   const [applyToRest, setApplyToRest] = useState(false);
   return (
     <Dialog open onOpenChange={(o) => { if (!o) onRespond("cancel", false); }}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>远端已存在同名文件</DialogTitle>
+          <DialogTitle>{t("zmodem.overwrite.title")}</DialogTitle>
         </DialogHeader>
         <p className="text-sm text-muted-foreground break-all">{filename}</p>
         <label className="flex items-center gap-2 text-sm mt-2">
           <input type="checkbox" checked={applyToRest} onChange={(e) => setApplyToRest(e.target.checked)} />
-          应用到其余冲突文件
+          {t("zmodem.overwrite.applyToRest")}
         </label>
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onRespond("cancel", applyToRest)}>取消</Button>
-          <Button variant="outline" onClick={() => onRespond("skip", applyToRest)}>跳过</Button>
-          <Button onClick={() => onRespond("overwrite", applyToRest)}>覆盖</Button>
+          <Button variant="ghost" onClick={() => onRespond("cancel", applyToRest)}>{t("zmodem.overwrite.cancel")}</Button>
+          <Button variant="outline" onClick={() => onRespond("skip", applyToRest)}>{t("zmodem.overwrite.skip")}</Button>
+          <Button onClick={() => onRespond("overwrite", applyToRest)}>{t("zmodem.overwrite.overwrite")}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/terminal/hooks/useZmodemTransfer.ts
+++ b/components/terminal/hooks/useZmodemTransfer.ts
@@ -27,6 +27,7 @@ const initialState: ZmodemTransferState = {
 
 export function useZmodemTransfer(sessionId: string | null) {
   const [state, setState] = useState<ZmodemTransferState>(initialState);
+  const [overwriteRequest, setOverwriteRequest] = useState<{ requestId: string; filename: string } | null>(null);
   const disposeRef = useRef<(() => void) | null>(null);
 
   const disposeExitRef = useRef<(() => void) | null>(null);
@@ -77,6 +78,10 @@ export function useZmodemTransfer(sessionId: string | null) {
       }
     });
 
+    const disposeOverwrite = bridge.onZmodemOverwriteRequest?.(sessionId, (payload) => {
+      setOverwriteRequest({ requestId: payload.requestId, filename: payload.filename });
+    });
+
     // If the session exits mid-transfer (disconnect, shell exit, etc.),
     // reset state so the progress indicator doesn't stay stuck.
     disposeExitRef.current = bridge.onSessionExit(sessionId, () => {
@@ -86,9 +91,11 @@ export function useZmodemTransfer(sessionId: string | null) {
     return () => {
       disposeRef.current?.();
       disposeRef.current = null;
+      disposeOverwrite?.();
       disposeExitRef.current?.();
       disposeExitRef.current = null;
       setState(initialState);
+      setOverwriteRequest(null);
     };
   }, [sessionId]);
 
@@ -98,5 +105,12 @@ export function useZmodemTransfer(sessionId: string | null) {
     bridge?.cancelZmodem?.(sessionId);
   }, [sessionId]);
 
-  return { ...state, cancel };
+  const respondOverwrite = useCallback((action: "overwrite" | "skip" | "cancel", applyToRest: boolean) => {
+    setOverwriteRequest((req) => {
+      if (req) netcattyBridge.get()?.respondZmodemOverwrite?.({ requestId: req.requestId, action, applyToRest });
+      return null;
+    });
+  }, []);
+
+  return { ...state, cancel, overwriteRequest, respondOverwrite };
 }

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1330,6 +1330,12 @@ async function startSSHSession(event, options) {
               interruptRemote() {
                 try { stream.signal?.("INT"); } catch { /* ignore */ }
               },
+              probeReceiveConflicts(names) {
+                return probeReceiveConflicts(sessions.get(sessionId), names);
+              },
+              removeRemoteFiles(paths) {
+                return removeRemoteFiles(sessions.get(sessionId), paths);
+              },
               getWebContents() {
                 return event.sender;
               },
@@ -2073,6 +2079,74 @@ exit 1`;
           resolve({ success: false, error: 'Could not determine cwd' });
         }
       });
+    });
+  });
+}
+
+// Resolve the directory the running `rz` writes to (its own cwd) and report
+// which of `names` already exist there. Returns { dir, existing } or null.
+function probeReceiveConflicts(session, names) {
+  return new Promise((resolve) => {
+    if (!session || !session.conn || !Array.isArray(names) || names.length === 0) {
+      return resolve(null);
+    }
+    const timer = setTimeout(() => resolve(null), 5000);
+    const script = `SELF=$$
+find_login_shell() {
+  ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
+    $1 != self && $2 == pp && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ {
+      if ($3 != "?") { print $1; found=1; exit }
+      if (any == "") any=$1
+    }
+    END { if (!found && any != "") print any }'
+}
+find_fg_leaf() {
+  ps -e -o pid=,ppid=,stat=,comm= 2>/dev/null | awk -v start="$1" '
+    { pp[$1]=$2; st[$1]=$3; ord[NR]=$1 }
+    function depth(p,  d){ d=0; while(p!="" && d<64){ if(p==start) return d; p=pp[p]; d++ } return -1 }
+    END { best=-1; bp=""; for(i=1;i<=NR;i++){ p=ord[i];
+      if(index(st[p],"+")==0) continue; d=depth(p); if(d<0) continue;
+      if(d>best){best=d; bp=p} } print bp }'
+}
+login=$(find_login_shell "$PPID")
+[ -n "$login" ] || exit 0
+leaf=$(find_fg_leaf "$login")
+[ -n "$leaf" ] || leaf="$login"
+dir=$(readlink /proc/$leaf/cwd 2>/dev/null)
+[ -n "$dir" ] || exit 0
+printf 'DIR\\t%s\\n' "$dir"
+cd "$dir" 2>/dev/null || exit 0
+for n in "$@"; do [ -e "$n" ] && printf 'EXIST\\t%s\\n' "$n"; done`;
+    const argv = names.map((n) => quoteShellArg(n)).join(" ");
+    const cmd = `exec sh -c ${quoteShellArg(script)} sh ${argv}`;
+    session.conn.exec(cmd, (err, stream) => {
+      if (err) { clearTimeout(timer); return resolve(null); }
+      let out = "";
+      stream.on("data", (d) => { out += d.toString(); });
+      stream.on("close", () => {
+        clearTimeout(timer);
+        let dir = null; const existing = [];
+        for (const line of out.split("\n")) {
+          const [tag, val] = line.split("\t");
+          if (tag === "DIR") dir = val;
+          else if (tag === "EXIST" && val) existing.push(val);
+        }
+        resolve(dir ? { dir, existing } : null);
+      });
+    });
+  });
+}
+
+// rm -f the given absolute remote paths (quoted; injection-safe).
+function removeRemoteFiles(session, paths) {
+  return new Promise((resolve) => {
+    if (!session || !session.conn || !Array.isArray(paths) || paths.length === 0) return resolve();
+    const argv = paths.map((p) => quoteShellArg(p)).join(" ");
+    const timer = setTimeout(resolve, 5000);
+    session.conn.exec(`exec sh -c 'rm -f -- "$@"' sh ${argv}`, (err, stream) => {
+      if (err) { clearTimeout(timer); return resolve(); }
+      stream.on("data", () => {}); stream.stderr?.on("data", () => {});
+      stream.on("close", () => { clearTimeout(timer); resolve(); });
     });
   });
 }

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -365,6 +365,8 @@ function resolveLangFromCharset(charset) {
 
 const { safeSend } = require("./ipcUtils.cjs");
 
+const zmodemOverwritePending = new Map(); // requestId -> (decision) => void
+
 /**
  * Initialize the SSH bridge with dependencies
  */
@@ -1335,6 +1337,22 @@ async function startSSHSession(event, options) {
               },
               removeRemoteFiles(paths) {
                 return removeRemoteFiles(sessions.get(sessionId), paths);
+              },
+              requestOverwriteDecision(filename) {
+                return new Promise((resolve) => {
+                  const requestId = randomUUID();
+                  const timer = setTimeout(() => {
+                    zmodemOverwritePending.delete(requestId);
+                    resolve({ action: "skip", applyToRest: false });
+                  }, 120000);
+                  zmodemOverwritePending.set(requestId, (payload) => {
+                    clearTimeout(timer);
+                    resolve({ action: payload.action, applyToRest: !!payload.applyToRest });
+                  });
+                  safeSend(event.sender, "netcatty:zmodem:overwrite-request", {
+                    sessionId, requestId, filename,
+                  });
+                });
               },
               getWebContents() {
                 return event.sender;
@@ -2726,6 +2744,10 @@ function registerHandlers(ipcMain) {
       // ~/.ssh doesn't exist
     }
     return keys;
+  });
+  ipcMain.on("netcatty:zmodem:overwrite-response", (_event, payload) => {
+    const resolve = zmodemOverwritePending.get(payload?.requestId);
+    if (resolve) { zmodemOverwritePending.delete(payload.requestId); resolve(payload); }
   });
   // Register the shared keyboard-interactive response handler
   keyboardInteractiveHandler.registerHandler(ipcMain);

--- a/electron/bridges/sshBridge.execCommandPassphrase.test.cjs
+++ b/electron/bridges/sshBridge.execCommandPassphrase.test.cjs
@@ -81,6 +81,7 @@ test("execCommand stops when an identity file passphrase prompt is cancelled", a
     handle(channel, handler) {
       this.handlers.set(channel, handler);
     },
+    on() {},
   };
   bridge.registerHandlers(ipcMain);
   const execHandler = ipcMain.handlers.get("netcatty:ssh:exec");

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -550,10 +550,44 @@ async function handleUpload(zsession, opts) {
   const filePaths = result.filePaths;
   const fileStats = filePaths.map((fp) => fs.statSync(fp));
 
-  for (let i = 0; i < filePaths.length; i++) {
-    const filePath = filePaths[i];
-    const stat = fileStats[i];
-    const name = path.basename(filePath);
+  const allNames = filePaths.map((fp) => path.basename(fp));
+
+  // Conflict handling (SSH only — callbacks absent on local/telnet/serial).
+  // On any failure we fall back to today's behavior (rz silently skips).
+  let plan = { filesToOffer: allNames, filesToRemove: [], aborted: false };
+  if (opts.probeReceiveConflicts && opts.requestOverwriteDecision) {
+    try {
+      const probe = await opts.probeReceiveConflicts(allNames);
+      if (probe && probe.dir && Array.isArray(probe.existing) && probe.existing.length > 0) {
+        plan = await buildUploadPlan(allNames, probe.existing, opts.requestOverwriteDecision);
+        if (plan.aborted) {
+          try { zsession.abort(); } catch { /* ignore */ }
+          abortRemoteProcess(opts.writeToRemote);
+          throw new Error("Transfer cancelled");
+        }
+        if (plan.filesToRemove.length && opts.removeRemoteFiles) {
+          const base = probe.dir.replace(/\/+$/, "");
+          const targets = plan.filesToRemove.map((n) => `${base}/${n}`);
+          try {
+            await opts.removeRemoteFiles(targets);
+          } catch (err) {
+            console.warn("[ZMODEM] removeRemoteFiles failed; rz will skip:", err?.message || err);
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === "Transfer cancelled") throw err;
+      console.warn("[ZMODEM] conflict probe failed; proceeding:", err?.message || err);
+    }
+  }
+
+  const offerSet = new Set(plan.filesToOffer);
+  const offers = filePaths
+    .map((filePath, i) => ({ filePath, stat: fileStats[i], name: allNames[i] }))
+    .filter((o) => offerSet.has(o.name));
+
+  for (let i = 0; i < offers.length; i++) {
+    const { filePath, stat, name } = offers[i];
 
     safeSend(contents, "netcatty:zmodem:progress", {
       sessionId,
@@ -561,18 +595,18 @@ async function handleUpload(zsession, opts) {
       transferred: 0,
       total: stat.size,
       fileIndex: i,
-      fileCount: filePaths.length,
+      fileCount: offers.length,
       transferType: "upload",
     });
 
     let bytesRemaining = 0;
-    for (let j = i; j < fileStats.length; j++) bytesRemaining += fileStats[j].size;
+    for (let j = i; j < offers.length; j++) bytesRemaining += offers[j].stat.size;
 
     const xfer = await zsession.send_offer({
       name,
       size: stat.size,
       mtime: new Date(stat.mtimeMs),
-      files_remaining: filePaths.length - i,
+      files_remaining: offers.length - i,
       bytes_remaining: bytesRemaining,
     });
 
@@ -605,7 +639,7 @@ async function handleUpload(zsession, opts) {
           transferred: sent,
           total: stat.size,
           fileIndex: i,
-          fileCount: filePaths.length,
+          fileCount: offers.length,
           transferType: "upload",
         });
 
@@ -623,7 +657,7 @@ async function handleUpload(zsession, opts) {
         transferred: stat.size,
         total: stat.size,
         fileIndex: i,
-        fileCount: filePaths.length,
+        fileCount: offers.length,
         transferType: "upload",
         finalizing: true,
       });

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -21,6 +21,32 @@ function getElectron() {
 }
 
 /**
+ * Resolve per-file overwrite choices into an upload plan. Pure (no I/O):
+ * `resolveDecision(name)` is awaited only for files in `existingList`, in order;
+ * `{ applyToRest: true }` reuses that action for the remaining conflicts.
+ * Actions: 'overwrite' (rm remote then send), 'skip' (don't send), 'cancel' (abort all).
+ */
+async function buildUploadPlan(names, existingList, resolveDecision) {
+  const existing = new Set(existingList);
+  const filesToOffer = [];
+  const filesToRemove = [];
+  let bulkAction = null;
+  for (const name of names) {
+    if (!existing.has(name)) { filesToOffer.push(name); continue; }
+    let action = bulkAction;
+    if (!action) {
+      const decision = (await resolveDecision(name)) || { action: "skip" };
+      action = decision.action;
+      if (decision.applyToRest && action !== "cancel") bulkAction = action;
+    }
+    if (action === "cancel") return { filesToOffer: [], filesToRemove: [], aborted: true };
+    if (action === "overwrite") { filesToRemove.push(name); filesToOffer.push(name); }
+    // 'skip' → omit from both
+  }
+  return { filesToOffer, filesToRemove, aborted: false };
+}
+
+/**
  * Create a ZMODEM sentry that wraps a session's data stream.
  *
  * All raw data from the PTY / SSH stream / socket should be fed into
@@ -791,4 +817,4 @@ function safeSend(contents, channel, data) {
   }
 }
 
-module.exports = { createZmodemSentry };
+module.exports = { createZmodemSentry, buildUploadPlan };

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -22,28 +22,31 @@ function getElectron() {
 
 /**
  * Resolve per-file overwrite choices into an upload plan. Pure (no I/O):
- * `resolveDecision(name)` is awaited only for files in `existingList`, in order;
- * `{ applyToRest: true }` reuses that action for the remaining conflicts.
+ * `resolveDecision(name)` is awaited only for files in `existingList`, in input
+ * order; `{ applyToRest: true }` reuses that action for the remaining conflicts.
+ * Returns indices into the original `names` array so callers preserve per-file
+ * identity even when two files share a basename.
  * Actions: 'overwrite' (rm remote then send), 'skip' (don't send), 'cancel' (abort all).
  */
 async function buildUploadPlan(names, existingList, resolveDecision) {
   const existing = new Set(existingList);
-  const filesToOffer = [];
-  const filesToRemove = [];
+  const offerIndices = [];
+  const removeIndices = [];
   let bulkAction = null;
-  for (const name of names) {
-    if (!existing.has(name)) { filesToOffer.push(name); continue; }
+  for (let idx = 0; idx < names.length; idx++) {
+    const name = names[idx];
+    if (!existing.has(name)) { offerIndices.push(idx); continue; }
     let action = bulkAction;
     if (!action) {
       const decision = (await resolveDecision(name)) || { action: "skip" };
       action = decision.action;
       if (decision.applyToRest && action !== "cancel") bulkAction = action;
     }
-    if (action === "cancel") return { filesToOffer: [], filesToRemove: [], aborted: true };
-    if (action === "overwrite") { filesToRemove.push(name); filesToOffer.push(name); }
+    if (action === "cancel") return { offerIndices: [], removeIndices: [], aborted: true };
+    if (action === "overwrite") { removeIndices.push(idx); offerIndices.push(idx); }
     // 'skip' → omit from both
   }
-  return { filesToOffer, filesToRemove, aborted: false };
+  return { offerIndices, removeIndices, aborted: false };
 }
 
 /**
@@ -554,7 +557,7 @@ async function handleUpload(zsession, opts) {
 
   // Conflict handling (SSH only — callbacks absent on local/telnet/serial).
   // On any failure we fall back to today's behavior (rz silently skips).
-  let plan = { filesToOffer: allNames, filesToRemove: [], aborted: false };
+  let plan = { offerIndices: allNames.map((_, i) => i), removeIndices: [], aborted: false };
   if (opts.probeReceiveConflicts && opts.requestOverwriteDecision) {
     try {
       const probe = await opts.probeReceiveConflicts(allNames);
@@ -565,9 +568,9 @@ async function handleUpload(zsession, opts) {
           abortRemoteProcess(opts.writeToRemote);
           throw new Error("Transfer cancelled");
         }
-        if (plan.filesToRemove.length && opts.removeRemoteFiles) {
+        if (plan.removeIndices.length && opts.removeRemoteFiles) {
           const base = probe.dir.replace(/\/+$/, "");
-          const targets = plan.filesToRemove.map((n) => `${base}/${n}`);
+          const targets = [...new Set(plan.removeIndices.map((i) => `${base}/${allNames[i]}`))];
           try {
             await opts.removeRemoteFiles(targets);
           } catch (err) {
@@ -581,10 +584,7 @@ async function handleUpload(zsession, opts) {
     }
   }
 
-  const offerSet = new Set(plan.filesToOffer);
-  const offers = filePaths
-    .map((filePath, i) => ({ filePath, stat: fileStats[i], name: allNames[i] }))
-    .filter((o) => offerSet.has(o.name));
+  const offers = plan.offerIndices.map((i) => ({ filePath: filePaths[i], stat: fileStats[i], name: allNames[i] }));
 
   for (let i = 0; i < offers.length; i++) {
     const { filePath, stat, name } = offers[i];

--- a/electron/bridges/zmodemHelper.test.cjs
+++ b/electron/bridges/zmodemHelper.test.cjs
@@ -4,27 +4,24 @@ const { buildUploadPlan } = require("./zmodemHelper.cjs");
 
 const never = () => { throw new Error("resolver should not be called"); };
 
-test("no conflicts: everything offered, nothing removed, resolver untouched", async () => {
+test("no conflicts: all indices offered, none removed, resolver untouched", async () => {
   const plan = await buildUploadPlan(["a.txt", "b.txt"], [], never);
-  assert.deepEqual(plan, { filesToOffer: ["a.txt", "b.txt"], filesToRemove: [], aborted: false });
+  assert.deepEqual(plan, { offerIndices: [0, 1], removeIndices: [], aborted: false });
 });
 
-test("overwrite a conflict: file is both removed and offered", async () => {
-  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
-    async () => ({ action: "overwrite" }));
-  assert.deepEqual(plan, { filesToOffer: ["a.txt", "b.txt"], filesToRemove: ["b.txt"], aborted: false });
+test("overwrite a conflict: index both removed and offered", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"], async () => ({ action: "overwrite" }));
+  assert.deepEqual(plan, { offerIndices: [0, 1], removeIndices: [1], aborted: false });
 });
 
-test("skip a conflict: omitted from offer and remove", async () => {
-  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
-    async () => ({ action: "skip" }));
-  assert.deepEqual(plan, { filesToOffer: ["a.txt"], filesToRemove: [], aborted: false });
+test("skip a conflict: index omitted from offer and remove", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"], async () => ({ action: "skip" }));
+  assert.deepEqual(plan, { offerIndices: [0], removeIndices: [], aborted: false });
 });
 
 test("cancel aborts the whole transfer", async () => {
-  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
-    async () => ({ action: "cancel" }));
-  assert.deepEqual(plan, { filesToOffer: [], filesToRemove: [], aborted: true });
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"], async () => ({ action: "cancel" }));
+  assert.deepEqual(plan, { offerIndices: [], removeIndices: [], aborted: true });
 });
 
 test("applyToRest reuses the action and stops prompting", async () => {
@@ -32,7 +29,7 @@ test("applyToRest reuses the action and stops prompting", async () => {
   const plan = await buildUploadPlan(["a", "b", "c"], ["a", "b", "c"],
     async () => { calls++; return { action: "overwrite", applyToRest: true }; });
   assert.equal(calls, 1);
-  assert.deepEqual(plan, { filesToOffer: ["a", "b", "c"], filesToRemove: ["a", "b", "c"], aborted: false });
+  assert.deepEqual(plan, { offerIndices: [0, 1, 2], removeIndices: [0, 1, 2], aborted: false });
 });
 
 test("only conflicting files invoke the resolver; order preserved", async () => {
@@ -40,5 +37,14 @@ test("only conflicting files invoke the resolver; order preserved", async () => 
   const plan = await buildUploadPlan(["a", "b", "c"], ["b"],
     async (n) => { seen.push(n); return { action: "skip" }; });
   assert.deepEqual(seen, ["b"]);
-  assert.deepEqual(plan.filesToOffer, ["a", "c"]);
+  assert.deepEqual(plan.offerIndices, [0, 2]);
+});
+
+test("duplicate basenames keep independent per-file decisions", async () => {
+  // Two different local files share a basename; skip the first, overwrite the second.
+  const actions = ["skip", "overwrite"];
+  let i = 0;
+  const plan = await buildUploadPlan(["x.txt", "x.txt"], ["x.txt"],
+    async () => ({ action: actions[i++] }));
+  assert.deepEqual(plan, { offerIndices: [1], removeIndices: [1], aborted: false });
 });

--- a/electron/bridges/zmodemHelper.test.cjs
+++ b/electron/bridges/zmodemHelper.test.cjs
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildUploadPlan } = require("./zmodemHelper.cjs");
+
+const never = () => { throw new Error("resolver should not be called"); };
+
+test("no conflicts: everything offered, nothing removed, resolver untouched", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], [], never);
+  assert.deepEqual(plan, { filesToOffer: ["a.txt", "b.txt"], filesToRemove: [], aborted: false });
+});
+
+test("overwrite a conflict: file is both removed and offered", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
+    async () => ({ action: "overwrite" }));
+  assert.deepEqual(plan, { filesToOffer: ["a.txt", "b.txt"], filesToRemove: ["b.txt"], aborted: false });
+});
+
+test("skip a conflict: omitted from offer and remove", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
+    async () => ({ action: "skip" }));
+  assert.deepEqual(plan, { filesToOffer: ["a.txt"], filesToRemove: [], aborted: false });
+});
+
+test("cancel aborts the whole transfer", async () => {
+  const plan = await buildUploadPlan(["a.txt", "b.txt"], ["b.txt"],
+    async () => ({ action: "cancel" }));
+  assert.deepEqual(plan, { filesToOffer: [], filesToRemove: [], aborted: true });
+});
+
+test("applyToRest reuses the action and stops prompting", async () => {
+  let calls = 0;
+  const plan = await buildUploadPlan(["a", "b", "c"], ["a", "b", "c"],
+    async () => { calls++; return { action: "overwrite", applyToRest: true }; });
+  assert.equal(calls, 1);
+  assert.deepEqual(plan, { filesToOffer: ["a", "b", "c"], filesToRemove: ["a", "b", "c"], aborted: false });
+});
+
+test("only conflicting files invoke the resolver; order preserved", async () => {
+  const seen = [];
+  const plan = await buildUploadPlan(["a", "b", "c"], ["b"],
+    async (n) => { seen.push(n); return { action: "skip" }; });
+  assert.deepEqual(seen, ["b"]);
+  assert.deepEqual(plan.filesToOffer, ["a", "c"]);
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -10,6 +10,7 @@ const transferErrorListeners = new Map();
 const transferCancelledListeners = new Map();
 const chainProgressListeners = new Map();
 const zmodemListeners = new Map();
+const zmodemOverwriteListeners = new Map(); // sessionId -> Set<cb>
 const sftpConnectionProgressListeners = new Set();
 const authFailedListeners = new Map();
 const telnetAutoLoginCompleteListeners = new Map();
@@ -137,6 +138,10 @@ ipcRenderer.on("netcatty:zmodem:error", (_event, payload) => {
   if (!set) return;
   set.forEach((cb) => { try { cb({ type: "error", ...payload }); } catch {} });
 });
+ipcRenderer.on("netcatty:zmodem:overwrite-request", (_event, payload) => {
+  const set = zmodemOverwriteListeners.get(payload.sessionId);
+  if (set) set.forEach((cb) => cb(payload));
+});
 
 ipcRenderer.on("netcatty:data", (_event, payload) => {
   const set = dataListeners.get(payload.sessionId);
@@ -185,6 +190,7 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
   telnetAutoLoginCompleteListeners.delete(payload.sessionId);
   telnetAutoLoginCancelledListeners.delete(payload.sessionId);
   zmodemListeners.delete(payload.sessionId);
+  zmodemOverwriteListeners.delete(payload.sessionId);
   const pendingTimer = _mcpFlushTimers.get(payload.sessionId);
   if (pendingTimer) {
     clearTimeout(pendingTimer);
@@ -681,6 +687,14 @@ const api = {
   },
   cancelZmodem: (sessionId) => {
     ipcRenderer.send("netcatty:zmodem:cancel", { sessionId });
+  },
+  onZmodemOverwriteRequest: (sessionId, cb) => {
+    if (!zmodemOverwriteListeners.has(sessionId)) zmodemOverwriteListeners.set(sessionId, new Set());
+    zmodemOverwriteListeners.get(sessionId).add(cb);
+    return () => zmodemOverwriteListeners.get(sessionId)?.delete(cb);
+  },
+  respondZmodemOverwrite: (payload) => {
+    ipcRenderer.send("netcatty:zmodem:overwrite-response", payload);
   },
   onSessionData: (sessionId, cb) => {
     if (!dataListeners.has(sessionId)) dataListeners.set(sessionId, new Set());

--- a/global.d.ts
+++ b/global.d.ts
@@ -341,6 +341,15 @@ declare global {
       }) => void
     ): () => void;
     cancelZmodem?(sessionId: string): void;
+    onZmodemOverwriteRequest?(
+      sessionId: string,
+      cb: (payload: { sessionId: string; requestId: string; filename: string }) => void
+    ): () => void;
+    respondZmodemOverwrite?(payload: {
+      requestId: string;
+      action: "overwrite" | "skip" | "cancel";
+      applyToRest: boolean;
+    }): void;
     onSessionData(sessionId: string, cb: (data: string) => void): () => void;
     onSessionExit(
       sessionId: string,


### PR DESCRIPTION
## Problem

Closes #1064. Uploading via `rz` silently fails when the remote directory already contains a file with the same name: lrzsz `rz` sends ZSKIP for existing files, and `handleUpload` treated the falsy `send_offer` result as "skipped" and `continue`d — so nothing uploaded and no feedback.

## Approach

Detect the conflict through a **separate SSH exec channel** (never touching the ZMODEM data stream) and prompt the user to overwrite, skip, or cancel, with an "apply to remaining conflicts" option. Overwrite is implemented by `rm`-ing the remote file via that same exec channel and then sending the ZMODEM offer normally — so no changes to the ZMODEM protocol / zmodem.js.

- **SSH only.** The detection/removal callbacks are supplied only by the SSH bridge; local/telnet/serial fall back to today's behavior.
- **Fail-safe.** If rz's cwd can't be resolved, the remote isn't Linux (no `/proc`), or the exec lacks permission (e.g. after `su`/`sudo` into another user) → silently fall back to today's behavior (rz skips). No regression.

## How it works

1. After the file picker, `handleUpload` calls `probeReceiveConflicts(basenames)` — an exec script that finds the running `rz` process's cwd (reusing the #1065 process-tree walk to find the foreground process, then `/proc/<pid>/cwd`) and `[ -e ]`-tests each basename there.
2. For each conflict, `requestOverwriteDecision(filename)` round-trips to the renderer (main→renderer→main IPC) and shows a dialog.
3. A pure, unit-tested `buildUploadPlan(names, existing, resolve)` turns the decisions into `{ filesToOffer, filesToRemove, aborted }` (handles overwrite/skip/cancel + applyToRest).
4. `removeRemoteFiles(paths)` `rm -f`s the overwrite targets; the offer loop then runs over the filtered list.

All remote paths derive from local basenames + the resolved cwd and are shell-quoted (`sh -c '…' sh "$@"`), so a crafted filename can't inject shell code; removal targets are never taken from the server's echoed output.

## Testing

- **Unit:** `buildUploadPlan` — 6 tests (overwrite/skip/cancel/applyToRest/no-conflict/selectivity). Full suite green: **1143 pass / 0 fail**.
- **Live server:** the exec probe + remove verified against a real `rz` waiting in `/tmp` with a duplicate present → probe returns `{dir:/tmp, existing:[dup]}` (ignores a non-existent name); the `rm` deletes it.
- **Build/lint/types:** `npm run build` passes; ESLint clean; `tsc` adds zero new errors.
- An independent full-feature code review (security/lifecycle/edge cases) was incorporated — including a fix for a test-mock regression (`ipcMain.on`) and i18n of the dialog across en/zh-CN/ru.

## Known limitations (documented, out of scope)

- Cross-uid `su`/`sudo` into another user's dir: the exec (login user) can't read/`rm` there → falls back to today's behavior.
- Non-Linux remotes (no `/proc`) → fallback.
- If the session drops while the dialog is open, the pending decision self-resolves to "skip" after 120s.

> Note: the end-to-end GUI click-through (real upload + dialog) should be confirmed in the running app before merge; every component + the exec mechanism are verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)