### PR TITLE
fix #1063: give each terminal its own WebGL texture atlas (disable cross-terminal sharing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pack:linux": "npm run build && cross-env NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --publish=never",
     "pack:linux-x64": "npm run build && cross-env npm_config_arch=x64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --x64 --publish=never",
     "pack:linux-arm64": "npm run build && cross-env npm_config_arch=arm64 NODE_OPTIONS=--disable-warning=DEP0190 electron-builder --config electron-builder.config.cjs --linux --arm64 --publish=never",
-    "postinstall": "electron-builder install-app-deps && patch-package",
+    "postinstall": "electron-builder install-app-deps && patch-package && node scripts/patch-xterm-webgl-atlas.cjs",
     "rebuild": "electron-builder install-app-deps",
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",

--- a/scripts/patch-xterm-webgl-atlas.cjs
+++ b/scripts/patch-xterm-webgl-atlas.cjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Disable @xterm/addon-webgl's cross-terminal texture-atlas sharing.
+ *
+ * xterm's WebGL addon shares ONE TextureAtlas across terminal instances whose
+ * config (font / size / theme / device-pixel-ratio) is equal — see
+ * `acquireTextureAtlas`, which does `if (configEquals) { ownedBy.push; return
+ * atlas }`. In a split workspace two panes then share an atlas, so clearing or
+ * rebuilding it for one pane (which netcatty does on resize / DPR change / font
+ * change / tab show to recover from glyph corruption) corrupts the OTHER pane's
+ * rendering — the persistent "花屏 / garbled" report in issue #1063, most
+ * visible in split view where both panes stay on screen.
+ *
+ * Fix: give every terminal its own atlas by removing the "reuse a matching
+ * atlas" loop, so each terminal falls through to creating its own. The published
+ * package is minified, so we string-replace the exact loop in both the CJS and
+ * ESM builds. This runs from `postinstall` (after patch-package).
+ *
+ * Idempotent. If the upstream code changes (e.g. an @xterm/addon-webgl upgrade)
+ * the loop won't be found; we warn loudly but do not fail the install, and the
+ * strings below must then be refreshed for the new version.
+ */
+"use strict";
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MARKER = "/*netcatty:#1063 atlas-isolation*/";
+
+// Exact (minified) "reuse a shared atlas" loop, per @xterm/addon-webgl@0.19.0.
+const TARGETS = [
+  {
+    file: "node_modules/@xterm/addon-webgl/lib/addon-webgl.mjs",
+    loop: "for(let h=0;h<le.length;h++){let f=le[h];if(Mi(f.config,u))return f.ownedBy.push(i),f.atlas}",
+  },
+  {
+    file: "node_modules/@xterm/addon-webgl/lib/addon-webgl.js",
+    loop: "for(let t=0;t<r.length;t++){const i=r[t];if((0,n.configEquals)(i.config,d))return i.ownedBy.push(e),i.atlas}",
+  },
+];
+
+let patched = 0;
+let already = 0;
+let missing = 0;
+
+for (const { file, loop } of TARGETS) {
+  const abs = path.resolve(process.cwd(), file);
+  let src;
+  try {
+    src = fs.readFileSync(abs, "utf8");
+  } catch {
+    console.warn(`[patch-xterm-webgl-atlas] skip (not found): ${file}`);
+    missing++;
+    continue;
+  }
+  if (src.includes(MARKER)) {
+    already++;
+    continue;
+  }
+  if (!src.includes(loop)) {
+    console.warn(
+      `[patch-xterm-webgl-atlas] WARNING: atlas-sharing loop not found in ${file}. ` +
+        "@xterm/addon-webgl likely changed — split-view WebGL may garble again (#1063). " +
+        "Refresh the minified target strings in scripts/patch-xterm-webgl-atlas.cjs.",
+    );
+    missing++;
+    continue;
+  }
+  fs.writeFileSync(abs, src.replace(loop, MARKER));
+  patched++;
+}
+
+console.log(
+  `[patch-xterm-webgl-atlas] atlas isolation: patched=${patched} already=${already} missing=${missing}`,
+);


### PR DESCRIPTION
## Problem

The WebGL garbled terminal (#1063) persisted after #1066 — most reliably reproducible in a **split workspace**, where one pane renders scrambled glyphs while the other is fine (and re-dragging the window temporarily fixes it). #1066 only re-rasterized on hidden→visible tab switches, which split panes (visible from creation) never hit.

## Root cause

xterm's WebGL addon **shares one `TextureAtlas` across terminal instances with equal config** (font / size / theme / device-pixel-ratio). `acquireTextureAtlas` does, in effect:

```js
for (const entry of cache) if (configEquals(entry.config, cfg)) { entry.ownedBy.push(term); return entry.atlas; }
```

So two split panes (same theme/font/DPR) **share an atlas**. netcatty calls `clearTextureAtlas()` to recover from single-terminal glyph corruption (on resize / DPR change / font change / tab show — added in #1049 and #1066). On a *shared* atlas those calls clobber the **other** pane's glyph→texture mapping → it garbles. This is why the earlier redraw/clear-based recovery attempts didn't fix it and only **bounced** the garble between panes.

## Fix

Give every terminal its **own** atlas by removing the "reuse a matching atlas" loop from `@xterm/addon-webgl`, so each terminal falls through to creating its own. With isolation, the existing `clearTextureAtlas` recovery calls only affect their own terminal (correct), and split panes can't corrupt each other.

The published package is minified, so this is applied with a small **idempotent postinstall script** (`scripts/patch-xterm-webgl-atlas.cjs`), wired after `patch-package`. A patch-package patch was rejected because diffing the minified single-line bundle produces a ~550KB unreadable blob; the script makes the intent reviewable, is idempotent, and **warns without failing** if `@xterm/addon-webgl` changes (so an upgrade can't silently break the build — the target strings just need refreshing).

Trade-off: each terminal now keeps its own glyph atlas → marginally more GPU memory per terminal, in exchange for correct multi-context rendering. The earlier `clearTextureAtlas` recovery paths are kept (now safe — per-terminal).

## Testing

- **Confirmed by the reporter**: split-view WebGL no longer garbles.
- Script is idempotent (`patched=2` → `already=2`) and degrades gracefully if the loop isn't found.
- `npm run build` unaffected.

> Note: the patch lives in `node_modules` (re-applied by postinstall), so it doesn't show in the source diff — the script + the `postinstall` wiring are the reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)