### PR TITLE
chore: silence two production build warnings

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -16,6 +16,7 @@ import {
   findSyncPayloadEncryptedCredentialPaths,
 } from '../../domain/credentials';
 import { isProviderReadyForSync, type CloudProvider, type SyncPayload } from '../../domain/sync';
+import { mergeSyncPayloads } from '../../domain/syncMerge';
 import {
   SYNCABLE_SETTING_STORAGE_KEYS,
   collectSyncableSettings,
@@ -506,7 +507,6 @@ export const useAutoSync = (config: AutoSyncConfig) => {
         return;
       }
 
-      const { mergeSyncPayloads } = await import('../../domain/syncMerge');
       const mergeResult = mergeSyncPayloads(base, localPayload, remotePayload);
 
       // Apply merged payload to local state BEFORE committing. If the apply

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,6 @@ export default defineConfig(() => {
           output: {
             manualChunks: {
               // Vendor chunks - rarely change, can be cached aggressively
-              'vendor-react': ['react', 'react-dom'],
               'vendor-radix': [
                 '@radix-ui/react-collapsible',
                 '@radix-ui/react-context-menu',


### PR DESCRIPTION
Two harmless, pre-existing warnings from `npm run build` (build already succeeds — these are warnings, not errors). Cleanup only, no behavior change.

## 1. `Generated an empty chunk: "vendor-react"`
`vite.config.ts` declared a `manualChunks` entry `'vendor-react': ['react', 'react-dom']`, but react/react-dom get bundled into another chunk, so this one was always **empty** — producing an empty output file + the warning with no caching benefit. Removed the entry.

## 2. `domain/syncMerge.ts is dynamically imported … but also statically imported … dynamic import will not move module into another chunk`
`useAutoSync.ts` did `await import('../../domain/syncMerge')`, but `CloudSyncManager.ts` already imports the same module **statically**, so it's in the eager graph and the dynamic `import()` could never be code-split — it only emitted the mixed-import warning. Switched `useAutoSync` to a static import (`syncMerge` only imports a type, so no circular-import risk).

## Verification
- `npm run build` is now **warning-free** (`✓ 3741 modules transformed`, `✓ built`).
- `tsc --noEmit`: no new errors (baseline 40 → 40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)