### PR TITLE
fix #1078: send macOS Option as Meta by wiring altAsMeta to xterm macOptionIsMeta

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -56,6 +56,7 @@ import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import { createTerminalSessionStarters, type PendingAuth } from "./terminal/runtime/createTerminalSessionStarters";
 import { createXTermRuntime, primaryFontFamily, type XTermRuntime } from "./terminal/runtime/createXTermRuntime";
 import { applyUserCursorPreference } from "./terminal/runtime/cursorPreference";
+import { terminalAltKeyOptions } from "./terminal/runtime/altKeyOptions";
 import {
   createPromptLineBreakState,
   type PromptLineBreakState,
@@ -1248,7 +1249,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             : 0;
         termRef.current.options.scrollOnUserInput =
           shouldEnableNativeUserInputAutoScroll(terminalSettings);
-        termRef.current.options.altClickMovesCursor = !terminalSettings.altAsMeta;
+        const altKeyOpts = terminalAltKeyOptions(terminalSettings.altAsMeta);
+        termRef.current.options.macOptionIsMeta = altKeyOpts.macOptionIsMeta;
+        termRef.current.options.altClickMovesCursor = altKeyOpts.altClickMovesCursor;
         termRef.current.options.wordSeparator = terminalSettings.wordSeparators;
         termRef.current.options.ignoreBracketedPasteMode = terminalSettings.disableBracketedPaste ?? false;
       }

--- a/components/terminal/runtime/altKeyOptions.test.ts
+++ b/components/terminal/runtime/altKeyOptions.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { terminalAltKeyOptions } from "./altKeyOptions";
+
+// Issue #1078: with "Use Option as Meta key" enabled, macOS Option must send
+// ESC-prefixed (Meta) sequences. xterm.js gates that on `macOptionIsMeta`. The
+// flag was read from settings but only ever wired to the mouse alt-click
+// behavior, so Option kept emitting layout characters (ƒ, ∫, …) instead of Meta.
+
+test("Option-as-Meta enabled: Option emits Meta and alt-click cursor move is disabled", () => {
+  assert.deepEqual(terminalAltKeyOptions(true), {
+    macOptionIsMeta: true,
+    altClickMovesCursor: false,
+  });
+});
+
+test("Option-as-Meta disabled: xterm keeps default macOS Option behavior", () => {
+  assert.deepEqual(terminalAltKeyOptions(false), {
+    macOptionIsMeta: false,
+    altClickMovesCursor: true,
+  });
+});

--- a/components/terminal/runtime/altKeyOptions.ts
+++ b/components/terminal/runtime/altKeyOptions.ts
@@ -1,0 +1,20 @@
+export interface TerminalAltKeyOptions {
+  /** xterm.js: treat macOS Option as the Meta key (emit ESC-prefixed sequences). */
+  macOptionIsMeta: boolean;
+  /** xterm.js: Option+click moves the cursor. Must be off when Option is Meta. */
+  altClickMovesCursor: boolean;
+}
+
+/**
+ * Map the user's "Use Option as Meta key" setting to xterm.js options.
+ *
+ * Kept in one place so terminal init (createXTermRuntime) and the live settings
+ * sync (Terminal.tsx) can't drift — that drift is what left `macOptionIsMeta`
+ * unset everywhere and broke Option/Meta shortcuts on macOS (issue #1078).
+ */
+export function terminalAltKeyOptions(altAsMeta: boolean): TerminalAltKeyOptions {
+  return {
+    macOptionIsMeta: altAsMeta,
+    altClickMovesCursor: !altAsMeta,
+  };
+}

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -43,6 +43,7 @@ import {
 } from "./kittyKeyboardProtocol";
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
+import { terminalAltKeyOptions } from "./altKeyOptions";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
@@ -294,7 +295,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     smoothScrollDuration,
     scrollOnUserInput,
     macOptionClickForcesSelection: true,
-    altClickMovesCursor: !altIsMeta,
+    ...terminalAltKeyOptions(altIsMeta),
     wordSeparator,
     theme: {
       ...ctx.terminalTheme.colors,


### PR DESCRIPTION
## Problem

Issue #1078: on macOS, enabling Use Option as Meta key still let Option produce special characters from the system keyboard layout. It did not send Meta as an ESC prefix, so readline and zle shortcuts such as Alt+f, Alt+b, and Alt+Backspace did not work.

## Root Cause

The `altAsMeta` setting was read into `altIsMeta`, but only used for mouse `altClickMovesCursor`. The xterm.js option that actually controls Option-to-Meta on macOS, `macOptionIsMeta`, was never set. The mapping was duplicated inline in both `createXTermRuntime` and `Terminal.tsx`, and both missed it.

## Changes

- Adds the pure helper `terminalAltKeyOptions(altAsMeta)` returning `{ macOptionIsMeta, altClickMovesCursor }`.
- Uses that helper in `createXTermRuntime` and `Terminal.tsx`.
- Sets `macOptionIsMeta` when Option-as-Meta is enabled.

## Tests

- Adds `altKeyOptions.test.ts` with red-to-green coverage for `macOptionIsMeta: true` when enabled.
- Full test suite passed: 1154 passed, 0 failed.
- `tsc` introduced no new errors.
- ESLint was clean.

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
