### PR TITLE
fix #1079: preserve remote file mode when rz overwrites a same-named file

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -1338,6 +1338,9 @@ async function startSSHSession(event, options) {
               removeRemoteFiles(paths) {
                 return removeRemoteFiles(sessions.get(sessionId), paths);
               },
+              restoreRemoteModes(entries) {
+                return restoreRemoteModes(sessions.get(sessionId), entries);
+              },
               requestOverwriteDecision(filename) {
                 return new Promise((resolve) => {
                   const requestId = randomUUID();
@@ -2175,7 +2178,11 @@ dir=$(readlink /proc/$leaf/cwd 2>/dev/null)
 [ -n "$dir" ] || exit 0
 printf 'DIR\\t%s\\n' "$dir"
 cd "$dir" 2>/dev/null || exit 0
-for n in "$@"; do [ -e "$n" ] && printf 'EXIST\\t%s\\n' "$n"; done`;
+for n in "$@"; do
+  [ -e "$n" ] || continue
+  m=$(stat -c %a "$n" 2>/dev/null || stat -f %Lp "$n" 2>/dev/null)
+  printf 'EXIST\\t%s\\t%s\\n' "$n" "$m"
+done`;
     const argv = names.map((n) => quoteShellArg(n)).join(" ");
     const cmd = `exec sh -c ${quoteShellArg(script)} sh ${argv}`;
     session.conn.exec(cmd, (err, stream) => {
@@ -2184,13 +2191,16 @@ for n in "$@"; do [ -e "$n" ] && printf 'EXIST\\t%s\\n' "$n"; done`;
       stream.on("data", (d) => { out += d.toString(); });
       stream.on("close", () => {
         clearTimeout(timer);
-        let dir = null; const existing = [];
+        let dir = null; const existing = []; const modes = {};
         for (const line of out.split("\n")) {
-          const [tag, val] = line.split("\t");
+          const [tag, val, mode] = line.split("\t");
           if (tag === "DIR") dir = val;
-          else if (tag === "EXIST" && val) existing.push(val);
+          else if (tag === "EXIST" && val) {
+            existing.push(val);
+            if (mode && /^[0-7]{3,4}$/.test(mode)) modes[val] = mode;
+          }
         }
-        resolve(dir ? { dir, existing } : null);
+        resolve(dir ? { dir, existing, modes } : null);
       });
     });
   });
@@ -2203,6 +2213,28 @@ function removeRemoteFiles(session, paths) {
     const argv = paths.map((p) => quoteShellArg(p)).join(" ");
     const timer = setTimeout(resolve, 5000);
     session.conn.exec(`exec sh -c 'rm -f -- "$@"' sh ${argv}`, (err, stream) => {
+      if (err) { clearTimeout(timer); return resolve(); }
+      stream.on("data", () => {}); stream.stderr?.on("data", () => {});
+      stream.on("close", () => { clearTimeout(timer); resolve(); });
+    });
+  });
+}
+
+// chmod the given { path, mode } entries back to their captured permissions
+// (parameterized; injection-safe). Modes are validated octal before use.
+function restoreRemoteModes(session, entries) {
+  return new Promise((resolve) => {
+    if (!session || !session.conn || !Array.isArray(entries) || entries.length === 0) return resolve();
+    const args = [];
+    for (const e of entries) {
+      if (!e || !e.path || !/^[0-7]{3,4}$/.test(String(e.mode))) continue;
+      args.push(quoteShellArg(String(e.mode)));
+      args.push(quoteShellArg(e.path));
+    }
+    if (args.length === 0) return resolve();
+    const timer = setTimeout(resolve, 5000);
+    const script = 'while [ "$#" -ge 2 ]; do chmod "$1" "$2" 2>/dev/null; shift 2; done';
+    session.conn.exec(`exec sh -c ${quoteShellArg(script)} sh ${args.join(" ")}`, (err, stream) => {
       if (err) { clearTimeout(timer); return resolve(); }
       stream.on("data", () => {}); stream.stderr?.on("data", () => {});
       stream.on("close", () => { clearTimeout(timer); resolve(); });

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2180,7 +2180,7 @@ printf 'DIR\\t%s\\n' "$dir"
 cd "$dir" 2>/dev/null || exit 0
 for n in "$@"; do
   [ -e "$n" ] || continue
-  m=$(stat -c %a "$n" 2>/dev/null || stat -f %Lp "$n" 2>/dev/null)
+  m=$(stat -c %a -- "$n" 2>/dev/null || stat -f %Lp -- "$n" 2>/dev/null)
   printf 'EXIST\\t%s\\t%s\\n' "$n" "$m"
 done`;
     const argv = names.map((n) => quoteShellArg(n)).join(" ");

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -50,6 +50,29 @@ async function buildUploadPlan(names, existingList, resolveDecision) {
 }
 
 /**
+ * Resolve which overwritten files need their original mode restored after rz
+ * re-creates them. rz writes new files with the remote umask, dropping the
+ * prior permission bits (issue #1079). Pure: returns absolute `{ path, mode }`
+ * entries for the overwritten files, skipping any whose mode wasn't captured
+ * and de-duplicating shared basenames.
+ */
+function buildModeRestores(dir, names, removeIndices, modes) {
+  const base = String(dir).replace(/\/+$/, "");
+  const seen = new Set();
+  const restores = [];
+  for (const i of removeIndices) {
+    const name = names[i];
+    const mode = modes && modes[name];
+    if (!mode) continue;
+    const target = `${base}/${name}`;
+    if (seen.has(target)) continue;
+    seen.add(target);
+    restores.push({ path: target, mode });
+  }
+  return restores;
+}
+
+/**
  * Create a ZMODEM sentry that wraps a session's data stream.
  *
  * All raw data from the PTY / SSH stream / socket should be fed into
@@ -558,10 +581,14 @@ async function handleUpload(zsession, opts) {
   // Conflict handling (SSH only — callbacks absent on local/telnet/serial).
   // On any failure we fall back to today's behavior (rz silently skips).
   let plan = { offerIndices: allNames.map((_, i) => i), removeIndices: [], aborted: false };
+  let probeDir = null;
+  let probeModes = null;
   if (opts.probeReceiveConflicts && opts.requestOverwriteDecision) {
     try {
       const probe = await opts.probeReceiveConflicts(allNames);
       if (probe && probe.dir && Array.isArray(probe.existing) && probe.existing.length > 0) {
+        probeDir = probe.dir;
+        probeModes = probe.modes || {};
         plan = await buildUploadPlan(allNames, probe.existing, opts.requestOverwriteDecision);
         if (plan.aborted) {
           try { zsession.abort(); } catch { /* ignore */ }
@@ -668,6 +695,20 @@ async function handleUpload(zsession, opts) {
   }
 
   await withTimeout(zsession.close(), 120000);
+
+  // rz re-creates overwritten files with the remote umask, dropping their
+  // original permission bits. Now that everything is on disk, restore them
+  // to the modes captured before the rm (issue #1079).
+  if (plan.removeIndices.length && probeDir && opts.restoreRemoteModes) {
+    const restores = buildModeRestores(probeDir, allNames, plan.removeIndices, probeModes);
+    if (restores.length) {
+      try {
+        await opts.restoreRemoteModes(restores);
+      } catch (err) {
+        console.warn("[ZMODEM] restoreRemoteModes failed:", err?.message || err);
+      }
+    }
+  }
 }
 
 /**
@@ -851,4 +892,4 @@ function safeSend(contents, channel, data) {
   }
 }
 
-module.exports = { createZmodemSentry, buildUploadPlan };
+module.exports = { createZmodemSentry, buildUploadPlan, buildModeRestores };

--- a/electron/bridges/zmodemHelper.test.cjs
+++ b/electron/bridges/zmodemHelper.test.cjs
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { buildUploadPlan } = require("./zmodemHelper.cjs");
+const { buildUploadPlan, buildModeRestores } = require("./zmodemHelper.cjs");
 
 const never = () => { throw new Error("resolver should not be called"); };
 
@@ -47,4 +47,28 @@ test("duplicate basenames keep independent per-file decisions", async () => {
   const plan = await buildUploadPlan(["x.txt", "x.txt"], ["x.txt"],
     async () => ({ action: actions[i++] }));
   assert.deepEqual(plan, { offerIndices: [1], removeIndices: [1], aborted: false });
+});
+
+// Issue #1079: overwriting (rm + rz re-create) drops the original permission
+// bits. buildModeRestores resolves which overwritten files to chmod back.
+
+test("buildModeRestores maps overwritten files to their captured modes", () => {
+  assert.deepEqual(
+    buildModeRestores("/home/u", ["a.sh", "b.txt"], [0], { "a.sh": "755" }),
+    [{ path: "/home/u/a.sh", mode: "755" }],
+  );
+});
+
+test("buildModeRestores skips files whose mode was not captured", () => {
+  assert.deepEqual(
+    buildModeRestores("/srv", ["a", "b"], [0, 1], { a: "644" }),
+    [{ path: "/srv/a", mode: "644" }],
+  );
+});
+
+test("buildModeRestores strips trailing slashes and dedupes duplicate basenames", () => {
+  assert.deepEqual(
+    buildModeRestores("/srv//", ["x", "x"], [0, 1], { x: "600" }),
+    [{ path: "/srv/x", mode: "600" }],
+  );
 });


### PR DESCRIPTION
## Problem

Issue #1079: when uploading with `rz` and choosing Replace for a same-named remote file, the new file did not preserve the original permissions. For example, an executable script with mode `0755` could become `0644`. Before #1070, same-name uploads were skipped, so the original file remained untouched.

## Root Cause

The overwrite implementation from #1070 deleted the remote file with `rm -f` and then let `rz` receive a new file. The recreated file used the remote `umask`. ZMODEM offers include name, size, and mtime, but not file mode.

## Changes

- During conflict probing, also reads the existing file mode using GNU `stat -c %a` or BSD `stat -f %Lp` fallback.
- After the transfer completes and `zsession.close()` has run, restores the original mode with `chmod`.
- Adds pure `buildModeRestores()` logic and `restoreRemoteModes()` with safe octal validation.
- Any failure silently falls back to the current behavior.

## Tests

- Adds three `buildModeRestores` cases in `zmodemHelper.test.cjs`.
- Full test suite passed: 1155 passed, 0 failed.
- `tsc` introduced no new errors.
- `node --check` passed.
- Local shell validation confirmed stat fallback and chmod argument pairing.

Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)
