### PR TITLE
feat #826: optional Option+←/→ word jump on macOS

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -301,6 +301,9 @@ const en: Messages = {
   'settings.terminal.keyboard.altAsMeta': 'Use Option as Meta key',
   'settings.terminal.keyboard.altAsMeta.desc':
     'Use Option (Alt) as the Meta key instead of for special characters',
+  'settings.terminal.keyboard.optionArrowWordJump': 'Option+←/→ jumps by word',
+  'settings.terminal.keyboard.optionArrowWordJump.desc':
+    'Send Meta-b / Meta-f on Option+Left/Right so the shell moves by word, instead of the default ^[[1;3D / ^[[1;3C',
   'settings.terminal.accessibility.minimumContrastRatio': 'Minimum contrast ratio',
   'settings.terminal.accessibility.minimumContrastRatio.desc':
     'Adjust colors to meet contrast requirements (1 = disabled, 21 = max)',

--- a/application/i18n/locales/ru.ts
+++ b/application/i18n/locales/ru.ts
@@ -301,6 +301,9 @@ const ru: Messages = {
   'settings.terminal.keyboard.altAsMeta': 'Использовать Option как клавишу Meta',
   'settings.terminal.keyboard.altAsMeta.desc':
     'Использовать Option (Alt) как клавишу Meta вместо ввода специальных символов',
+  'settings.terminal.keyboard.optionArrowWordJump': 'Option+←/→ переход по словам',
+  'settings.terminal.keyboard.optionArrowWordJump.desc':
+    'Отправлять Meta-b / Meta-f при Option+Влево/Вправо, чтобы оболочка перемещалась по словам, вместо стандартного ^[[1;3D / ^[[1;3C',
   'settings.terminal.accessibility.minimumContrastRatio': 'Минимальный коэффициент контрастности',
   'settings.terminal.accessibility.minimumContrastRatio.desc':
     'Подстраивать цвета под требования контрастности (1 = отключено, 21 = максимум)',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1445,6 +1445,8 @@ const zhCN: Messages = {
   'settings.terminal.cursor.blink': '光标闪烁',
   'settings.terminal.keyboard.altAsMeta': '将 Option 作为 Meta 键',
   'settings.terminal.keyboard.altAsMeta.desc': '使用 Option (Alt) 作为 Meta 键，而不是用于输入特殊字符',
+  'settings.terminal.keyboard.optionArrowWordJump': 'Option+←/→ 按单词跳转',
+  'settings.terminal.keyboard.optionArrowWordJump.desc': '按 Option+左/右 时发送 Meta-b / Meta-f，让 Shell 按单词移动光标（而非默认的 ^[[1;3D / ^[[1;3C）',
   'settings.terminal.accessibility.minimumContrastRatio': '最小对比度',
   'settings.terminal.accessibility.minimumContrastRatio.desc': '调整颜色以满足对比度要求 (1 = 禁用, 21 = 最大)',
   'settings.terminal.behavior.rightClick': '右键行为',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -164,7 +164,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'scrollback', 'drawBoldInBrightColors', 'terminalEmulationType',
   'fontLigatures', 'fontWeight', 'fontWeightBold', 'fallbackFont',
   'linePadding', 'cursorShape', 'cursorBlink', 'minimumContrastRatio',
-  'altAsMeta', 'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
+  'altAsMeta', 'optionArrowWordJump', 'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
   'smoothScrolling',
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -810,6 +810,12 @@ export default function SettingsTerminalTab(props: {
         >
           <Toggle checked={terminalSettings.altAsMeta} onChange={(v) => updateTerminalSetting("altAsMeta", v)} />
         </SettingRow>
+        <SettingRow
+          label={t("settings.terminal.keyboard.optionArrowWordJump")}
+          description={t("settings.terminal.keyboard.optionArrowWordJump.desc")}
+        >
+          <Toggle checked={terminalSettings.optionArrowWordJump} onChange={(v) => updateTerminalSetting("optionArrowWordJump", v)} />
+        </SettingRow>
       </div>
 
       <SectionHeader title={t("settings.terminal.section.accessibility")} />

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -664,6 +664,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     const wordJumpSequence = optionArrowWordJumpSequence(
       e,
       ctx.terminalSettingsRef.current?.optionArrowWordJump ?? false,
+      isMacPlatform(),
     );
     if (wordJumpSequence) {
       const id = ctx.sessionRef.current;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -44,6 +44,7 @@ import {
 import { installKittyKeyboardProtocolHandlers } from "./kittyKeyboardRuntime";
 import { installUserCursorPreferenceGuard } from "./cursorPreference";
 import { terminalAltKeyOptions } from "./altKeyOptions";
+import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
 import { watchDevicePixelRatio } from "./rendererDprWatch";
 import { handleSerialLineModeInput } from "./serialLineInput";
 import {
@@ -653,6 +654,28 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           ctx.onBroadcastInputRef.current(kittyControlSequence, ctx.sessionId);
         }
         scrollToBottomAfterInput(kittyControlSequence);
+        return false;
+      }
+    }
+
+    // macOS Option+←/→ → Meta-b / Meta-f so the shell jumps by word (discussion
+    // #826). After kitty mode so apps using the kitty protocol keep their own
+    // arrow encoding; read live so the toggle applies without reconnecting.
+    const wordJumpSequence = optionArrowWordJumpSequence(
+      e,
+      ctx.terminalSettingsRef.current?.optionArrowWordJump ?? false,
+    );
+    if (wordJumpSequence) {
+      const id = ctx.sessionRef.current;
+      if (id) {
+        e.preventDefault();
+        e.stopPropagation();
+        ctx.onAutocompleteInput?.(wordJumpSequence);
+        ctx.terminalBackend.writeToSession(id, wordJumpSequence);
+        if (ctx.isBroadcastEnabledRef.current && ctx.onBroadcastInputRef.current) {
+          ctx.onBroadcastInputRef.current(wordJumpSequence, ctx.sessionId);
+        }
+        scrollToBottomAfterInput(wordJumpSequence);
         return false;
       }
     }

--- a/components/terminal/runtime/optionArrowWordJump.test.ts
+++ b/components/terminal/runtime/optionArrowWordJump.test.ts
@@ -6,6 +6,7 @@ import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
 // Discussion #826: on macOS, Option+←/→ defaults to xterm's ^[[1;3D / ^[[1;3C,
 // which most shells don't bind. When enabled, remap them to Meta-b / Meta-f so
 // readline/zle does backward-word / forward-word out of the box (Termius-style).
+// Gated to macOS so the syncable setting can't rewrite Alt+←/→ on other platforms.
 
 const ev = (over: Partial<Parameters<typeof optionArrowWordJumpSequence>[0]> = {}) => ({
   key: "ArrowLeft",
@@ -16,30 +17,35 @@ const ev = (over: Partial<Parameters<typeof optionArrowWordJumpSequence>[0]> = {
   ...over,
 });
 
-test("Option+Left → Meta-b (backward-word) when enabled", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), true), "\x1bb");
+test("Option+Left → Meta-b (backward-word) when enabled on macOS", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), true, true), "\x1bb");
 });
 
-test("Option+Right → Meta-f (forward-word) when enabled", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), true), "\x1bf");
+test("Option+Right → Meta-f (forward-word) when enabled on macOS", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), true, true), "\x1bf");
+});
+
+test("not macOS → null (don't rewrite Alt+←/→ on Linux/Windows even if synced on)", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), true, false), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), true, false), null);
 });
 
 test("disabled → null (xterm default ^[[1;3D/C is kept)", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), false), null);
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), false), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), false, true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), false, true), null);
 });
 
 test("no Option held → null", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ altKey: false }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ altKey: false }), true, true), null);
 });
 
 test("extra modifiers with Option → null (don't hijack Shift/Ctrl/Cmd combos)", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ shiftKey: true }), true), null);
-  assert.equal(optionArrowWordJumpSequence(ev({ ctrlKey: true }), true), null);
-  assert.equal(optionArrowWordJumpSequence(ev({ metaKey: true }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ shiftKey: true }), true, true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ ctrlKey: true }), true, true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ metaKey: true }), true, true), null);
 });
 
 test("non-arrow keys → null", () => {
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowUp" }), true), null);
-  assert.equal(optionArrowWordJumpSequence(ev({ key: "f" }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowUp" }), true, true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "f" }), true, true), null);
 });

--- a/components/terminal/runtime/optionArrowWordJump.test.ts
+++ b/components/terminal/runtime/optionArrowWordJump.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { optionArrowWordJumpSequence } from "./optionArrowWordJump";
+
+// Discussion #826: on macOS, Option+←/→ defaults to xterm's ^[[1;3D / ^[[1;3C,
+// which most shells don't bind. When enabled, remap them to Meta-b / Meta-f so
+// readline/zle does backward-word / forward-word out of the box (Termius-style).
+
+const ev = (over: Partial<Parameters<typeof optionArrowWordJumpSequence>[0]> = {}) => ({
+  key: "ArrowLeft",
+  altKey: true,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...over,
+});
+
+test("Option+Left → Meta-b (backward-word) when enabled", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), true), "\x1bb");
+});
+
+test("Option+Right → Meta-f (forward-word) when enabled", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), true), "\x1bf");
+});
+
+test("disabled → null (xterm default ^[[1;3D/C is kept)", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowLeft" }), false), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowRight" }), false), null);
+});
+
+test("no Option held → null", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ altKey: false }), true), null);
+});
+
+test("extra modifiers with Option → null (don't hijack Shift/Ctrl/Cmd combos)", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ shiftKey: true }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ ctrlKey: true }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ metaKey: true }), true), null);
+});
+
+test("non-arrow keys → null", () => {
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "ArrowUp" }), true), null);
+  assert.equal(optionArrowWordJumpSequence(ev({ key: "f" }), true), null);
+});

--- a/components/terminal/runtime/optionArrowWordJump.ts
+++ b/components/terminal/runtime/optionArrowWordJump.ts
@@ -12,14 +12,19 @@ export interface OptionArrowKeyEvent {
  * When enabled, maps a bare Option+Left/Right to the Meta-b / Meta-f sequence so
  * readline/zle does backward-word / forward-word without per-host bindkey setup.
  * Returns the bytes to send, or null when the mapping doesn't apply (disabled,
- * not an arrow, or other modifiers held) — in which case xterm's default
- * ^[[1;3D / ^[[1;3C is left untouched.
+ * non-macOS, not an arrow, or other modifiers held) — in which case xterm's
+ * default ^[[1;3D / ^[[1;3C is left untouched.
+ *
+ * Gated to macOS (`isMac`): the setting is syncable, so without the gate,
+ * enabling it on a Mac would also rewrite Alt+←/→ on synced Linux/Windows
+ * devices (discussion #826 review).
  */
 export function optionArrowWordJumpSequence(
   e: OptionArrowKeyEvent,
   enabled: boolean,
+  isMac: boolean,
 ): string | null {
-  if (!enabled) return null;
+  if (!enabled || !isMac) return null;
   // Only a bare Option+Arrow — leave Shift/Ctrl/Cmd combos to xterm's defaults.
   if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
   if (e.key === "ArrowLeft") return "\x1bb"; // Meta-b → backward-word

--- a/components/terminal/runtime/optionArrowWordJump.ts
+++ b/components/terminal/runtime/optionArrowWordJump.ts
@@ -1,0 +1,28 @@
+export interface OptionArrowKeyEvent {
+  key: string;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * macOS Option+←/→ word-jump (discussion #826).
+ *
+ * When enabled, maps a bare Option+Left/Right to the Meta-b / Meta-f sequence so
+ * readline/zle does backward-word / forward-word without per-host bindkey setup.
+ * Returns the bytes to send, or null when the mapping doesn't apply (disabled,
+ * not an arrow, or other modifiers held) — in which case xterm's default
+ * ^[[1;3D / ^[[1;3C is left untouched.
+ */
+export function optionArrowWordJumpSequence(
+  e: OptionArrowKeyEvent,
+  enabled: boolean,
+): string | null {
+  if (!enabled) return null;
+  // Only a bare Option+Arrow — leave Shift/Ctrl/Cmd combos to xterm's defaults.
+  if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
+  if (e.key === "ArrowLeft") return "\x1bb"; // Meta-b → backward-word
+  if (e.key === "ArrowRight") return "\x1bf"; // Meta-f → forward-word
+  return null;
+}

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -493,6 +493,7 @@ export interface TerminalSettings {
 
   // Keyboard
   altAsMeta: boolean; // Use ⌥ as the Meta key
+  optionArrowWordJump: boolean; // macOS: Option+←/→ send Meta-b/f for word jump
   scrollOnInput: boolean; // Scroll terminal to bottom on input
   scrollOnOutput: boolean; // Scroll terminal to bottom on output
   scrollOnKeyPress: boolean; // Scroll terminal to bottom on key press
@@ -692,6 +693,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   cursorBlink: true,
   minimumContrastRatio: 1,
   altAsMeta: false,
+  optionArrowWordJump: false,
   scrollOnInput: true,
   scrollOnOutput: false,
   scrollOnKeyPress: false,


### PR DESCRIPTION
## Requirement

Discussion #826: on macOS, `Option+Left/Right` sends `^[[1;3D` / `^[[1;3C` by default. Most shells do not bind these sequences, so users cannot jump by word. The requested behavior is similar to Termius: send `^[b` / `^[f` so readline and zle perform backward-word and forward-word without per-server bindkey setup.

## Changes

- Adds the terminal setting `Option+Left/Right word jump` (`optionArrowWordJump`), disabled by default and included in cloud sync.
- When enabled, plain `Option+Left/Right` sends `^[b` / `^[f`.
- Other modifier combinations keep xterm defaults.
- Extracts the mapping into the pure helper `optionArrowWordJumpSequence()`.
- Reads the setting live so toggling it does not require reconnecting.
- Runs after kitty protocol handling and autocomplete so it does not steal those key paths.
- Adds English, Chinese, and Russian strings.

## Design Notes

This is a separate setting rather than part of Option-as-Meta. Existing Option-as-Meta behavior maps to xterm's current escape sequence behavior, while this feature intentionally remaps only the arrow keys to word-jump commands. Option+Backspace is out of scope.

## Tests

- Adds `optionArrowWordJump.test.ts` with red-to-green coverage for enabled mapping, disabled behavior, no Option key, extra modifiers, and non-arrow keys.
- Full test suite passed: 1163 passed, 0 failed.
- `tsc` introduced no new errors.
- ESLint was clean.

Refs #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)
