### PR TITLE
chore(eslint): lint electron/bridges for undefined references (no-undef)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,11 +3,16 @@ import tsParser from "@typescript-eslint/parser";
 import tsPlugin from "@typescript-eslint/eslint-plugin";
 import unusedImports from "eslint-plugin-unused-imports";
 import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
 
 export default [
-  js.configs.recommended,
+  // The recommended preset has no file scope of its own, so scope it off all of
+  // electron/ — that main-process tree is historically unlinted. The bridges
+  // get a focused rule set in the dedicated block at the end of this config;
+  // every other electron/ file matches no config and stays unlinted as before.
+  { ...js.configs.recommended, ignores: ["electron/**"] },
   {
-    ignores: ["node_modules/**", "dist/**", "electron/**", "scripts/**", "public/monaco/**", ".github/**", ".claude/**", "release/**", ".worktrees/**"],
+    ignores: ["node_modules/**", "dist/**", "scripts/**", "public/monaco/**", ".github/**", ".claude/**", "release/**", ".worktrees/**"],
   },
   {
     files: ["**/*.{ts,tsx}"],
@@ -166,6 +171,28 @@ export default [
           ],
         },
       ],
+    },
+  },
+  {
+    // Electron main-process bridges are CommonJS and were historically excluded
+    // from linting. Lint them for undefined references only — the cheap,
+    // high-value guard against e.g. a removed variable still referenced
+    // elsewhere. (The TS config disables no-undef because the type-checker
+    // already covers it there; these .cjs files have no such safety net.)
+    files: ["electron/bridges/**/*.cjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "commonjs",
+      globals: globals.node,
+    },
+    linterOptions: {
+      // Only no-undef is enabled here, so pre-existing eslint-disable comments
+      // for other rules (no-console, no-control-regex, …) would all report as
+      // "unused". Don't flag them — they stay valid for future rule additions.
+      reportUnusedDisableDirectives: "off",
+    },
+    rules: {
+      "no-undef": "error",
     },
   },
 ];


### PR DESCRIPTION
## What

ESLint globally ignored the entire `electron/` tree, so the CommonJS main-process **bridges** had no static checking at all. This brings `electron/bridges/**/*.cjs` into ESLint with a deliberately narrow, low-noise scope: just **`no-undef`**.

## Why

These `.cjs` bridges have no type-checker behind them (that's why `no-undef` is intentionally off for the TS code — the compiler covers it there). With no lint at all, an undefined-reference bug only surfaces at runtime, often on a path the unit tests don't exercise — e.g. deleting a block but leaving a reference to one of its locals elsewhere reads an undeclared identifier and throws `ReferenceError` on that path. That's exactly the class of bug fixed in #1085 (an orphaned `flushTimeout` reference left in the SSH close handler); it would have been caught at lint time with this in place.

## How

- Scope the broad `recommended` preset off all of `electron/`, preserving today's behavior — every other `electron/` file matches no config and stays unlinted.
- Add a focused block for `electron/bridges/**/*.cjs`: CommonJS `sourceType`, Node globals (so `require`/`process`/`Buffer`/`setImmediate`/… don't false-positive), and `rules: { "no-undef": "error" }`.
- Turn off unused-`eslint-disable` reporting for that block, so pre-existing disable comments for rules we haven't enabled (`no-console`, `no-control-regex`) don't warn.

## Noise assessment

`eslint .` on current `main`: **84 bridge files linted, 0 errors, 0 warnings.** Confirmed `no-undef` is live with a throwaway probe file (it flagged an undefined symbol as expected, then removed).

Intentionally minimal — `no-undef` only. Turning on more of the recommended set for these files is a possible follow-up, but would want its own noise pass first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
