### PR TITLE
perf(autocomplete): skip completion queries when nothing is shown

### DIFF
--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -47,6 +47,18 @@ export const DEFAULT_AUTOCOMPLETE_SETTINGS: AutocompleteSettings = {
   fastTypingThresholdMs: 40,
 };
 
+/**
+ * Whether completion work is worth doing — i.e. whether anything would
+ * actually be rendered. With both the popup and ghost text disabled, querying
+ * completions only to discard the result is pure main-thread waste, so callers
+ * skip it entirely.
+ */
+export function shouldQueryCompletions(
+  settings: Pick<AutocompleteSettings, "showPopupMenu" | "showGhostText">,
+): boolean {
+  return settings.showPopupMenu || settings.showGhostText;
+}
+
 /** Shared empty state to avoid creating new objects on every reset */
 const EMPTY_STATE: AutocompleteState = Object.freeze({
   suggestions: [],
@@ -637,6 +649,15 @@ export function useTerminalAutocomplete(
   const fetchSuggestions = useCallback(async () => {
     const term = termRef.current;
     if (!term || disposedRef.current || !settingsRef.current.enabled) {
+      return;
+    }
+
+    // Nothing will be rendered when both the popup and ghost text are off, so
+    // don't run the (potentially expensive) completion query just to throw the
+    // result away. Clear any stale state and bail before touching history,
+    // fig specs, or remote path lookups.
+    if (!shouldQueryCompletions(settingsRef.current)) {
+      clearState();
       return;
     }
 

--- a/components/terminal/completionGate.test.ts
+++ b/components/terminal/completionGate.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldQueryCompletions } from "./autocomplete/useTerminalAutocomplete.ts";
+
+test("queries completions when the popup menu is enabled", () => {
+  assert.equal(
+    shouldQueryCompletions({ showPopupMenu: true, showGhostText: false }),
+    true,
+  );
+});
+
+test("queries completions when ghost text is enabled", () => {
+  assert.equal(
+    shouldQueryCompletions({ showPopupMenu: false, showGhostText: true }),
+    true,
+  );
+});
+
+test("skips completion work when both popup and ghost text are off", () => {
+  assert.equal(
+    shouldQueryCompletions({ showPopupMenu: false, showGhostText: false }),
+    false,
+  );
+});


### PR DESCRIPTION
## What

Skip the completion query in `fetchSuggestions` when neither the popup menu nor ghost text is enabled.

## Why

When autocomplete is enabled but both display modes are off (the user turned suggestions off but didn't fully disable the feature), `fetchSuggestions` still ran the whole pipeline on the main thread — history prefix/fuzzy scan, fig-spec resolution, and remote path lookups — and then discarded the result because nothing renders. That's pure waste on the debounced path.

## How

- Add a small pure, exported predicate `shouldQueryCompletions(settings)` → `showPopupMenu || showGhostText`.
- Gate `fetchSuggestions` on it right after the `enabled` check: clear any stale state and return before doing any completion work.

Safe because the only consumers of the work (popup/ghost rendering, and sub-dir navigation which requires a visible popup) can't be active when both display modes are off. Fully disabling autocomplete (`enabled = false`) already short-circuits earlier in `handleInput`.

## Testing

- New unit tests for `shouldQueryCompletions` (popup on, ghost on, both off).
- `npm test` — full suite green (1167 passed, 0 failed).
- `eslint` clean on changed files; no new `tsc` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
