### PR TITLE
perf(terminal): isolate autocomplete re-renders into a child component

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -5,7 +5,6 @@ import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 import { Cpu, Copy, HardDrive, Maximize2, MemoryStick, Radio, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import ReactDOM from "react-dom";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { logger } from "../lib/logger";
 import { cn, normalizeLineEndings, wrapBracketedPaste } from "../lib/utils";
@@ -70,7 +69,7 @@ import { useTerminalContextActions } from "./terminal/hooks/useTerminalContextAc
 import { useTerminalAuthState } from "./terminal/hooks/useTerminalAuthState";
 import { useServerStats } from "./terminal/hooks/useServerStats";
 import { extractDropEntries, getPathForFile, DropEntry } from "../lib/sftpFileUtils";
-import { useTerminalAutocomplete, AutocompletePopup } from "./terminal/autocomplete";
+import { TerminalAutocomplete } from "./terminal/TerminalAutocomplete";
 import { createTerminalCwdTracker, resolvePreferredTerminalCwd } from "./terminal/sftpCwd";
 
 const MAX_CONNECTION_LOG_DATA_CHARS = 1_000_000;
@@ -389,10 +388,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const snippetsRef = useRef(snippets);
   snippetsRef.current = snippets;
 
-  // Autocomplete handler refs (set after hook initialization)
+  // Autocomplete handler refs — populated by <TerminalAutocomplete> so the
+  // xterm runtime (and a few effects here) can drive the hook without making
+  // Terminal re-render on every suggestion update.
   const autocompleteKeyEventRef = useRef<((e: KeyboardEvent) => boolean) | undefined>(undefined);
   const autocompleteInputRef = useRef<((data: string) => void) | undefined>(undefined);
   const autocompleteRepositionRef = useRef<(() => void) | undefined>(undefined);
+  const autocompleteCloseRef = useRef<(() => void) | undefined>(undefined);
 
   const terminalBackend = useTerminalBackend();
   const { resizeSession, setSessionEncoding } = terminalBackend;
@@ -541,31 +543,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
   };
 
-  const autocomplete = useTerminalAutocomplete({
-    termRef,
-    sessionId,
-    hostId: host.id,
-    hostOs: host.os || (host.protocol === "local"
-      ? (navigator.platform?.startsWith("Win") ? "windows" : navigator.platform?.startsWith("Mac") ? "macos" : "linux")
-      : "linux"),
-    settings: terminalSettings ? {
-      enabled: terminalSettings.autocompleteEnabled ?? true,
-      showGhostText: terminalSettings.autocompleteGhostText ?? true,
-      showPopupMenu: terminalSettings.autocompletePopupMenu ?? true,
-      debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
-      minChars: terminalSettings.autocompleteMinChars ?? 1,
-      maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
-    } : undefined,
-    onAcceptText: (text) => autocompleteAcceptTextRef.current?.(text),
-    protocol: host.protocol,
-    getCwd: () => terminalCwdTracker.getRendererCwd() ?? knownCwdRef.current,
-  });
-
-  // Wire up autocomplete handler refs so createXTermRuntime can use them
-  autocompleteKeyEventRef.current = autocomplete.handleKeyEvent;
-  autocompleteInputRef.current = autocomplete.handleInput;
-  autocompleteRepositionRef.current = autocomplete.repositionPopup;
-  const autocompleteClosePopup = autocomplete.closePopup;
+  // Autocomplete config — the hook itself lives in <TerminalAutocomplete> so
+  // its state updates don't re-render this component (see render below).
+  const autocompleteHostOs: "linux" | "windows" | "macos" = host.os || (host.protocol === "local"
+    ? (navigator.platform?.startsWith("Win") ? "windows" : navigator.platform?.startsWith("Mac") ? "macos" : "linux")
+    : "linux");
+  const autocompleteSettings = terminalSettings ? {
+    enabled: terminalSettings.autocompleteEnabled ?? true,
+    showGhostText: terminalSettings.autocompleteGhostText ?? true,
+    showPopupMenu: terminalSettings.autocompletePopupMenu ?? true,
+    debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
+    minChars: terminalSettings.autocompleteMinChars ?? 1,
+    maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
+  } : undefined;
 
   const resolveSftpInitialPath = useCallback(async (): Promise<string | undefined> => {
     const cwd = await resolvePreferredTerminalCwd({
@@ -640,9 +630,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   useEffect(() => {
     if (!isVisible) {
-      autocompleteClosePopup();
+      autocompleteCloseRef.current?.();
     }
-  }, [isVisible, autocompleteClosePopup]);
+  }, [isVisible]);
 
   // Check if this is a local or serial connection (doesn't need connection dialog during connecting)
   const isLocalConnection = host.protocol === "local";
@@ -2384,29 +2374,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             }}
           />
 
-          {/* Autocomplete popup — rendered via Portal to escape overflow:hidden */}
-          {isVisible && autocomplete.state.popupVisible && autocomplete.state.suggestions.length > 0 &&
-            ReactDOM.createPortal(
-              <AutocompletePopup
-                suggestions={autocomplete.state.suggestions}
-                selectedIndex={autocomplete.state.selectedIndex}
-                position={autocomplete.state.popupPosition}
-                cursorLineTop={autocomplete.state.popupCursorLineTop}
-                cursorLineBottom={autocomplete.state.popupCursorLineBottom}
-                visible={autocomplete.state.popupVisible}
-                expandUpward={autocomplete.state.expandUpward}
-                themeColors={effectiveTheme.colors}
-                onSelect={autocomplete.selectSuggestion}
-                subDirPanels={autocomplete.state.subDirPanels}
-                subDirFocusLevel={autocomplete.state.subDirFocusLevel}
-                containerRef={containerRef}
-                onRequestReposition={autocomplete.repositionPopup}
-                searchBarOffset={isSearchOpen ? 64 : 30}
-                onDismiss={autocompleteClosePopup}
-              />,
-              document.body,
-            )
-          }
+          {/* Autocomplete — owns the hook + popup in its own component so
+              suggestion/selection updates don't re-render Terminal. Mounted
+              unconditionally; it gates the popup on `visible` internally. */}
+          <TerminalAutocomplete
+            termRef={termRef}
+            sessionId={sessionId}
+            hostId={host.id}
+            hostOs={autocompleteHostOs}
+            settings={autocompleteSettings}
+            protocol={host.protocol}
+            getCwd={() => terminalCwdTracker.getRendererCwd() ?? knownCwdRef.current}
+            onAcceptText={(text) => autocompleteAcceptTextRef.current?.(text)}
+            visible={isVisible}
+            themeColors={effectiveTheme.colors}
+            containerRef={containerRef}
+            searchBarOffset={isSearchOpen ? 64 : 30}
+            keyEventRef={autocompleteKeyEventRef}
+            inputRef={autocompleteInputRef}
+            repositionRef={autocompleteRepositionRef}
+            closeRef={autocompleteCloseRef}
+          />
 
           {/* OSC-52 clipboard read prompt */}
           {osc52ReadPromptVisible && (

--- a/components/terminal/TerminalAutocomplete.tsx
+++ b/components/terminal/TerminalAutocomplete.tsx
@@ -1,0 +1,111 @@
+import ReactDOM from "react-dom";
+import type { ComponentProps, RefObject } from "react";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+  useTerminalAutocomplete,
+  AutocompletePopup,
+  type AutocompleteSettings,
+} from "./autocomplete";
+
+type PopupProps = ComponentProps<typeof AutocompletePopup>;
+
+/** A mutable handler ref Terminal hands down for the xterm runtime to call. */
+type HandlerRef<T> = { current: T | undefined };
+
+interface TerminalAutocompleteProps {
+  termRef: RefObject<XTerm | null>;
+  sessionId: string;
+  hostId: string;
+  hostOs: "linux" | "windows" | "macos";
+  settings?: Partial<AutocompleteSettings>;
+  protocol?: string;
+  getCwd?: () => string | undefined;
+  onAcceptText: (text: string) => void;
+  /** Whether this terminal tab is the visible one. */
+  visible: boolean;
+  themeColors: PopupProps["themeColors"];
+  containerRef: PopupProps["containerRef"];
+  searchBarOffset: number;
+  // Handlers exposed back to Terminal so createXTermRuntime can drive them.
+  keyEventRef: HandlerRef<(e: KeyboardEvent) => boolean>;
+  inputRef: HandlerRef<(data: string) => void>;
+  repositionRef: HandlerRef<() => void>;
+  closeRef: HandlerRef<() => void>;
+}
+
+/**
+ * Owns the terminal autocomplete hook and renders its popup.
+ *
+ * Kept as its own component so the frequent autocomplete state updates
+ * (suggestions, selection, live-preview navigation) re-render only this small
+ * subtree rather than the whole Terminal component. The hook's handlers are
+ * surfaced back to Terminal through refs so the xterm runtime can call them.
+ *
+ * Must be mounted unconditionally for the terminal session's lifetime: the hook
+ * records command history on Enter and intercepts completion keys even while no
+ * popup is visible. Visibility only gates the rendered popup, not the hook.
+ */
+export function TerminalAutocomplete({
+  termRef,
+  sessionId,
+  hostId,
+  hostOs,
+  settings,
+  protocol,
+  getCwd,
+  onAcceptText,
+  visible,
+  themeColors,
+  containerRef,
+  searchBarOffset,
+  keyEventRef,
+  inputRef,
+  repositionRef,
+  closeRef,
+}: TerminalAutocompleteProps) {
+  const autocomplete = useTerminalAutocomplete({
+    termRef,
+    sessionId,
+    hostId,
+    hostOs,
+    settings,
+    onAcceptText,
+    protocol,
+    getCwd,
+  });
+
+  // Surface the handlers for runtime wiring. They have stable identities
+  // (useCallback over refs), so assigning during render is cheap and mirrors
+  // the wiring Terminal did inline before this was extracted.
+  keyEventRef.current = autocomplete.handleKeyEvent;
+  inputRef.current = autocomplete.handleInput;
+  repositionRef.current = autocomplete.repositionPopup;
+  closeRef.current = autocomplete.closePopup;
+
+  const { state } = autocomplete;
+  if (!visible || !state.popupVisible || state.suggestions.length === 0) {
+    return null;
+  }
+
+  // Portal to body so the popup escapes the terminal container's overflow.
+  return ReactDOM.createPortal(
+    <AutocompletePopup
+      suggestions={state.suggestions}
+      selectedIndex={state.selectedIndex}
+      position={state.popupPosition}
+      cursorLineTop={state.popupCursorLineTop}
+      cursorLineBottom={state.popupCursorLineBottom}
+      visible={state.popupVisible}
+      expandUpward={state.expandUpward}
+      themeColors={themeColors}
+      onSelect={autocomplete.selectSuggestion}
+      subDirPanels={state.subDirPanels}
+      subDirFocusLevel={state.subDirFocusLevel}
+      containerRef={containerRef}
+      onRequestReposition={autocomplete.repositionPopup}
+      searchBarOffset={searchBarOffset}
+      onDismiss={autocomplete.closePopup}
+    />,
+    document.body,
+  );
+}


### PR DESCRIPTION
## What

Move the autocomplete hook and its popup out of `Terminal` into a dedicated `<TerminalAutocomplete>` component.

## Why

`useTerminalAutocomplete` (which holds the popup state via `useState`) was called directly in `Terminal`. Every autocomplete state change — new suggestions, selection move, live-preview navigation — therefore re-rendered the entire ~2775-line `Terminal` component (debounced and wrapped in `startTransition`, but still the heaviest single cost of the completion path). Relocating the hook means those frequent updates re-render only the small `<TerminalAutocomplete>` subtree.

## How

- New `components/terminal/TerminalAutocomplete.tsx` owns the hook and renders the popup (still portaled to `document.body`).
- It's mounted **unconditionally** in `Terminal` (visibility only gates the rendered popup, internally). This preserves the hook's session lifetime — it records command history on Enter and intercepts completion keys even when no popup is shown.
- The hook's handlers (`handleInput`, `handleKeyEvent`, `repositionPopup`, `closePopup`) are surfaced back to `Terminal` through refs — the same refs already used to wire `createXTermRuntime` — so runtime wiring is unchanged. Added one `closeRef` for the visibility effect.
- `ReactDOM`/`AutocompletePopup`/`useTerminalAutocomplete` imports moved out of `Terminal` into the new component.

No behavior change intended — pure render-scope refactor.

## Testing

- `npm test` — full suite green (1164 passed, 0 failed).
- `npm run build` (vite) — succeeds.
- `tsc` — no new type errors introduced (the 3 pre-existing theme-typing errors in `Terminal.tsx` are unchanged and present on `main`).
- ⚠️ **Please smoke-test the autocomplete UI before merging** — this is a structural React change that automated tests don't exercise. Worth a quick check: popup appears/navigates (↑/↓, Tab, →, Esc), ghost-text mode, live-preview while navigating, sub-directory panels, and that command history still records on Enter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
