### PR TITLE
perf(terminal): output flow control / back-pressure for heavy streams

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -73,6 +73,11 @@ export const useTerminalBackend = () => {
     bridge?.resizeSession?.(sessionId, cols, rows);
   }, []);
 
+  const setSessionFlowPaused = useCallback((sessionId: string, paused: boolean) => {
+    const bridge = netcattyBridge.get();
+    bridge?.setSessionFlowPaused?.(sessionId, paused);
+  }, []);
+
   const closeSession = useCallback((sessionId: string) => {
     const bridge = netcattyBridge.get();
     bridge?.closeSession?.(sessionId);
@@ -208,6 +213,7 @@ export const useTerminalBackend = () => {
       getServerStats,
       writeToSession,
       resizeSession,
+      setSessionFlowPaused,
       closeSession,
       setSessionEncoding,
       onSessionData,
@@ -240,6 +246,7 @@ export const useTerminalBackend = () => {
       getServerStats,
       writeToSession,
       resizeSession,
+      setSessionFlowPaused,
       closeSession,
       setSessionEncoding,
       onSessionData,

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -27,6 +27,7 @@ import {
   syncPromptLineBreakState,
   type PromptLineBreakState,
 } from "./promptLineBreak";
+import { createOutputFlowController, type OutputFlowController } from "./outputFlowController";
 
 /**
  * Per-connection token for stale-timer detection. The renderer reuses the
@@ -97,6 +98,8 @@ type TerminalBackendApi = {
   ) => (() => void) | undefined;
   writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   resizeSession: (sessionId: string, cols: number, rows: number) => void;
+  /** Pause/resume the source stream for output back-pressure (optional). */
+  setSessionFlowPaused?: (sessionId: string, paused: boolean) => void;
 };
 
 export type PendingAuth = {
@@ -251,6 +254,38 @@ const enqueueTerminalWrite = (
   }
 };
 
+// Output back-pressure. Without this the renderer can't slow a flooding source,
+// so a busy stream grows the write queue and xterm's buffer unbounded. The
+// controller tracks bytes received-but-not-yet-rendered and asks the main
+// process to pause/resume the session's source stream at these watermarks.
+const FLOW_HIGH_WATER_MARK = 256 * 1024; // pause the source above ~256KB backlog
+const FLOW_LOW_WATER_MARK = 64 * 1024; // resume once drained to ~64KB
+
+const terminalFlowControllers = new WeakMap<XTerm, OutputFlowController>();
+
+const getFlowController = (
+  ctx: TerminalSessionStartersContext,
+  term: XTerm,
+): OutputFlowController => {
+  let controller = terminalFlowControllers.get(term);
+  if (!controller) {
+    controller = createOutputFlowController({
+      highWaterMark: FLOW_HIGH_WATER_MARK,
+      lowWaterMark: FLOW_LOW_WATER_MARK,
+      onPause: () => {
+        const id = ctx.sessionRef.current;
+        if (id) ctx.terminalBackend.setSessionFlowPaused?.(id, true);
+      },
+      onResume: () => {
+        const id = ctx.sessionRef.current;
+        if (id) ctx.terminalBackend.setSessionFlowPaused?.(id, false);
+      },
+    });
+    terminalFlowControllers.set(term, controller);
+  }
+  return controller;
+};
+
 const writeTerminalLine = (
   ctx: TerminalSessionStartersContext,
   term: XTerm,
@@ -268,6 +303,8 @@ const writeSessionData = (
   term: XTerm,
   data: string,
 ) => {
+  const flow = getFlowController(ctx, term);
+  flow.received(data.length);
   enqueueTerminalWrite(term, (done) => {
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
@@ -301,6 +338,8 @@ const writeSessionData = (
         handleTerminalOutputAutoScroll(ctx, term);
       }
       done();
+      // Acknowledge the chunk so back-pressure can ease once xterm catches up.
+      flow.written(data.length);
     };
 
     term.write(displayData, afterWrite);
@@ -320,6 +359,8 @@ const attachSessionToTerminal = (
   },
 ) => {
   ctx.sessionRef.current = id;
+  // Clear any stale back-pressure accounting from a prior session on this term.
+  getFlowController(ctx, term).reset();
   ctx.onSessionAttached?.(id);
 
   ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {
@@ -1204,6 +1245,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       });
 
       ctx.sessionRef.current = id;
+      getFlowController(ctx, term).reset();
       ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {
         writeSessionData(ctx, term, chunk);
         if (!ctx.hasConnectedRef.current) {

--- a/components/terminal/runtime/outputFlowController.test.ts
+++ b/components/terminal/runtime/outputFlowController.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createOutputFlowController } from "./outputFlowController.ts";
+
+function make(high = 100, low = 30) {
+  const events: string[] = [];
+  const controller = createOutputFlowController({
+    highWaterMark: high,
+    lowWaterMark: low,
+    onPause: () => events.push("pause"),
+    onResume: () => events.push("resume"),
+  });
+  return { controller, events };
+}
+
+test("does not pause while below the high watermark", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(50);
+  controller.received(49); // 99 < 100
+  assert.deepEqual(events, []);
+  assert.equal(controller.isPaused(), false);
+});
+
+test("pauses once when crossing the high watermark", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(60);
+  controller.received(60); // 120 >= 100 -> pause
+  assert.deepEqual(events, ["pause"]);
+  assert.equal(controller.isPaused(), true);
+  // Further received while already paused must not re-fire pause.
+  controller.received(100);
+  assert.deepEqual(events, ["pause"]);
+});
+
+test("resumes once when draining to at/below the low watermark", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(120); // pause
+  controller.written(50); // 70 still > 30, no resume
+  assert.deepEqual(events, ["pause"]);
+  controller.written(50); // 20 <= 30 -> resume
+  assert.deepEqual(events, ["pause", "resume"]);
+  assert.equal(controller.isPaused(), false);
+});
+
+test("does not resume when still above the low watermark", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(120); // pause
+  controller.written(80); // 40 > 30
+  assert.deepEqual(events, ["pause"]);
+  assert.equal(controller.isPaused(), true);
+});
+
+test("never lets pending go negative", () => {
+  const { controller } = make(100, 30);
+  controller.received(10);
+  controller.written(50); // over-written
+  assert.equal(controller.pendingBytes(), 0);
+});
+
+test("supports repeated pause/resume cycles", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(120); // pause
+  controller.written(120); // resume (0 <= 30)
+  controller.received(120); // pause again
+  controller.written(120); // resume again
+  assert.deepEqual(events, ["pause", "resume", "pause", "resume"]);
+});
+
+test("reset clears state without firing callbacks", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(120); // pause
+  controller.reset();
+  assert.equal(controller.isPaused(), false);
+  assert.equal(controller.pendingBytes(), 0);
+  assert.deepEqual(events, ["pause"]); // reset itself is silent
+  // A fresh cycle works after reset.
+  controller.received(120);
+  assert.deepEqual(events, ["pause", "pause"]);
+});
+
+test("ignores non-positive amounts", () => {
+  const { controller, events } = make(100, 30);
+  controller.received(0);
+  controller.written(0);
+  controller.received(-5);
+  assert.equal(controller.pendingBytes(), 0);
+  assert.deepEqual(events, []);
+});

--- a/components/terminal/runtime/outputFlowController.ts
+++ b/components/terminal/runtime/outputFlowController.ts
@@ -1,0 +1,73 @@
+/**
+ * Watermark-based flow control for terminal output.
+ *
+ * SSH/PTY output has no back-pressure by default: the source streams as fast as
+ * it can, the main process forwards it over IPC, and the renderer queues every
+ * chunk into xterm. When output outpaces rendering (e.g. `cat` of a big file, a
+ * noisy build, `tail -f`, `yes`), the renderer-side backlog and xterm's internal
+ * buffer grow without bound — memory climbs and the whole UI, typing included,
+ * janks.
+ *
+ * This tracks bytes that have been received but not yet acknowledged by xterm's
+ * write callback. When the backlog crosses `highWaterMark` it asks the caller to
+ * pause the source; once it drains back to `lowWaterMark` it asks to resume. The
+ * hysteresis gap avoids rapid pause/resume flapping. During interactive use the
+ * backlog hovers near zero, so this never engages.
+ */
+export interface OutputFlowController {
+  /** Account bytes handed to xterm (call when a chunk is received). */
+  received(bytes: number): void;
+  /** Account bytes whose xterm write callback has fired. */
+  written(bytes: number): void;
+  /** Clear all state (e.g. on a fresh session attach). Fires no callbacks. */
+  reset(): void;
+  pendingBytes(): number;
+  isPaused(): boolean;
+}
+
+export interface OutputFlowControllerOptions {
+  highWaterMark: number;
+  lowWaterMark: number;
+  /** Asked to pause the source when the backlog crosses the high watermark. */
+  onPause: () => void;
+  /** Asked to resume the source when the backlog drains to the low watermark. */
+  onResume: () => void;
+}
+
+export function createOutputFlowController(
+  options: OutputFlowControllerOptions,
+): OutputFlowController {
+  const { highWaterMark, lowWaterMark, onPause, onResume } = options;
+  let pending = 0;
+  let paused = false;
+
+  return {
+    received(bytes: number): void {
+      if (bytes <= 0) return;
+      pending += bytes;
+      if (!paused && pending >= highWaterMark) {
+        paused = true;
+        onPause();
+      }
+    },
+    written(bytes: number): void {
+      if (bytes <= 0) return;
+      pending -= bytes;
+      if (pending < 0) pending = 0;
+      if (paused && pending <= lowWaterMark) {
+        paused = false;
+        onResume();
+      }
+    },
+    reset(): void {
+      pending = 0;
+      paused = false;
+    },
+    pendingBytes(): number {
+      return pending;
+    },
+    isPaused(): boolean {
+      return paused;
+    },
+  };
+}

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -1550,6 +1550,31 @@ function writeToSession(event, payload) {
 }
 
 /**
+ * Pause or resume a session's source stream for output back-pressure.
+ * The renderer asks for this when its write backlog crosses a watermark, so a
+ * flooding source can't outrun the terminal renderer. Works across session
+ * kinds: ssh2 channel (stream), node-pty (proc), telnet socket, serial port —
+ * all expose pause()/resume().
+ */
+function setSessionFlowPaused(event, payload) {
+  const session = sessions.get(payload.sessionId);
+  if (!session) return;
+  const target = session.stream || session.proc || session.socket || session.serialPort;
+  if (!target) return;
+  try {
+    if (payload.paused) {
+      target.pause?.();
+    } else {
+      target.resume?.();
+    }
+  } catch (err) {
+    if (err?.code !== 'EPIPE' && err?.code !== 'ERR_STREAM_DESTROYED') {
+      console.warn("Flow control toggle failed", err);
+    }
+  }
+}
+
+/**
  * Resize a session terminal
  */
 function resizeSession(event, payload) {
@@ -1663,6 +1688,7 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:terminal:setEncoding", setSessionEncoding);
   ipcMain.on("netcatty:write", writeToSession);
   ipcMain.on("netcatty:resize", resizeSession);
+  ipcMain.on("netcatty:flow", setSessionFlowPaused);
   ipcMain.on("netcatty:close", closeSession);
 }
 
@@ -1848,6 +1874,7 @@ module.exports = {
   listSerialPorts,
   writeToSession,
   resizeSession,
+  setSessionFlowPaused,
   closeSession,
   cleanupAllSessions,
   getDefaultShell,

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -669,6 +669,9 @@ const api = {
   resizeSession: (sessionId, cols, rows) => {
     ipcRenderer.send("netcatty:resize", { sessionId, cols, rows });
   },
+  setSessionFlowPaused: (sessionId, paused) => {
+    ipcRenderer.send("netcatty:flow", { sessionId, paused: Boolean(paused) });
+  },
   closeSession: (sessionId) => {
     ipcRenderer.send("netcatty:close", { sessionId });
   },

--- a/global.d.ts
+++ b/global.d.ts
@@ -323,6 +323,7 @@ declare global {
     setSessionEncoding?(sessionId: string, encoding: string): Promise<{ ok: boolean; encoding: string }>;
     writeToSession(sessionId: string, data: string, options?: { automated?: boolean }): void;
     resizeSession(sessionId: string, cols: number, rows: number): void;
+    setSessionFlowPaused(sessionId: string, paused: boolean): void;
     closeSession(sessionId: string): void;
     // ZMODEM file transfer
     onZmodemEvent?(


### PR DESCRIPTION
## What

Add watermark-based **flow control / back-pressure** to the terminal output path so a flooding source can't outrun the renderer.

## Why

SSH/PTY output had no back-pressure. The chain was:

```
source stream → (main) IPC → enqueueTerminalWrite queue (unbounded) → xterm buffer (unbounded)
```

When output outpaces rendering (`cat` a big file, a noisy build, `tail -f`, `yes`), the renderer-side backlog and xterm's internal buffer grow without bound — memory spikes and the whole UI, **typing included**, janks. This is the flooding-output jank case, and the one piece xterm.js-class terminals normally solve with flow control that we were missing.

## How

- **`outputFlowController`** (new, unit-tested): tracks bytes received-but-not-yet-acknowledged by xterm's write callback. Crossing `highWaterMark` (~256 KB) asks the caller to pause; draining to `lowWaterMark` (~64 KB) asks to resume. The hysteresis gap avoids flapping; during interactive use the backlog stays ~0 so it never engages.
- **`writeSessionData`** uses a per-terminal controller (WeakMap): `received(len)` when a chunk arrives, `written(len)` in the existing `term.write` callback. Both `onSessionData` sites get this for free. The controller is `reset()` on each fresh attach to avoid stale accounting on a reused terminal.
- **New `netcatty:flow` IPC**: `setSessionFlowPaused(sessionId, paused)` across preload → bridge type (`global.d.ts`) → `useTerminalBackend` → main handler. The main handler calls `pause()`/`resume()` on whichever source the session has — ssh2 channel / node-pty proc / telnet socket / serial port (all expose it). ssh2 propagates the pause as channel-window back-pressure to the remote.

## Testing

- New unit tests for `outputFlowController` (pause/resume transitions, hysteresis, no-negative, reset, repeated cycles).
- `npm test` — full suite green (1190 passed, 0 failed).
- `npm run build` (vite) ✓; `tsc` — no new type errors.
- ⚠️ **Please smoke-test before merging** (automated tests can't drive a real flood):
  - Heavy output over SSH (`yes`, `cat bigfile`, a verbose build): UI stays responsive, memory stays bounded, and it **recovers cleanly** when output stops / on `Ctrl-C` (no stuck-paused / frozen terminal).
  - Normal interactive typing and light output: unaffected (flow control shouldn't engage).
  - Quick check on telnet and a local shell too, since they share the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
