### PR TITLE
fix(ai): make Claude Code agent diagnosable + configurable (auth)

### DIFF
--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1954,8 +1954,8 @@ const en: Messages = {
   'ai.claude.configDir.placeholder': '~/.claude (leave blank for default)',
   'ai.claude.configDir.hint': 'Sets CLAUDE_CONFIG_DIR — point at a folder where you have run `claude` login (contains settings.json + credentials).',
   'ai.claude.envVars': 'Environment variables',
-  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
-  'ai.claude.envVars.hint': 'One KEY=VALUE per line. Passed to the Claude agent process.',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_BASE_URL=https://...\nANTHROPIC_MODEL=...',
+  'ai.claude.envVars.hint': 'One KEY=VALUE per line, passed to the Claude agent. Stored locally in plaintext — for API keys / credentials, prefer the config directory above (a `claude` login).',
   'ai.claude.check': 'Check',
 
   // AI GitHub Copilot CLI

--- a/application/i18n/locales/en.ts
+++ b/application/i18n/locales/en.ts
@@ -1949,6 +1949,13 @@ const en: Messages = {
   'ai.claude.path': 'Path:',
   'ai.claude.notFoundHint': 'Could not find claude in PATH. Install it or specify the executable path below.',
   'ai.claude.customPathPlaceholder': 'e.g. /usr/local/bin/claude',
+  'ai.claude.configSection': 'Authentication & config (optional)',
+  'ai.claude.configDir': 'Config directory',
+  'ai.claude.configDir.placeholder': '~/.claude (leave blank for default)',
+  'ai.claude.configDir.hint': 'Sets CLAUDE_CONFIG_DIR — point at a folder where you have run `claude` login (contains settings.json + credentials).',
+  'ai.claude.envVars': 'Environment variables',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
+  'ai.claude.envVars.hint': 'One KEY=VALUE per line. Passed to the Claude agent process.',
   'ai.claude.check': 'Check',
 
   // AI GitHub Copilot CLI

--- a/application/i18n/locales/ru.ts
+++ b/application/i18n/locales/ru.ts
@@ -1981,6 +1981,13 @@ const ru: Messages = {
   'ai.claude.path': 'Путь:',
   'ai.claude.notFoundHint': 'Не удалось найти claude в PATH. Установите его или укажите путь к исполняемому файлу ниже.',
   'ai.claude.customPathPlaceholder': 'например, /usr/local/bin/claude',
+  'ai.claude.configSection': 'Аутентификация и конфигурация (опционально)',
+  'ai.claude.configDir': 'Каталог конфигурации',
+  'ai.claude.configDir.placeholder': '~/.claude (пусто — по умолчанию)',
+  'ai.claude.configDir.hint': 'Задаёт CLAUDE_CONFIG_DIR — укажите папку, где выполнен вход `claude` (содержит settings.json и учётные данные).',
+  'ai.claude.envVars': 'Переменные окружения',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
+  'ai.claude.envVars.hint': 'По одному KEY=VALUE в строке. Передаётся процессу агента Claude.',
   'ai.claude.check': 'Проверить',
 
   // AI GitHub Copilot CLI

--- a/application/i18n/locales/ru.ts
+++ b/application/i18n/locales/ru.ts
@@ -1986,8 +1986,8 @@ const ru: Messages = {
   'ai.claude.configDir.placeholder': '~/.claude (пусто — по умолчанию)',
   'ai.claude.configDir.hint': 'Задаёт CLAUDE_CONFIG_DIR — укажите папку, где выполнен вход `claude` (содержит settings.json и учётные данные).',
   'ai.claude.envVars': 'Переменные окружения',
-  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
-  'ai.claude.envVars.hint': 'По одному KEY=VALUE в строке. Передаётся процессу агента Claude.',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_BASE_URL=https://...\nANTHROPIC_MODEL=...',
+  'ai.claude.envVars.hint': 'По одному KEY=VALUE в строке, передаётся агенту Claude. Хранится локально в открытом виде — для API-ключей и учётных данных используйте «Каталог конфигурации» выше (вход `claude`).',
   'ai.claude.check': 'Проверить',
 
   // AI GitHub Copilot CLI

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1962,8 +1962,8 @@ const zhCN: Messages = {
   'ai.claude.configDir.placeholder': '~/.claude（留空用默认）',
   'ai.claude.configDir.hint': '设置 CLAUDE_CONFIG_DIR —— 指向你已运行 `claude` 登录的目录（含 settings.json 和凭据）。',
   'ai.claude.envVars': '环境变量',
-  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
-  'ai.claude.envVars.hint': '每行一个 KEY=VALUE，会传给 Claude agent 进程。',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_BASE_URL=https://...\nANTHROPIC_MODEL=...',
+  'ai.claude.envVars.hint': '每行一个 KEY=VALUE，传给 Claude agent。明文存在本地——API key／凭据建议用上面的「配置目录」（claude 登录），不要放这里。',
   'ai.claude.check': '检查',
 
   // AI GitHub Copilot CLI

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1957,6 +1957,13 @@ const zhCN: Messages = {
   'ai.claude.path': '路径：',
   'ai.claude.notFoundHint': '在 PATH 中未找到 claude。请安装或在下方指定可执行文件路径。',
   'ai.claude.customPathPlaceholder': '例如 /usr/local/bin/claude',
+  'ai.claude.configSection': '认证与配置（可选）',
+  'ai.claude.configDir': '配置目录',
+  'ai.claude.configDir.placeholder': '~/.claude（留空用默认）',
+  'ai.claude.configDir.hint': '设置 CLAUDE_CONFIG_DIR —— 指向你已运行 `claude` 登录的目录（含 settings.json 和凭据）。',
+  'ai.claude.envVars': '环境变量',
+  'ai.claude.envVars.placeholder': 'ANTHROPIC_API_KEY=sk-...\nANTHROPIC_BASE_URL=https://...',
+  'ai.claude.envVars.hint': '每行一个 KEY=VALUE，会传给 Claude agent 进程。',
   'ai.claude.check': '检查',
 
   // AI GitHub Copilot CLI

--- a/components/ai/claudeConfigEnv.test.ts
+++ b/components/ai/claudeConfigEnv.test.ts
@@ -46,3 +46,16 @@ test("buildClaudeEnv merges config dir + parsed env, preserves CLAUDE_CODE_EXECU
 test("buildClaudeEnv omits config dir when blank and returns undefined when empty", () => {
   assert.equal(buildClaudeEnv(undefined, "  ", ""), undefined);
 });
+
+test("buildClaudeEnv ignores managed keys typed into the env editor", () => {
+  const next = buildClaudeEnv(
+    { CLAUDE_CODE_EXECUTABLE: "/usr/bin/claude" },
+    "/cfg",
+    "CLAUDE_CODE_EXECUTABLE=/evil/claude\nCLAUDE_CONFIG_DIR=/evil/dir\nANTHROPIC_API_KEY=sk-x",
+  );
+  assert.deepEqual(next, {
+    CLAUDE_CODE_EXECUTABLE: "/usr/bin/claude",
+    CLAUDE_CONFIG_DIR: "/cfg",
+    ANTHROPIC_API_KEY: "sk-x",
+  });
+});

--- a/components/ai/claudeConfigEnv.test.ts
+++ b/components/ai/claudeConfigEnv.test.ts
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  splitClaudeEnv,
+  buildClaudeEnv,
+  parseEnvLines,
+  serializeEnvLines,
+} from "../settings/tabs/ai/claudeConfigEnv";
+
+test("splitClaudeEnv pulls out config dir and hides CLAUDE_CODE_EXECUTABLE", () => {
+  const result = splitClaudeEnv({
+    CLAUDE_CONFIG_DIR: "/cfg",
+    CLAUDE_CODE_EXECUTABLE: "/usr/bin/claude",
+    ANTHROPIC_API_KEY: "sk-x",
+  });
+  assert.equal(result.configDir, "/cfg");
+  assert.equal(result.envText, "ANTHROPIC_API_KEY=sk-x");
+});
+
+test("splitClaudeEnv handles undefined env", () => {
+  assert.deepEqual(splitClaudeEnv(undefined), { configDir: "", envText: "" });
+});
+
+test("parseEnvLines parses KEY=VALUE, trims keys, keeps value as-is, skips blanks/comments", () => {
+  assert.deepEqual(
+    parseEnvLines("ANTHROPIC_API_KEY = sk-x\n# comment\n\nANTHROPIC_BASE_URL=https://h/?a=b"),
+    { ANTHROPIC_API_KEY: "sk-x", ANTHROPIC_BASE_URL: "https://h/?a=b" },
+  );
+});
+
+test("serializeEnvLines is the inverse for simple entries", () => {
+  assert.equal(serializeEnvLines({ A: "1", B: "2" }), "A=1\nB=2");
+});
+
+test("buildClaudeEnv merges config dir + parsed env, preserves CLAUDE_CODE_EXECUTABLE, drops empties", () => {
+  const prev = { CLAUDE_CODE_EXECUTABLE: "/usr/bin/claude", OLD: "x" };
+  const next = buildClaudeEnv(prev, "/cfg", "ANTHROPIC_API_KEY=sk-x");
+  assert.deepEqual(next, {
+    CLAUDE_CODE_EXECUTABLE: "/usr/bin/claude",
+    CLAUDE_CONFIG_DIR: "/cfg",
+    ANTHROPIC_API_KEY: "sk-x",
+  });
+});
+
+test("buildClaudeEnv omits config dir when blank and returns undefined when empty", () => {
+  assert.equal(buildClaudeEnv(undefined, "  ", ""), undefined);
+});

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -48,6 +48,7 @@ import {
   buildManagedAgentState,
   getInitialManagedAgentPaths,
 } from "./ai/managedAgentState";
+import { splitClaudeEnv, buildClaudeEnv } from "./ai/claudeConfigEnv";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -125,6 +126,29 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const [claudePathInfo, setClaudePathInfo] = useState<AgentPathInfo | null>(null);
   const [claudeCustomPath, setClaudeCustomPath] = useState("");
   const [isResolvingClaude, setIsResolvingClaude] = useState(false);
+
+  const claudeManagedEnv = useMemo(
+    () => externalAgents.find((a) => a.id === "discovered_claude")?.env,
+    [externalAgents],
+  );
+  const { configDir: claudeConfigDir, envText: claudeEnvText } = useMemo(
+    () => splitClaudeEnv(claudeManagedEnv),
+    [claudeManagedEnv],
+  );
+
+  const updateClaudeEnv = useCallback(
+    (nextConfigDir: string, nextEnvText: string) => {
+      setExternalAgents((prev) =>
+        prev.map((a) =>
+          a.id === "discovered_claude"
+            ? { ...a, env: buildClaudeEnv(a.env, nextConfigDir, nextEnvText) }
+            : a,
+        ),
+      );
+    },
+    [setExternalAgents],
+  );
+
   const initialManagedPathsRef = useRef<{
     codex: string;
     claude: string;
@@ -542,6 +566,10 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               customPath={claudeCustomPath}
               onCustomPathChange={setClaudeCustomPath}
               onRecheckPath={() => void handleCheckCustomPath("claude")}
+              configDir={claudeConfigDir}
+              onConfigDirChange={(v) => updateClaudeEnv(v, claudeEnvText)}
+              envText={claudeEnvText}
+              onEnvTextChange={(v) => updateClaudeEnv(claudeConfigDir, v)}
             />
           </div>
 

--- a/components/settings/tabs/ai/ClaudeCodeCard.tsx
+++ b/components/settings/tabs/ai/ClaudeCodeCard.tsx
@@ -98,8 +98,9 @@ export const ClaudeCodeCard: React.FC<{
           {t('ai.claude.configSection')}
         </div>
         <div className="space-y-1.5">
-          <label className="text-xs text-muted-foreground">{t('ai.claude.configDir')}</label>
+          <label htmlFor="claude-config-dir" className="text-xs text-muted-foreground">{t('ai.claude.configDir')}</label>
           <input
+            id="claude-config-dir"
             type="text"
             value={configDir}
             onChange={(e) => onConfigDirChange(e.target.value)}
@@ -109,8 +110,9 @@ export const ClaudeCodeCard: React.FC<{
           <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.configDir.hint')}</p>
         </div>
         <div className="space-y-1.5">
-          <label className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
+          <label htmlFor="claude-env-vars" className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
           <textarea
+            id="claude-env-vars"
             value={envText}
             onChange={(e) => onEnvTextChange(e.target.value)}
             placeholder={t('ai.claude.envVars.placeholder')}

--- a/components/settings/tabs/ai/ClaudeCodeCard.tsx
+++ b/components/settings/tabs/ai/ClaudeCodeCard.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { RefreshCw } from "lucide-react";
+import React, { useState } from "react";
+import { ChevronDown, RefreshCw } from "lucide-react";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
@@ -29,6 +29,11 @@ export const ClaudeCodeCard: React.FC<{
 }) => {
   const { t } = useI18n();
   const found = pathInfo?.available;
+  // Collapsed by default; auto-expand when the user already has config so it
+  // isn't hidden. Local UI state — not persisted.
+  const [configOpen, setConfigOpen] = useState(
+    () => Boolean(configDir.trim() || envText.trim()),
+  );
 
   const statusText = isResolvingPath
     ? t('ai.claude.detecting')
@@ -92,36 +97,51 @@ export const ClaudeCodeCard: React.FC<{
         </div>
       ) : null}
 
-      {/* Authentication & config (optional) */}
-      <div className="space-y-3 border-t border-border/60 pt-3">
-        <div className="text-xs font-medium text-muted-foreground">
-          {t('ai.claude.configSection')}
-        </div>
-        <div className="space-y-1.5">
-          <label htmlFor="claude-config-dir" className="text-xs text-muted-foreground">{t('ai.claude.configDir')}</label>
-          <input
-            id="claude-config-dir"
-            type="text"
-            value={configDir}
-            onChange={(e) => onConfigDirChange(e.target.value)}
-            placeholder={t('ai.claude.configDir.placeholder')}
-            className="w-full h-8 rounded-md border border-input bg-background px-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      {/* Authentication & config (optional, collapsible) */}
+      <div className="border-t border-border/60 pt-3">
+        <button
+          type="button"
+          onClick={() => setConfigOpen((v) => !v)}
+          aria-expanded={configOpen}
+          className="flex w-full items-center justify-between gap-2 text-left"
+        >
+          <span className="text-xs font-medium text-muted-foreground">
+            {t('ai.claude.configSection')}
+          </span>
+          <ChevronDown
+            size={14}
+            className={cn("text-muted-foreground transition-transform", configOpen && "rotate-180")}
           />
-          <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.configDir.hint')}</p>
-        </div>
-        <div className="space-y-1.5">
-          <label htmlFor="claude-env-vars" className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
-          <textarea
-            id="claude-env-vars"
-            value={envText}
-            onChange={(e) => onEnvTextChange(e.target.value)}
-            placeholder={t('ai.claude.envVars.placeholder')}
-            rows={3}
-            spellCheck={false}
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
-          />
-          <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.envVars.hint')}</p>
-        </div>
+        </button>
+        {configOpen && (
+          <div className="space-y-3 mt-3">
+            <div className="space-y-1.5">
+              <label htmlFor="claude-config-dir" className="text-xs text-muted-foreground">{t('ai.claude.configDir')}</label>
+              <input
+                id="claude-config-dir"
+                type="text"
+                value={configDir}
+                onChange={(e) => onConfigDirChange(e.target.value)}
+                placeholder={t('ai.claude.configDir.placeholder')}
+                className="w-full h-8 rounded-md border border-input bg-background px-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.configDir.hint')}</p>
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="claude-env-vars" className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
+              <textarea
+                id="claude-env-vars"
+                value={envText}
+                onChange={(e) => onEnvTextChange(e.target.value)}
+                placeholder={t('ai.claude.envVars.placeholder')}
+                rows={3}
+                spellCheck={false}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              />
+              <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.envVars.hint')}</p>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/settings/tabs/ai/ClaudeCodeCard.tsx
+++ b/components/settings/tabs/ai/ClaudeCodeCard.tsx
@@ -12,12 +12,20 @@ export const ClaudeCodeCard: React.FC<{
   customPath: string;
   onCustomPathChange: (path: string) => void;
   onRecheckPath: () => void;
+  configDir: string;
+  onConfigDirChange: (value: string) => void;
+  envText: string;
+  onEnvTextChange: (value: string) => void;
 }> = ({
   pathInfo,
   isResolvingPath,
   customPath,
   onCustomPathChange,
   onRecheckPath,
+  configDir,
+  onConfigDirChange,
+  envText,
+  onEnvTextChange,
 }) => {
   const { t } = useI18n();
   const found = pathInfo?.available;
@@ -83,6 +91,36 @@ export const ClaudeCodeCard: React.FC<{
           </div>
         </div>
       ) : null}
+
+      {/* Authentication & config (optional) */}
+      <div className="space-y-3 border-t border-border/60 pt-3">
+        <div className="text-xs font-medium text-muted-foreground">
+          {t('ai.claude.configSection')}
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs text-muted-foreground">{t('ai.claude.configDir')}</label>
+          <input
+            type="text"
+            value={configDir}
+            onChange={(e) => onConfigDirChange(e.target.value)}
+            placeholder={t('ai.claude.configDir.placeholder')}
+            className="w-full h-8 rounded-md border border-input bg-background px-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          />
+          <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.configDir.hint')}</p>
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
+          <textarea
+            value={envText}
+            onChange={(e) => onEnvTextChange(e.target.value)}
+            placeholder={t('ai.claude.envVars.placeholder')}
+            rows={3}
+            spellCheck={false}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+          />
+          <p className="text-[11px] text-muted-foreground leading-4">{t('ai.claude.envVars.hint')}</p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/components/settings/tabs/ai/ClaudeCodeCard.tsx
+++ b/components/settings/tabs/ai/ClaudeCodeCard.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ChevronDown, RefreshCw } from "lucide-react";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
 import type { AgentPathInfo } from "./types";
 import { ProviderIconBadge } from "./ProviderIconBadge";
+import { parseEnvLines, serializeEnvLines } from "./claudeConfigEnv";
 
 export const ClaudeCodeCard: React.FC<{
   pathInfo: AgentPathInfo | null;
@@ -34,6 +35,18 @@ export const ClaudeCodeCard: React.FC<{
   const [configOpen, setConfigOpen] = useState(
     () => Boolean(configDir.trim() || envText.trim()),
   );
+
+  // The env editor keeps the raw text the user types. Persisting parses it into
+  // a record (dropping incomplete lines), so binding the textarea directly to
+  // the persisted value would erase a key the moment it's typed before its "=".
+  // Only resync from the persisted value when it changes for some reason other
+  // than our own parse→serialize round-trip.
+  const [envDraft, setEnvDraft] = useState(envText);
+  useEffect(() => {
+    setEnvDraft((prev) =>
+      serializeEnvLines(parseEnvLines(prev)) === envText ? prev : envText,
+    );
+  }, [envText]);
 
   const statusText = isResolvingPath
     ? t('ai.claude.detecting')
@@ -131,8 +144,8 @@ export const ClaudeCodeCard: React.FC<{
               <label htmlFor="claude-env-vars" className="text-xs text-muted-foreground">{t('ai.claude.envVars')}</label>
               <textarea
                 id="claude-env-vars"
-                value={envText}
-                onChange={(e) => onEnvTextChange(e.target.value)}
+                value={envDraft}
+                onChange={(e) => { setEnvDraft(e.target.value); onEnvTextChange(e.target.value); }}
                 placeholder={t('ai.claude.envVars.placeholder')}
                 rows={3}
                 spellCheck={false}

--- a/components/settings/tabs/ai/claudeConfigEnv.ts
+++ b/components/settings/tabs/ai/claudeConfigEnv.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the Claude Code card's "config directory + environment
+ * variables" editor. The managed Claude agent stores everything in its
+ * ExternalAgentConfig.env; this splits that into the editable pieces and
+ * recombines them. CLAUDE_CODE_EXECUTABLE is owned by path discovery, so it
+ * is preserved across edits but never shown in the env editor.
+ */
+
+const CONFIG_DIR_KEY = "CLAUDE_CONFIG_DIR";
+const MANAGED_KEYS = new Set(["CLAUDE_CODE_EXECUTABLE", CONFIG_DIR_KEY]);
+
+export function parseEnvLines(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of String(text || "").split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+export function serializeEnvLines(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+}
+
+export function splitClaudeEnv(
+  env: Record<string, string> | undefined,
+): { configDir: string; envText: string } {
+  if (!env) return { configDir: "", envText: "" };
+  const configDir = env[CONFIG_DIR_KEY] ?? "";
+  const rest: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (MANAGED_KEYS.has(k)) continue;
+    rest[k] = v;
+  }
+  return { configDir, envText: serializeEnvLines(rest) };
+}
+
+export function buildClaudeEnv(
+  prevEnv: Record<string, string> | undefined,
+  configDir: string,
+  envText: string,
+): Record<string, string> | undefined {
+  const next: Record<string, string> = {};
+  // Preserve discovery-owned key if present.
+  const exe = prevEnv?.CLAUDE_CODE_EXECUTABLE;
+  if (exe) next.CLAUDE_CODE_EXECUTABLE = exe;
+
+  const trimmedDir = String(configDir || "").trim();
+  if (trimmedDir) next[CONFIG_DIR_KEY] = trimmedDir;
+
+  Object.assign(next, parseEnvLines(envText));
+
+  return Object.keys(next).length > 0 ? next : undefined;
+}

--- a/components/settings/tabs/ai/claudeConfigEnv.ts
+++ b/components/settings/tabs/ai/claudeConfigEnv.ts
@@ -55,7 +55,11 @@ export function buildClaudeEnv(
   const trimmedDir = String(configDir || "").trim();
   if (trimmedDir) next[CONFIG_DIR_KEY] = trimmedDir;
 
-  Object.assign(next, parseEnvLines(envText));
+  // Drop managed keys if a user typed them into the free-text editor — the
+  // config-dir field and path discovery own CLAUDE_CONFIG_DIR / CLAUDE_CODE_EXECUTABLE.
+  const parsed = parseEnvLines(envText);
+  for (const key of MANAGED_KEYS) delete parsed[key];
+  Object.assign(next, parsed);
 
   return Object.keys(next).length > 0 ? next : undefined;
 }

--- a/electron/bridges/ai/claudeAuth.cjs
+++ b/electron/bridges/ai/claudeAuth.cjs
@@ -15,9 +15,25 @@ const { existsSync } = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+/**
+ * Expand a leading "~" to the user's home directory. Env vars handed to a
+ * child process are NOT shell-expanded, so "~/.claude" would otherwise be
+ * treated as a literal directory named "~". Only a leading "~", "~/" or "~\"
+ * is expanded (not "~user"); other values pass through unchanged.
+ */
+function expandHomePath(p) {
+  if (typeof p !== "string") return p;
+  const trimmed = p.trim();
+  if (trimmed === "~") return os.homedir();
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(os.homedir(), trimmed.slice(2));
+  }
+  return p;
+}
+
 function getClaudeConfigDir(env) {
   const custom = typeof env?.CLAUDE_CONFIG_DIR === "string" ? env.CLAUDE_CONFIG_DIR.trim() : "";
-  return custom || path.join(os.homedir(), ".claude");
+  return custom ? expandHomePath(custom) : path.join(os.homedir(), ".claude");
 }
 
 /**
@@ -31,4 +47,4 @@ function detectClaudeAuthPresence(env, fileExists = existsSync) {
   return "none";
 }
 
-module.exports = { detectClaudeAuthPresence, getClaudeConfigDir };
+module.exports = { detectClaudeAuthPresence, getClaudeConfigDir, expandHomePath };

--- a/electron/bridges/ai/claudeAuth.cjs
+++ b/electron/bridges/ai/claudeAuth.cjs
@@ -1,0 +1,34 @@
+"use strict";
+
+/**
+ * Claude Code auth/config detection helpers (main process).
+ *
+ * claude-agent-acp authenticates from env (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN)
+ * or from credentials stored under CLAUDE_CONFIG_DIR (default ~/.claude). We use
+ * this to turn opaque "-32603 Internal error" failures into an actionable message
+ * when no auth is configured. NOTE: macOS may store credentials in the Keychain
+ * rather than a file, so 'none' is a heuristic — callers must NOT hard-block on it;
+ * only use it to improve the error message after an actual failure.
+ */
+
+const { existsSync } = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function getClaudeConfigDir(env) {
+  const custom = typeof env?.CLAUDE_CONFIG_DIR === "string" ? env.CLAUDE_CONFIG_DIR.trim() : "";
+  return custom || path.join(os.homedir(), ".claude");
+}
+
+/**
+ * @returns {'env'|'credentials-file'|'none'}
+ */
+function detectClaudeAuthPresence(env, fileExists = existsSync) {
+  const apiKey = typeof env?.ANTHROPIC_API_KEY === "string" ? env.ANTHROPIC_API_KEY.trim() : "";
+  const authToken = typeof env?.ANTHROPIC_AUTH_TOKEN === "string" ? env.ANTHROPIC_AUTH_TOKEN.trim() : "";
+  if (apiKey || authToken) return "env";
+  if (fileExists(path.join(getClaudeConfigDir(env), ".credentials.json"))) return "credentials-file";
+  return "none";
+}
+
+module.exports = { detectClaudeAuthPresence, getClaudeConfigDir };

--- a/electron/bridges/ai/claudeAuth.test.cjs
+++ b/electron/bridges/ai/claudeAuth.test.cjs
@@ -1,0 +1,41 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const os = require("node:os");
+
+const { detectClaudeAuthPresence, getClaudeConfigDir } = require("./claudeAuth.cjs");
+
+test("getClaudeConfigDir: defaults to ~/.claude", () => {
+  assert.equal(getClaudeConfigDir({}), path.join(os.homedir(), ".claude"));
+});
+
+test("getClaudeConfigDir: honors CLAUDE_CONFIG_DIR", () => {
+  assert.equal(getClaudeConfigDir({ CLAUDE_CONFIG_DIR: "/custom/dir" }), "/custom/dir");
+});
+
+test("detectClaudeAuthPresence: ANTHROPIC_API_KEY in env => 'env'", () => {
+  assert.equal(detectClaudeAuthPresence({ ANTHROPIC_API_KEY: "sk-x" }, () => false), "env");
+});
+
+test("detectClaudeAuthPresence: ANTHROPIC_AUTH_TOKEN in env => 'env'", () => {
+  assert.equal(detectClaudeAuthPresence({ ANTHROPIC_AUTH_TOKEN: "tok" }, () => false), "env");
+});
+
+test("detectClaudeAuthPresence: blank env token is ignored", () => {
+  assert.equal(detectClaudeAuthPresence({ ANTHROPIC_API_KEY: "   " }, () => false), "none");
+});
+
+test("detectClaudeAuthPresence: credentials file under config dir => 'credentials-file'", () => {
+  const seen = [];
+  const result = detectClaudeAuthPresence(
+    { CLAUDE_CONFIG_DIR: "/custom/dir" },
+    (p) => { seen.push(p); return p === path.join("/custom/dir", ".credentials.json"); },
+  );
+  assert.equal(result, "credentials-file");
+  assert.ok(seen.includes(path.join("/custom/dir", ".credentials.json")));
+});
+
+test("detectClaudeAuthPresence: nothing => 'none'", () => {
+  assert.equal(detectClaudeAuthPresence({}, () => false), "none");
+});

--- a/electron/bridges/ai/claudeAuth.test.cjs
+++ b/electron/bridges/ai/claudeAuth.test.cjs
@@ -4,7 +4,7 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 const os = require("node:os");
 
-const { detectClaudeAuthPresence, getClaudeConfigDir } = require("./claudeAuth.cjs");
+const { detectClaudeAuthPresence, getClaudeConfigDir, expandHomePath } = require("./claudeAuth.cjs");
 
 test("getClaudeConfigDir: defaults to ~/.claude", () => {
   assert.equal(getClaudeConfigDir({}), path.join(os.homedir(), ".claude"));
@@ -12,6 +12,21 @@ test("getClaudeConfigDir: defaults to ~/.claude", () => {
 
 test("getClaudeConfigDir: honors CLAUDE_CONFIG_DIR", () => {
   assert.equal(getClaudeConfigDir({ CLAUDE_CONFIG_DIR: "/custom/dir" }), "/custom/dir");
+});
+
+test("getClaudeConfigDir: expands a leading ~ in CLAUDE_CONFIG_DIR", () => {
+  assert.equal(
+    getClaudeConfigDir({ CLAUDE_CONFIG_DIR: "~/.claude-work" }),
+    path.join(os.homedir(), ".claude-work"),
+  );
+});
+
+test("expandHomePath: expands '~' and '~/...', leaves others unchanged", () => {
+  assert.equal(expandHomePath("~"), os.homedir());
+  assert.equal(expandHomePath("~/x/y"), path.join(os.homedir(), "x/y"));
+  assert.equal(expandHomePath("/abs/path"), "/abs/path");
+  assert.equal(expandHomePath("~user/x"), "~user/x");
+  assert.equal(expandHomePath(""), "");
 });
 
 test("detectClaudeAuthPresence: ANTHROPIC_API_KEY in env => 'env'", () => {

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2588,7 +2588,13 @@ function registerHandlers(ipcMain) {
 
       const authFingerprint = isCodexAgent
         ? getAcpProviderAuthFingerprint(apiKey, resolvedProvider?.provider, codexCustomConfig)
-        : null;
+        : isClaudeAgent
+          // Fingerprint the Claude agent env (config dir + user env vars) so a
+          // settings change invalidates the cached per-session provider and the
+          // next turn respawns with the new config instead of reusing a stale
+          // process spawned with the old env.
+          ? JSON.stringify(normalizeAgentEnv(requestedAgentEnv))
+          : null;
       const mcpSnapshot = isCodexAgent
         ? await resolveCodexMcpSnapshot(sessionCwd)
         : { mcpServers: [], fingerprint: getCodexMcpFingerprint([]) };

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -3064,10 +3064,18 @@ function registerHandlers(ipcMain) {
       // #3 (light): include JSON-RPC code/data when present so Claude's bare
       // "Internal error" isn't shown context-free.
       const errCode = typeof err?.code === "number" ? err.code : err?.data?.code;
-      const errDetail = err?.data && typeof err.data === "object"
-        ? (() => { try { return JSON.stringify(err.data); } catch { return ""; } })()
-        : "";
-      const errMsg = [normalized.message, errCode != null ? `(code ${errCode})` : "", errDetail && errDetail !== "{}" ? errDetail : ""]
+      // Only surface data fields we don't already show (message/code) so the
+      // detail doesn't echo them back.
+      let errDetail = "";
+      if (err?.data && typeof err.data === "object") {
+        const extra = { ...err.data };
+        delete extra.code;
+        delete extra.message;
+        if (Object.keys(extra).length > 0) {
+          try { errDetail = JSON.stringify(extra); } catch { errDetail = ""; }
+        }
+      }
+      const errMsg = [normalized.message, errCode != null ? `(code ${errCode})` : "", errDetail]
         .filter(Boolean)
         .join(" ");
       const isAuthErr = isCodexAuthError(normalized);

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -37,6 +37,11 @@ const {
   toUnpackedAsarPath,
 } = require("./ai/shellUtils.cjs");
 
+const { detectClaudeAuthPresence } = require("./ai/claudeAuth.cjs");
+
+const CLAUDE_AUTH_HELP_MESSAGE =
+  "Claude Code has no usable authentication. Open Settings -> AI -> Claude Code and set a Config directory (point it at a folder where you've run `claude` login) or add an ANTHROPIC_API_KEY under Environment variables. Alternatively, run `claude` in a terminal to log in.";
+
 const {
   codexLoginSessions,
   resolveCodexAcpBinaryPath,
@@ -2451,6 +2456,9 @@ function registerHandlers(ipcMain) {
       return { ok: false, error: "Unauthorized IPC sender" };
     }
     let abortController = null;
+    // Hoisted so the catch block can reference them for Claude-specific error handling.
+    let isClaudeAgent = false;
+    let claudeAuthPresence = null;
     try {
       const existingRun = acpChatRuns.get(chatSessionId);
       if (existingRun && existingRun.requestId !== requestId) {
@@ -2503,8 +2511,14 @@ function registerHandlers(ipcMain) {
       if (shouldAbortStartup()) return { ok: true };
       const sessionCwd = cwd || process.cwd();
       const isCodexAgent = matchesAgentCommand(acpCommand, "codex-acp");
-      const isClaudeAgent = matchesAgentCommand(acpCommand, "claude-agent-acp");
+      isClaudeAgent = matchesAgentCommand(acpCommand, "claude-agent-acp");
       const isCopilotAgent = matchesAgentCommand(acpCommand, "copilot");
+      // For Claude: detect whether any auth is reachable so we can turn an
+      // opaque "-32603 Internal error" into actionable guidance on failure.
+      // Heuristic only (macOS may keep creds in Keychain) — never hard-block.
+      claudeAuthPresence = isClaudeAgent
+        ? detectClaudeAuthPresence({ ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) })
+        : null;
       const agentLabel = isCodexAgent ? "codex" : isClaudeAgent ? "claude" : isCopilotAgent ? "copilot" : acpCommand;
       const effectiveToolIntegrationMode = normalizeToolIntegrationMode(toolIntegrationMode);
       debugMcpLog("ACP request start", {
@@ -3009,11 +3023,18 @@ function registerHandlers(ipcMain) {
         if (!isActiveAcpRun(chatSessionId, requestId)) {
           return { ok: true };
         }
+        if (isClaudeAgent) {
+          // Reap the persistent agent process so a failed turn doesn't leak
+          // node.exe processes (provider uses persistSession:true).
+          cleanupAcpProvider(chatSessionId);
+        }
         safeSend(event.sender, "netcatty:ai:acp:error", {
           requestId,
           error: isCodexAgent
             ? "Codex returned an empty response. Connect Codex in Settings -> AI, or configure an enabled OpenAI provider API key."
-            : "Agent returned an empty response.",
+            : isClaudeAgent && claudeAuthPresence === "none"
+              ? CLAUDE_AUTH_HELP_MESSAGE
+              : "Agent returned an empty response.",
         });
       } else {
         // Clear replay fallback when the recovered turn either streamed
@@ -3040,11 +3061,22 @@ function registerHandlers(ipcMain) {
     } catch (err) {
       console.error("[ACP] Handler caught error:", err?.message || err, err?.stack?.split("\n").slice(0, 3).join("\n"));
       const normalized = extractCodexError(err);
-      const errMsg = normalized.message;
+      // #3 (light): include JSON-RPC code/data when present so Claude's bare
+      // "Internal error" isn't shown context-free.
+      const errCode = typeof err?.code === "number" ? err.code : err?.data?.code;
+      const errDetail = err?.data && typeof err.data === "object"
+        ? (() => { try { return JSON.stringify(err.data); } catch { return ""; } })()
+        : "";
+      const errMsg = [normalized.message, errCode != null ? `(code ${errCode})` : "", errDetail && errDetail !== "{}" ? errDetail : ""]
+        .filter(Boolean)
+        .join(" ");
       const isAuthErr = isCodexAuthError(normalized);
 
       if (isAuthErr) {
         console.error("[ACP] Auth error — user needs to re-login:", errMsg);
+        cleanupAcpProvider(chatSessionId);
+      } else if (isClaudeAgent) {
+        // #4: always reap the Claude provider/process tree on error.
         cleanupAcpProvider(chatSessionId);
       }
 
@@ -3052,7 +3084,9 @@ function registerHandlers(ipcMain) {
         requestId,
         error: isAuthErr
           ? `Authentication failed. Connect Codex in Settings -> AI, or configure an enabled OpenAI provider API key.\n\nDetails: ${errMsg}`
-          : errMsg,
+          : isClaudeAgent && claudeAuthPresence === "none"
+            ? `${CLAUDE_AUTH_HELP_MESSAGE}\n\nDetails: ${errMsg}`
+            : errMsg,
       });
     } finally {
       acpActiveStreams.delete(requestId);

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -37,7 +37,7 @@ const {
   toUnpackedAsarPath,
 } = require("./ai/shellUtils.cjs");
 
-const { detectClaudeAuthPresence } = require("./ai/claudeAuth.cjs");
+const { detectClaudeAuthPresence, expandHomePath } = require("./ai/claudeAuth.cjs");
 
 const CLAUDE_AUTH_HELP_MESSAGE =
   "Claude Code has no usable authentication. Open Settings -> AI -> Claude Code and set a Config directory (point it at a folder where you've run `claude` login) or add an ANTHROPIC_API_KEY under Environment variables. Alternatively, run `claude` in a terminal to log in.";
@@ -563,6 +563,12 @@ function normalizeAgentEnv(env) {
   for (const [key, value] of Object.entries(env)) {
     if (!key || value == null) continue;
     result[key] = String(value);
+  }
+  // CLAUDE_CONFIG_DIR is consumed as a filesystem path by the spawned agent,
+  // which won't shell-expand "~". Expand it here so "~/.claude" works and the
+  // stored value stays portable (each device expands to its own home).
+  if (result.CLAUDE_CONFIG_DIR) {
+    result.CLAUDE_CONFIG_DIR = expandHomePath(result.CLAUDE_CONFIG_DIR);
   }
   return result;
 }


### PR DESCRIPTION
Fixes #1074, #1092 — the built-in Claude Code ACP agent returned an opaque "Internal error" on every message and leaked stuck `node.exe` processes on Windows.

## Root cause (from source research)
`@zed-industries/claude-agent-acp` authenticates from env (`ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`) or credentials under `CLAUDE_CONFIG_DIR` (default `~/.claude`). The app injected **no** Claude auth, offered **no** UI to set it, and `@mcpc-tech/acp-ai-provider` can't run the interactive ACP `authenticate` flow — so failures collapsed to JSON-RPC `-32603 "Internal error"`, and the `persistSession:true` agent process was never reaped. (Codex works because codex-acp does native env-var auth and the app injects it + has a login flow.)

## What changed
- **Actionable error (#2):** when a Claude turn fails and no auth is detected (`detectClaudeAuthPresence`: env token or `<CLAUDE_CONFIG_DIR>/.credentials.json`), show guidance ("set a Config directory or `ANTHROPIC_API_KEY`, or run `claude` login") instead of "Internal error". Detection is a heuristic used **only** to improve the message on actual failure — never a hard pre-block (macOS keeps creds in the Keychain).
- **Reap processes (#4):** clean up the Claude provider + child process tree on Claude turn failure, so `node.exe` no longer accumulates.
- **Light error surfacing (#3):** include JSON-RPC `code`/extra `data` in the error text.
- **Custom config UI:** Settings → AI → Claude Code now has a **Config directory** field (→ `CLAUDE_CONFIG_DIR`) and an **Environment variables** editor (`KEY=VALUE` per line), persisted into the managed Claude agent's existing `env` (which already flows to the spawned agent). This is the user's auth/config entry point.

Intentionally **not** done: auto-injecting the app's Anthropic provider key into Claude (keeps the agent's auth CLI-owned); full stderr capture (the provider inherits agent stderr).

## Tests
- [x] `npm test` — 1209 pass / 0 fail (new: `claudeAuth.test.cjs` ×7, `claudeConfigEnv.test.ts` ×7)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: with no auth, Claude shows the actionable message (not "Internal error") and leaves no stuck processes
- [ ] Manual: set Config directory to a logged-in `~/.claude` (or add `ANTHROPIC_API_KEY`) → Claude responds; settings persist
- [ ] Manual: Codex / Catty agents unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)