### PR TITLE
feat(shortcuts): Ctrl+W closes the tab directly + add configurable side-panel toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1197,12 +1197,10 @@ function App({ settings }: { settings: SettingsState }) {
   const addConnectionLogRef = useRef(addConnectionLog);
   addConnectionLogRef.current = addConnectionLog;
 
-  const closeSidePanelRef = useRef<(() => void) | null>(null);
   const toggleScriptsSidePanelRef = useRef<(() => void) | null>(null);
   // Populated below so the hotkey dispatcher can open the Settings window
   // even though `handleOpenSettings` is declared further down in the file.
   const handleOpenSettingsRef = useRef<() => void>(() => {});
-  const activeSidePanelTabRef = useRef<string | null>(null);
   const closeTabInFlightRef = useRef(false);
   // Populated by UnsavedChangesProvider render-prop below so that the hotkey
   // dispatcher (defined outside that scope) can still reach the dirty-confirm
@@ -1382,13 +1380,11 @@ function App({ settings }: { settings: SettingsState }) {
         const workspace = workspaces.find((w) => w.id === currentId) ?? null;
 
         const focusIsInsideTerminal = !!document.activeElement?.closest('[data-session-id]');
-        const activeSidePanel = activeSidePanelTabRef.current;
 
         const intent = resolveCloseIntent({
           activeTabId: currentId,
           workspace: workspace ? { id: workspace.id, focusedSessionId: workspace.focusedSessionId } : null,
           sessionForTab: session,
-          activeSidePanelTab: activeSidePanel,
           focusIsInsideTerminal,
         });
 
@@ -1400,10 +1396,6 @@ function App({ settings }: { settings: SettingsState }) {
               case 'closeSingleTab': {
                 const ok = await confirmIfBusyLocalTerminal([intent.sessionId]);
                 if (ok) closeSession(intent.sessionId);
-                return;
-              }
-              case 'closeSidePanel': {
-                closeSidePanelRef.current?.();
                 return;
               }
               case 'closeWorkspace': {
@@ -2147,9 +2139,7 @@ function App({ settings }: { settings: SettingsState }) {
           sessionLogsEnabled={sessionLogsEnabled}
           sessionLogsDir={sessionLogsDir}
           sessionLogsFormat={sessionLogsFormat}
-          closeSidePanelRef={closeSidePanelRef}
           toggleScriptsSidePanelRef={toggleScriptsSidePanelRef}
-          activeSidePanelTabRef={activeSidePanelTabRef}
         />
 
         {/* Log Views - readonly terminal replays */}

--- a/App.tsx
+++ b/App.tsx
@@ -1198,6 +1198,7 @@ function App({ settings }: { settings: SettingsState }) {
   addConnectionLogRef.current = addConnectionLog;
 
   const toggleScriptsSidePanelRef = useRef<(() => void) | null>(null);
+  const toggleSidePanelRef = useRef<(() => void) | null>(null);
   // Populated below so the hotkey dispatcher can open the Settings window
   // even though `handleOpenSettings` is declared further down in the file.
   const handleOpenSettingsRef = useRef<() => void>(() => {});
@@ -1472,6 +1473,9 @@ function App({ settings }: { settings: SettingsState }) {
           setActiveTabId('vault');
           setNavigateToSection('snippets');
         }
+        break;
+      case 'toggleSidePanel':
+        toggleSidePanelRef.current?.();
         break;
       case 'broadcast': {
         // Toggle broadcast mode for the active workspace
@@ -2140,6 +2144,7 @@ function App({ settings }: { settings: SettingsState }) {
           sessionLogsDir={sessionLogsDir}
           sessionLogsFormat={sessionLogsFormat}
           toggleScriptsSidePanelRef={toggleScriptsSidePanelRef}
+          toggleSidePanelRef={toggleSidePanelRef}
         />
 
         {/* Log Views - readonly terminal replays */}

--- a/application/i18n/locales/ru.ts
+++ b/application/i18n/locales/ru.ts
@@ -479,6 +479,7 @@ const ru: Messages = {
   'settings.shortcuts.binding.new-workspace': 'Новая рабочая область',
   'settings.shortcuts.binding.snippets': 'Открыть сниппеты',
   'settings.shortcuts.binding.broadcast': 'Переключить режим трансляции',
+  'settings.shortcuts.binding.toggle-side-panel': 'Переключить боковую панель',
   'settings.shortcuts.binding.sftp-copy': 'Копировать файл',
   'settings.shortcuts.binding.sftp-cut': 'Вырезать файл',
   'settings.shortcuts.binding.sftp-paste': 'Вставить файл',

--- a/application/i18n/locales/zh-CN.ts
+++ b/application/i18n/locales/zh-CN.ts
@@ -1606,6 +1606,7 @@ const zhCN: Messages = {
   'settings.shortcuts.binding.new-workspace': '新建工作区',
   'settings.shortcuts.binding.snippets': '打开代码片段',
   'settings.shortcuts.binding.broadcast': '切换广播模式',
+  'settings.shortcuts.binding.toggle-side-panel': '切换侧边栏',
   'settings.shortcuts.binding.sftp-copy': '复制文件',
   'settings.shortcuts.binding.sftp-cut': '剪切文件',
   'settings.shortcuts.binding.sftp-paste': '粘贴文件',

--- a/application/state/resolveCloseIntent.test.ts
+++ b/application/state/resolveCloseIntent.test.ts
@@ -3,33 +3,27 @@ import assert from "node:assert/strict";
 
 import { resolveCloseIntent } from "./resolveCloseIntent.ts";
 
-const baseWorkspace = {
-  id: "w1",
-  focusedSessionId: "s1",
-};
-
+const baseWorkspace = { id: "w1", focusedSessionId: "s1" };
 const baseSession = { id: "s1" };
 
 test("non-workspace tab → closeSingleTab with session id", () => {
-  const result = resolveCloseIntent({
+  const r = resolveCloseIntent({
     activeTabId: "s1",
     workspace: null,
     sessionForTab: baseSession,
-    activeSidePanelTab: null,
     focusIsInsideTerminal: true,
   });
-  assert.deepEqual(result, { kind: "closeSingleTab", sessionId: "s1" });
+  assert.deepEqual(r, { kind: "closeSingleTab", sessionId: "s1" });
 });
 
-test("non-workspace session tab + sidebar open → closeSidePanel (sidebar beats session close)", () => {
+test("non-workspace session tab → closeSingleTab even when focus is outside the terminal", () => {
   const r = resolveCloseIntent({
     activeTabId: "s1",
     workspace: null,
     sessionForTab: { id: "s1" },
-    activeSidePanelTab: "ai",
-    focusIsInsideTerminal: true, // focus IS in terminal, but sidebar wins
+    focusIsInsideTerminal: false,
   });
-  assert.deepEqual(r, { kind: "closeSidePanel" });
+  assert.deepEqual(r, { kind: "closeSingleTab", sessionId: "s1" });
 });
 
 test("vault/sftp tab → noop", () => {
@@ -37,74 +31,37 @@ test("vault/sftp tab → noop", () => {
     activeTabId: "vault",
     workspace: null,
     sessionForTab: null,
-    activeSidePanelTab: null,
     focusIsInsideTerminal: false,
   });
   assert.deepEqual(r, { kind: "noop" });
 });
 
-test("workspace + focus in terminal + sidebar open → closeSidePanel wins (sidebar beats focus)", () => {
+test("workspace + focus in terminal → closeTerminal (side panel no longer intercepts)", () => {
   const r = resolveCloseIntent({
     activeTabId: "w1",
     workspace: baseWorkspace,
     sessionForTab: null,
-    activeSidePanelTab: "ai",
-    focusIsInsideTerminal: true,
-  });
-  assert.deepEqual(r, { kind: "closeSidePanel" });
-});
-
-test("workspace + focus NOT in terminal + sidebar open → closeSidePanel", () => {
-  const r = resolveCloseIntent({
-    activeTabId: "w1",
-    workspace: baseWorkspace,
-    sessionForTab: null,
-    activeSidePanelTab: "sftp",
-    focusIsInsideTerminal: false,
-  });
-  assert.deepEqual(r, { kind: "closeSidePanel" });
-});
-
-test("workspace + sidebar closed + focus in terminal → closeTerminal", () => {
-  const r = resolveCloseIntent({
-    activeTabId: "w1",
-    workspace: baseWorkspace,
-    sessionForTab: null,
-    activeSidePanelTab: null,
     focusIsInsideTerminal: true,
   });
   assert.deepEqual(r, { kind: "closeTerminal", sessionId: "s1" });
 });
 
-test("workspace + sidebar closed + focus NOT in terminal → closeWorkspace", () => {
+test("workspace + focus NOT in terminal → closeWorkspace", () => {
   const r = resolveCloseIntent({
     activeTabId: "w1",
     workspace: baseWorkspace,
     sessionForTab: null,
-    activeSidePanelTab: null,
     focusIsInsideTerminal: false,
   });
   assert.deepEqual(r, { kind: "closeWorkspace", workspaceId: "w1" });
 });
 
-test("workspace with no focused session + sidebar closed → closeWorkspace", () => {
+test("workspace with no focused session → closeWorkspace", () => {
   const r = resolveCloseIntent({
     activeTabId: "w1",
     workspace: { id: "w1", focusedSessionId: undefined },
     sessionForTab: null,
-    activeSidePanelTab: null,
-    focusIsInsideTerminal: true, // even if flag true, no focused id → cannot closeTerminal
+    focusIsInsideTerminal: true,
   });
   assert.deepEqual(r, { kind: "closeWorkspace", workspaceId: "w1" });
-});
-
-test("workspace with no focused session + sidebar open → closeSidePanel", () => {
-  const r = resolveCloseIntent({
-    activeTabId: "w1",
-    workspace: { id: "w1", focusedSessionId: undefined },
-    sessionForTab: null,
-    activeSidePanelTab: "ai",
-    focusIsInsideTerminal: false,
-  });
-  assert.deepEqual(r, { kind: "closeSidePanel" });
 });

--- a/application/state/resolveCloseIntent.ts
+++ b/application/state/resolveCloseIntent.ts
@@ -1,6 +1,5 @@
 export type CloseIntent =
   | { kind: 'closeTerminal'; sessionId: string }
-  | { kind: 'closeSidePanel' }
   | { kind: 'closeWorkspace'; workspaceId: string }
   | { kind: 'closeSingleTab'; sessionId: string }
   | { kind: 'noop' };
@@ -9,21 +8,13 @@ export interface ResolveCloseInput {
   activeTabId: string | null;
   workspace: { id: string; focusedSessionId?: string } | null;
   sessionForTab: { id: string } | null;
-  activeSidePanelTab: string | null;
   focusIsInsideTerminal: boolean;
 }
 
 export function resolveCloseIntent(input: ResolveCloseInput): CloseIntent {
-  const { activeTabId, workspace, sessionForTab, activeSidePanelTab, focusIsInsideTerminal } = input;
+  const { activeTabId, workspace, sessionForTab, focusIsInsideTerminal } = input;
 
   if (!activeTabId) return { kind: 'noop' };
-
-  // Sidebar always wins — applies to any tab type (workspace, single-session, etc.).
-  // Modals take priority over this but are intercepted upstream in App.tsx before the
-  // hotkey reaches resolveCloseIntent.
-  if (activeSidePanelTab !== null) {
-    return { kind: 'closeSidePanel' };
-  }
 
   if (sessionForTab && !workspace) {
     return { kind: 'closeSingleTab', sessionId: sessionForTab.id };

--- a/application/state/resolveSidePanelToggleIntent.test.ts
+++ b/application/state/resolveSidePanelToggleIntent.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveSidePanelToggleIntent } from "./resolveSidePanelToggleIntent.ts";
+
+test("open: closed with a remembered tab → open that tab", () => {
+  const r = resolveSidePanelToggleIntent({ isOpen: false, lastTab: "sftp", fallbackTab: "scripts" });
+  assert.deepEqual(r, { kind: "open", tab: "sftp" });
+});
+
+test("open: closed with no memory → open the fallback tab", () => {
+  const r = resolveSidePanelToggleIntent({ isOpen: false, lastTab: null, fallbackTab: "scripts" });
+  assert.deepEqual(r, { kind: "open", tab: "scripts" });
+});
+
+test("close: already open → close", () => {
+  const r = resolveSidePanelToggleIntent({ isOpen: true, lastTab: "theme", fallbackTab: "sftp" });
+  assert.deepEqual(r, { kind: "close" });
+});

--- a/application/state/resolveSidePanelToggleIntent.ts
+++ b/application/state/resolveSidePanelToggleIntent.ts
@@ -1,0 +1,18 @@
+export type SidePanelToggleIntent<T extends string> =
+  | { kind: 'close' }
+  | { kind: 'open'; tab: T };
+
+/**
+ * Decide what the "toggle side panel" shortcut should do.
+ * - If a panel is open → close it.
+ * - If closed → reopen the last-shown sub-panel for the tab, falling back to
+ *   `fallbackTab` when the tab has no remembered panel.
+ */
+export function resolveSidePanelToggleIntent<T extends string>(input: {
+  isOpen: boolean;
+  lastTab: T | null;
+  fallbackTab: T;
+}): SidePanelToggleIntent<T> {
+  if (input.isOpen) return { kind: 'close' };
+  return { kind: 'open', tab: input.lastTab ?? input.fallbackTab };
+}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -57,6 +57,7 @@ import { Input } from './ui/input';
 import { ScrollArea } from './ui/scroll-area';
 import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate';
 import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
+import { resolveSidePanelToggleIntent } from '../application/state/resolveSidePanelToggleIntent';
 import { terminalLayerAreEqual } from './terminalLayerMemo';
 import { getTerminalPaneSnapshot, parseTerminalPaneSnapshot } from './terminalPaneVisibility';
 import { getScopedTopTabsThemeId } from './terminalTopTabsTheme';
@@ -465,9 +466,8 @@ interface TerminalLayerProps {
   sessionLogsEnabled?: boolean;
   sessionLogsDir?: string;
   sessionLogsFormat?: string;
-  closeSidePanelRef?: React.MutableRefObject<(() => void) | null>;
   toggleScriptsSidePanelRef?: React.MutableRefObject<(() => void) | null>;
-  activeSidePanelTabRef?: React.MutableRefObject<string | null>;
+  toggleSidePanelRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 interface TerminalPaneProps {
@@ -890,9 +890,8 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   sessionLogsEnabled,
   sessionLogsDir,
   sessionLogsFormat,
-  closeSidePanelRef,
   toggleScriptsSidePanelRef,
-  activeSidePanelTabRef,
+  toggleSidePanelRef,
 }) => {
   const { t } = useI18n();
   // Subscribe to activeTabId from external store
@@ -1101,13 +1100,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const sidePanelOpenTabsRef = useRef(sidePanelOpenTabs);
   sidePanelOpenTabsRef.current = sidePanelOpenTabs;
 
+  // Remember the last sub-panel shown per tab so the toggle shortcut can
+  // restore it after a close. Overwritten on open, never cleared on close.
+  const lastSidePanelTabRef = useRef<Map<string, SidePanelTab>>(new Map());
+  useEffect(() => {
+    sidePanelOpenTabs.forEach((tab, tabId) => {
+      lastSidePanelTabRef.current.set(tabId, tab);
+    });
+  }, [sidePanelOpenTabs]);
+
   // Whether side panel is open for the currently active tab and which sub-panel
   const isSidePanelOpenForCurrentTab = activeTabId ? sidePanelOpenTabs.has(activeTabId) : false;
   const activeSidePanelTab = activeTabId ? sidePanelOpenTabs.get(activeTabId) ?? null : null;
-  if (activeSidePanelTabRef) {
-    activeSidePanelTabRef.current = activeSidePanelTab;
-  }
-
   // Legacy compatibility helpers for SFTP-specific logic
   const isSftpOpenForCurrentTab = activeSidePanelTab === 'sftp';
 
@@ -1845,13 +1849,23 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     refocusTerminalSession(sessionIdToRefocus);
   }, [activeTabId, getActiveTerminalSessionId, refocusTerminalSession, syncWorkspaceFocusIfNeeded]);
 
-  useEffect(() => {
-    if (!closeSidePanelRef) return;
-    closeSidePanelRef.current = handleCloseSidePanel;
-    return () => {
-      closeSidePanelRef.current = null;
-    };
-  }, [closeSidePanelRef, handleCloseSidePanel]);
+  // Resolve the SFTP host for a tab: a previously-stored host, otherwise the
+  // host of the workspace's focused session or the active session. null = none.
+  const resolveSftpHostForTab = useCallback((tabId: string): Host | null => {
+    const stored = sftpHostForTabRef.current.get(tabId);
+    if (stored) return stored;
+    const currentWorkspace = activeWorkspaceRef.current;
+    const currentFocusedSessionId = focusedSessionIdRef.current;
+    const currentActiveSession = activeSessionRef.current;
+    const currentSessionHosts = sessionHostsMapRef.current;
+    if (currentWorkspace && currentFocusedSessionId) {
+      return currentSessionHosts.get(currentFocusedSessionId) ?? null;
+    }
+    if (currentActiveSession) {
+      return currentSessionHosts.get(currentActiveSession.id) ?? null;
+    }
+    return null;
+  }, []);
 
   // Switch side panel to a specific tab (or toggle if already on that tab)
   const handleSwitchSidePanelTab = useCallback((tab: SidePanelTab) => {
@@ -1864,16 +1878,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     // If switching to SFTP and no host is stored yet, resolve it
     if (tab === 'sftp' && !sftpHostForTabRef.current.has(tabId)) {
-      let host: Host | null = null;
-      const currentWorkspace = activeWorkspaceRef.current;
-      const currentFocusedSessionId = focusedSessionIdRef.current;
-      const currentActiveSession = activeSessionRef.current;
-      const currentSessionHosts = sessionHostsMapRef.current;
-      if (currentWorkspace && currentFocusedSessionId) {
-        host = currentSessionHosts.get(currentFocusedSessionId) ?? null;
-      } else if (currentActiveSession) {
-        host = currentSessionHosts.get(currentActiveSession.id) ?? null;
-      }
+      const host = resolveSftpHostForTab(tabId);
       if (!host) return;
       setSftpHostForTab(prev => {
         const next = new Map(prev);
@@ -1891,7 +1896,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.set(tabId, tab);
       return next;
     });
-  }, []);
+  }, [resolveSftpHostForTab]);
 
   // Toggle SFTP from activity bar header
   const handleToggleSftpFromBar = useCallback(() => {
@@ -1930,6 +1935,34 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       toggleScriptsSidePanelRef.current = null;
     };
   }, [toggleScriptsSidePanelRef, handleToggleScriptsSidePanel]);
+
+  // Toggle the whole side panel (new ⌘/Ctrl+\ shortcut). Close if open; if
+  // closed, reopen the tab's last sub-panel, defaulting to SFTP (when a host is
+  // available) or scripts.
+  const handleToggleSidePanel = useCallback(() => {
+    const tabId = activeTabIdRef.current;
+    if (!tabId) return;
+    const isOpen = sidePanelOpenTabsRef.current.has(tabId);
+    const sftpAvailable = !!resolveSftpHostForTab(tabId);
+    const fallbackTab: SidePanelTab = sftpAvailable ? 'sftp' : 'scripts';
+    const lastTab = lastSidePanelTabRef.current.get(tabId) ?? null;
+    const intent = resolveSidePanelToggleIntent<SidePanelTab>({ isOpen, lastTab, fallbackTab });
+    if (intent.kind === 'close') {
+      handleCloseSidePanel();
+      return;
+    }
+    // If the remembered panel is SFTP but no host is resolvable, use scripts.
+    const target: SidePanelTab = intent.tab === 'sftp' && !sftpAvailable ? 'scripts' : intent.tab;
+    handleSwitchSidePanelTab(target);
+  }, [handleCloseSidePanel, handleSwitchSidePanelTab, resolveSftpHostForTab]);
+
+  useEffect(() => {
+    if (!toggleSidePanelRef) return;
+    toggleSidePanelRef.current = handleToggleSidePanel;
+    return () => {
+      toggleSidePanelRef.current = null;
+    };
+  }, [toggleSidePanelRef, handleToggleSidePanel]);
 
   // Open theme side panel (called from Terminal toolbar)
   const handleOpenTheme = useCallback(() => {

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -37,5 +37,6 @@ export const terminalLayerAreEqual = (
   prev.isBroadcastEnabled === next.isBroadcastEnabled &&
   prev.onToggleBroadcast === next.onToggleBroadcast &&
   prev.toggleScriptsSidePanelRef === next.toggleScriptsSidePanelRef &&
+  prev.toggleSidePanelRef === next.toggleSidePanelRef &&
   prev.identities === next.identities
 );

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -435,6 +435,7 @@ export const DEFAULT_KEY_BINDINGS: KeyBinding[] = [
   { id: 'new-workspace', action: 'newWorkspace', label: 'New Workspace', mac: '⌘ + Shift + J', pc: 'Ctrl + Shift + J', category: 'app' },
   { id: 'snippets', action: 'snippets', label: 'Open Snippets', mac: '⌘ + Shift + S', pc: 'Ctrl + Shift + S', category: 'app' },
   { id: 'broadcast', action: 'broadcast', label: 'Switch the Broadcast Mode', mac: '⌘ + B', pc: 'Ctrl + B', category: 'app' },
+  { id: 'toggle-side-panel', action: 'toggleSidePanel', label: 'Toggle Side Panel', mac: '⌘ + \\', pc: 'Ctrl + \\', category: 'app' },
   { id: 'open-settings', action: 'openSettings', label: 'Open Settings', mac: '⌘ + ,', pc: 'Ctrl + ,', category: 'app' },
 
   // SFTP Operations


### PR DESCRIPTION
Addresses discussion #1091.

## Summary

`Cmd/Ctrl + W` used to close the **side panel first** when one was open, so closing a terminal tab took two presses — diverging from the macOS-standard "Cmd+W closes the current tab". This PR takes the discussion's alternative approach: make `Ctrl+W` close the tab directly, and give the side panel its own dedicated, user-configurable shortcut.

- **Ctrl/⌘+W closes the active tab directly.** The "side panel wins" branch is removed from the pure `resolveCloseIntent` resolver; it now resolves straight to close terminal / single tab / workspace (or no-op for pinned tabs). The orphaned `closeSidePanelRef` / `activeSidePanelTabRef` wiring is removed.
- **New "Toggle Side Panel" shortcut** — default **`⌘ + \`** (mac) / **`Ctrl + \`** (pc), editable & resettable in Settings → Shortcuts. Toggling open restores the tab's **last-shown** sub-panel (VS Code style); if the tab has no memory, it opens SFTP when an SSH host is available, otherwise the scripts panel.

The X button still closes the panel, so nothing is lost.

## Implementation

- New pure resolver `application/state/resolveSidePanelToggleIntent.ts` (generic, unit-tested), mirroring the existing `resolveScriptsSidePanelShortcutIntent`.
- `resolveCloseIntent.ts` drops the `closeSidePanel` variant + `activeSidePanelTab` input.
- `TerminalLayer.tsx`: per-tab last-sub-panel memory, a `handleToggleSidePanel` handler exposed via `toggleSidePanelRef`, and a reused `resolveSftpHostForTab` helper (extracted from the existing SFTP-open path).
- `App.tsx`: dispatches the `toggleSidePanel` hotkey; `domain/models.ts` registers the binding; `terminalLayerMemo.ts` compares the new ref; zh-CN/ru labels added (en uses the label fallback).

Note: on the PC scheme `Ctrl+\` shadows the terminal's SIGQUIT (`^\`) — consistent with the app already intercepting `Ctrl+L`/`Ctrl+K`/`Ctrl+W`, and it's rebindable.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1223 pass, 0 fail (9 resolver tests: 3 new toggle + 6 rewritten close-intent)
- [x] `npm run build` — success
- [ ] Manual: side panel open → `Ctrl/⌘+W` closes the tab in one press; `⌘/Ctrl+\` toggles the panel and restores the last sub-panel; on a local terminal with no SSH host the first toggle opens scripts; the binding is editable/resettable in Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)