### PR TITLE
fix(hosts): make group startup-command field multi-line typeable

### DIFF
--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -50,6 +50,7 @@ import { Card } from "./ui/card";
 import { Combobox } from "./ui/combobox";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { TerminalFontSelect } from "./settings/TerminalFontSelect";
@@ -861,12 +862,14 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
               onToggle={() => update("agentForwarding", !form.agentForwarding)}
             />
 
-            {/* Startup Command */}
-            <Input
+            {/* Startup Command — Textarea so multi-line sequences are typeable
+                here just like on the per-host details panel (#1083 follow-up). */}
+            <Textarea
               placeholder={t("hostDetails.startupCommand.placeholder")}
               value={form.startupCommand || ""}
               onChange={(e) => update("startupCommand", e.target.value || undefined)}
-              className="h-10"
+              className="min-h-[80px] font-mono text-sm"
+              rows={3}
             />
 
             {/* Legacy Algorithms */}


### PR DESCRIPTION
Follow-up to #1083 / #1096. User-reported (@pyroch): the multi-line startup-command sequence shipped in #1096 doesn't work for hosts under a group folder — only the first line ever runs.

## Cause

`GroupDetailsPanel.tsx` rendered the group's **Startup Command** field as a single-line `<Input>` (`className="h-10"`). HTML `<input>` can't hold newlines, so users literally can't type a multi-line command on the group — only the first line is stored, and that one line is what each host inherits. `HostDetailsPanel.tsx` already uses a 3-row `<Textarea>` for the same field, which is why the per-host case works. Execution (`scheduleStartupCommand`/`splitStartupCommandLines`) and group inheritance (`applyGroupDefaults` directly copies `startupCommand`) are fine.

## Fix

Replace the group panel's `<Input>` with the same `<Textarea rows={3} className="min-h-[80px] font-mono text-sm">` as the per-host panel.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 1223 pass, 0 fail
- [x] `npm run build` — success
- [ ] Manual: edit a host group → Startup Command field accepts newlines → save → host in that group runs each line in sequence on connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)