### PR TITLE
[codex] Fix Claude ACP Windows shim launch

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -7,7 +7,7 @@
 "use strict";
 
 const { execFileSync } = require("node:child_process");
-const { existsSync, statSync } = require("node:fs");
+const { existsSync, readFileSync, statSync } = require("node:fs");
 const path = require("node:path");
 
 // ── ANSI / URL regexes ──
@@ -214,6 +214,53 @@ function prepareCommandForSpawn(command, args) {
     command: buildWindowsShellCommandLine(command, spawnArgs),
     args: [],
     shell: true,
+  };
+}
+
+function resolveClaudeCodeExecutableForAcp(claudeExecutablePath, platform = process.platform) {
+  const normalized = String(claudeExecutablePath || "").trim();
+  if (!normalized) return null;
+  if (platform !== "win32") return normalized;
+
+  const ext = path.extname(normalized).toLowerCase();
+  if (ext && ext !== ".cmd" && ext !== ".bat") return normalized;
+
+  const baseDir = path.dirname(normalized);
+  const packageCliPath = path.join(baseDir, "node_modules", "@anthropic-ai", "claude-code", "cli.js");
+  if (existsSync(packageCliPath)) {
+    return packageCliPath;
+  }
+
+  const shimCandidates = [normalized];
+  if (!ext) {
+    shimCandidates.push(`${normalized}.cmd`, `${normalized}.bat`);
+  }
+
+  for (const shimPath of shimCandidates) {
+    try {
+      if (!existsSync(shimPath)) continue;
+      const contents = readFileSync(shimPath, "utf8");
+      if (!/node_modules[\\/]+@anthropic-ai[\\/]+claude-code[\\/]+cli\.js/i.test(contents)) {
+        continue;
+      }
+      if (existsSync(packageCliPath)) {
+        return packageCliPath;
+      }
+    } catch {
+      // Fall back to the original executable path below.
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeClaudeCodeExecutableEnvForAcp(env, platform = process.platform) {
+  if (!env?.CLAUDE_CODE_EXECUTABLE) return env;
+  const resolved = resolveClaudeCodeExecutableForAcp(env.CLAUDE_CODE_EXECUTABLE, platform);
+  if (!resolved || resolved === env.CLAUDE_CODE_EXECUTABLE) return env;
+  return {
+    ...env,
+    CLAUDE_CODE_EXECUTABLE: resolved,
   };
 }
 
@@ -433,6 +480,8 @@ module.exports = {
   quoteWindowsShellArg,
   buildWindowsShellCommandLine,
   prepareCommandForSpawn,
+  resolveClaudeCodeExecutableForAcp,
+  normalizeClaudeCodeExecutableEnvForAcp,
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   toUnpackedAsarPath,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -9,8 +9,12 @@ const {
   isPlausibleCliVersionOutput,
   looksLikeIdleAutoLogout,
   prepareCommandForSpawn,
+  resolveClaudeCodeExecutableForAcp,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 test("extracts a trailing PowerShell idle prompt", () => {
   assert.equal(
@@ -100,6 +104,48 @@ test("prepareCommandForSpawn wraps Windows cmd shims as a single shell command",
       args: ["--version"],
       shell: false,
     });
+  }
+});
+
+test("resolveClaudeCodeExecutableForAcp maps Windows npm cmd shim to Claude Code cli.js", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-shim-"));
+  try {
+    const shimPath = path.join(tmp, "claude.cmd");
+    const scriptPath = path.join(tmp, "node_modules", "@anthropic-ai", "claude-code", "cli.js");
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, "", "utf8");
+    fs.writeFileSync(
+      shimPath,
+      '@ECHO off\r\nnode "%basedir%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*\r\n',
+      "utf8",
+    );
+
+    assert.equal(resolveClaudeCodeExecutableForAcp(shimPath, "win32"), scriptPath);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveClaudeCodeExecutableForAcp leaves non-Windows Claude paths unchanged", () => {
+  assert.equal(
+    resolveClaudeCodeExecutableForAcp("/usr/local/bin/claude", "darwin"),
+    "/usr/local/bin/claude",
+  );
+});
+
+test("resolveClaudeCodeExecutableForAcp keeps Windows cmd shim when Claude Code cli.js is missing", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-missing-cli-"));
+  try {
+    const shimPath = path.join(tmp, "claude.cmd");
+    fs.writeFileSync(
+      shimPath,
+      '@ECHO off\r\nnode "%basedir%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*\r\n',
+      "utf8",
+    );
+
+    assert.equal(resolveClaudeCodeExecutableForAcp(shimPath, "win32"), shimPath);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
   }
 });
 

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -27,6 +27,7 @@ const {
   stripAnsi,
   normalizeCliPathForPlatform,
   prepareCommandForSpawn,
+  normalizeClaudeCodeExecutableEnvForAcp,
   resolveCliFromPath,
   resolveClaudeAcpBinaryPath,
   isPlausibleCliVersionOutput,
@@ -2375,7 +2376,10 @@ function registerHandlers(ipcMain) {
         }
       }
 
-      const agentEnv = withCliDiscoveryEnv({ ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) });
+      let agentEnv = withCliDiscoveryEnv({ ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) });
+      if (isClaudeAgent) {
+        agentEnv = normalizeClaudeCodeExecutableEnvForAcp(agentEnv);
+      }
       if (isCodexAgent && apiKey) {
         agentEnv.CODEX_API_KEY = apiKey;
       }
@@ -2699,7 +2703,10 @@ function registerHandlers(ipcMain) {
           );
         cleanupAcpProvider(chatSessionId);
 
-        const agentEnv = withCliDiscoveryEnv({ ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) });
+        let agentEnv = withCliDiscoveryEnv({ ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) });
+        if (isClaudeAgent) {
+          agentEnv = normalizeClaudeCodeExecutableEnvForAcp(agentEnv);
+        }
         if (isCodexAgent && apiKey) {
           agentEnv.CODEX_API_KEY = apiKey;
         }
@@ -2822,11 +2829,14 @@ function registerHandlers(ipcMain) {
             ? [...fallbackClaudeAcp.prependArgs, ...(acpArgs || [])]
             : acpArgs || [],
           env: (() => {
-            const fallbackEnv = withCliDiscoveryEnv(
+            let fallbackEnv = withCliDiscoveryEnv(
               isCodexAgent && apiKey
                 ? { ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv), CODEX_API_KEY: apiKey }
                 : { ...shellEnv, ...normalizeAgentEnv(requestedAgentEnv) },
             );
+            if (isClaudeAgent) {
+              fallbackEnv = normalizeClaudeCodeExecutableEnvForAcp(fallbackEnv);
+            }
             if (isCodexAgent && resolvedProvider?.provider?.baseURL) {
               fallbackEnv.OPENAI_BASE_URL = resolvedProvider.provider.baseURL;
             }

--- a/electron/bridges/aiBridge.test.cjs
+++ b/electron/bridges/aiBridge.test.cjs
@@ -147,6 +147,10 @@ function loadBridgeWithMocks(options = {}) {
         typeof options.prepareCommandForSpawn === "function"
           ? options.prepareCommandForSpawn(...args)
           : prepareCommandForSpawn(...args),
+      normalizeClaudeCodeExecutableEnvForAcp: (env) =>
+        typeof options.normalizeClaudeCodeExecutableEnvForAcp === "function"
+          ? options.normalizeClaudeCodeExecutableEnvForAcp(env)
+          : env,
       isPlausibleCliVersionOutput: (value) =>
         typeof options.isPlausibleCliVersionOutput === "function"
           ? options.isPlausibleCliVersionOutput(value)
@@ -1143,6 +1147,74 @@ test("ACP stream passes the configured system Claude executable to claude-agent-
     assert.equal(
       providerCreationArgs[0].env.CLAUDE_CODE_EXECUTABLE,
       "/opt/homebrew/bin/claude",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("ACP stream rewrites Windows Claude cmd shim env before creating claude-agent-acp", async (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-cmd-env-"));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const acpScriptPath = path.join(tempDir, "acp-index.js");
+  fs.writeFileSync(acpScriptPath, "process.exit(0);\n", "utf8");
+
+  const cmdPath = "D:\\ProgramData\\develop-cache\\node-global\\claude.cmd";
+  const cliPath = "D:\\ProgramData\\develop-cache\\node-global\\node_modules\\@anthropic-ai\\claude-code\\cli.js";
+  const { bridge, providerCreationArgs, restore } = loadBridgeWithMocks({
+    resolveClaudeAcpBinaryPath: () => ({
+      command: process.execPath,
+      prependArgs: [acpScriptPath],
+    }),
+    normalizeClaudeCodeExecutableEnvForAcp: (env) => ({
+      ...env,
+      CLAUDE_CODE_EXECUTABLE: env.CLAUDE_CODE_EXECUTABLE === cmdPath
+        ? cliPath
+        : env.CLAUDE_CODE_EXECUTABLE,
+    }),
+    createACPProvider: () => ({
+      tools: {},
+      languageModel() {
+        return { id: "fake-model" };
+      },
+      async initSession() {},
+      getSessionId() {
+        return "claude-session";
+      },
+      cleanup() {},
+    }),
+    streamText: () => createEmptyStreamResult(),
+  });
+  const ipcMain = createIpcMainStub();
+
+  bridge.init({
+    sessions: new Map(),
+    sftpClients: new Map(),
+    electronModule: { app: { getPath: () => process.cwd() } },
+  });
+  bridge.registerHandlers(ipcMain);
+
+  try {
+    const streamHandler = ipcMain.handlers.get("netcatty:ai:acp:stream");
+    assert.equal(typeof streamHandler, "function");
+
+    await streamHandler({ sender: { id: 1 } }, {
+      requestId: "req-claude-cmd-env",
+      chatSessionId: "chat-claude-cmd-env",
+      acpCommand: "claude-agent-acp",
+      acpArgs: [],
+      prompt: "hello",
+      historyMessages: [],
+      toolIntegrationMode: "mcp",
+      agentEnv: { CLAUDE_CODE_EXECUTABLE: cmdPath },
+    });
+
+    assert.equal(
+      providerCreationArgs[0].env.CLAUDE_CODE_EXECUTABLE,
+      cliPath,
     );
   } finally {
     restore();


### PR DESCRIPTION
## Summary

- Resolve Windows npm `claude.cmd` shims to the underlying Claude Code `cli.js` before launching Claude through ACP.
- Apply the rewrite when listing ACP models and when starting/retrying Claude ACP streams, including already-saved `CLAUDE_CODE_EXECUTABLE` values.
- Add coverage for Windows shim resolution and ACP environment rewriting.

## Root Cause

Windows npm installs can expose Claude Code as `claude.cmd`. Claude ACP passes `CLAUDE_CODE_EXECUTABLE` into the Claude SDK, which directly spawns that executable. Newer Node versions reject direct `.cmd`/`.bat` spawning without a shell, causing `spawn EINVAL`.

## Test Plan

- `npm test`
- `npm run lint`