### PR TITLE
perf(terminal): Reduce interactive terminal latency with TCP_NODELAY

### DIFF
--- a/electron/bridges/proxyUtils.cjs
+++ b/electron/bridges/proxyUtils.cjs
@@ -4,6 +4,7 @@
  */
 
 const net = require("node:net");
+const { enableTcpNoDelay } = require("./tcpNoDelay.cjs");
 
 /**
  * Create a socket through a proxy (HTTP CONNECT or SOCKS5)
@@ -25,6 +26,7 @@ function createProxySocket(proxy, targetHost, targetPort, options = {}) {
         if (proxy.type === 'http') {
             // HTTP CONNECT proxy
             const socket = net.connect(proxy.port, proxy.host, () => {
+                enableTcpNoDelay(socket);
                 let authHeader = '';
                 if (proxy.username && proxy.password) {
                     const auth = Buffer.from(`${proxy.username}:${proxy.password}`).toString('base64');
@@ -48,11 +50,13 @@ function createProxySocket(proxy, targetHost, targetPort, options = {}) {
                 };
                 socket.on('data', onData);
             });
+            enableTcpNoDelay(socket);
             try { onSocket?.(socket); } catch { /* ignore */ }
             socket.on('error', reject);
         } else if (proxy.type === 'socks5') {
             // SOCKS5 proxy
             const socket = net.connect(proxy.port, proxy.host, () => {
+                enableTcpNoDelay(socket);
                 // SOCKS5 greeting
                 const authMethods = proxy.username && proxy.password ? [0x00, 0x02] : [0x00];
                 socket.write(Buffer.from([0x05, authMethods.length, ...authMethods]));
@@ -127,6 +131,7 @@ function createProxySocket(proxy, targetHost, targetPort, options = {}) {
 
                 socket.on('data', onData);
             });
+            enableTcpNoDelay(socket);
             try { onSocket?.(socket); } catch { /* ignore */ }
             socket.on('error', reject);
         } else {

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -40,6 +40,7 @@ const {
   buildAlgorithms,
   _resetAlgorithmSupportCacheForTests,
 } = require("./sshAlgorithms.cjs");
+const { enableSshNoDelay, enableTcpNoDelay } = require("./tcpNoDelay.cjs");
 
 // Default SSH key names in priority order (preferred keys tried first)
 const PREFERRED_KEY_NAMES = ["id_ed25519", "id_ecdsa", "id_rsa"];
@@ -609,6 +610,8 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
           ),
         }));
         console.log(`[Chain] Hop ${i + 1}/${totalHops}: Connecting to ${hopLabel}...`);
+        conn.once('connect', () => enableSshNoDelay(conn));
+        if (connOpts.sock) enableTcpNoDelay(connOpts.sock);
         conn.connect(connOpts);
       });
 
@@ -1176,6 +1179,9 @@ async function startSSHSession(event, options) {
       const logPrefix = hasJumpHosts ? '[Chain]' : '[SSH]';
       let settled = false;
       let detachX11Forwarding = null;
+
+      conn.once("connect", () => enableSshNoDelay(conn));
+      if (connectOpts.sock) enableTcpNoDelay(connectOpts.sock);
 
       conn.once("handshake", () => {
         console.log(`${logPrefix} ${options.hostname} handshake complete`);

--- a/electron/bridges/tcpNoDelay.cjs
+++ b/electron/bridges/tcpNoDelay.cjs
@@ -1,0 +1,22 @@
+"use strict";
+
+function enableTcpNoDelay(socket) {
+  try {
+    socket?.setNoDelay?.(true);
+  } catch {
+    // Best-effort latency hint; the connection can continue without it.
+  }
+}
+
+function enableSshNoDelay(conn) {
+  try {
+    conn?.setNoDelay?.(true);
+  } catch {
+    // Best-effort latency hint; the SSH session can continue without it.
+  }
+}
+
+module.exports = {
+  enableSshNoDelay,
+  enableTcpNoDelay,
+};

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -26,6 +26,7 @@ const tempDirBridge = require("./tempDirBridge.cjs");
 const { createTelnetAutoLogin } = require("./telnetAutoLogin.cjs");
 const telnetProtocol = require("./telnetProtocol.cjs");
 const { createPtyOutputBuffer } = require("./ptyOutputBuffer.cjs");
+const { enableTcpNoDelay } = require("./tcpNoDelay.cjs");
 
 const execFileAsync = promisify(execFile);
 
@@ -482,6 +483,7 @@ async function startTelnetSession(event, options) {
 
   return new Promise((resolve, reject) => {
     const socket = new net.Socket();
+    enableTcpNoDelay(socket);
     let connected = false;
     // Token for the log stream we open on this connection. Captured here so
     // the close/error handlers below can pass it back to stopStream and
@@ -571,6 +573,7 @@ async function startTelnetSession(event, options) {
 
     socket.on('connect', () => {
       connected = true;
+      enableTcpNoDelay(socket);
       clearTimeout(connectTimeout);
       console.log(`[Telnet] Connected to ${hostname}:${port}`);
 


### PR DESCRIPTION
## Summary

Improve interactive terminal responsiveness on high-latency connections by enabling TCP_NODELAY for SSH, Telnet, and proxied terminal sockets.

## What changed

- Added a shared `tcpNoDelay` bridge helper.
- Enabled `TCP_NODELAY` for SSH sessions, including jump-host chains.
- Enabled `TCP_NODELAY` for HTTP/SOCKS proxy sockets used by SSH.
- Enabled `TCP_NODELAY` for native Telnet sockets.

## Why

On slow/high-ping hosts, terminal input can feel more delayed than the network RTT alone. Interactive terminal traffic sends many small packets, and leaving Nagle’s algorithm enabled can add extra packet coalescing delay. Disabling Nagle for terminal sockets favors lower latency, which is the better tradeoff for interactive shells.

This does not remove the inherent round-trip latency of SSH/Telnet remote echo, but it avoids adding extra transport-side delay on top of it.

## Testing

- `node --test electron\bridges\ptyOutputBuffer.test.cjs`
- `node --test --import tsx components\terminal\runtime\createTerminalSessionStarters.test.ts`