### PR TITLE
Hint that the provider icon is clickable

### DIFF
--- a/components/settings/tabs/ai/ProviderConfigForm.tsx
+++ b/components/settings/tabs/ai/ProviderConfigForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Upload, RotateCcw, X } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Eye, EyeOff, Pencil, Upload, RotateCcw, X } from "lucide-react";
 import type { ProviderConfig, ProviderAdvancedParams, ProviderStyle } from "../../../../infrastructure/ai/types";
 import { PROVIDER_PRESETS, resolveProviderStyle } from "../../../../infrastructure/ai/types";
 import { encryptField, decryptField } from "../../../../infrastructure/persistence/secureFieldAdapter";
@@ -181,11 +181,17 @@ export const ProviderConfigForm: React.FC<{
           <button
             type="button"
             onClick={() => setShowIconPicker((v) => !v)}
-            className="shrink-0"
+            className="group relative shrink-0 rounded-md transition-all hover:brightness-110 hover:ring-2 hover:ring-primary/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             aria-label={t('ai.providers.icon.change')}
             title={t('ai.providers.icon.change')}
           >
             <ProviderIconBadge provider={previewProvider} />
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full border border-background bg-primary text-primary-foreground opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+            >
+              <Pencil size={9} strokeWidth={2.5} />
+            </span>
           </button>
           <input
             type="text"


### PR DESCRIPTION
## Summary
The icon badge next to the Display Name input in **Settings → AI → Providers → \[edit\]** opens the icon picker, but it had zero visual cue — users had no reason to suspect it was clickable. Feedback flagged it as too hidden.

Adds two affordances on hover/focus, layout-stable:
- A primary-tinted ring (\`ring-2 ring-primary/45\`) + slight brightness lift on the badge.
- A 16×16 primary-tinted pencil bubble overlaid on the badge's bottom-right corner (\`opacity-0 → opacity-100\`).

Both are also surfaced on keyboard focus (\`focus-visible\`), so the cue isn't pointer-only.

## Test plan
- [x] Settings → AI → Providers → edit any provider. Hover the badge: ring + pencil show up; layout doesn't shift.
- [x] Tab to the badge with the keyboard: same cue appears via \`focus-visible\`.
- [x] Click the badge: existing picker opens normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)