### PR TITLE
Serialize Catty terminal_execute per session to fix the parallel tool_use race

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -912,7 +912,35 @@ function execViaChannel(sshClient, command, options) {
   } = options || {};
 
   return new Promise((resolve) => {
+    // Register a *pending* cancellation marker synchronously, before
+    // `sshClient.exec` opens the channel. Without this, a cancel that
+    // arrives while we're still waiting on `sshClient.exec`'s callback
+    // finds nothing in `activePtyExecs` to act on — the channel then
+    // opens, the real marker registers, and the command runs to
+    // completion despite the user already cancelling. The pending
+    // marker latches `cancelled = true`; when the callback fires we
+    // check the latch and short-circuit instead of starting work.
+    const pendingMarker = `__NCMCP_CH_PENDING_${Date.now().toString(36)}_${crypto.randomBytes(8).toString('hex')}__`;
+    let cancelled = false;
+    if (trackForCancellation) {
+      trackForCancellation.set(pendingMarker, {
+        chatSessionId: chatSessionId || null,
+        cancel: () => { cancelled = true; },
+        cleanup: () => { /* nothing pending to clean up before channel opens */ },
+      });
+    }
+
     sshClient.exec(command, (err, execStream) => {
+      if (trackForCancellation) {
+        trackForCancellation.delete(pendingMarker);
+      }
+      if (cancelled) {
+        if (execStream) {
+          try { execStream.close(); } catch { /* ignore */ }
+        }
+        resolve({ ok: false, stdout: "", stderr: "", exitCode: -1, error: "Cancelled" });
+        return;
+      }
       if (err) {
         resolve({ ok: false, error: err.message });
         return;

--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -930,7 +930,8 @@ function execViaChannel(sshClient, command, options) {
       });
     }
 
-    sshClient.exec(command, (err, execStream) => {
+    try {
+      sshClient.exec(command, (err, execStream) => {
       if (trackForCancellation) {
         trackForCancellation.delete(pendingMarker);
       }
@@ -991,6 +992,18 @@ function execViaChannel(sshClient, command, options) {
         }
       });
     });
+    } catch (err) {
+      // Rare path: `sshClient.exec` itself synchronously throws (e.g.
+      // because the underlying ssh2 client was destroyed between the
+      // session lookup and now). Drop the pending marker so it doesn't
+      // leak in `activePtyExecs`, and resolve as a normal failure
+      // result instead of letting the Promise reject — the tool layer
+      // expects `{ ok, error }` shape, not a thrown error.
+      if (trackForCancellation) {
+        trackForCancellation.delete(pendingMarker);
+      }
+      resolve({ ok: false, error: err?.message || String(err) });
+    }
   });
 }
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   resolveEffectiveShellKind,
+  execViaChannel,
 } = require("./ptyExec.cjs");
 
 test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
@@ -106,4 +107,69 @@ test("falls back to posix when neither shell kind nor prompt is informative", ()
 test("does not misclassify command output that happens to contain 'PS'", () => {
   assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix");
   assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix");
+});
+
+test("execViaChannel registers a pending-cancel marker before the SSH channel opens", () => {
+  // Regression for the IPC-transit race surfaced by codex on #1101
+  // problem 3: if `cancelPtyExecsForSession` runs while we're still
+  // waiting on `sshClient.exec`'s callback, the cancel finds nothing in
+  // `activePtyExecs` and the channel opens anyway. The fix registers a
+  // pending marker synchronously so the cancel has something to act on.
+  const track = new Map();
+  let execCallback;
+  const fakeClient = {
+    exec(_command, callback) {
+      // Capture but do not invoke yet — simulates the channel-open
+      // delay where the race window lives.
+      execCallback = callback;
+    },
+  };
+  void execViaChannel(fakeClient, "echo hi", {
+    trackForCancellation: track,
+    chatSessionId: "chat-1",
+    timeoutMs: 5_000,
+  });
+  assert.equal(track.size, 1, "pending marker should be registered before the channel opens");
+  const entry = Array.from(track.values())[0];
+  assert.equal(entry.chatSessionId, "chat-1");
+  assert.equal(typeof entry.cancel, "function");
+  // Drain the callback so the timeout the test set doesn't fire later.
+  execCallback(new Error("test teardown"), null);
+});
+
+test("execViaChannel short-circuits when cancel fires before the SSH channel opens", async () => {
+  const track = new Map();
+  let execCallback;
+  const fakeClient = {
+    exec(_command, callback) {
+      execCallback = callback;
+    },
+  };
+  const resultPromise = execViaChannel(fakeClient, "sleep 5", {
+    trackForCancellation: track,
+    chatSessionId: "chat-2",
+    timeoutMs: 5_000,
+  });
+
+  // Cancel while still waiting for the channel-open callback.
+  assert.equal(track.size, 1);
+  for (const entry of track.values()) {
+    if (entry.chatSessionId === "chat-2") entry.cancel();
+  }
+
+  // Now the channel "opens" — even though `sshClient.exec` would
+  // hand us a working stream, we must short-circuit because the user
+  // already cancelled.
+  const fakeExecStream = {
+    closed: false,
+    close() { this.closed = true; },
+    stderr: { on() {} },
+    on() {},
+  };
+  execCallback(null, fakeExecStream);
+  const result = await resultPromise;
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "Cancelled");
+  assert.equal(fakeExecStream.closed, true, "should close the now-unwanted stream");
+  assert.equal(track.size, 0, "pending marker should be removed after callback runs");
 });

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -137,6 +137,22 @@ test("execViaChannel registers a pending-cancel marker before the SSH channel op
   execCallback(new Error("test teardown"), null);
 });
 
+test("execViaChannel drops the pending marker and resolves cleanly when sshClient.exec throws synchronously", async () => {
+  const track = new Map();
+  const fakeClient = {
+    exec() {
+      throw new Error("client destroyed");
+    },
+  };
+  const result = await execViaChannel(fakeClient, "echo hi", {
+    trackForCancellation: track,
+    chatSessionId: "chat-throw",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "client destroyed");
+  assert.equal(track.size, 0, "pending marker must be removed even on sync throw");
+});
+
 test("execViaChannel short-circuits when cancel fires before the SSH channel opens", async () => {
   const track = new Map();
   let execCallback;

--- a/infrastructure/ai/cattyAgent/executor.ts
+++ b/infrastructure/ai/cattyAgent/executor.ts
@@ -25,6 +25,14 @@ export interface NetcattyBridge {
     exitCode?: number;
     error?: string;
   }>;
+  /**
+   * Cancel any in-flight Catty Agent command execution scoped to the
+   * given chat session. Idempotent — safe to call when nothing is
+   * running. Used by tools to re-issue cancel during the IPC transit
+   * window if the user clicks Stop after we've already dispatched
+   * `aiExec` but before the main process has registered it.
+   */
+  aiCattyCancelExec?(chatSessionId: string): Promise<unknown>;
 }
 
 // Workspace context provided to the executor

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -86,7 +86,28 @@ export function createCattyTools(
           if (abortSignal?.aborted) {
             return { error: 'Command cancelled before it could start.' };
           }
-          return unwrap(await executeTerminalExecute(deps, { sessionId, command }));
+          // There's a tiny race between this check and the main-process
+          // `mcpServerBridge.reserveSessionExecution` registering the new
+          // exec into the cancellation tracker: `handleStop` issues a
+          // cancel IPC and the user's abort signal fires, but if our
+          // `aiExec` IPC was already in transit, the cancel may run
+          // before the exec has registered — and find nothing to
+          // cancel. Re-issue the cancel from the abort listener so a
+          // duplicate `aiCattyCancelExec` lands once the registration
+          // is complete. The cancel is idempotent (it only acts on
+          // entries it finds in `activePtyExecs`), so issuing twice is
+          // harmless.
+          const cancelOnAbort = () => {
+            if (chatSessionId) {
+              void bridge.aiCattyCancelExec?.(chatSessionId);
+            }
+          };
+          abortSignal?.addEventListener('abort', cancelOnAbort, { once: true });
+          try {
+            return unwrap(await executeTerminalExecute(deps, { sessionId, command }));
+          } finally {
+            abortSignal?.removeEventListener('abort', cancelOnAbort);
+          }
         } finally {
           slot.release();
         }

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -14,6 +14,7 @@ import {
   type ToolExecResult,
 } from '../shared/toolExecutors';
 import { requestApproval } from '../shared/approvalGate';
+import { chainBySessionKey } from '../shared/sessionExecutionQueue';
 
 /** Unwrap a shared ToolExecResult into the shape expected by Vercel AI SDK tool results. */
 function unwrap<T>(r: ToolExecResult<T>): T | { error: string } {
@@ -50,14 +51,32 @@ export function createCattyTools(
       }),
       // No needsApproval — approval is handled inside execute via the approval gate.
       execute: async ({ sessionId, command }, { toolCallId }) => {
-        // In confirm mode, await user approval before executing
+        // In confirm mode, await user approval before executing. Approvals
+        // are intentionally kept *outside* the per-session queue below so
+        // that multiple parallel tool_use blocks from the same LLM turn
+        // each surface their own approval card immediately — the user can
+        // approve/deny them in any order, instead of seeing the prompts
+        // arrive one-by-one as earlier commands finish.
         if (permissionMode === 'confirm') {
           const approved = await requestApproval(toolCallId, 'terminal_execute', { sessionId, command }, chatSessionId);
           if (!approved) {
             return { error: 'User denied command execution.' };
           }
         }
-        return unwrap(await executeTerminalExecute(deps, { sessionId, command }));
+        // Serialize at the per-(chat, terminal) session granularity.
+        // Vercel AI SDK dispatches every tool_use block in a turn through
+        // `Promise.all(...)`, which would otherwise race three+ commands
+        // into the main-process session mutex — two of them get
+        // synthetic "Session already has another command" errors and the
+        // Anthropic API has rejected the resulting trace as
+        // `tool_use ids were found without tool_result blocks`. Queueing
+        // here gives the LLM real output for every call it asked for.
+        // Bridge-side mutex (mcpServerBridge.reserveSessionExecution)
+        // stays in place as defense-in-depth for non-LLM IPC paths.
+        const queueKey = `${chatSessionId ?? 'global'}:${sessionId}`;
+        return chainBySessionKey(queueKey, async () =>
+          unwrap(await executeTerminalExecute(deps, { sessionId, command })),
+        );
       },
     }),
 

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -14,7 +14,7 @@ import {
   type ToolExecResult,
 } from '../shared/toolExecutors';
 import { requestApproval } from '../shared/approvalGate';
-import { chainBySessionKey } from '../shared/sessionExecutionQueue';
+import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
 
 /** Unwrap a shared ToolExecResult into the shape expected by Vercel AI SDK tool results. */
 function unwrap<T>(r: ToolExecResult<T>): T | { error: string } {
@@ -50,33 +50,46 @@ export function createCattyTools(
         command: z.string().describe('The shell command to execute in the target session.'),
       }),
       // No needsApproval — approval is handled inside execute via the approval gate.
-      execute: async ({ sessionId, command }, { toolCallId }) => {
-        // In confirm mode, await user approval before executing. Approvals
-        // are intentionally kept *outside* the per-session queue below so
-        // that multiple parallel tool_use blocks from the same LLM turn
-        // each surface their own approval card immediately — the user can
-        // approve/deny them in any order, instead of seeing the prompts
-        // arrive one-by-one as earlier commands finish.
-        if (permissionMode === 'confirm') {
-          const approved = await requestApproval(toolCallId, 'terminal_execute', { sessionId, command }, chatSessionId);
-          if (!approved) {
-            return { error: 'User denied command execution.' };
-          }
-        }
-        // Serialize at the per-(chat, terminal) session granularity.
-        // Vercel AI SDK dispatches every tool_use block in a turn through
-        // `Promise.all(...)`, which would otherwise race three+ commands
-        // into the main-process session mutex — two of them get
-        // synthetic "Session already has another command" errors and the
-        // Anthropic API has rejected the resulting trace as
-        // `tool_use ids were found without tool_result blocks`. Queueing
-        // here gives the LLM real output for every call it asked for.
-        // Bridge-side mutex (mcpServerBridge.reserveSessionExecution)
-        // stays in place as defense-in-depth for non-LLM IPC paths.
+      execute: async ({ sessionId, command }, { toolCallId, abortSignal }) => {
+        // Snap our place in the per-session execution queue *first*,
+        // synchronously, so the eventual command-run order matches the
+        // LLM's tool_use emission order regardless of how long each
+        // call's approval prompt takes to settle. Vercel AI SDK
+        // dispatches every tool_use block in a turn through
+        // `Promise.all(...)`, so the three executes for "A then B then
+        // C" all start at the same instant; if we deferred slot
+        // reservation until after approval, B's approval could land
+        // first and run B before A. Reserving up front fixes that.
+        //
+        // The bridge-side mutex (mcpServerBridge.reserveSessionExecution)
+        // stays as defense-in-depth for non-LLM IPC paths
+        // (terminal_start, MCP, etc.) — this queue just keeps the
+        // renderer-side LLM path from racing into it.
         const queueKey = `${chatSessionId ?? 'global'}:${sessionId}`;
-        return chainBySessionKey(queueKey, async () =>
-          unwrap(await executeTerminalExecute(deps, { sessionId, command })),
-        );
+        const slot = reserveSessionSlot(queueKey);
+        try {
+          // In confirm mode, await user approval. Approvals run *while*
+          // the slot is held but before the serialized work, so multiple
+          // parallel tool_use blocks each surface their own approval
+          // card immediately and the user can approve/deny in any
+          // order — the queue still drains in reservation order.
+          if (permissionMode === 'confirm') {
+            const approved = await requestApproval(toolCallId, 'terminal_execute', { sessionId, command }, chatSessionId);
+            if (!approved) {
+              return { error: 'User denied command execution.' };
+            }
+          }
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          await slot.ready;
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          return unwrap(await executeTerminalExecute(deps, { sessionId, command }));
+        } finally {
+          slot.release();
+        }
       },
     }),
 

--- a/infrastructure/ai/sessionExecutionQueue.test.ts
+++ b/infrastructure/ai/sessionExecutionQueue.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chainBySessionKey,
+  resetSessionExecutionQueueForTests,
+} from "./shared/sessionExecutionQueue";
+
+function defer<T = void>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (err: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+test("chainBySessionKey serializes calls sharing the same key in dispatch order", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  const events: string[] = [];
+  const gateA = defer();
+  const gateB = defer();
+  const gateC = defer();
+
+  const a = chainBySessionKey("session-1", async () => {
+    events.push("a:start");
+    await gateA.promise;
+    events.push("a:end");
+    return "a";
+  });
+  const b = chainBySessionKey("session-1", async () => {
+    events.push("b:start");
+    await gateB.promise;
+    events.push("b:end");
+    return "b";
+  });
+  const c = chainBySessionKey("session-1", async () => {
+    events.push("c:start");
+    await gateC.promise;
+    events.push("c:end");
+    return "c";
+  });
+
+  // Only `a` should have started — b and c are queued behind it.
+  await new Promise((r) => setImmediate(r));
+  assert.deepEqual(events, ["a:start"]);
+
+  gateA.resolve();
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  assert.deepEqual(events, ["a:start", "a:end", "b:start"]);
+
+  gateB.resolve();
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  assert.deepEqual(events, ["a:start", "a:end", "b:start", "b:end", "c:start"]);
+
+  gateC.resolve();
+  assert.equal(await a, "a");
+  assert.equal(await b, "b");
+  assert.equal(await c, "c");
+});
+
+test("chainBySessionKey does not let one task's rejection poison the next", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  const a = chainBySessionKey("session-2", async () => {
+    throw new Error("a boom");
+  });
+  const b = chainBySessionKey("session-2", async () => "b ok");
+
+  await assert.rejects(a, /a boom/);
+  assert.equal(await b, "b ok");
+});
+
+test("chainBySessionKey isolates work across keys (different sessions run in parallel)", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  const gateA = defer();
+  const gateB = defer();
+
+  const a = chainBySessionKey("session-a", async () => {
+    await gateA.promise;
+    return "a";
+  });
+  const b = chainBySessionKey("session-b", async () => {
+    await gateB.promise;
+    return "b";
+  });
+
+  // Resolve B first; it should finish even though A is still blocked.
+  gateB.resolve();
+  assert.equal(await b, "b");
+  gateA.resolve();
+  assert.equal(await a, "a");
+});
+
+test("chainBySessionKey eventually removes the map entry once the last task drains", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  // Use a private helper to inspect: reset on entry, run one task,
+  // and rely on the map being empty after it settles.
+  resetSessionExecutionQueueForTests();
+  await chainBySessionKey("session-cleanup", async () => "done");
+  // Drain any microtasks the cleanup logic queued via `.finally`.
+  await new Promise((r) => setImmediate(r));
+  // Start a second task and confirm it doesn't see the previous tail —
+  // we can't introspect the map directly, but if the entry leaked,
+  // the new task would still chain off the old (resolved) promise and
+  // start immediately, which is functionally indistinguishable from a
+  // clean state. The real guarantee is the lack of unbounded growth
+  // exercised by stress-tests; here we just make sure correctness holds.
+  const value = await chainBySessionKey("session-cleanup", async () => "again");
+  assert.equal(value, "again");
+});

--- a/infrastructure/ai/sessionExecutionQueue.test.ts
+++ b/infrastructure/ai/sessionExecutionQueue.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   chainBySessionKey,
+  getSessionExecutionQueueSizeForTests,
+  reserveSessionSlot,
   resetSessionExecutionQueueForTests,
 } from "./shared/sessionExecutionQueue";
 
@@ -14,6 +16,13 @@ function defer<T = void>(): { promise: Promise<T>; resolve: (value: T) => void; 
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+// Drain pending microtasks and immediates so cleanup `.finally`s have run.
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await new Promise((r) => setImmediate(r));
+  }
 }
 
 test("chainBySessionKey serializes calls sharing the same key in dispatch order", async (t) => {
@@ -42,18 +51,15 @@ test("chainBySessionKey serializes calls sharing the same key in dispatch order"
     return "c";
   });
 
-  // Only `a` should have started — b and c are queued behind it.
-  await new Promise((r) => setImmediate(r));
+  await flushMicrotasks();
   assert.deepEqual(events, ["a:start"]);
 
   gateA.resolve();
-  await new Promise((r) => setImmediate(r));
-  await new Promise((r) => setImmediate(r));
+  await flushMicrotasks();
   assert.deepEqual(events, ["a:start", "a:end", "b:start"]);
 
   gateB.resolve();
-  await new Promise((r) => setImmediate(r));
-  await new Promise((r) => setImmediate(r));
+  await flushMicrotasks();
   assert.deepEqual(events, ["a:start", "a:end", "b:start", "b:end", "c:start"]);
 
   gateC.resolve();
@@ -94,20 +100,88 @@ test("chainBySessionKey isolates work across keys (different sessions run in par
   assert.equal(await a, "a");
 });
 
-test("chainBySessionKey eventually removes the map entry once the last task drains", async (t) => {
+test("queue Map drops the entry once the last task drains", async (t) => {
   t.afterEach(resetSessionExecutionQueueForTests);
-  // Use a private helper to inspect: reset on entry, run one task,
-  // and rely on the map being empty after it settles.
   resetSessionExecutionQueueForTests();
+  assert.equal(getSessionExecutionQueueSizeForTests(), 0);
   await chainBySessionKey("session-cleanup", async () => "done");
-  // Drain any microtasks the cleanup logic queued via `.finally`.
-  await new Promise((r) => setImmediate(r));
-  // Start a second task and confirm it doesn't see the previous tail —
-  // we can't introspect the map directly, but if the entry leaked,
-  // the new task would still chain off the old (resolved) promise and
-  // start immediately, which is functionally indistinguishable from a
-  // clean state. The real guarantee is the lack of unbounded growth
-  // exercised by stress-tests; here we just make sure correctness holds.
-  const value = await chainBySessionKey("session-cleanup", async () => "again");
-  assert.equal(value, "again");
+  await flushMicrotasks();
+  // Without the cleanup `finally`, the resolved tail would stay parked
+  // in the map; this is the regression guard that the previous version
+  // of this test was missing.
+  assert.equal(getSessionExecutionQueueSizeForTests(), 0);
+});
+
+test("reserveSessionSlot fixes order at reservation time regardless of pre-work duration", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  const events: string[] = [];
+
+  // Simulate three tool_use calls firing in parallel where each has
+  // some pre-work (e.g. an approval prompt) of varying length. The
+  // serialized work order must still match the slot-reservation order.
+  async function run(name: string, prework: Promise<void>) {
+    const slot = reserveSessionSlot("session-order");
+    try {
+      events.push(`${name}:reserved`);
+      await prework;
+      events.push(`${name}:prework-done`);
+      await slot.ready;
+      events.push(`${name}:serial-start`);
+      // Trivial serial work, just so we can observe the start order.
+      await new Promise((r) => setImmediate(r));
+      events.push(`${name}:serial-end`);
+      return name;
+    } finally {
+      slot.release();
+    }
+  }
+
+  const gateA = defer();
+  const gateB = defer();
+  const gateC = defer();
+  const a = run("A", gateA.promise);
+  const b = run("B", gateB.promise);
+  const c = run("C", gateC.promise);
+
+  // Approvals land in reverse order — C first, then B, then A.
+  await flushMicrotasks();
+  gateC.resolve();
+  await flushMicrotasks();
+  gateB.resolve();
+  await flushMicrotasks();
+  gateA.resolve();
+  await flushMicrotasks();
+  assert.deepEqual(await Promise.all([a, b, c]), ["A", "B", "C"]);
+
+  const serialStarts = events.filter((e) => e.endsWith(":serial-start"));
+  assert.deepEqual(
+    serialStarts,
+    ["A:serial-start", "B:serial-start", "C:serial-start"],
+    `serial work ran in reservation order, not approval order; got: ${events.join(", ")}`,
+  );
+});
+
+test("reserveSessionSlot lets later slots proceed once an early slot releases without serialized work", async (t) => {
+  t.afterEach(resetSessionExecutionQueueForTests);
+  const events: string[] = [];
+
+  async function maybeRun(name: string, run: boolean) {
+    const slot = reserveSessionSlot("session-skip");
+    try {
+      events.push(`${name}:reserved`);
+      if (!run) return `${name}:skipped`;
+      await slot.ready;
+      events.push(`${name}:ran`);
+      return `${name}:ran`;
+    } finally {
+      slot.release();
+    }
+  }
+
+  // Slot A reserves but skips serial work (mimics user denying approval
+  // or aborting). Slot B should still proceed.
+  const a = maybeRun("A", false);
+  const b = maybeRun("B", true);
+  assert.equal(await a, "A:skipped");
+  assert.equal(await b, "B:ran");
 });

--- a/infrastructure/ai/shared/sessionExecutionQueue.ts
+++ b/infrastructure/ai/shared/sessionExecutionQueue.ts
@@ -20,50 +20,108 @@
  * one command per session at a time. The bridge mutex stays as
  * defense-in-depth for non-LLM IPC paths (terminal_start, MCP, etc.).
  *
- * `chainBySessionKey` exposes that behavior as a tiny utility: callers
- * pass a stable key (e.g. `${chatSessionId}:${terminalSessionId}`) and a
- * thunk; the thunk is appended to that key's promise chain, so it only
- * starts after every previously-queued thunk has settled.
+ * The queue exposes both a high-level `chainBySessionKey(key, task)` for
+ * simple "run this when it's our turn" callers, and a lower-level
+ * `reserveSessionSlot(key)` for callers that need to do non-blocking work
+ * (e.g. await an approval prompt) *while* their queue slot is held — so
+ * the queue order matches the LLM's emission order independent of when
+ * each call's approval lands.
  */
 
 const queues = new Map<string, Promise<unknown>>();
 
 /**
- * Run `task` after every previously-queued task with the same `key` has
- * settled. Returns the task's resolved value (or rejects if the task
- * throws). A failure in one task does not poison the queue head for
- * subsequent callers — the chain only waits on settlement, not success.
+ * A reserved slot in a session's execution queue. The slot is added to
+ * the queue tail synchronously when {@link reserveSessionSlot} is called,
+ * so call order is fixed at reservation time — regardless of how long
+ * each caller spends on pre-work (approval prompts, abort checks, etc.)
+ * before they actually start.
  *
- * Exported for tests.
+ * Lifecycle:
+ *   1. `reserveSessionSlot(key)` — synchronously snaps a place in line.
+ *   2. caller does whatever pre-work they want, in parallel with siblings.
+ *   3. `await slot.ready` — blocks until the previous slot has released.
+ *   4. caller does the serialized work.
+ *   5. `slot.release()` — frees the next slot. Idempotent.
+ *
+ * The slot **must** be released exactly once (typically from a `finally`)
+ * even if the caller decides to skip the serialized work — otherwise
+ * subsequent slots queued behind it never start.
  */
-export function chainBySessionKey<T>(key: string, task: () => Promise<T>): Promise<T> {
+export interface SessionExecutionSlot {
+  /** Resolves when this slot is at the head of its queue. */
+  readonly ready: Promise<void>;
+  /** Releases this slot. Safe to call multiple times. */
+  release(): void;
+}
+
+export function reserveSessionSlot(key: string): SessionExecutionSlot {
   const prev = queues.get(key) ?? Promise.resolve();
-  // Wait for `prev` to settle (regardless of outcome), then run `task`.
-  // Using two-argument `.then(onFulfilled, onRejected)` here makes the
-  // chain treat fulfillment and rejection identically, so a thrown task
-  // doesn't propagate down the queue.
-  const ours = prev.then(task, task);
-  // Store a non-rejecting version as the new tail so the next caller
-  // chains cleanly even if `ours` ends up rejecting.
-  const tail: Promise<unknown> = ours.catch(() => undefined);
+
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+
+  // The new tail of this key's queue: previous tail → our `done`.
+  // Wrap in a non-rejecting chain so a thrown task never poisons later
+  // callers waiting on this tail.
+  const tail: Promise<unknown> = prev.then(() => done).catch(() => undefined);
   queues.set(key, tail);
-  // Best-effort cleanup once we're the last in line — keeps the map from
-  // growing without bound across many short-lived sessions. A later
-  // caller that arrived between `queues.set` and the finally would have
-  // already overwritten the tail; we only clear when we're still it.
+
+  // Best-effort cleanup once we're the last in line — keeps the map
+  // from growing without bound across many short-lived sessions. A
+  // later caller that arrived between `queues.set` and this finally
+  // will already have replaced the tail; we only clear when we're
+  // still it.
   void tail.finally(() => {
     if (queues.get(key) === tail) {
       queues.delete(key);
     }
   });
-  return ours;
+
+  let released = false;
+  return {
+    ready: prev.then(
+      () => undefined,
+      () => undefined,
+    ),
+    release(): void {
+      if (released) return;
+      released = true;
+      resolveDone();
+    },
+  };
 }
 
 /**
- * Test-only: drop all queued work for a key. The promise chain itself is
- * not cancelled (no API for that without instrumenting every task), but
- * future callers will start a fresh chain.
+ * Run `task` after every previously-reserved slot with the same `key`
+ * has released. Returns the task's resolved value (or rejects if the
+ * task throws). A failure in one task does not poison the queue head
+ * for subsequent callers — the chain only waits on settlement, not
+ * success.
+ *
+ * For callers that need to interleave pre-work with the queue wait
+ * (e.g. approval prompts that should run in parallel even though the
+ * actual command must run serially), use {@link reserveSessionSlot}
+ * directly.
  */
+export async function chainBySessionKey<T>(key: string, task: () => Promise<T>): Promise<T> {
+  const slot = reserveSessionSlot(key);
+  try {
+    await slot.ready;
+    return await task();
+  } finally {
+    slot.release();
+  }
+}
+
+/** Test-only: inspect the live queue. */
+export function getSessionExecutionQueueSizeForTests(): number {
+  return queues.size;
+}
+
+/** Test-only: drop all queued work. */
 export function resetSessionExecutionQueueForTests(): void {
   queues.clear();
 }

--- a/infrastructure/ai/shared/sessionExecutionQueue.ts
+++ b/infrastructure/ai/shared/sessionExecutionQueue.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-session execution queue for tool calls that target the same terminal
+ * session.
+ *
+ * Background — issue #1101 problem 3:
+ *
+ * Vercel AI SDK dispatches every tool_use block emitted in one assistant
+ * turn through `Promise.all(toolCalls.map(execute))`, so an LLM that asks
+ * for three commands "at once" sends three simultaneous `bridge.aiExec()`
+ * calls at the underlying PTY. The main-process session mutex
+ * (`mcpServerBridge.reserveSessionExecution`) only lets one through and
+ * rejects the rest with `{ ok: false, error: "Session already has another
+ * command in progress..." }`. The LLM then sees two synthetic errors plus
+ * one real result for a turn it expected to be all-or-nothing — and the
+ * Anthropic API has occasionally rejected the resulting trace with a
+ * `tool_use ids were found without tool_result blocks` 400.
+ *
+ * The cleanest fix is to never let those calls race in the first place:
+ * serialize at the renderer-side tool execute boundary so the bridge sees
+ * one command per session at a time. The bridge mutex stays as
+ * defense-in-depth for non-LLM IPC paths (terminal_start, MCP, etc.).
+ *
+ * `chainBySessionKey` exposes that behavior as a tiny utility: callers
+ * pass a stable key (e.g. `${chatSessionId}:${terminalSessionId}`) and a
+ * thunk; the thunk is appended to that key's promise chain, so it only
+ * starts after every previously-queued thunk has settled.
+ */
+
+const queues = new Map<string, Promise<unknown>>();
+
+/**
+ * Run `task` after every previously-queued task with the same `key` has
+ * settled. Returns the task's resolved value (or rejects if the task
+ * throws). A failure in one task does not poison the queue head for
+ * subsequent callers — the chain only waits on settlement, not success.
+ *
+ * Exported for tests.
+ */
+export function chainBySessionKey<T>(key: string, task: () => Promise<T>): Promise<T> {
+  const prev = queues.get(key) ?? Promise.resolve();
+  // Wait for `prev` to settle (regardless of outcome), then run `task`.
+  // Using two-argument `.then(onFulfilled, onRejected)` here makes the
+  // chain treat fulfillment and rejection identically, so a thrown task
+  // doesn't propagate down the queue.
+  const ours = prev.then(task, task);
+  // Store a non-rejecting version as the new tail so the next caller
+  // chains cleanly even if `ours` ends up rejecting.
+  const tail: Promise<unknown> = ours.catch(() => undefined);
+  queues.set(key, tail);
+  // Best-effort cleanup once we're the last in line — keeps the map from
+  // growing without bound across many short-lived sessions. A later
+  // caller that arrived between `queues.set` and the finally would have
+  // already overwritten the tail; we only clear when we're still it.
+  void tail.finally(() => {
+    if (queues.get(key) === tail) {
+      queues.delete(key);
+    }
+  });
+  return ours;
+}
+
+/**
+ * Test-only: drop all queued work for a key. The promise chain itself is
+ * not cancelled (no API for that without instrumenting every task), but
+ * future callers will start a fresh chain.
+ */
+export function resetSessionExecutionQueueForTests(): void {
+  queues.clear();
+}


### PR DESCRIPTION
## Summary
Closes problem 3 of #1101: when the LLM (DeepSeek's Anthropic-compat happily does this when info-gathering) emits multiple \`tool_use\` blocks in one assistant turn, the Vercel AI SDK dispatches all of them through \`Promise.all(toolCalls.map(execute))\`. They race into the per-session mutex in \`mcpServerBridge.reserveSessionExecution\`; one wins, the rest get \`{ ok: false, error: "Session already has another command in progress..." }\` back as the tool result. Symptoms users hit:

- UI tool-call cards look stuck on "executing".
- The Anthropic API has sometimes rejected the resulting trace as \`tool_use ids were found without tool_result blocks immediately after: <id>\` — there's no actual missing result in our history, but the half-success half-error shape upset the backend.

## Approach
Eliminate the race at its source: serialize at the renderer-side \`terminal_execute\` boundary so the bridge sees one command per chat-session/terminal-session pair at a time. The LLM can still parallel-call as many \`tool_use\` blocks as it wants; they resolve sequentially with real output instead of synthetic busy errors. The bridge-side mutex stays as defense-in-depth for non-LLM IPC paths.

- New \`infrastructure/ai/shared/sessionExecutionQueue.ts\` exposes \`reserveSessionSlot(key)\` (low-level) and \`chainBySessionKey(key, task)\` (high-level). Slots are reserved synchronously so queue order = LLM emission order, regardless of when each call's approval prompt settles.
- \`terminal_execute.execute\` reserves a slot up front, runs approval *while holding* the slot (so parallel approval prompts still show in parallel and the user can dispatch in any order), then \`await slot.ready\` + actual command. The slot is always released in \`finally\`.
- Two \`abortSignal\` checks short-circuit cancelled commands before they reach the bridge, and an \`abort\` listener re-issues \`aiCattyCancelExec\` so the cancel still lands once main-side registration completes (covers the IPC-transit window between dispatch and registration).
- \`execViaChannel\` (the SSH exec-channel fallback path) registers a *pending* cancellation marker synchronously before \`sshClient.exec\` opens the channel, so a cancel that arrives during the channel-open delay isn't a no-op. Sync throws from \`sshClient.exec\` itself also drop the pending marker and resolve cleanly instead of leaking.
- \`NetcattyBridge\` interface gains optional \`aiCattyCancelExec\`; runtime exposure was already in place via \`electron/preload.cjs:1358\`.

## Test coverage
- \`infrastructure/ai/sessionExecutionQueue.test.ts\` — 6 tests: ordering, rejection isolation, per-key parallelism, Map cleanup (with \`getSessionExecutionQueueSizeForTests\` so it's a real regression guard), reservation-order-vs-prework-order, skip-without-serialized-work.
- \`electron/bridges/ai/ptyExec.test.cjs\` — 3 new tests: pending marker present before channel opens, cancel-before-open short-circuits, sync-throw from \`sshClient.exec\` cleans up and resolves cleanly.
- Full suite locally: 1260 pass / 3 skipped / 0 fail.

This branch went through 5 rounds of local Codex review; every flagged issue was addressed and the last pass returned clean.

Refs #1101.

## Test plan
- [ ] \`npm test\` — should be 1260+/0 locally.
- [ ] \`npm run build\` — clean.
- [ ] Catty Agent: send a prompt that triggers multiple parallel \`tool_use\` blocks (e.g. "check current hermes config, sandbox config, and disk usage"). Expect all commands to run sequentially with real outputs; UI cards should each transition from running → completed; the assistant's next turn should land without a 400.
- [ ] Hit Stop mid-run: in-flight command cancels; queued commands return \`Command cancelled before it could start.\` instead of running silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)