### PR TITLE
fix(shortcuts) keyboard shortcuts on non-English and non-QWERTY layouts

### DIFF
--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -40,6 +40,14 @@ test('shortcut matching respects non-ASCII Latin layout characters', () => {
   assert.equal(keyEventToString(event, false), 'Ctrl + ß');
 });
 
+test('shortcut matching respects punctuation characters from non-QWERTY layouts', () => {
+  const event = keyboardEvent(',', 'KeyW', { ctrlKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + ,', false), true);
+  assert.equal(matchesKeyBinding(event, 'Ctrl + W', false), false);
+  assert.equal(keyEventToString(event, false), 'Ctrl + ,');
+});
+
 test('shortcut matching keeps physical digit ranges layout-independent', () => {
   const event = keyboardEvent('&', 'Digit1', { ctrlKey: true });
 

--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { keyEventToString, matchesKeyBinding } from './models.ts';
+
+const keyboardEvent = (
+  key: string,
+  code: string,
+  modifiers: Partial<KeyboardEvent> = {},
+): KeyboardEvent => ({
+  key,
+  code,
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...modifiers,
+}) as KeyboardEvent;
+
+test('shortcut matching falls back to physical keys for non-Latin layouts', () => {
+  const event = keyboardEvent('\u0446', 'KeyW', { ctrlKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + W', false), true);
+  assert.equal(keyEventToString(event, false), 'Ctrl + W');
+});
+
+test('shortcut matching respects Latin characters from non-QWERTY layouts', () => {
+  const event = keyboardEvent('w', 'Comma', { ctrlKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + W', false), true);
+  assert.equal(matchesKeyBinding(event, 'Ctrl + ,', false), false);
+  assert.equal(keyEventToString(event, false), 'Ctrl + W');
+});
+
+test('shortcut matching keeps physical digit ranges layout-independent', () => {
+  const event = keyboardEvent('&', 'Digit1', { ctrlKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + [1...9]', false), true);
+  assert.equal(keyEventToString(event, false), 'Ctrl + 1');
+});

--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -32,6 +32,14 @@ test('shortcut matching respects Latin characters from non-QWERTY layouts', () =
   assert.equal(keyEventToString(event, false), 'Ctrl + W');
 });
 
+test('shortcut matching respects non-ASCII Latin layout characters', () => {
+  const event = keyboardEvent('ß', 'Minus', { ctrlKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + ß', false), true);
+  assert.equal(matchesKeyBinding(event, 'Ctrl + -', false), false);
+  assert.equal(keyEventToString(event, false), 'Ctrl + ß');
+});
+
 test('shortcut matching keeps physical digit ranges layout-independent', () => {
   const event = keyboardEvent('&', 'Digit1', { ctrlKey: true });
 

--- a/domain/models.test.ts
+++ b/domain/models.test.ts
@@ -52,5 +52,13 @@ test('shortcut matching keeps physical digit ranges layout-independent', () => {
   const event = keyboardEvent('&', 'Digit1', { ctrlKey: true });
 
   assert.equal(matchesKeyBinding(event, 'Ctrl + [1...9]', false), true);
-  assert.equal(keyEventToString(event, false), 'Ctrl + 1');
+  assert.equal(keyEventToString(event, false), 'Ctrl + &');
+});
+
+test('shortcut matching preserves shifted number-row symbols', () => {
+  const event = keyboardEvent('!', 'Digit1', { ctrlKey: true, shiftKey: true });
+
+  assert.equal(matchesKeyBinding(event, 'Ctrl + Shift + !', false), true);
+  assert.equal(matchesKeyBinding(event, 'Ctrl + Shift + 1', false), false);
+  assert.equal(keyEventToString(event, false), 'Ctrl + Shift + !');
 });

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -305,9 +305,6 @@ const PRINTABLE_NON_LETTER_SHORTCUT_KEY_PATTERN = /^[^\p{Letter}\p{Number}\s]$/u
 
 const shortcutEventKey = (e: KeyboardEvent): string => {
   const physicalKey = physicalShortcutKeyName(e);
-  if (/^Digit[0-9]$/.test(e.code) && physicalKey) {
-    return physicalKey;
-  }
   if (
     LATIN_SHORTCUT_KEY_PATTERN.test(e.key) ||
     PRINTABLE_NON_LETTER_SHORTCUT_KEY_PATTERN.test(e.key)
@@ -364,11 +361,19 @@ export const matchesKeyBinding = (e: KeyboardEvent, keyStr: string, isMac: boole
   // Handle range patterns like "[1...9]"
   if (keyStr.includes('[1...9]')) {
     const basePattern = keyStr.replace('[1...9]', '');
-    const key = shortcutEventKey(e);
+    const key = physicalShortcutKeyName(e) ?? shortcutEventKey(e);
     if (!/^[1-9]$/.test(key)) return false;
     // Check modifiers match the base pattern
     const testStr = basePattern + key;
-    return matchesKeyBinding(e, testStr.trim(), isMac);
+    const physicalDigitEvent = {
+      key,
+      code: e.code,
+      metaKey: e.metaKey,
+      ctrlKey: e.ctrlKey,
+      altKey: e.altKey,
+      shiftKey: e.shiftKey,
+    } as KeyboardEvent;
+    return matchesKeyBinding(physicalDigitEvent, testStr.trim(), isMac);
   }
 
   // Handle arrow key patterns like "arrows"

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -299,7 +299,14 @@ const physicalShortcutKeyName = (e: KeyboardEvent): string | null => {
   return PHYSICAL_SHORTCUT_KEY_NAMES[code] ?? null;
 };
 
-const shortcutEventKey = (e: KeyboardEvent): string => physicalShortcutKeyName(e) ?? e.key;
+const LATIN_SHORTCUT_KEY_PATTERN = /^[A-Za-z]$/;
+
+const shortcutEventKey = (e: KeyboardEvent): string => {
+  if (LATIN_SHORTCUT_KEY_PATTERN.test(e.key)) {
+    return e.key;
+  }
+  return physicalShortcutKeyName(e) ?? e.key;
+};
 
 // Convert keyboard event to a key string
 export const keyEventToString = (e: KeyboardEvent, isMac: boolean): string => {

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -301,12 +301,20 @@ const physicalShortcutKeyName = (e: KeyboardEvent): string | null => {
 
 const LATIN_SHORTCUT_KEY_PATTERN = /^\p{Script=Latin}$/u;
 const ASCII_SHORTCUT_KEY_PATTERN = /^[A-Za-z]$/;
+const PRINTABLE_NON_LETTER_SHORTCUT_KEY_PATTERN = /^[^\p{Letter}\p{Number}\s]$/u;
 
 const shortcutEventKey = (e: KeyboardEvent): string => {
-  if (LATIN_SHORTCUT_KEY_PATTERN.test(e.key)) {
+  const physicalKey = physicalShortcutKeyName(e);
+  if (/^Digit[0-9]$/.test(e.code) && physicalKey) {
+    return physicalKey;
+  }
+  if (
+    LATIN_SHORTCUT_KEY_PATTERN.test(e.key) ||
+    PRINTABLE_NON_LETTER_SHORTCUT_KEY_PATTERN.test(e.key)
+  ) {
     return e.key;
   }
-  return physicalShortcutKeyName(e) ?? e.key;
+  return physicalKey ?? e.key;
 };
 
 // Convert keyboard event to a key string

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -278,6 +278,29 @@ export const parseKeyCombo = (keyStr: string): { modifiers: string[]; key: strin
   return { modifiers: parts, key };
 };
 
+const PHYSICAL_SHORTCUT_KEY_NAMES: Record<string, string> = {
+  Backquote: '`',
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+};
+
+const physicalShortcutKeyName = (e: KeyboardEvent): string | null => {
+  const code = e.code;
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  return PHYSICAL_SHORTCUT_KEY_NAMES[code] ?? null;
+};
+
+const shortcutEventKey = (e: KeyboardEvent): string => physicalShortcutKeyName(e) ?? e.key;
+
 // Convert keyboard event to a key string
 export const keyEventToString = (e: KeyboardEvent, isMac: boolean): string => {
   const parts: string[] = [];
@@ -295,7 +318,7 @@ export const keyEventToString = (e: KeyboardEvent, isMac: boolean): string => {
   }
 
   // Get the key name
-  let keyName = e.key;
+  let keyName = shortcutEventKey(e);
   // Normalize special keys
   if (keyName === ' ') keyName = 'Space';
   else if (keyName === 'ArrowUp') keyName = '↑';
@@ -325,7 +348,7 @@ export const matchesKeyBinding = (e: KeyboardEvent, keyStr: string, isMac: boole
   // Handle range patterns like "[1...9]"
   if (keyStr.includes('[1...9]')) {
     const basePattern = keyStr.replace('[1...9]', '');
-    const key = e.key;
+    const key = shortcutEventKey(e);
     if (!/^[1-9]$/.test(key)) return false;
     // Check modifiers match the base pattern
     const testStr = basePattern + key;
@@ -398,7 +421,7 @@ export const matchesKeyBinding = (e: KeyboardEvent, keyStr: string, isMac: boole
     return normalizedKey;
   };
 
-  const eventKey = normalizeKey(e.key);
+  const eventKey = normalizeKey(shortcutEventKey(e));
   const parsedKey = normalizeKey(key);
 
   return eventKey.toLowerCase() === parsedKey.toLowerCase();

--- a/domain/models.ts
+++ b/domain/models.ts
@@ -299,7 +299,8 @@ const physicalShortcutKeyName = (e: KeyboardEvent): string | null => {
   return PHYSICAL_SHORTCUT_KEY_NAMES[code] ?? null;
 };
 
-const LATIN_SHORTCUT_KEY_PATTERN = /^[A-Za-z]$/;
+const LATIN_SHORTCUT_KEY_PATTERN = /^\p{Script=Latin}$/u;
+const ASCII_SHORTCUT_KEY_PATTERN = /^[A-Za-z]$/;
 
 const shortcutEventKey = (e: KeyboardEvent): string => {
   if (LATIN_SHORTCUT_KEY_PATTERN.test(e.key)) {
@@ -337,7 +338,7 @@ export const keyEventToString = (e: KeyboardEvent, isMac: boolean): string => {
   else if (keyName === 'Delete') keyName = 'Del';
   else if (keyName === 'Enter') keyName = '↵';
   else if (keyName === 'Tab') keyName = '⇥';
-  else if (keyName.length === 1) keyName = keyName.toUpperCase();
+  else if (ASCII_SHORTCUT_KEY_PATTERN.test(keyName)) keyName = keyName.toUpperCase();
 
   // Don't include modifier keys themselves
   if (['Meta', 'Control', 'Alt', 'Shift'].includes(e.key)) {


### PR DESCRIPTION
This PR fixes app shortcut matching when the active keyboard layout does not emit QWERTY Latin characters.

Previously, shortcuts such as Ctrl+W could fail on non-English layouts because matching relied on event.key, which may be ц, й, etc. The first commit switches shortcut matching to use physical key names as a fallback.

The follow-up refines that behavior to match Tabby’s approach:

Use event.key when it is already a Latin letter, preserving Dvorak/Colemak/AZERTY-style layouts.
Fall back to event.code for non-Latin layouts, so shortcuts still work on Cyrillic/IME layouts.
Keep digit-range shortcuts layout-independent.

Added domain tests for:
non-Latin layout fallback to physical keys
Latin non-QWERTY layouts respecting event.key
physical digit range matching
Ran:
node --test --import tsx domain\models.test.ts