### PR TITLE
Suppress SDK reasoning/text state-machine error chunks

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -31,6 +31,7 @@ import type { NetcattyBridge, ExecutorContext } from '../../../infrastructure/ai
 import { runExternalAgentTurn } from '../../../infrastructure/ai/externalAgentAdapter';
 import { runAcpAgentTurn } from '../../../infrastructure/ai/acpAgentAdapter';
 import { classifyError } from '../../../infrastructure/ai/errorClassifier';
+import { isSdkStreamStateError } from '../../../infrastructure/ai/shared/streamStateErrors';
 import {
   extractProviderContinuationFromRawChunk,
   getOpenAIChatAssistantFieldsForHistoryMessage,
@@ -647,9 +648,27 @@ export function useAIChatStreaming({
         // inside the tool's execute function via the approvalGate module.
         // The SDK may still emit this chunk type but we simply ignore it.
         case 'error': {
+          const typedChunk = chunk as ErrorChunk;
+          // Internal SDK reasoning/text state-machine errors (e.g. a
+          // third-party Anthropic-compat backend like DeepSeek's
+          // `-v4-flash` streaming thinking deltas without first emitting
+          // the `reasoning-start` content-block signal) leak through
+          // fullStream once per orphan delta. They're not user-facing
+          // errors — and worse, surfacing one assistant message per
+          // event breaks tool_use/tool_result contiguity on the next
+          // turn, which the Anthropic backend then rejects as
+          // `messages.N: tool_use ids were found without tool_result
+          // blocks immediately after`. Filter them out at the chunk
+          // boundary: drop the placeholder assistant message and keep
+          // accepting subsequent chunks, so the rest of the stream
+          // (real text, tool calls, the genuine `finish`) lands intact.
+          if (isSdkStreamStateError(typedChunk.error)) {
+            // eslint-disable-next-line no-console
+            console.warn('[Catty] suppressed SDK stream state error:', typedChunk.error);
+            break;
+          }
           cancelPendingFlush();
           flushText();
-          const typedChunk = chunk as ErrorChunk;
           updateMessageById(streamSessionId, activeMsgId, msg => ({
             ...msg,
             statusText: '',

--- a/infrastructure/ai/shared/streamStateErrors.ts
+++ b/infrastructure/ai/shared/streamStateErrors.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers for detecting Vercel AI SDK internal stream-state errors.
+ *
+ * Background — issue #1101 follow-up:
+ *
+ * When a third-party Anthropic-compat backend (DeepSeek's
+ * `deepseek-v4-flash` is the canonical offender) streams thinking
+ * deltas without first emitting a `reasoning-start` content-block
+ * signal, the Vercel AI SDK's reasoning state machine has nothing
+ * registered for the incoming `part.id` and enqueues an
+ * `error` chunk on `fullStream` with the text
+ * `reasoning part <id> not found` — once per orphan delta. The
+ * analogous error exists for text parts.
+ *
+ * These chunks are *internal SDK bookkeeping noise*, not user-facing
+ * errors. Worse, treating them as real errors (adding a placeholder
+ * assistant message for each) breaks tool_use/tool_result contiguity
+ * on the next turn: the Anthropic message grouper splits the
+ * tool-result `role: 'tool'` messages from their parent tool_use
+ * `role: 'assistant'`, and the backend responds with
+ * `400 messages.N: tool_use ids were found without tool_result blocks
+ * immediately after`.
+ *
+ * Filtering these specific errors at the chunk-handler boundary
+ * stops the cascade: the orphan deltas are dropped silently (the SDK
+ * continues processing other chunks), no fake assistant messages
+ * land in history, and the next turn's request stays well-formed.
+ */
+
+const STATE_ERROR_PATTERN = /^(?:reasoning|text)\s+part\s+\S+\s+not\s+found$/i;
+
+/**
+ * Return true if `error` is one of the SDK's internal stream-state
+ * tracking errors (e.g. an out-of-order reasoning delta). Accepts
+ * the loose `unknown` shape that comes off the chunk so callers
+ * don't need to narrow upstream.
+ */
+export function isSdkStreamStateError(error: unknown): boolean {
+  if (typeof error === 'string') {
+    return STATE_ERROR_PATTERN.test(error.trim());
+  }
+  if (error instanceof Error) {
+    return STATE_ERROR_PATTERN.test(error.message.trim());
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === 'string') return STATE_ERROR_PATTERN.test(msg.trim());
+  }
+  return false;
+}

--- a/infrastructure/ai/streamStateErrors.test.ts
+++ b/infrastructure/ai/streamStateErrors.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSdkStreamStateError } from "./shared/streamStateErrors";
+
+test("isSdkStreamStateError matches the reasoning-part orphan-delta error", () => {
+  assert.equal(isSdkStreamStateError("reasoning part 0 not found"), true);
+  assert.equal(isSdkStreamStateError("reasoning part abc-123 not found"), true);
+  assert.equal(isSdkStreamStateError("Reasoning Part 0 Not Found"), true);
+  assert.equal(isSdkStreamStateError("  reasoning part 7 not found  "), true);
+});
+
+test("isSdkStreamStateError matches the text-part orphan-delta error", () => {
+  assert.equal(isSdkStreamStateError("text part 0 not found"), true);
+  assert.equal(isSdkStreamStateError("text part X not found"), true);
+});
+
+test("isSdkStreamStateError accepts the error wrapped in an Error or `{ message }`", () => {
+  assert.equal(isSdkStreamStateError(new Error("reasoning part 0 not found")), true);
+  assert.equal(isSdkStreamStateError({ message: "reasoning part 0 not found" }), true);
+});
+
+test("isSdkStreamStateError ignores unrelated error strings", () => {
+  assert.equal(isSdkStreamStateError("Network error"), false);
+  assert.equal(
+    isSdkStreamStateError("400 messages.13: tool_use ids were found without tool_result blocks"),
+    false,
+  );
+  assert.equal(isSdkStreamStateError("reasoning part not found"), false, "missing the id segment shouldn't match");
+  assert.equal(isSdkStreamStateError("a reasoning part 0 not found"), false, "leading text shouldn't match");
+});
+
+test("isSdkStreamStateError handles non-error inputs without throwing", () => {
+  assert.equal(isSdkStreamStateError(undefined), false);
+  assert.equal(isSdkStreamStateError(null), false);
+  assert.equal(isSdkStreamStateError(42), false);
+  assert.equal(isSdkStreamStateError({}), false);
+  assert.equal(isSdkStreamStateError([]), false);
+});


### PR DESCRIPTION
## Summary
Issue #1101 follow-up. The Catty Agent chat surfaced a wall of red \`reasoning part 0 not found\` banners and a follow-up \`400 messages.N: tool_use ids were found without tool_result blocks immediately after\` when talking to DeepSeek's \`deepseek-v4-flash\` (Anthropic-compat + thinking). Same chain, two visible symptoms:

1. DeepSeek streams thinking deltas without emitting the matching \`reasoning-start\` content-block signal first.
2. Vercel AI SDK's reasoning state machine has nothing registered for the incoming \`part.id\` and enqueues an \`error\` chunk \`reasoning part <id> not found\` onto \`fullStream\` — once per orphan delta. (Same path exists for \`text part\`.)
3. Our \`case 'error'\` handler in \`useAIChatStreaming.ts\` was treating each of these as a real error and pushing a \`role: 'assistant'\` placeholder message into history.
4. On the next turn the local history gets rebuilt into \`sdkMessages\`. The placeholders sit between the assistant that holds the parallel \`tool_use\` blocks and the \`role: 'tool'\` messages with their results. The Anthropic adapter's \`groupIntoBlocks\` only merges *consecutive* tool messages into a single user block, so the tool_results no longer immediately follow their tool_use parent — and the backend 400s. \`messages.N\` was literally counting our ~12 phantom assistants.

## The fix
- New \`infrastructure/ai/shared/streamStateErrors.ts\` exporting \`isSdkStreamStateError(error: unknown): boolean\` that matches \`/^(reasoning|text)\\s+part\\s+\\S+\\s+not\\s+found$/i\` against string / \`Error\` / \`{ message }\` shapes.
- \`useAIChatStreaming.ts\` \`case 'error'\` checks the predicate first; if it matches we \`console.warn\` and \`break\` without flipping \`executionStatus\` or adding a placeholder message — so subsequent text, tool calls, and \`finish\` chunks land intact and the next turn's API request stays well-formed.
- 5 unit tests cover positive matches, wrapped shapes, negative strings that should stay surfaced, and non-string inputs.

Codex review on this branch returned clean (no P1 / P2 / P3 findings).

Refs #1101.

## Test plan
- [ ] \`npm test\` — 1265 pass locally.
- [ ] \`npm run build\` — clean.
- [ ] Catty Agent + DeepSeek (Anthropic-compat, \`-v4-flash\`): trigger the same prompt that previously produced the wall of red banners (e.g. one that triggers parallel info-gathering tool_uses). Expect the banners to be gone and the next-turn 400 to not reappear. Devtools console still shows the suppressed errors for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)