### PR TITLE
chore(ai): drop unused eslint-disable around suppressed SDK warning

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -663,7 +663,6 @@ export function useAIChatStreaming({
           // accepting subsequent chunks, so the rest of the stream
           // (real text, tool calls, the genuine `finish`) lands intact.
           if (isSdkStreamStateError(typedChunk.error)) {
-            // eslint-disable-next-line no-console
             console.warn('[Catty] suppressed SDK stream state error:', typedChunk.error);
             break;
           }


### PR DESCRIPTION
## Summary
Trailing chore from #1110. The new \`console.warn\` for suppressed SDK reasoning/text state-machine errors carried an \`// eslint-disable-next-line no-console\` comment, but \`components/ai/hooks/useAIChatStreaming.ts\` already allows \`console.*\` (several pre-existing \`console.error\` calls in the same hook). ESLint correctly flagged the directive as unused at dev time:

\`\`\`
/Users/.../components/ai/hooks/useAIChatStreaming.ts
  666:13  warning  Unused eslint-disable directive (no problems were reported from 'no-console')
\`\`\`

Drops the directive. The \`console.warn\` stays — it's the diagnostic surface for the suppressed SDK stream-state errors.

## Test plan
- [ ] \`npx eslint components/ai/hooks/useAIChatStreaming.ts\` — clean.
- [ ] \`npm test\` — 1265 pass.
- [ ] \`npm run build\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)