### PR TITLE
fix(terminal): use client OS for local-shell autocomplete clear sequence (#1112)

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -6,6 +6,7 @@ import "@xterm/xterm/css/xterm.css";
 import { Cpu, Copy, HardDrive, Maximize2, MemoryStick, Radio, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
+import { detectLocalOs } from "../lib/localShell";
 import { logger } from "../lib/logger";
 import { cn, normalizeLineEndings, wrapBracketedPaste } from "../lib/utils";
 import {
@@ -540,9 +541,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   // Autocomplete config — the hook itself lives in <TerminalAutocomplete> so
   // its state updates don't re-render this component (see render below).
-  const autocompleteHostOs: "linux" | "windows" | "macos" = host.os || (host.protocol === "local"
-    ? (navigator.platform?.startsWith("Win") ? "windows" : navigator.platform?.startsWith("Mac") ? "macos" : "linux")
-    : "linux");
+  // For local protocol the effective OS is the client OS: synthetic fallback
+  // hosts (TerminalLayer) and saved-host defaults (HostDetailsPanel) both
+  // stamp os: "linux", which mis-routes the autocomplete clear sequence to
+  // Ctrl-U on Windows where cmd/PowerShell render it literally (#1112).
+  const autocompleteHostOs: "linux" | "windows" | "macos" = host.protocol === "local"
+    ? detectLocalOs(navigator.userAgent || navigator.platform)
+    : (host.os || "linux");
   const autocompleteSettings = terminalSettings ? {
     enabled: terminalSettings.autocompleteEnabled ?? true,
     showGhostText: terminalSettings.autocompleteGhostText ?? true,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1360,7 +1360,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
           hostname: session.hostname || 'localhost',
           username: session.username || 'local',
           port: session.port ?? 22,
-          os: 'linux',
+          os: detectLocalOs(navigator.userAgent || navigator.platform),
           group: '',
           tags: [],
           protocol: session.protocol ?? 'local' as const,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1354,16 +1354,25 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         }
       } else {
         // Create stable fallback host object
+        const fallbackProtocol = session.protocol ?? 'local' as const;
         map.set(session.id, {
           id: session.hostId,
           label: session.hostLabel || 'Local Terminal',
           hostname: session.hostname || 'localhost',
           username: session.username || 'local',
           port: session.port ?? 22,
-          os: detectLocalOs(navigator.userAgent || navigator.platform),
+          // Only local terminals adopt the client OS — unsaved serial
+          // sessions and orphaned remote sessions (whose host was deleted
+          // while the session lives on) also hit this fallback, and the
+          // non-local autocomplete path in Terminal.tsx trusts host.os, so
+          // a Windows-client 'windows' tag here would mis-shape POSIX
+          // remote/serial autocomplete (#1112 review).
+          os: fallbackProtocol === 'local'
+            ? detectLocalOs(navigator.userAgent || navigator.platform)
+            : 'linux',
           group: '',
           tags: [],
-          protocol: session.protocol ?? 'local' as const,
+          protocol: fallbackProtocol,
           moshEnabled: session.moshEnabled,
           charset: session.charset,
           localShell: session.localShell,


### PR DESCRIPTION
## Summary
Closes #1112. On Windows local PowerShell / cmd, switching candidates in the popup autocomplete (or fuzzy-accepting one) leaves a literal `^U` followed by the candidate text instead of replacing the input line.

The autocomplete live-preview / insert / accept-snippet paths emit a "clear current input" sequence sized to the host OS — Ctrl-U (`\x15`) for POSIX shells, backspaces for Windows (`components/terminal/autocomplete/livePreviewSequence.ts:22` and the matching branches at `useTerminalAutocomplete.ts:1330` and `:1367`). The branch logic itself is correct; it just never fires on Windows local shells because `hostOsRef.current` resolves to `"linux"` there.

### Root cause
- `components/Terminal.tsx:543` derived `autocompleteHostOs` as `host.os || (local ? navigator.platform check : "linux")`. Intent: "if `host.os` isn't set and we're local, detect the client OS."
- The synthetic fallback Host built for every local session at `components/TerminalLayer.tsx:1357-1373` hardcodes `os: 'linux'`, so `host.os` is always truthy and the `navigator.platform` branch never runs.
- Windows ConPTY → cmd / PSReadLine doesn't treat `\x15` as kill-line, so the byte renders literally as `^U` and the candidate gets appended to the original input instead of replacing it.

Both manifestations in the issue match this:
- History candidate → `\x15 + candidate` (fuzzy-match path).
- Snippet candidate → snippet preview reverts to the typed baseline (`useTerminalAutocomplete.ts:1303`); switching from a previously-rendered candidate back to baseline emits `\x15 + baseline`, i.e. `^U` + the letters that originally triggered the popup.

### Fix
- `components/Terminal.tsx`: invert the priority in `autocompleteHostOs` so local protocol always resolves the client OS via the existing `detectLocalOs` helper. `host.os` is still trusted for SSH / telnet / serial.
- `components/TerminalLayer.tsx`: fix the synthetic fallback Host at the source — replace hardcoded `os: 'linux'` with `detectLocalOs(navigator.userAgent || navigator.platform)`, same helper and call shape as the AI panel uses earlier in this file (lines 2344, 2402).

Both points together are necessary: the Terminal.tsx change is the targeted autocomplete fix; the TerminalLayer.tsx change quietly fixes `components/Terminal.tsx:642` `isSupportedOs` too — that gate had been wrongly enabling Unix-style server-stats probes (`top` / `vmstat` / `df`) on Windows local shells because `host.os === 'linux'` was bogusly true. Tab icons and distro avatars are unaffected — those read `localShellIcon` or do their own UA detection (`components/TopTabs.tsx:62-68` and `:88`).

## Test plan
- [ ] `npm test` — `livePreviewSequence.test.ts` and `localShell.test.ts` still pass. Existing tests already cover the Windows / Linux byte-sequence contract.
- [ ] `npm run build` — clean.
- [ ] Windows local PowerShell: type a fragment, open the popup, ↓/↑ through candidates — line content replaces cleanly, no `^U` leakage. Repeat with `cmd.exe`.
- [ ] Windows local PowerShell: Tab-accept a fuzzy-match candidate that doesn't share the typed prefix — line cleanly replaced.
- [ ] macOS / Linux local shell: regression — popup candidate switching still works (Ctrl-U path still fires for SSH / telnet / serial).
- [ ] Windows local PowerShell: confirm server-stats card is hidden (no Unix probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)