### PR TITLE
(fix) autocomplete popup visible after sending command

### DIFF
--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -382,6 +382,10 @@ export function useTerminalAutocomplete(
    * Clear popup/ghost state. Skips re-render if already empty.
    */
   const clearState = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
     ghostAddonRef.current?.hide();
     // Bump version to invalidate any in-flight async completions
     fetchVersionRef.current++;
@@ -744,6 +748,8 @@ export function useTerminalAutocomplete(
       const { position, cursorLineTop, cursorLineBottom, expandUpward } = calculatePopupPosition(term, completions.length);
       startTransition(() => {
         setState((prev) => {
+          if (version !== fetchVersionRef.current) return prev;
+
           const nextState: AutocompleteState = {
             suggestions: completions,
             selectedIndex: -1,
@@ -993,10 +999,12 @@ export function useTerminalAutocomplete(
       if (isFastTyping) {
         // Still debounce, but with a longer delay to wait for typing to pause
         debounceTimerRef.current = setTimeout(() => {
+          debounceTimerRef.current = null;
           fetchSuggestions();
         }, settingsRef.current.debounceMs * 3);
       } else {
         debounceTimerRef.current = setTimeout(() => {
+          debounceTimerRef.current = null;
           fetchSuggestions();
         }, settingsRef.current.debounceMs);
       }


### PR DESCRIPTION
Fixes (https://github.com/binaricat/Netcatty/issues/1120) a race where the terminal autocomplete popup could remain visible or reappear after pressing Enter, most noticeably on higher ping hosts.

The issue was caused by pending debounced autocomplete fetches surviving after autocomplete state had already been cleared. If one of those delayed fetches completed after Enter closed the popup, it could apply stale suggestions back into state.

Changes:

Cancel any pending autocomplete debounce timer when clearing autocomplete state.
Reset the debounce timer ref after the timer fires.
Add a final version check inside the React transition state update so stale async completion results cannot reopen the popup.
Validation:

Ran npx eslint components\terminal\autocomplete\useTerminalAutocomplete.ts successfully.