### PR TITLE
fix(ai): keep chat input toolbar on one row when sidebar is narrow

### DIFF
--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -418,7 +418,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const selectedSkillChipClassName =
     'inline-flex h-7 items-center gap-1.5 rounded-full border border-primary/18 bg-primary/8 pl-2.5 pr-1.5 text-[11px] font-medium text-foreground/86 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]';
   const iconButtonClassName =
-    'h-6 w-6 rounded-full bg-transparent text-foreground/62 hover:bg-muted/24 hover:text-foreground';
+    'h-6 w-6 shrink-0 rounded-full bg-transparent text-foreground/62 hover:bg-muted/24 hover:text-foreground';
 
   return (
     <div className="shrink-0 px-4 pb-4">
@@ -618,7 +618,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
 
         {/* Footer toolbar */}
         <PromptInputFooter className="gap-1.5 border-t-0 bg-transparent px-3 pb-2 pt-0">
-          <PromptInputTools className="gap-1 flex-wrap">
+          <PromptInputTools className="gap-1 min-w-0">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -717,7 +717,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                   closeAllMenus();
                 }
               }}
-              className={`${chipClassName} ${hasModelPicker ? 'cursor-pointer hover:bg-muted/24 transition-colors' : ''}`}
+              className={`${chipClassName} min-w-0 ${hasModelPicker ? 'cursor-pointer hover:bg-muted/24 transition-colors' : ''}`}
               aria-label={hasProviderSwitcher ? 'Select provider and model' : 'Select model'}
               aria-expanded={showModelPicker}
             >
@@ -726,7 +726,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
               ) : (
                 <Cpu size={11} className="text-muted-foreground/64" />
               )}
-              <span className={`truncate ${hasProviderSwitcher ? 'max-w-[180px]' : 'max-w-[82px]'}`}>{modelLabel}</span>
+              <span className={`truncate min-w-0 ${hasProviderSwitcher ? 'max-w-[180px]' : 'max-w-[82px]'}`}>{modelLabel}</span>
               {hasModelPicker && <ChevronDown size={9} className="text-muted-foreground/50" />}
             </button>
             {showModelPicker && hasModelPicker && menuPos && createPortal(
@@ -873,7 +873,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                           closeAllMenus();
                         }
                       }}
-                      className={`${chipClassName} cursor-pointer hover:bg-muted/24 transition-colors`}
+                      className={`${chipClassName} shrink-0 cursor-pointer hover:bg-muted/24 transition-colors`}
                       aria-label={t('ai.safety.permissionMode')}
                       aria-expanded={showPermPicker}
                     >


### PR DESCRIPTION
## Summary

- When the AI side panel is dragged narrow, the ChatInput footer's `+ / model / perm` chips used to wrap onto multiple lines via `flex-wrap`, wasting vertical space and looking messy
- Switched to a single-row, no-wrap layout: the bookending `+` and perm chips get `shrink-0` so they stay intact, while the middle model chip gets `min-w-0` so the existing `truncate` actually kicks in and the model label gets ellipsized when too long

## Test plan

- [x] Drag the AI side panel narrow and confirm `+` / model / perm stay on a single row
- [x] Model name (e.g. `DeepSeek · deepseek-v4-flash`) ellipsizes with `…` as width shrinks
- [x] Wide side panel looks identical to before — no visual regression
- [x] Verify across different providers, including the no-provider-switcher case (`max-w-[82px]` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)