### PR TITLE
fix(terminal): probe cwd via SSH_CONNECTION on older OpenSSH (#1123)

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2059,7 +2059,9 @@ async function getSessionPwd(event, payload) {
     }, 5000);
 
     // POSIX sh script that:
-    //   1. Finds the sibling interactive shell under sshd ($PPID).
+    //   1. Finds the user's interactive shell on the same SSH connection
+    //      (sibling under $PPID on newer OpenSSH, cousin reachable via the
+    //      shared SSH_CONNECTION env var on older OpenSSH like CentOS 7).
     //   2. Follows foreground child shells only, which covers bash->fish
     //      without mistaking background shell scripts for the active shell.
     //   3. Reads /proc/<pid>/cwd via readlink.
@@ -2069,20 +2071,57 @@ async function getSessionPwd(event, payload) {
     // so sh keeps the same PID and $PPID = sshd. Starting another shell
     // without exec would make $PPID point at the intermediate shell instead.
     const posixScript = `SELF=$$
-# Find the interactive shell child of this exec channel's sshd ($PPID).
+# Find the user's interactive shell on this SSH connection.
 # Prefer the one attached to a controlling tty (the user's shell): probe exec
 # channels like this one have no tty ("?"), and ps output is unsorted, so
 # without the tty preference a concurrent probe's shell could be picked when
 # several exist under the same sshd (#1065 review). Falls back to any shell
 # child if none has a tty.
+#
+# Strategy: try direct siblings of $PPID first — works on newer OpenSSH where
+# the PTY session and this exec channel share the same per-connection sshd
+# parent. Fall back to matching by SSH_CONNECTION env var, which covers older
+# OpenSSH (e.g. CentOS 7 / RHEL 7) that forks a SEPARATE sshd child per
+# channel — there the PTY shell ends up as a cousin (same grandparent sshd,
+# different parent) of this exec session, so the sibling search misses it
+# entirely (#1123).
 find_login_shell() {
-  ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
+  _shell=$(ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
     $1 != self && $2 == pp && $4 ~ /^-?(ba|z|fi|k|da|a)?sh$/ {
       if ($3 != "?") { print $1; found=1; exit }
       if (any == "") any=$1
     }
     END { if (!found && any != "") print any }
-  '
+  ')
+  [ -n "$_shell" ] && { echo "$_shell"; return; }
+  # SSH_CONNECTION is the unique client-port/server-port 4-tuple sshd injects
+  # into every channel of one SSH connection, so processes that share it are
+  # the channels of this very connection — and exactly one of them is the
+  # user's PTY shell. Read /proc/<pid>/environ (NUL-separated, same uid only)
+  # and pick the shell with a controlling tty.
+  _conn=$(tr '\\0' '\\n' < /proc/$SELF/environ 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
+  [ -z "$_conn" ] && return
+  _any=""
+  for _d in /proc/[0-9]*; do
+    _pid=$(basename "$_d")
+    [ "$_pid" = "$SELF" ] && continue
+    [ -r "$_d/environ" ] || continue
+    _conn2=$(tr '\\0' '\\n' < "$_d/environ" 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
+    [ "$_conn2" = "$_conn" ] || continue
+    _info=$(ps -p "$_pid" -o tty=,comm= 2>/dev/null)
+    [ -n "$_info" ] || continue
+    set -- $_info
+    case "$2" in
+      sh|bash|zsh|fish|ksh|dash|ash|-sh|-bash|-zsh|-fish|-ksh|-dash|-ash) ;;
+      *) continue ;;
+    esac
+    if [ "$1" != "?" ] && [ -n "$1" ]; then
+      echo "$_pid"
+      return
+    fi
+    [ -z "$_any" ] && _any="$_pid"
+  done
+  [ -n "$_any" ] && echo "$_any"
 }
 # From the login shell, pick the DEEPEST foreground shell in its process
 # subtree. "Foreground" = the controlling tty's foreground process group ("+"

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -2098,7 +2098,11 @@ find_login_shell() {
   # into every channel of one SSH connection, so processes that share it are
   # the channels of this very connection — and exactly one of them is the
   # user's PTY shell. Read /proc/<pid>/environ (NUL-separated, same uid only)
-  # and pick the shell with a controlling tty.
+  # to find candidates, then pick the one with a shell comm and a controlling
+  # tty. /proc/<pid>/comm is read directly here because ps -p PID -o tty=,comm=
+  # gets misparsed on older procps (CentOS 7): the trailing ",comm=" is folded
+  # into the tty column header instead of starting a second column, so tty and
+  # comm come back swapped.
   _conn=$(tr '\\0' '\\n' < /proc/$SELF/environ 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
   [ -z "$_conn" ] && return
   _any=""
@@ -2108,14 +2112,13 @@ find_login_shell() {
     [ -r "$_d/environ" ] || continue
     _conn2=$(tr '\\0' '\\n' < "$_d/environ" 2>/dev/null | sed -n 's/^SSH_CONNECTION=//p' | head -n1)
     [ "$_conn2" = "$_conn" ] || continue
-    _info=$(ps -p "$_pid" -o tty=,comm= 2>/dev/null)
-    [ -n "$_info" ] || continue
-    set -- $_info
-    case "$2" in
-      sh|bash|zsh|fish|ksh|dash|ash|-sh|-bash|-zsh|-fish|-ksh|-dash|-ash) ;;
+    _comm=$(cat "$_d/comm" 2>/dev/null)
+    case "$_comm" in
+      sh|bash|zsh|fish|ksh|dash|ash) ;;
       *) continue ;;
     esac
-    if [ "$1" != "?" ] && [ -n "$1" ]; then
+    _tty=$(ps -p "$_pid" -o tty= 2>/dev/null | tr -d '[:space:]')
+    if [ "$_tty" != "?" ] && [ -n "$_tty" ]; then
       echo "$_pid"
       return
     fi


### PR DESCRIPTION
Fixes #1123.

## Summary

- On CentOS 7 / RHEL 7 (OpenSSH 6.6.1) the "go to terminal cwd" feature always returns `$HOME` instead of the user's actual `cd`-ed directory.
- Root cause: the pwd-probe script assumed the user's PTY shell and the probe's exec channel are siblings (same per-connection sshd as `$PPID`). That holds on newer OpenSSH, but old OpenSSH forks a *separate* sshd child per channel — the PTY shell is a *cousin* (same grandparent sshd, different parent), so the sibling lookup returns nothing and we drop into the home-dir fallback.
- Added a second pass that matches by the `SSH_CONNECTION` env var. sshd injects the unique client-port / server-port 4-tuple into every channel of one SSH connection, so processes that share it are exactly the channels of this connection. We scan `/proc/<pid>/environ` (same-uid readable), filter for a shell `comm` with a controlling tty, and feed that PID into the existing `readlink /proc/<pid>/cwd` step.
- The sibling search stays as the fast path; the new `SSH_CONNECTION` lookup only runs when the fast path returns nothing. No change for non-Linux remotes (no `/proc` → unchanged home-dir fallback).

## Test plan

- [ ] CentOS 7 host: connect, `cd /tmp`, click "go to terminal cwd" — SFTP should land in `/tmp`, not `/root`. Try a few other dirs and nested `sudo bash` to confirm the `find_active_shell` step still walks down to the active shell.
- [ ] Modern Ubuntu / Debian host: same flow still works (fast path hits, fallback never runs)
- [ ] Multi-session same host: open two Netcatty terminals to the same server under the same user, each `cd` to a different directory, probe each — they should not cross-contaminate (`SSH_CONNECTION` 4-tuple is per-connection, not per-user)
- [ ] BSD / macOS remote (no `/proc`): unchanged — still falls back to `$HOME`
- [ ] Network device host classified by `shouldProbeSessionCwd` as non-probeable: probe is still skipped upstream, untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)