### PR TITLE
fix(ai): run bundled claude-agent-acp via Electron's Node

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -376,11 +376,17 @@ function invalidateShellEnvCache() {
 // ── Claude Code ACP binary resolution ──
 
 /**
- * Resolve the Claude ACP binary, returning { command, prependArgs }.
+ * Resolve the Claude ACP binary, returning { command, prependArgs, env }.
  *
- * On macOS/Linux a shebang-based .js script can be spawned directly, but on
- * Windows `child_process.spawn` does not interpret shebangs — so when the
- * resolved path is a JS file we invoke it via the system Node runtime.
+ * `@zed-industries/claude-agent-acp`'s `dist/index.js` is shipped as a Node
+ * script (`#!/usr/bin/env node`). We bundle it with the app, but the user's
+ * machine may not have `node` on PATH — Windows doesn't honour the shebang at
+ * all, and on macOS/Linux the shebang only works when `node` is installed.
+ *
+ * To make the bundled copy self-sufficient, packaged builds run the script
+ * with the Electron binary itself (via `ELECTRON_RUN_AS_NODE=1`). Dev mode
+ * still prefers a PATH-resolved `claude-agent-acp` wrapper since `node` is
+ * almost always available there.
  */
 function resolveClaudeAcpBinaryPath(shellEnv, electronModule) {
   const binaryName = "claude-agent-acp";
@@ -389,29 +395,34 @@ function resolveClaudeAcpBinaryPath(shellEnv, electronModule) {
   const isPackaged = electronModule?.app?.isPackaged;
   if (!isPackaged && shellEnv) {
     const systemPath = resolveCliFromPath(binaryName, shellEnv);
-    if (systemPath) return { command: systemPath, prependArgs: [] };
+    if (systemPath) return { command: systemPath, prependArgs: [], env: {} };
   }
 
-  // Packaged build (or dev fallback): use npm-bundled binary
+  // Packaged build (or dev fallback): run the npm-bundled JS via process.execPath.
+  // In packaged Electron `process.execPath` is the app binary (e.g. Netcatty.exe);
+  // setting `ELECTRON_RUN_AS_NODE=1` makes it behave as the embedded Node so we
+  // don't depend on the user having `node` installed.  When `process.execPath`
+  // is already a real `node` (e.g. during tests), no env var is needed.
   try {
     const resolved = require.resolve("@zed-industries/claude-agent-acp/dist/index.js");
     const scriptPath = toUnpackedAsarPath(resolved);
 
-    // On Windows, .js files cannot be spawned directly (no shebang support) —
-    // invoke via Node.  In packaged Electron builds process.execPath is the
-    // app binary (e.g. Netcatty.exe), not a Node runtime, so we must resolve
-    // the real `node` from PATH.  If Node is not installed, fall back to the
-    // bare command name and let the system find the npm-generated .cmd wrapper.
-    if (process.platform === "win32") {
-      const nodePath = resolveCliFromPath("node", shellEnv);
-      if (nodePath) {
-        return { command: nodePath, prependArgs: [scriptPath] };
-      }
-      return { command: binaryName, prependArgs: [] };
+    const runtime = process.execPath;
+    if (runtime && existsSync(runtime)) {
+      const runtimeBase = path.basename(runtime).toLowerCase();
+      const isNodeBinary = runtimeBase === "node" || runtimeBase.startsWith("node.");
+      const env = isNodeBinary ? {} : { ELECTRON_RUN_AS_NODE: "1" };
+      return { command: runtime, prependArgs: [scriptPath], env };
     }
-    return { command: scriptPath, prependArgs: [] };
+
+    // Last resort: try a system `node`, then the bare command name.
+    const nodePath = shellEnv ? resolveCliFromPath("node", shellEnv) : null;
+    if (nodePath) {
+      return { command: nodePath, prependArgs: [scriptPath], env: {} };
+    }
+    return { command: binaryName, prependArgs: [], env: {} };
   } catch {
-    return { command: binaryName, prependArgs: [] };
+    return { command: binaryName, prependArgs: [], env: {} };
   }
 }
 

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -9,6 +9,7 @@ const {
   isPlausibleCliVersionOutput,
   looksLikeIdleAutoLogout,
   prepareCommandForSpawn,
+  resolveClaudeAcpBinaryPath,
   resolveClaudeCodeExecutableForAcp,
   trackSessionIdlePrompt,
 } = require("./shellUtils.cjs");
@@ -282,4 +283,66 @@ test("looksLikeIdleAutoLogout returns false for empty / non-string input", () =>
   assert.equal(looksLikeIdleAutoLogout(""), false);
   assert.equal(looksLikeIdleAutoLogout(undefined), false);
   assert.equal(looksLikeIdleAutoLogout(null), false);
+});
+
+function withExecPath(fakePath, fn) {
+  const original = process.execPath;
+  Object.defineProperty(process, "execPath", { value: fakePath, configurable: true, writable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "execPath", { value: original, configurable: true, writable: true });
+  }
+}
+
+test("resolveClaudeAcpBinaryPath sets ELECTRON_RUN_AS_NODE when packaged execPath is not node", (t) => {
+  // Simulate the packaged Electron case where process.execPath is the app
+  // binary (e.g. Netcatty.exe).  We copy the real node binary to a fake path
+  // so existsSync() succeeds while basename != "node".
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-acp-runtime-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+  const fakeRuntime = path.join(tempDir, process.platform === "win32" ? "Netcatty.exe" : "Netcatty");
+  fs.copyFileSync(process.execPath, fakeRuntime);
+
+  const result = withExecPath(fakeRuntime, () =>
+    resolveClaudeAcpBinaryPath(null, { app: { isPackaged: true } }),
+  );
+
+  assert.equal(result.command, fakeRuntime);
+  assert.equal(result.prependArgs.length, 1);
+  assert.ok(
+    result.prependArgs[0].endsWith(path.join("claude-agent-acp", "dist", "index.js")),
+    `prependArgs[0] should point at the bundled script, got: ${result.prependArgs[0]}`,
+  );
+  assert.deepEqual(result.env, { ELECTRON_RUN_AS_NODE: "1" });
+});
+
+test("resolveClaudeAcpBinaryPath leaves env empty when execPath is a real node binary", (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-acp-runtime-node-"));
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+  const fakeRuntime = path.join(tempDir, process.platform === "win32" ? "node.exe" : "node");
+  fs.copyFileSync(process.execPath, fakeRuntime);
+
+  const result = withExecPath(fakeRuntime, () =>
+    resolveClaudeAcpBinaryPath(null, { app: { isPackaged: true } }),
+  );
+
+  assert.equal(result.command, fakeRuntime);
+  assert.deepEqual(result.env, {});
+});
+
+test("resolveClaudeAcpBinaryPath falls back to bundled script in dev mode when nothing is on PATH", () => {
+  // Dev mode (isPackaged = false) with a shellEnv whose PATH cannot resolve
+  // claude-agent-acp falls through to the bundled-script branch, which uses
+  // process.execPath as the runtime.
+  const result = resolveClaudeAcpBinaryPath({ PATH: "" }, { app: { isPackaged: false } });
+
+  assert.equal(result.command, process.execPath);
+  assert.equal(result.prependArgs.length, 1);
+  assert.ok(
+    result.prependArgs[0].endsWith(path.join("claude-agent-acp", "dist", "index.js")),
+    `prependArgs[0] should point at the bundled script, got: ${result.prependArgs[0]}`,
+  );
+  // Test runner's process.execPath is a real node, so no ELECTRON_RUN_AS_NODE here.
+  assert.deepEqual(result.env, {});
 });

--- a/electron/bridges/aiBridge.cjs
+++ b/electron/bridges/aiBridge.cjs
@@ -2407,6 +2407,9 @@ function registerHandlers(ipcMain) {
       const resolvedArgs = claudeAcp
         ? [...claudeAcp.prependArgs, ...(acpArgs || [])]
         : acpArgs || [];
+      if (claudeAcp?.env) {
+        Object.assign(agentEnv, claudeAcp.env);
+      }
 
       provider = createACPProvider({
         command: resolvedCommand,
@@ -2732,6 +2735,9 @@ function registerHandlers(ipcMain) {
         const resolvedArgs = claudeAcp
           ? [...claudeAcp.prependArgs, ...(acpArgs || [])]
           : acpArgs || [];
+        if (claudeAcp?.env) {
+          Object.assign(agentEnv, claudeAcp.env);
+        }
         const sessionMcpServers = isCopilotAgent ? [] : mcpSnapshot.mcpServers;
 
         const provider = createACPProvider({
@@ -2844,6 +2850,9 @@ function registerHandlers(ipcMain) {
             if (isCopilotAgent) {
               const fallbackCopilotConfig = prepareCopilotHome(shellEnv, mcpSnapshot.mcpServers, chatSessionId);
               fallbackEnv.COPILOT_HOME = fallbackCopilotConfig.copilotHome;
+            }
+            if (fallbackClaudeAcp?.env) {
+              Object.assign(fallbackEnv, fallbackClaudeAcp.env);
             }
             return fallbackEnv;
           })(),


### PR DESCRIPTION
## Summary
- Spawn the bundled `@zed-industries/claude-agent-acp` `dist/index.js` through `process.execPath` with `ELECTRON_RUN_AS_NODE=1` so the embedded Electron acts as the Node runtime, instead of relying on the user having `node` on PATH.
- Threads the new `env` returned by `resolveClaudeAcpBinaryPath` into all three Claude ACP spawn sites (`acp:list-models`, `acp:stream`, and the stream's fallback path).
- Mirrors the same trick `resolveMcpServerRuntimeCommand` already uses for the bundled MCP server.

## Why
Fixes #1118. The package is already in `package.json` and `electron-builder.config.cjs` asarUnpack, but `dist/index.js` is a Node script (`#!/usr/bin/env node`). Windows ignores the shebang and macOS/Linux only honour it when `node` is on PATH. The previous Windows branch tried to find `node` and fell back to spawning a bare `claude-agent-acp` command — that fallback only works if the user manually `npm install -g`-s the package, which is exactly what the reporter had to do to unblock themselves.

## Test plan
- [x] `npm test` — 1304 tests, 1301 pass, 3 skipped (baseline + 3 new tests for `resolveClaudeAcpBinaryPath`)
- [x] `npm run lint`
- [ ] Manual: install a packaged build on a Windows machine **without** Node on PATH and confirm Claude Code-via-ACP works without `npm install -g @zed-industries/claude-agent-acp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)