### PR TITLE
chore(ai): upgrade ACP packages and unwrap Skill+CLI command in tool-call panel

### DIFF
--- a/components/ai-elements/tool-call.tsx
+++ b/components/ai-elements/tool-call.tsx
@@ -8,6 +8,79 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useI18n } from '../../application/i18n/I18nProvider';
 
 /**
+ * Pull the user-meaningful shell command out of the tool-call args.
+ *
+ * Different tool surfaces hand us different shapes:
+ *   - Netcatty's own `terminal_execute` MCP tool → `{command: "<string>"}`
+ *   - Codex `local_shell` (ACP)                 → `{command: ["zsh","-lc","<full>"]}`
+ *   - Claude `Bash` (ACP)                       → `{command: "<string>"}`
+ *
+ * And under the "Skill + CLI" integration, the agent's shell tool wraps a
+ * call to our internal `netcatty-tool-cli` binary, so the real intent is one
+ * level deeper:
+ *
+ *   netcatty-tool-cli exec --session <id> --chat-session <id> -- <real-cmd>
+ *
+ * We unwrap both layers so the chat panel shows what the user actually
+ * cares about (the remote command), not Codex's wrapper title which is
+ * just the local path to the CLI binary.
+ */
+function extractDisplayCommand(args: Record<string, unknown> | undefined): string | null {
+  if (!args) return null;
+  const raw = (args as { command?: unknown }).command;
+
+  let cmdString: string;
+  if (typeof raw === 'string') {
+    if (!raw) return null;
+    cmdString = raw;
+  } else if (Array.isArray(raw) && raw.length > 0) {
+    const isShellWrap =
+      raw.length >= 3 &&
+      /(?:^|\/)(sh|bash|zsh|fish|ash|dash)$/.test(String(raw[0] ?? '')) &&
+      /^-l?c$/.test(String(raw[1] ?? ''));
+    cmdString = isShellWrap
+      ? String(raw[raw.length - 1] ?? '')
+      : raw.map((p) => String(p)).join(' ');
+  } else {
+    return null;
+  }
+
+  // Netcatty CLI wrapper extraction.
+  const cliIdx = cmdString.indexOf('netcatty-tool-cli');
+  if (cliIdx >= 0) {
+    const afterCli = cmdString
+      .slice(cliIdx + 'netcatty-tool-cli'.length)
+      .replace(/^["']?\s*/, '');
+    const subMatch = afterCli.match(/^(\S+)/);
+    const sub = subMatch ? subMatch[1] : '';
+
+    if (sub === 'exec' || sub === 'job-start') {
+      // Pull out the command after the ` -- ` separator.
+      const dashIdx = afterCli.indexOf(' -- ');
+      if (dashIdx >= 0) {
+        let inner = afterCli.slice(dashIdx + 4).trim();
+        if (
+          inner.length >= 2 &&
+          ((inner[0] === '"' && inner.endsWith('"')) ||
+            (inner[0] === "'" && inner.endsWith("'")))
+        ) {
+          inner = inner.slice(1, -1);
+        }
+        return inner;
+      }
+    }
+    if (sub === 'job-poll') return 'netcatty: poll job';
+    if (sub === 'job-stop') return 'netcatty: stop job';
+    if (sub === 'session') return 'netcatty: inspect session';
+    if (sub === 'env') return 'netcatty: list sessions';
+    if (sub === 'status') return 'netcatty: status';
+    if (sub) return `netcatty: ${sub}`;
+  }
+
+  return cmdString;
+}
+
+/**
  * Format tool result for display. Extracts stdout/stderr from structured
  * command results for terminal-like output.
  */
@@ -142,18 +215,22 @@ export const ToolCall = ({
           ? <ChevronDown size={12} className="text-muted-foreground/40 shrink-0" />
           : <ChevronRight size={12} className="text-muted-foreground/40 shrink-0" />
         }
-        {name === 'terminal_execute' && args?.command ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="font-mono text-muted-foreground/70 truncate cursor-default">
-                <span className="text-muted-foreground/40">$ </span>{String(args.command)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{String(args.command)}</TooltipContent>
-          </Tooltip>
-        ) : (
-          <span className="font-mono text-muted-foreground/70 truncate">{name}</span>
-        )}
+        {(() => {
+          const displayCmd = extractDisplayCommand(args);
+          if (displayCmd) {
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="font-mono text-muted-foreground/70 truncate cursor-default">
+                    <span className="text-muted-foreground/40">$ </span>{displayCmd}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{displayCmd}</TooltipContent>
+              </Tooltip>
+            );
+          }
+          return <span className="font-mono text-muted-foreground/70 truncate">{name}</span>;
+        })()}
         <span className="flex-1" />
         {/* Approval badge for resolved approvals */}
         {approvalStatus === 'approved' && (

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -42,7 +42,15 @@ module.exports = {
         '!electron/.dev-config.json',
         'skills/**/*',
         'public/**/*',
-        'node_modules/**/*'
+        'node_modules/**/*',
+        // @anthropic-ai/claude-agent-sdk@0.3.x bundles the native Claude Code
+        // CLI (~211MB per arch) as optional sibling packages. Netcatty is
+        // designed around the user's own Claude Code install — the wrapper
+        // honors `CLAUDE_CODE_EXECUTABLE` (set by useAgentDiscovery.ts) and
+        // only falls back to the bundled binary if that env var is empty.
+        // Excluding the sibling packages from the build keeps the installer
+        // ~150MB smaller and preserves the "bring your own Claude" design.
+        '!node_modules/@anthropic-ai/claude-agent-sdk-*/**/*'
     ],
     asarUnpack: [
         'node_modules/node-pty/**/*',

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -49,7 +49,7 @@ module.exports = {
         'node_modules/ssh2/**/*',
         'node_modules/cpu-features/**/*',
         'node_modules/@vscode/windows-process-tree/**/*',
-        'node_modules/@zed-industries/claude-agent-acp/**/*',
+        'node_modules/@agentclientprotocol/claude-agent-acp/**/*',
         'node_modules/@agentclientprotocol/sdk/**/*',
         'node_modules/@anthropic-ai/claude-agent-sdk/**/*',
         'node_modules/@zed-industries/codex-acp/**/*',

--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -394,7 +394,7 @@ function resolveClaudeAcpBinaryPath(shellEnv, electronModule) {
 
   // Packaged build (or dev fallback): use npm-bundled binary
   try {
-    const resolved = require.resolve("@zed-industries/claude-agent-acp/dist/index.js");
+    const resolved = require.resolve("@agentclientprotocol/claude-agent-acp/dist/index.js");
     const scriptPath = toUnpackedAsarPath(resolved);
 
     // On Windows, .js files cannot be spawned directly (no shebang support) —
@@ -429,12 +429,25 @@ function serializeStreamChunk(chunk) {
     case "reasoning-end":
       return { type: "reasoning-end", id: chunk.id ?? undefined };
     case "tool-call": {
-      // ACP wraps all tools as "acp.acp_provider_agent_dynamic_tool" —
-      // the real tool name and args are inside chunk.args
+      // ACP wraps all tools as "acp.acp_provider_agent_dynamic_tool".
+      // The real tool name and args are inside chunk.input — which the
+      // @mcpc-tech/acp-ai-provider emits as a JSON.stringified payload
+      // (see index.cjs, every controller.enqueue({ type: "tool-call", ...
+      // input: JSON.stringify({ toolCallId, toolName, args }) })). AI SDK
+      // may or may not pre-parse it before we see the chunk, so handle
+      // both string and object shapes.
       const isAcpWrapper = chunk.toolName === "acp.acp_provider_agent_dynamic_tool";
-      const acpInput = isAcpWrapper ? chunk.input : null;
+      let acpInput = null;
+      if (isAcpWrapper) {
+        const raw = chunk.input ?? chunk.args;
+        if (typeof raw === "string") {
+          try { acpInput = JSON.parse(raw); } catch { acpInput = null; }
+        } else if (raw && typeof raw === "object") {
+          acpInput = raw;
+        }
+      }
       let realToolName = isAcpWrapper ? (acpInput?.toolName || chunk.toolName) : chunk.toolName;
-      const realArgs = isAcpWrapper ? (acpInput?.args || chunk.args) : chunk.args;
+      const realArgs = isAcpWrapper ? (acpInput?.args || chunk.args || chunk.input) : (chunk.input ?? chunk.args);
       const realToolCallId = isAcpWrapper ? (acpInput?.toolCallId || chunk.toolCallId) : chunk.toolCallId;
       // Simplify MCP tool names: "mcp__netcatty-remote-hosts__get_environment" → "get_environment"
       if (realToolName && realToolName.includes("__")) {

--- a/infrastructure/ai/acpAgentAdapter.ts
+++ b/infrastructure/ai/acpAgentAdapter.ts
@@ -280,7 +280,13 @@ function handleStreamEvent(event: StreamEvent, callbacks: AcpAgentCallbacks): bo
     }
     case 'tool-call': {
       const toolName = (event.toolName as string) || 'unknown';
-      const input = (event.input as Record<string, unknown>) || {};
+      // The Electron bridge serializes tool args as `args` (see
+      // shellUtils.cjs serializeStreamChunk), while direct AI SDK paths
+      // use `input`. Read both so either source works.
+      const input =
+        (event.input as Record<string, unknown>) ||
+        (event.args as Record<string, unknown>) ||
+        {};
       const toolCallId = (event.toolCallId as string) || undefined;
       callbacks.onToolCall(toolName, input, toolCallId);
       return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@agentclientprotocol/claude-agent-acp": "0.37.0",
         "@ai-sdk/anthropic": "^3.0.58",
         "@ai-sdk/google": "^3.0.43",
         "@ai-sdk/openai": "^3.0.41",
@@ -17,7 +18,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/space-grotesk": "^5.2.10",
         "@google/genai": "1.33.0",
-        "@mcpc-tech/acp-ai-provider": "0.2.8",
+        "@mcpc-tech/acp-ai-provider": "0.3.3",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-collapsible": "1.1.12",
         "@radix-ui/react-context-menu": "2.2.16",
@@ -39,8 +40,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
-        "@zed-industries/claude-agent-acp": "0.22.2",
-        "@zed-industries/codex-acp": "0.10.0",
+        "@zed-industries/codex-acp": "0.15.0",
         "ai": "^6.0.116",
         "clsx": "2.1.1",
         "electron-updater": "^6.8.3",
@@ -88,6 +88,53 @@
       },
       "optionalDependencies": {
         "@vscode/windows-process-tree": "^0.7.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.37.0.tgz",
+      "integrity": "sha512-xZd/0tYQyUAQICMqx/msJJEtF07KJzUwQodHDrpUoaHG3miBKW635bLKo9kQInWYIhQ96ZJDhdSHHnH44e+KlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.22.1",
+        "@anthropic-ai/claude-agent-sdk": "0.3.146",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "bin": {
+        "claude-agent-acp": "dist/index.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@agentclientprotocol/sdk": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.22.1.tgz",
+      "integrity": "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.146.tgz",
+      "integrity": "sha512-hK9/Ng+hOyexUemTxdIUsSWJ9o2LFi2YNWzHwz8/YMCohUYOnFMZkBiENvUAb0WIc5hieOyBZrOIlg5OewuJMg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.146"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
@@ -206,27 +253,130 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.76",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.76.tgz",
-      "integrity": "sha512-HZxvnT8ZWkzCnQygaYCA0dl8RSUzuVbxE1YG4ecy6vh4nQbTT36CxUxBy+QVdR12pPQluncC0mCOLhI2918Eaw==",
-      "license": "SEE LICENSE IN README.md",
-      "engines": {
-        "node": ">=18.0.0"
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.146.tgz",
+      "integrity": "sha512-0IIvlEaenq2CRSVx5Bo5BaCtHQXS87GancM35WKEYveGVLn6DI+5G7ikYuTE4AKRPkMnogFtY4BJt6LulWGj+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.146.tgz",
+      "integrity": "sha512-Dk5xJ03Ff1JXbMRP1t2wc/TyfY6xF/2Ysp31wMhFPjoNiKSPHMWaIg242+T3CHdxLWmJ8plWHL1HL5cyZ/LCkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.146.tgz",
+      "integrity": "sha512-mzBXDDWWBAC/vDtAYpO1G/dq5QvJtYSPXsqcb+sNdcDhiuf4IYnYp7ytRncYlsUNDkLmX6Gk2jkWAHUUA2Lozg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.146.tgz",
+      "integrity": "sha512-QlCid0ucdrmhUAOewfQjaofN2wlokWcfFTxSFePTSj1umk35JO7TDFP700F7jU49r1fPWIdvJpPwWGyB0DeFPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.146.tgz",
+      "integrity": "sha512-B2baXU1tCBT5CVlD7jJMKjpC4xdO45NUIWpqImmwuOfKvlM/PITjyTXyTY662mGZf1dBmdqBBsqirwFH/jhi8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.146.tgz",
+      "integrity": "sha512-E3coK1ThQT08KIX80RLcsq7DWXFllCKOzoOe32it/bdtY56TBgPY9xemwXhIJ+cVBHTI9/MpBSIlKBcFCt+yQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.146.tgz",
+      "integrity": "sha512-CIwQxGX2r/yWpjCJ6ahB3smKXhghWgGTxL98+LGW52TUwqTiBnlNrH9DPqqgv1/+Hyquw6xfLrKU+StyfMgiLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.146.tgz",
+      "integrity": "sha512-qmxrsyaqA8s4HShqJls7ZCRjdoqN66Jo/hbjQNB3uHepD8tEO1iD19aPV4+osdLT7feMkhDBfLT07Q30R2NB5w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.99.0.tgz",
+      "integrity": "sha512-vdicFA9YjtvgpG8rxp39hqW4oxpkdRGPTq0QEts5TZhr2GkLozDduK/GiXrLQ7PzrKYBtIkQFdRW+QBjzlsABg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.34.2",
-        "@img/sharp-darwin-x64": "^0.34.2",
-        "@img/sharp-linux-arm": "^0.34.2",
-        "@img/sharp-linux-arm64": "^0.34.2",
-        "@img/sharp-linux-x64": "^0.34.2",
-        "@img/sharp-linuxmusl-arm64": "^0.34.2",
-        "@img/sharp-linuxmusl-x64": "^0.34.2",
-        "@img/sharp-win32-arm64": "^0.34.2",
-        "@img/sharp-win32-x64": "^0.34.2"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       },
       "peerDependencies": {
-        "zod": "^4.0.0"
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1158,6 +1308,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1379,6 +1530,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1803,7 +1963,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1825,7 +1984,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1842,7 +2000,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1857,7 +2014,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2723,310 +2879,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3265,12 +3117,13 @@
       }
     },
     "node_modules/@mcpc-tech/acp-ai-provider": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@mcpc-tech/acp-ai-provider/-/acp-ai-provider-0.2.8.tgz",
-      "integrity": "sha512-dO/sAT75JtNCbeIV1u9Wng5CHEdM5mDxmaeiT/JMB4UOkxajj8DNZVaP+Xi+rcBclqfhs58qKoqEI2GU4RzDaw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@mcpc-tech/acp-ai-provider/-/acp-ai-provider-0.3.3.tgz",
+      "integrity": "sha512-qWgE+/YFrGjYzgzb4ePFWlRPCI9wpyiVCS7hbWhixu3VT9WZfFFhzwx0hLuKWsRr7e4oe4hR5UqZBTf49bHzLQ==",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@ai-sdk/provider": "^3.0.0",
+        "@ai-sdk/provider-utils": "^4.0.0",
         "@modelcontextprotocol/sdk": "^1.8.0",
         "ai": "^6.0.0",
         "zod": "^3.24.2"
@@ -3286,10 +3139,11 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5817,6 +5671,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -6338,6 +6198,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -6418,6 +6279,7 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -6447,6 +6309,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6800,50 +6663,27 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/@zed-industries/claude-agent-acp": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/@zed-industries/claude-agent-acp/-/claude-agent-acp-0.22.2.tgz",
-      "integrity": "sha512-GLiKxy5MBNS9UoiE1XaM9EHVxlEcvk0sXSMCnyDp9JNAQliynt0axZrhptTl5AWe6PXGjVh5hMFdPp+yulw2uQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@agentclientprotocol/sdk": "0.16.1",
-        "@anthropic-ai/claude-agent-sdk": "0.2.76",
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "bin": {
-        "claude-agent-acp": "dist/index.js"
-      }
-    },
-    "node_modules/@zed-industries/claude-agent-acp/node_modules/@agentclientprotocol/sdk": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.16.1.tgz",
-      "integrity": "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
     "node_modules/@zed-industries/codex-acp": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.10.0.tgz",
-      "integrity": "sha512-vzwAUSHR7TaJh62JoE+6UD/HVm8fJbmMGsMBBMcHrKBIL7MF8yevlPDWVdoaDaGOsgqVZYRv9KhdT8ari0I4mg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.15.0.tgz",
+      "integrity": "sha512-eAv7sGBeiYrYkOulF729nrM51szS7WIhBtugRj5wWq6csRKZUhAZfoUZlF8xUWdHPtOIzd/eT6MNG6gMHu6z0w==",
       "license": "Apache-2.0",
       "bin": {
         "codex-acp": "bin/codex-acp.js"
       },
       "optionalDependencies": {
-        "@zed-industries/codex-acp-darwin-arm64": "0.10.0",
-        "@zed-industries/codex-acp-darwin-x64": "0.10.0",
-        "@zed-industries/codex-acp-linux-arm64": "0.10.0",
-        "@zed-industries/codex-acp-linux-x64": "0.10.0",
-        "@zed-industries/codex-acp-win32-arm64": "0.10.0",
-        "@zed-industries/codex-acp-win32-x64": "0.10.0"
+        "@zed-industries/codex-acp-darwin-arm64": "0.15.0",
+        "@zed-industries/codex-acp-darwin-x64": "0.15.0",
+        "@zed-industries/codex-acp-linux-arm64": "0.15.0",
+        "@zed-industries/codex-acp-linux-x64": "0.15.0",
+        "@zed-industries/codex-acp-win32-arm64": "0.15.0",
+        "@zed-industries/codex-acp-win32-x64": "0.15.0"
       }
     },
     "node_modules/@zed-industries/codex-acp-darwin-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-arm64/-/codex-acp-darwin-arm64-0.10.0.tgz",
-      "integrity": "sha512-zlIZH+X2aEfxC5UgnIoYbX0cG3/MpRUsQAGJbrcBbgKp0mhuBFtMJHZ426JC5rb3pv8amo1MmDeARZUQ99U/CQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-arm64/-/codex-acp-darwin-arm64-0.15.0.tgz",
+      "integrity": "sha512-9/tnj1fXeXIONgr+5FGwr3bkqd4jaORdr3X9/k++rzHW+UIzvgIeXrJKv43403gtuKp0BoxdzsFxe2qsAQhhkw==",
       "cpu": [
         "arm64"
       ],
@@ -6857,9 +6697,9 @@
       }
     },
     "node_modules/@zed-industries/codex-acp-darwin-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-x64/-/codex-acp-darwin-x64-0.10.0.tgz",
-      "integrity": "sha512-TFMF9YqfWplnYpWRaUauRbtps1ow1S47MVcBv21/Sd55gRMWWYWSogRLDyAcoMC4y9pdI2bYhx33u7jYhJnj5w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-x64/-/codex-acp-darwin-x64-0.15.0.tgz",
+      "integrity": "sha512-2cmflnVYM5yzvNu4ldff6OsfLzQThFToPszCT3t7jytWuG28V+W1cUEGsvFJGNkGC1Wo29Z4w5LZ3wyfOkvPxg==",
       "cpu": [
         "x64"
       ],
@@ -6873,9 +6713,9 @@
       }
     },
     "node_modules/@zed-industries/codex-acp-linux-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-arm64/-/codex-acp-linux-arm64-0.10.0.tgz",
-      "integrity": "sha512-tIm0uGKZuirZyqx9KAgIgh6cimVXdh+BMTFyUfH1xnez5Y3B6oFxzup/ZIP34OZ/W59Cnfi4wcIL3No0VV6Kmw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-arm64/-/codex-acp-linux-arm64-0.15.0.tgz",
+      "integrity": "sha512-ioCXCiZMd4v7Eqyed9Iz4xcPKsZbSH157wOitsWQKxUiX43c1Ti5fykZcrh9cNSLOgiGmI3V2nbYp0aTf66grQ==",
       "cpu": [
         "arm64"
       ],
@@ -6889,9 +6729,9 @@
       }
     },
     "node_modules/@zed-industries/codex-acp-linux-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-x64/-/codex-acp-linux-x64-0.10.0.tgz",
-      "integrity": "sha512-oiiN35wsecX1OwesV/KIu72o1OSw+OWFL86vQUUZTdfMXr9eyYFP1uZYLMxIx+tkhlJnm7KHC5L4raDg/MLVtA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-x64/-/codex-acp-linux-x64-0.15.0.tgz",
+      "integrity": "sha512-WtqI8KGX9z7XvdkazumYraoDwpip5lFBRtFXoIwYCSBoDZdOqQsfNQndIfTDttfQ1BdZYKczDnrfbRaiIFU9UA==",
       "cpu": [
         "x64"
       ],
@@ -6905,9 +6745,9 @@
       }
     },
     "node_modules/@zed-industries/codex-acp-win32-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-arm64/-/codex-acp-win32-arm64-0.10.0.tgz",
-      "integrity": "sha512-dfybabjibQQpXUs9TjwLjg+mrj8tGSopVcwkFy8u3XG4hrBZVCri91dtVhm7hs98lZlawxwiiPuj4Pmg+4hHyQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-arm64/-/codex-acp-win32-arm64-0.15.0.tgz",
+      "integrity": "sha512-L+OFIPOzAuxsImlq8E227MZxgujMLMEJSqiR9QjZq8fiIFCKh/HnxmvyXvjWaHbJdb1pZ09WKe3MNwV9ln/+GQ==",
       "cpu": [
         "arm64"
       ],
@@ -6921,9 +6761,9 @@
       }
     },
     "node_modules/@zed-industries/codex-acp-win32-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-x64/-/codex-acp-win32-x64-0.10.0.tgz",
-      "integrity": "sha512-xCm3xsE3lD66DlbaLKBqHahPY1Lhb+rGu2IIq60qUsBGiYcSXtpRjQ1LXI/Sym6iCKrPo+eQP0j6rg7CPh1AGw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-x64/-/codex-acp-win32-x64-0.15.0.tgz",
+      "integrity": "sha512-LDnADpCg1Rzbkyxs4hMaOvRwNa68KLp8CoNVom8ZE/sChSvcDrj/RCoMsZWrARJGWs7EQ9zYeLoeVk5VcVQoPQ==",
       "cpu": [
         "x64"
       ],
@@ -6997,6 +6837,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7047,6 +6888,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7630,6 +7472,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8372,8 +8215,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -8657,6 +8499,7 @@
       "integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.7.0",
         "builder-util": "26.4.1",
@@ -9038,7 +8881,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -9059,7 +8901,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9289,6 +9130,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9723,6 +9565,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -10667,6 +10515,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11240,6 +11089,19 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12156,6 +12018,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -12773,7 +12636,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13028,7 +12892,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -13041,6 +12904,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -13815,7 +13679,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -13833,7 +13696,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14024,6 +13886,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14033,6 +13896,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15086,6 +14950,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -15363,7 +15237,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -15428,7 +15301,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -15503,6 +15375,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15592,6 +15465,12 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -15617,6 +15496,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -15715,6 +15595,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15735,6 +15616,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -16073,6 +15955,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16166,6 +16049,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16444,6 +16328,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts lib/*.test.ts"
   },
   "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "0.37.0",
     "@ai-sdk/anthropic": "^3.0.58",
     "@ai-sdk/google": "^3.0.43",
     "@ai-sdk/openai": "^3.0.41",
@@ -43,7 +44,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/space-grotesk": "^5.2.10",
     "@google/genai": "1.33.0",
-    "@mcpc-tech/acp-ai-provider": "0.2.8",
+    "@mcpc-tech/acp-ai-provider": "0.3.3",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-context-menu": "2.2.16",
@@ -65,8 +66,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
-    "@zed-industries/claude-agent-acp": "0.22.2",
-    "@zed-industries/codex-acp": "0.10.0",
+    "@zed-industries/codex-acp": "0.15.0",
     "ai": "^6.0.116",
     "clsx": "2.1.1",
     "electron-updater": "^6.8.3",


### PR DESCRIPTION
## Summary

- Bump three ACP-related deps. The Claude package was renamed upstream, so this also migrates scope.
  - `@zed-industries/claude-agent-acp@0.22.2` → `@agentclientprotocol/claude-agent-acp@0.37.0` (old npm package is explicitly deprecated)
  - `@zed-industries/codex-acp` `0.10.0` → `0.15.0`
  - `@mcpc-tech/acp-ai-provider` `0.2.8` → `0.3.3`
  - `electron-builder` asarUnpack glob and the `require.resolve` in `shellUtils.cjs` follow the scope rename.
- Fix the regression that fell out of the upgrade: under Skill+CLI mode, Codex tool-call cards in the chat panel started showing the local worktree path instead of the actual remote command.
- Exclude the new `@anthropic-ai/claude-agent-sdk-*` per-arch sibling packages from the installer so we don't silently start shipping a 211MB Claude binary alongside Netcatty's existing "bring your own Claude" design.

## Why the tool-call panel broke after the upgrade

Three things lined up:

1. The new `@mcpc-tech/acp-ai-provider` maps ACP's `title` field to `toolName`. Codex's `title` is the full shell invocation it's about to run, which under Skill+CLI mode is `"…/netcatty-tool-cli" exec --session … -- "<real-cmd>"` — so the panel ended up showing `Run /Users/…/netcatty-tool-cli session --session …`.
2. Codex's `local_shell` ships args as `["/bin/zsh","-lc","<full>"]` (array), not as a string. The previous \`typeof args.command === 'string'\` branch in `ToolCall` therefore never fired and we fell back to printing `name` (the title).
3. The Electron bridge serializes tool args under `args`, but `acpAgentAdapter` only read `event.input`. Even when args _were_ present, the renderer received `{}`.

## Why we don't ship the bundled Claude binary

`@anthropic-ai/claude-agent-sdk@0.3.x` restructured: the native Claude Code CLI moved out of the main package and into per-arch optional siblings (`claude-agent-sdk-{darwin,linux,win32}-{x64,arm64}[-musl]`, ~211MB each). Netcatty's design has always been **bring your own Claude Code** — the entire path-discovery flow exists to honor that:

- `useAgentDiscovery.ts` scans `PATH` for the user's local `claude` and writes the absolute path into `env.CLAUDE_CODE_EXECUTABLE`.
- `aiBridge.cjs` calls `normalizeClaudeCodeExecutableEnvForAcp(env)` on every ACP spawn, forwarding the env var to the child process.
- The `@agentclientprotocol/claude-agent-acp` wrapper's `claudeCliPath()` (`acp-agent.js`) prefers `process.env.CLAUDE_CODE_EXECUTABLE` over the bundled binary and only falls back to sibling-package resolution when the env var is empty.

So the right place to enforce the design is `electron-builder.config.cjs`'s `files` glob: exclude `node_modules/@anthropic-ai/claude-agent-sdk-*/**/*` from the build entirely. Dev mode is unaffected (optional deps still install into `node_modules`); only the packaged installer drops the binaries, saving ~150MB. Users without Claude Code installed get the same SDK error (`Claude native binary not found … set CLAUDE_CODE_EXECUTABLE`) they got pre-upgrade.

## What changed

- **`infrastructure/ai/acpAgentAdapter.ts`** — read tool input from both `event.input` and `event.args`, so the bridge-serialized chunks and direct AI SDK chunks both work.
- **`components/ai-elements/tool-call.tsx`** — new `extractDisplayCommand()` helper:
  - Unwraps the `["sh","-c", …]` / `["/bin/zsh","-lc", …]` array form.
  - Detects the `netcatty-tool-cli <sub> … -- <real-cmd>` wrapper and surfaces `<real-cmd>` for `exec` / `job-start`.
  - For non-exec subcommands (`session`, `env`, `status`, `job-poll`, `job-stop`) renders a short label like `netcatty: inspect session` instead of exposing the binary path.
  - Falls back cleanly to the tool name when no command can be recovered.
- **`electron/bridges/ai/shellUtils.cjs`** — defensive JSON-parse of the ACP wrapper input in case AI SDK ever stops auto-parsing it; `require.resolve` updated to the new package name.
- **`electron-builder.config.cjs`** —
  - asarUnpack glob and require paths follow the `@agentclientprotocol` scope rename.
  - `files` excludes `node_modules/@anthropic-ai/claude-agent-sdk-*/**/*` to preserve the BYO Claude design and avoid a ~150MB installer bloat.
- **`package.json` / `package-lock.json`** — the dependency bumps described above.

## Before / after

| Before | After |
| --- | --- |
| `Run "/Users/…/netcatty-tool-cli" session --session 74e4…` | `$ netcatty: inspect session` |
| `Run "/Users/…/netcatty-tool-cli" exec --session … -- "hostname && uname -a && lscpu \| sed …"` | `$ hostname && uname -a && lscpu \| sed …` |

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 1298 pass / 0 fail (3 skipped, unchanged from baseline)
- [x] `npm run build` succeeds
- [x] `npm run dev` — Codex CLI agent, ran a multi-command server check; tool-call cards now show the actual remote command (`$ hostname && uname -a && …`) and the netcatty subcommand short labels (`$ netcatty: inspect session`). No `Cannot find module @agentclientprotocol/claude-agent-acp` or related runtime errors.
- [ ] Reviewer to also smoke-test the Claude Agent (ACP) chat — same code path, but tool args shape is `{command: "<string>"}` so `extractDisplayCommand` falls through cleanly to the original string branch.
- [ ] Reviewer to confirm with a packaged build (e.g. `npm run pack:mac`) that `app.asar` does not contain `node_modules/@anthropic-ai/claude-agent-sdk-*` and that the installer is ~150MB smaller than a build without the exclusion.

## Codex automated review

Codex flagged a P1 on this PR before the build exclusion was added — it correctly observed the new sibling packages weren't being unpacked from asar. The initial fix (8e46b194, now squashed away) added them to `asarUnpack`; the final version takes the better route and removes them from packaging entirely. Discussion in [the inline thread](https://github.com/binaricat/Netcatty/pull/1128#discussion_r3311706767).

## Known follow-up (not in this PR)

While testing, the renderer log surfaced an unrelated `toolResult is not iterable` from `@mcpc-tech/acp-ai-provider`'s `formatToolError` — its `for (const blk of toolResult)` doesn't guard against object-shaped `rawOutput`. Only affects failed tool calls (the error message is lost). Tracking separately; can be patched via `patch-package` or fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
