### PR TITLE
fix(ai): prefix wrapped AI commands with a leading space

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -152,8 +152,12 @@ function buildWrappedCommand(command, shellKind, marker) {
     }
 
     case "fish":
+      // Leading space: see the comment in the POSIX branch below. Fish
+      // does not skip leading-space commands by default, but users can
+      // define a `fish_should_add_to_history` function that filters them
+      // — this prefix is what lets that opt-in actually take effect.
       return (
-        `set ${marker} 0; function __ncmcp_int --on-signal INT; printf '%s\\n' '${marker}_E:130'; functions -e __ncmcp_int; end; ` +
+        ` set ${marker} 0; function __ncmcp_int --on-signal INT; printf '%s\\n' '${marker}_E:130'; functions -e __ncmcp_int; end; ` +
         `set -l ${marker}_cmd '${escapeFishSingleQuoted(command)}'; ` +
         `begin; set -gx PAGER cat; set -gx SYSTEMD_PAGER ''; set -gx GIT_PAGER cat; set -gx LESS ''; ` +
         `printf '%s\\n' '${marker}_S'; eval \$${marker}_cmd; set __NCMCP_rc $status; ` +
@@ -185,8 +189,15 @@ function buildWrappedCommand(command, shellKind, marker) {
       //    preventing the shell from aborting the compound command.
       const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
       const escaped = escapePosixSingleQuoted(command);
+      // Leading single space: lets bash/zsh skip recording this command
+      // in history when the user already has HISTCONTROL=ignorespace
+      // (bash) or HIST_IGNORE_SPACE (zsh) configured — Debian/Ubuntu and
+      // most Oh-My-Zsh setups have this on by default; CentOS/RHEL users
+      // can opt in by adding `HISTCONTROL=ignoreboth` to ~/.bashrc.
+      // Without that config the prefix is harmless; it just doesn't
+      // suppress history recording.
       return (
-        `${marker}=0; ${marker}_cmd='${escaped}'; { printf '%s\\n' '${marker}_S'; trap ':' INT; ${noPager}eval "$${marker}_cmd"; __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }\n`
+        ` ${marker}=0; ${marker}_cmd='${escaped}'; { printf '%s\\n' '${marker}_S'; trap ':' INT; ${noPager}eval "$${marker}_cmd"; __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }\n`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Prefix the POSIX (bash/zsh/dash) and Fish AI-command wrappers in `electron/bridges/ai/ptyExec.cjs` with a leading single space so the shells that already honor "ignore leading-space" naturally skip recording these wrappers to history.

## Why

Netcatty's AI / Skill+CLI integration sends marker-wrapped commands (`__NCMCP_xxx=0; { ... eval ...; }`) directly into the user's interactive shell. `preload.cjs` filters the PTY echo so the wrappers don't show in the visible terminal, but the remote shell still records them into `~/.bash_history` — so when the user later inspects history they see a long stretch of unreadable sentinel-laden lines.

The cheapest mitigation that respects existing user shell configuration is the leading-space convention. The bash/zsh ecosystem widely supports `HISTCONTROL=ignorespace` (bash) / `setopt HIST_IGNORE_SPACE` (zsh) — when set, a command beginning with whitespace is not added to history.

## What changed

Only `electron/bridges/ai/ptyExec.cjs` — both the POSIX branch and the Fish branch of `buildWrappedCommand` now produce a wrapper that starts with `' '`. Four characters of effective behavior + explanatory comments.

PowerShell, cmd, network-device, and serial paths are untouched on purpose:
- PowerShell history (PSReadLine) uses a different mechanism and doesn't recognize leading-space.
- cmd does not persist history across sessions.
- Network-device / vendor CLIs (Huawei VRP, Cisco IOS, etc.) don't run a POSIX shell and shouldn't be touched.

## Coverage by default

| Shell / config | Honors leading-space in history? |
|---|---|
| bash on Debian/Ubuntu | ✅ default `HISTCONTROL=ignoreboth` includes `ignorespace` |
| bash on macOS / Homebrew | ✅ |
| zsh under Oh-My-Zsh / Prezto | ✅ default `setopt HIST_IGNORE_SPACE` |
| zsh / Arch / Manjaro common templates | ✅ |
| bash on RHEL / CentOS 7/8 (default) | ❌ default `HISTCONTROL=ignoredups` |
| Vanilla zsh without OMZ | ❌ |
| Fish (default) | ❌ |

For the rows that don't honor it out of the box, the leading space is a harmless no-op and the wrapper still records to history as before — same situation as today.

## Known limitations & user opt-in (documented in code comments)

Users on shells/configs that don't honor leading-space by default can opt in:

- bash: add `HISTCONTROL=ignoreboth` to `~/.bashrc` (preserves any existing `ignoredups` semantics).
- zsh: add `setopt HIST_IGNORE_SPACE` to `~/.zshrc`.
- Fish: define a `fish_should_add_to_history` function that returns `0` for leading-space input. Example:

  ```fish
  function fish_should_add_to_history
      string match -q ' *' -- "$argv"; and return 1; or return 0
  end
  funcsave fish_should_add_to_history
  ```

We deliberately do **not** mutate `HISTCONTROL` from Netcatty's side at session start. The earlier exploration of that path ran into three real problems:
1. Injecting `export HISTCONTROL=…` into the interactive shell channel produces a visible PTY echo (unless wrapped in our `__NCMCP_` marker for `preload.cjs` to filter, which adds complexity).
2. On hosts that already had `ignorespace` set, the injection's own line is not recorded — so a follow-up `history -d $(history 1)` would silently delete an unrelated previous history entry.
3. The same POSIX snippet is a parse error on PowerShell / cmd, and the `2>/dev/null` redirect that silences errors on bash/fish is itself a parse error on PowerShell.

A future iteration could detect the shell from the first PS1 and selectively inject — but that's a separate change with its own complexity, and the leading-space prefix already covers the dominant case (bash/zsh on Debian/Ubuntu/macOS, plus all OMZ-style zsh setups).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 1301 pass / 0 fail / 3 skipped (unchanged from baseline; this PR adds no new tests because the change is a content-level prefix to two return strings, easier to verify by reading the diff than by mocking PTY)
- [ ] Manual check on `~/.bash_history` after an AI session against:
  - [ ] An Ubuntu/Debian host (expect: no `__NCMCP_*` entries)
  - [ ] A CentOS/RHEL host (expect: `__NCMCP_*` entries still present; documented limitation)
  - [ ] After adding `HISTCONTROL=ignoreboth` to that CentOS host's `.bashrc` (expect: no entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
