### PR TITLE
[codex] Fix packaged MCP blocklist assets

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -63,6 +63,8 @@ module.exports = {
         'node_modules/@zed-industries/codex-acp/**/*',
         'node_modules/@zed-industries/codex-acp-*/**/*',
         'node_modules/@modelcontextprotocol/sdk/**/*',
+        'lib/**/*.cjs',
+        'lib/**/*.json',
         'node_modules/zod/**/*',
         'node_modules/zod-to-json-schema/**/*',
         'node_modules/ajv/**/*',

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -1,0 +1,19 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const config = require("../electron-builder.config.cjs");
+
+test("unpacked MCP server includes its shared CommonJS dependencies", () => {
+  assert.ok(
+    config.asarUnpack.includes("electron/mcp/**/*"),
+    "MCP server must stay unpacked so Codex can launch it as a child process",
+  );
+  assert.ok(
+    config.asarUnpack.includes("lib/**/*.cjs"),
+    "MCP server requires ../../lib/commandBlocklist.cjs from the unpacked runtime path",
+  );
+  assert.ok(
+    config.asarUnpack.includes("lib/**/*.json"),
+    "unpacked lib CommonJS modules require sibling JSON data files at runtime",
+  );
+});


### PR DESCRIPTION
## Summary
- unpack shared lib CommonJS and JSON assets alongside the unpacked MCP server
- add a packaging config regression test for the MCP server shared dependencies

## Root cause
The packaged MCP entrypoint runs from `app.asar.unpacked/electron/mcp`, but `lib/commandBlocklist.cjs` and its sibling `commandBlocklist.json` stayed inside `app.asar`. That made the MCP process exit during startup before Codex could finish the initialize handshake.

Fixes #1130.

## Validation
- `npm run lint`
- `npm test`
- `npm run pack:dir`
- verified `release/mac-arm64/Netcatty.app/Contents/Resources/app.asar.unpacked/lib/commandBlocklist.cjs` exists
- verified `release/mac-arm64/Netcatty.app/Contents/Resources/app.asar.unpacked/lib/commandBlocklist.json` exists
- launched the packaged MCP entrypoint with a dummy port and confirmed it now reaches the expected connection failure instead of a missing-file crash