### PR TITLE
fix(vault): flat Vaults tab selection + fill host grid beside side panel

### DIFF
--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -280,9 +280,22 @@ interface RootTopTabProps {
 
 const RootTopTab: React.FC<RootTopTabProps> = memo(({ tabId, label, icon, className }) => {
   const isActive = useIsTabActive(tabId);
-  const handleClick = useCallback(() => {
+  // The Vaults tab is the app's persistent "home", so keep its selected state
+  // visually flat — no active background fill (the label/icon still brighten to
+  // the active foreground for subtle feedback). Other root tabs (SFTP) keep the
+  // normal filled active state.
+  const suppressActiveBg = tabId === 'vault';
+  const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // Flat tabs never change their React-managed backgroundColor (transparent
+    // when inactive AND active), so React can't diff transparent → transparent
+    // to clear the hover fill that onMouseEnter wrote imperatively. Clicking
+    // straight from a hover would otherwise leave a stuck highlight, so reset
+    // it here before activating.
+    if (suppressActiveBg) {
+      e.currentTarget.style.backgroundColor = 'transparent';
+    }
     activeTabStore.setActiveTabId(tabId);
-  }, [tabId]);
+  }, [tabId, suppressActiveBg]);
 
   return (
     <div
@@ -295,7 +308,7 @@ const RootTopTab: React.FC<RootTopTabProps> = memo(({ tabId, label, icon, classN
         className,
       )}
       style={{
-        backgroundColor: isActive
+        backgroundColor: isActive && !suppressActiveBg
           ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
           : 'transparent',
         color: isActive

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -303,6 +303,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [editingHost, setEditingHost] = useState<Host | null>(null);
   const [newHostGroupPath, setNewHostGroupPath] = useState<string | null>(null);
 
+  // When the side panel is open, Tailwind's viewport-based grid-cols-* can't
+  // react to the narrowed content area, so we drive the host-grid column count
+  // off the actual container width (measured below). A fixed column count keeps
+  // a lone card at one column's width instead of stretching it across the row
+  // the way auto-fit + 1fr would. The count is published as a CSS variable
+  // (set imperatively) rather than React state, so re-flowing the grid never
+  // re-renders this (large) component during panel transitions / window resize.
+  const hostListScrollRef = useRef<HTMLDivElement>(null);
+  const splitGridColsRef = useRef(0);
+
   // Close host panel if the host being edited was deleted.
   // Track previous host IDs so we only close for actual deletions, not for
   // unsaved new/duplicated hosts whose IDs were never in the hosts array.
@@ -1520,12 +1530,41 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const hasHostsSidePanel =
     isHostsSectionActive &&
     ((isGroupPanelOpen && !!editingGroupPath) || isHostPanelOpen);
+  // Fixed N columns (not auto-fit) so populated rows fill the width with no
+  // trailing gap AND a section with a single card (e.g. Pinned) keeps it at one
+  // column's width instead of stretching it across the whole row — matching the
+  // no-panel grid-cols-* behaviour, just measured from the container. The actual
+  // column count rides on the --vault-grid-cols custom property (set by the
+  // ResizeObserver below); the fallback applies until the first measurement.
   const splitViewGridStyle = hasHostsSidePanel
-    ? {
-      gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 220px), 280px))",
-      justifyContent: "start" as const,
-    }
+    ? { gridTemplateColumns: "var(--vault-grid-cols, repeat(2, minmax(0, 1fr)))" }
     : undefined;
+
+  // Track the host-list container width and derive the column count the same way
+  // the auto-fit grid did (≈220px min card + 12px gap), but as a fixed count so
+  // lone cards don't stretch. We write the whole grid-template-columns value into
+  // a CSS variable imperatively (no setState) and only when the count actually
+  // changes, so panel transitions / window resizing reflow the grid natively
+  // without re-rendering this component.
+  useEffect(() => {
+    const el = hostListScrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const GAP = 12; // matches gap-3
+    const MIN_CARD = 220;
+    const PADDING_X = 32; // matches px-4 on both sides
+    const recompute = () => {
+      const usable = el.clientWidth - PADDING_X;
+      if (usable <= 0) return; // hidden / not laid out yet
+      const next = Math.max(1, Math.floor((usable + GAP) / (MIN_CARD + GAP)));
+      if (next === splitGridColsRef.current) return;
+      splitGridColsRef.current = next;
+      el.style.setProperty("--vault-grid-cols", `repeat(${next}, minmax(0, 1fr))`);
+    };
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const isSameDropTarget = useCallback((a: DropTarget | null, b: DropTarget | null) => {
     if (!a || !b) return a === b;
@@ -2084,6 +2123,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
         {/* Keep hosts mounted so switching sections does not reset scroll or remount the list. */}
         <div
+          ref={hostListScrollRef}
           className={cn(
             "flex-1 overflow-auto px-4 py-4 space-y-6",
             !isHostsSectionActive && "hidden",


### PR DESCRIPTION
## Summary
Two small Vault-view polish fixes (both renderer-only):

- **Vaults tab** no longer fills with the active background when selected — it stays flat (text/icon still brighten for feedback). Matches the "home" feel; SFTP and other tabs keep their normal filled active state. Also clears the imperative hover fill on click so it can't get stuck (active bg is now transparent, so React can't diff it away).
- **Host grid beside the side panel** now fills the available width instead of leaving a big empty strip on the right. When the side panel is open, Tailwind's viewport-based `grid-cols-*` can't react to the narrowed content area, so the column count is derived from the container width as a **fixed N columns**:
  - multi-card sections fill the row with no trailing gap;
  - a lone card (e.g. Pinned) stays at one column's width instead of stretching across the whole row (the side effect of the earlier `auto-fit + 1fr` attempt);
  - the count rides on a CSS variable set imperatively via `ResizeObserver`, so reflowing the grid **never re-renders** the (large) VaultView component during panel transitions / window resize.

## Test plan
- [x] `tsc` — no new type errors in the touched files (only pre-existing unrelated ones remain)
- [x] `eslint components/TopTabs.tsx components/VaultView.tsx` — clean
- [x] `node --test` VaultView suites (memo + sortPersistence) — 5/5 pass
- [ ] Manual: open the "New Host" side panel → host grid fills width, Pinned single card stays one column wide; toggle Vaults/SFTP tabs → Vaults flat on select, no stuck hover bg; panel open/close stays smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)