### PR TITLE
[codex] Fix storage change render warning

### DIFF
--- a/infrastructure/persistence/localStorageAdapter.ts
+++ b/infrastructure/persistence/localStorageAdapter.ts
@@ -9,7 +9,10 @@ const safeParse = <T>(value: string | null): T | null => {
 
 export const LOCAL_STORAGE_ADAPTER_CHANGED_EVENT = 'netcatty:local-storage-adapter-changed';
 
-function emitLocalStorageAdapterChanged(key: string): void {
+const pendingChangedKeys = new Set<string>();
+let emitChangedKeysTimer: ReturnType<typeof setTimeout> | null = null;
+
+function dispatchLocalStorageAdapterChanged(key: string): void {
   try {
     const target = globalThis as typeof globalThis & {
       dispatchEvent?: (event: Event) => boolean;
@@ -23,6 +26,22 @@ function emitLocalStorageAdapterChanged(key: string): void {
   } catch {
     // ignore
   }
+}
+
+function emitLocalStorageAdapterChanged(key: string): void {
+  pendingChangedKeys.add(key);
+  if (emitChangedKeysTimer) return;
+
+  // Defer same-window storage notifications so React render-phase writes do
+  // not synchronously trigger state updates in unrelated components.
+  emitChangedKeysTimer = setTimeout(() => {
+    emitChangedKeysTimer = null;
+    const keys = Array.from(pendingChangedKeys);
+    pendingChangedKeys.clear();
+    for (const changedKey of keys) {
+      dispatchLocalStorageAdapterChanged(changedKey);
+    }
+  }, 0);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Defer same-window localStorage change notifications so they no longer fire during React render.
- Coalesce repeated key notifications in the same tick before dispatching.
- Fixes the warning where App state was updated while AIStateProviderInner was rendering.

## Validation
- `npm run lint -- --max-warnings=0`
- `npm run build`
- `npm test`
- localStorageAdapter async notification probe