### PR TITLE
fix(ssh): support PKCS#8 private keys (#1139)

### DIFF
--- a/electron/bridges/privateKeyNormalizer.cjs
+++ b/electron/bridges/privateKeyNormalizer.cjs
@@ -1,0 +1,103 @@
+/**
+ * Private key normalizer.
+ *
+ * ssh2's key parser only understands OpenSSH, legacy PKCS#1/SEC1
+ * (`BEGIN RSA/DSA/EC PRIVATE KEY`) and PuTTY keys. It rejects PKCS#8
+ * (`-----BEGIN PRIVATE KEY-----` / `-----BEGIN ENCRYPTED PRIVATE KEY-----`)
+ * with "Unsupported key format", even though such keys are valid and accepted
+ * by other clients (e.g. Termius). See issue #1139.
+ *
+ * Node's crypto can read PKCS#8 and re-export RSA/EC keys in the legacy PEM
+ * forms ssh2 accepts, so we transparently convert them before handing the key
+ * to ssh2. Ed25519 (and other) PKCS#8 keys have no legacy PEM representation
+ * and surface a clear, actionable error instead of ssh2's opaque one.
+ */
+
+const crypto = require("node:crypto");
+const { utils: sshUtils } = require("ssh2");
+
+const PKCS8_HEADER_RE = /-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----/;
+
+// Node asymmetricKeyType -> legacy PEM export type that ssh2 can parse.
+const LEGACY_EXPORT_TYPE = {
+  rsa: "pkcs1",
+  ec: "sec1",
+};
+
+class PrivateKeyPassphraseError extends Error {
+  constructor(message) {
+    super(message || "Incorrect passphrase for private key");
+    this.name = "PrivateKeyPassphraseError";
+    this.code = "ERR_PRIVATE_KEY_PASSPHRASE";
+  }
+}
+
+class UnsupportedPrivateKeyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UnsupportedPrivateKeyError";
+    this.code = "ERR_PRIVATE_KEY_UNSUPPORTED";
+  }
+}
+
+/**
+ * Normalize a private key into a form ssh2 can parse.
+ *
+ * @param {string} privateKey - PEM private key contents.
+ * @param {string} [passphrase] - Passphrase, if the key is encrypted.
+ * @returns {{ privateKey: string, passphrase: string|undefined, converted: boolean }}
+ * @throws {PrivateKeyPassphraseError} Encrypted PKCS#8 with a wrong/missing passphrase.
+ * @throws {UnsupportedPrivateKeyError} PKCS#8 key whose type has no legacy PEM form (e.g. Ed25519).
+ */
+function normalizePrivateKeyForSsh2(privateKey, passphrase) {
+  if (typeof privateKey !== "string" || privateKey.length === 0) {
+    return { privateKey, passphrase, converted: false };
+  }
+
+  // If ssh2 already understands the key, leave it exactly as-is.
+  const parsed = sshUtils.parseKey(privateKey, passphrase);
+  if (parsed && !(parsed instanceof Error)) {
+    return { privateKey, passphrase, converted: false };
+  }
+
+  // We can only rescue PKCS#8 keys, which Node's crypto can read.
+  if (!PKCS8_HEADER_RE.test(privateKey)) {
+    return { privateKey, passphrase, converted: false };
+  }
+
+  const encrypted = privateKey.includes("-----BEGIN ENCRYPTED PRIVATE KEY-----");
+
+  let keyObject;
+  try {
+    keyObject = crypto.createPrivateKey(
+      passphrase ? { key: privateKey, passphrase } : privateKey,
+    );
+  } catch (err) {
+    if (encrypted) {
+      throw new PrivateKeyPassphraseError(
+        "Could not decrypt the PKCS#8 private key with the provided passphrase",
+      );
+    }
+    throw new UnsupportedPrivateKeyError(
+      `Unable to read the PKCS#8 private key: ${err.message}. ` +
+        "Convert it with `ssh-keygen -p -m PEM -f <key>` and try again.",
+    );
+  }
+
+  const exportType = LEGACY_EXPORT_TYPE[keyObject.asymmetricKeyType];
+  if (!exportType) {
+    throw new UnsupportedPrivateKeyError(
+      `Private keys of type "${keyObject.asymmetricKeyType}" in PKCS#8 format are not supported. ` +
+        "Convert it to OpenSSH format with `ssh-keygen -p -f <key>` and try again.",
+    );
+  }
+
+  const converted = keyObject.export({ type: exportType, format: "pem" }).toString();
+  return { privateKey: converted, passphrase: undefined, converted: true };
+}
+
+module.exports = {
+  normalizePrivateKeyForSsh2,
+  PrivateKeyPassphraseError,
+  UnsupportedPrivateKeyError,
+};

--- a/electron/bridges/privateKeyNormalizer.test.cjs
+++ b/electron/bridges/privateKeyNormalizer.test.cjs
@@ -1,0 +1,92 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { utils: sshUtils } = require("ssh2");
+
+const {
+  normalizePrivateKeyForSsh2,
+  PrivateKeyPassphraseError,
+  UnsupportedPrivateKeyError,
+} = require("./privateKeyNormalizer.cjs");
+
+function genRsa(encoding) {
+  return crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: encoding,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  }).privateKey;
+}
+
+const rsaPkcs8 = () => genRsa({ type: "pkcs8", format: "pem" });
+const rsaPkcs1 = () => genRsa({ type: "pkcs1", format: "pem" });
+const encryptedRsaPkcs8 = (passphrase) =>
+  genRsa({ type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase });
+const ecPkcs8 = () =>
+  crypto.generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  }).privateKey;
+const ed25519Pkcs8 = () =>
+  crypto.generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  }).privateKey;
+
+function parseOk(key) {
+  const r = sshUtils.parseKey(key);
+  return r && !(r instanceof Error) ? r : null;
+}
+
+test("converts unencrypted RSA PKCS#8 into an ssh2-parseable key", () => {
+  const result = normalizePrivateKeyForSsh2(rsaPkcs8());
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed, "converted key should be parseable by ssh2");
+  assert.equal(parsed.type, "ssh-rsa");
+});
+
+test("converts unencrypted EC PKCS#8 into an ssh2-parseable key", () => {
+  const result = normalizePrivateKeyForSsh2(ecPkcs8());
+  assert.equal(result.converted, true);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ecdsa-sha2-nistp256");
+});
+
+test("leaves an already-supported PKCS#1 key untouched", () => {
+  const key = rsaPkcs1();
+  const result = normalizePrivateKeyForSsh2(key);
+  assert.equal(result.converted, false);
+  assert.equal(result.privateKey, key);
+});
+
+test("decrypts and converts an encrypted RSA PKCS#8 key with the correct passphrase", () => {
+  const result = normalizePrivateKeyForSsh2(encryptedRsaPkcs8("secret"), "secret");
+  assert.equal(result.converted, true);
+  assert.equal(result.passphrase, undefined);
+  const parsed = parseOk(result.privateKey);
+  assert.ok(parsed);
+  assert.equal(parsed.type, "ssh-rsa");
+});
+
+test("throws PrivateKeyPassphraseError for encrypted PKCS#8 with a wrong passphrase", () => {
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(encryptedRsaPkcs8("secret"), "wrong"),
+    (err) => err instanceof PrivateKeyPassphraseError,
+  );
+});
+
+test("throws UnsupportedPrivateKeyError for Ed25519 PKCS#8 with a conversion hint", () => {
+  assert.throws(
+    () => normalizePrivateKeyForSsh2(ed25519Pkcs8()),
+    (err) => err instanceof UnsupportedPrivateKeyError && /ssh-keygen/.test(err.message),
+  );
+});
+
+test("passes through content that is not a PKCS#8 key", () => {
+  const junk = "not a private key";
+  const result = normalizePrivateKeyForSsh2(junk);
+  assert.equal(result.converted, false);
+  assert.equal(result.privateKey, junk);
+});

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -10,6 +10,10 @@ const { exec } = require("node:child_process");
 const { utils: sshUtils } = require("ssh2");
 const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");
 const passphraseHandler = require("./passphraseHandler.cjs");
+const {
+  normalizePrivateKeyForSsh2,
+  PrivateKeyPassphraseError,
+} = require("./privateKeyNormalizer.cjs");
 
 // Default SSH key names in priority order
 const PREFERRED_KEY_NAMES = ["id_ed25519", "id_ecdsa", "id_rsa"];
@@ -133,6 +137,30 @@ function notifyPassphraseAuthFailed(sender, keyPath, resolvedPath, keyIds) {
   }
 }
 
+/**
+ * Resolve a private key (and optional passphrase) into a form ssh2 can parse.
+ * PKCS#8 keys, which ssh2 rejects, are transparently converted to a legacy PEM
+ * (see privateKeyNormalizer.cjs).
+ *
+ * @returns {{ privateKey: string, passphrase: string|undefined } | null}
+ *   The usable key, or null when the passphrase is wrong / the key can't be parsed.
+ * @throws {UnsupportedPrivateKeyError} When a PKCS#8 key has no convertible legacy form.
+ */
+function resolveKeyForAuth(privateKey, passphrase) {
+  let normalized;
+  try {
+    normalized = normalizePrivateKeyForSsh2(privateKey, passphrase);
+  } catch (err) {
+    if (err instanceof PrivateKeyPassphraseError) return null;
+    throw err;
+  }
+  const parsed = sshUtils.parseKey(normalized.privateKey, normalized.passphrase);
+  if (parsed && !(parsed instanceof Error)) {
+    return { privateKey: normalized.privateKey, passphrase: normalized.passphrase };
+  }
+  return null;
+}
+
 async function preparePrivateKeyForAuth({
   sender,
   privateKey,
@@ -147,7 +175,8 @@ async function preparePrivateKeyForAuth({
   if (!privateKey) return null;
 
   if (!isKeyEncrypted(privateKey)) {
-    return { privateKey, keyPath, keyName };
+    const resolved = resolveKeyForAuth(privateKey, undefined);
+    return { privateKey: resolved ? resolved.privateKey : privateKey, keyPath, keyName };
   }
 
   const promptKeyPath = keyPath || `SSH key for ${keyName || hostname || "connection"}`;
@@ -155,9 +184,9 @@ async function preparePrivateKeyForAuth({
   let passphraseInvalid = false;
 
   if (initialPassphrase) {
-    const parsed = sshUtils.parseKey(privateKey, initialPassphrase);
-    if (parsed && !(parsed instanceof Error)) {
-      return { privateKey, keyPath, keyName, passphrase: initialPassphrase };
+    const resolved = resolveKeyForAuth(privateKey, initialPassphrase);
+    if (resolved) {
+      return { privateKey: resolved.privateKey, keyPath, keyName, passphrase: resolved.passphrase };
     }
     console.log(`${logPrefix} Stored passphrase failed for private key`, { keyPath: promptKeyPath });
     notifyPassphraseAuthFailed(sender, promptKeyPath, undefined, keyId ? [keyId] : undefined);
@@ -184,9 +213,9 @@ async function preparePrivateKeyForAuth({
       return null;
     }
 
-    const parsed = sshUtils.parseKey(privateKey, result.passphrase);
-    if (parsed && !(parsed instanceof Error)) {
-      return { privateKey, keyPath, keyName, passphrase: result.passphrase };
+    const resolved = resolveKeyForAuth(privateKey, result.passphrase);
+    if (resolved) {
+      return { privateKey: resolved.privateKey, keyPath, keyName, passphrase: resolved.passphrase };
     }
 
     console.log(`${logPrefix} Entered passphrase failed for private key`, { keyPath: promptKeyPath });
@@ -208,14 +237,15 @@ async function loadIdentityFileForAuth({
   const keyName = path.basename(resolvedPath);
 
   if (!isKeyEncrypted(privateKey)) {
-    return { privateKey, keyPath: resolvedPath, keyName };
+    const resolved = resolveKeyForAuth(privateKey, undefined);
+    return { privateKey: resolved ? resolved.privateKey : privateKey, keyPath: resolvedPath, keyName };
   }
 
   let passphraseInvalid = false;
   if (initialPassphrase) {
-    const parsed = sshUtils.parseKey(privateKey, initialPassphrase);
-    if (parsed && !(parsed instanceof Error)) {
-      return { privateKey, keyPath: resolvedPath, keyName, passphrase: initialPassphrase };
+    const resolved = resolveKeyForAuth(privateKey, initialPassphrase);
+    if (resolved) {
+      return { privateKey: resolved.privateKey, keyPath: resolvedPath, keyName, passphrase: resolved.passphrase };
     }
     console.log(`${logPrefix} Stored passphrase failed for identity file`, { keyPath: resolvedPath });
     notifyPassphraseAuthFailed(sender, keyPath, resolvedPath);
@@ -242,9 +272,9 @@ async function loadIdentityFileForAuth({
       return null;
     }
 
-    const parsed = sshUtils.parseKey(privateKey, result.passphrase);
-    if (parsed && !(parsed instanceof Error)) {
-      return { privateKey, keyPath: resolvedPath, keyName, passphrase: result.passphrase };
+    const resolved = resolveKeyForAuth(privateKey, result.passphrase);
+    if (resolved) {
+      return { privateKey: resolved.privateKey, keyPath: resolvedPath, keyName, passphrase: resolved.passphrase };
     }
 
     console.log(`${logPrefix} Entered passphrase failed for identity file`, { keyPath: resolvedPath });

--- a/electron/bridges/sshAuthHelper.pkcs8.test.cjs
+++ b/electron/bridges/sshAuthHelper.pkcs8.test.cjs
@@ -1,0 +1,86 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { utils: sshUtils } = require("ssh2");
+
+const {
+  preparePrivateKeyForAuth,
+  loadIdentityFileForAuth,
+} = require("./sshAuthHelper.cjs");
+const passphraseHandler = require("./passphraseHandler.cjs");
+
+function genRsaPkcs8(passphrase) {
+  return crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: passphrase
+      ? { type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase }
+      : { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  }).privateKey;
+}
+
+function isParseable(key) {
+  const parsed = sshUtils.parseKey(key);
+  return !!parsed && !(parsed instanceof Error);
+}
+
+const sender = { isDestroyed: () => false, send: () => {} };
+
+test("preparePrivateKeyForAuth converts an unencrypted PKCS#8 key for ssh2", async () => {
+  const result = await preparePrivateKeyForAuth({
+    sender,
+    privateKey: genRsaPkcs8(),
+    keyName: "oracle.key",
+    hostname: "example.test",
+    logPrefix: "[Test]",
+  });
+
+  assert.ok(result, "expected a prepared key");
+  assert.ok(isParseable(result.privateKey), "prepared key should be parseable by ssh2");
+});
+
+test("preparePrivateKeyForAuth decrypts and converts an encrypted PKCS#8 key", async (t) => {
+  const original = passphraseHandler.requestPassphrase;
+  t.after(() => {
+    passphraseHandler.requestPassphrase = original;
+  });
+
+  let calls = 0;
+  passphraseHandler.requestPassphrase = async () => {
+    calls += 1;
+    return calls === 1 ? { passphrase: "secret" } : { passphrase: null };
+  };
+
+  const result = await preparePrivateKeyForAuth({
+    sender,
+    privateKey: genRsaPkcs8("secret"),
+    keyName: "oracle.key",
+    hostname: "example.test",
+    logPrefix: "[Test]",
+  });
+
+  assert.ok(result, "expected a prepared key");
+  assert.equal(calls, 1, "correct passphrase should not be re-prompted");
+  assert.ok(isParseable(result.privateKey), "prepared key should be parseable by ssh2");
+  assert.equal(result.passphrase, undefined, "passphrase is unnecessary after conversion");
+});
+
+test("loadIdentityFileForAuth converts an unencrypted PKCS#8 identity file", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-pkcs8-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const keyPath = path.join(dir, "oracle.key");
+  fs.writeFileSync(keyPath, genRsaPkcs8(), "utf8");
+
+  const result = await loadIdentityFileForAuth({
+    sender,
+    keyPath,
+    hostname: "example.test",
+    logPrefix: "[Test]",
+  });
+
+  assert.ok(result, "expected a loaded identity file");
+  assert.ok(isParseable(result.privateKey), "prepared key should be parseable by ssh2");
+});


### PR DESCRIPTION
## Problem

Connecting with a PKCS#8 private key (`-----BEGIN PRIVATE KEY-----` or `-----BEGIN ENCRYPTED PRIVATE KEY-----`) fails with:

```
Error invoking remote method 'netcatty:start': Error: Cannot parse privateKey: Unsupported key format
```

The same key connects fine in other clients such as Termius. Reported in #1139 (an Oracle Cloud key).

## Root cause

The error comes straight from `ssh2`'s `parseKey`. ssh2 only accepts OpenSSH, legacy PKCS#1/SEC1 (`BEGIN RSA/DSA/EC PRIVATE KEY`) and PuTTY keys — it has no support for PKCS#8. netcatty handed the key to ssh2 verbatim, so any PKCS#8 key (common from OpenSSL / Oracle / `keytool`) was rejected. Termius works because its SSH stack supports PKCS#8.

## Fix

New `electron/bridges/privateKeyNormalizer.cjs`: when ssh2 can't parse a key but it is PKCS#8, read it with Node's `crypto` and re-export RSA→PKCS#1 / EC→SEC1 — the legacy PEM forms ssh2 understands. Encrypted PKCS#8 is decrypted with the passphrase first. Ed25519 (and other) PKCS#8 keys have no legacy PEM form, so they now surface a clear "convert with `ssh-keygen`" message instead of ssh2's opaque error.

Wired into `sshAuthHelper`'s `preparePrivateKeyForAuth` and `loadIdentityFileForAuth`, so SSH, SFTP and port-forwarding all benefit. Keys ssh2 already supports (OpenSSH, PKCS#1, PuTTY) are passed through untouched.

Also fixes a latent bug: a correct passphrase on an encrypted PKCS#8 key used to be rejected and re-prompted indefinitely.

## Tests

- `privateKeyNormalizer.test.cjs` — RSA/EC PKCS#8 conversion, encrypted PKCS#8 (right/wrong passphrase), Ed25519 → typed error, already-supported keys untouched, non-key passthrough.
- `sshAuthHelper.pkcs8.test.cjs` — `preparePrivateKeyForAuth` / `loadIdentityFileForAuth` end-to-end on PKCS#8.
- Full `sshAuthHelper` + `sshBridge` suites pass; eslint clean.

Refs #1139 — PKCS#8 is one likely cause; malformed/mangled PEM (e.g. a real `BEGIN RSA PRIVATE KEY` whose newlines were lost) is handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

