### PR TITLE
fix(sftp): confirm delete/overwrite dialogs on Enter key

### DIFF
--- a/components/sftp/SftpPaneDialogs.tsx
+++ b/components/sftp/SftpPaneDialogs.tsx
@@ -111,6 +111,11 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
   onConnect,
   onDisconnect,
 }) => {
+  // Focus the confirm button when a confirmation dialog opens so Enter confirms it.
+  // These dialogs are opened from a context menu, whose focus-return can otherwise
+  // leave focus outside the dialog, making Enter do nothing.
+  const deleteConfirmButtonRef = React.useRef<HTMLButtonElement>(null);
+  const overwriteConfirmButtonRef = React.useRef<HTMLButtonElement>(null);
   const isSingleDeleteTarget = deleteTargets.length === 1;
   const deletePath = (() => {
     if (isSingleDeleteTarget) {
@@ -225,7 +230,13 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
 
     {/* Overwrite Confirmation Dialog */}
     <Dialog open={showOverwriteConfirm} onOpenChange={setShowOverwriteConfirm}>
-      <DialogContent className="max-w-sm">
+      <DialogContent
+        className="max-w-sm"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          overwriteConfirmButtonRef.current?.focus();
+        }}
+      >
         <DialogHeader>
           <HostHint label={hostLabel} />
           <DialogTitle>{t("sftp.overwrite.title")}</DialogTitle>
@@ -241,6 +252,7 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
             {t("common.cancel")}
           </Button>
           <Button
+            ref={overwriteConfirmButtonRef}
             variant="destructive"
             onClick={handleOverwriteConfirm}
           >
@@ -289,7 +301,13 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
     </Dialog>
 
     <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-      <DialogContent className="max-w-sm">
+      <DialogContent
+        className="max-w-sm"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          deleteConfirmButtonRef.current?.focus();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>
             {t("sftp.deleteConfirm.title", { count: deleteTargets.length })}
@@ -337,6 +355,7 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
             {t("common.cancel")}
           </Button>
           <Button
+            ref={deleteConfirmButtonRef}
             variant="destructive"
             onClick={handleDelete}
             disabled={isDeleting}


### PR DESCRIPTION
Fixes #1150.

In the SFTP file browser the delete confirmation dialog didn't respond to the Enter key — you had to click the button. The overwrite confirmation dialog had the same problem.

Both are plain confirm dialogs with no input field, and unlike the new-file / new-folder / rename dialogs (which focus their `<Input>` and handle Enter on it) they never wired Enter to confirm. They're also opened from a context menu, and that menu→dialog focus handoff can leave focus outside the dialog (on `<body>`), so Enter reached nothing and appeared to do nothing.

The fix focuses the confirm button when each dialog opens, via Radix's `onOpenAutoFocus`: `preventDefault()` the default "focus first tabbable element" and focus the confirm button through a ref instead. With focus on the button, Enter activates it natively. Esc-to-cancel and Tab-to-Cancel + Enter are unchanged — only the initial focus moved, there's no global Enter interception.

A note on testing: the repo has no DOM test harness (component tests render with `renderToStaticMarkup`), so this focus/keyboard behavior isn't something I could cover with an automated test. `eslint` is clean on the file and `tsc --noEmit` adds no new errors there; worth a quick manual check — right-click a file → Delete → press Enter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
