### PR TITLE
feat(vault): connect with the host's default protocol, prompt only for Telnet

### DIFF
--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -736,17 +736,11 @@ export function handleTerminalDataCaptureImpl(getCtx: AppContextGetter, sessionI
 export function hasMultipleProtocolsImpl(getCtx: AppContextGetter, host: Host) {
   const { resolveEffectiveHost } = getCtx();
 {
+    // Gates the protocol picker (legacy name kept for its existing wiring).
+    // Only prompt when Telnet is available but isn't the host's default protocol;
+    // SSH-only, SSH+Mosh and Telnet-default all connect directly.
     const effective = resolveEffectiveHost(host);
-    let count = 0;
-    // SSH is always available as base protocol (unless explicitly set to something else)
-    if (effective.protocol === 'ssh' || !effective.protocol) count++;
-    // Mosh adds another option
-    if (effective.moshEnabled) count++;
-    // Telnet adds another option
-    if (effective.telnetEnabled) count++;
-    // If protocol is explicitly telnet (not ssh), count it
-    if (effective.protocol === 'telnet' && !effective.telnetEnabled) count++;
-    return count > 1;
+    return Boolean(effective.telnetEnabled) && effective.protocol !== 'telnet';
   }
 }
 

--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -592,6 +592,7 @@ export const enVaultMessages: Messages = {
   'hostDetails.telnet.password': 'Telnet Password',
   'hostDetails.charset.placeholder': 'Charset (e.g. UTF-8)',
   'hostDetails.telnet.add': 'Add Telnet Protocol',
+  'hostDetails.telnet.setDefault': 'Connect with Telnet by default',
   'hostDetails.tags': 'Tags',
   'hostDetails.group': 'Group',
   'hostDetails.selectGroup': 'Select Group',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -626,6 +626,7 @@ export const ruVaultMessages: Messages = {
   'hostDetails.telnet.password': 'Пароль Telnet',
   'hostDetails.charset.placeholder': 'Кодировка (например, UTF-8)',
   'hostDetails.telnet.add': 'Добавить протокол Telnet',
+  'hostDetails.telnet.setDefault': 'Подключаться по Telnet по умолчанию',
   'hostDetails.tags': 'Теги',
   'hostDetails.group': 'Группа',
   'hostDetails.selectGroup': 'Выберите группу',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -152,6 +152,7 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.telnet.password': 'Telnet 密码',
   'hostDetails.charset.placeholder': '字符集（例如 UTF-8）',
   'hostDetails.telnet.add': '添加 Telnet 协议',
+  'hostDetails.telnet.setDefault': '默认用 Telnet 连接',
   'hostDetails.tags': '标签',
   'hostDetails.group': '分组',
   'hostDetails.selectGroup': '选择分组',

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -39,6 +39,7 @@ import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 import { Combobox, ComboboxOption, MultiCombobox } from "./ui/combobox";
 import { Input } from "./ui/input";
+import { Switch } from "./ui/switch";
 import { toast } from "./ui/toast";
 
 import {
@@ -854,6 +855,14 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
                   <X size={14} />
                 </Button>
               )}
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs text-muted-foreground">{t("hostDetails.telnet.setDefault")}</span>
+              <Switch
+                checked={form.protocol === "telnet"}
+                onCheckedChange={(checked) => update("protocol", checked ? "telnet" : "ssh")}
+              />
             </div>
 
             <p className="text-xs font-semibold">{t("hostDetails.telnet.credentials")}</p>

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -370,37 +370,27 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     [isSearchQuickConnect, handleConnectClick],
   );
 
-  // Check if host has multiple protocols enabled (using effective/resolved host)
-  const hasMultipleProtocols = useCallback((host: Host) => {
-    const effective = host.group
-      ? applyGroupDefaults(host, resolveGroupDefaults(host.group, groupConfigs, { validProxyProfileIds: proxyProfileIdSet }), { validProxyProfileIds: proxyProfileIdSet })
-      : applyGroupDefaults(host, {}, { validProxyProfileIds: proxyProfileIdSet });
-    let count = 0;
-    // SSH is always available as base protocol (unless explicitly set to something else)
-    if (effective.protocol === "ssh" || !effective.protocol) count++;
-    // Mosh adds another option
-    if (effective.moshEnabled) count++;
-    // Telnet adds another option
-    if (effective.telnetEnabled) count++;
-    // If protocol is explicitly telnet (not ssh), count it
-    if (effective.protocol === "telnet" && !effective.telnetEnabled) count++;
-    return count > 1;
-  }, [groupConfigs, proxyProfileIdSet]);
-
-  // Handle host connect with protocol selection
+  // Handle host connect. Resolution order:
+  //   Telnet set as default (protocol === 'telnet')  -> connect Telnet
+  //   Telnet enabled but not the default             -> ask (protocol picker)
+  //   Mosh enabled                                   -> connect Mosh
+  //   otherwise                                      -> connect SSH
   const handleHostConnect = useCallback(
     (host: Host) => {
-      if (hasMultipleProtocols(host)) {
-        // Pass effective host to protocol dialog so it shows correct ports/protocols
-        const effective = host.group
-          ? applyGroupDefaults(host, resolveGroupDefaults(host.group, groupConfigs, { validProxyProfileIds: proxyProfileIdSet }), { validProxyProfileIds: proxyProfileIdSet })
-          : applyGroupDefaults(host, {}, { validProxyProfileIds: proxyProfileIdSet });
+      const effective = host.group
+        ? applyGroupDefaults(host, resolveGroupDefaults(host.group, groupConfigs, { validProxyProfileIds: proxyProfileIdSet }), { validProxyProfileIds: proxyProfileIdSet })
+        : applyGroupDefaults(host, {}, { validProxyProfileIds: proxyProfileIdSet });
+      // Only prompt when Telnet is available but isn't the host's default protocol.
+      if (effective.telnetEnabled && effective.protocol !== "telnet") {
         setProtocolSelectHost(effective);
+      } else if (effective.protocol === "telnet") {
+        // Telnet-as-default wins over a stray moshEnabled flag.
+        onConnect({ ...host, moshEnabled: false });
       } else {
         onConnect(host);
       }
     },
-    [hasMultipleProtocols, onConnect, groupConfigs, proxyProfileIdSet],
+    [onConnect, groupConfigs, proxyProfileIdSet],
   );
 
   // Handle protocol selection


### PR DESCRIPTION
Addresses part 1 of #1099 — a Telnet host showing the protocol picker on every connect.

## What changed

Connecting now resolves to a clear default, and the picker only appears when it's genuinely a choice:

| Host setup | Connect (single-click & batch) |
|---|---|
| Telnet **set as default** (`protocol = telnet`) | Telnet — no picker |
| Telnet enabled but **not** default | **picker** (unchanged behavior) |
| Mosh enabled | Mosh — no picker |
| otherwise | SSH |

So the only thing that pops the picker is "Telnet is available but isn't this host's default". SSH-only, SSH+Mosh, and Telnet-default all connect directly.

## UI

The Telnet card in host settings gains a **"Connect with Telnet by default"** switch. Turning it on makes Telnet the host's primary protocol so it connects straight through; off restores SSH as primary while keeping Telnet available (which falls back to the picker).

## Notes / behavior changes

- **SSH+Mosh now connects Mosh directly** instead of prompting every time. If you enabled Mosh, it's used. (To use SSH on such a host, disable Mosh.)
- There's intentionally no "SSH-default while keeping Telnet, don't ask" — keeping Telnet available but not default means you get the picker (Telnet vs SSH is a deliberate, different-protocol/credentials choice). Set one as default to skip it.
- Batch-connecting a "Telnet-enabled-but-not-default" host can't show the picker, so it uses the host's default (SSH/Mosh), not Telnet.
- The earlier draft of this PR used a `skipProtocolPrompt` flag + a "remember" checkbox in the picker; that was dropped in favour of these simpler rules (which also sidesteps the Mosh-clearing edge Codex flagged).
- Parts 2 (Telnet password reveal) and 3 (copy from read-only logs) of the issue are separate, smaller asks — not included here.

## Verification

`eslint` clean on the changed files; `tsc --noEmit` adds no new errors (pre-existing project-wide errors are unrelated). No DOM test harness in the repo, so worth a manual check:
1. Host with SSH + Telnet → settings → toggle "Connect with Telnet by default" → connect goes straight to Telnet.
2. Host with SSH + Mosh → connect → goes straight to Mosh (no picker).
3. Host with SSH + Telnet, toggle off → connect → picker appears as before.
