### PR TITLE
fix: keep macOS Dock icon consistent with app bundle

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -596,15 +596,6 @@ if (!gotLock) {
       console.warn("[Main] Failed to install permission handlers:", err);
     }
 
-    // Set dock icon on macOS
-    if (isMac && appIcon && app.dock?.setIcon) {
-      try {
-        app.dock.setIcon(appIcon);
-      } catch (err) {
-        console.warn("Failed to set dock icon", err);
-      }
-    }
-
     // Build and set application menu. A broken menu should not take down
     // the entire app — fall back to no custom menu and continue startup.
     try {

--- a/scripts/mac-dock-icon.test.cjs
+++ b/scripts/mac-dock-icon.test.cjs
@@ -1,0 +1,17 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+test("main process leaves macOS Dock icon to the packaged app bundle", () => {
+  const mainProcess = fs.readFileSync(
+    path.join(__dirname, "../electron/main.cjs"),
+    "utf8",
+  );
+
+  assert.equal(
+    mainProcess.includes("app.dock.setIcon"),
+    false,
+    "Do not override the macOS Dock icon at runtime; it can render at a different size than the bundled .icns icon.",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes a macOS Dock icon size mismatch where the app icon appeared at different sizes between running and closed states.

## Root Cause

The packaged macOS app already provides `Contents/Resources/icon.icns`, but the main process also called `app.dock.setIcon(public/icon.png)` at runtime. This made the running Dock icon use Electron's dynamic icon rendering path, while the closed Dock icon used the bundled `.icns` through LaunchServices.

## Changes

- Removed the runtime `app.dock.setIcon(...)` override on macOS.
- Added a regression test to ensure the main process does not override the Dock icon at runtime.

## Verification

- `npm run lint -- --quiet`
- `node --test scripts/mac-dock-icon.test.cjs scripts/electron-builder-config.test.cjs scripts/afterPackMacUuid.test.cjs`
- Built macOS arm64 DMG with `npm run pack:mac`
- Installed the generated app locally and confirmed the Dock icon size stays consistent between running and closed states.

Fixes #1165 