### PR TITLE
fix(macos): keep dock icon size consistent between running and closed states

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -596,8 +596,11 @@ if (!gotLock) {
       console.warn("[Main] Failed to install permission handlers:", err);
     }
 
-    // Set dock icon on macOS
-    if (isMac && appIcon && app.dock?.setIcon) {
+    // Set the dock icon on macOS only when unpackaged (dev). Packaged builds
+    // already ship the multi-resolution Contents/Resources/icon.icns; overriding
+    // it at runtime with the single-resolution PNG makes the running dock icon
+    // render at a slightly different size than the closed-state .icns (#1165).
+    if (isMac && appIcon && app.dock?.setIcon && !app.isPackaged) {
       try {
         app.dock.setIcon(appIcon);
       } catch (err) {


### PR DESCRIPTION
Fixes the macOS dock-icon size mismatch reported in #1165 (and the reporter's own diagnosis is correct).

## Cause

A packaged macOS build already gets the multi-resolution `Contents/Resources/icon.icns` (generated by electron-builder from `public/icon.png`, which keeps Apple's HIG grid margin per #813). But [main.cjs](electron/main.cjs) also overrode the dock icon at runtime with `app.dock.setIcon(public/icon.png)` — a single-resolution PNG. The `.icns` (closed state) and the runtime PNG (running state) render at slightly different sizes, so the dock icon visibly changed size between the two states.

## Fix

Only set the dock icon at runtime when **unpackaged** (dev), where there's no bundled `.icns` and the app would otherwise show the generic Electron icon. Packaged builds now rely on the consistent `.icns` in both running and closed states.

```js
if (isMac && appIcon && app.dock?.setIcon && !app.isPackaged) {
```

## Verification

⚠️ This is macOS dock rendering — it **can't be verified by lint/types or in dev**. It needs a **packaged macOS build** (DMG/.app): install it, then compare the dock icon size while the app is running vs. closed — they should now match. Worth confirming on a real build before closing #1165 (hence `Refs`, not `Closes`).

Refs #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)