### PR TITLE
[codex] Fix Ruijie network device detection

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -481,6 +481,7 @@ export const enVaultMessages: Messages = {
   'hostDetails.distro.option.fortinet': 'Fortinet',
   'hostDetails.distro.option.paloalto': 'Palo Alto Networks',
   'hostDetails.distro.option.zyxel': 'ZyXEL',
+  'hostDetails.distro.option.ruijie': 'Ruijie',
   'hostDetails.section.mosh': 'Mosh',
   'hostDetails.username.placeholder': 'Username',
   'hostDetails.password.placeholder': 'Password',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -516,6 +516,7 @@ export const ruVaultMessages: Messages = {
   'hostDetails.distro.option.fortinet': 'Fortinet',
   'hostDetails.distro.option.paloalto': 'Palo Alto Networks',
   'hostDetails.distro.option.zyxel': 'ZyXEL',
+  'hostDetails.distro.option.ruijie': 'Ruijie',
   'hostDetails.section.mosh': 'Mosh',
   'hostDetails.username.placeholder': 'Имя пользователя',
   'hostDetails.password.placeholder': 'Пароль',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -75,6 +75,7 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.distro.option.fortinet': '飞塔',
   'hostDetails.distro.option.paloalto': 'Palo Alto Networks',
   'hostDetails.distro.option.zyxel': '合勤',
+  'hostDetails.distro.option.ruijie': '锐捷',
   'hostDetails.section.mosh': 'Mosh',
   'hostDetails.username.placeholder': '用户名',
   'hostDetails.password.placeholder': '密码',

--- a/components/DistroAvatar.tsx
+++ b/components/DistroAvatar.tsx
@@ -61,6 +61,7 @@ export const DISTRO_COLORS: Record<string, string> = {
   fortinet: "bg-[#EE3124]",
   paloalto: "bg-[#FA582D]",
   zyxel: "bg-[#00497A]",
+  ruijie: "bg-[#E60012]",
   default: "bg-slate-600",
 };
 

--- a/components/terminal/runtime/terminalDistroDetection.test.ts
+++ b/components/terminal/runtime/terminalDistroDetection.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  registerConnectionToken,
+  runDistroDetection,
+} from "./terminalDistroDetection.ts";
+
+test("runDistroDetection skips POSIX probes for manually marked network devices", async () => {
+  let remoteInfoCalls = 0;
+  let distroProbeCalls = 0;
+  const token = registerConnectionToken("ssh-session");
+
+  await runDistroDetection({
+    host: {
+      id: "host-1",
+      label: "Ruijie AP",
+      hostname: "192.168.2.2",
+      username: "root",
+      deviceType: "network",
+    },
+    terminalBackend: {
+      getSessionRemoteInfo: async () => {
+        remoteInfoCalls += 1;
+        return { success: true, remoteSshVersion: "RGOS_SSH" };
+      },
+      getSessionDistroInfo: async () => {
+        distroProbeCalls += 1;
+        return { success: false, error: "network device closed the extra channel" };
+      },
+    },
+  } as never, "ssh-session", token);
+
+  assert.equal(remoteInfoCalls, 0);
+  assert.equal(distroProbeCalls, 0);
+});

--- a/components/terminal/runtime/terminalDistroDetection.ts
+++ b/components/terminal/runtime/terminalDistroDetection.ts
@@ -1,4 +1,4 @@
-import { detectVendorFromSshVersion } from "../../../domain/host";
+import { classifyDistroId, detectVendorFromSshVersion } from "../../../domain/host";
 import { logger } from "../../../lib/logger";
 import type { TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
 
@@ -44,6 +44,12 @@ export const runDistroDetection = async (
   const isStillCurrent = () => isConnectionTokenCurrent(sessionId, connectionToken);
 
   if (!isStillCurrent()) return;
+  if (
+    ctx.host.deviceType === "network" ||
+    classifyDistroId(ctx.host.distro) === "network-device"
+  ) {
+    return;
+  }
 
   // Step 1: try to classify from the SSH server identification string
   // captured at handshake time. This is free (no extra channel) and
@@ -92,4 +98,3 @@ export const runDistroDetection = async (
     logger.warn("OS probe failed", err);
   }
 };
-

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -165,6 +165,11 @@ test("detectVendorFromSshVersion recognizes legacy Huawei VRP dash banner", () =
   assert.equal(detectVendorFromSshVersion("SSH-2.0--"), "huawei");
 });
 
+test("detectVendorFromSshVersion recognizes Ruijie RGOS banner", () => {
+  assert.equal(detectVendorFromSshVersion("RGOS_SSH"), "ruijie");
+  assert.equal(detectVendorFromSshVersion("SSH-2.0-RGOS_SSH"), "ruijie");
+});
+
 test("shouldProbeSessionCwd allows the probe on a plain Linux host", () => {
   assert.equal(
     shouldProbeSessionCwd({ isNetworkDevice: false, remoteSshVersion: "OpenSSH_9.6" }),

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -34,6 +34,7 @@ export const NETWORK_DEVICE_OPTIONS = [
   'fortinet',
   'paloalto',
   'zyxel',
+  'ruijie',
 ] as const;
 
 export type NetworkDeviceVendor = typeof NETWORK_DEVICE_OPTIONS[number];
@@ -117,6 +118,9 @@ export const detectVendorFromSshVersion = (softwareVersion?: string): '' | Netwo
 
   // ZyXEL ZyWALL
   if (/^Zyxel\s*SSH/i.test(s)) return 'zyxel';
+
+  // Ruijie RGOS
+  if (/^RGOS_SSH\b/i.test(s)) return 'ruijie';
 
   return '';
 };


### PR DESCRIPTION
## Summary
- Skip post-connect OS probing when a host is manually marked as a network device.
- Detect Ruijie RGOS SSH banners (`RGOS_SSH`) as network devices.
- Add Ruijie labels and tests covering the regression from issue #1142.

## Root cause
Network device mode stopped the working-directory probe, but the separate OS detection probe still ran after connect. Ruijie RGOS does not tolerate that extra POSIX-style probe, so the session could close right after successful authentication.

## Validation
- `node --test --import tsx domain/host.test.ts`
- `node --test --import tsx components/terminal/runtime/terminalDistroDetection.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`

Fixes #1142