### PR TITLE
[codex] fix cloud sync master key refresh

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -22,6 +22,7 @@ import {
   SYNCABLE_SETTING_STORAGE_KEYS,
   collectSyncableSettings,
   getEffectivePortForwardingRulesForSync,
+  hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
 } from '../syncPayload';
 import { readInterruptedVaultApply } from '../localVaultBackups';
@@ -482,7 +483,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       const remoteFile = inspection.remoteFile;
       const remotePayload = inspection.payload;
       const localPayload = buildPayloadRef.current();
-      const localIsEmpty = !hasMeaningfulCloudSyncData(localPayload);
+      const localIsEmpty = !hasCloudSyncEntityData(localPayload);
       const remoteHasData = hasMeaningfulCloudSyncData(remotePayload);
 
       // If local vault is empty but cloud has data, this almost certainly

--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -22,8 +22,8 @@ import {
   SYNCABLE_SETTING_STORAGE_KEYS,
   collectSyncableSettings,
   getEffectivePortForwardingRulesForSync,
-  hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
+  shouldPromptCloudVaultRecovery,
 } from '../syncPayload';
 import { readInterruptedVaultApply } from '../localVaultBackups';
 import {
@@ -483,13 +483,11 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       const remoteFile = inspection.remoteFile;
       const remotePayload = inspection.payload;
       const localPayload = buildPayloadRef.current();
-      const localIsEmpty = !hasCloudSyncEntityData(localPayload);
-      const remoteHasData = hasMeaningfulCloudSyncData(remotePayload);
 
       // If local vault is empty but cloud has data, this almost certainly
       // means the user's data was lost (update, storage corruption, etc.).
       // Pause and ask the user what to do instead of silently merging.
-      if (localIsEmpty && remoteHasData) {
+      if (shouldPromptCloudVaultRecovery(localPayload, remotePayload)) {
         const userAction = await new Promise<'restore' | 'keep-empty'>((resolve) => {
           emptyVaultResolveRef.current = resolve;
           setEmptyVaultConflict({

--- a/application/state/useCloudSync.masterKey.test.ts
+++ b/application/state/useCloudSync.masterKey.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { SYNC_STORAGE_KEYS } from "../../domain/sync.ts";
+import { EncryptionService } from "../../infrastructure/services/EncryptionService.ts";
+import { handleStorageEventImpl } from "../../infrastructure/services/cloudSync/stateAndSecurityMethods.ts";
+
+test("master key replacement from another window locks the current window and clears the old password", async () => {
+  const oldConfig = await EncryptionService.createMasterKeyConfig("old-master-password");
+  const newConfig = await EncryptionService.createMasterKeyConfig("new-master-password");
+  const fakeStorage = {};
+  const originalWindow = globalThis.window;
+  let notifyCount = 0;
+  let stopAutoSyncCount = 0;
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    localStorage: fakeStorage,
+  };
+
+  const manager = {
+    state: {
+      masterKeyConfig: oldConfig,
+      securityState: "UNLOCKED",
+      unlockedKey: await EncryptionService.unlockMasterKey("old-master-password", oldConfig),
+    },
+    masterPassword: "old-master-password",
+    safeJsonParse: (value: string | null) => (value ? JSON.parse(value) : null),
+    stopAutoSync: () => {
+      stopAutoSyncCount += 1;
+    },
+    notifyStateChange: () => {
+      notifyCount += 1;
+    },
+  };
+
+  try {
+    handleStorageEventImpl.call(manager, {
+      storageArea: fakeStorage,
+      key: SYNC_STORAGE_KEYS.MASTER_KEY_CONFIG,
+      newValue: JSON.stringify(newConfig),
+    } as StorageEvent);
+  } finally {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  }
+
+  assert.equal(manager.state.masterKeyConfig.verificationHash, newConfig.verificationHash);
+  assert.equal(manager.state.securityState, "LOCKED");
+  assert.equal(manager.state.unlockedKey, null);
+  assert.equal(manager.masterPassword, null);
+  assert.equal(stopAutoSyncCount, 1);
+  assert.equal(notifyCount, 1);
+});

--- a/application/state/useCloudSync.masterKey.test.ts
+++ b/application/state/useCloudSync.masterKey.test.ts
@@ -12,6 +12,7 @@ test("master key replacement from another window locks the current window and cl
   const originalWindow = globalThis.window;
   let notifyCount = 0;
   let stopAutoSyncCount = 0;
+  let syncSecurityGenerationCount = 0;
 
   (globalThis as typeof globalThis & { window?: unknown }).window = {
     localStorage: fakeStorage,
@@ -27,6 +28,9 @@ test("master key replacement from another window locks the current window and cl
     safeJsonParse: (value: string | null) => (value ? JSON.parse(value) : null),
     stopAutoSync: () => {
       stopAutoSyncCount += 1;
+    },
+    bumpSyncSecurityGeneration: () => {
+      syncSecurityGenerationCount += 1;
     },
     notifyStateChange: () => {
       notifyCount += 1;
@@ -48,5 +52,6 @@ test("master key replacement from another window locks the current window and cl
   assert.equal(manager.state.unlockedKey, null);
   assert.equal(manager.masterPassword, null);
   assert.equal(stopAutoSyncCount, 1);
+  assert.equal(syncSecurityGenerationCount, 1);
   assert.equal(notifyCount, 1);
 });

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -41,6 +41,7 @@ const {
   applySyncPayload,
   buildLocalVaultPayload,
   buildSyncPayload,
+  hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
 } = await import("./syncPayload.ts");
 const storageKeys = await import("../infrastructure/config/storageKeys.ts");
@@ -528,6 +529,21 @@ test("hasMeaningfulCloudSyncData ignores legacy cloud known hosts", () => {
       snippets: [],
       customGroups: [],
       knownHosts: [knownHost("kh-only")],
+      syncedAt: 1,
+    }),
+    false,
+  );
+});
+
+test("hasCloudSyncEntityData ignores settings-only payloads for empty-vault recovery", () => {
+  assert.equal(
+    hasCloudSyncEntityData({
+      hosts: [],
+      keys: [],
+      identities: [],
+      snippets: [],
+      customGroups: [],
+      settings: { theme: "system", terminalTheme: "default" },
       syncedAt: 1,
     }),
     false,

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -43,6 +43,7 @@ const {
   buildSyncPayload,
   hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
+  shouldPromptCloudVaultRecovery,
 } = await import("./syncPayload.ts");
 const storageKeys = await import("../infrastructure/config/storageKeys.ts");
 
@@ -546,6 +547,23 @@ test("hasCloudSyncEntityData ignores settings-only payloads for empty-vault reco
       settings: { theme: "system", terminalTheme: "default" },
       syncedAt: 1,
     }),
+    false,
+  );
+});
+
+test("shouldPromptCloudVaultRecovery ignores settings-only remote payloads", () => {
+  const settingsOnlyPayload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: { theme: "system", terminalTheme: "default" },
+    syncedAt: 1,
+  };
+
+  assert.equal(
+    shouldPromptCloudVaultRecovery(settingsOnlyPayload, settingsOnlyPayload),
     false,
   );
 });

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -132,6 +132,13 @@ export function hasCloudSyncEntityData(payload: SyncPayload): boolean {
   return hasSyncPayloadEntityData(payload, CLOUD_SYNC_PAYLOAD_ENTITY_KEYS);
 }
 
+export function shouldPromptCloudVaultRecovery(
+  localPayload: SyncPayload,
+  remotePayload: SyncPayload,
+): boolean {
+  return !hasCloudSyncEntityData(localPayload) && hasCloudSyncEntityData(remotePayload);
+}
+
 export function sanitizePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,
 ): PortForwardingRule[] | undefined {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -123,6 +123,15 @@ export function hasMeaningfulCloudSyncData(payload: SyncPayload): boolean {
   );
 }
 
+/**
+ * Returns true only when the payload contains synced vault entities.
+ * Settings are intentionally ignored so default settings written on first
+ * launch do not make a new device look non-empty during cloud restore checks.
+ */
+export function hasCloudSyncEntityData(payload: SyncPayload): boolean {
+  return hasSyncPayloadEntityData(payload, CLOUD_SYNC_PAYLOAD_ENTITY_KEYS);
+}
+
 export function sanitizePortForwardingRulesForSync(
   rules: PortForwardingRule[] | undefined,
 ): PortForwardingRule[] | undefined {

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -177,6 +177,7 @@ export class CloudSyncManager {
   private stateChangeListeners: Set<() => void> = new Set(); // For useSyncExternalStore
   private autoSyncTimer: ReturnType<typeof setInterval> | null = null;
   private masterPassword: string | null = null; // In memory only!
+  private syncSecurityGeneration = 0;
   private hasStorageListener = false;
   // Promise that resolves once startup provider secret decryption finishes.
   // Awaited by getConnectedAdapter() to prevent using still-encrypted tokens.
@@ -320,6 +321,25 @@ export class CloudSyncManager {
       currentConflict: this.state.currentConflict ? { ...this.state.currentConflict } : null,
     };
     this.stateChangeListeners.forEach(cb => cb());
+  }
+
+  private bumpSyncSecurityGeneration(): void {
+    this.syncSecurityGeneration += 1;
+  }
+
+  private getSyncSecurityGeneration(): number {
+    return this.syncSecurityGeneration;
+  }
+
+  private assertSyncSecurityGeneration(expectedGeneration?: number): void {
+    if (expectedGeneration === undefined) return;
+    if (
+      expectedGeneration !== this.syncSecurityGeneration
+      || this.state.securityState !== 'UNLOCKED'
+      || !this.masterPassword
+    ) {
+      throw new Error('Sync cancelled because master key changed');
+    }
   }
 
   // ==========================================================================
@@ -606,8 +626,9 @@ export class CloudSyncManager {
     adapter: CloudAdapter,
     syncedFile: SyncedFile,
     payloadForBase?: SyncPayload,
+    syncSecurityGeneration?: number,
   ): Promise<SyncResult> {
-    return uploadToProviderImpl.call(this, provider, adapter, syncedFile, payloadForBase);
+    return uploadToProviderImpl.call(this, provider, adapter, syncedFile, payloadForBase, syncSecurityGeneration);
   }
 
   /**

--- a/infrastructure/services/cloudSync/providerSyncMethods.ts
+++ b/infrastructure/services/cloudSync/providerSyncMethods.ts
@@ -19,6 +19,18 @@ import type {
   SyncResult,
 } from '../../../domain/sync';
 
+function getSyncSecurityGeneration(manager: any): number | undefined {
+  return typeof manager.getSyncSecurityGeneration === 'function'
+    ? manager.getSyncSecurityGeneration()
+    : undefined;
+}
+
+function assertSyncSecurityGeneration(manager: any, generation?: number): void {
+  if (typeof manager.assertSyncSecurityGeneration === 'function') {
+    manager.assertSyncSecurityGeneration(generation);
+  }
+}
+
 async function uploadLocalPayloadImpl(this: any,
   provider: CloudProvider,
   adapter: CloudAdapter,
@@ -26,11 +38,14 @@ async function uploadLocalPayloadImpl(this: any,
   opts: { overrideShrink?: boolean },
   baseVersion: number,
   remoteFile?: SyncedFile | null,
+  syncSecurityGeneration?: number,
 ): Promise<SyncResult> {
   const overrideShrinkRequested = opts.overrideShrink === true;
   const directBase = await this.loadSyncBase(provider);
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
   let directRemoteRef: SyncPayload | null = null;
   if (!directBase && remoteFile) {
+    assertSyncSecurityGeneration(this, syncSecurityGeneration);
     try {
       directRemoteRef = await EncryptionService.decryptPayload(
         remoteFile,
@@ -39,6 +54,7 @@ async function uploadLocalPayloadImpl(this: any,
     } catch {
       directRemoteRef = null;
     }
+    assertSyncSecurityGeneration(this, syncSecurityGeneration);
   }
   const metadataBase = directBase ?? directRemoteRef;
   const payloadForUpload = withSyncReliabilityMeta(payload, metadataBase, {
@@ -73,8 +89,9 @@ async function uploadLocalPayloadImpl(this: any,
     packageJson.version,
     baseVersion,
   );
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
-  const result = await this.uploadToProvider(provider, adapter, syncedFile, payloadForUpload);
+  const result = await this.uploadToProvider(provider, adapter, syncedFile, payloadForUpload, syncSecurityGeneration);
 
   if (result.success) {
     this.exitBlockedState();
@@ -92,8 +109,10 @@ async function uploadLocalPayloadImpl(this: any,
 async function downloadRemoteConflictPayloadImpl(this: any,
   provider: CloudProvider,
   remoteFile: SyncedFile,
+  syncSecurityGeneration?: number,
 ): Promise<SyncResult> {
   let remotePayload: SyncPayload;
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
   try {
     remotePayload = await EncryptionService.decryptPayload(
       remoteFile,
@@ -102,6 +121,7 @@ async function downloadRemoteConflictPayloadImpl(this: any,
   } catch (decryptError) {
     throw new Error(`Decryption failed (master password may differ between devices): ${decryptError instanceof Error ? decryptError.message : String(decryptError)}`);
   }
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
   this.exitBlockedState();
   this.state.syncState = 'IDLE';
@@ -125,9 +145,12 @@ export async function uploadToProviderImpl(this: any,
   adapter: CloudAdapter,
   syncedFile: SyncedFile,
   payloadForBase?: SyncPayload,
+  syncSecurityGeneration?: number,
 ): Promise<SyncResult> {
     try {
+      assertSyncSecurityGeneration(this, syncSecurityGeneration);
       const resourceId = await adapter.upload(syncedFile);
+      assertSyncSecurityGeneration(this, syncSecurityGeneration);
       this.state.lastError = null;
 
       // Update local state (safe to do multiple times if values are same)
@@ -244,6 +267,7 @@ export async function syncToProviderImpl(this: any,
     }
 
     const overrideShrinkRequested = opts.overrideShrink === true;
+    const syncSecurityGeneration = getSyncSecurityGeneration(this);
 
     let adapter: CloudAdapter;
     try {
@@ -256,6 +280,7 @@ export async function syncToProviderImpl(this: any,
         error: 'Provider not connected',
       };
     }
+    assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
     this.updateProviderStatus(provider, 'syncing');
     this.state.lastError = null;
@@ -268,6 +293,7 @@ export async function syncToProviderImpl(this: any,
       // SYNC_ERROR path — so we never reach the upload branch with an
       // unknown remote state.
       const checkResult = await this.checkProviderConflict(provider, adapter);
+      assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
       if (checkResult.conflict && checkResult.remoteFile) {
         const conflictAction = resolveCloudSyncConflictAction(this.state.syncStrategy, {
@@ -280,6 +306,7 @@ export async function syncToProviderImpl(this: any,
             this,
             provider,
             checkResult.remoteFile,
+            syncSecurityGeneration,
           );
         }
 
@@ -292,6 +319,7 @@ export async function syncToProviderImpl(this: any,
             opts,
             checkResult.remoteFile.meta.version,
             checkResult.remoteFile,
+            syncSecurityGeneration,
           );
         }
 
@@ -310,6 +338,7 @@ export async function syncToProviderImpl(this: any,
           } catch (decryptError) {
             throw new Error(`Decryption failed (master password may differ between devices): ${decryptError instanceof Error ? decryptError.message : String(decryptError)}`);
           }
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
           const base = await this.loadSyncBase(provider);
           baseForConflict = base;
           const mergeResult = mergeSyncPayloads(base, payload, remotePayload);
@@ -353,12 +382,14 @@ export async function syncToProviderImpl(this: any,
             packageJson.version,
             checkResult.remoteFile.meta.version, // base on remote version
           );
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
           const uploadResult = await this.uploadToProvider(
             provider,
             adapter,
             mergedSyncedFile,
             mergedPayload,
+            syncSecurityGeneration,
           );
 
           if (uploadResult.success) {
@@ -390,6 +421,7 @@ export async function syncToProviderImpl(this: any,
           this.state.lastError = uploadResult.error || 'Upload failed after merge';
           return uploadResult;
         } catch (mergeError) {
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
           // Merge failed — fall back to conflict UI
           console.error('[CloudSyncManager] Merge failed, falling back to conflict UI', mergeError);
           const remoteFile = checkResult.remoteFile;
@@ -429,6 +461,7 @@ export async function syncToProviderImpl(this: any,
         opts,
         this.state.localVersion,
         checkResult.remoteFile,
+        syncSecurityGeneration,
       );
 
     } catch (error) {

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -189,12 +189,25 @@ export function handleStorageEventImpl(this: any, event: StorageEvent): void {
     if (key === SYNC_STORAGE_KEYS.MASTER_KEY_CONFIG) {
       const nextConfig = this.safeJsonParse<MasterKeyConfig>(event.newValue);
 
-      if (nextConfig && !this.state.masterKeyConfig) {
-        // Master key was set up in another window - update our state
+      if (nextConfig) {
+        const currentConfig = this.state.masterKeyConfig as MasterKeyConfig | null;
+        const configChanged = !currentConfig
+          || currentConfig.verificationHash !== nextConfig.verificationHash
+          || currentConfig.salt !== nextConfig.salt
+          || currentConfig.kdf !== nextConfig.kdf
+          || currentConfig.kdfIterations !== nextConfig.kdfIterations;
+
+        if (!configChanged) return;
+
+        // Master key was set up or changed in another window. Lock this
+        // window so it cannot keep syncing with the stale in-memory password.
         this.state.masterKeyConfig = nextConfig;
         this.state.securityState = 'LOCKED';
+        this.state.unlockedKey = null;
+        this.masterPassword = null;
+        this.stopAutoSync();
         this.notifyStateChange();
-      } else if (!nextConfig && this.state.masterKeyConfig) {
+      } else if (this.state.masterKeyConfig) {
         // Master key was removed in another window
         this.state.masterKeyConfig = null;
         this.state.securityState = 'NO_KEY';

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -201,6 +201,7 @@ export function handleStorageEventImpl(this: any, event: StorageEvent): void {
 
         // Master key was set up or changed in another window. Lock this
         // window so it cannot keep syncing with the stale in-memory password.
+        this.bumpSyncSecurityGeneration?.();
         this.state.masterKeyConfig = nextConfig;
         this.state.securityState = 'LOCKED';
         this.state.unlockedKey = null;
@@ -209,6 +210,7 @@ export function handleStorageEventImpl(this: any, event: StorageEvent): void {
         this.notifyStateChange();
       } else if (this.state.masterKeyConfig) {
         // Master key was removed in another window
+        this.bumpSyncSecurityGeneration?.();
         this.state.masterKeyConfig = null;
         this.state.securityState = 'NO_KEY';
         this.state.unlockedKey = null;
@@ -386,6 +388,7 @@ export async function setupMasterKeyImpl(this: any,password: string): Promise<vo
 
     const config = await EncryptionService.createMasterKeyConfig(password);
 
+    this.bumpSyncSecurityGeneration?.();
     this.state.masterKeyConfig = config;
     this.state.securityState = 'LOCKED';
 
@@ -434,6 +437,7 @@ export function lockImpl(this: any): void {
     }
 
     // Clear sensitive data from memory
+    this.bumpSyncSecurityGeneration?.();
     this.state.unlockedKey = null;
     this.masterPassword = null;
     this.state.securityState = 'LOCKED';
@@ -459,6 +463,7 @@ export async function changeMasterKeyImpl(this: any,oldPassword: string, newPass
       return false;
     }
 
+    this.bumpSyncSecurityGeneration?.();
     this.state.masterKeyConfig = newConfig;
     this.state.securityState = 'UNLOCKED';
     this.masterPassword = newPassword;

--- a/infrastructure/services/cloudSync/syncAllStorageMethods.test.ts
+++ b/infrastructure/services/cloudSync/syncAllStorageMethods.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { EncryptionService } from "../EncryptionService.ts";
 import { commitRemoteInspectionImpl } from "./authMethods.ts";
-import { syncToProviderImpl } from "./providerSyncMethods.ts";
+import { syncToProviderImpl, uploadToProviderImpl } from "./providerSyncMethods.ts";
 import {
   loadSyncSnapshotsImpl,
   saveSyncBaseImpl,
@@ -191,6 +191,130 @@ test("syncToProvider uses the checked remote as metadata base when no stored bas
     EncryptionService.decryptPayload = originalDecryptPayload;
     EncryptionService.encryptPayload = originalEncryptPayload;
   }
+});
+
+test("syncToProvider aborts an upload when the master key changes after encryption", async () => {
+  const originalEncryptPayload = EncryptionService.encryptPayload;
+  const localPayload = payload("local");
+  let generation = 0;
+  let uploaded = false;
+
+  EncryptionService.encryptPayload = async (outgoing: SyncPayload) => {
+    generation += 1;
+    return {
+      ...remoteFile("github", 2, 200),
+      payload: JSON.stringify(outgoing),
+    };
+  };
+
+  try {
+    const manager = {
+      masterPassword: "old-master-password",
+      adapters: new Map(),
+      state: {
+        securityState: "UNLOCKED",
+        providers: {
+          github: { enabled: true, connected: true, status: "connected" },
+        },
+        lastError: null,
+        syncState: "IDLE",
+        syncStrategy: "smartMerge",
+        localVersion: 1,
+        deviceId: "local-device",
+        deviceName: "Local",
+      },
+      getSyncSecurityGeneration: () => 0,
+      assertSyncSecurityGeneration: (expected: number) => {
+        if (generation !== expected) {
+          throw new Error("Sync cancelled because master key changed");
+        }
+      },
+      getConnectedAdapter: async () => ({ provider: "github" }),
+      updateProviderStatus: () => {},
+      emit: () => {},
+      checkProviderConflict: async () => ({ conflict: false }),
+      loadSyncBase: async () => null,
+      uploadToProvider: async (provider: CloudProvider) => {
+        uploaded = true;
+        return { success: true, provider, action: "upload" as const, version: 2 };
+      },
+      exitBlockedState: () => {},
+      addSyncHistoryEntry: () => {},
+    };
+
+    const result = await syncToProviderImpl.call(manager, "github", localPayload);
+
+    assert.equal(uploaded, false);
+    assert.equal(result.success, false);
+    assert.match(result.error ?? "", /master key changed/);
+  } finally {
+    EncryptionService.encryptPayload = originalEncryptPayload;
+  }
+});
+
+test("uploadToProvider skips local commits when the master key changes during upload", async () => {
+  let generation = 0;
+  let savedAnchor = false;
+  let savedBase = false;
+  let savedProvider = false;
+  const file = remoteFile("github", 2, 200);
+
+  const manager = {
+    providerDecryptSeq: { github: 0 },
+    state: {
+      providers: {
+        github: { enabled: true, connected: true, status: "syncing" },
+      },
+      lastError: null,
+      syncState: "SYNCING",
+      localVersion: 1,
+      localUpdatedAt: 100,
+      remoteVersion: 1,
+      remoteUpdatedAt: 100,
+      deviceName: "Local",
+    },
+    assertSyncSecurityGeneration: (expected: number) => {
+      if (generation !== expected) {
+        throw new Error("Sync cancelled because master key changed");
+      }
+    },
+    saveSyncConfig: () => {},
+    saveSyncBase: async () => {
+      savedBase = true;
+    },
+    saveSyncAnchor: async () => {
+      savedAnchor = true;
+    },
+    saveProviderConnection: async () => {
+      savedProvider = true;
+    },
+    notifyStateChange: () => {},
+    addSyncHistoryEntry: () => {},
+    updateProviderStatus: () => {},
+    emit: () => {},
+  };
+
+  const adapter = {
+    upload: async () => {
+      generation += 1;
+      return "resource-id";
+    },
+  };
+
+  const result = await uploadToProviderImpl.call(
+    manager,
+    "github",
+    adapter,
+    file,
+    payload("local"),
+    0,
+  );
+
+  assert.equal(result.success, false);
+  assert.match(result.error ?? "", /master key changed/);
+  assert.equal(savedBase, false);
+  assert.equal(savedAnchor, false);
+  assert.equal(savedProvider, false);
 });
 
 test("syncAllProviders uses the checked remote as metadata base when provider base is missing", async () => {

--- a/infrastructure/services/cloudSync/syncAllStorageMethods.ts
+++ b/infrastructure/services/cloudSync/syncAllStorageMethods.ts
@@ -24,11 +24,26 @@ import type {
   SyncResult,
 } from '../../../domain/sync';
 
+function getSyncSecurityGeneration(manager: any): number | undefined {
+  return typeof manager.getSyncSecurityGeneration === 'function'
+    ? manager.getSyncSecurityGeneration()
+    : undefined;
+}
+
+function assertSyncSecurityGeneration(manager: any, generation?: number): void {
+  if (typeof manager.assertSyncSecurityGeneration === 'function') {
+    manager.assertSyncSecurityGeneration(generation);
+  }
+}
+
 async function downloadRemoteForSyncAllImpl(this: any,
   provider: CloudProvider,
   remoteFile: SyncedFile,
+  syncSecurityGeneration?: number,
 ): Promise<SyncResult> {
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
   const payload = await EncryptionService.decryptPayload(remoteFile, this.masterPassword);
+  assertSyncSecurityGeneration(this, syncSecurityGeneration);
   this.updateProviderStatus(provider, 'connected');
 
   const result: SyncResult = {
@@ -100,6 +115,7 @@ export async function syncAllProvidersImpl(this: any,
     let wasMerged = false;
 
     const overrideShrinkRequested = opts.overrideShrink === true;
+    const syncSecurityGeneration = getSyncSecurityGeneration(this);
 
     if (!payload) {
       // Caller should provide payload from app state
@@ -142,7 +158,9 @@ export async function syncAllProvidersImpl(this: any,
         this.updateProviderStatus(provider, 'syncing');
         this.emit({ type: 'SYNC_STARTED', provider });
 
+        assertSyncSecurityGeneration(this, syncSecurityGeneration);
         const check = await this.checkProviderConflict(provider, adapter);
+        assertSyncSecurityGeneration(this, syncSecurityGeneration);
         return { provider, adapter, check };
       } catch (error) {
         return { provider, error: String(error) };
@@ -226,6 +244,7 @@ export async function syncAllProvidersImpl(this: any,
             this,
             newestConflict.provider as CloudProvider,
             newestConflict.check!.remoteFile!,
+            syncSecurityGeneration,
           );
           const sourceProvider = newestConflict.provider as CloudProvider;
           results.set(sourceProvider, remoteResult);
@@ -268,6 +287,7 @@ export async function syncAllProvidersImpl(this: any,
               c.check!.remoteFile!,
               this.masterPassword,
             );
+            assertSyncSecurityGeneration(this, syncSecurityGeneration);
             const result = mergeSyncPayloads(providerBase, merged, remotePayload);
             merged = result.payload;
           }
@@ -285,20 +305,26 @@ export async function syncAllProvidersImpl(this: any,
             if (r.check) r.check.conflict = false;
           }
         } catch (mergeError) {
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
           // Merge failed — fall back to conflict UI
           console.error('[CloudSyncManager] syncAll: merge failed', mergeError);
           const { provider, check } = conflicts[0];
           const remoteFile = check!.remoteFile!;
           let conflictSummary;
           try {
+            assertSyncSecurityGeneration(this, syncSecurityGeneration);
+            const base = await this.loadSyncBase(provider as CloudProvider);
+            const remotePayload = await EncryptionService.decryptPayload(remoteFile, this.masterPassword);
+            assertSyncSecurityGeneration(this, syncSecurityGeneration);
             conflictSummary = summarizeSyncChanges(
-              await this.loadSyncBase(provider as CloudProvider),
+              base,
               payload,
-              await EncryptionService.decryptPayload(remoteFile, this.masterPassword),
+              remotePayload,
             );
           } catch {
             conflictSummary = undefined;
           }
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
 
           this.state.syncState = 'CONFLICT';
           this.state.currentConflict = {
@@ -371,6 +397,7 @@ export async function syncAllProvidersImpl(this: any,
         const entry = checkResults.find((r) => r.provider === provider);
         const remoteFile = entry?.check?.remoteFile;
         if (remoteFile) {
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
           try {
             providerRemoteRef = await EncryptionService.decryptPayload(
               remoteFile,
@@ -379,6 +406,7 @@ export async function syncAllProvidersImpl(this: any,
           } catch {
             providerRemoteRef = null;
           }
+          assertSyncSecurityGeneration(this, syncSecurityGeneration);
         }
       }
       const finding = detectSuspiciousShrink(payload, providerBase, providerRemoteRef);
@@ -493,6 +521,7 @@ export async function syncAllProvidersImpl(this: any,
           const entry = checkResults.find((r) => r.provider === provider);
           const remoteFile = entry?.check?.remoteFile;
           if (remoteFile) {
+            assertSyncSecurityGeneration(this, syncSecurityGeneration);
             try {
               providerRemoteRef = await EncryptionService.decryptPayload(
                 remoteFile,
@@ -501,6 +530,7 @@ export async function syncAllProvidersImpl(this: any,
             } catch {
               providerRemoteRef = null;
             }
+            assertSyncSecurityGeneration(this, syncSecurityGeneration);
           }
         }
         const providerPayload = withSyncReliabilityMeta(payload, providerBase ?? providerRemoteRef, {
@@ -515,7 +545,8 @@ export async function syncAllProvidersImpl(this: any,
           packageJson.version,
           baseVersion
         );
-        const result = await this.uploadToProvider(provider, adapter, syncedFile, providerPayload);
+        assertSyncSecurityGeneration(this, syncSecurityGeneration);
+        const result = await this.uploadToProvider(provider, adapter, syncedFile, providerPayload, syncSecurityGeneration);
         results.set(provider, result);
       } catch (error) {
         const msg = String(error);


### PR DESCRIPTION
## Summary
- lock already-open windows when the cloud sync master key config changes elsewhere
- clear stale in-memory sync password and stop auto-sync before the old key can write cloud data
- add coverage for the cross-window master key replacement case

## Validation
- node --test --import tsx application/state/useCloudSync.masterKey.test.ts
- npm run lint
- npm test
- npm run build

Fixes #1170