### PR TITLE
[codex] Fix Kimi tool stream parsing

### DIFF
--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -491,3 +491,219 @@ test('continues OpenAI-compatible tool streams when the introductory tool chunk 
   assert.ok(assistantMessage.tool_calls?.[0]?.id?.startsWith('call_netcatty_'));
   assert.equal(toolMessage.tool_call_id, assistantMessage.tool_calls?.[0]?.id);
 });
+
+test('continues OpenAI-compatible streams when provider chunks omit the top-level id', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'kimi-k2.6',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                type: 'function',
+                function: { name: 'terminal_exec', arguments: '' },
+              }],
+            });
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                function: { arguments: '{}' },
+              }],
+            });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { content: 'tool completed' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const model = createModelFromConfig({
+    id: 'kimi-custom',
+    providerId: 'custom',
+    name: 'Kimi',
+    apiKey: 'test-key',
+    baseURL: 'https://api.moonshot.cn/v1',
+    defaultModel: 'kimi-k2.6',
+    enabled: true,
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect the host' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({}),
+        execute: async () => ({ ok: true }),
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  let text = '';
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    }
+  }
+
+  assert.equal(text, 'tool completed');
+  const followUpMessages = sentBodies[1].messages as Array<Record<string, unknown>>;
+  const assistantMessage = followUpMessages[1] as { tool_calls?: Array<{ id?: string }> };
+  const toolMessage = followUpMessages[2] as { tool_call_id?: string };
+  assert.ok(assistantMessage.tool_calls?.[0]?.id?.startsWith('call_netcatty_'));
+  assert.equal(toolMessage.tool_call_id, assistantMessage.tool_calls?.[0]?.id);
+});
+
+test('continues OpenAI-compatible tool streams when arguments arrive before the tool id and name', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      id: 'chatcmpl-kimi-test',
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'kimi-k2.6',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                type: 'function',
+                function: { arguments: '{"command":' },
+              }],
+            });
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                type: 'function',
+                function: { name: 'terminal_exec', arguments: '"which docker"}' },
+              }],
+            });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { content: 'tool completed' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const executedCommands: string[] = [];
+  const model = createModelFromConfig({
+    id: 'kimi-custom',
+    providerId: 'custom',
+    name: 'Kimi',
+    apiKey: 'test-key',
+    baseURL: 'https://api.moonshot.cn/v1',
+    defaultModel: 'kimi-k2.6',
+    enabled: true,
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect docker' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          executedCommands.push(command);
+          return { ok: true };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  let text = '';
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    }
+  }
+
+  assert.deepEqual(executedCommands, ['which docker']);
+  assert.equal(text, 'tool completed');
+  const followUpMessages = sentBodies[1].messages as Array<Record<string, unknown>>;
+  const assistantMessage = followUpMessages[1] as { tool_calls?: Array<{ id?: string; function?: { arguments?: string } }> };
+  assert.ok(assistantMessage.tool_calls?.[0]?.id?.startsWith('call_netcatty_'));
+  assert.equal(assistantMessage.tool_calls?.[0]?.function?.arguments, '{"command":"which docker"}');
+});

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -118,6 +118,7 @@ function createOpenAIChatStreamFieldCapture(
 
 function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) => string {
   const toolCallIdsByChoiceAndIndex = new Map<string, string>();
+  const pendingToolCallsByChoiceAndIndex = new Map<string, Record<string, unknown>>();
   const requestIdToken = requestId.replace(/[^a-zA-Z0-9_-]/g, '_');
 
   return (data: string): string => {
@@ -146,28 +147,48 @@ function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) =
 
       const choiceIndex = typeof choiceRecord.index === 'number' ? choiceRecord.index : choicePosition;
       let deltaChanged = false;
-      const normalizedToolCalls = deltaRecord.tool_calls.map((toolCall, toolCallPosition) => {
-        if (!toolCall || typeof toolCall !== 'object') return toolCall;
+      const normalizedToolCalls: unknown[] = [];
+      for (const [toolCallPosition, toolCall] of deltaRecord.tool_calls.entries()) {
+        if (!toolCall || typeof toolCall !== 'object') {
+          normalizedToolCalls.push(toolCall);
+          continue;
+        }
         const toolCallRecord = toolCall as Record<string, unknown>;
         const toolCallIndex = typeof toolCallRecord.index === 'number' ? toolCallRecord.index : toolCallPosition;
         const key = `${choiceIndex}:${toolCallIndex}`;
         const existingId = toolCallIdsByChoiceAndIndex.get(key);
+        const pendingToolCall = pendingToolCallsByChoiceAndIndex.get(key);
+        const candidateToolCall = pendingToolCall
+          ? mergeOpenAIChatToolCallDeltas(pendingToolCall, toolCallRecord)
+          : toolCallRecord;
 
-        if (typeof toolCallRecord.id === 'string' && toolCallRecord.id) {
-          toolCallIdsByChoiceAndIndex.set(key, toolCallRecord.id);
-          return toolCall;
+        if (existingId) {
+          normalizedToolCalls.push(toolCall);
+          continue;
         }
 
-        if (existingId || !hasFunctionName(toolCallRecord)) {
-          return toolCall;
+        if (!hasFunctionName(candidateToolCall)) {
+          pendingToolCallsByChoiceAndIndex.set(key, candidateToolCall);
+          changed = true;
+          deltaChanged = true;
+          continue;
         }
 
-        const syntheticId = `call_netcatty_${requestIdToken}_${choiceIndex}_${toolCallIndex}`;
-        toolCallIdsByChoiceAndIndex.set(key, syntheticId);
+        const toolCallId = typeof candidateToolCall.id === 'string' && candidateToolCall.id
+          ? candidateToolCall.id
+          : `call_netcatty_${requestIdToken}_${choiceIndex}_${toolCallIndex}`;
+        toolCallIdsByChoiceAndIndex.set(key, toolCallId);
+        pendingToolCallsByChoiceAndIndex.delete(key);
+
+        if (candidateToolCall === toolCallRecord && toolCallId === toolCallRecord.id) {
+          normalizedToolCalls.push(toolCall);
+          continue;
+        }
+
         changed = true;
         deltaChanged = true;
-        return { ...toolCallRecord, id: syntheticId };
-      });
+        normalizedToolCalls.push({ ...candidateToolCall, id: toolCallId });
+      }
 
       if (!deltaChanged) return choice;
       return {
@@ -184,6 +205,35 @@ function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) =
       ...(parsed as Record<string, unknown>),
       choices: normalizedChoices,
     });
+  };
+}
+
+function mergeOpenAIChatToolCallDeltas(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const currentFn = current.function;
+  const incomingFn = incoming.function;
+  const currentFunction = currentFn && typeof currentFn === 'object'
+    ? currentFn as Record<string, unknown>
+    : undefined;
+  const incomingFunction = incomingFn && typeof incomingFn === 'object'
+    ? incomingFn as Record<string, unknown>
+    : undefined;
+  const mergedFunction = {
+    ...(currentFunction ?? {}),
+    ...(incomingFunction ?? {}),
+  };
+  const currentArgs = currentFunction?.arguments;
+  const incomingArgs = incomingFunction?.arguments;
+  if (typeof currentArgs === 'string' && typeof incomingArgs === 'string') {
+    mergedFunction.arguments = currentArgs + incomingArgs;
+  }
+
+  return {
+    ...current,
+    ...incoming,
+    function: mergedFunction,
   };
 }
 


### PR DESCRIPTION
## Summary
- Fix OpenAI-compatible streaming when providers send tool-call argument chunks before the tool id/name.
- Keep those early chunks until the tool call is complete, then pass a complete tool call through.
- Add regression coverage for Kimi-style tool streams and missing top-level chunk ids.

Fixes #1173

## Validation
- node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts infrastructure/ai/sdkProviders.test.ts infrastructure/ai/errorClassifier.test.ts
- npm run build