### PR TITLE
[codex] Polish Vault UI

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -191,6 +191,7 @@ export const enCoreMessages: Messages = {
   // Vault Sidebar
   'vault.sidebar.collapse': 'Collapse sidebar',
   'vault.sidebar.expand': 'Expand sidebar',
+  'vault.sidebar.resize': 'Resize sidebar',
 
   // Settings > Application
   'settings.application.checkUpdates': 'Check for updates',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -191,6 +191,7 @@ export const ruCoreMessages: Messages = {
   // Vault Sidebar
   'vault.sidebar.collapse': 'Свернуть боковую панель',
   'vault.sidebar.expand': 'Развернуть боковую панель',
+  'vault.sidebar.resize': 'Изменить ширину боковой панели',
 
   // Settings > Application
   'settings.application.checkUpdates': 'Проверить обновления',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -175,6 +175,7 @@ export const zhCNCoreMessages: Messages = {
   // Vault Sidebar
   'vault.sidebar.collapse': '收起侧边栏',
   'vault.sidebar.expand': '展开侧边栏',
+  'vault.sidebar.resize': '调整侧边栏宽度',
 
   // Settings > Application
   'settings.application.checkUpdates': '检查更新',

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -27,6 +27,8 @@ import ThemeSelectPanel from "./ThemeSelectPanel";
 import {
   ChainPanel,
   EnvVarsPanel,
+  HostDetailsSection,
+  HostDetailsSettingRow,
   ProxyPanel,
 } from "./host-details";
 import {
@@ -35,7 +37,6 @@ import {
   type AsidePanelLayout,
 } from "./ui/aside-panel";
 import { Button } from "./ui/button";
-import { Card } from "./ui/card";
 import { Combobox } from "./ui/combobox";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { Input } from "./ui/input";
@@ -532,13 +533,10 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
     >
       <AsidePanelContent>
         {/* General Section */}
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Settings2 size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("vault.groups.details.general")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<Settings2 size={14} className="text-muted-foreground" />}
+          title={t("vault.groups.details.general")}
+        >
           <Input
             placeholder={t("vault.groups.field.name")}
             value={groupName}
@@ -558,7 +556,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
             placeholder={t("vault.groups.details.parentGroup")}
             className="w-full"
           />
-        </Card>
+        </HostDetailsSection>
 
         <GroupSshSettingsSection
           sshEnabled={sshEnabled}
@@ -588,12 +586,10 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
 
         {/* Telnet Section (if enabled) */}
         {telnetEnabled && (
-          <Card className="p-3 space-y-3 bg-card border-border/80">
-            <div className="flex items-center gap-2">
-              <Globe size={14} className="text-muted-foreground" />
-              <p className="text-xs font-semibold flex-1">
-                {t("vault.groups.details.telnet")}
-              </p>
+          <HostDetailsSection
+            icon={<Globe size={14} className="text-muted-foreground" />}
+            title={t("vault.groups.details.telnet")}
+            action={
               <Dropdown>
                 <DropdownTrigger asChild>
                   <Button variant="ghost" size="icon" className="h-6 w-6">
@@ -610,7 +606,8 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
                   </button>
                 </DropdownContent>
               </Dropdown>
-            </div>
+            }
+          >
 
             <div className="flex items-center gap-2">
               <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
@@ -654,34 +651,28 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
                 {showTelnetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
               </button>
             </div>
-          </Card>
+          </HostDetailsSection>
         )}
 
         {/* Charset & Appearance — only when at least one protocol is added */}
         {(sshEnabled || telnetEnabled) && (<>
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Globe size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("vault.groups.details.advanced")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<Globe size={14} className="text-muted-foreground" />}
+          title={t("vault.groups.details.advanced")}
+        >
           <Input
             placeholder="UTF-8"
             value={form.charset || ""}
             onChange={(e) => update("charset", e.target.value || undefined)}
             className="h-10"
           />
-        </Card>
+        </HostDetailsSection>
 
         {/* Appearance Section */}
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Palette size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("vault.groups.details.appearance")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<Palette size={14} className="text-muted-foreground" />}
+          title={t("vault.groups.details.appearance")}
+        >
 
           <button
             type="button"
@@ -758,21 +749,23 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
           )}
 
           {/* Font Size */}
-          <Input
-            type="number"
-            placeholder={String(terminalFontSize)}
-            value={form.fontSize ?? ""}
-            onChange={(e) => {
-              const val = e.target.value ? parseInt(e.target.value) : undefined;
-              setForm((prev) => ({
-                ...prev,
-                fontSize: val,
-                fontSizeOverride: val !== undefined ? true : undefined,
-              }));
-            }}
-            className="h-10"
-          />
-        </Card>
+          <HostDetailsSettingRow label="Font Size">
+            <Input
+              type="number"
+              placeholder={String(terminalFontSize)}
+              value={form.fontSize ?? ""}
+              onChange={(e) => {
+                const val = e.target.value ? parseInt(e.target.value) : undefined;
+                setForm((prev) => ({
+                  ...prev,
+                  fontSize: val,
+                  fontSizeOverride: val !== undefined ? true : undefined,
+                }));
+              }}
+              className="h-8 w-24 text-center"
+            />
+          </HostDetailsSettingRow>
+        </HostDetailsSection>
         </>)}
 
         {/* Add Protocol Button — always at the bottom */}

--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -1,37 +1,27 @@
 import React from "react";
 import { ChevronDown, ChevronRight, ChevronUp, Eye, EyeOff, FileKey, FolderOpen, Globe, Key, Link2, MoreHorizontal, Plus, Shield, TerminalSquare, Trash2, Variable, X } from "lucide-react";
-import { useI18n } from "../application/i18n/I18nProvider";
 import { AlgorithmOverridesPanel } from "./host-details/AlgorithmOverridesPanel";
-import { cn } from "../lib/utils";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
-import { Card } from "./ui/card";
+import { HostDetailsSection, HostDetailsSettingRow } from "./host-details";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { Combobox } from "./ui/combobox";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Switch } from "./ui/switch";
 import { Textarea } from "./ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type GroupSshSettingsSectionProps = Record<string, any>;
 
-const ToggleRow: React.FC<{ label: string; enabled: boolean; onToggle: () => void }> = ({ label, enabled, onToggle }) => {
-  const { t } = useI18n();
+const ToggleRow: React.FC<{ label: string; hint?: React.ReactNode; enabled: boolean; onToggle: () => void }> = ({ label, hint, enabled, onToggle }) => {
   return (
-    <div className="flex items-center justify-between h-10 px-3 rounded-md border border-border/70 bg-secondary/70">
-      <span className="text-sm">{label}</span>
-      <Button
-        variant={enabled ? "secondary" : "ghost"}
-        size="sm"
-        className={cn("h-8 min-w-[72px]", enabled && "bg-primary/20")}
-        onClick={onToggle}
-      >
-        {enabled ? t("common.enabled") : t("common.disabled")}
-      </Button>
-    </div>
+    <HostDetailsSettingRow label={label} hint={hint}>
+      <Switch checked={enabled} onCheckedChange={() => onToggle()} />
+    </HostDetailsSettingRow>
   );
 };
 
@@ -63,12 +53,11 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
   if (!sshEnabled) return null;
 
   return (
-          <Card className="p-3 space-y-3 bg-card border-border/80 overflow-hidden">
-            <div className="flex items-center gap-2">
-              <TerminalSquare size={14} className="text-muted-foreground" />
-              <p className="text-xs font-semibold flex-1">
-                {t("vault.groups.details.ssh")}
-              </p>
+          <HostDetailsSection
+            icon={<TerminalSquare size={14} className="text-muted-foreground" />}
+            title={t("vault.groups.details.ssh")}
+            className="overflow-hidden"
+            action={
               <Dropdown>
                 <DropdownTrigger asChild>
                   <Button variant="ghost" size="icon" className="h-6 w-6">
@@ -85,7 +74,8 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
                   </button>
                 </DropdownContent>
               </Dropdown>
-            </div>
+            }
+          >
 
             <div className="flex items-center gap-2">
               <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
@@ -380,6 +370,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             <ToggleRow
               label={t("hostDetails.agentForwarding")}
+              hint={t("hostDetails.agentForwarding.desc")}
               enabled={!!form.agentForwarding}
               onToggle={() => update("agentForwarding", !form.agentForwarding)}
             />
@@ -401,6 +392,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
                 the UI while connections still applied it. */}
             <ToggleRow
               label={t("hostDetails.legacyAlgorithms")}
+              hint={t("hostDetails.legacyAlgorithms.desc")}
               enabled={!!(form.legacyAlgorithms ?? inheritedLegacyAlgorithms)}
               onToggle={() => update(
                 "legacyAlgorithms",
@@ -410,15 +402,13 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             <ToggleRow
               label={t("hostDetails.skipEcdsaHostKey")}
+              hint={t("hostDetails.skipEcdsaHostKey.desc")}
               enabled={!!(form.skipEcdsaHostKey ?? inheritedSkipEcdsaHostKey)}
               onToggle={() => update(
                 "skipEcdsaHostKey",
                 !(form.skipEcdsaHostKey ?? inheritedSkipEcdsaHostKey),
               )}
             />
-            <p className="text-xs text-muted-foreground break-words">
-              {t("hostDetails.skipEcdsaHostKey.desc")}
-            </p>
             <Collapsible open={showAlgorithmOverrides} onOpenChange={setShowAlgorithmOverrides}>
               <CollapsibleTrigger asChild>
                 <Button
@@ -451,7 +441,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             {/* Proxy */}
             <button
               type="button"
-              className="w-full flex items-center justify-between p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors cursor-pointer"
+              className="w-full flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3 py-2 transition-colors hover:bg-secondary/70"
               onClick={() => setActiveSubPanel("proxy")}
             >
               <div className="flex items-center gap-2">
@@ -481,7 +471,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             {/* Host Chaining */}
             <button
               type="button"
-              className="w-full flex items-center justify-between p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors cursor-pointer"
+              className="w-full flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3 py-2 transition-colors hover:bg-secondary/70"
               onClick={() => setActiveSubPanel("chain")}
             >
               <div className="flex items-center gap-2">
@@ -501,7 +491,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             {/* Environment Variables */}
             <button
               type="button"
-              className="w-full flex items-center justify-between p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors cursor-pointer"
+              className="w-full flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3 py-2 transition-colors hover:bg-secondary/70"
               onClick={() => setActiveSubPanel("env-vars")}
             >
               <div className="flex items-center gap-2">
@@ -536,8 +526,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             {/* Backspace behavior — terminal input mapping, lives at the
                 bottom of the SSH section so it doesn't get visually
                 grouped with the algorithm controls above. */}
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-xs text-muted-foreground">{t("hostDetails.backspaceBehavior")}</p>
+            <HostDetailsSettingRow label={t("hostDetails.backspaceBehavior")}>
               <Select
                 value={form.backspaceBehavior ?? "default"}
                 onValueChange={(v) => update("backspaceBehavior", v === "default" ? undefined : v)}
@@ -550,7 +539,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
                   <SelectItem value="ctrl-h">^H (0x08)</SelectItem>
                 </SelectContent>
               </Select>
-            </div>
-          </Card>
+            </HostDetailsSettingRow>
+          </HostDetailsSection>
   );
 };

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -6,32 +6,22 @@ import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../infrastructure/config/fonts";
 import { AlgorithmOverridesPanel } from "./host-details/AlgorithmOverridesPanel";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
-import { Card } from "./ui/card";
+import { HostDetailsSection, HostDetailsSettingRow } from "./host-details";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { Input } from "./ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Switch } from "./ui/switch";
 import { Textarea } from "./ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
-import { cn } from "../lib/utils";
-import { useI18n } from "../application/i18n/I18nProvider";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type HostDetailsAdvancedSectionsProps = Record<string, any>;
 
-const ToggleRow: React.FC<{ label: string; enabled: boolean; onToggle: () => void }> = ({ label, enabled, onToggle }) => {
-  const { t } = useI18n();
+const ToggleRow: React.FC<{ label: string; hint?: React.ReactNode; enabled: boolean; onToggle: () => void }> = ({ label, hint, enabled, onToggle }) => {
   return (
-    <div className="flex items-center justify-between h-10 px-3 rounded-md border border-border/70 bg-secondary/70">
-      <span className="text-sm">{label}</span>
-      <Button
-        variant={enabled ? "secondary" : "ghost"}
-        size="sm"
-        className={cn("h-8 min-w-[72px]", enabled && "bg-primary/20")}
-        onClick={onToggle}
-      >
-        {enabled ? t("common.enabled") : t("common.disabled")}
-      </Button>
-    </div>
+    <HostDetailsSettingRow label={label} hint={hint}>
+      <Switch checked={enabled} onCheckedChange={() => onToggle()} />
+    </HostDetailsSettingRow>
   );
 };
 
@@ -58,13 +48,10 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
   groupDefaults,
 }) => (
   <>
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Palette size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("hostDetails.section.appearance")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<Palette size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.appearance")}
+        >
 
           {/* SSH Theme Selection */}
           <button
@@ -107,78 +94,78 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
           )}
 
           {/* Font Size */}
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">Font Size:</span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                if (effectiveFontSize > MIN_FONT_SIZE) {
-                  setForm((prev) => ({
-                    ...prev,
-                    fontSize: effectiveFontSize - 1,
-                    fontSizeOverride: true,
-                  }));
-                }
-              }}
-              disabled={effectiveFontSize <= MIN_FONT_SIZE}
-              className="px-2 h-8"
-            >
-              -
-            </Button>
-            <Input
-              type="number"
-              min={MIN_FONT_SIZE}
-              max={MAX_FONT_SIZE}
-              value={effectiveFontSize}
-              onChange={(e) => {
-                const val = parseInt(e.target.value);
-                if (val >= MIN_FONT_SIZE && val <= MAX_FONT_SIZE) {
-                  setForm((prev) => ({
-                    ...prev,
-                    fontSize: val,
-                    fontSizeOverride: true,
-                  }));
-                }
-              }}
-              className="w-16 text-center h-8"
-            />
-            <span className="text-sm text-muted-foreground">pt</span>
-            {hasEffectiveFontSizeOverride && (
+          <HostDetailsSettingRow label="Font Size">
+            <div className="flex items-center gap-2">
               <Button
-                variant="ghost"
+                variant="outline"
                 size="sm"
-                className="ml-auto h-8 text-primary"
-                onClick={() => setForm((prev) => clearHostFontSizeOverride(prev))}
+                onClick={() => {
+                  if (effectiveFontSize > MIN_FONT_SIZE) {
+                    setForm((prev) => ({
+                      ...prev,
+                      fontSize: effectiveFontSize - 1,
+                      fontSizeOverride: true,
+                    }));
+                  }
+                }}
+                disabled={effectiveFontSize <= MIN_FONT_SIZE}
+                className="h-8 w-8 px-0"
               >
-                {t("common.useGlobal")}
+                -
               </Button>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                if (effectiveFontSize < MAX_FONT_SIZE) {
-                  setForm((prev) => ({
-                    ...prev,
-                    fontSize: effectiveFontSize + 1,
-                    fontSizeOverride: true,
-                  }));
-                }
-              }}
-              disabled={effectiveFontSize >= MAX_FONT_SIZE}
-              className="px-2 h-8"
-            >
-              +
-            </Button>
-          </div>
-        </Card>
+              <Input
+                type="number"
+                min={MIN_FONT_SIZE}
+                max={MAX_FONT_SIZE}
+                value={effectiveFontSize}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value);
+                  if (val >= MIN_FONT_SIZE && val <= MAX_FONT_SIZE) {
+                    setForm((prev) => ({
+                      ...prev,
+                      fontSize: val,
+                      fontSizeOverride: true,
+                    }));
+                  }
+                }}
+                className="h-8 w-16 text-center"
+              />
+              <span className="text-sm text-muted-foreground">pt</span>
+              {hasEffectiveFontSizeOverride && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-primary"
+                  onClick={() => setForm((prev) => clearHostFontSizeOverride(prev))}
+                >
+                  {t("common.useGlobal")}
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (effectiveFontSize < MAX_FONT_SIZE) {
+                    setForm((prev) => ({
+                      ...prev,
+                      fontSize: effectiveFontSize + 1,
+                      fontSizeOverride: true,
+                    }));
+                  }
+                }}
+                disabled={effectiveFontSize >= MAX_FONT_SIZE}
+                className="h-8 w-8 px-0"
+              >
+                +
+              </Button>
+            </div>
+          </HostDetailsSettingRow>
+        </HostDetailsSection>
 
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Wifi size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.mosh")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<Wifi size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.mosh")}
+        >
           <ToggleRow
             label="Mosh"
             enabled={!!form.moshEnabled}
@@ -196,22 +183,19 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               }
             }}
           />
-        </Card>
+        </HostDetailsSection>
 
         {/* Agent Forwarding */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Forward size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.agentForwarding")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<Forward size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.agentForwarding")}
+        >
           <ToggleRow
             label={t("hostDetails.agentForwarding")}
+            hint={t("hostDetails.agentForwarding.desc")}
             enabled={!!form.agentForwarding}
             onToggle={() => update("agentForwarding", !form.agentForwarding)}
           />
-          <p className="text-xs text-muted-foreground">
-            {t("hostDetails.agentForwarding.desc")}
-          </p>
           {form.agentForwarding && sshAgentStatus && !sshAgentStatus.running && (
             <div className="flex items-start gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
               <AlertTriangle size={14} className="text-yellow-500 mt-0.5 flex-shrink-0" />
@@ -225,41 +209,35 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               </div>
             </div>
           )}
-        </Card>
+        </HostDetailsSection>
 
         {/* X11 Forwarding */}
         {(!form.protocol || form.protocol === "ssh") && !form.moshEnabled && (
-          <Card className="p-3 space-y-2 bg-card border-border/80">
-            <div className="flex items-center gap-2">
-              <TerminalSquare size={14} className="text-muted-foreground" />
-              <p className="text-xs font-semibold">{t("hostDetails.section.x11Forwarding")}</p>
-            </div>
+          <HostDetailsSection
+            icon={<TerminalSquare size={14} className="text-muted-foreground" />}
+            title={t("hostDetails.section.x11Forwarding")}
+          >
             <ToggleRow
               label={t("hostDetails.x11Forwarding")}
+              hint={t("hostDetails.x11Forwarding.desc")}
               enabled={!!form.x11Forwarding}
               onToggle={() => update("x11Forwarding", !form.x11Forwarding)}
             />
-            <p className="text-xs text-muted-foreground">
-              {t("hostDetails.x11Forwarding.desc")}
-            </p>
-          </Card>
+          </HostDetailsSection>
         )}
 
         {/* Network Device Mode — only for SSH hosts without Mosh (serial already uses raw mode) */}
         {(!form.protocol || form.protocol === 'ssh') && !form.moshEnabled && (
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Router size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.deviceType")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<Router size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.deviceType")}
+        >
           <ToggleRow
             label={t("hostDetails.deviceType")}
+            hint={t("hostDetails.deviceType.desc")}
             enabled={form.deviceType === 'network'}
             onToggle={() => update("deviceType", form.deviceType === 'network' ? undefined : 'network')}
           />
-          <p className="text-xs text-muted-foreground break-words">
-            {t("hostDetails.deviceType.desc")}
-          </p>
           {form.deviceType === 'network' && (
             <div className="flex items-start gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
               <AlertTriangle size={14} className="text-yellow-500 mt-0.5 flex-shrink-0" />
@@ -268,15 +246,14 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               </p>
             </div>
           )}
-        </Card>
+        </HostDetailsSection>
         )}
 
         {/* SSH Algorithms */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <ShieldAlert size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.sshAlgorithms")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<ShieldAlert size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.sshAlgorithms")}
+        >
           {/* Display the *effective* value of these toggles (host field
               falling back to the resolved group default). Without the
               fallback a host that inherits the flag from its group would
@@ -285,15 +262,13 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               value from the raw host field. */}
           <ToggleRow
             label={t("hostDetails.legacyAlgorithms")}
+            hint={t("hostDetails.legacyAlgorithms.desc")}
             enabled={!!(form.legacyAlgorithms ?? effectiveGroupDefaults?.legacyAlgorithms)}
             onToggle={() => update(
               "legacyAlgorithms",
               !(form.legacyAlgorithms ?? effectiveGroupDefaults?.legacyAlgorithms),
             )}
           />
-          <p className="text-xs text-muted-foreground break-words">
-            {t("hostDetails.legacyAlgorithms.desc")}
-          </p>
           {(form.legacyAlgorithms ?? effectiveGroupDefaults?.legacyAlgorithms) && (
             <div className="flex items-start gap-2 p-2 rounded-md bg-yellow-500/10 border border-yellow-500/20">
               <AlertTriangle size={14} className="text-yellow-500 mt-0.5 flex-shrink-0" />
@@ -304,15 +279,13 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
           )}
           <ToggleRow
             label={t("hostDetails.skipEcdsaHostKey")}
+            hint={t("hostDetails.skipEcdsaHostKey.desc")}
             enabled={!!(form.skipEcdsaHostKey ?? effectiveGroupDefaults?.skipEcdsaHostKey)}
             onToggle={() => update(
               "skipEcdsaHostKey",
               !(form.skipEcdsaHostKey ?? effectiveGroupDefaults?.skipEcdsaHostKey),
             )}
           />
-          <p className="text-xs text-muted-foreground break-words">
-            {t("hostDetails.skipEcdsaHostKey.desc")}
-          </p>
           <Collapsible open={showAlgorithmOverrides} onOpenChange={setShowAlgorithmOverrides}>
             <CollapsibleTrigger asChild>
               <Button
@@ -349,21 +322,19 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               />
             </CollapsibleContent>
           </Collapsible>
-        </Card>
+        </HostDetailsSection>
 
         {/* Terminal Behavior — input/output key mappings (backspace, etc.) */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <TerminalSquare size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.terminalBehavior")}</p>
-          </div>
-          <div className="flex items-center justify-between gap-2">
-            <p className="text-xs text-muted-foreground">{t("hostDetails.backspaceBehavior")}</p>
+        <HostDetailsSection
+          icon={<TerminalSquare size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.terminalBehavior")}
+        >
+          <HostDetailsSettingRow label={t("hostDetails.backspaceBehavior")}>
             <Select
               value={form.backspaceBehavior ?? "default"}
               onValueChange={(v) => update("backspaceBehavior", v === "default" ? undefined : v)}
             >
-              <SelectTrigger className="h-8 w-auto text-xs">
+              <SelectTrigger className="h-10 w-36 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -371,17 +342,17 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
                 <SelectItem value="ctrl-h">^H (0x08)</SelectItem>
               </SelectContent>
             </Select>
-          </div>
-        </Card>
+          </HostDetailsSettingRow>
+        </HostDetailsSection>
 
         {/* Per-host keepalive override */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <HeartPulse size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.section.keepalive")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<HeartPulse size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.keepalive")}
+        >
           <ToggleRow
             label={t("hostDetails.keepalive.override")}
+            hint={t("hostDetails.keepalive.desc")}
             enabled={!!form.keepaliveOverride}
             onToggle={() => {
               const next = !form.keepaliveOverride;
@@ -394,18 +365,14 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               }
             }}
           />
-          <p className="text-xs text-muted-foreground break-words">
-            {t("hostDetails.keepalive.desc")}
-          </p>
           {form.keepaliveOverride && (
             <div className="space-y-2 pt-1">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs text-muted-foreground">{t("hostDetails.keepalive.interval")}</p>
-                <input
+              <HostDetailsSettingRow label={t("hostDetails.keepalive.interval")}>
+                <Input
                   type="number"
                   min={0}
                   max={3600}
-                  className="h-8 w-24 rounded-md border border-input bg-background px-2 text-xs"
+                  className="h-8 w-24 text-xs"
                   value={form.keepaliveInterval ?? 0}
                   onChange={(e) => {
                     const v = parseInt(e.target.value, 10);
@@ -414,14 +381,13 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
                     update("keepaliveInterval", v);
                   }}
                 />
-              </div>
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-xs text-muted-foreground">{t("hostDetails.keepalive.countMax")}</p>
-                <input
+              </HostDetailsSettingRow>
+              <HostDetailsSettingRow label={t("hostDetails.keepalive.countMax")}>
+                <Input
                   type="number"
                   min={1}
                   max={100}
-                  className="h-8 w-24 rounded-md border border-input bg-background px-2 text-xs"
+                  className="h-8 w-24 text-xs"
                   value={form.keepaliveCountMax ?? 3}
                   onChange={(e) => {
                     const v = parseInt(e.target.value, 10);
@@ -430,7 +396,7 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
                     update("keepaliveCountMax", v);
                   }}
                 />
-              </div>
+              </HostDetailsSettingRow>
               {(form.keepaliveInterval ?? 0) === 0 && (
                 <p className="text-xs text-muted-foreground break-words pl-1">
                   {t("hostDetails.keepalive.disabledHint")}
@@ -438,30 +404,24 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               )}
             </div>
           )}
-        </Card>
+        </HostDetailsSection>
 
         {/* Proxy via Hosts (Jump Hosts / ProxyJump) */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Link2 size={14} className="text-muted-foreground" />
-              <p className="text-xs font-semibold">
-                {t("hostDetails.jumpHosts")}
-              </p>
-            </div>
-            {chainedHosts.length > 0 ? (
+        <HostDetailsSection
+          icon={<Link2 size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.jumpHosts")}
+          action={
+            chainedHosts.length > 0 ? (
               <Badge variant="secondary" className="text-xs">
                 {t("hostDetails.jumpHosts.hops", { count: chainedHosts.length })}
               </Badge>
             ) : (
-              <Badge
-                variant="outline"
-                className="text-xs text-muted-foreground"
-              >
+              <Badge variant="outline" className="text-xs text-muted-foreground">
                 {t("hostDetails.jumpHosts.direct")}
               </Badge>
-            )}
-          </div>
+            )
+          }
+        >
           {chainedHosts.length > 0 && (
             <button
               className="w-full flex flex-col items-start gap-1 p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors cursor-pointer"
@@ -513,14 +473,14 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               {t("hostDetails.jumpHosts.configure")}
             </Button>
           )}
-        </Card>
+        </HostDetailsSection>
 
         {/* Proxy Configuration */}
-        <Card className="p-3 space-y-2 bg-card border-border/80 overflow-hidden">
-          <div className="flex items-center gap-2">
-            <Globe size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.proxy")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<Globe size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.proxy")}
+          className="overflow-hidden"
+        >
           {form.proxyConfig?.host || form.proxyProfileId ? (
             <div className="w-full min-w-0 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1">
               <button
@@ -565,16 +525,13 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               {t("hostDetails.proxy.configure")}
             </Button>
           )}
-        </Card>
+        </HostDetailsSection>
 
         {/* Environment Variables */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Variable size={14} className="text-muted-foreground" />
-              <p className="text-xs font-semibold">{t("hostDetails.envVars")}</p>
-            </div>
-          </div>
+        <HostDetailsSection
+          icon={<Variable size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.envVars")}
+        >
           {(form.environmentVariables?.length || 0) > 0 ? (
             <button
               className="w-full flex items-center gap-1 p-2 rounded-md bg-secondary/50 hover:bg-secondary transition-colors cursor-pointer"
@@ -606,14 +563,14 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
               {t("hostDetails.envVars.add")}
             </Button>
           )}
-        </Card>
+        </HostDetailsSection>
 
         {/* Startup Command */}
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <TerminalSquare size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">{t("hostDetails.startupCommand")}</p>
-          </div>
+        <HostDetailsSection
+          icon={<TerminalSquare size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.startupCommand")}
+          hint={t("hostDetails.startupCommand.help")}
+        >
           <Textarea
             placeholder={groupDefaults?.startupCommand || t("hostDetails.startupCommand.placeholder")}
             value={form.startupCommand || ""}
@@ -621,9 +578,6 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
             className="min-h-[80px] font-mono text-sm"
             rows={3}
           />
-          <p className="text-xs text-muted-foreground">
-            {t("hostDetails.startupCommand.help")}
-          </p>
-        </Card>
+        </HostDetailsSection>
   </>
 );

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -4,8 +4,8 @@ import type { Host } from "../types";
 import { cn } from "../lib/utils";
 import { DistroAvatar } from "./DistroAvatar";
 import { Button } from "./ui/button";
-import { Card } from "./ui/card";
 import { Combobox } from "./ui/combobox";
+import { HostDetailsSection, HostDetailsSettingRow } from "./host-details";
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { ScrollArea } from "./ui/scroll-area";
@@ -47,13 +47,10 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
   getDistroOptionLabel,
 }) => (
   <>
-        <Card className="p-3 space-y-2 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <MapPin size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("hostDetails.section.address")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<MapPin size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.address")}
+        >
           <div className="flex items-center gap-2">
             <DistroAvatar
               host={form as Host}
@@ -71,15 +68,13 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
               className="h-10 flex-1"
             />
           </div>
-        </Card>
+        </HostDetailsSection>
 
-        <Card className="p-3 space-y-3 bg-card border-border/80 overflow-hidden">
-          <div className="flex items-center gap-2">
-            <KeyRound size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("hostDetails.section.portCredentials")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<KeyRound size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.portCredentials")}
+          className="overflow-hidden"
+        >
           <div className="flex items-center gap-2">
             <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
               <span className="text-xs text-muted-foreground">SSH on</span>
@@ -594,48 +589,35 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 </div>
               )}
           </div>
-        </Card>
+        </HostDetailsSection>
 
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <FolderLock size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("hostDetails.section.sftp")}
-            </p>
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <div className="text-sm font-medium">
-                {t("hostDetails.sftp.sudo")}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {t("hostDetails.sftp.sudo.desc")}
-              </div>
-            </div>
+        <HostDetailsSection
+          icon={<FolderLock size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.sftp")}
+        >
+          <HostDetailsSettingRow
+            label={t("hostDetails.sftp.sudo")}
+            hint={t("hostDetails.sftp.sudo.desc")}
+          >
             <Switch
               checked={form.sftpSudo || false}
               onCheckedChange={(val) => update("sftpSudo", val)}
             />
-          </div>
+          </HostDetailsSettingRow>
           {form.sftpSudo && !form.password && !selectedIdentity?.password && (
             <p className="text-xs text-amber-500">
               {t("hostDetails.sftp.sudo.passwordWarning")}
             </p>
           )}
-          <div className="flex items-center justify-between gap-4">
-            <div className="space-y-0.5">
-              <div className="text-sm font-medium">
-                {t("hostDetails.sftp.encoding")}
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {t("hostDetails.sftp.encoding.desc")}
-              </div>
-            </div>
+          <HostDetailsSettingRow
+            label={t("hostDetails.sftp.encoding")}
+            hint={t("hostDetails.sftp.encoding.desc")}
+          >
             <Select
               value={form.sftpEncoding || "auto"}
               onValueChange={(val) => update("sftpEncoding", val as Host["sftpEncoding"])}
             >
-              <SelectTrigger className="h-8 w-28">
+              <SelectTrigger className="h-10 w-32">
                 <SelectValue placeholder={t("sftp.encoding.label")} />
               </SelectTrigger>
               <SelectContent>
@@ -644,17 +626,15 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 <SelectItem value="gb18030">{t("sftp.encoding.gb18030")}</SelectItem>
               </SelectContent>
             </Select>
-          </div>
-        </Card>
+          </HostDetailsSettingRow>
+        </HostDetailsSection>
 
         {form.os === "linux" && (
-          <Card className="p-3 space-y-3 bg-card border-border/80">
-            <div className="flex items-center gap-2">
-              <img src="/distro/linux.svg" alt="Linux" className="h-3.5 w-3.5 opacity-70 dark:invert" />
-              <p className="text-xs font-semibold">{t("hostDetails.distro.title")}</p>
-            </div>
-            <p className="text-xs text-muted-foreground">{t("hostDetails.distro.desc")}</p>
-
+          <HostDetailsSection
+            icon={<img src="/distro/linux.svg" alt="Linux" className="h-3.5 w-3.5 opacity-70 dark:invert" />}
+            title={t("hostDetails.distro.title")}
+            hint={t("hostDetails.distro.desc")}
+          >
             <div className="grid gap-2 md:grid-cols-2">
               <div className="space-y-1">
                 <span className="text-xs text-muted-foreground">{t("hostDetails.distro.mode")}</span>
@@ -749,7 +729,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 </div>
               )}
             </div>
-          </Card>
+          </HostDetailsSection>
         )}
   </>
 );

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   Eye,
   EyeOff,
+  FileText,
   FolderPlus,
   Plus,
   Settings2,
@@ -38,7 +39,6 @@ import { HostDetailsConnectionSections } from "./HostDetailsConnectionSections";
 import { LINUX_DISTRO_OPTION_IDS, parseOptionalPortInput, resolveDetailsTelnetPassword, resolveDetailsTelnetPort, resolveDetailsTelnetUsername } from "./HostDetailsPanel.helpers";
 export { parseOptionalPortInput } from "./HostDetailsPanel.helpers";
 import { Button } from "./ui/button";
-import { Card } from "./ui/card";
 import { Combobox, ComboboxOption, MultiCombobox } from "./ui/combobox";
 import { Input } from "./ui/input";
 import { Switch } from "./ui/switch";
@@ -47,6 +47,7 @@ import { toast } from "./ui/toast";
 import {
   ChainPanel,
   CreateGroupPanel,
+  HostDetailsSection,
   EnvVarsPanel,
   ProxyPanel,
 } from "./host-details";
@@ -703,13 +704,10 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       }
     >
       <AsidePanelContent>
-        <Card className="p-3 space-y-3 bg-card border-border/80">
-          <div className="flex items-center gap-2">
-            <Settings2 size={14} className="text-muted-foreground" />
-            <p className="text-xs font-semibold">
-              {t("hostDetails.section.general")}
-            </p>
-          </div>
+        <HostDetailsSection
+          icon={<Settings2 size={14} className="text-muted-foreground" />}
+          title={t("hostDetails.section.general")}
+        >
           <Input
             placeholder={t("hostDetails.label.placeholder")}
             value={form.label}
@@ -766,13 +764,20 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
               triggerClassName="flex-1 min-h-10"
             />
           </div>
+        </HostDetailsSection>
 
+        <HostDetailsSection
+          icon={<FileText size={14} className="text-muted-foreground shrink-0" />}
+          title={t("hostDetails.notes.label")}
+          hint={t("hostDetails.notes.help")}
+        >
           <HostNotesEditor
             panelKey={form.id}
             value={form.notes ?? ""}
             onChange={(notes) => update("notes", notes)}
+            showHeader={false}
           />
-        </Card>
+        </HostDetailsSection>
 
         <HostDetailsConnectionSections
           t={t}
@@ -835,7 +840,10 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         </div>
 
         {form.telnetEnabled || form.protocol === "telnet" ? (
-          <Card className="p-3 space-y-3 bg-card border-border/80">
+          <HostDetailsSection
+            icon={<Plus size={14} className="text-muted-foreground" />}
+            title="Telnet"
+          >
             <div className="flex items-center justify-between">
               <div className="flex-1 min-w-0 h-10 flex items-center gap-2 bg-secondary/70 border border-border/70 rounded-md px-3">
                 <span className="text-xs text-muted-foreground">{t("hostDetails.telnetOn")}</span>
@@ -932,7 +940,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
                 {customThemeStore.getThemeById(effectiveTelnetThemeId)?.name || "Flexoki Dark"}
               </span>
             </button>
-          </Card>
+          </HostDetailsSection>
         ) : (
           <Button
             variant="ghost"

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -7,7 +7,6 @@ import {
   List as ListIcon,
   MoreHorizontal,
   Plus,
-  Search,
   Shield,
   Trash2,
   Upload,
@@ -41,10 +40,14 @@ import {
   ContextMenuTrigger,
 } from "./ui/context-menu";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
-import { Input } from "./ui/input";
 import { toast } from "./ui/toast";
 import { KeychainExportPanel } from "./KeychainExportPanel";
 import { KeychainEditPanel } from "./KeychainEditPanel";
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+} from "./vault/VaultPageHeader";
 
 // Import utilities and components from keychain module
 import {
@@ -524,8 +527,7 @@ echo $3 >> "$FILE"`);
           panel.type !== "closed" && "mr-[380px]",
         )}
       >
-        {/* Toolbar */}
-        <div className="h-14 px-4 py-2 flex items-center gap-3 bg-secondary/80 supports-[backdrop-filter]:backdrop-blur-sm border-b border-border/50 shrink-0">
+        <VaultPageHeader>
           {/* Filter Tabs */}
           <div className="flex items-center gap-1">
             {/* KEY button with split interaction: left=switch view, right=dropdown */}
@@ -628,25 +630,19 @@ echo $3 >> "$FILE"`);
           {/* Search and View Mode - hide search when panel is open */}
           <div className="ml-auto flex items-center gap-2 min-w-0 flex-shrink">
             {panel.type === "closed" && (
-              <div className="relative flex-shrink min-w-[100px]">
-                <Search
-                  size={14}
-                  className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder={t("common.searchPlaceholder")}
-                  className="h-10 pl-9 w-full bg-secondary border-border/60 text-sm"
-                />
-              </div>
+              <VaultHeaderSearch
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t("common.searchPlaceholder")}
+                className="flex-shrink w-64"
+              />
             )}
             <Dropdown>
               <DropdownTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-10 w-10 flex-shrink-0"
+                  className={cn(vaultHeaderIconButtonClass, "flex-shrink-0")}
                 >
                   {viewMode === "grid" ? (
                     <LayoutGrid size={16} />
@@ -674,7 +670,7 @@ echo $3 >> "$FILE"`);
               </DropdownContent>
             </Dropdown>
           </div>
-        </div>
+        </VaultPageHeader>
 
         {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto">

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -6,7 +6,6 @@ import {
   LayoutGrid,
   List as ListIcon,
   RefreshCw,
-  Search,
   Server,
   Shield,
   Trash2,
@@ -35,11 +34,16 @@ import {
   ContextMenuTrigger,
 } from "./ui/context-menu";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
-import { Input } from "./ui/input";
 import { ScrollArea } from "./ui/scroll-area";
 import { SortDropdown, SortMode } from "./ui/sort-dropdown";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { toast } from "./ui/toast";
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
+} from "./vault/VaultPageHeader";
 
 interface KnownHostsManagerProps {
   knownHosts: KnownHost[];
@@ -476,27 +480,20 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="h-14 px-4 py-2 flex items-center gap-3 border-b border-border/50 bg-secondary/80 supports-[backdrop-filter]:backdrop-blur-sm">
+      <VaultPageHeader>
         <div className="flex-1 min-w-0 flex items-center gap-2">
-          <div className="relative flex-1 max-w-xs">
-            <Search
-              size={14}
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              placeholder={t("knownHosts.search.placeholder")}
-              className="pl-9 h-10 bg-secondary border-border/60 text-sm"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          </div>
+          <VaultHeaderSearch
+            placeholder={t("knownHosts.search.placeholder")}
+            className="flex-1 max-w-xs"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
         </div>
         <div className="flex items-center gap-1">
           {/* View Mode Toggle */}
           <Dropdown>
             <DropdownTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-10 w-10">
+              <Button variant="ghost" size="icon" className={vaultHeaderIconButtonClass}>
                 {viewMode === "grid" ? (
                   <LayoutGrid size={16} />
                 ) : (
@@ -527,14 +524,14 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
           <SortDropdown
             value={sortMode}
             onChange={setSortMode}
-            className="h-10 w-10"
+            className={vaultHeaderIconButtonClass}
           />
         </div>
         <div className="w-px h-5 bg-border/50" />
         <div className="flex items-center gap-2">
           <Button
             variant="secondary"
-            className="h-10 px-3 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+            className={vaultHeaderSecondaryButtonClass}
             onClick={() => handleScanSystem()}
             disabled={isScanning}
           >
@@ -553,14 +550,14 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
           />
           <Button
             variant="secondary"
-            className="h-10 px-3 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+            className={vaultHeaderSecondaryButtonClass}
             onClick={openFilePicker}
           >
             <Import size={14} className="mr-2" />
             {t("knownHosts.action.importFile")}
           </Button>
         </div>
-      </div>
+      </VaultPageHeader>
 
       {/* Content */}
       <ScrollArea className="flex-1">

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -5,7 +5,6 @@ import {
   Globe,
   LayoutGrid,
   List as ListIcon,
-  Search,
   Server,
   Shuffle,
   Zap,
@@ -41,9 +40,14 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
-import { Input } from "./ui/input";
 import { SortDropdown } from "./ui/sort-dropdown";
 import { toast } from "./ui/toast";
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
+} from "./vault/VaultPageHeader";
 
 // Import components and utilities from port-forwarding module
 import {
@@ -586,13 +590,12 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           showWizard || showEditPanel || showNewForm ? "mr-[360px]" : "",
         )}
       >
-        {/* Toolbar */}
-        <div className="h-14 px-4 py-2 flex items-center gap-3 bg-secondary/80 supports-[backdrop-filter]:backdrop-blur-sm border-b border-border/50 relative z-20">
+        <VaultPageHeader className="z-20">
           <Dropdown open={showNewMenu} onOpenChange={setShowNewMenu}>
             <DropdownTrigger asChild>
               <Button
                 variant="secondary"
-                className="h-10 px-3 gap-2 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+                className={vaultHeaderSecondaryButtonClass}
               >
                 <Zap size={14} />
                 {t("pf.action.newForwarding")}
@@ -634,23 +637,17 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
           </Dropdown>
 
           <div className="ml-auto flex items-center gap-2">
-            <div className="relative">
-              <Search
-                size={14}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                placeholder={t("common.searchPlaceholder")}
-                className="h-10 pl-9 w-44 bg-secondary border-border/60 text-sm"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-              />
-            </div>
+            <VaultHeaderSearch
+              placeholder={t("common.searchPlaceholder")}
+              className="w-64"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
 
             {/* View mode toggle */}
             <Dropdown>
               <DropdownTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-10 w-10">
+                <Button variant="ghost" size="icon" className={vaultHeaderIconButtonClass}>
                   {viewMode === "grid" ? (
                     <LayoutGrid size={16} />
                   ) : (
@@ -687,10 +684,10 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
             <SortDropdown
               value={sortMode}
               onChange={setSortMode}
-              className="h-10 w-10"
+              className={vaultHeaderIconButtonClass}
             />
           </div>
-        </div>
+        </VaultPageHeader>
 
         {/* Rules List */}
         <div className="flex-1 overflow-auto p-4">

--- a/components/ProxyProfilesManager.tsx
+++ b/components/ProxyProfilesManager.tsx
@@ -9,7 +9,7 @@ import {
   List as ListIcon,
   Pencil,
   Plus,
-  Search,
+  Route,
   Settings2,
   Trash2,
 } from "lucide-react";
@@ -48,6 +48,12 @@ import {
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { Input } from "./ui/input";
 import { toast } from "./ui/toast";
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
+} from "./vault/VaultPageHeader";
 
 interface ProxyProfilesManagerProps {
   proxyProfiles: ProxyProfile[];
@@ -83,6 +89,23 @@ const getProfileUsageCount = (
 
 type ProxyProfilesViewMode = "grid" | "list";
 
+const proxyProtocolMeta = {
+  http: {
+    label: "HTTP",
+    Icon: Globe,
+    iconClassName: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+  },
+  socks5: {
+    label: "SOCKS5",
+    Icon: Route,
+    iconClassName: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+  },
+} satisfies Record<ProxyConfig["type"], {
+  label: string;
+  Icon: React.ComponentType<{ size?: number; className?: string }>;
+  iconClassName: string;
+}>;
+
 interface ProxyProfileCardProps {
   profile: ProxyProfile;
   usageCount: number;
@@ -106,7 +129,9 @@ const ProxyProfileCard: React.FC<ProxyProfileCardProps> = ({
 }) => {
   const { t } = useI18n();
   const usageLabel = t("proxyProfiles.usage", { count: usageCount });
-  const accessibleLabel = `${profile.label}, ${profile.config.type.toUpperCase()}, ${profile.config.host}:${profile.config.port}, ${usageLabel}`;
+  const protocol = proxyProtocolMeta[profile.config.type];
+  const ProtocolIcon = protocol.Icon;
+  const accessibleLabel = `${profile.label}, ${protocol.label}, ${profile.config.host}:${profile.config.port}, ${usageLabel}`;
 
   return (
     <ContextMenu>
@@ -124,19 +149,22 @@ const ProxyProfileCard: React.FC<ProxyProfileCardProps> = ({
           onClick={onClick}
         >
           <div className="flex items-center gap-3 h-full">
-            <div className="h-11 w-11 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
-              <Globe size={18} />
+            <div
+              className={cn(
+                "h-11 w-11 rounded-xl flex items-center justify-center",
+                protocol.iconClassName,
+              )}
+              title={protocol.label}
+            >
+              <ProtocolIcon size={18} />
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 min-w-0">
                 <div className="text-sm font-semibold truncate">{profile.label}</div>
-                <Badge variant="secondary" className="text-[10px] shrink-0">
-                  {profile.config.type.toUpperCase()}
-                </Badge>
               </div>
               <div className="text-[11px] font-mono text-muted-foreground truncate">
                 {profile.config.host}:{profile.config.port} -{" "}
-                {usageLabel}
+                {protocol.label}
               </div>
             </div>
           </div>
@@ -289,34 +317,30 @@ export const ProxyProfilesManager: React.FC<ProxyProfilesManagerProps> = ({
   return (
     <div className="h-full flex relative">
       <div className={cn("flex-1 flex flex-col min-h-0 transition-all duration-200", draft && "mr-[380px]")}>
-        <header className="border-b border-border/50 bg-secondary/80 supports-[backdrop-filter]:backdrop-blur-sm shrink-0">
-          <div className="h-14 px-4 py-2 flex items-center gap-3">
+        <VaultPageHeader>
             <Button
               onClick={openCreate}
               variant="secondary"
-              className="h-10 px-3 gap-2 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+              className={vaultHeaderSecondaryButtonClass}
             >
               <Plus size={14} />
               {t("proxyProfiles.action.add")}
             </Button>
             <div className="ml-auto flex items-center gap-2 min-w-0 flex-shrink">
-              <div className="relative flex-shrink min-w-[100px]">
-                <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  aria-label={t("proxyProfiles.search.placeholder")}
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                  placeholder={t("proxyProfiles.search.placeholder")}
-                  className="h-10 pl-9 w-full bg-secondary border-border/60 text-sm"
-                />
-              </div>
+              <VaultHeaderSearch
+                aria-label={t("proxyProfiles.search.placeholder")}
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder={t("proxyProfiles.search.placeholder")}
+                className="flex-shrink w-64"
+              />
               <Dropdown>
                 <DropdownTrigger asChild>
                   <Button
                     aria-label={t("proxyProfiles.viewMode")}
                     variant="ghost"
                     size="icon"
-                    className="h-10 w-10 flex-shrink-0"
+                    className={cn(vaultHeaderIconButtonClass, "flex-shrink-0")}
                   >
                     {proxyProfilesViewMode === "grid" ? (
                       <LayoutGrid size={16} />
@@ -344,8 +368,7 @@ export const ProxyProfilesManager: React.FC<ProxyProfilesManagerProps> = ({
                 </DropdownContent>
               </Dropdown>
             </div>
-          </div>
-        </header>
+        </VaultPageHeader>
 
         <div className="flex-1 overflow-y-auto">
           <div className="space-y-3 p-3">

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -10,11 +10,16 @@ import { Button } from './ui/button';
 import { ComboboxOption } from './ui/combobox';
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger } from './ui/context-menu';
 import { Dropdown, DropdownContent, DropdownTrigger } from './ui/dropdown';
-import { Input } from './ui/input';
 import { SortDropdown, SortMode } from './ui/sort-dropdown';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { SnippetsRightPanel } from './SnippetsRightPanel';
 import { SnippetsPackageDialogs } from './SnippetsPackageDialogs';
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
+} from './vault/VaultPageHeader';
 
 interface SnippetsManagerProps {
   snippets: Snippet[];
@@ -695,18 +700,14 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     <TooltipProvider delayDuration={300}>
     <div className="h-full min-h-0 flex relative">
       <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-        <header className="border-b border-border/50 bg-secondary/80 supports-[backdrop-filter]:backdrop-blur-sm">
-          <div className="h-14 px-4 py-2 flex items-center gap-3">
-            <div className="relative w-64">
-              <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder={t('snippets.searchPlaceholder')}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="h-10 pl-9 bg-secondary border-border/60 text-sm"
-              />
-            </div>
-            <Button onClick={() => handleEdit()} size="sm" className="h-10">
+        <VaultPageHeader>
+            <VaultHeaderSearch
+              placeholder={t('snippets.searchPlaceholder')}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-64"
+            />
+            <Button onClick={() => handleEdit()} size="sm" className="h-10 px-3">
               <Plus size={14} className="mr-2" /> {t('snippets.action.newSnippet')}
             </Button>
             <Button
@@ -716,14 +717,17 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               }}
               size="sm"
               variant="secondary"
-              className="h-10 gap-2 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+              className={vaultHeaderSecondaryButtonClass}
             >
               <FolderPlus size={14} className="mr-1" /> {t('snippets.action.newPackage')}
             </Button>
             <Button
-              variant={rightPanelMode === 'history' ? 'secondary' : 'ghost'}
+              variant="secondary"
               size="sm"
-              className="h-10 gap-2"
+              className={cn(
+                vaultHeaderSecondaryButtonClass,
+                rightPanelMode === 'history' && "bg-foreground/10 hover:bg-foreground/15",
+              )}
               onClick={() => setRightPanelMode(rightPanelMode === 'history' ? 'none' : 'history')}
             >
               <Clock size={14} /> {t('snippets.history.title')}
@@ -731,7 +735,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
             <div className="flex items-center gap-1 ml-auto">
               <Dropdown>
                 <DropdownTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-10 w-10">
+                  <Button variant="ghost" size="icon" className={vaultHeaderIconButtonClass}>
                     {viewMode === 'grid' ? <LayoutGrid size={16} /> : <ListIcon size={16} />}
                     <ChevronDown size={10} className="ml-0.5" />
                   </Button>
@@ -756,11 +760,10 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               <SortDropdown
                 value={sortMode}
                 onChange={setSortMode}
-                className="h-10 w-10"
+                className={vaultHeaderIconButtonClass}
               />
             </div>
-          </div>
-        </header>
+        </VaultPageHeader>
         <div className="flex items-center gap-2 text-sm font-semibold px-4 py-2">
           <button className="text-primary hover:underline" onClick={() => setSelectedPackage(null)}>{t('snippets.breadcrumb.allPackages')}</button>
           {breadcrumb.map((b) => (

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -35,6 +35,7 @@ import React, { Suspense, lazy, memo, startTransition, useCallback, useEffect, u
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import { useStoredBoolean } from "../application/state/useStoredBoolean";
+import { useStoredNumber } from "../application/state/useStoredNumber";
 import { useStoredString } from "../application/state/useStoredString";
 import { useTreeExpandedState } from "../application/state/useTreeExpandedState";
 import { sanitizeCredentialValue } from "../domain/credentials";
@@ -53,6 +54,7 @@ import {
   STORAGE_KEY_VAULT_HOSTS_TREE_EXPANDED,
   STORAGE_KEY_VAULT_HOSTS_VIEW_MODE,
   STORAGE_KEY_VAULT_SIDEBAR_COLLAPSED,
+  STORAGE_KEY_VAULT_SIDEBAR_WIDTH,
 } from "../infrastructure/config/storageKeys";
 import { cn } from "../lib/utils";
 import { useInstantThemeSwitch } from "../lib/useInstantThemeSwitch";
@@ -118,6 +120,11 @@ const LazyProtocolSelectDialog = lazy(() => import("./ProtocolSelectDialog"));
 const LazyConnectionLogsManager = lazy(() => import("./ConnectionLogsManager"));
 
 export type VaultSection = "hosts" | "keys" | "proxies" | "snippets" | "port" | "knownhosts" | "logs";
+
+const VAULT_SIDEBAR_MIN_WIDTH = 56;
+const VAULT_SIDEBAR_DEFAULT_WIDTH = 208;
+const VAULT_SIDEBAR_MAX_WIDTH = 320;
+const VAULT_SIDEBAR_LABEL_THRESHOLD = 132;
 
 const isSortMode = (value: string): value is SortMode =>
   value === "az" ||
@@ -254,10 +261,34 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   useInstantThemeSwitch(rootRef);
 
   // Sidebar collapsed state with localStorage persistence
-  const [sidebarCollapsed, setSidebarCollapsed] = useStoredBoolean(
+  const [storedSidebarCollapsed, setStoredSidebarCollapsed] = useStoredBoolean(
     STORAGE_KEY_VAULT_SIDEBAR_COLLAPSED,
     false,
   );
+  const [sidebarWidth, setSidebarWidth, persistSidebarWidth] = useStoredNumber(
+    STORAGE_KEY_VAULT_SIDEBAR_WIDTH,
+    storedSidebarCollapsed ? VAULT_SIDEBAR_MIN_WIDTH : VAULT_SIDEBAR_DEFAULT_WIDTH,
+    {
+      min: VAULT_SIDEBAR_MIN_WIDTH,
+      max: VAULT_SIDEBAR_MAX_WIDTH,
+    },
+  );
+  const sidebarCollapsed = sidebarWidth < VAULT_SIDEBAR_LABEL_THRESHOLD;
+  const setSidebarCollapsed = useCallback((nextCollapsed: boolean) => {
+    const nextWidth = nextCollapsed ? VAULT_SIDEBAR_MIN_WIDTH : VAULT_SIDEBAR_DEFAULT_WIDTH;
+    setSidebarWidth(nextWidth);
+    persistSidebarWidth(nextWidth);
+    setStoredSidebarCollapsed(nextCollapsed);
+  }, [persistSidebarWidth, setSidebarWidth, setStoredSidebarCollapsed]);
+  const handleSidebarWidthCommit = useCallback((nextWidth: number) => {
+    const clampedWidth = Math.max(
+      VAULT_SIDEBAR_MIN_WIDTH,
+      Math.min(VAULT_SIDEBAR_MAX_WIDTH, nextWidth),
+    );
+    setSidebarWidth(clampedWidth);
+    persistSidebarWidth(clampedWidth);
+    setStoredSidebarCollapsed(clampedWidth < VAULT_SIDEBAR_LABEL_THRESHOLD);
+  }, [persistSidebarWidth, setSidebarWidth, setStoredSidebarCollapsed]);
 
   // Handle external navigation requests
   useEffect(() => {
@@ -942,7 +973,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
-  return <VaultViewLayout ctx={{ Activity, allGroupPaths, allTags, AppLogo, Array, Badge, BookMarked, Boolean, Button, CheckSquare, ChevronDown, clearHostSelection, ClipboardCopy, Clock, cn, connectionLogs, connectSelectedHosts, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, currentSection, customGroups, deleteGroupPath, deleteGroupWithHosts, deleteSelectedHosts, deleteTargetPath, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, displayedGroups, displayedHosts, DistroAvatar, Download, Dropdown, DropdownContent, DropdownTrigger, Edit2, editingGroupPath, editingHost, editingHostGroupDefaults, FileCode, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, Globe, groupConfigs, GroupDetailsPanel, groupedDisplayHosts, handleConnectClick, handleCopyCredentials, handleDeleteTag, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleEditTag, handleExportHosts, handleHostConnect, handleImportFileSelected, handleNewHost, handleProtocolSelect, handleQuickConnect, handleQuickConnectSaveHost, handleSaveGroupConfig, handleSearchKeyDown, handleUnmanageGroup, hasHostsSidePanel, HostDetailsPanel, hostListScrollRef, hosts, HostTreeView, hotkeyScheme, identities, ImportVaultDialog, Input, isDeleteGroupOpen, isGroupPanelOpen, isHostPanelOpen, isHostsSectionActive, isImportOpen, isMultiSelectMode, isNewFolderOpen, isQuickConnectOpen, isRenameGroupOpen, isSearchQuickConnect, isSerialModalOpen, Key, keyBindings, KeychainManager, keys, knownHostsManagerElement, Label, lastPinnedId, LayoutGrid, LazyConnectionLogsManager, LazyProtocolSelectDialog, List, managedGroupPaths, managedSources, moveGroup, moveHostToGroup, Network, newFolderName, newHostGroupPath, onClearUnsavedConnectionLogs, onConnectSerial, onCreateLocalTerminal, onDeleteConnectionLog, onDeleteHost, onImportOrReuseKey, onOpenLogView, onOpenSettings, onRunSnippet, onToggleConnectionLogSaved, onUpdateCustomGroups, onUpdateGroupConfigs, onUpdateHosts, onUpdateIdentities, onUpdateKeys, onUpdateProxyProfiles, onUpdateSnippetPackages, onUpdateSnippets, Pin, pinnedHosts, pinnedRecentIds, Plug, Plus, PortForwarding, protocolSelectHost, proxyProfiles, ProxyProfilesManager, quickConnectTarget, quickConnectWarnings, QuickConnectWizard, recentHosts, renameGroupError, renameGroupName, renameTargetPath, RippleButton, rootRef, sanitizeHost, search, Search, selectedGroupPath, selectedHostIds, selectedTags, SerialConnectModal, SerialHostDetailsPanel, sessionCount, Set, setCurrentSection, setDeleteGroupWithHosts, setDeleteTargetPath, setDragOverDropTarget, setEditingGroupPath, setEditingHost, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsGroupPanelOpen, setIsHostPanelOpen, setIsImportOpen, setIsMultiSelectMode, setIsNewFolderOpen, setIsQuickConnectOpen, setIsRenameGroupOpen, setIsSerialModalOpen, setLastPinnedId, setNewFolderName, setNewHostGroupPath, setProtocolSelectHost, setQuickConnectTarget, setQuickConnectWarnings, setRenameGroupError, setRenameGroupName, setRenameTargetPath, setSearch, setSelectedGroupPath, setSelectedHostIds, setSelectedTags, setSidebarCollapsed, setSortMode, setTargetParentPath, Settings, setViewMode, shellHistory, shouldHideEmptyRootHostsSection, showRecentHosts, sidebarCollapsed, snippetPackages, snippets, SnippetsManager, SortDropdown, sortMode, splitViewGridStyle, Square, Star, submitNewFolder, submitRenameGroup, Suspense, t, TagFilterDropdown, targetParentPath, terminalFontSize, terminalSettings, TerminalSquare, terminalThemeId, toggleHostPinned, toggleHostSelection, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, Upload, upsertHostById, Usb, viewMode, visibleDisplayedHosts, X, Zap }} />;
+  return <VaultViewLayout ctx={{ Activity, allGroupPaths, allTags, AppLogo, Array, Badge, BookMarked, Boolean, Button, CheckSquare, ChevronDown, clearHostSelection, ClipboardCopy, Clock, cn, connectionLogs, connectSelectedHosts, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, currentSection, customGroups, deleteGroupPath, deleteGroupWithHosts, deleteSelectedHosts, deleteTargetPath, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, displayedGroups, displayedHosts, DistroAvatar, Download, Dropdown, DropdownContent, DropdownTrigger, Edit2, editingGroupPath, editingHost, editingHostGroupDefaults, FileCode, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, Globe, groupConfigs, GroupDetailsPanel, groupedDisplayHosts, handleConnectClick, handleCopyCredentials, handleDeleteTag, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleEditTag, handleExportHosts, handleHostConnect, handleImportFileSelected, handleNewHost, handleProtocolSelect, handleQuickConnect, handleQuickConnectSaveHost, handleSaveGroupConfig, handleSearchKeyDown, handleUnmanageGroup, hasHostsSidePanel, HostDetailsPanel, hostListScrollRef, hosts, HostTreeView, hotkeyScheme, identities, ImportVaultDialog, Input, isDeleteGroupOpen, isGroupPanelOpen, isHostPanelOpen, isHostsSectionActive, isImportOpen, isMultiSelectMode, isNewFolderOpen, isQuickConnectOpen, isRenameGroupOpen, isSearchQuickConnect, isSerialModalOpen, Key, keyBindings, KeychainManager, keys, knownHostsManagerElement, Label, lastPinnedId, LayoutGrid, LazyConnectionLogsManager, LazyProtocolSelectDialog, List, managedGroupPaths, managedSources, moveGroup, moveHostToGroup, Network, newFolderName, newHostGroupPath, onClearUnsavedConnectionLogs, onConnectSerial, onCreateLocalTerminal, onDeleteConnectionLog, onDeleteHost, onImportOrReuseKey, onOpenLogView, onOpenSettings, onRunSnippet, onToggleConnectionLogSaved, onUpdateCustomGroups, onUpdateGroupConfigs, onUpdateHosts, onUpdateIdentities, onUpdateKeys, onUpdateProxyProfiles, onUpdateSnippetPackages, onUpdateSnippets, Pin, pinnedHosts, pinnedRecentIds, Plug, Plus, PortForwarding, protocolSelectHost, proxyProfiles, ProxyProfilesManager, quickConnectTarget, quickConnectWarnings, QuickConnectWizard, recentHosts, renameGroupError, renameGroupName, renameTargetPath, RippleButton, rootRef, sanitizeHost, search, Search, selectedGroupPath, selectedHostIds, selectedTags, SerialConnectModal, SerialHostDetailsPanel, sessionCount, Set, setCurrentSection, setDeleteGroupWithHosts, setDeleteTargetPath, setDragOverDropTarget, setEditingGroupPath, setEditingHost, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsGroupPanelOpen, setIsHostPanelOpen, setIsImportOpen, setIsMultiSelectMode, setIsNewFolderOpen, setIsQuickConnectOpen, setIsRenameGroupOpen, setIsSerialModalOpen, setLastPinnedId, setNewFolderName, setNewHostGroupPath, setProtocolSelectHost, setQuickConnectTarget, setQuickConnectWarnings, setRenameGroupError, setRenameGroupName, setRenameTargetPath, setSearch, setSelectedGroupPath, setSelectedHostIds, setSelectedTags, setSidebarCollapsed, setSidebarWidth, handleSidebarWidthCommit, setSortMode, setTargetParentPath, Settings, setViewMode, shellHistory, shouldHideEmptyRootHostsSection, showRecentHosts, sidebarCollapsed, sidebarWidth, snippetPackages, snippets, SnippetsManager, SortDropdown, sortMode, splitViewGridStyle, Square, Star, submitNewFolder, submitRenameGroup, Suspense, t, TagFilterDropdown, targetParentPath, terminalFontSize, terminalSettings, TerminalSquare, terminalThemeId, toggleHostPinned, toggleHostSelection, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, Upload, upsertHostById, Usb, viewMode, visibleDisplayedHosts, X, Zap }} />;
 };
 
 // Only re-render when data props change - isActive is now managed internally via store subscription

--- a/components/host-details/HostDetailsSection.tsx
+++ b/components/host-details/HostDetailsSection.tsx
@@ -1,0 +1,94 @@
+import { HelpCircle } from "lucide-react";
+import React from "react";
+import { cn } from "../../lib/utils";
+import { Card } from "../ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+export function HostDetailsHelp({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  if (!children) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "relative -top-px flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground [&>svg]:block",
+            className,
+          )}
+          aria-label={typeof children === "string" ? children : undefined}
+        >
+          <HelpCircle size={13} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[260px] text-left leading-relaxed">
+        {children}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function HostDetailsSection({
+  icon,
+  title,
+  hint,
+  children,
+  className,
+  action,
+}: {
+  icon: React.ReactNode;
+  title: React.ReactNode;
+  hint?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <Card className={cn("p-3 space-y-3 bg-card border-border/80 shadow-sm", className)}>
+      <div className="flex min-h-5 items-center gap-1.5">
+        <span className="flex h-5 w-4 shrink-0 items-center justify-center text-muted-foreground [&>img]:block [&>img]:h-4 [&>img]:w-4 [&>img]:object-contain [&>svg]:block [&>svg]:h-4 [&>svg]:w-4">
+          {icon}
+        </span>
+        <p className="flex min-h-5 items-center text-xs font-semibold leading-5 text-foreground">
+          {title}
+        </p>
+        {hint && <HostDetailsHelp>{hint}</HostDetailsHelp>}
+        {action && <div className="ml-auto flex items-center">{action}</div>}
+      </div>
+      {children}
+    </Card>
+  );
+}
+
+export function HostDetailsSettingRow({
+  label,
+  hint,
+  children,
+  className,
+}: {
+  label: React.ReactNode;
+  hint?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-12 items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/40 px-3 py-2",
+        className,
+      )}
+    >
+      <div className="flex min-h-5 min-w-0 items-center gap-1.5">
+        <span className="truncate text-sm font-medium leading-5 text-foreground">{label}</span>
+        {hint && <HostDetailsHelp>{hint}</HostDetailsHelp>}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}

--- a/components/host-details/index.ts
+++ b/components/host-details/index.ts
@@ -14,3 +14,9 @@ export type { ChainPanelProps } from './ChainPanel';
 
 export { EnvVarsPanel } from './EnvVarsPanel';
 export type { EnvVarsPanelProps } from './EnvVarsPanel';
+
+export {
+  HostDetailsHelp,
+  HostDetailsSection,
+  HostDetailsSettingRow,
+} from './HostDetailsSection';

--- a/components/host/HostNotesEditor.tsx
+++ b/components/host/HostNotesEditor.tsx
@@ -20,6 +20,7 @@ export interface HostNotesEditorProps {
   /** Changes when opening a different host (e.g. host id) to reset the active tab */
   panelKey?: string;
   className?: string;
+  showHeader?: boolean;
 }
 
 export const HostNotesEditor: React.FC<HostNotesEditorProps> = ({
@@ -27,6 +28,7 @@ export const HostNotesEditor: React.FC<HostNotesEditorProps> = ({
   onChange,
   panelKey,
   className,
+  showHeader = true,
 }) => {
   const { t } = useI18n();
   const [tab, setTab] = useState<"edit" | "preview">(() => defaultNotesTab(value));
@@ -42,13 +44,17 @@ export const HostNotesEditor: React.FC<HostNotesEditorProps> = ({
 
   return (
     <div className={cn("space-y-2", className)}>
-      <div className="flex items-center gap-2">
-        <FileText size={14} className="text-muted-foreground shrink-0" />
-        <p className="text-xs font-semibold text-muted-foreground">
-          {t("hostDetails.notes.label")}
-        </p>
-      </div>
-      <p className="text-xs text-muted-foreground">{t("hostDetails.notes.help")}</p>
+      {showHeader && (
+        <>
+          <div className="flex items-center gap-2">
+            <FileText size={14} className="text-muted-foreground shrink-0" />
+            <p className="text-xs font-semibold">
+              {t("hostDetails.notes.label")}
+            </p>
+          </div>
+          <p className="text-xs text-muted-foreground">{t("hostDetails.notes.help")}</p>
+        </>
+      )}
       <Tabs value={tab} onValueChange={(v) => setTab(v as "edit" | "preview")}>
         <TabsList className="h-8 w-full">
           <TabsTrigger value="edit" className="flex-1 text-xs">

--- a/components/host/HostNotesIndicator.tsx
+++ b/components/host/HostNotesIndicator.tsx
@@ -1,14 +1,8 @@
 import { FileText } from "lucide-react";
 import React from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
-
-const NOTES_TOOLTIP_MAX = 160;
-
-export function getHostNotesTooltipPreview(notes: string): string {
-  const flat = notes.replace(/\s+/g, " ").trim();
-  if (flat.length <= NOTES_TOOLTIP_MAX) return flat;
-  return `${flat.slice(0, NOTES_TOOLTIP_MAX)}...`;
-}
+import { cn } from "../../lib/utils";
+import { MessageResponse } from "../ai-elements/message";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "../ui/hover-card";
 
 export interface HostNotesIndicatorProps {
   notes?: string;
@@ -19,22 +13,38 @@ export const HostNotesIndicator: React.FC<HostNotesIndicatorProps> = ({
   notes,
   className,
 }) => {
-  if (!notes?.trim()) return null;
+  const trimmed = notes?.trim();
+  if (!trimmed) return null;
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={className}
+    <HoverCard openDelay={180} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 text-muted-foreground transition-colors hover:text-foreground",
+            className,
+          )}
+          aria-label="Host notes"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >
           <FileText size={12} className="text-muted-foreground" aria-hidden />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-xs text-xs whitespace-pre-wrap">
-        {getHostNotesTooltipPreview(notes)}
-      </TooltipContent>
-    </Tooltip>
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="start"
+        className="w-[320px] max-w-[calc(100vw-32px)] p-3"
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <div className="max-h-[240px] overflow-y-auto pr-1">
+          <MessageResponse className="text-xs leading-relaxed text-popover-foreground/90 [&_h1]:text-sm [&_h1]:mt-2 [&_h1]:mb-1 [&_h2]:text-sm [&_h2]:mt-2 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:mt-1.5 [&_h3]:mb-1 [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1">
+            {trimmed}
+          </MessageResponse>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   );
 };

--- a/components/vault/VaultPageHeader.tsx
+++ b/components/vault/VaultPageHeader.tsx
@@ -1,0 +1,78 @@
+import { Search } from "lucide-react";
+import React from "react";
+import { cn } from "../../lib/utils";
+import { Input } from "../ui/input";
+
+interface VaultPageHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  dataSection?: string;
+}
+
+export function VaultPageHeader({
+  children,
+  className,
+  contentClassName,
+  dataSection,
+}: VaultPageHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "relative shrink-0 bg-background/95 app-drag after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:origin-bottom after:[transform:scaleY(.5)] after:bg-border/40 after:content-['']",
+        className,
+      )}
+      data-section={dataSection}
+    >
+      <div
+        className={cn(
+          "h-14 px-4 py-2 flex items-center gap-3 app-no-drag",
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+    </header>
+  );
+}
+
+interface VaultHeaderSearchProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "className"> {
+  className?: string;
+  inputClassName?: string;
+  rightAdornment?: React.ReactNode;
+}
+
+export function VaultHeaderSearch({
+  className,
+  inputClassName,
+  rightAdornment,
+  ...props
+}: VaultHeaderSearchProps) {
+  return (
+    <div className={cn("relative min-w-[100px]", className)}>
+      <Search
+        size={14}
+        className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        {...props}
+        className={cn(
+          "pl-9 h-10 bg-secondary border-border/60 text-sm",
+          rightAdornment && "pr-9",
+          inputClassName,
+        )}
+      />
+      {rightAdornment && (
+        <div className="absolute right-3 top-1/2 -translate-y-1/2">
+          {rightAdornment}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const vaultHeaderSecondaryButtonClass =
+  "h-10 px-3 gap-2 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40";
+
+export const vaultHeaderIconButtonClass = "h-10 w-10";

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1,20 +1,69 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { VaultHostListSection } from "./VaultHostListSection";
+import {
+  VaultHeaderSearch,
+  VaultPageHeader,
+  vaultHeaderIconButtonClass,
+  vaultHeaderSecondaryButtonClass,
+} from "./VaultPageHeader";
 
 type VaultViewLayoutContext = Record<string, any>;
 
 export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
-  const { Activity, allGroupPaths, allTags, AppLogo, Array, Badge, BookMarked, Boolean, Button, CheckSquare, ChevronDown, clearHostSelection, ClipboardCopy, Clock, cn, connectionLogs, connectSelectedHosts, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, currentSection, customGroups, deleteGroupPath, deleteGroupWithHosts, deleteSelectedHosts, deleteTargetPath, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, displayedGroups, displayedHosts, DistroAvatar, Download, Dropdown, DropdownContent, DropdownTrigger, Edit2, editingGroupPath, editingHost, editingHostGroupDefaults, FileCode, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, Globe, groupConfigs, GroupDetailsPanel, groupedDisplayHosts, handleConnectClick, handleCopyCredentials, handleDeleteTag, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleEditTag, handleExportHosts, handleHostConnect, handleImportFileSelected, handleNewHost, handleProtocolSelect, handleQuickConnect, handleQuickConnectSaveHost, handleSaveGroupConfig, handleSearchKeyDown, handleUnmanageGroup, hasHostsSidePanel, HostDetailsPanel, hostListScrollRef, hosts, HostTreeView, hotkeyScheme, identities, ImportVaultDialog, Input, isDeleteGroupOpen, isGroupPanelOpen, isHostPanelOpen, isHostsSectionActive, isImportOpen, isMultiSelectMode, isNewFolderOpen, isQuickConnectOpen, isRenameGroupOpen, isSearchQuickConnect, isSerialModalOpen, Key, keyBindings, KeychainManager, keys, knownHostsManagerElement, Label, lastPinnedId, LayoutGrid, LazyConnectionLogsManager, LazyProtocolSelectDialog, List, managedGroupPaths, managedSources, moveGroup, moveHostToGroup, Network, newFolderName, newHostGroupPath, onClearUnsavedConnectionLogs, onConnectSerial, onCreateLocalTerminal, onDeleteConnectionLog, onDeleteHost, onImportOrReuseKey, onOpenLogView, onOpenSettings, onRunSnippet, onToggleConnectionLogSaved, onUpdateCustomGroups, onUpdateGroupConfigs, onUpdateHosts, onUpdateIdentities, onUpdateKeys, onUpdateProxyProfiles, onUpdateSnippetPackages, onUpdateSnippets, Pin, pinnedHosts, pinnedRecentIds, Plug, Plus, PortForwarding, protocolSelectHost, proxyProfiles, ProxyProfilesManager, quickConnectTarget, quickConnectWarnings, QuickConnectWizard, recentHosts, renameGroupError, renameGroupName, renameTargetPath, RippleButton, rootRef, sanitizeHost, search, Search, selectedGroupPath, selectedHostIds, selectedTags, SerialConnectModal, SerialHostDetailsPanel, sessionCount, Set, setCurrentSection, setDeleteGroupWithHosts, setDeleteTargetPath, setDragOverDropTarget, setEditingGroupPath, setEditingHost, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsGroupPanelOpen, setIsHostPanelOpen, setIsImportOpen, setIsMultiSelectMode, setIsNewFolderOpen, setIsQuickConnectOpen, setIsRenameGroupOpen, setIsSerialModalOpen, setLastPinnedId, setNewFolderName, setNewHostGroupPath, setProtocolSelectHost, setQuickConnectTarget, setQuickConnectWarnings, setRenameGroupError, setRenameGroupName, setRenameTargetPath, setSearch, setSelectedGroupPath, setSelectedHostIds, setSelectedTags, setSidebarCollapsed, setSortMode, setTargetParentPath, Settings, setViewMode, shellHistory, shouldHideEmptyRootHostsSection, showRecentHosts, sidebarCollapsed, snippetPackages, snippets, SnippetsManager, SortDropdown, sortMode, splitViewGridStyle, Square, Star, submitNewFolder, submitRenameGroup, Suspense, t, TagFilterDropdown, targetParentPath, terminalFontSize, terminalSettings, TerminalSquare, terminalThemeId, toggleHostPinned, toggleHostSelection, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, Upload, upsertHostById, Usb, viewMode, visibleDisplayedHosts, X, Zap } = ctx;
+  const { Activity, allGroupPaths, allTags, AppLogo, Array, Badge, BookMarked, Boolean, Button, CheckSquare, ChevronDown, clearHostSelection, ClipboardCopy, Clock, cn, connectionLogs, connectSelectedHosts, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, currentSection, customGroups, deleteGroupPath, deleteGroupWithHosts, deleteSelectedHosts, deleteTargetPath, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, displayedGroups, displayedHosts, DistroAvatar, Download, Dropdown, DropdownContent, DropdownTrigger, Edit2, editingGroupPath, editingHost, editingHostGroupDefaults, FileCode, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, Globe, groupConfigs, GroupDetailsPanel, groupedDisplayHosts, handleConnectClick, handleCopyCredentials, handleDeleteTag, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleEditTag, handleExportHosts, handleHostConnect, handleImportFileSelected, handleNewHost, handleProtocolSelect, handleQuickConnect, handleQuickConnectSaveHost, handleSaveGroupConfig, handleSearchKeyDown, handleUnmanageGroup, handleSidebarWidthCommit, hasHostsSidePanel, HostDetailsPanel, hostListScrollRef, hosts, HostTreeView, hotkeyScheme, identities, ImportVaultDialog, Input, isDeleteGroupOpen, isGroupPanelOpen, isHostPanelOpen, isHostsSectionActive, isImportOpen, isMultiSelectMode, isNewFolderOpen, isQuickConnectOpen, isRenameGroupOpen, isSearchQuickConnect, isSerialModalOpen, Key, keyBindings, KeychainManager, keys, knownHostsManagerElement, Label, lastPinnedId, LayoutGrid, LazyConnectionLogsManager, LazyProtocolSelectDialog, List, managedGroupPaths, managedSources, moveGroup, moveHostToGroup, Network, newFolderName, newHostGroupPath, onClearUnsavedConnectionLogs, onConnectSerial, onCreateLocalTerminal, onDeleteConnectionLog, onDeleteHost, onImportOrReuseKey, onOpenLogView, onOpenSettings, onRunSnippet, onToggleConnectionLogSaved, onUpdateCustomGroups, onUpdateGroupConfigs, onUpdateHosts, onUpdateIdentities, onUpdateKeys, onUpdateProxyProfiles, onUpdateSnippetPackages, onUpdateSnippets, Pin, pinnedHosts, pinnedRecentIds, Plug, Plus, PortForwarding, protocolSelectHost, proxyProfiles, ProxyProfilesManager, quickConnectTarget, quickConnectWarnings, QuickConnectWizard, recentHosts, renameGroupError, renameGroupName, renameTargetPath, RippleButton, rootRef, sanitizeHost, search, selectedGroupPath, selectedHostIds, selectedTags, SerialConnectModal, SerialHostDetailsPanel, sessionCount, Set, setCurrentSection, setDeleteGroupWithHosts, setDeleteTargetPath, setDragOverDropTarget, setEditingGroupPath, setEditingHost, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsGroupPanelOpen, setIsHostPanelOpen, setIsImportOpen, setIsMultiSelectMode, setIsNewFolderOpen, setIsQuickConnectOpen, setIsRenameGroupOpen, setIsSerialModalOpen, setLastPinnedId, setNewFolderName, setNewHostGroupPath, setProtocolSelectHost, setQuickConnectTarget, setQuickConnectWarnings, setRenameGroupError, setRenameGroupName, setRenameTargetPath, setSearch, setSelectedGroupPath, setSelectedHostIds, setSelectedTags, setSidebarCollapsed, setSidebarWidth, setSortMode, setTargetParentPath, Settings, setViewMode, shellHistory, shouldHideEmptyRootHostsSection, showRecentHosts, sidebarCollapsed, sidebarWidth, snippetPackages, snippets, SnippetsManager, SortDropdown, sortMode, splitViewGridStyle, Square, Star, submitNewFolder, submitRenameGroup, Suspense, t, TagFilterDropdown, targetParentPath, terminalFontSize, terminalSettings, TerminalSquare, terminalThemeId, toggleHostPinned, toggleHostSelection, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, Upload, upsertHostById, Usb, viewMode, visibleDisplayedHosts, X, Zap } = ctx;
+  const [isSidebarResizing, setIsSidebarResizing] = React.useState(false);
+  const sidebarMinWidth = 56;
+  const sidebarMaxWidth = 320;
+  const effectiveSidebarWidth = Math.max(
+    sidebarMinWidth,
+    Math.min(sidebarMaxWidth, Number(sidebarWidth) || 208),
+  );
+  const handleSidebarResizeStart = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startX = event.clientX;
+    const startWidth = effectiveSidebarWidth;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    setIsSidebarResizing(true);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const clampWidth = (value: number) =>
+      Math.max(sidebarMinWidth, Math.min(sidebarMaxWidth, value));
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      setSidebarWidth(clampWidth(startWidth + moveEvent.clientX - startX));
+    };
+    const handlePointerUp = (upEvent: PointerEvent) => {
+      const nextWidth = clampWidth(startWidth + upEvent.clientX - startX);
+      setSidebarWidth(nextWidth);
+      handleSidebarWidthCommit(nextWidth);
+      setIsSidebarResizing(false);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+  }, [effectiveSidebarWidth, handleSidebarWidthCommit, setSidebarWidth]);
   return (
-    <div ref={rootRef} className="absolute inset-0 min-h-0 flex" data-section="vault-view">
+    <div ref={rootRef} className="absolute inset-0 min-h-0 flex bg-secondary" data-section="vault-view">
       {/* Sidebar */}
       <TooltipProvider delayDuration={100}>
         <div
           className={cn(
-            "bg-secondary border-r border-border/60 flex flex-col transition-all duration-200",
-            sidebarCollapsed ? "w-14" : "w-52"
+            "relative shrink-0 bg-secondary flex flex-col",
+            isSidebarResizing ? "transition-none" : "transition-[width] duration-200",
           )}
+          style={{ width: effectiveSidebarWidth }}
           data-section="vault-sidebar"
         >
           <div className={cn(
@@ -197,50 +246,57 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
               {sidebarCollapsed && <TooltipContent side="right">{t("common.settings")}</TooltipContent>}
             </Tooltip>
           </div>
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={t("vault.sidebar.resize")}
+            className={cn(
+              "app-no-drag absolute right-0 top-0 z-20 h-full w-2 translate-x-1/2 cursor-col-resize",
+              "after:absolute after:right-1/2 after:top-2 after:h-[calc(100%-16px)] after:w-px after:translate-x-1/2 after:bg-border/0 after:transition-colors",
+              "hover:after:bg-border/70",
+              isSidebarResizing && "after:bg-primary/70",
+            )}
+            onPointerDown={handleSidebarResizeStart}
+          />
         </div>
       </TooltipProvider>
 
-      {/* Main Area */}
-      <div
-        className="flex-1 min-w-0 flex flex-col min-h-0 relative"
-        data-section="vault-main"
-      >
-        <header
-          className={cn(
-            "border-b border-border/50 bg-secondary/80 backdrop-blur app-drag",
-            !isHostsSectionActive && "hidden",
-          )}
-          data-section="vault-hosts-header"
+      <div className="flex min-w-0 flex-1 p-2 pl-1" data-section="vault-stage">
+        <div
+          className="relative flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border/60 bg-background shadow-sm"
+          data-section="vault-surface"
         >
-          <div className="h-14 px-4 py-2 flex items-center gap-3">
-            <div className="relative flex-1 app-no-drag">
-              <Search
-                size={14}
-                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
+          {/* Main Area */}
+          <div
+            className="flex-1 min-w-0 flex flex-col min-h-0 relative"
+            data-section="vault-main"
+          >
+        <VaultPageHeader
+          className={cn(!isHostsSectionActive && "hidden")}
+          dataSection="vault-hosts-header"
+        >
+              <VaultHeaderSearch
                 placeholder={t("vault.hosts.search.placeholder")}
-                className={cn(
-                  "pl-9 h-10 bg-secondary border-border/60 text-sm",
+                className="flex-1"
+                inputClassName={cn(
                   isSearchQuickConnect &&
                   "border-primary/50 ring-1 ring-primary/20",
                 )}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 onKeyDown={handleSearchKeyDown}
+                rightAdornment={
+                  isSearchQuickConnect ? (
+                    <Zap size={14} className="text-primary" />
+                  ) : null
+                }
               />
-              {isSearchQuickConnect && (
-                <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                  <Zap size={14} className="text-primary" />
-                </div>
-              )}
-            </div>
             <Button
               variant={isSearchQuickConnect ? "default" : "secondary"}
               className={cn(
-                "h-10 px-4 app-no-drag",
+                "h-10 px-4",
                 !isSearchQuickConnect &&
-                "bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40",
+                vaultHeaderSecondaryButtonClass,
               )}
               onClick={handleConnectClick}
             >
@@ -250,7 +306,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             <div className="flex items-center gap-1 app-no-drag">
               <Dropdown>
                 <DropdownTrigger asChild>
-                  <Button variant="ghost" size="icon" className="h-10 w-10 app-no-drag">
+                  <Button variant="ghost" size="icon" className={vaultHeaderIconButtonClass}>
                     {viewMode === "grid" ? (
                       <LayoutGrid size={16} />
                     ) : viewMode === "list" ? (
@@ -291,19 +347,19 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 onChange={setSelectedTags}
                 onEditTag={handleEditTag}
                 onDeleteTag={handleDeleteTag}
-                className="h-10 w-10"
+                className={vaultHeaderIconButtonClass}
               />
               <SortDropdown
                 value={sortMode}
                 onChange={setSortMode}
-                className="h-10 w-10"
+                className={vaultHeaderIconButtonClass}
               />
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant={isMultiSelectMode ? "secondary" : "ghost"}
                     size="icon"
-                    className="h-10 w-10"
+                    className={vaultHeaderIconButtonClass}
                     onClick={() => {
                       if (isMultiSelectMode) {
                         clearHostSelection();
@@ -334,7 +390,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 <div className="flex items-center rounded-md bg-primary text-primary-foreground">
                   <Button
                     size="sm"
-                    className="h-10 px-3 rounded-r-none bg-transparent hover:bg-white/10 shadow-none app-no-drag"
+                    className="h-10 px-3 rounded-r-none bg-transparent hover:bg-white/10 shadow-none"
                     onClick={handleNewHost}
                     tabIndex={isHostPanelOpen ? -1 : 0}
                   >
@@ -343,7 +399,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                   <DropdownTrigger asChild>
                     <Button
                       size="sm"
-                      className="h-10 px-2 rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none app-no-drag"
+                      className="h-10 px-2 rounded-l-none bg-transparent hover:bg-white/10 border-l border-primary-foreground/20 shadow-none"
                       tabIndex={isHostPanelOpen ? -1 : 0}
                     >
                       <ChevronDown size={14} />
@@ -396,7 +452,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
               <Button
                 size="sm"
                 variant="secondary"
-                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+                className={vaultHeaderSecondaryButtonClass}
                 onClick={onCreateLocalTerminal}
                 tabIndex={isHostPanelOpen ? -1 : 0}
               >
@@ -405,15 +461,14 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
               <Button
                 size="sm"
                 variant="secondary"
-                className="h-10 px-3 app-no-drag bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40"
+                className={vaultHeaderSecondaryButtonClass}
                 onClick={() => setIsSerialModalOpen(true)}
                 tabIndex={isHostPanelOpen ? -1 : 0}
               >
                 <Usb size={14} className="mr-2" /> {t("serial.button")}
               </Button>
             </div>
-          </div>
-        </header>
+        </VaultPageHeader>
 
         {isMultiSelectMode && isHostsSectionActive && (
           <div className="px-4 py-1.5 bg-background border-b border-border/40 flex items-center gap-2">
@@ -626,7 +681,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
         />
       )}
 
-      {/* Host Details Panel - positioned at VaultView root level for correct top alignment */}
+      {/* Host Details Panel */}
       {currentSection === "hosts" && isHostPanelOpen && editingHost?.protocol !== 'serial' && (
         <HostDetailsPanel
           initialData={editingHost}
@@ -683,6 +738,8 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
           layout="inline"
         />
       )}
+        </div>
+      </div>
 
       <Dialog open={isNewFolderOpen} onOpenChange={(open) => {
         setIsNewFolderOpen(open);

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -37,6 +37,7 @@ export const STORAGE_KEY_VAULT_HOSTS_VIEW_MODE = 'netcatty_vault_hosts_view_mode
 export const STORAGE_KEY_VAULT_HOSTS_SORT_MODE = 'netcatty_vault_hosts_sort_mode_v1';
 export const STORAGE_KEY_VAULT_HOSTS_TREE_EXPANDED = 'netcatty_vault_hosts_tree_expanded_v1';
 export const STORAGE_KEY_VAULT_SIDEBAR_COLLAPSED = 'netcatty_vault_sidebar_collapsed_v1';
+export const STORAGE_KEY_VAULT_SIDEBAR_WIDTH = 'netcatty_vault_sidebar_width_v1';
 export const STORAGE_KEY_VAULT_KEYS_VIEW_MODE = 'netcatty_vault_keys_view_mode_v1';
 export const STORAGE_KEY_VAULT_PROXY_PROFILES_VIEW_MODE = 'netcatty_vault_proxy_profiles_view_mode_v1';
 export const STORAGE_KEY_VAULT_SNIPPETS_VIEW_MODE = 'netcatty_vault_snippets_view_mode_v1';


### PR DESCRIPTION
## Summary

- Refines the Vault layout with an inset rounded content surface and a subtler header treatment.
- Adds shared Vault header and host detail form building blocks, then applies them across Vault subpages, host details, and group defaults.
- Makes the Vault sidebar resizable and persists the user-selected width.
- Improves proxy cards and host notes previews, including rendered Markdown in host list note hover cards.

## Validation

- `npm run lint`
- `npm run build`
- Render check for Markdown note previews with heading, list, and inline code