### PR TITLE
[codex] Remove default host seed data

### DIFF
--- a/infrastructure/config/defaultData.ts
+++ b/infrastructure/config/defaultData.ts
@@ -1,9 +1,6 @@
-import { Host,Snippet } from '../../domain/models';
+import { Host, Snippet } from '../../domain/models';
 
-export const INITIAL_HOSTS: Host[] = [
-  { id: '1', label: 'Production Web', hostname: '10.0.0.12', port: 22, username: 'ubuntu', group: 'AWS/Production', tags: ['prod', 'web'], os: 'linux' },
-  { id: '2', label: 'DB Master', hostname: 'db-01.internal', port: 22, username: 'admin', group: 'AWS/Production', tags: ['prod', 'db'], os: 'linux' },
-];
+export const INITIAL_HOSTS: Host[] = [];
 
 export const INITIAL_SNIPPETS: Snippet[] = [
   { id: '1', label: 'Check Disk Space', command: 'df -h', tags: [] },


### PR DESCRIPTION
## Summary

- Removes the seeded example hosts used for first-run vault initialization.
- Keeps existing user vault data untouched; only new installs without saved hosts now start empty.
- Leaves the default snippets unchanged.

## Validation

- Verified `INITIAL_HOSTS` is empty.
- `node --test --import tsx components/VaultView.sortPersistence.test.tsx`
- `npm run lint`
- `npm run build`