### PR TITLE
fix: blurry inline aside panel rendering

### DIFF
--- a/index.css
+++ b/index.css
@@ -159,7 +159,6 @@
     width: 0;
     min-width: 0;
     opacity: 0;
-    transform: translateX(22px);
   }
   55% {
     opacity: 0.88;
@@ -168,13 +167,12 @@
     width: var(--aside-inline-width);
     min-width: var(--aside-inline-width);
     opacity: 1;
-    transform: translateX(0);
   }
 }
 
 .split-panel-enter {
   animation: split-panel-enter 220ms cubic-bezier(0.24, 0.84, 0.32, 1) both;
-  will-change: width, opacity, transform;
+  will-change: width, opacity;
 }
 
 :root {


### PR DESCRIPTION
Removes the transform usage from the inline aside panel enter animation. On Windows, keeping the panel on a transformed composited layer could make text in panels like “Edit Snippet” appear blurry, while macOS rendered it acceptably.

The animation still expands the panel using width and opacity, but no longer applies horizontal translation.
Before:
<img width="383" height="811" alt="Netcatty_urw2kDmdTe" src="https://github.com/user-attachments/assets/8960a314-f914-4daa-bda8-2cf01c803486" />

After:
<img width="387" height="811" alt="Netcatty_DZUUcpcR4c" src="https://github.com/user-attachments/assets/4a269244-4c72-46a2-aa8a-41f27dc6942e" />


Validation:

Verified the snippet edit panel renders sharply after the change
Ran npm run lint successfully