### PR TITLE
Remove vault content left margin

### DIFF
--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -261,7 +261,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
         </div>
       </TooltipProvider>
 
-      <div className="flex min-w-0 flex-1 p-2 pl-1" data-section="vault-stage">
+      <div className="flex min-w-0 flex-1 p-2 pl-0" data-section="vault-stage">
         <div
           className="relative flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border/60 bg-background shadow-sm"
           data-section="vault-surface"


### PR DESCRIPTION
## What changed
- Removed the extra left padding between the Vault sidebar and content area.

## Validation
- npx eslint components/vault/VaultViewLayout.tsx
- npm run build