### PR TITLE
[codex] Balance vault sidebar spacing

### DIFF
--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -90,7 +90,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             </Tooltip>
           </div>
 
-          <div className={cn("space-y-1", sidebarCollapsed ? "px-1.5" : "px-3")}>
+          <div className={cn("space-y-1", sidebarCollapsed ? "px-1.5" : "px-2.5")}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <RippleButton
@@ -228,7 +228,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             </Tooltip>
           </div>
 
-          <div className={cn("mt-auto pb-4 space-y-2", sidebarCollapsed ? "px-1.5" : "px-3")}>
+          <div className={cn("mt-auto pb-4 space-y-2", sidebarCollapsed ? "px-1.5" : "px-2.5")}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button


### PR DESCRIPTION
## Summary
- Balance the expanded Vault sidebar navigation padding so items no longer look heavier on the right.
- Apply the same spacing to the bottom settings item for consistency.

## Validation
- npx eslint components/vault/VaultViewLayout.tsx
- npm run build