### PR TITLE
[codex] Fix Catty tool result history repair

### DIFF
--- a/infrastructure/ai/providerContinuation.test.ts
+++ b/infrastructure/ai/providerContinuation.test.ts
@@ -8,6 +8,7 @@ import {
   mergeProviderContinuation,
   normalizeProviderContinuationOptions,
   rawOpenAIChatChunkHasToolCalls,
+  repairOpenAIChatToolResultPairsInBody,
   withProviderContinuationSource,
 } from './providerContinuation';
 
@@ -353,4 +354,75 @@ test('leaves invalid or unchanged OpenAI-compatible request bodies alone', () =>
 
   const body = JSON.stringify({ stream: true, messages: [{ role: 'user', content: 'hi' }] });
   assert.equal(applyOpenAIChatContinuationToBody(body, [{ reasoning_content: 'unused' }]), body);
+});
+
+test('leaves complete OpenAI-compatible tool result pairs unchanged', () => {
+  const body = JSON.stringify({
+    stream: true,
+    messages: [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'terminal_execute', arguments: '{}' } },
+          { id: 'call_2', type: 'function', function: { name: 'terminal_execute', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'one' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'two' },
+      { role: 'user', content: 'continue' },
+    ],
+  });
+
+  assert.equal(repairOpenAIChatToolResultPairsInBody(body), body);
+});
+
+test('repairs partial OpenAI-compatible tool result pairs before sending history', () => {
+  const body = JSON.stringify({
+    stream: true,
+    messages: [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'terminal_execute', arguments: '{}' } },
+          { id: 'call_2', type: 'function', function: { name: 'terminal_execute', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_2', content: 'two' },
+      { role: 'user', content: 'continue' },
+    ],
+  });
+
+  const repaired = JSON.parse(repairOpenAIChatToolResultPairsInBody(body));
+
+  assert.deepEqual(
+    repaired.messages[0].tool_calls.map((toolCall: { id: string }) => toolCall.id),
+    ['call_2'],
+  );
+  assert.equal(repaired.messages[1].role, 'tool');
+  assert.equal(repaired.messages[1].tool_call_id, 'call_2');
+  assert.equal(repaired.messages[2].role, 'user');
+});
+
+test('drops orphaned OpenAI-compatible tool calls that have no results', () => {
+  const body = JSON.stringify({
+    stream: true,
+    messages: [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'terminal_execute', arguments: '{}' } },
+        ],
+      },
+      { role: 'user', content: 'are you there?' },
+    ],
+  });
+
+  const repaired = JSON.parse(repairOpenAIChatToolResultPairsInBody(body));
+
+  assert.deepEqual(repaired.messages, [
+    { role: 'user', content: 'are you there?' },
+  ]);
 });

--- a/infrastructure/ai/providerContinuation.ts
+++ b/infrastructure/ai/providerContinuation.ts
@@ -408,3 +408,99 @@ export function applyOpenAIChatContinuationToBody(
   if (!changed) return body;
   return JSON.stringify({ ...parsed, messages });
 }
+
+function messageHasAssistantContent(message: Record<string, unknown>): boolean {
+  const content = message.content;
+  if (typeof content === 'string') return content.trim().length > 0;
+  if (Array.isArray(content)) return content.length > 0;
+  return content !== undefined && content !== null;
+}
+
+/**
+ * OpenAI-compatible chat APIs reject a request when an assistant message
+ * contains tool_calls that are not immediately answered by matching tool
+ * messages. This can happen when a prior Catty tool loop was interrupted
+ * mid-flight. Repair the outgoing history instead of letting one broken
+ * turn permanently brick the chat session.
+ */
+export function repairOpenAIChatToolResultPairsInBody(body: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) return body;
+
+  let changed = false;
+  const repairedMessages: unknown[] = [];
+  const messages = parsed.messages;
+
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (!isRecord(message)) {
+      repairedMessages.push(message);
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      changed = true;
+      continue;
+    }
+
+    if (message.role !== 'assistant' || !Array.isArray(message.tool_calls) || message.tool_calls.length === 0) {
+      repairedMessages.push(message);
+      continue;
+    }
+
+    const followingToolMessages: Record<string, unknown>[] = [];
+    let lookahead = index + 1;
+    while (lookahead < messages.length) {
+      const nextMessage = messages[lookahead];
+      if (!isRecord(nextMessage) || nextMessage.role !== 'tool') break;
+      followingToolMessages.push(nextMessage);
+      lookahead += 1;
+    }
+
+    const toolMessagesById = new Map<string, Record<string, unknown>>();
+    for (const toolMessage of followingToolMessages) {
+      const toolCallId = toolMessage.tool_call_id;
+      if (typeof toolCallId === 'string' && !toolMessagesById.has(toolCallId)) {
+        toolMessagesById.set(toolCallId, toolMessage);
+      }
+    }
+
+    const validToolCalls = message.tool_calls.filter((toolCall) => {
+      if (!isRecord(toolCall)) return false;
+      const toolCallId = toolCall.id;
+      return typeof toolCallId === 'string' && toolMessagesById.has(toolCallId);
+    });
+
+    if (validToolCalls.length !== message.tool_calls.length || validToolCalls.length !== followingToolMessages.length) {
+      changed = true;
+    }
+
+    if (validToolCalls.length > 0) {
+      repairedMessages.push({
+        ...message,
+        tool_calls: validToolCalls,
+      });
+
+      for (const toolCall of validToolCalls) {
+        if (!isRecord(toolCall) || typeof toolCall.id !== 'string') continue;
+        const toolMessage = toolMessagesById.get(toolCall.id);
+        if (toolMessage) repairedMessages.push(toolMessage);
+      }
+    } else if (messageHasAssistantContent(message)) {
+      const { tool_calls: _toolCalls, ...messageWithoutToolCalls } = message;
+      void _toolCalls;
+      repairedMessages.push(messageWithoutToolCalls);
+    }
+
+    index = lookahead - 1;
+  }
+
+  if (!changed) return body;
+  return JSON.stringify({ ...parsed, messages: repairedMessages });
+}

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -8,6 +8,7 @@ import {
   extractProviderContinuationFromRawChunk,
   mergeProviderContinuation,
   rawOpenAIChatChunkHasToolCalls,
+  repairOpenAIChatToolResultPairsInBody,
   type OpenAIChatAssistantFields,
 } from '../providerContinuation';
 
@@ -330,10 +331,10 @@ export function createBridgeFetchForSDK(
     const body =
       resolvedInit?.body != null ? String(resolvedInit.body) : undefined;
     const requestBody = body != null
-      ? applyOpenAIChatContinuationToBody(
+      ? repairOpenAIChatToolResultPairsInBody(applyOpenAIChatContinuationToBody(
           body,
           requestContext?.getOpenAIChatAssistantFields?.() ?? [],
-        )
+        ))
       : undefined;
 
     // Streaming path


### PR DESCRIPTION
## Summary
- Repair outgoing OpenAI-compatible chat history when an earlier Catty tool turn has missing tool results.
- Keep complete parallel tool result pairs unchanged and drop only orphaned broken pairs before sending.
- Add regression coverage for complete, partial, and fully orphaned tool result histories.

## Root cause
Interrupted or incomplete parallel terminal tool runs could leave the next provider request with assistant tool calls that did not have matching tool result messages, causing OpenAI-compatible APIs to reject every later message in the same chat.

## Validation
- npm test
- npm run lint
- npm run build

Fixes #1190