### PR TITLE
[codex] Fix terminal wheel font zoom capture

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -50,6 +50,7 @@ import { handleSerialLineModeInput } from "./serialLineInput";
 import {
   nextTerminalFontSizeForAction,
   nextTerminalFontSizeForWheel,
+  terminalFontSizeWheelListenerOptions,
 } from "./terminalFontZoom";
 import {
   markExpectedTerminalCursorPositionReport,
@@ -526,7 +527,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     event.stopPropagation();
     applyTerminalFontSize(nextFontSize);
   };
-  ctx.container.addEventListener("wheel", handleFontSizeWheel, { passive: false });
+  ctx.container.addEventListener(
+    "wheel",
+    handleFontSizeWheel,
+    terminalFontSizeWheelListenerOptions,
+  );
 
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
     // Preserve mouse selection across keystrokes when enabled. xterm.js
@@ -984,7 +989,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     keywordHighlighter,
     clearTextureAtlas: clearWebglTextureAtlas,
     dispose: () => {
-      ctx.container.removeEventListener("wheel", handleFontSizeWheel);
+      ctx.container.removeEventListener(
+        "wheel",
+        handleFontSizeWheel,
+        terminalFontSizeWheelListenerOptions,
+      );
       cleanupMiddleClick?.();
       stopDprWatch();
       keywordHighlighter.dispose();

--- a/components/terminal/runtime/terminalFontZoom.test.ts
+++ b/components/terminal/runtime/terminalFontZoom.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   nextTerminalFontSizeForAction,
   nextTerminalFontSizeForWheel,
+  terminalFontSizeWheelListenerOptions,
 } from './terminalFontZoom.ts';
 
 test('terminal font size actions step and reset within bounds', () => {
@@ -24,4 +25,9 @@ test('wheel adjusts terminal font size with the platform modifier only', () => {
   assert.equal(nextTerminalFontSizeForWheel({ ctrlKey: true, metaKey: false, deltaY: -1 }, 14, true), null);
   assert.equal(nextTerminalFontSizeForWheel({ ctrlKey: false, metaKey: false, deltaY: -1 }, 14, false), null);
   assert.equal(nextTerminalFontSizeForWheel({ ctrlKey: true, metaKey: false, deltaY: 0 }, 14, false), null);
+});
+
+test('wheel font-size listener runs before xterm consumes terminal scrolling', () => {
+  assert.equal(terminalFontSizeWheelListenerOptions.capture, true);
+  assert.equal(terminalFontSizeWheelListenerOptions.passive, false);
 });

--- a/components/terminal/runtime/terminalFontZoom.ts
+++ b/components/terminal/runtime/terminalFontZoom.ts
@@ -6,6 +6,11 @@ import {
 
 type WheelLike = Pick<WheelEvent, "ctrlKey" | "metaKey" | "deltaY">;
 
+export const terminalFontSizeWheelListenerOptions = {
+  passive: false,
+  capture: true,
+} as const satisfies AddEventListenerOptions;
+
 export const clampTerminalFontSize = (fontSize: number): number =>
   Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, fontSize));
 


### PR DESCRIPTION
## Summary
- Make terminal Command/Ctrl + mouse wheel font-size zoom run during event capture.
- Keep normal terminal wheel scrolling unchanged when the zoom modifier is not held.
- Add regression coverage for the wheel listener configuration.

## Root cause
The terminal font-size wheel handler was registered on the terminal container in the bubble phase. xterm can consume wheel events for scrollback first, so modifier-wheel gestures sometimes scrolled terminal content instead of changing font size.

## Validation
- node --test --import tsx components/terminal/runtime/terminalFontZoom.test.ts application/AppHandlers.globalHotkeys.test.ts
- npm run lint
- npm run build