### PR TITLE
fix(hosts): restore local key credential echo

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -494,6 +494,7 @@ export const enVaultMessages: Messages = {
   'hostDetails.credential.key': 'Key',
   'hostDetails.credential.certificate': 'Certificate',
   'hostDetails.credential.localKeyFile': 'Local Key File',
+  'hostDetails.credential.defaultLocalKey': 'Local SSH key / SSH Agent',
   'hostDetails.credential.localKeyFilePlaceholder': '~/.ssh/id_ed25519',
   'hostDetails.credential.browseKeyFile': 'Browse...',
   'hostDetails.credential.missing': 'Credential not found',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -529,6 +529,7 @@ export const ruVaultMessages: Messages = {
   'hostDetails.credential.key': 'Ключ',
   'hostDetails.credential.certificate': 'Сертификат',
   'hostDetails.credential.localKeyFile': 'Локальный файл ключа',
+  'hostDetails.credential.defaultLocalKey': 'Локальный SSH-ключ / SSH Agent',
   'hostDetails.credential.localKeyFilePlaceholder': '~/.ssh/id_ed25519',
   'hostDetails.credential.browseKeyFile': 'Обзор...',
   'hostDetails.credential.missing': 'Учётные данные не найдены',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -88,6 +88,7 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.credential.key': '密钥',
   'hostDetails.credential.certificate': '证书',
   'hostDetails.credential.localKeyFile': '本地密钥文件',
+  'hostDetails.credential.defaultLocalKey': '本地 SSH 密钥 / SSH Agent',
   'hostDetails.credential.localKeyFilePlaceholder': '~/.ssh/id_ed25519',
   'hostDetails.credential.browseKeyFile': '浏览…',
   'hostDetails.credential.missing': '凭据不存在',

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -45,7 +45,27 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
   distroOptions,
   effectiveFormDistro,
   getDistroOptionLabel,
-}) => (
+}) => {
+  const selectedCredentialKey = form.identityFileId
+    ? availableKeys.find((key: { id: string }) => key.id === form.identityFileId)
+    : undefined;
+  const referenceKeyFilePath =
+    selectedCredentialKey?.source === "reference" && selectedCredentialKey.filePath
+      ? selectedCredentialKey.filePath
+      : undefined;
+  const isReferenceKeySelected = Boolean(form.identityFileId && referenceKeyFilePath);
+  const localKeyFilePaths =
+    form.identityFilePaths && form.identityFilePaths.length > 0
+      ? form.identityFilePaths
+      : referenceKeyFilePath
+        ? [referenceKeyFilePath]
+        : [];
+  const usesDefaultLocalKey =
+    form.authMethod === "key" &&
+    !form.identityFileId &&
+    localKeyFilePaths.length === 0;
+
+  return (
   <>
         <HostDetailsSection
           icon={<MapPin size={14} className="text-muted-foreground" />}
@@ -326,10 +346,34 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
               </div>
             )}
 
+            {/* Default local key / SSH agent display */}
+            {!selectedIdentity && usesDefaultLocalKey && (
+              <div className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60">
+                <FileKey size={14} className="text-primary shrink-0" />
+                <span className="text-sm flex-1 truncate">
+                  {t("hostDetails.credential.defaultLocalKey")}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => {
+                    update("authMethod", "password");
+                    setPendingReferenceKeyPath(null);
+                    setSelectedCredentialType(null);
+                  }}
+                >
+                  <X size={12} />
+                </Button>
+              </div>
+            )}
+
             {/* Local key file paths display */}
-            {!selectedIdentity && !form.identityFileId && form.identityFilePaths && form.identityFilePaths.length > 0 && (
+            {!selectedIdentity &&
+              localKeyFilePaths.length > 0 &&
+              (!form.identityFileId || isReferenceKeySelected) && (
               <div className="space-y-1.5">
-                {form.identityFilePaths.map((keyPath, idx) => (
+                {localKeyFilePaths.map((keyPath, idx) => (
                   <div key={idx} className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60 overflow-hidden">
                     <FileKey size={14} className="text-primary shrink-0" />
                     <Tooltip>
@@ -345,9 +389,18 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                       size="icon"
                       className="h-6 w-6 shrink-0"
                       onClick={() => {
-                        const paths = form.identityFilePaths?.filter((_, i) => i !== idx) || [];
+                        const paths = localKeyFilePaths.filter((_, i) => i !== idx);
+                        if (isReferenceKeySelected) {
+                          update("identityFileId", undefined);
+                        }
                         update("identityFilePaths", paths.length > 0 ? paths : undefined);
-                        if (keyPath === pendingReferenceKeyPath) {
+                        if (paths.length === 0) {
+                          update("authMethod", "password");
+                          setSelectedCredentialType(null);
+                        } else if (isReferenceKeySelected) {
+                          update("authMethod", "key");
+                        }
+                        if (keyPath === pendingReferenceKeyPath || keyPath === referenceKeyFilePath) {
                           setPendingReferenceKeyPath(null);
                         }
                       }}
@@ -360,7 +413,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
             )}
 
             {/* Selected credential display */}
-            {!selectedIdentity && form.identityFileId && (
+            {!selectedIdentity && form.identityFileId && !isReferenceKeySelected && (
               <div className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60">
                 {form.authMethod === "certificate" ? (
                   <Shield size={14} className="text-primary" />
@@ -368,8 +421,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                   <Key size={14} className="text-primary" />
                 )}
                 <span className="text-sm flex-1 truncate">
-                  {availableKeys.find((k) => k.id === form.identityFileId)
-                    ?.label || "Key"}
+                  {selectedCredentialKey?.label || "Key"}
                 </span>
                 <Button
                   variant="ghost"
@@ -390,6 +442,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
             {/* Credential type selection with inline popover - hidden when credential is selected */}
             {!selectedIdentity &&
               !form.identityFileId &&
+              !usesDefaultLocalKey &&
               !selectedCredentialType && (
                 <Popover
                   open={credentialPopoverOpen}
@@ -443,6 +496,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                         className="w-full flex items-center gap-3 px-3 py-2.5 rounded-md hover:bg-secondary/80 transition-colors text-left"
                         onClick={() => {
                           setSelectedCredentialType("localKeyFile");
+                          update("identityFileId", undefined);
                           setCredentialPopoverOpen(false);
                         }}
                       >
@@ -581,6 +635,9 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                       onClick={() => {
                         setSelectedCredentialType(null);
                         setNewKeyFilePath("");
+                        if (localKeyFilePaths.length === 0 && !form.identityFileId) {
+                          update("authMethod", "password");
+                        }
                       }}
                     >
                       <X size={14} />
@@ -732,4 +789,5 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
           </HostDetailsSection>
         )}
   </>
-);
+  );
+};

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { Trash2 } from "lucide-react";
 
 import { I18nProvider } from "../application/i18n/I18nProvider.tsx";
-import type { Host } from "../types.ts";
+import type { Host, SSHKey } from "../types.ts";
+import { HostDetailsConnectionSections } from "./HostDetailsConnectionSections.tsx";
 import HostDetailsPanel, { parseOptionalPortInput } from "./HostDetailsPanel.tsx";
 import { TooltipProvider } from "./ui/tooltip.tsx";
 
@@ -22,7 +24,31 @@ const hostWithMissingProxyProfile: Host = {
   createdAt: 1,
 };
 
-const renderHostDetails = (initialData: Host = hostWithMissingProxyProfile) =>
+const referenceKey: SSHKey = {
+  id: "reference-key-1",
+  label: "id_ed25519",
+  type: "ED25519",
+  privateKey: "",
+  source: "reference",
+  category: "key",
+  created: 1,
+  filePath: "/Users/alice/.ssh/id_ed25519",
+};
+
+const importedKey: SSHKey = {
+  id: "imported-key-1",
+  label: "Imported Key",
+  type: "ED25519",
+  privateKey: "PRIVATE KEY",
+  source: "imported",
+  category: "key",
+  created: 1,
+};
+
+const renderHostDetails = (
+  initialData: Host = hostWithMissingProxyProfile,
+  availableKeys: SSHKey[] = [],
+) =>
   renderToStaticMarkup(
     React.createElement(
       I18nProvider,
@@ -32,7 +58,7 @@ const renderHostDetails = (initialData: Host = hostWithMissingProxyProfile) =>
         null,
         React.createElement(HostDetailsPanel, {
           initialData,
-          availableKeys: [],
+          availableKeys,
           identities: [],
           proxyProfiles: [],
           groups: [],
@@ -47,6 +73,98 @@ const renderHostDetails = (initialData: Host = hostWithMissingProxyProfile) =>
       ),
     ),
   );
+
+type InspectableElementProps = {
+  children?: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+};
+type ConnectionSectionProps = React.ComponentProps<typeof HostDetailsConnectionSections>;
+
+const createConnectionSectionProps = (
+  overrides: Partial<ConnectionSectionProps> = {},
+): ConnectionSectionProps => ({
+  t: (key: string) => key,
+  form: {
+    ...hostWithMissingProxyProfile,
+    proxyProfileId: undefined,
+    os: "windows",
+    password: undefined,
+  },
+  update: () => {},
+  groupDefaults: undefined,
+  selectedIdentity: undefined,
+  clearIdentity: () => {},
+  identities: [],
+  identitySuggestionsOpen: false,
+  filteredIdentitySuggestions: [],
+  setIdentitySuggestionsOpen: () => {},
+  availableKeys: [],
+  applyIdentity: () => {},
+  showPassword: false,
+  setShowPassword: () => {},
+  pendingReferenceKeyPath: null,
+  setPendingReferenceKeyPath: () => {},
+  selectedCredentialType: null,
+  setSelectedCredentialType: () => {},
+  credentialPopoverOpen: true,
+  setCredentialPopoverOpen: () => {},
+  keysByCategory: { key: [], certificate: [], identity: [] },
+  newKeyFilePath: "",
+  setNewKeyFilePath: () => {},
+  addLocalKeyFilePath: () => {},
+  handleDistroModeChange: () => {},
+  distroOptions: [],
+  effectiveFormDistro: undefined,
+  getDistroOptionLabel: (value?: string) => value || "",
+  ...overrides,
+});
+
+const collectText = (node: React.ReactNode): string => {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(collectText).join("");
+  }
+  if (!React.isValidElement<InspectableElementProps>(node)) {
+    return "";
+  }
+  return collectText(node.props.children);
+};
+
+const containsElementType = (
+  node: React.ReactNode,
+  type: React.ElementType,
+): boolean => {
+  if (Array.isArray(node)) {
+    return node.some((child) => containsElementType(child, type));
+  }
+  if (!React.isValidElement<InspectableElementProps>(node)) {
+    return false;
+  }
+  return node.type === type || containsElementType(node.props.children, type);
+};
+
+const findElement = (
+  node: React.ReactNode,
+  predicate: (element: React.ReactElement<InspectableElementProps>) => boolean,
+): React.ReactElement<InspectableElementProps> | undefined => {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findElement(child, predicate);
+      if (match) return match;
+    }
+    return undefined;
+  }
+  if (!React.isValidElement<InspectableElementProps>(node)) {
+    return undefined;
+  }
+  if (predicate(node)) {
+    return node;
+  }
+  return findElement(node.props.children, predicate);
+};
 
 const findInputByValue = (markup: string, value: string) => {
   const match = markup.match(new RegExp(`<input(?=[^>]*value="${value}")[^>]*>`));
@@ -234,6 +352,145 @@ test("HostDetailsPanel displays inherited telnet credentials", () => {
   assert.match(markup, /placeholder="Telnet Password"[^>]*value="group-telnet-password"/);
   assert.doesNotMatch(markup, /placeholder="Telnet Username"[^>]*value="ssh-user"/);
   assert.doesNotMatch(markup, /placeholder="Telnet Password"[^>]*value="ssh-password"/);
+});
+
+test("HostDetailsPanel displays saved reference key identity paths as local key files", () => {
+  const markup = renderHostDetails(
+    {
+      ...hostWithMissingProxyProfile,
+      proxyProfileId: undefined,
+      authMethod: "key",
+      identityFileId: referenceKey.id,
+      identityFilePaths: [referenceKey.filePath!],
+      password: undefined,
+    },
+    [referenceKey],
+  );
+
+  assert.match(markup, /\/Users\/alice\/\.ssh\/id_ed25519/);
+  assert.match(markup, /placeholder="Password"/);
+});
+
+test("HostDetailsPanel falls back to reference key filePath when host paths are missing", () => {
+  const markup = renderHostDetails(
+    {
+      ...hostWithMissingProxyProfile,
+      proxyProfileId: undefined,
+      authMethod: "key",
+      identityFileId: referenceKey.id,
+      identityFilePaths: undefined,
+      password: undefined,
+    },
+    [referenceKey],
+  );
+
+  assert.match(markup, /\/Users\/alice\/\.ssh\/id_ed25519/);
+});
+
+test("HostDetailsPanel keeps imported keys in the regular key display", () => {
+  const markup = renderHostDetails(
+    {
+      ...hostWithMissingProxyProfile,
+      proxyProfileId: undefined,
+      authMethod: "key",
+      identityFileId: importedKey.id,
+      identityFilePaths: ["/Users/alice/.ssh/stale_ed25519"],
+      password: undefined,
+    },
+    [importedKey],
+  );
+
+  assert.match(markup, /Imported Key/);
+  assert.doesNotMatch(markup, /\/Users\/alice\/\.ssh\/stale_ed25519/);
+});
+
+test("HostDetailsPanel displays default local key auth when no concrete key path is saved", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    proxyProfileId: undefined,
+    authMethod: "key",
+    identityFileId: undefined,
+    identityFilePaths: undefined,
+    password: undefined,
+  });
+
+  assert.match(markup, /Local SSH key \/ SSH Agent/);
+  assert.doesNotMatch(markup, /Key, Certificate, Local Key File/);
+  assert.match(markup, /placeholder="Password"/);
+});
+
+test("HostDetailsConnectionSections waits for a local key file path before enabling key auth", () => {
+  const updateCalls: Array<[keyof Host, Host[keyof Host]]> = [];
+  const selectedTypes: Array<string | null> = [];
+  const props = createConnectionSectionProps({
+    update: <K extends keyof Host>(key: K, value: Host[K]) => {
+      updateCalls.push([key, value]);
+    },
+    setSelectedCredentialType: (type: string | null) => {
+      selectedTypes.push(type);
+    },
+  });
+
+  const tree = HostDetailsConnectionSections(props);
+  const localKeyFileButton = findElement(
+    tree,
+    (element) =>
+      element.type === "button" &&
+      collectText(element.props.children).includes("hostDetails.credential.localKeyFile"),
+  );
+
+  assert.ok(localKeyFileButton?.props.onClick, "expected local key file option");
+  localKeyFileButton.props.onClick();
+
+  assert.deepEqual(selectedTypes, ["localKeyFile"]);
+  assert.deepEqual(
+    updateCalls.filter(([key]) => key === "authMethod"),
+    [],
+  );
+});
+
+test("HostDetailsConnectionSections keeps key auth when deleting a reference key with paths remaining", () => {
+  const remainingPath = "/Users/alice/.ssh/backup_ed25519";
+  const updateCalls: Array<[keyof Host, Host[keyof Host]]> = [];
+  const props = createConnectionSectionProps({
+    form: {
+      ...hostWithMissingProxyProfile,
+      proxyProfileId: undefined,
+      os: "windows",
+      authMethod: "key",
+      identityFileId: referenceKey.id,
+      identityFilePaths: [referenceKey.filePath!, remainingPath],
+      password: undefined,
+    },
+    availableKeys: [referenceKey],
+    update: <K extends keyof Host>(key: K, value: Host[K]) => {
+      updateCalls.push([key, value]);
+    },
+  });
+
+  const tree = HostDetailsConnectionSections(props);
+  const deleteReferenceKeyButton = findElement(
+    tree,
+    (element) =>
+      typeof element.props.onClick === "function" &&
+      containsElementType(element.props.children, Trash2),
+  );
+
+  assert.ok(deleteReferenceKeyButton?.props.onClick, "expected reference key delete button");
+  deleteReferenceKeyButton.props.onClick();
+
+  assert.deepEqual(
+    updateCalls.find(([key]) => key === "identityFileId"),
+    ["identityFileId", undefined],
+  );
+  assert.deepEqual(
+    updateCalls.find(([key]) => key === "identityFilePaths"),
+    ["identityFilePaths", [remainingPath]],
+  );
+  assert.deepEqual(
+    updateCalls.filter(([key]) => key === "authMethod"),
+    [["authMethod", "key"]],
+  );
 });
 
 test("parseOptionalPortInput clears empty port values", () => {

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -421,6 +421,18 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         authMethod: "key",
       };
     }
+    const selectedReferenceKey = cleaned.identityFileId
+      ? availableKeys.find((key) => key.id === cleaned.identityFileId && key.source === "reference" && key.filePath)
+      : undefined;
+    if (selectedReferenceKey?.filePath) {
+      cleaned = {
+        ...cleaned,
+        authMethod: "key",
+        identityFilePaths: cleaned.identityFilePaths?.length
+          ? cleaned.identityFilePaths
+          : [selectedReferenceKey.filePath],
+      };
+    }
     const preserveLegacyTheme = initialData?.theme != null && cleaned.themeOverride !== false;
     const preserveLegacyFontFamily = initialData?.fontFamily != null && cleaned.fontFamilyOverride !== false;
     const preserveLegacyFontSize = initialData?.fontSize != null && cleaned.fontSizeOverride !== false;


### PR DESCRIPTION
Ensure host edit credentials correctly reflect saved local SSH key selection, including reference-key paths and default local key/agent auth.

Keep auth state consistent when removing reference-key paths and add regression coverage for local key display flows.