### PR TITLE
fix: hover feedback for window controls

### DIFF
--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -165,14 +165,14 @@ export const WindowControls: React.FC = memo(() => {
     <div className="flex items-center app-drag h-full">
       <button
         onClick={handleMinimize}
-        className="h-full w-10 flex items-center justify-center transition-all duration-150 app-no-drag"
+        className="h-full w-10 flex items-center justify-center hover:bg-foreground/10 transition-all duration-150 app-no-drag"
         style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
       >
         <Minus size={16} />
       </button>
       <button
         onClick={handleMaximize}
-        className="h-full w-10 flex items-center justify-center transition-all duration-150 app-no-drag"
+        className="h-full w-10 flex items-center justify-center hover:bg-foreground/10 transition-all duration-150 app-no-drag"
         style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
       >
         {isMaximized ? (


### PR DESCRIPTION
Fixed hover feedback for the custom Windows/Linux window controls.

Previously, only the close button showed a hover state, while minimize and maximize/restore had no visible feedback. Minimize and maximize/restore now use a neutral hover background, while close keeps its red hover state.

before:
https://github.com/user-attachments/assets/8d02e515-da19-4f4c-be3c-26d16ed3f206


After:
https://github.com/user-attachments/assets/8a34e2f7-5ae6-40f6-b848-23b77e289ee1

**Verification**
npm run lint