### PR TITLE
fix(autocomplete): flip popup at window edges and follow accent color (#1202)

### DIFF
--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useRef, useState, memo } from "react";
 import { Folder, File, Link } from "lucide-react";
 import type { CompletionSuggestion, SuggestionSource } from "./completionEngine";
+import { computeAutocompletePopupPlacement } from "./terminalAutocompleteLayout";
 
 export interface AutocompleteThemeColors {
   background: string;
@@ -195,10 +196,17 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
 
   const bg = themeColors?.background ?? "#1e1e2e";
   const fg = themeColors?.foreground ?? "#cdd6f4";
+  // Accent comes from the active terminal theme's cursor/selection colors,
+  // which already track the user's accent setting (custom accent rewrites them
+  // in applyCustomAccentToTerminalTheme). Falling back to selection, then a
+  // neutral fg-mix, keeps older/partial theme payloads working. This is what
+  // makes the popup's highlight follow the accent instead of a hardcoded blue.
+  const accent = themeColors?.cursor || themeColors?.selection || fg;
   const popupBg = `color-mix(in srgb, ${bg} 92%, ${fg} 8%)`;
   const popupBorder = `color-mix(in srgb, ${bg} 75%, ${fg} 25%)`;
-  const selectedBg = `color-mix(in srgb, ${bg} 78%, ${fg} 22%)`;
-  const hoverBg = `color-mix(in srgb, ${bg} 85%, ${fg} 15%)`;
+  const selectedBg = `color-mix(in srgb, ${accent} 26%, ${bg} 74%)`;
+  const selectedBorderAccent = `color-mix(in srgb, ${accent} 60%, ${bg} 40%)`;
+  const hoverBg = `color-mix(in srgb, ${accent} 12%, ${bg} 88%)`;
   const textColor = fg;
   const dimTextColor = `color-mix(in srgb, ${fg} 50%, ${bg} 50%)`;
 
@@ -220,31 +228,40 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const viewportWidth = typeof window !== "undefined" ? window.innerWidth : 1200;
   const estimatedPopupHeight = Math.min(maxHeight, suggestions.length * 28 + 8);
   const estimatedDetailHeight = showDetail && detailItem && detailItem.source !== "path" ? 96 : 0;
-  const desiredContentHeight = Math.min(
+  const desiredContentHeight = Math.max(estimatedPopupHeight, estimatedDetailHeight);
+
+  // Total horizontal extent so the WHOLE assembly is clamped inside the
+  // viewport — not just the main list. Mirrors the rendered maxWidths:
+  // main list (400) + each cascading sub-dir panel (240) + the detail
+  // tooltip (280), separated by the flex gap (4). Without this, expanding a
+  // directory near the right edge pushed the sub-panels off-screen (#1202).
+  const FLEX_GAP = 4;
+  const MAIN_LIST_MAX_WIDTH = 400;
+  const SUBDIR_PANEL_MAX_WIDTH = 240;
+  const DETAIL_PANEL_MAX_WIDTH = 280;
+  const hasDetailPanel = Boolean(showDetail && detailItem && detailItem.source !== "path");
+  const totalWidth =
+    MAIN_LIST_MAX_WIDTH +
+    subDirPanels.length * (FLEX_GAP + SUBDIR_PANEL_MAX_WIDTH) +
+    (hasDetailPanel ? FLEX_GAP + DETAIL_PANEL_MAX_WIDTH : 0);
+
+  const placement = computeAutocompletePopupPlacement({
+    anchorTop: fixedLineTop,
+    anchorBottom: fixedLineBottom,
+    anchorLeft: fixedLeft,
+    viewportWidth,
+    viewportHeight,
+    desiredHeight: desiredContentHeight,
+    totalWidth,
     maxHeight,
-    Math.max(estimatedPopupHeight, estimatedDetailHeight),
-  );
-  const spaceAbove = Math.max(0, fixedLineTop - viewportPadding - anchorGap);
-  const spaceBelow = Math.max(0, viewportHeight - fixedLineBottom - viewportPadding - anchorGap);
-  const canFullyRenderAbove = spaceAbove >= desiredContentHeight;
-  const canFullyRenderBelow = spaceBelow >= desiredContentHeight;
-  const renderUpward = canFullyRenderBelow
-    ? false
-    : canFullyRenderAbove
-      ? true
-      : expandUpward
-        ? spaceAbove >= Math.min(spaceBelow, 80)
-        : spaceAbove > spaceBelow;
-  const availableVerticalSpace = renderUpward ? spaceAbove : spaceBelow;
-  const effectiveMaxHeight = Math.max(0, Math.min(maxHeight, availableVerticalSpace));
-  const contentHeightForPlacement = Math.min(
-    effectiveMaxHeight,
-    desiredContentHeight,
-  );
-  const anchoredTop = renderUpward
-    ? Math.max(viewportPadding, fixedLineTop - anchorGap - contentHeightForPlacement)
-    : Math.min(fixedLineBottom + anchorGap, viewportHeight - viewportPadding - contentHeightForPlacement);
-  const clampedLeft = Math.max(viewportPadding, Math.min(fixedLeft, viewportWidth - viewportPadding - 400));
+    anchorGap,
+    viewportPadding,
+    expandUpwardHint: expandUpward,
+  });
+  const renderUpward = placement.renderUpward;
+  const effectiveMaxHeight = placement.maxHeight;
+  const anchoredTop = placement.top;
+  const clampedLeft = placement.left;
 
   const sharedBoxStyle = {
     backgroundColor: popupBg,
@@ -306,6 +323,9 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
                 padding: "5px 10px",
                 cursor: "pointer",
                 backgroundColor: isSelected ? selectedBg : isHovered ? hoverBg : "transparent",
+                // Accent rail on the active row so the highlight reads as the
+                // theme accent. Inset shadow avoids shifting row layout.
+                boxShadow: isSelected ? `inset 2px 0 0 0 ${selectedBorderAccent}` : undefined,
                 gap: "8px",
                 lineHeight: "1.4",
               }}
@@ -435,6 +455,7 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
                   backgroundColor: isSubSelected ? selectedBg
                     : (idx === panel.selectedIndex && level < subDirFocusLevel) ? hoverBg
                     : "transparent",
+                  boxShadow: isSubSelected ? `inset 2px 0 0 0 ${selectedBorderAccent}` : undefined,
                   gap: "8px",
                   lineHeight: "1.4",
                 }}
@@ -467,6 +488,10 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
             padding: "10px 12px",
             maxWidth: "280px",
             minWidth: "160px",
+            // Bound the tooltip too: a long multi-line snippet description must
+            // scroll, not push the panel past the viewport edge (#1202).
+            maxHeight: `${effectiveMaxHeight}px`,
+            overflowY: "auto",
             alignSelf: renderUpward ? "flex-end" : "flex-start",
           }}
         >

--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -273,6 +273,10 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const clampedLeft = placement.left;
 
   const sharedBoxStyle = {
+    // border-box so each panel's maxWidth is its true outer width (padding +
+    // border included). The horizontal clamp's totalWidth sums these maxWidths,
+    // so this keeps the off-screen math exact even for the padded detail panel.
+    boxSizing: "border-box" as const,
     backgroundColor: popupBg,
     border: `1px solid ${popupBorder}`,
     borderRadius: "6px",

--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -215,6 +215,14 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const detailItem = detailIndex >= 0 ? suggestions[detailIndex] : null;
   const showDetail = detailItem?.description && detailItem.description.length > 0;
 
+  // Whether ANY item in the current set can open the detail tooltip (non-path
+  // row with a description). Placement reserves space from this set-level flag
+  // rather than the hovered item, so moving the mouse between rows can't change
+  // totalWidth/height and shift the popup out from under the pointer.
+  const setMayShowDetailPanel = suggestions.some(
+    (s) => s.source !== "path" && Boolean(s.description && s.description.length > 0),
+  );
+
   // Calculate fixed viewport position from container rect + relative cursor position.
   // containerRef already has top offset for toolbar/search bar, so don't add it again.
   const containerRect = containerRef?.current?.getBoundingClientRect();
@@ -227,7 +235,9 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 800;
   const viewportWidth = typeof window !== "undefined" ? window.innerWidth : 1200;
   const estimatedPopupHeight = Math.min(maxHeight, suggestions.length * 28 + 8);
-  const estimatedDetailHeight = showDetail && detailItem && detailItem.source !== "path" ? 96 : 0;
+  // Reserve the detail height for the whole set (not the hovered row) so the
+  // chosen direction/height stays stable while hovering.
+  const estimatedDetailHeight = setMayShowDetailPanel ? 96 : 0;
   const desiredContentHeight = Math.max(estimatedPopupHeight, estimatedDetailHeight);
 
   // Total horizontal extent so the WHOLE assembly is clamped inside the
@@ -239,11 +249,10 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const MAIN_LIST_MAX_WIDTH = 400;
   const SUBDIR_PANEL_MAX_WIDTH = 240;
   const DETAIL_PANEL_MAX_WIDTH = 280;
-  const hasDetailPanel = Boolean(showDetail && detailItem && detailItem.source !== "path");
   const totalWidth =
     MAIN_LIST_MAX_WIDTH +
     subDirPanels.length * (FLEX_GAP + SUBDIR_PANEL_MAX_WIDTH) +
-    (hasDetailPanel ? FLEX_GAP + DETAIL_PANEL_MAX_WIDTH : 0);
+    (setMayShowDetailPanel ? FLEX_GAP + DETAIL_PANEL_MAX_WIDTH : 0);
 
   const placement = computeAutocompletePopupPlacement({
     anchorTop: fixedLineTop,

--- a/components/terminal/autocomplete/terminalAutocompleteLayout.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteLayout.ts
@@ -116,6 +116,112 @@ export function areSubDirPanelsEqual(left: SubDirPanel[], right: SubDirPanel[]):
   return true;
 }
 
+export interface PopupPlacementInput {
+  /** Anchor (current input line) top edge, in viewport coordinates. */
+  anchorTop: number;
+  /** Anchor (current input line) bottom edge, in viewport coordinates. */
+  anchorBottom: number;
+  /** Desired left edge (cursor column), in viewport coordinates. */
+  anchorLeft: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  /** Natural height the popup wants if unconstrained (main list or detail). */
+  desiredHeight: number;
+  /**
+   * Total horizontal extent of the popup including any cascading sub-directory
+   * panels and the detail tooltip — used so the whole assembly is clamped
+   * inside the viewport, not just the main list.
+   */
+  totalWidth: number;
+  /** Hard cap on rendered height (matches the list's maxHeight prop). */
+  maxHeight: number;
+  /** Gap between the anchor line and the popup. */
+  anchorGap: number;
+  /** Minimum distance to keep from the viewport edges. */
+  viewportPadding: number;
+  /**
+   * Direction hint from the cursor-cell based calculation. Only used to break
+   * ties when neither side can fully fit the desired height.
+   */
+  expandUpwardHint: boolean;
+}
+
+export interface PopupPlacement {
+  /** Whether the popup renders above the anchor line (flipped up). */
+  renderUpward: boolean;
+  /** Final top edge, in viewport coordinates (already clamped). */
+  top: number;
+  /** Final left edge, in viewport coordinates (already clamped). */
+  left: number;
+  /** Height budget for the rendered content (drives scrolling). */
+  maxHeight: number;
+}
+
+/**
+ * Decide where to place the autocomplete popup so it never spills past the
+ * viewport edges. Pure and deterministic so the boundary math is unit-tested
+ * independently of React/DOM.
+ *
+ * Vertical: prefer downward, but flip upward when the space below the input
+ * line can't fit the desired height and the space above is a better fit. The
+ * height is then clamped to whatever the chosen side actually offers so the
+ * list scrolls instead of overflowing.
+ *
+ * Horizontal: clamp the left edge using the popup's *total* width (main list +
+ * cascading sub-dir panels + detail tooltip), not just the main list, so wide
+ * assemblies near the right edge slide left instead of overflowing. When the
+ * assembly is wider than the viewport it pins to the left padding so the
+ * primary list stays visible.
+ */
+export function computeAutocompletePopupPlacement(
+  input: PopupPlacementInput,
+): PopupPlacement {
+  const {
+    anchorTop,
+    anchorBottom,
+    anchorLeft,
+    viewportWidth,
+    viewportHeight,
+    desiredHeight,
+    totalWidth,
+    maxHeight,
+    anchorGap,
+    viewportPadding,
+    expandUpwardHint,
+  } = input;
+
+  const cappedDesiredHeight = Math.min(maxHeight, Math.max(0, desiredHeight));
+  const spaceAbove = Math.max(0, anchorTop - viewportPadding - anchorGap);
+  const spaceBelow = Math.max(0, viewportHeight - anchorBottom - viewportPadding - anchorGap);
+  const canFullyRenderAbove = spaceAbove >= cappedDesiredHeight;
+  const canFullyRenderBelow = spaceBelow >= cappedDesiredHeight;
+  const renderUpward = canFullyRenderBelow
+    ? false
+    : canFullyRenderAbove
+      ? true
+      : expandUpwardHint
+        ? spaceAbove >= Math.min(spaceBelow, 80)
+        : spaceAbove > spaceBelow;
+
+  const availableVerticalSpace = renderUpward ? spaceAbove : spaceBelow;
+  const effectiveMaxHeight = Math.max(0, Math.min(maxHeight, availableVerticalSpace));
+  const contentHeightForPlacement = Math.min(effectiveMaxHeight, cappedDesiredHeight);
+  const top = renderUpward
+    ? Math.max(viewportPadding, anchorTop - anchorGap - contentHeightForPlacement)
+    : Math.min(
+        anchorBottom + anchorGap,
+        viewportHeight - viewportPadding - contentHeightForPlacement,
+      );
+
+  // Right edge that keeps the whole assembly inside the viewport. When the
+  // assembly is wider than the available room this goes below viewportPadding,
+  // so the final clamp pins the popup to the left padding (primary list wins).
+  const maxLeft = viewportWidth - viewportPadding - Math.max(0, totalWidth);
+  const left = Math.max(viewportPadding, Math.min(anchorLeft, maxLeft));
+
+  return { renderUpward, top, left, maxHeight: effectiveMaxHeight };
+}
+
 /**
  * Calculate popup position based on terminal cursor.
  */

--- a/components/terminal/terminalAutocompleteLayout.test.ts
+++ b/components/terminal/terminalAutocompleteLayout.test.ts
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeAutocompletePopupPlacement,
+  type PopupPlacementInput,
+} from "./autocomplete/terminalAutocompleteLayout.ts";
+
+const baseInput: PopupPlacementInput = {
+  anchorTop: 100,
+  anchorBottom: 120,
+  anchorLeft: 200,
+  viewportWidth: 1200,
+  viewportHeight: 800,
+  desiredHeight: 232,
+  totalWidth: 400,
+  maxHeight: 240,
+  anchorGap: 8,
+  viewportPadding: 8,
+  expandUpwardHint: false,
+};
+
+test("renders downward with full height when there is ample room below", () => {
+  const p = computeAutocompletePopupPlacement(baseInput);
+  assert.equal(p.renderUpward, false);
+  assert.equal(p.top, baseInput.anchorBottom + baseInput.anchorGap); // 128
+  assert.equal(p.maxHeight, 240);
+  // Whole popup stays within the viewport vertically.
+  assert.ok(p.top + p.maxHeight <= baseInput.viewportHeight - baseInput.viewportPadding);
+});
+
+test("flips upward when the cursor sits at the very bottom of the viewport", () => {
+  // Anchor line flush with the viewport bottom — classic "typing at the
+  // bottom of the terminal" case from the bug report.
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorTop: 780,
+    anchorBottom: 800,
+  });
+  assert.equal(p.renderUpward, true);
+  // Bottom edge of the *rendered content* sits just above the input line.
+  // p.maxHeight is only the scroll budget; actual content is min(budget,desired).
+  const contentHeight = Math.min(p.maxHeight, baseInput.desiredHeight);
+  assert.ok(p.top + contentHeight <= 780 - baseInput.anchorGap + 0.001);
+  assert.ok(p.top >= baseInput.viewportPadding);
+});
+
+test("never lets a downward popup overflow the viewport bottom", () => {
+  // A little room below but not enough for the full desired height: the popup
+  // must shrink + clamp so its bottom never crosses the viewport edge.
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorTop: 600,
+    anchorBottom: 620,
+    desiredHeight: 232,
+  });
+  const bottom = p.top + p.maxHeight;
+  assert.ok(
+    bottom <= baseInput.viewportHeight - baseInput.viewportPadding + 0.001,
+    `popup bottom ${bottom} should stay within viewport`,
+  );
+});
+
+test("clamps height to the larger side when neither side fully fits", () => {
+  // Short viewport: cursor in the middle, not enough above or below for 232px.
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    viewportHeight: 300,
+    anchorTop: 140,
+    anchorBottom: 160,
+    desiredHeight: 232,
+  });
+  // More space below (300-160-16=124) than above (140-16=124 ~ tie) — either
+  // way the rendered height must fit the chosen side and stay on-screen.
+  const contentHeight = Math.min(p.maxHeight, 232);
+  if (p.renderUpward) {
+    assert.ok(p.top >= baseInput.viewportPadding);
+    assert.ok(p.top + contentHeight <= 160 - baseInput.anchorGap + 0.001);
+  } else {
+    assert.ok(p.top + contentHeight <= 300 - baseInput.viewportPadding + 0.001);
+  }
+  assert.ok(p.maxHeight > 0);
+});
+
+test("honors the upward hint to break ties when neither side fits", () => {
+  const shared = {
+    ...baseInput,
+    viewportHeight: 300,
+    anchorTop: 150,
+    anchorBottom: 170,
+    desiredHeight: 232,
+  };
+  const withHint = computeAutocompletePopupPlacement({ ...shared, expandUpwardHint: true });
+  // spaceAbove = 150-16 = 134; min(spaceBelow,80) -> spaceBelow=300-170-16=114, min=80
+  // 134 >= 80 so the hint flips it upward.
+  assert.equal(withHint.renderUpward, true);
+});
+
+test("clamps the left edge so the FULL assembly (with sub-dir panels) fits", () => {
+  // Cursor near the right edge, popup widened by cascading sub-dir panels.
+  // The whole assembly (1100px wide) must slide left to stay on-screen.
+  const totalWidth = 1100; // main 400 + panels + detail
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorLeft: 1150,
+    totalWidth,
+  });
+  assert.ok(p.left >= baseInput.viewportPadding);
+  assert.ok(
+    p.left + totalWidth <= baseInput.viewportWidth - baseInput.viewportPadding + 0.001,
+    `right edge ${p.left + totalWidth} should stay within viewport`,
+  );
+});
+
+test("pins to the left padding when the assembly is wider than the viewport", () => {
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorLeft: 600,
+    viewportWidth: 500,
+    totalWidth: 900,
+  });
+  // Can't fit no matter what — keep the primary list visible at the left edge.
+  assert.equal(p.left, baseInput.viewportPadding);
+});
+
+test("does not shift left when the popup already fits at the cursor", () => {
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorLeft: 200,
+    totalWidth: 400,
+  });
+  assert.equal(p.left, 200);
+});


### PR DESCRIPTION
## Background

Fixes #1202:

1. When the cursor was near the bottom of the window, the autocomplete popup still opened downward and overflowed past the app boundary.
2. Popup selection colors were hard-coded blue instead of following the current accent color.

## Changes

### Boundary-aware placement

- Extracts popup placement into the pure helper `computeAutocompletePopupPlacement()`.
- Flips upward when there is not enough space below the cursor.
- Clamps height to available space and scrolls internally instead of overflowing.
- Fixes horizontal overflow by clamping against the combined width of the main list, nested path panels, and detail panel.
- Keeps the main list visible when the combined popup is wider than the viewport.
- Adds max-height and scrolling to the detail panel.
- Uses `box-sizing: border-box` consistently.

### Accent-aware colors

Selected and hovered rows, plus the selected-row accent bar, now derive from the terminal theme cursor and selection colors. In custom accent mode those colors are already rewritten by `applyCustomAccentToTerminalTheme`.

## Tests

- Adds `components/terminal/terminalAutocompleteLayout.test.ts`.
- `npm run lint` passed.
- Terminal-related tests passed.
- `npm run build` passed.
- Local Codex review converged after fixing popup jumping and detail-panel padding in width calculations.

## Scope

Only autocomplete popup placement, boundary behavior, and colors changed. Matching logic did not change.

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
