### PR TITLE
fix: persist OneDrive token refreshes and show reconnect prompts (#1189)

### DIFF
--- a/components/cloud-sync/CloudSyncDashboardTabs.tsx
+++ b/components/cloud-sync/CloudSyncDashboardTabs.tsx
@@ -2,7 +2,7 @@ import React, { type Dispatch, type RefObject, type SetStateAction } from 'react
 import { Database, Github, History, Server, Trash2 } from 'lucide-react';
 import type { CloudProvider, SyncPayload } from '../../domain/sync';
 import type { useCloudSync } from '../../application/state/useCloudSync';
-import { isProviderReadyForSync } from '../../domain/sync';
+import { cleanOneDriveErrorMessage, isProviderReadyForSync } from '../../domain/sync';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '../ui/select';
@@ -116,7 +116,11 @@ export const CloudSyncDashboardTabs: React.FC<CloudSyncDashboardTabsProps> = ({
                         }
                         account={sync.providers.onedrive.account}
                         lastSync={sync.providers.onedrive.lastSync}
-                        error={sync.providers.onedrive.error}
+                        error={
+                            sync.providers.onedrive.error
+                                ? cleanOneDriveErrorMessage(sync.providers.onedrive.error)
+                                : undefined
+                        }
                         disabled={isConnectDisabled('onedrive')}
                         onConnect={handleConnectOneDrive}
                         onCancelConnect={sync.cancelOAuthConnect}

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -92,6 +92,38 @@ export interface OAuthTokens {
 }
 
 /**
+ * Marker prefixed onto OneDrive refresh errors when Microsoft reports the
+ * refresh token can no longer be used (expired / revoked / consent withdrawn).
+ * Only an error's `message` survives the Electron IPC boundary, so the marker is
+ * the stable signal that the OneDrive session must be re-authorized. It is added
+ * in the bridge (electron/bridges/onedriveAuthBridge.cjs) and detected/cleaned
+ * here so the same logic is shared by infrastructure and UI layers.
+ */
+export const ONEDRIVE_REAUTH_REQUIRED_MARKER = 'ONEDRIVE_REAUTH_REQUIRED';
+
+/**
+ * True when an error indicates the OneDrive refresh token is dead and the user
+ * must reconnect. Robust to the error being re-wrapped (e.g. `new
+ * Error(String(err))`) as it bubbles through the provider-agnostic pipeline.
+ */
+export const isOneDriveReauthRequiredMessage = (message: string): boolean =>
+  message.includes(ONEDRIVE_REAUTH_REQUIRED_MARKER);
+
+/**
+ * Produce a clean, user-facing message from a (possibly multiply-wrapped) error
+ * string by dropping everything up to and including the internal reauth marker,
+ * e.g. "Error: OneDriveReauthRequiredError: ONEDRIVE_REAUTH_REQUIRED: OneDrive
+ * session expired..." -> "OneDrive session expired...". Returns the original
+ * string unchanged when the marker is absent.
+ */
+export const cleanOneDriveErrorMessage = (message: string): string => {
+  const token = `${ONEDRIVE_REAUTH_REQUIRED_MARKER}:`;
+  const markerIndex = message.lastIndexOf(token);
+  if (markerIndex === -1) return message;
+  return message.slice(markerIndex + token.length).trim();
+};
+
+/**
  * Provider account information
  */
 export interface ProviderAccount {

--- a/electron/bridges/onedriveAuthBridge.cjs
+++ b/electron/bridges/onedriveAuthBridge.cjs
@@ -12,6 +12,22 @@ const DEFAULT_SYNC_FILE_NAME = "netcatty-vault.json";
 const DEFAULT_SCOPE =
   "https://graph.microsoft.com/Files.ReadWrite.AppFolder https://graph.microsoft.com/User.Read offline_access";
 
+// Stable marker prefixed onto refresh errors when Microsoft says the refresh
+// token itself is dead (expired/revoked/consent withdrawn). Only IPC error
+// `message` survives the bridge boundary, so the renderer keys off this string
+// to flip OneDrive into a "needs reconnect" state instead of retrying forever.
+const ONEDRIVE_REAUTH_REQUIRED_MARKER = "ONEDRIVE_REAUTH_REQUIRED";
+
+// OAuth2 error codes that mean the refresh token can no longer be used and the
+// user must sign in again (vs. a transient/server error worth retrying).
+// https://learn.microsoft.com/azure/active-directory/develop/reference-error-codes
+const REFRESH_REAUTH_ERROR_CODES = new Set([
+  "invalid_grant", // expired/revoked refresh token (the common #1189 case)
+  "interaction_required",
+  "consent_required",
+  "login_required",
+]);
+
 const isNonEmptyString = (v) => typeof v === "string" && v.trim().length > 0;
 
 const safeJsonParse = (text) => {
@@ -135,8 +151,12 @@ function registerHandlers(ipcMain, electronModule) {
     const text = await res.text();
     if (!res.ok) {
       const data = safeJsonParse(text) || { error: text };
+      const reauthRequired = REFRESH_REAUTH_ERROR_CODES.has(data.error);
+      const description = data.error_description || data.error || res.status;
       throw new Error(
-        `OneDrive token refresh failed: ${data.error_description || data.error || res.status}`
+        reauthRequired
+          ? `${ONEDRIVE_REAUTH_REQUIRED_MARKER}: OneDrive session expired, please reconnect. (${description})`
+          : `OneDrive token refresh failed: ${description}`
       );
     }
 
@@ -321,4 +341,6 @@ function registerHandlers(ipcMain, electronModule) {
 
 module.exports = {
   registerHandlers,
+  ONEDRIVE_REAUTH_REQUIRED_MARKER,
+  REFRESH_REAUTH_ERROR_CODES,
 };

--- a/electron/bridges/onedriveAuthBridge.test.cjs
+++ b/electron/bridges/onedriveAuthBridge.test.cjs
@@ -1,0 +1,108 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  registerHandlers,
+  ONEDRIVE_REAUTH_REQUIRED_MARKER,
+} = require("./onedriveAuthBridge.cjs");
+
+function createIpcMainStub() {
+  const handlers = new Map();
+  return {
+    handlers,
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+}
+
+function makeJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return typeof body === "string" ? body : JSON.stringify(body);
+    },
+  };
+}
+
+function registerWithFetch(fetchImpl) {
+  const ipcMain = createIpcMainStub();
+  registerHandlers(ipcMain, { net: { fetch: fetchImpl } });
+  return ipcMain;
+}
+
+test("onedrive refresh tags invalid_grant with the reauth marker", async () => {
+  const ipcMain = registerWithFetch(async () =>
+    makeJsonResponse(400, {
+      error: "invalid_grant",
+      error_description: "AADSTS70000: refresh token expired",
+    })
+  );
+  const refresh = ipcMain.handlers.get("netcatty:onedrive:oauth:refresh");
+  assert.ok(refresh, "refresh handler registered");
+
+  await assert.rejects(
+    () => refresh({}, { clientId: "client", refreshToken: "stale-refresh" }),
+    (err) => {
+      assert.ok(
+        err.message.includes(ONEDRIVE_REAUTH_REQUIRED_MARKER),
+        `expected marker in message, got: ${err.message}`
+      );
+      assert.match(err.message, /AADSTS70000/);
+      return true;
+    }
+  );
+});
+
+test("onedrive refresh does NOT tag generic failures with the reauth marker", async () => {
+  const ipcMain = registerWithFetch(async () =>
+    makeJsonResponse(500, { error: "temporarily_unavailable" })
+  );
+  const refresh = ipcMain.handlers.get("netcatty:onedrive:oauth:refresh");
+
+  await assert.rejects(
+    () => refresh({}, { clientId: "client", refreshToken: "ok-refresh" }),
+    (err) => {
+      assert.ok(
+        !err.message.includes(ONEDRIVE_REAUTH_REQUIRED_MARKER),
+        `did not expect marker, got: ${err.message}`
+      );
+      assert.match(err.message, /OneDrive token refresh failed/);
+      return true;
+    }
+  );
+});
+
+test("onedrive refresh returns the rotated refresh token from the response", async () => {
+  const ipcMain = registerWithFetch(async () =>
+    makeJsonResponse(200, {
+      access_token: "new-access",
+      refresh_token: "rotated-refresh",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "scope",
+    })
+  );
+  const refresh = ipcMain.handlers.get("netcatty:onedrive:oauth:refresh");
+
+  const tokens = await refresh({}, { clientId: "client", refreshToken: "old-refresh" });
+  assert.equal(tokens.accessToken, "new-access");
+  assert.equal(tokens.refreshToken, "rotated-refresh");
+  assert.equal(tokens.tokenType, "Bearer");
+  assert.ok(tokens.expiresAt > Date.now());
+});
+
+test("onedrive refresh falls back to the supplied refresh token when none is returned", async () => {
+  const ipcMain = registerWithFetch(async () =>
+    makeJsonResponse(200, {
+      access_token: "new-access",
+      expires_in: 3600,
+      token_type: "Bearer",
+    })
+  );
+  const refresh = ipcMain.handlers.get("netcatty:onedrive:oauth:refresh");
+
+  const tokens = await refresh({}, { clientId: "client", refreshToken: "kept-refresh" });
+  assert.equal(tokens.refreshToken, "kept-refresh");
+});

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -112,6 +112,7 @@ import {
   lockImpl,
   changeMasterKeyImpl,
   verifyPasswordImpl,
+  handleProviderReauthRequiredImpl,
 } from './cloudSync/stateAndSecurityMethods';
 
 // ============================================================================
@@ -274,6 +275,15 @@ export class CloudSyncManager {
 
   private async getConnectedAdapter(provider: CloudProvider): Promise<CloudAdapter> {
     return getConnectedAdapterImpl.call(this, provider);
+  }
+
+  /**
+   * If `error` indicates OneDrive's refresh token is dead, clear the stale
+   * tokens so the provider drops to a reconnect state instead of retrying the
+   * dead token. Returns true when handled. Safe no-op otherwise.
+   */
+  private handleProviderReauthRequired(provider: CloudProvider, error: unknown): boolean {
+    return handleProviderReauthRequiredImpl.call(this, provider, error);
   }
 
   // ==========================================================================

--- a/infrastructure/services/adapters/OneDriveAdapter.test.ts
+++ b/infrastructure/services/adapters/OneDriveAdapter.test.ts
@@ -12,12 +12,14 @@ import {
   type OAuthTokens,
 } from '../../../domain/sync.ts';
 
-type WindowWithNetcatty = typeof globalThis & { window?: { netcatty?: Record<string, unknown> } };
+type WindowGlobal = typeof globalThis & { window?: unknown };
 
 function setBridge(bridge: Record<string, unknown>): () => void {
-  const g = globalThis as WindowWithNetcatty;
+  const g = globalThis as WindowGlobal;
   const original = g.window;
-  g.window = { netcatty: bridge };
+  // Loosely typed: the real window.netcatty is a large NetcattyBridge; tests
+  // only stub the handful of OneDrive methods the adapter actually calls.
+  g.window = { netcatty: bridge } as unknown as Window & typeof globalThis;
   return () => {
     g.window = original;
   };

--- a/infrastructure/services/adapters/OneDriveAdapter.test.ts
+++ b/infrastructure/services/adapters/OneDriveAdapter.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  OneDriveAdapter,
+  OneDriveReauthRequiredError,
+  isOneDriveReauthRequiredError,
+} from './OneDriveAdapter.ts';
+import {
+  ONEDRIVE_REAUTH_REQUIRED_MARKER,
+  cleanOneDriveErrorMessage,
+  type OAuthTokens,
+} from '../../../domain/sync.ts';
+
+type WindowWithNetcatty = typeof globalThis & { window?: { netcatty?: Record<string, unknown> } };
+
+function setBridge(bridge: Record<string, unknown>): () => void {
+  const g = globalThis as WindowWithNetcatty;
+  const original = g.window;
+  g.window = { netcatty: bridge };
+  return () => {
+    g.window = original;
+  };
+}
+
+const expiredTokens = (): OAuthTokens => ({
+  accessToken: 'old-access',
+  refreshToken: 'old-refresh',
+  // Already expired so any operation forces a refresh.
+  expiresAt: Date.now() - 60_000,
+  tokenType: 'Bearer',
+});
+
+test('isOneDriveReauthRequiredError detects the marker and the error class', () => {
+  assert.equal(isOneDriveReauthRequiredError(new OneDriveReauthRequiredError()), true);
+  assert.equal(
+    isOneDriveReauthRequiredError(new Error(`${ONEDRIVE_REAUTH_REQUIRED_MARKER}: x`)),
+    true,
+  );
+  // Survives re-wrapping the way the sync pipeline re-wraps errors.
+  const wrapped = new Error(String(new OneDriveReauthRequiredError('boom')));
+  assert.equal(isOneDriveReauthRequiredError(wrapped), true);
+  assert.equal(isOneDriveReauthRequiredError(new Error('network down')), false);
+});
+
+test('cleanOneDriveErrorMessage strips the marker and wrapping prefixes', () => {
+  const wrapped = `Error: OneDriveReauthRequiredError: ${ONEDRIVE_REAUTH_REQUIRED_MARKER}: OneDrive session expired, please reconnect. (AADSTS70000)`;
+  assert.equal(
+    cleanOneDriveErrorMessage(wrapped),
+    'OneDrive session expired, please reconnect. (AADSTS70000)',
+  );
+  // No marker -> returned unchanged.
+  assert.equal(cleanOneDriveErrorMessage('plain network error'), 'plain network error');
+});
+
+test('OneDriveReauthRequiredError always carries the marker in its message', () => {
+  assert.ok(new OneDriveReauthRequiredError('hi').message.includes(ONEDRIVE_REAUTH_REQUIRED_MARKER));
+  // Does not double-prefix when the marker is already present.
+  const once = new OneDriveReauthRequiredError(`${ONEDRIVE_REAUTH_REQUIRED_MARKER}: hi`).message;
+  assert.equal(once.indexOf(ONEDRIVE_REAUTH_REQUIRED_MARKER), once.lastIndexOf(ONEDRIVE_REAUTH_REQUIRED_MARKER));
+});
+
+test('refreshing tokens during an operation fires the persistence callback with rotated tokens', async () => {
+  const rotated: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'rotated-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  let refreshCalledWith: string | undefined;
+  // Returning a non-null synced file avoids the eventual-consistency retry loop
+  // (retryOnNotFound) that backs off on a null result and would slow the test.
+  const remoteSyncedFile = { meta: { version: 1 }, payload: 'x' };
+  const restore = setBridge({
+    onedriveRefreshAccessToken: async ({ refreshToken }: { refreshToken: string }) => {
+      refreshCalledWith = refreshToken;
+      return rotated;
+    },
+    onedriveDownloadSyncFile: async ({ accessToken }: { accessToken: string }) => {
+      // Operation must run with the refreshed access token.
+      assert.equal(accessToken, 'fresh-access');
+      return { syncedFile: remoteSyncedFile };
+    },
+  });
+
+  try {
+    const adapter = new OneDriveAdapter(expiredTokens(), 'file-1');
+    const persisted: OAuthTokens[] = [];
+    adapter.setOnTokensRefreshed((tokens) => persisted.push(tokens));
+
+    const result = await adapter.download();
+
+    assert.deepEqual(result, remoteSyncedFile);
+    assert.equal(refreshCalledWith, 'old-refresh');
+    assert.equal(persisted.length, 1);
+    assert.deepEqual(persisted[0], rotated);
+    // Adapter also exposes the rotated tokens for the caller to persist.
+    assert.deepEqual(adapter.getTokens(), rotated);
+  } finally {
+    restore();
+  }
+});
+
+test('a dead refresh token surfaces OneDriveReauthRequiredError and does not fire the callback', async () => {
+  const restore = setBridge({
+    onedriveRefreshAccessToken: async () => {
+      throw new Error(
+        `${ONEDRIVE_REAUTH_REQUIRED_MARKER}: OneDrive session expired, please reconnect. (AADSTS70000)`,
+      );
+    },
+  });
+
+  try {
+    const adapter = new OneDriveAdapter(expiredTokens(), 'file-1');
+    let callbackFired = false;
+    adapter.setOnTokensRefreshed(() => {
+      callbackFired = true;
+    });
+
+    await assert.rejects(
+      () => adapter.download(),
+      (err) => {
+        assert.equal(isOneDriveReauthRequiredError(err), true);
+        assert.ok(err instanceof OneDriveReauthRequiredError);
+        return true;
+      },
+    );
+    assert.equal(callbackFired, false);
+  } finally {
+    restore();
+  }
+});
+
+test('setTokens refreshes an expired token and persists the rotated tokens', async () => {
+  const rotated: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'rotated-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const restore = setBridge({
+    onedriveRefreshAccessToken: async () => rotated,
+    onedriveGetUserInfo: async () => ({ id: 'u1', email: 'u@example.com', name: 'User' }),
+  });
+
+  try {
+    const adapter = new OneDriveAdapter();
+    const persisted: OAuthTokens[] = [];
+    adapter.setOnTokensRefreshed((tokens) => persisted.push(tokens));
+
+    await adapter.setTokens(expiredTokens());
+
+    assert.deepEqual(persisted, [rotated]);
+    assert.deepEqual(adapter.getTokens(), rotated);
+    assert.equal(adapter.accountInfo?.id, 'u1');
+  } finally {
+    restore();
+  }
+});
+
+test('setTokens with an expired token and no refresh token requires reconnect', async () => {
+  const restore = setBridge({});
+  try {
+    const adapter = new OneDriveAdapter();
+    await assert.rejects(
+      () =>
+        adapter.setTokens({
+          accessToken: 'old-access',
+          expiresAt: Date.now() - 60_000,
+          tokenType: 'Bearer',
+        }),
+      (err) => {
+        assert.equal(isOneDriveReauthRequiredError(err), true);
+        return true;
+      },
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('signOut clears the refresh persistence callback', async () => {
+  const rotated: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'rotated-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const restore = setBridge({
+    onedriveRefreshAccessToken: async () => rotated,
+    onedriveGetUserInfo: async () => ({ id: 'u1', email: 'u@example.com', name: 'User' }),
+  });
+
+  try {
+    const adapter = new OneDriveAdapter(expiredTokens(), 'file-1');
+    let callbackFired = false;
+    adapter.setOnTokensRefreshed(() => {
+      callbackFired = true;
+    });
+    adapter.signOut();
+    // Re-arm tokens and refresh; the callback must not fire after signOut.
+    await adapter.setTokens(expiredTokens());
+    assert.equal(callbackFired, false);
+  } finally {
+    restore();
+  }
+});

--- a/infrastructure/services/adapters/OneDriveAdapter.ts
+++ b/infrastructure/services/adapters/OneDriveAdapter.ts
@@ -14,6 +14,8 @@
 
 import {
   SYNC_CONSTANTS,
+  ONEDRIVE_REAUTH_REQUIRED_MARKER,
+  isOneDriveReauthRequiredMessage,
   type OAuthTokens,
   type ProviderAccount,
   type SyncedFile,
@@ -48,6 +50,35 @@ const ONEDRIVE_SCOPES = [
 ];
 
 const ONEDRIVE_SCOPE = ONEDRIVE_SCOPES.join(' ');
+
+/**
+ * Raised when the OneDrive refresh token can no longer be exchanged for a new
+ * access token (expired / revoked / consent withdrawn). The user must
+ * re-authorize; silent refresh cannot recover. CloudSyncManager detects this to
+ * surface a clear "reconnect" state instead of a raw error.
+ *
+ * The message always carries ONEDRIVE_REAUTH_REQUIRED_MARKER so the condition is
+ * still detectable after the error is re-wrapped (e.g. `new Error(String(err))`)
+ * as it bubbles through the provider-agnostic sync pipeline.
+ */
+export class OneDriveReauthRequiredError extends Error {
+  constructor(message = 'OneDrive session expired, please reconnect.') {
+    super(
+      isOneDriveReauthRequiredMessage(message)
+        ? message
+        : `${ONEDRIVE_REAUTH_REQUIRED_MARKER}: ${message}`
+    );
+    this.name = 'OneDriveReauthRequiredError';
+  }
+}
+
+export const isOneDriveReauthRequiredError = (error: unknown): boolean => {
+  if (error instanceof OneDriveReauthRequiredError) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return isOneDriveReauthRequiredMessage(message);
+};
 
 const isUnauthorizedError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
@@ -497,12 +528,58 @@ export class OneDriveAdapter {
   private fileId: string | null = null;
   private account: ProviderAccount | null = null;
   private pkceChallenge: PKCEChallenge | null = null;
+  /**
+   * Invoked whenever the access token is silently refreshed. Lets the owner
+   * (CloudSyncManager) persist the rotated tokens — Microsoft consumer refresh
+   * tokens rotate on every refresh and invalidate the previous one, so without
+   * persisting the new refresh token the stored one eventually goes stale and
+   * forces the user to reconnect (#1189).
+   */
+  private onTokensRefreshed: ((tokens: OAuthTokens) => void) | null = null;
 
   constructor(tokens?: OAuthTokens, fileId?: string) {
     if (tokens) {
       this.tokens = tokens;
     }
     this.fileId = fileId || null;
+  }
+
+  /**
+   * Register a callback that receives refreshed tokens so the caller can
+   * persist them. Passing null removes the callback.
+   */
+  setOnTokensRefreshed(callback: ((tokens: OAuthTokens) => void) | null): void {
+    this.onTokensRefreshed = callback;
+  }
+
+  /**
+   * Refresh the access token using the supplied refresh token, store the
+   * rotated tokens in-memory, and notify the persistence callback. Refresh
+   * failures caused by a dead refresh token are normalized to
+   * OneDriveReauthRequiredError so callers can prompt for reconnect.
+   */
+  private async refreshTokens(refreshToken: string): Promise<OAuthTokens> {
+    let refreshed: OAuthTokens;
+    try {
+      refreshed = await refreshAccessToken(refreshToken);
+    } catch (error) {
+      if (isOneDriveReauthRequiredError(error)) {
+        // Preserve the message (it carries the marker the bridge added) so
+        // downstream layers can still detect this after any re-wrapping.
+        throw new OneDriveReauthRequiredError(
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+      throw error;
+    }
+    this.tokens = refreshed;
+    try {
+      this.onTokensRefreshed?.(refreshed);
+    } catch {
+      // Persistence is best-effort; a failed save must not abort the sync that
+      // triggered the refresh — the fresh tokens still work for this session.
+    }
+    return refreshed;
   }
 
   get isAuthenticated(): boolean {
@@ -562,9 +639,11 @@ export class OneDriveAdapter {
     // Refresh if expired
     if (tokens.expiresAt && Date.now() > tokens.expiresAt - 60000) {
       if (tokens.refreshToken) {
-        this.tokens = await refreshAccessToken(tokens.refreshToken);
+        this.tokens = await this.refreshTokens(tokens.refreshToken);
       } else {
-        throw new Error('Token expired and no refresh token');
+        throw new OneDriveReauthRequiredError(
+          'OneDrive session expired and no refresh token is available, please reconnect.'
+        );
       }
     }
 
@@ -585,9 +664,11 @@ export class OneDriveAdapter {
 
     if (this.tokens.expiresAt && Date.now() > this.tokens.expiresAt - 60000) {
       if (this.tokens.refreshToken) {
-        this.tokens = await refreshAccessToken(this.tokens.refreshToken);
+        this.tokens = await this.refreshTokens(this.tokens.refreshToken);
       } else {
-        throw new Error('Token expired');
+        throw new OneDriveReauthRequiredError(
+          'OneDrive session expired and no refresh token is available, please reconnect.'
+        );
       }
     }
 
@@ -603,8 +684,8 @@ export class OneDriveAdapter {
       return await operation(accessToken);
     } catch (error) {
       if (isUnauthorizedError(error) && this.tokens?.refreshToken) {
-        this.tokens = await refreshAccessToken(this.tokens.refreshToken);
-        return await operation(this.tokens.accessToken);
+        const refreshed = await this.refreshTokens(this.tokens.refreshToken);
+        return await operation(refreshed.accessToken);
       }
       throw error;
     }
@@ -618,6 +699,7 @@ export class OneDriveAdapter {
     this.fileId = null;
     this.account = null;
     this.pkceChallenge = null;
+    this.onTokensRefreshed = null;
   }
 
   /**

--- a/infrastructure/services/cloudSync/authMethods.ts
+++ b/infrastructure/services/cloudSync/authMethods.ts
@@ -495,6 +495,12 @@ export async function inspectProviderRemoteStateImpl(this: any,
         remoteFile,
       };
     } catch (error) {
+      // A dead OneDrive refresh token surfaces here during sync preflight,
+      // syncAll preflight, and startup inspection. Clear the stale credentials
+      // so the provider drops to a reconnect state instead of being retried.
+      if (typeof this.handleProviderReauthRequired === 'function') {
+        this.handleProviderReauthRequired(provider, error);
+      }
       return {
         remoteChanged: false,
         remoteFile: null,

--- a/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
+++ b/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
@@ -6,6 +6,7 @@ import {
   handleProviderReauthRequiredImpl,
   persistRefreshedProviderTokensImpl,
 } from './stateAndSecurityMethods.ts';
+import { inspectProviderRemoteStateImpl } from './authMethods.ts';
 import {
   ONEDRIVE_REAUTH_REQUIRED_MARKER,
   isProviderReadyForSync,
@@ -163,4 +164,35 @@ test('handleProviderReauthRequired ignores non-OneDrive providers and unrelated 
     false,
   );
   assert.ok(manager.state.providers.onedrive.tokens);
+});
+
+test('inspectProviderRemoteState clears OneDrive tokens on a reauth-required download error', async () => {
+  const { manager, saved } = createManager();
+  // Provide the manager surface inspectProviderRemoteState touches.
+  Object.assign(manager, {
+    handleProviderReauthRequired(provider: string, error: unknown) {
+      return handleProviderReauthRequiredImpl.call(manager, provider as never, error);
+    },
+    createSyncedFileSignature: async () => null,
+    loadSyncAnchor: () => null,
+  });
+
+  const adapter = {
+    resourceId: 'file-1',
+    download: async () => {
+      throw new Error(
+        `Download failed: ${ONEDRIVE_REAUTH_REQUIRED_MARKER}: OneDrive session expired, please reconnect.`,
+      );
+    },
+  };
+
+  const result = await inspectProviderRemoteStateImpl.call(manager, 'onedrive', adapter as never);
+  await Promise.resolve();
+
+  // The inspection reports an error (so callers fail closed)...
+  assert.ok(result.error);
+  // ...and the dead credentials were cleared so the provider is no longer ready.
+  assert.equal(manager.state.providers.onedrive.tokens, undefined);
+  assert.equal(isProviderReadyForSync(manager.state.providers.onedrive), false);
+  assert.equal(saved.length, 1);
 });

--- a/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
+++ b/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  attachTokenRefreshPersistence,
+  persistRefreshedProviderTokensImpl,
+} from './stateAndSecurityMethods.ts';
+import type { OAuthTokens } from '../../../domain/sync.ts';
+
+const newTokens = (): OAuthTokens => ({
+  accessToken: 'fresh-access',
+  refreshToken: 'rotated-refresh',
+  expiresAt: Date.now() + 3_600_000,
+  tokenType: 'Bearer',
+});
+
+function createManager() {
+  const saved: Array<{ provider: string; tokens?: OAuthTokens }> = [];
+  let notified = 0;
+  const manager = {
+    providerDecryptSeq: { onedrive: 0 } as Record<string, number>,
+    state: {
+      providers: {
+        onedrive: {
+          provider: 'onedrive',
+          status: 'connected',
+          tokens: { accessToken: 'old', refreshToken: 'old-refresh', tokenType: 'Bearer' },
+          account: { id: 'u1' },
+          resourceId: 'file-1',
+        },
+      },
+    },
+    saveProviderConnection: async (provider: string, connection: { tokens?: OAuthTokens }) => {
+      saved.push({ provider, tokens: connection.tokens });
+    },
+    notifyStateChange: () => {
+      notified += 1;
+    },
+  };
+  return { manager, saved, getNotified: () => notified };
+}
+
+test('persistRefreshedProviderTokens updates state, persists, and notifies', async () => {
+  const { manager, saved, getNotified } = createManager();
+  const tokens = newTokens();
+
+  persistRefreshedProviderTokensImpl.call(manager, 'onedrive', tokens);
+  // saveProviderConnection is fire-and-forget; let microtasks flush.
+  await Promise.resolve();
+
+  assert.deepEqual(manager.state.providers.onedrive.tokens, tokens);
+  // Other fields are preserved.
+  assert.equal(manager.state.providers.onedrive.account.id, 'u1');
+  assert.equal(manager.state.providers.onedrive.resourceId, 'file-1');
+  assert.equal(manager.state.providers.onedrive.status, 'connected');
+
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0].provider, 'onedrive');
+  assert.deepEqual(saved[0].tokens, tokens);
+
+  // Decrypt sequence is bumped so an in-flight decrypt cannot clobber the write.
+  assert.equal(manager.providerDecryptSeq.onedrive, 1);
+  assert.equal(getNotified(), 1);
+});
+
+test('persistRefreshedProviderTokens is a no-op when the provider was disconnected', async () => {
+  const { manager, saved } = createManager();
+  // Simulate a disconnect happening during the async refresh.
+  manager.state.providers.onedrive = { provider: 'onedrive', status: 'disconnected' } as never;
+
+  persistRefreshedProviderTokensImpl.call(manager, 'onedrive', newTokens());
+  await Promise.resolve();
+
+  assert.equal(saved.length, 0);
+  assert.equal(manager.state.providers.onedrive.tokens, undefined);
+});
+
+test('attachTokenRefreshPersistence wires adapters that expose setOnTokensRefreshed', () => {
+  const { manager, saved } = createManager();
+  let registered: ((tokens: OAuthTokens) => void) | null = null;
+  const adapter = {
+    setOnTokensRefreshed(cb: (tokens: OAuthTokens) => void) {
+      registered = cb;
+    },
+  };
+
+  attachTokenRefreshPersistence.call(manager, 'onedrive', adapter as never);
+  assert.equal(typeof registered, 'function');
+
+  // Invoking the registered callback persists, proving the wiring is correct.
+  const tokens = newTokens();
+  registered!(tokens);
+  assert.equal(saved.length, 1);
+  assert.deepEqual(saved[0].tokens, tokens);
+});
+
+test('attachTokenRefreshPersistence is a no-op for adapters without the hook', () => {
+  const { manager } = createManager();
+  // Adapter without setOnTokensRefreshed (e.g. GitHub) must not throw.
+  assert.doesNotThrow(() =>
+    attachTokenRefreshPersistence.call(manager, 'github', {} as never),
+  );
+});

--- a/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
+++ b/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
@@ -3,9 +3,15 @@ import test from 'node:test';
 
 import {
   attachTokenRefreshPersistence,
+  handleProviderReauthRequiredImpl,
   persistRefreshedProviderTokensImpl,
 } from './stateAndSecurityMethods.ts';
-import type { OAuthTokens } from '../../../domain/sync.ts';
+import {
+  ONEDRIVE_REAUTH_REQUIRED_MARKER,
+  isProviderReadyForSync,
+  type OAuthTokens,
+  type ProviderConnection,
+} from '../../../domain/sync.ts';
 
 const newTokens = (): OAuthTokens => ({
   accessToken: 'fresh-access',
@@ -18,7 +24,8 @@ function createManager() {
   const saved: Array<{ provider: string; tokens?: OAuthTokens }> = [];
   let notified = 0;
   const manager = {
-    providerDecryptSeq: { onedrive: 0 } as Record<string, number>,
+    providerDecryptSeq: { onedrive: 0, google: 0 } as Record<string, number>,
+    adapters: new Map<string, { signOut: () => void }>(),
     state: {
       providers: {
         onedrive: {
@@ -27,8 +34,8 @@ function createManager() {
           tokens: { accessToken: 'old', refreshToken: 'old-refresh', tokenType: 'Bearer' },
           account: { id: 'u1' },
           resourceId: 'file-1',
-        },
-      },
+        } as ProviderConnection,
+      } as Record<string, ProviderConnection>,
     },
     saveProviderConnection: async (provider: string, connection: { tokens?: OAuthTokens }) => {
       saved.push({ provider, tokens: connection.tokens });
@@ -50,7 +57,7 @@ test('persistRefreshedProviderTokens updates state, persists, and notifies', asy
 
   assert.deepEqual(manager.state.providers.onedrive.tokens, tokens);
   // Other fields are preserved.
-  assert.equal(manager.state.providers.onedrive.account.id, 'u1');
+  assert.equal(manager.state.providers.onedrive.account?.id, 'u1');
   assert.equal(manager.state.providers.onedrive.resourceId, 'file-1');
   assert.equal(manager.state.providers.onedrive.status, 'connected');
 
@@ -66,7 +73,7 @@ test('persistRefreshedProviderTokens updates state, persists, and notifies', asy
 test('persistRefreshedProviderTokens is a no-op when the provider was disconnected', async () => {
   const { manager, saved } = createManager();
   // Simulate a disconnect happening during the async refresh.
-  manager.state.providers.onedrive = { provider: 'onedrive', status: 'disconnected' } as never;
+  manager.state.providers.onedrive = { provider: 'onedrive', status: 'disconnected' };
 
   persistRefreshedProviderTokensImpl.call(manager, 'onedrive', newTokens());
   await Promise.resolve();
@@ -100,4 +107,60 @@ test('attachTokenRefreshPersistence is a no-op for adapters without the hook', (
   assert.doesNotThrow(() =>
     attachTokenRefreshPersistence.call(manager, 'github', {} as never),
   );
+});
+
+test('handleProviderReauthRequired clears OneDrive tokens and stops it being sync-ready', async () => {
+  const { manager, saved } = createManager();
+  let signedOut = false;
+  manager.adapters.set('onedrive', { signOut: () => { signedOut = true; } });
+
+  const handled = handleProviderReauthRequiredImpl.call(
+    manager,
+    'onedrive',
+    new Error(
+      `Download failed: ${ONEDRIVE_REAUTH_REQUIRED_MARKER}: OneDrive session expired, please reconnect. (AADSTS70000)`,
+    ),
+  );
+  await Promise.resolve();
+
+  assert.equal(handled, true);
+  assert.equal(signedOut, true);
+  // Stale adapter is evicted.
+  assert.equal(manager.adapters.has('onedrive'), false);
+
+  const conn = manager.state.providers.onedrive;
+  assert.equal(conn.tokens, undefined);
+  assert.equal(conn.status, 'error');
+  // Account is preserved for display; error message is cleaned of the marker.
+  assert.equal(conn.account?.id, 'u1');
+  assert.ok(conn.error && !conn.error.includes(ONEDRIVE_REAUTH_REQUIRED_MARKER));
+  assert.match(conn.error ?? '', /please reconnect/);
+
+  // Crucial: cleared tokens => not ready for sync => auto-sync won't retry.
+  assert.equal(isProviderReadyForSync(conn), false);
+
+  // Persisted the cleared connection.
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0].tokens, undefined);
+});
+
+test('handleProviderReauthRequired ignores non-OneDrive providers and unrelated errors', () => {
+  const { manager } = createManager();
+
+  // Wrong provider.
+  assert.equal(
+    handleProviderReauthRequiredImpl.call(
+      manager,
+      'google',
+      new Error(`${ONEDRIVE_REAUTH_REQUIRED_MARKER}: x`),
+    ),
+    false,
+  );
+
+  // OneDrive but an ordinary (retryable) error — must not clear tokens.
+  assert.equal(
+    handleProviderReauthRequiredImpl.call(manager, 'onedrive', new Error('network timeout')),
+    false,
+  );
+  assert.ok(manager.state.providers.onedrive.tokens);
 });

--- a/infrastructure/services/cloudSync/providerSyncMethods.ts
+++ b/infrastructure/services/cloudSync/providerSyncMethods.ts
@@ -31,6 +31,22 @@ function assertSyncSecurityGeneration(manager: any, generation?: number): void {
   }
 }
 
+/**
+ * Let the manager clear stale credentials when an error means a provider's
+ * refresh token is dead (OneDrive). Returns true when it set a reconnect state,
+ * so the caller skips the generic `error`-with-tokens status that would keep the
+ * provider "ready" and retrying. Safe no-op when the manager lacks the hook.
+ */
+function handleProviderReauthRequired(
+  manager: any,
+  provider: CloudProvider,
+  error: unknown,
+): boolean {
+  return typeof manager.handleProviderReauthRequired === 'function'
+    ? manager.handleProviderReauthRequired(provider, error)
+    : false;
+}
+
 async function uploadLocalPayloadImpl(this: any,
   provider: CloudProvider,
   adapter: CloudAdapter,
@@ -203,7 +219,9 @@ export async function uploadToProviderImpl(this: any,
       return result;
     } catch (error) {
       this.state.lastError = String(error);
-      this.updateProviderStatus(provider, 'error', String(error));
+      if (!handleProviderReauthRequired(this, provider, error)) {
+        this.updateProviderStatus(provider, 'error', String(error));
+      }
 
       // Add to sync history
       this.addSyncHistoryEntry({
@@ -467,7 +485,12 @@ export async function syncToProviderImpl(this: any,
     } catch (error) {
       this.state.syncState = 'ERROR';
       this.state.lastError = String(error);
-      this.updateProviderStatus(provider, 'error', String(error));
+      // A dead OneDrive refresh token clears its own credentials and sets a
+      // clean reconnect status; only fall back to the generic error status when
+      // it wasn't a reauth-required failure.
+      if (!handleProviderReauthRequired(this, provider, error)) {
+        this.updateProviderStatus(provider, 'error', String(error));
+      }
 
       // Add to sync history
       this.addSyncHistoryEntry({
@@ -519,6 +542,10 @@ export async function downloadFromProviderImpl(this: any,provider: CloudProvider
 
       return { provider, payload, remoteFile };
     } catch (error) {
+      // Surface a reconnect state if the failure was a dead OneDrive refresh
+      // token (clears stale credentials); the error is still rethrown to the
+      // caller below.
+      handleProviderReauthRequired(this, provider, error);
       // Add to sync history
       this.addSyncHistoryEntry({
         timestamp: Date.now(),

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -453,6 +453,13 @@ export function handleProviderReauthRequiredImpl(
   const message = error instanceof Error ? error.message : String(error);
   if (!isOneDriveReauthRequiredMessage(message)) return false;
 
+  // Idempotent: this error can surface on multiple paths in one sync (preflight
+  // inspection + the operation's own catch). Once the credentials are already
+  // cleared there is nothing more to do, but still report handled so callers
+  // skip the generic error status that would re-add the raw marker message.
+  const current = this.state.providers[provider];
+  if (!current?.tokens && !current?.config) return true;
+
   const adapter = this.adapters.get(provider);
   if (adapter) {
     adapter.signOut();
@@ -464,7 +471,7 @@ export function handleProviderReauthRequiredImpl(
   this.state.providers[provider] = {
     provider,
     status: 'error',
-    account: this.state.providers[provider]?.account,
+    account: current?.account,
     error: cleanOneDriveErrorMessage(message),
   };
   void this.saveProviderConnection(provider, this.state.providers[provider]);

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -2,8 +2,10 @@
 import {
   SYNC_CONSTANTS,
   SYNC_STORAGE_KEYS,
+  cleanOneDriveErrorMessage,
   generateDeviceId,
   getDefaultDeviceName,
+  isOneDriveReauthRequiredMessage,
 } from '../../../domain/sync';
 import {
   DEFAULT_CLOUD_SYNC_STRATEGY,
@@ -429,6 +431,45 @@ export function persistRefreshedProviderTokensImpl(
   };
   void this.saveProviderConnection(provider, this.state.providers[provider]);
   this.notifyStateChange();
+}
+
+/**
+ * Handle a sync error that means OneDrive's refresh token is dead. Clears the
+ * now-useless tokens and tears down the adapter so the provider drops to a real
+ * "reconnect" (disconnected) state instead of staying `error`-with-tokens —
+ * which `isProviderReadyForSync` keeps treating as ready, so auto-sync would
+ * otherwise retry the dead token forever and never surface a reconnect prompt.
+ *
+ * Returns true when it handled a reauth-required OneDrive error so the caller
+ * can preserve a clean status message. No-op (returns false) for any other
+ * provider or error.
+ */
+export function handleProviderReauthRequiredImpl(
+  this: any,
+  provider: CloudProvider,
+  error: unknown,
+): boolean {
+  if (provider !== 'onedrive') return false;
+  const message = error instanceof Error ? error.message : String(error);
+  if (!isOneDriveReauthRequiredMessage(message)) return false;
+
+  const adapter = this.adapters.get(provider);
+  if (adapter) {
+    adapter.signOut();
+    this.adapters.delete(provider);
+  }
+
+  // Bump decrypt seq so a stale in-flight decrypt cannot resurrect the tokens.
+  ++this.providerDecryptSeq[provider];
+  this.state.providers[provider] = {
+    provider,
+    status: 'error',
+    account: this.state.providers[provider]?.account,
+    error: cleanOneDriveErrorMessage(message),
+  };
+  void this.saveProviderConnection(provider, this.state.providers[provider]);
+  this.notifyStateChange();
+  return true;
 }
 
 export async function setupMasterKeyImpl(this: any,password: string): Promise<void> {

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -373,13 +373,63 @@ export async function getConnectedAdapterImpl(this: any,provider: CloudProvider)
 
     const existing = this.adapters.get(provider);
     if (existing?.isAuthenticated) {
+      attachTokenRefreshPersistence.call(this, provider, existing);
       return existing;
     }
 
     const adapter = await createAdapter(provider, tokens, connection.resourceId, config);
+    attachTokenRefreshPersistence.call(this, provider, adapter);
     this.adapters.set(provider, adapter);
     return adapter;
   }
+
+/**
+ * Wire an OAuth adapter's token-refresh callback so silently rotated tokens are
+ * persisted. Without this, OneDrive's rotating refresh tokens go stale after the
+ * first in-session refresh and the next launch is forced to reconnect (#1189).
+ * Only OneDrive currently exposes setOnTokensRefreshed; other adapters are no-ops.
+ */
+export function attachTokenRefreshPersistence(
+  this: any,
+  provider: CloudProvider,
+  adapter: CloudAdapter,
+): void {
+  const setCallback = (adapter as {
+    setOnTokensRefreshed?: (cb: (tokens: import('../../../domain/sync').OAuthTokens) => void) => void;
+  }).setOnTokensRefreshed;
+  if (typeof setCallback !== 'function') return;
+  setCallback.call(adapter, (tokens) => {
+    persistRefreshedProviderTokensImpl.call(this, provider, tokens);
+  });
+}
+
+/**
+ * Persist tokens that an adapter refreshed mid-session into provider state and
+ * encrypted storage. Bumps the decrypt sequence so a concurrent stale decrypt
+ * (startup / cross-window) can't clobber the rotated tokens; preserves the live
+ * status/account/resource fields. saveProviderConnection manages its own write
+ * sequence to serialize the encrypted persist.
+ */
+export function persistRefreshedProviderTokensImpl(
+  this: any,
+  provider: CloudProvider,
+  tokens: import('../../../domain/sync').OAuthTokens,
+): void {
+  const existing = this.state.providers[provider];
+  // Provider may have been disconnected during the async refresh — don't
+  // resurrect a connection that no longer has credentials.
+  if (!existing?.tokens) return;
+
+  // Invalidate any in-flight decrypt (startup / cross-window) so it cannot
+  // overwrite the rotated tokens we are about to commit.
+  ++this.providerDecryptSeq[provider];
+  this.state.providers[provider] = {
+    ...existing,
+    tokens,
+  };
+  void this.saveProviderConnection(provider, this.state.providers[provider]);
+  this.notifyStateChange();
+}
 
 export async function setupMasterKeyImpl(this: any,password: string): Promise<void> {
     if (this.state.masterKeyConfig) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts lib/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts infrastructure/services/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "0.37.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts infrastructure/services/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/ai/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "0.37.0",


### PR DESCRIPTION
## Background

Issue #1189 reported that OneDrive cloud sync started failing in version 1.1.20 and only recovered after the user disconnected OneDrive, deleted authorization, and signed in again.

## Root Cause

Two gaps were found in the OneDrive sync path:

1. Refreshed tokens were not persisted. `OneDriveAdapter` refreshed tokens silently during a session, but only stored them in memory. Microsoft consumer refresh tokens rotate, so the old persisted refresh token became invalid after the next launch.
2. Truly invalid refresh tokens produced a generic error and kept retrying instead of showing a stable reconnect state.

## Changes

- Adds `setOnTokensRefreshed()` to `OneDriveAdapter`.
- Wires refreshed-token persistence through `attachTokenRefreshPersistence` and encrypted provider storage.
- Detects OneDrive reauth-required errors such as `invalid_grant`, `interaction_required`, `consent_required`, and `login_required`.
- Normalizes those failures to `OneDriveReauthRequiredError`.
- Clears invalid tokens and unloads the adapter when reauth is required, so the provider becomes genuinely not ready for sync and shows a reconnect prompt.
- Shares marker, detection, and cleanup helpers through `domain/sync.ts`.

## Scope

Only OneDrive token refresh persistence and reconnect messaging changed. GitHub Gist, Google Drive, WebDAV, and S3 behavior stayed unchanged.

## Tests

- Adds `OneDriveAdapter.test.ts`.
- Adds `persistRefreshedTokens.test.ts`.
- Adds `onedriveAuthBridge.test.cjs`.
- Adds `infrastructure/services/*.test.ts` to the `npm test` glob so these tests run in CI.
- `npm run lint` passed.
- Full `npm test` passed: 1400 tests, 0 failures, 3 existing skips.
- `npm run build` passed.
- `tsc --noEmit` error count matched main; no new type errors were introduced.
- Local Codex review ran three rounds until clean.

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)
