### PR TITLE
fix: show host stats in Mosh mode with a companion SSH connection (#1198)

### DIFF
--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -137,6 +137,15 @@ export function useServerStats({
       // Discard stale responses from before a hide/show cycle or reconnect
       if (!isMountedRef.current || generation !== fetchGenerationRef.current) return;
 
+      if (result.pending) {
+        // Transient "not ready yet" — e.g. a Mosh session whose SSH handshake
+        // hasn't finished, so the stats companion connection can't exist yet
+        // (issue #1198). Do NOT count this toward the consecutive-failure
+        // give-up, or a slow/manual handshake would permanently disable stats
+        // before the credentials become available. Just wait for the next poll.
+        return;
+      }
+
       if (result.success && result.stats) {
         hasFetchedRef.current = true;
         consecutiveFailuresRef.current = 0;

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -719,6 +719,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         legacyAlgorithms: ctx.host.legacyAlgorithms,
         skipEcdsaHostKey: ctx.host.skipEcdsaHostKey,
         algorithmOverrides: ctx.host.algorithms,
+        // Lets the stats companion verify the host key before sending a saved
+        // password (#1198), so it never discloses it to an unvetted host.
+        knownHosts: ctx.knownHosts,
         cols: term.cols,
         rows: term.rows,
         charset: ctx.host.charset,

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -712,6 +712,13 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         port: ctx.host.port || 22,
         moshServerPath: ctx.host.moshServerPath,
         agentForwarding: ctx.host.agentForwarding,
+        // Forwarded for the host-info stats companion SSH connection (#1198):
+        // Mosh's own handshake uses the system ssh (which reads ~/.ssh/config),
+        // but Netcatty's ssh2 companion needs these to match the host's
+        // negotiation on legacy / ECDSA-restricted servers.
+        legacyAlgorithms: ctx.host.legacyAlgorithms,
+        skipEcdsaHostKey: ctx.host.skipEcdsaHostKey,
+        algorithmOverrides: ctx.host.algorithms,
         cols: term.cols,
         rows: term.rows,
         charset: ctx.host.charset,

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -971,7 +971,8 @@ const { createMoshStatsConnectionApi } = require("./sshBridge/moshStatsConnectio
 const { ensureMoshStatsConnection } = createMoshStatsConnectionApi({
   get sessions() { return sessions; },
   SSHClient, sshUtils, NetcattyAgent, buildAlgorithms, getSshAgentSocket,
-  readFileNoFollow, expandIdentityFilePath, isAutoFillablePasswordChallenge, log,
+  readFileNoFollow, expandIdentityFilePath, isAutoFillablePasswordChallenge,
+  hostKeyVerifier, log,
 });
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -28,6 +28,7 @@ const {
   getSshAgentSocket,
   readFileNoFollow,
   expandIdentityFilePath,
+  isAutoFillablePasswordChallenge,
   preparePrivateKeyForAuth,
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
@@ -970,7 +971,7 @@ const { createMoshStatsConnectionApi } = require("./sshBridge/moshStatsConnectio
 const { ensureMoshStatsConnection } = createMoshStatsConnectionApi({
   get sessions() { return sessions; },
   SSHClient, sshUtils, NetcattyAgent, buildAlgorithms, getSshAgentSocket,
-  readFileNoFollow, expandIdentityFilePath, log,
+  readFileNoFollow, expandIdentityFilePath, isAutoFillablePasswordChallenge, log,
 });
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -967,12 +967,20 @@ async function startSSHSessionWrapper(event, options) {
 // channel. This helper lazily establishes a best-effort, non-interactive
 // SSH connection reusing the handshake credentials and assigns it to
 // session.conn so the existing stats path works unchanged.
+const { createSystemKnownHostsApi } = require("./sshBridge/systemKnownHosts.cjs");
+// Lets the Mosh stats companion trust a host whose key is already recorded in
+// the user's system OpenSSH known_hosts (the trust source the Mosh handshake's
+// system `ssh` actually uses), in addition to Netcatty's in-app vault.
+const { isHostKeyTrustedBySystem } = createSystemKnownHostsApi({
+  fs, path, os, crypto, log,
+});
+
 const { createMoshStatsConnectionApi } = require("./sshBridge/moshStatsConnection.cjs");
 const { ensureMoshStatsConnection } = createMoshStatsConnectionApi({
   get sessions() { return sessions; },
   SSHClient, sshUtils, NetcattyAgent, buildAlgorithms, getSshAgentSocket,
   readFileNoFollow, expandIdentityFilePath, isAutoFillablePasswordChallenge,
-  hostKeyVerifier, log,
+  hostKeyVerifier, isHostKeyTrustedBySystem, log,
 });
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -27,6 +27,7 @@ const {
   findAllDefaultPrivateKeys: findAllDefaultPrivateKeysFromHelper,
   getSshAgentSocket,
   readFileNoFollow,
+  expandIdentityFilePath,
   preparePrivateKeyForAuth,
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
@@ -960,13 +961,25 @@ async function startSSHSessionWrapper(event, options) {
  * classify network devices from the banner without running any additional
  * exec channels.
  */
+// Companion stats connection for Mosh sessions (issue #1198). Mosh runs over
+// UDP and has no ssh2 connection, so getServerStats cannot open an exec
+// channel. This helper lazily establishes a best-effort, non-interactive
+// SSH connection reusing the handshake credentials and assigns it to
+// session.conn so the existing stats path works unchanged.
+const { createMoshStatsConnectionApi } = require("./sshBridge/moshStatsConnection.cjs");
+const { ensureMoshStatsConnection } = createMoshStatsConnectionApi({
+  get sessions() { return sessions; },
+  SSHClient, sshUtils, NetcattyAgent, buildAlgorithms, getSshAgentSocket,
+  readFileNoFollow, expandIdentityFilePath, log,
+});
+
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");
 const sessionOpsApi = createSessionOpsApi({
   get sessions() { return sessions; },
   get electronModule() { return electronModule; },
   fs, path, os, exec, randomUUID, iconv, Buffer, process, console, setTimeout, clearTimeout,
   getSessionDecoder, resetSessionDecoders, sessionEncodings, resolveLangFromCharset, safeSend,
-  quoteShellArg, log,
+  quoteShellArg, log, ensureMoshStatsConnection,
   getServerStats: undefined,
 });
 const {

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -253,6 +253,11 @@ function createMoshStatsConnectionApi(ctx) {
         conn.on("close", () => {
           if (session.conn === conn) session.conn = null;
           if (session.moshStatsConn === conn) session.moshStatsConn = null;
+          // If the socket closed mid-handshake without ever emitting "ready"
+          // or "error", settle the attempt here so the awaiting getServerStats
+          // call (and session.moshStatsConnPromise) don't hang forever. This
+          // is treated as transient — the next poll may retry.
+          finish(null);
         });
 
         try {

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -123,6 +123,13 @@ function createMoshStatsConnectionApi(ctx) {
 
       if (typeof auth.password === "string" && auth.password.length > 0) {
         connectOpts.password = auth.password;
+        // Many SSH servers (PAM-backed) only offer password auth through
+        // keyboard-interactive, not the plain "password" method. The Mosh
+        // handshake's system ssh handles that via its PTY responder, so the
+        // companion must too — otherwise stats stay empty on those hosts
+        // despite a saved password. The handler (attached at connect time)
+        // auto-fills non-interactively and never shows a prompt.
+        connectOpts.tryKeyboard = true;
       }
 
       // ssh-agent fallback whenever a socket is available and no inline
@@ -215,6 +222,26 @@ function createMoshStatsConnectionApi(ctx) {
           settled = true;
           resolve(value);
         };
+
+        // Non-interactive keyboard-interactive auth: auto-fill the saved
+        // password for a single password prompt and never show a modal. On a
+        // 2FA / multi-prompt / OTP challenge we finish empty so ssh2 moves on
+        // to the next method (or fails) instead of hanging on a prompt the
+        // user can't answer for a background connection.
+        if (connectOpts.tryKeyboard && connectOpts.password) {
+          // Only auto-fill once. If the password was wrong, ssh2 may re-issue
+          // the challenge; finishing empty on the retry lets auth fail cleanly
+          // instead of looping on the same wrong password.
+          let autoFilledOnce = false;
+          conn.on("keyboard-interactive", (_name, _instr, _lang, prompts, finishKbd) => {
+            if (!autoFilledOnce && isAutoFillablePasswordChallenge(prompts, connectOpts.password)) {
+              autoFilledOnce = true;
+              finishKbd([connectOpts.password]);
+            } else {
+              finishKbd([]);
+            }
+          });
+        }
 
         // `permanent` distinguishes futile retries (auth rejected, or a throw
         // building the connection) from transient ones (network blip,

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -1,0 +1,273 @@
+/* eslint-disable no-undef */
+
+/**
+ * Companion SSH connection for Mosh sessions.
+ *
+ * A Mosh session runs over UDP via a local `mosh-client` PTY and therefore
+ * has no ssh2 `Client` (`session.conn`) — the very thing `getServerStats`
+ * needs to run its periodic `/proc`-based stats command on an exec channel.
+ * Without it the terminal's host-info bar (CPU / memory / disk / network)
+ * stays empty for Mosh, while SSH sessions show it (issue #1198).
+ *
+ * This module lazily opens a *second*, stats-only ssh2 connection to the
+ * same host using the same credentials the Mosh handshake already used, and
+ * stores it as `session.conn` so the existing `getServerStats` code path
+ * works unchanged. It is intentionally best-effort and non-interactive:
+ *
+ *   - It never prompts the user for a password or key passphrase. The Mosh
+ *     handshake (driven by the system `ssh` in the user's PTY) is where the
+ *     real, interactive auth happens; this companion only reuses credentials
+ *     Netcatty already holds (stored password, parseable private key,
+ *     unencrypted / stored-passphrase identity files, ssh-agent).
+ *   - If it cannot authenticate or connect, it fails silently and records
+ *     the failure so it does not hammer the host on every stats poll. Mosh
+ *     keeps working; only the stats bar stays empty (graceful degradation).
+ *
+ * Host-key verification is intentionally skipped here, mirroring the
+ * existing one-off `execCommand` path: the user already established trust in
+ * this host through the Mosh handshake's system-`ssh` (which consults the
+ * real known_hosts), so re-prompting on a background stats connection would
+ * be confusing and redundant.
+ */
+function createMoshStatsConnectionApi(ctx) {
+  with (ctx) {
+    // Resolve a usable, non-interactive private key (+ passphrase) for the
+    // companion connection. Returns null when the key is missing, encrypted
+    // without a usable stored passphrase, or otherwise unparseable — the
+    // caller then falls back to password / agent auth or gives up.
+    function resolveNonInteractiveKey(privateKey, passphrase) {
+      if (typeof privateKey !== "string" || privateKey.trim().length === 0) {
+        return null;
+      }
+      try {
+        const parsed = sshUtils.parseKey(privateKey, passphrase);
+        if (parsed && !(parsed instanceof Error)) {
+          return { privateKey, passphrase: passphrase || undefined };
+        }
+      } catch {
+        // parseKey throws on malformed input — treat as unusable.
+      }
+      return null;
+    }
+
+    // Read identity files from disk without prompting. Only unencrypted keys
+    // (or keys whose stored passphrase parses them) are returned.
+    async function resolveNonInteractiveIdentityFile(identityFilePaths, passphrase) {
+      if (!Array.isArray(identityFilePaths) || identityFilePaths.length === 0) {
+        return null;
+      }
+      for (const rawPath of identityFilePaths) {
+        if (typeof rawPath !== "string" || rawPath.trim().length === 0) continue;
+        const resolvedPath = expandIdentityFilePath(rawPath);
+        let content;
+        try {
+          content = await readFileNoFollow(resolvedPath);
+        } catch {
+          continue;
+        }
+        if (!content) continue;
+        const key = resolveNonInteractiveKey(content, passphrase);
+        if (key) return key;
+      }
+      return null;
+    }
+
+    async function buildStatsConnectOpts(auth) {
+      const connectOpts = {
+        host: auth.hostname,
+        port: auth.port || 22,
+        username: auth.username || "root",
+        // Stats are a background nicety — keep the timeout short so a slow or
+        // firewalled host fails fast instead of holding a poll for 30s+.
+        readyTimeout: 10000,
+        keepaliveInterval: 0,
+        // Honor the host's algorithm settings so the companion negotiates the
+        // same KEX / cipher / host-key set as the interactive session would.
+        algorithms: buildAlgorithms(auth.legacyAlgorithms, {
+          skipEcdsaHostKey: auth.skipEcdsaHostKey,
+          algorithmOverrides: auth.algorithmOverrides,
+        }),
+      };
+
+      const hasCertificate =
+        typeof auth.certificate === "string" && auth.certificate.trim().length > 0;
+      const key =
+        resolveNonInteractiveKey(auth.privateKey, auth.passphrase) ||
+        await resolveNonInteractiveIdentityFile(auth.identityFilePaths, auth.passphrase);
+
+      let agent = null;
+      if (hasCertificate && key) {
+        try {
+          agent = new NetcattyAgent({
+            mode: "certificate",
+            webContents: auth.webContents,
+            meta: {
+              label: auth.keyId || auth.username || "",
+              certificate: auth.certificate,
+              privateKey: key.privateKey,
+              passphrase: key.passphrase,
+            },
+          });
+          connectOpts.agent = agent;
+        } catch {
+          // Certificate could not be parsed non-interactively — fall through
+          // to plain key / password auth below.
+          agent = null;
+        }
+      }
+
+      if (!agent && key) {
+        connectOpts.privateKey = key.privateKey;
+        if (key.passphrase) connectOpts.passphrase = key.passphrase;
+      }
+
+      if (typeof auth.password === "string" && auth.password.length > 0) {
+        connectOpts.password = auth.password;
+      }
+
+      // ssh-agent fallback whenever a socket is available and no inline
+      // credentials were resolved. The Mosh handshake runs the system `ssh`
+      // with the inherited environment, so it authenticates via the local
+      // ssh-agent by default — independent of agentForwarding (which only
+      // controls *remote* agent forwarding). Mirroring that here covers the
+      // common "key lives in the agent, no stored privateKey" case.
+      if (!agent && !connectOpts.privateKey && !connectOpts.password) {
+        const agentSocket = getSshAgentSocket();
+        if (agentSocket) {
+          connectOpts.agent = agentSocket;
+        }
+      }
+
+      const hasAnyAuth = Boolean(
+        connectOpts.agent || connectOpts.privateKey || connectOpts.password,
+      );
+
+      return { connectOpts, hasAnyAuth };
+    }
+
+    /**
+     * Ensure a Mosh session has a usable stats companion connection.
+     *
+     * Returns the ssh2 Client on success (also assigned to `session.conn`),
+     * or null when one could not be established. Safe to call repeatedly:
+     * concurrent calls share a single in-flight attempt, and a permanent
+     * failure is cached so later polls don't reconnect on every tick.
+     *
+     * @param {object} session - the shared session record
+     * @param {string} sessionId - the session's key in the shared sessions map
+     * @param {Electron.WebContents} [webContents] - sender of the stats IPC,
+     *   used only for certificate-agent construction.
+     */
+    function ensureMoshStatsConnection(session, sessionId, webContents) {
+      if (!session) return Promise.resolve(null);
+      // Already connected (either a real SSH session or a previously
+      // established companion).
+      if (session.conn) return Promise.resolve(session.conn);
+      // A prior attempt permanently failed — don't keep retrying every poll.
+      if (session.moshStatsConnFailed) return Promise.resolve(null);
+      // Reuse an in-flight attempt so two near-simultaneous polls don't open
+      // two connections.
+      if (session.moshStatsConnPromise) return session.moshStatsConnPromise;
+
+      const promise = establishMoshStatsConnection(session, sessionId, webContents).finally(() => {
+        session.moshStatsConnPromise = null;
+      });
+      session.moshStatsConnPromise = promise;
+      return promise;
+    }
+
+    // True once the session has gone away — either explicitly closed or
+    // dropped from the shared map (e.g. the mosh-client PTY exited while we
+    // were still connecting the companion).
+    function sessionGone(session, sessionId) {
+      return session.closed || sessions.get(sessionId) !== session;
+    }
+
+    async function establishMoshStatsConnection(session, sessionId, webContents) {
+      const auth = session.moshStatsAuth;
+      if (!auth || !auth.hostname) {
+        session.moshStatsConnFailed = true;
+        return null;
+      }
+
+      const { connectOpts, hasAnyAuth } = await buildStatsConnectOpts({
+        ...auth,
+        webContents,
+      });
+      if (!hasAnyAuth) {
+        // Nothing we can authenticate with non-interactively (e.g. the user
+        // typed a password into the Mosh handshake PTY that we never stored).
+        session.moshStatsConnFailed = true;
+        return null;
+      }
+
+      // The session may have been closed while we were reading identity files.
+      if (sessionGone(session, sessionId)) {
+        return null;
+      }
+
+      return new Promise((resolve) => {
+        const conn = new SSHClient();
+        let settled = false;
+
+        const finish = (value) => {
+          if (settled) return;
+          settled = true;
+          resolve(value);
+        };
+
+        // `permanent` distinguishes futile retries (auth rejected, or a throw
+        // building the connection) from transient ones (network blip,
+        // timeout). Only the former disables stats for the session's
+        // lifetime; transient errors just skip this poll and let the next one
+        // retry.
+        const fail = (err, permanent) => {
+          try { conn.end(); } catch { /* ignore */ }
+          if (permanent) session.moshStatsConnFailed = true;
+          finish(null);
+        };
+
+        conn.once("ready", () => {
+          // The session may have been closed while we were connecting.
+          if (sessionGone(session, sessionId)) {
+            try { conn.end(); } catch { /* ignore */ }
+            finish(null);
+            return;
+          }
+          session.conn = conn;
+          session.moshStatsConn = conn;
+          finish(conn);
+        });
+
+        conn.on("error", (err) => {
+          log("[Mosh] stats companion connection error:", err?.message || String(err));
+          // If this fired after we already adopted the connection, drop the
+          // stale handle so the next poll can rebuild a fresh one.
+          if (session.conn === conn) session.conn = null;
+          if (session.moshStatsConn === conn) session.moshStatsConn = null;
+          // Auth rejection won't change with the same stored credentials, so
+          // stop retrying. Everything else may be transient.
+          fail(err, err?.level === "client-authentication");
+        });
+
+        conn.on("close", () => {
+          if (session.conn === conn) session.conn = null;
+          if (session.moshStatsConn === conn) session.moshStatsConn = null;
+        });
+
+        try {
+          conn.connect(connectOpts);
+        } catch (err) {
+          log("[Mosh] stats companion connect threw:", err?.message || String(err));
+          // A synchronous throw from connect() (e.g. malformed options) won't
+          // succeed on retry either.
+          fail(err, true);
+        }
+      });
+    }
+
+    return { ensureMoshStatsConnection };
+  }
+}
+
+module.exports = { createMoshStatsConnectionApi };

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -166,13 +166,15 @@ function createMoshStatsConnectionApi(ctx) {
         connectOpts.tryKeyboard = true;
       }
 
-      // ssh-agent fallback whenever a socket is available and no inline
-      // credentials were resolved. The Mosh handshake runs the system `ssh`
-      // with the inherited environment, so it authenticates via the local
-      // ssh-agent by default — independent of agentForwarding (which only
-      // controls *remote* agent forwarding). Mirroring that here covers the
-      // common "key lives in the agent, no stored privateKey" case.
-      if (!agent && !connectOpts.privateKey && !connectOpts.password) {
+      // ssh-agent fallback whenever a socket is available and no *explicit*
+      // key / certificate-agent was resolved. The Mosh handshake runs the
+      // system `ssh` with the inherited environment, so it authenticates via
+      // the local ssh-agent by default — independent of agentForwarding
+      // (which only controls *remote* forwarding). This is offered alongside
+      // any saved password (ssh2 tries agent before password), so a
+      // public-key host that also happens to have a stored password still
+      // authenticates via the agent instead of failing on password-only.
+      if (!agent && !connectOpts.privateKey) {
         const agentSocket = getSshAgentSocket();
         if (agentSocket) {
           connectOpts.agent = agentSocket;
@@ -240,7 +242,12 @@ function createMoshStatsConnectionApi(ctx) {
     async function establishMoshStatsConnection(session, sessionId, webContents) {
       const auth = session.moshStatsAuth;
       if (!auth || !auth.hostname) {
-        session.moshStatsConnFailed = true;
+        // moshStatsAuth is only assigned once the handshake completes and the
+        // session swaps to mosh-client. The renderer can mark a session
+        // "connected" (and start polling) from the SSH bootstrap's visible
+        // PTY output *before* that swap, so a missing auth here is transient —
+        // do NOT permanently disable stats, or the companion would never be
+        // attempted after the handshake finishes.
         return null;
       }
 

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -44,6 +44,11 @@
  *     the verifier has confirmed trust, as defense in depth.
  */
 function createMoshStatsConnectionApi(ctx) {
+  // Read off ctx (not via the `with` scope) so an absent dependency reads as
+  // `undefined` instead of throwing a ReferenceError under `with`. Optional:
+  // when not wired in (e.g. older callers / some unit tests) the verifier
+  // simply skips the system-known_hosts fallback.
+  const isHostKeyTrustedBySystem = ctx.isHostKeyTrustedBySystem;
   with (ctx) {
     // Resolve a usable, non-interactive private key (+ passphrase) for the
     // companion connection. Returns null when the key is missing, encrypted
@@ -87,10 +92,22 @@ function createMoshStatsConnectionApi(ctx) {
     }
 
     // An ssh2 hostVerifier that ACCEPTS the transport only when the live host
-    // key is already trusted in Netcatty's known-hosts store, and REJECTS it
-    // for an unknown / changed key. It never prompts — an untrusted host fails
-    // the background companion silently (stats stay empty) instead of popping a
-    // modal the user can't meaningfully answer for a stats poll.
+    // key is already trusted — by Netcatty's in-app known-hosts store OR by the
+    // user's *system* OpenSSH known_hosts — and REJECTS it for an unknown /
+    // changed key. It never prompts — an untrusted host fails the background
+    // companion silently (stats stay empty) instead of popping a modal the user
+    // can't meaningfully answer for a stats poll.
+    //
+    // Why also consult the system known_hosts: a Mosh session is bootstrapped
+    // by the system `ssh`, which records (and vets, via its own prompt) the
+    // host key in `~/.ssh/known_hosts`. Netcatty's vault snapshot is NOT updated
+    // by that handshake, so a host the user trusted purely through system ssh
+    // would otherwise be misread as "unknown" and the companion permanently
+    // disabled — leaving the stats bar empty even though the system already
+    // trusts the exact key. We match the LIVE key's SHA-256 fingerprint against
+    // those files, so this only ever grants trust for the precise key the user's
+    // own OpenSSH already trusts; it never accepts an arbitrary or mismatched
+    // key. Unknown / changed keys stay rejected.
     //
     // Rejecting (not merely gating password auth) is required: a background,
     // user-invisible connection that completed key/agent auth against an
@@ -111,6 +128,17 @@ function createMoshStatsConnectionApi(ctx) {
             fingerprint: keyInfo.fingerprint,
           });
           trust.trusted = decision.status === "trusted";
+          // Fall back to the system OpenSSH known_hosts (Mosh's real trust
+          // source) only when Netcatty's snapshot does not already vouch for
+          // the key. Matching is by the live key's fingerprint, so this can
+          // only confirm — never override a mismatch into acceptance.
+          if (!trust.trusted && isHostKeyTrustedBySystem) {
+            trust.trusted = isHostKeyTrustedBySystem({
+              hostname,
+              port,
+              fingerprint: keyInfo.fingerprint,
+            }) === true;
+          }
         } catch (err) {
           log("[Mosh] stats companion host-key check failed:", err?.message || String(err));
           trust.trusted = false;

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -24,22 +24,24 @@
  *     keeps working; only the stats bar stays empty (graceful degradation).
  *
  * Security — host-key handling:
- *   - A *password* (plain or via keyboard-interactive) sends a plaintext,
- *     reusable secret to the server, so it is offered ONLY when the live host
- *     key is already "trusted" in Netcatty's known-hosts store. A
- *     trust-tracking host verifier records that during the transport
- *     handshake, and a gated authHandler withholds the password methods
- *     unless trusted. This is done silently and never prompts — the user
- *     drives host-key trust through the real interactive session, not a
- *     background stats poll. It prevents leaking a saved password to a
- *     spoofed / MITM host Netcatty has not vetted.
- *   - Public-key / ssh-agent auth proves possession via a session-bound
- *     signature and never discloses a reusable secret, so it is always
- *     allowed — even to a host Netcatty has not vetted — matching the
- *     existing one-off `execCommand` path (the handshake already vetted the
- *     host via system ssh's known_hosts). Gating the password at the
- *     authHandler rather than rejecting the whole connection is what lets
- *     key/agent auth keep working on such hosts.
+ *   - The companion connects ONLY to a host whose live key is already
+ *     "trusted" in Netcatty's known-hosts store. A host verifier classifies
+ *     the key during the transport handshake and REJECTS the connection for an
+ *     unknown / changed key — for every auth method, not just password. This is
+ *     done silently and never prompts: the user vets and trusts a host key
+ *     through the real interactive session (#1191), and this background stats
+ *     poll only ever rides on a host that vetting already approved. An
+ *     untrusted host just leaves the stats bar empty (graceful degradation).
+ *   - Rejecting outright (rather than merely withholding the password) is
+ *     deliberate. Even though public-key / ssh-agent auth discloses no reusable
+ *     secret and its signature is session-bound, a *background, user-invisible*
+ *     connection that authenticated against an unverified host would still run
+ *     the stats command there — letting a MITM / DNS-spoofed host feed bogus
+ *     host-info to the user and enumerate the agent's public keys. That breaks
+ *     the same host-key guarantee the interactive session enforces, so the
+ *     companion refuses unvetted hosts regardless of auth method.
+ *   - A gated authHandler additionally withholds the plaintext password until
+ *     the verifier has confirmed trust, as defense in depth.
  */
 function createMoshStatsConnectionApi(ctx) {
   with (ctx) {
@@ -84,19 +86,20 @@ function createMoshStatsConnectionApi(ctx) {
       return null;
     }
 
-    // An ssh2 hostVerifier that records whether the live host key is already
-    // trusted in Netcatty's known-hosts store, into the shared `trust` object,
-    // then accepts the transport so public-key / agent auth can proceed. It
-    // never prompts. The trust flag gates *password* auth in the authHandler
-    // below: ssh2 runs this verifier during the transport handshake, before
-    // any auth method, so `trust.trusted` is set by the time the authHandler
-    // is consulted.
+    // An ssh2 hostVerifier that ACCEPTS the transport only when the live host
+    // key is already trusted in Netcatty's known-hosts store, and REJECTS it
+    // for an unknown / changed key. It never prompts — an untrusted host fails
+    // the background companion silently (stats stay empty) instead of popping a
+    // modal the user can't meaningfully answer for a stats poll.
     //
-    // Accepting the transport for an unknown host is safe because the only
-    // secret-disclosing method (password) is withheld unless trusted;
-    // public-key / agent auth proves possession via a session-bound signature
-    // that a MITM cannot replay.
-    function createTrustTrackingHostVerifier({ hostname, port, knownHosts, trust }) {
+    // Rejecting (not merely gating password auth) is required: a background,
+    // user-invisible connection that completed key/agent auth against an
+    // unverified host would still run the stats command there, letting a MITM /
+    // DNS-spoofed host feed bogus host-info and enumerate the agent's public
+    // keys. `trust.trusted` additionally gates the password method in the
+    // authHandler (defense in depth); `trust.rejected` lets the caller treat an
+    // untrusted host as a permanent failure so it stops reconnecting every poll.
+    function createTrustEnforcingHostVerifier({ hostname, port, knownHosts, trust }) {
       return (rawKey, callback) => {
         try {
           const keyInfo = hostKeyVerifier.describeHostKey(rawKey);
@@ -112,7 +115,8 @@ function createMoshStatsConnectionApi(ctx) {
           log("[Mosh] stats companion host-key check failed:", err?.message || String(err));
           trust.trusted = false;
         }
-        callback(true);
+        if (!trust.trusted) trust.rejected = true;
+        callback(trust.trusted);
       };
     }
 
@@ -225,23 +229,24 @@ function createMoshStatsConnectionApi(ctx) {
         connectOpts.agent || connectOpts.privateKey || connectOpts.password,
       );
 
-      // Sending a plaintext password (directly or via keyboard-interactive)
-      // to an unverified host would disclose it to a possible MITM. When a
-      // password is in play, install a trust-tracking host verifier plus a
-      // gated authHandler: key/agent auth is always allowed (it discloses no
-      // reusable secret and lets stats work on unvetted hosts), but the
-      // password methods are offered ONLY when the host key is already trusted
-      // in Netcatty's known-hosts store. Gating at the authHandler — rather
-      // than rejecting the whole connection in the verifier — is what lets
-      // key/agent auth still succeed on a host Netcatty has not vetted.
+      // Always install a host verifier that refuses an untrusted host, for
+      // EVERY auth method — a background, user-invisible companion must never
+      // authenticate to or run commands against a host Netcatty has not vetted
+      // (it could feed bogus host-info or enumerate agent keys), even though
+      // key/agent auth discloses no reusable secret.
+      const trust = { trusted: false, rejected: false };
+      connectOpts.hostVerifier = createTrustEnforcingHostVerifier({
+        hostname: connectOpts.host,
+        port: connectOpts.port,
+        knownHosts: auth.knownHosts,
+        trust,
+      });
+
+      // When a plaintext password is in play, also gate it behind the trust
+      // flag in the authHandler (defense in depth): key/agent methods are
+      // offered first, and the password / keyboard-interactive methods only
+      // once the verifier has confirmed the host key is trusted.
       if (connectOpts.password) {
-        const trust = { trusted: false };
-        connectOpts.hostVerifier = createTrustTrackingHostVerifier({
-          hostname: connectOpts.host,
-          port: connectOpts.port,
-          knownHosts: auth.knownHosts,
-          trust,
-        });
         connectOpts.authHandler = createGatedAuthHandler({
           hasAgent: Boolean(connectOpts.agent),
           hasKey: Boolean(connectOpts.privateKey),
@@ -250,7 +255,7 @@ function createMoshStatsConnectionApi(ctx) {
         });
       }
 
-      return { connectOpts, hasAnyAuth };
+      return { connectOpts, hasAnyAuth, trust };
     }
 
     /**
@@ -313,7 +318,7 @@ function createMoshStatsConnectionApi(ctx) {
         return null;
       }
 
-      const { connectOpts, hasAnyAuth } = await buildStatsConnectOpts({
+      const { connectOpts, hasAnyAuth, trust } = await buildStatsConnectOpts({
         ...auth,
         webContents,
       });
@@ -388,9 +393,11 @@ function createMoshStatsConnectionApi(ctx) {
           // If this fired after we already adopted the connection, drop the
           // stale handle so the next poll can rebuild a fresh one.
           if (session.moshStatsConn === conn) session.moshStatsConn = null;
-          // Auth rejection won't change with the same stored credentials, so
-          // stop retrying. Everything else may be transient.
-          fail(err, err?.level === "client-authentication");
+          // Auth rejection won't change with the same stored credentials, and a
+          // host-key rejection (untrusted host) won't either until the user
+          // vets the host via a real session — treat both as permanent so we
+          // stop reconnecting on every poll. Everything else may be transient.
+          fail(err, err?.level === "client-authentication" || trust.rejected);
         });
 
         conn.on("close", () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -256,10 +256,21 @@ function createMoshStatsConnectionApi(ctx) {
     /**
      * Ensure a Mosh session has a usable stats companion connection.
      *
-     * Returns the ssh2 Client on success (also assigned to `session.conn`),
-     * or null when one could not be established. Safe to call repeatedly:
-     * concurrent calls share a single in-flight attempt, and a permanent
-     * failure is cached so later polls don't reconnect on every tick.
+     * Returns the ssh2 Client on success (also stored on
+     * `session.moshStatsConn`), or null when one could not be established.
+     *
+     * The companion is stored ONLY on `session.moshStatsConn`, deliberately
+     * NOT on `session.conn`: other bridges treat `session.conn` as the
+     * session's primary interactive SSH connection (getSessionPwd assumes its
+     * exec channel is a sibling of the interactive shell; SFTP / MCP exec run
+     * over it). A Mosh session's interactive shell lives on the UDP
+     * mosh-client, not on this background stats connection, so exposing it as
+     * `session.conn` would make those paths return bogus results or run over
+     * the wrong connection. Only getServerStats reads `session.moshStatsConn`.
+     *
+     * Safe to call repeatedly: concurrent calls share a single in-flight
+     * attempt, and a permanent failure is cached so later polls don't
+     * reconnect on every tick.
      *
      * @param {object} session - the shared session record
      * @param {string} sessionId - the session's key in the shared sessions map
@@ -268,9 +279,8 @@ function createMoshStatsConnectionApi(ctx) {
      */
     function ensureMoshStatsConnection(session, sessionId, webContents) {
       if (!session) return Promise.resolve(null);
-      // Already connected (either a real SSH session or a previously
-      // established companion).
-      if (session.conn) return Promise.resolve(session.conn);
+      // A previously established companion is reused.
+      if (session.moshStatsConn) return Promise.resolve(session.moshStatsConn);
       // A prior attempt permanently failed — don't keep retrying every poll.
       if (session.moshStatsConnFailed) return Promise.resolve(null);
       // Reuse an in-flight attempt so two near-simultaneous polls don't open
@@ -367,7 +377,8 @@ function createMoshStatsConnectionApi(ctx) {
             finish(null);
             return;
           }
-          session.conn = conn;
+          // Stored only on moshStatsConn — never on session.conn (see the
+          // ensureMoshStatsConnection docstring for why).
           session.moshStatsConn = conn;
           finish(conn);
         });
@@ -376,7 +387,6 @@ function createMoshStatsConnectionApi(ctx) {
           log("[Mosh] stats companion connection error:", err?.message || String(err));
           // If this fired after we already adopted the connection, drop the
           // stale handle so the next poll can rebuild a fresh one.
-          if (session.conn === conn) session.conn = null;
           if (session.moshStatsConn === conn) session.moshStatsConn = null;
           // Auth rejection won't change with the same stored credentials, so
           // stop retrying. Everything else may be transient.
@@ -384,7 +394,6 @@ function createMoshStatsConnectionApi(ctx) {
         });
 
         conn.on("close", () => {
-          if (session.conn === conn) session.conn = null;
           if (session.moshStatsConn === conn) session.moshStatsConn = null;
           // If the socket closed mid-handshake without ever emitting "ready"
           // or "error", settle the attempt here so the awaiting getServerStats

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -24,20 +24,22 @@
  *     keeps working; only the stats bar stays empty (graceful degradation).
  *
  * Security — host-key handling:
- *   - When the companion authenticates with a *password* (plain or via
- *     keyboard-interactive), the plaintext secret is sent to the server, so
- *     the companion MUST verify the host key first. It does so silently and
- *     non-interactively against Netcatty's known-hosts store: it proceeds
- *     only when the live key is already "trusted", and otherwise aborts
- *     without ever offering the password and without prompting (the user
+ *   - A *password* (plain or via keyboard-interactive) sends a plaintext,
+ *     reusable secret to the server, so it is offered ONLY when the live host
+ *     key is already "trusted" in Netcatty's known-hosts store. A
+ *     trust-tracking host verifier records that during the transport
+ *     handshake, and a gated authHandler withholds the password methods
+ *     unless trusted. This is done silently and never prompts — the user
  *     drives host-key trust through the real interactive session, not a
- *     background stats poll). This prevents leaking a saved password to a
- *     spoofed / MITM host whose key Netcatty has not vetted.
- *   - Public-key / ssh-agent auth proves possession via a signature and
- *     never discloses a reusable secret to the server, so — like the
- *     existing one-off `execCommand` path — it does not gate on host-key
- *     verification. (The handshake already vetted the host via system ssh's
- *     known_hosts.)
+ *     background stats poll. It prevents leaking a saved password to a
+ *     spoofed / MITM host Netcatty has not vetted.
+ *   - Public-key / ssh-agent auth proves possession via a session-bound
+ *     signature and never discloses a reusable secret, so it is always
+ *     allowed — even to a host Netcatty has not vetted — matching the
+ *     existing one-off `execCommand` path (the handshake already vetted the
+ *     host via system ssh's known_hosts). Gating the password at the
+ *     authHandler rather than rejecting the whole connection is what lets
+ *     key/agent auth keep working on such hosts.
  */
 function createMoshStatsConnectionApi(ctx) {
   with (ctx) {
@@ -82,12 +84,19 @@ function createMoshStatsConnectionApi(ctx) {
       return null;
     }
 
-    // A non-interactive ssh2 hostVerifier that accepts ONLY a host key
-    // already trusted in Netcatty's known-hosts store. Unknown / changed keys
-    // are rejected outright — no user prompt — so a background stats poll can
-    // never disclose a password to an unvetted host, and never pops a
-    // host-key dialog of its own.
-    function createTrustedOnlyHostVerifier({ hostname, port, knownHosts }) {
+    // An ssh2 hostVerifier that records whether the live host key is already
+    // trusted in Netcatty's known-hosts store, into the shared `trust` object,
+    // then accepts the transport so public-key / agent auth can proceed. It
+    // never prompts. The trust flag gates *password* auth in the authHandler
+    // below: ssh2 runs this verifier during the transport handshake, before
+    // any auth method, so `trust.trusted` is set by the time the authHandler
+    // is consulted.
+    //
+    // Accepting the transport for an unknown host is safe because the only
+    // secret-disclosing method (password) is withheld unless trusted;
+    // public-key / agent auth proves possession via a session-bound signature
+    // that a MITM cannot replay.
+    function createTrustTrackingHostVerifier({ hostname, port, knownHosts, trust }) {
       return (rawKey, callback) => {
         try {
           const keyInfo = hostKeyVerifier.describeHostKey(rawKey);
@@ -98,11 +107,42 @@ function createMoshStatsConnectionApi(ctx) {
             keyType: keyInfo.keyType,
             fingerprint: keyInfo.fingerprint,
           });
-          callback(decision.status === "trusted");
+          trust.trusted = decision.status === "trusted";
         } catch (err) {
           log("[Mosh] stats companion host-key check failed:", err?.message || String(err));
-          callback(false);
+          trust.trusted = false;
         }
+        callback(true);
+      };
+    }
+
+    // A function-form ssh2 authHandler that offers, in order: none, agent (if
+    // available), publickey (if a key was resolved), and — only when the host
+    // key is trusted — password and keyboard-interactive. Returning method
+    // name strings lets ssh2 pull the credential data from connectOpts. This
+    // is what actually withholds the password from an untrusted host while
+    // still letting key/agent auth succeed.
+    function createGatedAuthHandler({ hasAgent, hasKey, hasPassword, trust }) {
+      const methods = ["none"];
+      if (hasAgent) methods.push("agent");
+      if (hasKey) methods.push("publickey");
+      let index = 0;
+      let trustedMethodsAppended = false;
+      return (_methodsLeft, _partialSuccess, callback) => {
+        // Append the password methods lazily, the first time we run out of the
+        // always-allowed ones, so the trust flag (set by the verifier during
+        // the transport handshake) is up to date.
+        if (index >= methods.length && !trustedMethodsAppended) {
+          trustedMethodsAppended = true;
+          if (hasPassword && trust.trusted) {
+            methods.push("password", "keyboard-interactive");
+          }
+        }
+        if (index >= methods.length) {
+          callback(false);
+          return;
+        }
+        callback(methods[index++]);
       };
     }
 
@@ -181,22 +221,34 @@ function createMoshStatsConnectionApi(ctx) {
         }
       }
 
-      // Sending a plaintext password (directly or via keyboard-interactive)
-      // to an unverified host would disclose it to a possible MITM. Gate
-      // password auth behind a silent, trusted-only host-key check against
-      // Netcatty's known-hosts store. Public-key / agent auth never reveals a
-      // reusable secret, so it is not gated (see the module header).
-      if (connectOpts.password) {
-        connectOpts.hostVerifier = createTrustedOnlyHostVerifier({
-          hostname: connectOpts.host,
-          port: connectOpts.port,
-          knownHosts: auth.knownHosts,
-        });
-      }
-
       const hasAnyAuth = Boolean(
         connectOpts.agent || connectOpts.privateKey || connectOpts.password,
       );
+
+      // Sending a plaintext password (directly or via keyboard-interactive)
+      // to an unverified host would disclose it to a possible MITM. When a
+      // password is in play, install a trust-tracking host verifier plus a
+      // gated authHandler: key/agent auth is always allowed (it discloses no
+      // reusable secret and lets stats work on unvetted hosts), but the
+      // password methods are offered ONLY when the host key is already trusted
+      // in Netcatty's known-hosts store. Gating at the authHandler — rather
+      // than rejecting the whole connection in the verifier — is what lets
+      // key/agent auth still succeed on a host Netcatty has not vetted.
+      if (connectOpts.password) {
+        const trust = { trusted: false };
+        connectOpts.hostVerifier = createTrustTrackingHostVerifier({
+          hostname: connectOpts.host,
+          port: connectOpts.port,
+          knownHosts: auth.knownHosts,
+          trust,
+        });
+        connectOpts.authHandler = createGatedAuthHandler({
+          hasAgent: Boolean(connectOpts.agent),
+          hasKey: Boolean(connectOpts.privateKey),
+          hasPassword: true,
+          trust,
+        });
+      }
 
       return { connectOpts, hasAnyAuth };
     }

--- a/electron/bridges/sshBridge/moshStatsConnection.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.cjs
@@ -23,11 +23,21 @@
  *     the failure so it does not hammer the host on every stats poll. Mosh
  *     keeps working; only the stats bar stays empty (graceful degradation).
  *
- * Host-key verification is intentionally skipped here, mirroring the
- * existing one-off `execCommand` path: the user already established trust in
- * this host through the Mosh handshake's system-`ssh` (which consults the
- * real known_hosts), so re-prompting on a background stats connection would
- * be confusing and redundant.
+ * Security — host-key handling:
+ *   - When the companion authenticates with a *password* (plain or via
+ *     keyboard-interactive), the plaintext secret is sent to the server, so
+ *     the companion MUST verify the host key first. It does so silently and
+ *     non-interactively against Netcatty's known-hosts store: it proceeds
+ *     only when the live key is already "trusted", and otherwise aborts
+ *     without ever offering the password and without prompting (the user
+ *     drives host-key trust through the real interactive session, not a
+ *     background stats poll). This prevents leaking a saved password to a
+ *     spoofed / MITM host whose key Netcatty has not vetted.
+ *   - Public-key / ssh-agent auth proves possession via a signature and
+ *     never discloses a reusable secret to the server, so — like the
+ *     existing one-off `execCommand` path — it does not gate on host-key
+ *     verification. (The handshake already vetted the host via system ssh's
+ *     known_hosts.)
  */
 function createMoshStatsConnectionApi(ctx) {
   with (ctx) {
@@ -70,6 +80,30 @@ function createMoshStatsConnectionApi(ctx) {
         if (key) return key;
       }
       return null;
+    }
+
+    // A non-interactive ssh2 hostVerifier that accepts ONLY a host key
+    // already trusted in Netcatty's known-hosts store. Unknown / changed keys
+    // are rejected outright — no user prompt — so a background stats poll can
+    // never disclose a password to an unvetted host, and never pops a
+    // host-key dialog of its own.
+    function createTrustedOnlyHostVerifier({ hostname, port, knownHosts }) {
+      return (rawKey, callback) => {
+        try {
+          const keyInfo = hostKeyVerifier.describeHostKey(rawKey);
+          const decision = hostKeyVerifier.classifyHostKey({
+            knownHosts: Array.isArray(knownHosts) ? knownHosts : [],
+            hostname,
+            port,
+            keyType: keyInfo.keyType,
+            fingerprint: keyInfo.fingerprint,
+          });
+          callback(decision.status === "trusted");
+        } catch (err) {
+          log("[Mosh] stats companion host-key check failed:", err?.message || String(err));
+          callback(false);
+        }
+      };
     }
 
     async function buildStatsConnectOpts(auth) {
@@ -143,6 +177,19 @@ function createMoshStatsConnectionApi(ctx) {
         if (agentSocket) {
           connectOpts.agent = agentSocket;
         }
+      }
+
+      // Sending a plaintext password (directly or via keyboard-interactive)
+      // to an unverified host would disclose it to a possible MITM. Gate
+      // password auth behind a silent, trusted-only host-key check against
+      // Netcatty's known-hosts store. Public-key / agent auth never reveals a
+      // reusable secret, so it is not gated (see the module header).
+      if (connectOpts.password) {
+        connectOpts.hostVerifier = createTrustedOnlyHostVerifier({
+          hostname: connectOpts.host,
+          port: connectOpts.port,
+          knownHosts: auth.knownHosts,
+        });
       }
 
       const hasAnyAuth = Boolean(

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -306,8 +306,30 @@ test("does not enable keyboard-interactive when there is no password", async () 
   assert.notEqual(client.connectOpts.tryKeyboard, true);
 });
 
-test("password auth attaches a host-key verifier; key/agent auth does not", async () => {
-  // Password present -> verifier attached.
+// Drive an ssh2 function-form authHandler to completion, collecting the
+// method names it offers. Each call is answered by invoking the callback,
+// then we ask for the next method until it yields false (exhausted).
+function drainAuthHandler(authHandler) {
+  const offered = [];
+  let done = false;
+  let guard = 0;
+  while (!done && guard++ < 50) {
+    let answered = false;
+    authHandler([], false, (method) => {
+      answered = true;
+      if (method === false) {
+        done = true;
+      } else {
+        offered.push(method);
+      }
+    });
+    if (!answered) break;
+  }
+  return offered;
+}
+
+test("password auth attaches verifier + gated authHandler; key/agent auth does not", async () => {
+  // Password present -> verifier + authHandler attached.
   {
     const { api, sessions } = makeApi();
     const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
@@ -315,8 +337,9 @@ test("password auth attaches a host-key verifier; key/agent auth does not", asyn
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
     assert.equal(typeof FakeSSHClient.instances[0].connectOpts.hostVerifier, "function");
+    assert.equal(typeof FakeSSHClient.instances[0].connectOpts.authHandler, "function");
   }
-  // Key only -> no verifier (public-key auth discloses no reusable secret).
+  // Key only -> ssh2 defaults (no custom verifier / authHandler needed).
   {
     const { api, sessions } = makeApi();
     const session = {
@@ -330,8 +353,9 @@ test("password auth attaches a host-key verifier; key/agent auth does not", asyn
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
     assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+    assert.equal(FakeSSHClient.instances[0].connectOpts.authHandler, undefined);
   }
-  // Agent only -> no verifier.
+  // Agent only -> ssh2 defaults.
   {
     const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
     const session = { moshStatsAuth: { hostname: "h", username: "u", agentForwarding: true } };
@@ -339,19 +363,37 @@ test("password auth attaches a host-key verifier; key/agent auth does not", asyn
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
     assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+    assert.equal(FakeSSHClient.instances[0].connectOpts.authHandler, undefined);
   }
 });
 
-test("the password host-key verifier accepts only keys trusted in known-hosts", async () => {
+test("the trust-tracking verifier accepts the transport for any host (key/agent must work)", async () => {
   const hostKeyVerifier = require("../hostKeyVerifier.cjs");
-  // Build a known-hosts record that matches a specific fingerprint.
+  const { api, sessions } = makeApi({ hostKeyVerifier });
+  const session = {
+    moshStatsAuth: { hostname: "unknown.example.com", port: 22, username: "u", password: "p", knownHosts: [] },
+  };
+  sessions.set("sid", session);
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+
+  const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
+  let accepted = null;
+  verify(require("node:crypto").randomBytes(32), (ok) => { accepted = ok; });
+  // Always accepts the transport — password gating happens in the authHandler.
+  assert.equal(accepted, true);
+});
+
+test("the gated authHandler offers password ONLY when the host key is trusted", async () => {
+  const hostKeyVerifier = require("../hostKeyVerifier.cjs");
   const rawKey = require("node:crypto").randomBytes(32);
   const { keyType, fingerprint } = hostKeyVerifier.describeHostKey(rawKey);
   const knownHosts = [
     { id: "k1", hostname: "trusted.example.com", port: 22, keyType, fingerprint, publicKey: "" },
   ];
 
-  // Trusted host: verifier accepts.
+  // Trusted host: after the verifier runs, password + keyboard-interactive
+  // are offered.
   {
     const { api, sessions } = makeApi({ hostKeyVerifier });
     const session = {
@@ -360,13 +402,15 @@ test("the password host-key verifier accepts only keys trusted in known-hosts", 
     sessions.set("sid", session);
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
-    const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
-    let accepted = null;
-    verify(rawKey, (ok) => { accepted = ok; });
-    assert.equal(accepted, true);
+    const { hostVerifier, authHandler } = FakeSSHClient.instances[0].connectOpts;
+    hostVerifier(rawKey, () => {}); // verifier runs during transport, sets trust
+    const offered = drainAuthHandler(authHandler);
+    assert.ok(offered.includes("password"));
+    assert.ok(offered.includes("keyboard-interactive"));
   }
 
-  // Unknown host (no matching record): verifier rejects, password not sent.
+  // Untrusted host: password methods are withheld even though a password is
+  // saved, so the secret is never sent.
   {
     const { api, sessions } = makeApi({ hostKeyVerifier });
     const session = {
@@ -375,11 +419,30 @@ test("the password host-key verifier accepts only keys trusted in known-hosts", 
     sessions.set("sid", session);
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
-    const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
-    let accepted = null;
-    verify(rawKey, (ok) => { accepted = ok; });
-    assert.equal(accepted, false);
+    const { hostVerifier, authHandler } = FakeSSHClient.instances[0].connectOpts;
+    hostVerifier(rawKey, () => {});
+    const offered = drainAuthHandler(authHandler);
+    assert.ok(!offered.includes("password"));
+    assert.ok(!offered.includes("keyboard-interactive"));
   }
+});
+
+test("the gated authHandler still offers key/agent on an untrusted host", async () => {
+  const hostKeyVerifier = require("../hostKeyVerifier.cjs");
+  const { api, sessions } = makeApi({ hostKeyVerifier, getSshAgentSocket: () => "/tmp/agent.sock" });
+  // Untrusted host (empty known-hosts), with a saved password AND an agent.
+  const session = {
+    moshStatsAuth: { hostname: "unknown.example.com", port: 22, username: "u", password: "p", knownHosts: [] },
+  };
+  sessions.set("sid", session);
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const { hostVerifier, authHandler } = FakeSSHClient.instances[0].connectOpts;
+  hostVerifier(require("node:crypto").randomBytes(32), () => {});
+  const offered = drainAuthHandler(authHandler);
+  // Agent auth is offered even though the host is untrusted; password is not.
+  assert.ok(offered.includes("agent"));
+  assert.ok(!offered.includes("password"));
 });
 
 test("an explicit private key suppresses the ssh-agent fallback", async () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -330,8 +330,8 @@ function drainAuthHandler(authHandler) {
   return offered;
 }
 
-test("password auth attaches verifier + gated authHandler; key/agent auth does not", async () => {
-  // Password present -> verifier + authHandler attached.
+test("verifier is attached for every auth method; gated authHandler only with a password", async () => {
+  // Password present -> verifier + gated authHandler attached.
   {
     const { api, sessions } = makeApi();
     const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
@@ -341,7 +341,7 @@ test("password auth attaches verifier + gated authHandler; key/agent auth does n
     assert.equal(typeof FakeSSHClient.instances[0].connectOpts.hostVerifier, "function");
     assert.equal(typeof FakeSSHClient.instances[0].connectOpts.authHandler, "function");
   }
-  // Key only -> ssh2 defaults (no custom verifier / authHandler needed).
+  // Key only -> verifier still attached (the host must be vetted); no authHandler.
   {
     const { api, sessions } = makeApi();
     const session = {
@@ -354,26 +354,34 @@ test("password auth attaches verifier + gated authHandler; key/agent auth does n
     sessions.set("sid", session);
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
-    assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+    assert.equal(typeof FakeSSHClient.instances[0].connectOpts.hostVerifier, "function");
     assert.equal(FakeSSHClient.instances[0].connectOpts.authHandler, undefined);
   }
-  // Agent only -> ssh2 defaults.
+  // Agent only -> verifier still attached; no authHandler.
   {
     const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
     const session = { moshStatsAuth: { hostname: "h", username: "u", agentForwarding: true } };
     sessions.set("sid", session);
     api.ensureMoshStatsConnection(session, "sid");
     await tick();
-    assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+    assert.equal(typeof FakeSSHClient.instances[0].connectOpts.hostVerifier, "function");
     assert.equal(FakeSSHClient.instances[0].connectOpts.authHandler, undefined);
   }
 });
 
-test("the trust-tracking verifier accepts the transport for any host (key/agent must work)", async () => {
+test("the verifier rejects the transport for an untrusted host (key auth included)", async () => {
   const hostKeyVerifier = require("../hostKeyVerifier.cjs");
   const { api, sessions } = makeApi({ hostKeyVerifier });
+  // Untrusted host: empty known-hosts, key auth and NO password — must still be
+  // refused, even though key auth would leak no reusable secret.
   const session = {
-    moshStatsAuth: { hostname: "unknown.example.com", port: 22, username: "u", password: "p", knownHosts: [] },
+    moshStatsAuth: {
+      hostname: "unknown.example.com",
+      port: 22,
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      knownHosts: [],
+    },
   };
   sessions.set("sid", session);
   api.ensureMoshStatsConnection(session, "sid");
@@ -382,8 +390,8 @@ test("the trust-tracking verifier accepts the transport for any host (key/agent 
   const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
   let accepted = null;
   verify(require("node:crypto").randomBytes(32), (ok) => { accepted = ok; });
-  // Always accepts the transport — password gating happens in the authHandler.
-  assert.equal(accepted, true);
+  // Refuses an unvetted host outright — no auth attempted, no stats command run.
+  assert.equal(accepted, false);
 });
 
 test("the gated authHandler offers password ONLY when the host key is trusted", async () => {
@@ -427,24 +435,6 @@ test("the gated authHandler offers password ONLY when the host key is trusted", 
     assert.ok(!offered.includes("password"));
     assert.ok(!offered.includes("keyboard-interactive"));
   }
-});
-
-test("the gated authHandler still offers key/agent on an untrusted host", async () => {
-  const hostKeyVerifier = require("../hostKeyVerifier.cjs");
-  const { api, sessions } = makeApi({ hostKeyVerifier, getSshAgentSocket: () => "/tmp/agent.sock" });
-  // Untrusted host (empty known-hosts), with a saved password AND an agent.
-  const session = {
-    moshStatsAuth: { hostname: "unknown.example.com", port: 22, username: "u", password: "p", knownHosts: [] },
-  };
-  sessions.set("sid", session);
-  api.ensureMoshStatsConnection(session, "sid");
-  await tick();
-  const { hostVerifier, authHandler } = FakeSSHClient.instances[0].connectOpts;
-  hostVerifier(require("node:crypto").randomBytes(32), () => {});
-  const offered = drainAuthHandler(authHandler);
-  // Agent auth is offered even though the host is untrusted; password is not.
-  assert.ok(offered.includes("agent"));
-  assert.ok(!offered.includes("password"));
 });
 
 test("an explicit private key suppresses the ssh-agent fallback", async () => {
@@ -603,4 +593,81 @@ test("honors host algorithm settings via buildAlgorithms", async () => {
   assert.equal(calls[0].opts.skipEcdsaHostKey, true);
   assert.equal(calls[0].opts.algorithmOverrides, overrides);
   assert.deepEqual(FakeSSHClient.instances[0].connectOpts.algorithms, { built: true });
+});
+
+test("installs a host-key verifier even for key-only auth (no password)", async () => {
+  const { api, sessions } = makeApi();
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  // Regression (#1198 review): a background companion must verify the host key
+  // for EVERY auth method, not only when a password is present.
+  assert.equal(typeof client.connectOpts.hostVerifier, "function");
+});
+
+test("rejects an untrusted host key for key auth and treats it as permanent", async () => {
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "live-fp" }),
+      classifyHostKey: () => ({ status: "unknown" }),
+    },
+  });
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+    },
+  };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  // The verifier refuses the transport for an unvetted host, even though the
+  // companion would have authenticated with a key (no reusable secret leaked).
+  let verdict;
+  client.connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, false);
+
+  // ssh2 then aborts the handshake; an untrusted host must be a permanent
+  // failure so we don't reconnect (and re-reject) on every stats poll.
+  client.emitError(Object.assign(new Error("handshake failed"), { level: "protocol" }));
+  const result = await pending;
+  assert.equal(result, null);
+  assert.equal(session.moshStatsConnFailed, true);
+});
+
+test("accepts a trusted host key and adopts the connection", async () => {
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "fp" }),
+      classifyHostKey: () => ({ status: "trusted" }),
+    },
+  });
+  const session = {
+    moshStatsAuth: { hostname: "h", username: "u", password: "secret" },
+  };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  let verdict;
+  client.connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, true);
+
+  client.emitReady();
+  assert.equal(await pending, client);
 });

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -70,10 +70,10 @@ function makeApi(overrides = {}) {
   return { api, sessions, logs };
 }
 
-test("returns existing session.conn without opening a new connection", async () => {
+test("reuses an already-established companion (moshStatsConn) without reconnecting", async () => {
   const existing = { exec() {} };
   const { api } = makeApi();
-  const session = { conn: existing, moshStatsAuth: { hostname: "h", password: "p" } };
+  const session = { moshStatsConn: existing, moshStatsAuth: { hostname: "h", password: "p" } };
 
   const result = await api.ensureMoshStatsConnection(session, "sid");
 
@@ -134,8 +134,10 @@ test("connects with a stored password and adopts the connection on ready", async
   const result = await pending;
 
   assert.equal(result, client);
-  assert.equal(session.conn, client);
+  // Stored ONLY on moshStatsConn, never on session.conn (keeps the companion
+  // invisible to getSessionPwd / SFTP / MCP exec).
   assert.equal(session.moshStatsConn, client);
+  assert.equal(session.conn, undefined);
 });
 
 test("uses a parseable private key and passphrase, not password fallback only", async () => {
@@ -570,6 +572,7 @@ test("a connection that becomes ready after the session closed is discarded", as
   assert.equal(result, null);
   assert.equal(FakeSSHClient.instances[0].ended, true);
   assert.equal(session.conn, undefined);
+  assert.equal(session.moshStatsConn, undefined);
 });
 
 test("honors host algorithm settings via buildAlgorithms", async () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -58,6 +58,8 @@ function makeApi(overrides = {}) {
     getSshAgentSocket: overrides.getSshAgentSocket || (() => null),
     readFileNoFollow: overrides.readFileNoFollow || (async () => null),
     expandIdentityFilePath: overrides.expandIdentityFilePath || ((p) => p),
+    isAutoFillablePasswordChallenge:
+      overrides.isAutoFillablePasswordChallenge || (() => false),
     log: (...args) => logs.push(args),
   });
   return { api, sessions, logs };
@@ -204,6 +206,88 @@ test("does not attempt a connection when no agent socket and no inline creds", a
   const result = await api.ensureMoshStatsConnection(session, "sid");
   assert.equal(result, null);
   assert.equal(FakeSSHClient.instances.length, 0);
+});
+
+test("enables keyboard-interactive and auto-fills the saved password for a single prompt", async () => {
+  // Use the real auto-fill predicate so this exercises the actual handler.
+  const { isAutoFillablePasswordChallenge } = require("../sshAuthHelper.cjs");
+  const { api, sessions } = makeApi({ isAutoFillablePasswordChallenge });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "secret" } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.tryKeyboard, true);
+
+  let answered = null;
+  client.emit(
+    "keyboard-interactive",
+    "",
+    "",
+    "",
+    [{ prompt: "Password:", echo: false }],
+    (responses) => { answered = responses; },
+  );
+  assert.deepEqual(answered, ["secret"]);
+});
+
+test("keyboard-interactive finishes empty on a 2FA / OTP challenge (no hang, no prompt)", async () => {
+  const { isAutoFillablePasswordChallenge } = require("../sshAuthHelper.cjs");
+  const { api, sessions } = makeApi({ isAutoFillablePasswordChallenge });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "secret" } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  let answered = null;
+  client.emit(
+    "keyboard-interactive",
+    "",
+    "",
+    "",
+    [{ prompt: "Verification code:", echo: false }],
+    (responses) => { answered = responses; },
+  );
+  assert.deepEqual(answered, []);
+});
+
+test("keyboard-interactive only auto-fills once, then finishes empty to avoid a loop", async () => {
+  const { isAutoFillablePasswordChallenge } = require("../sshAuthHelper.cjs");
+  const { api, sessions } = makeApi({ isAutoFillablePasswordChallenge });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "secret" } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  const prompts = [{ prompt: "Password:", echo: false }];
+  let first = null;
+  let second = null;
+  client.emit("keyboard-interactive", "", "", "", prompts, (r) => { first = r; });
+  client.emit("keyboard-interactive", "", "", "", prompts, (r) => { second = r; });
+  assert.deepEqual(first, ["secret"]);
+  assert.deepEqual(second, []); // retry not re-filled with the same wrong password
+});
+
+test("does not enable keyboard-interactive when there is no password", async () => {
+  const { api, sessions } = makeApi();
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  assert.notEqual(client.connectOpts.tryKeyboard, true);
 });
 
 test("inline credentials take precedence over ssh-agent", async () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -60,6 +60,11 @@ function makeApi(overrides = {}) {
     expandIdentityFilePath: overrides.expandIdentityFilePath || ((p) => p),
     isAutoFillablePasswordChallenge:
       overrides.isAutoFillablePasswordChallenge || (() => false),
+    hostKeyVerifier: overrides.hostKeyVerifier || {
+      // Default: classify everything as trusted so password tests connect.
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "fp" }),
+      classifyHostKey: () => ({ status: "trusted" }),
+    },
     log: (...args) => logs.push(args),
   });
   return { api, sessions, logs };
@@ -288,6 +293,82 @@ test("does not enable keyboard-interactive when there is no password", async () 
   await tick();
   const client = FakeSSHClient.instances[0];
   assert.notEqual(client.connectOpts.tryKeyboard, true);
+});
+
+test("password auth attaches a host-key verifier; key/agent auth does not", async () => {
+  // Password present -> verifier attached.
+  {
+    const { api, sessions } = makeApi();
+    const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+    sessions.set("sid", session);
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    assert.equal(typeof FakeSSHClient.instances[0].connectOpts.hostVerifier, "function");
+  }
+  // Key only -> no verifier (public-key auth discloses no reusable secret).
+  {
+    const { api, sessions } = makeApi();
+    const session = {
+      moshStatsAuth: {
+        hostname: "h",
+        username: "u",
+        privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      },
+    };
+    sessions.set("sid", session);
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+  }
+  // Agent only -> no verifier.
+  {
+    const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
+    const session = { moshStatsAuth: { hostname: "h", username: "u", agentForwarding: true } };
+    sessions.set("sid", session);
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    assert.equal(FakeSSHClient.instances[0].connectOpts.hostVerifier, undefined);
+  }
+});
+
+test("the password host-key verifier accepts only keys trusted in known-hosts", async () => {
+  const hostKeyVerifier = require("../hostKeyVerifier.cjs");
+  // Build a known-hosts record that matches a specific fingerprint.
+  const rawKey = require("node:crypto").randomBytes(32);
+  const { keyType, fingerprint } = hostKeyVerifier.describeHostKey(rawKey);
+  const knownHosts = [
+    { id: "k1", hostname: "trusted.example.com", port: 22, keyType, fingerprint, publicKey: "" },
+  ];
+
+  // Trusted host: verifier accepts.
+  {
+    const { api, sessions } = makeApi({ hostKeyVerifier });
+    const session = {
+      moshStatsAuth: { hostname: "trusted.example.com", port: 22, username: "u", password: "p", knownHosts },
+    };
+    sessions.set("sid", session);
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
+    let accepted = null;
+    verify(rawKey, (ok) => { accepted = ok; });
+    assert.equal(accepted, true);
+  }
+
+  // Unknown host (no matching record): verifier rejects, password not sent.
+  {
+    const { api, sessions } = makeApi({ hostKeyVerifier });
+    const session = {
+      moshStatsAuth: { hostname: "other.example.com", port: 22, username: "u", password: "p", knownHosts },
+    };
+    sessions.set("sid", session);
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    const verify = FakeSSHClient.instances[0].connectOpts.hostVerifier;
+    let accepted = null;
+    verify(rawKey, (ok) => { accepted = ok; });
+    assert.equal(accepted, false);
+  }
 });
 
 test("inline credentials take precedence over ssh-agent", async () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -93,15 +93,26 @@ test("gives up (no connection) when there is no usable non-interactive auth", as
   assert.equal(FakeSSHClient.instances.length, 0);
 });
 
-test("gives up when moshStatsAuth is missing", async () => {
-  const { api } = makeApi();
+test("missing moshStatsAuth is transient (handshake not yet swapped), not a permanent failure", async () => {
+  const { api, sessions } = makeApi();
+  // Session is connected (renderer polls) but the handshake hasn't swapped to
+  // mosh-client yet, so moshStatsAuth is not assigned.
   const session = {};
+  sessions.set("sid", session);
 
   const result = await api.ensureMoshStatsConnection(session, "sid");
 
   assert.equal(result, null);
-  assert.equal(session.moshStatsConnFailed, true);
+  // Must NOT be permanently disabled — a later poll (after the swap sets
+  // moshStatsAuth) has to be able to establish the companion.
+  assert.notEqual(session.moshStatsConnFailed, true);
   assert.equal(FakeSSHClient.instances.length, 0);
+
+  // Once auth becomes available, a subsequent poll connects.
+  session.moshStatsAuth = { hostname: "h", username: "u", password: "p" };
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  assert.equal(FakeSSHClient.instances.length, 1);
 });
 
 test("connects with a stored password and adopts the connection on ready", async () => {
@@ -371,7 +382,28 @@ test("the password host-key verifier accepts only keys trusted in known-hosts", 
   }
 });
 
-test("inline credentials take precedence over ssh-agent", async () => {
+test("an explicit private key suppresses the ssh-agent fallback", async () => {
+  const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  assert.ok(client.connectOpts.privateKey);
+  assert.equal(client.connectOpts.agent, undefined);
+});
+
+test("a saved password does NOT suppress agent auth (agent offered alongside password)", async () => {
+  // A public-key host that authenticates via the agent may still carry a
+  // stored password; the companion must offer both so agent auth (tried
+  // first by ssh2) can succeed instead of failing on password only.
   const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
   const session = { moshStatsAuth: { hostname: "h", username: "u", password: "pw" } };
   sessions.set("sid", session);
@@ -379,8 +411,8 @@ test("inline credentials take precedence over ssh-agent", async () => {
   api.ensureMoshStatsConnection(session, "sid");
   await tick();
   const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.agent, "/tmp/agent.sock");
   assert.equal(client.connectOpts.password, "pw");
-  assert.equal(client.connectOpts.agent, undefined);
 });
 
 test("concurrent calls share a single in-flight connection attempt", async () => {

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -65,6 +65,13 @@ function makeApi(overrides = {}) {
       describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "fp" }),
       classifyHostKey: () => ({ status: "trusted" }),
     },
+    // Default: the system known_hosts vouches for nothing, so trust comes
+    // solely from the Netcatty classifier above. Individual tests override this
+    // to exercise the system-known_hosts fallback.
+    isHostKeyTrustedBySystem:
+      "isHostKeyTrustedBySystem" in overrides
+        ? overrides.isHostKeyTrustedBySystem
+        : () => false,
     log: (...args) => logs.push(args),
   });
   return { api, sessions, logs };
@@ -670,4 +677,152 @@ test("accepts a trusted host key and adopts the connection", async () => {
 
   client.emitReady();
   assert.equal(await pending, client);
+});
+
+test("trusts a host vouched for ONLY by the system known_hosts (Netcatty snapshot empty)", async () => {
+  // Netcatty's in-app vault has no record (classify -> unknown), but the user's
+  // system OpenSSH known_hosts already trusts the exact live key — which is
+  // what the Mosh handshake's system ssh actually used. The companion must
+  // accept it so Mosh stats appear.
+  const seen = [];
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "live-fp" }),
+      classifyHostKey: () => ({ status: "unknown" }),
+    },
+    isHostKeyTrustedBySystem: (args) => {
+      seen.push(args);
+      return args.hostname === "sys.example.com" && args.fingerprint === "live-fp";
+    },
+  });
+  const session = {
+    moshStatsAuth: {
+      hostname: "sys.example.com",
+      port: 22,
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      knownHosts: [],
+    },
+  };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  let verdict;
+  client.connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, true);
+  // The system check was consulted with the live key's fingerprint.
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].fingerprint, "live-fp");
+
+  client.emitReady();
+  assert.equal(await pending, client);
+});
+
+test("rejects (permanently) when NEITHER Netcatty nor the system known_hosts trust the key", async () => {
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "live-fp" }),
+      classifyHostKey: () => ({ status: "unknown" }),
+    },
+    isHostKeyTrustedBySystem: () => false,
+  });
+  const session = {
+    moshStatsAuth: {
+      hostname: "untrusted.example.com",
+      port: 22,
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      knownHosts: [],
+    },
+  };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+
+  let verdict;
+  client.connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, false);
+
+  // ssh2 aborts; an untrusted host is a permanent failure (no re-poll loop).
+  client.emitError(Object.assign(new Error("handshake failed"), { level: "protocol" }));
+  assert.equal(await pending, null);
+  assert.equal(session.moshStatsConnFailed, true);
+});
+
+test("the system fallback is NOT consulted when Netcatty already trusts the key", async () => {
+  // Netcatty says trusted -> accept without even touching the system files.
+  let consulted = false;
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "fp" }),
+      classifyHostKey: () => ({ status: "trusted" }),
+    },
+    isHostKeyTrustedBySystem: () => {
+      consulted = true;
+      return false;
+    },
+  });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p", knownHosts: [] } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  let verdict;
+  FakeSSHClient.instances[0].connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, true);
+  assert.equal(consulted, false);
+});
+
+test("a Netcatty 'changed' key is NOT rescued by a non-matching system check (key rotation stays rejected)", async () => {
+  // Netcatty flags a key rotation (changed). The system check is consulted with
+  // the LIVE fingerprint; since the system does not record this exact new key,
+  // it returns false and the connection is refused — the mismatch is never
+  // silently accepted.
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "rotated-fp" }),
+      classifyHostKey: () => ({ status: "changed", expectedFingerprint: "old-fp" }),
+    },
+    isHostKeyTrustedBySystem: () => false,
+  });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p", knownHosts: [] } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  let verdict;
+  FakeSSHClient.instances[0].connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, false);
+});
+
+test("works when isHostKeyTrustedBySystem is not wired in (optional dependency)", async () => {
+  // Backward-compat: an api built without the system-known_hosts dependency
+  // must not throw; it simply falls back to the Netcatty-only decision.
+  const { api, sessions } = makeApi({
+    hostKeyVerifier: {
+      describeHostKey: () => ({ keyType: "ssh-ed25519", fingerprint: "fp" }),
+      classifyHostKey: () => ({ status: "unknown" }),
+    },
+    isHostKeyTrustedBySystem: undefined,
+  });
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      knownHosts: [],
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  let verdict;
+  FakeSSHClient.instances[0].connectOpts.hostVerifier(Buffer.from("rawkey"), (ok) => { verdict = ok; });
+  assert.equal(verdict, false);
 });

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -272,6 +272,28 @@ test("a transient error allows a reconnect on the next poll", async () => {
   assert.equal(FakeSSHClient.instances.length, 2);
 });
 
+test("a socket that closes mid-handshake settles the attempt instead of hanging", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  // Socket drops during the handshake with no prior "ready" or "error".
+  FakeSSHClient.instances[0].emit("close");
+
+  const result = await pending;
+  assert.equal(result, null);
+  // Transient — must not permanently disable stats, and the promise must clear.
+  assert.notEqual(session.moshStatsConnFailed, true);
+  assert.equal(session.moshStatsConnPromise, null);
+
+  // The next poll is allowed to retry.
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  assert.equal(FakeSSHClient.instances.length, 2);
+});
+
 test("a connection that becomes ready after the session closed is discarded", async () => {
   const { api, sessions } = makeApi();
   const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };

--- a/electron/bridges/sshBridge/moshStatsConnection.test.cjs
+++ b/electron/bridges/sshBridge/moshStatsConnection.test.cjs
@@ -1,0 +1,321 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { createMoshStatsConnectionApi } = require("./moshStatsConnection.cjs");
+
+// The connection is created inside an async flow (after credentials are
+// resolved, which may touch the filesystem), so the fake SSH client appears a
+// few microtasks/immediates after ensureMoshStatsConnection() is called.
+function tick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+// Minimal fake ssh2 Client. Records connect() opts and lets the test drive
+// the lifecycle via emitReady / emitError.
+class FakeSSHClient extends EventEmitter {
+  constructor() {
+    super();
+    FakeSSHClient.instances.push(this);
+    this.connectOpts = null;
+    this.ended = false;
+  }
+
+  connect(opts) {
+    this.connectOpts = opts;
+    return this;
+  }
+
+  end() {
+    this.ended = true;
+  }
+
+  emitReady() {
+    this.emit("ready");
+  }
+
+  emitError(err) {
+    this.emit("error", err);
+  }
+}
+FakeSSHClient.instances = [];
+
+function makeApi(overrides = {}) {
+  FakeSSHClient.instances = [];
+  const sessions = overrides.sessions || new Map();
+  const logs = [];
+  const api = createMoshStatsConnectionApi({
+    get sessions() {
+      return sessions;
+    },
+    SSHClient: overrides.SSHClient || FakeSSHClient,
+    sshUtils: overrides.sshUtils || {
+      // Default: treat any non-empty string as a parseable key.
+      parseKey: (key) => (key && key.length > 0 ? { ok: true } : new Error("bad key")),
+    },
+    NetcattyAgent: overrides.NetcattyAgent || class {},
+    buildAlgorithms: overrides.buildAlgorithms || (() => ({ algos: true })),
+    getSshAgentSocket: overrides.getSshAgentSocket || (() => null),
+    readFileNoFollow: overrides.readFileNoFollow || (async () => null),
+    expandIdentityFilePath: overrides.expandIdentityFilePath || ((p) => p),
+    log: (...args) => logs.push(args),
+  });
+  return { api, sessions, logs };
+}
+
+test("returns existing session.conn without opening a new connection", async () => {
+  const existing = { exec() {} };
+  const { api } = makeApi();
+  const session = { conn: existing, moshStatsAuth: { hostname: "h", password: "p" } };
+
+  const result = await api.ensureMoshStatsConnection(session, "sid");
+
+  assert.equal(result, existing);
+  assert.equal(FakeSSHClient.instances.length, 0);
+});
+
+test("gives up (no connection) when there is no usable non-interactive auth", async () => {
+  const { api } = makeApi();
+  // Only an interactively-typed password would have worked; nothing stored.
+  const session = { moshStatsAuth: { hostname: "h", username: "u" } };
+
+  const result = await api.ensureMoshStatsConnection(session, "sid");
+
+  assert.equal(result, null);
+  assert.equal(session.moshStatsConnFailed, true);
+  assert.equal(FakeSSHClient.instances.length, 0);
+});
+
+test("gives up when moshStatsAuth is missing", async () => {
+  const { api } = makeApi();
+  const session = {};
+
+  const result = await api.ensureMoshStatsConnection(session, "sid");
+
+  assert.equal(result, null);
+  assert.equal(session.moshStatsConnFailed, true);
+  assert.equal(FakeSSHClient.instances.length, 0);
+});
+
+test("connects with a stored password and adopts the connection on ready", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "example.com", port: 2222, username: "alice", password: "secret" } };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  // One connection attempt with the password and host wired in.
+  assert.equal(FakeSSHClient.instances.length, 1);
+  const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.host, "example.com");
+  assert.equal(client.connectOpts.port, 2222);
+  assert.equal(client.connectOpts.username, "alice");
+  assert.equal(client.connectOpts.password, "secret");
+
+  client.emitReady();
+  const result = await pending;
+
+  assert.equal(result, client);
+  assert.equal(session.conn, client);
+  assert.equal(session.moshStatsConn, client);
+});
+
+test("uses a parseable private key and passphrase, not password fallback only", async () => {
+  const { api, sessions } = makeApi();
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----",
+      passphrase: "pw",
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.privateKey, session.moshStatsAuth.privateKey);
+  assert.equal(client.connectOpts.passphrase, "pw");
+});
+
+test("skips an unparseable (e.g. encrypted, wrong passphrase) private key", async () => {
+  const { api, sessions } = makeApi({
+    sshUtils: { parseKey: () => new Error("encrypted") },
+  });
+  const session = {
+    moshStatsAuth: { hostname: "h", username: "u", privateKey: "enc", password: "fallback" },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  // Falls back to the stored password instead of offering the bad key.
+  assert.equal(client.connectOpts.privateKey, undefined);
+  assert.equal(client.connectOpts.password, "fallback");
+});
+
+test("reads identity files non-interactively when no inline key is present", async () => {
+  const reads = [];
+  const { api, sessions } = makeApi({
+    readFileNoFollow: async (p) => {
+      reads.push(p);
+      return "FILEKEY";
+    },
+    sshUtils: { parseKey: (k) => (k === "FILEKEY" ? { ok: true } : new Error("no")) },
+  });
+  const session = {
+    moshStatsAuth: { hostname: "h", username: "u", identityFilePaths: ["~/.ssh/id_ed25519"] },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  await tick(); // allow chained async identity read + client creation
+
+  assert.deepEqual(reads, ["~/.ssh/id_ed25519"]);
+  const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.privateKey, "FILEKEY");
+});
+
+test("falls back to ssh-agent when a socket is available and no inline creds", async () => {
+  // The system ssh used by the Mosh handshake authenticates via the local
+  // agent by default, so the companion should too — regardless of the
+  // agentForwarding (remote forwarding) setting.
+  for (const agentForwarding of [true, false, undefined]) {
+    const { api, sessions } = makeApi({
+      getSshAgentSocket: () => "/tmp/agent.sock",
+    });
+    const session = { moshStatsAuth: { hostname: "h", username: "u", agentForwarding } };
+    sessions.set("sid", session);
+
+    api.ensureMoshStatsConnection(session, "sid");
+    await tick();
+    const client = FakeSSHClient.instances[0];
+    assert.equal(client.connectOpts.agent, "/tmp/agent.sock");
+  }
+});
+
+test("does not attempt a connection when no agent socket and no inline creds", async () => {
+  const { api } = makeApi({ getSshAgentSocket: () => null });
+  const session = { moshStatsAuth: { hostname: "h", username: "u" } };
+
+  const result = await api.ensureMoshStatsConnection(session, "sid");
+  assert.equal(result, null);
+  assert.equal(FakeSSHClient.instances.length, 0);
+});
+
+test("inline credentials take precedence over ssh-agent", async () => {
+  const { api, sessions } = makeApi({ getSshAgentSocket: () => "/tmp/agent.sock" });
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "pw" } };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const client = FakeSSHClient.instances[0];
+  assert.equal(client.connectOpts.password, "pw");
+  assert.equal(client.connectOpts.agent, undefined);
+});
+
+test("concurrent calls share a single in-flight connection attempt", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+  sessions.set("sid", session);
+
+  const p1 = api.ensureMoshStatsConnection(session, "sid");
+  const p2 = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+
+  assert.equal(FakeSSHClient.instances.length, 1);
+  FakeSSHClient.instances[0].emitReady();
+  const [r1, r2] = await Promise.all([p1, p2]);
+  assert.equal(r1, FakeSSHClient.instances[0]);
+  assert.equal(r2, FakeSSHClient.instances[0]);
+});
+
+test("auth rejection is permanent: no reconnect on the next poll", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+  sessions.set("sid", session);
+
+  const p1 = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const authErr = new Error("All configured authentication methods failed");
+  authErr.level = "client-authentication";
+  FakeSSHClient.instances[0].emitError(authErr);
+  assert.equal(await p1, null);
+  assert.equal(session.moshStatsConnFailed, true);
+
+  // Second poll must not open a new connection.
+  const r2 = await api.ensureMoshStatsConnection(session, "sid");
+  assert.equal(r2, null);
+  assert.equal(FakeSSHClient.instances.length, 1);
+});
+
+test("a transient error allows a reconnect on the next poll", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+  sessions.set("sid", session);
+
+  const p1 = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  const netErr = new Error("connect ETIMEDOUT");
+  netErr.level = "client-socket";
+  FakeSSHClient.instances[0].emitError(netErr);
+  assert.equal(await p1, null);
+  assert.notEqual(session.moshStatsConnFailed, true);
+
+  // Next poll is allowed to try again.
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  assert.equal(FakeSSHClient.instances.length, 2);
+});
+
+test("a connection that becomes ready after the session closed is discarded", async () => {
+  const { api, sessions } = makeApi();
+  const session = { moshStatsAuth: { hostname: "h", username: "u", password: "p" } };
+  sessions.set("sid", session);
+
+  const pending = api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  // Session goes away before the handshake completes.
+  session.closed = true;
+  sessions.delete("sid");
+  FakeSSHClient.instances[0].emitReady();
+
+  const result = await pending;
+  assert.equal(result, null);
+  assert.equal(FakeSSHClient.instances[0].ended, true);
+  assert.equal(session.conn, undefined);
+});
+
+test("honors host algorithm settings via buildAlgorithms", async () => {
+  const calls = [];
+  const { api, sessions } = makeApi({
+    buildAlgorithms: (legacy, opts) => {
+      calls.push({ legacy, opts });
+      return { built: true };
+    },
+  });
+  const overrides = { cipher: ["aes128-cbc"] };
+  const session = {
+    moshStatsAuth: {
+      hostname: "h",
+      username: "u",
+      password: "p",
+      legacyAlgorithms: true,
+      skipEcdsaHostKey: true,
+      algorithmOverrides: overrides,
+    },
+  };
+  sessions.set("sid", session);
+
+  api.ensureMoshStatsConnection(session, "sid");
+  await tick();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].legacy, true);
+  assert.equal(calls[0].opts.skipEcdsaHostKey, true);
+  assert.equal(calls[0].opts.algorithmOverrides, overrides);
+  assert.deepEqual(FakeSSHClient.instances[0].connectOpts.algorithms, { built: true });
+});

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -491,17 +491,19 @@ function createSessionOpsApi(ctx) {
       // Mosh sessions run over UDP via a local mosh-client PTY and have no
       // ssh2 connection of their own. Lazily open a best-effort companion SSH
       // connection (reusing the handshake credentials) so the host-info bar
-      // works for Mosh too (issue #1198). This is a no-op for real SSH
-      // sessions, which already carry session.conn.
-      if (!session.conn && typeof ensureMoshStatsConnection === 'function') {
+      // works for Mosh too (issue #1198). The companion lives on
+      // session.moshStatsConn — deliberately NOT session.conn — so it stays
+      // invisible to other bridges (getSessionPwd / SFTP / MCP exec) that key
+      // off session.conn as the interactive connection. This is a no-op for
+      // real SSH sessions, which already carry session.conn.
+      if (!session.conn && !session.moshStatsConn && typeof ensureMoshStatsConnection === 'function') {
         await ensureMoshStatsConnection(session, sessionId, event?.sender);
       }
 
-      if (!session.conn) {
+      const conn = session.conn || session.moshStatsConn;
+      if (!conn) {
         return { success: false, error: 'Session not found or not connected' };
       }
-
-      const conn = session.conn;
     
       // macOS stats command: uses sysctl, vm_stat, top, ps, df, netstat
       // CPU reported as direct percentage (top computes delta internally)

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -483,11 +483,24 @@ function createSessionOpsApi(ctx) {
     async function getServerStats(event, payload) {
       const { sessionId } = payload;
       const session = sessions.get(sessionId);
-    
-      if (!session || !session.conn) {
+
+      if (!session) {
         return { success: false, error: 'Session not found or not connected' };
       }
-    
+
+      // Mosh sessions run over UDP via a local mosh-client PTY and have no
+      // ssh2 connection of their own. Lazily open a best-effort companion SSH
+      // connection (reusing the handshake credentials) so the host-info bar
+      // works for Mosh too (issue #1198). This is a no-op for real SSH
+      // sessions, which already carry session.conn.
+      if (!session.conn && typeof ensureMoshStatsConnection === 'function') {
+        await ensureMoshStatsConnection(session, sessionId, event?.sender);
+      }
+
+      if (!session.conn) {
+        return { success: false, error: 'Session not found or not connected' };
+      }
+
       const conn = session.conn;
     
       // macOS stats command: uses sysctl, vm_stat, top, ps, df, netstat

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -502,6 +502,15 @@ function createSessionOpsApi(ctx) {
 
       const conn = session.conn || session.moshStatsConn;
       if (!conn) {
+        // A Mosh session can be marked "connected" (and start polling) from
+        // the SSH bootstrap's visible output before swapToMoshClient stores
+        // moshStatsAuth. During that window there is nothing to connect with
+        // yet — report it as `pending` (not a hard failure) so the renderer's
+        // give-up-after-N-failures counter doesn't permanently disable stats
+        // before the handshake finishes and credentials become available.
+        if (session.type === 'mosh' && !session.moshStatsAuth && !session.moshStatsConnFailed) {
+          return { success: false, pending: true, error: 'Mosh handshake in progress' };
+        }
         return { success: false, error: 'Session not found or not connected' };
       }
     

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -1,0 +1,130 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { createSessionOpsApi } = require("./sessionOps.cjs");
+
+// A fake ssh2 exec stream that emits the canned stdout then closes.
+function fakeStream(stdout) {
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  setImmediate(() => {
+    if (stdout) stream.emit("data", Buffer.from(stdout));
+    stream.emit("close", 0);
+  });
+  return stream;
+}
+
+// A fake connection whose exec() always returns the same canned Linux stats
+// line so getServerStats parses a successful result.
+function fakeConn(stdout) {
+  return {
+    exec(_command, cb) {
+      cb(null, fakeStream(stdout));
+    },
+  };
+}
+
+// Minimal Linux stats payload: enough for the parser to report success
+// (memTotal present). CPU needs two samples for a delta, which is fine — the
+// success gate only requires cpu OR memTotal OR cpuCores to be non-null.
+const LINUX_STATS =
+  "CPURAW:1000 900|CORES:4|PERCORERAW:|MEMINFO:8000 4000 100 900 0 0|PROCS:|DISKS:|NET:";
+
+function makeSessionOps(sessions) {
+  return createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    // The rest of the sessionOps surface isn't exercised by getServerStats.
+  });
+}
+
+test("getServerStats opens a Mosh stats companion connection when session.conn is missing", async () => {
+  const sessions = new Map();
+  const session = { type: "mosh", moshStatsAuth: { hostname: "h", password: "p" } };
+  sessions.set("sid", session);
+
+  let ensureCalls = 0;
+  const api = createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    ensureMoshStatsConnection: async (s, id) => {
+      ensureCalls += 1;
+      assert.equal(s, session);
+      assert.equal(id, "sid");
+      // Simulate a successful companion connection.
+      s.conn = fakeConn(LINUX_STATS);
+      return s.conn;
+    },
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(ensureCalls, 1);
+  assert.equal(result.success, true);
+  assert.equal(result.stats.memTotal, 8000);
+  assert.equal(result.stats.cpuCores, 4);
+});
+
+test("getServerStats fails gracefully when the companion connection cannot be established", async () => {
+  const sessions = new Map();
+  const session = { type: "mosh", moshStatsAuth: { hostname: "h" } };
+  sessions.set("sid", session);
+
+  const api = createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    ensureMoshStatsConnection: async () => null, // no usable auth, etc.
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /not connected/);
+});
+
+test("getServerStats does not touch the companion path for a normal SSH session", async () => {
+  const sessions = new Map();
+  const session = { type: "ssh", conn: fakeConn(LINUX_STATS) };
+  sessions.set("sid", session);
+
+  let ensureCalls = 0;
+  const api = createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    ensureMoshStatsConnection: async () => {
+      ensureCalls += 1;
+      return null;
+    },
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(ensureCalls, 0);
+  assert.equal(result.success, true);
+});
+
+test("getServerStats returns an error for an unknown session", async () => {
+  const sessions = new Map();
+  const api = makeSessionOps(sessions);
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "missing" });
+
+  assert.equal(result.success, false);
+});

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -60,15 +60,18 @@ test("getServerStats opens a Mosh stats companion connection when session.conn i
       ensureCalls += 1;
       assert.equal(s, session);
       assert.equal(id, "sid");
-      // Simulate a successful companion connection.
-      s.conn = fakeConn(LINUX_STATS);
-      return s.conn;
+      // Simulate a successful companion connection. The real helper stores it
+      // on moshStatsConn (NOT conn) so it stays invisible to other bridges.
+      s.moshStatsConn = fakeConn(LINUX_STATS);
+      return s.moshStatsConn;
     },
   });
 
   const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
 
   assert.equal(ensureCalls, 1);
+  // session.conn must remain unset — only moshStatsConn carries the companion.
+  assert.equal(session.conn, undefined);
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.cpuCores, 4);

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -123,6 +123,58 @@ test("getServerStats does not touch the companion path for a normal SSH session"
   assert.equal(result.success, true);
 });
 
+test("getServerStats reports pending (not a hard failure) for a Mosh session before the handshake swap", async () => {
+  const sessions = new Map();
+  // Connected (renderer polls) but moshStatsAuth not yet assigned.
+  const session = { type: "mosh" };
+  sessions.set("sid", session);
+
+  let ensureCalls = 0;
+  const api = createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    ensureMoshStatsConnection: async () => {
+      ensureCalls += 1;
+      return null; // nothing to connect with yet
+    },
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(ensureCalls, 1);
+  assert.equal(result.success, false);
+  // pending must be set so the renderer doesn't count this toward give-up.
+  assert.equal(result.pending, true);
+});
+
+test("getServerStats reports a hard failure (not pending) once the companion permanently failed", async () => {
+  const sessions = new Map();
+  // moshStatsAuth present but the companion has permanently failed (e.g. auth
+  // rejected) — this is a real failure, the renderer should be allowed to give
+  // up.
+  const session = { type: "mosh", moshStatsAuth: { hostname: "h" }, moshStatsConnFailed: true };
+  sessions.set("sid", session);
+
+  const api = createSessionOpsApi({
+    get sessions() {
+      return sessions;
+    },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    ensureMoshStatsConnection: async () => null,
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, false);
+  assert.notEqual(result.pending, true);
+});
+
 test("getServerStats returns an error for an unknown session", async () => {
   const sessions = new Map();
   const api = makeSessionOps(sessions);

--- a/electron/bridges/sshBridge/systemKnownHosts.cjs
+++ b/electron/bridges/sshBridge/systemKnownHosts.cjs
@@ -1,0 +1,306 @@
+/**
+ * System OpenSSH known_hosts trust source.
+ *
+ * Mosh sessions are bootstrapped by the *system* `ssh`, which records the
+ * server's host key in the user's OpenSSH known_hosts files (e.g.
+ * `~/.ssh/known_hosts`). That file — not Netcatty's in-app known-hosts vault —
+ * is the real trust source for a Mosh connection: the user vetted and accepted
+ * the key through OpenSSH's own prompt during the handshake.
+ *
+ * The stats companion (moshStatsConnection.cjs) opens a *second*, background
+ * ssh2 connection and must only ever ride on a host whose key is already
+ * trusted. Netcatty's vault snapshot does not get updated when OpenSSH accepts
+ * a key, so a host trusted purely via the system would be wrongly classified as
+ * "unknown" and the companion permanently disabled (issue: Mosh stats never
+ * appear unless the user manually imports/scans the host into Netcatty).
+ *
+ * This module parses the system known_hosts files and answers a single
+ * question: "does a non-revoked system entry for this (host, port) record the
+ * EXACT public key the server just presented?" — matched by the key's SHA-256
+ * fingerprint. It only ever *adds* trust for keys the user's own OpenSSH
+ * already trusts; it never accepts an unknown or mismatched key. Unknown /
+ * changed keys remain rejected by the caller.
+ *
+ * Format handling (OpenSSH known_hosts(5)):
+ *   - comments (`#…`) and blank lines are ignored;
+ *   - plain host tokens, comma-separated host lists, and `[host]:port`;
+ *   - hashed entries `|1|<b64 salt>|<b64 HMAC-SHA1(salt, token)>` — the token
+ *     hashed is the canonical name OpenSSH uses (`[host]:port` for a non-default
+ *     port, the bare host otherwise), matched by recomputing the HMAC;
+ *   - marker lines: `@revoked` entries are treated as explicitly NOT trusted
+ *     (a revoked key never grants trust, even if its fingerprint matches);
+ *     `@cert-authority` lines are skipped (they delegate to a CA, not a literal
+ *     host key, which the fingerprint-equality check cannot model);
+ *   - multiple key types / multiple lines per host.
+ *
+ * Negation patterns (`!pattern`) and wildcard patterns (`*`, `?`) are NOT
+ * honored for matching: a wildcard could make an unrelated entry vouch for a
+ * host whose key we have not actually seen. We only trust exact host-token
+ * matches, which is the safe subset for "has the user's OpenSSH seen THIS key
+ * for THIS host". This is intentionally conservative — failing to match just
+ * leaves the Mosh stats bar empty (graceful degradation), never weakens
+ * security.
+ */
+function createSystemKnownHostsApi(ctx) {
+  const { fs, path, os, crypto, log } = ctx;
+
+  const HASH_MARKER = "|1|";
+
+  const normalizeHostname = (value) => String(value || "").trim().toLowerCase();
+
+  const stripFingerprintPadding = (value) =>
+    String(value || "").replace(/=+$/g, "");
+
+  // SHA-256 base64 fingerprint (no padding) of an OpenSSH public-key blob,
+  // computed the same way the live host-key verifier does so the two values
+  // are directly comparable.
+  const fingerprintFromKeyBlob = (base64Key) => {
+    if (typeof base64Key !== "string" || base64Key.length === 0) return "";
+    let blob;
+    try {
+      blob = Buffer.from(base64Key, "base64");
+    } catch {
+      return "";
+    }
+    if (blob.length === 0) return "";
+    return stripFingerprintPadding(
+      crypto.createHash("sha256").update(blob).digest("base64"),
+    );
+  };
+
+  // The canonical host token OpenSSH uses as the hashed/plain lookup key:
+  // the bare host on the default port, `[host]:port` otherwise. Built for the
+  // host exactly as supplied and (when different) its lowercase form, so a
+  // case-insensitive hostname still matches a hashed entry hashed in either
+  // case. Only ever broadens matching against the user's own trusted file.
+  const buildLookupTokens = (hostname, port) => {
+    const raw = String(hostname || "").trim();
+    if (!raw) return [];
+    const variants = new Set([raw]);
+    const lower = raw.toLowerCase();
+    variants.add(lower);
+    const tokens = new Set();
+    const usePort = Number.isFinite(port) && Number(port) !== 22;
+    for (const variant of variants) {
+      tokens.add(usePort ? `[${variant}]:${Number(port)}` : variant);
+    }
+    return [...tokens];
+  };
+
+  // Does a plain (non-hashed) host field cover (hostname, port)? Handles
+  // comma-separated lists and `[host]:port`. Wildcards and negations are not
+  // honored (see module header).
+  const plainHostFieldMatches = (hostField, hostname, port) => {
+    const wantHost = normalizeHostname(hostname);
+    if (!wantHost) return false;
+    const wantPort = Number.isFinite(port) ? Number(port) : 22;
+    const patterns = String(hostField || "").split(",");
+    for (const pattern of patterns) {
+      const token = pattern.trim();
+      if (!token) continue;
+      // Skip negations and wildcard patterns — not a safe exact match.
+      if (token.startsWith("!") || token.includes("*") || token.includes("?")) {
+        continue;
+      }
+      const bracket = token.match(/^\[([^\]]+)\]:(\d+)$/);
+      if (bracket) {
+        if (
+          normalizeHostname(bracket[1]) === wantHost &&
+          Number.parseInt(bracket[2], 10) === wantPort
+        ) {
+          return true;
+        }
+        continue;
+      }
+      // A bare token implies the default SSH port.
+      if (normalizeHostname(token) === wantHost && wantPort === 22) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Does a hashed host field (`|1|salt|hash`) cover (hostname, port)? Matches
+  // by recomputing HMAC-SHA1(salt, token) for each canonical lookup token.
+  const hashedHostFieldMatches = (hostField, hostname, port) => {
+    const field = String(hostField || "");
+    if (!field.startsWith(HASH_MARKER)) return false;
+    const rest = field.slice(HASH_MARKER.length);
+    const sep = rest.indexOf("|");
+    if (sep <= 0) return false;
+    const saltB64 = rest.slice(0, sep);
+    const expected = rest.slice(sep + 1);
+    if (!saltB64 || !expected) return false;
+
+    let salt;
+    try {
+      salt = Buffer.from(saltB64, "base64");
+    } catch {
+      return false;
+    }
+    if (salt.length === 0) return false;
+
+    let expectedBuf;
+    try {
+      expectedBuf = Buffer.from(expected, "base64");
+    } catch {
+      return false;
+    }
+    if (expectedBuf.length === 0) return false;
+
+    // Use the host string exactly as supplied (and its lowercase form) when
+    // building tokens — a hashed entry preserves the literal name OpenSSH saw.
+    for (const token of buildLookupTokens(hostname, port)) {
+      let computed;
+      try {
+        computed = crypto.createHmac("sha1", salt).update(token).digest();
+      } catch {
+        continue;
+      }
+      if (
+        computed.length === expectedBuf.length &&
+        crypto.timingSafeEqual(computed, expectedBuf)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const hostFieldMatches = (hostField, hostname, port) => {
+    if (String(hostField || "").startsWith(HASH_MARKER)) {
+      return hashedHostFieldMatches(hostField, hostname, port);
+    }
+    return plainHostFieldMatches(hostField, hostname, port);
+  };
+
+  // Parse one known_hosts line into { revoked, certAuthority, hostField,
+  // keyType, fingerprint } or null when it is a comment / blank / malformed.
+  // The fingerprint is the SHA-256 of the line's key blob.
+  const parseKnownHostsLine = (rawLine) => {
+    const line = String(rawLine || "").trim();
+    if (!line || line.startsWith("#")) return null;
+
+    let rest = line;
+    let revoked = false;
+    let certAuthority = false;
+
+    // Leading markers: `@revoked` / `@cert-authority` (one per line in
+    // practice). Consume any leading `@…` token.
+    while (rest.startsWith("@")) {
+      const spaceIdx = rest.search(/\s/);
+      if (spaceIdx < 0) return null;
+      const marker = rest.slice(0, spaceIdx);
+      if (marker === "@revoked") revoked = true;
+      else if (marker === "@cert-authority") certAuthority = true;
+      // Unknown markers are ignored but still consumed.
+      rest = rest.slice(spaceIdx).trim();
+    }
+
+    const parts = rest.split(/\s+/);
+    if (parts.length < 3) return null;
+    const [hostField, keyType, keyBlob] = parts;
+    if (!hostField || !keyType || !keyBlob) return null;
+
+    const fingerprint = fingerprintFromKeyBlob(keyBlob);
+    if (!fingerprint) return null;
+
+    return { revoked, certAuthority, hostField, keyType, fingerprint };
+  };
+
+  // The OpenSSH default trust files, mirroring localFsBridge.readKnownHosts so
+  // the companion trusts exactly what the user's system ssh would.
+  const getSystemKnownHostsPaths = () => {
+    const homeDir = os.homedir();
+    const paths = [path.join(homeDir, ".ssh", "known_hosts")];
+    if (process.platform === "win32") {
+      paths.push(
+        path.join(process.env.PROGRAMDATA || "C:\\ProgramData", "ssh", "known_hosts"),
+      );
+    } else {
+      paths.push("/etc/ssh/ssh_known_hosts");
+    }
+    return paths;
+  };
+
+  const readSystemKnownHostsContent = () => {
+    let combined = "";
+    for (const filePath of getSystemKnownHostsPaths()) {
+      let content;
+      try {
+        content = fs.readFileSync(filePath, "utf8");
+      } catch {
+        // Missing / unreadable file is expected (e.g. no /etc/ssh on macOS).
+        continue;
+      }
+      if (content && content.length > 0) {
+        combined += combined ? `\n${content}` : content;
+      }
+    }
+    return combined;
+  };
+
+  /**
+   * Is the host key the server just presented already trusted by the user's
+   * system OpenSSH known_hosts?
+   *
+   * Returns true ONLY when a non-revoked plain/hashed entry for (hostname,
+   * port) records a key whose SHA-256 fingerprint equals `fingerprint`. A
+   * `@revoked` entry that matches the fingerprint forces a hard `false` — a
+   * revoked key must never be trusted, even if an older non-revoked entry also
+   * lists it. Any read/parse error fails closed (returns false).
+   *
+   * @param {object} params
+   * @param {string} params.hostname - SSH host the companion targets.
+   * @param {number} [params.port=22] - SSH port.
+   * @param {string} params.fingerprint - SHA-256 base64 (no padding, no
+   *   `SHA256:` prefix) of the live host key.
+   * @returns {boolean}
+   */
+  const isHostKeyTrustedBySystem = ({ hostname, port = 22, fingerprint } = {}) => {
+    const wantFingerprint = stripFingerprintPadding(fingerprint);
+    if (!hostname || !wantFingerprint) return false;
+
+    let content;
+    try {
+      content = readSystemKnownHostsContent();
+    } catch (err) {
+      log?.(
+        "[Mosh] failed to read system known_hosts:",
+        err?.message || String(err),
+      );
+      return false;
+    }
+    if (!content) return false;
+
+    let trusted = false;
+    for (const rawLine of content.split(/\r?\n/)) {
+      const entry = parseKnownHostsLine(rawLine);
+      if (!entry) continue;
+      // @cert-authority delegates to a CA rather than pinning a literal host
+      // key; the fingerprint-equality model does not apply, so skip it.
+      if (entry.certAuthority) continue;
+      if (entry.fingerprint !== wantFingerprint) continue;
+      if (!hostFieldMatches(entry.hostField, hostname, port)) continue;
+      // A matching @revoked entry is an explicit "never trust this key" and
+      // overrides any non-revoked match.
+      if (entry.revoked) return false;
+      trusted = true;
+    }
+    return trusted;
+  };
+
+  return {
+    isHostKeyTrustedBySystem,
+    // Exposed for unit testing.
+    parseKnownHostsLine,
+    hostFieldMatches,
+    plainHostFieldMatches,
+    hashedHostFieldMatches,
+    fingerprintFromKeyBlob,
+    buildLookupTokens,
+    getSystemKnownHostsPaths,
+  };
+}
+
+module.exports = { createSystemKnownHostsApi };

--- a/electron/bridges/sshBridge/systemKnownHosts.test.cjs
+++ b/electron/bridges/sshBridge/systemKnownHosts.test.cjs
@@ -1,0 +1,393 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const path = require("node:path");
+const os = require("node:os");
+
+const { createSystemKnownHostsApi } = require("./systemKnownHosts.cjs");
+
+// Build an api whose fs.readFileSync returns the given content for the FIRST
+// system known_hosts path and throws (ENOENT-like) for the rest, mirroring the
+// common case of only `~/.ssh/known_hosts` existing.
+function makeApi(fileContents = {}) {
+  const reads = [];
+  const fs = {
+    readFileSync(filePath) {
+      reads.push(filePath);
+      if (Object.prototype.hasOwnProperty.call(fileContents, filePath)) {
+        return fileContents[filePath];
+      }
+      const err = new Error(`ENOENT: ${filePath}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+  const logs = [];
+  const api = createSystemKnownHostsApi({
+    fs,
+    path,
+    os,
+    crypto,
+    log: (...args) => logs.push(args),
+  });
+  return { api, reads, logs };
+}
+
+// SHA-256 base64 (no padding) fingerprint of an OpenSSH public-key blob.
+function fingerprintOf(base64Key) {
+  return crypto
+    .createHash("sha256")
+    .update(Buffer.from(base64Key, "base64"))
+    .digest("base64")
+    .replace(/=+$/g, "");
+}
+
+// A valid-looking ed25519 key blob seeded deterministically.
+function keyBlob(seed) {
+  return (
+    "AAAAC3NzaC1lZDI1NTE5AAAAI" +
+    crypto.createHash("sha256").update(seed).digest("base64").slice(0, 27)
+  );
+}
+
+// Produce a hashed host field `|1|salt|HMAC-SHA1(salt, token)` for `token`,
+// exactly as `ssh-keygen -H` would (verified empirically against ssh-keygen).
+function hashedHostField(token, salt = crypto.randomBytes(20)) {
+  const hash = crypto.createHmac("sha1", salt).update(token).digest("base64");
+  return `|1|${salt.toString("base64")}|${hash}`;
+}
+
+const HOME_KH = path.join(os.homedir(), ".ssh", "known_hosts");
+
+test("system known_hosts paths include the OpenSSH defaults for the platform", () => {
+  const { api } = makeApi();
+  const paths = api.getSystemKnownHostsPaths();
+  assert.ok(paths.includes(HOME_KH), "must include ~/.ssh/known_hosts");
+  if (process.platform === "win32") {
+    assert.ok(
+      paths.some((p) => /ssh[\\/]known_hosts$/i.test(p) && /ProgramData/i.test(p)),
+      "Windows must include %PROGRAMDATA%/ssh/known_hosts",
+    );
+  } else {
+    assert.ok(paths.includes("/etc/ssh/ssh_known_hosts"));
+  }
+});
+
+test("trusts a plain entry whose fingerprint matches (default port)", () => {
+  const blob = keyBlob("plain");
+  const { api } = makeApi({
+    [HOME_KH]: `example.com ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      port: 22,
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("matches hostnames case-insensitively", () => {
+  const blob = keyBlob("case");
+  const { api } = makeApi({ [HOME_KH]: `Example.COM ssh-ed25519 ${blob}\n` });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("matches a comma-separated host list", () => {
+  const blob = keyBlob("list");
+  const { api } = makeApi({
+    [HOME_KH]: `alias.example.com,192.0.2.5 ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "192.0.2.5",
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("matches a [host]:port entry only on the right non-default port", () => {
+  const blob = keyBlob("port");
+  const { api } = makeApi({
+    [HOME_KH]: `[example.com]:2222 ssh-ed25519 ${blob}\n`,
+  });
+  const fingerprint = fingerprintOf(blob);
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", port: 2222, fingerprint }),
+    true,
+  );
+  // Same host, wrong port -> not trusted.
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", port: 22, fingerprint }),
+    false,
+  );
+});
+
+test("does NOT trust a fingerprint mismatch (different key for the same host)", () => {
+  const stored = keyBlob("stored");
+  const live = keyBlob("live-different");
+  const { api } = makeApi({ [HOME_KH]: `example.com ssh-ed25519 ${stored}\n` });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      fingerprint: fingerprintOf(live),
+    }),
+    false,
+  );
+});
+
+test("does NOT trust when the host does not appear at all", () => {
+  const blob = keyBlob("other");
+  const { api } = makeApi({ [HOME_KH]: `other.example.com ssh-ed25519 ${blob}\n` });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    false,
+  );
+});
+
+test("trusts a hashed entry whose token + fingerprint match (default port)", () => {
+  const blob = keyBlob("hashed-default");
+  const { api } = makeApi({
+    [HOME_KH]: `${hashedHostField("example.com")} ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      port: 22,
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("trusts a hashed entry for a non-default port ([host]:port token)", () => {
+  const blob = keyBlob("hashed-port");
+  const { api } = makeApi({
+    [HOME_KH]: `${hashedHostField("[h.example.com]:2022")} ssh-ed25519 ${blob}\n`,
+  });
+  const fingerprint = fingerprintOf(blob);
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "h.example.com", port: 2022, fingerprint }),
+    true,
+  );
+  // The same hashed entry must NOT match the default-port (bare-host) token.
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "h.example.com", port: 22, fingerprint }),
+    false,
+  );
+});
+
+test("hashed entry does not match a different hostname (HMAC differs)", () => {
+  const blob = keyBlob("hashed-wrong-host");
+  const { api } = makeApi({
+    [HOME_KH]: `${hashedHostField("example.com")} ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "evil.example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    false,
+  );
+});
+
+test("matches against ssh-keygen-generated hashed entries (real fixtures)", () => {
+  // These two lines were produced by `ssh-keygen -H` from:
+  //   example.com         ssh-ed25519 …KEYDATA0000…
+  //   [example.com]:2222  ssh-ed25519 …KEYDATA1111…
+  // and pin the exact HMAC-SHA1 hashing OpenSSH uses (incl. the bracketed
+  // token for the non-default port).
+  const blobA = "AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYDATA0000000000000000000000000";
+  const blobB = "AAAAC3NzaC1lZDI1NTE5AAAAITESTKEYDATA1111111111111111111111111";
+  const content =
+    `|1|GjfxyrxES8V34vZje/1Lt1hHg/Y=|ZEnB8OFqAbq3mcme43V+dukJ51I= ssh-ed25519 ${blobA}\n` +
+    `|1|uZT6RsKBJirh9q9ycDnQUhVSmqI=|auufYDNOuFA17oSrmJwneIyl9po= ssh-ed25519 ${blobB}\n`;
+  const { api } = makeApi({ [HOME_KH]: content });
+
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      port: 22,
+      fingerprint: fingerprintOf(blobA),
+    }),
+    true,
+    "default-port hashed entry must match",
+  );
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      port: 2222,
+      fingerprint: fingerprintOf(blobB),
+    }),
+    true,
+    "non-default-port hashed entry must match",
+  );
+  // The 2222 key must NOT be accepted for port 22 (token differs).
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      port: 22,
+      fingerprint: fingerprintOf(blobB),
+    }),
+    false,
+  );
+});
+
+test("a @revoked entry with a matching fingerprint forces NOT trusted", () => {
+  const blob = keyBlob("revoked");
+  const fingerprint = fingerprintOf(blob);
+  // Even if a non-revoked entry would also match, the revoked one wins.
+  const content =
+    `example.com ssh-ed25519 ${blob}\n` +
+    `@revoked example.com ssh-ed25519 ${blob}\n`;
+  const { api } = makeApi({ [HOME_KH]: content });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", fingerprint }),
+    false,
+  );
+});
+
+test("a @revoked hashed entry also forces NOT trusted", () => {
+  const blob = keyBlob("revoked-hashed");
+  const fingerprint = fingerprintOf(blob);
+  const content = `@revoked ${hashedHostField("example.com")} ssh-ed25519 ${blob}\n`;
+  const { api } = makeApi({ [HOME_KH]: content });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", fingerprint }),
+    false,
+  );
+});
+
+test("a @cert-authority line is skipped (not a literal host-key match)", () => {
+  const blob = keyBlob("ca");
+  const { api } = makeApi({
+    [HOME_KH]: `@cert-authority *.example.com ssh-ed25519 ${blob}\n`,
+  });
+  // Fingerprint matches the CA key, but CA delegation is not modeled -> not
+  // trusted via this path.
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "host.example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    false,
+  );
+});
+
+test("comments, blank lines, and malformed lines are ignored", () => {
+  const blob = keyBlob("with-comments");
+  const content = [
+    "# a comment",
+    "",
+    "   ",
+    "garbage-without-enough-fields",
+    `example.com ssh-ed25519 ${blob}`,
+    "# trailing comment",
+  ].join("\n");
+  const { api } = makeApi({ [HOME_KH]: content });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("wildcard / negation host patterns are not honored for trust", () => {
+  const blob = keyBlob("wild");
+  const fingerprint = fingerprintOf(blob);
+  const wildcard = makeApi({ [HOME_KH]: `*.example.com ssh-ed25519 ${blob}\n` });
+  assert.equal(
+    wildcard.api.isHostKeyTrustedBySystem({ hostname: "host.example.com", fingerprint }),
+    false,
+    "a wildcard entry must not vouch for a specific host's key we never saw",
+  );
+  const negated = makeApi({
+    [HOME_KH]: `!example.com,example.com ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    negated.api.isHostKeyTrustedBySystem({ hostname: "example.com", fingerprint }),
+    true,
+    "the non-negated token in the list still matches",
+  );
+});
+
+test("combines multiple system files (home + /etc) into the trust set", () => {
+  const blob = keyBlob("etc");
+  const etcPath = process.platform === "win32"
+    ? path.join(process.env.PROGRAMDATA || "C:\\ProgramData", "ssh", "known_hosts")
+    : "/etc/ssh/ssh_known_hosts";
+  const { api } = makeApi({
+    [HOME_KH]: "# only comments here\n",
+    [etcPath]: `shared.example.com ssh-ed25519 ${blob}\n`,
+  });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "shared.example.com",
+      fingerprint: fingerprintOf(blob),
+    }),
+    true,
+  );
+});
+
+test("returns false (fail-closed) when no system files exist", () => {
+  const { api, reads } = makeApi(); // every read throws ENOENT
+  assert.equal(
+    api.isHostKeyTrustedBySystem({
+      hostname: "example.com",
+      fingerprint: "anything",
+    }),
+    false,
+  );
+  assert.ok(reads.length >= 1, "should have attempted to read at least one path");
+});
+
+test("returns false on empty/whitespace fingerprint or hostname", () => {
+  const blob = keyBlob("guard");
+  const { api } = makeApi({ [HOME_KH]: `example.com ssh-ed25519 ${blob}\n` });
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "", fingerprint: fingerprintOf(blob) }),
+    false,
+  );
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", fingerprint: "" }),
+    false,
+  );
+  assert.equal(api.isHostKeyTrustedBySystem({}), false);
+});
+
+test("fingerprint comparison ignores base64 padding differences", () => {
+  const blob = keyBlob("padding");
+  const { api } = makeApi({ [HOME_KH]: `example.com ssh-ed25519 ${blob}\n` });
+  const padded = `${fingerprintOf(blob)}==`;
+  assert.equal(
+    api.isHostKeyTrustedBySystem({ hostname: "example.com", fingerprint: padded }),
+    true,
+  );
+});
+
+test("parseKnownHostsLine extracts markers and fingerprint", () => {
+  const blob = keyBlob("parse-line");
+  const { api } = makeApi();
+  const entry = api.parseKnownHostsLine(`@revoked example.com ssh-rsa ${blob}`);
+  assert.equal(entry.revoked, true);
+  assert.equal(entry.certAuthority, false);
+  assert.equal(entry.hostField, "example.com");
+  assert.equal(entry.keyType, "ssh-rsa");
+  assert.equal(entry.fingerprint, fingerprintOf(blob));
+  assert.equal(api.parseKnownHostsLine("# comment"), null);
+  assert.equal(api.parseKnownHostsLine(""), null);
+  assert.equal(api.parseKnownHostsLine("too few"), null);
+});

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -786,9 +786,9 @@ function closeSession(event, payload) {
     } else if (session.proc) {
       session.proc.kill();
       // Mosh sessions may also carry a companion ssh2 connection opened
-      // lazily for host-info stats (issue #1198). It lives on session.conn
-      // but has no session.stream, so close it here too to avoid leaking it.
-      session.conn?.end();
+      // lazily for host-info stats (issue #1198), stored on moshStatsConn so
+      // it stays separate from session.conn. Close it here to avoid leaking it.
+      session.moshStatsConn?.end();
     } else if (session.socket) {
       session.socket.destroy();
     } else if (session.serialPort) {
@@ -923,8 +923,8 @@ function cleanupAllSessions() {
           // Ignore errors during cleanup
         }
         // Tear down a Mosh stats companion ssh2 connection if one was opened
-        // (issue #1198) — it has no session.stream of its own.
-        try { session.conn?.end(); } catch (e) { /* ignore */ }
+        // (issue #1198) — it lives on moshStatsConn, separate from session.conn.
+        try { session.moshStatsConn?.end(); } catch (e) { /* ignore */ }
       } else if (session.socket) {
         session.socket.destroy();
       } else if (session.serialPort) {

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -785,6 +785,10 @@ function closeSession(event, payload) {
       session.conn?.end();
     } else if (session.proc) {
       session.proc.kill();
+      // Mosh sessions may also carry a companion ssh2 connection opened
+      // lazily for host-info stats (issue #1198). It lives on session.conn
+      // but has no session.stream, so close it here too to avoid leaking it.
+      session.conn?.end();
     } else if (session.socket) {
       session.socket.destroy();
     } else if (session.serialPort) {
@@ -918,6 +922,9 @@ function cleanupAllSessions() {
         } catch (e) {
           // Ignore errors during cleanup
         }
+        // Tear down a Mosh stats companion ssh2 connection if one was opened
+        // (issue #1198) — it has no session.stream of its own.
+        try { session.conn?.end(); } catch (e) { /* ignore */ }
       } else if (session.socket) {
         session.socket.destroy();
       } else if (session.serialPort) {

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -371,6 +371,57 @@ test("startMoshSession handshake path sends the existing exit event after mosh-c
   assert.equal(exit.payload.reason, "exited");
 });
 
+test("startMoshSession stashes stats-companion auth after a successful handshake", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(
+    h.event,
+    {
+      ...h.options,
+      port: 2200,
+      password: "secret",
+      keyId: "key-1",
+      legacyAlgorithms: true,
+      skipEcdsaHostKey: true,
+      algorithmOverrides: { cipher: ["aes128-cbc"] },
+    },
+    { moshClientLookup: h.lookupOpts },
+  );
+
+  // No stats auth before the handshake completes — a failed handshake must
+  // not leave usable credentials lying around for the companion connection.
+  const before = h.sessions.get("mosh-test-session");
+  assert.equal(before.moshStatsAuth, undefined);
+
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+
+  const session = h.sessions.get("mosh-test-session");
+  assert.ok(session.moshStatsAuth, "expected moshStatsAuth to be set after swap");
+  assert.equal(session.moshStatsAuth.hostname, "example.com");
+  assert.equal(session.moshStatsAuth.port, 2200);
+  assert.equal(session.moshStatsAuth.username, "alice");
+  assert.equal(session.moshStatsAuth.password, "secret");
+  assert.equal(session.moshStatsAuth.legacyAlgorithms, true);
+  assert.equal(session.moshStatsAuth.skipEcdsaHostKey, true);
+  assert.deepEqual(session.moshStatsAuth.algorithmOverrides, { cipher: ["aes128-cbc"] });
+});
+
+test("closeSession ends a Mosh stats companion connection", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+
+  // Simulate a lazily-opened companion ssh2 connection on the live session.
+  const session = h.sessions.get("mosh-test-session");
+  let ended = false;
+  session.conn = { end() { ended = true; } };
+
+  h.bridge.closeSession(h.event, { sessionId: "mosh-test-session" });
+  assert.equal(ended, true);
+});
+
 test("startMoshSession fails when bundled mosh-client is missing even if PATH has mosh-client", async (t) => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-mosh-session-missing-"));
   t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -414,9 +414,10 @@ test("closeSession ends a Mosh stats companion connection", async (t) => {
   h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
 
   // Simulate a lazily-opened companion ssh2 connection on the live session.
+  // It lives on moshStatsConn (separate from session.conn) per #1198.
   const session = h.sessions.get("mosh-test-session");
   let ended = false;
-  session.conn = { end() { ended = true; } };
+  session.moshStatsConn = { end() { ended = true; } };
 
   h.bridge.closeSession(h.event, { sessionId: "mosh-test-session" });
   assert.equal(ended, true);

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -605,8 +605,9 @@ function createMoshSessionApi(ctx) {
           return;
         }
         // Tear down the host-info stats companion ssh2 connection (issue
-        // #1198) if one was opened — it outlives the mosh-client PTY otherwise.
-        try { session.conn?.end(); } catch { /* ignore */ }
+        // #1198) if one was opened — it lives on moshStatsConn and outlives
+        // the mosh-client PTY otherwise.
+        try { session.moshStatsConn?.end(); } catch { /* ignore */ }
         flush();
         sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
         const contents = electronModule.webContents.fromId(session.webContentsId);

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -549,7 +549,12 @@ function createMoshSessionApi(ctx) {
       // Netcatty already holds are kept — a password typed interactively into
       // the handshake PTY is not captured, so that case degrades gracefully.
       session.moshStatsAuth = {
-        hostname: parsed.host || options.hostname,
+        // Use the configured SSH host, NOT parsed.host: a `MOSH IP` line
+        // advertises the UDP endpoint for mosh-client, which can differ from
+        // the SSH endpoint on NAT / multi-homed hosts. The companion is an
+        // SSH connection, so it must target the same host the handshake's ssh
+        // did.
+        hostname: options.hostname,
         port: options.port || 22,
         username: options.username,
         password: options.password,

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -541,6 +541,27 @@ function createMoshSessionApi(ctx) {
       session.proc = mcPty;
       session.pty = mcPty;
       session.moshHandshakePhase = "mosh-client";
+
+      // The SSH handshake just succeeded, so these credentials are known
+      // good. Stash them so sshBridge can lazily open a best-effort companion
+      // SSH connection for host-info stats (CPU/mem/disk), which Mosh's UDP
+      // channel cannot provide on its own (issue #1198). Only credentials
+      // Netcatty already holds are kept — a password typed interactively into
+      // the handshake PTY is not captured, so that case degrades gracefully.
+      session.moshStatsAuth = {
+        hostname: parsed.host || options.hostname,
+        port: options.port || 22,
+        username: options.username,
+        password: options.password,
+        privateKey: options.privateKey,
+        passphrase: options.passphrase,
+        certificate: options.certificate,
+        keyId: options.keyId,
+        identityFilePaths: options.identityFilePaths,
+        legacyAlgorithms: options.legacyAlgorithms,
+        skipEcdsaHostKey: options.skipEcdsaHostKey,
+        algorithmOverrides: options.algorithmOverrides,
+      };
     
       if (process.platform !== "win32") {
         const decoder = new StringDecoder("utf8");
@@ -574,6 +595,9 @@ function createMoshSessionApi(ctx) {
         if (sessions.get(sessionId) !== session || session.closed) {
           return;
         }
+        // Tear down the host-info stats companion ssh2 connection (issue
+        // #1198) if one was opened — it outlives the mosh-client PTY otherwise.
+        try { session.conn?.end(); } catch { /* ignore */ }
         flush();
         sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
         const contents = electronModule.webContents.fromId(session.webContentsId);

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -566,6 +566,10 @@ function createMoshSessionApi(ctx) {
         legacyAlgorithms: options.legacyAlgorithms,
         skipEcdsaHostKey: options.skipEcdsaHostKey,
         algorithmOverrides: options.algorithmOverrides,
+        // Used to verify the host key before the companion sends a saved
+        // password (see moshStatsConnection.cjs). Public-key / agent auth
+        // does not depend on this.
+        knownHosts: options.knownHosts,
       };
     
       if (process.platform !== "win32") {

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -29,6 +29,12 @@ declare global {
       moshServerPath?: string;
       moshClientPath?: string;
       agentForwarding?: boolean;
+      // Algorithm settings, forwarded so the host-info stats companion SSH
+      // connection (issue #1198) negotiates the same KEX / cipher / host-key
+      // set the interactive session would.
+      legacyAlgorithms?: boolean;
+      skipEcdsaHostKey?: boolean;
+      algorithmOverrides?: import("../../domain/models").HostAlgorithmOverrides;
       cols?: number;
       rows?: number;
       charset?: string;

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -120,6 +120,10 @@ declare global {
     /** Get server stats (CPU, Memory, Disk, Network) from an active SSH session */
     getServerStats?(sessionId: string): Promise<{
       success: boolean;
+      // Transient "not ready yet" (e.g. a Mosh session whose SSH handshake is
+      // still in progress, #1198). Callers should keep polling and NOT count
+      // this toward any consecutive-failure give-up.
+      pending?: boolean;
       error?: string;
       stats?: {
         cpu: number | null;           // CPU usage percentage (0-100)

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -35,6 +35,9 @@ declare global {
       legacyAlgorithms?: boolean;
       skipEcdsaHostKey?: boolean;
       algorithmOverrides?: import("../../domain/models").HostAlgorithmOverrides;
+      // Known hosts, used to verify the host key before the stats companion
+      // connection (issue #1198) sends a saved password.
+      knownHosts?: import("../../domain/models").KnownHost[];
       cols?: number;
       rows?: number;
       charset?: string;


### PR DESCRIPTION
## Problem

When connecting with Mosh, the terminal header did not show CPU, memory, or other host stats. SSH sessions worked correctly. See #1198.

## Root Cause

Host stats are collected by periodically executing commands over an SSH channel and reading `/proc`. A Mosh session runs through `mosh-server` and `mosh-client` over UDP, and after the session starts there is no reusable ssh2 connection in `session.conn`.

## Approach

For Mosh sessions, create a lightweight stats companion SSH connection used only for periodic host-stat collection. It reuses the target host and credentials already used for the Mosh handshake, and stores the connection as `session.moshStatsConn` rather than `session.conn` so SFTP, MCP exec, and getSessionPwd do not accidentally use it.

SSH behavior is unchanged. If non-interactive authentication is unavailable or the host cannot be reached, stats silently remain empty.

## Host-Key Safety

The companion connection is background-only, so host-key verification is strict. All auth methods install a verifier, and the connection is allowed only when the host key is already trusted in Netcatty known-hosts. Unknown or changed keys are rejected without prompting, and stats stay empty.

## Tests

- Added and updated tests for Mosh stats connections, server stats session ops, and Mosh handshake behavior.
- Covered host verifier accept, reject, and permanent-failure paths, including key-only and agent-only auth.
- `npm run lint` passed.
- Related bridge tests passed.
- `npm run build` passed.

Closes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
