### PR TITLE
fix: persist Google Drive token refreshes (follow-up to #1208)

### DIFF
--- a/infrastructure/services/adapters/GoogleDriveAdapter.test.ts
+++ b/infrastructure/services/adapters/GoogleDriveAdapter.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { GoogleDriveAdapter } from './GoogleDriveAdapter.ts';
+import type { OAuthTokens } from '../../../domain/sync.ts';
+
+type WindowGlobal = typeof globalThis & { window?: unknown };
+
+function setBridge(bridge: Record<string, unknown>): () => void {
+  const g = globalThis as WindowGlobal;
+  const original = g.window;
+  // Loosely typed: the real window.netcatty is a large NetcattyBridge; tests
+  // only stub the handful of Google methods the adapter actually calls.
+  g.window = { netcatty: bridge } as unknown as Window & typeof globalThis;
+  return () => {
+    g.window = original;
+  };
+}
+
+const expiredTokens = (): OAuthTokens => ({
+  accessToken: 'old-access',
+  refreshToken: 'old-refresh',
+  // Already expired so any operation forces a refresh.
+  expiresAt: Date.now() - 60_000,
+  tokenType: 'Bearer',
+});
+
+test('refreshing tokens during an operation fires the persistence callback with refreshed tokens', async () => {
+  const refreshed: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  let refreshCalledWith: string | undefined;
+  const remoteSyncedFile = { meta: { version: 1 }, payload: 'x' };
+  const restore = setBridge({
+    googleRefreshAccessToken: async ({ refreshToken }: { refreshToken: string }) => {
+      refreshCalledWith = refreshToken;
+      return refreshed;
+    },
+    googleDriveDownloadSyncFile: async ({ accessToken }: { accessToken: string }) => {
+      // Operation must run with the refreshed access token.
+      assert.equal(accessToken, 'fresh-access');
+      return { syncedFile: remoteSyncedFile };
+    },
+  });
+
+  try {
+    const adapter = new GoogleDriveAdapter(expiredTokens(), 'file-1');
+    const persisted: OAuthTokens[] = [];
+    adapter.setOnTokensRefreshed((tokens) => persisted.push(tokens));
+
+    const result = await adapter.download();
+
+    assert.deepEqual(result, remoteSyncedFile);
+    assert.equal(refreshCalledWith, 'old-refresh');
+    assert.equal(persisted.length, 1);
+    assert.deepEqual(persisted[0], refreshed);
+    // Adapter also exposes the refreshed tokens for the caller to persist.
+    assert.deepEqual(adapter.getTokens(), refreshed);
+  } finally {
+    restore();
+  }
+});
+
+test('refresh preserves the prior refresh token when Google omits a new one', async () => {
+  // Google's refresh response frequently has no refresh_token. The persisted
+  // tokens must keep the previous refresh token, or the connection becomes
+  // unrefreshable on the next launch.
+  const refreshedWithoutRefreshToken: OAuthTokens = {
+    accessToken: 'fresh-access',
+    // No refreshToken — mirrors a real Google refresh_token response.
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const remoteSyncedFile = { meta: { version: 1 }, payload: 'x' };
+  const restore = setBridge({
+    googleRefreshAccessToken: async () => refreshedWithoutRefreshToken,
+    googleDriveDownloadSyncFile: async () => ({ syncedFile: remoteSyncedFile }),
+  });
+
+  try {
+    const adapter = new GoogleDriveAdapter(expiredTokens(), 'file-1');
+    const persisted: OAuthTokens[] = [];
+    adapter.setOnTokensRefreshed((tokens) => persisted.push(tokens));
+
+    await adapter.download();
+
+    assert.equal(persisted.length, 1);
+    // The persisted (and in-memory) tokens carry the original refresh token.
+    assert.equal(persisted[0].refreshToken, 'old-refresh');
+    assert.equal(persisted[0].accessToken, 'fresh-access');
+    assert.equal(adapter.getTokens()?.refreshToken, 'old-refresh');
+  } finally {
+    restore();
+  }
+});
+
+test('setTokens refreshes an expired token and persists the refreshed tokens', async () => {
+  const refreshed: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const restore = setBridge({
+    googleRefreshAccessToken: async () => refreshed,
+    googleGetUserInfo: async () => ({
+      id: 'u1',
+      email: 'u@example.com',
+      name: 'User',
+      picture: '',
+    }),
+  });
+
+  try {
+    const adapter = new GoogleDriveAdapter();
+    const persisted: OAuthTokens[] = [];
+    adapter.setOnTokensRefreshed((tokens) => persisted.push(tokens));
+
+    await adapter.setTokens(expiredTokens());
+
+    assert.deepEqual(persisted, [refreshed]);
+    assert.deepEqual(adapter.getTokens(), refreshed);
+    assert.equal(adapter.accountInfo?.id, 'u1');
+  } finally {
+    restore();
+  }
+});
+
+test('a persistence callback that throws does not abort the operation', async () => {
+  const refreshed: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const remoteSyncedFile = { meta: { version: 1 }, payload: 'x' };
+  const restore = setBridge({
+    googleRefreshAccessToken: async () => refreshed,
+    googleDriveDownloadSyncFile: async () => ({ syncedFile: remoteSyncedFile }),
+  });
+
+  try {
+    const adapter = new GoogleDriveAdapter(expiredTokens(), 'file-1');
+    adapter.setOnTokensRefreshed(() => {
+      throw new Error('persist boom');
+    });
+
+    // Refresh succeeds, the throwing callback is swallowed, the op completes.
+    const result = await adapter.download();
+    assert.deepEqual(result, remoteSyncedFile);
+    assert.deepEqual(adapter.getTokens(), refreshed);
+  } finally {
+    restore();
+  }
+});
+
+test('signOut clears the refresh persistence callback', async () => {
+  const refreshed: OAuthTokens = {
+    accessToken: 'fresh-access',
+    refreshToken: 'old-refresh',
+    expiresAt: Date.now() + 3_600_000,
+    tokenType: 'Bearer',
+  };
+  const restore = setBridge({
+    googleRefreshAccessToken: async () => refreshed,
+    googleGetUserInfo: async () => ({
+      id: 'u1',
+      email: 'u@example.com',
+      name: 'User',
+      picture: '',
+    }),
+  });
+
+  try {
+    const adapter = new GoogleDriveAdapter(expiredTokens(), 'file-1');
+    let callbackFired = false;
+    adapter.setOnTokensRefreshed(() => {
+      callbackFired = true;
+    });
+    adapter.signOut();
+    // Re-arm tokens and refresh; the callback must not fire after signOut.
+    await adapter.setTokens(expiredTokens());
+    assert.equal(callbackFired, false);
+  } finally {
+    restore();
+  }
+});

--- a/infrastructure/services/adapters/GoogleDriveAdapter.ts
+++ b/infrastructure/services/adapters/GoogleDriveAdapter.ts
@@ -485,12 +485,55 @@ export class GoogleDriveAdapter {
   private fileId: string | null = null;
   private account: ProviderAccount | null = null;
   private pkceChallenge: PKCEChallenge | null = null;
+  /**
+   * Invoked whenever the access token is silently refreshed. Lets the owner
+   * (CloudSyncManager) persist the rotated tokens so the next launch doesn't
+   * load a stale access token and force a reconnect. Mirrors the OneDrive fix
+   * (#1189 / #1208); Google differs in that its refresh response usually omits a
+   * new refresh token, so refreshTokens() carries the previous one forward.
+   */
+  private onTokensRefreshed: ((tokens: OAuthTokens) => void) | null = null;
 
   constructor(tokens?: OAuthTokens, fileId?: string) {
     if (tokens) {
       this.tokens = tokens;
     }
     this.fileId = fileId || null;
+  }
+
+  /**
+   * Register a callback that receives refreshed tokens so the caller can
+   * persist them. Passing null removes the callback.
+   */
+  setOnTokensRefreshed(callback: ((tokens: OAuthTokens) => void) | null): void {
+    this.onTokensRefreshed = callback;
+  }
+
+  /**
+   * Refresh the access token using the supplied refresh token, store the
+   * rotated tokens in-memory, and notify the persistence callback. Google
+   * typically returns the same (or no) refresh token on refresh, so the prior
+   * refresh token is preserved when the response omits one — otherwise the
+   * persisted credentials would lose the ability to refresh again and force a
+   * reconnect on the next launch.
+   */
+  private async refreshTokens(refreshToken: string): Promise<OAuthTokens> {
+    const refreshed = await refreshAccessToken(refreshToken);
+    // Google's refresh response frequently omits refresh_token (it does not
+    // rotate on every refresh). Never let a missing value clobber the working
+    // refresh token, or the persisted connection becomes unrefreshable.
+    const merged: OAuthTokens = {
+      ...refreshed,
+      refreshToken: refreshed.refreshToken || refreshToken,
+    };
+    this.tokens = merged;
+    try {
+      this.onTokensRefreshed?.(merged);
+    } catch {
+      // Persistence is best-effort; a failed save must not abort the sync that
+      // triggered the refresh — the fresh tokens still work for this session.
+    }
+    return merged;
   }
 
   get isAuthenticated(): boolean {
@@ -550,7 +593,7 @@ export class GoogleDriveAdapter {
     // Refresh if expired
     if (tokens.expiresAt && Date.now() > tokens.expiresAt - 60000) {
       if (tokens.refreshToken) {
-        this.tokens = await refreshAccessToken(tokens.refreshToken);
+        this.tokens = await this.refreshTokens(tokens.refreshToken);
       } else {
         throw new Error('Token expired and no refresh token');
       }
@@ -573,7 +616,7 @@ export class GoogleDriveAdapter {
 
     if (this.tokens.expiresAt && Date.now() > this.tokens.expiresAt - 60000) {
       if (this.tokens.refreshToken) {
-        this.tokens = await refreshAccessToken(this.tokens.refreshToken);
+        this.tokens = await this.refreshTokens(this.tokens.refreshToken);
       } else {
         throw new Error('Token expired');
       }
@@ -590,6 +633,7 @@ export class GoogleDriveAdapter {
     this.fileId = null;
     this.account = null;
     this.pkceChallenge = null;
+    this.onTokensRefreshed = null;
   }
 
   /**

--- a/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
+++ b/infrastructure/services/cloudSync/persistRefreshedTokens.test.ts
@@ -110,6 +110,71 @@ test('attachTokenRefreshPersistence is a no-op for adapters without the hook', (
   );
 });
 
+test('attachTokenRefreshPersistence persists Google tokens refreshed mid-session', async () => {
+  // End-to-end: the real GoogleDriveAdapter refreshes during an operation and
+  // the rotated tokens reach saveProviderConnection (the regression #1208 fixed
+  // for OneDrive — Google previously had no setOnTokensRefreshed hook).
+  const { manager, saved } = createManager();
+  manager.providerDecryptSeq.google = 0;
+  manager.state.providers.google = {
+    provider: 'google',
+    status: 'connected',
+    tokens: { accessToken: 'old', refreshToken: 'google-refresh', tokenType: 'Bearer' },
+    account: { id: 'g1' },
+    resourceId: 'gfile-1',
+  } as ProviderConnection;
+
+  const g = globalThis as typeof globalThis & { window?: unknown };
+  const originalWindow = g.window;
+  g.window = {
+    netcatty: {
+      // Google's refresh response omits refresh_token — the adapter must carry
+      // the previous one forward so the persisted connection stays refreshable.
+      googleRefreshAccessToken: async () => ({
+        accessToken: 'fresh-access',
+        expiresAt: Date.now() + 3_600_000,
+        tokenType: 'Bearer',
+      }),
+      googleDriveDownloadSyncFile: async () => ({
+        syncedFile: { meta: { version: 1 }, payload: 'x' },
+      }),
+    },
+  } as unknown as Window & typeof globalThis;
+
+  try {
+    const { GoogleDriveAdapter } = await import('../adapters/GoogleDriveAdapter.ts');
+    const adapter = new GoogleDriveAdapter(
+      {
+        accessToken: 'old',
+        refreshToken: 'google-refresh',
+        // Expired so the operation forces a refresh.
+        expiresAt: Date.now() - 60_000,
+        tokenType: 'Bearer',
+      },
+      'gfile-1',
+    );
+
+    attachTokenRefreshPersistence.call(manager, 'google', adapter as never);
+
+    await adapter.download();
+    // persistRefreshedProviderTokens fires saveProviderConnection fire-and-forget.
+    await Promise.resolve();
+
+    assert.equal(saved.length, 1);
+    assert.equal(saved[0].provider, 'google');
+    assert.equal(saved[0].tokens?.accessToken, 'fresh-access');
+    // Original refresh token preserved despite the omitted refresh_token.
+    assert.equal(saved[0].tokens?.refreshToken, 'google-refresh');
+    // State updated and other fields preserved.
+    assert.equal(manager.state.providers.google.tokens?.accessToken, 'fresh-access');
+    assert.equal(manager.state.providers.google.account?.id, 'g1');
+    assert.equal(manager.state.providers.google.resourceId, 'gfile-1');
+    assert.equal(manager.providerDecryptSeq.google, 1);
+  } finally {
+    g.window = originalWindow;
+  }
+});
+
 test('handleProviderReauthRequired clears OneDrive tokens and stops it being sync-ready', async () => {
   const { manager, saved } = createManager();
   let signedOut = false;

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -386,10 +386,13 @@ export async function getConnectedAdapterImpl(this: any,provider: CloudProvider)
   }
 
 /**
- * Wire an OAuth adapter's token-refresh callback so silently rotated tokens are
- * persisted. Without this, OneDrive's rotating refresh tokens go stale after the
- * first in-session refresh and the next launch is forced to reconnect (#1189).
- * Only OneDrive currently exposes setOnTokensRefreshed; other adapters are no-ops.
+ * Wire an OAuth adapter's token-refresh callback so silently refreshed tokens
+ * are persisted. Without this, an adapter that refreshes its access token only
+ * updates memory and the next launch loads a stale token and is forced to
+ * reconnect — OneDrive's rotating refresh tokens go stale after the first
+ * in-session refresh (#1189), and Google's refreshed access token is likewise
+ * lost on restart. OneDrive and Google expose setOnTokensRefreshed; adapters
+ * without it (GitHub, WebDAV, S3) are no-ops.
  */
 export function attachTokenRefreshPersistence(
   this: any,


### PR DESCRIPTION
## Background

This is the Google Drive counterpart to #1208, which fixed OneDrive access-token refresh persistence. `GoogleDriveAdapter` had the same gap: refreshed access tokens were stored only in memory and were not persisted, so the next app launch could load an expired token and force the user to authorize again.

Refs #1189

## Changes

- Adds `setOnTokensRefreshed(callback)` to `GoogleDriveAdapter`.
- Adds a shared `refreshTokens()` helper so `setTokens` and `ensureValidToken` both update memory and trigger persistence.
- Clears the refresh callback on `signOut()`.
- Preserves the previous Google refresh token when a refresh response omits a new one, matching Google OAuth behavior.
- Updates comments around token refresh persistence to include Google.

## Out of Scope

This PR does not generalize OneDrive's reauth-required marker flow to Google. That would require a broader cross-layer refactor and is left for follow-up work.

## Tests

- Adds `GoogleDriveAdapter.test.ts` for refreshed-token persistence, refresh-token preservation, expired-token refresh, best-effort callbacks, and sign-out cleanup.
- Extends `persistRefreshedTokens.test.ts` with a real Google adapter path through `attachTokenRefreshPersistence`.
- `npm run lint` passed.
- New, related, and existing OneDrive tests passed.
- Local `codex review --base main` completed clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
