### PR TITLE
fix(terminal): encode input with the session charset (#1216)

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -386,6 +386,7 @@ const sessionEncodings = new Map();
 // Per-session stateful iconv decoders (keyed by sessionId, value: { stdout, stderr })
 const sessionDecoders = new Map();
 const iconv = require("iconv-lite");
+const { encodeTerminalInput } = require("./terminalEncoding.cjs");
 
 function getSessionDecoder(sessionId, stream) {
   let decoders = sessionDecoders.get(sessionId);
@@ -786,7 +787,7 @@ const startSessionApi = createStartSessionApi({
   fs, path, os, net, crypto, Buffer, process, console, setTimeout, clearTimeout,
   createProxySocket, attachX11Forwarding, createPtyOutputBuffer, sessionLogStreamManager,
   trackSessionIdlePrompt, looksLikeIdleAutoLogout, createZmodemSentry, enableSshNoDelay, enableTcpNoDelay,
-  iconv, getSessionDecoder, resetSessionDecoders, sessionEncodings, sessionDecoders,
+  iconv, getSessionDecoder, resetSessionDecoders, sessionEncodings, sessionDecoders, encodeTerminalInput,
   connectThroughChain, getAvailableAgentSocket, getCachedAuthMethod, setCachedAuthMethod, clearCachedAuthMethod,
   attachSshDebugLogger, logSshAlgorithms, resolveLangFromCharset, safeSend, zmodemOverwritePending,
   shouldLogSshDebugMessage, log, createSshDiagnosticLogger,

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -896,6 +896,11 @@ function createSessionOpsApi(ctx) {
         return { ok: false, encoding: enc };
       }
       sessionEncodings.set(sessionId, enc);
+      // Mirror onto the session record so the terminal input path
+      // (terminalBridge.writeToSession) encodes keystrokes with the same
+      // charset the output decoder now uses — keeping input/output symmetric
+      // on non-UTF-8 devices (issue #1216).
+      session.encoding = enc;
       // Reset stateful decoders so new data uses the updated encoding
       resetSessionDecoders(sessionId);
       return { ok: true, encoding: enc };

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -218,15 +218,27 @@ function createStartSessionApi(ctx) {
         }
       });
 
-      // Pre-seed encoding from host charset if it's a GB variant
-      if (options.charset && /^gb/i.test(String(options.charset).trim())) {
+      // Pre-seed encoding from host charset if it's a GB variant. Seed BOTH the
+      // output decoder (sessionEncodings) and the terminal input encoder
+      // (session.encoding, read by terminalBridge.writeToSession) so they agree
+      // from the first byte — otherwise a GB18030 host decoded output as GB18030
+      // while encoding keystrokes as UTF-8 until the user re-picked the encoding
+      // (issue #1216). The gate matches the renderer's two-value encoding state
+      // (Terminal.tsx) so behavior for other/arbitrary charsets is unchanged:
+      // the renderer pushes the effective encoding via setEncoding on attach,
+      // and that handler keeps both halves in sync.
+      const gbCharset = options.charset && /^gb/i.test(String(options.charset).trim());
+      if (gbCharset) {
         sessionEncodings.set(sessionId, "gb18030");
+        session.encoding = "gb18030";
       }
 
-      // Run startup command if specified
+      // Run startup command if specified. Encode it with the same charset the
+      // interactive input path uses (issue #1216) so a startup command with
+      // non-ASCII characters reaches a GB18030 host correctly too.
       if (options.startupCommand) {
         setTimeout(() => {
-          stream.write(`${options.startupCommand}\n`);
+          stream.write(encodeTerminalInput(`${options.startupCommand}\n`, session.encoding));
         }, 300);
       }
 

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -28,26 +28,13 @@ const telnetProtocol = require("./telnetProtocol.cjs");
 const { createPtyOutputBuffer } = require("./ptyOutputBuffer.cjs");
 const { enableTcpNoDelay } = require("./tcpNoDelay.cjs");
 const { releaseConnectionRef } = require("./sshConnectionPool.cjs");
+const { normalizeTerminalEncoding, encodeTerminalInput } = require("./terminalEncoding.cjs");
 
 const execFileAsync = promisify(execFile);
 
 // Shared references
 let sessions = null;
 let electronModule = null;
-
-// Normalize user-facing charset names into an iconv-lite encoding identifier.
-// iconv-lite accepts a wide range of aliases directly ("utf-8", "gbk", etc.),
-// so mostly this just lowercases + collapses non-alphanumerics and maps a few
-// obvious GB* variants to gb18030 which is the superset we ship the encoding
-// switcher with. Anything iconv doesn't recognize falls back to utf-8.
-function normalizeTerminalEncoding(charset) {
-  if (!charset) return 'utf-8';
-  const raw = String(charset).trim().toLowerCase();
-  const normalized = raw.replace(/[^a-z0-9]/g, '');
-  if (['utf8', 'utf-8'].includes(normalized)) return 'utf-8';
-  if (normalized === 'gb18030' || normalized === 'gbk' || normalized === 'gb2312') return 'gb18030';
-  return iconv.encodingExists(raw) ? raw : 'utf-8';
-}
 
 const DEFAULT_UTF8_LOCALE = "en_US.UTF-8";
 const LOGIN_SHELLS = new Set(["bash", "zsh", "fish", "ksh"]);
@@ -679,26 +666,35 @@ function writeToSession(event, payload) {
       session.autoLogin?.handleUserInput();
     }
 
+    // Encode keystrokes with the SAME charset the output path decodes with so
+    // input and output stay symmetric on non-UTF-8 devices (issue #1216).
+    // session.encoding is the normalized iconv identifier; it is only set on
+    // sessions whose output is iconv-decoded (SSH / telnet / serial). Mosh and
+    // local PTY leave it unset, so encodeTerminalInput returns the original
+    // UTF-8 string for them. For UTF-8 it also returns the string unchanged, so
+    // the transport's native string serialization keeps handling that case.
+    const outgoing = encodeTerminalInput(payload.data, session.encoding);
+
     if (session.stream) {
-      session.stream.write(payload.data);
+      session.stream.write(outgoing);
     } else if (session.proc) {
-      session.proc.write(payload.data);
+      session.proc.write(outgoing);
     } else if (session.socket) {
       // Telnet only: any 0xFF byte going out the wire must be doubled, or
       // the peer will treat it as the start of an IAC command sequence and
       // eat the next byte (RFC 854 §"Data Stream"). UTF-8 keyboard input
       // never produces 0xFF, but paste of binary content and some legacy
       // encodings do. Cheap no-op when there is no 0xFF.
-      let outgoing = payload.data;
+      let wireData = outgoing;
       if (session.type === 'telnet-native' && session.telnetProtocolActive) {
-        if (typeof outgoing === 'string') {
-          outgoing = Buffer.from(outgoing, 'utf8');
+        if (typeof wireData === 'string') {
+          wireData = Buffer.from(wireData, 'utf8');
         }
-        outgoing = telnetProtocol.escapeIacForWire(outgoing);
+        wireData = telnetProtocol.escapeIacForWire(wireData);
       }
-      session.socket.write(outgoing);
+      session.socket.write(wireData);
     } else if (session.serialPort) {
-      session.serialPort.write(payload.data);
+      session.serialPort.write(outgoing);
     }
   } catch (err) {
     if (err.code !== 'EPIPE' && err.code !== 'ERR_STREAM_DESTROYED') {
@@ -989,6 +985,7 @@ module.exports = {
   startSerialSession,
   listSerialPorts,
   writeToSession,
+  setSessionEncoding,
   resizeSession,
   setSessionFlowPaused,
   closeSession,

--- a/electron/bridges/terminalBridge.inputEncoding.test.cjs
+++ b/electron/bridges/terminalBridge.inputEncoding.test.cjs
@@ -1,0 +1,190 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const net = require("node:net");
+const iconv = require("iconv-lite");
+
+const terminalBridge = require("./terminalBridge.cjs");
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve(server.address().port);
+    });
+  });
+}
+
+function waitFor(predicate, timeoutMs = 1000) {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error("Timed out waiting for telnet input bytes"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+// These tests drive the real terminalBridge.writeToSession path over a raw TCP
+// "device" that never speaks the Telnet protocol (no IAC bytes), so the bytes
+// captured server-side are exactly what the input path serialized — proving
+// the keystroke encoding without IAC-escaping noise. They guard issue #1216:
+// input must use the SAME charset the output decoder uses.
+
+function initBridge(sessions) {
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({ send() {} }),
+      },
+    },
+  });
+}
+
+test("Telnet input is encoded with the session's GB18030 charset", async () => {
+  const chunks = [];
+  const sockets = new Set();
+  let serverSocket = null;
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", (buf) => chunks.push(buf));
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  initBridge(sessions);
+
+  try {
+    await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-gb18030-input",
+        hostname: "127.0.0.1",
+        port,
+        // No saved credentials → auto-login stays idle and does not inject bytes.
+        charset: "GB18030",
+      },
+    );
+    await waitFor(() => serverSocket);
+
+    terminalBridge.writeToSession(
+      {},
+      { sessionId: "telnet-gb18030-input", data: "你好\r" },
+    );
+
+    await waitFor(() => Buffer.concat(chunks).length >= 5);
+    const received = Buffer.concat(chunks);
+    assert.deepEqual([...received], [...iconv.encode("你好\r", "gb18030")]);
+    // It must NOT be the UTF-8 serialization that the old code always sent.
+    assert.notDeepEqual([...received], [...Buffer.from("你好\r", "utf8")]);
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("Telnet input stays UTF-8 when no charset is configured", async () => {
+  const chunks = [];
+  const sockets = new Set();
+  let serverSocket = null;
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", (buf) => chunks.push(buf));
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  initBridge(sessions);
+
+  try {
+    await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-utf8-input",
+        hostname: "127.0.0.1",
+        port,
+      },
+    );
+    await waitFor(() => serverSocket);
+
+    terminalBridge.writeToSession(
+      {},
+      { sessionId: "telnet-utf8-input", data: "你好\r" },
+    );
+
+    await waitFor(() => Buffer.concat(chunks).length >= 7);
+    const received = Buffer.concat(chunks);
+    assert.deepEqual([...received], [...Buffer.from("你好\r", "utf8")]);
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("setSessionEncoding switches the Telnet input charset at runtime", async () => {
+  const chunks = [];
+  const sockets = new Set();
+  let serverSocket = null;
+  const server = net.createServer((socket) => {
+    serverSocket = socket;
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("data", (buf) => chunks.push(buf));
+  });
+
+  const port = await listen(server);
+  const sessions = new Map();
+  initBridge(sessions);
+
+  try {
+    await terminalBridge.startTelnetSession(
+      { sender: { id: 1 } },
+      {
+        sessionId: "telnet-switch-input",
+        hostname: "127.0.0.1",
+        port,
+      },
+    );
+    await waitFor(() => serverSocket);
+
+    const switchResult = terminalBridge.setSessionEncoding(
+      {},
+      { sessionId: "telnet-switch-input", encoding: "gbk" },
+    );
+    // "gbk" normalizes onto the gb18030 superset and is mirrored to
+    // session.encoding so the input path picks it up immediately.
+    assert.deepEqual(switchResult, { ok: true, encoding: "gb18030" });
+    assert.equal(sessions.get("telnet-switch-input").encoding, "gb18030");
+
+    terminalBridge.writeToSession(
+      {},
+      { sessionId: "telnet-switch-input", data: "测试\r" },
+    );
+
+    await waitFor(() => Buffer.concat(chunks).length >= 5);
+    const received = Buffer.concat(chunks);
+    assert.deepEqual([...received], [...iconv.encode("测试\r", "gb18030")]);
+  } finally {
+    terminalBridge.cleanupAllSessions();
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/electron/bridges/terminalEncoding.cjs
+++ b/electron/bridges/terminalEncoding.cjs
@@ -1,0 +1,98 @@
+/**
+ * Terminal encoding helpers — the single source of truth for turning a
+ * user-facing charset name into an iconv-lite identifier and for keeping the
+ * terminal input (keystrokes → remote) and output (remote → display) paths on
+ * the *same* encoding.
+ *
+ * Background (issue #1216): the output path already decodes remote bytes with
+ * an iconv decoder built from the user's configured charset (GB18030, etc.),
+ * but the input path used to serialize keystrokes as UTF-8 unconditionally.
+ * On a non-UTF-8 device that made input and output asymmetric — typing Chinese
+ * showed up garbled on the device while the device's own output decoded fine
+ * (or vice-versa, depending on which side the user matched). Encoding input
+ * with the *same* charset closes that gap.
+ */
+
+const iconv = require("iconv-lite");
+
+// Normalize user-facing charset names into an iconv-lite encoding identifier.
+// iconv-lite accepts a wide range of aliases directly ("utf-8", "gbk", etc.),
+// so mostly this just lowercases + collapses non-alphanumerics and maps a few
+// obvious GB* variants to gb18030 which is the superset we ship the encoding
+// switcher with. Anything iconv doesn't recognize falls back to utf-8.
+function normalizeTerminalEncoding(charset) {
+  if (!charset) return "utf-8";
+  const raw = String(charset).trim().toLowerCase();
+  const normalized = raw.replace(/[^a-z0-9]/g, "");
+  if (["utf8", "utf-8"].includes(normalized)) return "utf-8";
+  if (normalized === "gb18030" || normalized === "gbk" || normalized === "gb2312") return "gb18030";
+  return iconv.encodingExists(raw) ? raw : "utf-8";
+}
+
+// True when the encoding is UTF-8 (the JS/Node default for string → bytes).
+// Callers use this to skip the iconv round-trip on the hot input path: for
+// UTF-8 the platform's native string serialization is already correct, so
+// there is nothing to convert.
+function isUtf8Encoding(encoding) {
+  if (!encoding) return true;
+  return /^utf-?8$/i.test(String(encoding).trim());
+}
+
+// Cache of encoding identifier -> whether it is ASCII-compatible (each ASCII
+// byte encodes to exactly itself, one byte). iconv probing is cheap but this is
+// the keystroke hot path, so memoize it.
+const asciiCompatibleCache = new Map();
+
+// A terminal speaks ASCII control bytes: CR, LF, ESC and the bytes of CSI
+// escape sequences (Enter, arrows, Ctrl-C, …). Encodings like GB18030 / GBK /
+// Big5 / Shift_JIS / EUC / latin1 are ASCII supersets, so those bytes survive
+// untouched and only the non-ASCII characters change. But ASCII-incompatible
+// multi-byte encodings (UTF-16LE/BE, UCS-2, UTF-32, …) would turn "\r" into
+// `0d 00` and "\x1b[A" into `1b 00 5b 00 41 00`, breaking line discipline and
+// escape parsing on the remote. We probe a representative ASCII control byte
+// and refuse to use iconv for input on encodings that don't preserve it.
+function isAsciiCompatibleEncoding(encoding) {
+  const cached = asciiCompatibleCache.get(encoding);
+  if (cached !== undefined) return cached;
+  let compatible = false;
+  try {
+    // \r and ESC cover the control bytes we care about; a single C0 probe is
+    // enough since ASCII-incompatible encodings widen every code point.
+    const cr = iconv.encode("\r", encoding);
+    const esc = iconv.encode("\x1b", encoding);
+    compatible = cr.length === 1 && cr[0] === 0x0d && esc.length === 1 && esc[0] === 0x1b;
+  } catch {
+    compatible = false;
+  }
+  asciiCompatibleCache.set(encoding, compatible);
+  return compatible;
+}
+
+/**
+ * Encode a terminal input string for the wire using the session's charset.
+ *
+ * Returns the original string unchanged for UTF-8 (let the transport's native
+ * string handling serialize it) and a Buffer encoded with iconv-lite for any
+ * other ASCII-compatible charset. ASCII control bytes (CR, ESC, Ctrl-C, the
+ * bytes of CSI escape sequences, …) stay single-byte under those encodings, so
+ * encoding the whole string is safe — only the non-ASCII characters change.
+ *
+ * `encoding` is expected to already be a normalized iconv identifier (what
+ * normalizeTerminalEncoding returns and what sessions store on
+ * `session.encoding`). Falls back to the UTF-8 string — i.e. today's behavior —
+ * for unknown encodings and for ASCII-incompatible ones (UTF-16/UCS-2/…) where
+ * widening the control bytes would break Enter / arrows / Ctrl-C on the remote.
+ */
+function encodeTerminalInput(data, encoding) {
+  if (typeof data !== "string") return data;
+  if (isUtf8Encoding(encoding)) return data;
+  if (!iconv.encodingExists(encoding)) return data;
+  if (!isAsciiCompatibleEncoding(encoding)) return data;
+  return iconv.encode(data, encoding);
+}
+
+module.exports = {
+  normalizeTerminalEncoding,
+  isUtf8Encoding,
+  encodeTerminalInput,
+};

--- a/electron/bridges/terminalEncoding.test.cjs
+++ b/electron/bridges/terminalEncoding.test.cjs
@@ -1,0 +1,110 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const iconv = require("iconv-lite");
+const {
+  normalizeTerminalEncoding,
+  isUtf8Encoding,
+  encodeTerminalInput,
+} = require("./terminalEncoding.cjs");
+
+test("normalizeTerminalEncoding maps GB variants onto the gb18030 superset", () => {
+  assert.equal(normalizeTerminalEncoding("GB18030"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("gbk"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("GB2312"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("gb-18030"), "gb18030");
+});
+
+test("normalizeTerminalEncoding normalizes utf-8 spellings and defaults", () => {
+  assert.equal(normalizeTerminalEncoding("UTF-8"), "utf-8");
+  assert.equal(normalizeTerminalEncoding("utf8"), "utf-8");
+  assert.equal(normalizeTerminalEncoding(""), "utf-8");
+  assert.equal(normalizeTerminalEncoding(undefined), "utf-8");
+  // Unknown / unsupported charset falls back to utf-8 rather than throwing.
+  assert.equal(normalizeTerminalEncoding("not-a-real-charset"), "utf-8");
+});
+
+test("isUtf8Encoding recognizes utf-8 spellings and treats unset as utf-8", () => {
+  assert.equal(isUtf8Encoding("utf-8"), true);
+  assert.equal(isUtf8Encoding("UTF8"), true);
+  assert.equal(isUtf8Encoding(undefined), true);
+  assert.equal(isUtf8Encoding(""), true);
+  assert.equal(isUtf8Encoding("gb18030"), false);
+});
+
+test("encodeTerminalInput leaves UTF-8 input as the original string", () => {
+  // For UTF-8 we hand the string straight to the transport's native
+  // serialization, so the value must be returned unchanged (no Buffer).
+  assert.equal(encodeTerminalInput("ls -la 你好\r", "utf-8"), "ls -la 你好\r");
+  // Unset encoding (mosh / local PTY) behaves like UTF-8.
+  assert.equal(encodeTerminalInput("你好", undefined), "你好");
+});
+
+test("encodeTerminalInput encodes non-UTF-8 input to matching bytes", () => {
+  const out = encodeTerminalInput("你好", "gb18030");
+  assert.ok(Buffer.isBuffer(out), "non-UTF-8 input should produce a Buffer");
+  assert.deepEqual([...out], [...iconv.encode("你好", "gb18030")]);
+  // Crucially, the GB18030 bytes differ from the UTF-8 bytes — this is the bug:
+  // the old path always sent UTF-8 bytes regardless of the configured charset.
+  assert.notDeepEqual([...out], [...Buffer.from("你好", "utf8")]);
+});
+
+test("encodeTerminalInput preserves ASCII control bytes under GB18030", () => {
+  // CSI cursor-up, CR, Ctrl-C — all ASCII, must pass through byte-for-byte so
+  // escape sequences and control keys keep working on non-UTF-8 sessions.
+  const input = "\x1b[A\r\x03";
+  const out = encodeTerminalInput(input, "gb18030");
+  assert.deepEqual([...out], [0x1b, 0x5b, 0x41, 0x0d, 0x03]);
+});
+
+test("encodeTerminalInput round-trips with the GB18030 output decoder", () => {
+  // Input/output symmetry guarantee (issue #1216): bytes we write for a
+  // keystroke decode back to the same text the output path would show.
+  const text = "查看版本 v1.2\tabc\r";
+  const wireBytes = encodeTerminalInput(text, "gb18030");
+  const decoder = iconv.getDecoder("gb18030");
+  assert.equal(decoder.write(wireBytes), text);
+});
+
+test("encodeTerminalInput round-trips with the UTF-8 output decoder", () => {
+  const text = "echo 你好世界\r";
+  // UTF-8 path returns a string; the transport serializes it natively, which is
+  // byte-identical to encoding it as UTF-8.
+  const wire = encodeTerminalInput(text, "utf-8");
+  const wireBytes = typeof wire === "string" ? Buffer.from(wire, "utf8") : wire;
+  const decoder = iconv.getDecoder("utf-8");
+  assert.equal(decoder.write(wireBytes), text);
+});
+
+test("encodeTerminalInput falls back to the string for unknown encodings", () => {
+  // A misconfigured charset must degrade to today's UTF-8 behavior instead of
+  // throwing on the keystroke hot path.
+  assert.equal(encodeTerminalInput("你好", "definitely-not-real"), "你好");
+});
+
+test("encodeTerminalInput refuses ASCII-incompatible encodings (UTF-16/UCS-2)", () => {
+  // iconv accepts these, but encoding control bytes would widen "\r" to 0d 00
+  // and "\x1b[A" to 1b 00 5b 00 ..., breaking Enter / arrows on the remote.
+  // Fall back to the original string (today's UTF-8 behavior) instead.
+  for (const enc of ["utf-16le", "utf-16be", "ucs2", "utf-16"]) {
+    assert.equal(
+      encodeTerminalInput("ls\r", enc),
+      "ls\r",
+      `${enc} should fall back to the original string`,
+    );
+  }
+});
+
+test("encodeTerminalInput still encodes other ASCII-superset CJK charsets", () => {
+  // Sanity check that the ASCII-compat guard does not over-reject: legacy
+  // multi-byte charsets that ARE ASCII supersets keep working for input.
+  for (const enc of ["big5", "shift_jis", "euc-jp"]) {
+    const out = encodeTerminalInput("\r", enc);
+    assert.ok(Buffer.isBuffer(out), `${enc} should encode to a Buffer`);
+    assert.deepEqual([...out], [0x0d], `${enc} must keep CR single-byte`);
+  }
+});
+
+test("encodeTerminalInput passes non-string payloads through untouched", () => {
+  const buf = Buffer.from([0x01, 0x02, 0x03]);
+  assert.equal(encodeTerminalInput(buf, "gb18030"), buf);
+});


### PR DESCRIPTION
## Problem

On non-UTF-8 devices such as GB18030 systems, terminal input and output used different encodings (#1216). Output was decoded with the user-configured charset, but typed input was always serialized as UTF-8. That made Chinese input garbled when the session charset was GB18030, while switching to UTF-8 made device output garbled instead.

## Root Cause

The output path already used iconv with the session charset. The input path was hard-coded to UTF-8, so the two directions were asymmetric.

## Fix

Adds `terminalEncoding.cjs` and encodes terminal input with the same charset used for output via `encodeTerminalInput`. UTF-8 skips conversion. ASCII-incompatible encodings such as UTF-16 are rejected for iconv because they would corrupt control bytes such as CR, LF, and ESC. Telnet IAC escaping is preserved. Mosh and local sessions keep their existing raw behavior because they do not set a terminal encoding.

## Tests

Adds `terminalEncoding.test.cjs` and `terminalBridge.inputEncoding.test.cjs` with 15 cases, including GB18030 and UTF-8 round trips. Lint passed and local Codex review was clean.

## Scope

This PR focuses only on making input and output encodings consistent. Two follow-up suggestions from the issue, adding an SSH encoding configuration entry and changing Telnet/Serial encoding inputs to dropdowns, are left for separate work.

Closes #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
