### PR TITLE
fix: unblock macOS auto-update installation by allowing the app to quit

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -509,7 +509,12 @@ function App({ settings }: { settings: SettingsState }) {
   }, [handleSyncNow]);
 
   // Update check hook - checks for new versions on startup
-  const { updateState, dismissUpdate, installUpdate } = useUpdateCheck();
+  const { updateState, dismissUpdate, installUpdate } = useUpdateCheck({
+    // Install blocked because an editor has unsaved changes (#1215). The main
+    // process broadcasts this; show an actionable toast telling the user to save
+    // and click "Restart Now" again.
+    onNeedsSave: () => toast.warning(t('update.needsSave.message'), t('update.needsSave.title')),
+  });
 
   // Window controls - must be before update toast effect which uses openSettingsWindow
   const { openSettingsWindow } = useWindowControls();

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -238,6 +238,8 @@ export const enCoreMessages: Messages = {
   'update.restartNow': 'Restart Now',
   'update.downloadFailed.title': 'Update Failed',
   'update.downloadFailed.message': 'Failed to download update. You can download it manually.',
+  'update.needsSave.title': 'Unsaved Changes',
+  'update.needsSave.message': 'Save your open editors first, then click Restart Now again to install the update.',
   'update.openReleases': 'Open Releases',
   'update.remindLater': 'Remind Later',
   'update.skipVersion': 'Skip This Version',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -238,6 +238,8 @@ export const ruCoreMessages: Messages = {
   'update.restartNow': 'Перезапустить сейчас',
   'update.downloadFailed.title': 'Ошибка обновления',
   'update.downloadFailed.message': 'Не удалось скачать обновление. Вы можете скачать его вручную.',
+  'update.needsSave.title': 'Несохранённые изменения',
+  'update.needsSave.message': 'Сначала сохраните открытые редакторы, затем снова нажмите «Перезапустить сейчас», чтобы установить обновление.',
   'update.openReleases': 'Открыть релизы',
   'update.remindLater': 'Напомнить позже',
   'update.skipVersion': 'Пропустить эту версию',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -222,6 +222,8 @@ export const zhCNCoreMessages: Messages = {
   'update.restartNow': '立即重启',
   'update.downloadFailed.title': '更新失败',
   'update.downloadFailed.message': '下载更新失败，可前往 GitHub 手动下载。',
+  'update.needsSave.title': '有未保存内容',
+  'update.needsSave.message': '请先保存已打开的编辑器，然后再次点击「立即重启」以安装更新。',
   'update.openReleases': '打开 Releases',
   'update.remindLater': '稍后提醒',
   'update.skipVersion': '跳过此版本',

--- a/application/state/useUpdateCheck.ts
+++ b/application/state/useUpdateCheck.ts
@@ -53,12 +53,19 @@ export interface UseUpdateCheckResult {
  * - Respects dismissed version to avoid nagging
  * - Provides manual check capability
  */
-export function useUpdateCheck(options?: { autoUpdateEnabled?: boolean }): UseUpdateCheckResult {
+export function useUpdateCheck(options?: { autoUpdateEnabled?: boolean; onNeedsSave?: () => void }): UseUpdateCheckResult {
   // Accept auto-update toggle from the caller (e.g. useSettingsState) so it
   // reacts immediately in the same window. Falls back to reading localStorage
   // when no caller provides the value (e.g. in non-settings contexts).
   const autoUpdateEnabled = options?.autoUpdateEnabled ??
     (localStorageAdapter.readString(STORAGE_KEY_AUTO_UPDATE_ENABLED) !== 'false');
+
+  // Latest "install blocked by unsaved editors" callback (#1215). Kept in a ref
+  // so the listener effect (empty deps) always calls the current one without
+  // re-subscribing on every render. The consuming component shows the toast;
+  // this hook only owns the bridge subscription (toasts live in the view layer).
+  const onNeedsSaveRef = useRef(options?.onNeedsSave);
+  onNeedsSaveRef.current = options?.onNeedsSave;
 
   const [updateState, setUpdateState] = useState<UpdateState>({
     isChecking: false,
@@ -252,12 +259,22 @@ export function useUpdateCheck(options?: { autoUpdateEnabled?: boolean }): UseUp
       }));
     });
 
+    // Install was requested but blocked by unsaved editors (#1215). The main
+    // process broadcasts this to every window so whichever one the user clicked
+    // "Restart Now" from gets feedback. Delegate to the caller's handler (which
+    // shows the toast) — registered here because bridge subscriptions belong in
+    // the state layer, not in components.
+    const cleanupNeedsSave = bridge?.onUpdateNeedsSave?.(() => {
+      onNeedsSaveRef.current?.();
+    });
+
     return () => {
       cleanupNotAvailable?.();
       cleanupAvailable?.();
       cleanupProgress?.();
       cleanupDownloaded?.();
       cleanupError?.();
+      cleanupNeedsSave?.();
     };
   }, []);
 

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { useUpdateCheck } from "../application/state/useUpdateCheck";
 import { useAIState } from "../application/state/useAIState";
 import { I18nProvider, useI18n } from "../application/i18n/I18nProvider";
 import { sanitizePortForwardingRulesForSync } from "../application/syncPayload";
+import { toast } from "./ui/toast";
 import SettingsApplicationTab from "./SettingsApplicationTab";
 import SettingsAppearanceTab from "./settings/tabs/SettingsAppearanceTab";
 import SettingsFileAssociationsTab from "./settings/tabs/SettingsFileAssociationsTab";
@@ -164,7 +165,12 @@ const SettingsSyncTabWithVault: React.FC<{ onSettingsApplied?: () => void }> = (
 const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }) => {
     const { t } = useI18n();
     const { notifyRendererReady, closeSettingsWindow } = useWindowControls();
-    const { updateState, checkNow, installUpdate, openReleasePage, startDownload, isUpdateDemoMode } = useUpdateCheck({ autoUpdateEnabled: settings.autoUpdateEnabled });
+    const { updateState, checkNow, installUpdate, openReleasePage, startDownload, isUpdateDemoMode } = useUpdateCheck({
+        autoUpdateEnabled: settings.autoUpdateEnabled,
+        // Install blocked by unsaved editors in the main window — surface a toast
+        // here so a click from the Settings window isn't a silent no-op (#1215).
+        onNeedsSave: () => toast.warning(t('update.needsSave.message'), t('update.needsSave.title')),
+    });
     const [activeTab, setActiveTab] = useState("application");
     const [mountedTabs, setMountedTabs] = useState(() => new Set(["application"]));
 

--- a/electron/bridges/autoUpdateBridge.cjs
+++ b/electron/bridges/autoUpdateBridge.cjs
@@ -221,6 +221,48 @@ function cancelAutoCheck() {
   }
 }
 
+/**
+ * Flip the windowManager "quitting for update" flag, swallowing the case where
+ * the window manager module isn't available. Used by the install handler to
+ * commit the app to a clean quit before quitAndInstall, and to roll back if the
+ * install never actually quits (#1215).
+ */
+function setQuittingForUpdate(enabled) {
+  try {
+    const windowManager = require("./windowManager.cjs");
+    windowManager.setQuittingForUpdate(!!enabled);
+  } catch {
+    // ignore — window manager may not be available
+  }
+}
+
+/**
+ * If quitAndInstall doesn't lead to the app actually quitting (it returns
+ * without app.quit(), e.g. on a Squirrel.Mac follow-up error or a stale
+ * downloaded file), the quitting-for-update flags would stay set and
+ * permanently bypass close-to-tray + the dirty-editor quit guard. This
+ * watchdog clears them if we're still running after a short grace period.
+ */
+let _quittingForUpdateWatchdog = null;
+const QUITTING_FOR_UPDATE_WATCHDOG_MS = 10000;
+
+function scheduleQuittingForUpdateWatchdog() {
+  if (_quittingForUpdateWatchdog) {
+    clearTimeout(_quittingForUpdateWatchdog);
+  }
+  _quittingForUpdateWatchdog = setTimeout(() => {
+    _quittingForUpdateWatchdog = null;
+    // Still alive after the grace period — the install did not quit the app.
+    console.warn("[AutoUpdate] App still running after quitAndInstall; clearing quitting-for-update state");
+    setQuittingForUpdate(false);
+  }, QUITTING_FOR_UPDATE_WATCHDOG_MS);
+  // Don't let the watchdog keep the event loop (and thus the process) alive —
+  // if the app is otherwise ready to quit, the timer must not block it.
+  if (typeof _quittingForUpdateWatchdog.unref === "function") {
+    _quittingForUpdateWatchdog.unref();
+  }
+}
+
 function init(deps) {
   _deps = deps;
   setupGlobalListeners();
@@ -366,6 +408,18 @@ function registerHandlers(ipcMain) {
     const updater = getAutoUpdater();
     if (!updater) return;
 
+    // Commit the app to a real quit BEFORE quitAndInstall fires app.quit().
+    // Without this the in-place install silently fails (#1215): the main-window
+    // close handler hides to tray when close-to-tray is on, and the before-quit
+    // dirty-editor guard preventDefault()s the quit for a 5s renderer
+    // round-trip. Either keeps the process alive, so Squirrel.Mac's ShipIt
+    // helper — which waits on the parent PID to die before swapping the
+    // bundle — ends up in launchd "pending spawn" limbo and never installs.
+    // setQuittingForUpdate(true) also sets isQuitting so close-to-tray is
+    // bypassed; the before-quit handler checks isQuittingForUpdate() to skip
+    // the dirty-editor round-trip.
+    setQuittingForUpdate(true);
+
     // On macOS, the system tray keeps the app process alive even after all
     // windows are closed, which prevents quitAndInstall from completing.
     // Destroy the tray (and its panel window) before quitting so the app
@@ -377,7 +431,24 @@ function registerHandlers(ipcMain) {
       // ignore — bridge may not be available
     }
 
-    updater.quitAndInstall(false, true);
+    try {
+      updater.quitAndInstall(false, true);
+    } catch (err) {
+      // quitAndInstall threw synchronously — the app will NOT quit. Roll back
+      // the quitting-for-update flags so later closes/quits behave normally
+      // instead of permanently bypassing close-to-tray + the dirty-editor
+      // guard (#1215 review).
+      console.error("[AutoUpdate] quitAndInstall failed:", err?.message || err);
+      setQuittingForUpdate(false);
+      return;
+    }
+
+    // quitAndInstall can also fail to quit asynchronously (e.g. Squirrel.Mac's
+    // follow-up check errors, or a stale/missing downloaded file) — it returns
+    // without app.quit() ever firing. A watchdog clears the flags if we're
+    // still alive shortly after, so the app doesn't get stuck in a state where
+    // every window close bypasses close-to-tray and the dirty-editor guard.
+    scheduleQuittingForUpdateWatchdog();
   });
 
   // ---- Get auto-update preference -----------------------------------------

--- a/electron/bridges/autoUpdateBridge.cjs
+++ b/electron/bridges/autoUpdateBridge.cjs
@@ -237,14 +237,82 @@ function setQuittingForUpdate(enabled) {
 }
 
 /**
+ * The webContents of the main window, or null if there's no usable main window
+ * to talk to. Used by the install handler to (a) ask the renderer about unsaved
+ * editors before committing to a quit, and (b) tell it to surface a "save
+ * first" notice. Targets the main window specifically (not getAllWindows()[0])
+ * so we never query the tray panel / settings window, whose renderers don't
+ * participate in the dirty-editor protocol.
+ */
+function getMainWebContents() {
+  try {
+    const windowManager = require("./windowManager.cjs");
+    const win = windowManager.getMainWindow?.();
+    if (!win || win.isDestroyed?.()) return null;
+    const wc = win.webContents;
+    if (!wc || wc.isDestroyed?.() || wc.isCrashed?.()) return null;
+    return wc;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tell the renderer that the update can't install yet because there are unsaved
+ * editors. The renderer surfaces a toast asking the user to save, then click
+ * "Restart Now" again.
+ *
+ * Broadcast to ALL windows, not just the main one: the install can be triggered
+ * from the Settings window's "Restart to Update" button, and that's the focused
+ * window the user is looking at. Sending only to the (possibly hidden/behind)
+ * main window would make the click appear to do nothing (#1215 review). The
+ * unsaved editors live in the main window, but every window surfaces the same
+ * "save first" notice so it lands wherever the user is.
+ */
+function notifyNeedsSave() {
+  broadcastToAllWindows("netcatty:update:needs-save");
+}
+
+/** Max time to wait for the renderer's unsaved-editors reply before the install
+ *  fails open and proceeds (matches the before-quit guard timeout). */
+const INSTALL_DIRTY_CHECK_TIMEOUT_MS = 5000;
+
+/**
+ * Ask the main-window renderer whether it has unsaved editor changes, reusing
+ * the shared dirty-editor round-trip. Resolves false (fail open) if the helper
+ * is unavailable, so a missing module can never block an install. `ipcMain` is
+ * the instance passed to registerHandlers; the helper needs it to listen for
+ * the reply.
+ */
+function queryDirtyEditorsSafe(webContents, ipcMain) {
+  try {
+    const { queryDirtyEditors } = require("./dirtyEditorGuard.cjs");
+    return queryDirtyEditors(webContents, INSTALL_DIRTY_CHECK_TIMEOUT_MS, { ipcMain });
+  } catch (err) {
+    console.warn("[AutoUpdate] dirty-editor guard unavailable:", err?.message || err);
+    return Promise.resolve(false);
+  }
+}
+
+/**
  * If quitAndInstall doesn't lead to the app actually quitting (it returns
  * without app.quit(), e.g. on a Squirrel.Mac follow-up error or a stale
  * downloaded file), the quitting-for-update flags would stay set and
  * permanently bypass close-to-tray + the dirty-editor quit guard. This
- * watchdog clears them if we're still running after a short grace period.
+ * watchdog clears them if we're still running after a grace period.
+ *
+ * The grace period is deliberately long. On macOS quitAndInstall() can return
+ * while Squirrel.Mac is still pulling the already-downloaded ZIP from the local
+ * update server before it actually closes the windows; for a large/slow update
+ * that second stage can take well over 10s. If the watchdog cleared isQuitting
+ * during that window, the eventual native quit would hit a *non*-quitting
+ * close-to-tray handler and get stranded again — the exact #1215 failure. So we
+ * only roll back after a window long enough that the app is realistically stuck,
+ * not merely slow. The cost of waiting longer is just that close-to-tray stays
+ * bypassed a bit longer in the rare genuine-failure case (#1215 review).
  */
 let _quittingForUpdateWatchdog = null;
-const QUITTING_FOR_UPDATE_WATCHDOG_MS = 10000;
+const QUITTING_FOR_UPDATE_WATCHDOG_MS = 60000;
 
 function scheduleQuittingForUpdateWatchdog() {
   if (_quittingForUpdateWatchdog) {
@@ -404,20 +472,42 @@ function registerHandlers(ipcMain) {
   });
 
   // ---- Install (quit & install) ------------------------------------------
-  ipcMain.handle("netcatty:update:install", () => {
+  ipcMain.handle("netcatty:update:install", async () => {
     const updater = getAutoUpdater();
     if (!updater) return;
 
+    // Check for unsaved editors BEFORE committing to a quit (#1215 review).
+    //
+    // On macOS quitAndInstall() closes windows first and only then fires
+    // before-quit. Once setQuittingForUpdate(true) lets the main window
+    // actually close (instead of hiding to tray), the before-quit dirty-editor
+    // guard can run after the window is already gone — isReachableByUser is
+    // false, so it commits the quit and silently drops unsaved SFTP edits.
+    //
+    // So we ask the renderer here, while the window and renderer are still
+    // alive. If there's unsaved work, abort the install (don't touch the
+    // quitting flags, don't quitAndInstall) and tell the renderer to prompt the
+    // user to save; they can click "Restart Now" again afterwards. If the main
+    // window isn't reachable (no window / crashed renderer) there's no user to
+    // ask, so we install directly — matching the before-quit fail-open path.
+    const mainWc = getMainWebContents();
+    if (mainWc) {
+      const hasDirty = await queryDirtyEditorsSafe(mainWc, ipcMain);
+      if (hasDirty) {
+        // Broadcast so the notice reaches whichever window the user clicked
+        // from (main or Settings), not just the main window we queried.
+        notifyNeedsSave();
+        return;
+      }
+    }
+
     // Commit the app to a real quit BEFORE quitAndInstall fires app.quit().
     // Without this the in-place install silently fails (#1215): the main-window
-    // close handler hides to tray when close-to-tray is on, and the before-quit
-    // dirty-editor guard preventDefault()s the quit for a 5s renderer
-    // round-trip. Either keeps the process alive, so Squirrel.Mac's ShipIt
-    // helper — which waits on the parent PID to die before swapping the
-    // bundle — ends up in launchd "pending spawn" limbo and never installs.
-    // setQuittingForUpdate(true) also sets isQuitting so close-to-tray is
-    // bypassed; the before-quit handler checks isQuittingForUpdate() to skip
-    // the dirty-editor round-trip.
+    // close handler hides to tray when close-to-tray is on, so the process
+    // stays alive and Squirrel.Mac's ShipIt helper — which waits on the parent
+    // PID to die before swapping the bundle — ends up in launchd "pending
+    // spawn" limbo and never installs. setQuittingForUpdate(true) sets
+    // isQuitting so close-to-tray is bypassed and the window actually closes.
     setQuittingForUpdate(true);
 
     // On macOS, the system tray keeps the app process alive even after all

--- a/electron/bridges/autoUpdateBridge.test.cjs
+++ b/electron/bridges/autoUpdateBridge.test.cjs
@@ -6,6 +6,7 @@ const Module = require("node:module");
 const BRIDGE_PATH = require.resolve("./autoUpdateBridge.cjs");
 const WINDOW_MANAGER_PATH = require.resolve("./windowManager.cjs");
 const GLOBAL_SHORTCUT_PATH = require.resolve("./globalShortcutBridge.cjs");
+const DIRTY_EDITOR_GUARD_PATH = require.resolve("./dirtyEditorGuard.cjs");
 
 // electron-updater pulls in native/electron-only code, so it can't be required
 // in a plain `node --test` process. We intercept the bare `electron-updater`
@@ -21,7 +22,7 @@ const ELECTRON_UPDATER_ID = "electron-updater";
  * assert on their interactions. Restores Module._load and the bridge cache on
  * exit so tests stay isolated.
  */
-function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShortcutBridge } = {}, fn) {
+async function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShortcutBridge, dirtyEditorGuard, browserWindows } = {}, fn) {
   const fakeAutoUpdater = autoUpdater || {
     autoDownload: true,
     autoInstallOnAppQuit: false,
@@ -44,6 +45,11 @@ function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShort
       this.cleanupCount += 1;
     },
   };
+  // Default: no dirty-editor guard override. The bridge requires the real
+  // dirtyEditorGuard.cjs (harmless — it only resolves ipcMain lazily, and the
+  // install handler only reaches it when there's a reachable main window). Most
+  // tests don't supply a main window, so the guard is never invoked.
+  const fakeDirtyEditorGuard = dirtyEditorGuard;
 
   const originalLoad = Module._load;
   Module._load = function patchedLoad(request, parent, isMain) {
@@ -59,6 +65,9 @@ function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShort
       const withExt = resolved.endsWith(".cjs") ? resolved : `${resolved}.cjs`;
       if (withExt === WINDOW_MANAGER_PATH) return fakeWindowManager;
       if (withExt === GLOBAL_SHORTCUT_PATH) return fakeGlobalShortcut;
+      if (withExt === DIRTY_EDITOR_GUARD_PATH && fakeDirtyEditorGuard) {
+        return fakeDirtyEditorGuard;
+      }
     }
     return originalLoad.call(this, request, parent, isMain);
   };
@@ -74,13 +83,82 @@ function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShort
       getVersion: () => "1.1.17",
     };
     bridge.init({
-      electronModule: { app: fakeApp, BrowserWindow: { getAllWindows: () => [] } },
+      electronModule: {
+        app: fakeApp,
+        // browserWindows lets a test observe broadcastToAllWindows (used by the
+        // needs-save notice). Defaults to none.
+        BrowserWindow: { getAllWindows: () => browserWindows || [] },
+      },
     });
-    return fn({ bridge, fakeAutoUpdater, fakeWindowManager, fakeGlobalShortcut });
+    // Await so the Module._load patch stays installed for the *entire* test
+    // body, including after the now-async install handler yields on its first
+    // `await` (otherwise the lazy windowManager/dirtyEditorGuard requires would
+    // resolve the real modules once the finally below restored Module._load).
+    return await fn({ bridge, fakeAutoUpdater, fakeWindowManager, fakeGlobalShortcut });
   } finally {
     Module._load = originalLoad;
     delete require.cache[BRIDGE_PATH];
   }
+}
+
+/**
+ * A fake BrowserWindow for broadcastToAllWindows() (used by the needs-save
+ * notice). Records every channel sent to its webContents so a test can assert
+ * whether netcatty:update:needs-save was broadcast.
+ */
+function makeBroadcastWindow() {
+  const sentChannels = [];
+  return {
+    sentChannels,
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      send(channel) {
+        sentChannels.push(channel);
+      },
+    },
+  };
+}
+
+/**
+ * Build a fake windowManager that also exposes a main window whose webContents
+ * the install handler can query for dirty editors. `sentChannels` records every
+ * webContents.send() on the *main window* (i.e. the dirty-editor query), kept
+ * separate from broadcast windows so tests can distinguish the two.
+ */
+function makeWindowManagerWithMainWindow() {
+  const sentChannels = [];
+  const webContents = {
+    send(channel) {
+      sentChannels.push(channel);
+    },
+    isDestroyed() {
+      return false;
+    },
+    isCrashed() {
+      return false;
+    },
+  };
+  return {
+    calls: [],
+    sentChannels,
+    webContents,
+    setQuittingForUpdate(value) {
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return this.calls[this.calls.length - 1] === true;
+    },
+    getMainWindow() {
+      return {
+        webContents,
+        isDestroyed() {
+          return false;
+        },
+      };
+    },
+  };
 }
 
 /**
@@ -105,7 +183,7 @@ function makeIpcMain() {
   };
 }
 
-test("install handler marks quitting-for-update before quitAndInstall", () => {
+test("install handler marks quitting-for-update before quitAndInstall", async () => {
   const order = [];
   const autoUpdater = {
     autoDownload: true,
@@ -128,10 +206,10 @@ test("install handler marks quitting-for-update before quitAndInstall", () => {
     },
   };
 
-  withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge, fakeGlobalShortcut }) => {
+  await withMocks({ autoUpdater, windowManager: fakeWindowManager }, async ({ bridge, fakeGlobalShortcut }) => {
     const ipcMain = makeIpcMain();
     bridge.registerHandlers(ipcMain);
-    ipcMain.invoke("netcatty:update:install");
+    await ipcMain.invoke("netcatty:update:install");
 
     // The flag must be set with `true`...
     assert.deepEqual(fakeWindowManager.calls, [true]);
@@ -145,7 +223,7 @@ test("install handler marks quitting-for-update before quitAndInstall", () => {
   });
 });
 
-test("install handler is a no-op when the updater fails to load", () => {
+test("install handler is a no-op when the updater fails to load", async () => {
   const fakeWindowManager = {
     calls: [],
     setQuittingForUpdate(value) {
@@ -159,17 +237,17 @@ test("install handler is a no-op when the updater fails to load", () => {
   // so the handler must return early WITHOUT committing the app to a quit. Doing
   // so otherwise would leave isQuitting=true and break close-to-tray even though
   // no install actually started.
-  withMocks({ autoUpdaterExports: {}, windowManager: fakeWindowManager }, ({ bridge, fakeGlobalShortcut }) => {
+  await withMocks({ autoUpdaterExports: {}, windowManager: fakeWindowManager }, async ({ bridge, fakeGlobalShortcut }) => {
     const ipcMain = makeIpcMain();
     bridge.registerHandlers(ipcMain);
-    ipcMain.invoke("netcatty:update:install");
+    await ipcMain.invoke("netcatty:update:install");
 
     assert.deepEqual(fakeWindowManager.calls, []);
     assert.equal(fakeGlobalShortcut.cleanupCount, 0);
   });
 });
 
-test("install handler rolls back quitting-for-update when quitAndInstall throws", () => {
+test("install handler rolls back quitting-for-update when quitAndInstall throws", async () => {
   const autoUpdater = {
     autoDownload: true,
     autoInstallOnAppQuit: false,
@@ -189,10 +267,10 @@ test("install handler rolls back quitting-for-update when quitAndInstall throws"
     },
   };
 
-  withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge }) => {
+  await withMocks({ autoUpdater, windowManager: fakeWindowManager }, async ({ bridge }) => {
     const ipcMain = makeIpcMain();
     bridge.registerHandlers(ipcMain);
-    ipcMain.invoke("netcatty:update:install");
+    await ipcMain.invoke("netcatty:update:install");
 
     // First set true (commit), then reset to false on the synchronous throw so
     // the app doesn't get stuck bypassing close-to-tray / the quit guard (#1215).
@@ -201,7 +279,7 @@ test("install handler rolls back quitting-for-update when quitAndInstall throws"
   });
 });
 
-test("install handler watchdog clears quitting-for-update if the app never quits", () => {
+test("install handler watchdog clears quitting-for-update if the app never quits", async () => {
   const autoUpdater = {
     autoDownload: true,
     autoInstallOnAppQuit: false,
@@ -231,10 +309,10 @@ test("install handler watchdog clears quitting-for-update if the app never quits
   };
 
   try {
-    withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge }) => {
+    await withMocks({ autoUpdater, windowManager: fakeWindowManager }, async ({ bridge }) => {
       const ipcMain = makeIpcMain();
       bridge.registerHandlers(ipcMain);
-      ipcMain.invoke("netcatty:update:install");
+      await ipcMain.invoke("netcatty:update:install");
 
       // Committed to quit, watchdog scheduled but not yet fired.
       assert.deepEqual(fakeWindowManager.calls, [true]);
@@ -245,6 +323,173 @@ test("install handler watchdog clears quitting-for-update if the app never quits
       assert.deepEqual(fakeWindowManager.calls, [true, false]);
       assert.equal(fakeWindowManager.isQuittingForUpdate(), false);
     });
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1215 P1: the install handler must check for unsaved editors BEFORE
+// committing to a quit. On macOS quitAndInstall() closes the window first and
+// only then fires before-quit, so the before-quit dirty guard can run after the
+// window is gone and silently drop unsaved SFTP edits. Checking up front (while
+// the renderer is alive) is the fix.
+// ---------------------------------------------------------------------------
+
+test("install handler aborts and notifies when the renderer reports dirty editors", async () => {
+  const order = [];
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall() {
+      order.push("quitAndInstall");
+    },
+  };
+  const fakeWindowManager = makeWindowManagerWithMainWindow();
+  const originalSetQuitting = fakeWindowManager.setQuittingForUpdate;
+  fakeWindowManager.setQuittingForUpdate = function (value) {
+    order.push("setQuittingForUpdate");
+    originalSetQuitting.call(this, value);
+  };
+  // queryDirtyEditors reports unsaved work.
+  let queriedWebContents = null;
+  const fakeDirtyEditorGuard = {
+    queryDirtyEditors(webContents) {
+      order.push("queryDirtyEditors");
+      queriedWebContents = webContents;
+      return Promise.resolve(true);
+    },
+  };
+  // Two windows (e.g. main + settings) so we can assert the needs-save notice is
+  // broadcast to BOTH, not just the queried main window (#1215 review).
+  const win1 = makeBroadcastWindow();
+  const win2 = makeBroadcastWindow();
+
+  await withMocks(
+    {
+      autoUpdater,
+      windowManager: fakeWindowManager,
+      dirtyEditorGuard: fakeDirtyEditorGuard,
+      browserWindows: [win1, win2],
+    },
+    async ({ bridge, fakeGlobalShortcut }) => {
+      const ipcMain = makeIpcMain();
+      bridge.registerHandlers(ipcMain);
+      await ipcMain.invoke("netcatty:update:install");
+
+      // Dirty editors → the install must be fully aborted:
+      // - no quitAndInstall, no setQuittingForUpdate, no tray cleanup
+      assert.equal(order.includes("quitAndInstall"), false);
+      assert.equal(order.includes("setQuittingForUpdate"), false);
+      assert.deepEqual(fakeWindowManager.calls, []);
+      assert.equal(fakeGlobalShortcut.cleanupCount, 0);
+      // - every window is told to prompt the user to save (broadcast needs-save)
+      assert.equal(win1.sentChannels.includes("netcatty:update:needs-save"), true);
+      assert.equal(win2.sentChannels.includes("netcatty:update:needs-save"), true);
+      // - the dirty check ran first, against the main window's webContents
+      assert.equal(order[0], "queryDirtyEditors");
+      assert.equal(queriedWebContents, fakeWindowManager.webContents);
+    },
+  );
+});
+
+test("install handler proceeds to quitAndInstall when there are no dirty editors", async () => {
+  const order = [];
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall() {
+      order.push("quitAndInstall");
+    },
+  };
+  const fakeWindowManager = makeWindowManagerWithMainWindow();
+  const originalSetQuitting = fakeWindowManager.setQuittingForUpdate;
+  fakeWindowManager.setQuittingForUpdate = function (value) {
+    order.push("setQuittingForUpdate");
+    originalSetQuitting.call(this, value);
+  };
+  // queryDirtyEditors reports a clean editor state.
+  const fakeDirtyEditorGuard = {
+    queryDirtyEditors() {
+      order.push("queryDirtyEditors");
+      return Promise.resolve(false);
+    },
+  };
+  const win = makeBroadcastWindow();
+
+  // Capture the watchdog so the test doesn't wait on the real 10s timer.
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = () => ({ unref() {} });
+  try {
+    await withMocks(
+      {
+        autoUpdater,
+        windowManager: fakeWindowManager,
+        dirtyEditorGuard: fakeDirtyEditorGuard,
+        browserWindows: [win],
+      },
+      async ({ bridge, fakeGlobalShortcut }) => {
+        const ipcMain = makeIpcMain();
+        bridge.registerHandlers(ipcMain);
+        await ipcMain.invoke("netcatty:update:install");
+
+        // Clean editors → install runs as before:
+        // dirty check first, then commit-to-quit, then quitAndInstall.
+        assert.equal(order[0], "queryDirtyEditors");
+        assert.deepEqual(fakeWindowManager.calls, [true]);
+        assert.ok(order.indexOf("setQuittingForUpdate") < order.indexOf("quitAndInstall"));
+        assert.equal(order.includes("quitAndInstall"), true);
+        assert.equal(fakeGlobalShortcut.cleanupCount, 1);
+        // No needs-save broadcast when nothing is dirty.
+        assert.equal(win.sentChannels.includes("netcatty:update:needs-save"), false);
+      },
+    );
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("install handler installs directly when no main window is reachable", async () => {
+  const order = [];
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall() {
+      order.push("quitAndInstall");
+    },
+  };
+  // Default fake windowManager has no getMainWindow() → getMainWebContents()
+  // returns null → there's no user to ask, so the install must proceed without
+  // ever calling queryDirtyEditors (matches the before-quit fail-open path).
+  let dirtyCheckCalled = false;
+  const fakeDirtyEditorGuard = {
+    queryDirtyEditors() {
+      dirtyCheckCalled = true;
+      return Promise.resolve(true);
+    },
+  };
+
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = () => ({ unref() {} });
+  try {
+    await withMocks(
+      { autoUpdater, dirtyEditorGuard: fakeDirtyEditorGuard },
+      async ({ bridge, fakeWindowManager }) => {
+        const ipcMain = makeIpcMain();
+        bridge.registerHandlers(ipcMain);
+        await ipcMain.invoke("netcatty:update:install");
+
+        assert.equal(dirtyCheckCalled, false);
+        assert.deepEqual(fakeWindowManager.calls, [true]);
+        assert.equal(order.includes("quitAndInstall"), true);
+      },
+    );
   } finally {
     global.setTimeout = originalSetTimeout;
   }

--- a/electron/bridges/autoUpdateBridge.test.cjs
+++ b/electron/bridges/autoUpdateBridge.test.cjs
@@ -1,0 +1,251 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const Module = require("node:module");
+
+const BRIDGE_PATH = require.resolve("./autoUpdateBridge.cjs");
+const WINDOW_MANAGER_PATH = require.resolve("./windowManager.cjs");
+const GLOBAL_SHORTCUT_PATH = require.resolve("./globalShortcutBridge.cjs");
+
+// electron-updater pulls in native/electron-only code, so it can't be required
+// in a plain `node --test` process. We intercept the bare `electron-updater`
+// specifier and the bridge's lazy sibling requires at load time and hand back
+// lightweight fakes. The patch stays installed for the whole test body because
+// the bridge resolves electron-updater / windowManager / globalShortcutBridge
+// lazily at IPC-invoke time, not at module load.
+const ELECTRON_UPDATER_ID = "electron-updater";
+
+/**
+ * Run `fn` with electron-updater, windowManager, and globalShortcutBridge
+ * replaced by the supplied fakes. The fakes are also exposed to `fn` so it can
+ * assert on their interactions. Restores Module._load and the bridge cache on
+ * exit so tests stay isolated.
+ */
+function withMocks({ autoUpdater, autoUpdaterExports, windowManager, globalShortcutBridge } = {}, fn) {
+  const fakeAutoUpdater = autoUpdater || {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall() {},
+  };
+  const fakeWindowManager = windowManager || {
+    calls: [],
+    setQuittingForUpdate(value) {
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return this.calls[this.calls.length - 1] === true;
+    },
+  };
+  const fakeGlobalShortcut = globalShortcutBridge || {
+    cleanupCount: 0,
+    cleanup() {
+      this.cleanupCount += 1;
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === ELECTRON_UPDATER_ID) {
+      // autoUpdaterExports lets a test simulate a broken electron-updater
+      // (e.g. {} with no autoUpdater) so getAutoUpdater() resolves to null.
+      return autoUpdaterExports !== undefined
+        ? autoUpdaterExports
+        : { autoUpdater: fakeAutoUpdater };
+    }
+    if (parent && parent.filename === BRIDGE_PATH) {
+      const resolved = path.resolve(path.dirname(BRIDGE_PATH), request);
+      const withExt = resolved.endsWith(".cjs") ? resolved : `${resolved}.cjs`;
+      if (withExt === WINDOW_MANAGER_PATH) return fakeWindowManager;
+      if (withExt === GLOBAL_SHORTCUT_PATH) return fakeGlobalShortcut;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[BRIDGE_PATH];
+  try {
+    const bridge = require("./autoUpdateBridge.cjs");
+    // Provide a minimal electronModule so readAutoUpdatePreference and
+    // broadcastToAllWindows don't throw. getPath returns a throwaway dir; the
+    // pref read falls back to its default when the file is absent.
+    const fakeApp = {
+      getPath: () => path.join("/", "tmp", "nc-autoupdate-test"),
+      getVersion: () => "1.1.17",
+    };
+    bridge.init({
+      electronModule: { app: fakeApp, BrowserWindow: { getAllWindows: () => [] } },
+    });
+    return fn({ bridge, fakeAutoUpdater, fakeWindowManager, fakeGlobalShortcut });
+  } finally {
+    Module._load = originalLoad;
+    delete require.cache[BRIDGE_PATH];
+  }
+}
+
+/**
+ * Minimal ipcMain stand-in that captures the handlers the bridge registers so a
+ * test can invoke a single channel directly.
+ */
+function makeIpcMain() {
+  const handlers = new Map();
+  return {
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+    on() {},
+    invoke(channel, ...args) {
+      const handler = handlers.get(channel);
+      if (!handler) throw new Error(`No handler registered for ${channel}`);
+      return handler({}, ...args);
+    },
+    has(channel) {
+      return handlers.has(channel);
+    },
+  };
+}
+
+test("install handler marks quitting-for-update before quitAndInstall", () => {
+  const order = [];
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall(isSilent, isForceRunAfter) {
+      order.push("quitAndInstall");
+      autoUpdater._installArgs = [isSilent, isForceRunAfter];
+    },
+  };
+  const fakeWindowManager = {
+    calls: [],
+    setQuittingForUpdate(value) {
+      order.push("setQuittingForUpdate");
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return this.calls[this.calls.length - 1] === true;
+    },
+  };
+
+  withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge, fakeGlobalShortcut }) => {
+    const ipcMain = makeIpcMain();
+    bridge.registerHandlers(ipcMain);
+    ipcMain.invoke("netcatty:update:install");
+
+    // The flag must be set with `true`...
+    assert.deepEqual(fakeWindowManager.calls, [true]);
+    // ...and it must happen BEFORE quitAndInstall fires app.quit(), otherwise the
+    // close-to-tray / before-quit guards would already be racing the quit (#1215).
+    assert.equal(order[0], "setQuittingForUpdate");
+    assert.ok(order.indexOf("setQuittingForUpdate") < order.indexOf("quitAndInstall"));
+    // Tray cleanup still runs so the tray doesn't keep the process alive.
+    assert.equal(fakeGlobalShortcut.cleanupCount, 1);
+    assert.equal(order.includes("quitAndInstall"), true);
+  });
+});
+
+test("install handler is a no-op when the updater fails to load", () => {
+  const fakeWindowManager = {
+    calls: [],
+    setQuittingForUpdate(value) {
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return false;
+    },
+  };
+  // electron-updater exports no `autoUpdater` => getAutoUpdater() returns null,
+  // so the handler must return early WITHOUT committing the app to a quit. Doing
+  // so otherwise would leave isQuitting=true and break close-to-tray even though
+  // no install actually started.
+  withMocks({ autoUpdaterExports: {}, windowManager: fakeWindowManager }, ({ bridge, fakeGlobalShortcut }) => {
+    const ipcMain = makeIpcMain();
+    bridge.registerHandlers(ipcMain);
+    ipcMain.invoke("netcatty:update:install");
+
+    assert.deepEqual(fakeWindowManager.calls, []);
+    assert.equal(fakeGlobalShortcut.cleanupCount, 0);
+  });
+});
+
+test("install handler rolls back quitting-for-update when quitAndInstall throws", () => {
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    quitAndInstall() {
+      throw new Error("boom");
+    },
+  };
+  const fakeWindowManager = {
+    calls: [],
+    setQuittingForUpdate(value) {
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return this.calls[this.calls.length - 1] === true;
+    },
+  };
+
+  withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge }) => {
+    const ipcMain = makeIpcMain();
+    bridge.registerHandlers(ipcMain);
+    ipcMain.invoke("netcatty:update:install");
+
+    // First set true (commit), then reset to false on the synchronous throw so
+    // the app doesn't get stuck bypassing close-to-tray / the quit guard (#1215).
+    assert.deepEqual(fakeWindowManager.calls, [true, false]);
+    assert.equal(fakeWindowManager.isQuittingForUpdate(), false);
+  });
+});
+
+test("install handler watchdog clears quitting-for-update if the app never quits", () => {
+  const autoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    logger: undefined,
+    on() {},
+    // Returns without ever quitting the app (simulates a Squirrel follow-up
+    // failure / stale download where app.quit() is never reached).
+    quitAndInstall() {},
+  };
+  const fakeWindowManager = {
+    calls: [],
+    setQuittingForUpdate(value) {
+      this.calls.push(value);
+    },
+    isQuittingForUpdate() {
+      return this.calls[this.calls.length - 1] === true;
+    },
+  };
+
+  // Capture the watchdog timer instead of waiting for the real delay.
+  const originalSetTimeout = global.setTimeout;
+  let watchdogFn = null;
+  global.setTimeout = (fn) => {
+    watchdogFn = fn;
+    // Return a fake timer handle with an unref() no-op so the bridge can call it.
+    return { unref() {} };
+  };
+
+  try {
+    withMocks({ autoUpdater, windowManager: fakeWindowManager }, ({ bridge }) => {
+      const ipcMain = makeIpcMain();
+      bridge.registerHandlers(ipcMain);
+      ipcMain.invoke("netcatty:update:install");
+
+      // Committed to quit, watchdog scheduled but not yet fired.
+      assert.deepEqual(fakeWindowManager.calls, [true]);
+      assert.equal(typeof watchdogFn, "function");
+
+      // Fire the watchdog — the app is still alive, so it must clear the flag.
+      watchdogFn();
+      assert.deepEqual(fakeWindowManager.calls, [true, false]);
+      assert.equal(fakeWindowManager.isQuittingForUpdate(), false);
+    });
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});

--- a/electron/bridges/dirtyEditorGuard.cjs
+++ b/electron/bridges/dirtyEditorGuard.cjs
@@ -1,0 +1,99 @@
+/**
+ * Dirty-editor guard helper.
+ *
+ * Both the before-quit handler (electron/main.cjs) and the auto-update install
+ * handler (electron/bridges/autoUpdateBridge.cjs) need to ask the renderer
+ * whether any SFTP editor tab has unsaved changes before letting the process
+ * exit. This module centralizes that one-shot request/response round-trip so
+ * the two call sites stay in sync (#1215).
+ *
+ * The renderer side lives in application/app/useAppStartupEffects.ts: it
+ * listens for "app:query-dirty-editors" and replies on
+ * "app:dirty-editors-result" with { hasDirty: boolean }.
+ */
+
+/**
+ * Ask a specific renderer whether it has unsaved editor changes.
+ *
+ * Sends "app:query-dirty-editors" to the given webContents and resolves with
+ * the renderer's reply. Resolves `false` (fail-open) if the renderer never
+ * answers within `timeoutMs`, if the webContents can't be messaged, or if the
+ * send throws — in every one of those cases there is no usable UI to surface a
+ * "save first" warning on, so blocking the quit would only strand the user.
+ *
+ * Only a reply whose `event.sender` is the exact `webContents` we queried is
+ * accepted; replies from any other window are ignored so a stray/rogue message
+ * can't decide the result. The listener and timer are always torn down before
+ * resolving, so a late timeout can't override an already-received reply (and
+ * vice versa).
+ *
+ * @param {import("electron").WebContents | null | undefined} webContents
+ * @param {number} timeoutMs - Max time to wait for the renderer reply.
+ * @param {{ ipcMain?: import("electron").IpcMain }} [options] - Inject ipcMain
+ *   for tests; defaults to electron's ipcMain.
+ * @returns {Promise<boolean>} true when the renderer reports unsaved changes.
+ */
+function queryDirtyEditors(webContents, timeoutMs, options = {}) {
+  const ipcMain = options.ipcMain || resolveIpcMain();
+
+  // No renderer to ask, or no ipcMain to listen with — fail open.
+  if (!ipcMain || !webContents) return Promise.resolve(false);
+  if (webContents.isDestroyed?.() || webContents.isCrashed?.()) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timeoutId = null;
+
+    const settle = (hasDirty) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      ipcMain.removeListener("app:dirty-editors-result", onResult);
+      resolve(hasDirty);
+    };
+
+    function onResult(evt, payload) {
+      // Defence in depth: only the renderer we queried may decide the result.
+      // Use `.on` (not `.once`) so a rogue reply from another window doesn't
+      // consume the listener slot and let the real reply fall through. A
+      // missing/falsy sender is anomalous and treated as a wrong-window reply.
+      if (evt?.sender !== webContents) return;
+      settle(payload?.hasDirty === true);
+    }
+    ipcMain.on("app:dirty-editors-result", onResult);
+
+    // Timeout fallback: if the renderer never replies (crash, unhandled
+    // exception in its listener, etc.) we must not hang forever. Fail open.
+    timeoutId = setTimeout(() => settle(false), timeoutMs);
+
+    try {
+      webContents.send("app:query-dirty-editors");
+    } catch (err) {
+      // webContents.send can throw if the renderer was destroyed between the
+      // isCrashed?.() check above and this call (a real race when the GPU
+      // process is dying). Tear down synchronously and fail open.
+      console.warn("[DirtyEditorGuard] Failed to query renderer for dirty editors:", err);
+      settle(false);
+    }
+  });
+}
+
+/**
+ * Lazily resolve electron's ipcMain. Kept out of module top-level so this file
+ * can be required in a plain `node --test` process (where `electron` isn't a
+ * loadable module) as long as the caller injects ipcMain.
+ */
+function resolveIpcMain() {
+  try {
+    return require("electron").ipcMain;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { queryDirtyEditors };

--- a/electron/bridges/dirtyEditorGuard.test.cjs
+++ b/electron/bridges/dirtyEditorGuard.test.cjs
@@ -1,0 +1,223 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { queryDirtyEditors } = require("./dirtyEditorGuard.cjs");
+
+/**
+ * Minimal ipcMain stand-in. Records on/removeListener so a test can both drive
+ * a reply (by invoking the captured listener) and assert the listener was
+ * cleaned up afterwards.
+ */
+function makeIpcMain() {
+  const listeners = new Map(); // channel -> Set<fn>
+  return {
+    on(channel, fn) {
+      if (!listeners.has(channel)) listeners.set(channel, new Set());
+      listeners.get(channel).add(fn);
+    },
+    removeListener(channel, fn) {
+      listeners.get(channel)?.delete(fn);
+    },
+    emit(channel, evt, payload) {
+      for (const fn of listeners.get(channel) || []) fn(evt, payload);
+    },
+    listenerCount(channel) {
+      return listeners.get(channel)?.size ?? 0;
+    },
+  };
+}
+
+/** Fake webContents that records sends and is alive by default. */
+function makeWebContents() {
+  const sent = [];
+  return {
+    sent,
+    send(channel) {
+      sent.push(channel);
+    },
+    isDestroyed() {
+      return false;
+    },
+    isCrashed() {
+      return false;
+    },
+  };
+}
+
+test("resolves true when the renderer reports dirty editors", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+
+  const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+  // The request is sent on the queried webContents.
+  assert.deepEqual(wc.sent, ["app:query-dirty-editors"]);
+  // Renderer replies from the same webContents.
+  ipcMain.emit("app:dirty-editors-result", { sender: wc }, { hasDirty: true });
+
+  assert.equal(await promise, true);
+  // Listener was torn down.
+  assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+});
+
+test("resolves false when the renderer reports no dirty editors", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+
+  const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+  ipcMain.emit("app:dirty-editors-result", { sender: wc }, { hasDirty: false });
+
+  assert.equal(await promise, false);
+  assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+});
+
+test("a missing hasDirty payload is treated as not-dirty (fail open)", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+
+  const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+  ipcMain.emit("app:dirty-editors-result", { sender: wc }, undefined);
+
+  assert.equal(await promise, false);
+});
+
+test("ignores replies from a different webContents, then times out to false", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+  const otherWc = makeWebContents();
+
+  const originalSetTimeout = global.setTimeout;
+  let timeoutFn = null;
+  global.setTimeout = (fn) => {
+    timeoutFn = fn;
+    return { unref() {} };
+  };
+  try {
+    const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+
+    // A rogue reply from another window claims dirty — it must be ignored, and
+    // the listener must remain installed (we use .on, not .once).
+    ipcMain.emit("app:dirty-editors-result", { sender: otherWc }, { hasDirty: true });
+    assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 1);
+
+    // No real reply ever arrives → the timeout fires and resolves false.
+    assert.equal(typeof timeoutFn, "function");
+    timeoutFn();
+    assert.equal(await promise, false);
+    assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("a falsy sender on the reply is rejected (treated as wrong window)", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+
+  const originalSetTimeout = global.setTimeout;
+  let timeoutFn = null;
+  global.setTimeout = (fn) => {
+    timeoutFn = fn;
+    return { unref() {} };
+  };
+  try {
+    const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+    ipcMain.emit("app:dirty-editors-result", { sender: null }, { hasDirty: true });
+    // Not settled by the anomalous reply.
+    assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 1);
+    timeoutFn();
+    assert.equal(await promise, false);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("a late timeout cannot override an already-received reply", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = makeWebContents();
+
+  const originalSetTimeout = global.setTimeout;
+  let timeoutFn = null;
+  global.setTimeout = (fn) => {
+    timeoutFn = fn;
+    return { unref() {} };
+  };
+  try {
+    const promise = queryDirtyEditors(wc, 5000, { ipcMain });
+    // Real reply: dirty=true.
+    ipcMain.emit("app:dirty-editors-result", { sender: wc }, { hasDirty: true });
+    // A stale timeout fires afterwards — it must be a no-op (settled guard).
+    timeoutFn();
+    assert.equal(await promise, true);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test("resolves false without sending when there is no webContents", async () => {
+  const ipcMain = makeIpcMain();
+  assert.equal(await queryDirtyEditors(null, 5000, { ipcMain }), false);
+  assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+});
+
+test("resolves false without sending when the webContents is destroyed", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = {
+    sent: [],
+    send(channel) {
+      this.sent.push(channel);
+    },
+    isDestroyed() {
+      return true;
+    },
+    isCrashed() {
+      return false;
+    },
+  };
+  assert.equal(await queryDirtyEditors(wc, 5000, { ipcMain }), false);
+  assert.deepEqual(wc.sent, []);
+  assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+});
+
+test("resolves false without sending when the renderer is crashed", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = {
+    sent: [],
+    send(channel) {
+      this.sent.push(channel);
+    },
+    isDestroyed() {
+      return false;
+    },
+    isCrashed() {
+      return true;
+    },
+  };
+  assert.equal(await queryDirtyEditors(wc, 5000, { ipcMain }), false);
+  assert.deepEqual(wc.sent, []);
+});
+
+test("resolves false and tears down when webContents.send throws", async () => {
+  const ipcMain = makeIpcMain();
+  const wc = {
+    send() {
+      throw new Error("renderer gone");
+    },
+    isDestroyed() {
+      return false;
+    },
+    isCrashed() {
+      return false;
+    },
+  };
+  assert.equal(await queryDirtyEditors(wc, 5000, { ipcMain }), false);
+  // Listener must be removed even on the throw path.
+  assert.equal(ipcMain.listenerCount("app:dirty-editors-result"), 0);
+});
+
+test("resolves false when no ipcMain can be resolved", async () => {
+  // No ipcMain injected and electron isn't loadable in `node --test`, so
+  // resolveIpcMain() returns null → fail open.
+  const wc = makeWebContents();
+  assert.equal(await queryDirtyEditors(wc, 5000), false);
+  assert.deepEqual(wc.sent, []);
+});

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -35,6 +35,17 @@ let handlersRegistered = false; // Prevent duplicate IPC handler registration
 let menuDeps = null;
 let electronApp = null; // Reference to Electron app for userData path
 let isQuitting = false;
+// Set right before electron-updater's quitAndInstall() drives app.quit() for a
+// macOS/Windows in-place update. The install only succeeds if the app process
+// exits cleanly: Squirrel.Mac's ShipIt helper waits on the parent PID to die
+// before swapping the bundle. Two normal-quit behaviors would otherwise keep
+// the process alive and strand the installer (see #1215):
+//   1. close-to-tray hides the window instead of closing it, and
+//   2. the before-quit dirty-editor guard preventDefault()s the quit for a
+//      5s renderer round-trip.
+// This flag lets both paths recognize an update install and let the quit
+// through immediately.
+let quittingForUpdate = false;
 const rendererReadyCallbacksByWebContentsId = new Map();
 const rendererReadySeenByWebContentsId = new Set();
 const rendererReadyWaitersByWebContentsId = new Map();
@@ -68,6 +79,39 @@ function debugLog(...args) {
 
 function setIsQuitting(nextValue) {
   isQuitting = Boolean(nextValue);
+}
+
+/**
+ * Read the generic "app is quitting" flag. Window close handlers gate
+ * close-to-tray / settings-window hiding on this; exposed so the update-quit
+ * rollback can be verified.
+ */
+function getIsQuitting() {
+  return isQuitting;
+}
+
+/**
+ * Mark that the app is quitting to install a downloaded update. Mirrors the
+ * generic isQuitting flag so the main-window close handler bypasses
+ * close-to-tray. Call this right before electron-updater's quitAndInstall().
+ *
+ * Passing false rolls BOTH flags back — used when a quitAndInstall never
+ * actually quits the app (throw / Squirrel follow-up error / stale download).
+ * Without resetting isQuitting too, close-to-tray and settings-window hiding
+ * would stay disabled for the rest of the session (#1215 review).
+ */
+function setQuittingForUpdate(nextValue) {
+  quittingForUpdate = Boolean(nextValue);
+  isQuitting = quittingForUpdate;
+}
+
+/**
+ * True when quitAndInstall() initiated the current quit. The before-quit guard
+ * checks this to skip the dirty-editor round-trip and let the app exit so the
+ * updater's installer can run.
+ */
+function isQuittingForUpdate() {
+  return quittingForUpdate;
 }
 
 /**
@@ -943,6 +987,9 @@ module.exports = {
   restoreWindowInputFocus,
   waitForRendererReady,
   setIsQuitting,
+  getIsQuitting,
+  setQuittingForUpdate,
+  isQuittingForUpdate,
   openFallbackBrowser,
   tryOpenExternalWithFallback,
   resolveSettingsWindowBounds,

--- a/electron/bridges/windowManager.quittingForUpdate.test.cjs
+++ b/electron/bridges/windowManager.quittingForUpdate.test.cjs
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const WINDOW_MANAGER_PATH = require.resolve("./windowManager.cjs");
+
+function loadFreshWindowManager() {
+  // windowManager keeps the quitting flags in module-level closures, so reload
+  // a fresh copy per test to avoid cross-test state leakage.
+  delete require.cache[WINDOW_MANAGER_PATH];
+  return require("./windowManager.cjs");
+}
+
+test("isQuittingForUpdate defaults to false", () => {
+  const wm = loadFreshWindowManager();
+  assert.equal(wm.isQuittingForUpdate(), false);
+});
+
+test("setQuittingForUpdate(true) flips the update-install flag and commits isQuitting", () => {
+  const wm = loadFreshWindowManager();
+  assert.equal(wm.getIsQuitting(), false);
+  wm.setQuittingForUpdate(true);
+  assert.equal(wm.isQuittingForUpdate(), true);
+  // Must also set the generic isQuitting flag so the main-window close handler
+  // bypasses close-to-tray during the update quit (#1215).
+  assert.equal(wm.getIsQuitting(), true);
+});
+
+test("setQuittingForUpdate(false) clears BOTH the update flag and isQuitting", () => {
+  const wm = loadFreshWindowManager();
+  wm.setQuittingForUpdate(true);
+  assert.equal(wm.isQuittingForUpdate(), true);
+  assert.equal(wm.getIsQuitting(), true);
+  // Rollback (failed install) must restore normal close behavior — resetting
+  // isQuitting too, otherwise close-to-tray / settings hiding stay disabled for
+  // the rest of the session (#1215 review).
+  wm.setQuittingForUpdate(false);
+  assert.equal(wm.isQuittingForUpdate(), false);
+  assert.equal(wm.getIsQuitting(), false);
+});
+
+test("setQuittingForUpdate coerces truthy/falsy values to booleans", () => {
+  const wm = loadFreshWindowManager();
+  wm.setQuittingForUpdate(1);
+  assert.equal(wm.isQuittingForUpdate(), true);
+  wm.setQuittingForUpdate(0);
+  assert.equal(wm.isQuittingForUpdate(), false);
+  wm.setQuittingForUpdate(undefined);
+  assert.equal(wm.isQuittingForUpdate(), false);
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -726,12 +726,13 @@ if (!gotLock) {
     // app.quit() re-fired before-quit. Let it through.
     if (quitConfirmed) return;
 
-    // Update install in progress: electron-updater's quitAndInstall() is
-    // driving this quit so its installer can swap the app bundle. The dirty
-    // editor round-trip would preventDefault() and stall the quit, leaving the
-    // process alive — which strands Squirrel.Mac's ShipIt helper (it waits on
-    // the parent PID to exit). Let the quit through immediately (#1215).
-    if (getWindowManager().isQuittingForUpdate()) return;
+    // NOTE: an update install (quitAndInstall) intentionally still runs the
+    // dirty-editor check below. setQuittingForUpdate(true) only bypasses
+    // close-to-tray (so the window actually closes and Squirrel.Mac's ShipIt
+    // can swap the bundle); it must NOT skip the unsaved-work guard, or
+    // clicking "Restart Now" with a dirty SFTP editor would silently lose
+    // edits (#1215 review). If the user cancels to save, the quit is aborted
+    // and autoUpdateBridge's watchdog clears the quitting-for-update flags.
 
     // A check is already in flight — swallow this event; the in-flight handler
     // will issue commitQuit() when it completes if appropriate.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -124,6 +124,7 @@ const getAiBridge = createLazyModule("./bridges/aiBridge.cjs");
 const getWindowManager = createLazyModule("./bridges/windowManager.cjs");
 const getVaultBackupBridge = createLazyModule("./bridges/vaultBackupBridge.cjs");
 const ptyProcessTree = require("./bridges/ptyProcessTree.cjs");
+const { queryDirtyEditors } = require("./bridges/dirtyEditorGuard.cjs");
 
 // GPU settings
 // NOTE: Do not disable Chromium sandbox by default.
@@ -777,28 +778,20 @@ if (!gotLock) {
     quitGuardChannelBusy = true;
     event.preventDefault();
 
-    // The response and the timeout race against each other; whichever
-    // one fires first wins. A naive `clearTimeout` is not enough — once
-    // the timer has already been queued for the next tick, clearTimeout
-    // is a no-op and the timeout callback runs even after the response
-    // arrived, which would commit the quit even on a `hasDirty=true`
-    // reply (i.e. silently override the user's "save first" intent).
-    let settled = false;
-    let timeoutId = null;
-    const settle = (decision) => {
-      if (settled) return;
-      settled = true;
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      _ipcMain.removeListener("app:dirty-editors-result", onResult);
-      quitGuardChannelBusy = false;
-      if (decision === "commit") {
-        commitQuit();
-      } else {
-        // decision === "stay": renderer showed a toast for dirty editors and
-        // the user is saving instead of quitting.
+    // Ask the renderer whether any editor tab has unsaved changes. The same
+    // round-trip is used by the auto-update install handler (#1215); both go
+    // through queryDirtyEditors so the request/reply/timeout handling stays in
+    // one place. It fails open (resolves false) on timeout / dead renderer, so
+    // a hung renderer can never strand the quit.
+    queryDirtyEditors(wc, QUIT_GUARD_TIMEOUT_MS, { ipcMain: _ipcMain })
+      .then((hasDirty) => {
+        quitGuardChannelBusy = false;
+        if (!hasDirty) {
+          commitQuit();
+          return;
+        }
+        // hasDirty: the renderer showed a toast for dirty editors and the user
+        // is saving instead of quitting.
         //
         // A normal quit never sets isQuitting before commitQuit, so there is
         // nothing to undo. But an update install (quitAndInstall) calls
@@ -810,38 +803,15 @@ if (!gotLock) {
         // (#1215 review).
         const wm = getWindowManager();
         if (wm.isQuittingForUpdate?.()) wm.setQuittingForUpdate(false);
-      }
-    };
-    function onResult(evt, payload) {
-      // Defence in depth: this channel is queried with a specific
-      // webContents in mind. A reply from any other window (e.g. a
-      // misbehaving extension or a future bug that wires the channel
-      // elsewhere) is silently ignored so it can't decide the quit.
-      // We use `.on` (not `.once`) so a rogue reply doesn't consume
-      // the listener slot and let the real reply fall through. Reject
-      // strictly: a missing/falsy sender is anomalous in real IPC and
-      // is treated the same as a wrong-window reply.
-      if (evt?.sender !== wc) return;
-      const hasDirty = payload && payload.hasDirty === true;
-      settle(hasDirty ? "stay" : "commit");
-    }
-    _ipcMain.on("app:dirty-editors-result", onResult);
-
-    // Timeout fallback: if the renderer never replies (crash, unhandled
-    // exception in the listener, etc.) we'd otherwise be stuck with
-    // quitGuardChannelBusy=true and the app un-quittable.
-    timeoutId = setTimeout(() => settle("commit"), QUIT_GUARD_TIMEOUT_MS);
-
-    try {
-      wc.send("app:query-dirty-editors");
-    } catch (err) {
-      // `webContents.send` can throw if the renderer was destroyed
-      // between our `isCrashed?.()` check and this call (a real race
-      // when the GPU process is dying). Tear the listener/timer down
-      // synchronously so we don't strand quitGuardChannelBusy=true.
-      console.warn("[Main] Failed to query renderer for dirty editors:", err);
-      settle("commit");
-    }
+      })
+      .catch((err) => {
+        // queryDirtyEditors is written to never reject, but guard anyway: a
+        // throw here would leave quitGuardChannelBusy=true and wedge the app
+        // un-quittable. Fail open and let the quit through.
+        console.warn("[Main] dirty-editor quit guard failed:", err);
+        quitGuardChannelBusy = false;
+        commitQuit();
+      });
   });
 
   // Cleanup all PTY sessions and port forwarding tunnels before quitting

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -726,6 +726,13 @@ if (!gotLock) {
     // app.quit() re-fired before-quit. Let it through.
     if (quitConfirmed) return;
 
+    // Update install in progress: electron-updater's quitAndInstall() is
+    // driving this quit so its installer can swap the app bundle. The dirty
+    // editor round-trip would preventDefault() and stall the quit, leaving the
+    // process alive — which strands Squirrel.Mac's ShipIt helper (it waits on
+    // the parent PID to exit). Let the quit through immediately (#1215).
+    if (getWindowManager().isQuittingForUpdate()) return;
+
     // A check is already in flight — swallow this event; the in-flight handler
     // will issue commitQuit() when it completes if appropriate.
     if (quitGuardChannelBusy) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -794,9 +794,23 @@ if (!gotLock) {
       }
       _ipcMain.removeListener("app:dirty-editors-result", onResult);
       quitGuardChannelBusy = false;
-      if (decision === "commit") commitQuit();
-      // decision === "stay": renderer showed a toast for dirty editors.
-      // Do not touch isQuitting so tray / close-to-tray gating keeps working.
+      if (decision === "commit") {
+        commitQuit();
+      } else {
+        // decision === "stay": renderer showed a toast for dirty editors and
+        // the user is saving instead of quitting.
+        //
+        // A normal quit never sets isQuitting before commitQuit, so there is
+        // nothing to undo. But an update install (quitAndInstall) calls
+        // setQuittingForUpdate(true) — which also flips isQuitting=true to
+        // bypass close-to-tray — BEFORE this dirty check runs. If the user
+        // cancels to save, clear it NOW instead of waiting up to 10s for
+        // autoUpdateBridge's watchdog; otherwise close-to-tray and other
+        // !isQuitting-gated behavior stay bypassed while the app keeps running
+        // (#1215 review).
+        const wm = getWindowManager();
+        if (wm.isQuittingForUpdate?.()) wm.setQuittingForUpdate(false);
+      }
     };
     function onResult(evt, payload) {
       // Defence in depth: this channel is queried with a specific

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -29,6 +29,7 @@ const updateDownloadedListeners = new Set();
 const updateAvailableListeners = new Set();
 const updateNotAvailableListeners = new Set();
 const updateErrorListeners = new Set();
+const updateNeedsSaveListeners = new Set();
 
 function cleanupTransferListeners(transferId) {
   transferProgressListeners.delete(transferId);
@@ -400,6 +401,17 @@ ipcRenderer.on("netcatty:update:error", (_event, payload) => {
   });
 });
 
+// Update can't install yet because there are unsaved editors (#1215).
+ipcRenderer.on("netcatty:update:needs-save", () => {
+  updateNeedsSaveListeners.forEach((cb) => {
+    try {
+      cb();
+    } catch (err) {
+      console.error("Update needs-save callback failed", err);
+    }
+  });
+});
+
 // Transfer progress events
 ipcRenderer.on("netcatty:transfer:progress", (_event, payload) => {
   const cb = transferProgressListeners.get(payload.transferId);
@@ -623,6 +635,7 @@ const api = createPreloadApi({
   updateAvailableListeners,
   updateNotAvailableListeners,
   updateErrorListeners,
+  updateNeedsSaveListeners,
   uploadProgressListeners,
   uploadCompleteListeners,
   uploadErrorListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -744,6 +744,10 @@ function createPreloadApi(ctx) {
     updateErrorListeners.add(cb);
     return () => updateErrorListeners.delete(cb);
   },
+  onUpdateNeedsSave: (cb) => {
+    updateNeedsSaveListeners.add(cb);
+    return () => updateNeedsSaveListeners.delete(cb);
+  },
 
   // ── AI Bridge ──
   aiSyncProviders: async (providers) => {

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -29,6 +29,8 @@ declare global {
     onUpdateNotAvailable?(cb: () => void): () => void;
     onUpdateDownloaded?(cb: () => void): () => void;
     onUpdateError?(cb: (payload: { error: string }) => void): () => void;
+    // Fired when an install was requested but blocked by unsaved editors (#1215).
+    onUpdateNeedsSave?(cb: () => void): () => void;
 
     // Global Toggle Hotkey (Quake Mode)
     registerGlobalHotkey?(hotkey: string): Promise<{ success: boolean; enabled?: boolean; error?: string; accelerator?: string }>;


### PR DESCRIPTION
## Root Cause

macOS auto-update downloaded successfully but never installed because the app process did not actually exit. Close-to-tray could hide the main window instead of exiting, and the dirty-editor quit guard could delay quit while waiting for the renderer. Squirrel.Mac ShipIt cannot replace the app bundle until the parent process exits.

## Fix

- Bypass close-to-tray during update installation by setting the update-quit flag before `quitAndInstall()`.
- Destroy the tray before installation so it does not keep the process alive.
- Roll the update-quit flag back with a watchdog if installation does not exit the app.
- Clear the update-quit flag immediately if the dirty-editor guard cancels quit.
- Check dirty editors before calling `quitAndInstall()`, while the renderer is still reachable.
- Broadcast `netcatty:update:needs-save` to all windows when unsaved editors block installation.
- Keep the `before-quit` dirty-editor guard as a secondary safety check.
- Extract shared dirty-editor query logic to `electron/bridges/dirtyEditorGuard.cjs`.
- Extend the watchdog timeout from 10 seconds to 60 seconds to avoid resetting the quit flag too early.

## Tests

- Added coverage for dirty-editor query result, no-dirty, timeout, wrong sender, destroyed or crashed webContents, send failures, and missing ipcMain.
- Added install-handler tests for dirty-editor blocking, clean install flow, and no-main-window behavior.
- `npm run lint` passed.
- `npm test` passed: 1514 tests.
- Local Codex review was run until clean.

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
