### PR TITLE
fix(terminal): destructure sshDebugLogEnabled in TerminalPane (fixes ReferenceError)

### DIFF
--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -569,6 +569,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   isResizing,
   isComposeBarOpen,
   sessionLog,
+  sshDebugLogEnabled,
   onHotkeyAction,
   onTerminalFontSizeChange,
   onOpenSftp,


### PR DESCRIPTION
## Problem

In `components/terminalLayer/TerminalLayerSupport.tsx`, `TerminalPane` forwarded `sshDebugLogEnabled` to child components during render, but never destructured it from props. That caused a runtime `ReferenceError: sshDebugLogEnabled is not defined` and crashed terminal panel rendering.

- The prop already existed in `TerminalPaneProps` and the memo comparator; it was only missing from the component's prop destructuring.
- `tsc` already reported `TS2304: Cannot find name 'sshDebugLogEnabled'`, but the build uses Vite/esbuild without type-check gating, so the issue reached runtime.
- Introduced by commit `85f486e6` (`feat(ssh): reuse authenticated connection for Copy Tab`).

## Fix

Add `sshDebugLogEnabled,` to the `TerminalPane` prop destructuring next to `sessionLog,`. This is a one-line runtime fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
