### PR TITLE
fix(terminal): use composed CJK font stack in xterm constructor to fix Chinese char width (#1226)

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -100,6 +100,7 @@ export type CreateXTermRuntimeContext = {
   container: HTMLDivElement;
   host: Host;
   fontFamilyId: string;
+  resolvedFontFamily: string;
   fontSize: number;
   terminalTheme: TerminalTheme;
   terminalSettingsRef: RefObject<TerminalSettings | undefined>;
@@ -225,7 +226,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   const hostFontId = resolveHostTerminalFontFamilyId(ctx.host, ctx.fontFamilyId) || "menlo";
   // Use fontStore for font lookup - guarantees non-empty result
   const fontObj = fontStore.getFontById(hostFontId);
-  const fontFamily = fontObj.family;
+  const fontFamily = ctx.resolvedFontFamily || fontObj.family;
 
   const effectiveFontSize = resolveHostTerminalFontSize(ctx.host, ctx.fontSize);
 

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -178,6 +178,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
           container: containerRef.current,
           host,
           fontFamilyId,
+          resolvedFontFamily,
           fontSize,
           terminalTheme: effectiveTheme,
           terminalSettingsRef,


### PR DESCRIPTION
## Summary
- Thread the composed `resolvedFontFamily` from `Terminal.tsx` into `createXTermRuntime`.
- Use that composed font stack as the initial xterm `fontFamily`, with the raw font-store family retained only as a fallback.
- Preserve existing CJK handling: `rescaleOverlappingGlyphs: true` and Unicode `15-graphemes`.

## Root cause
`Terminal.tsx` already resolves the terminal font with `composeFontFamilyStack(...)`, including CJK monospace fallbacks from `infrastructure/config/cjkFonts.ts`. During initial xterm construction, `createXTermRuntime` ignored that composed stack and used only `fontStore.getFontById(...).family`. That let Chromium choose a proportional/system CJK fallback for Chinese glyphs, whose metrics do not match xterm's two-cell grid.

## Verification
- `npm run build`
- `node --test --import tsx infrastructure/config/cjkFonts.test.ts components/terminal/runtime/*.test.ts components/terminal/*.test.ts`

Closes #1226