### PR TITLE
fix: route Cmd+W through existing tab close flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,6 +36,7 @@ import { selectConnectionLogForTerminalDataCapture } from './domain/connectionLo
 import { collectSessionIds } from './domain/workspace';
 import { resolveCloseIntent } from './application/state/resolveCloseIntent';
 import { resolveSnippetsShortcutIntent } from './application/state/resolveSnippetsShortcutIntent';
+import { resolveWindowCommandCloseIntent } from './application/state/windowCommandClose';
 import { TERMINAL_THEMES } from './infrastructure/config/terminalThemes';
 import { useCustomThemes } from './application/state/customThemeStore';
 import type { SyncPayload } from './domain/sync';
@@ -705,7 +706,7 @@ function App({ settings }: { settings: SettingsState }) {
   // Populated by UnsavedChangesProvider render-prop below so that the hotkey
   // dispatcher (defined outside that scope) can still reach the dirty-confirm
   // close flow.
-  const handleRequestCloseEditorTabRef = useRef<(id: string) => void>(() => {});
+  const handleRequestCloseEditorTabRef = useRef<(id: string) => boolean | Promise<boolean>>(() => false);
 
   const createLocalTerminalWithCurrentShell = useCallback(() => { return createLocalTerminalWithCurrentShellImpl(() => ({ classifyLocalShellType, createLocalTerminal, discoveredShells, resolveShellSetting, terminalSettings })); }, [createLocalTerminal, terminalSettings, discoveredShells]);
 
@@ -727,6 +728,12 @@ function App({ settings }: { settings: SettingsState }) {
 
   const closeTabsInFlightRef = useRef(false);
 
+  // 顶层标签顺序需要包含编辑器标签，供顶部标签和编辑器邻居计算使用。
+  const orderedTabsWithEditors = useMemo(
+    () => [...orderedTabs, ...editorTabs.map((tab) => toEditorTabId(tab.id))],
+    [orderedTabs, editorTabs],
+  );
+
   // Close many tabs at once with a single batched busy-shell confirmation.
   // Used by the "Close all / Close others / Close to the right" context-menu
   // actions on tabs (#748).
@@ -737,6 +744,43 @@ function App({ settings }: { settings: SettingsState }) {
 
   // Shared hotkey action handler - used by both global handler and terminal callback
   const executeHotkeyAction = useCallback((action: string, e: KeyboardEvent) => { return executeHotkeyActionImpl(() => ({ IS_DEV, MOVE_FOCUS_DEBOUNCE_MS, action, activeTabStore, addConnectionLogRef, closeSession, closeTabInFlightRef, closeWorkspace, collectSessionIds, confirmIfBusyLocalTerminal, createLocalTerminalWithCurrentShell, e, editorTabs, fromEditorTabId, handleOpenSettingsRef, handleRequestCloseEditorTabRef, isEditorTabId, lastMoveFocusTimeRef, moveFocusInWorkspace, orderedTabs, resolveCloseIntent, resolveSnippetsShortcutIntent, sessions, setActiveTabId, setAddToWorkspaceDialog, setIsQuickSwitcherOpen, setNavigateToSection, settings, splitSessionWithCurrentShell, systemInfoRef, toEditorTabId, toggleBroadcast, toggleScriptsSidePanelRef, toggleSidePanelRef, workspaces }), action, e); }, [orderedTabs, editorTabs, sessions, workspaces, setActiveTabId, closeSession, closeWorkspace, createLocalTerminalWithCurrentShell, splitSessionWithCurrentShell, moveFocusInWorkspace, toggleBroadcast, settings, confirmIfBusyLocalTerminal]);
+
+  const handleWindowCommandCloseRequest = useCallback(async () => {
+    const openDialogs = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"][data-state="open"]'));
+    const topmostOpenDialog = openDialogs[openDialogs.length - 1] ?? null;
+    const topmostDialogClose = topmostOpenDialog?.querySelector<HTMLElement>('[data-dialog-close="true"]');
+    if (topmostDialogClose) {
+      topmostDialogClose.click();
+      return;
+    }
+
+    const intent = resolveWindowCommandCloseIntent({
+      activeTabId,
+      editorTabIds: editorTabs.map((tab) => toEditorTabId(tab.id)),
+      sessionIds: sessions.map((session) => session.id),
+      workspaceIds: workspaces.map((workspace) => workspace.id),
+      logViewIds: logViews.map((logView) => logView.id),
+    });
+
+    if (intent.kind === 'closeTab') {
+      executeHotkeyAction('closeTab', new KeyboardEvent('keydown', { key: 'w', metaKey: true }));
+      return;
+    }
+
+    if (intent.kind === 'closeLogView') {
+      closeLogView(intent.tabId);
+      return;
+    }
+
+    await netcattyBridge.get()?.windowClose?.();
+  }, [activeTabId, closeLogView, editorTabs, executeHotkeyAction, logViews, sessions, workspaces]);
+
+  useEffect(() => {
+    const unsubscribe = netcattyBridge.get()?.onWindowCommandCloseRequested?.(() => {
+      void handleWindowCommandCloseRequest();
+    });
+    return () => unsubscribe?.();
+  }, [handleWindowCommandCloseRequest]);
 
   // Callback for terminal to invoke app-level hotkey actions
   const handleHotkeyAction = useCallback((action: string, e: KeyboardEvent) => {
@@ -940,12 +984,6 @@ function App({ settings }: { settings: SettingsState }) {
   }, [setDraggingSessionId]);
 
   const handleRootContextMenu = useCallback((e: React.MouseEvent<HTMLDivElement>) => { return handleRootContextMenuImpl(() => ({ e }), e); }, []);
-
-  // Combined ordered tab list including editor tab ids (for TopTabs scrollable area)
-  const orderedTabsWithEditors = useMemo(
-    () => [...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))],
-    [orderedTabs, editorTabs],
-  );
 
   return <AppView ctx={{ accentMode, activeTabId, activeTerminalTheme, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace, clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, closeLogView, closeSession, closeTabsBatch, copySessionWithCurrentShell, closeWorkspace, connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets, createWorkspaceWithHosts, customAccent, customGroups, currentTerminalTheme, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict, followAppTerminalTheme, groupConfigs, handleAddKnownHost, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDeleteHost, handleEndSessionDrag, handleHostConnectWithProtocolCheck, handleHotkeyAction, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit, handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect, handleRequestCloseEditorTabRef, handleSessionStatusChange, handleSyncNowManual, handleTerminalDataCapture, handleToggleTheme, handleUpdateHostFromTerminal, hostById, hosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen, keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, openLogView, orderedTabsWithEditors, orphanSessions, passphraseQueue, protocolSelectHost, proxyProfiles, quickResults, quickSearch, reorderTabs, reorderWorkspaceSessions, resetSessionRename, resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet: handleRunSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionRenameTarget, sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen, setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior, sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, sshDebugLogsEnabled: settings.sshDebugLogsEnabled, startSessionRename, startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, toggleBroadcast, toggleConnectionLogSaved, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, unmanageSource, updateConnectionLog, updateCustomGroups, updateGroupConfigs, updateHostDistro, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources, updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateTerminalSetting, workspaceRenameTarget, workspaceRenameValue, workspaces, VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper }} />;
 }

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -72,31 +72,34 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         };
 
         // Real dirty-confirm close handler.
-        const handleRequestCloseEditorTab = async (id: string) => {
+        const handleRequestCloseEditorTab = async (id: string): Promise<boolean> => {
           const tab = editorTabStore.getTab(id);
-          if (!tab) return;
+          if (!tab) return false;
           const dirty = tab.content !== tab.baselineContent;
           if (!dirty) {
             closeEditorAndActivateNeighbor(id);
-            return;
+            return true;
           }
           const choice = await prompt(tab.fileName);
-          if (choice === 'cancel') return;
+          if (choice === 'cancel') return false;
           if (choice === 'discard') {
             closeEditorAndActivateNeighbor(id);
-            return;
+            return true;
           }
           if (choice === 'save') {
             const ok = await saveEditorTab(id);
             if (!ok) {
               const msg = editorTabStore.getTab(id)?.saveError ?? 'Save failed';
               toast.error(msg, 'SFTP');
-              return;
+              return false;
             }
             const latest = editorTabStore.getTab(id);
-            if (!latest || latest.content !== latest.baselineContent) return;
+            if (!latest || latest.content !== latest.baselineContent) return false;
             closeEditorAndActivateNeighbor(id);
+            return true;
           }
+
+          return false;
         };
 
         // Expose to the hotkey dispatcher (Cmd/Ctrl+W).

--- a/application/state/useWindowControls.ts
+++ b/application/state/useWindowControls.ts
@@ -50,6 +50,11 @@ export const useWindowControls = () => {
     return bridge?.onWindowFullScreenChanged?.(cb) ?? (() => {});
   }, []);
 
+  const onWindowCommandCloseRequested = useCallback((cb: () => void) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.onWindowCommandCloseRequested?.(cb) ?? (() => {});
+  }, []);
+
   return {
     notifyRendererReady,
     closeSettingsWindow,
@@ -60,5 +65,6 @@ export const useWindowControls = () => {
     isMaximized,
     isFullscreen,
     onFullscreenChanged,
+    onWindowCommandCloseRequested,
   };
 };

--- a/application/state/windowCommandClose.test.ts
+++ b/application/state/windowCommandClose.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveWindowCommandCloseIntent } from "./windowCommandClose.ts";
+
+test("Cmd+W closes the active closable tab first", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "s1",
+      editorTabIds: [],
+      sessionIds: ["s1", "s2"],
+      workspaceIds: [],
+      logViewIds: [],
+    }),
+    { kind: "closeTab" },
+  );
+});
+
+test("Cmd+W on a log view closes the log view", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "log-1",
+      editorTabIds: [],
+      sessionIds: ["s1", "s2"],
+      workspaceIds: [],
+      logViewIds: ["log-1"],
+    }),
+    { kind: "closeLogView", tabId: "log-1" },
+  );
+});
+
+test("Cmd+W closes an editor tab through the existing close flow", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "editor:1",
+      editorTabIds: ["editor:1"],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: [],
+    }),
+    { kind: "closeTab" },
+  );
+});
+
+test("Cmd+W closes the window from the Vault page", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: "vault",
+      editorTabIds: [],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: [],
+    }),
+    { kind: "closeWindow" },
+  );
+});
+
+test("Cmd+W closes the window when nothing else is active", () => {
+  assert.deepEqual(
+    resolveWindowCommandCloseIntent({
+      activeTabId: null,
+      editorTabIds: [],
+      sessionIds: [],
+      workspaceIds: [],
+      logViewIds: [],
+    }),
+    { kind: "closeWindow" },
+  );
+});

--- a/application/state/windowCommandClose.ts
+++ b/application/state/windowCommandClose.ts
@@ -1,0 +1,42 @@
+export type WindowCommandCloseIntent =
+  | { kind: 'closeTab' }
+  | { kind: 'closeLogView'; tabId: string }
+  | { kind: 'closeWindow' };
+
+interface ResolveWindowCommandCloseIntentInput {
+  activeTabId: string | null;
+  editorTabIds: string[];
+  sessionIds: string[];
+  workspaceIds: string[];
+  logViewIds: string[];
+}
+
+export function resolveWindowCommandCloseIntent({
+  activeTabId,
+  editorTabIds,
+  sessionIds,
+  workspaceIds,
+  logViewIds,
+}: ResolveWindowCommandCloseIntentInput): WindowCommandCloseIntent {
+  if (!activeTabId) {
+    return { kind: 'closeWindow' };
+  }
+
+  if (editorTabIds.includes(activeTabId)) {
+    return { kind: 'closeTab' };
+  }
+
+  if (sessionIds.includes(activeTabId) || workspaceIds.includes(activeTabId)) {
+    return { kind: 'closeTab' };
+  }
+
+  if (logViewIds.includes(activeTabId)) {
+    return { kind: 'closeLogView', tabId: activeTabId };
+  }
+
+  if (activeTabId === 'vault' || activeTabId === 'sftp') {
+    return { kind: 'closeWindow' };
+  }
+
+  return { kind: 'closeWindow' };
+}

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -164,7 +164,7 @@ const SettingsSyncTabWithVault: React.FC<{ onSettingsApplied?: () => void }> = (
 
 const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }) => {
     const { t } = useI18n();
-    const { notifyRendererReady, closeSettingsWindow } = useWindowControls();
+    const { notifyRendererReady, closeSettingsWindow, onWindowCommandCloseRequested } = useWindowControls();
     const { updateState, checkNow, installUpdate, openReleasePage, startDownload, isUpdateDemoMode } = useUpdateCheck({
         autoUpdateEnabled: settings.autoUpdateEnabled,
         // Install blocked by unsaved editors in the main window — surface a toast
@@ -177,6 +177,13 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
     useEffect(() => {
         notifyRendererReady();
     }, [notifyRendererReady]);
+
+    useEffect(() => {
+        const unsubscribe = onWindowCommandCloseRequested(() => {
+            void closeSettingsWindow();
+        });
+        return () => unsubscribe?.();
+    }, [closeSettingsWindow, onWindowCommandCloseRequested]);
 
     useEffect(() => {
         setMountedTabs((prev) => {

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -939,6 +939,12 @@ function buildAppMenu(Menu, app, isMac, language = currentLanguage) {
   // Save deps so later language changes can rebuild the menu.
   menuDeps = { Menu, app, isMac };
   const closeFocusedWindow = (_menuItem, browserWindow) => {
+    // 只有主窗口/设置窗口会接收 command-close；其他 BrowserWindow 直接关闭。
+    if (browserWindow && browserWindow !== mainWindow && browserWindow !== settingsWindow) {
+      closeBrowserWindow(browserWindow);
+      return;
+    }
+
     // macOS 的 Cmd+W 先交给渲染层关闭标签页；没有标签页时渲染层再关闭窗口。
     requestWindowCommandClose(browserWindow) || requestWindowCommandClose(mainWindow);
   };

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -54,6 +54,7 @@ const DEBUG_WINDOWS = process.env.NETCATTY_DEBUG_WINDOWS === "1";
 const OAUTH_DEFAULT_WIDTH = 600;
 const OAUTH_DEFAULT_HEIGHT = 700;
 const OAUTH_OVERLAY_ID = "__netcatty_oauth_loading__";
+const WINDOW_COMMAND_CLOSE_CHANNEL = "netcatty:window:command-close";
 // The OAuth callback port is chosen dynamically by oauthBridge (prefers
 // 45678, falls back to an OS-assigned free port if that is in use, #823),
 // so the in-app popup allow-list has to consult the bridge at popup-open
@@ -79,6 +80,17 @@ function debugLog(...args) {
 
 function setIsQuitting(nextValue) {
   isQuitting = Boolean(nextValue);
+}
+
+function shouldCloseWindowFromInput(input) {
+  return Boolean(
+    input?.type === "keyDown" &&
+    input?.meta &&
+    !input?.control &&
+    !input?.alt &&
+    !input?.shift &&
+    String(input?.key || "").toLowerCase() === "w",
+  );
 }
 
 /**
@@ -228,8 +240,8 @@ function getWindowBoundsState(win, overrideBounds) {
 }
 
 const MENU_LABELS = {
-  en: { edit: "Edit", view: "View", window: "Window", reload: "Reload" },
-  "zh-CN": { edit: "编辑", view: "视图", window: "窗口", reload: "重新加载" },
+  en: { edit: "Edit", view: "View", window: "Window", reload: "Reload", closeWindow: "Close Window" },
+  "zh-CN": { edit: "编辑", view: "视图", window: "窗口", reload: "重新加载", closeWindow: "关闭窗口" },
 };
 
 function tMenu(language, key) {
@@ -257,6 +269,28 @@ function getWindowForIpcEvent(event) {
     // ignore
   }
   return mainWindow;
+}
+
+function closeBrowserWindow(win) {
+  if (!win || win.isDestroyed?.()) return false;
+  try {
+    win.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function requestWindowCommandClose(win) {
+  if (!win || win.isDestroyed?.()) return false;
+  try {
+    const webContents = win.webContents;
+    if (!webContents || webContents.isDestroyed?.()) return closeBrowserWindow(win);
+    webContents.send(WINDOW_COMMAND_CLOSE_CHANNEL);
+    return true;
+  } catch {
+    return closeBrowserWindow(win);
+  }
 }
 
 function broadcastLanguageChanged() {
@@ -682,6 +716,8 @@ const mainWindowApi = createMainWindowApi({
   createAppWindowOpenHandler,
   attachOAuthLoadingOverlay,
   registerWindowHandlers,
+  requestWindowCommandClose,
+  shouldCloseWindowFromInput,
   closeSettingsWindow: (...args) => closeSettingsWindow(...args),
   hideSettingsWindow: (...args) => hideSettingsWindow(...args),
 });
@@ -902,6 +938,10 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
 function buildAppMenu(Menu, app, isMac, language = currentLanguage) {
   // Save deps so later language changes can rebuild the menu.
   menuDeps = { Menu, app, isMac };
+  const closeFocusedWindow = (_menuItem, browserWindow) => {
+    // macOS 的 Cmd+W 先交给渲染层关闭标签页；没有标签页时渲染层再关闭窗口。
+    requestWindowCommandClose(browserWindow) || requestWindowCommandClose(mainWindow);
+  };
   const template = [
     ...(isMac
       ? [
@@ -951,7 +991,15 @@ function buildAppMenu(Menu, app, isMac, language = currentLanguage) {
         { role: "minimize" },
         { role: "zoom" },
         ...(isMac
-          ? [{ type: "separator" }, { role: "front" }]
+          ? [
+            { type: "separator" },
+            {
+              label: tMenu(language, "closeWindow"),
+              accelerator: "CommandOrControl+W",
+              click: closeFocusedWindow,
+            },
+            { role: "front" },
+          ]
           : [{ role: "close" }]),
       ],
     },
@@ -985,6 +1033,9 @@ module.exports = {
   isWindowUsable,
   registerWindowHandlers,
   restoreWindowInputFocus,
+  requestWindowCommandClose,
+  shouldCloseWindowFromInput,
+  WINDOW_COMMAND_CLOSE_CHANNEL,
   waitForRendererReady,
   setIsQuitting,
   getIsQuitting,

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -139,7 +139,13 @@ function createMainWindowApi(ctx) {
       // Terminal apps need these keys to pass through to the remote shell (e.g., byobu, tmux).
       // Using setIgnoreMenuShortcuts lets the keydown still reach the page (xterm.js)
       // while preventing Chromium's built-in shortcuts from triggering.
-      win.webContents.on("before-input-event", (_event, input) => {
+      win.webContents.on("before-input-event", (event, input) => {
+        if (isMac && shouldCloseWindowFromInput(input)) {
+          event.preventDefault();
+          requestWindowCommandClose(win);
+          return;
+        }
+
         if (input.alt && !input.control && !input.meta) {
           if (input.key === "ArrowLeft" || input.key === "ArrowRight") {
             win.webContents.setIgnoreMenuShortcuts(true);

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -7,6 +7,7 @@ const {
   registerWindowHandlers,
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
+  requestWindowCommandClose,
   shouldCloseWindowFromInput,
 } = require("./windowManager.cjs");
 const { createMainWindowApi } = require("./windowManager/mainWindow.cjs");
@@ -172,7 +173,7 @@ test("restoreWindowInputFocus can show the window when requested", () => {
   assert.deepEqual(calls, ["show", "focus", "webContents.focus"]);
 });
 
-test("buildAppMenu wires macOS Command+W to close the focused window", () => {
+test("buildAppMenu closes a non-app window directly when Cmd+W is invoked", () => {
   let capturedTemplate = null;
   const Menu = {
     buildFromTemplate(template) {
@@ -189,15 +190,36 @@ test("buildAppMenu wires macOS Command+W to close the focused window", () => {
   assert.ok(closeItem);
   assert.equal(closeItem.label, "Close Window");
 
-  const sentChannels = [];
+  const calls = [];
   closeItem.click(null, {
     isDestroyed() { return false; },
+    close() {
+      calls.push("close");
+    },
     webContents: {
       isDestroyed() { return false; },
-      send(channel) { sentChannels.push(channel); },
+      send(channel) {
+        calls.push(`send:${channel}`);
+      },
     },
   });
 
+  assert.deepEqual(calls, ["close"]);
+});
+
+test("requestWindowCommandClose sends command-close to renderer-capable windows", () => {
+  const sentChannels = [];
+  const win = {
+    isDestroyed() { return false; },
+    webContents: {
+      isDestroyed() { return false; },
+      send(channel) {
+        sentChannels.push(channel);
+      },
+    },
+  };
+
+  assert.equal(requestWindowCommandClose(win), true);
   assert.deepEqual(sentChannels, ["netcatty:window:command-close"]);
 });
 

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -2,11 +2,14 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  buildAppMenu,
   isWindowUsable,
   registerWindowHandlers,
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
+  shouldCloseWindowFromInput,
 } = require("./windowManager.cjs");
+const { createMainWindowApi } = require("./windowManager/mainWindow.cjs");
 
 function createWindowStub({ destroyed = false, webContents } = {}) {
   return {
@@ -167,6 +170,154 @@ test("restoreWindowInputFocus can show the window when requested", () => {
 
   assert.equal(restored, true);
   assert.deepEqual(calls, ["show", "focus", "webContents.focus"]);
+});
+
+test("buildAppMenu wires macOS Command+W to close the focused window", () => {
+  let capturedTemplate = null;
+  const Menu = {
+    buildFromTemplate(template) {
+      capturedTemplate = template;
+      return { template };
+    },
+  };
+
+  buildAppMenu(Menu, { name: "Netcatty" }, true);
+
+  const windowMenu = capturedTemplate.find((item) => item.label === "Window");
+  assert.ok(windowMenu);
+  const closeItem = windowMenu.submenu.find((item) => item.accelerator === "CommandOrControl+W");
+  assert.ok(closeItem);
+  assert.equal(closeItem.label, "Close Window");
+
+  const sentChannels = [];
+  closeItem.click(null, {
+    isDestroyed() { return false; },
+    webContents: {
+      isDestroyed() { return false; },
+      send(channel) { sentChannels.push(channel); },
+    },
+  });
+
+  assert.deepEqual(sentChannels, ["netcatty:window:command-close"]);
+});
+
+test("shouldCloseWindowFromInput only matches macOS Command+W keydown", () => {
+  assert.equal(shouldCloseWindowFromInput({ type: "keyDown", meta: true, key: "w" }), true);
+  assert.equal(shouldCloseWindowFromInput({ type: "keyDown", meta: true, key: "W" }), true);
+  assert.equal(shouldCloseWindowFromInput({ type: "keyUp", meta: true, key: "w" }), false);
+  assert.equal(shouldCloseWindowFromInput({ type: "keyDown", control: true, key: "w" }), false);
+  assert.equal(shouldCloseWindowFromInput({ type: "keyDown", meta: true, shift: true, key: "w" }), false);
+});
+
+test("main window asks renderer to close tabs from macOS Command+W before-input-event", async () => {
+  let beforeInputHandler = null;
+  const commandCloseRequests = [];
+
+  class BrowserWindowStub {
+    constructor() {
+      this.webContents = {
+        id: 1,
+        on(channel, handler) {
+          if (channel === "before-input-event") beforeInputHandler = handler;
+        },
+        once() {},
+        isDestroyed() {
+          return false;
+        },
+        isCrashed() {
+          return false;
+        },
+        setIgnoreMenuShortcuts() {},
+        setWindowOpenHandler() {},
+        openDevTools() {},
+      };
+    }
+
+    on() {}
+    once() {}
+    isDestroyed() { return false; }
+    isMaximized() { return false; }
+    isFullScreen() { return false; }
+    getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
+    setBackgroundColor() {}
+    async loadURL() {}
+    close() {}
+  }
+
+  const api = createMainWindowApi({
+    mainWindow: null,
+    electronApp: null,
+    currentTheme: "light",
+    isQuitting: false,
+    pendingWindowStateWrite: null,
+    queuedWindowState: null,
+    windowStateCloseRequested: false,
+    DEFAULT_WINDOW_WIDTH: 1400,
+    DEFAULT_WINDOW_HEIGHT: 900,
+    MIN_WINDOW_WIDTH: 1100,
+    MIN_WINDOW_HEIGHT: 640,
+    V8_CACHE_OPTIONS: "bypassHeatCheck",
+    THEME_COLORS: { light: { background: "#fff" } },
+    unhealthyWebContentsIds: new Set(),
+    rendererReadySeenByWebContentsId: new Set(),
+    __dirname,
+    URL,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    getGlobalShortcutBridge() {
+      return { handleWindowClose: () => false };
+    },
+    debugLog() {},
+    resolveFrontendBackgroundColor() { return null; },
+    loadWindowState() { return null; },
+    getDevRendererBaseUrl(url) { return url; },
+    getWindowBoundsState() { return null; },
+    queueWindowStateSave() {},
+    saveWindowStateSync() {},
+    setupDeferredShow() {},
+    createExternalOnlyWindowOpenHandler() { return {}; },
+    createAppWindowOpenHandler() { return {}; },
+    attachOAuthLoadingOverlay() {},
+    registerWindowHandlers() {},
+    requestWindowCommandClose(win) {
+      commandCloseRequests.push(win);
+      return true;
+    },
+    shouldCloseWindowFromInput,
+    closeSettingsWindow() {},
+    hideSettingsWindow() {},
+  });
+
+  await api.createWindow(
+    {
+      BrowserWindow: BrowserWindowStub,
+      nativeTheme: {},
+      app: {},
+      screen: {},
+      shell: {},
+      ipcMain: {},
+    },
+    {
+      preload: "/tmp/preload.cjs",
+      devServerUrl: "http://localhost:5173",
+      isDev: true,
+      appIcon: null,
+      isMac: true,
+      electronDir: __dirname,
+    },
+  );
+
+  let prevented = false;
+  beforeInputHandler({ preventDefault: () => { prevented = true; } }, {
+    type: "keyDown",
+    meta: true,
+    key: "w",
+  });
+
+  assert.equal(prevented, true);
+  assert.equal(commandCloseRequests.length, 1);
 });
 
 test("window focus IPC handler focuses the sender owner window", async () => {

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -350,6 +350,11 @@ function createPreloadApi(ctx) {
   windowIsMaximized: () => ipcRenderer.invoke("netcatty:window:isMaximized"),
   windowIsFullscreen: () => ipcRenderer.invoke("netcatty:window:isFullscreen"),
   windowFocus: () => ipcRenderer.invoke("netcatty:window:focus"),
+  onWindowCommandCloseRequested: (cb) => {
+    const handler = () => cb();
+    ipcRenderer.on("netcatty:window:command-close", handler);
+    return () => ipcRenderer.removeListener("netcatty:window:command-close", handler);
+  },
   onWindowFullScreenChanged: (cb) => {
     fullscreenChangeListeners.add(cb);
     return () => fullscreenChangeListeners.delete(cb);

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -12,6 +12,7 @@ declare global {
     windowIsMaximized?(): Promise<boolean>;
     windowIsFullscreen?(): Promise<boolean>;
     windowFocus?(): Promise<boolean>;
+    onWindowCommandCloseRequested?(cb: () => void): () => void;
     onWindowFullScreenChanged?(cb: (isFullscreen: boolean) => void): () => void;
 
     // Settings window


### PR DESCRIPTION
## What
- Route `Cmd+W` through the existing close-handling path
- Keep tab-closing behavior unchanged
- Close the main window when the active context is not a closable tab
- Wire the settings window into the same close-request bridge

## Why
- Prevent `Cmd+W` from becoming a no-op in non-tab contexts
- Keep close behavior consistent across the main window and the settings window

## Validation
- Ran the relevant unit tests
- Verified the build
- Rebased onto the latest `main` before pushing
- Windows testing has not been performed yet because I currently do not have access to a Windows test environment
- From the code path, Windows still uses Electron’s default `role: "close"` behavior, so `Ctrl+W` has not yet been fully routed through the same command-close dispatch path