### PR TITLE
[codex] fix CJK IME composition overflow

### DIFF
--- a/index.css
+++ b/index.css
@@ -243,6 +243,23 @@ body {
   left: 3px !important;
 }
 
+/* Keep focused IME helper text from making the terminal content drift sideways. */
+.xterm,
+.xterm .xterm-screen,
+.xterm .xterm-viewport,
+.xterm .xterm-scrollable-element {
+  overflow-x: hidden !important;
+}
+
+@supports (overflow: clip) {
+  .xterm,
+  .xterm .xterm-screen,
+  .xterm .xterm-viewport,
+  .xterm .xterm-scrollable-element {
+    overflow-x: clip !important;
+  }
+}
+
 @keyframes shimmer {
   0% {
     transform: translateX(-100%);


### PR DESCRIPTION
## Summary
- Replace the runtime listener approach with a CSS-only horizontal scroll guard for xterm containers.
- Prevent terminal content from drifting sideways without moving or resizing IME helper/candidate positioning.
- Remove the previous JavaScript scroll-lock helper.

## Root cause
When CJK IME composition happens near the right edge, Chromium can horizontally scroll xterm containers to bring the helper textarea into view. That makes the terminal content appear to move left.

This patch forbids horizontal overflow/scroll on the terminal display containers with CSS, leaving IME positioning untouched.

## Verification
- `node --test --import tsx components/terminal/runtime/*.test.ts components/terminal/*.test.ts`
- `npm run lint`
- `npm run build`

Fixes #1223
Fixes #1226