### PR TITLE
[codex] redact attachment payloads during context compaction

### DIFF
--- a/infrastructure/ai/contextCompaction.test.ts
+++ b/infrastructure/ai/contextCompaction.test.ts
@@ -175,6 +175,66 @@ test("prepareContextCompaction summarizes older tool results instead of dropping
   assert.match(result.messages[0]?.content as string, /81% full/);
 });
 
+test("formatMessagesForCompaction redacts image and file payloads", () => {
+  const imagePayload = "iVBORw0KGgo".repeat(200);
+  const filePayload = "JVBERi0xLjQK".repeat(200);
+  const formatted = formatMessagesForCompaction([
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Please inspect these attachments." },
+        {
+          type: "image",
+          image: imagePayload,
+          mediaType: "image/png",
+        },
+        {
+          type: "file",
+          data: filePayload,
+          filename: "report.pdf",
+          mediaType: "application/pdf",
+        },
+      ],
+    },
+  ]);
+
+  assert.match(formatted, /Please inspect these attachments/);
+  assert.match(formatted, /redacted image payload/);
+  assert.match(formatted, /mediaType=image\/png/);
+  assert.match(formatted, /redacted file payload/);
+  assert.match(formatted, /filename=report\.pdf/);
+  assert.doesNotMatch(formatted, new RegExp(imagePayload.slice(0, 40)));
+  assert.doesNotMatch(formatted, new RegExp(filePayload.slice(0, 40)));
+});
+
+test("formatMessagesForCompaction keeps non-attachment data fields", () => {
+  const formatted = formatMessagesForCompaction([
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "read_json",
+          output: {
+            type: "json",
+            value: {
+              data: {
+                host: "prod-1",
+                status: "healthy",
+              },
+            },
+          },
+        },
+      ],
+    },
+  ]);
+
+  assert.match(formatted, /prod-1/);
+  assert.match(formatted, /healthy/);
+  assert.doesNotMatch(formatted, /redacted data payload/);
+});
+
 test("estimateModelMessagesTokens counts multimodal and tool content", () => {
   const tokens = estimateModelMessagesTokens([
     { role: "user", content: [{ type: "text", text: "hello world" }] },
@@ -198,10 +258,6 @@ test("resolveContextWindow prefers manual override, then fetched model metadata,
   assert.equal(
     resolveContextWindow({
       provider: {
-        id: "p1",
-        providerId: "openrouter",
-        name: "OpenRouter",
-        enabled: true,
         contextWindow: 262144,
         modelContextWindows: { "qwen/test": 131072 },
       },
@@ -214,10 +270,6 @@ test("resolveContextWindow prefers manual override, then fetched model metadata,
   assert.equal(
     resolveContextWindow({
       provider: {
-        id: "p1",
-        providerId: "openrouter",
-        name: "OpenRouter",
-        enabled: true,
         modelContextWindows: { "qwen/test": 131072 },
       },
       modelId: "qwen/test",
@@ -228,12 +280,7 @@ test("resolveContextWindow prefers manual override, then fetched model metadata,
 
   assert.equal(
     resolveContextWindow({
-      provider: {
-        id: "p1",
-        providerId: "custom",
-        name: "Custom",
-        enabled: true,
-      },
+      provider: {},
       modelId: "unknown",
       defaultContextWindow: 128000,
     }),

--- a/infrastructure/ai/contextCompaction.ts
+++ b/infrastructure/ai/contextCompaction.ts
@@ -3,6 +3,7 @@ import type { ProviderConfig } from "./types";
 
 const DEFAULT_COMPACTION_RATIO = 0.85;
 const TOKEN_CHARS = 4;
+const REDACTED_PAYLOAD_PREVIEW_CHARS = 80;
 
 export const DEFAULT_CONTEXT_WINDOW_TOKENS = 128_000;
 export const DEFAULT_PROTECT_RECENT_MESSAGES = 10;
@@ -203,7 +204,108 @@ function endsWithToolCall(message: ModelMessage | undefined): boolean {
 
 function formatMessageContent(content: ModelMessage["content"]): string {
   if (typeof content === "string") return content;
-  return JSON.stringify(content, null, 2);
+  return JSON.stringify(sanitizeContentForCompaction(content), null, 2);
+}
+
+function sanitizeContentForCompaction(content: Exclude<ModelMessage["content"], string>): unknown {
+  if (!Array.isArray(content)) return sanitizeUnknownForCompaction(content);
+  return content.map((part) => sanitizeContentPartForCompaction(part));
+}
+
+function sanitizeContentPartForCompaction(part: unknown): unknown {
+  if (!isRecord(part)) return sanitizeUnknownForCompaction(part);
+
+  if (part.type === "image") {
+    const sanitized = sanitizeRecordForCompaction(part);
+    return {
+      ...sanitized,
+      image: describeRedactedPayload(part.image, {
+        label: "image",
+        mediaType: typeof part.mediaType === "string" ? part.mediaType : undefined,
+      }),
+    };
+  }
+
+  if (part.type === "file") {
+    const sanitized = sanitizeRecordForCompaction(part);
+    return {
+      ...sanitized,
+      data: describeRedactedPayload(part.data, {
+        label: "file",
+        mediaType: typeof part.mediaType === "string" ? part.mediaType : undefined,
+        filename: typeof part.filename === "string" ? part.filename : undefined,
+      }),
+    };
+  }
+
+  return sanitizeUnknownForCompaction(part);
+}
+
+function sanitizeRecordForCompaction(value: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value)) {
+    sanitized[entryKey] = sanitizeUnknownForCompaction(entryValue, entryKey);
+  }
+  return sanitized;
+}
+
+function sanitizeUnknownForCompaction(value: unknown, key?: string): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") {
+    if (key === "base64Data" || key === "dataUrl" || key === "file_data") {
+      return describeRedactedPayload(value, { label: key });
+    }
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (value instanceof URL) return value.toString();
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+    return describeRedactedPayload(value, { label: key ?? "binary" });
+  }
+  if (Array.isArray(value)) return value.map((part) => sanitizeUnknownForCompaction(part));
+  if (isRecord(value)) return sanitizeRecordForCompaction(value);
+  return String(value);
+}
+
+function describeRedactedPayload(
+  value: unknown,
+  {
+    label,
+    filename,
+    mediaType,
+  }: {
+    label: string;
+    filename?: string;
+    mediaType?: string;
+  },
+): string {
+  const details = [
+    filename ? `filename=${filename}` : undefined,
+    mediaType ? `mediaType=${mediaType}` : undefined,
+    describePayloadSize(value),
+    typeof value === "string" ? describeStringPreview(value) : undefined,
+  ].filter(Boolean);
+
+  return `[redacted ${label} payload${details.length ? `: ${details.join(", ")}` : ""}]`;
+}
+
+function describePayloadSize(value: unknown): string {
+  if (typeof value === "string") return `${value.length} chars`;
+  if (value instanceof ArrayBuffer) return `${value.byteLength} bytes`;
+  if (ArrayBuffer.isView(value)) return `${value.byteLength} bytes`;
+  if (value instanceof URL) return "url";
+  return typeof value;
+}
+
+function describeStringPreview(value: string): string | undefined {
+  if (!value.startsWith("data:")) return undefined;
+  const commaIndex = value.indexOf(",");
+  const header = commaIndex >= 0 ? value.slice(0, commaIndex) : value.slice(0, REDACTED_PAYLOAD_PREVIEW_CHARS);
+  return `source=${header.slice(0, REDACTED_PAYLOAD_PREVIEW_CHARS)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function escapeXml(value: string): string {


### PR DESCRIPTION
## Summary
- Redacts image and file payloads before formatting old messages for context compaction summaries
- Keeps attachment metadata such as media type, filename, and payload size
- Adds coverage that normal tool result data is preserved

Follow-up for the post-merge review comment on #1237: https://github.com/binaricat/Netcatty/pull/1237#discussion_r3355138112

## Verification
- `node --test --import tsx infrastructure/ai/contextCompaction.test.ts`
- `npm run lint` (passes with one existing SFTP hook warning)
- `npm test`
- `npx tsc --noEmit` still has existing repo-wide errors, but no `infrastructure/ai/contextCompaction*` errors after this change
