### PR TITLE
[codex] fix copilot thinking stream

### DIFF
--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -4,7 +4,7 @@
  * Copilot backend driver — wraps @github/copilot-sdk.
  *
  * new CopilotClient({ connection: RuntimeConnection.forStdio({ path }), useLoggedInUser })
- *   .createSession({ model, onPermissionRequest: approveAll, mcpServers })
+ *   .createSession({ model, streaming, onPermissionRequest: approveAll, mcpServers })
  *   .sendAndWait({ prompt }) -> response.data.content
  *
  * - The bundled copilot runtime (@github/copilot) is excluded from packaging
@@ -52,6 +52,11 @@ function buildCopilotSessionOptions({ model, injectedMcpServers }) {
   // onPermissionRequest is wired in runCopilotTurn (it needs the SDK's approveAll).
   const options = {
     mcpServers: toCopilotMcpServers(injectedMcpServers),
+    // Copilot SDK enables assistant.message_delta / assistant.reasoning_delta
+    // from SessionConfig.streaming, not from MessageOptions. Without this the
+    // renderer only receives final assistant.message and the thinking panel never
+    // has live reasoning to render.
+    streaming: true,
   };
   if (model) options.model = model;
   return options;
@@ -71,8 +76,8 @@ function extractCopilotContent(response) {
   return (response && response.data && response.data.content) || "";
 }
 
-function buildCopilotMessageOptions({ prompt, attachments, streamDeltas = true }) {
-  const options = { prompt: String(prompt || ""), streamDeltas };
+function buildCopilotMessageOptions({ prompt, attachments }) {
+  const options = { prompt: String(prompt || "") };
   const nativeAttachments = [];
   for (const attachment of Array.isArray(attachments) ? attachments : []) {
     if (!attachment) continue;
@@ -117,9 +122,9 @@ function extractCopilotResultText(data) {
 /**
  * Translate one copilot SessionEvent into emitter calls — gives copilot the same
  * live tool-card + thinking-panel UX as codex/claude (it previously showed only
- * the final text). `state` ({ reasoningOpen, streamedText }) threads the thinking
- * block and records whether any delta streamed, so runCopilotTurn can fall back
- * to the final consolidated message when the runtime emits no deltas.
+ * the final text). `state` ({ reasoningOpen, streamedText, streamedReasoning })
+ * threads the thinking block and records whether any delta streamed, so
+ * runCopilotTurn can fall back to final consolidated events when needed.
  * Event shapes calibrated against @github/copilot-sdk generated session-events.
  */
 function translateCopilotEvent(event, emitter, state) {
@@ -131,7 +136,18 @@ function translateCopilotEvent(event, emitter, state) {
   };
   switch (event.type) {
     case "assistant.reasoning_delta":
-      if (data.deltaContent) { emitter.reasoning(data.deltaContent); st.reasoningOpen = true; }
+      if (data.deltaContent) {
+        emitter.reasoning(data.deltaContent);
+        st.reasoningOpen = true;
+        st.streamedReasoning = true;
+      }
+      return;
+    case "assistant.reasoning":
+      if (data.content && !st.streamedReasoning) {
+        emitter.reasoning(data.content);
+        st.reasoningOpen = true;
+        closeReasoning();
+      }
       return;
     case "assistant.message_delta":
       if (data.deltaContent) { closeReasoning(); emitter.text(data.deltaContent); st.streamedText = true; }
@@ -181,6 +197,7 @@ async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptio
     client = new CopilotClient(realClientOptions);
     const sessionConfig = {
       ...sessionOptions,
+      streaming: true,
       // Allow only MCP calls; netcatty MCP performs scope/approval/blocklist checks.
       onPermissionRequest: approveNetcattyMcpOnly,
     };
@@ -207,9 +224,9 @@ async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptio
 
     // Stream tool calls + text/reasoning deltas in real time (parity with
     // codex/claude — copilot previously showed only the final text). on() gets
-    // every SessionEvent; streamDeltas enables assistant.message_delta /
-    // assistant.reasoning_delta; tool.execution_* events arrive regardless.
-    const state = { reasoningOpen: false, streamedText: false };
+    // every SessionEvent; SessionConfig.streaming enables assistant.message_delta
+    // / assistant.reasoning_delta; tool.execution_* events arrive regardless.
+    const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
     let unsubscribe = () => {};
     if (typeof session.on === "function") {
       unsubscribe = session.on((ev) => translateCopilotEvent(ev, emitter, state));
@@ -232,7 +249,7 @@ async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptio
     }
     let final;
     try {
-      final = await session.sendAndWait(buildCopilotMessageOptions({ prompt, attachments, streamDeltas: true }));
+      final = await session.sendAndWait(buildCopilotMessageOptions({ prompt, attachments }));
     } finally {
       try { unsubscribe(); } catch { /* best effort */ }
       removeAbortListener();

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -47,6 +47,7 @@ test("buildCopilotSessionOptions maps injected MCP to local stdio servers", () =
     }],
   });
   assert.equal(o.model, "claude-sonnet-4.5");
+  assert.equal(o.streaming, true);
   const srv = o.mcpServers["netcatty-remote-hosts"];
   assert.equal(srv.type, "stdio");
   assert.equal(srv.command, "/abs/electron");
@@ -86,7 +87,7 @@ test("buildCopilotMessageOptions sends pasted images/files as native attachments
     ],
   });
   assert.equal(opts.prompt, "inspect these");
-  assert.equal(opts.streamDeltas, true);
+  assert.equal("streamDeltas" in opts, false);
   assert.deepEqual(opts.attachments, [
     { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
     { type: "file", path: "/tmp/note.txt", displayName: "note.txt" },
@@ -151,6 +152,30 @@ test("translateCopilotEvent: deltas -> text/reasoning, tool start/complete -> to
   assert.equal(state.streamedText, true);
 });
 
+test("translateCopilotEvent: final reasoning is shown when no reasoning deltas streamed", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
+  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "complete thinking" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "complete thinking" },
+    { k: "reasoningEnd" },
+  ]);
+  assert.equal(state.reasoningOpen, false);
+});
+
+test("translateCopilotEvent: final reasoning is ignored after streamed reasoning deltas", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
+  translateCopilotEvent({ type: "assistant.reasoning_delta", data: { deltaContent: "thinking" } }, emitter, state);
+  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "thinking" } }, emitter, state);
+  translateCopilotEvent({ type: "assistant.message_delta", data: { deltaContent: "hello" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "thinking" },
+    { k: "reasoningEnd" },
+    { k: "text", t: "hello" },
+  ]);
+});
+
 test("runCopilotTurn streams tool calls + deltas via session.on (no final-text dup)", async () => {
   const { events, emitter } = collector();
   const captured = {};
@@ -186,7 +211,8 @@ test("runCopilotTurn streams tool calls + deltas via session.on (no final-text d
     emitter,
     sdkModule,
   });
-  assert.equal(captured.opts.streamDeltas, true, "requested delta streaming");
+  assert.equal(captured.created.streaming, true, "requested session streaming");
+  assert.equal("streamDeltas" in captured.opts, false, "does not send unsupported message streaming flag");
   assert.deepEqual(captured.opts.attachments, [
     { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
   ]);


### PR DESCRIPTION
## What changed

- Enables streaming on Copilot SDK sessions so message and reasoning deltas reach the chat UI.
- Stops sending the streaming flag in the per-message payload, where the Copilot SDK does not read it.
- Handles final Copilot reasoning events as a fallback when no reasoning deltas were streamed.

## Why

Copilot SDK exposes thinking through session events, but Netcatty was enabling streaming in the wrong place and ignored final reasoning events. That left the thinking panel empty even when the SDK/runtime had reasoning content available.

## Validation

- `node --test electron/bridges/aiBridge/sdk/copilotDriver.test.cjs`
- `npm test`
- `npm run lint` (passes with one existing warning in `application/state/sftp/useSftpExternalOperations.ts`)
- `npm run build`