### PR TITLE
[codex] improve codex live progress

### DIFF
--- a/electron/bridges/aiBridge/sdk/codexDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/codexDriver.cjs
@@ -134,6 +134,47 @@ function extractMcpResultText(item) {
   return "";
 }
 
+function ensureStateSet(state, key) {
+  if (!state[key]) state[key] = new Set();
+  return state[key];
+}
+
+function ensureStateMap(state, key) {
+  if (!state[key]) state[key] = new Map();
+  return state[key];
+}
+
+function emitCodexReasoning(item, emitter, state) {
+  if (!item || typeof item.text !== "string" || !item.text) return;
+  const textById = ensureStateMap(state, "reasoningTextById");
+  const itemId = item.id || "__default_reasoning";
+  const previous = textById.get(itemId) || "";
+  const delta = item.text.startsWith(previous) ? item.text.slice(previous.length) : item.text;
+  textById.set(itemId, item.text);
+  if (delta) {
+    emitter.reasoning(delta);
+    state.reasoningOpen = true;
+  }
+}
+
+function emitCodexToolCallOnce(item, emitter, state, toolName, args) {
+  if (!item || !item.id) return false;
+  const emittedToolCalls = ensureStateSet(state, "emittedToolCalls");
+  if (emittedToolCalls.has(item.id)) return false;
+  emittedToolCalls.add(item.id);
+  emitter.toolCall(toolName, args || {}, item.id);
+  return true;
+}
+
+function emitCodexToolResultOnce(item, emitter, state, output, toolName) {
+  if (!item || !item.id) return false;
+  const emittedToolResults = ensureStateSet(state, "emittedToolResults");
+  if (emittedToolResults.has(item.id)) return false;
+  emittedToolResults.add(item.id);
+  emitter.toolResult(item.id, output || "", toolName);
+  return true;
+}
+
 /**
  * Translate one Codex ThreadEvent into emitter calls.
  * `state` ({ reasoningOpen }) is threaded across events so reasoning summary
@@ -152,15 +193,14 @@ function translateCodexEvent(event, emitter, state) {
     emitter.emitError(event.error?.message || "Codex turn failed");
     return;
   }
-  if (event.type !== "item.completed" || !event.item) return;
+  if (!["item.started", "item.updated", "item.completed"].includes(event.type) || !event.item) return;
 
   const item = event.item;
 
-  // Reasoning summary items feed the thinking panel (reasoning-delta). codex
-  // emits them as complete items; keep the block open so consecutive summaries
-  // concatenate, and close it below as soon as real content follows.
+  // Reasoning summary items feed the thinking panel. Codex may update the same
+  // item with cumulative text before completion, so emit only the new suffix.
   if (item.type === "reasoning") {
-    if (item.text) { emitter.reasoning(item.text); st.reasoningOpen = true; }
+    emitCodexReasoning(item, emitter, st);
     return;
   }
 
@@ -168,14 +208,14 @@ function translateCodexEvent(event, emitter, state) {
 
   switch (item.type) {
     case "agent_message":
-      if (item.text) emitter.text(item.text);
+      if (event.type === "item.completed" && item.text) emitter.text(item.text);
       return;
     case "command_execution": {
       // Calibrated against @openai/codex-sdk CommandExecutionItem (command +
       // aggregated_output).
-      emitter.toolCall("shell", { command: item.command || "" }, item.id);
-      if (item.aggregated_output) {
-        emitter.toolResult(item.id, item.aggregated_output, "shell");
+      emitCodexToolCallOnce(item, emitter, st, "shell", { command: item.command || "" });
+      if (event.type === "item.completed" && item.aggregated_output) {
+        emitCodexToolResultOnce(item, emitter, st, item.aggregated_output, "shell");
       }
       return;
     }
@@ -183,8 +223,10 @@ function translateCodexEvent(event, emitter, state) {
       // Calibrated against @openai/codex-sdk McpToolCallItem (tool + arguments;
       // result.content is an MCP ContentBlock[], errors carry .message).
       const toolName = item.tool || "mcp_tool";
-      emitter.toolCall(toolName, item.arguments || {}, item.id);
-      emitter.toolResult(item.id, extractMcpResultText(item), toolName);
+      emitCodexToolCallOnce(item, emitter, st, toolName, item.arguments || {});
+      if (event.type === "item.completed") {
+        emitCodexToolResultOnce(item, emitter, st, extractMcpResultText(item), toolName);
+      }
       return;
     }
     default:

--- a/electron/bridges/aiBridge/sdk/codexDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/codexDriver.test.cjs
@@ -49,6 +49,22 @@ test("reasoning then agent_message -> reasoning, reasoningEnd, text (block close
   assert.equal(state.reasoningOpen, false);
 });
 
+test("reasoning item updates stream only new thinking text", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false };
+  const item = { id: "r-1", type: "reasoning" };
+  translateCodexEvent({ type: "item.started", item: { ...item, text: "step 1" } }, emitter, state);
+  translateCodexEvent({ type: "item.updated", item: { ...item, text: "step 1\nstep 2" } }, emitter, state);
+  translateCodexEvent({ type: "item.completed", item: { ...item, text: "step 1\nstep 2" } }, emitter, state);
+  translateCodexEvent({ type: "item.completed", item: { type: "agent_message", text: "done" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "step 1" },
+    { k: "reasoning", d: "\nstep 2" },
+    { k: "reasoningEnd" },
+    { k: "text", t: "done" },
+  ]);
+});
+
 test("mcp_tool_call item -> toolCall + toolResult events (extracts content text)", () => {
   const { events, emitter } = collector();
   translateCodexEvent(
@@ -68,6 +84,53 @@ test("mcp_tool_call item -> toolCall + toolResult events (extracts content text)
   assert.equal(events[0].id, "i-1");
   assert.equal(events[0].n, "terminal_execute");
   assert.equal(events[1].o, "files");
+});
+
+test("mcp_tool_call streams start early and completes without duplicate tool cards", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false };
+  const item = {
+    type: "mcp_tool_call", id: "i-live",
+    server: "netcatty-remote-hosts", tool: "terminal_execute",
+    arguments: { command: "uptime" },
+  };
+  translateCodexEvent({ type: "item.started", item: { ...item, status: "in_progress" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "toolCall", n: "terminal_execute", a: { command: "uptime" }, id: "i-live" },
+  ]);
+  translateCodexEvent({ type: "item.updated", item: { ...item, status: "in_progress" } }, emitter, state);
+  translateCodexEvent(
+    {
+      type: "item.completed",
+      item: {
+        ...item,
+        result: { content: [{ type: "text", text: "up 1 day" }] },
+        status: "completed",
+      },
+    },
+    emitter,
+    state,
+  );
+  assert.deepEqual(events, [
+    { k: "toolCall", n: "terminal_execute", a: { command: "uptime" }, id: "i-live" },
+    { k: "toolResult", id: "i-live", o: "up 1 day", n: "terminal_execute" },
+  ]);
+});
+
+test("command_execution streams start early and completes without duplicate tool cards", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false };
+  const item = { type: "command_execution", id: "cmd-live", command: "pwd" };
+  translateCodexEvent({ type: "item.started", item: { ...item, status: "in_progress", aggregated_output: "" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "toolCall", n: "shell", a: { command: "pwd" }, id: "cmd-live" },
+  ]);
+  translateCodexEvent({ type: "item.updated", item: { ...item, status: "in_progress", aggregated_output: "/tmp" } }, emitter, state);
+  translateCodexEvent({ type: "item.completed", item: { ...item, status: "completed", aggregated_output: "/tmp\n" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "toolCall", n: "shell", a: { command: "pwd" }, id: "cmd-live" },
+    { k: "toolResult", id: "cmd-live", o: "/tmp\n", n: "shell" },
+  ]);
 });
 
 test("mcp_tool_call failure -> toolResult carries the error message", () => {


### PR DESCRIPTION
## What changed

- Streams Codex reasoning item updates into the thinking panel as new text arrives instead of waiting for the completed item.
- Shows Codex command and MCP tool cards as soon as their item starts.
- Tracks emitted reasoning/tool item ids so completed events fill in results without duplicating cards or repeated thinking text.

## Why

The Codex SDK exposes `item.started`, `item.updated`, and `item.completed` events. Netcatty previously rendered only completed items, so users saw delayed thinking and tool cards even though Codex had already reported progress.

## Validation

- `node --test electron/bridges/aiBridge/sdk/codexDriver.test.cjs`
- `npm test`
- `npm run lint` (passes with one existing warning in `application/state/sftp/useSftpExternalOperations.ts`)
- `npm run build`