### PR TITLE
Support pasting local files into SFTP

### DIFF
--- a/application/state/uploadService.test.ts
+++ b/application/state/uploadService.test.ts
@@ -139,6 +139,55 @@ test("uploads picked folder files with their relative directory structure", asyn
   ]);
 });
 
+test("uploads path-backed clipboard files through stream transfer", async () => {
+  const transfers: Array<{ sourcePath: string; targetPath: string; totalBytes?: number }> = [];
+  const taskTotals: number[] = [];
+
+  const results = await uploadEntriesDirect(
+    [
+      {
+        file: null,
+        localPath: "/Users/me/Desktop/report.txt",
+        relativePath: "report.txt",
+        isDirectory: false,
+        size: 42,
+      },
+    ],
+    {
+      targetPath: "/target",
+      sftpId: "sftp-1",
+      isLocal: false,
+      bridge: {
+        mkdirSftp: async () => {},
+        startStreamTransfer: async (payload) => {
+          transfers.push({
+            sourcePath: payload.sourcePath,
+            targetPath: payload.targetPath,
+            totalBytes: payload.totalBytes,
+          });
+          return { transferId: payload.transferId };
+        },
+      },
+      joinPath: (base, name) => `${base}/${name}`,
+      callbacks: {
+        onTaskCreated: (task) => taskTotals.push(task.totalBytes),
+      },
+    },
+  );
+
+  assert.deepEqual(taskTotals, [42]);
+  assert.deepEqual(transfers, [
+    {
+      sourcePath: "/Users/me/Desktop/report.txt",
+      targetPath: "/target/report.txt",
+      totalBytes: 42,
+    },
+  ]);
+  assert.deepEqual(results, [
+    { fileName: "report.txt", success: true },
+  ]);
+});
+
 test("reports empty directory creation failures", async () => {
   const madeDirs: string[] = [];
 

--- a/application/state/uploadService.test.ts
+++ b/application/state/uploadService.test.ts
@@ -188,6 +188,52 @@ test("uploads path-backed clipboard files through stream transfer", async () => 
   ]);
 });
 
+test("copies path-backed clipboard files into local panes through stream transfer", async () => {
+  const transfers: Array<{ sourcePath: string; targetPath: string; targetType: string; totalBytes?: number }> = [];
+
+  const results = await uploadEntriesDirect(
+    [
+      {
+        file: null,
+        localPath: "/Users/me/Desktop/report.txt",
+        relativePath: "report.txt",
+        isDirectory: false,
+        size: 42,
+      },
+    ],
+    {
+      targetPath: "/target",
+      sftpId: null,
+      isLocal: true,
+      bridge: {
+        mkdirLocal: async () => {},
+        startStreamTransfer: async (payload) => {
+          transfers.push({
+            sourcePath: payload.sourcePath,
+            targetPath: payload.targetPath,
+            targetType: payload.targetType,
+            totalBytes: payload.totalBytes,
+          });
+          return { transferId: payload.transferId };
+        },
+      },
+      joinPath: (base, name) => `${base}/${name}`,
+    },
+  );
+
+  assert.deepEqual(transfers, [
+    {
+      sourcePath: "/Users/me/Desktop/report.txt",
+      targetPath: "/target/report.txt",
+      targetType: "local",
+      totalBytes: 42,
+    },
+  ]);
+  assert.deepEqual(results, [
+    { fileName: "report.txt", success: true },
+  ]);
+});
+
 test("reports empty directory creation failures", async () => {
   const madeDirs: string[] = [];
 

--- a/components/SftpClipboardUpload.test.ts
+++ b/components/SftpClipboardUpload.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   createDropEntriesFromClipboardFiles,
   resolveSftpClipboardUploadTarget,
+  shouldLetNativePasteEventHandleSftpPaste,
   type ClipboardLocalFile,
 } from "./sftp/clipboardUpload.ts";
 import type { SftpFileEntry } from "../types";
@@ -77,4 +78,10 @@ test("clipboard files become path-backed upload entries", () => {
       size: 42,
     },
   ]);
+});
+
+test("SFTP paste keydown lets the native paste event handle OS clipboard files", () => {
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", false), true);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", true), false);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpCopy", false), false);
 });

--- a/components/SftpClipboardUpload.test.ts
+++ b/components/SftpClipboardUpload.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 
 import {
   createDropEntriesFromClipboardFiles,
+  getSftpClipboardSystemTextPaths,
+  getSupportedClipboardUploadFiles,
+  isSftpNativeClipboardPasteEnabled,
   resolveSftpClipboardUploadTarget,
   shouldLetNativePasteEventHandleSftpPaste,
   type ClipboardLocalFile,
@@ -64,6 +67,31 @@ test("clipboard upload targets the selected folder in the tree", () => {
   assert.equal(target, "/var/logs");
 });
 
+test("SFTP clipboard system text uses selected list paths", () => {
+  assert.deepEqual(
+    getSftpClipboardSystemTextPaths({
+      currentPath: "/home/app",
+      selectedFileNames: ["one.txt", "nested two.txt"],
+      treeSelection: [],
+    }),
+    ["/home/app/one.txt", "/home/app/nested two.txt"],
+  );
+});
+
+test("SFTP clipboard system text uses selected tree paths", () => {
+  assert.deepEqual(
+    getSftpClipboardSystemTextPaths({
+      currentPath: "/home/app",
+      selectedFileNames: ["ignored.txt"],
+      treeSelection: [
+        { name: "logs", path: "/var/logs", isDirectory: true },
+        { name: "report.txt", path: "/var/report.txt", isDirectory: false },
+      ],
+    }),
+    ["/var/logs", "/var/report.txt"],
+  );
+});
+
 test("clipboard files become path-backed upload entries", () => {
   const files: ClipboardLocalFile[] = [
     { path: "/Users/me/Desktop/report.txt", name: "report.txt", isDirectory: false, size: 42 },
@@ -80,8 +108,55 @@ test("clipboard files become path-backed upload entries", () => {
   ]);
 });
 
+test("clipboard upload ignores directories until recursive paste is supported", () => {
+  const files: ClipboardLocalFile[] = [
+    { path: "/Users/me/Desktop/report.txt", name: "report.txt", isDirectory: false, size: 42 },
+    { path: "/Users/me/Desktop/folder", name: "folder", isDirectory: true, size: 0 },
+  ];
+
+  assert.deepEqual(getSupportedClipboardUploadFiles(files), [
+    { path: "/Users/me/Desktop/report.txt", name: "report.txt", isDirectory: false, size: 42 },
+  ]);
+});
+
 test("SFTP paste keydown lets the native paste event handle OS clipboard files", () => {
-  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", false), true);
-  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", true), false);
-  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpCopy", false), false);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "Ctrl + V"), true);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "⌘ + V"), true);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "Ctrl + Shift + V"), false);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "Cmd + Shift + V"), false);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpPaste", "F9"), false);
+  assert.equal(shouldLetNativePasteEventHandleSftpPaste("sftpCopy", "Ctrl + V"), false);
+});
+
+test("native clipboard paste follows SFTP paste shortcut availability", () => {
+  assert.equal(
+    isSftpNativeClipboardPasteEnabled("disabled", [
+      { id: "sftp-paste", action: "sftpPaste", label: "Paste", mac: "⌘ + V", pc: "Ctrl + V", category: "sftp" },
+    ]),
+    false,
+  );
+  assert.equal(
+    isSftpNativeClipboardPasteEnabled("pc", [
+      { id: "sftp-paste", action: "sftpPaste", label: "Paste", mac: "⌘ + V", pc: "Disabled", category: "sftp" },
+    ]),
+    false,
+  );
+  assert.equal(
+    isSftpNativeClipboardPasteEnabled("pc", [
+      { id: "sftp-paste", action: "sftpPaste", label: "Paste", mac: "⌘ + V", pc: "F9", category: "sftp" },
+    ]),
+    false,
+  );
+  assert.equal(
+    isSftpNativeClipboardPasteEnabled("pc", [
+      { id: "sftp-paste", action: "sftpPaste", label: "Paste", mac: "⌘ + V", pc: "Ctrl + Shift + V", category: "sftp" },
+    ]),
+    false,
+  );
+  assert.equal(
+    isSftpNativeClipboardPasteEnabled("pc", [
+      { id: "sftp-paste", action: "sftpPaste", label: "Paste", mac: "⌘ + V", pc: "Ctrl + V", category: "sftp" },
+    ]),
+    true,
+  );
 });

--- a/components/SftpClipboardUpload.test.ts
+++ b/components/SftpClipboardUpload.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createDropEntriesFromClipboardFiles,
+  resolveSftpClipboardUploadTarget,
+  type ClipboardLocalFile,
+} from "./sftp/clipboardUpload.ts";
+import type { SftpFileEntry } from "../types";
+
+const file = (name: string, overrides: Partial<SftpFileEntry> = {}): SftpFileEntry => ({
+  name,
+  type: "file",
+  size: 1,
+  modified: new Date(0),
+  permissions: "-rw-r--r--",
+  owner: "",
+  group: "",
+  ...overrides,
+});
+
+test("clipboard upload targets the selected folder in the file list", () => {
+  const target = resolveSftpClipboardUploadTarget({
+    currentPath: "/home/app",
+    selectedFileNames: ["logs"],
+    files: [file("logs", { type: "directory" })],
+    treeSelection: [],
+  });
+
+  assert.equal(target, "/home/app/logs");
+});
+
+test("clipboard upload targets the current directory without a concrete folder selection", () => {
+  const target = resolveSftpClipboardUploadTarget({
+    currentPath: "/home/app",
+    selectedFileNames: [],
+    files: [file("logs", { type: "directory" })],
+    treeSelection: [],
+  });
+
+  assert.equal(target, "/home/app");
+});
+
+test("clipboard upload ignores selected regular files when resolving the target", () => {
+  const target = resolveSftpClipboardUploadTarget({
+    currentPath: "/home/app",
+    selectedFileNames: ["readme.md"],
+    files: [file("readme.md")],
+    treeSelection: [],
+  });
+
+  assert.equal(target, "/home/app");
+});
+
+test("clipboard upload targets the selected folder in the tree", () => {
+  const target = resolveSftpClipboardUploadTarget({
+    currentPath: "/home/app",
+    selectedFileNames: [],
+    files: [],
+    treeSelection: [{ name: "logs", path: "/var/logs", isDirectory: true }],
+  });
+
+  assert.equal(target, "/var/logs");
+});
+
+test("clipboard files become path-backed upload entries", () => {
+  const files: ClipboardLocalFile[] = [
+    { path: "/Users/me/Desktop/report.txt", name: "report.txt", isDirectory: false, size: 42 },
+  ];
+
+  assert.deepEqual(createDropEntriesFromClipboardFiles(files), [
+    {
+      file: null,
+      localPath: "/Users/me/Desktop/report.txt",
+      relativePath: "report.txt",
+      isDirectory: false,
+      size: 42,
+    },
+  ]);
+});

--- a/components/sftp/SftpClipboardUploadDialog.tsx
+++ b/components/sftp/SftpClipboardUploadDialog.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import type { SftpClipboardUploadRequest } from "./clipboardUpload";
+import { sftpClipboardUploadStore } from "./clipboardUpload";
+
+interface SftpClipboardUploadDialogProps {
+  request: SftpClipboardUploadRequest | null;
+  currentPath?: string;
+  onUploaded?: (targetPath: string) => void;
+}
+
+export const SftpClipboardUploadDialog: React.FC<SftpClipboardUploadDialogProps> = ({
+  request,
+  currentPath,
+  onUploaded,
+}) => {
+  const [uploading, setUploading] = useState(false);
+  const open = !!request;
+  const fileCount = request?.files.length ?? 0;
+  const previewFiles = request?.files.slice(0, 5) ?? [];
+  const remainingCount = Math.max(0, fileCount - previewFiles.length);
+
+  const handleClose = (nextOpen: boolean) => {
+    if (nextOpen || uploading) return;
+    sftpClipboardUploadStore.clear(request);
+  };
+
+  const handleConfirm = async () => {
+    if (!request) return;
+    setUploading(true);
+    try {
+      await request.onConfirm();
+      onUploaded?.(request.targetPath);
+      sftpClipboardUploadStore.clear(request);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Upload clipboard files?</DialogTitle>
+          <DialogDescription>
+            Upload {fileCount} item{fileCount === 1 ? "" : "s"} to:
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm font-mono break-all">
+            {request?.targetPath ?? currentPath}
+          </div>
+          {previewFiles.length > 0 && (
+            <div className="max-h-40 overflow-auto rounded-md border border-border/60">
+              {previewFiles.map((file) => (
+                <div key={file.path} className="px-3 py-2 text-sm border-b border-border/40 last:border-b-0 truncate">
+                  {file.name}
+                </div>
+              ))}
+              {remainingCount > 0 && (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  and {remainingCount} more...
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => sftpClipboardUploadStore.clear(request)}
+            disabled={uploading}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={uploading || !request}>
+            {uploading && <Loader2 size={14} className="mr-2 animate-spin" />}
+            Upload
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/sftp/SftpPaneView.tsx
+++ b/components/sftp/SftpPaneView.tsx
@@ -1,9 +1,10 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, useTransition } from "react";
 import { useI18n } from "../../application/i18n/I18nProvider";
 import { logger } from "../../lib/logger";
 import { useRenderTracker } from "../../lib/useRenderTracker";
 import { cn } from "../../lib/utils";
 import { SftpPaneDialogs } from "./SftpPaneDialogs";
+import { SftpClipboardUploadDialog } from "./SftpClipboardUploadDialog";
 import { SftpPaneEmptyState } from "./SftpPaneEmptyState";
 import { SftpPaneFileList } from "./SftpPaneFileList";
 import { SftpPaneToolbar } from "./SftpPaneToolbar";
@@ -32,6 +33,7 @@ import { useGlobalSftpBookmarks } from "./hooks/useGlobalSftpBookmarks";
 import { useSftpHostViewMode } from "./hooks/useSftpHostViewMode";
 import { sftpListOrderStore } from "./hooks/useSftpListOrderStore";
 import { sftpTreeSelectionStore } from "./hooks/useSftpTreeSelectionStore";
+import { sftpClipboardUploadStore } from "./clipboardUpload";
 
 interface TreeReloadRequest {
   token: number;
@@ -113,6 +115,17 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
     if (viewMode === 'tree' && !treeEverMounted) setTreeEverMounted(true);
   }, [viewMode, treeEverMounted]);
   const filterInputRef = useRef<HTMLInputElement>(null);
+  const clipboardUploadRequestSnapshot = useSyncExternalStore(
+    sftpClipboardUploadStore.subscribe,
+    sftpClipboardUploadStore.getSnapshot,
+    sftpClipboardUploadStore.getSnapshot,
+  );
+  const clipboardUploadRequest =
+    clipboardUploadRequestSnapshot?.scopeId === dialogActionScopeId
+    && clipboardUploadRequestSnapshot.side === side
+    && isActive
+      ? clipboardUploadRequestSnapshot
+      : null;
 
   const requestTreeReload = useCallback((paths?: string[], full = false) => {
     setTreeReloadRequest((prev) => ({
@@ -646,6 +659,16 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
         setHostSearch={setHostSearch}
         onConnect={callbacks.onConnect}
         onDisconnect={callbacks.onDisconnect}
+      />
+
+      <SftpClipboardUploadDialog
+        request={clipboardUploadRequest}
+        currentPath={pane.connection?.currentPath}
+        onUploaded={(targetPath) => {
+          if (targetPath && targetPath !== pane.connection?.currentPath) {
+            requestTreeReload([targetPath]);
+          }
+        }}
       />
     </div>
   );

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -1,5 +1,6 @@
 import type { SftpFileEntry } from "../../types";
 import type { DropEntry } from "../../lib/sftpFileUtils";
+import type { KeyBinding } from "../../domain/models";
 import { joinPath } from "../../application/state/sftp/utils";
 import { isNavigableDirectory } from "./utils";
 
@@ -20,6 +21,12 @@ export interface ResolveSftpClipboardUploadTargetParams {
   currentPath: string;
   selectedFileNames: string[];
   files: SftpFileEntry[];
+  treeSelection: SftpClipboardUploadTreeSelection[];
+}
+
+export interface GetSftpClipboardSystemTextPathsParams {
+  currentPath: string;
+  selectedFileNames: string[];
   treeSelection: SftpClipboardUploadTreeSelection[];
 }
 
@@ -45,6 +52,18 @@ export function resolveSftpClipboardUploadTarget({
   return currentPath;
 }
 
+export function getSftpClipboardSystemTextPaths({
+  currentPath,
+  selectedFileNames,
+  treeSelection,
+}: GetSftpClipboardSystemTextPathsParams): string[] {
+  if (treeSelection.length > 0) {
+    return treeSelection.map((entry) => entry.path);
+  }
+
+  return selectedFileNames.map((name) => joinPath(currentPath, name));
+}
+
 export function createDropEntriesFromClipboardFiles(files: ClipboardLocalFile[]): DropEntry[] {
   return files.map((file) => ({
     file: null,
@@ -55,11 +74,35 @@ export function createDropEntriesFromClipboardFiles(files: ClipboardLocalFile[])
   }));
 }
 
+export function getSupportedClipboardUploadFiles(files: ClipboardLocalFile[]): ClipboardLocalFile[] {
+  return files.filter((file) => !file.isDirectory);
+}
+
 export function shouldLetNativePasteEventHandleSftpPaste(
   action: string,
-  hasInternalClipboardFiles: boolean,
+  key: string | undefined,
 ): boolean {
-  return action === "sftpPaste" && !hasInternalClipboardFiles;
+  if (action !== "sftpPaste" || !key) return false;
+  const normalized = key.toLowerCase().replace(/\s+/g, "");
+  return [
+    "ctrl+v",
+    "⌘+v",
+    "cmd+v",
+    "command+v",
+  ].includes(normalized);
+}
+
+export function isSftpNativeClipboardPasteEnabled(
+  hotkeyScheme: "disabled" | "mac" | "pc",
+  keyBindings: KeyBinding[],
+): boolean {
+  if (hotkeyScheme === "disabled") return false;
+  const pasteBinding = keyBindings.find((binding) => (
+    binding.category === "sftp" && binding.action === "sftpPaste"
+  ));
+  if (!pasteBinding) return false;
+  const key = hotkeyScheme === "mac" ? pasteBinding.mac : pasteBinding.pc;
+  return shouldLetNativePasteEventHandleSftpPaste("sftpPaste", key);
 }
 
 export interface SftpClipboardUploadRequest {

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -55,6 +55,13 @@ export function createDropEntriesFromClipboardFiles(files: ClipboardLocalFile[])
   }));
 }
 
+export function shouldLetNativePasteEventHandleSftpPaste(
+  action: string,
+  hasInternalClipboardFiles: boolean,
+): boolean {
+  return action === "sftpPaste" && !hasInternalClipboardFiles;
+}
+
 export interface SftpClipboardUploadRequest {
   scopeId: string;
   side: "left" | "right";

--- a/components/sftp/clipboardUpload.ts
+++ b/components/sftp/clipboardUpload.ts
@@ -1,0 +1,90 @@
+import type { SftpFileEntry } from "../../types";
+import type { DropEntry } from "../../lib/sftpFileUtils";
+import { joinPath } from "../../application/state/sftp/utils";
+import { isNavigableDirectory } from "./utils";
+
+export interface ClipboardLocalFile {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+  size?: number;
+}
+
+export interface SftpClipboardUploadTreeSelection {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+export interface ResolveSftpClipboardUploadTargetParams {
+  currentPath: string;
+  selectedFileNames: string[];
+  files: SftpFileEntry[];
+  treeSelection: SftpClipboardUploadTreeSelection[];
+}
+
+export function resolveSftpClipboardUploadTarget({
+  currentPath,
+  selectedFileNames,
+  files,
+  treeSelection,
+}: ResolveSftpClipboardUploadTargetParams): string {
+  const selectedTreeFolders = treeSelection.filter((entry) => entry.isDirectory && entry.name !== "..");
+  if (selectedTreeFolders.length === 1) {
+    return selectedTreeFolders[0].path;
+  }
+
+  if (selectedFileNames.length === 1) {
+    const filesByName = new Map(files.map((entry) => [entry.name, entry]));
+    const selectedEntry = filesByName.get(selectedFileNames[0]);
+    if (selectedEntry && isNavigableDirectory(selectedEntry)) {
+      return joinPath(currentPath, selectedEntry.name);
+    }
+  }
+
+  return currentPath;
+}
+
+export function createDropEntriesFromClipboardFiles(files: ClipboardLocalFile[]): DropEntry[] {
+  return files.map((file) => ({
+    file: null,
+    localPath: file.path,
+    relativePath: file.name,
+    isDirectory: file.isDirectory,
+    size: file.size,
+  }));
+}
+
+export interface SftpClipboardUploadRequest {
+  scopeId: string;
+  side: "left" | "right";
+  targetPath: string;
+  files: ClipboardLocalFile[];
+  onConfirm: () => Promise<void>;
+}
+
+type ClipboardUploadListener = () => void;
+
+let clipboardUploadRequest: SftpClipboardUploadRequest | null = null;
+const clipboardUploadListeners = new Set<ClipboardUploadListener>();
+
+const notifyClipboardUploadListeners = () => {
+  clipboardUploadListeners.forEach((listener) => listener());
+};
+
+export const sftpClipboardUploadStore = {
+  trigger: (request: SftpClipboardUploadRequest) => {
+    clipboardUploadRequest = request;
+    notifyClipboardUploadListeners();
+  },
+  clear: (request?: SftpClipboardUploadRequest | null) => {
+    if (request && clipboardUploadRequest !== request) return;
+    clipboardUploadRequest = null;
+    notifyClipboardUploadListeners();
+  },
+  getSnapshot: () => clipboardUploadRequest,
+  subscribe: (listener: ClipboardUploadListener) => {
+    clipboardUploadListeners.add(listener);
+    return () => clipboardUploadListeners.delete(listener);
+  },
+};

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -22,6 +22,9 @@ import type { SftpFileEntry } from "../../../types";
 import { toast } from "../../ui/toast";
 import {
   createDropEntriesFromClipboardFiles,
+  getSftpClipboardSystemTextPaths,
+  getSupportedClipboardUploadFiles,
+  isSftpNativeClipboardPasteEnabled,
   resolveSftpClipboardUploadTarget,
   shouldLetNativePasteEventHandleSftpPaste,
   sftpClipboardUploadStore,
@@ -42,6 +45,32 @@ const SFTP_ACTIONS = new Set([
   "sftpGoParent",
   "sftpNavigateTo",
 ]);
+
+let pendingSftpSystemClipboardWrite: Promise<void> | null = null;
+
+const replaceSystemClipboardWithSftpPaths = async (paths: string[]) => {
+  const text = paths.join("\n");
+  if (!text) return;
+  const writeTask = (async () => {
+    const bridge = netcattyBridge.get();
+    try {
+      if (bridge?.writeClipboardText && await bridge.writeClipboardText(text)) return;
+    } catch {
+      // Fall back to the browser clipboard API.
+    }
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
+    await navigator.clipboard.writeText(text).catch(() => {});
+  })();
+
+  pendingSftpSystemClipboardWrite = writeTask;
+  try {
+    await writeTask;
+  } finally {
+    if (pendingSftpSystemClipboardWrite === writeTask) {
+      pendingSftpSystemClipboardWrite = null;
+    }
+  }
+};
 
 // ── Tree Enter key action store ──────────────────────────────────────
 // Allows the keyboard shortcut hook to signal tree views to handle Enter.
@@ -184,13 +213,20 @@ export const useSftpKeyboardShortcuts = ({
     targetPath: string,
   ) => {
     const sftp = sftpRef.current;
-    const entries = createDropEntriesFromClipboardFiles(files);
+    const uploadFiles = getSupportedClipboardUploadFiles(files);
+    const skippedDirectoryCount = files.length - uploadFiles.length;
+    if (skippedDirectoryCount > 0) {
+      toast.info("Folder paste is not supported yet. Only files will be uploaded.", "SFTP");
+    }
+    if (uploadFiles.length === 0) return;
+
+    const entries = createDropEntriesFromClipboardFiles(uploadFiles);
 
     sftpClipboardUploadStore.trigger({
       scopeId: dialogActionScopeId,
       side: focusedSide,
       targetPath,
-      files,
+      files: uploadFiles,
       onConfirm: async () => {
         try {
           const results = await sftp.uploadExternalEntries(focusedSide, entries, { targetPath });
@@ -232,18 +268,123 @@ export const useSftpKeyboardShortcuts = ({
     });
   }, [dialogActionScopeId, showUploadResults, sftpRef]);
 
+  const pasteInternalSftpClipboard = useCallback(async (
+    focusedSide: "left" | "right",
+    pane: NonNullable<ReturnType<typeof getFocusedPane>["pane"]>,
+  ) => {
+    const sftp = sftpRef.current;
+    const clipboard = sftpClipboardStore.get();
+    if (!clipboard || clipboard.files.length === 0) return;
+
+    const isSameConnection = clipboard.sourceSide === focusedSide
+      && clipboard.sourceConnectionId === pane.connection!.id;
+    if (isSameConnection) {
+      toast.info("Paste within the same pane is not supported. Use copy to other pane instead.", "SFTP");
+      return;
+    }
+
+    const sourceTabs = clipboard.sourceSide === "left" ? sftp.leftTabs.tabs : sftp.rightTabs.tabs;
+    const sourcePane = sourceTabs.find((tab) => tab.connection?.id === clipboard.sourceConnectionId);
+
+    if (!sourcePane?.connection) {
+      toast.info("Paste source is no longer available.", "SFTP");
+      return;
+    }
+
+    try {
+      const isCut = clipboard.operation === "cut";
+      const pendingNames = new Set(clipboard.files.map((file) => file.name));
+      const completedNames = new Set<string>();
+      const failedNames = new Set<string>();
+
+      const updateClipboardAfterCompletion = (showToast: boolean) => {
+        if (!isCut) return;
+        const current = sftpClipboardStore.get();
+        if (
+          !current ||
+          current.operation !== "cut" ||
+          current.sourceConnectionId !== clipboard.sourceConnectionId ||
+          current.sourcePath !== clipboard.sourcePath ||
+          current.sourceSide !== clipboard.sourceSide
+        ) {
+          return;
+        }
+
+        const remainingFiles = current.files.filter((file) => !completedNames.has(file.name));
+        if (remainingFiles.length === 0) {
+          sftpClipboardStore.clear();
+        } else {
+          sftpClipboardStore.updateFiles(remainingFiles);
+        }
+
+        if (showToast && failedNames.size > 0) {
+          toast.info("Some items could not be transferred and were kept in the clipboard.", "SFTP");
+        }
+      };
+
+      const handleTransferComplete = async (result: {
+        fileName: string;
+        originalFileName?: string;
+        status: string;
+      }) => {
+        if (!isCut) return;
+        const sourceFileName = result.originalFileName ?? result.fileName;
+        if (!pendingNames.has(sourceFileName)) return;
+        pendingNames.delete(sourceFileName);
+
+        if (result.status === "completed") {
+          try {
+            await sftp.deleteFilesAtPath(
+              clipboard.sourceSide,
+              clipboard.sourceConnectionId,
+              clipboard.sourcePath,
+              [sourceFileName],
+            );
+            completedNames.add(sourceFileName);
+          } catch {
+            failedNames.add(sourceFileName);
+          }
+        } else {
+          failedNames.add(sourceFileName);
+        }
+
+        updateClipboardAfterCompletion(pendingNames.size === 0);
+      };
+
+      await sftp.startTransfer(clipboard.files, clipboard.sourceSide, focusedSide, {
+        sourcePane,
+        sourcePath: clipboard.sourcePath,
+        sourceConnectionId: clipboard.sourceConnectionId,
+        onTransferComplete: handleTransferComplete,
+      });
+    } catch {
+      toast.error("Paste failed. Please try again.", "SFTP");
+    }
+  }, [sftpRef]);
+
   const handlePaste = useCallback(
     (e: ClipboardEvent) => {
       if (!isActive) return;
+      if (!isSftpNativeClipboardPasteEnabled(hotkeyScheme, keyBindings)) return;
 
       const target = e.target as HTMLElement;
       if (isEditableShortcutTarget(target) || hasOpenDialog()) return;
-      if (sftpClipboardStore.hasFiles()) return;
+      const hasInternalClipboardFiles = sftpClipboardStore.hasFiles();
 
       const { focusedSide, pane } = getFocusedPane();
       if (!pane?.connection) return;
 
       const targetPath = getClipboardUploadTarget(pane);
+      const pendingClipboardWrite = pendingSftpSystemClipboardWrite;
+      if (pendingClipboardWrite && hasInternalClipboardFiles) {
+        e.preventDefault();
+        e.stopPropagation();
+        void pendingClipboardWrite.finally(() => {
+          void pasteInternalSftpClipboard(focusedSide, pane);
+        });
+        return;
+      }
+
       const pastedFiles = Array.from(e.clipboardData?.files ?? []).filter((file) => file.name);
       if (pastedFiles.length > 0) {
         e.preventDefault();
@@ -254,19 +395,33 @@ export const useSftpKeyboardShortcuts = ({
 
       const bridge = netcattyBridge.get();
       const clipboardFilesPromise = bridge?.readClipboardFiles?.();
-      if (!clipboardFilesPromise) return;
+      if (!clipboardFilesPromise) {
+        if (!hasInternalClipboardFiles) return;
+        e.preventDefault();
+        e.stopPropagation();
+        void pasteInternalSftpClipboard(focusedSide, pane);
+        return;
+      }
 
       e.preventDefault();
       e.stopPropagation();
       void clipboardFilesPromise.then((files) => {
-        if (files.length === 0) return;
+        if (files.length === 0) {
+          if (hasInternalClipboardFiles) {
+            void pasteInternalSftpClipboard(focusedSide, pane);
+          }
+          return;
+        }
         triggerPathBackedClipboardUpload(files, focusedSide, targetPath);
       });
     },
     [
       getClipboardUploadTarget,
       getFocusedPane,
+      hotkeyScheme,
       isActive,
+      keyBindings,
+      pasteInternalSftpClipboard,
       triggerFileListClipboardUpload,
       triggerPathBackedClipboardUpload,
     ],
@@ -405,7 +560,8 @@ export const useSftpKeyboardShortcuts = ({
       const action = basicNavAction ?? matched?.action;
       if (!action || !SFTP_ACTIONS.has(action)) return;
 
-      if (shouldLetNativePasteEventHandleSftpPaste(action, sftpClipboardStore.hasFiles())) {
+      const matchedKey = isMac ? matched?.binding.mac : matched?.binding.pc;
+      if (shouldLetNativePasteEventHandleSftpPaste(action, matchedKey)) {
         return;
       }
 
@@ -446,6 +602,11 @@ export const useSftpKeyboardShortcuts = ({
               pane.connection.id,
               focusedSide,
             );
+            await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
+              currentPath: pane.connection.currentPath,
+              selectedFileNames: [],
+              treeSelection: treeActionSelection,
+            }));
             break;
           }
 
@@ -469,6 +630,11 @@ export const useSftpKeyboardShortcuts = ({
               pane.connection.id,
               focusedSide
             );
+            await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
+              currentPath: pane.connection.currentPath,
+              selectedFileNames: selectedFiles,
+              treeSelection: [],
+            }));
           }
           break;
         }
@@ -492,6 +658,11 @@ export const useSftpKeyboardShortcuts = ({
               pane.connection.id,
               focusedSide,
             );
+            await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
+              currentPath: pane.connection.currentPath,
+              selectedFileNames: [],
+              treeSelection: treeActionSelection,
+            }));
             break;
           }
 
@@ -515,102 +686,17 @@ export const useSftpKeyboardShortcuts = ({
               pane.connection.id,
               focusedSide
             );
+            await replaceSystemClipboardWithSftpPaths(getSftpClipboardSystemTextPaths({
+              currentPath: pane.connection.currentPath,
+              selectedFileNames: selectedFiles,
+              treeSelection: [],
+            }));
           }
           break;
         }
 
         case "sftpPaste": {
-          // Paste files from clipboard
-          const clipboard = sftpClipboardStore.get();
-          if (!clipboard || clipboard.files.length === 0) return;
-
-          // Use startTransfer to paste files from source to current pane
-          // Allow paste when source and target are different connections, even on the same side
-          const isSameConnection = clipboard.sourceSide === focusedSide
-            && clipboard.sourceConnectionId === pane.connection.id;
-          if (!isSameConnection) {
-            const sourceTabs = clipboard.sourceSide === "left" ? sftp.leftTabs.tabs : sftp.rightTabs.tabs;
-            const sourcePane = sourceTabs.find((tab) => tab.connection?.id === clipboard.sourceConnectionId);
-
-            if (!sourcePane?.connection) {
-              toast.info("Paste source is no longer available.", "SFTP");
-              return;
-            }
-
-            // Cross-pane paste - use startTransfer
-            try {
-              const isCut = clipboard.operation === "cut";
-              const pendingNames = new Set(clipboard.files.map((file) => file.name));
-              const completedNames = new Set<string>();
-              const failedNames = new Set<string>();
-
-              const updateClipboardAfterCompletion = (showToast: boolean) => {
-                if (!isCut) return;
-                const current = sftpClipboardStore.get();
-                if (
-                  !current ||
-                  current.operation !== "cut" ||
-                  current.sourceConnectionId !== clipboard.sourceConnectionId ||
-                  current.sourcePath !== clipboard.sourcePath ||
-                  current.sourceSide !== clipboard.sourceSide
-                ) {
-                  return;
-                }
-
-                const remainingFiles = current.files.filter((file) => !completedNames.has(file.name));
-                if (remainingFiles.length === 0) {
-                  sftpClipboardStore.clear();
-                } else {
-                  sftpClipboardStore.updateFiles(remainingFiles);
-                }
-
-                if (showToast && failedNames.size > 0) {
-                  toast.info("Some items could not be transferred and were kept in the clipboard.", "SFTP");
-                }
-              };
-
-              const handleTransferComplete = async (result: {
-                fileName: string;
-                originalFileName?: string;
-                status: string;
-              }) => {
-                if (!isCut) return;
-                const sourceFileName = result.originalFileName ?? result.fileName;
-                if (!pendingNames.has(sourceFileName)) return;
-                pendingNames.delete(sourceFileName);
-
-                if (result.status === "completed") {
-                  try {
-                    await sftp.deleteFilesAtPath(
-                      clipboard.sourceSide,
-                      clipboard.sourceConnectionId,
-                      clipboard.sourcePath,
-                      [sourceFileName],
-                    );
-                    completedNames.add(sourceFileName);
-                  } catch {
-                    failedNames.add(sourceFileName);
-                  }
-                } else {
-                  failedNames.add(sourceFileName);
-                }
-
-                updateClipboardAfterCompletion(pendingNames.size === 0);
-              };
-
-              await sftp.startTransfer(clipboard.files, clipboard.sourceSide, focusedSide, {
-                sourcePane,
-                sourcePath: clipboard.sourcePath,
-                sourceConnectionId: clipboard.sourceConnectionId,
-                onTransferComplete: handleTransferComplete,
-              });
-            } catch {
-              toast.error("Paste failed. Please try again.", "SFTP");
-            }
-          } else {
-            // Same-pane paste is not supported - show info toast
-            toast.info("Paste within the same pane is not supported. Use copy to other pane instead.", "SFTP");
-          }
+          await pasteInternalSftpClipboard(focusedSide, pane);
           break;
         }
 
@@ -742,7 +828,7 @@ export const useSftpKeyboardShortcuts = ({
         }
       }
     },
-    [dialogActionScopeId, hotkeyScheme, isActive, keyBindings, sftpRef]
+    [dialogActionScopeId, hotkeyScheme, isActive, keyBindings, pasteInternalSftpClipboard, sftpRef]
   );
 
   useEffect(() => {

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -23,7 +23,9 @@ import { toast } from "../../ui/toast";
 import {
   createDropEntriesFromClipboardFiles,
   resolveSftpClipboardUploadTarget,
+  shouldLetNativePasteEventHandleSftpPaste,
   sftpClipboardUploadStore,
+  type ClipboardLocalFile,
 } from "../clipboardUpload";
 
 // SFTP action names that we handle
@@ -95,6 +97,15 @@ const BASIC_NAV_KEYS: Record<string, string> = {
   'Backspace': 'sftpGoParent',
 };
 
+const isEditableShortcutTarget = (target: HTMLElement): boolean =>
+  target.tagName === "INPUT" ||
+  target.tagName === "TEXTAREA" ||
+  target.isContentEditable ||
+  !!target.closest?.(".monaco-editor, .monaco-diff-editor, .monaco-inputbox");
+
+const hasOpenDialog = (): boolean =>
+  !!document.querySelector('[role="dialog"][data-state="open"]');
+
 interface UseSftpKeyboardShortcutsParams {
   keyBindings: KeyBinding[];
   hotkeyScheme: "disabled" | "mac" | "pc";
@@ -128,6 +139,139 @@ export const useSftpKeyboardShortcuts = ({
   dialogActionScopeId,
   isActive,
 }: UseSftpKeyboardShortcutsParams) => {
+  const getFocusedPane = useCallback(() => {
+    const sftp = sftpRef.current;
+    const focusedSide = sftpFocusStore.getFocusedSide();
+    const pane = focusedSide === "left"
+      ? sftp.leftTabs.tabs.find(p => p.id === sftp.leftTabs.activeTabId)
+      : sftp.rightTabs.tabs.find(p => p.id === sftp.rightTabs.activeTabId);
+    return { sftp, focusedSide, pane };
+  }, [sftpRef]);
+
+  const getClipboardUploadTarget = useCallback((pane: NonNullable<ReturnType<typeof getFocusedPane>["pane"]>) => {
+    const treeSelection = sftpTreeSelectionStore.getSelectedItems(pane.id);
+    const treeActionSelection = treeSelection.filter((entry) => entry.name !== '..');
+    const selectedFiles = Array.from(pane.selectedFiles) as string[];
+
+    return resolveSftpClipboardUploadTarget({
+      currentPath: pane.connection!.currentPath,
+      selectedFileNames: selectedFiles,
+      files: pane.files as SftpFileEntry[],
+      treeSelection: treeActionSelection,
+    });
+  }, []);
+
+  const showUploadResults = useCallback((results: Awaited<ReturnType<SftpStateApi["uploadExternalEntries"]>>) => {
+    if (results.some((result) => result.cancelled)) {
+      toast.info("Upload cancelled.", "SFTP");
+      return;
+    }
+
+    const successCount = results.filter((result) => result.success).length;
+    const failedFiles = results.filter((result) => !result.success && !result.cancelled);
+    if (successCount > 0) {
+      toast.success(`Uploaded ${successCount} item${successCount === 1 ? "" : "s"}.`, "SFTP");
+    }
+    failedFiles.forEach((failed) => {
+      const errorMsg = failed.error ? ` - ${failed.error}` : "";
+      toast.error(`Upload failed: ${failed.fileName}${errorMsg}`, "SFTP");
+    });
+  }, []);
+
+  const triggerPathBackedClipboardUpload = useCallback((
+    files: ClipboardLocalFile[],
+    focusedSide: "left" | "right",
+    targetPath: string,
+  ) => {
+    const sftp = sftpRef.current;
+    const entries = createDropEntriesFromClipboardFiles(files);
+
+    sftpClipboardUploadStore.trigger({
+      scopeId: dialogActionScopeId,
+      side: focusedSide,
+      targetPath,
+      files,
+      onConfirm: async () => {
+        try {
+          const results = await sftp.uploadExternalEntries(focusedSide, entries, { targetPath });
+          showUploadResults(results);
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : "Upload failed.", "SFTP");
+        }
+      },
+    });
+  }, [dialogActionScopeId, showUploadResults, sftpRef]);
+
+  const triggerFileListClipboardUpload = useCallback((
+    files: File[],
+    focusedSide: "left" | "right",
+    targetPath: string,
+  ) => {
+    const sftp = sftpRef.current;
+    const bridge = netcattyBridge.get();
+    const dialogFiles: ClipboardLocalFile[] = files.map((file) => ({
+      path: bridge?.getPathForFile?.(file) || file.name,
+      name: file.name,
+      isDirectory: false,
+      size: file.size,
+    }));
+
+    sftpClipboardUploadStore.trigger({
+      scopeId: dialogActionScopeId,
+      side: focusedSide,
+      targetPath,
+      files: dialogFiles,
+      onConfirm: async () => {
+        try {
+          const results = await sftp.uploadExternalFileList(focusedSide, files, targetPath);
+          showUploadResults(results);
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : "Upload failed.", "SFTP");
+        }
+      },
+    });
+  }, [dialogActionScopeId, showUploadResults, sftpRef]);
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent) => {
+      if (!isActive) return;
+
+      const target = e.target as HTMLElement;
+      if (isEditableShortcutTarget(target) || hasOpenDialog()) return;
+      if (sftpClipboardStore.hasFiles()) return;
+
+      const { focusedSide, pane } = getFocusedPane();
+      if (!pane?.connection) return;
+
+      const targetPath = getClipboardUploadTarget(pane);
+      const pastedFiles = Array.from(e.clipboardData?.files ?? []).filter((file) => file.name);
+      if (pastedFiles.length > 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        triggerFileListClipboardUpload(pastedFiles, focusedSide, targetPath);
+        return;
+      }
+
+      const bridge = netcattyBridge.get();
+      const clipboardFilesPromise = bridge?.readClipboardFiles?.();
+      if (!clipboardFilesPromise) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      void clipboardFilesPromise.then((files) => {
+        if (files.length === 0) return;
+        triggerPathBackedClipboardUpload(files, focusedSide, targetPath);
+      });
+    },
+    [
+      getClipboardUploadTarget,
+      getFocusedPane,
+      isActive,
+      triggerFileListClipboardUpload,
+      triggerPathBackedClipboardUpload,
+    ],
+  );
+
   const handleKeyDown = useCallback(
     async (e: KeyboardEvent) => {
       // Basic SFTP keyboard navigation should work whenever the SFTP tab is active,
@@ -136,18 +280,13 @@ export const useSftpKeyboardShortcuts = ({
 
       // Skip if focus is on an input element
       const target = e.target as HTMLElement;
-      const isEditableTarget =
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable ||
-        !!target.closest?.(".monaco-editor, .monaco-diff-editor, .monaco-inputbox");
-      if (isEditableTarget) {
+      if (isEditableShortcutTarget(target)) {
         return;
       }
 
       // Skip when a dialog or overlay is open to prevent SFTP shortcuts from
       // firing while interacting with unrelated dialogs (e.g. settings, confirm).
-      if (document.querySelector('[role="dialog"][data-state="open"]')) {
+      if (hasOpenDialog()) {
         return;
       }
 
@@ -266,6 +405,10 @@ export const useSftpKeyboardShortcuts = ({
       const action = basicNavAction ?? matched?.action;
       if (!action || !SFTP_ACTIONS.has(action)) return;
 
+      if (shouldLetNativePasteEventHandleSftpPaste(action, sftpClipboardStore.hasFiles())) {
+        return;
+      }
+
       // Prevent default behavior
       e.preventDefault();
       e.stopPropagation();
@@ -379,49 +522,7 @@ export const useSftpKeyboardShortcuts = ({
         case "sftpPaste": {
           // Paste files from clipboard
           const clipboard = sftpClipboardStore.get();
-          if (!clipboard || clipboard.files.length === 0) {
-            const bridge = netcattyBridge.get();
-            const localClipboardFiles = await bridge?.readClipboardFiles?.();
-            if (!localClipboardFiles || localClipboardFiles.length === 0) return;
-
-            const selectedFiles = Array.from(pane.selectedFiles) as string[];
-            const targetPath = resolveSftpClipboardUploadTarget({
-              currentPath: pane.connection.currentPath,
-              selectedFileNames: selectedFiles,
-              files: pane.files as SftpFileEntry[],
-              treeSelection: treeActionSelection,
-            });
-            const entries = createDropEntriesFromClipboardFiles(localClipboardFiles);
-
-            sftpClipboardUploadStore.trigger({
-              scopeId: dialogActionScopeId,
-              side: focusedSide,
-              targetPath,
-              files: localClipboardFiles,
-              onConfirm: async () => {
-                try {
-                  const results = await sftp.uploadExternalEntries(focusedSide, entries, { targetPath });
-                  if (results.some((result) => result.cancelled)) {
-                    toast.info("Upload cancelled.", "SFTP");
-                    return;
-                  }
-
-                  const successCount = results.filter((result) => result.success).length;
-                  const failedFiles = results.filter((result) => !result.success && !result.cancelled);
-                  if (successCount > 0) {
-                    toast.success(`Uploaded ${successCount} item${successCount === 1 ? "" : "s"}.`, "SFTP");
-                  }
-                  failedFiles.forEach((failed) => {
-                    const errorMsg = failed.error ? ` - ${failed.error}` : "";
-                    toast.error(`Upload failed: ${failed.fileName}${errorMsg}`, "SFTP");
-                  });
-                } catch (error) {
-                  toast.error(error instanceof Error ? error.message : "Upload failed.", "SFTP");
-                }
-              },
-            });
-            return;
-          }
+          if (!clipboard || clipboard.files.length === 0) return;
 
           // Use startTransfer to paste files from source to current pane
           // Allow paste when source and target are different connections, even on the same side
@@ -649,4 +750,9 @@ export const useSftpKeyboardShortcuts = ({
     window.addEventListener("keydown", handleKeyDown, true);
     return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [handleKeyDown]);
+
+  useEffect(() => {
+    window.addEventListener("paste", handlePaste, true);
+    return () => window.removeEventListener("paste", handlePaste, true);
+  }, [handlePaste]);
 };

--- a/components/sftp/hooks/useSftpKeyboardShortcuts.ts
+++ b/components/sftp/hooks/useSftpKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect } from "react";
 import type { MutableRefObject } from "react";
 import { KeyBinding, matchesKeyBinding } from "../../../domain/models";
 import { getParentPath, joinPath } from "../../../application/state/sftp/utils";
+import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { sftpClipboardStore, SftpClipboardFile } from "./useSftpClipboard";
 import { sftpFocusStore } from "./useSftpFocusedPane";
 import { sftpDialogActionStore } from "./useSftpDialogAction";
@@ -19,6 +20,11 @@ import type { SftpStateApi } from "../../../application/state/useSftpState";
 import { filterHiddenFiles, isNavigableDirectory } from "../utils";
 import type { SftpFileEntry } from "../../../types";
 import { toast } from "../../ui/toast";
+import {
+  createDropEntriesFromClipboardFiles,
+  resolveSftpClipboardUploadTarget,
+  sftpClipboardUploadStore,
+} from "../clipboardUpload";
 
 // SFTP action names that we handle
 const SFTP_ACTIONS = new Set([
@@ -373,7 +379,49 @@ export const useSftpKeyboardShortcuts = ({
         case "sftpPaste": {
           // Paste files from clipboard
           const clipboard = sftpClipboardStore.get();
-          if (!clipboard || clipboard.files.length === 0) return;
+          if (!clipboard || clipboard.files.length === 0) {
+            const bridge = netcattyBridge.get();
+            const localClipboardFiles = await bridge?.readClipboardFiles?.();
+            if (!localClipboardFiles || localClipboardFiles.length === 0) return;
+
+            const selectedFiles = Array.from(pane.selectedFiles) as string[];
+            const targetPath = resolveSftpClipboardUploadTarget({
+              currentPath: pane.connection.currentPath,
+              selectedFileNames: selectedFiles,
+              files: pane.files as SftpFileEntry[],
+              treeSelection: treeActionSelection,
+            });
+            const entries = createDropEntriesFromClipboardFiles(localClipboardFiles);
+
+            sftpClipboardUploadStore.trigger({
+              scopeId: dialogActionScopeId,
+              side: focusedSide,
+              targetPath,
+              files: localClipboardFiles,
+              onConfirm: async () => {
+                try {
+                  const results = await sftp.uploadExternalEntries(focusedSide, entries, { targetPath });
+                  if (results.some((result) => result.cancelled)) {
+                    toast.info("Upload cancelled.", "SFTP");
+                    return;
+                  }
+
+                  const successCount = results.filter((result) => result.success).length;
+                  const failedFiles = results.filter((result) => !result.success && !result.cancelled);
+                  if (successCount > 0) {
+                    toast.success(`Uploaded ${successCount} item${successCount === 1 ? "" : "s"}.`, "SFTP");
+                  }
+                  failedFiles.forEach((failed) => {
+                    const errorMsg = failed.error ? ` - ${failed.error}` : "";
+                    toast.error(`Upload failed: ${failed.fileName}${errorMsg}`, "SFTP");
+                  });
+                } catch (error) {
+                  toast.error(error instanceof Error ? error.message : "Upload failed.", "SFTP");
+                }
+              },
+            });
+            return;
+          }
 
           // Use startTransfer to paste files from source to current pane
           // Allow paste when source and target are different connections, even on the same side

--- a/electron/bridges/clipboardFiles.cjs
+++ b/electron/bridges/clipboardFiles.cjs
@@ -2,6 +2,10 @@
 
 const path = require("node:path");
 const fs = require("node:fs");
+const { fileURLToPath } = require("node:url");
+
+const HDROP_FORMATS = ["CF_HDROP", "FileDrop"];
+const URI_LIST_FORMATS = ["text/uri-list", "text/x-moz-url"];
 
 function decodeWindowsFileNameW(buffer) {
   if (!Buffer.isBuffer(buffer) || buffer.length === 0) return [];
@@ -21,10 +25,23 @@ function decodeWindowsFileName(buffer) {
     .filter(Boolean);
 }
 
-function decodeFileUri(value) {
+function decodeWindowsHDrop(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 20) return [];
+  const filesOffset = buffer.readUInt32LE(0);
+  if (filesOffset <= 0 || filesOffset >= buffer.length) return [];
+  const isWide = buffer.readUInt32LE(16) !== 0;
+  const payload = buffer.subarray(filesOffset);
+  const text = payload.toString(isWide ? "utf16le" : "utf8");
+  return text
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function decodeFileUri(value, { windows = process.platform === "win32" } = {}) {
   if (!value.startsWith("file://")) return value;
   try {
-    return decodeURIComponent(new URL(value).pathname);
+    return fileURLToPath(value, { windows });
   } catch {
     return value;
   }
@@ -68,8 +85,8 @@ function parseClipboardTextFilePaths(text, options = {}) {
   const candidates = text
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => line && !line.startsWith("#"))
-    .map(decodeFileUri);
+    .filter((line) => line && !line.startsWith("#") && line.startsWith("file://"))
+    .map((line) => decodeFileUri(line, options));
   return collectExistingFiles(candidates, options);
 }
 
@@ -86,6 +103,14 @@ function readClipboardFiles({
       ? clipboard.availableFormats()
       : [];
 
+    if (typeof clipboard.readBuffer === "function") {
+      for (const format of HDROP_FORMATS) {
+        if (!formats.includes(format)) continue;
+        const files = collectExistingFiles(decodeWindowsHDrop(clipboard.readBuffer(format)), options);
+        if (files.length > 0) return files;
+      }
+    }
+
     if (formats.includes("FileNameW") && typeof clipboard.readBuffer === "function") {
       const files = collectExistingFiles(decodeWindowsFileNameW(clipboard.readBuffer("FileNameW")), options);
       if (files.length > 0) return files;
@@ -96,7 +121,10 @@ function readClipboardFiles({
       if (files.length > 0) return files;
     }
 
-    if (typeof clipboard.readText === "function") {
+    if (
+      typeof clipboard.readText === "function" &&
+      formats.some((format) => URI_LIST_FORMATS.includes(format))
+    ) {
       return parseClipboardTextFilePaths(clipboard.readText(), options);
     }
   } catch {
@@ -107,6 +135,7 @@ function readClipboardFiles({
 }
 
 module.exports = {
+  decodeWindowsHDrop,
   decodeWindowsFileNameW,
   parseClipboardTextFilePaths,
   readClipboardFiles,

--- a/electron/bridges/clipboardFiles.cjs
+++ b/electron/bridges/clipboardFiles.cjs
@@ -1,0 +1,113 @@
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function decodeWindowsFileNameW(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) return [];
+  return buffer
+    .toString("utf16le")
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function decodeWindowsFileName(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) return [];
+  return buffer
+    .toString("utf8")
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function decodeFileUri(value) {
+  if (!value.startsWith("file://")) return value;
+  try {
+    return decodeURIComponent(new URL(value).pathname);
+  } catch {
+    return value;
+  }
+}
+
+function toClipboardFile(filePath, { fsImpl = fs, pathImpl = path } = {}) {
+  if (!filePath || !fsImpl.existsSync(filePath)) return null;
+
+  try {
+    const stat = fsImpl.statSync(filePath);
+    const isDirectory = stat.isDirectory();
+    if (!isDirectory && !stat.isFile()) return null;
+    const name = filePath.includes("\\")
+      ? path.win32.basename(filePath)
+      : pathImpl.basename(filePath);
+    return {
+      path: filePath,
+      name,
+      isDirectory,
+      size: isDirectory ? 0 : stat.size,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function collectExistingFiles(paths, options = {}) {
+  const seen = new Set();
+  const files = [];
+  for (const candidate of paths) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    const file = toClipboardFile(candidate, options);
+    if (file) files.push(file);
+  }
+  return files;
+}
+
+function parseClipboardTextFilePaths(text, options = {}) {
+  if (!text) return [];
+  const candidates = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .map(decodeFileUri);
+  return collectExistingFiles(candidates, options);
+}
+
+function readClipboardFiles({
+  clipboard,
+  fsImpl = fs,
+  pathImpl = path,
+} = {}) {
+  if (!clipboard) return [];
+
+  const options = { fsImpl, pathImpl };
+  try {
+    const formats = typeof clipboard.availableFormats === "function"
+      ? clipboard.availableFormats()
+      : [];
+
+    if (formats.includes("FileNameW") && typeof clipboard.readBuffer === "function") {
+      const files = collectExistingFiles(decodeWindowsFileNameW(clipboard.readBuffer("FileNameW")), options);
+      if (files.length > 0) return files;
+    }
+
+    if (formats.includes("FileName") && typeof clipboard.readBuffer === "function") {
+      const files = collectExistingFiles(decodeWindowsFileName(clipboard.readBuffer("FileName")), options);
+      if (files.length > 0) return files;
+    }
+
+    if (typeof clipboard.readText === "function") {
+      return parseClipboardTextFilePaths(clipboard.readText(), options);
+    }
+  } catch {
+    return [];
+  }
+
+  return [];
+}
+
+module.exports = {
+  decodeWindowsFileNameW,
+  parseClipboardTextFilePaths,
+  readClipboardFiles,
+};

--- a/electron/bridges/clipboardFiles.test.cjs
+++ b/electron/bridges/clipboardFiles.test.cjs
@@ -4,6 +4,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  decodeWindowsHDrop,
   decodeWindowsFileNameW,
   parseClipboardTextFilePaths,
   readClipboardFiles,
@@ -19,22 +20,35 @@ const createFs = (entries) => ({
 });
 
 test("decodes Windows FileNameW clipboard buffers", () => {
-  const buffer = Buffer.from("C:\\Users\\me\\a.txt\0D:\\b.txt\0\0", "utf16le");
+  const buffer = Buffer.from("C:\\Users\\me\\a.txt\0\0", "utf16le");
 
   assert.deepEqual(decodeWindowsFileNameW(buffer), [
+    "C:\\Users\\me\\a.txt",
+  ]);
+});
+
+test("decodes Windows CF_HDROP clipboard buffers", () => {
+  const paths = "C:\\Users\\me\\a.txt\0D:\\b.txt\0\0";
+  const filesOffset = 20;
+  const header = Buffer.alloc(filesOffset);
+  header.writeUInt32LE(filesOffset, 0);
+  header.writeUInt32LE(1, 16);
+  const buffer = Buffer.concat([header, Buffer.from(paths, "utf16le")]);
+
+  assert.deepEqual(decodeWindowsHDrop(buffer), [
     "C:\\Users\\me\\a.txt",
     "D:\\b.txt",
   ]);
 });
 
-test("parses text and uri-list clipboard file paths", () => {
+test("parses text and uri-list clipboard file urls", () => {
   const fsImpl = createFs({
     "/Users/me/a.txt": "file",
     "/Users/me/folder": "directory",
   });
 
   const files = parseClipboardTextFilePaths(
-    "file:///Users/me/a.txt\n/Users/me/folder\n/Users/me/missing.txt",
+    "file:///Users/me/a.txt\nfile:///Users/me/folder\n/Users/me/missing.txt",
     { fsImpl, pathImpl: require("node:path") },
   );
 
@@ -44,16 +58,52 @@ test("parses text and uri-list clipboard file paths", () => {
   ]);
 });
 
-test("reads FileNameW before falling back to clipboard text", () => {
+test("parses Windows file urls with drive letters and UNC paths", () => {
+  const fsImpl = createFs({
+    "C:\\Users\\me\\a file.txt": "file",
+    "\\\\server\\share\\b.txt": "file",
+  });
+
+  const files = parseClipboardTextFilePaths(
+    "file:///C:/Users/me/a%20file.txt\nfile://server/share/b.txt",
+    { fsImpl, pathImpl: require("node:path"), windows: true },
+  );
+
+  assert.deepEqual(files, [
+    { path: "C:\\Users\\me\\a file.txt", name: "a file.txt", isDirectory: false, size: 42 },
+    { path: "\\\\server\\share\\b.txt", name: "b.txt", isDirectory: false, size: 42 },
+  ]);
+});
+
+test("ignores plain text paths without file uri formats", () => {
+  const fsImpl = createFs({ "/Users/me/a.txt": "file" });
+
+  assert.deepEqual(parseClipboardTextFilePaths("/Users/me/a.txt", { fsImpl, pathImpl: require("node:path") }), []);
+});
+
+test("reads CF_HDROP before falling back to FileNameW", () => {
+  const filesOffset = 20;
+  const header = Buffer.alloc(filesOffset);
+  header.writeUInt32LE(filesOffset, 0);
+  header.writeUInt32LE(1, 16);
+  const hdropBuffer = Buffer.concat([
+    header,
+    Buffer.from("C:\\Users\\me\\a.txt\0D:\\b.txt\0\0", "utf16le"),
+  ]);
   const buffer = Buffer.from("C:\\Users\\me\\a.txt\0\0", "utf16le");
-  const fsImpl = createFs({ "C:\\Users\\me\\a.txt": "file" });
+  const fsImpl = createFs({ "C:\\Users\\me\\a.txt": "file", "D:\\b.txt": "file" });
   const clipboard = {
-    availableFormats: () => ["FileNameW", "text/plain"],
-    readBuffer: (format) => format === "FileNameW" ? buffer : Buffer.alloc(0),
-    readText: () => "/fallback.txt",
+    availableFormats: () => ["CF_HDROP", "FileNameW", "text/plain"],
+    readBuffer: (format) => {
+      if (format === "CF_HDROP") return hdropBuffer;
+      if (format === "FileNameW") return buffer;
+      return Buffer.alloc(0);
+    },
+    readText: () => "file:///fallback.txt",
   };
 
   assert.deepEqual(readClipboardFiles({ clipboard, fsImpl, pathImpl: require("node:path") }), [
     { path: "C:\\Users\\me\\a.txt", name: "a.txt", isDirectory: false, size: 42 },
+    { path: "D:\\b.txt", name: "b.txt", isDirectory: false, size: 42 },
   ]);
 });

--- a/electron/bridges/clipboardFiles.test.cjs
+++ b/electron/bridges/clipboardFiles.test.cjs
@@ -1,0 +1,59 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  decodeWindowsFileNameW,
+  parseClipboardTextFilePaths,
+  readClipboardFiles,
+} = require("./clipboardFiles.cjs");
+
+const createFs = (entries) => ({
+  existsSync: (filePath) => filePath in entries,
+  statSync: (filePath) => ({
+    isDirectory: () => entries[filePath] === "directory",
+    isFile: () => entries[filePath] === "file",
+    size: entries[filePath] === "file" ? 42 : 0,
+  }),
+});
+
+test("decodes Windows FileNameW clipboard buffers", () => {
+  const buffer = Buffer.from("C:\\Users\\me\\a.txt\0D:\\b.txt\0\0", "utf16le");
+
+  assert.deepEqual(decodeWindowsFileNameW(buffer), [
+    "C:\\Users\\me\\a.txt",
+    "D:\\b.txt",
+  ]);
+});
+
+test("parses text and uri-list clipboard file paths", () => {
+  const fsImpl = createFs({
+    "/Users/me/a.txt": "file",
+    "/Users/me/folder": "directory",
+  });
+
+  const files = parseClipboardTextFilePaths(
+    "file:///Users/me/a.txt\n/Users/me/folder\n/Users/me/missing.txt",
+    { fsImpl, pathImpl: require("node:path") },
+  );
+
+  assert.deepEqual(files, [
+    { path: "/Users/me/a.txt", name: "a.txt", isDirectory: false, size: 42 },
+    { path: "/Users/me/folder", name: "folder", isDirectory: true, size: 0 },
+  ]);
+});
+
+test("reads FileNameW before falling back to clipboard text", () => {
+  const buffer = Buffer.from("C:\\Users\\me\\a.txt\0\0", "utf16le");
+  const fsImpl = createFs({ "C:\\Users\\me\\a.txt": "file" });
+  const clipboard = {
+    availableFormats: () => ["FileNameW", "text/plain"],
+    readBuffer: (format) => format === "FileNameW" ? buffer : Buffer.alloc(0),
+    readText: () => "/fallback.txt",
+  };
+
+  assert.deepEqual(readClipboardFiles({ clipboard, fsImpl, pathImpl: require("node:path") }), [
+    { path: "C:\\Users\\me\\a.txt", name: "a.txt", isDirectory: false, size: 42 },
+  ]);
+});

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -403,6 +403,16 @@ function createBridgeRegistrar(context) {
       }
     });
 
+    ipcMain.handle("netcatty:clipboard:writeText", async (_event, text) => {
+      try {
+        if (typeof clipboard?.writeText !== "function") return false;
+        clipboard.writeText(typeof text === "string" ? text : "");
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
     ipcMain.handle("netcatty:clipboard:readFiles", async () => {
       return readClipboardFiles({ clipboard, fsImpl: fs, pathImpl: path });
     });

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -2,6 +2,7 @@
 
 let bridgesRegistered = false;
 let cloudSyncSessionPassword = null;
+const { readClipboardFiles } = require("../bridges/clipboardFiles.cjs");
 
 function createBridgeRegistrar(context) {
   const {
@@ -400,6 +401,10 @@ function createBridgeRegistrar(context) {
       } catch {
         return "";
       }
+    });
+
+    ipcMain.handle("netcatty:clipboard:readFiles", async () => {
+      return readClipboardFiles({ clipboard, fsImpl: fs, pathImpl: path });
     });
   
     // Select an application from system file picker

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -722,6 +722,9 @@ function createPreloadApi(ctx) {
   readClipboardText: async () => {
     return ipcRenderer.invoke("netcatty:clipboard:readText");
   },
+  writeClipboardText: async (text) => {
+    return ipcRenderer.invoke("netcatty:clipboard:writeText", text);
+  },
   readClipboardFiles: async () => {
     return ipcRenderer.invoke("netcatty:clipboard:readFiles");
   },

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -722,6 +722,9 @@ function createPreloadApi(ctx) {
   readClipboardText: async () => {
     return ipcRenderer.invoke("netcatty:clipboard:readText");
   },
+  readClipboardFiles: async () => {
+    return ipcRenderer.invoke("netcatty:clipboard:readFiles");
+  },
 
   // Credential encryption (field-level safeStorage)
   credentialsAvailable: () => ipcRenderer.invoke("netcatty:credentials:available"),

--- a/lib/sftpFileUtils.ts
+++ b/lib/sftpFileUtils.ts
@@ -433,6 +433,8 @@ export function getSupportedLanguages(): { id: string; name: string }[] {
  */
 export interface DropEntry {
   file: File | null;  // null for directory entries
+  localPath?: string;
+  size?: number;
   relativePath: string;  // Path relative to the root of the drop (e.g., "folder/subfolder/file.txt")
   isDirectory: boolean;
 }

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -31,6 +31,12 @@ import type { UploadBridge, UploadCallbacks, UploadConfig, UploadResult } from "
 const formatUploadError = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const getDropEntrySize = (entry: DropEntry): number => entry.file?.size ?? entry.size ?? 0;
+const getDropEntryLocalPath = (entry: DropEntry): string | undefined =>
+  entry.localPath ?? (entry.file as (File & { path?: string }) | null | undefined)?.path;
+const isUploadableFileEntry = (entry: DropEntry): boolean =>
+  !entry.isDirectory && (!!entry.file || !!getDropEntryLocalPath(entry));
+
 export interface UploadScanningTask {
   taskId: string;
   complete: () => void;
@@ -407,7 +413,7 @@ async function uploadEntries(
         continue;
       }
 
-      const newSize = groupEntries.reduce((sum, entry) => sum + (entry.file?.size ?? 0), 0);
+      const newSize = groupEntries.reduce((sum, entry) => sum + getDropEntrySize(entry), 0);
       const action = await resolveConflict({
         fileName: rootName,
         targetPath: rootTargetPath,
@@ -589,7 +595,7 @@ async function uploadEntries(
     standaloneTransferId: string,
     fileTotalBytes: number,
   ): Promise<{ cancelled?: boolean; error?: string }> => {
-    const localFilePath = (entry.file as File & { path?: string }).path;
+    const localFilePath = getDropEntryLocalPath(entry);
 
     // Progress callback factory for both stream and memory paths
     const makeOnProgress = () => {
@@ -653,7 +659,10 @@ async function uploadEntries(
           return { error: streamResult.error };
         }
     } else {
-        const arrayBuffer = await entry.file!.arrayBuffer();
+        if (!entry.file) {
+          return { error: "No local file data available" };
+        }
+        const arrayBuffer = await entry.file.arrayBuffer();
 
         if (isLocal) {
           if (!bridge.writeLocalFile) throw new Error("writeLocalFile not available");
@@ -700,7 +709,7 @@ async function uploadEntries(
   };
 
   // Filter to only file entries (directories are pre-created above)
-  const fileEntries = sortedEntries.filter(e => !e.isDirectory && e.file);
+  const fileEntries = sortedEntries.filter(isUploadableFileEntry);
 
   // Create standalone task entries upfront so they're visible immediately.
   // Bundled child tasks are created lazily when upload actually starts, so
@@ -718,7 +727,7 @@ async function uploadEntries(
           displayName: entry.relativePath,
           isDirectory: false,
           progressMode: 'bytes',
-          totalBytes: entry.file!.size,
+          totalBytes: getDropEntrySize(entry),
           transferredBytes: 0,
           speed: 0,
           fileCount: 1,
@@ -739,7 +748,7 @@ async function uploadEntries(
         isDirectory: false,
         progressMode: 'bytes',
         parentTaskId: bundleTaskId,
-        totalBytes: entry.file!.size,
+        totalBytes: getDropEntrySize(entry),
         transferredBytes: 0,
         speed: 0,
         fileCount: 1,
@@ -774,7 +783,7 @@ async function uploadEntries(
         const bundleTaskId = getBundleTaskId(entry);
         const bundledChildTaskId = bundleTaskId ? createBundledChildTask(entry, bundleTaskId) : "";
         const standaloneTransferId = standaloneTaskIds.get(entry.relativePath) || "";
-        const fileTotalBytes = entry.file!.size;
+        const fileTotalBytes = getDropEntrySize(entry);
 
         try {
           const uploadResult = await uploadSingleFile(

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -627,7 +627,7 @@ async function uploadEntries(
       };
     };
 
-    if (localFilePath && bridge.startStreamTransfer && sftpId && !isLocal) {
+    if (localFilePath && bridge.startStreamTransfer && (!isLocal ? !!sftpId : true)) {
         const onProgress = makeOnProgress();
         const fileTransferId = crypto.randomUUID();
         controller?.addActiveTransfer(fileTransferId);
@@ -640,8 +640,8 @@ async function uploadEntries(
               sourcePath: localFilePath,
               targetPath: entryTargetPath,
               sourceType: 'local',
-              targetType: 'sftp',
-              targetSftpId: sftpId,
+              targetType: isLocal ? 'local' : 'sftp',
+              targetSftpId: isLocal ? undefined : sftpId,
               totalBytes: fileTotalBytes,
             },
             onProgress,

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -86,6 +86,7 @@ declare global {
     // Get file path from File object (for drag-and-drop, uses Electron's webUtils)
     getPathForFile?(file: File): string | undefined;
     readClipboardText?(): Promise<string>;
+    writeClipboardText?(text: string): Promise<boolean>;
     readClipboardFiles?(): Promise<Array<{ path: string; name: string; isDirectory: boolean; size?: number }>>;
 
     // Credential encryption (field-level safeStorage for sensitive data at rest)

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -86,6 +86,7 @@ declare global {
     // Get file path from File object (for drag-and-drop, uses Electron's webUtils)
     getPathForFile?(file: File): string | undefined;
     readClipboardText?(): Promise<string>;
+    readClipboardFiles?(): Promise<Array<{ path: string; name: string; isDirectory: boolean; size?: number }>>;
 
     // Credential encryption (field-level safeStorage for sensitive data at rest)
     credentialsAvailable?(): Promise<boolean>;


### PR DESCRIPTION
## Summary
- Add SFTP Ctrl/Cmd+V support for local files copied from the OS clipboard
- Confirm the upload target before uploading, using the selected SFTP folder when there is one or the current directory otherwise
- Support path-backed uploads from Electron clipboard file paths

Closes #1133

## Testing
- node --test --import tsx components/SftpClipboardUpload.test.ts
- node --test --import tsx electron/bridges/clipboardFiles.test.cjs
- node --test --import tsx application/state/uploadService.test.ts
- npm run lint
- npm run build
- npm test