### PR TITLE
[codex] reuse SSH channel for terminal splits

### DIFF
--- a/application/state/sftp/useSftpExternalOperations.ts
+++ b/application/state/sftp/useSftpExternalOperations.ts
@@ -445,7 +445,7 @@ export const useSftpExternalOperations = (
         notify.error(err instanceof Error ? err.message : String(err), "SFTP");
       }
     },
-    [downloadToTemp, getActivePane],
+    [downloadToTemp, getActivePane, updateExternalUpload],
   );
 
   // Create upload callbacks that translate to TransferTask updates

--- a/application/state/terminalConnectionReuse.test.ts
+++ b/application/state/terminalConnectionReuse.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { TerminalSession } from "../../domain/models";
+import {
+  canReuseTerminalConnection,
+  createCopiedTerminalSessionClone,
+  createSplitTerminalSessionClone,
+} from "./terminalConnectionReuse";
+
+const session = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
+  id: "session-1",
+  hostId: "host-1",
+  hostLabel: "Host",
+  hostname: "example.com",
+  username: "alice",
+  status: "connected",
+  protocol: "ssh",
+  ...overrides,
+});
+
+test("connected SSH sessions can reuse their authenticated connection", () => {
+  assert.equal(canReuseTerminalConnection(session()), true);
+  assert.equal(canReuseTerminalConnection(session({ protocol: undefined })), true);
+});
+
+test("non-SSH or unavailable sessions do not reuse a connection", () => {
+  assert.equal(canReuseTerminalConnection(session({ status: "connecting" })), false);
+  assert.equal(canReuseTerminalConnection(session({ status: "disconnected" })), false);
+  assert.equal(canReuseTerminalConnection(session({ protocol: "local" })), false);
+  assert.equal(canReuseTerminalConnection(session({ protocol: "serial" })), false);
+  assert.equal(canReuseTerminalConnection(session({ protocol: "telnet" })), false);
+  assert.equal(canReuseTerminalConnection(session({ moshEnabled: true })), false);
+  assert.equal(canReuseTerminalConnection(session({ etEnabled: true })), false);
+});
+
+test("split session clones reuse only connected SSH sources", () => {
+  assert.equal(
+    createSplitTerminalSessionClone(session(), { id: "split-1", workspaceId: "workspace-1" }).reuseConnectionFromSessionId,
+    "session-1",
+  );
+  assert.equal(
+    createSplitTerminalSessionClone(session({ etEnabled: true }), { id: "split-2" }).reuseConnectionFromSessionId,
+    undefined,
+  );
+  assert.equal(
+    createSplitTerminalSessionClone(session({ moshEnabled: true }), { id: "split-3" }).reuseConnectionFromSessionId,
+    undefined,
+  );
+});
+
+test("copy session clones reuse SSH sources and preserve serial config", () => {
+  const copied = createCopiedTerminalSessionClone(
+    session({
+      serialConfig: { path: "/dev/tty.usbserial", baudRate: 115200 },
+    }),
+    { id: "copy-1" },
+  );
+
+  assert.equal(copied.reuseConnectionFromSessionId, "session-1");
+  assert.deepEqual(copied.serialConfig, { path: "/dev/tty.usbserial", baudRate: 115200 });
+});

--- a/application/state/terminalConnectionReuse.ts
+++ b/application/state/terminalConnectionReuse.ts
@@ -1,0 +1,71 @@
+import type { TerminalSession } from "../../domain/models";
+
+export function canReuseTerminalConnection(session: TerminalSession): boolean {
+  return (
+    (session.protocol === "ssh" || session.protocol === undefined) &&
+    !session.moshEnabled &&
+    !session.etEnabled &&
+    session.status === "connected"
+  );
+}
+
+type CloneSessionOptions = {
+  id: string;
+  localShellType?: TerminalSession["shellType"];
+  workspaceId?: string;
+};
+
+function getClonedShellType(
+  session: TerminalSession,
+  localShellType?: TerminalSession["shellType"],
+): TerminalSession["shellType"] {
+  return session.protocol === "local" ? localShellType : session.shellType;
+}
+
+function createTerminalSessionClone(
+  session: TerminalSession,
+  options: CloneSessionOptions,
+): TerminalSession {
+  const clonedSession: TerminalSession = {
+    id: options.id,
+    hostId: session.hostId,
+    hostLabel: session.hostLabel,
+    hostname: session.hostname,
+    username: session.username,
+    status: "connecting",
+    protocol: session.protocol,
+    port: session.port,
+    moshEnabled: session.moshEnabled,
+    etEnabled: session.etEnabled,
+    shellType: getClonedShellType(session, options.localShellType),
+    charset: session.charset,
+    localShell: session.localShell,
+    localShellArgs: session.localShellArgs,
+    localShellName: session.localShellName,
+    localShellIcon: session.localShellIcon,
+    reuseConnectionFromSessionId: canReuseTerminalConnection(session) ? session.id : undefined,
+  };
+
+  if (options.workspaceId) {
+    clonedSession.workspaceId = options.workspaceId;
+  }
+
+  return clonedSession;
+}
+
+export function createSplitTerminalSessionClone(
+  session: TerminalSession,
+  options: CloneSessionOptions,
+): TerminalSession {
+  return createTerminalSessionClone(session, options);
+}
+
+export function createCopiedTerminalSessionClone(
+  session: TerminalSession,
+  options: CloneSessionOptions,
+): TerminalSession {
+  return {
+    ...createTerminalSessionClone(session, options),
+    serialConfig: session.serialConfig,
+  };
+}

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -17,6 +17,10 @@ SplitHint,
 updateWorkspaceSplitSizes,
 } from '../../domain/workspace';
 import { activeTabStore } from './activeTabStore';
+import {
+  createCopiedTerminalSessionClone,
+  createSplitTerminalSessionClone,
+} from './terminalConnectionReuse';
 
 
 export const useSessionState = () => {
@@ -577,32 +581,15 @@ export const useSessionState = () => {
 	    setSessions(prevSessions => {
       const session = prevSessions.find(s => s.id === sessionId);
       if (!session) return prevSessions;
-      const nextShellType = session.protocol === 'local'
-        ? options?.localShellType
-        : session.shellType;
       
       // If session is already in a workspace, split within that workspace
       if (session.workspaceId) {
         // Create a new session with the same host
-        const newSession: TerminalSession = {
+        const newSession = createSplitTerminalSessionClone(session, {
           id: crypto.randomUUID(),
-          hostId: session.hostId,
-          hostLabel: session.hostLabel,
-          hostname: session.hostname,
-          username: session.username,
-          status: 'connecting',
+          localShellType: options?.localShellType,
           workspaceId: session.workspaceId,
-          protocol: session.protocol,
-          port: session.port,
-          moshEnabled: session.moshEnabled,
-          etEnabled: session.etEnabled,
-          shellType: nextShellType,
-          charset: session.charset,
-          localShell: session.localShell,
-          localShellArgs: session.localShellArgs,
-          localShellName: session.localShellName,
-          localShellIcon: session.localShellIcon,
-        };
+        });
 
         // Add pane to existing workspace
         const hint: SplitHint = {
@@ -622,24 +609,10 @@ export const useSessionState = () => {
       }
       
       // Session is standalone - create a new workspace
-      const newSession: TerminalSession = {
+      const newSession = createSplitTerminalSessionClone(session, {
         id: crypto.randomUUID(),
-        hostId: session.hostId,
-        hostLabel: session.hostLabel,
-        hostname: session.hostname,
-        username: session.username,
-        status: 'connecting',
-        protocol: session.protocol,
-        port: session.port,
-        moshEnabled: session.moshEnabled,
-        etEnabled: session.etEnabled,
-        shellType: nextShellType,
-        charset: session.charset,
-        localShell: session.localShell,
-        localShellArgs: session.localShellArgs,
-        localShellName: session.localShellName,
-        localShellIcon: session.localShellIcon,
-      };
+        localShellType: options?.localShellType,
+      });
 
       const hint: SplitHint = {
         direction,
@@ -807,41 +780,10 @@ export const useSessionState = () => {
       // update running; in that case skip entirely — do NOT switch the
       // active tab or insert into tabOrder, which would leave dangling ids.
       if (!session) return prevSessions;
-      const nextShellType = session.protocol === 'local'
-        ? options?.localShellType
-        : session.shellType;
-
-      // Reuse the source connection only for plain (non-mosh) SSH shell
-      // sessions that are actually connected. ssh2 multiplexes multiple shell
-      // channels over one authenticated connection, so the copy can skip a
-      // second MFA prompt (issue #1204). Local/serial/telnet/mosh sessions have
-      // no such reusable channel concept, and reusing a still-connecting or
-      // disconnected source would be pointless, so they connect fresh.
-      const isReusableSshSource =
-        (session.protocol === 'ssh' || session.protocol === undefined) &&
-        !session.moshEnabled &&
-        session.status === 'connected';
-
-      const newSession: TerminalSession = {
+      const newSession = createCopiedTerminalSessionClone(session, {
         id: newSessionId,
-        hostId: session.hostId,
-        hostLabel: session.hostLabel,
-        hostname: session.hostname,
-        username: session.username,
-        status: 'connecting',
-        protocol: session.protocol,
-        port: session.port,
-        moshEnabled: session.moshEnabled,
-        etEnabled: session.etEnabled,
-        shellType: nextShellType,
-        charset: session.charset,
-        serialConfig: session.serialConfig,
-        localShell: session.localShell,
-        localShellArgs: session.localShellArgs,
-        localShellName: session.localShellName,
-        localShellIcon: session.localShellIcon,
-        reuseConnectionFromSessionId: isReusableSshSource ? sessionId : undefined,
-      };
+        localShellType: options?.localShellType,
+      });
 
       // Schedule the activeTab + tabOrder updates only when creation
       // actually happens. These nested setStates are idempotent, so

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -127,6 +127,11 @@ export const useTerminalBackend = () => {
     return bridge?.onChainProgress?.(cb);
   }, []);
 
+  const onConnectionReuseFallback = useCallback((cb: (sessionId: string, sourceSessionId?: string) => void) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.onConnectionReuseFallback?.(cb);
+  }, []);
+
   const onHostKeyVerification = useCallback((cb: Parameters<NonNullable<NetcattyBridge["onHostKeyVerification"]>>[0]) => {
     const bridge = netcattyBridge.get();
     return bridge?.onHostKeyVerification?.(cb);
@@ -234,6 +239,7 @@ export const useTerminalBackend = () => {
       onTelnetAutoLoginComplete,
       onTelnetAutoLoginCancelled,
       onChainProgress,
+      onConnectionReuseFallback,
       onHostKeyVerification,
       respondHostKeyVerification,
       openExternal,
@@ -269,6 +275,7 @@ export const useTerminalBackend = () => {
       onTelnetAutoLoginComplete,
       onTelnetAutoLoginCancelled,
       onChainProgress,
+      onConnectionReuseFallback,
       onHostKeyVerification,
       respondHostKeyVerification,
       openExternal,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -73,6 +73,8 @@ import {
   forceSyncRenderAfterResize,
   formatNetSpeed,
   MAX_CONNECTION_LOG_DATA_CHARS,
+  shouldHideConnectingDialogForConnectionReuse,
+  shouldShowTerminalConnectionDialog,
   type TerminalProps,
 } from "./terminal/terminalHelpers";
 
@@ -231,6 +233,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const [progressValue, setProgressValue] = useState(15);
   const [hasSelection, setHasSelection] = useState(false);
   const [isDisconnectedDialogDismissed, setIsDisconnectedDialogDismissed] = useState(false);
+  const [connectionReuseFellBack, setConnectionReuseFellBack] = useState(false);
 
   const statusRef = useRef<TerminalSession["status"]>(status);
   statusRef.current = status;
@@ -641,6 +644,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   });
   sessionStartersRef.current = sessionStarters;
 
+  useEffect(() => {
+    setConnectionReuseFellBack(false);
+    if (!reuseConnectionFromSessionId) return undefined;
+
+    return terminalBackend.onConnectionReuseFallback?.((fallbackSessionId) => {
+      if (fallbackSessionId === sessionId) {
+        setConnectionReuseFellBack(true);
+      }
+    });
+  }, [reuseConnectionFromSessionId, sessionId, terminalBackend]);
+
   const safeFit = (options?: { force?: boolean; requireVisible?: boolean }) => {
     const fitAddon = fitAddonRef.current;
     if (!fitAddon) return;
@@ -887,6 +901,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     terminalDataCapturedRef.current = false;
     hasRunStartupCommandRef.current = false;
     setIsDisconnectedDialogDismissed(false);
+    setConnectionReuseFellBack(false);
     setStatus("connecting");
     setError(null);
     setProgressLogs(["Retrying secure channel..."]);
@@ -940,9 +955,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     });
   };
 
-  const shouldShowConnectionDialog = status !== "connected"
-    && !((isLocalConnection || isSerialConnection) && status === "connecting")
-    && !(status === "disconnected" && isDisconnectedDialogDismissed);
+  const shouldShowConnectionDialog = shouldShowTerminalConnectionDialog({
+    status,
+    isLocalConnection,
+    isSerialConnection,
+    isDisconnectedDialogDismissed,
+    hideConnectingDialogForConnectionReuse: shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId,
+      host,
+      connectionReuseFellBack,
+    }),
+  });
 
   const {
     handleDragEnter,

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -59,6 +59,9 @@ export type TerminalBackendApi = {
   onChainProgress: (
     cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void,
   ) => (() => void) | undefined;
+  onConnectionReuseFallback?: (
+    cb: (sessionId: string, sourceSessionId?: string) => void,
+  ) => (() => void) | undefined;
   writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   resizeSession: (sessionId: string, cols: number, rows: number) => void;
   /** Pause/resume the source stream for output back-pressure (optional). */
@@ -93,7 +96,7 @@ export type TerminalSessionStartersContext = {
   resolvedChainHosts: Host[];
   sessionId: string;
   // Source session id to reuse an authenticated SSH connection from when this
-  // tab is a "Copy Tab" duplicate (issue #1204).
+  // terminal was created from an existing SSH session.
   reuseConnectionFromSessionId?: string;
   startupCommand?: string;
   noAutoRun?: boolean;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -85,9 +85,9 @@ export interface TerminalProps {
   sessionId: string;
   startupCommand?: string;
   noAutoRun?: boolean;
-  // When this tab was created via "Copy Tab" on a connected SSH session, the id
-  // of the source session whose authenticated connection should be reused for a
-  // new shell channel — skipping a second MFA prompt (issue #1204).
+  // When this tab was created from a connected SSH session, the id of the
+  // source session whose authenticated connection should be reused for a new
+  // shell channel — skipping a second MFA prompt (issue #1204).
   reuseConnectionFromSessionId?: string;
   serialConfig?: SerialConfig;
   hotkeyScheme?: "disabled" | "mac" | "pc";
@@ -142,6 +142,41 @@ export function formatNetSpeed(bytesPerSec: number): string {
   } else {
     return `${(bytesPerSec / (1024 * 1024 * 1024)).toFixed(1)}G/s`;
   }
+}
+
+export function shouldShowTerminalConnectionDialog({
+  status,
+  isLocalConnection,
+  isSerialConnection,
+  isDisconnectedDialogDismissed,
+  hideConnectingDialogForConnectionReuse,
+}: {
+  status: TerminalSession["status"];
+  isLocalConnection: boolean;
+  isSerialConnection: boolean;
+  isDisconnectedDialogDismissed: boolean;
+  hideConnectingDialogForConnectionReuse?: boolean;
+}): boolean {
+  return status !== "connected"
+    && !(!!hideConnectingDialogForConnectionReuse && status === "connecting")
+    && !((isLocalConnection || isSerialConnection) && status === "connecting")
+    && !(status === "disconnected" && isDisconnectedDialogDismissed);
+}
+
+export function shouldHideConnectingDialogForConnectionReuse({
+  reuseConnectionFromSessionId,
+  host,
+  connectionReuseFellBack,
+}: {
+  reuseConnectionFromSessionId?: string;
+  host: Host;
+  connectionReuseFellBack: boolean;
+}): boolean {
+  return !!reuseConnectionFromSessionId
+    && !connectionReuseFellBack
+    && !host.x11Forwarding
+    && !host.moshEnabled
+    && !host.etEnabled;
 }
 
 type XTermWithPrivateRenderService = XTerm & {

--- a/components/terminalHelpers.test.ts
+++ b/components/terminalHelpers.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host } from "../domain/models";
+import {
+  shouldHideConnectingDialogForConnectionReuse,
+  shouldShowTerminalConnectionDialog,
+} from "./terminal/terminalHelpers";
+
+const host = (overrides: Partial<Host> = {}): Host => ({
+  id: "host-1",
+  label: "Host",
+  hostname: "example.com",
+  username: "alice",
+  authMethod: "password",
+  ...overrides,
+});
+
+test("connection dialog is hidden while a reused SSH channel is opening", () => {
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "connecting",
+      isLocalConnection: false,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: false,
+      hideConnectingDialogForConnectionReuse: true,
+    }),
+    false,
+  );
+});
+
+test("connection dialog remains visible when reuse is not actually supported", () => {
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "connecting",
+      isLocalConnection: false,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: false,
+      hideConnectingDialogForConnectionReuse: false,
+    }),
+    true,
+  );
+});
+
+test("connection dialog still appears for fresh remote connections", () => {
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "connecting",
+      isLocalConnection: false,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: false,
+    }),
+    true,
+  );
+});
+
+test("connection dialog keeps existing local and disconnected behavior", () => {
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "connecting",
+      isLocalConnection: true,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "connected",
+      isLocalConnection: false,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldShowTerminalConnectionDialog({
+      status: "disconnected",
+      isLocalConnection: false,
+      isSerialConnection: false,
+      isDisconnectedDialogDismissed: true,
+    }),
+    false,
+  );
+});
+
+test("connection reuse hides connecting dialog only while reuse is still possible", () => {
+  assert.equal(
+    shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId: "source-session",
+      host: host(),
+      connectionReuseFellBack: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId: "source-session",
+      host: host({ x11Forwarding: true }),
+      connectionReuseFellBack: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId: "source-session",
+      host: host({ moshEnabled: true }),
+      connectionReuseFellBack: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId: "source-session",
+      host: host({ etEnabled: true }),
+      connectionReuseFellBack: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldHideConnectingDialogForConnectionReuse({
+      reuseConnectionFromSessionId: "source-session",
+      host: host(),
+      connectionReuseFellBack: true,
+    }),
+    false,
+  );
+});

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -338,11 +338,11 @@ export interface TerminalSession {
   localShellArgs?: string[]; // Shell args for local terminals (from discovery)
   localShellName?: string;   // Display name for local shell (e.g., "Zsh", "Ubuntu (WSL)")
   localShellIcon?: string;   // Icon identifier for local shell (e.g., "zsh", "ubuntu")
-  // For tabs created via "Copy Tab" on an SSH session: the id of the source
-  // session whose already-authenticated connection should be reused so the
-  // duplicate does not trigger a second MFA prompt (issue #1204). The bridge
-  // reuses the source connection when it is still live, otherwise it falls back
-  // to a fresh connection — so this also applies on reconnect: a reconnect
-  // reuses the source again if still connected, else dials fresh.
+  // For sessions created from an existing SSH session: the id of the source
+  // session whose already-authenticated connection should be reused so the new
+  // shell channel does not trigger a second MFA prompt (issue #1204). The
+  // bridge reuses the source connection when it is still live, otherwise it
+  // falls back to a fresh connection — so this also applies on reconnect: a
+  // reconnect reuses the source again if still connected, else dials fresh.
   reuseConnectionFromSessionId?: string;
 }

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -59,6 +59,10 @@ function makeSender() {
   };
 }
 
+function getConnectionReuseFallbackEvents(sender) {
+  return sender.sent.filter((m) => m.channel === "netcatty:connection-reuse:fallback");
+}
+
 // A fake ssh2 shell channel.
 function makeStream() {
   const stream = new EventEmitter();
@@ -181,6 +185,7 @@ test("Copy Tab reuses the source connection instead of dialing fresh", async (t)
   // A 'connected' progress event was emitted for the renderer.
   const progress = sender.sent.filter((m) => m.channel === "netcatty:chain:progress");
   assert.ok(progress.some((m) => m.payload.status === "connected"));
+  assert.equal(getConnectionReuseFallbackEvents(sender).length, 0, "successful reuse should not emit fallback");
 });
 
 test("closing the reused channel keeps the source connection alive", async (t) => {
@@ -319,15 +324,20 @@ test("synchronous shell failure releases the ref and falls back to fresh", async
   sessions.set("source", source);
 
   const start = registerStartHandler(bridge, sessions);
+  const sender = makeSender();
   await assert.rejects(
     () => start(
-      { sender: makeSender() },
+      { sender },
       { sessionId: "copy", hostname: "10.0.0.1", username: "alice", sourceSessionId: "source" },
     ),
   );
   // The up-front ref hold must be released so the source's count isn't leaked.
   assert.equal(connRef.count, 1, "ref count restored after synchronous shell failure");
   assert.equal(getClientConstructCount(), 1, "should fall back to a fresh connection");
+  assert.deepEqual(
+    getConnectionReuseFallbackEvents(sender).map((m) => m.payload),
+    [{ sessionId: "copy", sourceSessionId: "source" }],
+  );
 });
 
 test("falls back to a fresh connection when the source is gone", async (t) => {
@@ -338,9 +348,10 @@ test("falls back to a fresh connection when the source is gone", async (t) => {
   // sourceSessionId points at a session that doesn't exist -> fresh connect.
   // The mocked client emits an error on connect, so the start call rejects;
   // the important assertion is that a fresh connection was attempted.
+  const sender = makeSender();
   await assert.rejects(
     () => start(
-      { sender: makeSender() },
+      { sender },
       {
         sessionId: "copy",
         hostname: "10.0.0.1",
@@ -350,4 +361,8 @@ test("falls back to a fresh connection when the source is gone", async (t) => {
     ),
   );
   assert.equal(getClientConstructCount(), 1, "should attempt one fresh connection");
+  assert.deepEqual(
+    getConnectionReuseFallbackEvents(sender).map((m) => m.payload),
+    [{ sessionId: "copy", sourceSessionId: "missing-source" }],
+  );
 });

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -378,9 +378,18 @@ function createStartSessionApi(ctx) {
 
     async function startSSHSession(event, options) {
       const sessionId = options.sessionId || randomUUID();
+      const sender = event.sender;
       const log = createSshDiagnosticLogger(
         !!options.sshDebugLogEnabled || process.env.NETCATTY_SSH_DEBUG === "1",
       );
+      const sendConnectionReuseFallback = () => {
+        if (!sender.isDestroyed()) {
+          sender.send("netcatty:connection-reuse:fallback", {
+            sessionId,
+            sourceSessionId: options.sourceSessionId,
+          });
+        }
+      };
 
       // Connection reuse (issue #1204): when a tab is duplicated we try to open
       // a new shell channel on the source tab's already-authenticated
@@ -408,6 +417,7 @@ function createStartSessionApi(ctx) {
               sourceSessionId: options.sourceSessionId,
               error: reuseErr?.message,
             });
+            sendConnectionReuseFallback();
             // Fall through to establish a fresh connection.
           }
         } else {
@@ -415,12 +425,12 @@ function createStartSessionApi(ctx) {
             sessionId,
             sourceSessionId: options.sourceSessionId,
           });
+          sendConnectionReuseFallback();
         }
       }
 
       const cols = options.cols || 80;
       const rows = options.rows || 24;
-      const sender = event.sender;
 
       const sendProgress = (hop, total, label, status, error) => {
         if (!sender.isDestroyed()) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -10,6 +10,7 @@ const transferCompleteListeners = new Map();
 const transferErrorListeners = new Map();
 const transferCancelledListeners = new Map();
 const chainProgressListeners = new Map();
+const connectionReuseFallbackListeners = new Set();
 const zmodemListeners = new Map();
 const zmodemOverwriteListeners = new Map(); // sessionId -> Set<cb>
 const sftpConnectionProgressListeners = new Set();
@@ -210,6 +211,16 @@ ipcRenderer.on("netcatty:chain:progress", (_event, payload) => {
       cb(sessionId, hop, total, label, status, error);
     } catch (err) {
       console.error("Chain progress callback failed", err);
+    }
+  });
+});
+
+ipcRenderer.on("netcatty:connection-reuse:fallback", (_event, payload) => {
+  connectionReuseFallbackListeners.forEach((cb) => {
+    try {
+      cb(payload.sessionId, payload.sourceSessionId);
+    } catch (err) {
+      console.error("Connection reuse fallback callback failed", err);
     }
   });
 });
@@ -616,6 +627,7 @@ const api = createPreloadApi({
   transferErrorListeners,
   transferCancelledListeners,
   chainProgressListeners,
+  connectionReuseFallbackListeners,
   zmodemListeners,
   zmodemOverwriteListeners,
   sftpConnectionProgressListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -497,6 +497,12 @@ function createPreloadApi(ctx) {
       chainProgressListeners.delete(id);
     };
   },
+  onConnectionReuseFallback: (cb) => {
+    connectionReuseFallbackListeners.add(cb);
+    return () => {
+      connectionReuseFallbackListeners.delete(cb);
+    };
+  },
   // SFTP connection progress listener (auth method logs)
   onSftpConnectionProgress: (cb) => {
     sftpConnectionProgressListeners.add(cb);

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -152,6 +152,10 @@ declare global {
     // Callback receives: (sessionId: string, currentHop: number, totalHops: number, hostLabel: string, status: string, error?: string)
     onChainProgress?(cb: (sessionId: string, hop: number, total: number, label: string, status: string, error?: string) => void): () => void;
 
+    // Fired when a requested SSH connection reuse cannot be honored and the
+    // session falls back to a regular fresh connection.
+    onConnectionReuseFallback?(cb: (sessionId: string, sourceSessionId?: string) => void): () => void;
+
     // SFTP connection progress listener (auth method logs)
     onSftpConnectionProgress?(cb: (sessionId: string, label: string, status: string, detail?: string) => void): () => void;
 


### PR DESCRIPTION
## Summary
- Reuse an already connected SSH session when splitting a terminal pane, matching the Copy Tab behavior.
- Hide the connection progress dialog while a reused SSH channel is opening.
- Fix the existing SFTP external operation hook dependency warning.

## Validation
- npm run lint
- npm run build
- npm test
