### PR TITLE
fix(host-details): auto-switch default port when toggling primary protocol between SSH/Telnet

### DIFF
--- a/components/HostDetailsPanel.helpers.ts
+++ b/components/HostDetailsPanel.helpers.ts
@@ -8,9 +8,20 @@ export const parseOptionalPortInput = (value: string): number | undefined =>
 export const resolvePrimaryProtocolSwitchPort = (
   currentPort: number | undefined,
   nextProtocol: "ssh" | "telnet",
+  hasGroupTelnetPortDefault: boolean,
+  hasGroupSshPortDefault: boolean,
 ): number | undefined => {
-  if (nextProtocol === "telnet" && currentPort === 22) return 23;
-  if (nextProtocol === "ssh" && currentPort === 23) return 22;
+  if (nextProtocol === "telnet") {
+    // Don't override if group provides a Telnet default
+    if (hasGroupTelnetPortDefault || hasGroupSshPortDefault) return currentPort;
+    if (currentPort === 22 || currentPort === undefined) return 23;
+    return currentPort;
+  }
+  if (nextProtocol === "ssh") {
+    if (hasGroupSshPortDefault) return currentPort;
+    if (currentPort === 23 || currentPort === undefined) return 22;
+    return currentPort;
+  }
   return currentPort;
 };
 

--- a/components/HostDetailsPanel.helpers.ts
+++ b/components/HostDetailsPanel.helpers.ts
@@ -18,8 +18,13 @@ export const resolvePrimaryProtocolSavePort = (
   protocol: Host["protocol"],
   currentPort: number | undefined,
   hasGroupSshPortDefault: boolean,
+  hasGroupTelnetPortDefault: boolean,
 ): number | undefined => {
-  if (protocol === "telnet") return currentPort ?? 23;
+  if (protocol === "telnet") {
+    if (currentPort !== undefined) return currentPort;
+    if (hasGroupTelnetPortDefault || hasGroupSshPortDefault) return undefined;
+    return 23;
+  }
   return currentPort ?? (hasGroupSshPortDefault ? undefined : 22);
 };
 

--- a/components/HostDetailsPanel.helpers.ts
+++ b/components/HostDetailsPanel.helpers.ts
@@ -5,6 +5,24 @@ import { LINUX_DISTRO_OPTIONS, NETWORK_DEVICE_OPTIONS } from "../domain/host";
 export const parseOptionalPortInput = (value: string): number | undefined =>
   value ? Number(value) : undefined;
 
+export const resolvePrimaryProtocolSwitchPort = (
+  currentPort: number | undefined,
+  nextProtocol: "ssh" | "telnet",
+): number | undefined => {
+  if (nextProtocol === "telnet" && currentPort === 22) return 23;
+  if (nextProtocol === "ssh" && currentPort === 23) return 22;
+  return currentPort;
+};
+
+export const resolvePrimaryProtocolSavePort = (
+  protocol: Host["protocol"],
+  currentPort: number | undefined,
+  hasGroupSshPortDefault: boolean,
+): number | undefined => {
+  if (protocol === "telnet") return currentPort ?? 23;
+  return currentPort ?? (hasGroupSshPortDefault ? undefined : 22);
+};
+
 export const resolveDetailsTelnetPort = (
   host: Host,
   groupDefaults?: Partial<GroupConfig>,

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -246,11 +246,14 @@ test("parseOptionalPortInput clears empty port values", () => {
 });
 
 test("resolvePrimaryProtocolSwitchPort only migrates opposite protocol defaults", () => {
-  assert.equal(resolvePrimaryProtocolSwitchPort(22, "telnet"), 23);
-  assert.equal(resolvePrimaryProtocolSwitchPort(23, "ssh"), 22);
-  assert.equal(resolvePrimaryProtocolSwitchPort(2222, "telnet"), 2222);
-  assert.equal(resolvePrimaryProtocolSwitchPort(2323, "ssh"), 2323);
-  assert.equal(resolvePrimaryProtocolSwitchPort(undefined, "telnet"), undefined);
+  assert.equal(resolvePrimaryProtocolSwitchPort(22, "telnet", false, false), 23);
+  assert.equal(resolvePrimaryProtocolSwitchPort(23, "ssh", false, false), 22);
+  assert.equal(resolvePrimaryProtocolSwitchPort(2222, "telnet", false, false), 2222);
+  assert.equal(resolvePrimaryProtocolSwitchPort(2323, "ssh", false, false), 2323);
+  assert.equal(resolvePrimaryProtocolSwitchPort(undefined, "telnet", false, false), 23);
+  assert.equal(resolvePrimaryProtocolSwitchPort(undefined, "ssh", false, false), 22);
+  assert.equal(resolvePrimaryProtocolSwitchPort(22, "telnet", false, true), 22);
+  assert.equal(resolvePrimaryProtocolSwitchPort(22, "telnet", true, false), 22);
 });
 
 test("resolvePrimaryProtocolSavePort falls back to telnet default for primary telnet", () => {

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -254,10 +254,12 @@ test("resolvePrimaryProtocolSwitchPort only migrates opposite protocol defaults"
 });
 
 test("resolvePrimaryProtocolSavePort falls back to telnet default for primary telnet", () => {
-  assert.equal(resolvePrimaryProtocolSavePort("telnet", undefined, false), 23);
-  assert.equal(resolvePrimaryProtocolSavePort("telnet", 2323, false), 2323);
-  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, false), 22);
-  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, true), undefined);
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", undefined, false, false), 23);
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", 2323, false, false), 2323);
+  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, false, false), 22);
+  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, true, false), undefined);
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", undefined, false, true), undefined);
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", undefined, true, false), undefined);
 });
 
 test("HostDetailsPanel does not offer to disable telnet when telnet is the primary protocol", () => {

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -6,6 +6,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { I18nProvider } from "../application/i18n/I18nProvider.tsx";
 import type { Host } from "../types.ts";
 import HostDetailsPanel, { parseOptionalPortInput } from "./HostDetailsPanel.tsx";
+import {
+  resolvePrimaryProtocolSavePort,
+  resolvePrimaryProtocolSwitchPort,
+} from "./HostDetailsPanel.helpers.ts";
 import { TooltipProvider } from "./ui/tooltip.tsx";
 
 const hostWithMissingProxyProfile: Host = {
@@ -239,6 +243,21 @@ test("HostDetailsPanel displays inherited telnet credentials", () => {
 test("parseOptionalPortInput clears empty port values", () => {
   assert.equal(parseOptionalPortInput(""), undefined);
   assert.equal(parseOptionalPortInput("2325"), 2325);
+});
+
+test("resolvePrimaryProtocolSwitchPort only migrates opposite protocol defaults", () => {
+  assert.equal(resolvePrimaryProtocolSwitchPort(22, "telnet"), 23);
+  assert.equal(resolvePrimaryProtocolSwitchPort(23, "ssh"), 22);
+  assert.equal(resolvePrimaryProtocolSwitchPort(2222, "telnet"), 2222);
+  assert.equal(resolvePrimaryProtocolSwitchPort(2323, "ssh"), 2323);
+  assert.equal(resolvePrimaryProtocolSwitchPort(undefined, "telnet"), undefined);
+});
+
+test("resolvePrimaryProtocolSavePort falls back to telnet default for primary telnet", () => {
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", undefined, false), 23);
+  assert.equal(resolvePrimaryProtocolSavePort("telnet", 2323, false), 2323);
+  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, false), 22);
+  assert.equal(resolvePrimaryProtocolSavePort("ssh", undefined, true), undefined);
 });
 
 test("HostDetailsPanel does not offer to disable telnet when telnet is the primary protocol", () => {

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -888,7 +888,12 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
                   setForm((prev) => ({
                     ...prev,
                     protocol: nextProtocol,
-                    port: resolvePrimaryProtocolSwitchPort(prev.port, nextProtocol),
+                    port: resolvePrimaryProtocolSwitchPort(
+                      prev.port,
+                      nextProtocol,
+                      Boolean(groupDefaults?.telnetPort),
+                      Boolean(groupDefaults?.port),
+                    ),
                   }));
                 }}
               />

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -36,7 +36,15 @@ import {
 } from "./ui/aside-panel";
 import { HostDetailsAdvancedSections } from "./HostDetailsAdvancedSections";
 import { HostDetailsConnectionSections } from "./HostDetailsConnectionSections";
-import { LINUX_DISTRO_OPTION_IDS, parseOptionalPortInput, resolveDetailsTelnetPassword, resolveDetailsTelnetPort, resolveDetailsTelnetUsername } from "./HostDetailsPanel.helpers";
+import {
+  LINUX_DISTRO_OPTION_IDS,
+  parseOptionalPortInput,
+  resolveDetailsTelnetPassword,
+  resolveDetailsTelnetPort,
+  resolveDetailsTelnetUsername,
+  resolvePrimaryProtocolSavePort,
+  resolvePrimaryProtocolSwitchPort,
+} from "./HostDetailsPanel.helpers";
 export { parseOptionalPortInput } from "./HostDetailsPanel.helpers";
 import { Button } from "./ui/button";
 import { Combobox, ComboboxOption, MultiCombobox } from "./ui/combobox";
@@ -385,10 +393,11 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
     }
 
     const { proxyConfig: _draftProxyConfig, ...formWithoutProxyDraft } = form;
-    const finalPort =
-      form.protocol === "telnet"
-        ? form.port
-        : form.port ?? (groupDefaults?.port ? undefined : 22);
+    const finalPort = resolvePrimaryProtocolSavePort(
+      form.protocol,
+      form.port,
+      Boolean(groupDefaults?.port),
+    );
     let cleaned: Host = {
       ...formWithoutProxyDraft,
       ...(normalizedProxyConfig && { proxyConfig: normalizedProxyConfig }),
@@ -873,7 +882,14 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
               <span className="text-xs text-muted-foreground">{t("hostDetails.telnet.setDefault")}</span>
               <Switch
                 checked={form.protocol === "telnet"}
-                onCheckedChange={(checked) => update("protocol", checked ? "telnet" : "ssh")}
+                onCheckedChange={(checked) => {
+                  const nextProtocol = checked ? "telnet" : "ssh";
+                  setForm((prev) => ({
+                    ...prev,
+                    protocol: nextProtocol,
+                    port: resolvePrimaryProtocolSwitchPort(prev.port, nextProtocol),
+                  }));
+                }}
               />
             </div>
 

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -397,6 +397,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       form.protocol,
       form.port,
       Boolean(groupDefaults?.port),
+      Boolean(groupDefaults?.telnetPort),
     );
     let cleaned: Host = {
       ...formWithoutProxyDraft,


### PR DESCRIPTION
Closes #1251

**问题**: 将主机主协议切换为 Telnet 时，端口仍显示 22 而非 23。

**根因**: 协议切换只更新 protocol 字段，未同步更新 port；保存时 Telnet 模式下也没有默认回退到 23。

**修复**:
- 切换 SSH↔Telnet 时自动切换默认端口（22↔23），自定义端口不受影响
- 保存时 Telnet 模式 fallback 到 23
- 新增辅助函数 + 单元测试