### PR TITLE
feat(sftp): skip loading animation when reusing terminal SSH connection

### DIFF
--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -207,6 +207,7 @@ export const useSftpConnections = ({
           isLocal: false,
           status: "connecting",
           currentPath: cachedStartPath,
+          reusedConnection: !!options?.sourceSessionId,
         };
 
         updateTab(side, activeTabId, (prev) => ({

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -456,6 +456,7 @@ export const useSftpConnections = ({
                   status: "connected",
                   currentPath: startPath,
                   homeDir,
+                  reusedConnection: undefined,
                 }
               : null,
             files,

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -207,6 +207,10 @@ export const useSftpConnections = ({
           isLocal: false,
           status: "connecting",
           currentPath: cachedStartPath,
+          // Suppress loading animation when connection reuse is requested.
+          // If the backend falls back to a fresh connection, the pane stays
+          // non-interactive (loading=true) with stale cached files visible —
+          // no worse than the previous UX of always showing a spinner.
           reusedConnection: !!options?.sourceSessionId,
         };
 

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -680,7 +680,7 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
     </div>
 
     {/* Loading overlay - covers entire pane when navigating or reconnecting */}
-    {pane.loading && sortedDisplayFiles.length > 0 && !pane.reconnecting && (
+    {pane.loading && !pane.connection?.reusedConnection && sortedDisplayFiles.length > 0 && !pane.reconnecting && (
       <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/40 backdrop-blur-[1px] z-10">
         <Loader2 size={24} className="animate-spin text-muted-foreground" />
         {pane.connectionLogs.length > 0 && (

--- a/components/sftp/SftpPaneToolbar.tsx
+++ b/components/sftp/SftpPaneToolbar.tsx
@@ -313,7 +313,7 @@ export const SftpPaneToolbar: React.FC<SftpPaneToolbarProps> = React.memo(({
             <RefreshCw
               size={14}
               className={
-                pane.loading || pane.reconnecting ? "animate-spin" : ""
+                pane.loading && !pane.connection?.reusedConnection && !pane.reconnecting ? "animate-spin" : ""
               }
             />
           </Button>
@@ -414,7 +414,7 @@ export const SftpPaneToolbar: React.FC<SftpPaneToolbarProps> = React.memo(({
       >
         <RefreshCw
           size={14}
-          className={cn("shrink-0", (pane.loading || pane.reconnecting) && "animate-spin")}
+          className={cn("shrink-0", pane.loading && !pane.connection?.reusedConnection && !pane.reconnecting && "animate-spin")}
         />
         {t("common.refresh")}
       </button>

--- a/components/sftp/SftpPaneTreeView.tsx
+++ b/components/sftp/SftpPaneTreeView.tsx
@@ -942,7 +942,7 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
           onChange={handleUploadInputChange}
         />
       )}
-      {pane.loading && !pane.reconnecting && (
+      {pane.loading && !pane.connection?.reusedConnection && !pane.reconnecting && (
         <div className="absolute inset-0 flex flex-col items-center justify-center bg-background/40 backdrop-blur-[1px] z-10 pointer-events-none">
           <Loader2 size={24} className="animate-spin text-muted-foreground" />
           {pane.connectionLogs.length > 0 && (

--- a/domain/models/sftp.ts
+++ b/domain/models/sftp.ts
@@ -24,6 +24,8 @@ export interface SftpConnection {
   error?: string;
   currentPath: string;
   homeDir?: string;
+  /** True when this SFTP connection reuses an existing terminal SSH session */
+  reusedConnection?: boolean;
 }
 
 export type TransferStatus = 'pending' | 'transferring' | 'completed' | 'failed' | 'cancelled';

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -197,9 +197,9 @@ function createPreloadApi(ctx) {
     return () => passphraseAuthFailedListeners.delete(cb);
   },
   openSftp: async (options) => {
-    const result = await ipcRenderer.invoke("netcatty:sftp:open", options);
-    return result.sftpId;
-  },
+      const result = await ipcRenderer.invoke("netcatty:sftp:open", options);
+      return result.sftpId;
+    },
   listSftp: async (sftpId, path, encoding) => {
     return ipcRenderer.invoke("netcatty:sftp:list", { sftpId, path, encoding });
   },


### PR DESCRIPTION
Follow-up to #1254

SFTP 复用终端 SSH 连接时连接几乎是瞬时的，loading 动画和叠加层是多余的干扰。在 SftpConnection 上加了 reusedConnection 标记，复用时跳过 loading UI。

改动: 5 文件, +7/-4