### PR TITLE
fix(ssh): support chacha20-poly1305 cipher

### DIFF
--- a/domain/sshAlgorithmList.test.ts
+++ b/domain/sshAlgorithmList.test.ts
@@ -42,6 +42,11 @@ test("effectiveDefaultAlgorithms (modern) never seeds CBC / arcfour / MD5", () =
   }
 });
 
+test("effectiveDefaultAlgorithms (modern) includes chacha20-poly1305", () => {
+  const result = effectiveDefaultAlgorithms(false);
+  assert.ok(result.cipher.includes("chacha20-poly1305@openssh.com"));
+});
+
 test("effectiveDefaultAlgorithms (legacy) appends sha1 KEX, CBC, and ssh-dss", () => {
   const modern = effectiveDefaultAlgorithms(false);
   const legacy = effectiveDefaultAlgorithms(true);

--- a/domain/sshAlgorithmList.ts
+++ b/domain/sshAlgorithmList.ts
@@ -137,6 +137,7 @@ const MODERN_DEFAULT_ALGORITHMS: Readonly<Record<SSHAlgorithmCategory, readonly 
     "aes128-ctr",
     "aes192-ctr",
     "aes256-ctr",
+    "chacha20-poly1305@openssh.com",
   ],
   hmac: [
     "hmac-sha2-256-etm@openssh.com",

--- a/electron/bridges/sshAlgorithms.cjs
+++ b/electron/bridges/sshAlgorithms.cjs
@@ -8,7 +8,23 @@ const FIXED_DH_GROUP_BY_KEX = Object.freeze({
   "diffie-hellman-group18-sha512": "modp18",
 });
 
+const CIPHER_SSL_NAME_BY_ALGORITHM = Object.freeze({
+  "chacha20-poly1305@openssh.com": "chacha20",
+  "aes128-gcm@openssh.com": "aes-128-gcm",
+  "aes256-gcm@openssh.com": "aes-256-gcm",
+  "aes128-gcm": "aes-128-gcm",
+  "aes256-gcm": "aes-256-gcm",
+  "aes128-ctr": "aes-128-ctr",
+  "aes192-ctr": "aes-192-ctr",
+  "aes256-ctr": "aes-256-ctr",
+  "aes128-cbc": "aes-128-cbc",
+  "aes192-cbc": "aes-192-cbc",
+  "aes256-cbc": "aes-256-cbc",
+  "3des-cbc": "des-ede3-cbc",
+});
+
 let _md5Supported = null;
+let _supportedCiphers = null;
 const dhGroupSupport = new Map();
 
 // MODP groups that every SSH runtime we target supports, so we skip the
@@ -52,12 +68,29 @@ function filterSupportedFixedDhKex(kexAlgorithms) {
   });
 }
 
+function supportedCiphers() {
+  if (_supportedCiphers === null) {
+    try { _supportedCiphers = new Set(crypto.getCiphers()); }
+    catch { _supportedCiphers = new Set(); }
+  }
+  return _supportedCiphers;
+}
+
+function filterRuntimeUnsupportedCiphers(cipherAlgorithms) {
+  const ciphers = supportedCiphers();
+  return cipherAlgorithms.filter((algo) => {
+    const sslName = CIPHER_SSL_NAME_BY_ALGORITHM[algo];
+    return !sslName || ciphers.has(sslName);
+  });
+}
+
 function buildBaseAlgorithms() {
   return {
-    cipher: [
+    cipher: filterRuntimeUnsupportedCiphers([
       "aes128-gcm@openssh.com", "aes256-gcm@openssh.com",
       "aes128-ctr", "aes192-ctr", "aes256-ctr",
-    ],
+      "chacha20-poly1305@openssh.com",
+    ]),
     kex: filterSupportedFixedDhKex([
       "curve25519-sha256", "curve25519-sha256@libssh.org",
       "ecdh-sha2-nistp256", "ecdh-sha2-nistp384", "ecdh-sha2-nistp521",
@@ -76,7 +109,9 @@ function applyLegacyAlgorithms(algorithms) {
     "diffie-hellman-group-exchange-sha1",
   ]));
   algorithms.cipher.push(
-    "aes128-cbc", "aes256-cbc", "3des-cbc",
+    ...filterRuntimeUnsupportedCiphers([
+      "aes128-cbc", "aes256-cbc", "3des-cbc",
+    ]),
   );
   algorithms.serverHostKey = [
     "ssh-ed25519", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521",
@@ -168,6 +203,8 @@ function applyAlgorithmOverrides(algorithms, overrides) {
         filtered = filterSupportedFixedDhKex(copy);
       } else if (key === "hmac") {
         filtered = filterRuntimeUnsupportedHmac(copy);
+      } else if (key === "cipher") {
+        filtered = filterRuntimeUnsupportedCiphers(copy);
       } else {
         filtered = copy;
       }
@@ -240,6 +277,7 @@ function buildSftpAlgorithms(legacyEnabled, options = {}) {
 
 function _resetAlgorithmSupportCacheForTests() {
   _md5Supported = null;
+  _supportedCiphers = null;
   dhGroupSupport.clear();
 }
 

--- a/electron/bridges/sshAlgorithms.test.cjs
+++ b/electron/bridges/sshAlgorithms.test.cjs
@@ -23,9 +23,14 @@ function resetSupportCache() {
   sftpBridge._resetAlgorithmSupportCacheForTests?.();
 }
 
-function withAlgorithmRuntime({ unsupportedGroups = new Set(), hashes = ["sha1", "sha256", "sha512", "md5"] }, callback) {
+function withAlgorithmRuntime({
+  unsupportedGroups = new Set(),
+  hashes = ["sha1", "sha256", "sha512", "md5"],
+  ciphers = crypto.getCiphers(),
+}, callback) {
   const originalCreateGroup = crypto.createDiffieHellmanGroup;
   const originalGetHashes = crypto.getHashes;
+  const originalGetCiphers = crypto.getCiphers;
   const probedGroups = [];
 
   crypto.createDiffieHellmanGroup = (name) => {
@@ -36,6 +41,7 @@ function withAlgorithmRuntime({ unsupportedGroups = new Set(), hashes = ["sha1",
     return {};
   };
   crypto.getHashes = () => hashes;
+  crypto.getCiphers = () => ciphers;
 
   resetSupportCache();
   try {
@@ -43,6 +49,7 @@ function withAlgorithmRuntime({ unsupportedGroups = new Set(), hashes = ["sha1",
   } finally {
     crypto.createDiffieHellmanGroup = originalCreateGroup;
     crypto.getHashes = originalGetHashes;
+    crypto.getCiphers = originalGetCiphers;
     resetSupportCache();
   }
 }
@@ -126,6 +133,41 @@ for (const [label, buildAlgorithms] of [
   ["SSH", sshBridge.buildAlgorithms],
   ["SFTP", sftpBridge.buildSftpAlgorithms],
 ]) {
+  test(`${label} offers chacha20-poly1305 in modern defaults when the runtime supports it`, () => {
+    withAlgorithmRuntime({}, () => {
+      const algorithms = buildAlgorithms(false);
+
+      assert.ok(
+        algorithms.cipher.includes("chacha20-poly1305@openssh.com"),
+        "chacha20-poly1305@openssh.com should be offered",
+      );
+    });
+  });
+
+  test(`${label} drops chacha20-poly1305 when the runtime lacks chacha20`, () => {
+    const ciphersWithoutChacha20 = crypto.getCiphers().filter((cipher) => cipher !== "chacha20");
+
+    withAlgorithmRuntime({ ciphers: ciphersWithoutChacha20 }, () => {
+      const algorithms = buildAlgorithms(false);
+
+      assert.equal(algorithms.cipher.includes("chacha20-poly1305@openssh.com"), false);
+    });
+  });
+
+  test(`${label} cipher override is filtered against runtime support`, () => {
+    const ciphersWithoutChacha20 = crypto.getCiphers().filter((cipher) => cipher !== "chacha20");
+
+    withAlgorithmRuntime({ ciphers: ciphersWithoutChacha20 }, () => {
+      const algorithms = buildAlgorithms(false, {
+        algorithmOverrides: {
+          cipher: ["chacha20-poly1305@openssh.com", "aes256-ctr"],
+        },
+      });
+
+      assert.deepEqual(algorithms.cipher, ["aes256-ctr"]);
+    });
+  });
+
   test(`${label} keeps standard DH groups without an expensive runtime probe`, () => {
     assert.equal(typeof buildAlgorithms, "function");
 


### PR DESCRIPTION
## Summary
- add chacha20-poly1305@openssh.com to Netcatty's modern SSH/SFTP cipher offer when the local crypto runtime supports it
- filter explicit cipher overrides through runtime-supported OpenSSL cipher names to avoid ssh2 unsupported-algorithm failures
- keep the host algorithm override UI defaults in sync with the connection defaults

## Validation
- npm run lint
- node --test --import tsx electron/bridges/sshAlgorithms.test.cjs
- node --test --import tsx domain/sshAlgorithmList.test.ts
- node --test --import tsx lib/localFonts.test.ts
- npm test (fails in full-suite run due an existing/transient lib/localFonts.test.ts failure; the localFonts file passes when rerun directly)

Closes #1256