### PR TITLE
Use dropdown for proxy type selection

### DIFF
--- a/components/ProxyPanel.test.tsx
+++ b/components/ProxyPanel.test.tsx
@@ -118,3 +118,12 @@ test("ProxyPanel supports custom ProxyCommand settings", () => {
   assert.doesNotMatch(markup, /Proxy host/);
   assert.doesNotMatch(markup, /Credentials/);
 });
+
+test("ProxyPanel uses a dropdown for proxy type selection", () => {
+  const markup = renderPanel({
+    proxyConfig: { type: "http", host: "manual-proxy.example.com", port: 3128 },
+  });
+
+  assert.match(markup, /role="combobox"/);
+  assert.match(markup, /aria-label="Type"/);
+});

--- a/components/ProxyProfilesManager.tsx
+++ b/components/ProxyProfilesManager.tsx
@@ -1,6 +1,5 @@
 import {
   AlertTriangle,
-  Check,
   ChevronDown,
   Copy,
   Globe,
@@ -53,6 +52,7 @@ import {
 } from "./ui/dialog";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { Input } from "./ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { toast } from "./ui/toast";
 import {
   VaultHeaderSearch,
@@ -470,40 +470,24 @@ export const ProxyProfilesManager: React.FC<ProxyProfilesManagerProps> = ({
             </Card>
 
             <Card className="p-3 space-y-3 bg-card border-border/80">
-              <div className="flex items-center justify-between gap-3">
+              <div className="space-y-2">
                 <div className="flex items-center gap-2">
                   <Globe size={14} className="text-muted-foreground" />
                   <p className="text-xs font-semibold">{t("field.type")}</p>
                 </div>
-                <div className="flex gap-2">
-                  <Button
-                    variant={draft.config.type === "http" ? "secondary" : "ghost"}
-                    size="sm"
-                    className={cn("h-8", draft.config.type === "http" && "bg-primary/15")}
-                    onClick={() => updateDraftConfig("type", "http")}
-                  >
-                    <Check size={14} className={cn("mr-1", draft.config.type !== "http" && "opacity-0")} />
-                    HTTP
-                  </Button>
-                  <Button
-                    variant={draft.config.type === "socks5" ? "secondary" : "ghost"}
-                    size="sm"
-                    className={cn("h-8", draft.config.type === "socks5" && "bg-primary/15")}
-                    onClick={() => updateDraftConfig("type", "socks5")}
-                  >
-                    <Check size={14} className={cn("mr-1", draft.config.type !== "socks5" && "opacity-0")} />
-                    SOCKS5
-                  </Button>
-                  <Button
-                    variant={draft.config.type === "command" ? "secondary" : "ghost"}
-                    size="sm"
-                    className={cn("h-8", draft.config.type === "command" && "bg-primary/15")}
-                    onClick={() => updateDraftConfig("type", "command")}
-                  >
-                    <Check size={14} className={cn("mr-1", draft.config.type !== "command" && "opacity-0")} />
-                    {t("hostDetails.proxyPanel.command")}
-                  </Button>
-                </div>
+                <Select
+                  value={draft.config.type}
+                  onValueChange={(value) => updateDraftConfig("type", value as ProxyConfig["type"])}
+                >
+                  <SelectTrigger aria-label={t("field.type")} className="h-10">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="http">HTTP</SelectItem>
+                    <SelectItem value="socks5">SOCKS5</SelectItem>
+                    <SelectItem value="command">{t("hostDetails.proxyPanel.command")}</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
 
               {isProxyCommandConfig(draft.config) ? (

--- a/components/host-details/ProxyPanel.tsx
+++ b/components/host-details/ProxyPanel.tsx
@@ -2,11 +2,10 @@
  * Proxy Configuration Sub-Panel
  * Panel for configuring HTTP/SOCKS5/ProxyCommand proxy settings
  */
-import { Check, Globe, KeyRound, SquareTerminal, Trash2 } from 'lucide-react';
+import { Globe, KeyRound, SquareTerminal, Trash2 } from 'lucide-react';
 import React, { useCallback, useMemo } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { formatProxyConfigEndpoint, formatProxyConfigType, isProxyCommandConfig, isValidProxyPort } from '../../domain/proxyProfiles';
-import { cn } from '../../lib/utils';
 import { ProxyConfig, ProxyProfile } from '../../types';
 import { AsidePanel, AsidePanelContent, type AsidePanelLayout } from '../ui/aside-panel';
 import { Badge } from '../ui/badge';
@@ -121,40 +120,24 @@ export const ProxyPanel: React.FC<ProxyPanelProps> = ({
                 {!isUsingProfile && (
                     <>
                         <Card className="p-3 space-y-3 bg-card border-border/80">
-                            <div className="flex items-center justify-between gap-3">
+                            <div className="space-y-2">
                                 <div className="flex items-center gap-2">
                                     <Globe size={14} className="text-muted-foreground" />
                                     <p className="text-xs font-semibold">{t('field.type')}</p>
                                 </div>
-                                <div className="flex gap-2">
-                                    <Button
-                                        variant={proxyConfig?.type === 'http' ? "secondary" : "ghost"}
-                                        size="sm"
-                                        className={cn("h-8", proxyConfig?.type === 'http' && "bg-primary/15")}
-                                        onClick={() => onUpdateProxy('type', 'http')}
-                                    >
-                                        <Check size={14} className={cn("mr-1", proxyConfig?.type !== 'http' && "opacity-0")} />
-                                        HTTP
-                                    </Button>
-                                    <Button
-                                        variant={proxyConfig?.type === 'socks5' ? "secondary" : "ghost"}
-                                        size="sm"
-                                        className={cn("h-8", proxyConfig?.type === 'socks5' && "bg-primary/15")}
-                                        onClick={() => onUpdateProxy('type', 'socks5')}
-                                    >
-                                        <Check size={14} className={cn("mr-1", proxyConfig?.type !== 'socks5' && "opacity-0")} />
-                                        SOCKS5
-                                    </Button>
-                                    <Button
-                                        variant={proxyConfig?.type === 'command' ? "secondary" : "ghost"}
-                                        size="sm"
-                                        className={cn("h-8", proxyConfig?.type === 'command' && "bg-primary/15")}
-                                        onClick={() => onUpdateProxy('type', 'command')}
-                                    >
-                                        <Check size={14} className={cn("mr-1", proxyConfig?.type !== 'command' && "opacity-0")} />
-                                        {t('hostDetails.proxyPanel.command')}
-                                    </Button>
-                                </div>
+                                <Select
+                                    value={proxyConfig?.type || 'http'}
+                                    onValueChange={(value) => onUpdateProxy('type', value as ProxyConfig['type'])}
+                                >
+                                    <SelectTrigger aria-label={t('field.type')} className="h-10">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="http">HTTP</SelectItem>
+                                        <SelectItem value="socks5">SOCKS5</SelectItem>
+                                        <SelectItem value="command">{t('hostDetails.proxyPanel.command')}</SelectItem>
+                                    </SelectContent>
+                                </Select>
                             </div>
 
                             {isCommandProxy ? (


### PR DESCRIPTION
## Summary
- Replace the proxy type button row with a dropdown in host proxy settings.
- Apply the same dropdown in reusable proxy profile editing.
- Add a regression check for the dropdown control.

## Checks
- node --test --import tsx components/ProxyPanel.test.tsx components/ProxyProfilesManager.test.tsx
- npm run lint
- npm run build