### PR TITLE
Fix cmd PTY wrapper expansion

### DIFF
--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -5,6 +5,9 @@ const {
   resolveEffectiveShellKind,
   execViaChannel,
 } = require("./ptyExec.cjs");
+const {
+  buildWrappedCommand,
+} = require("./ptyExecHelpers.cjs");
 
 test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
   // SSH sessions don't set shellKind (sshBridge never assigns one), which
@@ -107,6 +110,12 @@ test("falls back to posix when neither shell kind nor prompt is informative", ()
 test("does not misclassify command output that happens to contain 'PS'", () => {
   assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix");
   assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix");
+});
+
+test("cmd wrapper uses interactive cmd variable expansion", () => {
+  const wrapped = buildWrappedCommand("ipconfig /all", "cmd", "__NCMCP_TEST__");
+  assert.match(wrapped, /"%__NCMCP_TEST___CMD%"/);
+  assert.doesNotMatch(wrapped, /"%%__NCMCP_TEST___CMD%%"/);
 });
 
 test("execViaChannel registers a pending-cancel marker before the SSH channel opens", () => {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -137,7 +137,7 @@ function buildWrappedCommand(command, shellKind, marker) {
     case "cmd": {
       const cmdEscaped = escapeCmdForNestedShell(command);
       return (
-        `set "${marker}=0" & set "${marker}_CMD=${cmdEscaped}" & (echo ${marker}_S & set "PAGER=cat" & set "SYSTEMD_PAGER=" & set "GIT_PAGER=cat" & set "LESS=" & call cmd /d /s /c "%%${marker}_CMD%%" & call echo ${marker}_E:^%errorlevel^%)\r\n`
+        `set "${marker}=0" & set "${marker}_CMD=${cmdEscaped}" & (echo ${marker}_S & set "PAGER=cat" & set "SYSTEMD_PAGER=" & set "GIT_PAGER=cat" & set "LESS=" & call cmd /d /s /c "%${marker}_CMD%" & call echo ${marker}_E:^%errorlevel^%)\r\n`
       );
     }
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -47,6 +47,7 @@ function cleanupTransferListeners(transferId) {
 
 const _mcpLineBufs = new Map(); // sessionId -> trailing fragment string
 const _mcpFlushTimers = new Map(); // sessionId -> delayed-flush timer
+const _mcpDroppingWrappedLine = new Set(); // sessionIds with a split marker echo line in progress
 
 // Returns true if `s` ends with a non-empty prefix of "__NCMCP_"
 // (i.e. the next chunk might complete it into a marker-containing line).
@@ -72,13 +73,13 @@ function filterMcpChunk(sessionId, chunk) {
   _mcpLineBufs.delete(sessionId);
 
   // Fast path: nothing suspicious in the combined data
-  if (!data.includes("__NCMCP_") && !_endsWithMarkerPrefix(data)) {
+  if (!_mcpDroppingWrappedLine.has(sessionId) && !data.includes("__NCMCP_") && !_endsWithMarkerPrefix(data)) {
     return data;
   }
 
   // Slow path: scan line by line
   let result = "";
-  let droppedAny = false;
+  let droppedAny = _mcpDroppingWrappedLine.has(sessionId);
   let pos = 0;
   while (pos < data.length) {
     const nlIdx = data.indexOf("\n", pos);
@@ -91,16 +92,18 @@ function filterMcpChunk(sessionId, chunk) {
       const tail = data.slice(pos);
       if (droppedAny || tail.includes("__NCMCP_") || _endsWithMarkerPrefix(tail)) {
         _mcpLineBufs.set(sessionId, tail);
+        if (droppedAny) _mcpDroppingWrappedLine.add(sessionId);
       } else {
         result += tail; // safe to display immediately
       }
       break;
     }
     const line = data.slice(pos, nlIdx + 1); // includes the \n
-    if (!line.includes("__NCMCP_")) {
-      result += line;
+    if (droppedAny || line.includes("__NCMCP_")) {
+      droppedAny = false;
+      _mcpDroppingWrappedLine.delete(sessionId);
     } else {
-      droppedAny = true;
+      result += line;
     }
     pos = nlIdx + 1;
   }
@@ -172,6 +175,10 @@ ipcRenderer.on("netcatty:data", (_event, payload) => {
       const held = _mcpLineBufs.get(sid);
       _mcpLineBufs.delete(sid);
       _mcpFlushTimers.delete(sid);
+      if (_mcpDroppingWrappedLine.has(sid)) {
+        _mcpDroppingWrappedLine.delete(sid);
+        return;
+      }
       if (held) _deliverToListeners(sid, held);
     }, 80));
   }
@@ -200,6 +207,7 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
     _mcpFlushTimers.delete(payload.sessionId);
   }
   _mcpLineBufs.delete(payload.sessionId); // clean up any held fragment
+  _mcpDroppingWrappedLine.delete(payload.sessionId);
 });
 
 // Chain progress events (for jump host connections)


### PR DESCRIPTION
## Summary
- Fix cmd PTY command wrapping so interactive variable expansion uses single-percent variable references.
- Add regression coverage for cmd wrapper expansion.
- Keep preload PTY exec handling aligned with the wrapper behavior.

## Tests
- `node --test electron/bridges/ai/ptyExec.test.cjs`

Fixes #1151