### PR TITLE
[codex] Fix sudo autofill prompt verification

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
@@ -9,8 +9,10 @@ const prepareSudoPrompt = (
   autofill: { prepareCommand: (command: string) => string | null } | null,
 ): string => {
   const prepared = autofill?.prepareCommand("sudo whoami");
-  assert.equal(prepared, "sudo whoami");
-  return "[sudo] password for alice: ";
+  assert.ok(prepared);
+  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
+  assert.ok(prompt);
+  return prompt.replace("%p", "alice");
 };
 
 const makeBackend = (

--- a/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
@@ -12,8 +12,10 @@ const prepareSudoPrompt = (
   autofill: { prepareCommand: (command: string) => string | null } | null,
 ): string => {
   const prepared = autofill?.prepareCommand("sudo whoami");
-  assert.equal(prepared, "sudo whoami");
-  return "[sudo] password for alice: ";
+  assert.ok(prepared);
+  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
+  assert.ok(prompt);
+  return prompt.replace("%p", "alice");
 };
 
 test("startMosh enables sudo autofill with the host saved password", async () => {

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -16,8 +16,10 @@ const prepareSudoPrompt = (
   command = "sudo whoami",
 ): string => {
   const prepared = autofill?.prepareCommand(command);
-  assert.equal(prepared, command);
-  return "[sudo] password for alice: ";
+  assert.ok(prepared);
+  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
+  assert.ok(prompt);
+  return prompt.replace("%p", "alice");
 };
 
 const createTermStub = () => ({

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -8,6 +8,9 @@ import {
 import { recordTerminalCommandExecution } from "./terminalCommandExecution";
 import { createPromptLineBreakState } from "./promptLineBreak";
 
+const TEST_MARKER = "__NETCATTY_SUDO_test__";
+const TEST_PREPARED_SUDO_WHOAMI = `sudo -p '[sudo] password for %p: ${TEST_MARKER}' whoami`;
+
 function createFakeTerm(lineText = "$ echo ok", cursorX = lineText.length) {
   return {
     buffer: {
@@ -52,27 +55,42 @@ function createWrappedFakeTerm(rows: string[], cursorY: number, cursorX: number,
   };
 }
 
-test("sudo autofill input preparation keeps submitted sudo commands visible as typed", () => {
+test("sudo autofill input preparation rewrites submitted sudo commands for the remote side", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: () => {},
   });
 
   assert.equal(
     prepareSudoAutofillInput("\r", "sudo whoami", autofill),
-    "\r",
+    `\x15${TEST_PREPARED_SUDO_WHOAMI}\r`,
   );
 });
 
-test("sudo autofill input preparation keeps single-line pasted sudo commands unchanged", () => {
+test("sudo autofill input preparation rewrites single-line pasted sudo commands", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: () => {},
   });
 
   assert.equal(
     prepareSudoAutofillInput("sudo whoami\n", null, autofill),
-    "sudo whoami\n",
+    `\x15${TEST_PREPARED_SUDO_WHOAMI}\n`,
+  );
+});
+
+test("sudo autofill input preparation preserves bracketed pasted sudo commands", () => {
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: () => {},
+  });
+
+  assert.equal(
+    prepareSudoAutofillInput("\x1b[200~sudo whoami\n\x1b[201~", null, autofill),
+    "\x1b[200~sudo whoami\n\x1b[201~",
   );
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -38,6 +38,13 @@ const createContext = (showLineTimestamps: boolean) => ({
   promptLineBreakStateRef: { current: undefined },
 });
 
+const extractSudoPromptFromPrepared = (prepared: string | null | undefined): string => {
+  assert.ok(prepared);
+  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
+  assert.ok(prompt);
+  return prompt.replace("%p", "alice");
+};
+
 test("writeSessionData prefixes terminal output lines when enabled", () => {
   const { term, writes } = createFakeTerm();
   writeSessionData(createContext(true) as never, term, "hello\r\nnext");
@@ -104,7 +111,7 @@ test("attachSessionToTerminal resets timestamp state for a reused terminal", () 
 });
 
 test("attachSessionToTerminal auto-fills sudo password prompts when configured", () => {
-  const { term } = createFakeTerm();
+  const { term, writes } = createFakeTerm();
   const sent: Array<{ id: string; data: string; automated?: boolean }> = [];
   let onData: ((data: string) => void) | null = null;
   const sudoAutofillRef = { current: null };
@@ -139,10 +146,14 @@ test("attachSessionToTerminal auto-fills sudo password prompts when configured",
     sudoAutofillPassword: "secret",
   });
   const prepared = sudoAutofillRef.current?.prepareCommand("sudo whoami");
-  assert.equal(prepared, "sudo whoami");
-  onData?.("[sudo] password for alice: ");
+  const prompt = extractSudoPromptFromPrepared(prepared);
+  onData?.(`${prepared ?? ""}\r\n`);
+  onData?.(prompt);
 
   assert.deepEqual(sent, [{ id: "session-1", data: "secret\n", automated: true }]);
+  assert.equal(writes[0], "sudo whoami\r\n");
+  assert.equal(writes[1], "[sudo] password for alice: ");
+  assert.ok(!writes.join("").includes("NETCATTY_SUDO"));
 });
 
 test("attachSessionToTerminal does not auto-fill unarmed sudo-looking output", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -246,7 +246,7 @@ export const attachSessionToTerminal = (
       // Replace \n that is not preceded by \r with \r\n
       data = data.replace(/(?<!\r)\n/g, "\r\n");
     }
-    sudoAutofill?.handleOutput(data);
+    data = sudoAutofill?.handleOutput(data) ?? data;
     writeSessionData(ctx, term, data);
     if (!ctx.hasConnectedRef.current) {
       ctx.updateStatus("connected");

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -8,6 +8,11 @@ import {
 } from "./terminalSudoAutofill";
 
 const TEST_PROMPT = "[sudo] password for alice: ";
+const TEST_MARKER = "__NETCATTY_SUDO_test__";
+const TEST_MARKED_PROMPT = `[sudo] password for alice: ${TEST_MARKER}`;
+
+const markedCommand = (commandTail: string) =>
+  `sudo -p '[sudo] password for %p: ${TEST_MARKER}'${commandTail}`;
 
 test("isSudoPasswordPrompt detects the standard sudo password prompt", () => {
   assert.equal(isSudoPasswordPrompt("[sudo] password for alice: "), true);
@@ -18,17 +23,23 @@ test("isSudoPasswordPrompt ignores ordinary output mentioning sudo and password"
   assert.equal(isSudoPasswordPrompt("password for alice: "), false);
 });
 
-test("sudo autofill handles prompts split across chunks without changing the command", () => {
+test("isSudoPasswordPrompt requires the expected prompt marker when provided", () => {
+  assert.equal(isSudoPasswordPrompt(TEST_MARKED_PROMPT, TEST_MARKER), true);
+  assert.equal(isSudoPasswordPrompt("[sudo] password for alice: ", TEST_MARKER), false);
+});
+
+test("sudo autofill handles marked prompts split across chunks", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
     now: () => 1_000,
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo apt update"), "sudo apt update");
-  autofill.handleOutput("[sudo] password");
-  autofill.handleOutput(" for alice: ");
+  assert.equal(autofill.prepareCommand("sudo apt update"), markedCommand(" apt update"));
+  assert.equal(autofill.handleOutput("[sudo] password for alice: "), "[sudo] password for alice: ");
+  assert.equal(autofill.handleOutput(TEST_MARKER), "");
 
   assert.deepEqual(writes, ["secret\n"]);
 });
@@ -51,15 +62,16 @@ test("sudo autofill sends the password once for a submitted sudo command", () =>
   const autofill = createSudoPasswordAutofill({
     password: "secret",
     now: () => now,
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo -i"), "sudo -i");
-  autofill.handleOutput(TEST_PROMPT);
+  assert.equal(autofill.prepareCommand("sudo -i"), markedCommand(" -i"));
+  autofill.handleOutput(TEST_MARKED_PROMPT);
   now += 500;
-  autofill.handleOutput(TEST_PROMPT);
+  autofill.handleOutput(TEST_MARKED_PROMPT);
   now += 5_000;
-  autofill.handleOutput(TEST_PROMPT);
+  autofill.handleOutput(TEST_MARKED_PROMPT);
 
   assert.deepEqual(writes, ["secret\n"]);
 });
@@ -68,21 +80,23 @@ test("sudo autofill allows target command prompt-like options", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo ssh -p 22 host"), "sudo ssh -p 22 host");
-  assert.equal(autofill.prepareCommand("sudo useradd -p hash alice"), "sudo useradd -p hash alice");
+  assert.equal(autofill.prepareCommand("sudo ssh -p 22 host"), markedCommand(" ssh -p 22 host"));
+  assert.equal(autofill.prepareCommand("sudo useradd -p hash alice"), markedCommand(" useradd -p hash alice"));
   assert.deepEqual(writes, []);
 });
 
 test("sudo autofill handles sudo short options with attached arguments", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: () => {},
   });
 
-  assert.equal(autofill.prepareCommand("sudo -upostgres whoami"), "sudo -upostgres whoami");
+  assert.equal(autofill.prepareCommand("sudo -upostgres whoami"), markedCommand(" -upostgres whoami"));
 });
 
 test("sudo autofill leaves commands with explicit sudo prompts unchanged", () => {
@@ -106,37 +120,179 @@ test("sudo autofill ignores expired sudo command arms", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
     now: () => now,
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo whoami"), "sudo whoami");
+  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
   now += 31_000;
-  autofill.handleOutput(TEST_PROMPT);
+  autofill.handleOutput(TEST_MARKED_PROMPT);
 
   assert.deepEqual(writes, []);
 });
 
-test("sudo autofill handles default sudo-looking output after a submitted command", () => {
+test("sudo autofill ignores default sudo-looking output after a submitted command", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo ./program"), "sudo ./program");
+  assert.equal(autofill.prepareCommand("sudo ./program"), markedCommand(" ./program"));
   autofill.handleOutput("[sudo] password for alice: ");
 
+  assert.deepEqual(writes, []);
+});
+
+test("sudo autofill ignores prompt-shaped command output after a submitted command", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  assert.equal(
+    autofill.prepareCommand("sudo printf '[sudo] password for alice: '"),
+    markedCommand(" printf '[sudo] password for alice: '"),
+  );
+  autofill.handleOutput("[sudo] password for alice: ");
+
+  assert.deepEqual(writes, []);
+});
+
+test("sudo autofill stays armed after ordinary output before the password prompt", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
+  assert.equal(autofill.handleOutput("sudo: this is the first time notice"), "sudo: this is the first time notice");
+  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
+
   assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill releases prompt-shaped warm sudo output without sending a password", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  assert.equal(
+    autofill.prepareCommand("sudo printf '[sudo] password for alice: '"),
+    markedCommand(" printf '[sudo] password for alice: '"),
+  );
+  assert.equal(autofill.handleOutput("[sudo] password for alice: "), "[sudo] password for alice: ");
+
+  assert.deepEqual(writes, []);
+});
+
+test("sudo autofill hides the prepared command and marker from output", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  const prepared = autofill.prepareCommand("sudo whoami");
+  assert.equal(prepared, markedCommand(" whoami"));
+
+  assert.equal(autofill.handleOutput(`${prepared ?? ""}\r\n`), "sudo whoami\r\n");
+  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill hides split prepared command and marker output", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  const prepared = autofill.prepareCommand("sudo whoami");
+  assert.equal(prepared, markedCommand(" whoami"));
+  const preparedText = prepared ?? "";
+  const preparedSplitIndex = Math.floor(preparedText.length / 2);
+  assert.equal(autofill.handleOutput(preparedText.slice(0, preparedSplitIndex)), "");
+  assert.equal(
+    autofill.handleOutput(`${preparedText.slice(preparedSplitIndex)}\r\n`),
+    "sudo whoami\r\n",
+  );
+
+  const promptSplitIndex = TEST_MARKED_PROMPT.length - 6;
+  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT.slice(0, promptSplitIndex)), "");
+  assert.equal(
+    autofill.handleOutput(TEST_MARKED_PROMPT.slice(promptSplitIndex)),
+    "[sudo] password for alice: ",
+  );
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill keeps sanitizing later shell-history echoes", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  const prepared = autofill.prepareCommand("sudo whoami");
+  assert.equal(prepared, markedCommand(" whoami"));
+  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
+  assert.equal(autofill.handleOutput(`${prepared ?? ""}\r\n`), "sudo whoami\r\n");
+
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill does not hide completed output when sudo timestamp is warm", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  const prepared = autofill.prepareCommand("sudo true");
+  assert.equal(prepared, markedCommand(" true"));
+
+  assert.equal(autofill.handleOutput(`${prepared}\r\n`), "sudo true\r\n");
+  assert.deepEqual(writes, []);
+});
+
+test("sudo autofill releases non-prompt output when sudo timestamp is warm", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    createPromptMarker: () => TEST_MARKER,
+    write: (data) => writes.push(data),
+  });
+
+  const prepared = autofill.prepareCommand("sudo printf ok");
+  assert.equal(prepared, markedCommand(" printf ok"));
+
+  assert.equal(autofill.handleOutput(`${prepared}\r\n`), "sudo printf ok\r\n");
+  assert.equal(autofill.handleOutput("ok"), "ok");
+  assert.deepEqual(writes, []);
 });
 
 test("sudo autofill ignores hidden control-sequence prompt text", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
+    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo whoami"), "sudo whoami");
+  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
   autofill.handleOutput(`\x1b[8m${TEST_PROMPT}\x1b[0m`);
 
   assert.deepEqual(writes, []);

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -34,8 +34,11 @@ export const isSudoPasswordPrompt = (
   data: string,
   expectedPrompt?: string,
 ): boolean => {
+  if (expectedPrompt) {
+    if (!data.includes(expectedPrompt)) return false;
+    return isSudoPasswordPrompt(data.replaceAll(expectedPrompt, ""));
+  }
   if (hasTerminalControlSequences(data)) return false;
-  if (expectedPrompt) return data.endsWith(expectedPrompt);
   const text = stripTerminalControlSequences(data);
   return SUDO_PROMPT_PATTERN.test(text);
 };
@@ -45,7 +48,7 @@ export const shouldArmSudoPasswordAutofill = (command: string): boolean =>
 
 export type SudoPasswordAutofill = {
   prepareCommand: (command: string) => string | null;
-  handleOutput: (data: string) => void;
+  handleOutput: (data: string) => string;
   updatePassword: (password?: string) => void;
 };
 
@@ -55,13 +58,18 @@ export const prepareSudoAutofillInput = (
   sudoAutofill: SudoPasswordAutofill | null | undefined,
 ): string => {
   if (data !== "\r" && data !== "\n") {
+    if (data.startsWith(BRACKETED_PASTE_START) && data.endsWith(BRACKETED_PASTE_END)) {
+      return data;
+    }
     const pastedCommand = getSinglePastedCommand(data);
     if (!pastedCommand) return data;
-    sudoAutofill?.prepareCommand(pastedCommand.command);
-    return data;
+    const preparedCommand = sudoAutofill?.prepareCommand(pastedCommand.command);
+    if (!preparedCommand) return data;
+    return `\x15${preparedCommand}${pastedCommand.lineEnding}`;
   }
   if (recordedCommand) {
-    sudoAutofill?.prepareCommand(recordedCommand);
+    const preparedCommand = sudoAutofill?.prepareCommand(recordedCommand);
+    if (preparedCommand) return `\x15${preparedCommand}${data}`;
   }
   return data;
 };
@@ -92,6 +100,12 @@ const unwrapBracketedPaste = (data: string): string => {
   }
   return data;
 };
+
+const shellQuote = (value: string): string =>
+  `'${value.replaceAll("'", "'\\''")}'`;
+
+const createDefaultSudoPromptMarker = (): string =>
+  `__NETCATTY_SUDO_${Math.random().toString(36).slice(2, 14)}__`;
 
 const splitShellWords = (input: string): string[] => {
   const words: string[] = [];
@@ -164,49 +178,141 @@ const hasSudoPromptOption = (command: string): boolean => {
   return false;
 };
 
+const buildSudoCommandWithPrompt = (
+  command: string,
+  prompt: string,
+): string | null => {
+  if (hasSudoPromptOption(command)) return null;
+  const match = command.match(SUDO_COMMAND_HEAD_PATTERN);
+  if (!match) return null;
+  return `${match[1]} -p ${shellQuote(prompt)}${match[2]}`;
+};
+
+const isPotentialPreparedCommandPrefix = (
+  data: string,
+  preparedCommand?: string | null,
+): boolean =>
+  Boolean(preparedCommand && data && (
+    preparedCommand.startsWith(data) || data.startsWith(preparedCommand)
+  ));
+
+const hasExpectedMarkerPrefix = (data: string, marker?: string | null): boolean => {
+  if (!data || !marker) return false;
+  const maxPrefixLength = Math.min(data.length, marker.length - 1);
+  for (let length = maxPrefixLength; length > 0; length -= 1) {
+    if (data.endsWith(marker.slice(0, length))) return true;
+  }
+  return false;
+};
+
 export const createSudoPasswordAutofill = (_options: {
   password?: string;
   write: (data: string) => void;
   now?: () => number;
+  createPromptMarker?: () => string;
 }): SudoPasswordAutofill => {
   const options = {
     now: () => Date.now(),
+    createPromptMarker: createDefaultSudoPromptMarker,
     ..._options,
   };
   let password = options.password ?? "";
   const cooldownMs = 3_000;
   const armWindowMs = 30_000;
   let tail = "";
+  let expectedPromptMarker: string | null = null;
+  let originalCommand: string | null = null;
+  let preparedCommand: string | null = null;
+  let outputSanitizePending = "";
   let lastSentAt = Number.NEGATIVE_INFINITY;
   let armedUntil = Number.NEGATIVE_INFINITY;
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
     tail = "";
+    outputSanitizePending = "";
+  };
+  const applyOutputSanitizers = (data: string): string => {
+    let nextData = data;
+    if (preparedCommand && originalCommand) {
+      nextData = nextData.replaceAll(preparedCommand, originalCommand);
+    }
+    if (expectedPromptMarker) {
+      nextData = nextData.replaceAll(expectedPromptMarker, "");
+    }
+    return nextData;
+  };
+  const sanitizeOutput = (data: string, opts: { final?: boolean } = {}): string => {
+    if (!preparedCommand && !expectedPromptMarker && !outputSanitizePending) return data;
+
+    outputSanitizePending += data;
+    const lastLineBreakIndex = Math.max(
+      outputSanitizePending.lastIndexOf("\n"),
+      outputSanitizePending.lastIndexOf("\r"),
+    );
+    if (!opts.final && lastLineBreakIndex < 0) {
+      return "";
+    }
+
+    const readyLength = opts.final
+      ? outputSanitizePending.length
+      : lastLineBreakIndex + 1;
+    const readyData = outputSanitizePending.slice(0, readyLength);
+    outputSanitizePending = outputSanitizePending.slice(readyLength);
+    return applyOutputSanitizers(readyData);
   };
 
   return {
     prepareCommand: (command: string) => {
       if (!password || !shouldArmSudoPasswordAutofill(command)) return null;
-      if (hasSudoPromptOption(command)) return null;
+      const promptMarker = options.createPromptMarker();
+      const prompt = `[sudo] password for %p: ${promptMarker}`;
+      const nextPreparedCommand = buildSudoCommandWithPrompt(command, prompt);
+      if (!nextPreparedCommand) return null;
+      expectedPromptMarker = promptMarker;
+      originalCommand = command;
+      preparedCommand = nextPreparedCommand;
       armedUntil = options.now() + armWindowMs;
       tail = "";
-      return command;
+      return nextPreparedCommand;
     },
     handleOutput: (data: string) => {
-      if (!password || armedUntil === Number.NEGATIVE_INFINITY) return;
+      const sanitizedData = sanitizeOutput(data);
+      if (!password || armedUntil === Number.NEGATIVE_INFINITY) {
+        if (
+          !sanitizedData &&
+          outputSanitizePending &&
+          !isPotentialPreparedCommandPrefix(outputSanitizePending, preparedCommand) &&
+          !hasExpectedMarkerPrefix(outputSanitizePending, expectedPromptMarker)
+        ) {
+          return sanitizeOutput("", { final: true });
+        }
+        return sanitizedData;
+      }
       tail = `${tail}${data}`.slice(-1024);
       const currentTime = options.now();
       if (currentTime > armedUntil) {
+        const finalSanitizedData = sanitizedData + sanitizeOutput("", { final: true });
         disarm();
-        return;
+        return finalSanitizedData;
       }
-      if (currentTime - lastSentAt < cooldownMs) return;
+      if (currentTime - lastSentAt < cooldownMs) return sanitizedData;
       const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
-      if (!isSudoPasswordPrompt(lastLine)) return;
+      if (!expectedPromptMarker || !isSudoPasswordPrompt(lastLine, expectedPromptMarker)) {
+        if (
+          lastLine &&
+          !isPotentialPreparedCommandPrefix(lastLine, preparedCommand) &&
+          !hasExpectedMarkerPrefix(lastLine, expectedPromptMarker)
+        ) {
+          return sanitizedData + sanitizeOutput("", { final: true });
+        }
+        return sanitizedData;
+      }
 
       options.write(`${password}\n`);
       lastSentAt = currentTime;
+      const finalSanitizedData = sanitizedData + sanitizeOutput("", { final: true });
       disarm();
+      return finalSanitizedData;
     },
     updatePassword: (nextPassword?: string) => {
       password = nextPassword ?? "";

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -20,6 +20,9 @@ const activeStreams = new Map();
 const FLUSH_INTERVAL = 500;
 // Max buffer size before immediate flush (bytes)
 const MAX_BUFFER_SIZE = 64 * 1024;
+const SUDO_AUTOFILL_MARKER_PATTERN = /__NETCATTY_SUDO_[a-z0-9_]+__/gi;
+const SUDO_AUTOFILL_REWRITE_PATTERN =
+  /\x15?((?:builtin\s+|command\s+)?sudo)\s+-p\s+'\[sudo\] password for %p: (__NETCATTY_SUDO_[a-z0-9_]+__)'([^\r\n]*)(?:\r\n|\r|\n|$)/i;
 
 function formatLogTimestamp(timestamp = Date.now()) {
   const date = new Date(timestamp);
@@ -56,6 +59,72 @@ function createRenderedLineTimestampPrefixer(opts = {}) {
         : `[${formatLogTimestamp(timestampsByLine[index])}] ${line}`;
     }).join("\n");
   };
+}
+
+function parseSudoAutofillRewrite(input) {
+  if (!input || typeof input !== "string") return null;
+  const match = input.match(SUDO_AUTOFILL_REWRITE_PATTERN);
+  if (!match) return null;
+  return {
+    marker: match[2],
+    preparedCommand: `${match[1]} -p '[sudo] password for %p: ${match[2]}'${match[3]}`,
+    originalCommand: `${match[1]}${match[3]}`,
+  };
+}
+
+function applySudoAutofillRewrites(entry, data) {
+  if (!data || !entry.sudoAutofillRewrites?.length) return data;
+  let nextData = data;
+  for (const rewrite of entry.sudoAutofillRewrites) {
+    nextData = nextData.replaceAll(rewrite.preparedCommand, rewrite.originalCommand);
+    nextData = nextData.replaceAll(rewrite.marker, "");
+  }
+  return nextData.replace(SUDO_AUTOFILL_MARKER_PATTERN, "");
+}
+
+function isPotentialSudoAutofillCommandPending(entry, data) {
+  if (!data) return true;
+  return (entry.sudoAutofillRewrites ?? []).some((rewrite) =>
+    rewrite.preparedCommand.startsWith(data) || data.startsWith(rewrite.preparedCommand)
+  );
+}
+
+function hasSudoAutofillMarkerPrefix(entry, data) {
+  if (!data) return false;
+  return (entry.sudoAutofillRewrites ?? []).some((rewrite) => {
+    const maxPrefixLength = Math.min(data.length, rewrite.marker.length - 1);
+    for (let length = maxPrefixLength; length > 0; length -= 1) {
+      if (data.endsWith(rewrite.marker.slice(0, length))) return true;
+    }
+    return false;
+  });
+}
+
+function sanitizeSudoAutofillLogData(entry, dataChunk, { final = false } = {}) {
+  if (!entry.sudoAutofillRewrites?.length) return dataChunk;
+  entry.sudoAutofillPending += dataChunk;
+  const lastLineBreakIndex = Math.max(
+    entry.sudoAutofillPending.lastIndexOf("\n"),
+    entry.sudoAutofillPending.lastIndexOf("\r"),
+  );
+  if (!final && lastLineBreakIndex < 0) {
+    if (
+      isPotentialSudoAutofillCommandPending(entry, entry.sudoAutofillPending) ||
+      hasSudoAutofillMarkerPrefix(entry, entry.sudoAutofillPending)
+    ) {
+      return "";
+    }
+    const pending = entry.sudoAutofillPending;
+    const sanitizedPending = applySudoAutofillRewrites(entry, pending);
+    entry.sudoAutofillPending = "";
+    return sanitizedPending;
+  }
+  const readyLength = final
+    ? entry.sudoAutofillPending.length
+    : lastLineBreakIndex + 1;
+  const readyData = entry.sudoAutofillPending.slice(0, readyLength);
+  entry.sudoAutofillPending = entry.sudoAutofillPending.slice(readyLength);
+  return applySudoAutofillRewrites(entry, readyData);
 }
 
 /**
@@ -133,6 +202,8 @@ function startStream(sessionId, opts) {
       hostLabel: hostLabel || hostname || "unknown",
       startTime: startTime || Date.now(),
       buffer: "",
+      sudoAutofillRewrites: [],
+      sudoAutofillPending: "",
       flushTimer: null,
       snapshotPromise: null,
       snapshotRequested: false,
@@ -178,6 +249,15 @@ function flushBuffer(entry) {
     console.error("[SessionLogStream] Flush error:", err.message);
     entry.disabled = true;
   }
+}
+
+function registerSudoAutofillInput(sessionId, input) {
+  const entry = activeStreams.get(sessionId);
+  if (!entry || entry.disabled) return;
+  const rewrite = parseSudoAutofillRewrite(input);
+  if (!rewrite) return;
+  entry.sudoAutofillRewrites.unshift(rewrite);
+  entry.sudoAutofillRewrites = entry.sudoAutofillRewrites.slice(0, 8);
 }
 
 function renderSnapshotContent(entry, { finalize = false } = {}) {
@@ -235,10 +315,10 @@ function appendData(sessionId, dataChunk) {
   const entry = activeStreams.get(sessionId);
   if (!entry || entry.disabled) return;
 
-  entry.buffer += dataChunk;
+  entry.buffer += sanitizeSudoAutofillLogData(entry, dataChunk);
 
   // Immediate flush if buffer is large
-  if (entry.buffer.length >= MAX_BUFFER_SIZE) {
+  if (entry.buffer.length + entry.sudoAutofillPending.length >= MAX_BUFFER_SIZE) {
     flushBuffer(entry);
   }
 }
@@ -278,6 +358,7 @@ async function stopStream(sessionId, expectedToken) {
   }
 
   // Flush remaining buffer
+  entry.buffer += sanitizeSudoAutofillLogData(entry, "", { final: true });
   flushBuffer(entry);
   await waitForSnapshotIdle(entry);
 
@@ -323,6 +404,7 @@ async function cleanupAll() {
 module.exports = {
   startStream,
   appendData,
+  registerSudoAutofillInput,
   stopStream,
   hasStream,
   cleanupAll,

--- a/electron/bridges/sessionLogStreamManager.test.cjs
+++ b/electron/bridges/sessionLogStreamManager.test.cjs
@@ -5,6 +5,7 @@ const path = require("node:path");
 const {
   appendData,
   hasStream,
+  registerSudoAutofillInput,
   startStream,
   stopStream,
 } = require("./sessionLogStreamManager.cjs");
@@ -135,6 +136,219 @@ test("stopStream without a token still tears down the current stream (back-compa
     assert.equal(fs.readFileSync(finalPath, "utf8"), "data\n");
     assert.equal(hasStream(sessionId), false);
   } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream hides sudo autofill prompt markers and rewritten command echoes", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_test__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' whoami`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, `${prepared}\r\n`);
+    appendData(sessionId, `[sudo] password for alice: ${marker}`);
+    appendData(sessionId, "\r\nroot\n");
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "sudo whoami\r\n[sudo] password for alice: \r\nroot\n");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+    assert.ok(!content.includes("sudo -p"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream hides split sudo autofill markers", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-split-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_split__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' id`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, "sudo -p '[sudo] password for %p: __NET");
+    appendData(sessionId, "CATTY_SUDO_split__' id\r\n[sudo] password for alice: __NET");
+    appendData(sessionId, "CATTY_SUDO_split__\r\nuid=0\n");
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "sudo id\r\n[sudo] password for alice: \r\nuid=0\n");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+    assert.ok(!content.includes("sudo -p"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream hides sudo autofill rewrites for long commands", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-long-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_long__";
+  const longArg = "a".repeat(6000);
+  const original = `sudo printf '${longArg}'`;
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' printf '${longArg}'`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, prepared.slice(0, 2500));
+    appendData(sessionId, prepared.slice(2500, 5200));
+    appendData(sessionId, `${prepared.slice(5200)}\r\n`);
+    appendData(sessionId, `[sudo] password for alice: ${marker}\r\n`);
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, `${original}\r\n[sudo] password for alice: \r\n`);
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+    assert.ok(!content.includes("sudo -p"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream releases non-prompt output after sudo autofill rewrite", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-warm-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_warm__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' printf ok`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, `${prepared}\r\n`);
+    appendData(sessionId, "ok");
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "sudo printf ok\r\nok");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+    assert.ok(!content.includes("sudo -p"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream keeps sudo autofill rewrite after ordinary output before prompt", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-notice-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_notice__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' whoami`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, "sudo: this is the first time notice");
+    appendData(sessionId, `[sudo] password for alice: ${marker}\r\nroot\n`);
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "sudo: this is the first time notice[sudo] password for alice: \r\nroot\n");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream releases prompt-shaped warm sudo output", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-warm-prompt-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_warm_prompt__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' printf '[sudo] password for alice: '`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, "[sudo] password for alice: ");
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "[sudo] password for alice: ");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("raw stream sanitizes later shell-history echoes after sudo autofill completes", async () => {
+  const directory = path.join(TEMP_ROOT, `stream-sudo-history-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const marker = "__NETCATTY_SUDO_history__";
+  const prepared = `sudo -p '[sudo] password for %p: ${marker}' whoami`;
+
+  try {
+    startStream(sessionId, {
+      hostLabel: "host",
+      hostname: "host.example",
+      directory,
+      format: "raw",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+    registerSudoAutofillInput(sessionId, `\x15${prepared}\r`);
+    appendData(sessionId, `[sudo] password for alice: ${marker}\r\nroot\n`);
+    appendData(sessionId, `${prepared}\r\n`);
+
+    const finalPath = await stopStream(sessionId);
+    const content = fs.readFileSync(finalPath, "utf8");
+
+    assert.equal(content, "[sudo] password for alice: \r\nroot\nsudo whoami\r\n");
+    assert.ok(!content.includes("NETCATTY_SUDO"));
+    assert.ok(!content.includes("sudo -p"));
+  } finally {
+    await stopStream(sessionId);
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -699,6 +699,7 @@ function writeToSession(event, payload) {
     // local PTY leave it unset, so encodeTerminalInput returns the original
     // UTF-8 string for them. For UTF-8 it also returns the string unchanged, so
     // the transport's native string serialization keeps handling that case.
+    sessionLogStreamManager.registerSudoAutofillInput(payload.sessionId, payload.data);
     const outgoing = encodeTerminalInput(payload.data, session.encoding);
 
     if (session.stream) {


### PR DESCRIPTION
## Summary
- Require a unique sudo prompt marker before auto-filling saved sudo passwords.
- Keep terminal display and live session logs from showing the rewritten sudo command or internal marker.
- Cover warm sudo, split output, prompt-shaped command output, and shell-history echo cases.

## Why
A sudo command could previously be armed and then auto-fill on arbitrary output that merely looked like a sudo password prompt. In warm timestamp cases or prompt-shaped command output, that could send the saved password after the command completed.

## Validation
- `node --test --import tsx components/terminal/runtime/terminalSudoAutofill.test.ts components/terminal/runtime/createXTermRuntime.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts components/terminal/runtime/createTerminalSessionStarters.et.test.ts electron/bridges/sessionLogStreamManager.test.cjs`
- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Multi-agent review: clean
