### PR TITLE
Fix duplicate-tab clone payload dropped on renderer readiness timeout

### DIFF
--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -734,6 +734,33 @@ function waitForRendererReady(win, { timeoutMs = 15000 } = {}) {
 }
 
 /**
+ * Wait for a freshly created window's renderer to report ready, then deliver an
+ * IPC message to it. The renderer only registers its IPC listeners (and reports
+ * ready) after React mounts, and Electron does not queue messages for listeners
+ * that do not exist yet. So if readiness times out we must NOT send — the
+ * message would be silently dropped, leaving the window blank while the caller
+ * still saw "success". Returning a failure here lets the caller surface the
+ * existing error path instead.
+ */
+async function sendWhenRendererReady(win, channel, payload, options = {}) {
+  const { timeoutMs = 8000, waitForReady = waitForRendererReady } = options;
+  try {
+    await waitForReady(win, { timeoutMs });
+  } catch (err) {
+    return {
+      success: false,
+      error: "New window did not become ready in time",
+      reason: err?.message || String(err),
+    };
+  }
+  if (win?.isDestroyed?.() || win?.webContents?.isDestroyed?.()) {
+    return { success: false, error: "Window closed before message could be delivered" };
+  }
+  win.webContents.send(channel, payload);
+  return { success: true };
+}
+
+/**
  * Create the main application window
  */
 const { createMainWindowApi } = require("./windowManager/mainWindow.cjs");
@@ -1129,6 +1156,7 @@ module.exports = {
   shouldCloseWindowFromInput,
   WINDOW_COMMAND_CLOSE_CHANNEL,
   waitForRendererReady,
+  sendWhenRendererReady,
   setIsQuitting,
   getIsQuitting,
   setQuittingForUpdate,

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -9,6 +9,7 @@ const {
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
   requestWindowCommandClose,
+  sendWhenRendererReady,
   shouldCloseWindowFromInput,
   unregisterMainWindow,
 } = require("./windowManager.cjs");
@@ -706,4 +707,86 @@ test("resolveSettingsWindowBounds centers settings on the requesting window disp
     }),
     { x: 2150, y: 90 },
   );
+});
+
+function createSendableWindowStub({ destroyed = false, webContentsDestroyed = false } = {}) {
+  const sent = [];
+  return {
+    sent,
+    win: {
+      isDestroyed() {
+        return destroyed;
+      },
+      webContents: {
+        id: 7,
+        isDestroyed() {
+          return webContentsDestroyed;
+        },
+        send(channel, payload) {
+          sent.push({ channel, payload });
+        },
+      },
+    },
+  };
+}
+
+test("sendWhenRendererReady delivers the payload once the renderer reports ready", async () => {
+  const { win, sent } = createSendableWindowStub();
+  const waited = [];
+
+  const result = await sendWhenRendererReady(
+    win,
+    "netcatty:window:openSession",
+    { title: "Prod" },
+    {
+      timeoutMs: 8000,
+      waitForReady: async (target, opts) => {
+        waited.push({ target, opts });
+      },
+    },
+  );
+
+  assert.deepEqual(result, { success: true });
+  assert.equal(waited.length, 1);
+  assert.equal(waited[0].target, win);
+  assert.deepEqual(waited[0].opts, { timeoutMs: 8000 });
+  assert.deepEqual(sent, [
+    { channel: "netcatty:window:openSession", payload: { title: "Prod" } },
+  ]);
+});
+
+test("sendWhenRendererReady reports failure without sending when readiness times out", async () => {
+  const { win, sent } = createSendableWindowStub();
+
+  const result = await sendWhenRendererReady(
+    win,
+    "netcatty:window:openSession",
+    { title: "Prod" },
+    {
+      timeoutMs: 5,
+      waitForReady: async () => {
+        throw new Error("Renderer did not report ready before timeout.");
+      },
+    },
+  );
+
+  assert.equal(result.success, false);
+  assert.equal(sent.length, 0);
+});
+
+test("sendWhenRendererReady reports failure without sending when the window is gone after readiness", async () => {
+  const { win, sent } = createSendableWindowStub({ destroyed: true });
+
+  const result = await sendWhenRendererReady(
+    win,
+    "netcatty:window:openSession",
+    { title: "Prod" },
+    {
+      timeoutMs: 8000,
+      waitForReady: async () => {},
+    },
+  );
+
+  assert.equal(result.success, false);
+  assert.equal(sent.length, 0);
 });

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -322,19 +322,23 @@ function createBridgeRegistrar(context) {
         } catch {
           // ignore
         }
-        try {
-          await getWindowManager().waitForRendererReady(win, { timeoutMs: 8000 });
-        } catch (err) {
-          console.warn("[Main] New session window did not report ready before payload send:", err?.message || err);
+        const delivery = await getWindowManager().sendWhenRendererReady(
+          win,
+          "netcatty:window:openSession",
+          {
+            title,
+            sourceSession: payload.sourceSession,
+            localShellType: payload.localShellType,
+          },
+          { timeoutMs: 8000 },
+        );
+        if (!delivery.success) {
+          console.warn(
+            "[Main] New session window could not receive the duplicated tab:",
+            delivery.reason || delivery.error,
+          );
+          return { success: false, error: delivery.error || "Failed to open new window" };
         }
-        if (win.isDestroyed?.() || win.webContents?.isDestroyed?.()) {
-          return { success: false, error: "Window closed before session could open" };
-        }
-        win.webContents.send("netcatty:window:openSession", {
-          title,
-          sourceSession: payload.sourceSession,
-          localShellType: payload.localShellType,
-        });
         return { success: true };
       } catch (err) {
         console.error("[Main] Failed to open session in new window:", err);


### PR DESCRIPTION
## Summary
Follow-up to the codex review on #1275.

The `netcatty:window:openSession` handler awaited renderer readiness with an 8s timeout, but on timeout it only logged a warning and still called `webContents.send` before returning `{ success: true }`. The renderer registers its `onOpenSessionInNewWindow` listener during React startup — the same milestone that fires the readiness signal — so a send issued on the timeout path lands before the listener exists, and Electron drops it (IPC isn't queued for absent listeners). The result was a blank new window with no duplicated tab and no error feedback.

- Extract the readiness-then-send logic into `windowManager.sendWhenRendererReady`, which returns a failure instead of sending a doomed payload when readiness never arrives.
- The handler now surfaces that failure, so the caller shows its existing "copy tab to new window failed" toast instead of a false success.
- Add unit coverage for the helper: ready → send, timeout → no send + failure, window gone → no send + failure.

## Verification
- `node --test --import tsx electron/bridges/windowManagerReadiness.test.cjs application/AppHandlers.newWindow.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (1843 passed, 0 failed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)