### PR TITLE
fix(terminal): simplify sudo password autofill (#1281)

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -297,7 +297,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (!pastedCommand || !shouldRecordShellHistory(pastedCommand[1], termRef.current)) {
       return data;
     }
-    return prepareSudoAutofillInput(data, null, sudoAutofillRef.current);
+    prepareSudoAutofillInput(data, null, sudoAutofillRef.current);
+    return data;
   }, []);
 
   // Terminal autocomplete — onAcceptText writes directly to session (no CustomEvent)

--- a/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
@@ -5,14 +5,11 @@ import { createTerminalSessionStarters } from "./createTerminalSessionStarters";
 
 const noop = () => undefined;
 
-const prepareSudoPrompt = (
-  autofill: { prepareCommand: (command: string) => string | null } | null,
+const armSudoPrompt = (
+  autofill: { armForCommand: (command: string) => void } | null,
 ): string => {
-  const prepared = autofill?.prepareCommand("sudo whoami");
-  assert.ok(prepared);
-  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
-  assert.ok(prompt);
-  return prompt.replace("%p", "alice");
+  autofill?.armForCommand("sudo whoami");
+  return "[sudo] password for alice: ";
 };
 
 const makeBackend = (
@@ -110,7 +107,7 @@ test("startEt enables sudo autofill with the host saved password", async () => {
   };
 
   await createTerminalSessionStarters(ctx as never).startEt(term as never);
-  onData?.(prepareSudoPrompt(sudoAutofillRef.current));
+  onData?.(armSudoPrompt(sudoAutofillRef.current));
 
   assert.deepEqual(sent, ["saved-secret\n"]);
 });

--- a/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts
@@ -8,14 +8,11 @@ import {
 const noop = () => undefined;
 const ENCRYPTED_CREDENTIAL_PLACEHOLDER = "enc:v1:djEwAAAA";
 
-const prepareSudoPrompt = (
-  autofill: { prepareCommand: (command: string) => string | null } | null,
+const armSudoPrompt = (
+  autofill: { armForCommand: (command: string) => void } | null,
 ): string => {
-  const prepared = autofill?.prepareCommand("sudo whoami");
-  assert.ok(prepared);
-  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
-  assert.ok(prompt);
-  return prompt.replace("%p", "alice");
+  autofill?.armForCommand("sudo whoami");
+  return "[sudo] password for alice: ";
 };
 
 test("startMosh enables sudo autofill with the host saved password", async () => {
@@ -88,7 +85,7 @@ test("startMosh enables sudo autofill with the host saved password", async () =>
   };
 
   await createTerminalSessionStarters(ctx as never).startMosh(term as never);
-  onData?.(prepareSudoPrompt(sudoAutofillRef.current));
+  onData?.(armSudoPrompt(sudoAutofillRef.current));
 
   assert.deepEqual(sent, ["saved-secret\n"]);
 });

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -11,15 +11,12 @@ import { pasteTextIntoTerminal } from "./terminalUserPaste";
 const noop = () => undefined;
 const ENCRYPTED_CREDENTIAL_PLACEHOLDER = "enc:v1:djEwAAAA";
 
-const prepareSudoPrompt = (
-  autofill: { prepareCommand: (command: string) => string | null } | null,
+const armSudoPrompt = (
+  autofill: { armForCommand: (command: string) => void } | null,
   command = "sudo whoami",
 ): string => {
-  const prepared = autofill?.prepareCommand(command);
-  assert.ok(prepared);
-  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
-  assert.ok(prompt);
-  return prompt.replace("%p", "alice");
+  autofill?.armForCommand(command);
+  return "[sudo] password for alice: ";
 };
 
 const createTermStub = () => ({
@@ -202,7 +199,7 @@ test("startSSH enables sudo autofill only with the host saved password", async (
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  onData?.(prepareSudoPrompt(ctx.sudoAutofillRef.current));
+  onData?.(armSudoPrompt(ctx.sudoAutofillRef.current));
 
   assert.deepEqual(sent, ["saved-secret\n"]);
 });
@@ -252,7 +249,7 @@ test("startSSH does not use unsaved retry passwords for sudo autofill", async ()
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  assert.equal(ctx.sudoAutofillRef.current?.prepareCommand("sudo whoami"), null);
+  ctx.sudoAutofillRef.current?.armForCommand("sudo whoami");
   onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, []);
@@ -305,7 +302,7 @@ test("startSSH prefers latest sudo autofill password state over pending saved au
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  assert.equal(ctx.sudoAutofillRef.current?.prepareCommand("sudo whoami"), null);
+  ctx.sudoAutofillRef.current?.armForCommand("sudo whoami");
   onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, []);
@@ -349,7 +346,7 @@ test("startSSH does not use merged group default passwords for sudo autofill", a
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  assert.equal(ctx.sudoAutofillRef.current?.prepareCommand("sudo whoami"), null);
+  ctx.sudoAutofillRef.current?.armForCommand("sudo whoami");
   onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, []);
@@ -393,7 +390,7 @@ test("startSSH uses the provided sudo autofill password", async () => {
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  onData?.(prepareSudoPrompt(ctx.sudoAutofillRef.current));
+  onData?.(armSudoPrompt(ctx.sudoAutofillRef.current));
 
   assert.deepEqual(sent, ["host-secret\n"]);
 });
@@ -436,7 +433,7 @@ test("startSSH leaves sudo autofill disabled when the host switch is off", async
   });
 
   await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
-  assert.equal(ctx.sudoAutofillRef.current?.prepareCommand("sudo whoami"), null);
+  ctx.sudoAutofillRef.current?.armForCommand("sudo whoami");
   onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, []);

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -8,9 +8,6 @@ import {
 import { recordTerminalCommandExecution } from "./terminalCommandExecution";
 import { createPromptLineBreakState } from "./promptLineBreak";
 
-const TEST_MARKER = "__NETCATTY_SUDO_test__";
-const TEST_PREPARED_SUDO_WHOAMI = `sudo -p '[sudo] password for %p: ${TEST_MARKER}' whoami`;
-
 function createFakeTerm(lineText = "$ echo ok", cursorX = lineText.length) {
   return {
     buffer: {
@@ -55,36 +52,33 @@ function createWrappedFakeTerm(rows: string[], cursorY: number, cursorX: number,
   };
 }
 
-test("sudo autofill input preparation rewrites submitted sudo commands for the remote side", () => {
+test("sudo autofill input preparation arms on a submitted sudo command without altering input", () => {
+  const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: () => {},
+    write: (data) => writes.push(data),
   });
 
-  assert.equal(
-    prepareSudoAutofillInput("\r", "sudo whoami", autofill),
-    `\x15${TEST_PREPARED_SUDO_WHOAMI}\r`,
-  );
+  assert.equal(prepareSudoAutofillInput("\r", "sudo whoami", autofill), "\r");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.deepEqual(writes, ["secret\n"]);
 });
 
-test("sudo autofill input preparation rewrites single-line pasted sudo commands", () => {
+test("sudo autofill input preparation arms on a single-line pasted sudo command", () => {
+  const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: () => {},
+    write: (data) => writes.push(data),
   });
 
-  assert.equal(
-    prepareSudoAutofillInput("sudo whoami\n", null, autofill),
-    `\x15${TEST_PREPARED_SUDO_WHOAMI}\n`,
-  );
+  assert.equal(prepareSudoAutofillInput("sudo whoami\n", null, autofill), "sudo whoami\n");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.deepEqual(writes, ["secret\n"]);
 });
 
 test("sudo autofill input preparation preserves bracketed pasted sudo commands", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
     write: () => {},
   });
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -804,11 +804,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       const recordedCommand = recordTerminalCommandExecution(ctx.commandBufferRef.current, ctx, term);
       handledSubmittedInput = true;
       if (!willBroadcastInput) {
-        dataToWrite = prepareSudoAutofillInput(
-          data,
-          recordedCommand,
-          ctx.sudoAutofillRef?.current,
-        );
+        prepareSudoAutofillInput(data, recordedCommand, ctx.sudoAutofillRef?.current);
       }
     } else if (ctx.statusRef.current === "connected" && !willBroadcastInput) {
       const pastedCommand = getSinglePastedCommand(data);
@@ -820,13 +816,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         );
         handledSubmittedInput = true;
         if (recordedCommand) {
-          const submittedCommand = `${recordedCommand}${pastedCommand.lineEnding}`;
-          const preparedInput = prepareSudoAutofillInput(
-            submittedCommand,
+          prepareSudoAutofillInput(
+            `${recordedCommand}${pastedCommand.lineEnding}`,
             null,
             ctx.sudoAutofillRef?.current,
           );
-          dataToWrite = preparedInput === submittedCommand ? data : preparedInput;
         }
       }
     }

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -38,13 +38,6 @@ const createContext = (showLineTimestamps: boolean) => ({
   promptLineBreakStateRef: { current: undefined },
 });
 
-const extractSudoPromptFromPrepared = (prepared: string | null | undefined): string => {
-  assert.ok(prepared);
-  const prompt = prepared.match(/\s-p '([^']*)'/)?.[1];
-  assert.ok(prompt);
-  return prompt.replace("%p", "alice");
-};
-
 test("writeSessionData prefixes terminal output lines when enabled", () => {
   const { term, writes } = createFakeTerm();
   writeSessionData(createContext(true) as never, term, "hello\r\nnext");
@@ -145,15 +138,13 @@ test("attachSessionToTerminal auto-fills sudo password prompts when configured",
   attachSessionToTerminal(ctx as never, term, "session-1", {
     sudoAutofillPassword: "secret",
   });
-  const prepared = sudoAutofillRef.current?.prepareCommand("sudo whoami");
-  const prompt = extractSudoPromptFromPrepared(prepared);
-  onData?.(`${prepared ?? ""}\r\n`);
-  onData?.(prompt);
+  sudoAutofillRef.current?.armForCommand("sudo whoami");
+  onData?.("sudo whoami\r\n");
+  onData?.("[sudo] password for alice: ");
 
   assert.deepEqual(sent, [{ id: "session-1", data: "secret\n", automated: true }]);
   assert.equal(writes[0], "sudo whoami\r\n");
   assert.equal(writes[1], "[sudo] password for alice: ");
-  assert.ok(!writes.join("").includes("NETCATTY_SUDO"));
 });
 
 test("attachSessionToTerminal does not auto-fill unarmed sudo-looking output", () => {

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -18,9 +18,17 @@ test("isSudoPasswordPrompt detects a bare Password prompt", () => {
   assert.equal(isSudoPasswordPrompt("password for alice: "), true);
 });
 
-test("isSudoPasswordPrompt detects localized password prompts", () => {
+test("isSudoPasswordPrompt detects localized sudo prompts", () => {
   assert.equal(isSudoPasswordPrompt("[sudo] alice 的密码："), true);
-  assert.equal(isSudoPasswordPrompt("请输入密码: "), true);
+  assert.equal(isSudoPasswordPrompt("密码："), true);
+});
+
+test("isSudoPasswordPrompt rejects sub-command password prompts", () => {
+  // sudo runs these; if sudo creds are cached it stays silent and the child
+  // asks for its OWN password. Filling the sudo password here would leak it.
+  assert.equal(isSudoPasswordPrompt("Enter password: "), false); // mysql -p
+  assert.equal(isSudoPasswordPrompt("alice@host's password: "), false); // ssh
+  assert.equal(isSudoPasswordPrompt("MySQL root password: "), false);
 });
 
 test("isSudoPasswordPrompt detects color-wrapped prompts", () => {
@@ -99,6 +107,23 @@ test("sudo autofill fills the Ubuntu PAM-style prompt from #1281", () => {
   autofill.handleOutput("[sudo: [sudo] password for alice: ] Password: ");
 
   assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill does not leak the password to sub-command prompts", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  // sudo creds warm: sudo stays silent, mysql asks for its own password.
+  autofill.armForCommand("sudo mysql -p");
+  autofill.handleOutput("Enter password: ");
+  assert.deepEqual(writes, []);
+
+  autofill.armForCommand("sudo ssh user@host");
+  autofill.handleOutput("user@host's password: ");
+  assert.deepEqual(writes, []);
 });
 
 test("sudo autofill keeps the prompt text in the output while filling", () => {

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -131,6 +131,22 @@ test("sudo autofill does not leak the password to sub-command prompts", () => {
   assert.deepEqual(writes, []);
 });
 
+test("sudo autofill disarms when a later non-sudo command is submitted", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  // sudo did not prompt (cached creds / noninteractive); a later non-sudo
+  // command must clear the pending arm so its own Password: isn't filled.
+  autofill.armForCommand("sudo -n true");
+  autofill.armForCommand("mysql -p");
+  autofill.handleOutput("Password: ");
+
+  assert.deepEqual(writes, []);
+});
+
 test("sudo autofill keeps the prompt text in the output while filling", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -15,7 +15,6 @@ test("isSudoPasswordPrompt detects the standard sudo password prompt", () => {
 
 test("isSudoPasswordPrompt detects a bare Password prompt", () => {
   assert.equal(isSudoPasswordPrompt("Password: "), true);
-  assert.equal(isSudoPasswordPrompt("password for alice: "), true);
 });
 
 test("isSudoPasswordPrompt detects localized sudo prompts", () => {
@@ -29,6 +28,8 @@ test("isSudoPasswordPrompt rejects sub-command password prompts", () => {
   assert.equal(isSudoPasswordPrompt("Enter password: "), false); // mysql -p
   assert.equal(isSudoPasswordPrompt("alice@host's password: "), false); // ssh
   assert.equal(isSudoPasswordPrompt("MySQL root password: "), false);
+  assert.equal(isSudoPasswordPrompt("Password for user alice: "), false); // psql/libpq
+  assert.equal(isSudoPasswordPrompt("password for alice: "), false); // no [sudo] tag
 });
 
 test("isSudoPasswordPrompt detects color-wrapped prompts", () => {
@@ -123,6 +124,10 @@ test("sudo autofill does not leak the password to sub-command prompts", () => {
 
   autofill.armForCommand("sudo ssh user@host");
   autofill.handleOutput("user@host's password: ");
+  assert.deepEqual(writes, []);
+
+  autofill.armForCommand("sudo psql -h db -U alice");
+  autofill.handleOutput("Password for user alice: ");
   assert.deepEqual(writes, []);
 });
 

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -7,42 +7,44 @@ import {
   shouldArmSudoPasswordAutofill,
 } from "./terminalSudoAutofill";
 
-const TEST_PROMPT = "[sudo] password for alice: ";
-const TEST_MARKER = "__NETCATTY_SUDO_test__";
-const TEST_MARKED_PROMPT = `[sudo] password for alice: ${TEST_MARKER}`;
-
-const markedCommand = (commandTail: string) =>
-  `sudo -p '[sudo] password for %p: ${TEST_MARKER}'${commandTail}`;
+// --- isSudoPasswordPrompt ---
 
 test("isSudoPasswordPrompt detects the standard sudo password prompt", () => {
   assert.equal(isSudoPasswordPrompt("[sudo] password for alice: "), true);
 });
 
-test("isSudoPasswordPrompt ignores ordinary output mentioning sudo and password", () => {
+test("isSudoPasswordPrompt detects a bare Password prompt", () => {
+  assert.equal(isSudoPasswordPrompt("Password: "), true);
+  assert.equal(isSudoPasswordPrompt("password for alice: "), true);
+});
+
+test("isSudoPasswordPrompt detects localized password prompts", () => {
+  assert.equal(isSudoPasswordPrompt("[sudo] alice 的密码："), true);
+  assert.equal(isSudoPasswordPrompt("请输入密码: "), true);
+});
+
+test("isSudoPasswordPrompt detects color-wrapped prompts", () => {
+  assert.equal(isSudoPasswordPrompt("\x1b[32m[sudo] password for alice: \x1b[0m"), true);
+});
+
+test("isSudoPasswordPrompt ignores ordinary output mentioning password", () => {
   assert.equal(isSudoPasswordPrompt("try sudo if the password is required\n"), false);
-  assert.equal(isSudoPasswordPrompt("password for alice: "), false);
+  assert.equal(isSudoPasswordPrompt("the password was changed\n"), false);
+  assert.equal(isSudoPasswordPrompt("sudo: command not found\n"), false);
 });
 
-test("isSudoPasswordPrompt requires the expected prompt marker when provided", () => {
-  assert.equal(isSudoPasswordPrompt(TEST_MARKED_PROMPT, TEST_MARKER), true);
-  assert.equal(isSudoPasswordPrompt("[sudo] password for alice: ", TEST_MARKER), false);
+test("isSudoPasswordPrompt refuses concealed prompt text", () => {
+  assert.equal(isSudoPasswordPrompt("\x1b[8m[sudo] password for alice: \x1b[0m"), false);
 });
 
-test("sudo autofill handles marked prompts split across chunks", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    now: () => 1_000,
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  assert.equal(autofill.prepareCommand("sudo apt update"), markedCommand(" apt update"));
-  assert.equal(autofill.handleOutput("[sudo] password for alice: "), "[sudo] password for alice: ");
-  assert.equal(autofill.handleOutput(TEST_MARKER), "");
-
-  assert.deepEqual(writes, ["secret\n"]);
+test("isSudoPasswordPrompt detects the Ubuntu PAM-style prompt from #1281", () => {
+  // The trailing bare "Password:" is what PAM emits on Ubuntu; the leading
+  // "[sudo: ...]" wrapper was an artifact of the old -p injection.
+  assert.equal(isSudoPasswordPrompt("[sudo: [sudo] password for alice: ] Password: "), true);
+  assert.equal(isSudoPasswordPrompt("Password:"), true);
 });
+
+// --- arming + autofill ---
 
 test("sudo autofill ignores sudo-looking output until a sudo command is submitted", () => {
   const writes: string[] = [];
@@ -56,62 +58,122 @@ test("sudo autofill ignores sudo-looking output until a sudo command is submitte
   assert.deepEqual(writes, []);
 });
 
-test("sudo autofill sends the password once for a submitted sudo command", () => {
+test("sudo autofill sends the password once after a submitted sudo command", () => {
   const writes: string[] = [];
   let now = 1_000;
   const autofill = createSudoPasswordAutofill({
     password: "secret",
     now: () => now,
-    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo -i"), markedCommand(" -i"));
-  autofill.handleOutput(TEST_MARKED_PROMPT);
+  autofill.armForCommand("sudo -i");
+  autofill.handleOutput("[sudo] password for alice: ");
   now += 500;
-  autofill.handleOutput(TEST_MARKED_PROMPT);
-  now += 5_000;
-  autofill.handleOutput(TEST_MARKED_PROMPT);
+  autofill.handleOutput("[sudo] password for alice: ");
 
   assert.deepEqual(writes, ["secret\n"]);
 });
 
-test("sudo autofill allows target command prompt-like options", () => {
+test("sudo autofill fills a bare Password prompt within the arm window", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo ssh -p 22 host"), markedCommand(" ssh -p 22 host"));
-  assert.equal(autofill.prepareCommand("sudo useradd -p hash alice"), markedCommand(" useradd -p hash alice"));
+  autofill.armForCommand("sudo apt update");
+  autofill.handleOutput("Password: ");
+
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill fills the Ubuntu PAM-style prompt from #1281", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autofill.armForCommand("sudo -i");
+  autofill.handleOutput("[sudo: [sudo] password for alice: ] Password: ");
+
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill keeps the prompt text in the output while filling", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autofill.armForCommand("sudo whoami");
+
+  assert.equal(
+    autofill.handleOutput("[sudo] password for alice: "),
+    "[sudo] password for alice: ",
+  );
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("sudo autofill passes ordinary output through unchanged without filling", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    write: (data) => writes.push(data),
+  });
+
+  autofill.armForCommand("sudo apt update");
+
+  assert.equal(autofill.handleOutput("Reading package lists...\r\n"), "Reading package lists...\r\n");
   assert.deepEqual(writes, []);
 });
 
-test("sudo autofill handles sudo short options with attached arguments", () => {
+test("sudo autofill handles prompts split across chunks", () => {
+  const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: () => {},
+    write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo -upostgres whoami"), markedCommand(" -upostgres whoami"));
+  autofill.armForCommand("sudo apt update");
+  autofill.handleOutput("[sudo] password ");
+  autofill.handleOutput("for alice: ");
+
+  assert.deepEqual(writes, ["secret\n"]);
 });
 
-test("sudo autofill leaves commands with explicit sudo prompts unchanged", () => {
+test("sudo autofill stays armed through ordinary output before the prompt", () => {
+  const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    write: () => {},
+    write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo -p custom whoami"), null);
-  assert.equal(autofill.prepareCommand("sudo --prompt=custom whoami"), null);
+  autofill.armForCommand("sudo whoami");
+  autofill.handleOutput("sudo: a first-time notice\r\n");
+  autofill.handleOutput("[sudo] password for alice: ");
+
+  assert.deepEqual(writes, ["secret\n"]);
 });
 
-test("sudo autofill extracts single-line bracketed paste content", () => {
-  assert.equal(getSingleBracketedPasteLine("\x1b[200~sudo whoami\x1b[201~"), "sudo whoami");
-  assert.equal(getSingleBracketedPasteLine("\x1b[200~sudo whoami\rpwd\x1b[201~"), null);
+test("sudo autofill fills again for a second sudo command", () => {
+  const writes: string[] = [];
+  let now = 1_000;
+  const autofill = createSudoPasswordAutofill({
+    password: "secret",
+    now: () => now,
+    write: (data) => writes.push(data),
+  });
+
+  autofill.armForCommand("sudo first");
+  autofill.handleOutput("[sudo] password for alice: ");
+  now += 1_000;
+  autofill.armForCommand("sudo second");
+  autofill.handleOutput("[sudo] password for alice: ");
+
+  assert.deepEqual(writes, ["secret\n", "secret\n"]);
 });
 
 test("sudo autofill ignores expired sudo command arms", () => {
@@ -120,180 +182,25 @@ test("sudo autofill ignores expired sudo command arms", () => {
   const autofill = createSudoPasswordAutofill({
     password: "secret",
     now: () => now,
-    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
+  autofill.armForCommand("sudo whoami");
   now += 31_000;
-  autofill.handleOutput(TEST_MARKED_PROMPT);
-
-  assert.deepEqual(writes, []);
-});
-
-test("sudo autofill ignores default sudo-looking output after a submitted command", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  assert.equal(autofill.prepareCommand("sudo ./program"), markedCommand(" ./program"));
   autofill.handleOutput("[sudo] password for alice: ");
 
   assert.deepEqual(writes, []);
 });
 
-test("sudo autofill ignores prompt-shaped command output after a submitted command", () => {
+test("sudo autofill does not arm for non-sudo commands", () => {
   const writes: string[] = [];
   const autofill = createSudoPasswordAutofill({
     password: "secret",
-    createPromptMarker: () => TEST_MARKER,
     write: (data) => writes.push(data),
   });
 
-  assert.equal(
-    autofill.prepareCommand("sudo printf '[sudo] password for alice: '"),
-    markedCommand(" printf '[sudo] password for alice: '"),
-  );
+  autofill.armForCommand("echo '[sudo] password for alice:'");
   autofill.handleOutput("[sudo] password for alice: ");
-
-  assert.deepEqual(writes, []);
-});
-
-test("sudo autofill stays armed after ordinary output before the password prompt", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
-  assert.equal(autofill.handleOutput("sudo: this is the first time notice"), "sudo: this is the first time notice");
-  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
-
-  assert.deepEqual(writes, ["secret\n"]);
-});
-
-test("sudo autofill releases prompt-shaped warm sudo output without sending a password", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  assert.equal(
-    autofill.prepareCommand("sudo printf '[sudo] password for alice: '"),
-    markedCommand(" printf '[sudo] password for alice: '"),
-  );
-  assert.equal(autofill.handleOutput("[sudo] password for alice: "), "[sudo] password for alice: ");
-
-  assert.deepEqual(writes, []);
-});
-
-test("sudo autofill hides the prepared command and marker from output", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  const prepared = autofill.prepareCommand("sudo whoami");
-  assert.equal(prepared, markedCommand(" whoami"));
-
-  assert.equal(autofill.handleOutput(`${prepared ?? ""}\r\n`), "sudo whoami\r\n");
-  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
-  assert.deepEqual(writes, ["secret\n"]);
-});
-
-test("sudo autofill hides split prepared command and marker output", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  const prepared = autofill.prepareCommand("sudo whoami");
-  assert.equal(prepared, markedCommand(" whoami"));
-  const preparedText = prepared ?? "";
-  const preparedSplitIndex = Math.floor(preparedText.length / 2);
-  assert.equal(autofill.handleOutput(preparedText.slice(0, preparedSplitIndex)), "");
-  assert.equal(
-    autofill.handleOutput(`${preparedText.slice(preparedSplitIndex)}\r\n`),
-    "sudo whoami\r\n",
-  );
-
-  const promptSplitIndex = TEST_MARKED_PROMPT.length - 6;
-  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT.slice(0, promptSplitIndex)), "");
-  assert.equal(
-    autofill.handleOutput(TEST_MARKED_PROMPT.slice(promptSplitIndex)),
-    "[sudo] password for alice: ",
-  );
-  assert.deepEqual(writes, ["secret\n"]);
-});
-
-test("sudo autofill keeps sanitizing later shell-history echoes", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  const prepared = autofill.prepareCommand("sudo whoami");
-  assert.equal(prepared, markedCommand(" whoami"));
-  assert.equal(autofill.handleOutput(TEST_MARKED_PROMPT), "[sudo] password for alice: ");
-  assert.equal(autofill.handleOutput(`${prepared ?? ""}\r\n`), "sudo whoami\r\n");
-
-  assert.deepEqual(writes, ["secret\n"]);
-});
-
-test("sudo autofill does not hide completed output when sudo timestamp is warm", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  const prepared = autofill.prepareCommand("sudo true");
-  assert.equal(prepared, markedCommand(" true"));
-
-  assert.equal(autofill.handleOutput(`${prepared}\r\n`), "sudo true\r\n");
-  assert.deepEqual(writes, []);
-});
-
-test("sudo autofill releases non-prompt output when sudo timestamp is warm", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  const prepared = autofill.prepareCommand("sudo printf ok");
-  assert.equal(prepared, markedCommand(" printf ok"));
-
-  assert.equal(autofill.handleOutput(`${prepared}\r\n`), "sudo printf ok\r\n");
-  assert.equal(autofill.handleOutput("ok"), "ok");
-  assert.deepEqual(writes, []);
-});
-
-test("sudo autofill ignores hidden control-sequence prompt text", () => {
-  const writes: string[] = [];
-  const autofill = createSudoPasswordAutofill({
-    password: "secret",
-    createPromptMarker: () => TEST_MARKER,
-    write: (data) => writes.push(data),
-  });
-
-  assert.equal(autofill.prepareCommand("sudo whoami"), markedCommand(" whoami"));
-  autofill.handleOutput(`\x1b[8m${TEST_PROMPT}\x1b[0m`);
 
   assert.deepEqual(writes, []);
 });
@@ -305,9 +212,15 @@ test("sudo autofill does nothing without a saved password", () => {
     write: (data) => writes.push(data),
   });
 
+  autofill.armForCommand("sudo whoami");
   autofill.handleOutput("[sudo] password for alice: ");
 
   assert.deepEqual(writes, []);
+});
+
+test("getSingleBracketedPasteLine extracts single-line bracketed paste content", () => {
+  assert.equal(getSingleBracketedPasteLine("\x1b[200~sudo whoami\x1b[201~"), "sudo whoami");
+  assert.equal(getSingleBracketedPasteLine("\x1b[200~sudo whoami\rpwd\x1b[201~"), null);
 });
 
 test("shouldArmSudoPasswordAutofill only arms direct sudo commands", () => {

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -11,12 +11,17 @@ const OSC_PATTERN = new RegExp(
 // output as a real prompt so a remote can't disguise a fake prompt and harvest
 // the autofilled password.
 const CONCEAL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[(?:[0-9]+;)*8(?:;[0-9]+)*m`);
-// A line that ends in a colon and mentions a password/密码/口令. We intentionally
-// do NOT require the word "sudo" on the line: PAM-driven distros (Ubuntu/Debian)
-// print a bare "Password:" that sudo's own prompt never reaches. Misfires are
-// bounded by the arm window — autofill only runs right after a sudo command.
-const SUDO_PROMPT_PATTERN =
-  /(?:^|[\r\n])[^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*[:：]\s*$/i;
+// An explicit sudo prompt carries a sudo-specific signal: the "[sudo]" tag or
+// the "password for <user>" phrasing. No other tool prompts this way, so it is
+// safe to fill even if sudo's creds were warm and other output followed.
+const EXPLICIT_SUDO_PROMPT_PATTERN =
+  /(?:^|[\r\n])[^\r\n]*?(?:\[sudo\][^\r\n]*?(?:password|密\s*码|口\s*令)|password\s+for\s+\S[^\r\n:：]*)[^\r\n:：]*[:：]\s*$/i;
+// A bare prompt is a line that on its own is just "Password:" / "密码:". PAM
+// emits this on some distros, so we accept it inside the arm window. We reject
+// PREFIXED prompts like "Enter password:" (mysql -p) or "user@host's password:"
+// (ssh): those belong to programs sudo launches, and filling them would leak the
+// sudo password to that program.
+const BARE_PASSWORD_PATTERN = /^\s*(?:password|密\s*码|口\s*令)\s*[:：]\s*$/i;
 const SUDO_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?sudo(?:\s|$)/;
 
 export const stripTerminalControlSequences = (data: string): string =>
@@ -24,7 +29,10 @@ export const stripTerminalControlSequences = (data: string): string =>
 
 export const isSudoPasswordPrompt = (data: string): boolean => {
   if (CONCEAL_PATTERN.test(data)) return false;
-  return SUDO_PROMPT_PATTERN.test(stripTerminalControlSequences(data));
+  const text = stripTerminalControlSequences(data);
+  if (EXPLICIT_SUDO_PROMPT_PATTERN.test(text)) return true;
+  const lastLine = text.split(/[\r\n]/).pop() ?? text;
+  return BARE_PASSWORD_PATTERN.test(lastLine);
 };
 
 export const shouldArmSudoPasswordAutofill = (command: string): boolean =>

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -114,7 +114,12 @@ export const createSudoPasswordAutofill = (_options: {
 
   return {
     armForCommand: (command: string) => {
-      if (!password || !shouldArmSudoPasswordAutofill(command)) return;
+      // Any non-sudo command (or no saved password) clears a pending arm, so a
+      // later command's own "Password:" prompt is never mistaken for sudo's.
+      if (!password || !shouldArmSudoPasswordAutofill(command)) {
+        disarm();
+        return;
+      }
       armedUntil = options.now() + armWindowMs;
       tail = "";
     },

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -7,69 +7,38 @@ const OSC_PATTERN = new RegExp(
   `${ESCAPE_SEQUENCE}\\][^${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
   "g",
 );
+// SGR conceal (parameter 8) hides the text it wraps. Refuse to treat concealed
+// output as a real prompt so a remote can't disguise a fake prompt and harvest
+// the autofilled password.
+const CONCEAL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[(?:[0-9]+;)*8(?:;[0-9]+)*m`);
+// A line that ends in a colon and mentions a password/密码/口令. We intentionally
+// do NOT require the word "sudo" on the line: PAM-driven distros (Ubuntu/Debian)
+// print a bare "Password:" that sudo's own prompt never reaches. Misfires are
+// bounded by the arm window — autofill only runs right after a sudo command.
 const SUDO_PROMPT_PATTERN =
-  /(?:^|[\r\n])\s*(?:\[[^\]\r\n]*sudo[^\]\r\n]*\]\s*)?(?=.*\bsudo\b)(?:.*\bpassword\b(?:\s+for\s+[^:\r\n]+)?|.*密码(?:\s*[:：前为给]\s*[^:\r\n]*)?)\s*[:：]\s*$/i;
+  /(?:^|[\r\n])[^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*[:：]\s*$/i;
 const SUDO_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?sudo(?:\s|$)/;
-const SUDO_COMMAND_HEAD_PATTERN = /^(\s*(?:builtin\s+|command\s+)?sudo)(?=\s|$)(.*)$/;
-const SUDO_SHORT_OPTIONS_WITH_ARGUMENT = new Set(["C", "D", "g", "h", "p", "T", "t", "U", "u"]);
-const SUDO_LONG_OPTIONS_WITH_ARGUMENT = new Set([
-  "chdir",
-  "close-from",
-  "command-timeout",
-  "group",
-  "host",
-  "prompt",
-  "role",
-  "type",
-  "user",
-]);
 
 export const stripTerminalControlSequences = (data: string): string =>
   data.replace(OSC_PATTERN, "").replace(ANSI_PATTERN, "");
 
-export const hasTerminalControlSequences = (data: string): boolean =>
-  data.includes("\x1b") || data.includes("\x07");
-
-export const isSudoPasswordPrompt = (
-  data: string,
-  expectedPrompt?: string,
-): boolean => {
-  if (expectedPrompt) {
-    if (!data.includes(expectedPrompt)) return false;
-    return isSudoPasswordPrompt(data.replaceAll(expectedPrompt, ""));
-  }
-  if (hasTerminalControlSequences(data)) return false;
-  const text = stripTerminalControlSequences(data);
-  return SUDO_PROMPT_PATTERN.test(text);
+export const isSudoPasswordPrompt = (data: string): boolean => {
+  if (CONCEAL_PATTERN.test(data)) return false;
+  return SUDO_PROMPT_PATTERN.test(stripTerminalControlSequences(data));
 };
 
 export const shouldArmSudoPasswordAutofill = (command: string): boolean =>
   SUDO_COMMAND_PATTERN.test(command);
 
 export type SudoPasswordAutofill = {
-  prepareCommand: (command: string) => string | null;
+  armForCommand: (command: string) => void;
   handleOutput: (data: string) => string;
   updatePassword: (password?: string) => void;
 };
 
-export const prepareSudoAutofillInput = (
-  data: string,
-  recordedCommand: string | null,
-  sudoAutofill: SudoPasswordAutofill | null | undefined,
-): string => {
-  if (data !== "\r" && data !== "\n") {
-    if (data.startsWith(BRACKETED_PASTE_START) && data.endsWith(BRACKETED_PASTE_END)) {
-      return data;
-    }
-    const pastedCommand = getSinglePastedCommand(data);
-    if (!pastedCommand) return data;
-    const preparedCommand = sudoAutofill?.prepareCommand(pastedCommand.command);
-    if (!preparedCommand) return data;
-    return `\x15${preparedCommand}${pastedCommand.lineEnding}`;
-  }
-  if (recordedCommand) {
-    const preparedCommand = sudoAutofill?.prepareCommand(recordedCommand);
-    if (preparedCommand) return `\x15${preparedCommand}${data}`;
+const unwrapBracketedPaste = (data: string): string => {
+  if (data.startsWith(BRACKETED_PASTE_START) && data.endsWith(BRACKETED_PASTE_END)) {
+    return data.slice(BRACKETED_PASTE_START.length, -BRACKETED_PASTE_END.length);
   }
   return data;
 };
@@ -94,225 +63,65 @@ export const getSingleBracketedPasteLine = (data: string): string | null => {
   return text;
 };
 
-const unwrapBracketedPaste = (data: string): string => {
-  if (data.startsWith(BRACKETED_PASTE_START) && data.endsWith(BRACKETED_PASTE_END)) {
-    return data.slice(BRACKETED_PASTE_START.length, -BRACKETED_PASTE_END.length);
-  }
-  return data;
-};
-
-const shellQuote = (value: string): string =>
-  `'${value.replaceAll("'", "'\\''")}'`;
-
-const createDefaultSudoPromptMarker = (): string =>
-  `__NETCATTY_SUDO_${Math.random().toString(36).slice(2, 14)}__`;
-
-const splitShellWords = (input: string): string[] => {
-  const words: string[] = [];
-  let current = "";
-  let quote: "'" | '"' | null = null;
-  let escaped = false;
-
-  for (const char of input) {
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
-    }
-    if (char === "\\" && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if ((char === "'" || char === "\"") && !quote) {
-      quote = char;
-      continue;
-    }
-    if (quote === char) {
-      quote = null;
-      continue;
-    }
-    if (!quote && /\s/.test(char)) {
-      if (current) {
-        words.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += char;
-  }
-
-  if (current) words.push(current);
-  return words;
-};
-
-const hasSudoPromptOption = (command: string): boolean => {
-  const match = command.match(SUDO_COMMAND_HEAD_PATTERN);
-  if (!match) return false;
-  const tokens = splitShellWords(match[2]);
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    if (token === "--") return false;
-    if (!token.startsWith("-") || token === "-") return false;
-
-    if (token === "--prompt" || token.startsWith("--prompt=")) return true;
-    if (token.startsWith("--")) {
-      const optionName = token.slice(2).split("=")[0];
-      if (SUDO_LONG_OPTIONS_WITH_ARGUMENT.has(optionName) && !token.includes("=")) {
-        index += 1;
-      }
-      continue;
-    }
-
-    const shortOptions = token.slice(1);
-    for (let optionIndex = 0; optionIndex < shortOptions.length; optionIndex += 1) {
-      const option = shortOptions[optionIndex];
-      if (option === "p") return true;
-      if (SUDO_SHORT_OPTIONS_WITH_ARGUMENT.has(option)) {
-        if (optionIndex === shortOptions.length - 1 && index + 1 < tokens.length) {
-          index += 1;
-        }
-        break;
-      }
-    }
-  }
-  return false;
-};
-
-const buildSudoCommandWithPrompt = (
-  command: string,
-  prompt: string,
-): string | null => {
-  if (hasSudoPromptOption(command)) return null;
-  const match = command.match(SUDO_COMMAND_HEAD_PATTERN);
-  if (!match) return null;
-  return `${match[1]} -p ${shellQuote(prompt)}${match[2]}`;
-};
-
-const isPotentialPreparedCommandPrefix = (
+// Arm the autofill when a sudo command is submitted. The user's input is sent to
+// the remote verbatim — we never rewrite it — so the terminal echo and cursor
+// stay correct.
+export const prepareSudoAutofillInput = (
   data: string,
-  preparedCommand?: string | null,
-): boolean =>
-  Boolean(preparedCommand && data && (
-    preparedCommand.startsWith(data) || data.startsWith(preparedCommand)
-  ));
-
-const hasExpectedMarkerPrefix = (data: string, marker?: string | null): boolean => {
-  if (!data || !marker) return false;
-  const maxPrefixLength = Math.min(data.length, marker.length - 1);
-  for (let length = maxPrefixLength; length > 0; length -= 1) {
-    if (data.endsWith(marker.slice(0, length))) return true;
+  recordedCommand: string | null,
+  sudoAutofill: SudoPasswordAutofill | null | undefined,
+): string => {
+  if (!sudoAutofill) return data;
+  if (data === "\r" || data === "\n") {
+    if (recordedCommand) sudoAutofill.armForCommand(recordedCommand);
+    return data;
   }
-  return false;
+  if (data.startsWith(BRACKETED_PASTE_START) && data.endsWith(BRACKETED_PASTE_END)) {
+    return data;
+  }
+  const pastedCommand = getSinglePastedCommand(data);
+  if (pastedCommand) sudoAutofill.armForCommand(pastedCommand.command);
+  return data;
 };
 
 export const createSudoPasswordAutofill = (_options: {
   password?: string;
   write: (data: string) => void;
   now?: () => number;
-  createPromptMarker?: () => string;
 }): SudoPasswordAutofill => {
   const options = {
     now: () => Date.now(),
-    createPromptMarker: createDefaultSudoPromptMarker,
     ..._options,
   };
   let password = options.password ?? "";
-  const cooldownMs = 3_000;
-  const armWindowMs = 30_000;
+  const armWindowMs = 10_000;
   let tail = "";
-  let expectedPromptMarker: string | null = null;
-  let originalCommand: string | null = null;
-  let preparedCommand: string | null = null;
-  let outputSanitizePending = "";
-  let lastSentAt = Number.NEGATIVE_INFINITY;
   let armedUntil = Number.NEGATIVE_INFINITY;
+
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
     tail = "";
-    outputSanitizePending = "";
-  };
-  const applyOutputSanitizers = (data: string): string => {
-    let nextData = data;
-    if (preparedCommand && originalCommand) {
-      nextData = nextData.replaceAll(preparedCommand, originalCommand);
-    }
-    if (expectedPromptMarker) {
-      nextData = nextData.replaceAll(expectedPromptMarker, "");
-    }
-    return nextData;
-  };
-  const sanitizeOutput = (data: string, opts: { final?: boolean } = {}): string => {
-    if (!preparedCommand && !expectedPromptMarker && !outputSanitizePending) return data;
-
-    outputSanitizePending += data;
-    const lastLineBreakIndex = Math.max(
-      outputSanitizePending.lastIndexOf("\n"),
-      outputSanitizePending.lastIndexOf("\r"),
-    );
-    if (!opts.final && lastLineBreakIndex < 0) {
-      return "";
-    }
-
-    const readyLength = opts.final
-      ? outputSanitizePending.length
-      : lastLineBreakIndex + 1;
-    const readyData = outputSanitizePending.slice(0, readyLength);
-    outputSanitizePending = outputSanitizePending.slice(readyLength);
-    return applyOutputSanitizers(readyData);
   };
 
   return {
-    prepareCommand: (command: string) => {
-      if (!password || !shouldArmSudoPasswordAutofill(command)) return null;
-      const promptMarker = options.createPromptMarker();
-      const prompt = `[sudo] password for %p: ${promptMarker}`;
-      const nextPreparedCommand = buildSudoCommandWithPrompt(command, prompt);
-      if (!nextPreparedCommand) return null;
-      expectedPromptMarker = promptMarker;
-      originalCommand = command;
-      preparedCommand = nextPreparedCommand;
+    armForCommand: (command: string) => {
+      if (!password || !shouldArmSudoPasswordAutofill(command)) return;
       armedUntil = options.now() + armWindowMs;
       tail = "";
-      return nextPreparedCommand;
     },
     handleOutput: (data: string) => {
-      const sanitizedData = sanitizeOutput(data);
-      if (!password || armedUntil === Number.NEGATIVE_INFINITY) {
-        if (
-          !sanitizedData &&
-          outputSanitizePending &&
-          !isPotentialPreparedCommandPrefix(outputSanitizePending, preparedCommand) &&
-          !hasExpectedMarkerPrefix(outputSanitizePending, expectedPromptMarker)
-        ) {
-          return sanitizeOutput("", { final: true });
-        }
-        return sanitizedData;
+      if (!password || armedUntil === Number.NEGATIVE_INFINITY) return data;
+      if (options.now() > armedUntil) {
+        disarm();
+        return data;
       }
       tail = `${tail}${data}`.slice(-1024);
-      const currentTime = options.now();
-      if (currentTime > armedUntil) {
-        const finalSanitizedData = sanitizedData + sanitizeOutput("", { final: true });
-        disarm();
-        return finalSanitizedData;
-      }
-      if (currentTime - lastSentAt < cooldownMs) return sanitizedData;
       const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
-      if (!expectedPromptMarker || !isSudoPasswordPrompt(lastLine, expectedPromptMarker)) {
-        if (
-          lastLine &&
-          !isPotentialPreparedCommandPrefix(lastLine, preparedCommand) &&
-          !hasExpectedMarkerPrefix(lastLine, expectedPromptMarker)
-        ) {
-          return sanitizedData + sanitizeOutput("", { final: true });
-        }
-        return sanitizedData;
+      if (isSudoPasswordPrompt(lastLine)) {
+        options.write(`${password}\n`);
+        disarm();
       }
-
-      options.write(`${password}\n`);
-      lastSentAt = currentTime;
-      const finalSanitizedData = sanitizedData + sanitizeOutput("", { final: true });
-      disarm();
-      return finalSanitizedData;
+      return data;
     },
     updatePassword: (nextPassword?: string) => {
       password = nextPassword ?? "";

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -11,11 +11,12 @@ const OSC_PATTERN = new RegExp(
 // output as a real prompt so a remote can't disguise a fake prompt and harvest
 // the autofilled password.
 const CONCEAL_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[(?:[0-9]+;)*8(?:;[0-9]+)*m`);
-// An explicit sudo prompt carries a sudo-specific signal: the "[sudo]" tag or
-// the "password for <user>" phrasing. No other tool prompts this way, so it is
-// safe to fill even if sudo's creds were warm and other output followed.
+// An explicit sudo prompt carries the sudo-specific "[sudo]" tag, so it is safe
+// to fill even if sudo's creds were warm and other output followed. The
+// "password for <user>" phrasing alone is NOT sudo-specific (psql emits
+// "Password for user alice:", for one), so we require the tag.
 const EXPLICIT_SUDO_PROMPT_PATTERN =
-  /(?:^|[\r\n])[^\r\n]*?(?:\[sudo\][^\r\n]*?(?:password|密\s*码|口\s*令)|password\s+for\s+\S[^\r\n:：]*)[^\r\n:：]*[:：]\s*$/i;
+  /(?:^|[\r\n])[^\r\n]*?\[sudo\][^\r\n]*?(?:password|密\s*码|口\s*令)[^\r\n:：]*[:：]\s*$/i;
 // A bare prompt is a line that on its own is just "Password:" / "密码:". PAM
 // emits this on some distros, so we accept it inside the arm window. We reject
 // PREFIXED prompts like "Enter password:" (mysql -p) or "user@host's password:"


### PR DESCRIPTION
## What

Simplifies sudo password autofill from a command-rewriting scheme to passive prompt observation.

- **Before:** rewrite `sudo X` → `sudo -p '[sudo] password for %p: <random-marker>' X`, wait for the marker in output, fill, then sanitize the marker/echo out (with a Ctrl-U retype).
- **After:** when a `sudo` command is submitted, arm a 10s window; within it, fill the password as soon as a prompt-shaped line appears (ANSI-color tolerant). Input is sent verbatim; output passes through unchanged.

## Why — fixes #1281

| Bug | Root cause | Fix |
|---|---|---|
| Ubuntu never autofilled | PAM overrides `sudo -p`; the injected marker never appears, and fill was gated on that marker | Detection no longer needs a marker; matches a bare `Password:` too |
| Cursor jumps below the prompt | wire command (long) vs displayed command (short) + Ctrl-U retype desync xterm's cursor | command is no longer rewritten |
| Typed cmd fails, autocomplete works | rewrite needed the exact reconstructed command | arming only needs the command to start with `sudo` |

The author's reported Ubuntu prompt `[sudo: [sudo] password for {user}: ] Password:` is covered by a regression test, as is a bare `Password:`. (The nested `[sudo: ...]` wrapper was itself an artifact of the old `-p` injection — it should no longer appear once we stop rewriting.)

## Notes

- Implementation: **322 → 131 lines**.
- Prompt detection strips ANSI color before matching but still refuses SGR-concealed text (anti-spoofing — a remote can't disguise a fake prompt to harvest the password).
- Removed the 3s cooldown: fill-once-then-disarm already prevents repeats, and the cooldown blocked back-to-back sudo commands.
- **Tradeoff:** within the arm window, if you immediately run another program that asks `Password:` (and this sudo didn't prompt due to cached creds), it could fill once. Bounded by the short window + fill-once.

## Test

- `node --test --import tsx components/terminal/runtime/*.test.ts` — green; full suite **1845 pass / 0 fail**.
- Recommend a real-device pass on Ubuntu 24.04/26.04 + Kylin v11 (the issue environments), since sudo+PAM behavior is environment-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)