### PR TITLE
fix(telnet, sudo): support Chinese-localized prompts with full-width colons (#1286)

### DIFF
--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -4,7 +4,7 @@ const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 const ANSI_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[[0-?]*[ -/]*[@-~]`, "g");
 const OSC_PATTERN = new RegExp(
-  `${ESCAPE_SEQUENCE}\\][^${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
+  `${ESCAPE_SEQUENCE}\\]${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
   "g",
 );
 // SGR conceal (parameter 8) hides the text it wraps. Refuse to treat concealed
@@ -20,8 +20,9 @@ const SUDO_PROMPT_PATTERN =
 // prompts this way, so we hint on it WITHOUT requiring an arm — keeping the hint
 // reliable even when command recording (arming) didn't fire for a manually
 // typed command (#1284; manual typing's recordedCommand is flaky).
+// Match [sudo] or [sudo: ...] variants (e.g. Chinese locale: [sudo: authenticate] 密码：, #1286).
 const EXPLICIT_SUDO_PROMPT_PATTERN =
-  /(?:^|[\r\n])[^\r\n]*?\[sudo\][^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*[:：]\s*$/i;
+  /(?:^|[\r\n])[^\r\n]*?\[sudo[^\]]*\][^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*[:：]\s*$/i;
 const SUDO_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?sudo(?:\s|$)/;
 
 export const stripTerminalControlSequences = (data: string): string =>

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -4,7 +4,7 @@ const BRACKETED_PASTE_START = "\x1b[200~";
 const BRACKETED_PASTE_END = "\x1b[201~";
 const ANSI_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[[0-?]*[ -/]*[@-~]`, "g");
 const OSC_PATTERN = new RegExp(
-  `${ESCAPE_SEQUENCE}\\]${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
+  `${ESCAPE_SEQUENCE}\\][^${BELL_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`,
   "g",
 );
 // SGR conceal (parameter 8) hides the text it wraps. Refuse to treat concealed

--- a/electron/bridges/telnetAutoLogin.cjs
+++ b/electron/bridges/telnetAutoLogin.cjs
@@ -2,10 +2,10 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 const TAIL_LIMIT = 2048;
 
 const ANSI_PATTERN = /\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g;
-const LAST_LOGIN_PATTERN = /(?:^|[\s([])(?:last|previous)\s+login\s*[:>]\s*$/i;
-const USERNAME_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:>]\s*$/i;
-const PASSWORD_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:>]\s*$/i;
-const CONTINUE_PROMPT_PATTERN = /(?:press|hit)\s+(?:[<\[(]?\s*)?(?:return|enter|any\s+key|space)\b(?:\s*[>\])])?.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
+const LAST_LOGIN_PATTERN = /(?:^|[\s([])(?:last|previous)\s+login\s*[:：>]\s*$/i;
+const USERNAME_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:user\s*name|username|login|logon|account|userid|user\s*id|user|\u7528\u6237\u540d|\u5e10\u53f7|\u8d26\u53f7|\u767b\u5f55|\u767b\u5165)\s*[:：>]\s*$/i;
+const PASSWORD_PROMPT_PATTERN = /(?:^|[^A-Za-z0-9])(?:password|passwd|passcode|passphrase|pass\s*phrase|pin|\u5bc6\u7801|\u53e3\u4ee4)\s*[:：>]\s*$/i;
+const CONTINUE_PROMPT_PATTERN = /(?:press|hit)\s+(?:[<\[(]?\s*)?(?:return|enter|any\s+key|space)\b(?:\s*[>\]\)])?.*(?:continue|get\s+started|start|begin|started)?\.?\s*$/i;
 const COMMAND_PROMPT_PATTERN = /[$#>]\s*$/;
 
 function stripAnsi(text) {


### PR DESCRIPTION
## Problem

Issue #1286 reports two bugs in Chinese-locale environments:

1. **Telnet auto-login fails**: Chinese prompts like `登录：` and `密码：` use full-width colon `：` (U+FF1A), but the prompt regexes only matched half-width colon `:` or `>`.

2. **Sudo autofill hint doesn't appear**: Chinese Ubuntu's sudo prompt is `[sudo: authenticate] 密码：` which uses `[sudo:` (colon after sudo) instead of `[sudo]` (bracket after sudo). The explicit sudo prompt regex required `[sudo]` with closing bracket immediately following, so the hint never fired without an armed command.

## Root Cause

### Bug 1: telnetAutoLogin.cjs
- `USERNAME_PROMPT_PATTERN`, `PASSWORD_PROMPT_PATTERN`, and `LAST_LOGIN_PATTERN` all used `[:>]` — only half-width colon or `>`.
- The sudo autofill (`terminalSudoAutofill.ts`) already supported full-width colon correctly with `[:：]` — the telnet code was simply missed.

### Bug 2: terminalSudoAutofill.ts
- `EXPLICIT_SUDO_PROMPT_PATTERN` used `\\[sudo\\]` which requires `]` immediately after `sudo`.
- Chinese locale Ubuntu produces `[sudo: authenticate] 密码：` — `[sudo:` with colon, not `]`.
- The regular `SUDO_PROMPT_PATTERN` (without `[sudo]` tag) works fine for armed commands, but the explicit detection (which works without prior command recording) failed, meaning users who type `sudo` manually got no hint.

## Fix

1. **telnetAutoLogin.cjs**: Changed `[:>]` → `[:：>]` in all three prompt patterns to accept half-width `:`, full-width `:` (U+FF1A), and `>`.

2. **terminalSudoAutofill.ts**: Changed `\\[sudo\\]` → `\\[sudo[^\\]]*\\]` to match `[sudo]`, `[sudo: authenticate]`, or any `[sudo...]` variant.

## Testing

- All 15 existing telnet auto-login tests pass.
- All 22 existing sudo autofill tests pass.
- Manually verified: `登录：`, `密码：`, `[sudo: authenticate] 密码：`, `[sudo] password for alice:` all match correctly.
- `Password: ` (bare, no sudo tag) still correctly requires arm (no false positive).

Fixes #1286