### PR TITLE
fix(ai): auto-switch to Codex agent after ChatGPT OAuth login (#1285)

### DIFF
--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -123,6 +123,10 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const [codexPathInfo, setCodexPathInfo] = useState<AgentPathInfo | null>(null);
   const [codexCustomPath, setCodexCustomPath] = useState("");
   const [isResolvingCodex, setIsResolvingCodex] = useState(false);
+  // Tracks whether the current connected_chatgpt state is the result of a
+  // just-completed `codex login` flow (as opposed to a stale refresh). Used
+  // by the auto-agent-switch effect below.
+  const codexLoginJustCompletedRef = useRef(false);
 
   const [claudePathInfo, setClaudePathInfo] = useState<AgentPathInfo | null>(null);
   const [claudeCustomPath, setClaudeCustomPath] = useState("");
@@ -308,6 +312,27 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     void refreshCodexIntegration();
   }, [refreshCodexIntegration]);
 
+  // When Codex ChatGPT OAuth login completes successfully and the user has no
+  // provider configured for the Catty Agent, auto-switch the default agent to
+  // Codex so they can start using it immediately instead of seeing "no model
+  // selected" in the chat interface.
+  useEffect(() => {
+    if (
+      codexLoginJustCompletedRef.current &&
+      codexIntegration?.state === 'connected_chatgpt' &&
+      defaultAgentId === 'catty' &&
+      providers.length === 0
+    ) {
+      codexLoginJustCompletedRef.current = false;
+      const codexAgentId = externalAgents.find(
+        (a) => a.command === 'codex' || a.id.startsWith('discovered_codex') || a.id === 'codex',
+      )?.id;
+      if (codexAgentId) {
+        setDefaultAgentId(codexAgentId);
+      }
+    }
+  }, [codexIntegration, defaultAgentId, providers.length, externalAgents, setDefaultAgentId]);
+
   useEffect(() => {
     if (!codexLoginSession || codexLoginSession.state !== "running") {
       return;
@@ -326,6 +351,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         setCodexLoginSession(result.session);
         if (result.session.state !== "running") {
           if (result.session.state === "success") {
+            codexLoginJustCompletedRef.current = true;
             void refreshCodexIntegration();
           }
         }


### PR DESCRIPTION
## Fix: Auto-switch to Codex agent after ChatGPT OAuth login

**Issue:** After successful OpenAI web OAuth authorization through `codex login`, the chat interface still showed a no-model-selected state.

**Root cause:** The Codex OAuth flow does not provide an API key for the Catty Agent provider. The Codex agent was authenticated and available, but the user was never auto-switched to it. Because the default agent (`catty`) had no configured provider, the chat UI showed that no model was selected.

**Fix:** Add a ref flag to detect when Codex login just completed. When the login transitions to `connected_chatgpt`, if the default agent is `catty` with no providers configured, auto-switch to the first discovered Codex agent so the user can start using it immediately.

Closes #1285