### PR TITLE
feat: add adjustable window opacity (#1304)

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -129,6 +129,8 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         onOpenQuickSwitcher={handleOpenQuickSwitcher}
         onToggleTheme={handleToggleTheme}
         onOpenSettings={handleOpenSettings}
+        windowOpacity={settings.windowOpacity}
+        setWindowOpacity={settings.setWindowOpacity}
         onSyncNow={handleSyncNowManual}
         isImmersiveActive={activeTerminalTheme !== null}
         onStartSessionDrag={setDraggingSessionId}

--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -234,6 +234,7 @@ export const enAiMessages: Messages = {
   'topTabs.openQuickSwitcher': 'Open quick switcher',
   'topTabs.moreTabs': 'More tabs',
   'topTabs.aiAssistant': 'AI Assistant',
+  'topTabs.windowOpacity': 'Window opacity',
   'topTabs.toggleTheme': 'Toggle theme',
   'topTabs.openSettings': 'Open Settings',
   'ai.chat.sessionHistory': 'Session history',

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -271,7 +271,8 @@ export const enCoreMessages: Messages = {
   'settings.appearance.language.desc': 'Choose the UI language',
   'settings.appearance.uiFont': 'Interface Font',
   'settings.appearance.uiFont.desc': 'Choose the font for the application interface',
-
+  'settings.appearance.windowOpacity': 'Window Opacity',
+  'settings.appearance.windowOpacity.desc': 'Adjust the transparency of the entire application window. Lower values also fade terminal text. Some Linux desktop environments may not support this.',
   // Settings > Terminal
   'settings.terminal.section.theme': 'Terminal Theme',
   'settings.terminal.themeModal.title': 'Select Theme',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -234,6 +234,7 @@ export const ruAiMessages: Messages = {
   'topTabs.openQuickSwitcher': 'Открыть быстрый переключатель',
   'topTabs.moreTabs': 'Больше вкладок',
   'topTabs.aiAssistant': 'AI-помощник',
+  'topTabs.windowOpacity': 'Прозрачность окна',
   'topTabs.toggleTheme': 'Переключить тему',
   'topTabs.openSettings': 'Открыть настройки',
   'ai.chat.sessionHistory': 'История сессий',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -271,7 +271,8 @@ export const ruCoreMessages: Messages = {
   'settings.appearance.language.desc': 'Выберите язык интерфейса',
   'settings.appearance.uiFont': 'Шрифт интерфейса',
   'settings.appearance.uiFont.desc': 'Выберите шрифт для интерфейса приложения',
-
+  'settings.appearance.windowOpacity': 'Прозрачность окна',
+  'settings.appearance.windowOpacity.desc': 'Настройте прозрачность всего окна приложения. При низких значениях текст терминала тоже бледнеет. В некоторых средах Linux это может не поддерживаться.',
   // Settings > Terminal
   'settings.terminal.section.theme': 'Тема терминала',
   'settings.terminal.themeModal.title': 'Выберите тему',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -234,6 +234,7 @@ export const zhCNAiMessages: Messages = {
   'topTabs.openQuickSwitcher': '打开快速切换',
   'topTabs.moreTabs': '更多标签页',
   'topTabs.aiAssistant': 'AI 助手',
+  'topTabs.windowOpacity': '窗口透明度',
   'topTabs.toggleTheme': '切换主题',
   'topTabs.openSettings': '打开设置',
   'ai.chat.sessionHistory': '会话历史',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -255,7 +255,8 @@ export const zhCNCoreMessages: Messages = {
   'settings.appearance.language.desc': '选择界面语言',
   'settings.appearance.uiFont': '界面字体',
   'settings.appearance.uiFont.desc': '选择软件界面使用的字体',
-
+  'settings.appearance.windowOpacity': '窗口透明度',
+  'settings.appearance.windowOpacity.desc': '调节整个应用窗口的透明度，方便叠在其他内容上方。较低时终端文字也会变淡；部分 Linux 桌面环境可能不支持。',
   // Context menus / common actions
   'action.newHost': '新建主机',
   'action.newSubfolder': '新建文件夹',

--- a/application/state/settingsIpcSync.ts
+++ b/application/state/settingsIpcSync.ts
@@ -33,9 +33,14 @@ import {
   STORAGE_KEY_UI_THEME_DARK,
   STORAGE_KEY_UI_THEME_LIGHT,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
+  STORAGE_KEY_WINDOW_OPACITY,
 } from '../../infrastructure/config/storageKeys';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
-import { isValidUiFontId, migrateIncomingTerminalFontId } from './settingsStateDefaults';
+import {
+  clampWindowOpacity,
+  isValidUiFontId,
+  migrateIncomingTerminalFontId,
+} from './settingsStateDefaults';
 
 interface UseSettingsIpcSyncParams {
   syncAppearanceFromStorage: () => void;
@@ -59,6 +64,7 @@ interface UseSettingsIpcSyncParams {
   applyIncomingCustomKeyBindings: (incoming: { bindings: CustomKeyBindings; version: number; origin: string }) => void;
   setIsHotkeyRecordingState: Dispatch<SetStateAction<boolean>>;
   setGlobalHotkeyEnabled: Dispatch<SetStateAction<boolean>>;
+  setWindowOpacity: Dispatch<SetStateAction<number>>;
   setAutoUpdateEnabled: Dispatch<SetStateAction<boolean>>;
   setSftpAutoOpenSidebar: Dispatch<SetStateAction<boolean>>;
   setSftpDefaultViewMode: Dispatch<SetStateAction<'list' | 'tree'>>;
@@ -88,6 +94,7 @@ export function useSettingsIpcSync({
   applyIncomingCustomKeyBindings,
   setIsHotkeyRecordingState,
   setGlobalHotkeyEnabled,
+  setWindowOpacity,
   setAutoUpdateEnabled,
   setSftpAutoOpenSidebar,
   setSftpDefaultViewMode,
@@ -191,6 +198,10 @@ export function useSettingsIpcSync({
       if (key === STORAGE_KEY_GLOBAL_HOTKEY_ENABLED && typeof value === 'boolean') {
         setGlobalHotkeyEnabled((prev) => (prev === value ? prev : value));
       }
+      if (key === STORAGE_KEY_WINDOW_OPACITY && (typeof value === 'number' || typeof value === 'string')) {
+        const nextOpacity = clampWindowOpacity(value);
+        setWindowOpacity((prev) => (prev === nextOpacity ? prev : nextOpacity));
+      }
       if (key === STORAGE_KEY_AUTO_UPDATE_ENABLED && typeof value === 'boolean') {
         setAutoUpdateEnabled((prev) => (prev === value ? prev : value));
       }
@@ -223,6 +234,7 @@ export function useSettingsIpcSync({
     setEditorWordWrapState,
     setFollowAppTerminalThemeState,
     setGlobalHotkeyEnabled,
+    setWindowOpacity,
     setHotkeyScheme,
     setIsHotkeyRecordingState,
     setSessionLogsDir,

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -8,6 +8,12 @@ import { localStorageAdapter } from '../../infrastructure/persistence/localStora
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
 
 export const DEFAULT_THEME: 'light' | 'dark' | 'system' = 'dark';
+export const DEFAULT_WINDOW_OPACITY = 1;
+export function clampWindowOpacity(opacity: unknown): number {
+  const value = Number(opacity);
+  if (!Number.isFinite(value)) return DEFAULT_WINDOW_OPACITY;
+  return Math.min(1, Math.max(0.5, value));
+}
 
 /** Resolve the current OS color scheme preference. */
 export const getSystemPreference = (): 'light' | 'dark' =>

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -39,8 +39,10 @@ import {
   STORAGE_KEY_UI_THEME_DARK,
   STORAGE_KEY_UI_THEME_LIGHT,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
+  STORAGE_KEY_WINDOW_OPACITY,
 } from '../../infrastructure/config/storageKeys';
 import {
+  clampWindowOpacity,
   isValidHslToken,
   isValidTheme,
   isValidUiFontId,
@@ -79,6 +81,7 @@ interface UseSettingsStorageSyncParams {
   sshDebugLogsEnabled: boolean;
   globalHotkeyEnabled: boolean;
   autoUpdateEnabled: boolean;
+  windowOpacity: number;
   setTheme: Dispatch<SetStateAction<'dark' | 'light' | 'system'>>;
   setLightUiThemeId: Dispatch<SetStateAction<string>>;
   setDarkUiThemeId: Dispatch<SetStateAction<string>>;
@@ -110,6 +113,7 @@ interface UseSettingsStorageSyncParams {
   setSessionLogsTimestampsEnabled: Dispatch<SetStateAction<boolean>>;
   setSshDebugLogsEnabled: Dispatch<SetStateAction<boolean>>;
   setGlobalHotkeyEnabled: Dispatch<SetStateAction<boolean>>;
+  setWindowOpacity: Dispatch<SetStateAction<number>>;
   setAutoUpdateEnabled: Dispatch<SetStateAction<boolean>>;
   setWorkspaceFocusStyleState: Dispatch<SetStateAction<'dim' | 'border'>>;
   setSftpTransferConcurrencyState: Dispatch<SetStateAction<number>>;
@@ -125,7 +129,7 @@ export function useSettingsStorageSync({
   sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpDefaultViewMode,
   showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
   editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
-  globalHotkeyEnabled, autoUpdateEnabled,
+  globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
   setCustomCSS, setUiFontFamilyId, setHotkeyScheme, setUiLanguage,
   setTerminalThemeId, setTerminalThemeDarkId, setTerminalThemeLightId,
@@ -134,7 +138,7 @@ export function useSettingsStorageSync({
   setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpDefaultViewMode,
   setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState,
   setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
-  setGlobalHotkeyEnabled, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
+  setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
   setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
 }: UseSettingsStorageSyncParams) {
   // Fix 4: Keep a ref snapshot of current settings so the storage event handler
@@ -148,7 +152,7 @@ export function useSettingsStorageSync({
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
-    globalHotkeyEnabled, autoUpdateEnabled,
+    globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   });
   settingsSnapshotRef.current = {
     theme, lightUiThemeId, darkUiThemeId, accentMode, customAccent,
@@ -158,7 +162,7 @@ export function useSettingsStorageSync({
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
-    globalHotkeyEnabled, autoUpdateEnabled,
+    globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   };
 
   // Listen for storage changes from other windows (cross-window sync)
@@ -372,6 +376,12 @@ export function useSettingsStorageSync({
           setAutoUpdateEnabled(newValue);
         }
       }
+      if (e.key === STORAGE_KEY_WINDOW_OPACITY && e.newValue !== null) {
+        const newValue = clampWindowOpacity(e.newValue);
+        if (newValue !== s.windowOpacity) {
+          setWindowOpacity(newValue);
+        }
+      }
       // Sync workspace focus style from other windows
       if (e.key === STORAGE_KEY_WORKSPACE_FOCUS_STYLE && e.newValue !== null) {
         if (e.newValue === 'dim' || e.newValue === 'border') {
@@ -400,6 +410,7 @@ export function useSettingsStorageSync({
     setEditorWordWrapState,
     setFollowAppTerminalThemeState,
     setGlobalHotkeyEnabled,
+    setWindowOpacity,
     setHotkeyScheme,
     setLightUiThemeId,
     setSessionLogsDir,

--- a/application/state/systemSettingsEffects.ts
+++ b/application/state/systemSettingsEffects.ts
@@ -4,6 +4,7 @@ import {
   STORAGE_KEY_CLOSE_TO_TRAY,
   STORAGE_KEY_GLOBAL_HOTKEY_ENABLED,
   STORAGE_KEY_TOGGLE_WINDOW_HOTKEY,
+  STORAGE_KEY_WINDOW_OPACITY,
 } from '../../infrastructure/config/storageKeys';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
@@ -12,6 +13,7 @@ interface UseSystemSettingsEffectsParams {
   toggleWindowHotkey: string;
   globalHotkeyEnabled: boolean;
   closeToTray: boolean;
+  windowOpacity: number;
   autoUpdateEnabled: boolean;
   persistMountedRef: MutableRefObject<boolean>;
   setHotkeyRegistrationError: (error: string | null) => void;
@@ -23,6 +25,7 @@ export function useSystemSettingsEffects({
   toggleWindowHotkey,
   globalHotkeyEnabled,
   closeToTray,
+  windowOpacity,
   autoUpdateEnabled,
   persistMountedRef,
   setHotkeyRegistrationError,
@@ -88,6 +91,17 @@ export function useSystemSettingsEffects({
     if (!persistMountedRef.current) return;
     notifySettingsChanged(STORAGE_KEY_CLOSE_TO_TRAY, closeToTray);
   }, [closeToTray, notifySettingsChanged, persistMountedRef]);
+
+  // Persist and sync window opacity
+  useEffect(() => {
+    const bridge = netcattyBridge.get();
+    bridge?.setWindowOpacity?.(windowOpacity).catch((err) => {
+      console.warn('[WindowOpacity] Failed to apply window opacity:', err);
+    });
+    localStorageAdapter.writeString(STORAGE_KEY_WINDOW_OPACITY, String(windowOpacity));
+    if (!persistMountedRef.current) return;
+    notifySettingsChanged(STORAGE_KEY_WINDOW_OPACITY, windowOpacity);
+  }, [windowOpacity, notifySettingsChanged, persistMountedRef]);
 
   // Hydrate auto-update state from the main-process preference file on mount.
   // This reconciles localStorage (renderer) with auto-update-pref.json (main)

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -36,6 +36,7 @@ import {
   STORAGE_KEY_TOGGLE_WINDOW_HOTKEY,
   STORAGE_KEY_CLOSE_TO_TRAY,
   STORAGE_KEY_GLOBAL_HOTKEY_ENABLED,
+  STORAGE_KEY_WINDOW_OPACITY,
   STORAGE_KEY_AUTO_UPDATE_ENABLED,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
   STORAGE_KEY_SHOW_RECENT_HOSTS,
@@ -83,6 +84,8 @@ import {
   DEFAULT_SSH_DEBUG_LOGS_ENABLED,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
+  DEFAULT_WINDOW_OPACITY,
+  clampWindowOpacity,
   applyThemeTokens,
   areTerminalSettingsEqual,
   createCustomKeyBindingsSyncOrigin,
@@ -278,6 +281,19 @@ export const useSettingsState = () => {
     if (stored === null) return true; // Default to enabled
     return stored === 'true';
   });
+  const [windowOpacity, setWindowOpacityState] = useState<number>(() => {
+    const stored = readStoredString(STORAGE_KEY_WINDOW_OPACITY);
+    if (stored === null) return DEFAULT_WINDOW_OPACITY;
+    return clampWindowOpacity(stored);
+  });
+  const setWindowOpacity = useCallback((nextValue: SetStateAction<number>) => {
+    setWindowOpacityState((prev) => {
+      const candidate = typeof nextValue === 'function'
+        ? (nextValue as (prevState: number) => number)(prev)
+        : nextValue;
+      return clampWindowOpacity(candidate);
+    });
+  }, []);
   const incomingTerminalSettingsSignatureRef = useRef<string | null>(null);
   const localTerminalSettingsVersionRef = useRef(0);
   const broadcastedLocalTerminalSettingsVersionRef = useRef(0);
@@ -576,6 +592,7 @@ export const useSettingsState = () => {
     applyIncomingCustomKeyBindings,
     setIsHotkeyRecordingState,
     setGlobalHotkeyEnabled,
+    setWindowOpacity,
     setAutoUpdateEnabled,
     setSftpAutoOpenSidebar,
     setSftpDefaultViewMode,
@@ -608,7 +625,7 @@ export const useSettingsState = () => {
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
-    globalHotkeyEnabled, autoUpdateEnabled,
+    globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
     setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
     setCustomCSS, setUiFontFamilyId, setHotkeyScheme, setUiLanguage,
     setTerminalThemeId, setTerminalThemeDarkId, setTerminalThemeLightId,
@@ -617,7 +634,7 @@ export const useSettingsState = () => {
     setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpDefaultViewMode,
     setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState,
     setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
-    setGlobalHotkeyEnabled, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
+    setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
     setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
   });
 
@@ -815,6 +832,7 @@ export const useSettingsState = () => {
     toggleWindowHotkey,
     globalHotkeyEnabled,
     closeToTray,
+    windowOpacity,
     autoUpdateEnabled,
     persistMountedRef,
     setHotkeyRegistrationError,
@@ -986,6 +1004,8 @@ export const useSettingsState = () => {
     hotkeyRegistrationError,
     globalHotkeyEnabled,
     setGlobalHotkeyEnabled,
+    windowOpacity,
+    setWindowOpacity,
     rehydrateAllFromStorage,
     reapplyCurrentTheme,
     workspaceFocusStyle,

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -325,6 +325,8 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
                             setShowOnlyUngroupedHostsInRoot={settings.setShowOnlyUngroupedHostsInRoot}
                             showSftpTab={settings.showSftpTab}
                             setShowSftpTab={settings.setShowSftpTab}
+                            windowOpacity={settings.windowOpacity}
+                            setWindowOpacity={settings.setWindowOpacity}
                         />
                     )}
 

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -12,6 +12,7 @@ import { Button } from './ui/button';
 import { ContextMenuItem, ContextMenuSeparator } from './ui/context-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { SyncStatusButton } from './SyncStatusButton';
+import { WindowOpacityButton } from './WindowOpacityButton';
 import {
   ActiveTabAutoScroller,
   EditorTopTab,
@@ -49,6 +50,8 @@ interface TopTabsProps {
   onOpenQuickSwitcher: () => void;
   onToggleTheme: () => void;
   onOpenSettings: () => void;
+  windowOpacity: number;
+  setWindowOpacity: (opacity: number) => void;
   onSyncNow?: () => Promise<void>;
   isImmersiveActive?: boolean;
   onStartSessionDrag: (sessionId: string) => void;
@@ -82,6 +85,8 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onOpenQuickSwitcher,
   onToggleTheme,
   onOpenSettings,
+  windowOpacity,
+  setWindowOpacity,
   onSyncNow,
   isImmersiveActive,
   onStartSessionDrag,
@@ -610,6 +615,12 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             </TooltipTrigger>
             <TooltipContent>{t('topTabs.aiAssistant')}</TooltipContent>
           </Tooltip>
+          <WindowOpacityButton
+            windowOpacity={windowOpacity}
+            setWindowOpacity={setWindowOpacity}
+            className="h-7 w-7 shrink-0"
+            style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
+          />
           <SyncStatusButton
             onOpenSettings={onOpenSettings}
             onSyncNow={onSyncNow}
@@ -669,6 +680,8 @@ const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
     prev.onCopySession === next.onCopySession &&
     prev.onCopySessionToNewWindow === next.onCopySessionToNewWindow &&
     prev.onOpenSettings === next.onOpenSettings &&
+    prev.windowOpacity === next.windowOpacity &&
+    prev.setWindowOpacity === next.setWindowOpacity &&
     prev.onSyncNow === next.onSyncNow &&
     prev.onToggleTheme === next.onToggleTheme &&
     prev.followAppTerminalTheme === next.followAppTerminalTheme &&

--- a/components/WindowOpacityButton.tsx
+++ b/components/WindowOpacityButton.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Droplets } from 'lucide-react';
+import { useI18n } from '../application/i18n/I18nProvider';
+import { cn } from '../lib/utils';
+import { Button } from './ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+
+const OPACITY_PRESETS = [
+  { label: '100%', value: 1 },
+  { label: '85%', value: 0.85 },
+  { label: '70%', value: 0.7 },
+] as const;
+
+interface WindowOpacityButtonProps {
+  windowOpacity: number;
+  setWindowOpacity: (opacity: number) => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const WindowOpacityButton: React.FC<WindowOpacityButtonProps> = ({
+  windowOpacity,
+  setWindowOpacity,
+  className,
+  style,
+}) => {
+  const { t } = useI18n();
+  const [isOpen, setIsOpen] = useState(false);
+  const percent = Math.round(windowOpacity * 100);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn('h-7 w-7 shrink-0 app-no-drag', className)}
+              style={style}
+              aria-label={t('topTabs.windowOpacity')}
+            >
+              <Droplets
+                size={16}
+                className={percent < 100 ? 'opacity-80' : undefined}
+              />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{t('topTabs.windowOpacity')}</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        className="w-60 p-3 app-no-drag"
+        align="end"
+        sideOffset={6}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-2">
+          <div className="text-sm font-medium">{t('topTabs.windowOpacity')}</div>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={50}
+              max={100}
+              step={5}
+              value={percent}
+              onChange={(e) => setWindowOpacity(Number(e.target.value) / 100)}
+              className="flex-1 accent-primary"
+            />
+            <span className="text-xs text-muted-foreground w-9 text-right tabular-nums">
+              {percent}%
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            {OPACITY_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => setWindowOpacity(preset.value)}
+                className={cn(
+                  'flex-1 px-2 py-1 rounded-md text-xs font-medium transition-colors border',
+                  windowOpacity === preset.value
+                    ? 'bg-primary text-primary-foreground border-primary'
+                    : 'bg-muted/50 text-muted-foreground border-border hover:text-foreground',
+                )}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default WindowOpacityButton;

--- a/components/settings/tabs/SettingsAppearanceTab.tsx
+++ b/components/settings/tabs/SettingsAppearanceTab.tsx
@@ -32,6 +32,8 @@ export default function SettingsAppearanceTab(props: {
   setShowOnlyUngroupedHostsInRoot: (enabled: boolean) => void;
   showSftpTab: boolean;
   setShowSftpTab: (enabled: boolean) => void;
+  windowOpacity: number;
+  setWindowOpacity: (opacity: number) => void;
 }) {
   const { t } = useI18n();
   const availableUIFonts = useAvailableUIFonts();
@@ -58,7 +60,15 @@ export default function SettingsAppearanceTab(props: {
     setShowOnlyUngroupedHostsInRoot,
     showSftpTab,
     setShowSftpTab,
+    windowOpacity,
+    setWindowOpacity,
   } = props;
+
+  const WINDOW_OPACITY_PRESETS = [
+    { label: '100%', value: 1 },
+    { label: '85%', value: 0.85 },
+    { label: '70%', value: 0.7 },
+  ] as const;
 
   const getHslStyle = useCallback((hsl: string) => ({ backgroundColor: `hsl(${hsl})` }), []);
 
@@ -169,6 +179,48 @@ export default function SettingsAppearanceTab(props: {
             onChange={(v) => setUiFontFamilyId(v)}
             className="w-48"
           />
+        </SettingRow>
+      </div>
+
+      <SectionHeader title={t("settings.appearance.windowOpacity")} />
+      <div className="space-y-0 divide-y divide-border rounded-lg border bg-card px-4">
+        <SettingRow
+          label={t("settings.appearance.windowOpacity")}
+          description={t("settings.appearance.windowOpacity.desc")}
+        >
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex items-center gap-2">
+              <input
+                type="range"
+                min={50}
+                max={100}
+                step={5}
+                value={Math.round(windowOpacity * 100)}
+                onChange={(e) => setWindowOpacity(Number(e.target.value) / 100)}
+                className="w-28 accent-primary"
+              />
+              <span className="text-sm text-muted-foreground w-10 text-right tabular-nums">
+                {Math.round(windowOpacity * 100)}%
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              {WINDOW_OPACITY_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => setWindowOpacity(preset.value)}
+                  className={cn(
+                    "px-2.5 py-1 rounded-md text-xs font-medium transition-colors border",
+                    windowOpacity === preset.value
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-muted/50 text-muted-foreground border-border hover:text-foreground",
+                  )}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
         </SettingRow>
       </div>
 

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -33,6 +33,9 @@ let lastFocusedMainWindow = null;
 let settingsWindow = null;
 let currentTheme = "light";
 let currentLanguage = "en";
+let currentWindowOpacity = 1;
+let cachedNativeTheme = null;
+
 let handlersRegistered = false; // Prevent duplicate IPC handler registration
 let menuDeps = null;
 let electronApp = null; // Reference to Electron app for userData path
@@ -322,6 +325,30 @@ function forEachMainWindow(callback) {
       // ignore per-window broadcast failures
     }
   }
+}
+
+function clampWindowOpacity(opacity) {
+  const value = Number(opacity);
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(1, Math.max(0.5, value));
+}
+
+function applyWindowOpacityToWindow(win) {
+  if (!win || win.isDestroyed?.()) return;
+  try {
+    win.setOpacity?.(currentWindowOpacity);
+  } catch {
+    // ignore
+  }
+}
+
+function applyWindowOpacity(opacity) {
+  currentWindowOpacity = clampWindowOpacity(opacity);
+  forEachMainWindow(applyWindowOpacityToWindow);
+  if (settingsWindow && !settingsWindow.isDestroyed()) {
+    applyWindowOpacityToWindow(settingsWindow);
+  }
+  return currentWindowOpacity;
 }
 
 function getMainWindowCount() {
@@ -809,6 +836,7 @@ const mainWindowApi = createMainWindowApi({
   registerMainWindow,
   unregisterMainWindow,
   getMainWindowCount,
+  applyWindowOpacityToWindow,
   closeSettingsWindow: (...args) => closeSettingsWindow(...args),
   hideSettingsWindow: (...args) => hideSettingsWindow(...args),
 });
@@ -852,6 +880,7 @@ const settingsWindowApi = createSettingsWindowApi({
   createAppWindowOpenHandler,
   createExternalOnlyWindowOpenHandler,
   getDevRendererBaseUrl,
+  applyWindowOpacityToWindow,
 });
 const {
   restoreWindowInputFocus,
@@ -874,6 +903,7 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
     return;
   }
   handlersRegistered = true;
+  cachedNativeTheme = nativeTheme;
 
   ipcMain.handle("netcatty:window:minimize", (event) => {
     const win = getWindowForIpcEvent(event);
@@ -952,7 +982,6 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
       : theme;
     const themeConfig = THEME_COLORS[effectiveTheme] || THEME_COLORS.light;
     forEachMainWindow((win) => win.setBackgroundColor(themeConfig.background));
-    // Also update settings window if open
     if (settingsWindow && !settingsWindow.isDestroyed()) {
       settingsWindow.setBackgroundColor(themeConfig.background);
     }
@@ -966,6 +995,11 @@ function registerWindowHandlers(ipcMain, nativeTheme) {
     if (settingsWindow && !settingsWindow.isDestroyed()) {
       settingsWindow.setBackgroundColor(normalized);
     }
+    return true;
+  });
+
+  ipcMain.handle("netcatty:setWindowOpacity", (_event, opacity) => {
+    applyWindowOpacity(opacity);
     return true;
   });
 
@@ -1165,4 +1199,7 @@ module.exports = {
   tryOpenExternalWithFallback,
   resolveSettingsWindowBounds,
   THEME_COLORS,
+  clampWindowOpacity,
+  applyWindowOpacity,
+  applyWindowOpacityToWindow,
 };

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -279,6 +279,8 @@ function createMainWindowApi(ctx) {
       } catch {
         // ignore
       }
+
+      applyWindowOpacityToWindow(win);
     
       // Defer show until renderer is ready; use fallback timeout to avoid keeping window hidden forever.
       // Production gets a shorter timeout since the splash screen provides visual feedback.

--- a/electron/bridges/windowManager/settingsWindow.cjs
+++ b/electron/bridges/windowManager/settingsWindow.cjs
@@ -233,6 +233,8 @@ function createSettingsWindowApi(ctx) {
       } catch {
         // ignore
       }
+
+      applyWindowOpacityToWindow(win);
     
       // Hide instead of close so the window can be reused instantly.
       // When the app is quitting, allow normal close/destroy.

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -3,6 +3,8 @@ const assert = require("node:assert/strict");
 
 const {
   buildAppMenu,
+  clampWindowOpacity,
+  applyWindowOpacity,
   isWindowUsable,
   registerMainWindow,
   registerWindowHandlers,
@@ -26,6 +28,44 @@ function createWindowStub({ destroyed = false, webContents } = {}) {
     webContents,
   };
 }
+
+test("clampWindowOpacity keeps values within 0.5 and 1", () => {
+  assert.equal(clampWindowOpacity(1), 1);
+  assert.equal(clampWindowOpacity(0.85), 0.85);
+  assert.equal(clampWindowOpacity(0.3), 0.5);
+  assert.equal(clampWindowOpacity(1.5), 1);
+  assert.equal(clampWindowOpacity("bad"), 1);
+});
+
+test("applyWindowOpacity clamps and applies to registered main windows", () => {
+  const opacityCalls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    setOpacity(value) {
+      opacityCalls.push(value);
+    },
+    webContents: {
+      id: 901,
+      isDestroyed() {
+        return false;
+      },
+    },
+  };
+  registerMainWindow(win);
+
+  try {
+    assert.equal(applyWindowOpacity(0.85), 0.85);
+    assert.deepEqual(opacityCalls, [0.85]);
+
+    assert.equal(applyWindowOpacity(0.2), 0.5);
+    assert.deepEqual(opacityCalls, [0.85, 0.5]);
+  } finally {
+    unregisterMainWindow(win);
+    applyWindowOpacity(1);
+  }
+});
 
 test("isWindowUsable returns false when webContents is crashed", () => {
   const win = createWindowStub({
@@ -312,6 +352,7 @@ test("main window asks renderer to close tabs from macOS Command+W before-input-
     isFullScreen() { return false; }
     getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
     setBackgroundColor() {}
+    setOpacity() {}
     async loadURL() {}
     close() {}
   }
@@ -358,6 +399,7 @@ test("main window asks renderer to close tabs from macOS Command+W before-input-
       return true;
     },
     shouldCloseWindowFromInput,
+    applyWindowOpacityToWindow() {},
     closeSettingsWindow() {},
     hideSettingsWindow() {},
   });
@@ -423,6 +465,7 @@ test("createWindow registers each main window as an independent app window", asy
     isFullScreen() { return false; }
     getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
     setBackgroundColor() {}
+    setOpacity() {}
     async loadURL() {}
     close() {
       this._closedHandler?.();
@@ -476,6 +519,7 @@ test("createWindow registers each main window as an independent app window", asy
     unregisterMainWindow(win) {
       unregistered.push(win);
     },
+    applyWindowOpacityToWindow() {},
     closeSettingsWindow() {},
     hideSettingsWindow() {},
   });
@@ -540,6 +584,7 @@ test("each main window close saves its own state", async () => {
     isFullScreen() { return false; }
     getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
     setBackgroundColor() {}
+    setOpacity() {}
     async loadURL() {}
     close() {}
   }
@@ -591,6 +636,7 @@ test("each main window close saves its own state", async () => {
     shouldCloseWindowFromInput,
     registerMainWindow() {},
     unregisterMainWindow() {},
+    applyWindowOpacityToWindow() {},
     closeSettingsWindow() {},
     hideSettingsWindow() {},
   });
@@ -679,6 +725,26 @@ test("window IPC handlers target the sender owner window", async () => {
 
   assert.equal(titleResult, true);
   assert.deepEqual(titles, ["Prod SSH"]);
+
+  const opacityCalls = [];
+  registerMainWindow({
+    isDestroyed() {
+      return false;
+    },
+    setOpacity(value) {
+      opacityCalls.push(value);
+    },
+    webContents: {
+      id: 303,
+      isDestroyed() {
+        return false;
+      },
+    },
+  });
+
+  const opacityResult = await handlers.get("netcatty:setWindowOpacity")(null, 0.7);
+  assert.equal(opacityResult, true);
+  assert.deepEqual(opacityCalls, [0.7]);
 });
 
 test("resolveSettingsWindowBounds centers settings on the requesting window display", () => {

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -303,6 +303,9 @@ function createPreloadApi(ctx) {
   setBackgroundColor: async (color) => {
     return ipcRenderer.invoke("netcatty:setBackgroundColor", color);
   },
+  setWindowOpacity: async (opacity) => {
+    return ipcRenderer.invoke("netcatty:setWindowOpacity", opacity);
+  },
   setLanguage: async (language) => {
     return ipcRenderer.invoke("netcatty:setLanguage", language);
   },

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -119,7 +119,7 @@ export const STORAGE_KEY_MANAGED_SOURCES = 'netcatty_managed_sources_v1';
 export const STORAGE_KEY_TOGGLE_WINDOW_HOTKEY = 'netcatty_toggle_window_hotkey_v1';
 export const STORAGE_KEY_CLOSE_TO_TRAY = 'netcatty_close_to_tray_v1';
 export const STORAGE_KEY_GLOBAL_HOTKEY_ENABLED = 'netcatty_global_hotkey_enabled_v1';
-
+export const STORAGE_KEY_WINDOW_OPACITY = 'netcatty_window_opacity_v1';
 // Custom Terminal Themes
 export const STORAGE_KEY_CUSTOM_THEMES = 'netcatty_custom_themes_v1';
 

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface NetcattyBridge {
     setTheme?(theme: 'light' | 'dark' | 'system'): Promise<boolean>;
     setBackgroundColor?(color: string): Promise<boolean>;
+    setWindowOpacity?(opacity: number): Promise<boolean>;
     setLanguage?(language: string): Promise<boolean>;
     // Window controls for custom title bar (Windows/Linux)
     windowMinimize?(): Promise<void>;


### PR DESCRIPTION
## Summary
- Add whole-window transparency via Electron `setOpacity` (50–100%), persisted in settings and synced across windows.
- Settings → Appearance slider with 100% / 85% / 70% presets, plus a top-bar droplet quick control.
- Apply opacity when main/settings windows are created and on IPC updates; includes window manager unit tests.

## Test plan
- [x] Restart app, open Settings → Appearance, drag opacity slider and use presets; window fades including terminal text.
- [x] Use top-bar droplet control; value stays in sync with Settings.
- [x] Change opacity in one window; confirm settings window / second main window updates.
- [x] Quit and relaunch; opacity restores from storage.
- [x] macOS / Windows: verify no broken window chrome at 70–85%.


Made with [Cursor](https://cursor.com)