### PR TITLE
fix(linux): restore tray icon context menu for Linux via setContextMenu (#1314)

### DIFF
--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -632,8 +632,15 @@ function createTray() {
       tray.on("right-click", () => {
         toggleTrayPanel();
       });
+    } else if (process.platform === "linux") {
+      // Linux: GtkStatusIcon left-click can toggle the custom panel; StatusNotifier
+      // activation shows the native context menu set via setContextMenu() (there is
+      // no right-click / popUpContextMenu API on Linux — see Electron Tray docs).
+      tray.on("click", () => {
+        toggleTrayPanel();
+      });
     } else {
-      // macOS/Linux: Click toggles custom tray panel
+      // macOS: Click toggles custom tray panel
       tray.on("click", () => {
         toggleTrayPanel();
       });
@@ -746,10 +753,16 @@ function buildTrayMenuTemplate() {
  */
 function updateTrayMenu() {
   if (!tray) return;
-  // Avoid showing a context menu on left-click; we toggle our custom panel instead.
-  // On macOS, right-click may still show a menu if one is set, so we don't set any.
   try {
-    tray.setContextMenu(null);
+    if (process.platform === "linux") {
+      const { Menu } = electronModule;
+      const menu = Menu.buildFromTemplate(buildTrayMenuTemplate());
+      tray.setContextMenu(menu);
+    } else {
+      // Avoid showing a context menu on left-click; we toggle our custom panel instead.
+      // On macOS, right-click may still show a menu if one is set, so we don't set any.
+      tray.setContextMenu(null);
+    }
   } catch {
     // ignore
   }

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -65,10 +65,17 @@ function createElectronStub() {
   class FakeTray {
     constructor() {
       this.handlers = new Map();
+      this.contextMenu = null;
+      this.contextMenuPopped = false;
     }
 
     setToolTip() {}
-    setContextMenu() {}
+    setContextMenu(menu) {
+      this.contextMenu = menu;
+    }
+    popUpContextMenu() {
+      this.contextMenuPopped = true;
+    }
     destroy() {}
 
     on(eventName, handler) {
@@ -78,7 +85,11 @@ function createElectronStub() {
 
   return {
     Tray: FakeTray,
-    Menu: {},
+    Menu: {
+      buildFromTemplate(template) {
+        return { template };
+      },
+    },
     BrowserWindow: {
       getAllWindows() {
         return [];
@@ -496,22 +507,50 @@ test("tray icon event registration is platform-dependent", async () => {
   // Test win32 platform
   await withPlatform("win32", async () => {
     const bridge = loadBridge();
-    const { electronModule } = await enableCloseToTray(bridge);
+    await enableCloseToTray(bridge);
     const trayInstance = bridge.getTray();
     assert.ok(trayInstance, "Tray instance should be created");
     assert.ok(trayInstance.handlers.has("click"), "win32 tray should have click handler");
     assert.ok(trayInstance.handlers.has("right-click"), "win32 tray should have right-click handler");
+    assert.equal(trayInstance.contextMenu, null, "win32 tray should not set a context menu");
+    bridge.cleanup();
+  });
+
+  // Test Linux platform
+  await withPlatform("linux", async () => {
+    const bridge = loadBridge();
+    const { ipcMain } = await enableCloseToTray(bridge);
+    const trayInstance = bridge.getTray();
+    assert.ok(trayInstance, "Tray instance should be created");
+    assert.ok(trayInstance.handlers.has("click"), "linux tray should have click handler");
+    assert.ok(!trayInstance.handlers.has("right-click"), "linux tray should not use right-click handler");
+    assert.ok(trayInstance.contextMenu, "linux tray should have a native context menu");
+    const labels = trayInstance.contextMenu.template.map((item) => item.label);
+    assert.ok(labels.includes("Open Main Window"), "linux context menu should include Open Main Window");
+    assert.ok(labels.includes("Quit"), "linux context menu should include Quit");
+
+    await ipcMain.handlers.get("netcatty:tray:updateMenuData")(null, {
+      sessions: [{ id: "s1", label: "dev", hostLabel: "dev.example", status: "connected" }],
+    });
+    const updatedLabels = trayInstance.contextMenu.template
+      .map((item) => item.label)
+      .filter(Boolean);
+    assert.ok(
+      updatedLabels.some((label) => label.includes("dev.example")),
+      "linux context menu should rebuild when tray menu data changes",
+    );
     bridge.cleanup();
   });
 
   // Test other platform (darwin)
   await withPlatform("darwin", async () => {
     const bridge = loadBridge();
-    const { electronModule } = await enableCloseToTray(bridge);
+    await enableCloseToTray(bridge);
     const trayInstance = bridge.getTray();
     assert.ok(trayInstance, "Tray instance should be created");
     assert.ok(trayInstance.handlers.has("click"), "darwin tray should have click handler");
     assert.ok(!trayInstance.handlers.has("right-click"), "darwin tray should not have right-click handler");
+    assert.equal(trayInstance.contextMenu, null, "darwin tray should not set a context menu");
     bridge.cleanup();
   });
 });


### PR DESCRIPTION
## Problem

Issue #1314: on Ubuntu 22.04, right-clicking the tray icon did not show a menu.

## Root Cause

`updateTrayMenu()` in `electron/bridges/globalShortcutBridge.cjs` forced `setContextMenu(null)` on every platform (commit 41ee8e71), which left Linux tray clicks and right-clicks with no menu feedback.

## Fix

- Add a Linux-specific branch that restores the native context menu with `setContextMenu(buildTrayMenuTemplate())`.
- Include Open Main Window, dynamic session entries, dynamic port-forwarding entries, and Quit.
- Keep left-click behavior on the custom `toggleTrayPanel()` panel.
- Keep Windows and macOS behavior unchanged with `setContextMenu(null)`.
- Add Linux platform tests for menu creation, menu contents, and rebuilding after data updates.

## Notes

Electron does not support `right-click` or `popUpContextMenu` tray events on Linux; those APIs are available only on darwin/win32. This fix uses `setContextMenu()` so the desktop environment can show the native menu through StatusNotifier or GtkStatusIcon.

## Testing

`12 tests, 12 passed` after three clean Cursor review rounds.

Closes #1314