### PR TITLE
feat(settings): unify settings page UI (#1316)

### DIFF
--- a/components/settings/settings-ui.tsx
+++ b/components/settings/settings-ui.tsx
@@ -112,8 +112,67 @@ export const SectionHeader: React.FC<{ title: string; className?: string }> = ({
   className,
 }) => <h3 className={cn("text-sm font-semibold text-foreground mb-3", className)}>{title}</h3>;
 
+/** Section title row → content gap (shared across settings pages). */
+export const settingsSectionGapClassName = "gap-2";
+
+/** Groups a section title (optional icon/actions) with its content at a uniform gap. */
+export const SettingsSection: React.FC<{
+  title?: string;
+  leading?: React.ReactNode;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}> = ({ title, leading, actions, children, className }) => (
+  <section className={cn("flex flex-col", settingsSectionGapClassName, className)}>
+    {(title || leading || actions) && (
+      <div
+        className={cn(
+          "flex min-h-8 items-center gap-2",
+          actions && "justify-between gap-4",
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {leading}
+          {title ? <h3 className="text-sm font-semibold text-foreground">{title}</h3> : null}
+        </div>
+        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      </div>
+    )}
+    {children}
+  </section>
+);
+
+export const settingCardClassName = "rounded-lg border bg-card";
+
+interface SettingCardProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Row list with dividers; vertical spacing comes from SettingRow. */
+  divided?: boolean;
+  /** Free-form content; apply even padding on all sides. */
+  padded?: boolean;
+}
+
+export const SettingCard: React.FC<SettingCardProps> = ({
+  children,
+  className,
+  divided = false,
+  padded = false,
+}) => (
+  <div
+    className={cn(
+      settingCardClassName,
+      padded ? "p-4" : "px-4",
+      divided && "space-y-0 divide-y divide-border",
+      className,
+    )}
+  >
+    {children}
+  </div>
+);
+
 interface SettingRowProps {
-  label: string;
+  label?: string;
   description?: string;
   children: React.ReactNode;
 }
@@ -121,8 +180,10 @@ interface SettingRowProps {
 export const SettingRow: React.FC<SettingRowProps> = ({ label, description, children }) => (
   <div className="flex items-center justify-between py-3 gap-4">
     <div className="flex-1 min-w-0">
-      <div className="text-sm font-medium">{label}</div>
-      {description && <div className="text-xs text-muted-foreground mt-0.5">{description}</div>}
+      {label && <div className="text-sm font-medium">{label}</div>}
+      {description && (
+        <div className={cn("text-xs text-muted-foreground", label && "mt-0.5")}>{description}</div>
+      )}
     </div>
     <div className="shrink-0">{children}</div>
   </div>

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -7,7 +7,7 @@
  *   - CodexConnectionCard, ClaudeCodeCard
  *   - SafetySettings
  */
-import { AlertTriangle, Bot, FolderOpen, Globe, Link, Package, RefreshCcw } from "lucide-react";
+import { AlertTriangle, Bot, FolderOpen, RefreshCcw } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AIPermissionMode,
@@ -20,9 +20,8 @@ import type {
 import type { ManagedAgentKey } from "../../../infrastructure/ai/managedAgents";
 import { PROVIDER_PRESETS } from "../../../infrastructure/ai/types";
 import { useI18n } from "../../../application/i18n/I18nProvider";
-import { TabsContent } from "../../ui/tabs";
 import { Button } from "../../ui/button";
-import { Select, SettingRow } from "../settings-ui";
+import { Select, SettingCard, SettingsSection, SettingsTabContent, SettingRow } from "../settings-ui";
 import { AgentIconBadge } from "../../ai/AgentIconBadge";
 import { canSendWithAgent } from "../../ai/agentSendEligibility";
 
@@ -454,30 +453,11 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   }, []);
 
   return (
-    <TabsContent
-      value="ai"
-      className="data-[state=inactive]:hidden h-full flex flex-col"
-    >
-      <div className="flex-1 overflow-y-auto overflow-x-hidden px-8 py-6">
-        <div className="max-w-2xl space-y-8">
-          {/* Header */}
-          <div>
-            <h2 className="text-xl font-semibold">{t('ai.title')}</h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              {t('ai.description')}
-            </p>
-          </div>
-
-          {/* -- Providers Section -- */}
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Globe size={18} className="text-muted-foreground" />
-                <h3 className="text-base font-medium">{t('ai.providers')}</h3>
-              </div>
-              <AddProviderDropdown onAdd={handleAddProvider} />
-            </div>
-
+    <SettingsTabContent value="ai">
+          <SettingsSection
+            title={t('ai.providers')}
+            actions={<AddProviderDropdown onAdd={handleAddProvider} />}
+          >
             {providers.length === 0 ? (
               <div className="rounded-lg border border-dashed border-border/60 p-6 text-center">
                 <Bot size={24} className="mx-auto text-muted-foreground mb-2" />
@@ -534,15 +514,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                 ))}
               </div>
             )}
-          </div>
+          </SettingsSection>
 
-          {/* -- Codex Section -- */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <ProviderIconBadge providerId="openai" size="sm" />
-              <h3 className="text-base font-medium">{t('ai.codex')}</h3>
-            </div>
-
+          <SettingsSection
+            title={t('ai.codex')}
+            leading={<ProviderIconBadge providerId="openai" size="sm" />}
+          >
             <CodexConnectionCard
               pathInfo={codexPathInfo}
               isResolvingPath={isResolvingCodex}
@@ -559,15 +536,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               onOpenUrl={handleOpenCodexLoginUrl}
               onLogout={() => void handleCodexLogout()}
             />
-          </div>
+          </SettingsSection>
 
-          {/* -- Claude Code Section -- */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <ProviderIconBadge providerId="claude" size="sm" />
-              <h3 className="text-base font-medium">{t('ai.claude.title')}</h3>
-            </div>
-
+          <SettingsSection
+            title={t('ai.claude.title')}
+            leading={<ProviderIconBadge providerId="claude" size="sm" />}
+          >
             <ClaudeCodeCard
               pathInfo={claudePathInfo}
               isResolvingPath={isResolvingClaude}
@@ -581,15 +555,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               envText={claudeEnvText}
               onEnvTextChange={(v) => updateClaudeEnv(claudeConfigDir, claudeSettingsPath, v)}
             />
-          </div>
+          </SettingsSection>
 
-          {/* -- GitHub Copilot CLI Section -- */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <ProviderIconBadge providerId="copilot" size="sm" />
-              <h3 className="text-base font-medium">{t('ai.copilot.title')}</h3>
-            </div>
-
+          <SettingsSection
+            title={t('ai.copilot.title')}
+            leading={<ProviderIconBadge providerId="copilot" size="sm" />}
+          >
             <CopilotCliCard
               pathInfo={copilotPathInfo}
               isResolvingPath={isResolvingCopilot}
@@ -597,21 +568,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               onCustomPathChange={setCopilotCustomPath}
               onRecheckPath={() => void handleCheckCustomPath("copilot")}
             />
-          </div>
+          </SettingsSection>
 
-          {/* -- Default Agent Section -- */}
           {agentOptions.length > 1 && (
-            <div className="space-y-4">
-              <div className="flex items-center gap-2">
-                <Bot size={18} className="text-muted-foreground" />
-                <h3 className="text-base font-medium">{t('ai.defaultAgent')}</h3>
-              </div>
-
-              <div className="bg-muted/30 rounded-lg p-4">
-                <SettingRow
-                  label={t('ai.defaultAgent')}
-                  description={t('ai.defaultAgent.description')}
-                >
+            <SettingsSection title={t('ai.defaultAgent')}>
+              <SettingCard>
+                <SettingRow description={t('ai.defaultAgent.description')}>
                   <Select
                     value={defaultAgentId}
                     options={agentOptions}
@@ -619,21 +581,13 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                     className="w-64"
                   />
                 </SettingRow>
-              </div>
-            </div>
+              </SettingCard>
+            </SettingsSection>
           )}
 
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Link size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t('ai.toolAccess.title')}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4">
-              <SettingRow
-                label={t('ai.toolAccess.mode')}
-                description={t('ai.toolAccess.description')}
-              >
+          <SettingsSection title={t('ai.toolAccess.title')}>
+            <SettingCard>
+              <SettingRow description={t('ai.toolAccess.description')}>
                 <Select
                   value={toolIntegrationMode}
                   options={[
@@ -644,16 +598,13 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                   className="w-48"
                 />
               </SettingRow>
-            </div>
-          </div>
+            </SettingCard>
+          </SettingsSection>
 
-          <div className="space-y-4">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex items-center gap-2">
-                <Package size={18} className="text-muted-foreground" />
-                <h3 className="text-base font-medium">{t('ai.userSkills.title')}</h3>
-              </div>
-              <div className="flex items-center gap-2">
+          <SettingsSection
+            title={t('ai.userSkills.title')}
+            actions={(
+              <>
                 <Button
                   variant="outline"
                   size="sm"
@@ -672,10 +623,10 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                   <FolderOpen size={14} className="mr-2" />
                   {t('ai.userSkills.openFolder')}
                 </Button>
-              </div>
-            </div>
-
-            <div className="rounded-lg bg-muted/30 p-4 space-y-4">
+              </>
+            )}
+          >
+            <SettingCard padded className="space-y-4">
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">
                   {t('ai.userSkills.description')}
@@ -744,10 +695,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
                   {t('ai.userSkills.empty')}
                 </div>
               ) : null}
-            </div>
-          </div>
+            </SettingCard>
+          </SettingsSection>
 
-          {/* -- Web Search Section -- */}
           <WebSearchSettings
             webSearchConfig={webSearchConfig}
             setWebSearchConfig={setWebSearchConfig}
@@ -764,9 +714,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
             maxIterations={maxIterations}
             setMaxIterations={setMaxIterations}
           />
-        </div>
-      </div>
-    </TabsContent>
+    </SettingsTabContent>
   );
 };
 

--- a/components/settings/tabs/SettingsFileAssociationsTab.tsx
+++ b/components/settings/tabs/SettingsFileAssociationsTab.tsx
@@ -2,17 +2,22 @@
  * SettingsFileAssociationsTab - Manage SFTP file opener associations and behavior
  */
 import { FileType, Pencil, Trash2 } from "lucide-react";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useI18n } from "../../../application/i18n/I18nProvider";
 import { useSftpFileAssociations } from "../../../application/state/useSftpFileAssociations";
 import { useSettingsState } from "../../../application/state/useSettingsState";
 import type { FileOpenerType, SystemAppInfo } from "../../../lib/sftpFileUtils";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
-import { cn } from "../../../lib/utils";
 import { Button } from "../../ui/button";
-import { Label } from "../../ui/label";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
-import { SectionHeader, SettingsTabContent } from "../settings-ui";
+import {
+  SectionHeader,
+  SettingCard,
+  SettingsTabContent,
+  SettingRow,
+  Select,
+  Toggle,
+} from "../settings-ui";
 
 const getOpenerLabel = (
   openerType: FileOpenerType,
@@ -36,6 +41,12 @@ export default function SettingsFileAssociationsTab() {
   const [editingExtension, setEditingExtension] = useState<string | null>(null);
   const [isSelectingDefaultApp, setIsSelectingDefaultApp] = useState(false);
 
+  const defaultOpenerValue = useMemo(() => {
+    if (!defaultOpener) return 'ask';
+    if (defaultOpener.openerType === 'builtin-editor') return 'builtin-editor';
+    return 'system-app';
+  }, [defaultOpener]);
+
   const handleRemove = useCallback((extension: string) => {
     if (confirm(t('settings.sftpFileAssociations.removeConfirm', { ext: extension === 'file' ? t('sftp.opener.noExtension') : extension }))) {
       removeAssociation(extension);
@@ -58,6 +69,18 @@ export default function SettingsFileAssociationsTab() {
     }
   }, [setDefaultOpener]);
 
+  const handleDefaultOpenerChange = useCallback((value: string) => {
+    if (value === 'ask') {
+      removeDefaultOpener();
+      return;
+    }
+    if (value === 'builtin-editor') {
+      setDefaultOpener('builtin-editor');
+      return;
+    }
+    void handleSelectDefaultSystemApp();
+  }, [handleSelectDefaultSystemApp, removeDefaultOpener, setDefaultOpener]);
+
   const handleEdit = useCallback(async (extension: string) => {
     setEditingExtension(extension);
     try {
@@ -78,354 +101,90 @@ export default function SettingsFileAssociationsTab() {
 
   return (
     <SettingsTabContent value="file-associations">
-      <div className="space-y-8">
-        {/* Double-click behavior section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.doubleClickBehavior')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.doubleClickBehavior.desc')}
-          </p>
-          <div className="space-y-3">
-            <button
-              onClick={() => setSftpDoubleClickBehavior('open')}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                sftpDoubleClickBehavior === 'open'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  sftpDoubleClickBehavior === 'open'
-                    ? "border-primary"
-                    : "border-muted-foreground/30"
-                )}>
-                  {sftpDoubleClickBehavior === 'open' && (
-                    <div className="h-2.5 w-2.5 rounded-full bg-primary" />
-                  )}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('settings.sftp.doubleClickBehavior.open')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.doubleClickBehavior.openDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-            <button
-              onClick={() => setSftpDoubleClickBehavior('transfer')}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                sftpDoubleClickBehavior === 'transfer'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  sftpDoubleClickBehavior === 'transfer'
-                    ? "border-primary"
-                    : "border-muted-foreground/30"
-                )}>
-                  {sftpDoubleClickBehavior === 'transfer' && (
-                    <div className="h-2.5 w-2.5 rounded-full bg-primary" />
-                  )}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('settings.sftp.doubleClickBehavior.transfer')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.doubleClickBehavior.transferDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-          </div>
-        </div>
+      <SectionHeader title={t('settings.sftp.doubleClickBehavior')} />
+      <SettingCard>
+        <SettingRow description={t('settings.sftp.doubleClickBehavior.desc')}>
+          <Select
+            value={sftpDoubleClickBehavior}
+            options={[
+              { value: 'open', label: t('settings.sftp.doubleClickBehavior.open') },
+              { value: 'transfer', label: t('settings.sftp.doubleClickBehavior.transfer') },
+            ]}
+            onChange={(value) => setSftpDoubleClickBehavior(value as 'open' | 'transfer')}
+            className="w-48"
+          />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Default view mode section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.defaultViewMode')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.defaultViewMode.desc')}
-          </p>
-          <div className="space-y-3">
-            <button
-              onClick={() => setSftpDefaultViewMode('list')}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                sftpDefaultViewMode === 'list'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  sftpDefaultViewMode === 'list'
-                    ? "border-primary"
-                    : "border-muted-foreground/30"
-                )}>
-                  {sftpDefaultViewMode === 'list' && (
-                    <div className="h-2.5 w-2.5 rounded-full bg-primary" />
-                  )}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('settings.sftp.defaultViewMode.list')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.defaultViewMode.listDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-            <button
-              onClick={() => setSftpDefaultViewMode('tree')}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                sftpDefaultViewMode === 'tree'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  sftpDefaultViewMode === 'tree'
-                    ? "border-primary"
-                    : "border-muted-foreground/30"
-                )}>
-                  {sftpDefaultViewMode === 'tree' && (
-                    <div className="h-2.5 w-2.5 rounded-full bg-primary" />
-                  )}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('settings.sftp.defaultViewMode.tree')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.defaultViewMode.treeDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-          </div>
-        </div>
+      <SectionHeader title={t('settings.sftp.defaultViewMode')} />
+      <SettingCard>
+        <SettingRow description={t('settings.sftp.defaultViewMode.desc')}>
+          <Select
+            value={sftpDefaultViewMode}
+            options={[
+              { value: 'list', label: t('settings.sftp.defaultViewMode.list') },
+              { value: 'tree', label: t('settings.sftp.defaultViewMode.tree') },
+            ]}
+            onChange={(value) => setSftpDefaultViewMode(value as 'list' | 'tree')}
+            className="w-48"
+          />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Auto-sync section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.autoSync')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.autoSync.desc')}
-          </p>
-          <button
-            onClick={() => setSftpAutoSync(!sftpAutoSync)}
-            className={cn(
-              "w-full text-left p-4 rounded-lg border-2 transition-colors",
-              sftpAutoSync
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/50 hover:bg-secondary/50"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div className={cn(
-                "h-5 w-5 rounded border-2 flex items-center justify-center mt-0.5 shrink-0",
-                sftpAutoSync
-                  ? "border-primary bg-primary"
-                  : "border-muted-foreground/30"
-              )}>
-                {sftpAutoSync && (
-                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </div>
-              <div className="space-y-1">
-                <Label className="font-medium cursor-pointer">
-                  {t('settings.sftp.autoSync.enable')}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.sftp.autoSync.enableDesc')}
-                </p>
-              </div>
-            </div>
-          </button>
-        </div>
+      <SectionHeader title={t('settings.sftp.showHiddenFiles')} />
+      <SettingCard>
+        <SettingRow
+          label={t('settings.sftp.showHiddenFiles.enable')}
+          description={t('settings.sftp.showHiddenFiles.enableDesc')}
+        >
+          <Toggle checked={sftpShowHiddenFiles} onChange={setSftpShowHiddenFiles} />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Show hidden files section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.showHiddenFiles')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.showHiddenFiles.desc')}
-          </p>
-          <button
-            onClick={() => setSftpShowHiddenFiles(!sftpShowHiddenFiles)}
-            className={cn(
-              "w-full text-left p-4 rounded-lg border-2 transition-colors",
-              sftpShowHiddenFiles
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/50 hover:bg-secondary/50"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div className={cn(
-                "h-5 w-5 rounded border-2 flex items-center justify-center mt-0.5 shrink-0",
-                sftpShowHiddenFiles
-                  ? "border-primary bg-primary"
-                  : "border-muted-foreground/30"
-              )}>
-                {sftpShowHiddenFiles && (
-                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </div>
-              <div className="space-y-1">
-                <Label className="font-medium cursor-pointer">
-                  {t('settings.sftp.showHiddenFiles.enable')}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.sftp.showHiddenFiles.enableDesc')}
-                </p>
-              </div>
-            </div>
-          </button>
-        </div>
+      <SectionHeader title={t('settings.sftp.autoSync')} />
+      <SettingCard>
+        <SettingRow
+          label={t('settings.sftp.autoSync.enable')}
+          description={t('settings.sftp.autoSync.enableDesc')}
+        >
+          <Toggle checked={sftpAutoSync} onChange={setSftpAutoSync} />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Compressed folder upload section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.compressedUpload')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.compressedUpload.desc')}
-          </p>
-          <button
-            onClick={() => setSftpUseCompressedUpload(!sftpUseCompressedUpload)}
-            className={cn(
-              "w-full text-left p-4 rounded-lg border-2 transition-colors",
-              sftpUseCompressedUpload
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/50 hover:bg-secondary/50"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div className={cn(
-                "h-5 w-5 rounded border-2 flex items-center justify-center mt-0.5 shrink-0",
-                sftpUseCompressedUpload
-                  ? "border-primary bg-primary"
-                  : "border-muted-foreground/30"
-              )}>
-                {sftpUseCompressedUpload && (
-                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </div>
-              <div className="space-y-1">
-                <Label className="font-medium cursor-pointer">
-                  {t('settings.sftp.compressedUpload.enable')}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.sftp.compressedUpload.enableDesc')}
-                </p>
-              </div>
-            </div>
-          </button>
-        </div>
+      <SectionHeader title={t('settings.sftp.compressedUpload')} />
+      <SettingCard>
+        <SettingRow
+          label={t('settings.sftp.compressedUpload.enable')}
+          description={t('settings.sftp.compressedUpload.enableDesc')}
+        >
+          <Toggle checked={sftpUseCompressedUpload} onChange={setSftpUseCompressedUpload} />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Follow terminal directory section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.followTerminalCwd')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.followTerminalCwd.desc')}
-          </p>
-          <button
-            onClick={() => setSftpFollowTerminalCwd(!sftpFollowTerminalCwd)}
-            className={cn(
-              "w-full text-left p-4 rounded-lg border-2 transition-colors",
-              sftpFollowTerminalCwd
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/50 hover:bg-secondary/50"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div className={cn(
-                "h-5 w-5 rounded border-2 flex items-center justify-center mt-0.5 shrink-0",
-                sftpFollowTerminalCwd
-                  ? "border-primary bg-primary"
-                  : "border-muted-foreground/30"
-              )}>
-                {sftpFollowTerminalCwd && (
-                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </div>
-              <div className="space-y-1">
-                <Label className="font-medium cursor-pointer">
-                  {t('settings.sftp.followTerminalCwd.enable')}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.sftp.followTerminalCwd.enableDesc')}
-                </p>
-              </div>
-            </div>
-          </button>
-        </div>
+      <SectionHeader title={t('settings.sftp.followTerminalCwd')} />
+      <SettingCard>
+        <SettingRow
+          label={t('settings.sftp.followTerminalCwd.enable')}
+          description={t('settings.sftp.followTerminalCwd.enableDesc')}
+        >
+          <Toggle checked={sftpFollowTerminalCwd} onChange={setSftpFollowTerminalCwd} />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Auto-open sidebar section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.autoOpenSidebar')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.autoOpenSidebar.desc')}
-          </p>
-          <button
-            onClick={() => setSftpAutoOpenSidebar(!sftpAutoOpenSidebar)}
-            className={cn(
-              "w-full text-left p-4 rounded-lg border-2 transition-colors",
-              sftpAutoOpenSidebar
-                ? "border-primary bg-primary/5"
-                : "border-border hover:border-primary/50 hover:bg-secondary/50"
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div className={cn(
-                "h-5 w-5 rounded border-2 flex items-center justify-center mt-0.5 shrink-0",
-                sftpAutoOpenSidebar
-                  ? "border-primary bg-primary"
-                  : "border-muted-foreground/30"
-              )}>
-                {sftpAutoOpenSidebar && (
-                  <svg className="h-3 w-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </div>
-              <div className="space-y-1">
-                <Label className="font-medium cursor-pointer">
-                  {t('settings.sftp.autoOpenSidebar.enable')}
-                </Label>
-                <p className="text-sm text-muted-foreground">
-                  {t('settings.sftp.autoOpenSidebar.enableDesc')}
-                </p>
-              </div>
-            </div>
-          </button>
-        </div>
+      <SectionHeader title={t('settings.sftp.autoOpenSidebar')} />
+      <SettingCard>
+        <SettingRow
+          label={t('settings.sftp.autoOpenSidebar.enable')}
+          description={t('settings.sftp.autoOpenSidebar.enableDesc')}
+        >
+          <Toggle checked={sftpAutoOpenSidebar} onChange={setSftpAutoOpenSidebar} />
+        </SettingRow>
+      </SettingCard>
 
-        {/* Transfer concurrency section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.transferConcurrency')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.transferConcurrency.desc')}
-          </p>
-          <div className="flex items-center gap-3">
+      <SectionHeader title={t('settings.sftp.transferConcurrency')} />
+      <SettingCard>
+        <SettingRow description={t('settings.sftp.transferConcurrency.desc')}>
+          <div className="flex items-center gap-2">
             <input
               type="range"
               min={1}
@@ -433,188 +192,133 @@ export default function SettingsFileAssociationsTab() {
               step={1}
               value={sftpTransferConcurrency}
               onChange={(e) => setSftpTransferConcurrency(Number(e.target.value))}
-              className="flex-1 accent-primary"
+              className="w-40 accent-primary"
             />
-            <span className="text-sm font-mono w-6 text-center">{sftpTransferConcurrency}</span>
+            <span className="text-sm text-muted-foreground w-6 text-center tabular-nums">
+              {sftpTransferConcurrency}
+            </span>
           </div>
-        </div>
+        </SettingRow>
+      </SettingCard>
 
-        {/* Default opener section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftp.defaultOpener')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftp.defaultOpener.desc')}
-          </p>
-          <div className="space-y-3">
-            <button
-              onClick={() => removeDefaultOpener()}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                !defaultOpener
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  !defaultOpener ? "border-primary" : "border-muted-foreground/30"
-                )}>
-                  {!defaultOpener && <div className="h-2.5 w-2.5 rounded-full bg-primary" />}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('settings.sftp.defaultOpener.ask')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.defaultOpener.askDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-            <button
-              onClick={() => setDefaultOpener('builtin-editor')}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                defaultOpener?.openerType === 'builtin-editor'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  defaultOpener?.openerType === 'builtin-editor' ? "border-primary" : "border-muted-foreground/30"
-                )}>
-                  {defaultOpener?.openerType === 'builtin-editor' && <div className="h-2.5 w-2.5 rounded-full bg-primary" />}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {t('sftp.opener.builtInEditor')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.defaultOpener.builtInDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
-            <button
-              onClick={handleSelectDefaultSystemApp}
-              disabled={isSelectingDefaultApp}
-              className={cn(
-                "w-full text-left p-4 rounded-lg border-2 transition-colors",
-                defaultOpener?.openerType === 'system-app'
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:border-primary/50 hover:bg-secondary/50"
-              )}
-            >
-              <div className="flex items-start gap-3">
-                <div className={cn(
-                  "h-5 w-5 rounded-full border-2 flex items-center justify-center mt-0.5 shrink-0",
-                  defaultOpener?.openerType === 'system-app' ? "border-primary" : "border-muted-foreground/30"
-                )}>
-                  {defaultOpener?.openerType === 'system-app' && <div className="h-2.5 w-2.5 rounded-full bg-primary" />}
-                </div>
-                <div className="space-y-1">
-                  <Label className="font-medium cursor-pointer">
-                    {defaultOpener?.openerType === 'system-app' && defaultOpener.systemApp
+      <SectionHeader title={t('settings.sftp.defaultOpener')} />
+      <SettingCard>
+        <SettingRow description={t('settings.sftp.defaultOpener.desc')}>
+          <div className="flex flex-col items-end gap-2">
+            <Select
+              value={defaultOpenerValue}
+              options={[
+                { value: 'ask', label: t('settings.sftp.defaultOpener.ask') },
+                { value: 'builtin-editor', label: t('sftp.opener.builtInEditor') },
+                {
+                  value: 'system-app',
+                  label:
+                    defaultOpener?.openerType === 'system-app' && defaultOpener.systemApp
                       ? defaultOpener.systemApp.name
-                      : t('settings.sftp.defaultOpener.systemApp')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.sftp.defaultOpener.systemAppDesc')}
-                  </p>
-                </div>
-              </div>
-            </button>
+                      : t('settings.sftp.defaultOpener.systemApp'),
+                },
+              ]}
+              onChange={handleDefaultOpenerChange}
+              className="w-56"
+              disabled={isSelectingDefaultApp}
+            />
+            {defaultOpener?.openerType === 'system-app' && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleSelectDefaultSystemApp()}
+                disabled={isSelectingDefaultApp}
+              >
+                {t('settings.sftp.defaultOpener.systemApp')}
+              </Button>
+            )}
           </div>
-        </div>
+        </SettingRow>
+      </SettingCard>
 
-        {/* File associations section */}
-        <div className="space-y-4">
-          <SectionHeader title={t('settings.sftpFileAssociations.title')} />
-          <p className="text-sm text-muted-foreground">
-            {t('settings.sftpFileAssociations.desc')}
-          </p>
+      <SectionHeader title={t('settings.sftpFileAssociations.title')} />
+      <p className="text-xs text-muted-foreground -mt-3 mb-1">
+        {t('settings.sftpFileAssociations.desc')}
+      </p>
 
-        {associations.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+      {associations.length === 0 ? (
+        <SettingCard className="py-12">
+          <div className="flex flex-col items-center justify-center text-muted-foreground">
             <FileType size={48} strokeWidth={1} className="mb-4 opacity-50" />
             <p className="text-sm">{t('settings.sftpFileAssociations.noAssociations')}</p>
           </div>
-        ) : (
-          <div className="border border-border rounded-md overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-muted/50 border-b border-border">
-                  <th className="text-left px-4 py-2 font-medium">
-                    {t('settings.sftpFileAssociations.extension')}
-                  </th>
-                  <th className="text-left px-4 py-2 font-medium">
-                    {t('settings.sftpFileAssociations.application')}
-                  </th>
-                  <th className="text-right px-4 py-2 font-medium w-28">
-                    {/* Actions */}
-                  </th>
+        </SettingCard>
+      ) : (
+        <div className="rounded-lg border bg-card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-muted/50 border-b border-border">
+                <th className="text-left px-4 py-2 font-medium">
+                  {t('settings.sftpFileAssociations.extension')}
+                </th>
+                <th className="text-left px-4 py-2 font-medium">
+                  {t('settings.sftpFileAssociations.application')}
+                </th>
+                <th className="text-right px-4 py-2 font-medium w-28">
+                  {/* Actions */}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {associations.map(({ extension, openerType, systemApp }) => (
+                <tr key={extension} className="border-b border-border last:border-b-0 hover:bg-muted/30">
+                  <td className="px-4 py-3">
+                    <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                      {extension === 'file' ? t('sftp.opener.noExtension') : `.${extension}`}
+                    </code>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {openerType === 'system-app' && systemApp ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="cursor-default">{systemApp.name}</span>
+                        </TooltipTrigger>
+                        <TooltipContent>{systemApp.path}</TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      getOpenerLabel(openerType, systemApp, t)
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right space-x-1">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => handleEdit(extension)}
+                          disabled={editingExtension === extension}
+                        >
+                          <Pencil size={14} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('common.edit')}</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
+                          onClick={() => handleRemove(extension)}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('settings.sftpFileAssociations.remove')}</TooltipContent>
+                    </Tooltip>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {associations.map(({ extension, openerType, systemApp }) => (
-                  <tr key={extension} className="border-b border-border last:border-b-0 hover:bg-muted/30">
-                    <td className="px-4 py-3">
-                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                        {extension === 'file' ? t('sftp.opener.noExtension') : `.${extension}`}
-                      </code>
-                    </td>
-                    <td className="px-4 py-3 text-muted-foreground">
-                      {openerType === 'system-app' && systemApp ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="cursor-default">{systemApp.name}</span>
-                          </TooltipTrigger>
-                          <TooltipContent>{systemApp.path}</TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        getOpenerLabel(openerType, systemApp, t)
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-right space-x-1">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            onClick={() => handleEdit(extension)}
-                            disabled={editingExtension === extension}
-                          >
-                            <Pencil size={14} />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>{t('common.edit')}</TooltipContent>
-                      </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
-                            onClick={() => handleRemove(extension)}
-                          >
-                            <Trash2 size={14} />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>{t('settings.sftpFileAssociations.remove')}</TooltipContent>
-                      </Tooltip>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+              ))}
+            </tbody>
+          </table>
         </div>
-      </div>
+      )}
     </SettingsTabContent>
   );
 }

--- a/components/settings/tabs/SettingsSystemTab.tsx
+++ b/components/settings/tabs/SettingsSystemTab.tsx
@@ -1,17 +1,16 @@
 /**
  * Settings System Tab - System information, temp file management, session logs, and global hotkey
  */
-import { AlertTriangle, ChevronDown, ChevronRight, Download, ExternalLink, FileText, FolderOpen, HardDrive, Keyboard, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Download, ExternalLink, FolderOpen, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
 import { useI18n } from "../../../application/i18n/I18nProvider";
 import { getCredentialProtectionAvailability } from "../../../infrastructure/services/credentialProtection";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import type { UpdateState } from '../../../application/state/useUpdateCheck';
 import { SessionLogFormat, keyEventToString } from "../../../domain/models";
-import { TabsContent } from "../../ui/tabs";
 import { Button } from "../../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
-import { Toggle, Select, SettingRow } from "../settings-ui";
+import { Toggle, Select, SettingRow, SectionHeader, SettingCard, SettingsTabContent } from "../settings-ui";
 import { cn } from "../../../lib/utils";
 
 interface CrashLogFile {
@@ -392,27 +391,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
   ];
 
   return (
-    <TabsContent
-      value="system"
-      className="data-[state=inactive]:hidden h-full flex flex-col"
-    >
-      <div className="flex-1 overflow-y-auto overflow-x-hidden px-8 py-6">
-        <div className="max-w-2xl space-y-8">
-          {/* Header */}
-          <div>
-            <h2 className="text-xl font-semibold">{t("settings.system.title")}</h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              {t("settings.system.description")}
-            </p>
-          </div>
-
-          {/* Software Update Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Download size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t('settings.update.title')}</h3>
-            </div>
-            <div className="rounded-lg border border-border/60 p-4 space-y-3">
+    <SettingsTabContent value="system">
+          <SectionHeader title={t('settings.update.title')} />
+            <SettingCard className="space-y-3 py-4">
               {/* Current version */}
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
@@ -525,16 +506,16 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   </Button>
                 )}
               </div>
-            </div>
-            <SettingRow
-              label={t('settings.update.autoUpdateEnabled')}
-              description={t('settings.update.autoUpdateEnabledDesc')}
-            >
-              <Toggle
-                checked={autoUpdateEnabled}
-                onChange={setAutoUpdateEnabled}
-              />
-            </SettingRow>
+              <SettingRow
+                label={t('settings.update.autoUpdateEnabled')}
+                description={t('settings.update.autoUpdateEnabledDesc')}
+              >
+                <Toggle
+                  checked={autoUpdateEnabled}
+                  onChange={setAutoUpdateEnabled}
+                />
+              </SettingRow>
+            </SettingCard>
             <p className="text-xs text-muted-foreground">
               {updateState.lastCheckedAt && (
                 <span>
@@ -545,16 +526,9 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               )}
               {t('settings.update.hint')}
             </p>
-          </div>
 
-          {/* Credential Protection Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <HardDrive size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.system.credentials.title")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-3">
+          <SectionHeader title={t("settings.system.credentials.title")} />
+            <SettingCard className="space-y-3 py-4">
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <p className="text-sm text-muted-foreground">
@@ -597,17 +571,10 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
               <p className="text-xs text-muted-foreground">
                 {t("settings.system.credentials.portabilityHint")}
               </p>
-            </div>
-          </div>
+            </SettingCard>
 
-          {/* Crash Logs Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <AlertTriangle size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.system.crashLogs.title")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-3">
+          <SectionHeader title={t("settings.system.crashLogs.title")} />
+            <SettingCard className="space-y-3 py-4">
               <p className="text-sm text-muted-foreground">
                 {t("settings.system.crashLogs.description")}
               </p>
@@ -744,21 +711,14 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   {t("settings.system.crashLogs.cleared").replace("{count}", String(crashLogClearResult.deletedCount))}
                 </p>
               )}
-            </div>
+            </SettingCard>
 
             <p className="text-xs text-muted-foreground">
               {t("settings.system.crashLogs.hint")}
             </p>
-          </div>
 
-          {/* Temp Directory Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <HardDrive size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.system.tempDirectory")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-3">
+          <SectionHeader title={t("settings.system.tempDirectory")} />
+            <SettingCard className="space-y-3 py-4">
               {/* Path */}
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0 flex-1">
@@ -832,21 +792,14 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   })}
                 </p>
               )}
-            </div>
+            </SettingCard>
 
             <p className="text-xs text-muted-foreground">
               {t("settings.system.tempDirectoryHint")}
             </p>
-          </div>
 
-          {/* Session Logs Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <FileText size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.sessionLogs.title")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-4">
+          <SectionHeader title={t("settings.sessionLogs.title")} />
+            <SettingCard className="space-y-4 py-4">
               {/* Enable Toggle */}
               <SettingRow
                 label={t("settings.sessionLogs.enableAutoSave")}
@@ -922,21 +875,14 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   disabled={!sessionLogsEnabled}
                 />
               </SettingRow>
-            </div>
+            </SettingCard>
 
             <p className="text-xs text-muted-foreground">
               {t("settings.sessionLogs.hint")}
             </p>
-          </div>
 
-          {/* SSH Debug Logs Section */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <FileText size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.sshDebugLogs.title")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-4">
+          <SectionHeader title={t("settings.sshDebugLogs.title")} />
+            <SettingCard className="space-y-4 py-4">
               <SettingRow
                 label={t("settings.sshDebugLogs.enable")}
                 description={t("settings.sshDebugLogs.enableDesc")}
@@ -989,21 +935,14 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   </span>
                 </div>
               </div>
-            </div>
+            </SettingCard>
 
             <p className="text-xs text-muted-foreground">
               {t("settings.sshDebugLogs.hint")}
             </p>
-          </div>
 
-          {/* Global Toggle Window Section (Quake Mode) */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <Keyboard size={18} className="text-muted-foreground" />
-              <h3 className="text-base font-medium">{t("settings.globalHotkey.title")}</h3>
-            </div>
-
-            <div className="bg-muted/30 rounded-lg p-4 space-y-4">
+          <SectionHeader title={t("settings.globalHotkey.title")} />
+            <SettingCard className="space-y-4 py-4">
               {/* Enable/Disable Global Hotkey */}
               <SettingRow
                 label={t('settings.globalHotkey.enabled')}
@@ -1068,15 +1007,12 @@ const SettingsSystemTab: React.FC<SettingsSystemTabProps> = ({
                   onChange={setCloseToTray}
                 />
               </SettingRow>
-            </div>
+            </SettingCard>
 
             <p className="text-xs text-muted-foreground">
               {t("settings.globalHotkey.hint")}
             </p>
-          </div>
-        </div>
-      </div>
-    </TabsContent>
+    </SettingsTabContent>
   );
 };
 

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -885,7 +885,7 @@ export default function SettingsTerminalTab(props: {
       </div>
       {/* Autocomplete */}
       <SectionHeader title={t("settings.terminal.section.workspaceFocus")} />
-      <div className="space-y-1">
+      <div className="space-y-0 divide-y divide-border rounded-lg border bg-card px-4">
         <SettingRow
           label={t("settings.terminal.workspaceFocus.style")}
           description={t("settings.terminal.workspaceFocus.style.desc")}
@@ -897,6 +897,7 @@ export default function SettingsTerminalTab(props: {
               { value: 'dim', label: t("settings.terminal.workspaceFocus.dim") },
               { value: 'border', label: t("settings.terminal.workspaceFocus.border") },
             ]}
+            className="w-40"
           />
         </SettingRow>
       </div>

--- a/components/settings/tabs/ai/ClaudeCodeCard.tsx
+++ b/components/settings/tabs/ai/ClaudeCodeCard.tsx
@@ -4,7 +4,6 @@ import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
 import type { AgentPathInfo } from "./types";
-import { ProviderIconBadge } from "./ProviderIconBadge";
 import { parseEnvLines, serializeEnvLines } from "./claudeConfigEnv";
 
 export const ClaudeCodeCard: React.FC<{
@@ -65,17 +64,11 @@ export const ClaudeCodeCard: React.FC<{
       : "text-amber-500";
 
   return (
-    <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3">
+    <div className="rounded-lg border bg-card p-4 space-y-3">
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <ProviderIconBadge providerId="claude" size="sm" />
-            <span className="text-sm font-medium">{t('ai.claude.title')}</span>
-          </div>
-          <p className="text-xs text-muted-foreground mt-2 leading-5">
-            {t('ai.claude.description')}
-          </p>
-        </div>
+        <p className="min-w-0 text-xs text-muted-foreground leading-5">
+          {t('ai.claude.description')}
+        </p>
         <div className={cn("text-xs font-medium shrink-0", statusClassName)}>
           {statusText}
         </div>

--- a/components/settings/tabs/ai/CodexConnectionCard.tsx
+++ b/components/settings/tabs/ai/CodexConnectionCard.tsx
@@ -4,7 +4,6 @@ import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
 import type { AgentPathInfo, CodexIntegrationStatus, CodexLoginSession } from "./types";
-import { ProviderIconBadge } from "./ProviderIconBadge";
 
 export const CodexConnectionCard: React.FC<{
   pathInfo: AgentPathInfo | null;
@@ -87,17 +86,11 @@ export const CodexConnectionCard: React.FC<{
         : "";
 
   return (
-    <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3">
+    <div className="rounded-lg border bg-card p-4 space-y-3">
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <ProviderIconBadge providerId="openai" size="sm" />
-            <span className="text-sm font-medium">{t('ai.codex.title')}</span>
-          </div>
-          <p className="text-xs text-muted-foreground mt-2 leading-5">
-            {t('ai.codex.description')}
-          </p>
-        </div>
+        <p className="min-w-0 text-xs text-muted-foreground leading-5">
+          {t('ai.codex.description')}
+        </p>
         <div className={cn("text-xs font-medium shrink-0", statusClassName)}>
           {status}
         </div>

--- a/components/settings/tabs/ai/CopilotCliCard.tsx
+++ b/components/settings/tabs/ai/CopilotCliCard.tsx
@@ -4,7 +4,6 @@ import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
 import { cn } from "../../../../lib/utils";
 import type { AgentPathInfo } from "./types";
-import { ProviderIconBadge } from "./ProviderIconBadge";
 
 export const CopilotCliCard: React.FC<{
   pathInfo: AgentPathInfo | null;
@@ -35,17 +34,11 @@ export const CopilotCliCard: React.FC<{
       : "text-amber-500";
 
   return (
-    <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3">
+    <div className="rounded-lg border bg-card p-4 space-y-3">
       <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <ProviderIconBadge providerId="copilot" size="sm" />
-            <span className="text-sm font-medium">{t('ai.copilot.title')}</span>
-          </div>
-          <p className="text-xs text-muted-foreground mt-2 leading-5">
-            {t('ai.copilot.description')}
-          </p>
-        </div>
+        <p className="min-w-0 text-xs text-muted-foreground leading-5">
+          {t('ai.copilot.description')}
+        </p>
         <div className={cn("text-xs font-medium shrink-0", statusClassName)}>
           {statusText}
         </div>

--- a/components/settings/tabs/ai/ProviderCard.tsx
+++ b/components/settings/tabs/ai/ProviderCard.tsx
@@ -25,7 +25,7 @@ export const ProviderCard: React.FC<{
     <div
       className={cn(
         "rounded-lg border p-4 transition-colors",
-        isActive ? "border-primary/50 bg-primary/5" : "border-border/60 bg-muted/20",
+        isActive ? "border-primary/50 bg-primary/5" : "border-border bg-card",
       )}
     >
       <div className="flex items-center gap-3">

--- a/components/settings/tabs/ai/SafetySettings.tsx
+++ b/components/settings/tabs/ai/SafetySettings.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useState } from "react";
-import { Plus, Shield, X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import type { AIPermissionMode } from "../../../../infrastructure/ai/types";
 import { DEFAULT_COMMAND_BLOCKLIST } from "../../../../infrastructure/ai/types";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
 import { Button } from "../../../ui/button";
-import { Select, SettingRow } from "../../settings-ui";
+import { Select, SettingCard, SettingRow, SettingsSection } from "../../settings-ui";
 
 export const SafetySettings: React.FC<{
   globalPermissionMode: AIPermissionMode;
@@ -68,13 +68,9 @@ export const SafetySettings: React.FC<{
   ];
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
-        <Shield size={18} className="text-muted-foreground" />
-        <h3 className="text-base font-medium">{t('ai.safety.title')}</h3>
-      </div>
-
-      <div className="bg-muted/30 rounded-lg p-4 space-y-1">
+    <SettingsSection title={t('ai.safety.title')}>
+      <div className="flex flex-col gap-4">
+        <SettingCard divided>
         <SettingRow
           label={t('ai.safety.permissionMode')}
           description={t('ai.safety.permissionMode.description')}
@@ -123,10 +119,10 @@ export const SafetySettings: React.FC<{
             className="w-20 h-9 rounded-md border border-input bg-background px-3 text-sm text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />
         </SettingRow>
-      </div>
+        </SettingCard>
 
       {/* Command Blocklist */}
-      <div className="bg-muted/30 rounded-lg p-4 space-y-3">
+      <SettingCard padded className="space-y-3">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-sm font-medium">{t('ai.safety.blocklist')}</p>
@@ -194,11 +190,12 @@ export const SafetySettings: React.FC<{
           <Plus size={14} className="mr-1" />
           {t('ai.safety.blocklist.add')}
         </Button>
-      </div>
+      </SettingCard>
 
-      <p className="text-xs text-muted-foreground">
-        {t('ai.safety.note')}
-      </p>
-    </div>
+        <p className="text-xs text-muted-foreground">
+          {t('ai.safety.note')}
+        </p>
+      </div>
+    </SettingsSection>
   );
 };

--- a/components/settings/tabs/ai/WebSearchSettings.tsx
+++ b/components/settings/tabs/ai/WebSearchSettings.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Globe, Eye, EyeOff } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
 import type { WebSearchConfig, WebSearchProviderId } from "../../../../infrastructure/ai/types";
 import { WEB_SEARCH_PROVIDER_PRESETS } from "../../../../infrastructure/ai/types";
 import { encryptField, decryptField } from "../../../../infrastructure/persistence/secureFieldAdapter";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
-import { Select, SettingRow } from "../../settings-ui";
+import { Select, SettingCard, SettingRow, SettingsSection, Toggle } from "../../settings-ui";
 
 const SEARCH_ICON_PATHS: Record<WebSearchProviderId, string> = {
   tavily: "/ai/search/tavily.svg",
@@ -114,27 +114,16 @@ export const WebSearchSettings: React.FC<{
   }, [apiKeyInput, updateConfig]);
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
-        <Globe size={18} className="text-muted-foreground" />
-        <h3 className="text-base font-medium">{t("ai.webSearch.title")}</h3>
-      </div>
-
-      <div className="bg-muted/30 rounded-lg p-4 space-y-1">
-        {/* Enable/Disable */}
+    <SettingsSection title={t("ai.webSearch.title")}>
+      <SettingCard divided>
         <SettingRow
           label={t("ai.webSearch.enable")}
           description={t("ai.webSearch.enable.description")}
         >
-          <label className="relative inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={config.enabled}
-              onChange={(e) => updateConfig({ enabled: e.target.checked })}
-              className="sr-only peer"
-            />
-            <div className="w-9 h-5 bg-muted-foreground/20 peer-focus-visible:ring-2 peer-focus-visible:ring-ring rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border after:border-gray-300 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-primary" />
-          </label>
+          <Toggle
+            checked={config.enabled}
+            onChange={(enabled) => updateConfig({ enabled })}
+          />
         </SettingRow>
 
         {/* Provider */}
@@ -214,7 +203,7 @@ export const WebSearchSettings: React.FC<{
             className="w-20 h-9 rounded-md border border-input bg-background px-3 text-sm text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           />
         </SettingRow>
-      </div>
-    </div>
+      </SettingCard>
+    </SettingsSection>
   );
 };


### PR DESCRIPTION
## Summary
- Introduce shared `SettingCard`, `SettingsSection`, and optional `padded` card padding in `settings-ui.tsx` for consistent section title → content spacing
- Unify AI, SFTP, system, and terminal settings tabs to white-card + `SettingRow` + `Toggle`/`Select` pattern (replaces gray muted cards and SFTP radio-card selectors)
- Remove duplicate in-card titles for Codex / Claude / Copilot agent cards; align Command Blocklist and User Skills card padding

## Test plan
- [x] `npm run lint`
- [x] Open Settings → AI tab: verify section spacing, agent cards, default agent, tool access, user skills, web search, safety/blocklist padding
- [x] Open Settings → SFTP tab: verify toggles/selects including follow terminal CWD
- [x] Open Settings → System tab: verify update, logs, hotkey sections render correctly
- [x] Open Settings → Terminal tab: workspace focus style card

Closes #1316

Made with [Cursor](https://cursor.com)