### PR TITLE
fix(sftp): leave Always Open With unchecked for extensionless files

### DIFF
--- a/components/FileOpenerDialog.tsx
+++ b/components/FileOpenerDialog.tsx
@@ -2,10 +2,10 @@
  * FileOpenerDialog - Dialog for choosing how to open a file
  */
 import { Edit2, FolderOpen } from 'lucide-react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import type { FileOpenerType, SystemAppInfo } from '../lib/sftpFileUtils';
-import { getFileExtension, isKnownBinaryFile } from '../lib/sftpFileUtils';
+import { getFileExtension, hasFileExtension, isKnownBinaryFile } from '../lib/sftpFileUtils';
 import { Button } from './ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog';
 
@@ -26,13 +26,17 @@ const FileOpenerDialog: React.FC<FileOpenerDialogProps> = ({
 }) => {
   const { t } = useI18n();
   const [isSelectingApp, setIsSelectingApp] = useState(false);
-  const [rememberChoice, setRememberChoice] = useState(true);
+  const [rememberChoice, setRememberChoice] = useState(() => hasFileExtension(fileName));
+
+  useEffect(() => {
+    if (open) {
+      setRememberChoice(hasFileExtension(fileName));
+    }
+  }, [open, fileName]);
 
   const extension = getFileExtension(fileName);
   // Show edit option for files that are not known binary formats
   const canEdit = !isKnownBinaryFile(fileName);
-  // For files without extension, we use 'file' as virtual extension
-  // So we always allow setting default (hasExtension is always true)
   const displayExtension = extension === 'file' ? t('sftp.opener.noExtension') : `.${extension}`;
 
   const handleSelectBuiltIn = useCallback((openerType: FileOpenerType) => {

--- a/lib/sftpFileUtils.test.ts
+++ b/lib/sftpFileUtils.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getFileExtension, hasFileExtension } from "./sftpFileUtils.ts";
+
+test("hasFileExtension identifies extensionless and dotted filenames", () => {
+  assert.equal(hasFileExtension("nginx"), false);
+  assert.equal(hasFileExtension("my-binary"), false);
+  assert.equal(hasFileExtension(".git"), false);
+  assert.equal(getFileExtension("nginx"), "file");
+
+  assert.equal(hasFileExtension("readme.txt"), true);
+  assert.equal(hasFileExtension(".bashrc"), false);
+  assert.equal(hasFileExtension("archive.tar.gz"), true);
+});

--- a/lib/sftpFileUtils.ts
+++ b/lib/sftpFileUtils.ts
@@ -189,6 +189,11 @@ export function getFileExtension(fileName: string): string {
   return fileName.slice(lastDot + 1).toLowerCase();
 }
 
+/** True when the filename has a real extension (e.g. `foo.txt`), not a dot-only name like `.git`. */
+export function hasFileExtension(fileName: string): boolean {
+  return fileName.lastIndexOf('.') > 0;
+}
+
 /**
  * Check if a file is a text file based on its extension and name
  */


### PR DESCRIPTION
## Summary
- Fix the issue where the SFTP open-with dialog checked “Always open with this app” by default for extensionless files (closes #1311).
- Add a `hasFileExtension()` helper that matches the existing `getFileExtension()` behavior.
- Reset the checkbox state by filename each time the dialog opens: files with extensions stay checked by default, while extensionless files stay unchecked by default.

## Test plan
- [x] `node --test --import tsx lib/sftpFileUtils.test.ts`
- [x] ESLint passed for the changed files
- [ ] Manual: double-click an extensionless binary file and confirm the checkbox is unchecked by default
- [ ] Manual: double-click a file such as `.txt` and confirm the checkbox is still checked by default
- [ ] Manual: manually check the box for an extensionless file and confirm the preference can still be saved

Made with [Cursor](https://cursor.com)