### PR TITLE
fix(ai): compact and retry oversized Catty agent requests (#1323)

### DIFF
--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 
 import type { ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types.ts";
 import {
+  buildHistoricalToolReplayMaps,
   buildHistoricalToolResultReplayText,
   buildHistoricalUserReplayContent,
 } from "./cattyHistoryReplay.ts";
+import type { ChatMessage } from "../../infrastructure/ai/types.ts";
 
 test("buildHistoricalUserReplayContent replaces historical image data with a placeholder", () => {
   const attachment: ChatMessageAttachment = {
@@ -87,4 +89,47 @@ test("buildHistoricalToolResultReplayText keeps non-terminal tool results intact
   };
 
   assert.equal(buildHistoricalToolResultReplayText(result, toolCall), "search result summary");
+});
+
+test("buildHistoricalToolReplayMaps pairs reused tool ids with the nearest preceding call", () => {
+  const messages: ChatMessage[] = [
+    {
+      id: "assistant-1",
+      role: "assistant",
+      content: "",
+      timestamp: 1,
+      toolCalls: [{ id: "call1", name: "url_fetch", arguments: { url: "https://example.com" } }],
+    },
+    {
+      id: "tool-1",
+      role: "tool",
+      content: "",
+      timestamp: 2,
+      toolResults: [{ toolCallId: "call1", content: "PAGE" }],
+    },
+    {
+      id: "assistant-2",
+      role: "assistant",
+      content: "",
+      timestamp: 3,
+      toolCalls: [{ id: "call1", name: "terminal_execute", arguments: { command: "cat /tmp/log" } }],
+    },
+    {
+      id: "tool-2",
+      role: "tool",
+      content: "",
+      timestamp: 4,
+      toolResults: [{ toolCallId: "call1", content: "TERMINAL BYTES" }],
+    },
+  ];
+
+  const maps = buildHistoricalToolReplayMaps(messages);
+  const secondResult = messages[3].toolResults?.[0];
+  assert.ok(secondResult);
+  const pairedCall = maps.toolCallByToolResult.get(secondResult);
+
+  assert.equal(pairedCall?.name, "terminal_execute");
+  assert.equal(maps.resolvedToolCallsByAssistant.get(messages[0])?.has(messages[0].toolCalls![0]), true);
+  assert.equal(maps.resolvedToolCallsByAssistant.get(messages[1]), undefined);
+  assert.equal(maps.resolvedToolCallsByAssistant.get(messages[2])?.has(messages[2].toolCalls![0]), true);
 });

--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types.ts";
+import {
+  buildHistoricalToolResultReplayText,
+  buildHistoricalUserReplayContent,
+} from "./cattyHistoryReplay.ts";
+
+test("buildHistoricalUserReplayContent replaces historical image data with a placeholder", () => {
+  const attachment: ChatMessageAttachment = {
+    base64Data: "A".repeat(100_000),
+    mediaType: "image/png",
+    filename: "screenshot.png",
+  };
+
+  const result = buildHistoricalUserReplayContent("inspect this", [attachment]);
+
+  assert.match(result, /inspect this/);
+  assert.match(result, /Historical image attachment omitted from replay/);
+  assert.match(result, /filename=screenshot\.png/);
+  assert.doesNotMatch(result, /AAAAA/);
+});
+
+test("buildHistoricalUserReplayContent replaces historical terminal selections with metadata only", () => {
+  const attachment: ChatMessageAttachment = {
+    base64Data: "VGhpcyBpcyBhIGxvbmcgdGVybWluYWwgc2VsZWN0aW9u",
+    mediaType: "text/plain",
+    filename: "terminal-selection.log",
+    terminalSelection: true,
+    previewText: "npm run build failed on vite",
+    lineCount: 42,
+  };
+
+  const result = buildHistoricalUserReplayContent("", [attachment]);
+
+  assert.match(result, /Historical terminal selection omitted from replay/);
+  assert.match(result, /filename=terminal-selection\.log/);
+  assert.match(result, /lines=42/);
+  assert.match(result, /preview=npm run build failed on vite/);
+  assert.doesNotMatch(result, /long terminal selection/);
+});
+
+test("buildHistoricalToolResultReplayText replaces historical terminal output with a replay placeholder", () => {
+  const toolCall: ToolCall = {
+    id: "call-1",
+    name: "terminal_execute",
+    arguments: { command: "npm run build" },
+  };
+  const result: ToolResult = {
+    toolCallId: "call-1",
+    content: "BUILD ".repeat(20_000),
+    isError: true,
+  };
+
+  const replay = buildHistoricalToolResultReplayText(result, toolCall);
+
+  assert.match(replay, /Historical terminal output omitted from replay/);
+  assert.match(replay, /command=npm run build/);
+  assert.match(replay, /status=error/);
+  assert.doesNotMatch(replay, /BUILD BUILD BUILD/);
+});
+
+test("buildHistoricalToolResultReplayText keeps non-terminal tool results intact", () => {
+  const toolCall: ToolCall = {
+    id: "call-1",
+    name: "web_search",
+    arguments: { query: "Vercel AI SDK" },
+  };
+  const result: ToolResult = {
+    toolCallId: "call-1",
+    content: "search result summary",
+  };
+
+  assert.equal(buildHistoricalToolResultReplayText(result, toolCall), "search result summary");
+});

--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -22,6 +22,20 @@ test("buildHistoricalUserReplayContent replaces historical image data with a pla
   assert.doesNotMatch(result, /AAAAA/);
 });
 
+test("buildHistoricalUserReplayContent preserves historical file path metadata", () => {
+  const content = buildHistoricalUserReplayContent("inspect this file", [{
+    base64Data: "A".repeat(200),
+    mediaType: "text/plain",
+    filename: "deploy.log",
+    filePath: "/tmp/netcatty/deploy.log",
+  }]);
+
+  assert.match(content, /Historical file attachment omitted from replay/);
+  assert.match(content, /filename=deploy\.log/);
+  assert.match(content, /path=\/tmp\/netcatty\/deploy\.log/);
+  assert.doesNotMatch(content, /AAAAAAAA/);
+});
+
 test("buildHistoricalUserReplayContent replaces historical terminal selections with metadata only", () => {
   const attachment: ChatMessageAttachment = {
     base64Data: "VGhpcyBpcyBhIGxvbmcgdGVybWluYWwgc2VsZWN0aW9u",

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -35,6 +35,7 @@ function formatAttachmentPlaceholder(
   const label = attachment.mediaType.startsWith("image/") ? "image" : "file";
   const details = [
     attachment.filename ? `filename=${attachment.filename}` : undefined,
+    attachment.filePath ? `path=${attachment.filePath}` : undefined,
     `mediaType=${attachment.mediaType}`,
     describeAttachmentSize(attachment),
   ].filter(Boolean).join(", ");

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -1,4 +1,4 @@
-import type { ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types";
+import type { ChatMessage, ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types";
 import { isTerminalSelectionAttachment } from "../../application/state/terminalSelectionAttachment";
 
 const MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS = 120;
@@ -63,6 +63,50 @@ function getToolCommand(toolCall?: ToolCall): string | undefined {
   if (typeof args.command === "string") return args.command;
   const serialized = JSON.stringify(args);
   return serialized && serialized !== "{}" ? serialized : undefined;
+}
+
+export function buildHistoricalToolReplayMaps(messages: ChatMessage[]): {
+  resolvedToolCallsByAssistant: Map<ChatMessage, Set<ToolCall>>;
+  toolCallByToolResult: Map<ToolResult, ToolCall>;
+} {
+  const resolvedToolCallsByAssistant = new Map<ChatMessage, Set<ToolCall>>();
+  const toolCallByToolResult = new Map<ToolResult, ToolCall>();
+  const pendingToolCalls: Array<{ message: ChatMessage; toolCall: ToolCall }> = [];
+
+  for (const message of messages) {
+    if (message.role === "assistant" && message.toolCalls?.length) {
+      for (const toolCall of message.toolCalls) {
+        pendingToolCalls.push({ message, toolCall });
+      }
+      continue;
+    }
+
+    if (message.role !== "tool" || !message.toolResults?.length) continue;
+
+    for (const result of message.toolResults) {
+      const pendingIndex = findLastIndex(
+        pendingToolCalls,
+        ({ toolCall }) => toolCall.id === result.toolCallId,
+      );
+      if (pendingIndex < 0) continue;
+
+      const [paired] = pendingToolCalls.splice(pendingIndex, 1);
+      toolCallByToolResult.set(result, paired.toolCall);
+
+      const resolved = resolvedToolCallsByAssistant.get(paired.message) ?? new Set<ToolCall>();
+      resolved.add(paired.toolCall);
+      resolvedToolCallsByAssistant.set(paired.message, resolved);
+    }
+  }
+
+  return { resolvedToolCallsByAssistant, toolCallByToolResult };
+}
+
+function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index])) return index;
+  }
+  return -1;
 }
 
 export function buildHistoricalToolResultReplayText(

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -1,0 +1,88 @@
+import type { ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types";
+import { isTerminalSelectionAttachment } from "../../application/state/terminalSelectionAttachment";
+
+const MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS = 120;
+const MAX_TOOL_COMMAND_CHARS = 220;
+
+function truncateInline(value: string, maxChars: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function describeAttachmentSize(attachment: ChatMessageAttachment): string {
+  return `${attachment.base64Data.length} base64 chars`;
+}
+
+function formatTerminalSelectionPlaceholder(
+  attachment: ChatMessageAttachment,
+  index: number,
+): string {
+  const details = [
+    `filename=${attachment.filename || `terminal-selection-${index + 1}.log`}`,
+    attachment.lineCount != null ? `lines=${attachment.lineCount}` : undefined,
+    attachment.previewText ? `preview=${truncateInline(attachment.previewText, MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS)}` : undefined,
+    describeAttachmentSize(attachment),
+  ].filter(Boolean).join(", ");
+
+  return `[Historical terminal selection omitted from replay: ${details}]`;
+}
+
+function formatAttachmentPlaceholder(
+  attachment: ChatMessageAttachment,
+  index: number,
+): string {
+  const label = attachment.mediaType.startsWith("image/") ? "image" : "file";
+  const details = [
+    attachment.filename ? `filename=${attachment.filename}` : undefined,
+    `mediaType=${attachment.mediaType}`,
+    describeAttachmentSize(attachment),
+  ].filter(Boolean).join(", ");
+
+  return `[Historical ${label} attachment omitted from replay: ${details || `attachment-${index + 1}`}]`;
+}
+
+export function buildHistoricalUserReplayContent(
+  content: string,
+  attachments: ChatMessageAttachment[] = [],
+): string {
+  const placeholders = attachments.map((attachment, index) => (
+    isTerminalSelectionAttachment(attachment)
+      ? formatTerminalSelectionPlaceholder(attachment, index)
+      : formatAttachmentPlaceholder(attachment, index)
+  ));
+
+  if (!placeholders.length) return content;
+  const attachmentBlock = placeholders.map((line) => `\n\n${line}`).join("");
+  return content.trim() ? `${content}${attachmentBlock}` : placeholders.join("\n\n");
+}
+
+function getToolCommand(toolCall?: ToolCall): string | undefined {
+  const args = toolCall?.arguments ?? {};
+  if (typeof args.command === "string") return args.command;
+  const serialized = JSON.stringify(args);
+  return serialized && serialized !== "{}" ? serialized : undefined;
+}
+
+export function buildHistoricalToolResultReplayText(
+  result: ToolResult,
+  toolCall?: ToolCall,
+): string {
+  const toolName = toolCall?.name ?? "unknown";
+  if (!isTerminalToolName(toolName)) {
+    return result.content;
+  }
+
+  const details = [
+    `toolCallId=${result.toolCallId}`,
+    getToolCommand(toolCall) ? `command=${truncateInline(getToolCommand(toolCall) ?? "", MAX_TOOL_COMMAND_CHARS)}` : undefined,
+    `outputChars=${result.content.length}`,
+    result.isError ? "status=error" : "status=success",
+  ].filter(Boolean).join(", ");
+
+  return `[Historical terminal output omitted from replay: ${details}. Re-run terminal_execute if exact output is needed.]`;
+}
+
+function isTerminalToolName(toolName: string): boolean {
+  return toolName === "terminal" || toolName === "terminal_exec" || toolName === "terminal_execute";
+}

--- a/components/ai/externalAgentHistory.test.ts
+++ b/components/ai/externalAgentHistory.test.ts
@@ -75,7 +75,7 @@ test("buildExternalAgentHistoryMessagesForBridge keeps fallback history availabl
   );
 });
 
-test("buildExternalAgentHistoryMessages expands terminal selection attachments", () => {
+test("buildExternalAgentHistoryMessages replaces historical terminal selection attachments with placeholders", () => {
   const terminalSelection = createTerminalSelectionAttachment("docker ps -a\npermission denied");
   assert.ok(terminalSelection);
   const messages: ChatMessage[] = [
@@ -88,9 +88,9 @@ test("buildExternalAgentHistoryMessages expands terminal selection attachments",
 
   assert.equal(result.length, 1);
   assert.equal(result[0].role, "user");
-  assert.match(result[0].content, /\[Terminal selection:/);
+  assert.match(result[0].content, /Historical terminal selection omitted from replay/);
   assert.match(result[0].content, /docker ps -a/);
-  assert.match(result[0].content, /permission denied/);
+  assert.doesNotMatch(result[0].content, /permission denied/);
 });
 
 test("buildExternalAgentHistoryMessages preserves older substantive user instructions outside the recent raw window", () => {
@@ -292,12 +292,9 @@ test("buildExternalAgentHistoryMessages still drops one-word filler user message
   }
 });
 
-test("buildExternalAgentHistoryMessages preserves recent tool results verbatim (up to the raw budget) for follow-up references", () => {
-  // Regression: tool results used to only reach fallback replay via the
-  // 500-char compact summary. If the user's last interaction produced a
-  // large tool output (cat/rg/fetched file), any "use that output"-style
-  // follow-up lost the actual bytes. Now tool messages flow through the
-  // recent raw window at MAX_RAW_MESSAGE_CHARS (2000).
+test("buildExternalAgentHistoryMessages replaces recent terminal tool output with a replay placeholder", () => {
+  // Historical terminal output should remain self-describing without
+  // replaying the actual bytes on every follow-up.
   const bigToolOutput = "DATA ".repeat(300); // ~1500 chars — bigger than summary cap but smaller than raw cap
   const messages: ChatMessage[] = [
     message("u1", "user", "cat /etc/hosts"),
@@ -315,16 +312,15 @@ test("buildExternalAgentHistoryMessages preserves recent tool results verbatim (
   const result = buildExternalAgentHistoryMessages(messages);
   const flat = result.map((m) => m.content).join("\n---\n");
 
-  // Raw-window tool result carries both the [from ...] provenance label
-  // and the actual bytes (not just the 500-char compact summary).
-  assert.match(flat, /Tool result \[from terminal.*?cat \/etc\/hosts.*?\] \(call1\): DATA DATA DATA/);
-  // Confirm we kept enough bytes to exceed the compact-summary cap.
+  assert.match(flat, /Tool result \[from terminal.*?cat \/etc\/hosts.*?\] \(call1\): \[Historical terminal output omitted from replay/);
+  assert.match(flat, /outputChars=1500/);
+  assert.doesNotMatch(flat, /DATA DATA DATA/);
   const toolResultIdx = flat.indexOf("Tool result [from terminal");
   assert.ok(toolResultIdx >= 0, "tool result line must appear in raw window");
   const toolResultChunk = flat.slice(toolResultIdx);
   assert.ok(
-    toolResultChunk.length > 600,
-    `expected tool result chunk to exceed compact cap (~500 chars), got ${toolResultChunk.length}`,
+    toolResultChunk.length < 500,
+    `expected terminal result placeholder to stay compact, got ${toolResultChunk.length}`,
   );
 });
 
@@ -650,8 +646,10 @@ test("buildExternalAgentHistoryMessages resolves tool_call provenance correctly 
   //
   // Extract the two Tool-result lines and match each to its expected
   // args. Use non-greedy .*? — the args JSON can contain parentheses.
-  const hostsMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/hosts[^\]]*?\][^\n]*HOSTS_BYTES/);
-  const resolvMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/resolv\.conf[^\]]*?\][^\n]*RESOLV_BYTES/);
+  const hostsMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/hosts[^\]]*?\][^\n]*Historical terminal output omitted from replay[^\n]*cat \/etc\/hosts/);
+  const resolvMatch = flat.match(/Tool result \[from [^\]]*?cat \/etc\/resolv\.conf[^\]]*?\][^\n]*Historical terminal output omitted from replay[^\n]*cat \/etc\/resolv\.conf/);
+  assert.doesNotMatch(flat, /HOSTS_BYTES/);
+  assert.doesNotMatch(flat, /RESOLV_BYTES/);
 
   assert.ok(hostsMatch, "hosts result must still be labeled with cat /etc/hosts despite later id reuse");
   assert.ok(resolvMatch, "resolv result must be labeled with cat /etc/resolv.conf");

--- a/components/ai/externalAgentHistory.ts
+++ b/components/ai/externalAgentHistory.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from "../../infrastructure/ai/types.ts";
-import { buildPromptWithTerminalSelectionAttachments } from "../../application/state/terminalSelectionAttachment.ts";
+import { buildHistoricalToolResultReplayText, buildHistoricalUserReplayContent } from "./cattyHistoryReplay.ts";
 
 type ExternalAgentHistoryMessage = { role: "user" | "assistant"; content: string };
 type RawHistoryMessage = ExternalAgentHistoryMessage & { sourceId: string };
@@ -62,7 +62,7 @@ function isDurableConstraintText(value: string): boolean {
 
 function getUserHistoryContent(message: ChatMessage): string {
   if (message.role !== "user") return message.content || "";
-  return buildPromptWithTerminalSelectionAttachments(
+  return buildHistoricalUserReplayContent(
     message.content || "",
     message.attachments ?? [],
   );
@@ -127,7 +127,6 @@ function summarizeToolMessage(
   if (!message.toolResults?.length) return [];
   return message.toolResults.map((result) => {
     const prefix = result.isError ? "Tool error" : "Tool result";
-    const content = normalizeWhitespace(result.content || "");
     // Same provenance problem as the raw-window path: once a tool result
     // lands in the compact section (older than the 6-item raw window),
     // its paired assistant tool_call is almost always gone. Without the
@@ -139,7 +138,10 @@ function summarizeToolMessage(
     const callLabel = callInfo
       ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
       : "";
-    return `${prefix}${callLabel} (${result.toolCallId}): ${truncateText(content, MAX_TOOL_SUMMARY_CHARS)}`;
+    const replayContent = buildHistoricalToolResultReplayText(result, callInfo
+      ? { id: result.toolCallId, name: callInfo.name, arguments: callInfo.arguments as Record<string, unknown> }
+      : undefined);
+    return `${prefix}${callLabel} (${result.toolCallId}): ${truncateText(normalizeWhitespace(replayContent), MAX_TOOL_SUMMARY_CHARS)}`;
   });
 }
 
@@ -247,13 +249,11 @@ function toRawHistoryMessage(
   }
 
   if (message.role === "tool" && message.toolResults?.length) {
-    // Keep tool output in the recent raw window (up to MAX_RAW_MESSAGE_CHARS
-    // per message, ~2000). Without this, follow-up turns after stale-session
-    // recovery would only see the 500-char compact summary in
-    // summarizeToolMessage, losing the actual bytes the user might reference
-    // ("use that output", "what did cat show?"). external agent replay only supports user/
-    // assistant roles, so we flatten to "assistant" — the tool results were
-    // produced during the assistant's turn.
+    // Keep recent tool results self-describing while replacing terminal
+    // output with placeholders, so stale-session recovery doesn't replay
+    // bulky command output on every follow-up. External agent replay only
+    // supports user/assistant roles, so we flatten to "assistant" — the
+    // tool results were produced during the assistant's turn.
     //
     // Inline the originating tool_call's name+args. Tool calls and their
     // results live in separate messages; if the last six raw items start
@@ -266,7 +266,10 @@ function toRawHistoryMessage(
       const callLabel = callInfo
         ? ` [from ${callInfo.name}(${truncateText(JSON.stringify(callInfo.arguments ?? {}), MAX_TOOL_CALL_LABEL_CHARS)})]`
         : "";
-      return `${prefix}${callLabel} (${result.toolCallId}): ${result.content || ""}`;
+      const replayContent = buildHistoricalToolResultReplayText(result, callInfo
+        ? { id: result.toolCallId, name: callInfo.name, arguments: callInfo.arguments as Record<string, unknown> }
+        : undefined);
+      return `${prefix}${callLabel} (${result.toolCallId}): ${replayContent}`;
     });
     return [{
       sourceId: message.id,

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -51,6 +51,7 @@ import {
   isTerminalSelectionAttachment,
 } from '../../../application/state/terminalSelectionAttachment';
 import {
+  buildHistoricalToolReplayMaps,
   buildHistoricalToolResultReplayText,
   buildHistoricalUserReplayContent,
 } from '../cattyHistoryReplay';
@@ -799,24 +800,7 @@ export function useAIChatStreaming({
       // so the LLM maintains full conversation context
       const allMessages = currentSession?.messages ?? [];
 
-      // Collect all tool call IDs that have a corresponding tool result,
-      // so we can skip orphaned tool calls (e.g. from user stopping mid-execution)
-      const resolvedToolCallIds = new Set<string>();
-      for (const m of allMessages) {
-        if (m.role === 'tool' && m.toolResults) {
-          for (const tr of m.toolResults) resolvedToolCallIds.add(tr.toolCallId);
-        }
-      }
-
-      const findToolCall = (toolCallId: string) => {
-        for (const prev of allMessages) {
-          if (prev.role === 'assistant' && prev.toolCalls) {
-            const tc = prev.toolCalls.find(t => t.id === toolCallId);
-            if (tc) return tc;
-          }
-        }
-        return undefined;
-      };
+      const { resolvedToolCallsByAssistant, toolCallByToolResult } = buildHistoricalToolReplayMaps(allMessages);
 
       const sdkMessages: Array<ModelMessage> = [];
       const openAIChatAssistantFieldsByMessage = new Map<ModelMessage, OpenAIChatAssistantFields | undefined>();
@@ -844,7 +828,10 @@ export function useAIChatStreaming({
           );
           if (m.toolCalls?.length) {
             // Only include tool calls that have matching results
-            const resolvedCalls = m.toolCalls.filter(tc => resolvedToolCallIds.has(tc.id));
+            const resolvedToolCalls = resolvedToolCallsByAssistant.get(m);
+            const resolvedCalls = resolvedToolCalls
+              ? m.toolCalls.filter(tc => resolvedToolCalls.has(tc))
+              : [];
             const contentParts: AssistantContentPart[] = [];
             if (resolvedCalls.length > 0) {
               for (const part of activeContinuation?.reasoningParts ?? []) {
@@ -909,7 +896,7 @@ export function useAIChatStreaming({
           sdkMessages.push({
             role: 'tool',
             content: m.toolResults.map(tr => {
-              const toolCall = findToolCall(tr.toolCallId);
+              const toolCall = toolCallByToolResult.get(tr);
               return {
                 type: 'tool-result' as const,
                 toolCallId: tr.toolCallId,

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -342,6 +342,7 @@ export function useAIChatStreaming({
     // Track the current assistant message ID so updates target the correct message
     let activeMsgId = currentAssistantMsgId;
     let lastAddedRole: 'assistant' | 'tool' = 'assistant';
+    let hasRetryUnsafeToolProgress = false;
     const reader = result.fullStream.getReader();
 
     // -- Text-delta batching: accumulate deltas and flush periodically --
@@ -484,6 +485,7 @@ export function useAIChatStreaming({
           cancelPendingFlush();
           flushText();
           const typedChunk = chunk as ToolCallChunk;
+          hasRetryUnsafeToolProgress = true;
           const messageId = ensureAssistantMessage();
           const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
           updateMessageById(streamSessionId, messageId, msg => ({
@@ -509,6 +511,7 @@ export function useAIChatStreaming({
           cancelPendingFlush();
           flushText();
           const typedChunk = chunk as ToolResultChunk;
+          hasRetryUnsafeToolProgress = true;
           // Mark the assistant message's tool execution as completed
           updateMessageById(streamSessionId, activeMsgId, msg =>
             msg.role === 'assistant' && msg.executionStatus === 'running'
@@ -555,7 +558,7 @@ export function useAIChatStreaming({
             console.warn('[Catty] suppressed SDK stream state error:', typedChunk.error);
             break;
           }
-          if (isRequestTooLargeError(typedChunk.error)) {
+          if (isRequestTooLargeError(typedChunk.error) && !hasRetryUnsafeToolProgress) {
             cancelPendingFlush();
             flushText();
             throw typedChunk.error;
@@ -1090,6 +1093,18 @@ export function useAIChatStreaming({
         }
 
         console.warn('[Catty] Request hit HTTP 413; forcing context compaction and retrying once.', streamErr);
+        updateMessageById(sessionId, assistantMsgId, msg => ({
+          ...msg,
+          content: '',
+          thinking: undefined,
+          thinkingDurationMs: undefined,
+          providerContinuation: undefined,
+          toolCalls: undefined,
+          errorInfo: undefined,
+          executionStatus: undefined,
+          pendingApproval: undefined,
+          statusText: 'Request was too large. Compacting context and retrying...',
+        }));
         const retryMessages = prepareMessagesForStream(await compactAndBudgetMessages(messagesForStream, {
           force: true,
           statusText: 'Request was too large. Compacting context and retrying...',
@@ -1121,7 +1136,7 @@ export function useAIChatStreaming({
     }
   }, [
     processCattyStream, reportStreamError, setStreamingForScope,
-    updateLastMessage,
+    updateLastMessage, updateMessageById,
   ]);
 
   return {

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -44,12 +44,16 @@ import { createCattyTools } from '../../../infrastructure/ai/sdk/tools';
 import type { ExecutorContext } from '../../../infrastructure/ai/cattyAgent/executor';
 import { getExternalAgentSdkBackend } from '../../../infrastructure/ai/managedAgents';
 import { runSdkAgentTurn } from '../../../infrastructure/ai/sdkAgentAdapter';
-import { classifyError } from '../../../infrastructure/ai/errorClassifier';
+import { classifyError, isRequestTooLargeError } from '../../../infrastructure/ai/errorClassifier';
 import { isSdkStreamStateError } from '../../../infrastructure/ai/shared/streamStateErrors';
 import {
   buildPromptWithTerminalSelectionAttachments,
   isTerminalSelectionAttachment,
 } from '../../../application/state/terminalSelectionAttachment';
+import {
+  buildHistoricalToolResultReplayText,
+  buildHistoricalUserReplayContent,
+} from '../cattyHistoryReplay';
 import {
   extractProviderContinuationFromRawChunk,
   getOpenAIChatAssistantFieldsForHistoryMessage,
@@ -551,6 +555,11 @@ export function useAIChatStreaming({
             console.warn('[Catty] suppressed SDK stream state error:', typedChunk.error);
             break;
           }
+          if (isRequestTooLargeError(typedChunk.error)) {
+            cancelPendingFlush();
+            flushText();
+            throw typedChunk.error;
+          }
           cancelPendingFlush();
           flushText();
           updateMessageById(streamSessionId, activeMsgId, msg => ({
@@ -796,14 +805,14 @@ export function useAIChatStreaming({
         }
       }
 
-      const findToolName = (toolCallId: string): string => {
+      const findToolCall = (toolCallId: string) => {
         for (const prev of allMessages) {
           if (prev.role === 'assistant' && prev.toolCalls) {
             const tc = prev.toolCalls.find(t => t.id === toolCallId);
-            if (tc) return tc.name;
+            if (tc) return tc;
           }
         }
-        return 'unknown';
+        return undefined;
       };
 
       const sdkMessages: Array<ModelMessage> = [];
@@ -812,28 +821,13 @@ export function useAIChatStreaming({
       for (const m of allMessages) {
         const currentMessageFollowsToolResult = previousHistoryMessageWasToolResult;
         if (m.role === 'user') {
-          // Build multimodal content when attachments are present (fallback to legacy `images` field)
+          // Historical attachments are replayed as placeholders so screenshots,
+          // files, and terminal selections do not balloon every follow-up request.
           const messageAttachments = m.attachments ?? m.images;
-          const modelText = messageAttachments?.length
-            ? buildPromptWithTerminalSelectionAttachments(m.content, messageAttachments)
-            : m.content;
-          const modelAttachments = messageAttachments?.filter(
-            (attachment) => !isTerminalSelectionAttachment(attachment),
-          );
-          if (modelAttachments?.length) {
-            const parts: Array<{ type: 'text'; text: string } | { type: 'image'; image: string; mediaType?: string } | { type: 'file'; data: string; mediaType: string; filename?: string }> = [];
-            parts.push({ type: 'text', text: modelText });
-            for (const att of modelAttachments) {
-              if (att.mediaType.startsWith('image/')) {
-                parts.push({ type: 'image', image: att.base64Data, mediaType: att.mediaType });
-              } else {
-                parts.push({ type: 'file', data: att.base64Data, mediaType: att.mediaType, filename: att.filename });
-              }
-            }
-            sdkMessages.push({ role: 'user', content: parts });
-          } else {
-            sdkMessages.push({ role: 'user', content: modelText });
-          }
+          sdkMessages.push({
+            role: 'user',
+            content: buildHistoricalUserReplayContent(m.content, messageAttachments ?? []),
+          });
         } else if (m.role === 'assistant') {
           const activeContinuation = isProviderContinuationForSource(
             m.providerContinuation,
@@ -911,21 +905,31 @@ export function useAIChatStreaming({
         } else if (m.role === 'tool' && m.toolResults?.length) {
           sdkMessages.push({
             role: 'tool',
-            content: m.toolResults.map(tr => ({
-              type: 'tool-result' as const,
-              toolCallId: tr.toolCallId,
-              toolName: findToolName(tr.toolCallId),
-              output: { type: 'text' as const, value: tr.content },
-            })),
+            content: m.toolResults.map(tr => {
+              const toolCall = findToolCall(tr.toolCallId);
+              return {
+                type: 'tool-result' as const,
+                toolCallId: tr.toolCallId,
+                toolName: toolCall?.name ?? 'unknown',
+                output: { type: 'text' as const, value: buildHistoricalToolResultReplayText(tr, toolCall) },
+              };
+            }),
           });
         }
         previousHistoryMessageWasToolResult = m.role === 'tool' && !!m.toolResults?.length;
       }
       // Build the current user message — include attachments as multimodal content
       if (attachments?.length) {
+        const modelText = buildPromptWithTerminalSelectionAttachments(trimmed, attachments);
+        const modelAttachments = attachments.filter(
+          (attachment) => !isTerminalSelectionAttachment(attachment),
+        );
+        if (!modelAttachments.length) {
+          sdkMessages.push({ role: 'user', content: modelText });
+        } else {
         const parts: Array<{ type: 'text'; text: string } | { type: 'image'; image: string; mediaType?: string } | { type: 'file'; data: string; mediaType: string; filename?: string }> = [];
-        parts.push({ type: 'text', text: trimmed });
-        for (const att of attachments) {
+        parts.push({ type: 'text', text: modelText });
+        for (const att of modelAttachments) {
           if (att.mediaType.startsWith('image/')) {
             parts.push({ type: 'image', image: att.base64Data, mediaType: att.mediaType });
           } else {
@@ -933,6 +937,7 @@ export function useAIChatStreaming({
           }
         }
         sdkMessages.push({ role: 'user', content: parts });
+        }
       } else {
         sdkMessages.push({ role: 'user', content: trimmed });
       }
@@ -977,6 +982,82 @@ export function useAIChatStreaming({
         messages,
         reservedBytes: payloadReservedBytes,
       });
+      const summarizeForCompaction = async (messagesToSummarize: ModelMessage[]) => {
+        updateLastMessage(sessionId, msg => ({ ...msg, statusText: 'Compacting earlier context...' }));
+        const result = await generateText({
+          model,
+          system: CONTEXT_COMPACTION_SYSTEM_PROMPT,
+          messages: [{
+            role: 'user',
+            content: `Summarize this earlier conversation context for the next model turn:\n\n${formatMessagesForCompaction(messagesToSummarize)}`,
+          }],
+          abortSignal: abortController.signal,
+          maxOutputTokens: 1600,
+          temperature: 0,
+        });
+        return result.text;
+      };
+      const prepareMessagesForStream = (messages: ModelMessage[]): ModelMessage[] => {
+        const pruned = pruneMessages({
+          messages,
+          reasoning: 'all',
+          emptyMessages: 'remove',
+        });
+        continuationContext.openAIChatAssistantFields = collectOpenAIChatAssistantFieldsForMessages(
+          pruned,
+          openAIChatAssistantFieldsByMessage,
+        );
+        return pruned;
+      };
+      const compactAndBudgetMessages = async (
+        messages: ModelMessage[],
+        {
+          force = false,
+          statusText,
+          trimLog,
+          fallbackLog,
+        }: {
+          force?: boolean;
+          statusText?: string;
+          trimLog: string;
+          fallbackLog: string;
+        },
+      ): Promise<ModelMessage[]> => {
+        try {
+          if (statusText) {
+            updateLastMessage(sessionId, msg => ({ ...msg, statusText }));
+          }
+          const compacted = await prepareContextCompaction({
+            messages,
+            contextWindow,
+            reservedTokens: requestReserveTokens,
+            thresholdRatio: force ? 0 : undefined,
+            protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
+            summarize: summarizeForCompaction,
+          });
+          let nextMessages = force && !compacted.didCompact
+            ? keepRecentContextMessages(messages, DEFAULT_PROTECT_RECENT_MESSAGES)
+            : compacted.messages;
+          const budgetResult = applyRequestPayloadBudget(nextMessages);
+          if (budgetResult.didAdjust) {
+            console.warn(`${trimLog} ${budgetResult.estimatedBytes} bytes.`);
+            nextMessages = budgetResult.messages;
+          }
+          return nextMessages;
+        } catch (err) {
+          if (abortController.signal.aborted) throw err;
+          console.warn(fallbackLog, err);
+          const fallbackBudget = applyRequestPayloadBudget(
+            keepRecentContextMessages(messages, DEFAULT_PROTECT_RECENT_MESSAGES),
+          );
+          if (fallbackBudget.didAdjust) {
+            console.warn(
+              `[Catty] Request payload trimmed to ${fallbackBudget.estimatedBytes} bytes after compaction fallback.`,
+            );
+          }
+          return fallbackBudget.messages;
+        }
+      };
       const payloadBudgetResult = applyRequestPayloadBudget(sdkMessages);
       let messagesForStream = payloadBudgetResult.messages;
       if (payloadBudgetResult.didAdjust) {
@@ -984,71 +1065,50 @@ export function useAIChatStreaming({
           `[Catty] Request payload trimmed to ${payloadBudgetResult.estimatedBytes} bytes to avoid HTTP 413.`,
         );
       }
-      try {
-        const compacted = await prepareContextCompaction({
-          messages: messagesForStream,
-          contextWindow,
-          reservedTokens: requestReserveTokens,
-          protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
-          summarize: async (messagesToSummarize) => {
-            updateLastMessage(sessionId, msg => ({ ...msg, statusText: 'Compacting earlier context...' }));
-            const result = await generateText({
-              model,
-              system: CONTEXT_COMPACTION_SYSTEM_PROMPT,
-              messages: [{
-                role: 'user',
-                content: `Summarize this earlier conversation context for the next model turn:\n\n${formatMessagesForCompaction(messagesToSummarize)}`,
-              }],
-              abortSignal: abortController.signal,
-              maxOutputTokens: 1600,
-              temperature: 0,
-            });
-            return result.text;
-          },
-        });
-        messagesForStream = compacted.messages;
-        const postCompactionBudget = applyRequestPayloadBudget(messagesForStream);
-        if (postCompactionBudget.didAdjust) {
-          console.warn(
-            `[Catty] Request payload re-trimmed to ${postCompactionBudget.estimatedBytes} bytes after context compaction.`,
-          );
-          messagesForStream = postCompactionBudget.messages;
-        }
-      } catch (err) {
-        if (abortController.signal.aborted) throw err;
-        console.warn('[Catty] Context compaction failed; falling back to recent messages only:', err);
-        const fallbackBudget = applyRequestPayloadBudget(
-          keepRecentContextMessages(messagesForStream, DEFAULT_PROTECT_RECENT_MESSAGES),
-        );
-        messagesForStream = fallbackBudget.messages;
-        if (fallbackBudget.didAdjust) {
-          console.warn(
-            `[Catty] Request payload trimmed to ${fallbackBudget.estimatedBytes} bytes after compaction fallback.`,
-          );
-        }
-      }
-
-      messagesForStream = pruneMessages({
-        messages: messagesForStream,
-        reasoning: 'all',
-        emptyMessages: 'remove',
+      messagesForStream = await compactAndBudgetMessages(messagesForStream, {
+        trimLog: '[Catty] Request payload re-trimmed after context compaction to',
+        fallbackLog: '[Catty] Context compaction failed; falling back to recent messages only:',
       });
-      continuationContext.openAIChatAssistantFields = collectOpenAIChatAssistantFieldsForMessages(
-        messagesForStream,
-        openAIChatAssistantFieldsByMessage,
-      );
 
-      await processCattyStream(
-        sessionId,
-        model,
-        systemPrompt,
-        tools,
-        messagesForStream,
-        abortController.signal,
-        assistantMsgId,
-        context.activeProvider?.advancedParams,
-        continuationContext,
-      );
+      messagesForStream = prepareMessagesForStream(messagesForStream);
+
+      try {
+        await processCattyStream(
+          sessionId,
+          model,
+          systemPrompt,
+          tools,
+          messagesForStream,
+          abortController.signal,
+          assistantMsgId,
+          context.activeProvider?.advancedParams,
+          continuationContext,
+        );
+      } catch (streamErr) {
+        if (abortController.signal.aborted || !isRequestTooLargeError(streamErr)) {
+          throw streamErr;
+        }
+
+        console.warn('[Catty] Request hit HTTP 413; forcing context compaction and retrying once.', streamErr);
+        const retryMessages = prepareMessagesForStream(await compactAndBudgetMessages(messagesForStream, {
+          force: true,
+          statusText: 'Request was too large. Compacting context and retrying...',
+          trimLog: '[Catty] Request payload trimmed after forced context compaction to',
+          fallbackLog: '[Catty] Forced context compaction after 413 failed; falling back to recent messages only:',
+        }));
+
+        await processCattyStream(
+          sessionId,
+          model,
+          systemPrompt,
+          tools,
+          retryMessages,
+          abortController.signal,
+          assistantMsgId,
+          context.activeProvider?.advancedParams,
+          continuationContext,
+        );
+      }
     } catch (err) {
       console.error('[Catty] streamText error:', err);
       reportStreamError(sessionId, abortController.signal, err);

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -969,13 +969,15 @@ export function useAIChatStreaming({
         openAIChatAssistantFields: Array.from(openAIChatAssistantFieldsByMessage.values()),
       });
 
-      const payloadBudgetResult = fitMessagesToRequestPayloadBudget({
-        messages: sdkMessages,
-        reservedBytes: estimateUtf8Bytes({
-          system: systemPrompt,
-          tools: Object.keys(tools),
-        }),
+      const payloadReservedBytes = estimateUtf8Bytes({
+        system: systemPrompt,
+        tools: Object.keys(tools),
       });
+      const applyRequestPayloadBudget = (messages: ModelMessage[]) => fitMessagesToRequestPayloadBudget({
+        messages,
+        reservedBytes: payloadReservedBytes,
+      });
+      const payloadBudgetResult = applyRequestPayloadBudget(sdkMessages);
       let messagesForStream = payloadBudgetResult.messages;
       if (payloadBudgetResult.didAdjust) {
         console.warn(
@@ -984,7 +986,7 @@ export function useAIChatStreaming({
       }
       try {
         const compacted = await prepareContextCompaction({
-          messages: sdkMessages,
+          messages: messagesForStream,
           contextWindow,
           reservedTokens: requestReserveTokens,
           protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
@@ -1005,10 +1007,25 @@ export function useAIChatStreaming({
           },
         });
         messagesForStream = compacted.messages;
+        const postCompactionBudget = applyRequestPayloadBudget(messagesForStream);
+        if (postCompactionBudget.didAdjust) {
+          console.warn(
+            `[Catty] Request payload re-trimmed to ${postCompactionBudget.estimatedBytes} bytes after context compaction.`,
+          );
+          messagesForStream = postCompactionBudget.messages;
+        }
       } catch (err) {
         if (abortController.signal.aborted) throw err;
         console.warn('[Catty] Context compaction failed; falling back to recent messages only:', err);
-        messagesForStream = keepRecentContextMessages(sdkMessages, DEFAULT_PROTECT_RECENT_MESSAGES);
+        const fallbackBudget = applyRequestPayloadBudget(
+          keepRecentContextMessages(messagesForStream, DEFAULT_PROTECT_RECENT_MESSAGES),
+        );
+        messagesForStream = fallbackBudget.messages;
+        if (fallbackBudget.didAdjust) {
+          console.warn(
+            `[Catty] Request payload trimmed to ${fallbackBudget.estimatedBytes} bytes after compaction fallback.`,
+          );
+        }
       }
 
       messagesForStream = pruneMessages({

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -35,6 +35,10 @@ import {
   prepareContextCompaction,
   resolveContextWindow,
 } from '../../../infrastructure/ai/contextCompaction';
+import {
+  estimateUtf8Bytes,
+  fitMessagesToRequestPayloadBudget,
+} from '../../../infrastructure/ai/requestPayloadBudget';
 import { createModelFromConfig } from '../../../infrastructure/ai/sdk/providers';
 import { createCattyTools } from '../../../infrastructure/ai/sdk/tools';
 import type { ExecutorContext } from '../../../infrastructure/ai/cattyAgent/executor';
@@ -965,7 +969,19 @@ export function useAIChatStreaming({
         openAIChatAssistantFields: Array.from(openAIChatAssistantFieldsByMessage.values()),
       });
 
-      let messagesForStream = sdkMessages;
+      const payloadBudgetResult = fitMessagesToRequestPayloadBudget({
+        messages: sdkMessages,
+        reservedBytes: estimateUtf8Bytes({
+          system: systemPrompt,
+          tools: Object.keys(tools),
+        }),
+      });
+      let messagesForStream = payloadBudgetResult.messages;
+      if (payloadBudgetResult.didAdjust) {
+        console.warn(
+          `[Catty] Request payload trimmed to ${payloadBudgetResult.estimatedBytes} bytes to avoid HTTP 413.`,
+        );
+      }
       try {
         const compacted = await prepareContextCompaction({
           messages: sdkMessages,

--- a/infrastructure/ai/errorClassifier.test.ts
+++ b/infrastructure/ai/errorClassifier.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { classifyError, sanitizeErrorMessage } from "./errorClassifier.ts";
+import { classifyError, isRequestTooLargeError, sanitizeErrorMessage } from "./errorClassifier.ts";
 
 // -------------------------------------------------------------------
 // sanitizeErrorMessage — regression guard for pre-existing behavior
@@ -52,6 +52,13 @@ test("classifyError handles 413 via the message when no statusCode field is set"
   const info = classifyError(new Error("AI_APICallError: 413 payload rejected"));
   assert.equal(info.type, "network");
   assert.match(info.message, /Request too large/i);
+});
+
+test("isRequestTooLargeError detects structured and textual 413 errors", () => {
+  assert.equal(isRequestTooLargeError(Object.assign(new Error("blocked"), { statusCode: 413 })), true);
+  assert.equal(isRequestTooLargeError("413 Request Entity Too Large"), true);
+  assert.equal(isRequestTooLargeError(new Error("AI_APICallError: 413 payload rejected")), true);
+  assert.equal(isRequestTooLargeError(Object.assign(new Error("bad gateway"), { statusCode: 502 })), false);
 });
 
 // -------------------------------------------------------------------

--- a/infrastructure/ai/errorClassifier.test.ts
+++ b/infrastructure/ai/errorClassifier.test.ts
@@ -61,6 +61,14 @@ test("isRequestTooLargeError detects structured and textual 413 errors", () => {
   assert.equal(isRequestTooLargeError(Object.assign(new Error("bad gateway"), { statusCode: 502 })), false);
 });
 
+test("isRequestTooLargeError detects 413 hidden in an HTML response body", () => {
+  const err = Object.assign(new Error("Failed to parse provider response"), {
+    responseBody: "<html><body><center><h1>413 Request Entity Too Large</h1></center></body></html>",
+  });
+
+  assert.equal(isRequestTooLargeError(err), true);
+});
+
 // -------------------------------------------------------------------
 // classifyError — 502 / 503 / 504 upstream gateway
 // -------------------------------------------------------------------

--- a/infrastructure/ai/errorClassifier.test.ts
+++ b/infrastructure/ai/errorClassifier.test.ts
@@ -71,6 +71,7 @@ test("isRequestTooLargeError detects 413 hidden in an HTML response body", () =>
 
 test("isRequestTooLargeError does not treat timing text as HTTP 413", () => {
   assert.equal(isRequestTooLargeError("upstream timed out in 413 ms"), false);
+  assert.equal(isRequestTooLargeError("413 ms"), false);
 });
 
 // -------------------------------------------------------------------
@@ -88,8 +89,10 @@ test("classifyError marks 502/503/504 as network+retryable", () => {
 
 test("classifyError does not treat timing text as a gateway status", () => {
   const info = classifyError("retry after 502 ms");
+  const leadingInfo = classifyError("502 ms");
 
   assert.equal(info.type, "unknown");
+  assert.equal(leadingInfo.type, "unknown");
 });
 
 // -------------------------------------------------------------------

--- a/infrastructure/ai/errorClassifier.test.ts
+++ b/infrastructure/ai/errorClassifier.test.ts
@@ -69,6 +69,10 @@ test("isRequestTooLargeError detects 413 hidden in an HTML response body", () =>
   assert.equal(isRequestTooLargeError(err), true);
 });
 
+test("isRequestTooLargeError does not treat timing text as HTTP 413", () => {
+  assert.equal(isRequestTooLargeError("upstream timed out in 413 ms"), false);
+});
+
 // -------------------------------------------------------------------
 // classifyError — 502 / 503 / 504 upstream gateway
 // -------------------------------------------------------------------
@@ -80,6 +84,12 @@ test("classifyError marks 502/503/504 as network+retryable", () => {
     assert.equal(info.retryable, true, `code ${code} should be retryable`);
     assert.match(info.message, new RegExp(String(code)));
   }
+});
+
+test("classifyError does not treat timing text as a gateway status", () => {
+  const info = classifyError("retry after 502 ms");
+
+  assert.equal(info.type, "unknown");
 });
 
 // -------------------------------------------------------------------

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -56,8 +56,10 @@ function extractResponseBody(error: unknown): string | undefined {
 
 export function isRequestTooLargeError(error: unknown): boolean {
   const message = extractMessage(error).trim();
-  const statusCode = extractStatusCode(error, message);
-  return statusCode === 413 || /\brequest entity too large\b/i.test(message);
+  const responseBody = extractResponseBody(error) ?? "";
+  const combined = `${message}\n${responseBody}`;
+  const statusCode = extractStatusCode(error, combined);
+  return statusCode === 413 || /\brequest entity too large\b/i.test(combined);
 }
 
 function looksLikeHtml(text: string): boolean {

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -40,7 +40,7 @@ function extractStatusCode(error: unknown, message: string): number | undefined 
     /\bHTTP\s*(4\d{2}|5\d{2})\b/i,
     /\bstatus(?:Code)?\s*[:=]?\s*(4\d{2}|5\d{2})\b/i,
     /\bcode\s*[:=]\s*(4\d{2}|5\d{2})\b/i,
-    /^\s*(4\d{2}|5\d{2})\b/i,
+    /^\s*(4\d{2}|5\d{2})\b(?!\s*ms\b)/i,
   ];
   for (const pattern of statusPatterns) {
     const match = message.match(pattern);

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -54,6 +54,12 @@ function extractResponseBody(error: unknown): string | undefined {
   return undefined;
 }
 
+export function isRequestTooLargeError(error: unknown): boolean {
+  const message = extractMessage(error).trim();
+  const statusCode = extractStatusCode(error, message);
+  return statusCode === 413 || /\brequest entity too large\b/i.test(message);
+}
+
 function looksLikeHtml(text: string): boolean {
   if (!text) return false;
   const lower = text.toLowerCase();
@@ -120,7 +126,7 @@ export function classifyError(error: unknown): ErrorInfo {
 
   const sanitizedRaw = sanitizeErrorMessage(rawMessage);
 
-  if (statusCode === 413 || /\brequest entity too large\b/i.test(rawMessage)) {
+  if (isRequestTooLargeError(error)) {
     return {
       type: 'network',
       message:

--- a/infrastructure/ai/errorClassifier.ts
+++ b/infrastructure/ai/errorClassifier.ts
@@ -36,10 +36,16 @@ function extractStatusCode(error: unknown, message: string): number | undefined 
       if (typeof causeStatus === 'number') return causeStatus;
     }
   }
-  // Last resort: look for a standalone 3-digit HTTP status in the message.
-  // Bound by word boundaries to avoid picking up "in 413 ms" etc.
-  const match = message.match(/\b(4\d{2}|5\d{2})\b/);
-  if (match) return Number(match[1]);
+  const statusPatterns = [
+    /\bHTTP\s*(4\d{2}|5\d{2})\b/i,
+    /\bstatus(?:Code)?\s*[:=]?\s*(4\d{2}|5\d{2})\b/i,
+    /\bcode\s*[:=]\s*(4\d{2}|5\d{2})\b/i,
+    /^\s*(4\d{2}|5\d{2})\b/i,
+  ];
+  for (const pattern of statusPatterns) {
+    const match = message.match(pattern);
+    if (match) return Number(match[1]);
+  }
   return undefined;
 }
 
@@ -59,7 +65,11 @@ export function isRequestTooLargeError(error: unknown): boolean {
   const responseBody = extractResponseBody(error) ?? "";
   const combined = `${message}\n${responseBody}`;
   const statusCode = extractStatusCode(error, combined);
-  return statusCode === 413 || /\brequest entity too large\b/i.test(combined);
+  return (
+    statusCode === 413 ||
+    /\brequest entity too large\b/i.test(combined) ||
+    /\b413\b(?!\s*ms\b).*\b(payload|request|too large|entity)\b/i.test(combined)
+  );
 }
 
 function looksLikeHtml(text: string): boolean {

--- a/infrastructure/ai/requestPayloadBudget.test.ts
+++ b/infrastructure/ai/requestPayloadBudget.test.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ModelMessage } from "ai";
+
+import {
+  compressVerboseText,
+  estimateUtf8Bytes,
+  fitMessagesToRequestPayloadBudget,
+  truncateTextWithHeadAndTail,
+} from "./requestPayloadBudget.ts";
+
+test("compressVerboseText collapses repeated blank lines and duplicate runs", () => {
+  const input = "line1\n\n\n\n\nline2\nsame\nsame\nsame\nsame\nline3";
+  const output = compressVerboseText(input);
+  assert.match(output, /line1\n\n\nline2/);
+  assert.ok(output.split("\nsame\n").length <= 3);
+});
+
+test("truncateTextWithHeadAndTail keeps both ends of long terminal output", () => {
+  const value = `${"A".repeat(500)}${"B".repeat(20_000)}${"C".repeat(500)}`;
+  const truncated = truncateTextWithHeadAndTail(value, 2_000);
+  assert.ok(truncated.startsWith("AAA"));
+  assert.ok(truncated.includes("[... output truncated for request size ...]"));
+  assert.ok(truncated.endsWith("CCC"));
+  assert.ok(truncated.length <= 2_000);
+});
+
+test("fitMessagesToRequestPayloadBudget truncates verbose tool results before dropping recent turns", () => {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "run build" },
+    {
+      role: "assistant",
+      content: [{
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "terminal_execute",
+        input: { command: "npm run build" },
+      }],
+    },
+    {
+      role: "tool",
+      content: [{
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "terminal_execute",
+        output: { type: "text", value: "X".repeat(200_000) },
+      }],
+    },
+    { role: "user", content: "what failed?" },
+  ];
+
+  const result = fitMessagesToRequestPayloadBudget({
+    messages,
+    maxPayloadBytes: 20_000,
+    reservedBytes: 2_000,
+    maxToolResultChars: 4_000,
+    protectRecentMessages: 4,
+  });
+
+  assert.equal(result.messages.length, 4);
+  const toolMessage = result.messages[2];
+  assert.equal(toolMessage.role, "tool");
+  assert.ok(Array.isArray(toolMessage.content));
+  const toolPart = toolMessage.content[0] as { output?: { value?: string } };
+  assert.ok((toolPart.output?.value?.length ?? 0) < 5_000);
+  assert.ok(result.estimatedBytes <= 20_000);
+});
+
+test("fitMessagesToRequestPayloadBudget drops older turns when truncation alone is insufficient", () => {
+  const messages: ModelMessage[] = [];
+  for (let turn = 0; turn < 12; turn += 1) {
+    messages.push({ role: "user", content: `question ${turn}` });
+    messages.push({ role: "assistant", content: `answer ${turn} ${"Z".repeat(20_000)}` });
+  }
+  messages.push({ role: "user", content: "latest question" });
+
+  const result = fitMessagesToRequestPayloadBudget({
+    messages,
+    maxPayloadBytes: 8_000,
+    reservedBytes: 500,
+    protectRecentMessages: 4,
+    maxMessageTextChars: 2_000,
+  });
+
+  assert.ok(result.messages.length < messages.length);
+  assert.equal(result.messages.at(-1)?.role, "user");
+  assert.match(String(result.messages.at(-1)?.content ?? ""), /latest question/);
+  assert.ok(result.estimatedBytes <= 8_000);
+});
+
+test("estimateUtf8Bytes measures JSON payload size in UTF-8 bytes", () => {
+  const bytes = estimateUtf8Bytes({ text: "caf\u00e9" });
+  assert.ok(bytes > 8);
+});

--- a/infrastructure/ai/requestPayloadBudget.test.ts
+++ b/infrastructure/ai/requestPayloadBudget.test.ts
@@ -108,6 +108,17 @@ test("default payload budget remains a general gateway guard", () => {
   assert.equal(DEFAULT_MAX_REQUEST_PAYLOAD_BYTES, 1_500_000);
 });
 
+test("fitMessagesToRequestPayloadBudget preserves current long text when the request is under budget", () => {
+  const currentText = "CURRENT ".repeat(4_000);
+  const result = fitMessagesToRequestPayloadBudget({
+    messages: [{ role: "user", content: currentText }],
+    maxPayloadBytes: 100_000,
+  });
+
+  assert.equal(result.didAdjust, false);
+  assert.equal(result.messages[0].content, currentText);
+});
+
 test("fitMessagesToRequestPayloadBudget reports didAdjust when initial truncation succeeds", () => {
   const messages: ModelMessage[] = [
     { role: "user", content: "run build" },
@@ -173,7 +184,7 @@ test("fitMessagesToRequestPayloadBudget returns empty messages when budget is fu
   assert.equal(result.estimatedBytes, 0);
 });
 
-test("fitMessagesToRequestPayloadBudget omits oversized attachment payloads as a last resort", () => {
+test("fitMessagesToRequestPayloadBudget preserves latest message attachment payloads", () => {
   const result = fitMessagesToRequestPayloadBudget({
     messages: [{
       role: "user",
@@ -185,8 +196,30 @@ test("fitMessagesToRequestPayloadBudget omits oversized attachment payloads as a
     maxPayloadBytes: 20_000,
   });
 
-  assert.ok(result.estimatedBytes <= 20_000);
   assert.equal(result.messages.length, 1);
+  const content = result.messages[0].content;
+  assert.ok(Array.isArray(content));
+  assert.deepEqual(content[1], { type: "image", image: "A".repeat(1_000_000), mediaType: "image/png" });
+});
+
+test("fitMessagesToRequestPayloadBudget omits older oversized attachment payloads as a last resort", () => {
+  const result = fitMessagesToRequestPayloadBudget({
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "older image" },
+          { type: "image", image: "A".repeat(1_000_000), mediaType: "image/png" },
+        ],
+      },
+      { role: "user", content: "current question" },
+    ],
+    maxPayloadBytes: 20_000,
+    protectRecentMessages: 2,
+  });
+
+  assert.ok(result.estimatedBytes <= 20_000);
+  assert.equal(result.messages.length, 2);
   const content = result.messages[0].content;
   assert.ok(Array.isArray(content));
   assert.deepEqual(content[1], {

--- a/infrastructure/ai/requestPayloadBudget.test.ts
+++ b/infrastructure/ai/requestPayloadBudget.test.ts
@@ -92,3 +92,68 @@ test("estimateUtf8Bytes measures JSON payload size in UTF-8 bytes", () => {
   const bytes = estimateUtf8Bytes({ text: "caf\u00e9" });
   assert.ok(bytes > 8);
 });
+
+test("fitMessagesToRequestPayloadBudget reports didAdjust when initial truncation succeeds", () => {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "run build" },
+    {
+      role: "tool",
+      content: [{
+        type: "tool-result",
+        toolCallId: "call-1",
+        toolName: "terminal_execute",
+        output: { type: "text", value: "X".repeat(200_000) },
+      }],
+    },
+  ];
+
+  const result = fitMessagesToRequestPayloadBudget({
+    messages,
+    maxPayloadBytes: 20_000,
+    reservedBytes: 2_000,
+  });
+
+  assert.equal(result.didAdjust, true);
+  assert.ok(result.estimatedBytes <= 20_000);
+});
+
+test("fitMessagesToRequestPayloadBudget keeps dropping messages after emergency caps when still over budget", () => {
+  const messages: ModelMessage[] = [];
+  for (let turn = 0; turn < 8; turn += 1) {
+    messages.push({ role: "user", content: `question ${turn} ${"Q".repeat(5_000)}` });
+    messages.push({ role: "assistant", content: `answer ${turn} ${"A".repeat(5_000)}` });
+  }
+
+  const result = fitMessagesToRequestPayloadBudget({
+    messages,
+    maxPayloadBytes: 5_000,
+    protectRecentMessages: 8,
+    maxMessageTextChars: 2_000,
+  });
+
+  assert.ok(result.messages.length < messages.length);
+  assert.ok(result.estimatedBytes <= 5_000);
+});
+
+test("fitMessagesToRequestPayloadBudget shrinks a single oversized message for very small budgets", () => {
+  const result = fitMessagesToRequestPayloadBudget({
+    messages: [{ role: "assistant", content: "Z".repeat(1_000_000) }],
+    maxPayloadBytes: 1_000,
+    maxMessageTextChars: 500,
+  });
+
+  assert.equal(result.messages.length, 1);
+  assert.ok(result.estimatedBytes <= 1_000);
+});
+
+test("fitMessagesToRequestPayloadBudget returns empty messages when budget is fully reserved", () => {
+  const result = fitMessagesToRequestPayloadBudget({
+    messages: [{ role: "user", content: "hello" }],
+    maxPayloadBytes: 100,
+    reservedBytes: 200,
+  });
+
+  assert.deepEqual(result.messages, []);
+  assert.equal(result.didAdjust, true);
+  assert.equal(result.estimatedBytes, 0);
+});

--- a/infrastructure/ai/requestPayloadBudget.test.ts
+++ b/infrastructure/ai/requestPayloadBudget.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { ModelMessage } from "ai";
 
 import {
+  DEFAULT_MAX_REQUEST_PAYLOAD_BYTES,
   compressVerboseText,
   estimateUtf8Bytes,
   fitMessagesToRequestPayloadBudget,
@@ -93,6 +94,20 @@ test("estimateUtf8Bytes measures JSON payload size in UTF-8 bytes", () => {
   assert.ok(bytes > 8);
 });
 
+test("estimateUtf8Bytes works in renderer-like environments without Buffer", () => {
+  const originalBuffer = globalThis.Buffer;
+  try {
+    (globalThis as typeof globalThis & { Buffer?: typeof Buffer }).Buffer = undefined;
+    assert.equal(estimateUtf8Bytes({ text: "caf\u00e9" }), new TextEncoder().encode(JSON.stringify({ text: "caf\u00e9" })).byteLength);
+  } finally {
+    (globalThis as typeof globalThis & { Buffer?: typeof Buffer }).Buffer = originalBuffer;
+  }
+});
+
+test("default payload budget remains a general gateway guard", () => {
+  assert.equal(DEFAULT_MAX_REQUEST_PAYLOAD_BYTES, 1_500_000);
+});
+
 test("fitMessagesToRequestPayloadBudget reports didAdjust when initial truncation succeeds", () => {
   const messages: ModelMessage[] = [
     { role: "user", content: "run build" },
@@ -156,4 +171,26 @@ test("fitMessagesToRequestPayloadBudget returns empty messages when budget is fu
   assert.deepEqual(result.messages, []);
   assert.equal(result.didAdjust, true);
   assert.equal(result.estimatedBytes, 0);
+});
+
+test("fitMessagesToRequestPayloadBudget omits oversized attachment payloads as a last resort", () => {
+  const result = fitMessagesToRequestPayloadBudget({
+    messages: [{
+      role: "user",
+      content: [
+        { type: "text", text: "please inspect this image" },
+        { type: "image", image: "A".repeat(1_000_000), mediaType: "image/png" },
+      ],
+    }],
+    maxPayloadBytes: 20_000,
+  });
+
+  assert.ok(result.estimatedBytes <= 20_000);
+  assert.equal(result.messages.length, 1);
+  const content = result.messages[0].content;
+  assert.ok(Array.isArray(content));
+  assert.deepEqual(content[1], {
+    type: "text",
+    text: "[image attachment omitted to keep the AI request small: mediaType=image/png, 1000000 chars]",
+  });
 });

--- a/infrastructure/ai/requestPayloadBudget.test.ts
+++ b/infrastructure/ai/requestPayloadBudget.test.ts
@@ -184,7 +184,7 @@ test("fitMessagesToRequestPayloadBudget returns empty messages when budget is fu
   assert.equal(result.estimatedBytes, 0);
 });
 
-test("fitMessagesToRequestPayloadBudget preserves latest message attachment payloads", () => {
+test("fitMessagesToRequestPayloadBudget omits latest attachments only when they are still over budget at the last resort", () => {
   const result = fitMessagesToRequestPayloadBudget({
     messages: [{
       role: "user",
@@ -196,10 +196,14 @@ test("fitMessagesToRequestPayloadBudget preserves latest message attachment payl
     maxPayloadBytes: 20_000,
   });
 
+  assert.ok(result.estimatedBytes <= 20_000);
   assert.equal(result.messages.length, 1);
   const content = result.messages[0].content;
   assert.ok(Array.isArray(content));
-  assert.deepEqual(content[1], { type: "image", image: "A".repeat(1_000_000), mediaType: "image/png" });
+  assert.deepEqual(content[1], {
+    type: "text",
+    text: "[image attachment omitted to keep the AI request small: mediaType=image/png, 1000000 chars]",
+  });
 });
 
 test("fitMessagesToRequestPayloadBudget omits older oversized attachment payloads as a last resort", () => {

--- a/infrastructure/ai/requestPayloadBudget.ts
+++ b/infrastructure/ai/requestPayloadBudget.ts
@@ -21,6 +21,7 @@ export interface FitMessagesToRequestPayloadBudgetInput {
   maxToolResultChars?: number;
   maxMessageTextChars?: number;
   protectRecentMessages?: number;
+  preserveLatestMessage?: boolean;
 }
 
 export interface FitMessagesToRequestPayloadBudgetResult {
@@ -117,12 +118,16 @@ export function truncateModelMessageForPayload(
     maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
     maxMessageTextChars = DEFAULT_MAX_MESSAGE_TEXT_CHARS,
     omitLargeAttachments = false,
+    preserveContent = false,
   }: {
     maxToolResultChars?: number;
     maxMessageTextChars?: number;
     omitLargeAttachments?: boolean;
+    preserveContent?: boolean;
   } = {},
 ): ModelMessage {
+  if (preserveContent) return message;
+
   if (typeof message.content === "string") {
     const compressed = compressVerboseText(message.content);
     return {
@@ -215,17 +220,27 @@ export function fitMessagesToRequestPayloadBudget({
   maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
   maxMessageTextChars = DEFAULT_MAX_MESSAGE_TEXT_CHARS,
   protectRecentMessages = DEFAULT_PROTECT_RECENT_PAYLOAD_MESSAGES,
+  preserveLatestMessage = true,
 }: FitMessagesToRequestPayloadBudgetInput): FitMessagesToRequestPayloadBudgetResult {
   const budget = Math.max(0, maxPayloadBytes - Math.max(0, reservedBytes));
   if (budget === 0) {
     return { messages: [], didAdjust: messages.length > 0, estimatedBytes: 0 };
   }
-  let adjusted = messages.map((message) => truncateModelMessageForPayload(message, {
+  const originalBytes = estimateUtf8Bytes(messages);
+  if (originalBytes <= budget) {
+    return { messages, didAdjust: false, estimatedBytes: originalBytes };
+  }
+
+  const shouldPreserveMessage = (message: ModelMessage, index: number, list: ModelMessage[]) => (
+    preserveLatestMessage && index === list.length - 1 && message.role === "user"
+  );
+
+  let adjusted = messages.map((message, index) => truncateModelMessageForPayload(message, {
     maxToolResultChars,
     maxMessageTextChars,
+    preserveContent: shouldPreserveMessage(message, index, messages),
   }));
   let estimatedBytes = estimateUtf8Bytes(adjusted);
-  const originalBytes = estimateUtf8Bytes(messages);
   let didAdjust = estimatedBytes !== originalBytes;
   if (estimatedBytes <= budget) {
     return { messages: adjusted, didAdjust, estimatedBytes };
@@ -249,9 +264,10 @@ export function fitMessagesToRequestPayloadBudget({
   ];
 
   for (let i = 1; i < toolResultCaps.length; i += 1) {
-    adjusted = adjusted.map((message) => truncateModelMessageForPayload(message, {
+    adjusted = adjusted.map((message, index) => truncateModelMessageForPayload(message, {
       maxToolResultChars: toolResultCaps[i],
       maxMessageTextChars: messageTextCaps[i],
+      preserveContent: shouldPreserveMessage(message, index, adjusted),
     }));
     estimatedBytes = estimateUtf8Bytes(adjusted);
     didAdjust = true;
@@ -274,10 +290,11 @@ export function fitMessagesToRequestPayloadBudget({
 
   const emergencyToolCap = 600;
   const emergencyTextCap = 1_200;
-  working = working.map((message) => truncateModelMessageForPayload(message, {
+  working = working.map((message, index) => truncateModelMessageForPayload(message, {
     maxToolResultChars: emergencyToolCap,
     maxMessageTextChars: emergencyTextCap,
     omitLargeAttachments: true,
+    preserveContent: shouldPreserveMessage(message, index, working),
   }));
   estimatedBytes = estimateUtf8Bytes(working);
   didAdjust = true;
@@ -291,10 +308,11 @@ export function fitMessagesToRequestPayloadBudget({
     } else {
       working = working.slice(splitAt);
     }
-    working = working.map((message) => truncateModelMessageForPayload(message, {
+    working = working.map((message, index) => truncateModelMessageForPayload(message, {
       maxToolResultChars: emergencyToolCap,
       maxMessageTextChars: emergencyTextCap,
       omitLargeAttachments: true,
+      preserveContent: shouldPreserveMessage(message, index, working),
     }));
     estimatedBytes = estimateUtf8Bytes(working);
   }
@@ -304,10 +322,11 @@ export function fitMessagesToRequestPayloadBudget({
   while (estimatedBytes > budget && (finalTextCap > 32 || finalToolCap > 32)) {
     finalTextCap = Math.max(32, Math.floor(finalTextCap * 0.6));
     finalToolCap = Math.max(32, Math.floor(finalToolCap * 0.6));
-    working = working.map((message) => truncateModelMessageForPayload(message, {
+    working = working.map((message, index) => truncateModelMessageForPayload(message, {
       maxToolResultChars: finalToolCap,
       maxMessageTextChars: finalTextCap,
       omitLargeAttachments: true,
+      preserveContent: shouldPreserveMessage(message, index, working),
     }));
     estimatedBytes = estimateUtf8Bytes(working);
   }

--- a/infrastructure/ai/requestPayloadBudget.ts
+++ b/infrastructure/ai/requestPayloadBudget.ts
@@ -1,0 +1,243 @@
+import type { ModelMessage } from "ai";
+import { findSafeCompactionSplitIndex } from "./contextCompaction";
+
+/** Stay below typical nginx `client_max_body_size` defaults (often 1-2 MB). */
+export const DEFAULT_MAX_REQUEST_PAYLOAD_BYTES = 1_500_000;
+/** Per tool-result text cap before the sliding window drops older turns. */
+export const DEFAULT_MAX_TOOL_RESULT_CHARS = 12_000;
+/** Per plain user/assistant text cap inside a single history message. */
+export const DEFAULT_MAX_MESSAGE_TEXT_CHARS = 24_000;
+/** Keep this many recent messages while trimming payload size. */
+export const DEFAULT_PROTECT_RECENT_PAYLOAD_MESSAGES = 8;
+
+const TRUNCATION_MARKER = "\n\n[... output truncated for request size ...]\n\n";
+const HEAD_CHARS = 800;
+const TAIL_CHARS = 4_000;
+
+export interface FitMessagesToRequestPayloadBudgetInput {
+  messages: ModelMessage[];
+  maxPayloadBytes?: number;
+  reservedBytes?: number;
+  maxToolResultChars?: number;
+  maxMessageTextChars?: number;
+  protectRecentMessages?: number;
+}
+
+export interface FitMessagesToRequestPayloadBudgetResult {
+  messages: ModelMessage[];
+  didAdjust: boolean;
+  estimatedBytes: number;
+}
+
+export function estimateUtf8Bytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return Buffer.byteLength(String(value ?? ""), "utf8");
+  }
+}
+
+/**
+ * Collapse noisy terminal/build output before measuring payload size.
+ * Keeps semantics while removing repeated blank lines and long duplicate runs.
+ */
+export function compressVerboseText(value: string): string {
+  if (!value) return value;
+
+  let compressed = value.replace(/\r\n/g, "\n");
+  compressed = compressed.replace(/\n{4,}/g, "\n\n\n");
+
+  const lines = compressed.split("\n");
+  const deduped: string[] = [];
+  let repeatCount = 0;
+  for (const line of lines) {
+    const previous = deduped[deduped.length - 1];
+    if (previous === line) {
+      repeatCount += 1;
+      if (repeatCount <= 2) deduped.push(line);
+      continue;
+    }
+    repeatCount = 0;
+    deduped.push(line);
+  }
+
+  return deduped.join("\n");
+}
+
+export function truncateTextWithHeadAndTail(
+  value: string,
+  maxChars: number,
+  {
+    headChars = HEAD_CHARS,
+    tailChars = TAIL_CHARS,
+    marker = TRUNCATION_MARKER,
+  }: {
+    headChars?: number;
+    tailChars?: number;
+    marker?: string;
+  } = {},
+): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= marker.length + 16) {
+    return value.slice(0, maxChars);
+  }
+
+  const budget = maxChars - marker.length;
+  let head = Math.min(headChars, budget);
+  let tail = Math.min(tailChars, Math.max(0, budget - head));
+  if (head + tail > budget) {
+    tail = Math.max(0, budget - head);
+  }
+  if (head + tail >= value.length) {
+    return value.slice(0, maxChars);
+  }
+  if (head + tail <= 0) {
+    return value.slice(0, maxChars);
+  }
+
+  return `${value.slice(0, head).trimEnd()}${marker}${value.slice(-tail).trimStart()}`;
+}
+
+export function truncateModelMessageForPayload(
+  message: ModelMessage,
+  {
+    maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
+    maxMessageTextChars = DEFAULT_MAX_MESSAGE_TEXT_CHARS,
+  }: {
+    maxToolResultChars?: number;
+    maxMessageTextChars?: number;
+  } = {},
+): ModelMessage {
+  if (typeof message.content === "string") {
+    const compressed = compressVerboseText(message.content);
+    return {
+      ...message,
+      content: truncateTextWithHeadAndTail(compressed, maxMessageTextChars),
+    };
+  }
+
+  if (!Array.isArray(message.content)) return message;
+
+  return {
+    ...message,
+    content: message.content.map((part) => truncateContentPartForPayload(part, {
+      maxToolResultChars,
+      maxMessageTextChars,
+    })),
+  };
+}
+
+function truncateContentPartForPayload(
+  part: unknown,
+  limits: {
+    maxToolResultChars: number;
+    maxMessageTextChars: number;
+  },
+): unknown {
+  if (!part || typeof part !== "object") return part;
+  const record = part as Record<string, unknown>;
+  const type = record.type;
+
+  if (type === "text" && typeof record.text === "string") {
+    const compressed = compressVerboseText(record.text);
+    return {
+      ...record,
+      text: truncateTextWithHeadAndTail(compressed, limits.maxMessageTextChars),
+    };
+  }
+
+  if (type === "tool-result") {
+    const output = record.output;
+    if (output && typeof output === "object") {
+      const outputRecord = output as Record<string, unknown>;
+      if (outputRecord.type === "text" && typeof outputRecord.value === "string") {
+        const compressed = compressVerboseText(outputRecord.value);
+        return {
+          ...record,
+          output: {
+            ...outputRecord,
+            value: truncateTextWithHeadAndTail(compressed, limits.maxToolResultChars),
+          },
+        };
+      }
+    }
+  }
+
+  return part;
+}
+
+export function fitMessagesToRequestPayloadBudget({
+  messages,
+  maxPayloadBytes = DEFAULT_MAX_REQUEST_PAYLOAD_BYTES,
+  reservedBytes = 0,
+  maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
+  maxMessageTextChars = DEFAULT_MAX_MESSAGE_TEXT_CHARS,
+  protectRecentMessages = DEFAULT_PROTECT_RECENT_PAYLOAD_MESSAGES,
+}: FitMessagesToRequestPayloadBudgetInput): FitMessagesToRequestPayloadBudgetResult {
+  const budget = Math.max(0, maxPayloadBytes - Math.max(0, reservedBytes));
+  if (budget === 0) {
+    return { messages: [], didAdjust: messages.length > 0, estimatedBytes: 0 };
+  }
+  let adjusted = messages.map((message) => truncateModelMessageForPayload(message, {
+    maxToolResultChars,
+    maxMessageTextChars,
+  }));
+  let estimatedBytes = estimateUtf8Bytes(adjusted);
+  if (estimatedBytes <= budget) {
+    return { messages: adjusted, didAdjust: false, estimatedBytes };
+  }
+
+  let didAdjust = estimatedBytes !== estimateUtf8Bytes(messages);
+
+  const toolResultCaps = [
+    maxToolResultChars,
+    Math.floor(maxToolResultChars * 0.6),
+    Math.floor(maxToolResultChars * 0.35),
+    4_000,
+    2_000,
+    1_000,
+  ];
+  const messageTextCaps = [
+    maxMessageTextChars,
+    Math.floor(maxMessageTextChars * 0.6),
+    Math.floor(maxMessageTextChars * 0.35),
+    8_000,
+    4_000,
+    2_000,
+  ];
+
+  for (let i = 1; i < toolResultCaps.length; i += 1) {
+    adjusted = adjusted.map((message) => truncateModelMessageForPayload(message, {
+      maxToolResultChars: toolResultCaps[i],
+      maxMessageTextChars: messageTextCaps[i],
+    }));
+    estimatedBytes = estimateUtf8Bytes(adjusted);
+    didAdjust = true;
+    if (estimatedBytes <= budget) {
+      return { messages: adjusted, didAdjust, estimatedBytes };
+    }
+  }
+
+  let working = [...adjusted];
+  while (working.length > protectRecentMessages) {
+    const splitAt = findSafeCompactionSplitIndex(working, protectRecentMessages);
+    if (splitAt <= 0) break;
+    working = working.slice(splitAt);
+    estimatedBytes = estimateUtf8Bytes(working);
+    didAdjust = true;
+    if (estimatedBytes <= budget) {
+      return { messages: working, didAdjust, estimatedBytes };
+    }
+  }
+
+  const emergencyToolCap = 600;
+  const emergencyTextCap = 1_200;
+  working = working.map((message) => truncateModelMessageForPayload(message, {
+    maxToolResultChars: emergencyToolCap,
+    maxMessageTextChars: emergencyTextCap,
+  }));
+  estimatedBytes = estimateUtf8Bytes(working);
+  didAdjust = true;
+
+  return { messages: working, didAdjust, estimatedBytes };
+}

--- a/infrastructure/ai/requestPayloadBudget.ts
+++ b/infrastructure/ai/requestPayloadBudget.ts
@@ -183,11 +183,11 @@ export function fitMessagesToRequestPayloadBudget({
     maxMessageTextChars,
   }));
   let estimatedBytes = estimateUtf8Bytes(adjusted);
+  const originalBytes = estimateUtf8Bytes(messages);
+  let didAdjust = estimatedBytes !== originalBytes;
   if (estimatedBytes <= budget) {
-    return { messages: adjusted, didAdjust: false, estimatedBytes };
+    return { messages: adjusted, didAdjust, estimatedBytes };
   }
-
-  let didAdjust = estimatedBytes !== estimateUtf8Bytes(messages);
 
   const toolResultCaps = [
     maxToolResultChars,
@@ -238,6 +238,34 @@ export function fitMessagesToRequestPayloadBudget({
   }));
   estimatedBytes = estimateUtf8Bytes(working);
   didAdjust = true;
+
+  let emergencyProtect = Math.min(protectRecentMessages, working.length);
+  while (estimatedBytes > budget && working.length > 1) {
+    emergencyProtect = Math.max(1, emergencyProtect - 1);
+    const splitAt = findSafeCompactionSplitIndex(working, emergencyProtect);
+    if (splitAt <= 0) {
+      working = working.slice(-1);
+    } else {
+      working = working.slice(splitAt);
+    }
+    working = working.map((message) => truncateModelMessageForPayload(message, {
+      maxToolResultChars: emergencyToolCap,
+      maxMessageTextChars: emergencyTextCap,
+    }));
+    estimatedBytes = estimateUtf8Bytes(working);
+  }
+
+  let finalTextCap = emergencyTextCap;
+  let finalToolCap = emergencyToolCap;
+  while (estimatedBytes > budget && (finalTextCap > 32 || finalToolCap > 32)) {
+    finalTextCap = Math.max(32, Math.floor(finalTextCap * 0.6));
+    finalToolCap = Math.max(32, Math.floor(finalToolCap * 0.6));
+    working = working.map((message) => truncateModelMessageForPayload(message, {
+      maxToolResultChars: finalToolCap,
+      maxMessageTextChars: finalTextCap,
+    }));
+    estimatedBytes = estimateUtf8Bytes(working);
+  }
 
   return { messages: working, didAdjust, estimatedBytes };
 }

--- a/infrastructure/ai/requestPayloadBudget.ts
+++ b/infrastructure/ai/requestPayloadBudget.ts
@@ -30,11 +30,24 @@ export interface FitMessagesToRequestPayloadBudgetResult {
 }
 
 export function estimateUtf8Bytes(value: unknown): number {
+  const text = stringifyForByteEstimate(value);
+  return utf8ByteLength(text);
+}
+
+function stringifyForByteEstimate(value: unknown): string {
   try {
-    return Buffer.byteLength(JSON.stringify(value), "utf8");
+    return JSON.stringify(value);
   } catch {
-    return Buffer.byteLength(String(value ?? ""), "utf8");
+    return String(value ?? "");
   }
+}
+
+function utf8ByteLength(value: string | undefined): number {
+  const text = value ?? "";
+  if (typeof Buffer !== "undefined" && typeof Buffer.byteLength === "function") {
+    return Buffer.byteLength(text, "utf8");
+  }
+  return new TextEncoder().encode(text).byteLength;
 }
 
 /**
@@ -103,9 +116,11 @@ export function truncateModelMessageForPayload(
   {
     maxToolResultChars = DEFAULT_MAX_TOOL_RESULT_CHARS,
     maxMessageTextChars = DEFAULT_MAX_MESSAGE_TEXT_CHARS,
+    omitLargeAttachments = false,
   }: {
     maxToolResultChars?: number;
     maxMessageTextChars?: number;
+    omitLargeAttachments?: boolean;
   } = {},
 ): ModelMessage {
   if (typeof message.content === "string") {
@@ -123,6 +138,7 @@ export function truncateModelMessageForPayload(
     content: message.content.map((part) => truncateContentPartForPayload(part, {
       maxToolResultChars,
       maxMessageTextChars,
+      omitLargeAttachments,
     })),
   };
 }
@@ -132,6 +148,7 @@ function truncateContentPartForPayload(
   limits: {
     maxToolResultChars: number;
     maxMessageTextChars: number;
+    omitLargeAttachments: boolean;
   },
 ): unknown {
   if (!part || typeof part !== "object") return part;
@@ -163,7 +180,32 @@ function truncateContentPartForPayload(
     }
   }
 
+  if (limits.omitLargeAttachments && type === "image" && typeof record.image === "string") {
+    return omittedAttachmentTextPart("image", record.image, record);
+  }
+
+  if (limits.omitLargeAttachments && type === "file" && typeof record.data === "string") {
+    return omittedAttachmentTextPart("file", record.data, record);
+  }
+
   return part;
+}
+
+function omittedAttachmentTextPart(
+  label: "image" | "file",
+  payload: string,
+  record: Record<string, unknown>,
+): { type: "text"; text: string } {
+  const details = [
+    typeof record.filename === "string" ? `filename=${record.filename}` : undefined,
+    typeof record.mediaType === "string" ? `mediaType=${record.mediaType}` : undefined,
+    `${payload.length} chars`,
+  ].filter(Boolean).join(", ");
+
+  return {
+    type: "text",
+    text: `[${label} attachment omitted to keep the AI request small: ${details}]`,
+  };
 }
 
 export function fitMessagesToRequestPayloadBudget({
@@ -235,6 +277,7 @@ export function fitMessagesToRequestPayloadBudget({
   working = working.map((message) => truncateModelMessageForPayload(message, {
     maxToolResultChars: emergencyToolCap,
     maxMessageTextChars: emergencyTextCap,
+    omitLargeAttachments: true,
   }));
   estimatedBytes = estimateUtf8Bytes(working);
   didAdjust = true;
@@ -251,6 +294,7 @@ export function fitMessagesToRequestPayloadBudget({
     working = working.map((message) => truncateModelMessageForPayload(message, {
       maxToolResultChars: emergencyToolCap,
       maxMessageTextChars: emergencyTextCap,
+      omitLargeAttachments: true,
     }));
     estimatedBytes = estimateUtf8Bytes(working);
   }
@@ -263,6 +307,7 @@ export function fitMessagesToRequestPayloadBudget({
     working = working.map((message) => truncateModelMessageForPayload(message, {
       maxToolResultChars: finalToolCap,
       maxMessageTextChars: finalTextCap,
+      omitLargeAttachments: true,
     }));
     estimatedBytes = estimateUtf8Bytes(working);
   }

--- a/infrastructure/ai/requestPayloadBudget.ts
+++ b/infrastructure/ai/requestPayloadBudget.ts
@@ -322,11 +322,11 @@ export function fitMessagesToRequestPayloadBudget({
   while (estimatedBytes > budget && (finalTextCap > 32 || finalToolCap > 32)) {
     finalTextCap = Math.max(32, Math.floor(finalTextCap * 0.6));
     finalToolCap = Math.max(32, Math.floor(finalToolCap * 0.6));
-    working = working.map((message, index) => truncateModelMessageForPayload(message, {
+    working = working.map((message) => truncateModelMessageForPayload(message, {
       maxToolResultChars: finalToolCap,
       maxMessageTextChars: finalTextCap,
       omitLargeAttachments: true,
-      preserveContent: shouldPreserveMessage(message, index, working),
+      preserveContent: false,
     }));
     estimatedBytes = estimateUtf8Bytes(working);
   }

--- a/infrastructure/ai/sdk/tools.test.ts
+++ b/infrastructure/ai/sdk/tools.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { fitTerminalExecuteResultForModel } from "./tools.ts";
+
+test("fitTerminalExecuteResultForModel keeps command output compact for model replay", () => {
+  const result = fitTerminalExecuteResultForModel({
+    stdout: "A".repeat(200_000),
+    stderr: "B".repeat(50_000),
+    exitCode: 0,
+  });
+
+  assert.ok(result.stdout.length < 25_000);
+  assert.ok(result.stderr.length < 12_000);
+  assert.match(result.stdout, /output truncated for request size/);
+  assert.equal(result.exitCode, 0);
+});

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -15,11 +15,27 @@ import {
 } from '../shared/toolExecutors';
 import { requestApproval } from '../shared/approvalGate';
 import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
+import { truncateTextWithHeadAndTail } from '../requestPayloadBudget';
+
+const MAX_LIVE_TERMINAL_STDOUT_CHARS = 24_000;
+const MAX_LIVE_TERMINAL_STDERR_CHARS = 12_000;
 
 /** Unwrap a shared ToolExecResult into the shape expected by Vercel AI SDK tool results. */
 function unwrap<T>(r: ToolExecResult<T>): T | { error: string } {
   if (r.ok === false) return { error: r.error };
   return r.data;
+}
+
+export function fitTerminalExecuteResultForModel(result: {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}): { stdout: string; stderr: string; exitCode: number | null } {
+  return {
+    ...result,
+    stdout: truncateTextWithHeadAndTail(result.stdout, MAX_LIVE_TERMINAL_STDOUT_CHARS),
+    stderr: truncateTextWithHeadAndTail(result.stderr, MAX_LIVE_TERMINAL_STDERR_CHARS),
+  };
 }
 
 /**
@@ -104,7 +120,9 @@ export function createCattyTools(
           };
           abortSignal?.addEventListener('abort', cancelOnAbort, { once: true });
           try {
-            return unwrap(await executeTerminalExecute(deps, { sessionId, command }));
+            const result = await executeTerminalExecute(deps, { sessionId, command });
+            if (result.ok === false) return unwrap(result);
+            return fitTerminalExecuteResultForModel(result.data);
           } finally {
             abortSignal?.removeEventListener('abort', cancelOnAbort);
           }


### PR DESCRIPTION
## Problem

Long-running Catty Agent chats could grow the AI request body beyond common gateway/proxy limits, especially after terminal output, attachments, and replayed history accumulated. When the gateway returned HTTP 413, the active chat could fail even though token-based context compaction had not reached the model limit yet.

## What Changed

- Replays historical attachments and terminal output as compact placeholders instead of sending the original large payloads every turn.
- Adds a request payload budget before Catty Agent requests, with log compression, head/tail truncation, safe message dropping, and last-resort attachment omission.
- Applies the payload budget again after context compaction or compaction fallback so the final request is still size-checked.
- Detects HTTP 413 more precisely, avoids false positives such as timing text like `413 ms`, forces context compaction, and retries once.
- Clears the failed partial assistant message before retrying so the user sees one clean recovery attempt.
- Keeps live `terminal_execute` output smaller before it enters model history.
- Pairs replayed tool results with the nearest preceding matching tool call, so reused tool IDs are handled in chronological order.

## Flow

```mermaid
flowchart TD
  A[User sends Catty message] --> B[Build model history]
  B --> C[Replace old attachments and terminal output with placeholders]
  C --> D[Apply request size budget]
  D --> E[Compact older context when needed]
  E --> F[Apply size budget again]
  F --> G[Send request to AI provider]
  G --> H{HTTP 413?}
  H -- No --> I[Continue normal stream]
  H -- Yes --> J[Clear failed partial reply]
  J --> K[Force context compaction]
  K --> L[Trim request again]
  L --> M[Retry once]
  M --> N[Show response or final error]
```

## Testing

- Added and updated tests for request payload trimming, history replay, 413 detection, false-positive handling, and terminal result trimming.
- Verified locally with:

```bash
node --test --import tsx components/ai/cattyHistoryReplay.test.ts components/ai/externalAgentHistory.test.ts infrastructure/ai/requestPayloadBudget.test.ts infrastructure/ai/errorClassifier.test.ts infrastructure/ai/sdk/tools.test.ts
```

Result: 58 tests passed.

Closes #1323
