### PR TITLE
Fix terminal tabs overlapping host tree on first Vault connect

### DIFF
--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+});
+
+const { computeHostTreeTabGutter } = await import("./TopTabs.tsx");
+
+test("host tree tab gutter fills the remaining sidebar width", () => {
+  assert.equal(computeHostTreeTabGutter(280, 120), 160);
+});
+
+test("host tree tab gutter never goes negative", () => {
+  assert.equal(computeHostTreeTabGutter(120, 280), 0);
+});

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -36,6 +36,10 @@ const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties;
 const dragRegionNoSelect = { WebkitAppRegion: 'drag', userSelect: 'none' } as React.CSSProperties;
 const emptyTabStyle: React.CSSProperties = {};
 
+export function computeHostTreeTabGutter(hostTreeLayoutWidth: number, toggleRight: number): number {
+  return Math.max(0, hostTreeLayoutWidth - toggleRight);
+}
+
 interface TopTabsProps {
   theme: 'dark' | 'light';
   followAppTerminalTheme?: boolean;
@@ -114,6 +118,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const activeTabId = useActiveTabId();
   const { getTabAnimationClass } = useTopTabLifecycleAnimations(orderedTabs);
   const [hostTreeTogglePop, setHostTreeTogglePop] = useState(false);
+  const fixedLeftTabsRef = useRef<HTMLDivElement>(null);
   const hostTreeToggleSlotRef = useRef<HTMLDivElement>(null);
   const [hostTreeTabGutter, setHostTreeTabGutter] = useState(0);
 
@@ -237,19 +242,23 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     }
     const rootLeft = root.getBoundingClientRect().left;
     const toggleRight = toggleSlot.getBoundingClientRect().right - rootLeft;
-    setHostTreeTabGutter(Math.max(0, hostTreeLayoutWidth - toggleRight));
+    setHostTreeTabGutter(computeHostTreeTabGutter(hostTreeLayoutWidth, toggleRight));
   }, [hostTreeLayoutWidth, showHostTreeToggle]);
 
   useLayoutEffect(() => {
     updateHostTreeTabGutter();
+    const rafId = window.requestAnimationFrame(updateHostTreeTabGutter);
+    const settleTimer = window.setTimeout(updateHostTreeTabGutter, 320);
     const root = tabsContainerRef.current?.closest('[data-top-tabs-root]') as HTMLElement | null;
-    if (!root) return;
     const ro = new ResizeObserver(() => updateHostTreeTabGutter());
-    ro.observe(root);
+    if (root) ro.observe(root);
+    if (fixedLeftTabsRef.current) ro.observe(fixedLeftTabsRef.current);
     if (tabsContainerRef.current) ro.observe(tabsContainerRef.current);
     if (hostTreeToggleSlotRef.current) ro.observe(hostTreeToggleSlotRef.current);
     window.addEventListener('resize', updateHostTreeTabGutter);
     return () => {
+      window.cancelAnimationFrame(rafId);
+      window.clearTimeout(settleTimer);
       ro.disconnect();
       window.removeEventListener('resize', updateHostTreeTabGutter);
     };
@@ -580,7 +589,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         style={{ ...dragRegionStyle, paddingLeft: isMacClient && !isWindowFullscreen ? 76 : 12, paddingRight: isMacClient ? 12 : 0 }}
       >
         {/* Fixed left tabs: Vaults and SFTP */}
-        <div className="flex items-end gap-0 flex-shrink-0 app-drag">
+        <div ref={fixedLeftTabsRef} className="flex items-end gap-0 flex-shrink-0 app-drag">
           <RootTopTab
             tabId="vault"
             label="Vaults"


### PR DESCRIPTION
Fixes the first terminal tab overlapping the expanded host tree when connecting from Vault.\n\nWhat changed:\n- Re-measure the top-tab host-tree gutter after the fixed left tabs animate/collapse.\n- Observe the fixed left tab area so the gutter updates when its width changes.\n- Add a small regression test for the gutter calculation.\n\nVerification:\n- node --import tsx --test components/TopTabs.test.ts components/terminalLayer/terminalLayerViewMemo.test.ts\n- npm run lint\n- npm run build