### PR TITLE
fix: host tree tab jump on first terminal open

### DIFF
--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -658,6 +658,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           {showHostTreeToggle && (
             <div
               className="top-tab-host-tree-gutter flex-shrink-0"
+              data-instant={isHostTreeOpen && hostTreeTogglePop ? 'true' : 'false'}
               style={{ width: hostTreeTabGutter }}
               aria-hidden
             />

--- a/index.css
+++ b/index.css
@@ -178,6 +178,10 @@
   pointer-events: none;
 }
 
+.top-tab-host-tree-gutter[data-instant='true'] {
+  transition: none;
+}
+
 .top-tab-host-tree-toggle-pop {
   animation: pop-in 320ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }


### PR DESCRIPTION
This PR removes the visual jump in the top tab bar when opening the first terminal/workspace tab while the host tree is already expanded.

The host tree gutter still keeps its normal width transition for regular interactions, but temporarily disables that transition during the initial host-tree toggle appearance. This lets the first terminal tab render immediately in its final position instead of sliding right after mount.

Before:
https://github.com/user-attachments/assets/ee03cb3c-05d1-4a53-bde2-25ac5c7e2703

After:
https://github.com/user-attachments/assets/757617f9-c86b-4c10-a3ee-1865cc909cd0



Testing

Ran npm run lint successfully.