### PR TITLE
fix(vault): add duplicate host to tree view context menu

### DIFF
--- a/application/state/vaultHostTreeActionsStore.ts
+++ b/application/state/vaultHostTreeActionsStore.ts
@@ -4,6 +4,7 @@ import type { Host } from '../../types';
 
 export interface VaultHostTreeActions {
   onDeleteHost: (host: Host) => void;
+  onDuplicateHost: (host: Host) => void;
   onCopyCredentials: (host: Host) => void;
   onNewGroup: (parentPath?: string) => void;
   onRenameGroup: (groupPath: string) => void;

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -359,7 +359,7 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
   depth,
   onConnect,
   onEditHost,
-  onDuplicateHost: _onDuplicateHost,
+  onDuplicateHost,
   onDeleteHost,
   onCopyCredentials,
   moveHostToGroup: _moveHostToGroup,
@@ -452,6 +452,7 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
       <HostTreeHostContextMenuContent
         host={host}
         onConnect={onConnect}
+        onDuplicateHost={onDuplicateHost}
         onCopyCredentials={onCopyCredentials}
         onDeleteHost={onDeleteHost}
       />

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -482,6 +482,9 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   }, []);
 
   const handleDuplicateHost = useCallback((host: Host) => {
+    setCurrentSection("hosts");
+    setIsGroupPanelOpen(false);
+    setEditingGroupPath(null);
     // Create a copy of the host with a new ID and modified label
     const duplicatedHost: Host = {
       ...host,

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -964,6 +964,7 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
 
   useRegisterVaultHostTreeActions({
     handleCopyCredentials,
+    handleDuplicateHost,
     onDeleteHost,
     handleUnmanageGroup,
     moveHostToGroup,

--- a/components/host/HostTreeContextMenus.tsx
+++ b/components/host/HostTreeContextMenus.tsx
@@ -1,4 +1,4 @@
-import { FileSymlink, Folder, FolderOpen, Monitor, Server } from 'lucide-react';
+import { Copy, FileSymlink, Folder, FolderOpen, Monitor, Server } from 'lucide-react';
 import React from 'react';
 
 import { useI18n } from '../../application/i18n/I18nProvider';
@@ -8,6 +8,7 @@ import { ContextMenuContent, ContextMenuItem } from '../ui/context-menu';
 
 export interface HostTreeHostContextMenuHandlers {
   onConnect: (host: Host) => void;
+  onDuplicateHost: (host: Host) => void;
   onCopyCredentials: (host: Host) => void;
   onDeleteHost: (host: Host) => void;
 }
@@ -17,6 +18,7 @@ export const HostTreeHostContextMenuContent: React.FC<
 > = ({
   host,
   onConnect,
+  onDuplicateHost,
   onCopyCredentials,
   onDeleteHost,
 }) => {
@@ -27,6 +29,9 @@ export const HostTreeHostContextMenuContent: React.FC<
     <ContextMenuContent>
       <ContextMenuItem onClick={() => onConnect(safeHost)}>
         <Monitor className="mr-2 h-4 w-4" /> {t('vault.hosts.connect')}
+      </ContextMenuItem>
+      <ContextMenuItem onClick={() => onDuplicateHost(host)}>
+        <Copy className="mr-2 h-4 w-4" /> {t('action.duplicate')}
       </ContextMenuItem>
       <ContextMenuItem onClick={() => onCopyCredentials(host)}>
         <Server className="mr-2 h-4 w-4" /> {t('vault.hosts.copyCredentials')}

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -231,6 +231,7 @@ const HostTreeFlatRowItem = memo<HostTreeFlatRowProps>(({
         <HostTreeHostContextMenuContent
           host={row.host}
           onConnect={onConnect}
+          onDuplicateHost={menuActions.onDuplicateHost}
           onCopyCredentials={menuActions.onCopyCredentials}
           onDeleteHost={menuActions.onDeleteHost}
         />

--- a/components/vault/useRegisterVaultHostTreeActions.ts
+++ b/components/vault/useRegisterVaultHostTreeActions.ts
@@ -9,6 +9,7 @@ import type { Host } from '../../types';
 
 type RegisterVaultHostTreeActionsParams = {
   handleCopyCredentials: (host: Host) => void;
+  handleDuplicateHost: (host: Host) => void;
   onDeleteHost: (hostId: string) => void;
   handleUnmanageGroup?: (groupPath: string) => void;
   moveHostToGroup: (hostId: string, groupPath: string | null) => void;
@@ -34,6 +35,7 @@ function withVaultFocus<T extends (...args: never[]) => void>(fn: T): T {
 
 export function useRegisterVaultHostTreeActions({
   handleCopyCredentials,
+  handleDuplicateHost,
   onDeleteHost,
   handleUnmanageGroup,
   moveHostToGroup,
@@ -48,6 +50,7 @@ export function useRegisterVaultHostTreeActions({
   useEffect(() => {
     const actions: VaultHostTreeActions = {
       onCopyCredentials: handleCopyCredentials,
+      onDuplicateHost: withVaultFocus(handleDuplicateHost),
       onDeleteHost: (host) => onDeleteHost(host.id),
       onNewGroup: startInlineNewGroup,
       onRenameGroup: startInlineRenameGroup,
@@ -68,6 +71,7 @@ export function useRegisterVaultHostTreeActions({
     cancelInlineGroupEdit,
     commitInlineGroupRename,
     handleCopyCredentials,
+    handleDuplicateHost,
     handleUnmanageGroup,
     managedGroupPaths,
     moveGroup,


### PR DESCRIPTION
## Summary
- 在 Vault 树形视图的主机右键菜单中补上「复制」操作，与网格/列表视图行为一致
- 将 `onDuplicateHost` 接入终端侧栏共用的主机树右键菜单
- 从终端侧栏触发复制时自动切换到 Vault 的 Hosts 分区，确保主机编辑面板可见

Fixes #1329

## Test plan
- [x] 在 Vault 树形视图中右键主机，确认出现「复制」菜单项
- [x] 点击复制后打开主机编辑面板，标签带「(复制)」后缀
- [x] 运行 `components/HostTreeView.test.tsx` 通过
- [ ] 从终端侧栏主机树右键复制，确认跳转到 Vault Hosts 并显示编辑面板


Made with [Cursor](https://cursor.com)