### PR TITLE
fix: keep connection logs fully visible

### DIFF
--- a/components/terminal/TerminalConnectionDialog.test.ts
+++ b/components/terminal/TerminalConnectionDialog.test.ts
@@ -133,6 +133,26 @@ test("fills both progress segments for disconnected states", () => {
   assert.equal(fullSegments.length >= 2, true);
 });
 
+test("keeps connection log padding inside the scrollable content", () => {
+  const markup = renderDialog({
+    status: "disconnected",
+    error: "Connection timed out.",
+    showLogs: true,
+    progressProps: {
+      timeLeft: 0,
+      isCancelling: false,
+      progressLogs: Array.from({ length: 12 }, (_, index) => `Log line ${index + 1}`),
+      onCancelConnect: () => {},
+      onCloseSession: () => {},
+      onRetry: () => {},
+    },
+  });
+
+  assert.match(markup, /class="[^"]*max-h-44/);
+  assert.doesNotMatch(markup, /class="[^"]*max-h-44[^"]*p-2\.5/);
+  assert.match(markup, /class="[^"]*p-2\.5[^"]*pb-4[^"]*pr-4/);
+});
+
 test("shows the ET server port (not the SSH port) for an ET host with a custom etPort", () => {
   const markup = renderDialog({
     host: { ...host, etEnabled: true, port: 22, etPort: 9022 },

--- a/components/terminal/TerminalConnectionProgress.tsx
+++ b/components/terminal/TerminalConnectionProgress.tsx
@@ -30,8 +30,8 @@ export const TerminalConnectionLogList: React.FC<TerminalConnectionLogListProps>
     error,
 }) => (
     <div className="rounded-md border border-border/35 bg-background/40">
-        <ScrollArea className="max-h-44 p-2.5">
-            <div className="space-y-1 text-xs text-foreground/90">
+        <ScrollArea className="max-h-44">
+            <div className="space-y-1 p-2.5 pb-4 pr-4 text-xs text-foreground/90">
                 {progressLogs.map((line, idx) => (
                     <div key={idx} className="flex items-start gap-2">
                         <div className="mt-[0.4rem] h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-500" />


### PR DESCRIPTION
## Summary
- Fixes the disconnected connection log list so the final log entry is fully visible after scrolling to the bottom.
- Moves padding into the scrollable content and adds bottom breathing room to avoid clipping near the action buttons.
- Adds a regression check for the log list spacing.

## Root cause
The connection log list applied padding to the scroll container itself. With the fixed-height scroll area, the final row could sit flush against the bottom edge and appear clipped or obscured when scrolled all the way down.

## Validation
- `node --test --import tsx components/terminal/TerminalConnectionDialog.test.ts`
- `npx eslint components/terminal/TerminalConnectionProgress.tsx components/terminal/TerminalConnectionDialog.test.ts`
- `npm run build`
- Local visual check matching the reported disconnected-log layout: scrolled to the bottom and confirmed the final log line remained fully visible.

Fixes #1333
