### PR TITLE
Fix host sidebar behavior for editor tabs

### DIFF
--- a/application/app/AppMounts.test.ts
+++ b/application/app/AppMounts.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+});
+
+const { getLogViewWrapperStyle } = await import('./AppMounts.tsx');
+
+test('visible log view leaves room for the terminal host sidebar', () => {
+  assert.deepEqual(getLogViewWrapperStyle(true, 220), {
+    left: 220,
+  });
+});
+
+test('hidden log view remains hidden while preserving host sidebar offset', () => {
+  assert.deepEqual(getLogViewWrapperStyle(false, 220), {
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    position: 'absolute',
+    zIndex: -1,
+    left: 220,
+  });
+});

--- a/application/app/AppMounts.tsx
+++ b/application/app/AppMounts.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { useActiveTabId, useIsSftpActive, useIsTerminalLayerVisible, useIsVaultActive } from '../state/activeTabStore';
+import { useTerminalHostTreeLayoutWidth } from '../state/terminalHostTreeStore';
 import { cn } from '../../lib/utils';
 import { ConnectionLog, TerminalTheme } from '../../types';
 import type { LogView as LogViewType } from '../state/logViewState';
@@ -29,14 +30,21 @@ interface LogViewWrapperProps {
   onUpdateLog: (logId: string, updates: Partial<ConnectionLog>) => void;
 }
 
+export function getLogViewWrapperStyle(
+  isVisible: boolean,
+  hostTreeLayoutWidth: number,
+): React.CSSProperties {
+  return isVisible
+    ? { left: hostTreeLayoutWidth }
+    : { visibility: 'hidden', pointerEvents: 'none', position: 'absolute', zIndex: -1, left: hostTreeLayoutWidth };
+}
+
 export const LogViewWrapper: React.FC<LogViewWrapperProps> = ({ logView, defaultTerminalTheme, defaultFontSize, onClose, onUpdateLog }) => {
   const activeTabId = useActiveTabId();
   const isVisible = activeTabId === logView.id;
+  const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
 
-  // Use same pattern as VaultViewContainer for visibility
-  const containerStyle: React.CSSProperties = isVisible
-    ? {}
-    : { visibility: 'hidden', pointerEvents: 'none', position: 'absolute', zIndex: -1 };
+  const containerStyle = getLogViewWrapperStyle(isVisible, hostTreeLayoutWidth);
 
   return (
     <div className={cn("absolute inset-0", isVisible ? "z-20" : "")} style={containerStyle}>

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -2,7 +2,6 @@
 import React, { Suspense, lazy } from 'react';
 import { AlertTriangle, Download, Trash2 } from 'lucide-react';
 import { activeTabStore, toEditorTabId } from '../state/activeTabStore';
-import { useImmersiveActive } from '../state/immersiveStore';
 import { editorTabStore } from '../state/editorTabStore';
 import { releaseEditorTabSaveCoordinator, saveEditorTab } from '../state/editorTabSave';
 import { TopTabs } from '../../components/TopTabs';
@@ -19,7 +18,6 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import { toast } from '../../components/ui/toast';
-import { cn } from '../../lib/utils';
 
 const LazyProtocolSelectDialog = lazy(() => import('../../components/ProtocolSelectDialog'));
 const LazyQuickSwitcher = lazy(() =>
@@ -55,12 +53,6 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateTerminalSetting, workspaceRenameTarget, workspaceRenameValue, workspaces,
     VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper,
   } = ctx;
-
-  // Immersive flag from store (not ctx) so toggling it doesn't re-render <App>.
-  // Note: we intentionally do NOT subscribe to the active tab id here — editor
-  // tab visibility self-subscribes inside TextEditorTabView — so plain tab
-  // switches don't re-render AppView/App at all.
-  const isImmersive = useImmersiveActive();
 
   return (
     <SnippetExecutionProvider>
@@ -113,7 +105,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         handleRequestCloseEditorTabRef.current = handleRequestCloseEditorTab;
 
         return (
-    <div className={cn("flex flex-col h-screen text-foreground font-sans netcatty-shell", isImmersive && "immersive-transition")} onContextMenu={handleRootContextMenu}>
+    <div className="flex flex-col h-screen text-foreground font-sans netcatty-shell" onContextMenu={handleRootContextMenu}>
       <TopTabs
         theme={resolvedTheme}
         followAppTerminalTheme={followAppTerminalTheme}
@@ -139,11 +131,11 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         windowOpacity={settings.windowOpacity}
         setWindowOpacity={settings.setWindowOpacity}
         onSyncNow={handleSyncNowManual}
-        isImmersiveActive={isImmersive}
         onStartSessionDrag={setDraggingSessionId}
         onEndSessionDrag={handleEndSessionDrag}
         onReorderTabs={reorderTabs}
         showSftpTab={settings.showSftpTab}
+        showHostTreeSidebar={settings.showHostTreeSidebar}
         editorTabs={editorTabs}
         onRequestCloseEditorTab={handleRequestCloseEditorTab}
         hostById={hostById}
@@ -289,6 +281,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
           sessionLogsFormat={sessionLogsFormat}
           sessionLogsTimestampsEnabled={sessionLogsTimestampsEnabled}
           sshDebugLogsEnabled={sshDebugLogsEnabled}
+          showHostTreeSidebar={settings.showHostTreeSidebar}
           toggleScriptsSidePanelRef={toggleScriptsSidePanelRef}
           toggleSidePanelRef={toggleSidePanelRef}
         />

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -225,6 +225,8 @@ export const enCoreMessages: Messages = {
   'settings.vault.showOnlyUngroupedHostsInRootDesc': 'When enabled, the root host list only shows hosts without a group. Open a group from the sidebar to see grouped hosts.',
   'settings.vault.showSftpTab': 'Show SFTP tab',
   'settings.vault.showSftpTabDesc': 'Display the standalone SFTP view in the top tab bar. When hidden, use the in-session SFTP side panel instead.',
+  'settings.vault.showHostTreeSidebar': 'Show host list sidebar',
+  'settings.vault.showHostTreeSidebarDesc': 'Display the host list sidebar and its top-bar toggle on terminal and editor tabs.',
 
   // Update notifications
   'update.available.title': 'Update Available',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -225,6 +225,8 @@ export const ruCoreMessages: Messages = {
   'settings.vault.showOnlyUngroupedHostsInRootDesc': 'Если включено, в корневом списке хостов будут показаны только хосты без группы. Откройте группу на боковой панели, чтобы увидеть сгруппированные хосты.',
   'settings.vault.showSftpTab': 'Показывать вкладку SFTP',
   'settings.vault.showSftpTabDesc': 'Показывать отдельный SFTP-вид в верхней панели вкладок. Если скрыто, используйте боковую панель SFTP внутри сессии.',
+  'settings.vault.showHostTreeSidebar': 'Показывать боковую панель хостов',
+  'settings.vault.showHostTreeSidebarDesc': 'Показывать список хостов и кнопку в верхней панели для вкладок терминала и редактора.',
 
   // Update notifications
   'update.available.title': 'Доступно обновление',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -209,6 +209,8 @@ export const zhCNCoreMessages: Messages = {
   'settings.vault.showOnlyUngroupedHostsInRootDesc': '开启后，主机库根目录的主机列表只显示没有分组的主机，已分组主机请从左侧分组进入查看。',
   'settings.vault.showSftpTab': '显示 SFTP 标签页',
   'settings.vault.showSftpTabDesc': '在顶部标签栏显示独立的 SFTP 视图。关闭后可改用会话内左侧的 SFTP 侧栏。',
+  'settings.vault.showHostTreeSidebar': '显示主机列表侧栏',
+  'settings.vault.showHostTreeSidebarDesc': '在终端和编辑器标签页显示主机列表侧栏及顶部开关。',
 
   // Update notifications
   'update.available.title': '发现新版本',

--- a/application/state/activeTabStore.test.ts
+++ b/application/state/activeTabStore.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isTerminalLayerVisibleTab } from './activeTabStore';
+
+test('terminal layer stays visible for editor tabs so the host sidebar can be used', () => {
+  assert.equal(isTerminalLayerVisibleTab('editor:file-1'), true);
+});
+
+test('terminal layer visibility excludes root pages and includes work tabs', () => {
+  assert.equal(isTerminalLayerVisibleTab('vault'), false);
+  assert.equal(isTerminalLayerVisibleTab('sftp'), false);
+  assert.equal(isTerminalLayerVisibleTab('session-1'), true);
+  assert.equal(isTerminalLayerVisibleTab('workspace-1'), true);
+});

--- a/application/state/activeTabStore.ts
+++ b/application/state/activeTabStore.ts
@@ -110,13 +110,16 @@ export const useIsEditorTabActive = (tabId: string): boolean => {
   return useSyncExternalStore(activeTabStore.subscribe, getSnapshot, getSnapshot);
 };
 
+export const isTerminalLayerVisibleTab = (activeTabId: string): boolean => {
+  return activeTabId !== 'vault' && activeTabId !== 'sftp';
+};
+
 // Check if terminal layer should be visible
-// Editor tabs are NOT terminal tabs, so exclude them from the visibility condition.
+// Editor tabs share the terminal work surface so the host sidebar remains usable.
 export const useIsTerminalLayerVisible = (draggingSessionId: string | null) => {
   const getSnapshot = useCallback(() => {
     const activeTabId = activeTabStore.getActiveTabId();
-    const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp' && !isEditorTabId(activeTabId);
-    return isTerminalTab || !!draggingSessionId;
+    return isTerminalLayerVisibleTab(activeTabId) || !!draggingSessionId;
   }, [draggingSessionId]);
 
   return useSyncExternalStore(activeTabStore.subscribe, getSnapshot, getSnapshot);

--- a/application/state/settingsIpcSync.ts
+++ b/application/state/settingsIpcSync.ts
@@ -34,6 +34,7 @@ import {
   STORAGE_KEY_UI_THEME_DARK,
   STORAGE_KEY_UI_THEME_LIGHT,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
+  STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
   STORAGE_KEY_WINDOW_OPACITY,
 } from '../../infrastructure/config/storageKeys';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
@@ -71,6 +72,7 @@ interface UseSettingsIpcSyncParams {
   setSftpFollowTerminalCwd: Dispatch<SetStateAction<boolean>>;
   setSftpDefaultViewMode: Dispatch<SetStateAction<'list' | 'tree'>>;
   setWorkspaceFocusStyleState: Dispatch<SetStateAction<'dim' | 'border'>>;
+  setShowHostTreeSidebarState: Dispatch<SetStateAction<boolean>>;
   setSftpTransferConcurrencyState: Dispatch<SetStateAction<number>>;
 }
 
@@ -102,6 +104,7 @@ export function useSettingsIpcSync({
   setSftpFollowTerminalCwd,
   setSftpDefaultViewMode,
   setWorkspaceFocusStyleState,
+  setShowHostTreeSidebarState,
   setSftpTransferConcurrencyState,
 }: UseSettingsIpcSyncParams) {
   // Listen for settings changes from other windows via IPC
@@ -222,6 +225,9 @@ export function useSettingsIpcSync({
       if (key === STORAGE_KEY_WORKSPACE_FOCUS_STYLE && (value === 'dim' || value === 'border')) {
         setWorkspaceFocusStyleState((prev) => (prev === value ? prev : value));
       }
+      if (key === STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR && typeof value === 'boolean') {
+        setShowHostTreeSidebarState((prev) => (prev === value ? prev : value));
+      }
       if (key === STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY && typeof value === 'number') {
         setSftpTransferConcurrencyState((prev) => (prev === value ? prev : value));
       }
@@ -251,6 +257,7 @@ export function useSettingsIpcSync({
     setSftpAutoOpenSidebar,
     setSftpFollowTerminalCwd,
     setSftpDefaultViewMode,
+    setShowHostTreeSidebarState,
     setSftpTransferConcurrencyState,
     setTerminalFontFamilyId,
     setTerminalFontSize,

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -63,6 +63,7 @@ export const DEFAULT_SFTP_DEFAULT_VIEW_MODE: 'list' | 'tree' = 'list';
 export const DEFAULT_SHOW_RECENT_HOSTS = true;
 export const DEFAULT_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT = false;
 export const DEFAULT_SHOW_SFTP_TAB = true;
+export const DEFAULT_SHOW_HOST_TREE_SIDEBAR = true;
 
 // Editor defaults
 export const DEFAULT_EDITOR_WORD_WRAP = false;

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -27,6 +27,7 @@ import {
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
   STORAGE_KEY_TERM_FOLLOW_APP_THEME,
   STORAGE_KEY_TERM_FONT_FAMILY,
   STORAGE_KEY_TERM_FONT_SIZE,
@@ -75,6 +76,7 @@ interface UseSettingsStorageSyncParams {
   showRecentHosts: boolean;
   showOnlyUngroupedHostsInRoot: boolean;
   showSftpTab: boolean;
+  showHostTreeSidebar: boolean;
   editorWordWrap: boolean;
   sessionLogsEnabled: boolean;
   sessionLogsDir: string;
@@ -109,6 +111,7 @@ interface UseSettingsStorageSyncParams {
   setShowRecentHostsState: Dispatch<SetStateAction<boolean>>;
   setShowOnlyUngroupedHostsInRootState: Dispatch<SetStateAction<boolean>>;
   setShowSftpTabState: Dispatch<SetStateAction<boolean>>;
+  setShowHostTreeSidebarState: Dispatch<SetStateAction<boolean>>;
   setEditorWordWrapState: Dispatch<SetStateAction<boolean>>;
   setSessionLogsEnabled: Dispatch<SetStateAction<boolean>>;
   setSessionLogsDir: Dispatch<SetStateAction<string>>;
@@ -130,7 +133,7 @@ export function useSettingsStorageSync({
   terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
   sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
   sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-  showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
+  showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
   editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
   globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
@@ -139,7 +142,7 @@ export function useSettingsStorageSync({
   setFollowAppTerminalThemeState, setTerminalFontFamilyId, setTerminalFontSize,
   setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
   setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
-  setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState,
+  setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState,
   setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
   setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
   setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
@@ -153,7 +156,7 @@ export function useSettingsStorageSync({
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   });
@@ -163,7 +166,7 @@ export function useSettingsStorageSync({
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   };
@@ -371,6 +374,12 @@ export function useSettingsStorageSync({
           setShowSftpTabState(newValue);
         }
       }
+      if (e.key === STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR && e.newValue !== null) {
+        const newValue = e.newValue === 'true';
+        if (newValue !== s.showHostTreeSidebar) {
+          setShowHostTreeSidebarState(newValue);
+        }
+      }
       // Sync global hotkey enabled setting from other windows
       if (e.key === STORAGE_KEY_GLOBAL_HOTKEY_ENABLED && e.newValue !== null) {
         const newValue = e.newValue === 'true';
@@ -436,6 +445,7 @@ export function useSettingsStorageSync({
     setSftpTransferConcurrencyState,
     setSftpUseCompressedUpload,
     setShowOnlyUngroupedHostsInRootState,
+    setShowHostTreeSidebarState,
     setShowRecentHostsState,
     setShowSftpTabState,
     setTerminalFontFamilyId,

--- a/application/state/terminalHostTreeStore.test.ts
+++ b/application/state/terminalHostTreeStore.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+});
+
+const { terminalHostTreeStore } = await import('./terminalHostTreeStore.ts');
+
+test('closing host tree keeps layout width until the sidebar animation releases it', () => {
+  terminalHostTreeStore.setIsOpen(true);
+  terminalHostTreeStore.setLayoutWidth(240);
+
+  terminalHostTreeStore.setIsOpen(false);
+
+  assert.equal(terminalHostTreeStore.getLayoutWidth(), 240);
+  terminalHostTreeStore.setLayoutWidth(0);
+});

--- a/application/state/terminalHostTreeStore.ts
+++ b/application/state/terminalHostTreeStore.ts
@@ -26,9 +26,6 @@ class TerminalHostTreeStore {
   setIsOpen = (open: boolean) => {
     if (this.isOpen === open) return;
     this.isOpen = open;
-    if (!open) {
-      this.layoutWidth = 0;
-    }
     localStorageAdapter.writeString(
       STORAGE_KEY_TERMINAL_HOST_TREE_COLLAPSED,
       open ? 'false' : 'true',

--- a/application/state/useImmersiveMode.test.ts
+++ b/application/state/useImmersiveMode.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldFadeImmersiveRestoreForTab } from './useImmersiveMode';
+
+test('skips immersive restore fade when switching to an editor tab', () => {
+  assert.equal(shouldFadeImmersiveRestoreForTab('editor:/tmp/example.txt'), false);
+});
+
+test('keeps immersive restore fade for root pages and log tabs', () => {
+  assert.equal(shouldFadeImmersiveRestoreForTab('vault'), true);
+  assert.equal(shouldFadeImmersiveRestoreForTab('sftp'), true);
+  assert.equal(shouldFadeImmersiveRestoreForTab('log-127.0.0.1'), true);
+});

--- a/application/state/useImmersiveMode.ts
+++ b/application/state/useImmersiveMode.ts
@@ -11,6 +11,7 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 import { TerminalTheme } from '../../domain/models';
 import { TERMINAL_THEMES } from '../../infrastructure/config/terminalThemes';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
+import { isEditorTabId } from './activeTabStore';
 
 // ---------------------------------------------------------------------------
 // Hex → HSL conversion (returns "H S% L%" without the hsl() wrapper)
@@ -123,6 +124,17 @@ function getImmersiveCss(theme: TerminalTheme): string {
 
 const STYLE_ID = 'netcatty-immersive-override';
 
+export function isImmersiveTerminalTab(activeTabId: string): boolean {
+  return activeTabId !== 'vault'
+    && activeTabId !== 'sftp'
+    && !activeTabId.startsWith('log-')
+    && !isEditorTabId(activeTabId);
+}
+
+export function shouldFadeImmersiveRestoreForTab(activeTabId: string): boolean {
+  return !isEditorTabId(activeTabId);
+}
+
 function applyImmersiveStyle(css: string, isDark: boolean, bg: string) {
   const root = document.documentElement;
   const targetClass = isDark ? 'dark' : 'light';
@@ -165,7 +177,7 @@ export function useImmersiveMode({
   const restoreRef = useRef(restoreOriginalTheme);
   restoreRef.current = restoreOriginalTheme;
 
-  const isTerminalTab = activeTabId !== 'vault' && activeTabId !== 'sftp' && !activeTabId.startsWith('log-');
+  const isTerminalTab = isImmersiveTerminalTab(activeTabId);
 
   // APPLY: useLayoutEffect — runs before paint, O(1) Map lookup, single DOM write
   useLayoutEffect(() => {
@@ -185,6 +197,11 @@ export function useImmersiveMode({
     if (!overrideActiveRef.current) return;
     overrideActiveRef.current = false;
     appliedFpRef.current = null;
+    if (!shouldFadeImmersiveRestoreForTab(activeTabId)) {
+      removeImmersiveStyle();
+      restoreOriginalTheme();
+      return;
+    }
     const bg = getComputedStyle(document.documentElement).getPropertyValue('--background').trim();
     const overlay = document.createElement('div');
     overlay.className = 'immersive-fade-overlay';
@@ -198,7 +215,7 @@ export function useImmersiveMode({
     });
     const fallback = setTimeout(() => { if (overlay.parentNode) overlay.remove(); }, 400);
     return () => { clearTimeout(fallback); if (overlay.parentNode) overlay.remove(); };
-  }, [isTerminalTab, activeTerminalTheme, restoreOriginalTheme]);
+  }, [activeTabId, isTerminalTab, activeTerminalTheme, restoreOriginalTheme]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -43,6 +43,7 @@ import {
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
 } from '../../infrastructure/config/storageKeys';
 import { DEFAULT_UI_LOCALE, resolveSupportedLocale } from '../../infrastructure/config/i18n';
 import {
@@ -83,6 +84,7 @@ import {
   DEFAULT_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   DEFAULT_SHOW_RECENT_HOSTS,
   DEFAULT_SHOW_SFTP_TAB,
+  DEFAULT_SHOW_HOST_TREE_SIDEBAR,
   DEFAULT_SSH_DEBUG_LOGS_ENABLED,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
@@ -228,6 +230,10 @@ export const useSettingsState = () => {
   const [showSftpTab, setShowSftpTabState] = useState<boolean>(() => {
     const stored = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_SFTP_TAB);
     return stored ?? DEFAULT_SHOW_SFTP_TAB;
+  });
+  const [showHostTreeSidebar, setShowHostTreeSidebarState] = useState<boolean>(() => {
+    const stored = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
+    return stored ?? DEFAULT_SHOW_HOST_TREE_SIDEBAR;
   });
   const [sftpTransferConcurrency, setSftpTransferConcurrencyState] = useState<number>(() => {
     const stored = localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY);
@@ -523,6 +529,8 @@ export const useSettingsState = () => {
     setShowOnlyUngroupedHostsInRootState(storedShowOnlyUngroupedHostsInRoot ?? DEFAULT_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT);
     const storedShowSftpTab = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_SFTP_TAB);
     setShowSftpTabState(storedShowSftpTab ?? DEFAULT_SHOW_SFTP_TAB);
+    const storedShowHostTreeSidebar = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
+    setShowHostTreeSidebarState(storedShowHostTreeSidebar ?? DEFAULT_SHOW_HOST_TREE_SIDEBAR);
 
     // Workspace focus style
     const storedFocusStyle = readStoredString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE);
@@ -608,6 +616,7 @@ export const useSettingsState = () => {
     setSftpFollowTerminalCwd,
     setSftpDefaultViewMode,
     setWorkspaceFocusStyleState,
+    setShowHostTreeSidebarState,
     setSftpTransferConcurrencyState,
   });
 
@@ -634,7 +643,7 @@ export const useSettingsState = () => {
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
     setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
@@ -643,7 +652,7 @@ export const useSettingsState = () => {
     setFollowAppTerminalThemeState, setTerminalFontFamilyId, setTerminalFontSize,
     setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
     setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
-    setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState,
+    setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState,
     setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
     setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
     setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
@@ -748,6 +757,13 @@ export const useSettingsState = () => {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_SFTP_TAB, enabled);
     if (!persistMountedRef.current) return;
     notifySettingsChanged(STORAGE_KEY_SHOW_SFTP_TAB, enabled);
+  }, [notifySettingsChanged]);
+
+  const setShowHostTreeSidebar = useCallback((enabled: boolean) => {
+    setShowHostTreeSidebarState(enabled);
+    localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, enabled);
+    if (!persistMountedRef.current) return;
+    notifySettingsChanged(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, enabled);
   }, [notifySettingsChanged]);
 
   // Apply and persist custom CSS
@@ -994,6 +1010,8 @@ export const useSettingsState = () => {
     setShowOnlyUngroupedHostsInRoot,
     showSftpTab,
     setShowSftpTab,
+    showHostTreeSidebar,
+    setShowHostTreeSidebar,
     sftpTransferConcurrency,
     setSftpTransferConcurrency,
     // Editor Settings
@@ -1038,7 +1056,7 @@ export const useSettingsState = () => {
       terminalThemeId, terminalFontFamilyId, terminalFontSize, terminalSettings,
       customKeyBindings, editorWordWrap,
       sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles, sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-      showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab,
+      showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
       customThemes, workspaceFocusStyle, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     ]),
   };

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -143,6 +143,14 @@ test("buildSyncPayload includes AI configuration settings", () => {
   });
 });
 
+test("buildSyncPayload includes host tree sidebar visibility setting", () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, "false");
+
+  const payload = buildSyncPayload(vault([]));
+
+  assert.equal(payload.settings?.showHostTreeSidebar, false);
+});
+
 test("buildSyncPayload excludes externalAgents (device-local OS-bound config)", () => {
   localStorage.setItem(storageKeys.STORAGE_KEY_AI_EXTERNAL_AGENTS, JSON.stringify([
     { id: "codex", name: "Codex", command: "/opt/homebrew/bin/codex", enabled: true },
@@ -226,6 +234,24 @@ test("applySyncPayload restores AI configuration settings", async () => {
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_AGENT_MODEL_MAP)!), { claude: "claude-test" });
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_AGENT_PROVIDER_MAP)!), { catty: "anthropic-main" });
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!), webSearch);
+});
+
+test("applySyncPayload restores host tree sidebar visibility setting", async () => {
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      showHostTreeSidebar: false,
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR), "false");
 });
 
 test("applySyncPayload dispatches a same-window AI-state-changed event so the open chat panel rehydrates", async () => {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -63,6 +63,7 @@ import {
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
   STORAGE_KEY_AI_PROVIDERS,
   STORAGE_KEY_AI_ACTIVE_PROVIDER,
@@ -404,6 +405,8 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   if (showOnlyUngroupedHostsInRoot != null) settings.showOnlyUngroupedHostsInRoot = showOnlyUngroupedHostsInRoot;
   const showSftpTab = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_SFTP_TAB);
   if (showSftpTab != null) settings.showSftpTab = showSftpTab;
+  const showHostTreeSidebar = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
+  if (showHostTreeSidebar != null) settings.showHostTreeSidebar = showHostTreeSidebar;
   const workspaceFocusStyle = localStorageAdapter.readString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE);
   if (workspaceFocusStyle === 'dim' || workspaceFocusStyle === 'border') {
     settings.workspaceFocusStyle = workspaceFocusStyle;
@@ -534,6 +537,9 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
   }
   if (settings.showSftpTab != null) {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_SFTP_TAB, settings.showSftpTab);
+  }
+  if (settings.showHostTreeSidebar != null) {
+    localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, settings.showHostTreeSidebar);
   }
   if (settings.workspaceFocusStyle != null) {
     localStorageAdapter.writeString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE, settings.workspaceFocusStyle);

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -325,9 +325,11 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
                             setShowOnlyUngroupedHostsInRoot={settings.setShowOnlyUngroupedHostsInRoot}
                             showSftpTab={settings.showSftpTab}
                             setShowSftpTab={settings.setShowSftpTab}
+                            showHostTreeSidebar={settings.showHostTreeSidebar}
+                            setShowHostTreeSidebar={settings.setShowHostTreeSidebar}
                             windowOpacity={settings.windowOpacity}
                             setWindowOpacity={settings.setWindowOpacity}
-                        />
+                          />
                     )}
 
                     {mountedTabs.has("terminal") && (

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -136,6 +136,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   sessionLogsFormat,
   sessionLogsTimestampsEnabled,
   sshDebugLogsEnabled,
+  showHostTreeSidebar = true,
   toggleScriptsSidePanelRef,
   toggleSidePanelRef,
 }) => {
@@ -1108,6 +1109,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     setSftpInitialLocationForTab,
     setSftpPendingUploadsForTab,
     setupMcpApprovalBridge,
+    showHostTreeSidebar,
     sidePanelOpenTabs,
     sidePanelPosition,
     sidePanelWidth,

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -11,7 +11,7 @@ Object.defineProperty(globalThis, "localStorage", {
   },
 });
 
-const { computeHostTreeTabGutter } = await import("./TopTabs.tsx");
+const { computeHostTreeTabGutter, shouldShowHostTreeToggle } = await import("./TopTabs.tsx");
 
 test("host tree tab gutter fills the remaining sidebar width", () => {
   assert.equal(computeHostTreeTabGutter(280, 120), 160);
@@ -19,4 +19,51 @@ test("host tree tab gutter fills the remaining sidebar width", () => {
 
 test("host tree tab gutter never goes negative", () => {
   assert.equal(computeHostTreeTabGutter(120, 280), 0);
+});
+
+test("host tree toggle is shown for an active editor tab", () => {
+  assert.equal(shouldShowHostTreeToggle({
+    enabled: true,
+    activeTabId: "editor:file-1",
+    orderedTabs: ["session-1", "editor:file-1"],
+    sessionIds: new Set(["session-1"]),
+    workspaceIds: new Set(),
+  }), true);
+});
+
+test("host tree toggle is shown for log tabs", () => {
+  assert.equal(shouldShowHostTreeToggle({
+    enabled: true,
+    activeTabId: "log-1",
+    orderedTabs: ["session-1", "log-1"],
+    sessionIds: new Set(["session-1"]),
+    workspaceIds: new Set(),
+  }), true);
+});
+
+test("host tree toggle is hidden when host sidebar is disabled", () => {
+  assert.equal(shouldShowHostTreeToggle({
+    enabled: false,
+    activeTabId: "session-1",
+    orderedTabs: ["session-1"],
+    sessionIds: new Set(["session-1"]),
+    workspaceIds: new Set(),
+  }), false);
+});
+
+test("host tree toggle is hidden on root pages", () => {
+  assert.equal(shouldShowHostTreeToggle({
+    enabled: true,
+    activeTabId: "vault",
+    orderedTabs: ["session-1", "editor:file-1"],
+    sessionIds: new Set(["session-1"]),
+    workspaceIds: new Set(),
+  }), false);
+  assert.equal(shouldShowHostTreeToggle({
+    enabled: true,
+    activeTabId: "sftp",
+    orderedTabs: ["session-1", "editor:file-1"],
+    sessionIds: new Set(["session-1"]),
+    workspaceIds: new Set(),
+  }), false);
 });

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -2,6 +2,7 @@ import { Folder, FolderLock, Menu, Moon, MoreHorizontal, Plus, Settings, Sparkle
 import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { fromEditorTabId, isEditorTabId, useActiveTabId } from '../application/state/activeTabStore';
 import type { EditorTab } from '../application/state/editorTabStore';
+import { useImmersiveActive } from '../application/state/immersiveStore';
 import { buildWorkspaceActivityMap } from '../application/state/sessionActivity';
 import { useSessionActivityMap } from '../application/state/sessionActivityStore';
 import {
@@ -34,10 +35,29 @@ import { useTopTabLifecycleAnimations } from './top-tabs/useTopTabLifecycleAnima
 // Helper styles for Electron drag regions (use type assertion to include non-standard WebkitAppRegion)
 const dragRegionStyle = { WebkitAppRegion: 'drag' } as React.CSSProperties;
 const dragRegionNoSelect = { WebkitAppRegion: 'drag', userSelect: 'none' } as React.CSSProperties;
+const noDragRegionStyle = { WebkitAppRegion: 'no-drag' } as React.CSSProperties;
 const emptyTabStyle: React.CSSProperties = {};
 
 export function computeHostTreeTabGutter(hostTreeLayoutWidth: number, toggleRight: number): number {
   return Math.max(0, hostTreeLayoutWidth - toggleRight);
+}
+
+export function shouldShowHostTreeToggle({
+  enabled,
+  activeTabId,
+  orderedTabs,
+  sessionIds,
+  workspaceIds,
+}: {
+  enabled: boolean;
+  activeTabId: string;
+  orderedTabs: readonly string[];
+  sessionIds: ReadonlySet<string>;
+  workspaceIds: ReadonlySet<string>;
+}): boolean {
+  if (!enabled) return false;
+  if (activeTabId === 'vault' || activeTabId === 'sftp') return false;
+  return orderedTabs.includes(activeTabId) || isEditorTabId(activeTabId) || sessionIds.has(activeTabId) || workspaceIds.has(activeTabId);
 }
 
 interface TopTabsProps {
@@ -70,6 +90,7 @@ interface TopTabsProps {
   onEndSessionDrag: () => void;
   onReorderTabs: (draggedId: string, targetId: string, position: 'before' | 'after') => void;
   showSftpTab: boolean;
+  showHostTreeSidebar: boolean;
   editorTabs: readonly EditorTab[];
   onRequestCloseEditorTab: (editorTabId: string) => void;
   hostById: Map<string, Host>;
@@ -105,12 +126,15 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onEndSessionDrag,
   onReorderTabs,
   showSftpTab,
+  showHostTreeSidebar,
   editorTabs,
   onRequestCloseEditorTab,
   hostById,
 }) => {
   const { t } = useI18n();
   const { maximize, isFullscreen, onFullscreenChanged } = useWindowControls();
+  const immersiveActiveFromStore = useImmersiveActive();
+  const effectiveImmersiveActive = isImmersiveActive ?? immersiveActiveFromStore;
   const sessionActivityMap = useSessionActivityMap();
   const isHostTreeOpen = useTerminalHostTreeOpen();
   const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
@@ -120,6 +144,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const [hostTreeTogglePop, setHostTreeTogglePop] = useState(false);
   const fixedLeftTabsRef = useRef<HTMLDivElement>(null);
   const hostTreeToggleSlotRef = useRef<HTMLDivElement>(null);
+  const suppressHostTreeToggleClickRef = useRef(false);
   const [hostTreeTabGutter, setHostTreeTabGutter] = useState(0);
 
   // Tab reorder drag state
@@ -225,9 +250,15 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     return counts;
   }, [sessions]);
 
-  const hasTerminalOrWorkspaceTabs = sessions.length > 0 || workspaces.length > 0;
-  const isActiveTerminalOrWorkspaceTab = orphanSessionMap.has(activeTabId) || workspaceMap.has(activeTabId);
-  const showHostTreeToggle = hasTerminalOrWorkspaceTabs && isActiveTerminalOrWorkspaceTab;
+  const activeWorkTabCount = orderedTabs.length;
+  const showHostTreeToggle = shouldShowHostTreeToggle({
+    enabled: showHostTreeSidebar,
+    activeTabId,
+    orderedTabs,
+    sessionIds: new Set(orphanSessionMap.keys()),
+    workspaceIds: new Set(workspaceMap.keys()),
+  });
+  const hasHostTreeToggleSurface = showHostTreeSidebar && activeWorkTabCount > 0;
 
   const updateHostTreeTabGutter = useCallback(() => {
     if (!showHostTreeToggle || hostTreeLayoutWidth <= 0) {
@@ -344,6 +375,24 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
     if (!tab || !e.currentTarget.contains(tab)) return;
     scrollTopTabIntoComfortView(e.currentTarget, tab, 'smooth');
   }, []);
+
+  const handleHostTreeTogglePointerDown = useCallback((e: React.PointerEvent) => {
+    if (!showHostTreeToggle) return;
+    e.preventDefault();
+    e.stopPropagation();
+    suppressHostTreeToggleClickRef.current = true;
+    toggleHostTree();
+  }, [showHostTreeToggle, toggleHostTree]);
+
+  const handleHostTreeToggleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (suppressHostTreeToggleClickRef.current) {
+      suppressHostTreeToggleClickRef.current = false;
+      return;
+    }
+    if (!showHostTreeToggle) return;
+    toggleHostTree();
+  }, [showHostTreeToggle, toggleHostTree]);
 
   // Pre-compute tab shift styles for all tabs to avoid recalculation during render
   const tabShiftStyles = useMemo(() => {
@@ -621,11 +670,12 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             }
           }}
         >
-          {hasTerminalOrWorkspaceTabs && (
+          {hasHostTreeToggleSurface && (
             <div
               ref={hostTreeToggleSlotRef}
-              className="top-tab-host-tree-toggle-slot mb-0 flex-shrink-0 self-end"
+              className="top-tab-host-tree-toggle-slot mb-0 flex-shrink-0 self-end app-no-drag"
               data-visible={showHostTreeToggle ? 'true' : 'false'}
+              style={noDragRegionStyle}
             >
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -643,8 +693,10 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                         ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
                         : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
                       pointerEvents: showHostTreeToggle ? 'auto' : 'none',
+                      ...noDragRegionStyle,
                     }}
-                    onClick={toggleHostTree}
+                    onPointerDown={handleHostTreeTogglePointerDown}
+                    onClick={handleHostTreeToggleClick}
                   >
                     <Menu size={14} />
                   </Button>
@@ -770,7 +822,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
                 className="h-7 w-7 shrink-0 app-no-drag"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={onToggleTheme}
-                disabled={isImmersiveActive && !followAppTerminalTheme}
+                disabled={effectiveImmersiveActive && !followAppTerminalTheme}
               >
                 {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
               </Button>
@@ -821,7 +873,8 @@ const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
     prev.onToggleTheme === next.onToggleTheme &&
     prev.followAppTerminalTheme === next.followAppTerminalTheme &&
     prev.isImmersiveActive === next.isImmersiveActive &&
-    prev.showSftpTab === next.showSftpTab
+    prev.showSftpTab === next.showSftpTab &&
+    prev.showHostTreeSidebar === next.showHostTreeSidebar
   );
 };
 

--- a/components/editor/TextEditorPane.test.tsx
+++ b/components/editor/TextEditorPane.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   canPromoteTextEditor,
+  getTextEditorContentStats,
   isTextEditorReadOnly,
   TextEditorPromoteButton,
 } from "./TextEditorPane.tsx";
@@ -42,4 +43,9 @@ test("renders the promote button disabled while a save is running", () => {
 
   assert.match(savingMarkup, /disabled=""/);
   assert.doesNotMatch(idleMarkup, /disabled=""/);
+});
+
+test("counts editor content without allocating line arrays", () => {
+  assert.deepEqual(getTextEditorContentStats(""), { lineCount: 1, charCount: 0 });
+  assert.deepEqual(getTextEditorContentStats("one\ntwo\n"), { lineCount: 3, charCount: 8 });
 });

--- a/components/editor/TextEditorPane.tsx
+++ b/components/editor/TextEditorPane.tsx
@@ -182,11 +182,19 @@ export const isTextEditorReadOnly = ({ saving }: { saving: boolean }): boolean =
 
 export const canPromoteTextEditor = ({ saving }: { saving: boolean }): boolean => !saving;
 
+export function getTextEditorContentStats(content: string): { lineCount: number; charCount: number } {
+  let lineCount = 1;
+  for (let i = 0; i < content.length; i += 1) {
+    if (content.charCodeAt(i) === 10) lineCount += 1;
+  }
+  return { lineCount, charCount: content.length };
+}
+
 export const TextEditorPromoteButton: React.FC<{
   saving: boolean;
   onPromoteToTab: () => void;
   title: string;
-}> = ({ saving, onPromoteToTab, title }) => (
+}> = React.memo(({ saving, onPromoteToTab, title }) => (
   <Tooltip>
     <TooltipTrigger asChild>
       <Button
@@ -201,9 +209,10 @@ export const TextEditorPromoteButton: React.FC<{
     </TooltipTrigger>
     <TooltipContent>{title}</TooltipContent>
   </Tooltip>
-);
+));
+TextEditorPromoteButton.displayName = 'TextEditorPromoteButton';
 
-export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
+const TextEditorPaneInner: React.FC<TextEditorPaneProps> = ({
   fileName,
   content,
   languageId,
@@ -465,6 +474,8 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
 
   const supportedLanguages = useMemo(() => getSupportedLanguages(), []);
   const monacoLanguage = useMemo(() => languageIdToMonaco(languageId), [languageId]);
+  const languageName = useMemo(() => getLanguageName(languageId), [languageId]);
+  const contentStats = useMemo(() => getTextEditorContentStats(content), [content]);
   const languageOptions = useMemo(
     () => supportedLanguages.map((lang) => ({ value: lang.id, label: lang.name })),
     [supportedLanguages],
@@ -618,14 +629,17 @@ export const TextEditorPane: React.FC<TextEditorPaneProps> = ({
       {/* Footer */}
       <div className="px-4 py-2 border-t border-border/60 flex items-center justify-between text-xs text-muted-foreground bg-muted/30 flex-shrink-0">
         <span>
-          {getLanguageName(languageId)}
+          {languageName}
         </span>
         <span>
-          {content.split('\n').length} lines • {content.length} characters
+          {contentStats.lineCount} lines • {contentStats.charCount} characters
         </span>
       </div>
     </div>
   );
 };
+
+export const TextEditorPane = React.memo(TextEditorPaneInner);
+TextEditorPane.displayName = 'TextEditorPane';
 
 export default TextEditorPane;

--- a/components/editor/TextEditorTabView.test.ts
+++ b/components/editor/TextEditorTabView.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+});
+
+const { getTextEditorTabShellStyle } = await import('./TextEditorTabView');
+
+test('visible editor tab leaves room for the terminal host sidebar', () => {
+  assert.deepEqual(getTextEditorTabShellStyle(true, 280), {
+    zIndex: 20,
+    left: 280,
+  });
+});
+
+test('hidden editor tab stays hidden', () => {
+  assert.deepEqual(getTextEditorTabShellStyle(false, 280), {
+    pointerEvents: 'none',
+    visibility: 'hidden',
+    zIndex: 20,
+    left: 280,
+  });
+});

--- a/components/editor/TextEditorTabView.tsx
+++ b/components/editor/TextEditorTabView.tsx
@@ -11,6 +11,7 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import { saveEditorTab } from '../../application/state/editorTabSave';
 import { editorTabStore, useEditorTab, type EditorTabId } from '../../application/state/editorTabStore';
 import { useIsEditorTabActive } from '../../application/state/activeTabStore';
+import { useTerminalHostTreeLayoutWidth } from '../../application/state/terminalHostTreeStore';
 import type { HotkeyScheme, KeyBinding } from '../../domain/models';
 import type { Host } from '../../types';
 import { toast } from '../ui/toast';
@@ -27,6 +28,14 @@ export interface TextEditorTabViewProps {
   onRequestClose: (tabId: EditorTabId) => void;
 }
 
+export function getTextEditorTabShellStyle(isVisible: boolean, hostTreeLayoutWidth: number): React.CSSProperties {
+  return {
+    ...(isVisible ? null : { pointerEvents: 'none', visibility: 'hidden' }),
+    zIndex: 20,
+    left: hostTreeLayoutWidth,
+  };
+}
+
 export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   tabId,
   hotkeyScheme,
@@ -39,6 +48,7 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
   // Self-subscribe visibility so switching tabs only re-renders this editor
   // instance, not AppView/App.
   const isVisible = useIsEditorTabActive(tabId);
+  const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
 
   const handleContentChange = useCallback(
     (content: string, viewState: Monaco.editor.ICodeEditorViewState | null) => {
@@ -70,6 +80,10 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
     }
   }, [tabId, t]);
 
+  const handleRequestClose = useCallback(() => {
+    onRequestClose(tabId);
+  }, [onRequestClose, tabId]);
+
   // Tab has been closed — render nothing (parent should remove this instance,
   // but guard here in case of a transient render before unmount).
   if (!tab) return null;
@@ -87,18 +101,17 @@ export const TextEditorTabView: React.FC<TextEditorTabViewProps> = ({
     // all fill their flex-1 parent via `absolute inset-0`. Match that here so
     // an inactive editor tab doesn't collapse to zero height in normal flow,
     // and an active one fills the viewport instead of stacking beneath others.
-    // z-index high enough to stay above the TerminalLayer's inner `z-10` panels
-    // (TerminalLayer root is visibility:hidden when editor tabs are active, but
-    // its children's stacking contexts can still overlap without an explicit z.)
+    // z-index high enough to stay above the terminal workspace while leaving
+    // room for the shared host sidebar when it is open.
     <div
-      style={{ display: isVisible ? undefined : 'none', zIndex: 20 }}
-      className="absolute inset-0 min-h-0 flex flex-col bg-background"
+      style={getTextEditorTabShellStyle(isVisible, hostTreeLayoutWidth)}
+      className="absolute top-0 right-0 bottom-0 min-h-0 flex flex-col bg-background"
     >
       <TextEditorPane
         chrome="tab"
         fileName={`${tab.fileName}${isDirty ? ' *' : ''}`}
         subtitle={subtitle}
-        onRequestClose={() => onRequestClose(tabId)}
+        onRequestClose={handleRequestClose}
         content={tab.content}
         languageId={tab.languageId}
         wordWrap={tab.wordWrap}

--- a/components/settings/tabs/SettingsAppearanceTab.tsx
+++ b/components/settings/tabs/SettingsAppearanceTab.tsx
@@ -32,6 +32,8 @@ export default function SettingsAppearanceTab(props: {
   setShowOnlyUngroupedHostsInRoot: (enabled: boolean) => void;
   showSftpTab: boolean;
   setShowSftpTab: (enabled: boolean) => void;
+  showHostTreeSidebar: boolean;
+  setShowHostTreeSidebar: (enabled: boolean) => void;
   windowOpacity: number;
   setWindowOpacity: (opacity: number) => void;
 }) {
@@ -60,6 +62,8 @@ export default function SettingsAppearanceTab(props: {
     setShowOnlyUngroupedHostsInRoot,
     showSftpTab,
     setShowSftpTab,
+    showHostTreeSidebar,
+    setShowHostTreeSidebar,
     windowOpacity,
     setWindowOpacity,
   } = props;
@@ -351,6 +355,12 @@ export default function SettingsAppearanceTab(props: {
           description={t('settings.vault.showSftpTabDesc')}
         >
           <Toggle checked={showSftpTab} onChange={setShowSftpTab} />
+        </SettingRow>
+        <SettingRow
+          label={t('settings.vault.showHostTreeSidebar')}
+          description={t('settings.vault.showHostTreeSidebarDesc')}
+        >
+          <Toggle checked={showHostTreeSidebar} onChange={setShowHostTreeSidebar} />
         </SettingRow>
       </div>
 

--- a/components/terminalLayer/TerminalHostTreeSidebar.test.ts
+++ b/components/terminalLayer/TerminalHostTreeSidebar.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const storage = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+});
+
+const {
+  getTerminalHostTreeSidebarPanelStyle,
+  getTerminalHostTreeSidebarShellStyle,
+  isTerminalHostTreeSidebarVisible,
+} = await import('./TerminalHostTreeSidebar.tsx');
+
+test('host tree sidebar is visually hidden when disabled even if it remains open', () => {
+  assert.equal(isTerminalHostTreeSidebarVisible(true, false), false);
+});
+
+test('host tree sidebar visibility still follows open state when enabled', () => {
+  assert.equal(isTerminalHostTreeSidebarVisible(true, true), true);
+  assert.equal(isTerminalHostTreeSidebarVisible(false, true), false);
+});
+
+test('host tree sidebar keeps the inner panel width while the shell hides', () => {
+  const theme = {
+    termBg: '#000000',
+    termFg: '#ffffff',
+    mutedFg: '#999999',
+    separator: '#333333',
+    rowHoverBg: '#111111',
+    rowActiveBg: '#222222',
+    rowDropBg: '#444444',
+    folderFg: '#cccccc',
+  };
+
+  assert.deepEqual(getTerminalHostTreeSidebarShellStyle(false, 240, 'width 220ms ease'), {
+    width: 0,
+    transition: 'width 220ms ease',
+    pointerEvents: 'none',
+  });
+  assert.equal(getTerminalHostTreeSidebarPanelStyle({
+    isVisible: false,
+    displayWidth: 240,
+    panelTransition: 'opacity 180ms ease-out',
+    theme,
+  }).width, 240);
+});

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -53,6 +53,7 @@ type HostTreeDropTarget =
   | { kind: 'group'; path: string };
 
 interface TerminalHostTreeSidebarProps {
+  enabled?: boolean;
   hosts: Host[];
   customGroups: string[];
   resolvedPreviewTheme: TerminalTheme;
@@ -71,6 +72,43 @@ type HostTreeTheme = {
   rowDropBg: string;
   folderFg: string;
 };
+
+export function isTerminalHostTreeSidebarVisible(isOpen: boolean, enabled = true): boolean {
+  return enabled && isOpen;
+}
+
+export function getTerminalHostTreeSidebarShellStyle(
+  isVisible: boolean,
+  displayWidth: number,
+  shellTransition: string,
+): React.CSSProperties {
+  return {
+    width: isVisible ? displayWidth : 0,
+    transition: shellTransition,
+    pointerEvents: isVisible ? 'auto' : 'none',
+  };
+}
+
+export function getTerminalHostTreeSidebarPanelStyle({
+  isVisible,
+  displayWidth,
+  panelTransition,
+  theme,
+}: {
+  isVisible: boolean;
+  displayWidth: number;
+  panelTransition: string;
+  theme: HostTreeTheme;
+}): React.CSSProperties {
+  return {
+    width: displayWidth,
+    opacity: isVisible ? 1 : 0,
+    transition: panelTransition,
+    backgroundColor: theme.termBg,
+    color: theme.termFg,
+    borderRight: isVisible ? `1px solid ${theme.separator}` : '1px solid transparent',
+  };
+}
 
 function hostMatchesSearch(host: Host, search: string): boolean {
   const s = search.toLowerCase();
@@ -366,6 +404,7 @@ const HostTreeFlatRowItem = memo<HostTreeFlatRowProps>(({
 HostTreeFlatRowItem.displayName = 'HostTreeFlatRowItem';
 
 const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
+  enabled = true,
   hosts,
   customGroups,
   resolvedPreviewTheme,
@@ -375,6 +414,7 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
 }) => {
   const { t } = useI18n();
   const isOpen = useTerminalHostTreeOpen();
+  const isVisible = isTerminalHostTreeSidebarVisible(isOpen, enabled);
   const [search, setSearch] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [expandedPanel, setExpandedPanel] = useState<HostTreeToolbarPanel>(null);
@@ -458,14 +498,13 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
   }, [searchActive, searchTerm, ungroupedHosts]);
 
   const flatRows = useMemo(() => {
-    if (!isOpen) return [];
     return flattenHostGroupTree({
       groupNodes: filteredTree,
       ungroupedHosts: filteredUngrouped,
       expandedPaths,
       searchActive: treeExpandAll,
     });
-  }, [expandedPaths, filteredTree, filteredUngrouped, isOpen, treeExpandAll]);
+  }, [expandedPaths, filteredTree, filteredUngrouped, treeExpandAll]);
 
   const canDrag = Boolean(menuActions) && !searchActive && !tagsActive;
 
@@ -620,7 +659,7 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
     : `opacity ${SIDEBAR_ANIM_MS - 40}ms ease-out, border-color ${SIDEBAR_ANIM_MS}ms ease-out`;
 
   const handleResizeStart = useCallback((event: React.MouseEvent) => {
-    if (!isOpen) return;
+    if (!isVisible) return;
     event.preventDefault();
     setIsResizing(true);
     terminalLayoutSuppressStore.begin();
@@ -655,13 +694,13 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
     };
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
-  }, [isOpen, persistSidebarWidth, setSidebarWidth, sidebarWidth]);
+  }, [isVisible, persistSidebarWidth, setSidebarWidth, sidebarWidth]);
 
-  const prevIsOpenRef = useRef(isOpen);
+  const prevIsVisibleRef = useRef(isVisible);
 
   useEffect(() => {
-    if (prevIsOpenRef.current === isOpen) return;
-    prevIsOpenRef.current = isOpen;
+    if (prevIsVisibleRef.current === isVisible) return;
+    prevIsVisibleRef.current = isVisible;
 
     const el = shellRef.current;
     if (!el) return;
@@ -671,6 +710,7 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
     const finish = () => {
       if (ended) return;
       ended = true;
+      if (!isVisible) terminalHostTreeStore.setLayoutWidth(0);
       terminalLayoutSuppressStore.end();
     };
     const onTransitionEnd = (event: TransitionEvent) => {
@@ -684,39 +724,34 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
       window.clearTimeout(timer);
       finish();
     };
-  }, [isOpen]);
+  }, [isVisible]);
 
   const displayWidth = resizePreviewWidth ?? sidebarWidth;
 
   useEffect(() => {
-    terminalHostTreeStore.setLayoutWidth(isOpen ? displayWidth : 0);
-  }, [displayWidth, isOpen]);
+    if (isVisible) terminalHostTreeStore.setLayoutWidth(displayWidth);
+  }, [displayWidth, isVisible]);
 
   return (
     <div
       ref={shellRef}
       className="relative flex-shrink-0 h-full overflow-hidden"
-      style={{
-        width: isOpen ? displayWidth : 0,
-        transition: shellTransition,
-        pointerEvents: isOpen ? 'auto' : 'none',
-      }}
+      style={getTerminalHostTreeSidebarShellStyle(isVisible, displayWidth, shellTransition)}
       data-section="terminal-host-tree-sidebar-shell"
-      data-open={isOpen ? 'true' : 'false'}
+      data-open={isVisible ? 'true' : 'false'}
+      data-enabled={enabled ? 'true' : 'false'}
     >
       <div
         className="relative flex flex-col h-full"
-        style={{
-          width: displayWidth,
-          opacity: isOpen ? 1 : 0,
-          transition: panelTransition,
-          backgroundColor: theme.termBg,
-          color: theme.termFg,
-          borderRight: isOpen ? `1px solid ${theme.separator}` : '1px solid transparent',
-        }}
+        style={getTerminalHostTreeSidebarPanelStyle({
+          isVisible,
+          displayWidth,
+          panelTransition,
+          theme,
+        })}
         data-section="terminal-host-tree-sidebar"
       >
-        {isOpen && (
+        {isVisible && (
           <div
             className="absolute top-0 right-[-3px] h-full w-2 cursor-ew-resize z-30"
             onMouseDown={handleResizeStart}
@@ -776,6 +811,7 @@ export const TerminalHostTreeSidebar = memo(
   TerminalHostTreeSidebarInner,
   (prev, next) => (
     prev.hosts === next.hosts
+    && prev.enabled === next.enabled
     && prev.customGroups === next.customGroups
     && prev.resolvedPreviewTheme === next.resolvedPreviewTheme
     && prev.activeHostId === next.activeHostId

--- a/components/terminalLayer/TerminalLayerHostTreeSection.tsx
+++ b/components/terminalLayer/TerminalLayerHostTreeSection.tsx
@@ -9,6 +9,7 @@ type HostTreeContext = Record<string, any>;
 function TerminalLayerHostTreeSectionInner({ ctx }: { ctx: HostTreeContext }) {
   return (
     <TerminalHostTreeSidebar
+      enabled={ctx.showHostTreeSidebar !== false}
       hosts={ctx.hosts}
       customGroups={ctx.customGroups}
       resolvedPreviewTheme={ctx.resolvedPreviewTheme}

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -518,6 +518,7 @@ export interface TerminalLayerProps {
   sessionLogsFormat?: string;
   sessionLogsTimestampsEnabled?: boolean;
   sshDebugLogsEnabled?: boolean;
+  showHostTreeSidebar?: boolean;
   toggleScriptsSidePanelRef?: React.MutableRefObject<(() => void) | null>;
   toggleSidePanelRef?: React.MutableRefObject<(() => void) | null>;
 }

--- a/components/terminalLayer/TerminalLayerTabBridge.test.ts
+++ b/components/terminalLayer/TerminalLayerTabBridge.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('./TerminalLayerTabBridge.tsx', import.meta.url), 'utf8');
+
+test('terminal layer bridge forwards host tree visibility data to the view context', () => {
+  assert.match(source, /const showHostTreeSidebar = s\.showHostTreeSidebar/);
+  assert.match(source, /\bshowHostTreeSidebar,\n/);
+  assert.match(source, /customGroups:\s*s\.customGroups/);
+  assert.match(source, /\bactiveHostIdForSidebar\b/);
+});

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -25,6 +25,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
   const sessionHostsMap = s.sessionHostsMap as Map<string, Host>;
   const sftpHostForTab = s.sftpHostForTab as Map<string, Host>;
   const sidePanelOpenTabs = s.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const showHostTreeSidebar = s.showHostTreeSidebar as boolean | undefined;
 
   const activeWorkspace = useMemo(
     () => (activeTabId ? workspaceById.get(activeTabId) : undefined),
@@ -355,6 +356,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     setEditorWordWrap: s.setEditorWordWrap,
     setIsComposeBarOpen: s.setIsComposeBarOpen,
     setResizing,
+    showHostTreeSidebar,
     setSidePanelPosition: s.setSidePanelPosition,
     setSftpFollowTerminalCwd: s.setSftpFollowTerminalCwd,
     sftpActiveHost,
@@ -420,6 +422,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     resolveAIExecutorContext,
     sessionHostsMap,
     sessions,
+    showHostTreeSidebar,
     sftpActiveHost,
     themeState,
     workspaceById,

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -276,7 +276,8 @@ export function terminalLayerWorkspaceCtxEqual(prev: Ctx, next: Ctx): boolean {
 }
 
 export function terminalLayerHostTreePropsEqual(prev: Ctx, next: Ctx): boolean {
-  return eq(prev, next, 'hosts')
+  return eq(prev, next, 'showHostTreeSidebar')
+    && eq(prev, next, 'hosts')
     && eq(prev, next, 'customGroups')
     && eq(prev, next, 'resolvedPreviewTheme')
     && eq(prev, next, 'activeHostIdForSidebar')

--- a/components/terminalLayerMemo.ts
+++ b/components/terminalLayerMemo.ts
@@ -30,6 +30,7 @@ export const terminalLayerAreEqual = (
   prev.setSftpFollowTerminalCwd === next.setSftpFollowTerminalCwd &&
   prev.editorWordWrap === next.editorWordWrap &&
   prev.sshDebugLogsEnabled === next.sshDebugLogsEnabled &&
+  prev.showHostTreeSidebar === next.showHostTreeSidebar &&
   prev.setEditorWordWrap === next.setEditorWordWrap &&
   prev.onHotkeyAction === next.onHotkeyAction &&
   prev.onUpdateHost === next.onUpdateHost &&

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -251,6 +251,8 @@ export interface SyncPayload {
     showOnlyUngroupedHostsInRoot?: boolean;
     // Top tabs: show standalone SFTP view tab
     showSftpTab?: boolean;
+    // Terminal/editor tabs: show left host list sidebar
+    showHostTreeSidebar?: boolean;
     // Workspace focus indicator style
     workspaceFocusStyle?: 'dim' | 'border';
     // AI configuration

--- a/index.css
+++ b/index.css
@@ -287,7 +287,7 @@ body {
 }
 
 /* Immersive mode: override agent icon badge colors to follow the theme */
-.immersive-transition [data-agent-badge] {
+:root[data-immersive-theme] [data-agent-badge] {
   border-color: hsl(var(--primary) / 0.2) !important;
   background-color: hsl(var(--primary) / 0.1) !important;
 }

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -157,6 +157,7 @@ export const STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT = 'netcatty_show_only
 
 // Top tabs: Show standalone SFTP view tab
 export const STORAGE_KEY_SHOW_SFTP_TAB = 'netcatty_show_sftp_tab_v1';
+export const STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR = 'netcatty_show_host_tree_sidebar_v1';
 
 // Group Configurations (default settings inherited by hosts)
 export const STORAGE_KEY_GROUP_CONFIGS = 'netcatty_group_configs_v1';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tool:cli": "node electron/cli/netcatty-tool-cli.cjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs electron/bridges/aiBridge/sdk/*.test.cjs scripts/*.test.cjs application/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.tsx components/editor/*.test.tsx components/settings/tabs/ai/*.test.ts components/ai/*.test.ts components/ai-elements/*.test.tsx components/sftp/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts"
+    "test": "node --test --import tsx electron/bridges/*.test.cjs electron/bridges/*/*.test.cjs electron/bridges/aiBridge/sdk/*.test.cjs scripts/*.test.cjs application/*.test.ts application/app/*.test.ts application/state/*.test.ts application/state/*/*.test.ts components/*.test.ts components/*.test.tsx components/editor/*.test.ts components/editor/*.test.tsx components/terminalLayer/*.test.ts components/settings/tabs/ai/*.test.ts components/ai/*.test.ts components/ai-elements/*.test.tsx components/sftp/*.test.ts components/terminal/*.test.ts components/terminal/runtime/*.test.ts domain/*.test.ts infrastructure/ai/*.test.ts infrastructure/config/*.test.ts infrastructure/services/*/*.test.ts lib/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",


### PR DESCRIPTION
## Summary
- Treat editor and log tabs like work tabs for the host-list sidebar while keeping Vault/SFTP root pages clean.
- Add a default-on setting to hide the host-list sidebar and its top-bar button.
- Smooth sidebar/editor transitions and reduce editor tab-switching work.
- Expand tests so the new sidebar, sync, editor, and log-view behavior is covered by npm test.

## Validation
- npm run lint
- npm run build
- npm test
- git diff --check
- multi-agent review completed; follow-up sidebar review clean
