### PR TITLE
fix: upload terminal drops to current cwd

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -170,10 +170,10 @@ export const useTerminalBackend = () => {
     return bridge.listSerialPorts();
   }, []);
 
-  const getSessionPwd = useCallback(async (sessionId: string) => {
+  const getSessionPwd = useCallback(async (sessionId: string, options?: { allowHomeFallback?: boolean }) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.getSessionPwd) return { success: false, error: 'getSessionPwd unavailable' };
-    return bridge.getSessionPwd(sessionId);
+    return bridge.getSessionPwd(sessionId, options);
   }, []);
 
   const getSessionRemoteInfo = useCallback(async (sessionId: string) => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -413,11 +413,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
   } : undefined;
 
-  const resolveSftpInitialPath = useCallback(async (): Promise<string | undefined> => {
+  const resolveSftpInitialPath = useCallback(async (options?: { preferFreshBackend?: boolean }): Promise<string | undefined> => {
     const cwd = await resolvePreferredTerminalCwd({
       rendererCwd: terminalCwdTracker.getRendererCwd(),
       sessionId: sessionRef.current,
-      getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
+      getSessionPwd: (id, options) => terminalBackend.getSessionPwd(id, options),
+      preferFreshBackend: options?.preferFreshBackend,
     });
     return cwd ?? undefined;
   }, [terminalBackend, terminalCwdTracker]);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -569,7 +569,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       sessionId,
       cwdRevisionAtCommand: revisionAtCommand,
       getCwdRevision: () => terminalCwdRevisionRef.current,
-      getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
+      getSessionPwd: (id, options) => terminalBackend.getSessionPwd(id, options),
       canProbe: async () => {
         if (cwdProbeGenerationRef.current.get(sessionId) !== probeGeneration) return false;
         const host = sessionHostsMapRef.current.get(sessionId);
@@ -706,7 +706,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     return resolvePreferredTerminalCwd({
       rendererCwd: sessionId ? terminalRendererCwdBySessionRef.current.get(sessionId) : undefined,
       sessionId,
-      getSessionPwd: (id) => terminalBackend.getSessionPwd(id),
+      getSessionPwd: (id, options) => terminalBackend.getSessionPwd(id, options),
       preferFreshBackend: options?.preferFreshBackend,
     });
   }, [getActiveTerminalSessionId, terminalBackend]);

--- a/components/terminal/hooks/useTerminalDragDrop.ts
+++ b/components/terminal/hooks/useTerminalDragDrop.ts
@@ -3,7 +3,7 @@ import type React from "react";
 import { useRef, useState } from "react";
 
 import { logger } from "../../../lib/logger";
-import { extractDropEntries } from "../../../lib/sftpFileUtils";
+import { extractDropEntries, type DropEntry } from "../../../lib/sftpFileUtils";
 import type { Host, TerminalSession } from "../../../types";
 import { toast } from "../../ui/toast";
 import {
@@ -15,7 +15,7 @@ interface UseTerminalDragDropOptions {
   host: Host;
   isLocalConnection: boolean;
   onOpenSftp?: TerminalProps["onOpenSftp"];
-  resolveSftpInitialPath: () => Promise<string | undefined>;
+  resolveSftpInitialPath: (options?: { preferFreshBackend?: boolean }) => Promise<string | undefined>;
   scrollToBottomAfterProgrammaticInput: (data: string) => void;
   sessionId: string;
   sessionRef: React.MutableRefObject<string | null>;
@@ -25,6 +25,59 @@ interface UseTerminalDragDropOptions {
     writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   };
   termRef: React.MutableRefObject<XTerm | null>;
+}
+
+export async function resolveTerminalDropUploadInitialPath(
+  resolveSftpInitialPath: UseTerminalDragDropOptions["resolveSftpInitialPath"],
+): Promise<string | undefined> {
+  return resolveSftpInitialPath({ preferFreshBackend: true });
+}
+
+export async function handleTerminalDropEntries({
+  dropEntries,
+  host,
+  isLocalConnection,
+  onOpenSftp,
+  resolveSftpInitialPath,
+  scrollToBottomAfterProgrammaticInput,
+  sessionId,
+  sessionRef,
+  terminalBackend,
+  termRef,
+}: Pick<
+  UseTerminalDragDropOptions,
+  | "host"
+  | "isLocalConnection"
+  | "onOpenSftp"
+  | "resolveSftpInitialPath"
+  | "scrollToBottomAfterProgrammaticInput"
+  | "sessionId"
+  | "sessionRef"
+  | "terminalBackend"
+  | "termRef"
+> & {
+  dropEntries: DropEntry[];
+}): Promise<void> {
+  if (dropEntries.length === 0) {
+    return;
+  }
+
+  if (isLocalConnection) {
+    const paths = extractRootPathsFromDropEntries(dropEntries);
+
+    if (paths.length > 0 && termRef.current && sessionRef.current) {
+      const pathsText = paths.join(" ");
+      terminalBackend.writeToSession(sessionRef.current, pathsText);
+      scrollToBottomAfterProgrammaticInput(pathsText);
+      termRef.current.focus();
+    }
+    return;
+  }
+
+  if (onOpenSftp) {
+    const initialPath = await resolveTerminalDropUploadInitialPath(resolveSftpInitialPath);
+    onOpenSftp(host, initialPath, dropEntries, sessionId);
+  }
 }
 
 export function useTerminalDragDrop({
@@ -86,24 +139,18 @@ export function useTerminalDragDrop({
 
     try {
       const dropEntries = await extractDropEntries(e.dataTransfer);
-
-      if (dropEntries.length === 0) {
-        return;
-      }
-
-      if (isLocalConnection) {
-        const paths = extractRootPathsFromDropEntries(dropEntries);
-
-        if (paths.length > 0 && termRef.current && sessionRef.current) {
-          const pathsText = paths.join(" ");
-          terminalBackend.writeToSession(sessionRef.current, pathsText);
-          scrollToBottomAfterProgrammaticInput(pathsText);
-          termRef.current.focus();
-        }
-      } else if (onOpenSftp) {
-        const initialPath = await resolveSftpInitialPath();
-        onOpenSftp(host, initialPath, dropEntries, sessionId);
-      }
+      await handleTerminalDropEntries({
+        dropEntries,
+        host,
+        isLocalConnection,
+        onOpenSftp,
+        resolveSftpInitialPath,
+        scrollToBottomAfterProgrammaticInput,
+        sessionId,
+        sessionRef,
+        terminalBackend,
+        termRef,
+      });
     } catch (error) {
       logger.error("Failed to handle file drop", error);
       toast.error(t("terminal.dragDrop.errorMessage"), t("terminal.dragDrop.errorTitle"));

--- a/components/terminal/sftpCwd.test.ts
+++ b/components/terminal/sftpCwd.test.ts
@@ -14,8 +14,9 @@ test("resolvePreferredTerminalCwd prefers fresh backend pwd when requested", asy
     rendererCwd: "/srv/app/current",
     sessionId: "session-1",
     preferFreshBackend: true,
-    getSessionPwd: async () => {
+    getSessionPwd: async (_sessionId, options) => {
       backendCalls += 1;
+      assert.deepEqual(options, { allowHomeFallback: false });
       return { success: true, cwd: "/lost+found" };
     },
   });
@@ -38,6 +39,20 @@ test("resolvePreferredTerminalCwd returns the renderer cwd without probing the b
 
   assert.equal(cwd, "/srv/app/current");
   assert.equal(backendCalls, 0);
+});
+
+test("resolvePreferredTerminalCwd falls back to renderer cwd when fresh backend pwd fails", async () => {
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: "/srv/app/current",
+    sessionId: "session-1",
+    preferFreshBackend: true,
+    getSessionPwd: async (_sessionId, options) => {
+      assert.deepEqual(options, { allowHomeFallback: false });
+      return { success: false, error: "Could not determine cwd" };
+    },
+  });
+
+  assert.equal(cwd, "/srv/app/current");
 });
 
 test("resolvePreferredTerminalCwd falls back to backend pwd when no renderer cwd is known", async () => {

--- a/components/terminal/sftpCwd.ts
+++ b/components/terminal/sftpCwd.ts
@@ -3,10 +3,14 @@ type SessionPwdResult = {
   cwd?: string | null;
 };
 
+type SessionPwdOptions = {
+  allowHomeFallback?: boolean;
+};
+
 type ResolvePreferredTerminalCwdOptions = {
   rendererCwd?: string | null;
   sessionId?: string | null;
-  getSessionPwd: (sessionId: string) => Promise<SessionPwdResult>;
+  getSessionPwd: (sessionId: string, options?: SessionPwdOptions) => Promise<SessionPwdResult>;
   /** When true, always probe the backend instead of trusting renderer cwd. */
   preferFreshBackend?: boolean;
 };
@@ -43,17 +47,19 @@ export const resolvePreferredTerminalCwd = async ({
   getSessionPwd,
   preferFreshBackend = false,
 }: ResolvePreferredTerminalCwdOptions): Promise<string | null> => {
-  if (!preferFreshBackend) {
-    const knownCwd = normalizeCwd(rendererCwd);
-    if (knownCwd) return knownCwd;
-  }
+  const knownCwd = normalizeCwd(rendererCwd);
+  if (!preferFreshBackend && knownCwd) return knownCwd;
   if (!sessionId) return null;
 
   try {
-    const result = await getSessionPwd(sessionId);
-    return result.success ? normalizeCwd(result.cwd) : null;
+    const result = await getSessionPwd(
+      sessionId,
+      preferFreshBackend ? { allowHomeFallback: false } : undefined,
+    );
+    const backendCwd = result.success ? normalizeCwd(result.cwd) : null;
+    return backendCwd ?? knownCwd;
   } catch {
-    return null;
+    return knownCwd;
   }
 };
 
@@ -63,7 +69,7 @@ export type ProbeBackendSessionCwdAfterCommandOptions = {
   sessionId: string;
   cwdRevisionAtCommand: number;
   getCwdRevision: () => number;
-  getSessionPwd: (sessionId: string) => Promise<SessionPwdResult>;
+  getSessionPwd: (sessionId: string, options?: SessionPwdOptions) => Promise<SessionPwdResult>;
   canProbe?: () => boolean | Promise<boolean>;
 };
 

--- a/components/terminal/terminalDragDropCwd.test.ts
+++ b/components/terminal/terminalDragDropCwd.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { DropEntry } from "../../lib/sftpFileUtils";
+import type { Host } from "../../types";
+import { handleTerminalDropEntries } from "./hooks/useTerminalDragDrop";
+import { resolvePreferredTerminalCwd } from "./sftpCwd";
+
+const host = {
+  id: "host-1",
+  label: "Host",
+  hostname: "example.com",
+  port: 22,
+  username: "alice",
+  protocol: "ssh",
+} as Host;
+
+const dropEntries: DropEntry[] = [
+  {
+    file: null,
+    relativePath: "report.txt",
+    isDirectory: false,
+  },
+];
+
+test("remote terminal drop opens SFTP upload with a freshly resolved cwd", async () => {
+  let receivedOptions: { preferFreshBackend?: boolean } | undefined;
+  let openedPath: string | undefined;
+  let openedEntries: DropEntry[] | undefined;
+  let openedSessionId: string | undefined;
+
+  await handleTerminalDropEntries({
+    dropEntries,
+    host,
+    isLocalConnection: false,
+    onOpenSftp: (_host, initialPath, pendingUploadEntries, sourceSessionId) => {
+      openedPath = initialPath;
+      openedEntries = pendingUploadEntries;
+      openedSessionId = sourceSessionId;
+    },
+    resolveSftpInitialPath: async (options) => {
+      receivedOptions = options;
+      return "/srv/app/current";
+    },
+    scrollToBottomAfterProgrammaticInput: () => {},
+    sessionId: "session-1",
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      writeToSession: () => {},
+    },
+    termRef: { current: null },
+  });
+
+  assert.deepEqual(receivedOptions, { preferFreshBackend: true });
+  assert.equal(openedPath, "/srv/app/current");
+  assert.equal(openedEntries, dropEntries);
+  assert.equal(openedSessionId, "session-1");
+});
+
+test("fresh cwd resolution falls back to the renderer cwd when backend probe has no real cwd", async () => {
+  const cwd = await resolvePreferredTerminalCwd({
+    rendererCwd: "/srv/app/current",
+    sessionId: "session-1",
+    preferFreshBackend: true,
+    getSessionPwd: async (_sessionId, options) => {
+      assert.deepEqual(options, { allowHomeFallback: false });
+      return { success: false, error: "Could not determine cwd" };
+    },
+  });
+
+  assert.equal(cwd, "/srv/app/current");
+});

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -76,6 +76,7 @@ function createSessionOpsApi(ctx) {
     
     async function getSessionPwd(event, payload) {
       const { sessionId } = payload;
+      const allowHomeFallback = payload?.allowHomeFallback !== false;
       const session = sessions.get(sessionId);
     
       if (!session || !session.conn) {
@@ -98,12 +99,13 @@ function createSessionOpsApi(ctx) {
         //   2. Follows foreground child shells only, which covers bash->fish
         //      without mistaking background shell scripts for the active shell.
         //   3. Reads /proc/<pid>/cwd via readlink.
-        //   4. Falls back to the user's home directory if anything fails.
+        //   4. Falls back to the user's home directory if the caller allows it.
         //
         // `exec` makes sh replace the user's login shell (fish/bash/...)
         // so sh keeps the same PID and $PPID = sshd. Starting another shell
         // without exec would make $PPID point at the intermediate shell instead.
         const posixScript = `SELF=$$
+    ALLOW_FALLBACK=${allowHomeFallback ? "1" : "0"}
     # Find the user's interactive shell on this SSH connection.
     # Prefer the one attached to a controlling tty (the user's shell): probe exec
     # channels like this one have no tty ("?"), and ps output is unsorted, so
@@ -193,11 +195,12 @@ function createSessionOpsApi(ctx) {
       # this unprivileged exec channel cannot read a su'd / sudo'd shell owned by
       # another user. Fall back to the same-uid login shell's cwd before giving up
       # to the home directory (#1065 review).
-      if [ -z "$cwd" ] && [ "$pid" != "$login" ]; then
+      if [ -z "$cwd" ] && [ "$pid" != "$login" ] && [ "$ALLOW_FALLBACK" = "1" ]; then
         cwd=$(readlink /proc/$login/cwd 2>/dev/null)
       fi
       [ -n "$cwd" ] && printf '%s\\n' "$cwd" && exit 0
     fi
+    [ "$ALLOW_FALLBACK" = "1" ] || exit 1
     emit_home() {
       case "$1" in
         /*) printf '%s\\n' "$1"; exit 0 ;;

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -59,8 +59,11 @@ function createPreloadApi(ctx) {
   execCommand: async (options) => {
     return ipcRenderer.invoke("netcatty:ssh:exec", options);
   },
-  getSessionPwd: async (sessionId) => {
-    return ipcRenderer.invoke("netcatty:ssh:pwd", { sessionId });
+  getSessionPwd: async (sessionId, options) => {
+    return ipcRenderer.invoke("netcatty:ssh:pwd", {
+      sessionId,
+      allowHomeFallback: options?.allowHomeFallback,
+    });
   },
   getSessionRemoteInfo: async (sessionId) => {
     return ipcRenderer.invoke("netcatty:ssh:remoteInfo", { sessionId });

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -114,7 +114,10 @@ declare global {
       sessionId?: string;
     }): Promise<{ stdout: string; stderr: string; code: number | null }>;
     /** Get current working directory from an active SSH session */
-    getSessionPwd?(sessionId: string): Promise<{ success: boolean; cwd?: string; error?: string }>;
+    getSessionPwd?(
+      sessionId: string,
+      options?: { allowHomeFallback?: boolean },
+    ): Promise<{ success: boolean; cwd?: string; error?: string }>;
     /**
      * Get metadata about an already-connected SSH session — currently the
      * SSH server identification string (the `software` part of the


### PR DESCRIPTION
## Summary
- make terminal drag-and-drop uploads resolve a fresh terminal cwd before opening SFTP
- prevent fresh cwd probes from treating fallback home/login-shell directories as real cwd
- keep renderer-known cwd as fallback when backend cannot determine the active cwd
- add regression coverage for remote terminal drop upload path and cwd fallback behavior

Fixes #1330.

## Validation
- node --test --import tsx components/terminal/terminalDragDropCwd.test.ts components/terminal/sftpCwd.test.ts
- npm run lint -- --quiet
- git diff --check
- node --check electron/bridges/sshBridge/sessionOps.cjs && node --check electron/preload/api.cjs
- npm run build
- npm test currently has 2 unrelated failures in SSH compatibility tests: electron/bridges/sshAlgorithms.test.cjs and electron/bridges/sshIdentificationCompatibility.test.cjs