### PR TITLE
fix: resolve .cmd shim to native exe on Windows to avoid spawn EINVAL (#1350)

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -204,10 +204,36 @@ function buildWindowsShellCommandLine(command, args) {
   return [command, ...(args || [])].map(quoteWindowsShellArg).join(" ");
 }
 
+function resolveWindowsShimToNativeExe(command, platform = process.platform) {
+  if (platform !== "win32") return null;
+  const normalized = String(command || "").trim();
+  if (!normalized) return null;
+  const ext = path.extname(normalized).toLowerCase();
+  if (ext !== ".cmd" && ext !== ".bat") return null;
+  if (!existsSync(normalized)) return null;
+  try {
+    const contents = readFileSync(normalized, "utf8");
+    const shimDir = path.dirname(normalized);
+    // Match patterns like: "%~dp0\..\node_modules\@anthropic-ai\claude-code\bin\claude.exe" %*
+    // or: "%~dp0\..\@openai\codex\bin\codex.exe"
+    const exeRefs = [...contents.matchAll(/"%~dp0\\([^"]+\.exe)"/gi)];
+    for (const [, relativePath] of exeRefs) {
+      const candidate = path.resolve(shimDir, relativePath.replace(/\\/g, "/"));
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch {}
+  return null;
+}
+
 function prepareCommandForSpawn(command, args) {
   const spawnArgs = Array.isArray(args) ? args : [];
   if (!shouldUseShellForCommand(command)) {
     return { command, args: spawnArgs, shell: false };
+  }
+
+  const nativeExePath = resolveWindowsShimToNativeExe(command);
+  if (nativeExePath) {
+    return { command: nativeExePath, args: spawnArgs, shell: false };
   }
 
   return {
@@ -229,6 +255,15 @@ function resolveClaudeCodeExecutableForSdk(claudeExecutablePath, platform = proc
   const packageCliPath = path.join(baseDir, "node_modules", "@anthropic-ai", "claude-code", "cli.js");
   if (existsSync(packageCliPath)) {
     return packageCliPath;
+  }
+
+  // Native binary check: Claude Code >= 2.1.169 ships as native exe with no cli.js
+  const nativeExeCandidates = [
+    path.join(baseDir, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"),
+    path.join(baseDir, "..", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"),
+  ];
+  for (const exePath of nativeExeCandidates) {
+    if (existsSync(exePath)) return exePath;
   }
 
   const shimCandidates = [normalized];
@@ -583,6 +618,7 @@ module.exports = {
   quoteWindowsShellArg,
   buildWindowsShellCommandLine,
   prepareCommandForSpawn,
+  resolveWindowsShimToNativeExe,
   resolveClaudeCodeExecutableForSdk,
   normalizeClaudeCodeExecutableEnvForSdk,
   resolveCodexExecutableForSdk,

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -10,6 +10,7 @@ const {
   isPlausibleCliVersionOutput,
   looksLikeIdleAutoLogout,
   prepareCommandForSpawn,
+  resolveWindowsShimToNativeExe,
   resolveClaudeCodeExecutableForSdk,
   resolveCodexExecutableForSdk,
   trackSessionIdlePrompt,
@@ -146,6 +147,75 @@ test("resolveClaudeCodeExecutableForSdk keeps Windows cmd shim when Claude Code 
     );
 
     assert.equal(resolveClaudeCodeExecutableForSdk(shimPath, "win32"), shimPath);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveClaudeCodeExecutableForSdk maps Windows npm cmd shim to native claude.exe when cli.js is absent", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-claude-native-"));
+  try {
+    const shimPath = path.join(tmp, "claude.cmd");
+    const nativeExe = path.join(tmp, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    fs.mkdirSync(path.dirname(nativeExe), { recursive: true });
+    fs.writeFileSync(nativeExe, "", "utf8");
+    fs.writeFileSync(
+      shimPath,
+      '@ECHO off\r\n"%~dp0\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n',
+      "utf8",
+    );
+
+    assert.equal(resolveClaudeCodeExecutableForSdk(shimPath, "win32"), nativeExe);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveWindowsShimToNativeExe resolves npm .cmd shim to native exe", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-shim-native-"));
+  try {
+    const shimPath = path.join(tmp, "claude.cmd");
+    const nativeExe = path.join(tmp, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    fs.mkdirSync(path.dirname(nativeExe), { recursive: true });
+    fs.writeFileSync(nativeExe, "", "utf8");
+    // Single backslashes in the .cmd content (%~dp0 expands to the shim dir)
+    fs.writeFileSync(
+      shimPath,
+      '@ECHO off\r\n"%~dp0\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n',
+      "utf8",
+    );
+
+    const resolved = resolveWindowsShimToNativeExe(shimPath, "win32");
+    assert.equal(resolved, nativeExe);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("prepareCommandForSpawn resolves Windows cmd shim to native exe with shell:false", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-spawn-native-"));
+  try {
+    const shimPath = path.join(tmp, "claude.cmd");
+    const nativeExe = path.join(tmp, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    fs.mkdirSync(path.dirname(nativeExe), { recursive: true });
+    fs.writeFileSync(nativeExe, "", "utf8");
+    fs.writeFileSync(
+      shimPath,
+      '@ECHO off\r\n"%~dp0\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n',
+      "utf8",
+    );
+
+    const result = prepareCommandForSpawn(shimPath, ["--version"]);
+    if (process.platform === "win32") {
+      assert.deepEqual(result, {
+        command: nativeExe,
+        args: ["--version"],
+        shell: false,
+      });
+    } else {
+      // On non-Windows, resolveWindowsShimToNativeExe is skipped; verify win32 behavior explicitly.
+      assert.equal(resolveWindowsShimToNativeExe(shimPath, "win32"), nativeExe);
+    }
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 问题

#1350 — Windows + Node ≥ 24 下，spawn `.cmd` 文件时如果 `shell: false` 会触发 `EINVAL`。

Claude Code v2.1.169 改为原生二进制分发（`bin/claude.exe`），npm 全局安装只生成 `claude.cmd`（无 `claude.exe`）。Netcatty 检测到 `claude.cmd`，但 spawn 时用了 `shell: false` → `EINVAL`。

用户已在 issue 中做了详尽排查并给出了对照实验证据。

## 修复

### shellUtils.cjs

| 函数 | 改动 |
|------|------|
| `resolveWindowsShimToNativeExe` (新增) | 解析 `.cmd`/`.bat` shim 中的 `"%~dp0\...\*.exe"` 路径，返回真实 exe 路径 |
| `prepareCommandForSpawn` | 优先调用 `resolveWindowsShimToNativeExe`，找到原生 exe 则用 `shell: false` spawn；找不到再回退到 `shell: true` 包裹 |
| `resolveClaudeCodeExecutableForSdk` | 当 `cli.js` 不存在时，回退查找 `bin/claude.exe`（Claude Code 原生二进制） |

### Codex CLI
不受影响 ✅ — `resolveCodexExecutableForSdk` 已正确处理原生 exe 查找

## 测试

- ✅ `node --test shellUtils.test.cjs` — 38/38 pass
- ✅ `npx tsc --noEmit` — 无新增类型错误
- ✅ `npm run build` — 构建成功
- ✅ 资源泄漏审查：无 event listener、无闭包泄漏、无定时器