### PR TITLE
fix(ui): restore Windows title bar window control hover (#1352)

### DIFF
--- a/components/SyncStatusButton.tsx
+++ b/components/SyncStatusButton.tsx
@@ -179,7 +179,7 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
                             variant="ghost"
                             size="icon"
                             className={cn(
-                                "h-7 w-7 relative text-muted-foreground hover:text-foreground app-no-drag",
+                                "h-7 w-7 relative app-no-drag top-tab-utility-btn",
                                 className
                             )}
                             style={style}

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -168,6 +168,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const [hostTreeChromeReady, setHostTreeChromeReady] = useState(false);
   const [hostTreeGutterExiting, setHostTreeGutterExiting] = useState(false);
   const [rootTabsCompact, setRootTabsCompact] = useState(false);
+  const showWindowControls = !isMacClient;
 
   // Tab reorder drag state
   const [dropIndicator, setDropIndicator] = useState<{ tabId: string; position: 'before' | 'after' } | null>(null);
@@ -767,8 +768,12 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
       {/* Always-on drag stripe so the window can be moved even when tabs fill the bar */}
       <div className="absolute inset-x-0 top-0 h-1 app-drag pointer-events-auto z-10" style={dragRegionStyle} aria-hidden />
       <div
-        className="h-9 flex items-end gap-0 app-drag"
-        style={{ ...dragRegionStyle, paddingLeft: isMacClient && !isWindowFullscreen ? 76 : 12, paddingRight: isMacClient ? 12 : 0 }}
+        className="h-9 flex items-end gap-0 app-drag overflow-visible"
+        style={{
+          ...dragRegionStyle,
+          paddingLeft: isMacClient && !isWindowFullscreen ? 76 : 12,
+          paddingRight: showWindowControls ? 0 : 12,
+        }}
       >
         {/* Fixed left tabs: Vaults and SFTP */}
         <div ref={fixedLeftTabsRef} className="flex items-end gap-0 flex-shrink-0 app-drag">
@@ -917,9 +922,9 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           </Tooltip>
         )}
 
-        {/* Fixed right controls — utility icons + window controls share one row */}
+        {/* Fixed right controls — utility icons + window controls share one h-7 row */}
         <div
-          className="flex-shrink-0 flex items-center gap-0.5 app-drag self-end h-7"
+          className="flex-shrink-0 flex items-center gap-0.5 app-drag self-end h-7 overflow-visible"
           style={dragRegionStyle}
         >
           <Tooltip>
@@ -927,7 +932,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 shrink-0 app-no-drag"
+                className="h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={() => window.dispatchEvent(new CustomEvent('netcatty:toggle-ai-panel'))}
               >
@@ -939,13 +944,13 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           <WindowOpacityButton
             windowOpacity={windowOpacity}
             setWindowOpacity={setWindowOpacity}
-            className="h-7 w-7 shrink-0"
+            className="h-7 w-7 shrink-0 top-tab-utility-btn"
             style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
           />
           <SyncStatusButton
             onOpenSettings={onOpenSettings}
             onSyncNow={onSyncNow}
-            className="h-7 w-7 shrink-0"
+            className="h-7 w-7 shrink-0 top-tab-utility-btn"
             style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
           />
           <Tooltip>
@@ -953,7 +958,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 shrink-0 app-no-drag"
+                className="h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={onToggleTheme}
               >
@@ -967,7 +972,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 shrink-0 app-no-drag"
+                className="h-7 w-7 shrink-0 app-no-drag top-tab-utility-btn"
                 style={{ color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' }}
                 onClick={onOpenSettings}
               >
@@ -976,10 +981,12 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             </TooltipTrigger>
             <TooltipContent>{t('topTabs.openSettings')}</TooltipContent>
           </Tooltip>
-          {!isMacClient && <WindowControls />}
+          {showWindowControls && <WindowControls />}
         </div>
         {/* Small drag shim to the right edge (macOS only – on Windows the close button should touch the edge) */}
-        {isMacClient && <div className="w-2 h-9 app-drag flex-shrink-0 self-end" />}
+        {isMacClient && !showWindowControls && (
+          <div className="w-2 h-9 app-drag flex-shrink-0 self-end" />
+        )}
       </div>
     </div>
   );

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -164,19 +164,18 @@ export const WindowControls: React.FC = memo(() => {
     close();
   };
 
-  const controlStyle = { color: 'var(--top-tabs-muted, hsl(var(--muted-foreground)))' };
-  const controlClassName =
-    'h-7 w-10 flex items-center justify-center rounded-none hover:bg-foreground/10 transition-colors app-no-drag';
+  const controlClassName = 'window-control-btn app-no-drag';
+  const closeControlClassName = 'window-control-btn window-control-btn--close app-no-drag';
 
   return (
-    <div className="ml-2 flex items-center h-7">
-      <button type="button" className={controlClassName} style={controlStyle} onClick={handleMinimize}>
+    <div className="ml-2 flex items-center h-7 overflow-visible app-no-drag">
+      <button type="button" className={controlClassName} onClick={handleMinimize}>
         <Minus size={16} />
       </button>
-      <button type="button" className={controlClassName} style={controlStyle} onClick={handleMaximize}>
+      <button type="button" className={controlClassName} onClick={handleMaximize}>
         {isMaximized ? <Copy size={14} /> : <Square size={14} />}
       </button>
-      <button type="button" className={controlClassName} style={controlStyle} onClick={handleClose}>
+      <button type="button" className={closeControlClassName} onClick={handleClose}>
         <X size={16} />
       </button>
     </div>

--- a/index.css
+++ b/index.css
@@ -477,6 +477,50 @@ html[data-theme-transition] *::after {
   -webkit-user-select: auto;
 }
 
+/* Window controls: icons sit in the h-7 tab row; hover fills the full h-9 title bar */
+[data-section="top-tabs"] .window-control-btn {
+  position: relative;
+  z-index: 0;
+  display: flex;
+  height: 1.75rem;
+  width: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0;
+  color: var(--top-tabs-muted, hsl(var(--muted-foreground)));
+  transition: color 150ms ease;
+}
+
+[data-section="top-tabs"] .window-control-btn::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: calc(1.75rem - 2.25rem);
+  z-index: -1;
+  background: transparent;
+  transition: background-color 150ms ease;
+}
+
+[data-section="top-tabs"] .window-control-btn:hover::before {
+  background: hsl(var(--foreground) / 0.1);
+}
+
+[data-section="top-tabs"] .window-control-btn--close:hover {
+  color: white;
+}
+
+[data-section="top-tabs"] .window-control-btn--close:hover::before {
+  background: rgb(239 68 68);
+}
+
+[data-section="top-tabs"] .top-tab-utility-btn:hover,
+[data-section="top-tabs"] .top-tab-utility-btn[data-state="open"] {
+  background-color: hsl(var(--foreground) / 0.1);
+  color: var(--top-tabs-muted, hsl(var(--muted-foreground)));
+}
+
 .no-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- Fix Windows/Linux window controls hover being clipped after #1298 alignment change
- Restore red close-button hover and flush close button to the right edge
- Keep window control icons aligned with utility icons in the h-7 row via pseudo-element hover
- Use neutral gray hover for top-bar utility buttons instead of accent color

## Test plan
- [x] Hover minimize/maximize/close — gray/red fills full bar height
- [x] Close button sits flush against right edge
- [x] AI/sync/theme/settings buttons hover with gray background, tooltips unchanged
- [ ] Verify on Windows build

Fixes #1352

Made with [Cursor](https://cursor.com)