### PR TITLE
Polish vault and log icons

### DIFF
--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -2,10 +2,16 @@
 import type React from 'react';
 import type { Host, HostProtocol } from '../../types';
 import type { PassphraseRequest } from '../../components/PassphraseModal';
+import { getEffectiveHostDistro } from '../../domain/host';
 import { getTerminalPassthroughActions } from '../state/useGlobalHotkeys';
 
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
+
+const getLogHostVisualSnapshot = (host: Host) => ({
+  hostOs: host.os,
+  hostDistro: getEffectiveHostDistro(host) || undefined,
+});
 
 export function handleTrayJumpToSessionImpl(getCtx: AppContextGetter, sessionId: string) {
   const { sessions, setActiveTabId, setWorkspaceFocusedSession } = getCtx();
@@ -65,6 +71,7 @@ export function handleTrayPanelConnectImpl(getCtx: AppContextGetter, hostId: str
         hostname: host.hostname,
         username,
         protocol: 'serial',
+        ...getLogHostVisualSnapshot(effectiveHost),
         startTime: Date.now(),
         localUsername: username,
         localHostname: localHost,
@@ -83,6 +90,7 @@ export function handleTrayPanelConnectImpl(getCtx: AppContextGetter, hostId: str
       hostname: host.hostname,
       username: resolvedAuth.username || 'root',
       protocol: protocol as 'ssh' | 'telnet' | 'local' | 'mosh' | 'et',
+      ...getLogHostVisualSnapshot(effectiveHost),
       startTime: Date.now(),
       localUsername: username,
       localHostname: localHost,
@@ -708,6 +716,7 @@ export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host) {
         hostname: host.hostname,
         username: username,
         protocol: 'serial',
+        ...getLogHostVisualSnapshot(effectiveHost),
         startTime: Date.now(),
         localUsername: username,
         localHostname: localHost,
@@ -726,6 +735,7 @@ export function handleConnectToHostImpl(getCtx: AppContextGetter, host: Host) {
       hostname: host.hostname,
       username: resolvedAuth.username || 'root',
       protocol: protocol as 'ssh' | 'telnet' | 'local' | 'mosh' | 'et',
+      ...getLogHostVisualSnapshot(effectiveHost),
       startTime: Date.now(),
       localUsername: username,
       localHostname: localHost,

--- a/components/ConnectionLogsManager.tsx
+++ b/components/ConnectionLogsManager.tsx
@@ -1,16 +1,17 @@
 import {
     Bookmark,
     ChevronDown,
+    CircleUserRound,
     Server,
     Terminal,
     Trash2,
     Usb,
-    User,
 } from "lucide-react";
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { cn } from "../lib/utils";
 import { ConnectionLog, Host } from "../types";
+import { DistroAvatar } from "./DistroAvatar";
 import { ScrollArea } from "./ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
@@ -66,6 +67,7 @@ const LogItem = memo<LogItemProps>(({ log, onToggleSaved, onDelete, onClick }) =
     const { t, resolvedLocale } = useI18n();
     const isLocal = log.protocol === "local" || log.hostname === "localhost";
     const isSerial = log.protocol === "serial";
+    const hasPersistedHostIcon = !isLocal && !isSerial && !!log.hostDistro;
 
     return (
         <div
@@ -82,8 +84,8 @@ const LogItem = memo<LogItemProps>(({ log, onToggleSaved, onDelete, onClick }) =
 
             {/* User column */}
             <div className="flex items-center gap-2 w-56 shrink-0">
-                <div className="h-8 w-8 rounded-full bg-primary/10 text-primary flex items-center justify-center shrink-0">
-                    <User size={14} />
+                <div className="h-9 w-9 rounded-xl bg-emerald-600 text-white dark:bg-emerald-400 dark:text-slate-950 flex items-center justify-center shrink-0">
+                    <CircleUserRound size={18} strokeWidth={2.25} />
                 </div>
                 <div className="min-w-0">
                     <div className="text-sm font-medium truncate">{log.localUsername}</div>
@@ -93,12 +95,28 @@ const LogItem = memo<LogItemProps>(({ log, onToggleSaved, onDelete, onClick }) =
 
             {/* Host column */}
             <div className="flex items-center gap-2 flex-1 min-w-0">
-                <div className={cn(
-                    "h-8 w-8 rounded-lg flex items-center justify-center shrink-0",
-                    isSerial ? "bg-amber-500/10 text-amber-500" : isLocal ? "bg-emerald-500/10 text-emerald-500" : "bg-blue-500/10 text-blue-500"
-                )}>
-                    {isSerial ? <Usb size={14} /> : isLocal ? <Terminal size={14} /> : <Server size={14} />}
-                </div>
+                {hasPersistedHostIcon ? (
+                    <DistroAvatar
+                        host={{
+                            os: log.hostOs ?? "linux",
+                            distro: log.hostDistro,
+                            distroMode: "auto",
+                        }}
+                        fallback={(log.hostOs ?? "linux")[0].toUpperCase()}
+                        size="log"
+                    />
+                ) : (
+                    <div className={cn(
+                        "h-9 w-9 rounded-xl flex items-center justify-center shrink-0",
+                        isSerial
+                            ? "bg-amber-600 text-white dark:bg-amber-400 dark:text-slate-950"
+                            : isLocal
+                                ? "bg-slate-600 text-white dark:bg-slate-300 dark:text-slate-950"
+                                : "bg-primary text-primary-foreground"
+                    )}>
+                        {isSerial ? <Usb size={17} /> : isLocal ? <Terminal size={17} /> : <Server size={17} />}
+                    </div>
+                )}
                 <div className="min-w-0">
                     <div className="text-sm font-medium truncate">{isLocal ? t("logs.localTerminal") : log.hostLabel}</div>
                     <div className="text-xs text-muted-foreground truncate">

--- a/components/DistroAvatar.tsx
+++ b/components/DistroAvatar.tsx
@@ -68,11 +68,12 @@ export const DISTRO_COLORS: Record<string, string> = {
 };
 
 type DistroAvatarProps = {
-  host: Host;
+  host: Pick<Host, "distro" | "manualDistro" | "distroMode" | "os"> &
+    Partial<Pick<Host, "protocol">>;
   fallback: string;
   className?: string;
   /** xs matches top tab bar icons (h-4 rounded rect) */
-  size?: "xs" | "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "tree" | "log" | "lg";
 };
 
 const DistroAvatarInner: React.FC<DistroAvatarProps> = ({
@@ -91,12 +92,16 @@ const DistroAvatarInner: React.FC<DistroAvatarProps> = ({
     xs: "h-4 w-4 rounded",
     sm: "h-5 w-5 rounded",
     md: "h-8 w-8 rounded",
-    lg: "h-11 w-11 rounded",
+    tree: "h-8 w-8 rounded-lg",
+    log: "h-9 w-9 rounded-xl",
+    lg: "h-11 w-11 rounded-xl",
   };
   const iconSizes = {
     xs: "h-2.5 w-2.5",
     sm: "h-3 w-3",
     md: "h-4 w-4",
+    tree: "h-4 w-4",
+    log: "h-5 w-5",
     lg: "h-5 w-5",
   };
 
@@ -108,7 +113,7 @@ const DistroAvatarInner: React.FC<DistroAvatarProps> = ({
     return (
       <div
         className={cn(
-          "shrink-0 rounded flex items-center justify-center bg-amber-500/15 text-amber-500",
+          "shrink-0 rounded flex items-center justify-center bg-amber-600 text-white dark:bg-amber-400 dark:text-slate-950",
           containerClass,
           className,
         )}
@@ -141,7 +146,7 @@ const DistroAvatarInner: React.FC<DistroAvatarProps> = ({
   return (
     <div
       className={cn(
-        "shrink-0 rounded flex items-center justify-center bg-primary/15 text-primary",
+        "shrink-0 rounded flex items-center justify-center bg-primary text-primary-foreground",
         containerClass,
         className,
       )}

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -213,8 +213,12 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                     </div>
                   )}
                 </div>
-                <div className="mr-3 text-primary/80 group-hover:text-primary transition-colors">
-                  {isExpanded ? <FolderOpen size={18} /> : <Folder size={18} />}
+                <div className="mr-3 flex h-8 w-8 shrink-0 items-center justify-center text-primary transition-colors dark:text-primary">
+                  {isExpanded ? (
+                    <FolderOpen size={21} strokeWidth={2.35} />
+                  ) : (
+                    <Folder size={21} strokeWidth={2.35} />
+                  )}
                 </div>
                 {isInlineEditing && commitRename && cancelRename ? (
                   <HostTreeGroupInlineRenameInput
@@ -414,7 +418,7 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
           )}
           {!isMultiSelectMode && <div className="mr-2 flex-shrink-0 w-4 h-4" />}
           <div className="mr-3 flex-shrink-0">
-            <DistroAvatar host={host} fallback={(host.os || "L")[0].toUpperCase()} size="xs" />
+            <DistroAvatar host={host} fallback={(host.os || "L")[0].toUpperCase()} size="tree" />
           </div>
           <div className="flex-1 min-w-0">
             <div className="font-medium truncate flex items-center gap-1.5">

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -48,6 +48,7 @@ import {
   VaultHeaderSearch,
   VaultPageHeader,
   vaultHeaderIconButtonClass,
+  vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
 
 // Import utilities and components from keychain module
@@ -678,7 +679,7 @@ echo $3 >> "$FILE"`);
           {/* Keys Section */}
           <div className="space-y-3 p-3">
           <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-muted-foreground">
+            <h2 className={vaultSectionTitleClass}>
               {t("keychain.section.keys")}
             </h2>
             <span className="text-xs text-muted-foreground">
@@ -743,7 +744,7 @@ echo $3 >> "$FILE"`);
         {activeFilter === "key" && filteredIdentities.length > 0 && (
           <div className="space-y-3 px-3 pb-3">
             <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold text-muted-foreground">
+              <h2 className={vaultSectionTitleClass}>
                 {t("keychain.section.identities")}
               </h2>
               <span className="text-xs text-muted-foreground">

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -44,6 +44,7 @@ import {
   vaultHeaderIconButtonClass,
   vaultHeaderSecondaryButtonClass,
 } from "./vault/VaultPageHeader";
+import { VaultEntityIcon, vaultPrimaryIconClass } from "./vault/VaultEntityIcon";
 
 interface KnownHostsManagerProps {
   knownHosts: KnownHost[];
@@ -167,9 +168,10 @@ const HostItem = React.memo<HostItemProps>(
                 </Tooltip>
               </div>
               <div className="flex items-center gap-3 h-full">
-                <div className="h-11 w-11 rounded-xl bg-primary/10 text-primary flex items-center justify-center flex-shrink-0">
-                  <Server size={18} />
-                </div>
+                <VaultEntityIcon
+                  className={vaultPrimaryIconClass}
+                  icon={<Server size={18} />}
+                />
                 <div className="flex-1 min-w-0">
                   <span className="text-sm font-semibold truncate block">
                     {knownHost.hostname}
@@ -205,9 +207,10 @@ const HostItem = React.memo<HostItemProps>(
               converted && "opacity-60",
             )}
           >
-            <div className="h-11 w-11 rounded-xl bg-primary/10 text-primary flex items-center justify-center flex-shrink-0">
-              <Server size={18} />
-            </div>
+            <VaultEntityIcon
+              className={vaultPrimaryIconClass}
+              icon={<Server size={18} />}
+            />
             <div className="flex-1 min-w-0">
               <span className="text-sm font-semibold truncate block">
                 {knownHost.hostname}

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -47,6 +47,7 @@ import {
   VaultPageHeader,
   vaultHeaderIconButtonClass,
   vaultHeaderSecondaryButtonClass,
+  vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
 
 // Import components and utilities from port-forwarding module
@@ -690,9 +691,9 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
         </VaultPageHeader>
 
         {/* Rules List */}
-        <div className="flex-1 overflow-auto p-4">
+        <div className="flex-1 overflow-y-auto">
           {!hasRules ? (
-            <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <div className="flex h-full flex-col items-center justify-center p-3 text-muted-foreground">
               <div className="h-16 w-16 rounded-2xl bg-secondary/80 flex items-center justify-center mb-4">
                 <Zap size={32} className="opacity-60" />
               </div>
@@ -704,9 +705,9 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
               </p>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-3 p-3">
               <div className="flex items-center justify-between">
-                <h2 className="text-base font-semibold">{t("pf.title")}</h2>
+                <h2 className={vaultSectionTitleClass}>{t("pf.title")}</h2>
                 <span className="text-xs text-muted-foreground">
                   {t("pf.rulesCount", { count: filteredRules.length })}
                 </span>

--- a/components/ProxyProfilesManager.tsx
+++ b/components/ProxyProfilesManager.tsx
@@ -59,7 +59,14 @@ import {
   VaultPageHeader,
   vaultHeaderIconButtonClass,
   vaultHeaderSecondaryButtonClass,
+  vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
+import {
+  VaultEntityIcon,
+  vaultProxyCommandIconClass,
+  vaultProxyHttpIconClass,
+  vaultProxySocksIconClass,
+} from "./vault/VaultEntityIcon";
 
 interface ProxyProfilesManagerProps {
   proxyProfiles: ProxyProfile[];
@@ -99,17 +106,17 @@ const proxyProtocolMeta = {
   http: {
     label: "HTTP",
     Icon: Globe,
-    iconClassName: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    iconClassName: vaultProxyHttpIconClass,
   },
   socks5: {
     label: "SOCKS5",
     Icon: Route,
-    iconClassName: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+    iconClassName: vaultProxySocksIconClass,
   },
   command: {
     labelKey: "hostDetails.proxyPanel.command",
     Icon: SquareTerminal,
-    iconClassName: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+    iconClassName: vaultProxyCommandIconClass,
   },
 } satisfies Record<ProxyConfig["type"], {
   label?: string;
@@ -163,15 +170,11 @@ const ProxyProfileCard: React.FC<ProxyProfileCardProps> = ({
           onClick={onClick}
         >
           <div className="flex items-center gap-3 h-full">
-            <div
-              className={cn(
-                "h-11 w-11 rounded-xl flex items-center justify-center",
-                protocol.iconClassName,
-              )}
+            <VaultEntityIcon
+              className={protocol.iconClassName}
               title={protocolLabel}
-            >
-              <ProtocolIcon size={18} />
-            </div>
+              icon={<ProtocolIcon size={18} />}
+            />
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 min-w-0">
                 <div className="text-sm font-semibold truncate">{profile.label}</div>
@@ -397,7 +400,7 @@ export const ProxyProfilesManager: React.FC<ProxyProfilesManagerProps> = ({
         <div className="flex-1 overflow-y-auto">
           <div className="space-y-3 p-3">
             <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold text-muted-foreground">
+              <h2 className={vaultSectionTitleClass}>
                 {t("proxyProfiles.section.proxies")}
               </h2>
               <span className="text-xs text-muted-foreground">

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -19,7 +19,13 @@ import {
   VaultPageHeader,
   vaultHeaderIconButtonClass,
   vaultHeaderSecondaryButtonClass,
+  vaultSectionTitleClass,
 } from './vault/VaultPageHeader';
+import {
+  VaultEntityIcon,
+  vaultPrimaryIconClass,
+  vaultSnippetIconClass,
+} from './vault/VaultEntityIcon';
 
 interface SnippetsManagerProps {
   snippets: Snippet[];
@@ -790,7 +796,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
           {displayedPackages.length > 0 && !search.trim() && (
             <>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold text-muted-foreground">{t('snippets.section.packages')}</h3>
+                <h3 className={vaultSectionTitleClass}>{t('snippets.section.packages')}</h3>
               </div>
               <div className={cn(
                 viewMode === 'grid'
@@ -823,9 +829,10 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                         onClick={() => setSelectedPackage(pkg.path)}
                       >
                         <div className="flex items-center gap-3 h-full min-w-0">
-                          <div className="h-11 w-11 rounded-xl bg-primary/15 text-primary flex items-center justify-center flex-shrink-0">
-                            <Package size={18} />
-                          </div>
+                          <VaultEntityIcon
+                            className={vaultPrimaryIconClass}
+                            icon={<Package size={18} />}
+                          />
                           <div className="w-0 flex-1">
                             <div className="text-sm font-semibold truncate">{pkg.name}</div>
                             <div className="text-[11px] text-muted-foreground">{t('snippets.package.count', { count: pkg.count })}</div>
@@ -846,7 +853,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
 
           {displayedSnippets.length > 0 && (
             <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-muted-foreground">{t('snippets.section.snippets')}</h3>
+              <h3 className={vaultSectionTitleClass}>{t('snippets.section.snippets')}</h3>
               <div className={cn(
                 viewMode === 'grid'
                   ? "grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
@@ -870,9 +877,10 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                         onClick={() => handleEdit(snippet)}
                       >
                         <div className="flex items-center gap-3 h-full min-w-0">
-                          <div className="h-11 w-11 rounded-xl bg-primary/15 text-primary flex items-center justify-center flex-shrink-0">
-                            <FileCode size={18} />
-                          </div>
+                          <VaultEntityIcon
+                            className={vaultSnippetIconClass}
+                            icon={<FileCode size={18} />}
+                          />
                           <div className="w-0 flex-1">
                             <div className="text-sm font-semibold truncate">{snippet.label}</div>
                             <Tooltip>

--- a/components/keychain/IdentityCard.tsx
+++ b/components/keychain/IdentityCard.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import { cn } from '../../lib/utils';
 import { Identity } from '../../types';
 import { Button } from '../ui/button';
+import { VaultEntityIcon, vaultIdentityIconClass } from '../vault/VaultEntityIcon';
 
 interface IdentityCardProps {
     identity: Identity;
@@ -52,9 +53,10 @@ export const IdentityCard: React.FC<IdentityCardProps> = ({
             onClick={onClick}
         >
             <div className="flex items-center gap-3 h-full">
-                <div className="h-11 w-11 rounded-xl bg-green-500/15 text-green-500 flex items-center justify-center">
-                    <User size={18} />
-                </div>
+                <VaultEntityIcon
+                    className={vaultIdentityIconClass}
+                    icon={<User size={18} />}
+                />
                 <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold truncate">{identity.label || 'Add a label...'}</div>
                     <div className="text-[11px] font-mono text-muted-foreground truncate">

--- a/components/keychain/IdentityPanel.tsx
+++ b/components/keychain/IdentityPanel.tsx
@@ -73,7 +73,7 @@ export const IdentityPanel: React.FC<IdentityPanelProps> = ({
     return (
         <>
             <div className="flex items-center gap-3 mb-4">
-                <div className="h-10 w-10 rounded-lg bg-green-500/15 text-green-500 flex items-center justify-center">
+                <div className="h-10 w-10 rounded-lg bg-emerald-600 text-white dark:bg-emerald-400 dark:text-slate-950 flex items-center justify-center">
                     <User size={20} />
                 </div>
                 <Input

--- a/components/keychain/KeyCard.tsx
+++ b/components/keychain/KeyCard.tsx
@@ -9,6 +9,11 @@ import { cn } from '../../lib/utils';
 import { SSHKey } from '../../types';
 import { Button } from '../ui/button';
 import {
+    VaultEntityIcon,
+    vaultCertificateIconClass,
+    vaultKeyIconClass,
+} from '../vault/VaultEntityIcon';
+import {
 ContextMenu,
 ContextMenuContent,
 ContextMenuItem,
@@ -55,14 +60,12 @@ export const KeyCard: React.FC<KeyCardProps> = ({
                     onClick={onClick}
                 >
                     <div className="flex items-center gap-3 h-full">
-                        <div className={cn(
-                            "h-11 w-11 rounded-xl flex items-center justify-center",
-                            keyItem.certificate
-                              ? "bg-emerald-500/15 text-emerald-500"
-                              : "bg-primary/15 text-primary"
-                        )}>
-                            {getKeyIcon(keyItem)}
-                        </div>
+                        <VaultEntityIcon
+                            className={keyItem.certificate
+                              ? vaultCertificateIconClass
+                              : vaultKeyIconClass}
+                            icon={getKeyIcon(keyItem)}
+                        />
                         <div className="min-w-0 flex-1">
                             <div className="text-sm font-semibold truncate">{keyItem.label}</div>
                             <div className="text-[11px] font-mono text-muted-foreground truncate">

--- a/components/port-forwarding/RuleCard.tsx
+++ b/components/port-forwarding/RuleCard.tsx
@@ -10,6 +10,7 @@ import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { ContextMenu,ContextMenuContent,ContextMenuItem,ContextMenuSeparator,ContextMenuTrigger } from '../ui/context-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
+import { vaultEntityIconClass } from '../vault/VaultEntityIcon';
 import { getStatusColor,getTypeColor } from './utils';
 
 export type ViewMode = 'grid' | 'list';
@@ -60,7 +61,8 @@ export const RuleCard: React.FC<RuleCardProps> = ({
                 >
                     <div className="flex items-center gap-3 h-full">
                         <div className={cn(
-                            "h-11 w-11 rounded-xl flex items-center justify-center text-sm font-bold transition-colors",
+                            vaultEntityIconClass,
+                            "text-sm font-bold transition-colors",
                             getTypeColor(rule.type, isActive)
                         )}>
                             {rule.type[0].toUpperCase()}

--- a/components/port-forwarding/utils.tsx
+++ b/components/port-forwarding/utils.tsx
@@ -63,9 +63,9 @@ export function getStatusColor(status: string): string {
  */
 export function getTypeColor(type: PortForwardingType, isActive: boolean): string {
   const colors = {
-    local: isActive ? 'bg-blue-500 text-white' : 'bg-blue-500/15 text-blue-500',
-    remote: isActive ? 'bg-orange-500 text-white' : 'bg-orange-500/15 text-orange-500',
-    dynamic: isActive ? 'bg-purple-500 text-white' : 'bg-purple-500/15 text-purple-500',
+    local: isActive ? 'bg-sky-500 text-white' : 'bg-sky-600 text-white dark:bg-sky-400 dark:text-slate-950',
+    remote: isActive ? 'bg-indigo-500 text-white' : 'bg-indigo-600 text-white dark:bg-indigo-400 dark:text-slate-950',
+    dynamic: isActive ? 'bg-violet-500 text-white' : 'bg-violet-600 text-white dark:bg-violet-400 dark:text-slate-950',
   };
   return colors[type];
 }

--- a/components/vault/VaultEntityIcon.tsx
+++ b/components/vault/VaultEntityIcon.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { cn } from "../../lib/utils";
+
+type VaultEntityIconProps = {
+  icon: React.ReactNode;
+  className?: string;
+  title?: string;
+};
+
+export const vaultEntityIconClass =
+  "h-11 w-11 rounded-xl flex items-center justify-center shrink-0";
+
+export const vaultPrimaryIconClass = "bg-primary text-primary-foreground";
+export const vaultSnippetIconClass = "bg-amber-600 text-white dark:bg-amber-400 dark:text-slate-950";
+export const vaultKeyIconClass = "bg-cyan-600 text-white dark:bg-cyan-400 dark:text-slate-950";
+export const vaultCertificateIconClass = "bg-teal-600 text-white dark:bg-teal-400 dark:text-slate-950";
+export const vaultIdentityIconClass = "bg-emerald-600 text-white dark:bg-emerald-400 dark:text-slate-950";
+export const vaultProxyHttpIconClass = "bg-teal-600 text-white dark:bg-teal-400 dark:text-slate-950";
+export const vaultProxySocksIconClass = "bg-sky-600 text-white dark:bg-sky-400 dark:text-slate-950";
+export const vaultProxyCommandIconClass = "bg-violet-600 text-white dark:bg-violet-400 dark:text-slate-950";
+
+export const VaultEntityIcon: React.FC<VaultEntityIconProps> = ({
+  icon,
+  className,
+  title,
+}) => (
+  <div
+    className={cn(vaultEntityIconClass, className)}
+    title={title}
+  >
+    {icon}
+  </div>
+);

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { HostNotesIndicator } from "../host/HostNotesIndicator";
+import { VaultEntityIcon, vaultPrimaryIconClass } from "./VaultEntityIcon";
 
 type VaultHostListSectionContext = Record<string, any>;
 
@@ -150,7 +151,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         )}
                                       </div>
                                     )}
-                                    <DistroAvatar host={safeHost} fallback={distroBadge.text} />
+                                    <DistroAvatar host={safeHost} fallback={distroBadge.text} size="lg" />
                                     <div className="min-w-0 flex flex-col justify-center gap-0.5 flex-1">
                                       <div className="flex items-center gap-1.5">
                                         <span className="text-sm font-semibold truncate leading-5">
@@ -258,7 +259,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         )}
                                       </div>
                                     )}
-                                    <DistroAvatar host={safeHost} fallback={distroBadge.text} />
+                                    <DistroAvatar host={safeHost} fallback={distroBadge.text} size="lg" />
                                     <div className="min-w-0 flex flex-col justify-center gap-0.5 flex-1">
                                       <div className="flex items-center gap-1.5">
                                         <span className="text-sm font-semibold truncate leading-5">
@@ -391,9 +392,10 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                               }}
                             >
                               <div className="flex items-center gap-3 h-full">
-                                <div className="h-11 w-11 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
-                                  <FolderTree size={20} />
-                                </div>
+                                <VaultEntityIcon
+                                  className={vaultPrimaryIconClass}
+                                  icon={<FolderTree size={20} />}
+                                />
                                 <div className="flex-1 min-w-0">
                                   <div className="text-sm font-semibold truncate flex items-center gap-2">
                                     {node.name}
@@ -579,6 +581,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                           <DistroAvatar
                                             host={safeHost}
                                             fallback={distroBadge.text}
+                                            size="lg"
                                           />
                                           <div className="min-w-0 flex flex-col justify-center gap-0.5 flex-1">
                                             <div className="flex items-center gap-1.5">
@@ -725,6 +728,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                     <DistroAvatar
                                       host={safeHost}
                                       fallback={distroBadge.text}
+                                      size="lg"
                                     />
                                     <div className="min-w-0 flex flex-col justify-center gap-0.5 flex-1">
                                       <div className="flex items-center gap-1.5">

--- a/components/vault/VaultPageHeader.tsx
+++ b/components/vault/VaultPageHeader.tsx
@@ -76,3 +76,5 @@ export const vaultHeaderSecondaryButtonClass =
   "h-10 px-3 gap-2 bg-foreground/5 text-foreground hover:bg-foreground/10 border-border/40";
 
 export const vaultHeaderIconButtonClass = "h-10 w-10";
+
+export const vaultSectionTitleClass = "text-base font-semibold text-muted-foreground";

--- a/domain/models/history.ts
+++ b/domain/models/history.ts
@@ -30,6 +30,8 @@ export interface ConnectionLog {
   hostname: string; // Target hostname or 'localhost'
   username: string; // SSH username or system username
   protocol: 'ssh' | 'telnet' | 'local' | 'mosh' | 'et' | 'serial';
+  hostOs?: 'linux' | 'windows' | 'macos'; // Snapshot of the connected host OS for log icons
+  hostDistro?: string; // Snapshot of the connected host distro/vendor icon id
   startTime: number; // Connection start timestamp
   endTime?: number; // Connection end timestamp (undefined if still active)
   localUsername: string; // System username of the local user


### PR DESCRIPTION
## Summary
- unify Vault section title styling and Port Forwarding spacing
- standardize Vault entity icon sizing, radius, and filled colors
- improve Logs icons and persist host OS/distro icon data for new connection logs

## Verification
- npm run lint
- node --test --import tsx components/HostTreeView.test.tsx components/VaultView.sortPersistence.test.tsx domain/connectionLog.test.ts
- npm run build
- checked Logs and Snippets in the local app