### PR TITLE
fix(terminal): refocus input when switching work tabs (#1339)

### DIFF
--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -198,6 +198,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     onToggleWorkspaceViewModeRef: s.onToggleWorkspaceViewModeRef,
     prevFocusedSessionIdRef,
     previewTargetSessionId: themeState.previewTargetSessionId,
+    refocusActiveTerminalSession: s.refocusActiveTerminalSession,
     requestAnimationFrame,
     ResizeObserver,
     sessionActivityStore: s.sessionActivityStore,

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -6,7 +6,7 @@ import { terminalLayoutSuppressStore } from '../../application/state/terminalLay
 type TerminalLayerEffectsContext = Record<string, any>;
 
 export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
-  const { activeSidePanelTab, activeTabId, activeTabIdRef, activeTopTabsThemeId, activeWorkspace, activityTrackedSessions, appliedPreviewSessionRef, applyTerminalPreviewVars, applyTopTabsPreviewVars, cancelAnimationFrame, ChunkedEscapeFilter, clearTerminalPreviewVars, clearTimeout, clearTopTabsPreviewVars, document, dropHint, filterTabsMap, focusedSessionId, followAppTerminalTheme, getSessionActivityIdsToClear, handleToggleAiFromTopBar, handleToggleScriptsSidePanel, handleToggleSidePanel, hasNotifiableTerminalOutput, isFocusMode, isTerminalLayerVisible, lastSidePanelTabRef, Map, onSessionData, onSplitSessionRef, onToggleBroadcastRef, onToggleWorkspaceViewModeRef, prevFocusedSessionIdRef, previewTargetSessionId, requestAnimationFrame, ResizeObserver, sessionActivityStore, sessions, Set, setAiMountedTabIds, setDropHint, setScriptsMountedTabIds, setSftpHostForTab, setSftpInitialLocationForTab, setSftpPendingUploadsForTab, setSidePanelOpenTabs, setThemeMountedTabIds, setThemePreview, setTimeout, setupMcpApprovalBridge, setWorkspaceArea, sftpActiveHost, sftpHostForTab, shouldMarkSessionActivity, sidePanelOpenTabs, splitHorizontalHandlersRef, splitVerticalHandlersRef, terminalRendererCwdBySessionRef, themeCommitTimerRef, themePreview, toggleScriptsSidePanelRef, toggleSidePanelRef, validAIScopeTargetIds, validSessionActivityIds, visibleFocusedThemeId, window, workspaceBroadcastHandlersRef, workspaceFocusHandlersRef, workspaceInnerRef, workspaces } = ctx;
+  const { activeSidePanelTab, activeTabId, activeTabIdRef, activeTopTabsThemeId, activeWorkspace, activityTrackedSessions, appliedPreviewSessionRef, applyTerminalPreviewVars, applyTopTabsPreviewVars, cancelAnimationFrame, ChunkedEscapeFilter, clearTerminalPreviewVars, clearTimeout, clearTopTabsPreviewVars, document, dropHint, filterTabsMap, focusedSessionId, followAppTerminalTheme, getSessionActivityIdsToClear, handleToggleAiFromTopBar, handleToggleScriptsSidePanel, handleToggleSidePanel, hasNotifiableTerminalOutput, isFocusMode, isTerminalLayerVisible, lastSidePanelTabRef, Map, onSessionData, onSplitSessionRef, onToggleBroadcastRef, onToggleWorkspaceViewModeRef, prevFocusedSessionIdRef, previewTargetSessionId, refocusActiveTerminalSession, requestAnimationFrame, ResizeObserver, sessionActivityStore, sessions, Set, setAiMountedTabIds, setDropHint, setScriptsMountedTabIds, setSftpHostForTab, setSftpInitialLocationForTab, setSftpPendingUploadsForTab, setSidePanelOpenTabs, setThemeMountedTabIds, setThemePreview, setTimeout, setupMcpApprovalBridge, setWorkspaceArea, sftpActiveHost, sftpHostForTab, shouldMarkSessionActivity, sidePanelOpenTabs, splitHorizontalHandlersRef, splitVerticalHandlersRef, terminalRendererCwdBySessionRef, themeCommitTimerRef, themePreview, toggleScriptsSidePanelRef, toggleSidePanelRef, validAIScopeTargetIds, validSessionActivityIds, visibleFocusedThemeId, window, workspaceBroadcastHandlersRef, workspaceFocusHandlersRef, workspaceInnerRef, workspaces } = ctx;
 
   useEffect(() => {
       const liveSessionIds = new Set(sessions.map((session) => session.id));
@@ -310,6 +310,23 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
     }, [isFocusMode, dropHint]);
   
   const wasTerminalLayerVisibleRef = useRef(false);
+  const prevActiveTabIdRef = useRef<string | undefined>(undefined);
+
+  // Restore keyboard focus to the active terminal after switching work tabs.
+  useEffect(() => {
+    if (!isTerminalLayerVisible) {
+      prevActiveTabIdRef.current = activeTabId;
+      return;
+    }
+
+    const tabChanged =
+      prevActiveTabIdRef.current !== undefined &&
+      prevActiveTabIdRef.current !== activeTabId;
+    prevActiveTabIdRef.current = activeTabId;
+
+    if (!tabChanged) return;
+    refocusActiveTerminalSession?.();
+  }, [activeTabId, isTerminalLayerVisible, refocusActiveTerminalSession]);
 
   // When focusedSessionId changes or terminal layer becomes visible,
     // focus the corresponding terminal to restore :focus-within CSS state


### PR DESCRIPTION
## Summary
- 切换顶部工作标签（终端会话 / 工作区）后，自动调用 `refocusActiveTerminalSession` 将键盘焦点交还给 xterm 输入框
- 修复 macOS 上切换标签后需要额外点击才能输入的问题（[Discussion #1339](https://github.com/binaricat/Netcatty/discussions/1339)）

## Test plan
- [ ] macOS：打开多个终端标签，用鼠标切换标签，确认光标/输入焦点立即生效，可直接打字
- [ ] macOS：用快捷键 `Cmd+Shift+]` / `Cmd+Shift+[` 切换标签，确认同样可立即输入
- [ ] 从 Vault 切到终端标签，确认焦点正常
- [ ] 工作区内分屏切换焦点行为不受影响
- [ ] 打开侧边栏（SFTP / AI）后关闭侧边栏，确认原有 refocus 逻辑仍正常


Made with [Cursor](https://cursor.com)