### PR TITLE
feat(shortcuts): add option to skip pinned tabs for number keys

### DIFF
--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -4,6 +4,7 @@ import type { Host, HostProtocol } from '../../types';
 import type { PassphraseRequest } from '../../components/PassphraseModal';
 import { getEffectiveHostDistro } from '../../domain/host';
 import { getTerminalPassthroughActions } from '../state/useGlobalHotkeys';
+import { buildNumberShortcutTabTargets } from './tabShortcutTargets';
 
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
@@ -444,13 +445,19 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
     const allTabs = settings.showSftpTab
       ? ['vault', 'sftp', ...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))]
       : ['vault', ...orderedTabs, ...editorTabs.map((t) => toEditorTabId(t.id))];
+    const numberShortcutTabs = buildNumberShortcutTabTargets({
+      showSftpTab: settings.showSftpTab ?? true,
+      shellOnlyTabNumberShortcuts: settings.shellOnlyTabNumberShortcuts ?? false,
+      orderedTabs,
+      editorTabIds: editorTabs.map((t) => toEditorTabId(t.id)),
+    });
     switch (action) {
       case 'switchToTab': {
         // Get the number key pressed (1-9)
         const num = parseInt(e.key, 10);
         if (num >= 1 && num <= 9) {
-          if (num <= allTabs.length) {
-            setActiveTabId(allTabs[num - 1]);
+          if (num <= numberShortcutTabs.length) {
+            setActiveTabId(numberShortcutTabs[num - 1]);
           }
         }
         break;

--- a/application/app/tabShortcutTargets.test.ts
+++ b/application/app/tabShortcutTargets.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildNumberShortcutTabTargets } from './tabShortcutTargets.ts';
+
+test('number shortcut tabs include vault and sftp by default', () => {
+  assert.deepEqual(
+    buildNumberShortcutTabTargets({
+      showSftpTab: true,
+      shellOnlyTabNumberShortcuts: false,
+      orderedTabs: ['session-1', 'workspace-1'],
+      editorTabIds: ['editor:file-1'],
+    }),
+    ['vault', 'sftp', 'session-1', 'workspace-1', 'editor:file-1'],
+  );
+});
+
+test('number shortcut tabs skip vault and sftp when shell-only mode is enabled', () => {
+  assert.deepEqual(
+    buildNumberShortcutTabTargets({
+      showSftpTab: true,
+      shellOnlyTabNumberShortcuts: true,
+      orderedTabs: ['session-1', 'workspace-1'],
+      editorTabIds: ['editor:file-1'],
+    }),
+    ['session-1', 'workspace-1', 'editor:file-1'],
+  );
+});
+
+test('hidden sftp tab is omitted from default number shortcut targets', () => {
+  assert.deepEqual(
+    buildNumberShortcutTabTargets({
+      showSftpTab: false,
+      shellOnlyTabNumberShortcuts: false,
+      orderedTabs: ['session-1'],
+      editorTabIds: [],
+    }),
+    ['vault', 'session-1'],
+  );
+});

--- a/application/app/tabShortcutTargets.ts
+++ b/application/app/tabShortcutTargets.ts
@@ -1,0 +1,14 @@
+/** Tab ids targeted by Cmd/Ctrl+[1...9] number shortcuts. */
+export function buildNumberShortcutTabTargets(params: {
+  showSftpTab: boolean;
+  shellOnlyTabNumberShortcuts: boolean;
+  orderedTabs: readonly string[];
+  editorTabIds: readonly string[];
+}): string[] {
+  const workTabs = [...params.orderedTabs, ...params.editorTabIds];
+  if (params.shellOnlyTabNumberShortcuts) {
+    return workTabs;
+  }
+  const pinnedTabs = params.showSftpTab ? ['vault', 'sftp'] : ['vault'];
+  return [...pinnedTabs, ...workTabs];
+}

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -468,6 +468,8 @@ export const enCoreMessages: Messages = {
   'settings.shortcuts.scheme.disabled': 'Disabled',
   'settings.shortcuts.scheme.mac': 'Mac (Cmd)',
   'settings.shortcuts.scheme.pc': 'PC (Ctrl)',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.label': 'Number keys skip pinned tabs',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.desc': 'When enabled, Cmd/Ctrl+[1...9] switches only work tabs (terminals, workspaces, editors), not the pinned Vault or SFTP tabs.',
   'settings.shortcuts.section.custom': 'Custom Shortcuts',
   'settings.shortcuts.resetAll': 'Reset All',
   'settings.shortcuts.recording': 'Press keys...',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -468,6 +468,8 @@ export const ruCoreMessages: Messages = {
   'settings.shortcuts.scheme.disabled': 'Отключено',
   'settings.shortcuts.scheme.mac': 'Mac (Cmd)',
   'settings.shortcuts.scheme.pc': 'PC (Ctrl)',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.label': 'Цифры без закреплённых вкладок',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.desc': 'Если включено, Cmd/Ctrl+[1...9] переключает только рабочие вкладки (терминалы, рабочие области, редакторы), а не закреплённые Vault и SFTP.',
   'settings.shortcuts.section.custom': 'Пользовательские сочетания',
   'settings.shortcuts.resetAll': 'Сбросить все',
   'settings.shortcuts.recording': 'Нажмите клавиши...',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -311,6 +311,8 @@ export const zhCNTerminalMessages: Messages = {
   'settings.shortcuts.scheme.disabled': '禁用',
   'settings.shortcuts.scheme.mac': 'Mac (Cmd)',
   'settings.shortcuts.scheme.pc': 'PC (Ctrl)',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.label': '数字键跳过固定标签',
+  'settings.shortcuts.shellOnlyTabNumberShortcuts.desc': '开启后，Cmd/Ctrl+[1...9] 仅在终端、工作区、编辑器等可关闭标签页之间切换，不包括固定的 Vault 和 SFTP 标签页。',
   'settings.shortcuts.section.custom': '自定义快捷键',
   'settings.shortcuts.resetAll': '全部重置',
   'settings.shortcuts.recording': '请按键...',

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -64,6 +64,7 @@ export const DEFAULT_SHOW_RECENT_HOSTS = true;
 export const DEFAULT_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT = false;
 export const DEFAULT_SHOW_SFTP_TAB = true;
 export const DEFAULT_SHOW_HOST_TREE_SIDEBAR = true;
+export const DEFAULT_SHELL_ONLY_TAB_NUMBER_SHORTCUTS = false;
 
 // Editor defaults
 export const DEFAULT_EDITOR_WORD_WRAP = false;

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -28,6 +28,7 @@ import {
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_SFTP_TAB,
   STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
+  STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
   STORAGE_KEY_TERM_FOLLOW_APP_THEME,
   STORAGE_KEY_TERM_FONT_FAMILY,
   STORAGE_KEY_TERM_FONT_SIZE,
@@ -77,6 +78,7 @@ interface UseSettingsStorageSyncParams {
   showOnlyUngroupedHostsInRoot: boolean;
   showSftpTab: boolean;
   showHostTreeSidebar: boolean;
+  shellOnlyTabNumberShortcuts: boolean;
   editorWordWrap: boolean;
   sessionLogsEnabled: boolean;
   sessionLogsDir: string;
@@ -112,6 +114,7 @@ interface UseSettingsStorageSyncParams {
   setShowOnlyUngroupedHostsInRootState: Dispatch<SetStateAction<boolean>>;
   setShowSftpTabState: Dispatch<SetStateAction<boolean>>;
   setShowHostTreeSidebarState: Dispatch<SetStateAction<boolean>>;
+  setShellOnlyTabNumberShortcutsState: Dispatch<SetStateAction<boolean>>;
   setEditorWordWrapState: Dispatch<SetStateAction<boolean>>;
   setSessionLogsEnabled: Dispatch<SetStateAction<boolean>>;
   setSessionLogsDir: Dispatch<SetStateAction<string>>;
@@ -133,7 +136,7 @@ export function useSettingsStorageSync({
   terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
   sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
   sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-  showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
+  showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts,
   editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
   globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
@@ -142,7 +145,7 @@ export function useSettingsStorageSync({
   setFollowAppTerminalThemeState, setTerminalFontFamilyId, setTerminalFontSize,
   setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
   setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
-  setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState,
+  setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState, setShellOnlyTabNumberShortcutsState,
   setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
   setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
   setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
@@ -156,7 +159,7 @@ export function useSettingsStorageSync({
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   });
@@ -166,7 +169,7 @@ export function useSettingsStorageSync({
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   };
@@ -380,6 +383,12 @@ export function useSettingsStorageSync({
           setShowHostTreeSidebarState(newValue);
         }
       }
+      if (e.key === STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS && e.newValue !== null) {
+        const newValue = e.newValue === 'true';
+        if (newValue !== s.shellOnlyTabNumberShortcuts) {
+          setShellOnlyTabNumberShortcutsState(newValue);
+        }
+      }
       // Sync global hotkey enabled setting from other windows
       if (e.key === STORAGE_KEY_GLOBAL_HOTKEY_ENABLED && e.newValue !== null) {
         const newValue = e.newValue === 'true';
@@ -448,6 +457,7 @@ export function useSettingsStorageSync({
     setShowHostTreeSidebarState,
     setShowRecentHostsState,
     setShowSftpTabState,
+    setShellOnlyTabNumberShortcutsState,
     setTerminalFontFamilyId,
     setTerminalFontSize,
     setTerminalThemeDarkId,

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -46,6 +46,7 @@ import {
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
   STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
+  STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
 } from '../../infrastructure/config/storageKeys';
 import { DEFAULT_UI_LOCALE, resolveSupportedLocale } from '../../infrastructure/config/i18n';
 import {
@@ -87,6 +88,7 @@ import {
   DEFAULT_SHOW_RECENT_HOSTS,
   DEFAULT_SHOW_SFTP_TAB,
   DEFAULT_SHOW_HOST_TREE_SIDEBAR,
+  DEFAULT_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
   DEFAULT_SSH_DEBUG_LOGS_ENABLED,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
@@ -237,6 +239,10 @@ export const useSettingsState = () => {
   const [showHostTreeSidebar, setShowHostTreeSidebarState] = useState<boolean>(() => {
     const stored = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
     return stored ?? DEFAULT_SHOW_HOST_TREE_SIDEBAR;
+  });
+  const [shellOnlyTabNumberShortcuts, setShellOnlyTabNumberShortcutsState] = useState<boolean>(() => {
+    const stored = localStorageAdapter.readBoolean(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS);
+    return stored ?? DEFAULT_SHELL_ONLY_TAB_NUMBER_SHORTCUTS;
   });
   const [sftpTransferConcurrency, setSftpTransferConcurrencyState] = useState<number>(() => {
     const stored = localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY);
@@ -536,6 +542,8 @@ export const useSettingsState = () => {
     setShowSftpTabState(storedShowSftpTab ?? DEFAULT_SHOW_SFTP_TAB);
     const storedShowHostTreeSidebar = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
     setShowHostTreeSidebarState(storedShowHostTreeSidebar ?? DEFAULT_SHOW_HOST_TREE_SIDEBAR);
+    const storedShellOnlyTabNumberShortcuts = localStorageAdapter.readBoolean(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS);
+    setShellOnlyTabNumberShortcutsState(storedShellOnlyTabNumberShortcuts ?? DEFAULT_SHELL_ONLY_TAB_NUMBER_SHORTCUTS);
 
     // Workspace focus style
     const storedFocusStyle = readStoredString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE);
@@ -653,7 +661,7 @@ export const useSettingsState = () => {
     terminalThemeId, followAppTerminalTheme, terminalFontFamilyId, terminalFontSize,
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
+    showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts,
     editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
     setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
@@ -662,7 +670,7 @@ export const useSettingsState = () => {
     setFollowAppTerminalThemeState, setTerminalFontFamilyId, setTerminalFontSize,
     setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
     setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
-    setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState,
+    setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState, setShellOnlyTabNumberShortcutsState,
     setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
     setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
     setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
@@ -774,6 +782,13 @@ export const useSettingsState = () => {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, enabled);
     if (!persistMountedRef.current) return;
     notifySettingsChanged(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, enabled);
+  }, [notifySettingsChanged]);
+
+  const setShellOnlyTabNumberShortcuts = useCallback((enabled: boolean) => {
+    setShellOnlyTabNumberShortcutsState(enabled);
+    localStorageAdapter.writeBoolean(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS, enabled);
+    if (!persistMountedRef.current) return;
+    notifySettingsChanged(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS, enabled);
   }, [notifySettingsChanged]);
 
   // Apply and persist custom CSS
@@ -1014,6 +1029,8 @@ export const useSettingsState = () => {
     setShowSftpTab,
     showHostTreeSidebar,
     setShowHostTreeSidebar,
+    shellOnlyTabNumberShortcuts,
+    setShellOnlyTabNumberShortcuts,
     sftpTransferConcurrency,
     setSftpTransferConcurrency,
     // Editor Settings
@@ -1058,7 +1075,7 @@ export const useSettingsState = () => {
       terminalThemeId, terminalFontFamilyId, terminalFontSize, terminalSettings,
       customKeyBindings, editorWordWrap,
       sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles, sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
-      showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar,
+      showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts,
       customThemes, workspaceFocusStyle, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
     ]),
   };

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -64,6 +64,7 @@ import {
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
   STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR,
+  STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
   STORAGE_KEY_AI_PROVIDERS,
   STORAGE_KEY_AI_ACTIVE_PROVIDER,
@@ -228,6 +229,7 @@ export const SYNCABLE_SETTING_STORAGE_KEYS = [
   STORAGE_KEY_SHOW_RECENT_HOSTS,
   STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT,
   STORAGE_KEY_SHOW_SFTP_TAB,
+  STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
   STORAGE_KEY_AI_PROVIDERS,
   STORAGE_KEY_AI_ACTIVE_PROVIDER,
@@ -405,6 +407,8 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   if (showOnlyUngroupedHostsInRoot != null) settings.showOnlyUngroupedHostsInRoot = showOnlyUngroupedHostsInRoot;
   const showSftpTab = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_SFTP_TAB);
   if (showSftpTab != null) settings.showSftpTab = showSftpTab;
+  const shellOnlyTabNumberShortcuts = localStorageAdapter.readBoolean(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS);
+  if (shellOnlyTabNumberShortcuts != null) settings.shellOnlyTabNumberShortcuts = shellOnlyTabNumberShortcuts;
   const showHostTreeSidebar = localStorageAdapter.readBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR);
   if (showHostTreeSidebar != null) settings.showHostTreeSidebar = showHostTreeSidebar;
   const workspaceFocusStyle = localStorageAdapter.readString(STORAGE_KEY_WORKSPACE_FOCUS_STYLE);
@@ -536,6 +540,9 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
   }
   if (settings.showSftpTab != null) {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_SFTP_TAB, settings.showSftpTab);
+  }
+  if (settings.shellOnlyTabNumberShortcuts != null) {
+    localStorageAdapter.writeBoolean(STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS, settings.shellOnlyTabNumberShortcuts);
   }
   if (settings.showHostTreeSidebar != null) {
     localStorageAdapter.writeBoolean(STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR, settings.showHostTreeSidebar);

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -397,6 +397,8 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
                         <SettingsShortcutsTab
                             hotkeyScheme={settings.hotkeyScheme}
                             setHotkeyScheme={settings.setHotkeyScheme}
+                            shellOnlyTabNumberShortcuts={settings.shellOnlyTabNumberShortcuts}
+                            setShellOnlyTabNumberShortcuts={settings.setShellOnlyTabNumberShortcuts}
                             keyBindings={settings.keyBindings}
                             updateKeyBinding={settings.updateKeyBinding}
                             resetKeyBinding={settings.resetKeyBinding}

--- a/components/settings/tabs/SettingsShortcutsTab.tsx
+++ b/components/settings/tabs/SettingsShortcutsTab.tsx
@@ -5,11 +5,13 @@ import { keyEventToString } from "../../../domain/models";
 import { useI18n } from "../../../application/i18n/I18nProvider";
 import { cn } from "../../../lib/utils";
 import { Button } from "../../ui/button";
-import { SectionHeader, Select, SettingsTabContent, SettingRow } from "../settings-ui";
+import { SectionHeader, Select, SettingsTabContent, SettingRow, Toggle } from "../settings-ui";
 
 export default function SettingsShortcutsTab(props: {
   hotkeyScheme: HotkeyScheme;
   setHotkeyScheme: (scheme: HotkeyScheme) => void;
+  shellOnlyTabNumberShortcuts: boolean;
+  setShellOnlyTabNumberShortcuts: (enabled: boolean) => void;
   keyBindings: KeyBinding[];
   updateKeyBinding?: (bindingId: string, scheme: "mac" | "pc", newKey: string) => void;
   resetKeyBinding?: (bindingId: string, scheme?: "mac" | "pc") => void;
@@ -19,6 +21,8 @@ export default function SettingsShortcutsTab(props: {
   const {
     hotkeyScheme,
     setHotkeyScheme,
+    shellOnlyTabNumberShortcuts,
+    setShellOnlyTabNumberShortcuts,
     keyBindings,
     updateKeyBinding,
     resetKeyBinding,
@@ -134,6 +138,15 @@ export default function SettingsShortcutsTab(props: {
             ]}
             onChange={(v) => setHotkeyScheme(v as HotkeyScheme)}
             className="w-32"
+          />
+        </SettingRow>
+        <SettingRow
+          label={t("settings.shortcuts.shellOnlyTabNumberShortcuts.label")}
+          description={t("settings.shortcuts.shellOnlyTabNumberShortcuts.desc")}
+        >
+          <Toggle
+            checked={shellOnlyTabNumberShortcuts}
+            onChange={setShellOnlyTabNumberShortcuts}
           />
         </SettingRow>
       </div>

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -249,6 +249,8 @@ export interface SyncPayload {
     showOnlyUngroupedHostsInRoot?: boolean;
     // Top tabs: show standalone SFTP view tab
     showSftpTab?: boolean;
+    // Shortcuts: Cmd/Ctrl+[1...9] skip pinned Vault/SFTP tabs
+    shellOnlyTabNumberShortcuts?: boolean;
     // Terminal/editor tabs: show left host list sidebar
     showHostTreeSidebar?: boolean;
     // Workspace focus indicator style

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -160,6 +160,9 @@ export const STORAGE_KEY_SHOW_ONLY_UNGROUPED_HOSTS_IN_ROOT = 'netcatty_show_only
 export const STORAGE_KEY_SHOW_SFTP_TAB = 'netcatty_show_sftp_tab_v1';
 export const STORAGE_KEY_SHOW_HOST_TREE_SIDEBAR = 'netcatty_show_host_tree_sidebar_v1';
 
+// Shortcuts: Cmd/Ctrl+[1...9] skip pinned Vault/SFTP tabs
+export const STORAGE_KEY_SHELL_ONLY_TAB_NUMBER_SHORTCUTS = 'netcatty_shell_only_tab_number_shortcuts_v1';
+
 // Group Configurations (default settings inherited by hosts)
 export const STORAGE_KEY_GROUP_CONFIGS = 'netcatty_group_configs_v1';
 


### PR DESCRIPTION
## Summary
- Add a **Settings → Shortcuts** toggle (`数字键跳过固定标签`) so Cmd/Ctrl+[1…9] can target only work tabs (terminals, workspaces, editors, log views) instead of counting Vault/SFTP first
- Default remains off to preserve the existing Terminus-style behavior discussed in #1375
- Includes persistence, cross-window sync, cloud sync, and unit tests for tab-target resolution

## Test plan
- [x] Unit tests for `buildNumberShortcutTabTargets` (default / shell-only / hidden SFTP)
- [ ] With toggle **off**: Cmd+1 → Vault, Cmd+2 → SFTP (when visible), Cmd+3 → first shell tab
- [ ] With toggle **on**: Cmd+1 → first shell tab; Vault/SFTP only reachable via click or dedicated shortcuts
- [ ] Verify setting persists across app restart and syncs across windows

Fixes #1375


Made with [Cursor](https://cursor.com)