### PR TITLE
fix(terminal): refresh Nerd Font glyphs on cold start (fixes #1363)

### DIFF
--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -652,6 +652,16 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         await fontFaceSet.ready;
         if (cancelled) return;
 
+        // Ensure bundled Nerd Font icon fallbacks are loaded at the terminal's
+        // cell size. Shell prompts can arrive before these faces finish loading
+        // on cold start (Linux), leaving Powerline glyphs cached as tofu (#1363).
+        try {
+          await fontFaceSet.load(`${effectiveFontSize}px "Symbols Nerd Font Mono"`);
+        } catch (err) {
+          logger.warn("Nerd Font preload failed", err);
+        }
+        if (cancelled) return;
+
         const term = termRef.current as {
           cols: number;
           rows: number;
@@ -662,6 +672,13 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
           term?.renderer?.remeasureFont?.();
         } catch (err) {
           logger.warn("Font remeasure failed", err);
+        }
+
+        // remeasureFont does not invalidate cells rasterized before fonts were ready.
+        xtermRuntimeRef.current?.clearTextureAtlas();
+        const visibleTerm = termRef.current;
+        if (visibleTerm) {
+          forceSyncRenderAfterResize(visibleTerm);
         }
 
         try {


### PR DESCRIPTION
## Summary
- 修复 Linux 冷启动后立刻打开本地终端时，Powerline/Nerd Font 提示符图标显示为方框（tofu）的问题
- 在 `document.fonts.ready` 后显式预加载 `Symbols Nerd Font Mono`，并清除 xterm 纹理 atlas、强制重绘已缓存的单元格

## Root cause
Shell prompt 可能在打包的 Nerd Font fallback 字体加载完成前就输出到终端，xterm 会缓存缺字字形。原有的 `waitForFonts` 仅调用 `remeasureFont()`，不会使已绘制的单元格重新光栅化，因此图标会一直异常，直到 resize、切换标签或新开终端触发 atlas 刷新。

## Test plan
- [ ] Linux：冷启动应用后立即打开本地终端（zsh + Powerlevel10k / Oh My Zsh），确认 Powerline 分段图标正常显示
- [ ] 操作一段时间后首个终端标签的图标仍保持正常（无需新开终端才能恢复）
- [ ] 切换字体、调整字号后终端渲染仍正常
- [ ] macOS / Windows 本地终端 smoke test

Fixes #1363


Made with [Cursor](https://cursor.com)