### PR TITLE
fix(ai): reset panel view when deleting the last chat session

### DIFF
--- a/application/state/aiDraftState.test.ts
+++ b/application/state/aiDraftState.test.ts
@@ -10,6 +10,7 @@ import {
   ensureDraftForScopeState,
   getDraftMutationVersionState,
   getDraftUploadGenerationState,
+  pruneStaleSessionPanelViews,
   pruneTerminalScopeState,
   pruneTerminalTransientState,
   resolvePanelView,
@@ -87,6 +88,39 @@ test("setSessionView records target session id", () => {
   assert.deepEqual(setSessionView({}, "workspace:abc", "session-123"), {
     "workspace:abc": { mode: "session", sessionId: "session-123" },
   });
+});
+
+test("pruneStaleSessionPanelViews resets session views that no longer exist", () => {
+  const panelViewByScope = {
+    "terminal:1": { mode: "session", sessionId: "deleted-session" },
+    "workspace:2": { mode: "session", sessionId: "session-keep" },
+    "terminal:3": { mode: "draft" },
+  } satisfies Record<string, { mode: "draft" } | { mode: "session"; sessionId: string }>;
+
+  const next = pruneStaleSessionPanelViews(
+    panelViewByScope,
+    new Set(["session-keep"]),
+  );
+
+  assert.deepEqual(next, {
+    "terminal:1": { mode: "draft" },
+    "workspace:2": { mode: "session", sessionId: "session-keep" },
+    "terminal:3": { mode: "draft" },
+  });
+});
+
+test("pruneStaleSessionPanelViews returns the original ref when nothing is stale", () => {
+  const panelViewByScope = {
+    "terminal:1": { mode: "session", sessionId: "session-keep" },
+    "terminal:2": { mode: "draft" },
+  } satisfies Record<string, { mode: "draft" } | { mode: "session"; sessionId: string }>;
+
+  const next = pruneStaleSessionPanelViews(
+    panelViewByScope,
+    new Set(["session-keep"]),
+  );
+
+  assert.equal(next, panelViewByScope);
 });
 
 test("clearScopeDraftState removes both the draft and current panel view", () => {

--- a/application/state/aiDraftState.ts
+++ b/application/state/aiDraftState.ts
@@ -115,6 +115,25 @@ export function setSessionView(
   };
 }
 
+export function pruneStaleSessionPanelViews(
+  panelViewByScope: PanelViewByScope,
+  validSessionIds: Set<string>,
+): PanelViewByScope {
+  let next = panelViewByScope;
+
+  for (const [scopeKey, panelView] of Object.entries(panelViewByScope)) {
+    if (panelView?.mode !== 'session' || validSessionIds.has(panelView.sessionId)) {
+      continue;
+    }
+    const updated = setDraftView(next, scopeKey);
+    if (updated !== next) {
+      next = updated;
+    }
+  }
+
+  return next;
+}
+
 export function updateDraftForScope(
   draftsByScope: DraftsByScope,
   scopeKey: string,

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -35,6 +35,8 @@ import {
   activateDraftView,
   clearScopeDraftState,
   ensureDraftForScopeState,
+  pruneStaleSessionPanelViews,
+  setDraftView,
   setSessionView,
   updateDraftForScope,
 } from './aiDraftState';
@@ -187,12 +189,22 @@ export function useAIState() {
       }
     }
 
-    if (!changed) return;
+    if (changed) {
+      setLatestAIActiveSessionMapSnapshot(nextActiveSessionIdMap);
+      localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, nextActiveSessionIdMap);
+      setActiveSessionIdMapRaw(nextActiveSessionIdMap);
+      emitAIStateChanged(STORAGE_KEY_AI_ACTIVE_SESSION_MAP);
+    }
 
-    setLatestAIActiveSessionMapSnapshot(nextActiveSessionIdMap);
-    localStorageAdapter.write(STORAGE_KEY_AI_ACTIVE_SESSION_MAP, nextActiveSessionIdMap);
-    setActiveSessionIdMapRaw(nextActiveSessionIdMap);
-    emitAIStateChanged(STORAGE_KEY_AI_ACTIVE_SESSION_MAP);
+    setPanelViewByScopeRaw((prev) => {
+      const next = pruneStaleSessionPanelViews(prev, validSessionIds);
+      if (next === prev) {
+        return prev;
+      }
+      setLatestAIPanelViewByScopeSnapshot(next);
+      emitAIStateChanged(AI_STATE_CHANGED_PANEL_VIEW_BY_SCOPE);
+      return next;
+    });
   }, [sessions, activeSessionIdMap]);
 
   const setActiveSessionId = useCallback((scopeKey: string, id: string | null) => {
@@ -592,6 +604,19 @@ export function useAIState() {
           return next;
         }
         return prev;
+      });
+      setPanelViewByScopeRaw((prev) => {
+        const currentPanelView = prev[scopeKey];
+        if (currentPanelView?.mode !== 'session' || currentPanelView.sessionId !== sessionId) {
+          return prev;
+        }
+        const next = setDraftView(prev, scopeKey);
+        if (next === prev) {
+          return prev;
+        }
+        setLatestAIPanelViewByScopeSnapshot(next);
+        emitAIStateChanged(AI_STATE_CHANGED_PANEL_VIEW_BY_SCOPE);
+        return next;
       });
     }
   }, [persistSessions]);

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -860,22 +860,26 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     clearScopeDraft, showScopeSessionView, setActiveSessionId,
   ]);
 
-  const handleStop = useCallback(() => {
-    if (!activeSessionId) return;
-    const controller = abortControllersRef.current.get(activeSessionId);
+  const stopStreamingForSession = useCallback((sessionId: string) => {
+    const controller = abortControllersRef.current.get(sessionId);
     controller?.abort();
-    abortControllersRef.current.delete(activeSessionId);
-    setStreamingForScope(activeSessionId, false);
-    updateLastMessage(activeSessionId, msg => ({
+    abortControllersRef.current.delete(sessionId);
+    setStreamingForScope(sessionId, false);
+    updateLastMessage(sessionId, (msg) => ({
       ...msg,
       statusText: '',
       executionStatus: msg.executionStatus === 'running' ? 'cancelled' : msg.executionStatus,
     }));
-    clearAllPendingApprovals(activeSessionId);
+    clearAllPendingApprovals(sessionId);
     const bridge = getNetcattyBridge();
-    bridge?.aiCattyCancelExec?.(activeSessionId);
-    bridge?.aiSdkAgentCancel?.('', activeSessionId);
-  }, [activeSessionId, setStreamingForScope, updateLastMessage, abortControllersRef]);
+    bridge?.aiCattyCancelExec?.(sessionId);
+    bridge?.aiSdkAgentCancel?.('', sessionId);
+  }, [setStreamingForScope, updateLastMessage, abortControllersRef]);
+
+  const handleStop = useCallback(() => {
+    if (!activeSessionId) return;
+    stopStreamingForSession(activeSessionId);
+  }, [activeSessionId, stopStreamingForSession]);
 
   const handleSelectSession = useCallback(
     (sessionId: string) => {
@@ -891,15 +895,39 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const handleDeleteSession = useCallback(
     (e: React.MouseEvent, sessionId: string) => {
       e.stopPropagation();
+      const deletingActiveSession =
+        activeSessionId === sessionId
+        || persistedSessionId === sessionId
+        || (
+          explicitPanelView?.mode === 'session'
+          && explicitPanelView.sessionId === sessionId
+        );
       const deletingLastScopedSession =
         historySessions.length === 1 && historySessions[0]?.id === sessionId;
+
+      if (streamingSessionIds.has(sessionId)) {
+        stopStreamingForSession(sessionId);
+      }
+
       deleteSession(sessionId, scopeKey);
-      if (deletingLastScopedSession) {
+
+      if (deletingActiveSession || deletingLastScopedSession) {
         setShowHistory(false);
         ensureScopeDraft(defaultAgentId);
       }
     },
-    [deleteSession, defaultAgentId, ensureScopeDraft, historySessions, scopeKey],
+    [
+      activeSessionId,
+      deleteSession,
+      defaultAgentId,
+      ensureScopeDraft,
+      explicitPanelView,
+      historySessions,
+      persistedSessionId,
+      scopeKey,
+      stopStreamingForSession,
+      streamingSessionIds,
+    ],
   );
 
   const handleAgentChange = useCallback((agentId: string) => {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -22,6 +22,7 @@ import {
 import {
   applyDraftEntrySelection,
   applyHistorySessionSelection,
+  panelViewsEqual,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
 } from './ai/aiPanelViewState';
@@ -252,7 +253,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   useEffect(() => {
     if (!isVisible) return;
-    if (!explicitPanelView || normalizedPanelView === explicitPanelView) return;
+    if (!explicitPanelView || panelViewsEqual(normalizedPanelView, explicitPanelView)) return;
     showDraftView(scopeKey);
   }, [isVisible, normalizedPanelView, explicitPanelView, scopeKey, showDraftView]);
 
@@ -890,9 +891,15 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const handleDeleteSession = useCallback(
     (e: React.MouseEvent, sessionId: string) => {
       e.stopPropagation();
+      const deletingLastScopedSession =
+        historySessions.length === 1 && historySessions[0]?.id === sessionId;
       deleteSession(sessionId, scopeKey);
+      if (deletingLastScopedSession) {
+        setShowHistory(false);
+        ensureScopeDraft(defaultAgentId);
+      }
     },
-    [deleteSession, scopeKey],
+    [deleteSession, defaultAgentId, ensureScopeDraft, historySessions, scopeKey],
   );
 
   const handleAgentChange = useCallback((agentId: string) => {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -904,8 +904,11 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
         );
       const deletingLastScopedSession =
         historySessions.length === 1 && historySessions[0]?.id === sessionId;
+      const deletedSessionAgentId =
+        historySessions.find((session) => session.id === sessionId)?.agentId
+        ?? currentAgentId;
 
-      if (streamingSessionIds.has(sessionId)) {
+      if (abortControllersRef.current.has(sessionId) || streamingSessionIds.has(sessionId)) {
         stopStreamingForSession(sessionId);
       }
 
@@ -913,13 +916,14 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
       if (deletingActiveSession || deletingLastScopedSession) {
         setShowHistory(false);
-        ensureScopeDraft(defaultAgentId);
+        ensureScopeDraft(deletedSessionAgentId);
       }
     },
     [
       activeSessionId,
+      abortControllersRef,
+      currentAgentId,
       deleteSession,
-      defaultAgentId,
       ensureScopeDraft,
       explicitPanelView,
       historySessions,

--- a/components/ai/aiPanelViewState.test.ts
+++ b/components/ai/aiPanelViewState.test.ts
@@ -9,6 +9,7 @@ import {
   applyDraftEntrySelection,
   applyHistorySessionSelection,
   normalizePanelView,
+  panelViewsEqual,
   resolveDisplayedPanelView,
   resolveDisplayedSession,
 } from "./aiPanelViewState.ts";
@@ -27,6 +28,23 @@ function createSession(id: string): AISession {
     },
   };
 }
+
+test("panelViewsEqual treats draft views as equal even when refs differ", () => {
+  assert.equal(
+    panelViewsEqual({ mode: "draft" }, { mode: "draft" }),
+    true,
+  );
+});
+
+test("panelViewsEqual distinguishes session targets", () => {
+  assert.equal(
+    panelViewsEqual(
+      { mode: "session", sessionId: "session-1" },
+      { mode: "session", sessionId: "session-2" },
+    ),
+    false,
+  );
+});
 
 test("draft view never falls back to most recent history", () => {
   const panelView: AIPanelView = { mode: "draft" };

--- a/components/ai/aiPanelViewState.ts
+++ b/components/ai/aiPanelViewState.ts
@@ -5,6 +5,22 @@ import type {
 
 const DEFAULT_PANEL_VIEW: AIPanelView = { mode: "draft" };
 
+export function panelViewsEqual(
+  left: AIPanelView,
+  right: AIPanelView,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.mode !== right.mode) {
+    return false;
+  }
+  if (left.mode === "session" && right.mode === "session") {
+    return left.sessionId === right.sessionId;
+  }
+  return true;
+}
+
 interface HistorySessionSelectionActions {
   showSessionView: (sessionId: string) => void;
   setActiveSessionId: (sessionId: string) => void;


### PR DESCRIPTION
## Summary
- 删除 AI 会话时同步清理 `panelViewByScope` 中指向已删 session 的视图，并在 sessions 变更时全局 prune stale panel view
- 使用 `panelViewsEqual` 按语义比较 draft/session 视图，避免 `showDraftView` 因对象引用不同而重复触发
- 删除当前 scope 最后一条历史记录后关闭历史抽屉并确保空白 draft，回到可继续输入的新对话界面

Fixes #1382

## Test plan
- [x] `node --import tsx --test application/state/aiDraftState.test.ts components/ai/aiPanelViewState.test.ts components/AIChatSidePanel.mountRetention.test.ts`
- [ ] 打开 SSH 连接 → 打开 AI 助手 → 产生会话历史 → 在历史列表中逐条删除至最后一条，确认侧栏按钮与 AI 面板仍正常显示
- [ ] 删除最后一条后应回到空白新对话界面，而非空白/卡死状态


Made with [Cursor](https://cursor.com)