### PR TITLE
fix(terminal): add clear button to host tree search field

### DIFF
--- a/components/terminalLayer/TerminalHostTreeToolbar.tsx
+++ b/components/terminalLayer/TerminalHostTreeToolbar.tsx
@@ -206,7 +206,7 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
         )}
         style={{ borderBottom: expandedPanel === 'search' ? `1px solid ${theme.separator}` : undefined }}
       >
-        <div className="h-9 flex items-center px-1.5">
+        <div className="h-9 flex items-center gap-0.5 px-1.5">
           <div className="relative flex-1 min-w-0">
             <Search
               size={12}
@@ -222,6 +222,26 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
               style={{ color: theme.termFg }}
             />
           </div>
+          {hasSearch && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClass}
+                  style={{ color: theme.mutedFg }}
+                  onClick={() => {
+                    onSearchChange('');
+                    searchInputRef.current?.focus();
+                  }}
+                  aria-label={t('common.clear')}
+                >
+                  <X size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('common.clear')}</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add a clear (X) button to the right of the host sidebar search input
- Button appears when search text is non-empty and refocuses the input after clearing

## Test plan
- [ ] Open terminal host sidebar and expand search
- [ ] Type a query and verify the clear button appears on the right
- [ ] Click clear and confirm search resets and input stays focused
- [ ] Verify the button is hidden when search is empty


Made with [Cursor](https://cursor.com)