### PR TITLE
[codex] Clarify Windows renderer termination logs

### DIFF
--- a/electron/bridges/crashLogBridge.cjs
+++ b/electron/bridges/crashLogBridge.cjs
@@ -20,6 +20,7 @@ let electronShell = null;
 let sessionsMap = null;
 
 const LOG_RETENTION_DAYS = 30;
+const WINDOWS_EXTERNAL_TERMINATION_EXIT_CODE = 0x40010004;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -65,6 +66,42 @@ function todayFileName() {
   return `crash-${ymd}.log`;
 }
 
+function normalizeExitCode(exitCode) {
+  if (typeof exitCode !== "number" || !Number.isFinite(exitCode)) return null;
+  return exitCode >>> 0;
+}
+
+function formatExitCodeHex(exitCode) {
+  const normalized = normalizeExitCode(exitCode);
+  if (normalized === null) return undefined;
+  return `0x${normalized.toString(16).toUpperCase().padStart(8, "0")}`;
+}
+
+function describeWindowsExitCode(exitCode) {
+  const normalized = normalizeExitCode(exitCode);
+  if (normalized === null) return undefined;
+  if (normalized === WINDOWS_EXTERNAL_TERMINATION_EXIT_CODE) {
+    return "Windows external process termination (DBG_TERMINATE_PROCESS); commonly seen when Windows, a debugger, or another external process terminates the renderer.";
+  }
+  return undefined;
+}
+
+function buildDiagnostic(extra, platform = process.platform) {
+  if (!extra || typeof extra !== "object") return undefined;
+
+  const exitCode = extra.exitCode;
+  const exitCodeHex = formatExitCodeHex(exitCode);
+  const windowsExitCodeMeaning = platform === "win32"
+    ? describeWindowsExitCode(exitCode)
+    : undefined;
+
+  if (!exitCodeHex && !windowsExitCodeMeaning) return undefined;
+  return {
+    exitCodeHex,
+    windowsExitCodeMeaning,
+  };
+}
+
 function buildEntry(source, err, extra) {
   const error = err instanceof Error ? err : new Error(String(err ?? "unknown"));
 
@@ -88,6 +125,8 @@ function buildEntry(source, err, extra) {
     }
   }
 
+  const diagnostic = buildDiagnostic(extra);
+
   return {
     timestamp: new Date().toISOString(),
     source,
@@ -104,6 +143,7 @@ function buildEntry(source, err, extra) {
     memoryMB: mem,
     activeSessionCount: sessionsMap?.size ?? -1,
     uptimeSeconds: Math.round(process.uptime()),
+    diagnostic,
   };
 }
 
@@ -323,4 +363,9 @@ module.exports = {
   init,
   captureError,
   registerHandlers,
+  _private: {
+    buildDiagnostic,
+    describeWindowsExitCode,
+    formatExitCodeHex,
+  },
 };

--- a/electron/bridges/crashLogBridge.test.cjs
+++ b/electron/bridges/crashLogBridge.test.cjs
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { _private } = require("./crashLogBridge.cjs");
+
+test("formats renderer exit codes as unsigned Windows-style hex", () => {
+  assert.equal(_private.formatExitCodeHex(1073807364), "0x40010004");
+  assert.equal(_private.formatExitCodeHex(-1073741510), "0xC000013A");
+});
+
+test("explains Windows external termination exit code in diagnostics", () => {
+  const diagnostic = _private.buildDiagnostic(
+    { reason: "killed", exitCode: 1073807364 },
+    "win32",
+  );
+
+  assert.equal(diagnostic.exitCodeHex, "0x40010004");
+  assert.match(diagnostic.windowsExitCodeMeaning, /external process termination/);
+});
+
+test("keeps non-Windows diagnostics to portable exit-code data", () => {
+  const diagnostic = _private.buildDiagnostic(
+    { reason: "killed", exitCode: 1073807364 },
+    "darwin",
+  );
+
+  assert.deepEqual(diagnostic, {
+    exitCodeHex: "0x40010004",
+    windowsExitCodeMeaning: undefined,
+  });
+});


### PR DESCRIPTION
## Summary
- Add diagnostic metadata to crash logs for renderer exit codes, including unsigned hex formatting.
- Recognize Windows `0x40010004` as `DBG_TERMINATE_PROCESS` and label it as an external renderer termination signal.
- Add focused tests for the Windows exit-code interpretation.

## Why
Issue #1394 reports `render-process-gone` with `reason=killed` and `exitCode=1073807364`. Online research points to this being `0x40010004`:
- Microsoft's NTSTATUS reference maps `0x40010004` to `DBG_TERMINATE_PROCESS` with the description "Debugger terminated the process".
- Electron documents `reason: "killed"` as a renderer that was sent SIGTERM or otherwise killed externally.
- Community debugging notes commonly see this code when Windows shuts down/logs off and force-terminates a GUI process.

That means the submitted log does not currently identify an app-level stack trace. This PR makes future logs self-explanatory so maintainers can distinguish external Windows termination from a renderer crash or OOM.

Refs #1394

## Validation
- `npm run lint`
- `node --test electron/bridges/crashLogBridge.test.cjs`
- `npm test`