### PR TITLE
Make terminal timestamps per-host

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -451,8 +451,6 @@ export const enCoreMessages: Messages = {
   'settings.terminal.rendering.renderer': 'Renderer',
   'settings.terminal.rendering.renderer.desc': 'Choose the terminal rendering technology. Auto will use DOM on low-memory devices. Changes take effect on new terminal sessions.',
   'settings.terminal.rendering.auto': 'Auto',
-  'settings.terminal.rendering.lineTimestamps': 'Prefix output with timestamps',
-  'settings.terminal.rendering.lineTimestamps.desc': 'Insert local time before terminal output lines. The timestamp becomes part of the visible terminal content.',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': 'Workspace Focus Indicator',

--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -530,6 +530,8 @@ export const enVaultMessages: Messages = {
   'hostDetails.deviceType.warning': 'AI agent commands will be sent directly without exit code tracking. Only enable for devices that do not run a standard shell.',
   'hostDetails.section.sshAlgorithms': 'SSH Algorithms',
   'hostDetails.section.terminalBehavior': 'Terminal Behavior',
+  'hostDetails.lineTimestamps': 'Prefix output with timestamps',
+  'hostDetails.lineTimestamps.desc': 'Add local time before visible output lines for this host. Disable it for prompts that render incorrectly when output is prefixed.',
   'hostDetails.legacyAlgorithms': 'Allow Legacy Algorithms',
   'hostDetails.legacyAlgorithms.desc': 'Enable deprecated SSH algorithms (diffie-hellman-group1, ssh-dss, 3des-cbc, etc.) for connecting to older network equipment.',
   'hostDetails.legacyAlgorithms.warning': 'These algorithms have known security weaknesses. Only enable for legacy devices that do not support modern cryptography.',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -451,8 +451,6 @@ export const ruCoreMessages: Messages = {
   'settings.terminal.rendering.renderer': 'Рендерер',
   'settings.terminal.rendering.renderer.desc': 'Выберите технологию рендеринга терминала. В режиме "Авто" на устройствах с малым объёмом памяти будет использоваться DOM. Изменения применяются к новым терминальным сессиям.',
   'settings.terminal.rendering.auto': 'Авто',
-  'settings.terminal.rendering.lineTimestamps': 'Добавлять время к выводу',
-  'settings.terminal.rendering.lineTimestamps.desc': 'Вставлять локальное время перед строками вывода терминала. Метка времени становится частью видимого содержимого терминала.',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': 'Индикатор фокуса рабочей области',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -562,6 +562,8 @@ export const ruVaultMessages: Messages = {
   'hostDetails.deviceType.warning': 'Команды AI-агента будут отправляться напрямую без отслеживания кода выхода. Включайте только для устройств, на которых нет стандартной оболочки.',
   'hostDetails.section.sshAlgorithms': 'SSH-алгоритмы',
   'hostDetails.section.terminalBehavior': 'Поведение терминала',
+  'hostDetails.lineTimestamps': 'Добавлять время к выводу',
+  'hostDetails.lineTimestamps.desc': 'Добавлять локальное время перед видимыми строками вывода только для этого хоста. Отключите, если из-за этого некорректно отображается приглашение.',
   'hostDetails.legacyAlgorithms': 'Разрешить устаревшие алгоритмы',
   'hostDetails.legacyAlgorithms.desc': 'Включить устаревшие SSH-алгоритмы (diffie-hellman-group1, ssh-dss, 3des-cbc и т. д.) для подключения к старому сетевому оборудованию.',
   'hostDetails.legacyAlgorithms.warning': 'У этих алгоритмов есть известные слабые места безопасности. Включайте только для устаревших устройств, которые не поддерживают современную криптографию.',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -317,8 +317,6 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.rendering.renderer': '渲染器',
   'settings.terminal.rendering.renderer.desc': '选择终端渲染技术。自动模式会在低内存设备上使用 DOM 渲染。更改将在新终端会话中生效。',
   'settings.terminal.rendering.auto': '自动',
-  'settings.terminal.rendering.lineTimestamps': '给输出加时间戳',
-  'settings.terminal.rendering.lineTimestamps.desc': '在终端输出行前插入本地时间，时间戳会成为终端可见内容的一部分。',
 
   // Settings > Terminal > Autocomplete
   'settings.terminal.section.autocomplete': '自动补全',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -113,6 +113,8 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.deviceType.warning': 'AI 代理命令将直接发送，无法获取退出码。仅建议在设备不运行标准 Shell 时启用。',
   'hostDetails.section.sshAlgorithms': 'SSH 算法',
   'hostDetails.section.terminalBehavior': '终端行为',
+  'hostDetails.lineTimestamps': '给输出加时间戳',
+  'hostDetails.lineTimestamps.desc': '仅为这个主机的终端输出行添加本地时间。如果提示符因此渲染异常，请关闭。',
   'hostDetails.legacyAlgorithms': '允许旧版算法',
   'hostDetails.legacyAlgorithms.desc': '启用已弃用的 SSH 算法（diffie-hellman-group1、ssh-dss、3des-cbc 等）以连接老旧网络设备。',
   'hostDetails.legacyAlgorithms.warning': '这些算法存在已知安全漏洞，仅建议在老旧设备不支持现代加密时启用。',

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { normalizeDistroId, sanitizeHost } from "../../domain/host";
+import { migrateHostsFromLegacyLineTimestamps, normalizeDistroId, sanitizeHost } from "../../domain/host";
 import { sanitizeGroupConfig } from "../../domain/groupConfig";
 import { normalizeKnownHosts } from "../../domain/knownHosts";
 import {
@@ -33,6 +33,7 @@ import {
   STORAGE_KEY_SHELL_HISTORY,
   STORAGE_KEY_SNIPPET_PACKAGES,
   STORAGE_KEY_SNIPPETS,
+  STORAGE_KEY_TERM_SETTINGS,
 } from "../../infrastructure/config/storageKeys";
 import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
 import { mergeGlobalHistoryOnAppend } from "../../domain/globalHistory";
@@ -131,6 +132,11 @@ const pruneConnectionLogsForStorage = (logs: ConnectionLog[]): ConnectionLog[] =
     return rest;
   });
   return changed ? next : logs;
+};
+
+const readLegacyLineTimestampsEnabled = (): boolean => {
+  const stored = localStorageAdapter.read<Record<string, unknown>>(STORAGE_KEY_TERM_SETTINGS);
+  return stored?.showLineTimestamps === true;
 };
 
 export const useVaultState = () => {
@@ -433,7 +439,10 @@ export const useVaultState = () => {
           const ver = ++hostsWriteVersion.current;
           const decrypted = await decryptHosts(savedHosts);
           if (ver === hostsWriteVersion.current) {
-            const sanitized = decrypted.map(sanitizeHost);
+            const sanitized = migrateHostsFromLegacyLineTimestamps(
+              decrypted.map(sanitizeHost),
+              readLegacyLineTimestampsEnabled(),
+            );
             setHosts(sanitized);
             encryptHosts(sanitized).then((enc) => {
               if (ver === hostsWriteVersion.current)

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -696,6 +696,49 @@ test("applySyncPayload preserves host proxy references when group configs are ab
   assert.equal("groupConfigs" in imported, false);
 });
 
+test("applySyncPayload migrates legacy global line timestamps onto hosts", async () => {
+  let imported: Record<string, unknown> | null = null;
+  const payload: SyncPayload = {
+    hosts: [
+      {
+        id: "host-1",
+        label: "Inherited",
+        hostname: "example.com",
+        username: "root",
+        tags: [],
+        os: "linux",
+      },
+      {
+        id: "host-2",
+        label: "Explicit",
+        hostname: "example.net",
+        username: "root",
+        tags: [],
+        os: "linux",
+        showLineTimestamps: false,
+      },
+    ],
+    keys: [],
+    identities: [],
+    proxyProfiles: [],
+    snippets: [],
+    customGroups: [],
+    syncedAt: 1,
+    settings: { terminalSettings: { showLineTimestamps: true } },
+  };
+
+  await applySyncPayload(payload, {
+    importVaultData: (json) => {
+      imported = JSON.parse(json);
+    },
+  });
+
+  assert.ok(imported);
+  const hosts = imported.hosts as SyncPayload["hosts"];
+  assert.equal(hosts[0]?.showLineTimestamps, true);
+  assert.equal(hosts[1]?.showLineTimestamps, false);
+});
+
 test("applySyncPayload waits for async vault imports", async () => {
   let finished = false;
   const payload: SyncPayload = {

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -24,6 +24,7 @@ import {
   hasSyncPayloadEntityData,
   type SyncPayload,
 } from '../domain/sync';
+import { migrateHostsFromLegacyLineTimestamps } from '../domain/host';
 import {
   nextCustomKeyBindingsSyncVersion,
   parseCustomKeyBindingsStorageRecord,
@@ -195,7 +196,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'rightClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'keepaliveCountMax', 'disableBracketedPaste', 'clearWipesScrollback',
-  'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'showServerStats', 'showLineTimestamps',
+  'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'showServerStats',
   'serverStatsRefreshInterval',
   'systemManagerProcessRefreshInterval', 'systemManagerTmuxRefreshInterval',
   'systemManagerDockerListRefreshInterval', 'systemManagerDockerStatsRefreshInterval',
@@ -726,10 +727,11 @@ function applyPayload(
   importers: SyncPayloadImporters,
   options: { includeLocalOnlyData: boolean },
 ): Promise<void> {
+  const legacyLineTimestampsEnabled = payload.settings?.terminalSettings?.showLineTimestamps === true;
   // Build the vault import object. Cloud sync intentionally ignores
   // local-only trust records even if legacy cloud snapshots still carry them.
   const vaultImport: Record<string, unknown> = {
-    hosts: payload.hosts,
+    hosts: migrateHostsFromLegacyLineTimestamps(payload.hosts, legacyLineTimestampsEnabled),
     keys: payload.keys,
     identities: payload.identities,
     proxyProfiles: payload.proxyProfiles,

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -370,6 +370,12 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
           icon={<TerminalSquare size={14} className="text-muted-foreground" />}
           title={t("hostDetails.section.terminalBehavior")}
         >
+          <ToggleRow
+            label={t("hostDetails.lineTimestamps")}
+            hint={t("hostDetails.lineTimestamps.desc")}
+            enabled={!!form.showLineTimestamps}
+            onToggle={() => update("showLineTimestamps", !form.showLineTimestamps)}
+          />
           <HostDetailsSettingRow label={t("hostDetails.backspaceBehavior")}>
             <Select
               value={form.backspaceBehavior ?? "default"}

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -961,15 +961,6 @@ function SettingsTerminalTab(props: {
             className="w-32"
           />
         </SettingRow>
-        <SettingRow
-          label={t("settings.terminal.rendering.lineTimestamps")}
-          description={t("settings.terminal.rendering.lineTimestamps.desc")}
-        >
-          <Toggle
-            checked={terminalSettings.showLineTimestamps}
-            onChange={(v) => updateTerminalSetting("showLineTimestamps", v)}
-          />
-        </SettingRow>
       </div>
       {/* Autocomplete */}
       <SectionHeader title={t("settings.terminal.section.workspaceFocus")} />

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -593,6 +593,7 @@ test("local session resets terminal timestamp state when reusing a terminal", as
       hostname: "local",
       username: "",
       protocol: "local",
+      showLineTimestamps: true,
     },
     keys: [],
     resolvedChainHosts: [],

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -24,7 +24,8 @@ const createFakeTerm = (activeType = "normal") => {
   return { term, writes };
 };
 
-const createContext = (showLineTimestamps: boolean) => ({
+const createContext = (showLineTimestamps: boolean, host: Record<string, unknown> = {}) => ({
+  host,
   terminalSettingsRef: {
     current: {
       showLineTimestamps,
@@ -44,7 +45,7 @@ const createContext = (showLineTimestamps: boolean) => ({
 
 test("writeSessionData prefixes terminal output lines when enabled", () => {
   const { term, writes } = createFakeTerm();
-  writeSessionData(createContext(true) as never, term, "hello\r\nnext");
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "hello\r\nnext");
 
   assert.equal(writes.length, 1);
   assert.equal((writes[0].match(/\[\d{2}:\d{2}:\d{2}\]/g) ?? []).length, 2);
@@ -53,23 +54,38 @@ test("writeSessionData prefixes terminal output lines when enabled", () => {
   assert.ok(writes[0].endsWith("] \x1b[22;39mnext"));
 });
 
+test("writeSessionData does not use the global timestamp setting", () => {
+  const { term, writes } = createFakeTerm();
+  writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello");
+
+  assert.deepEqual(writes, ["hello"]);
+});
+
+test("writeSessionData only prefixes timestamps for hosts with timestamps enabled", () => {
+  const { term, writes } = createFakeTerm();
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "hello");
+
+  assert.equal(writes.length, 1);
+  assert.equal((writes[0].match(/\[\d{2}:\d{2}:\d{2}\]/g) ?? []).length, 1);
+});
+
 test("writeSessionData skips timestamps on the alternate screen", () => {
   const { term, writes } = createFakeTerm("alternate");
-  writeSessionData(createContext(true) as never, term, "vim screen");
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "vim screen");
 
   assert.deepEqual(writes, ["vim screen"]);
 });
 
 test("writeSessionData does not timestamp output that enters alternate screen in the same chunk", () => {
   const { term, writes } = createFakeTerm();
-  writeSessionData(createContext(true) as never, term, "\x1b[?1049hvim screen");
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "\x1b[?1049hvim screen");
 
   assert.deepEqual(writes, ["\x1b[?1049hvim screen"]);
 });
 
 test("writeSessionData resumes timestamps after leaving alternate screen in the same chunk", () => {
   const { term, writes } = createFakeTerm("alternate");
-  writeSessionData(createContext(true) as never, term, "\x1b[?1049lprompt");
+  writeSessionData(createContext(false, { showLineTimestamps: true }) as never, term, "\x1b[?1049lprompt");
 
   assert.equal(writes.length, 1);
   assert.ok(writes[0].startsWith("\x1b[?1049l\x1b[2;90m["));
@@ -79,7 +95,7 @@ test("writeSessionData resumes timestamps after leaving alternate screen in the 
 test("attachSessionToTerminal resets timestamp state for a reused terminal", () => {
   const { term, writes } = createFakeTerm();
   const ctx = {
-    ...createContext(true),
+    ...createContext(false, { showLineTimestamps: true }),
     sessionId: "session-1",
     sessionRef: { current: null },
     hasConnectedRef: { current: true },

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -171,7 +171,7 @@ export const writeSessionData = (
   flow.received(data.length);
   enqueueTerminalWrite(term, (done) => {
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
-    const timestampsEnabled = settings?.showLineTimestamps === true;
+    const timestampsEnabled = ctx.host?.showLineTimestamps === true;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
     if (!forcePromptNewLine && ctx.promptLineBreakStateRef?.current) {
       ctx.promptLineBreakStateRef.current.pendingCommand = false;

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import type { Host } from "./models.ts";
 import {
   detectVendorFromSshVersion,
+  migrateHostsFromLegacyLineTimestamps,
   normalizeDistroId,
   normalizePrimaryTelnetState,
   resolveHostKeepalive,
@@ -107,6 +108,31 @@ test("normalizePrimaryTelnetState leaves optional telnet hosts unchanged", () =>
 
   assert.equal(result.telnetEnabled, false);
   assert.equal(result.telnetPort, undefined);
+});
+
+test("migrateHostsFromLegacyLineTimestamps preserves the old global opt-in", () => {
+  const host = makeHost();
+
+  assert.deepEqual(migrateHostsFromLegacyLineTimestamps([host], true), [
+    { ...host, showLineTimestamps: true },
+  ]);
+});
+
+test("migrateHostsFromLegacyLineTimestamps does not override explicit host choices", () => {
+  const enabled = makeHost({ id: "enabled", showLineTimestamps: true });
+  const disabled = makeHost({ id: "disabled", showLineTimestamps: false });
+
+  assert.deepEqual(migrateHostsFromLegacyLineTimestamps([enabled, disabled], true), [enabled, disabled]);
+});
+
+test("migrateHostsFromLegacyLineTimestamps fills only missing host choices", () => {
+  const inherited = makeHost({ id: "inherited" });
+  const disabled = makeHost({ id: "disabled", showLineTimestamps: false });
+
+  assert.deepEqual(migrateHostsFromLegacyLineTimestamps([inherited, disabled], true), [
+    { ...inherited, showLineTimestamps: true },
+    disabled,
+  ]);
 });
 
 test("normalizePrimaryTelnetState preserves an explicit telnet port", () => {

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -243,6 +243,20 @@ export const normalizePrimaryTelnetState = (host: Host): Host =>
     ? { ...host, telnetEnabled: true }
     : host;
 
+export const migrateHostsFromLegacyLineTimestamps = (
+  hosts: Host[],
+  legacyEnabled: boolean,
+): Host[] => {
+  if (!legacyEnabled) return hosts;
+  let changed = false;
+  const migrated = hosts.map((host) => {
+    if (host.showLineTimestamps !== undefined) return host;
+    changed = true;
+    return { ...host, showLineTimestamps: true };
+  });
+  return changed ? migrated : hosts;
+};
+
 export const upsertHostById = (hosts: Host[], host: Host): Host[] => {
   const hostExists = hosts.some((entry) => entry.id === host.id);
   return hostExists

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -167,6 +167,10 @@ export interface Host {
   keepaliveInterval?: number; // Seconds; 0 = disabled
   keepaliveCountMax?: number; // Unanswered keepalives before declaring dead
   keepaliveOverride?: boolean;
+  // Prefix visible terminal output for this host with local timestamps.
+  // Kept per-host because some shells/prompts (notably PowerShell + oh-my-posh)
+  // break when extra printable content is injected into the terminal stream.
+  showLineTimestamps?: boolean;
   // What the Backspace key sends: undefined = xterm default (no interception), 'ctrl-h' = ^H (0x08)
   backspaceBehavior?: 'ctrl-h';
   // Local SSH key file paths (from SSH config IdentityFile or user-added)


### PR DESCRIPTION
## Summary
- Move visible terminal output timestamps from a global terminal setting to a per-host setting.
- Remove the Settings > Terminal timestamp toggle and add the toggle under Host Details > Terminal Behavior.
- Preserve old users' enabled timestamp preference by migrating legacy global-on data onto hosts, including old sync payloads.

## Why
Fixes #1405. Prefixing terminal output changes what the shell sees on screen, which can break rich prompts such as Windows PowerShell with oh-my-posh. A single global switch cannot safely fit every host.

## Validation
- Multi-agent review: runtime, UI/i18n, data compatibility, final full diff
- `npm test`
- `npm run lint`
- `npm run build`
