### PR TITLE
[codex] Avoid broadcasting remote image paste paths

### DIFF
--- a/components/terminal/clipboardImagePaste.test.ts
+++ b/components/terminal/clipboardImagePaste.test.ts
@@ -28,7 +28,7 @@ test("remote paths are quoted for shell-safe insertion", () => {
   );
 });
 
-test("remote clipboard image paste uploads and inserts the remote image path", async () => {
+test("remote clipboard image paste uploads and inserts the remote image path without broadcasting", async () => {
   const writes: Array<{ sessionId: string; data: string }> = [];
   const scrolled: string[] = [];
   let focused = false;
@@ -67,7 +67,6 @@ test("remote clipboard image paste uploads and inserts the remote image path", a
     terminalBackend: {
       writeToSession: (sessionId, data) => writes.push({ sessionId, data }),
     },
-    onPasteData: (data) => broadcastData.push(data),
     term: {
       focus: () => {
         focused = true;
@@ -95,7 +94,7 @@ test("remote clipboard image paste uploads and inserts the remote image path", a
     },
   ]);
   assert.deepEqual(scrolled, ["/home/alice/project/.netcatty-paste-images/shot_1.png"]);
-  assert.deepEqual(broadcastData, ["/home/alice/project/.netcatty-paste-images/shot_1.png"]);
+  assert.deepEqual(broadcastData, []);
   assert.equal(focused, true);
   assert.equal(closedSftpId, "sftp-1");
   assert.equal(deletedTempFile, "/tmp/netcatty/shot.png");

--- a/components/terminal/clipboardImagePaste.ts
+++ b/components/terminal/clipboardImagePaste.ts
@@ -21,7 +21,6 @@ type HandleRemoteClipboardImagePasteOptions = {
   createTransferId?: () => string;
   getRemoteCwd: () => Promise<string | null | undefined>;
   scrollToBottomAfterProgrammaticInput?: (data: string) => void;
-  onPasteData?: (data: string) => boolean | void;
   sessionId: string | null | undefined;
   terminalBackend: {
     writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
@@ -71,7 +70,6 @@ export async function handleRemoteClipboardImagePaste({
   createTransferId = defaultTransferId,
   getRemoteCwd,
   scrollToBottomAfterProgrammaticInput,
-  onPasteData,
   sessionId,
   terminalBackend,
   term,
@@ -105,7 +103,6 @@ export async function handleRemoteClipboardImagePaste({
 
     const pastedPath = quoteRemotePathForShell(targetPath);
     terminalBackend.writeToSession(sessionId, pastedPath);
-    onPasteData?.(pastedPath);
     scrollToBottomAfterProgrammaticInput?.(pastedPath);
     term?.focus?.();
     return true;

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -85,7 +85,6 @@ export const useTerminalContextActions = ({
           sessionId: sessionRef.current,
           terminalBackend,
           term,
-          onPasteData: broadcastUserPasteData,
           scrollToBottomAfterProgrammaticInput,
         });
         if (handled) return;

--- a/components/terminal/hooks/useTerminalFilePaste.ts
+++ b/components/terminal/hooks/useTerminalFilePaste.ts
@@ -74,7 +74,6 @@ export function useTerminalFilePaste({
               sessionId: sessionRef.current,
               terminalBackend,
               term: termRef.current,
-              onPasteData,
               scrollToBottomAfterProgrammaticInput,
             });
             if (!handled) fallbackToTextPaste();


### PR DESCRIPTION
## Summary
- Stop remote image paste from broadcasting its generated remote path to other terminal sessions
- Keep normal text paste broadcast behavior unchanged
- Update the remote image paste test expectation

## Validation
- node --test --import tsx components/terminal/clipboardImagePaste.test.ts
- npm run lint
- npm run build
- npm test was also run; it currently fails in unrelated Cursor discovery tests on this machine