### PR TITLE
[codex] Optimize terminal side panel performance

### DIFF
--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -3,6 +3,7 @@ import type { Messages } from '../types';
 export const enAiMessages: Messages = {
   // AI Settings
   'ai.agentSettings': 'Agent Settings',
+  'ai.chat.preparing': 'Preparing…',
   'ai.title': 'AI',
   'ai.description': 'Configure AI providers, agents, and safety settings',
   'ai.providers': 'Providers',

--- a/application/i18n/locales/en/systemManager.ts
+++ b/application/i18n/locales/en/systemManager.ts
@@ -44,6 +44,8 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.processes.elapsed': 'Elapsed',
   'systemManager.processes.stat': 'State',
   'systemManager.processes.meta': '{{count}} process(es)',
+  'systemManager.processes.loading': 'Loading processes…',
+  'systemManager.processes.loadingMore': 'Loading more processes…',
   'systemManager.processes.state.running': 'Running',
   'systemManager.processes.state.sleeping': 'Sleeping',
   'systemManager.processes.state.stopped': 'Stopped',
@@ -55,6 +57,10 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.processes.sort.user': 'User',
 
   'systemManager.common.dismiss': 'Dismiss',
+  'systemManager.common.checkingAvailability': 'Checking availability…',
+  'systemManager.common.loading': 'Loading…',
+  'systemManager.common.loadingDetails': 'Loading details…',
+  'systemManager.common.loadingStats': 'Loading stats…',
 
   'systemManager.tmux.new': 'New',
   'systemManager.tmux.search': 'Search sessions…',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -3,6 +3,7 @@ import type { Messages } from '../types';
 export const ruAiMessages: Messages = {
   // AI Settings
   'ai.agentSettings': 'Настройки агента',
+  'ai.chat.preparing': 'Подготовка…',
   'ai.title': 'AI',
   'ai.description': 'Настройка AI-провайдеров, агентов и параметров безопасности',
   'ai.providers': 'Провайдеры',

--- a/application/i18n/locales/ru/systemManager.ts
+++ b/application/i18n/locales/ru/systemManager.ts
@@ -44,6 +44,8 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.processes.elapsed': 'Время работы',
   'systemManager.processes.stat': 'Состояние',
   'systemManager.processes.meta': '{{count}} проц.',
+  'systemManager.processes.loading': 'Загрузка процессов…',
+  'systemManager.processes.loadingMore': 'Загрузка следующих процессов…',
   'systemManager.processes.state.running': 'Активен',
   'systemManager.processes.state.sleeping': 'Сон',
   'systemManager.processes.state.stopped': 'Остановлен',
@@ -55,6 +57,10 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.processes.sort.user': 'Пользователь',
 
   'systemManager.common.dismiss': 'Закрыть',
+  'systemManager.common.checkingAvailability': 'Проверка доступности…',
+  'systemManager.common.loading': 'Загрузка…',
+  'systemManager.common.loadingDetails': 'Загрузка деталей…',
+  'systemManager.common.loadingStats': 'Загрузка статистики…',
 
   'systemManager.tmux.new': 'Создать',
   'systemManager.tmux.search': 'Поиск сессий…',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -3,6 +3,7 @@ import type { Messages } from '../types';
 export const zhCNAiMessages: Messages = {
   // AI Settings
   'ai.agentSettings': 'Agent 设置',
+  'ai.chat.preparing': '准备中…',
   'ai.title': 'AI',
   'ai.description': '配置 AI 提供商、Agent 和安全设置',
   'ai.providers': '提供商',

--- a/application/i18n/locales/zh-CN/systemManager.ts
+++ b/application/i18n/locales/zh-CN/systemManager.ts
@@ -44,6 +44,8 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.processes.elapsed': '运行时长',
   'systemManager.processes.stat': '状态',
   'systemManager.processes.meta': '{{count}} 个进程',
+  'systemManager.processes.loading': '正在加载进程…',
+  'systemManager.processes.loadingMore': '正在显示更多进程…',
   'systemManager.processes.state.running': '运行中',
   'systemManager.processes.state.sleeping': '睡眠',
   'systemManager.processes.state.stopped': '已暂停',
@@ -55,6 +57,10 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.processes.sort.user': '用户',
 
   'systemManager.common.dismiss': '关闭',
+  'systemManager.common.checkingAvailability': '正在检查可用状态…',
+  'systemManager.common.loading': '正在加载…',
+  'systemManager.common.loadingDetails': '正在加载详情…',
+  'systemManager.common.loadingStats': '正在加载性能数据…',
 
   'systemManager.tmux.new': '新建',
   'systemManager.tmux.search': '搜索会话…',

--- a/application/state/aiStateSnapshots.ts
+++ b/application/state/aiStateSnapshots.ts
@@ -196,6 +196,21 @@ export function setLatestAIActiveSessionMapSnapshot(activeSessionIdMap: Record<s
   latestAIActiveSessionMapSnapshot = activeSessionIdMap;
 }
 
+export function prewarmAIStateStorageSnapshots() {
+  try {
+    if (latestAISessionsSnapshot === null) {
+      latestAISessionsSnapshot =
+        localStorageAdapter.read<AISession[]>(STORAGE_KEY_AI_SESSIONS) ?? [];
+    }
+    if (latestAIActiveSessionMapSnapshot === null) {
+      latestAIActiveSessionMapSnapshot =
+        localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP) ?? {};
+    }
+  } catch (error) {
+    console.warn('[AIState] Failed to prewarm AI state storage snapshots:', error);
+  }
+}
+
 export function setLatestAIDraftsByScopeSnapshot(draftsByScope: DraftsByScope) {
   latestAIDraftsByScopeSnapshot = draftsByScope;
 }

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -115,7 +115,9 @@ export function useAIState() {
 
   // ── Sessions ──
   const [sessions, setSessionsRaw] = useState<AISession[]>(() =>
-    localStorageAdapter.read<AISession[]>(STORAGE_KEY_AI_SESSIONS) ?? []
+    latestAISessionsSnapshot
+      ?? localStorageAdapter.read<AISession[]>(STORAGE_KEY_AI_SESSIONS)
+      ?? []
   );
   // Ref that always holds the latest sessions for use inside debounced callbacks
   const sessionsRef = useRef(sessions);
@@ -124,7 +126,9 @@ export function useAIState() {
   }, [sessions]);
   // Per-scope active session: keyed by `${scopeType}:${scopeTargetId}`
   const [activeSessionIdMap, setActiveSessionIdMapRaw] = useState<Record<string, string | null>>(() =>
-    localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP) ?? {}
+    latestAIActiveSessionMapSnapshot
+      ?? localStorageAdapter.read<Record<string, string | null>>(STORAGE_KEY_AI_ACTIVE_SESSION_MAP)
+      ?? {}
   );
   // Per-scope draft/view state is intentionally memory-only so a relaunch
   // does not restore stale composer input or panel intent against new history.
@@ -185,7 +189,7 @@ export function useAIState() {
   }, [panelViewByScope]);
 
   useEffect(() => {
-    const validSessionIds = new Set(sessions.map((session) => session.id));
+    const validSessionIds = new Set<string>(sessions.map((session) => session.id));
     let changed = false;
     const nextActiveSessionIdMap: Record<string, string | null> = {};
 

--- a/application/state/useAgentDiscovery.ts
+++ b/application/state/useAgentDiscovery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { startTransition, useCallback, useEffect, useRef, useState } from 'react';
 import type { DiscoveredAgent, ExternalAgentConfig } from '../../infrastructure/ai/types';
 import { getExternalAgentSdkBackend } from '../../infrastructure/ai/managedAgents';
 
@@ -10,6 +10,15 @@ function getBridge(): NetcattyBridge | undefined {
   return (window as unknown as { netcatty?: NetcattyBridge }).netcatty;
 }
 
+const AGENT_DISCOVERY_CACHE_TTL_MS = 60_000;
+let agentDiscoveryCache: {
+  agents: DiscoveredAgent[];
+  apiKeyPresent: boolean;
+  updatedAt: number;
+} | null = null;
+const agentDiscoveryPromises = new Map<string, Promise<DiscoveredAgent[]>>();
+let agentDiscoveryWriteGeneration = 0;
+
 export function useAgentDiscovery(
   externalAgents: ExternalAgentConfig[],
   setExternalAgents?: (value: ExternalAgentConfig[] | ((prev: ExternalAgentConfig[]) => ExternalAgentConfig[])) => void,
@@ -18,28 +27,86 @@ export function useAgentDiscovery(
   const enabled = options?.enabled ?? true;
   const [discoveredAgents, setDiscoveredAgents] = useState<DiscoveredAgent[]>([]);
   const [isDiscovering, setIsDiscovering] = useState(false);
+  const discoverSeqRef = useRef(0);
+  const mountedRef = useRef(true);
+  const enabledRef = useRef(enabled);
+
+  enabledRef.current = enabled;
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    discoverSeqRef.current += 1;
+  }, []);
 
   const cursorApiKeyPresent = externalAgents.some(
     (agent) => agent.id === "discovered_cursor" && Boolean(agent.apiKey),
   );
 
   const discover = useCallback(async (discoverOptions?: { refreshShellEnv?: boolean }) => {
+    if (!enabledRef.current) return;
     const bridge = getBridge();
     if (!bridge) return;
 
+    const forceRefresh = discoverOptions?.refreshShellEnv === true;
+    const cacheFresh =
+      agentDiscoveryCache
+      && agentDiscoveryCache.apiKeyPresent === cursorApiKeyPresent
+      && Date.now() - agentDiscoveryCache.updatedAt < AGENT_DISCOVERY_CACHE_TTL_MS;
+
+    if (!forceRefresh && cacheFresh) {
+      startTransition(() => setDiscoveredAgents(agentDiscoveryCache?.agents ?? []));
+      return;
+    }
+
     setIsDiscovering(true);
+    const discoverSeq = ++discoverSeqRef.current;
+    const writeGeneration = ++agentDiscoveryWriteGeneration;
+    const promiseKey = JSON.stringify({
+      apiKeyPresent: cursorApiKeyPresent,
+      refreshShellEnv: forceRefresh,
+    });
     try {
-      const agents = await bridge.aiDiscoverAgents({
-        ...discoverOptions,
+      let discoveryPromise = agentDiscoveryPromises.get(promiseKey) ?? null;
+      if (!discoveryPromise) {
+        const sharedPromise = bridge.aiDiscoverAgents({
+          ...discoverOptions,
+          apiKeyPresent: cursorApiKeyPresent,
+        }).finally(() => {
+          if (agentDiscoveryPromises.get(promiseKey) === sharedPromise) {
+            agentDiscoveryPromises.delete(promiseKey);
+          }
+        });
+        agentDiscoveryPromises.set(promiseKey, sharedPromise);
+        discoveryPromise = sharedPromise;
+      }
+      const agents = await discoveryPromise;
+      if (
+        !mountedRef.current
+        || !enabledRef.current
+        || discoverSeq !== discoverSeqRef.current
+        || writeGeneration !== agentDiscoveryWriteGeneration
+      ) return;
+      agentDiscoveryCache = {
+        agents,
         apiKeyPresent: cursorApiKeyPresent,
-      });
-      setDiscoveredAgents(agents);
+        updatedAt: Date.now(),
+      };
+      startTransition(() => setDiscoveredAgents(agents));
     } catch (err) {
       console.error('Agent discovery failed:', err);
     } finally {
-      setIsDiscovering(false);
+      if (mountedRef.current && discoverSeq === discoverSeqRef.current) {
+        setIsDiscovering(false);
+      }
     }
   }, [cursorApiKeyPresent]);
+
+  useEffect(() => {
+    discoverSeqRef.current += 1;
+    if (!enabled) {
+      setIsDiscovering(false);
+    }
+  }, [cursorApiKeyPresent, enabled]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -68,6 +135,7 @@ export function useAgentDiscovery(
   // the canonical args from discovery change (e.g. after an app update).
   useEffect(() => {
     if (!setExternalAgents || discoveredAgents.length === 0) return;
+    if (!enabled) return;
 
     setExternalAgents((prev) => {
       let changed = false;
@@ -102,7 +170,7 @@ export function useAgentDiscovery(
       });
       return changed ? next : prev;
     });
-  }, [discoveredAgents, setExternalAgents]);
+  }, [discoveredAgents, enabled, setExternalAgents]);
 
   // Filter out agents that are already configured as external agents
   const unconfiguredAgents = discoveredAgents.filter(

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import type { AIDraft, AISession } from '../infrastructure/ai/types';
 import {
+  aiChatSidePanelPropsAreEqual,
   hasAIChatSidePanelRetainedContent,
   shouldKeepAIChatSidePanelMounted,
 } from './AIChatSidePanel.tsx';
@@ -99,4 +100,18 @@ test('hidden AI side panel is retained when it has session messages', () => {
 
 test('visible AI side panel is always mounted even when empty', () => {
   assert.equal(shouldKeepAIChatSidePanelMounted(baseProps({ isVisible: true })), true);
+});
+
+test('AI side panel re-renders when retained content becomes visible again', () => {
+  const hiddenProps = baseProps({
+    isVisible: false,
+    draftsByScope: {
+      'terminal:terminal-1': draft({ text: 'hello' }),
+    },
+  });
+
+  assert.equal(aiChatSidePanelPropsAreEqual(
+    hiddenProps,
+    { ...hiddenProps, isVisible: true },
+  ), false);
 });

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -1,6 +1,7 @@
 
 
 import React, { useCallback, useEffect, useDeferredValue, useMemo, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { useWindowControls } from '../application/state/useWindowControls';
 import type {
@@ -19,6 +20,7 @@ import {
   getNextSelectedUserSkillSlugsMap,
   type UserSkillOption,
 } from './ai/userSkillsState';
+import { subscribeUserSkillsStatusChanged } from './ai/userSkillsStatusEvents';
 import {
   applyDraftEntrySelection,
   applyHistorySessionSelection,
@@ -55,6 +57,77 @@ import {
   profileAIPanelCalculation,
 } from './ai/aiPanelDiagnostics';
 
+type UserSkillsStatusResult = { ok: boolean; skills?: Array<{
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  status: 'ready' | 'warning';
+}> } | null;
+type UserSkillsStatusLoadResult = UserSkillsStatusResult | undefined;
+
+const USER_SKILLS_STATUS_CACHE_TTL_MS = 60_000;
+let userSkillsStatusCache: {
+  version: number;
+  result: UserSkillsStatusResult;
+  updatedAt: number;
+} | null = null;
+let userSkillsStatusPromise: {
+  version: number;
+  promise: Promise<UserSkillsStatusLoadResult>;
+} | null = null;
+let userSkillsStatusCacheVersion = 0;
+
+function invalidateUserSkillsStatusCache() {
+  userSkillsStatusCacheVersion += 1;
+  userSkillsStatusCache = null;
+  userSkillsStatusPromise = null;
+}
+
+if (typeof window !== 'undefined') {
+  subscribeUserSkillsStatusChanged(invalidateUserSkillsStatusCache);
+}
+
+function loadUserSkillsStatus(
+  bridge: ReturnType<typeof getNetcattyBridge>,
+): Promise<UserSkillsStatusLoadResult> {
+  const requestVersion = userSkillsStatusCacheVersion;
+  if (!bridge?.aiUserSkillsGetStatus) {
+    userSkillsStatusCache = { version: requestVersion, result: null, updatedAt: Date.now() };
+    return Promise.resolve(null);
+  }
+
+  if (
+    userSkillsStatusCache
+    && userSkillsStatusCache.version === requestVersion
+    && Date.now() - userSkillsStatusCache.updatedAt < USER_SKILLS_STATUS_CACHE_TTL_MS
+  ) {
+    return Promise.resolve(userSkillsStatusCache.result);
+  }
+
+  if (!userSkillsStatusPromise || userSkillsStatusPromise.version !== requestVersion) {
+    const promise = bridge.aiUserSkillsGetStatus()
+      .then((result) => {
+        if (userSkillsStatusCacheVersion !== requestVersion) return undefined;
+        userSkillsStatusCache = { version: requestVersion, result, updatedAt: Date.now() };
+        return result;
+      })
+      .catch(() => {
+        if (userSkillsStatusCacheVersion !== requestVersion) return undefined;
+        userSkillsStatusCache = { version: requestVersion, result: null, updatedAt: Date.now() };
+        return null;
+      })
+      .finally(() => {
+        if (userSkillsStatusPromise?.version === requestVersion) {
+          userSkillsStatusPromise = null;
+        }
+      });
+    userSkillsStatusPromise = { version: requestVersion, promise };
+  }
+
+  return userSkillsStatusPromise.promise;
+}
+
 export function hasAIChatSidePanelRetainedContent(props: Pick<
   AIChatSidePanelProps,
   'activeSessionIdMap' | 'draftsByScope' | 'sessions' | 'scopeTargetId' | 'scopeType'
@@ -89,6 +162,49 @@ export function shouldKeepAIChatSidePanelMounted(props: AIChatSidePanelProps): b
   }
   return isAIChatSessionStreaming(sessionId);
 }
+
+function shouldDelayAIChatSidePanelActivation(props: AIChatSidePanelProps): boolean {
+  if (!(props.isVisible ?? true)) return false;
+  const scopeKey = `${props.scopeType}:${props.scopeTargetId ?? ''}`;
+  const sessionId = props.activeSessionIdMap[scopeKey] ?? null;
+  if (isAIChatSessionStreaming(sessionId)) return false;
+  return !hasAIChatSidePanelRetainedContent(props);
+}
+
+function schedulePanelActivation(callback: () => void): () => void {
+  let timeoutId: number | null = null;
+  if (typeof requestAnimationFrame === 'function') {
+    const rafId = requestAnimationFrame(() => {
+      timeoutId = window.setTimeout(callback, 0);
+    });
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
+  }
+
+  timeoutId = window.setTimeout(callback, 0);
+  return () => {
+    if (timeoutId !== null) window.clearTimeout(timeoutId);
+  };
+}
+
+const AIChatSidePanelPreparing = React.memo(function AIChatSidePanelPreparing() {
+  const { t } = useI18n();
+  return (
+    <div className="flex h-full flex-col bg-background" data-section="ai-chat-panel-preparing">
+      <div className="shrink-0 border-b border-border/50 px-2.5 py-1.5">
+        <div className="h-8 w-36 rounded-md bg-muted/45" />
+      </div>
+      <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Loader2 size={14} className="animate-spin" />
+          {t('ai.chat.preparing')}
+        </div>
+      </div>
+    </div>
+  );
+});
 
 const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   sessions,
@@ -141,6 +257,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const [showHistory, setShowHistory] = useState(false);
   const [runtimeAgentModelPresets, setRuntimeAgentModelPresets] = useState<Record<string, AgentModelPreset[]>>({});
   const [userSkillOptions, setUserSkillOptions] = useState<UserSkillOption[]>([]);
+  const [userSkillsStatusVersion, setUserSkillsStatusVersion] = useState(0);
   const { openSettingsWindow } = useWindowControls();
   const terminalSessionsRef = useRef(terminalSessions);
   terminalSessionsRef.current = terminalSessions;
@@ -367,25 +484,25 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     };
 
     const bridge = getNetcattyBridge();
-    if (!bridge?.aiUserSkillsGetStatus) {
-      applyUserSkillsStatus(null);
-      return;
-    }
-
-    void bridge.aiUserSkillsGetStatus()
+    void loadUserSkillsStatus(bridge)
       .then((result) => {
         if (cancelled) return;
+        if (result === undefined) return;
         applyUserSkillsStatus(result);
       })
-      .catch(() => {
-        if (cancelled) return;
-        applyUserSkillsStatus(null);
-      });
+      .catch(() => {});
 
     return () => {
       cancelled = true;
     };
-  }, [isVisible, scopeKey, toolIntegrationMode, updateScopeDraft]);
+  }, [isVisible, scopeKey, toolIntegrationMode, updateScopeDraft, userSkillsStatusVersion]);
+
+  useEffect(() => {
+    const handleUserSkillsChanged = () => {
+      setUserSkillsStatusVersion((version) => version + 1);
+    };
+    return subscribeUserSkillsStatusChanged(handleUserSkillsChanged);
+  }, []);
 
   useEffect(() => {
     if (!isVisible) return;
@@ -1034,7 +1151,7 @@ const AI_CHAT_SIDE_PANEL_AI_STATE_KEYS = [
   'quickMessages',
 ] as const satisfies readonly (keyof AIChatSidePanelProps)[];
 
-function aiChatSidePanelPropsAreEqual(
+export function aiChatSidePanelPropsAreEqual(
   prev: AIChatSidePanelProps,
   next: AIChatSidePanelProps,
 ): boolean {
@@ -1050,6 +1167,7 @@ function aiChatSidePanelPropsAreEqual(
   if (prev.scopeType !== next.scopeType) return false;
   if (prev.scopeTargetId !== next.scopeTargetId) return false;
   if (prev.scopeLabel !== next.scopeLabel) return false;
+  if ((prev.isVisible ?? true) !== (next.isVisible ?? true)) return false;
   if (prev.scopeHostIds !== next.scopeHostIds) return false;
   if (prev.terminalSessions !== next.terminalSessions) return false;
   if (prev.resolveExecutorContext !== next.resolveExecutorContext) return false;
@@ -1061,7 +1179,25 @@ function aiChatSidePanelPropsAreEqual(
 }
 
 const AIChatSidePanel = React.memo(function AIChatSidePanel(props: AIChatSidePanelProps) {
-  if (!shouldKeepAIChatSidePanelMounted(props)) return null;
+  const shouldKeepMounted = shouldKeepAIChatSidePanelMounted(props);
+  const shouldDelayActivation = shouldKeepMounted && shouldDelayAIChatSidePanelActivation(props);
+  const activationKey = `${props.scopeType}:${props.scopeTargetId ?? ''}`;
+  const [activationReady, setActivationReady] = useState(!shouldDelayActivation);
+
+  useEffect(() => {
+    if (!shouldDelayActivation) {
+      setActivationReady(true);
+      return undefined;
+    }
+
+    setActivationReady(false);
+    return schedulePanelActivation(() => setActivationReady(true));
+  }, [activationKey, shouldDelayActivation]);
+
+  if (!shouldKeepMounted) return null;
+  if (shouldDelayActivation && !activationReady) {
+    return <AIChatSidePanelPreparing />;
+  }
   // Keep hidden panels alive only when they contain real work (messages, draft
   // content, or an active stream). Empty hidden panels can drop their heavy
   // input/agent-picker subtree and remount cheaply when shown again.

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -3,6 +3,7 @@ import React, { memo, startTransition, useCallback, useEffect, useMemo, useRef, 
 import { activeTabStore } from '../application/state/activeTabStore';
 import { canReuseTerminalConnection } from '../application/state/terminalConnectionReuse';
 import { resolveTerminalSessionExitIntent, type TerminalSessionExitEvent } from '../application/state/resolveTerminalSessionExitIntent';
+import { prewarmAIStateStorageSnapshots } from '../application/state/aiStateSnapshots';
 import {
   getSessionActivityIdsToClear,
   getValidSessionActivityIds,
@@ -161,9 +162,23 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const cwdProbeCancelersRef = useRef<Map<string, () => void>>(new Map());
   const cwdProbeGenerationRef = useRef<Map<string, number>>(new Map());
 
+  useEffect(() => {
+    const runPrewarm = () => prewarmAIStateStorageSnapshots();
+    if (typeof window.requestIdleCallback === 'function') {
+      const idleId = window.requestIdleCallback(runPrewarm, { timeout: 2500 });
+      return () => window.cancelIdleCallback(idleId);
+    }
+    const timeoutId = window.setTimeout(runPrewarm, 500);
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
   const handleTerminalCwdChange = useCallback((sessionId: string, cwd: string | null) => {
-    if (cwd && cwd.trim().length > 0) {
-      terminalRendererCwdBySessionRef.current.set(sessionId, cwd);
+    const currentCwd = terminalRendererCwdBySessionRef.current.get(sessionId) ?? null;
+    const nextCwd = cwd && cwd.trim().length > 0 ? cwd : null;
+    if (currentCwd === nextCwd) return;
+
+    if (nextCwd) {
+      terminalRendererCwdBySessionRef.current.set(sessionId, nextCwd);
     } else {
       terminalRendererCwdBySessionRef.current.delete(sessionId);
     }

--- a/components/ai/userSkillsStatusEvents.ts
+++ b/components/ai/userSkillsStatusEvents.ts
@@ -1,0 +1,38 @@
+export const USER_SKILLS_STATUS_CHANGED_EVENT = 'netcatty:user-skills-status-changed';
+const USER_SKILLS_STATUS_CHANGED_KEY = 'ai:user-skills-status-changed';
+
+type SettingsBridge = {
+  notifySettingsChanged?: (payload: { key: string; value: unknown }) => void;
+  onSettingsChanged?: (callback: (payload: { key: string; value: unknown }) => void) => () => void;
+};
+
+function getSettingsBridge(): SettingsBridge | undefined {
+  return (window as unknown as { netcatty?: SettingsBridge }).netcatty;
+}
+
+export function notifyUserSkillsStatusChanged() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(USER_SKILLS_STATUS_CHANGED_EVENT));
+  getSettingsBridge()?.notifySettingsChanged?.({
+    key: USER_SKILLS_STATUS_CHANGED_KEY,
+    value: Date.now(),
+  });
+}
+
+export function subscribeUserSkillsStatusChanged(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const handleLocalEvent = () => callback();
+  window.addEventListener(USER_SKILLS_STATUS_CHANGED_EVENT, handleLocalEvent);
+
+  const unsubscribeSettings = getSettingsBridge()?.onSettingsChanged?.((payload) => {
+    if (payload.key === USER_SKILLS_STATUS_CHANGED_KEY) {
+      callback();
+    }
+  });
+
+  return () => {
+    window.removeEventListener(USER_SKILLS_STATUS_CHANGED_EVENT, handleLocalEvent);
+    unsubscribeSettings?.();
+  };
+}

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -25,6 +25,7 @@ import { Select, SettingCard, SettingsSection, SettingsTabContent, SettingRow } 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
 import { AgentIconBadge } from "../../ai/AgentIconBadge";
 import { canSendWithAgent } from "../../ai/agentSendEligibility";
+import { notifyUserSkillsStatusChanged } from "../../ai/userSkillsStatusEvents";
 
 import type {
   AgentPathInfo,
@@ -274,6 +275,17 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const autoResolvedAgentStateRef = useRef<Partial<Record<ManagedAgentKey, "pending" | "done">>>({});
   const codexIntegrationLoadedRef = useRef(false);
   const userSkillsLoadedRef = useRef(false);
+  const mountedRef = useRef(true);
+  const agentPathRequestIdRef = useRef<Partial<Record<ManagedAgentKey, number>>>({});
+  const codexRequestIdRef = useRef(0);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    codexRequestIdRef.current += 1;
+    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy"] as ManagedAgentKey[]) {
+      agentPathRequestIdRef.current[key] = (agentPathRequestIdRef.current[key] ?? 0) + 1;
+    }
+  }, []);
 
   const applyResolvedAgentPath = useCallback((agentKey: ManagedAgentKey, result: AgentPathInfo | null) => {
     const setInfo = agentKey === "codex"
@@ -321,6 +333,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
             : setIsResolvingCodebuddy;
 
     setResolving(true);
+    const requestId = (agentPathRequestIdRef.current[agentKey] ?? 0) + 1;
+    agentPathRequestIdRef.current[agentKey] = requestId;
+    const isCurrentRequest = () => (
+      mountedRef.current
+      && agentPathRequestIdRef.current[agentKey] === requestId
+    );
     try {
       const result = await bridge.aiResolveCli({
         command: agentKey,
@@ -328,6 +346,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         refreshShellEnv: Boolean(options?.refreshShellEnv),
         ...(agentKey === "cursor" ? { apiKeyPresent: Boolean(options?.apiKeyPresent ?? cursorApiKeyEncrypted) } : {}),
       });
+      if (!isCurrentRequest()) return null;
       applyResolvedAgentPath(agentKey, result);
 
       return result;
@@ -335,7 +354,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
       console.error("Path resolution failed:", err);
       return null;
     } finally {
-      setResolving(false);
+      if (isCurrentRequest()) {
+        setResolving(false);
+      }
     }
   }, [applyResolvedAgentPath, cursorApiKeyEncrypted]);
 
@@ -476,15 +497,23 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     const bridge = getBridge();
     if (!bridge?.aiCodexGetIntegration) return;
 
+    const requestId = codexRequestIdRef.current + 1;
+    codexRequestIdRef.current = requestId;
+    const isCurrentRequest = () => mountedRef.current && codexRequestIdRef.current === requestId;
     setIsCodexLoading(true);
     setCodexError(null);
     try {
       const integration = await bridge.aiCodexGetIntegration(opts);
+      if (!isCurrentRequest()) return;
       setCodexIntegration(integration);
     } catch (err) {
-      setCodexError(normalizeCodexBridgeError(err));
+      if (isCurrentRequest()) {
+        setCodexError(normalizeCodexBridgeError(err));
+      }
     } finally {
-      setIsCodexLoading(false);
+      if (isCurrentRequest()) {
+        setIsCodexLoading(false);
+      }
     }
   }, []);
 
@@ -535,18 +564,26 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     const bridge = getBridge();
     if (!bridge?.aiCodexStartLogin) return;
 
+    const requestId = codexRequestIdRef.current + 1;
+    codexRequestIdRef.current = requestId;
+    const isCurrentRequest = () => mountedRef.current && codexRequestIdRef.current === requestId;
     setCodexError(null);
     setIsCodexLoading(true);
     try {
       const result = await bridge.aiCodexStartLogin();
+      if (!isCurrentRequest()) return;
       if (!result.ok || !result.session) {
         throw new Error(result.error || "Failed to start Codex login");
       }
       setCodexLoginSession(result.session);
     } catch (err) {
-      setCodexError(normalizeCodexBridgeError(err));
+      if (isCurrentRequest()) {
+        setCodexError(normalizeCodexBridgeError(err));
+      }
     } finally {
-      setIsCodexLoading(false);
+      if (isCurrentRequest()) {
+        setIsCodexLoading(false);
+      }
     }
   }, []);
 
@@ -578,19 +615,27 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     const bridge = getBridge();
     if (!bridge?.aiCodexLogout) return;
 
+    const requestId = codexRequestIdRef.current + 1;
+    codexRequestIdRef.current = requestId;
+    const isCurrentRequest = () => mountedRef.current && codexRequestIdRef.current === requestId;
     setCodexError(null);
     setIsCodexLoading(true);
     try {
       const result = await bridge.aiCodexLogout();
+      if (!isCurrentRequest()) return;
       if (!result.ok) {
         throw new Error(result.error || "Failed to log out from Codex");
       }
       setCodexLoginSession(null);
       await refreshCodexIntegration({ refreshShellEnv: true, validateChatGptAuth: true });
     } catch (err) {
-      setCodexError(normalizeCodexBridgeError(err));
+      if (isCurrentRequest()) {
+        setCodexError(normalizeCodexBridgeError(err));
+      }
     } finally {
-      setIsCodexLoading(false);
+      if (isCurrentRequest()) {
+        setIsCodexLoading(false);
+      }
     }
   }, [refreshCodexIntegration]);
 
@@ -608,6 +653,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     try {
       const result = await bridge.aiUserSkillsGetStatus();
       setUserSkillsStatus(result);
+      notifyUserSkillsStatusChanged();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setUserSkillsStatus({ ok: false, error: message });
@@ -642,6 +688,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     try {
       const result = await bridge.aiUserSkillsOpenFolder();
       setUserSkillsStatus(result);
+      notifyUserSkillsStatusChanged();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setUserSkillsStatus({ ok: false, error: message });

--- a/components/systemManager/DockerContainerDetail.tsx
+++ b/components/systemManager/DockerContainerDetail.tsx
@@ -1,7 +1,6 @@
-import { Pause, Pencil, Play, Trash2, Zap } from 'lucide-react';
-import React, { memo, useCallback, useState } from 'react';
+import { Loader2, Pause, Pencil, Play, Trash2, Zap } from 'lucide-react';
+import React, { memo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
-import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import type { DockerContainerAction, DockerContainerInfo, DockerStatInfo } from '../../domain/systemManager/types';
 import { getContainerFlags } from '../../domain/systemManager/containerState';
 import { DockerInspectView } from './DockerInspectView';
@@ -9,18 +8,17 @@ import { ResourceBar } from './ResourceBar';
 import {
   SystemPanelActionChip,
   SystemPanelDetailStrip,
+  SystemPanelInlineError,
 } from './SystemPanelUi';
 import { SystemPanelPromptDialog } from './SystemPanelPromptDialog';
-import { usePolling } from './hooks/useSystemManager';
-
-type Backend = ReturnType<typeof useSystemManagerBackend>;
 
 interface DockerContainerDetailProps {
   container: DockerContainerInfo;
-  sessionId: string;
-  backend: Backend;
-  statsRefreshIntervalSec: number;
   inspect: Record<string, unknown> | null;
+  inspectError?: string | null;
+  inspectLoading?: boolean;
+  stat?: DockerStatInfo | null;
+  statsLoading?: boolean;
   pendingAction: DockerContainerAction | null;
   onCloseInspect: () => void;
   onRunAction: (containerId: string, action: DockerContainerAction, newName?: string) => Promise<void>;
@@ -28,10 +26,11 @@ interface DockerContainerDetailProps {
 
 export const DockerContainerDetail = memo(function DockerContainerDetail({
   container,
-  sessionId,
-  backend,
-  statsRefreshIntervalSec,
   inspect,
+  inspectError = null,
+  inspectLoading = false,
+  stat = null,
+  statsLoading = false,
   pendingAction,
   onCloseInspect,
   onRunAction,
@@ -40,20 +39,6 @@ export const DockerContainerDetail = memo(function DockerContainerDetail({
   const shortId = container.id.slice(0, 12);
   const { isRunning, isPaused } = getContainerFlags(container);
 
-  const statsFetcher = useCallback(async () => {
-    const result = await backend.getDockerStats({ sessionId, ids: [container.id] });
-    if (!result.success || !result.stats) {
-      throw new Error(result.error || t('systemManager.errors.loadDockerStats'));
-    }
-    return result.stats;
-  }, [backend, container.id, sessionId, t]);
-
-  const statsIntervalMs = Math.max(2, statsRefreshIntervalSec) * 1000;
-  // docker stats still reports paused containers, so keep polling them.
-  const { data: stats } = usePolling<DockerStatInfo[]>(statsFetcher, statsIntervalMs, isRunning || isPaused);
-
-  const stat = stats?.find((s) => s.id === container.id || s.id.startsWith(shortId)) ?? stats?.[0];
-
   const [renameOpen, setRenameOpen] = useState(false);
   const actionBusy = pendingAction !== null;
 
@@ -61,13 +46,19 @@ export const DockerContainerDetail = memo(function DockerContainerDetail({
     <>
       <SystemPanelDetailStrip>
         {container.ports && (
-          <div className="text-[10px] text-muted-foreground mb-2 truncate">{container.ports}</div>
+          <div className="text-[10px] text-muted-foreground mb-2 break-all">{container.ports}</div>
         )}
         {stat && (
           <div className="space-y-1 mb-2">
             <ResourceBar label="CPU" value={stat.cpuPercent} />
             <ResourceBar label="MEM" value={stat.memPercent} />
             <div className="text-[10px] text-muted-foreground">{stat.netIO} · {stat.memUsage}</div>
+          </div>
+        )}
+        {!stat && statsLoading && (isRunning || isPaused) && (
+          <div className="mb-2 flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <Loader2 size={11} className="animate-spin" />
+            {t('systemManager.common.loadingStats')}
           </div>
         )}
         <div className="flex flex-wrap items-center gap-0.5">
@@ -94,6 +85,15 @@ export const DockerContainerDetail = memo(function DockerContainerDetail({
           </SystemPanelActionChip>
         </div>
       </SystemPanelDetailStrip>
+      {inspectLoading && !inspect && (
+        <div className="flex items-center gap-1.5 border-b border-border/40 bg-muted/20 px-3 py-2 text-[10px] text-muted-foreground">
+          <Loader2 size={11} className="animate-spin" />
+          {t('systemManager.common.loadingDetails')}
+        </div>
+      )}
+      {inspectError && !inspect && (
+        <SystemPanelInlineError message={inspectError} />
+      )}
       {inspect && (
         <DockerInspectView
           kind="container"

--- a/components/systemManager/DockerContainersPanel.tsx
+++ b/components/systemManager/DockerContainersPanel.tsx
@@ -1,10 +1,10 @@
 import { Box, FileText, Play, RotateCcw, Square, Terminal } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { writeSystemManagerDiagnostic } from '../../application/state/systemManagerDiagnostics';
 import type { TerminalSession } from '../../types';
-import type { DockerContainerAction, DockerContainerInfo, TerminalPopupIcon } from '../../domain/systemManager/types';
+import type { DockerContainerAction, DockerContainerInfo, DockerStatInfo, TerminalPopupIcon } from '../../domain/systemManager/types';
 import { dockerContainerInfoEqual } from '../../domain/systemManager/pollEquals';
 import { getContainerFlags, getContainerTone } from '../../domain/systemManager/containerState';
 import { buildDockerExecShellCommand, buildDockerLogsCommand } from '../../domain/systemManager/dockerShell';
@@ -16,6 +16,7 @@ import {
   SystemPanelEmpty,
   SystemPanelError,
   SystemPanelList,
+  SystemPanelLoading,
   SystemPanelMetaBar,
   SystemPanelRefreshButton,
   SystemPanelRoundButton,
@@ -25,6 +26,7 @@ import {
   SystemPanelStatusBadge,
   SystemPanelToolbar,
 } from './SystemPanelUi';
+import { useAsyncRecordCache } from './hooks/useAsyncRecordCache';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 import { openInteractiveTerminal } from './openInteractiveTerminal';
 import { showSystemManagerError } from './systemManagerToast';
@@ -53,6 +55,7 @@ interface DockerContainersPanelProps {
   sessionId: string;
   parentSession: TerminalSession;
   isVisible: boolean;
+  warmupEnabled?: boolean;
   backend: Backend;
   listRefreshIntervalSec: number;
   statsRefreshIntervalSec: number;
@@ -150,6 +153,7 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   sessionId,
   parentSession,
   isVisible,
+  warmupEnabled = false,
   backend,
   listRefreshIntervalSec,
   statsRefreshIntervalSec,
@@ -159,10 +163,6 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<ContainerFilter>('all');
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [inspect, setInspect] = useState<Record<string, unknown> | null>(null);
-  // Invalidates in-flight inspect fetches when the selection changes —
-  // a slow response for container A must not render under container B.
-  const inspectSeqRef = useRef(0);
   // Spinner feedback while a container action (stop/restart/…) runs;
   // cleared only after the follow-up list refresh lands.
   const [pendingAction, setPendingAction] = useState<{ id: string; action: DockerContainerAction } | null>(null);
@@ -179,13 +179,15 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   const { data: containers, error, loading, refresh } = usePolling<DockerContainerInfo[]>(
     containersFetcher,
     listIntervalMs,
-    isVisible,
+    isVisible || warmupEnabled,
     (prev, next) => mergePollListByKey(prev, next, (c) => c.id, dockerContainerInfoEqual),
+    { poll: isVisible, resetKey: sessionId },
   );
 
-  const matched = useMemo(() => {
+  const matched = useMemo<DockerContainerInfo[]>(() => {
     const q = query.trim().toLowerCase();
-    return (containers ?? []).filter((container) => {
+    const containerList = containers ?? [];
+    return containerList.filter((container) => {
       const { isRunning, isPaused } = getContainerFlags(container);
       if (filter === 'running' && !isRunning) return false;
       if (filter === 'stopped' && (isRunning || isPaused)) return false;
@@ -202,7 +204,7 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
     (a: DockerContainerInfo, b: DockerContainerInfo) => a.name.localeCompare(b.name),
     [],
   );
-  const displayList = useStableListOrder(
+  const displayList = useStableListOrder<DockerContainerInfo, string>(
     matched,
     (c) => c.id,
     `${filter}|${query}`,
@@ -213,6 +215,69 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
     () => displayList.find((c) => c.id === selectedId) ?? null,
     [displayList, selectedId],
   );
+
+  const statContainerIds = useMemo(
+    () => {
+      if (!selectedContainer) return [];
+      const { isRunning, isPaused } = getContainerFlags(selectedContainer);
+      return isRunning || isPaused ? [selectedContainer.id] : [];
+    },
+    [selectedContainer],
+  );
+  const statsFetcher = useCallback(async () => {
+    if (statContainerIds.length === 0) return [];
+    const result = await backend.getDockerStats({ sessionId, ids: statContainerIds });
+    if (!result.success || !result.stats) {
+      throw new Error(result.error || stableT('systemManager.errors.loadDockerStats'));
+    }
+    return result.stats;
+  }, [backend, sessionId, stableT, statContainerIds]);
+
+  const statsIntervalMs = Math.max(2, statsRefreshIntervalSec) * 1000;
+  const { data: stats, loading: statsLoading } = usePolling<DockerStatInfo[]>(
+    statsFetcher,
+    statsIntervalMs,
+    isVisible && statContainerIds.length > 0,
+    undefined,
+    { poll: isVisible, resetKey: `${sessionId}:${statContainerIds.join(',')}` },
+  );
+
+  const statsByContainerId = useMemo(() => {
+    const map = new Map<string, DockerStatInfo>();
+    for (const stat of stats ?? []) {
+      map.set(stat.id, stat);
+      map.set(stat.id.slice(0, 12), stat);
+    }
+    return map;
+  }, [stats]);
+
+  const getContainerInspectKey = useCallback((container: DockerContainerInfo) => (
+    `${sessionId}:${container.id}`
+  ), [sessionId]);
+  const fetchContainerInspect = useCallback(async (container: DockerContainerInfo) => {
+    const result = await backend.dockerInspect({
+      sessionId,
+      containerId: container.id.slice(0, 12),
+    });
+    if (!result.success) {
+      throw new Error(result.error || stableT('systemManager.errors.actionFailed'));
+    }
+    return result.inspect ?? null;
+  }, [backend, sessionId, stableT]);
+  const {
+    records: inspectByContainerId,
+    loadRecord: loadContainerInspect,
+    refreshRecord: refreshContainerInspect,
+    invalidateMatching: invalidateContainerInspectMatching,
+  } = useAsyncRecordCache<DockerContainerInfo, Record<string, unknown>>({
+    items: containers ?? [],
+    enabled: isVisible && (containers?.length ?? 0) > 0,
+    getKey: getContainerInspectKey,
+    fetchRecord: fetchContainerInspect,
+    prefetchLimit: 24,
+    prefetchDelayMs: 40,
+    staleTimeMs: 20_000,
+  });
 
   const runAction = useCallback(async (
     containerId: string,
@@ -234,34 +299,42 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
         showSystemManagerError(result.error || t('systemManager.errors.actionFailed'), t('common.error'));
         return;
       }
+      const affectedContainer = (containers ?? []).find((container) => (
+        container.id === containerId || container.id.startsWith(containerId)
+      ));
+      invalidateContainerInspectMatching((key) => (
+        key === `${sessionId}:${containerId}` || key.startsWith(`${sessionId}:${containerId}`)
+      ));
       if (action === 'rm') {
         setSelectedId(null);
-        setInspect(null);
-        inspectSeqRef.current += 1;
       }
       await refresh();
+      if (affectedContainer && action !== 'rm') {
+        void refreshContainerInspect(affectedContainer);
+      }
     } finally {
       setPendingAction(null);
     }
-  }, [backend, refresh, sessionId, t]);
+  }, [
+    backend,
+    containers,
+    invalidateContainerInspectMatching,
+    refresh,
+    refreshContainerInspect,
+    sessionId,
+    t,
+  ]);
 
   const handleRowAction = useCallback((container: DockerContainerInfo, action: DockerContainerAction) => {
     void runAction(container.id.slice(0, 12), action);
   }, [runAction]);
 
-  const selectContainer = useCallback(async (container: DockerContainerInfo) => {
+  const selectContainer = useCallback((container: DockerContainerInfo) => {
     const next = selectedId === container.id ? null : container.id;
     setSelectedId(next);
-    setInspect(null);
-    const seq = ++inspectSeqRef.current;
     if (!next) return;
-    const result = await backend.dockerInspect({
-      sessionId,
-      containerId: container.id.slice(0, 12),
-    });
-    if (inspectSeqRef.current !== seq) return;
-    setInspect(result.success ? (result.inspect ?? null) : null);
-  }, [backend, selectedId, sessionId]);
+    void loadContainerInspect(container, { force: true, urgent: true });
+  }, [loadContainerInspect, selectedId]);
 
   const openShell = useCallback(async (container: DockerContainerInfo) => {
     const id = container.id.slice(0, 12);
@@ -354,6 +427,9 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
         {error && (
           <SystemPanelError message={error} onRetry={() => void refresh()} retryLabel={t('history.action.retry')} loading={loading} />
         )}
+        {!error && displayList.length === 0 && loading && (
+          <SystemPanelLoading message={t('systemManager.common.loading')} />
+        )}
         {!error && displayList.length === 0 && !loading && (
           <SystemPanelEmpty icon={Box} message={t('systemManager.docker.empty')} />
         )}
@@ -363,6 +439,8 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
           const rowPending = pendingAction && pendingAction.id === container.id.slice(0, 12)
             ? pendingAction.action
             : null;
+          const selectedInspectKey = selectedContainer ? getContainerInspectKey(selectedContainer) : null;
+          const selectedInspectRecord = selectedInspectKey ? inspectByContainerId[selectedInspectKey] : undefined;
           return (
             <React.Fragment key={container.id}>
               <DockerContainerRow
@@ -378,12 +456,13 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
                 {selectedContainer && (
                   <DockerContainerDetail
                     container={selectedContainer}
-                    sessionId={sessionId}
-                    backend={backend}
-                    statsRefreshIntervalSec={statsRefreshIntervalSec}
-                    inspect={inspect}
+                    inspect={selectedInspectRecord?.data ?? null}
+                    inspectError={selectedInspectRecord?.error ?? null}
+                    inspectLoading={selectedInspectRecord?.loading ?? false}
+                    stat={statsByContainerId.get(selectedContainer.id) ?? statsByContainerId.get(selectedContainer.id.slice(0, 12)) ?? null}
+                    statsLoading={statsLoading}
                     pendingAction={rowPending}
-                    onCloseInspect={() => { setSelectedId(null); setInspect(null); }}
+                    onCloseInspect={() => { setSelectedId(null); }}
                     onRunAction={runAction}
                   />
                 )}

--- a/components/systemManager/DockerImagesPanel.tsx
+++ b/components/systemManager/DockerImagesPanel.tsx
@@ -1,5 +1,5 @@
-import { Layers, Tag, Trash2 } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { Layers, Loader2, Tag, Trash2 } from 'lucide-react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { dockerImageRowKey, type DockerImageInfo } from '../../domain/systemManager/types';
@@ -11,7 +11,9 @@ import {
   SystemPanelCollapsible,
   SystemPanelEmpty,
   SystemPanelError,
+  SystemPanelInlineError,
   SystemPanelList,
+  SystemPanelLoading,
   SystemPanelMetaBar,
   SystemPanelRefreshButton,
   SystemPanelRoundButton,
@@ -20,6 +22,7 @@ import {
   SystemPanelToolbar,
 } from './SystemPanelUi';
 import { SystemPanelPromptDialog } from './SystemPanelPromptDialog';
+import { useAsyncRecordCache } from './hooks/useAsyncRecordCache';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 import { showSystemManagerError } from './systemManagerToast';
 
@@ -28,6 +31,7 @@ type Backend = ReturnType<typeof useSystemManagerBackend>;
 interface DockerImagesPanelProps {
   sessionId: string;
   isVisible: boolean;
+  warmupEnabled?: boolean;
   backend: Backend;
   listRefreshIntervalSec: number;
 }
@@ -81,6 +85,7 @@ const DockerImageRow = memo(function DockerImageRow({
 export const DockerImagesPanel = memo(function DockerImagesPanel({
   sessionId,
   isVisible,
+  warmupEnabled = false,
   backend,
   listRefreshIntervalSec,
 }: DockerImagesPanelProps) {
@@ -88,8 +93,12 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   const stableT = useStableTranslate();
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [inspect, setInspect] = useState<Record<string, unknown> | null>(null);
-  const inspectSeqRef = useRef(0);
+  const [tagTarget, setTagTarget] = useState<DockerImageInfo | null>(null);
+
+  useEffect(() => {
+    setSelectedId(null);
+    setTagTarget(null);
+  }, [sessionId]);
 
   const imagesFetcher = useCallback(async () => {
     const result = await backend.listDockerImages(sessionId);
@@ -103,8 +112,9 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   const { data: images, error, loading, refresh } = usePolling<DockerImageInfo[]>(
     imagesFetcher,
     listIntervalMs,
-    isVisible,
+    isVisible || warmupEnabled,
     (prev, next) => mergePollListByKey(prev, next, dockerImageRowKey, dockerImageInfoEqual),
+    { poll: isVisible, resetKey: sessionId },
   );
 
   const filtered = useMemo(() => {
@@ -130,6 +140,33 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   );
   const displayList = useStableListOrder(filtered, dockerImageRowKey, query, compareImages);
 
+  const getImageInspectKey = useCallback((image: DockerImageInfo) => (
+    `${sessionId}:${dockerImageRowKey(image)}`
+  ), [sessionId]);
+  const fetchImageInspect = useCallback(async (image: DockerImageInfo) => {
+    const result = await backend.dockerImageInspect({
+      sessionId,
+      imageId: image.id.slice(0, 12),
+    });
+    if (!result.success) {
+      throw new Error(result.error || stableT('systemManager.errors.actionFailed'));
+    }
+    return result.inspect ?? null;
+  }, [backend, sessionId, stableT]);
+  const {
+    records: inspectByImageKey,
+    loadRecord: loadImageInspect,
+    invalidateRecord: invalidateImageInspect,
+  } = useAsyncRecordCache<DockerImageInfo, Record<string, unknown>>({
+    items: images ?? [],
+    enabled: isVisible && (images?.length ?? 0) > 0,
+    getKey: getImageInspectKey,
+    fetchRecord: fetchImageInspect,
+    prefetchLimit: 24,
+    prefetchDelayMs: 40,
+    staleTimeMs: 20_000,
+  });
+
   const handleRemove = useCallback(async (image: DockerImageInfo) => {
     const label = image.name || image.id.slice(0, 12);
     const ok = window.confirm(t('systemManager.docker.confirmRemoveImage', { name: label }));
@@ -146,11 +183,10 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
     }
     if (selectedId === dockerImageRowKey(image)) {
       setSelectedId(null);
-      setInspect(null);
-      inspectSeqRef.current += 1;
     }
+    invalidateImageInspect(getImageInspectKey(image));
     await refresh();
-  }, [backend, refresh, selectedId, sessionId, t]);
+  }, [backend, getImageInspectKey, invalidateImageInspect, refresh, selectedId, sessionId, t]);
 
   const handlePrune = async (all: boolean) => {
     const ok = window.confirm(all
@@ -164,8 +200,6 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
     }
     await refresh();
   };
-
-  const [tagTarget, setTagTarget] = useState<DockerImageInfo | null>(null);
 
   const handleTagSubmit = async (image: DockerImageInfo, repository: string, tag: string) => {
     const result = await backend.dockerImageAction({
@@ -182,20 +216,13 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
     await refresh();
   };
 
-  const selectImage = useCallback(async (image: DockerImageInfo) => {
+  const selectImage = useCallback((image: DockerImageInfo) => {
     const rowKey = dockerImageRowKey(image);
     const next = selectedId === rowKey ? null : rowKey;
     setSelectedId(next);
-    setInspect(null);
-    const seq = ++inspectSeqRef.current;
     if (!next) return;
-    const result = await backend.dockerImageInspect({
-      sessionId,
-      imageId: image.id.slice(0, 12),
-    });
-    if (inspectSeqRef.current !== seq) return;
-    setInspect(result.success ? (result.inspect ?? null) : null);
-  }, [backend, selectedId, sessionId]);
+    void loadImageInspect(image, { force: true, urgent: true });
+  }, [loadImageInspect, selectedId]);
 
   const openTagDialog = useCallback((image: DockerImageInfo) => {
     setTagTarget(image);
@@ -243,12 +270,16 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
         {error && (
           <SystemPanelError message={error} onRetry={() => void refresh()} retryLabel={t('history.action.retry')} loading={loading} />
         )}
+        {!error && displayList.length === 0 && loading && (
+          <SystemPanelLoading message={t('systemManager.common.loading')} />
+        )}
         {!error && displayList.length === 0 && !loading && (
           <SystemPanelEmpty icon={Layers} message={t('systemManager.docker.imagesEmpty')} />
         )}
 
         {displayList.map((image) => {
           const rowKey = dockerImageRowKey(image);
+          const inspectKey = getImageInspectKey(image);
           const shortId = image.id.slice(0, 12);
           const displayName = image.repository && image.tag
             ? `${image.repository}:${image.tag}`
@@ -266,11 +297,20 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
                 onRemove={handleRemove}
               />
               <SystemPanelCollapsible open={selected}>
-                {inspect && (
+                {inspectByImageKey[inspectKey]?.loading && !inspectByImageKey[inspectKey]?.data && (
+                  <div className="flex items-center gap-1.5 border-b border-border/40 bg-muted/20 px-3 py-2 text-[10px] text-muted-foreground">
+                    <Loader2 size={11} className="animate-spin" />
+                    {t('systemManager.common.loadingDetails')}
+                  </div>
+                )}
+                {inspectByImageKey[inspectKey]?.error && !inspectByImageKey[inspectKey]?.data && (
+                  <SystemPanelInlineError message={inspectByImageKey[inspectKey].error} />
+                )}
+                {inspectByImageKey[inspectKey]?.data && (
                   <DockerInspectView
                     kind="image"
-                    data={inspect}
-                    onClose={() => { setSelectedId(null); setInspect(null); }}
+                    data={inspectByImageKey[inspectKey].data}
+                    onClose={() => { setSelectedId(null); }}
                   />
                 )}
               </SystemPanelCollapsible>

--- a/components/systemManager/DockerInspectView.tsx
+++ b/components/systemManager/DockerInspectView.tsx
@@ -23,7 +23,7 @@ function InspectList({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="text-[10px] leading-relaxed">
       <div className="text-muted-foreground mb-0.5">{label}</div>
-      <div className="space-y-0.5 max-h-28 overflow-y-auto font-mono">
+      <div className="space-y-0.5 font-mono">
         {items.map((item, index) => (
           <div key={index} className="break-all text-foreground/90">{item}</div>
         ))}

--- a/components/systemManager/DockerManagerTab.tsx
+++ b/components/systemManager/DockerManagerTab.tsx
@@ -15,6 +15,7 @@ interface DockerManagerTabProps {
   sessionId: string;
   parentSession: TerminalSession;
   isVisible: boolean;
+  warmupEnabled?: boolean;
   backend: Backend;
   listRefreshIntervalSec: number;
   statsRefreshIntervalSec: number;
@@ -24,6 +25,7 @@ export const DockerManagerTab = memo(function DockerManagerTab({
   sessionId,
   parentSession,
   isVisible,
+  warmupEnabled = false,
   backend,
   listRefreshIntervalSec,
   statsRefreshIntervalSec,
@@ -58,23 +60,26 @@ export const DockerManagerTab = memo(function DockerManagerTab({
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col">
-        {subTab === 'containers' ? (
+        <div className={cn('flex-1 min-h-0 flex flex-col', subTab !== 'containers' && 'hidden')}>
           <DockerContainersPanel
             sessionId={sessionId}
             parentSession={parentSession}
-            isVisible={isVisible}
+            isVisible={isVisible && subTab === 'containers'}
+            warmupEnabled={warmupEnabled || (isVisible && subTab !== 'containers')}
             backend={backend}
             listRefreshIntervalSec={listRefreshIntervalSec}
             statsRefreshIntervalSec={statsRefreshIntervalSec}
           />
-        ) : (
+        </div>
+        <div className={cn('flex-1 min-h-0 flex flex-col', subTab !== 'images' && 'hidden')}>
           <DockerImagesPanel
             sessionId={sessionId}
-            isVisible={isVisible}
+            isVisible={isVisible && subTab === 'images'}
+            warmupEnabled={warmupEnabled || (isVisible && subTab !== 'images')}
             backend={backend}
             listRefreshIntervalSec={listRefreshIntervalSec}
           />
-        )}
+        </div>
       </div>
     </SystemPanelShell>
   );

--- a/components/systemManager/ProcessManagerTab.tsx
+++ b/components/systemManager/ProcessManagerTab.tsx
@@ -1,7 +1,7 @@
 import {
-  Gauge, LayoutList, Pause, Play, Skull, XCircle,
+  Gauge, LayoutList, Loader2, Pause, Play, Skull, XCircle,
 } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import {
@@ -38,6 +38,15 @@ type Backend = ReturnType<typeof useSystemManagerBackend>;
 type SortKey = 'cpuPercent' | 'memPercent' | 'pid' | 'command' | 'user';
 type ProcessFilter = 'all' | 'running';
 
+const PROCESS_INITIAL_RENDER_LIMIT = 60;
+const PROCESS_RENDER_CHUNK_SIZE = 80;
+const PROCESS_CACHE_TTL_MS = 30_000;
+
+const processListCache = new Map<string, {
+  processes: SystemProcessInfo[];
+  updatedAt: number;
+}>();
+
 const SORT_OPTIONS: Array<{ key: SortKey; labelKey: string }> = [
   { key: 'cpuPercent', labelKey: 'systemManager.processes.sort.cpu' },
   { key: 'memPercent', labelKey: 'systemManager.processes.sort.mem' },
@@ -61,6 +70,38 @@ const mergeProcesses = (
   next: SystemProcessInfo[],
 ) => mergePollListByKey(prev, next, (p) => p.pid, systemProcessInfoEqual);
 
+function getCachedProcesses(sessionId: string): SystemProcessInfo[] | null {
+  const cached = processListCache.get(sessionId);
+  if (!cached) return null;
+  if (Date.now() - cached.updatedAt > PROCESS_CACHE_TTL_MS) {
+    processListCache.delete(sessionId);
+    return null;
+  }
+  return cached.processes;
+}
+
+function scheduleProcessRenderTask(callback: () => void): () => void {
+  if (typeof window.requestIdleCallback === 'function') {
+    const id = window.requestIdleCallback(callback, { timeout: 400 });
+    return () => window.cancelIdleCallback(id);
+  }
+  const id = window.setTimeout(callback, 32);
+  return () => window.clearTimeout(id);
+}
+
+const ProcessListLoading = memo(function ProcessListLoading({
+  message,
+}: {
+  message: string;
+}) {
+  return (
+    <div className="flex min-h-[180px] flex-col items-center justify-center px-4 py-10 text-center text-xs text-muted-foreground">
+      <Loader2 size={18} className="mb-2 animate-spin opacity-70" />
+      <span>{message}</span>
+    </div>
+  );
+});
+
 interface ProcessRowProps {
   proc: SystemProcessInfo;
   selected: boolean;
@@ -79,55 +120,61 @@ const ProcessRow = memo(function ProcessRow({
   const { t } = useI18n();
   const { isStopped, isZombie } = getProcessFlags(proc);
 
+  const actions = (
+    <div className="flex w-[112px] shrink-0 items-center justify-end gap-1">
+      {!isStopped && !isZombie && (
+        <SystemPanelRoundButton
+          title={t('systemManager.processes.stop')}
+          onClick={() => onSignal(proc.pid, 'STOP')}
+        >
+          <Pause size={12} />
+        </SystemPanelRoundButton>
+      )}
+      {isStopped && !isZombie && (
+        <SystemPanelRoundButton
+          title={t('systemManager.processes.cont')}
+          onClick={() => onSignal(proc.pid, 'CONT')}
+        >
+          <Play size={12} />
+        </SystemPanelRoundButton>
+      )}
+      <SystemPanelRoundButton
+        title={t('systemManager.processes.term')}
+        onClick={() => onSignal(proc.pid, 'TERM')}
+      >
+        <XCircle size={12} />
+      </SystemPanelRoundButton>
+      <SystemPanelRoundButton
+        title={t('systemManager.processes.kill')}
+        destructive
+        onClick={() => onSignal(proc.pid, 'KILL')}
+      >
+        <Skull size={12} />
+      </SystemPanelRoundButton>
+      <SystemPanelRoundButton
+        title={t('systemManager.processes.renice')}
+        onClick={() => onRenice(proc.pid)}
+      >
+        <Gauge size={12} />
+      </SystemPanelRoundButton>
+    </div>
+  );
+
   return (
-    <>
+    <div>
       <SystemPanelRow
         selected={selected}
         onClick={() => onToggle(proc.pid)}
         title={proc.command}
         subtitle={`${proc.user || '—'} · PID ${proc.pid}`}
         trailing={(
-          <div className="flex shrink-0 items-center gap-1">
+          <div className="flex w-[88px] shrink-0 items-center justify-end">
             <SystemPanelStatusBadge tone={getProcessTone(proc)}>
               {t(getProcessStatusLabelKey(proc))}
             </SystemPanelStatusBadge>
-            {!isStopped && !isZombie && (
-              <SystemPanelRoundButton
-                title={t('systemManager.processes.stop')}
-                onClick={() => onSignal(proc.pid, 'STOP')}
-              >
-                <Pause size={12} />
-              </SystemPanelRoundButton>
-            )}
-            {isStopped && !isZombie && (
-              <SystemPanelRoundButton
-                title={t('systemManager.processes.cont')}
-                onClick={() => onSignal(proc.pid, 'CONT')}
-              >
-                <Play size={12} />
-              </SystemPanelRoundButton>
-            )}
-            <SystemPanelRoundButton
-              title={t('systemManager.processes.term')}
-              onClick={() => onSignal(proc.pid, 'TERM')}
-            >
-              <XCircle size={12} />
-            </SystemPanelRoundButton>
-            <SystemPanelRoundButton
-              title={t('systemManager.processes.kill')}
-              destructive
-              onClick={() => onSignal(proc.pid, 'KILL')}
-            >
-              <Skull size={12} />
-            </SystemPanelRoundButton>
-            <SystemPanelRoundButton
-              title={t('systemManager.processes.renice')}
-              onClick={() => onRenice(proc.pid)}
-            >
-              <Gauge size={12} />
-            </SystemPanelRoundButton>
           </div>
         )}
+        actions={actions}
       />
       <SystemPanelCollapsible open={selected}>
         <SystemPanelDetailStrip>
@@ -144,7 +191,7 @@ const ProcessRow = memo(function ProcessRow({
           </div>
         </SystemPanelDetailStrip>
       </SystemPanelCollapsible>
-    </>
+    </div>
   );
 });
 
@@ -170,14 +217,54 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
   const [selectedPid, setSelectedPid] = useState<number | null>(null);
   const [reniceTarget, setReniceTarget] = useState<number | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [cachedProcesses, setCachedProcesses] = useState<SystemProcessInfo[] | null>(() => getCachedProcesses(sessionId));
+  const [cachedProcessesSessionId, setCachedProcessesSessionId] = useState(sessionId);
+  const [renderLimit, setRenderLimit] = useState(PROCESS_INITIAL_RENDER_LIMIT);
+  const [processListPending, setProcessListPending] = useState(false);
+  const processFetchGenerationRef = useRef(0);
+  const currentSessionIdRef = useRef(sessionId);
+
+  if (currentSessionIdRef.current !== sessionId) {
+    currentSessionIdRef.current = sessionId;
+    processFetchGenerationRef.current += 1;
+  }
+
+  useEffect(() => {
+    processFetchGenerationRef.current += 1;
+    setCachedProcesses(getCachedProcesses(sessionId));
+    setCachedProcessesSessionId(sessionId);
+    setRenderLimit(PROCESS_INITIAL_RENDER_LIMIT);
+    setProcessListPending(false);
+  }, [sessionId]);
+
+  useEffect(() => () => {
+    processFetchGenerationRef.current += 1;
+  }, []);
 
   const fetcher = useCallback(async () => {
-    const result = await backend.listSystemProcesses(sessionId);
-    if (result.pending) return null;
-    if (!result.success || !result.processes) {
-      throw new Error(result.error || stableT('systemManager.errors.loadProcesses'));
+    const fetchGeneration = processFetchGenerationRef.current;
+    const fetchSessionId = sessionId;
+    const isCurrentFetch = () => (
+      processFetchGenerationRef.current === fetchGeneration
+      && currentSessionIdRef.current === fetchSessionId
+    );
+    try {
+      const result = await backend.listSystemProcesses(sessionId);
+      if (!isCurrentFetch()) return null;
+      if (result.pending) {
+        setProcessListPending(true);
+        return null;
+      }
+      setProcessListPending(false);
+      if (!result.success || !result.processes) {
+        throw new Error(result.error || stableT('systemManager.errors.loadProcesses'));
+      }
+      return result.processes;
+    } catch (err) {
+      if (!isCurrentFetch()) return null;
+      setProcessListPending(false);
+      throw err;
     }
-    return result.processes;
   }, [backend, sessionId, stableT]);
 
   const intervalMs = Math.max(2, refreshIntervalSec) * 1000;
@@ -186,10 +273,24 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
     intervalMs,
     isVisible,
     mergeProcesses,
+    { resetKey: sessionId },
   );
 
-  const matched = useMemo(() => {
-    const list = processes ?? [];
+  useEffect(() => {
+    if (!processes) return;
+    processListCache.set(sessionId, { processes, updatedAt: Date.now() });
+    setCachedProcesses(processes);
+    setCachedProcessesSessionId(sessionId);
+  }, [processes, sessionId]);
+
+  const sessionCachedProcesses = cachedProcessesSessionId === sessionId
+    ? cachedProcesses
+    : getCachedProcesses(sessionId);
+  const visibleProcesses = processes ?? sessionCachedProcesses;
+  const showingCachedProcesses = processes === null && sessionCachedProcesses !== null;
+
+  const matched = useMemo<SystemProcessInfo[]>(() => {
+    const list = visibleProcesses ?? [];
     const q = query.trim().toLowerCase();
     return list.filter((p) => {
       if (filter === 'running' && !isProcessRunning(p.stat)) return false;
@@ -199,7 +300,7 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
         || p.user.toLowerCase().includes(q)
         || p.command.toLowerCase().includes(q);
     });
-  }, [processes, query, filter]);
+  }, [visibleProcesses, query, filter]);
 
   const compareProcesses = useCallback((a: SystemProcessInfo, b: SystemProcessInfo) => {
     let cmp = 0;
@@ -216,7 +317,32 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
   }, [sortAsc, sortKey]);
 
   const sortToken = `${sortKey}|${sortAsc}|${filter}|${query}`;
-  const displayList = useStableListOrder(matched, (p) => p.pid, sortToken, compareProcesses);
+  const displayList = useStableListOrder<SystemProcessInfo, number>(
+    matched,
+    (p) => p.pid,
+    sortToken,
+    compareProcesses,
+  );
+  const renderedList = useMemo(
+    () => displayList.slice(0, Math.min(renderLimit, displayList.length)),
+    [displayList, renderLimit],
+  );
+  const hasMoreRowsToRender = renderLimit < displayList.length;
+  const isProcessRefreshActive = loading || processListPending;
+  const showInitialLoading = isProcessRefreshActive && displayList.length === 0;
+  const showBlockingError = Boolean(error && !isProcessRefreshActive && displayList.length === 0);
+  const showInlineRefreshError = Boolean(error && !isProcessRefreshActive && displayList.length > 0);
+
+  useEffect(() => {
+    setRenderLimit(PROCESS_INITIAL_RENDER_LIMIT);
+  }, [sortToken]);
+
+  useEffect(() => {
+    if (!hasMoreRowsToRender) return undefined;
+    return scheduleProcessRenderTask(() => {
+      setRenderLimit((current) => Math.min(current + PROCESS_RENDER_CHUNK_SIZE, displayList.length));
+    });
+  }, [displayList.length, hasMoreRowsToRender, renderLimit]);
 
   const cycleSort = (key: SortKey) => {
     if (sortKey === key) setSortAsc((v) => !v);
@@ -265,7 +391,7 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
         trailing={(
           <SystemPanelRefreshButton
             title={t('history.action.refresh')}
-            loading={loading}
+            loading={isProcessRefreshActive}
             onClick={() => void refresh()}
           />
         )}
@@ -305,19 +431,26 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
           ))}
         </div>
       )}>
-        {t('systemManager.processes.meta', { count: String(displayList.length) })}
+        <span className={cn(showingCachedProcesses && isProcessRefreshActive && 'inline-flex items-center gap-1.5')}>
+          {showingCachedProcesses && isProcessRefreshActive && <Loader2 size={10} className="animate-spin" />}
+          {t('systemManager.processes.meta', { count: String(displayList.length) })}
+        </span>
       </SystemPanelMetaBar>
 
       {actionError && <SystemPanelInlineError message={actionError} />}
+      {showInlineRefreshError && error && <SystemPanelInlineError message={error} />}
 
       <SystemPanelList>
-        {error && (
+        {showBlockingError && error && (
           <SystemPanelError message={error} onRetry={() => void refresh()} retryLabel={t('history.action.retry')} loading={loading} />
         )}
-        {!error && displayList.length === 0 && !loading && (
+        {showInitialLoading && (
+          <ProcessListLoading message={t('systemManager.processes.loading')} />
+        )}
+        {!error && displayList.length === 0 && !loading && !showInitialLoading && (
           <SystemPanelEmpty icon={LayoutList} message={t('systemManager.empty')} />
         )}
-        {displayList.map((proc) => (
+        {renderedList.map((proc) => (
           <ProcessRow
             key={proc.pid}
             proc={proc}
@@ -327,6 +460,12 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
             onRenice={openRenicePrompt}
           />
         ))}
+        {hasMoreRowsToRender && (
+          <div className="flex items-center justify-center gap-1.5 border-b border-border/30 px-3 py-2 text-[10px] text-muted-foreground">
+            <Loader2 size={11} className="animate-spin" />
+            {t('systemManager.processes.loadingMore')}
+          </div>
+        )}
       </SystemPanelList>
 
       <SystemPanelPromptDialog

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -1,4 +1,4 @@
-import { Activity, Box, LayoutList, TerminalSquare } from 'lucide-react';
+import { Activity, Box, LayoutList, Loader2, TerminalSquare } from 'lucide-react';
 import React, { memo, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
@@ -14,6 +14,19 @@ import { TmuxManagerTab } from './TmuxManagerTab';
 import { WorkspaceSidebarHostHeader } from '../terminalLayer/WorkspaceSidebarHostHeader';
 import { SystemPanelEmpty, SystemPanelShell } from './SystemPanelUi';
 import { useSessionCapabilities } from './hooks/useSystemManager';
+
+const SystemPanelChecking = memo(function SystemPanelChecking({
+  message,
+}: {
+  message: string;
+}) {
+  return (
+    <div className="flex h-full min-h-[180px] flex-col items-center justify-center px-4 py-10 text-center text-xs text-muted-foreground">
+      <Loader2 size={18} className="mb-2 animate-spin opacity-70" />
+      <span>{message}</span>
+    </div>
+  );
+});
 
 interface SystemManagerSidePanelProps {
   session: TerminalSession | null;
@@ -82,6 +95,8 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   const dockerReady = capabilities?.hasDocker === true;
   const tmuxUnavailable = !probing && capabilities !== undefined && !tmuxReady;
   const dockerUnavailable = !probing && capabilities !== undefined && !dockerReady;
+  const tmuxChecking = resolvedTab === 'tmux' && !tmuxReady && !tmuxUnavailable;
+  const dockerChecking = resolvedTab === 'docker' && !dockerReady && !dockerUnavailable;
 
   return (
     <SystemPanelShell section="system-manager-panel">
@@ -106,42 +121,56 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col">
-        {resolvedTab === 'processes' && (
+        <div className={cn('flex-1 min-h-0 flex flex-col', resolvedTab !== 'processes' && 'hidden')}>
           <ProcessManagerTab
             sessionId={sessionId}
-            isVisible={isVisible}
+            isVisible={isVisible && resolvedTab === 'processes'}
             backend={backend}
             refreshIntervalSec={terminalSettings.systemManagerProcessRefreshInterval}
           />
-        )}
-        {resolvedTab === 'tmux' && (
-          tmuxUnavailable ? (
+        </div>
+        {tmuxUnavailable && resolvedTab === 'tmux' ? (
+          <div className="flex-1 min-h-0">
             <SystemPanelEmpty icon={TerminalSquare} message={t('systemManager.tmux.unavailable')} />
-          ) : (
+          </div>
+        ) : tmuxChecking ? (
+          <div className="flex-1 min-h-0">
+            <SystemPanelChecking message={t('systemManager.common.checkingAvailability')} />
+          </div>
+        ) : tmuxReady ? (
+          <div className={cn('flex-1 min-h-0 flex flex-col', resolvedTab !== 'tmux' && 'hidden')}>
             <TmuxManagerTab
               sessionId={sessionId}
               parentSession={session}
-              isVisible={isVisible && tmuxReady}
+              isVisible={isVisible && resolvedTab === 'tmux'}
+              warmupEnabled={isVisible && resolvedTab !== 'tmux'}
               backend={backend}
               refreshIntervalSec={terminalSettings.systemManagerTmuxRefreshInterval}
               snippets={snippets}
             />
-          )
-        )}
-        {resolvedTab === 'docker' && (
-          dockerUnavailable ? (
+          </div>
+        ) : null}
+        {dockerUnavailable && resolvedTab === 'docker' ? (
+          <div className="flex-1 min-h-0">
             <SystemPanelEmpty icon={Box} message={t('systemManager.docker.unavailable')} />
-          ) : (
+          </div>
+        ) : dockerChecking ? (
+          <div className="flex-1 min-h-0">
+            <SystemPanelChecking message={t('systemManager.common.checkingAvailability')} />
+          </div>
+        ) : dockerReady ? (
+          <div className={cn('flex-1 min-h-0 flex flex-col', resolvedTab !== 'docker' && 'hidden')}>
             <DockerManagerTab
               sessionId={sessionId}
               parentSession={session}
-              isVisible={isVisible && dockerReady}
+              isVisible={isVisible && resolvedTab === 'docker'}
+              warmupEnabled={isVisible && resolvedTab !== 'docker'}
               backend={backend}
               listRefreshIntervalSec={terminalSettings.systemManagerDockerListRefreshInterval}
               statsRefreshIntervalSec={terminalSettings.systemManagerDockerStatsRefreshInterval}
             />
-          )
-        )}
+          </div>
+        ) : null}
       </div>
     </SystemPanelShell>
   );

--- a/components/systemManager/SystemPanelUi.tsx
+++ b/components/systemManager/SystemPanelUi.tsx
@@ -203,6 +203,19 @@ export const SystemPanelEmpty = memo(function SystemPanelEmpty({
   );
 });
 
+export const SystemPanelLoading = memo(function SystemPanelLoading({
+  message,
+}: {
+  message: string;
+}) {
+  return (
+    <div className="flex min-h-[180px] flex-col items-center justify-center px-4 py-10 text-center text-xs text-muted-foreground">
+      <Loader2 size={18} className="mb-2 animate-spin opacity-70" />
+      <span>{message}</span>
+    </div>
+  );
+});
+
 export const SystemPanelError = memo(function SystemPanelError({
   message,
   onRetry,
@@ -292,7 +305,7 @@ export const SystemPanelRow = memo(function SystemPanelRow({
       {trailing}
       {actions && (
         <div
-          className="flex shrink-0 items-center justify-end gap-0.5 invisible group-hover:visible group-focus-within:visible"
+          className="flex shrink-0 items-center justify-end gap-0.5"
           onClick={(e) => e.stopPropagation()}
         >
           {actions}

--- a/components/systemManager/TmuxManagerTab.tsx
+++ b/components/systemManager/TmuxManagerTab.tsx
@@ -1,21 +1,23 @@
 import { Plus, TerminalSquare } from 'lucide-react';
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import type { Snippet, TerminalSession } from '../../types';
-import type { TmuxSessionInfo } from '../../domain/systemManager/types';
+import type { TmuxClientInfo, TmuxSessionInfo, TmuxWindowInfo } from '../../domain/systemManager/types';
 import { tmuxSessionInfoEqual } from '../../domain/systemManager/pollEquals';
 import {
   SystemPanelEmpty,
   SystemPanelError,
   SystemPanelIconButton,
   SystemPanelList,
+  SystemPanelLoading,
   SystemPanelMetaBar,
   SystemPanelRefreshButton,
   SystemPanelSearch,
   SystemPanelShell,
   SystemPanelToolbar,
 } from './SystemPanelUi';
+import { useAsyncRecordCache } from './hooks/useAsyncRecordCache';
 import { usePolling, useStableTranslate } from './hooks/useSystemManager';
 import { TmuxNewSessionModal } from './TmuxNewSessionModal';
 import { TmuxSessionCard } from './TmuxSessionCard';
@@ -23,10 +25,16 @@ import { useStableListOrder, mergePollListByKey } from './listStable';
 
 type Backend = ReturnType<typeof useSystemManagerBackend>;
 
+export interface TmuxSessionDetails {
+  windows: TmuxWindowInfo[];
+  clients: TmuxClientInfo[];
+}
+
 interface TmuxManagerTabProps {
   sessionId: string;
   parentSession: TerminalSession;
   isVisible: boolean;
+  warmupEnabled?: boolean;
   backend: Backend;
   refreshIntervalSec: number;
   snippets: Snippet[];
@@ -36,6 +44,7 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
   sessionId,
   parentSession,
   isVisible,
+  warmupEnabled = false,
   backend,
   refreshIntervalSec,
   snippets,
@@ -48,11 +57,20 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
   const [modalError, setModalError] = useState<string | null>(null);
 
   const [tmuxVersion, setTmuxVersion] = useState<string | null>(null);
+  const currentSessionIdRef = useRef(sessionId);
+  currentSessionIdRef.current = sessionId;
+
+  useEffect(() => {
+    setTmuxVersion(null);
+  }, [sessionId]);
 
   const fetcher = useCallback(async () => {
+    const fetchSessionId = sessionId;
     const result = await backend.listTmuxSessions(sessionId);
     const version = result.tmuxVersion ?? null;
-    setTmuxVersion((prev) => (prev === version ? prev : version));
+    if (currentSessionIdRef.current === fetchSessionId) {
+      setTmuxVersion((prev) => (prev === version ? prev : version));
+    }
     if (!result.success) {
       throw new Error(result.error || stableT('systemManager.errors.loadTmux'));
     }
@@ -63,11 +81,12 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
   const { data: sessions, error, loading, refresh } = usePolling<TmuxSessionInfo[]>(
     fetcher,
     intervalMs,
-    isVisible,
+    isVisible || warmupEnabled,
     (prev, next) => mergePollListByKey(prev, next, (s) => s.name, tmuxSessionInfoEqual),
+    { poll: isVisible, resetKey: sessionId },
   );
 
-  const filtered = useMemo(() => {
+  const filtered = useMemo<TmuxSessionInfo[]>(() => {
     const q = query.trim().toLowerCase();
     const list = sessions ?? [];
     if (!q) return list;
@@ -78,12 +97,68 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
     (a: TmuxSessionInfo, b: TmuxSessionInfo) => a.name.localeCompare(b.name),
     [],
   );
-  const displaySessions = useStableListOrder(
+  const displaySessions = useStableListOrder<TmuxSessionInfo, string>(
     filtered,
     (s) => s.name,
     query,
     compareSessions,
   );
+
+  const formatTmuxLoadError = useCallback((
+    message: string,
+    debug?: { lastOutput?: string; tried?: string[] },
+  ) => {
+    const parts = [message];
+    if (debug?.lastOutput) parts.push(debug.lastOutput);
+    if (debug?.tried?.length) {
+      parts.push(t('systemManager.tmux.lastCommand', { command: debug.tried[debug.tried.length - 1] ?? '' }));
+    }
+    return parts.filter(Boolean).join(' · ');
+  }, [t]);
+
+  const getTmuxDetailsKey = useCallback((session: TmuxSessionInfo) => (
+    `${sessionId}:${session.name}:${session.created}`
+  ), [sessionId]);
+  const fetchTmuxDetails = useCallback(async (session: TmuxSessionInfo): Promise<TmuxSessionDetails> => {
+    const [windowsResult, clientsResult] = await Promise.all([
+      backend.listTmuxWindows({ sessionId, sessionName: session.name }),
+      backend.listTmuxClients({ sessionId, sessionName: session.name }),
+    ]);
+    if (!windowsResult.success) {
+      throw new Error(formatTmuxLoadError(
+        windowsResult.error || stableT('systemManager.errors.loadTmuxWindows'),
+        windowsResult.debug,
+      ));
+    }
+    if (!clientsResult.success) {
+      throw new Error(clientsResult.error || stableT('systemManager.errors.loadTmuxClients'));
+    }
+    const freshWindows = windowsResult.windows ?? [];
+    if (freshWindows.length === 0 && session.windows > 0) {
+      throw new Error(formatTmuxLoadError(
+        stableT('systemManager.tmux.windowsMismatch', { count: String(session.windows) }),
+        windowsResult.debug,
+      ));
+    }
+    return {
+      windows: freshWindows,
+      clients: clientsResult.clients ?? [],
+    };
+  }, [backend, formatTmuxLoadError, sessionId, stableT]);
+
+  const {
+    records: tmuxDetailsByName,
+    loadRecord: loadTmuxDetails,
+    refreshRecord: refreshTmuxDetails,
+  } = useAsyncRecordCache<TmuxSessionInfo, TmuxSessionDetails>({
+    items: sessions ?? [],
+    enabled: isVisible && (sessions?.length ?? 0) > 0,
+    getKey: getTmuxDetailsKey,
+    fetchRecord: fetchTmuxDetails,
+    prefetchLimit: 16,
+    prefetchDelayMs: 40,
+    staleTimeMs: 20_000,
+  });
 
   const handleCreate = useCallback(async (name: string, command: string) => {
     setCreating(true);
@@ -140,6 +215,9 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
       </SystemPanelMetaBar>
 
       <SystemPanelList>
+        {!error && displaySessions.length === 0 && loading && (
+          <SystemPanelLoading message={t('systemManager.common.loading')} />
+        )}
         {!error && displaySessions.length === 0 && !loading && (
           <SystemPanelEmpty icon={TerminalSquare} message={t('systemManager.tmux.empty')} />
         )}
@@ -148,11 +226,14 @@ export const TmuxManagerTab = memo(function TmuxManagerTab({
         )}
         {displaySessions.map((session) => (
           <TmuxSessionCard
-            key={session.name}
+            key={`${session.name}:${session.created}`}
             session={session}
             sessionId={sessionId}
             parentSession={parentSession}
             backend={backend}
+            detailsRecord={tmuxDetailsByName[getTmuxDetailsKey(session)]}
+            onLoadDetails={loadTmuxDetails}
+            onRefreshDetails={refreshTmuxDetails}
             onSessionsChanged={refresh}
           />
         ))}

--- a/components/systemManager/TmuxSessionCard.tsx
+++ b/components/systemManager/TmuxSessionCard.tsx
@@ -1,17 +1,17 @@
 import {
   Loader2, MonitorPlay, Pencil, Plus, Trash2, Unplug,
 } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { buildTmuxAttachCommand } from '../../domain/systemManager/tmuxShell';
 import type {
-  TmuxClientInfo,
   TmuxManageAction,
   TmuxSessionInfo,
-  TmuxWindowInfo,
 } from '../../domain/systemManager/types';
 import type { TerminalSession } from '../../types';
+import type { AsyncRecordState } from './hooks/useAsyncRecordCache';
+import type { TmuxSessionDetails } from './TmuxManagerTab';
 import {
   SystemPanelCollapsible,
   SystemPanelDetailStrip,
@@ -46,6 +46,9 @@ interface TmuxSessionCardProps {
   sessionId: string;
   parentSession: TerminalSession;
   backend: Backend;
+  detailsRecord?: AsyncRecordState<TmuxSessionDetails>;
+  onLoadDetails: (session: TmuxSessionInfo, options?: { force?: boolean; urgent?: boolean }) => Promise<void>;
+  onRefreshDetails: (session: TmuxSessionInfo) => Promise<void>;
   onSessionsChanged: () => Promise<void>;
 }
 
@@ -54,74 +57,42 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
   sessionId,
   parentSession,
   backend,
+  detailsRecord,
+  onLoadDetails,
+  onRefreshDetails,
   onSessionsChanged,
 }: TmuxSessionCardProps) {
   const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
-  const [loadingDetails, setLoadingDetails] = useState(false);
-  const [windows, setWindows] = useState<TmuxWindowInfo[]>([]);
-  const [clients, setClients] = useState<TmuxClientInfo[]>([]);
   const [renamePrompt, setRenamePrompt] = useState<RenamePromptTarget | null>(null);
   const [newWindowOpen, setNewWindowOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [windowsLoadDetail, setWindowsLoadDetail] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [pending, setPending] = useState<PendingTarget | null>(null);
 
-  const formatTmuxLoadError = useCallback((
-    message: string,
-    debug?: { lastOutput?: string; tried?: string[] },
-  ) => {
-    const parts = [message];
-    if (debug?.lastOutput) parts.push(debug.lastOutput);
-    if (debug?.tried?.length) {
-      parts.push(t('systemManager.tmux.lastCommand', { command: debug.tried[debug.tried.length - 1] ?? '' }));
-    }
-    return parts.filter(Boolean).join(' · ');
-  }, [t]);
-
-  const loadDetails = useCallback(async (): Promise<TmuxWindowInfo[] | null> => {
-    setLoadingDetails(true);
-    setActionError(null);
-    setWindowsLoadDetail(null);
-    try {
-      const [windowsResult, clientsResult] = await Promise.all([
-        backend.listTmuxWindows({ sessionId, sessionName: session.name }),
-        backend.listTmuxClients({ sessionId, sessionName: session.name }),
-      ]);
-      if (!windowsResult.success) {
-        const detail = formatTmuxLoadError(
-          windowsResult.error || t('systemManager.errors.loadTmuxWindows'),
-          windowsResult.debug,
-        );
-        setWindowsLoadDetail(detail);
-        throw new Error(detail);
-      }
-      if (!clientsResult.success) throw new Error(clientsResult.error || t('systemManager.errors.loadTmuxClients'));
-      const freshWindows = windowsResult.windows ?? [];
-      if (freshWindows.length === 0 && session.windows > 0) {
-        const detail = formatTmuxLoadError(
-          t('systemManager.tmux.windowsMismatch', { count: String(session.windows) }),
-          windowsResult.debug,
-        );
-        setWindowsLoadDetail(detail);
-        throw new Error(detail);
-      }
-      setWindows(freshWindows);
-      setClients(clientsResult.clients ?? []);
-      return freshWindows;
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : t('systemManager.errors.actionFailed'));
-      setWindows([]);
-      return null;
-    } finally {
-      setLoadingDetails(false);
-    }
-  }, [backend, formatTmuxLoadError, session.name, session.windows, sessionId, t]);
+  const windows = detailsRecord?.data?.windows ?? [];
+  const clients = detailsRecord?.data?.clients ?? [];
+  const loadingDetails = detailsRecord?.loading ?? false;
+  const windowsLoadDetail = detailsRecord?.error ?? null;
+  const summaryKey = useMemo(
+    () => `${session.name}|${session.created}|${session.windows}|${session.attached}|${session.activity ?? ''}`,
+    [session.activity, session.attached, session.created, session.name, session.windows],
+  );
+  const lastExpandedSummaryKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (expanded) void loadDetails();
-  }, [expanded, loadDetails]);
+    if (!expanded) {
+      lastExpandedSummaryKeyRef.current = null;
+      return;
+    }
+    if (lastExpandedSummaryKeyRef.current === null) {
+      lastExpandedSummaryKeyRef.current = summaryKey;
+      return;
+    }
+    if (lastExpandedSummaryKeyRef.current === summaryKey) return;
+    lastExpandedSummaryKeyRef.current = summaryKey;
+    void onRefreshDetails(session);
+  }, [expanded, onRefreshDetails, session, summaryKey]);
 
   const runAction = async (action: TmuxManageAction) => {
     setBusy(true);
@@ -135,7 +106,7 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
       if (!result.success) throw new Error(result.error || t('systemManager.errors.actionFailed'));
       const cardWillRemount = action.action === 'killSession' || action.action === 'renameSession';
       if (!cardWillRemount && expanded) {
-        await loadDetails();
+        await onRefreshDetails(session);
       }
       await onSessionsChanged();
     } catch (err) {
@@ -170,7 +141,13 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
     <>
       <SystemPanelRow
         selected={expanded}
-        onClick={() => setExpanded((v) => !v)}
+        onClick={() => {
+          const nextExpanded = !expanded;
+          setExpanded(nextExpanded);
+          if (nextExpanded) {
+            void onLoadDetails(session, { force: true, urgent: true });
+          }
+        }}
         title={session.name}
         subtitle={t('systemManager.tmux.windows', { count: String(session.windows) })}
         trailing={(

--- a/components/systemManager/hooks/useAsyncRecordCache.ts
+++ b/components/systemManager/hooks/useAsyncRecordCache.ts
@@ -1,0 +1,269 @@
+import { startTransition, useCallback, useEffect, useRef, useState } from 'react';
+
+export interface AsyncRecordState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  updatedAt: number | null;
+}
+
+type RecordMap<T> = Record<string, AsyncRecordState<T>>;
+
+interface UseAsyncRecordCacheOptions<TItem, TValue> {
+  items: TItem[];
+  enabled: boolean;
+  getKey: (item: TItem) => string;
+  fetchRecord: (item: TItem) => Promise<TValue | null>;
+  prefetchLimit?: number;
+  prefetchDelayMs?: number;
+  staleTimeMs?: number;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function scheduleIdleTask(callback: () => void): () => void {
+  if (typeof window.requestIdleCallback === 'function') {
+    const id = window.requestIdleCallback(callback, { timeout: 1200 });
+    return () => window.cancelIdleCallback(id);
+  }
+
+  const id = window.setTimeout(callback, 80);
+  return () => window.clearTimeout(id);
+}
+
+function normalizeRecordError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || 'Unknown error');
+}
+
+function isRecordFresh<TValue>(record: AsyncRecordState<TValue> | undefined, staleTimeMs: number): boolean {
+  if (!record || record.error || record.updatedAt === null) return false;
+  if (!Number.isFinite(staleTimeMs)) return true;
+  return Date.now() - record.updatedAt < staleTimeMs;
+}
+
+const EMPTY_RECORDS = {};
+
+export function useAsyncRecordCache<TItem, TValue>({
+  items,
+  enabled,
+  getKey,
+  fetchRecord,
+  prefetchLimit = 64,
+  prefetchDelayMs = 16,
+  staleTimeMs = 30_000,
+}: UseAsyncRecordCacheOptions<TItem, TValue>) {
+  const [records, setRecords] = useState<RecordMap<TValue>>(() => EMPTY_RECORDS);
+  const recordsRef = useRef<RecordMap<TValue>>(records);
+  const enabledRef = useRef(enabled);
+  const inflightRef = useRef(new Set<string>());
+  const requestVersionRef = useRef(new Map<string, number>());
+  const queuedForceRef = useRef(new Set<string>());
+  const loadRecordRef = useRef<(
+    item: TItem,
+    options?: { force?: boolean; urgent?: boolean },
+  ) => Promise<void>>(async () => {});
+
+  recordsRef.current = records;
+  enabledRef.current = enabled;
+
+  const commitRecords = useCallback((
+    updater: (prev: RecordMap<TValue>) => RecordMap<TValue>,
+    urgent = false,
+  ) => {
+    const apply = () => {
+      setRecords((prev) => {
+        const next = updater(prev);
+        recordsRef.current = next;
+        return next;
+      });
+    };
+
+    if (urgent) {
+      apply();
+      return;
+    }
+
+    startTransition(apply);
+  }, []);
+
+  const loadRecord = useCallback(async (
+    item: TItem,
+    options?: { force?: boolean; urgent?: boolean },
+  ) => {
+    if (!enabledRef.current) return;
+    const key = getKey(item);
+    if (!key) return;
+    if (inflightRef.current.has(key)) {
+      if (options?.force) {
+        queuedForceRef.current.add(key);
+        requestVersionRef.current.set(key, (requestVersionRef.current.get(key) ?? 0) + 1);
+      }
+      return;
+    }
+
+    const existing = recordsRef.current[key];
+    if (!options?.force && isRecordFresh(existing, staleTimeMs)) {
+      return;
+    }
+
+    const requestVersion = (requestVersionRef.current.get(key) ?? 0) + 1;
+    requestVersionRef.current.set(key, requestVersion);
+    inflightRef.current.add(key);
+    commitRecords((prev) => ({
+      ...prev,
+      [key]: {
+        data: prev[key]?.data ?? null,
+        loading: true,
+        error: null,
+        updatedAt: prev[key]?.updatedAt ?? null,
+      },
+    }), options?.urgent);
+
+    try {
+      const data = await fetchRecord(item);
+      if (requestVersionRef.current.get(key) !== requestVersion) return;
+      commitRecords((prev) => ({
+        ...prev,
+        [key]: {
+          data,
+          loading: false,
+          error: null,
+          updatedAt: Date.now(),
+        },
+      }));
+    } catch (error) {
+      if (requestVersionRef.current.get(key) !== requestVersion) return;
+      commitRecords((prev) => ({
+        ...prev,
+        [key]: {
+          data: prev[key]?.data ?? null,
+          loading: false,
+          error: normalizeRecordError(error),
+          updatedAt: prev[key]?.updatedAt ?? null,
+        },
+      }));
+    } finally {
+      inflightRef.current.delete(key);
+      if (queuedForceRef.current.has(key)) {
+        if (enabledRef.current) {
+          queuedForceRef.current.delete(key);
+          void loadRecordRef.current(item, { force: true, urgent: options?.urgent });
+        } else {
+          commitRecords((prev) => {
+            const current = prev[key];
+            if (!current?.loading) return prev;
+            return {
+              ...prev,
+              [key]: {
+                ...current,
+                loading: false,
+              },
+            };
+          }, true);
+        }
+      }
+    }
+  }, [commitRecords, fetchRecord, getKey, staleTimeMs]);
+
+  loadRecordRef.current = loadRecord;
+
+  useEffect(() => {
+    const itemKeys = new Set(items.map(getKey).filter(Boolean));
+    for (const key of queuedForceRef.current) {
+      if (!itemKeys.has(key)) {
+        queuedForceRef.current.delete(key);
+      }
+    }
+    commitRecords((prev) => {
+      let changed = false;
+      const next: RecordMap<TValue> = {};
+      for (const [key, value] of Object.entries(prev) as Array<[string, AsyncRecordState<TValue>]>) {
+        if (!itemKeys.has(key)) {
+          changed = true;
+          continue;
+        }
+        next[key] = value;
+      }
+      return changed ? next : prev;
+    });
+  }, [commitRecords, getKey, items]);
+
+  useEffect(() => {
+    if (!enabled || queuedForceRef.current.size === 0) return;
+    for (const item of items) {
+      const key = getKey(item);
+      if (!key || !queuedForceRef.current.has(key)) continue;
+      queuedForceRef.current.delete(key);
+      void loadRecord(item, { force: true, urgent: true });
+    }
+  }, [enabled, getKey, items, loadRecord]);
+
+  useEffect(() => {
+    if (!enabled || items.length === 0 || prefetchLimit <= 0) return undefined;
+
+    let cancelled = false;
+    const candidates = items.slice(0, prefetchLimit);
+    const cancelIdleTask = scheduleIdleTask(() => {
+      void (async () => {
+        for (const item of candidates) {
+          if (cancelled) return;
+          await loadRecord(item);
+          if (prefetchDelayMs > 0) {
+            await delay(prefetchDelayMs);
+          }
+        }
+      })();
+    });
+
+    return () => {
+      cancelled = true;
+      cancelIdleTask();
+    };
+  }, [enabled, items, loadRecord, prefetchDelayMs, prefetchLimit]);
+
+  const invalidateRecord = useCallback((key: string) => {
+    requestVersionRef.current.set(key, (requestVersionRef.current.get(key) ?? 0) + 1);
+    queuedForceRef.current.delete(key);
+    commitRecords((prev) => {
+      if (!(key in prev)) return prev;
+      const { [key]: _removed, ...next } = prev;
+      return next;
+    }, true);
+  }, [commitRecords]);
+
+  const invalidateMatching = useCallback((matches: (key: string) => boolean) => {
+    for (const key of requestVersionRef.current.keys()) {
+      if (matches(key)) {
+        requestVersionRef.current.set(key, (requestVersionRef.current.get(key) ?? 0) + 1);
+        queuedForceRef.current.delete(key);
+      }
+    }
+    commitRecords((prev) => {
+      let changed = false;
+      const next: RecordMap<TValue> = {};
+      for (const [key, value] of Object.entries(prev) as Array<[string, AsyncRecordState<TValue>]>) {
+        if (matches(key)) {
+          changed = true;
+          continue;
+        }
+        next[key] = value;
+      }
+      return changed ? next : prev;
+    }, true);
+  }, [commitRecords]);
+
+  const refreshRecord = useCallback(
+    (item: TItem) => loadRecord(item, { force: true, urgent: true }),
+    [loadRecord],
+  );
+
+  return {
+    records,
+    loadRecord,
+    refreshRecord,
+    invalidateRecord,
+    invalidateMatching,
+  };
+}

--- a/components/systemManager/hooks/useSystemManager.ts
+++ b/components/systemManager/hooks/useSystemManager.ts
@@ -113,20 +113,37 @@ export function usePolling<T>(
   intervalMs: number,
   enabled: boolean,
   merge?: (prev: T | null, next: T) => T,
+  options?: { poll?: boolean; resetKey?: string },
 ) {
   const stableT = useStableTranslate();
+  const resetKey = options?.resetKey ?? '';
   const [data, setData] = useState<T | null>(null);
+  const [dataKey, setDataKey] = useState(resetKey);
   const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState(resetKey);
   const [loading, setLoading] = useState(false);
+  const [loadingKey, setLoadingKey] = useState(resetKey);
   const failuresRef = useRef(0);
   const hasDataRef = useRef(false);
-  const inflightRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  const generationRef = useRef(0);
+  const runIdRef = useRef(0);
+  const loadingRunIdRef = useRef(0);
+  const inflightRef = useRef<{ generation: number; runId: number } | null>(null);
+  const queuedRunRef = useRef<{
+    options?: { withLoading?: boolean; minLoadingMs?: number };
+    resolve: () => void;
+  } | null>(null);
   const fetcherRef = useRef(fetcher);
   const mergeRef = useRef(merge);
+  const pollRef = useRef(options?.poll ?? true);
+  const resetKeyRef = useRef(resetKey);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  enabledRef.current = enabled;
   fetcherRef.current = fetcher;
   mergeRef.current = merge;
+  pollRef.current = options?.poll ?? true;
 
   const clearPollTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -140,70 +157,163 @@ export function usePolling<T>(
     return intervalMs;
   }, [intervalMs]);
 
+  const resolveQueuedRun = useCallback(() => {
+    queuedRunRef.current?.resolve();
+    queuedRunRef.current = null;
+  }, []);
+
   const run = useCallback(async (options?: { withLoading?: boolean; minLoadingMs?: number }) => {
-    if (!enabled || inflightRef.current) return;
-    inflightRef.current = true;
+    const generation = generationRef.current;
+    const runResetKey = resetKeyRef.current;
+    if (!enabledRef.current) return;
+    if (inflightRef.current?.generation === generation) {
+      if (options?.withLoading) {
+        queuedRunRef.current?.resolve();
+        loadingRunIdRef.current = 0;
+        setLoadingKey(runResetKey);
+        setLoading(true);
+        return new Promise<void>((resolve) => {
+          queuedRunRef.current = { options, resolve };
+        });
+      }
+      return;
+    }
+    const runId = ++runIdRef.current;
+    inflightRef.current = { generation, runId };
     const showLoading = options?.withLoading ?? !hasDataRef.current;
     const startedAt = Date.now();
-    if (showLoading) setLoading(true);
+    const isCurrent = () => (
+      generationRef.current === generation
+      && enabledRef.current
+      && inflightRef.current?.runId === runId
+      && resetKeyRef.current === runResetKey
+    );
+    if (showLoading) {
+      loadingRunIdRef.current = runId;
+      setLoadingKey(runResetKey);
+      setLoading(true);
+    }
     try {
       const result = await fetcherRef.current();
+      if (!isCurrent()) return;
       if (result !== null) {
+        setDataKey(runResetKey);
         setData((prev) => {
           const mergeFn = mergeRef.current;
           const next = mergeFn ? mergeFn(prev, result) : nextPollData(prev, result);
           if (next !== prev) hasDataRef.current = true;
           return next;
         });
+        setErrorKey(runResetKey);
         setError(null);
         failuresRef.current = 0;
       }
     } catch (err) {
+      if (!isCurrent()) return;
       failuresRef.current += 1;
+      setDataKey(runResetKey);
       setData(null);
       hasDataRef.current = false;
+      setErrorKey(runResetKey);
       setError(normalizePollingErrorMessage(err, stableT));
     } finally {
-      inflightRef.current = false;
+      if (inflightRef.current?.runId === runId) {
+        inflightRef.current = null;
+      }
       if (showLoading) {
         const remaining = Math.max(0, (options?.minLoadingMs ?? 0) - (Date.now() - startedAt));
         if (remaining > 0) await delay(remaining);
-        setLoading(false);
+        if (
+          generationRef.current === generation
+          && enabledRef.current
+          && resetKeyRef.current === runResetKey
+          && loadingRunIdRef.current === runId
+        ) {
+          loadingRunIdRef.current = 0;
+          setLoadingKey(runResetKey);
+          setLoading(false);
+        }
+      }
+      const queued = queuedRunRef.current;
+      if (
+        queued
+        && generationRef.current === generation
+        && enabledRef.current
+        && resetKeyRef.current === runResetKey
+      ) {
+        queuedRunRef.current = null;
+        await run(queued.options);
+        queued.resolve();
       }
     }
-  }, [enabled, stableT]);
+  }, [stableT]);
 
   const scheduleNextPoll = useCallback(() => {
     clearPollTimer();
-    if (!enabled) return;
+    if (!enabledRef.current || !pollRef.current) return;
+    const generation = generationRef.current;
     timerRef.current = setTimeout(() => {
       void run({ withLoading: false }).finally(() => {
-        scheduleNextPoll();
+        if (generationRef.current === generation) {
+          scheduleNextPoll();
+        }
       });
     }, pollDelayMs());
-  }, [clearPollTimer, enabled, pollDelayMs, run]);
+  }, [clearPollTimer, pollDelayMs, run]);
 
   useEffect(() => {
+    const resetChanged = resetKeyRef.current !== resetKey;
+    resetKeyRef.current = resetKey;
+    generationRef.current += 1;
+    inflightRef.current = null;
+    clearPollTimer();
     if (!enabled) {
-      clearPollTimer();
+      resolveQueuedRun();
+      loadingRunIdRef.current = 0;
+      setLoading(false);
+      setLoadingKey(resetKey);
+      setDataKey(resetKey);
       setData(null);
+      setErrorKey(resetKey);
       setError(null);
       failuresRef.current = 0;
       hasDataRef.current = false;
       return undefined;
     }
+    if (resetChanged) {
+      resolveQueuedRun();
+      loadingRunIdRef.current = 0;
+      setLoading(false);
+      setLoadingKey(resetKey);
+      setDataKey(resetKey);
+      setData(null);
+      setErrorKey(resetKey);
+      setError(null);
+      failuresRef.current = 0;
+      hasDataRef.current = false;
+    }
+    const generation = generationRef.current;
     void run({ withLoading: true }).finally(() => {
-      scheduleNextPoll();
+      if (generationRef.current === generation && pollRef.current) scheduleNextPoll();
     });
     return () => {
+      generationRef.current += 1;
+      resolveQueuedRun();
+      loadingRunIdRef.current = 0;
+      inflightRef.current = null;
       clearPollTimer();
     };
-  }, [clearPollTimer, enabled, intervalMs, run, scheduleNextPoll]);
+  }, [clearPollTimer, enabled, intervalMs, options?.poll, resetKey, resolveQueuedRun, run, scheduleNextPoll]);
 
   const refresh = useCallback(async () => {
     failuresRef.current = 0;
     await run({ withLoading: true, minLoadingMs: 450 });
   }, [run]);
 
-  return { data, error, loading, refresh };
+  return {
+    data: dataKey === resetKey ? data : null,
+    error: errorKey === resetKey ? error : null,
+    loading: loadingKey === resetKey ? loading : enabled,
+    refresh,
+  };
 }

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -484,7 +484,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                   editorWordWrap={editorWordWrap}
                   setEditorWordWrap={setEditorWordWrap}
                   onGetTerminalCwd={getTerminalCwd}
-                  activeTerminalCwd={activeTerminalCwd}
+                  activeTerminalCwd={isVisibleSftpPanel && sftpFollowTerminalCwd ? activeTerminalCwd : null}
                   sftpFollowTerminalCwd={sftpFollowTerminalCwd}
                   onSftpFollowTerminalCwdChange={setSftpFollowTerminalCwd}
                   onRequestTerminalFocus={refocusActiveTerminalSession}

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -22,6 +22,8 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
     sidePanelWidth,
   });
 
+  const activityEscapeFiltersRef = useRef<any>(new Map());
+
   const remeasureWorkspaceArea = useCallback(() => {
     const el = workspaceInnerRef.current;
     if (!el) return;
@@ -219,11 +221,22 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
     }, [activeTabId, sessions]);
   
   useEffect(() => {
+      const activeSessionIds = new Set(activityTrackedSessions.map((session) => session.id));
+      for (const sessionId of activityEscapeFiltersRef.current.keys()) {
+        if (!activeSessionIds.has(sessionId)) {
+          activityEscapeFiltersRef.current.delete(sessionId);
+        }
+      }
+
       const unsubscribers = activityTrackedSessions.map((session) => {
-        const filter = new ChunkedEscapeFilter();
+        let filter = activityEscapeFiltersRef.current.get(session.id);
+        if (!filter) {
+          filter = new ChunkedEscapeFilter();
+          activityEscapeFiltersRef.current.set(session.id, filter);
+        }
         return onSessionData(session.id, (chunk) => {
           if (!hasNotifiableTerminalOutput(filter, chunk)) return;
-  
+
           if (!shouldMarkSessionActivity(activeTabIdRef.current, session)) {
             return;
           }


### PR DESCRIPTION
## Summary
- Keep terminal side panel data warm so AI, system, tmux, Docker, and process views can render from already-fetched state where possible.
- Reduce first-paint pressure in heavier panels by showing cached or pending states instead of blank screens.
- Virtualize the process list so only visible rows are rendered, while keeping Sleeping/status pills and action buttons visible and aligned.

## Test Plan
- npm run lint -- --max-warnings=0
- npm test
- npm run build