### PR TITLE
Prevent app reload shortcut from closing sessions

### DIFF
--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1132,7 +1132,6 @@ function buildAppMenu(Menu, app, isMac, language = currentLanguage) {
       label: tMenu(language, "view"),
       submenu: [
         { label: tMenu(language, "reload"), click: (_, win) => { if (win) win.reload(); } },
-        { role: "forceReload" },
         { role: "toggleDevTools" },
         { type: "separator" },
         { role: "resetZoom" },

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -297,6 +297,39 @@ test("buildAppMenu sends Cmd+W to any registered main window renderer", () => {
   }
 });
 
+test("buildAppMenu keeps app reload click-only so custom reload-like shortcuts reach the renderer", () => {
+  let capturedTemplate = null;
+  const Menu = {
+    buildFromTemplate(template) {
+      capturedTemplate = template;
+      return { template };
+    },
+  };
+
+  buildAppMenu(Menu, { name: "Netcatty" }, false);
+
+  const viewMenu = capturedTemplate.find((item) => item.label === "View");
+  assert.ok(viewMenu);
+  assert.equal(viewMenu.submenu.some((item) => item.role === "reload"), false);
+  assert.equal(viewMenu.submenu.some((item) => item.role === "forceReload"), false);
+  assert.equal(viewMenu.submenu.some((item) => item.accelerator === "CommandOrControl+R"), false);
+  assert.equal(viewMenu.submenu.some((item) => item.accelerator === "CommandOrControl+Shift+R"), false);
+
+  const reloadItem = viewMenu.submenu.find((item) => item.label === "Reload");
+  assert.ok(reloadItem);
+  assert.equal(reloadItem.role, undefined);
+  assert.equal(reloadItem.accelerator, undefined);
+
+  const calls = [];
+  reloadItem.click(null, {
+    reload() {
+      calls.push("reload");
+    },
+  });
+
+  assert.deepEqual(calls, ["reload"]);
+});
+
 test("requestWindowCommandClose sends command-close to renderer-capable windows", () => {
   const sentChannels = [];
   const win = {
@@ -432,6 +465,121 @@ test("main window asks renderer to close tabs from macOS Command+W before-input-
 
   assert.equal(prevented, true);
   assert.equal(commandCloseRequests.length, 1);
+});
+
+test("main window leaves primary-modifier reload-like shortcuts available to renderer handlers", async () => {
+  let beforeInputHandler = null;
+  const ignoreMenuShortcutValues = [];
+
+  class BrowserWindowStub {
+    constructor() {
+      this.webContents = {
+        id: 1,
+        on(channel, handler) {
+          if (channel === "before-input-event") beforeInputHandler = handler;
+        },
+        once() {},
+        isDestroyed() {
+          return false;
+        },
+        isCrashed() {
+          return false;
+        },
+        setIgnoreMenuShortcuts(value) {
+          ignoreMenuShortcutValues.push(value);
+        },
+        setWindowOpenHandler() {},
+        openDevTools() {},
+      };
+    }
+
+    on() {}
+    once() {}
+    isDestroyed() { return false; }
+    isMaximized() { return false; }
+    isFullScreen() { return false; }
+    getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
+    setBackgroundColor() {}
+    setOpacity() {}
+    async loadURL() {}
+    close() {}
+  }
+
+  const api = createMainWindowApi({
+    mainWindow: null,
+    electronApp: null,
+    currentTheme: "light",
+    isQuitting: false,
+    pendingWindowStateWrite: null,
+    queuedWindowState: null,
+    windowStateCloseRequested: false,
+    DEFAULT_WINDOW_WIDTH: 1400,
+    DEFAULT_WINDOW_HEIGHT: 900,
+    MIN_WINDOW_WIDTH: 1100,
+    MIN_WINDOW_HEIGHT: 640,
+    V8_CACHE_OPTIONS: "bypassHeatCheck",
+    THEME_COLORS: { light: { background: "#fff" } },
+    unhealthyWebContentsIds: new Set(),
+    rendererReadySeenByWebContentsId: new Set(),
+    __dirname,
+    URL,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    getGlobalShortcutBridge() {
+      return { handleWindowClose: () => false };
+    },
+    debugLog() {},
+    resolveFrontendBackgroundColor() { return null; },
+    loadWindowState() { return null; },
+    getDevRendererBaseUrl(url) { return url; },
+    getWindowBoundsState() { return null; },
+    queueWindowStateSave() {},
+    saveWindowStateSync() {},
+    setupDeferredShow() {},
+    createExternalOnlyWindowOpenHandler() { return {}; },
+    createAppWindowOpenHandler() { return {}; },
+    attachOAuthLoadingOverlay() {},
+    registerWindowHandlers() {},
+    requestWindowCommandClose() {
+      return true;
+    },
+    shouldCloseWindowFromInput,
+    applyWindowOpacityToWindow() {},
+    closeSettingsWindow() {},
+    hideSettingsWindow() {},
+  });
+
+  await api.createWindow(
+    {
+      BrowserWindow: BrowserWindowStub,
+      nativeTheme: {},
+      app: {},
+      screen: {},
+      shell: {},
+      ipcMain: {},
+    },
+    {
+      preload: "/tmp/preload.cjs",
+      devServerUrl: "http://localhost:5173",
+      isDev: true,
+      appIcon: null,
+      isMac: false,
+      electronDir: __dirname,
+    },
+  );
+
+  let prevented = false;
+  beforeInputHandler({ preventDefault: () => { prevented = true; } }, {
+    type: "keyDown",
+    control: true,
+    shift: true,
+    key: "R",
+  });
+
+  assert.equal(prevented, false);
+  assert.deepEqual(ignoreMenuShortcutValues, [false]);
 });
 
 test("createWindow registers each main window as an independent app window", async () => {


### PR DESCRIPTION
## Summary
- Remove the built-in force reload menu shortcut from the main app window.
- Keep the manual Reload menu item available by click only.
- Add coverage so reload-like shortcuts remain available to renderer/custom shortcut handlers.

Fixes #1428

## Validation
- npm test
- npm run lint
- git diff --check
