### PR TITLE
[codex] Add SFTP tab duplication menu

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -258,6 +258,8 @@ export const enVaultMessages: Messages = {
   'sftp.tabs.addTab': 'Add new tab',
   'sftp.tabs.closeTab': 'Close tab',
   'sftp.tabs.newTab': 'New Tab',
+  'sftp.tabs.copyDefaultPath': 'Copy tab (default path)',
+  'sftp.tabs.copyCurrentPath': 'Copy and go to current path',
   'sftp.conflict.title': 'File Conflict',
   'sftp.conflict.desc': 'A file with the same name already exists at the destination',
   'sftp.conflict.alreadyExistsSuffix': 'already exists',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -293,6 +293,8 @@ export const ruVaultMessages: Messages = {
   'sftp.tabs.addTab': 'Добавить новую вкладку',
   'sftp.tabs.closeTab': 'Закрыть вкладку',
   'sftp.tabs.newTab': 'Новая вкладка',
+  'sftp.tabs.copyDefaultPath': 'Копировать вкладку (путь по умолчанию)',
+  'sftp.tabs.copyCurrentPath': 'Копировать и перейти к текущему пути',
   'sftp.conflict.title': 'Конфликт файлов',
   'sftp.conflict.desc': 'В месте назначения уже существует файл с таким именем',
   'sftp.conflict.alreadyExistsSuffix': 'уже существует',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -676,6 +676,8 @@ export const zhCNVaultMessages: Messages = {
   'sftp.tabs.addTab': '新建标签页',
   'sftp.tabs.closeTab': '关闭标签页',
   'sftp.tabs.newTab': '新标签页',
+  'sftp.tabs.copyDefaultPath': '复制标签页（默认路径）',
+  'sftp.tabs.copyCurrentPath': '复制并跳转到当前路径',
   'sftp.conflict.title': '文件冲突',
   'sftp.conflict.desc': '目标位置已存在同名文件',
   'sftp.conflict.alreadyExistsSuffix': '已存在',

--- a/application/state/sftp/sftpConnectStartPath.test.ts
+++ b/application/state/sftp/sftpConnectStartPath.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { RemoteSftpStartCache } from "./sftpConnectStartPath.ts";
+import {
+  normalizeSftpInitialPath,
+  resolveRemoteSftpStartState,
+} from "./sftpConnectStartPath.ts";
+
+const cached: RemoteSftpStartCache = {
+  path: "/var/cache",
+  homeDir: "/home/deploy",
+  files: [],
+  filenameEncoding: "auto",
+};
+
+test("remote SFTP default-path duplication ignores the shared host cache", () => {
+  const state = resolveRemoteSftpStartState({
+    filenameEncoding: "auto",
+    ignoreSharedCache: true,
+    sharedHostCacheCandidate: cached,
+  });
+
+  assert.equal(state.initialPath, undefined);
+  assert.equal(state.sharedHostCache, null);
+  assert.equal(state.cachedStartPath, "/");
+});
+
+test("remote SFTP current-path duplication uses the requested path instead of stale cache", () => {
+  const state = resolveRemoteSftpStartState({
+    filenameEncoding: "auto",
+    initialPath: "/var/www/app",
+    sharedHostCacheCandidate: cached,
+  });
+
+  assert.equal(state.initialPath, "/var/www/app");
+  assert.equal(state.sharedHostCache, null);
+  assert.equal(state.cachedStartPath, "/var/www/app");
+});
+
+test("remote SFTP initial paths preserve meaningful whitespace", () => {
+  assert.equal(normalizeSftpInitialPath("/var/www/app "), "/var/www/app ");
+
+  const state = resolveRemoteSftpStartState({
+    filenameEncoding: "auto",
+    initialPath: "/var/www/app ",
+    sharedHostCacheCandidate: {
+      ...cached,
+      path: "/var/www/app",
+    },
+  });
+
+  assert.equal(state.initialPath, "/var/www/app ");
+  assert.equal(state.sharedHostCache, null);
+  assert.equal(state.cachedStartPath, "/var/www/app ");
+});

--- a/application/state/sftp/sftpConnectStartPath.ts
+++ b/application/state/sftp/sftpConnectStartPath.ts
@@ -1,0 +1,44 @@
+import type { SftpFileEntry, SftpFilenameEncoding } from "../../../domain/models";
+
+export interface RemoteSftpStartCache {
+  path: string;
+  homeDir: string;
+  files: SftpFileEntry[];
+  filenameEncoding: SftpFilenameEncoding;
+}
+
+interface ResolveRemoteSftpStartStateParams {
+  filenameEncoding: SftpFilenameEncoding;
+  ignoreSharedCache?: boolean;
+  initialPath?: string;
+  sharedHostCacheCandidate: RemoteSftpStartCache | null;
+}
+
+export function normalizeSftpInitialPath(initialPath?: string): string | undefined {
+  return initialPath === undefined || initialPath.length === 0 ? undefined : initialPath;
+}
+
+export function resolveRemoteSftpStartState({
+  filenameEncoding,
+  ignoreSharedCache,
+  initialPath,
+  sharedHostCacheCandidate,
+}: ResolveRemoteSftpStartStateParams): {
+  initialPath: string | undefined;
+  sharedHostCache: RemoteSftpStartCache | null;
+  cachedStartPath: string;
+} {
+  const requestedInitialPath = normalizeSftpInitialPath(initialPath);
+  const sharedHostCache =
+    !ignoreSharedCache
+      && sharedHostCacheCandidate?.filenameEncoding === filenameEncoding
+      && (!requestedInitialPath || sharedHostCacheCandidate.path === requestedInitialPath)
+      ? sharedHostCacheCandidate
+      : null;
+
+  return {
+    initialPath: requestedInitialPath,
+    sharedHostCache,
+    cachedStartPath: requestedInitialPath ?? sharedHostCache?.path ?? "/",
+  };
+}

--- a/application/state/sftp/sharedRemoteHostCache.ts
+++ b/application/state/sftp/sharedRemoteHostCache.ts
@@ -1,6 +1,6 @@
 import type { SftpFileEntry, SftpFilenameEncoding } from "../../../domain/models";
 
-interface SharedRemoteHostCacheEntry {
+export interface SharedRemoteHostCacheEntry {
   path: string;
   homeDir: string;
   files: SftpFileEntry[];

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -34,8 +34,16 @@ interface UseSftpConnectionsParams {
   autoConnectLocalOnMount?: boolean;
 }
 
+export interface SftpConnectOptions {
+  forceNewTab?: boolean;
+  ignoreSharedCache?: boolean;
+  initialPath?: string;
+  onTabCreated?: (tabId: string) => void;
+  sourceSessionId?: string;
+}
+
 interface UseSftpConnectionsResult {
-  connect: (side: "left" | "right", host: Host | "local", options?: { forceNewTab?: boolean; onTabCreated?: (tabId: string) => void }) => Promise<void>;
+  connect: (side: "left" | "right", host: Host | "local", options?: SftpConnectOptions) => Promise<void>;
   disconnect: (side: "left" | "right") => Promise<void>;
   listLocalFiles: (path: string) => Promise<SftpFileEntry[]>;
   listRemoteFiles: (sftpId: string, path: string, encoding?: SftpFilenameEncoding) => Promise<SftpFileEntry[]>;
@@ -71,7 +79,7 @@ export const useSftpConnections = ({
   const { listLocalFiles, listRemoteFiles } = useSftpDirectoryListing();
 
   const connect = useCallback(
-    async (side: "left" | "right", host: Host | "local", options?: { forceNewTab?: boolean; onTabCreated?: (tabId: string) => void; sourceSessionId?: string }) => {
+    async (side: "left" | "right", host: Host | "local", options?: SftpConnectOptions) => {
       const setTabs = side === "left" ? setLeftTabs : setRightTabs;
 
       let activeTabId: string | null = null;
@@ -147,13 +155,15 @@ export const useSftpConnections = ({
           homeDir = isWindows ? "C:\\Users\\damao" : "/Users/damao";
         }
 
+        const startPath = options?.initialPath || homeDir;
+
         const connection: SftpConnection = {
           id: connectionId,
           hostId: "local",
           hostLabel: "Local",
           isLocal: true,
           status: "connected",
-          currentPath: homeDir,
+          currentPath: startPath,
           homeDir,
         };
 
@@ -168,9 +178,9 @@ export const useSftpConnections = ({
         }));
 
         try {
-          const files = await listLocalFiles(homeDir);
+          const files = await listLocalFiles(startPath);
           if (navSeqRef.current[side] !== connectRequestId) return;
-          dirCacheRef.current.set(makeCacheKey(connectionId, homeDir, filenameEncoding), {
+          dirCacheRef.current.set(makeCacheKey(connectionId, startPath, filenameEncoding), {
             files,
             timestamp: Date.now(),
           });
@@ -193,12 +203,16 @@ export const useSftpConnections = ({
         }
       } else {
         const hostCacheKey = buildCacheKey(host.id, host.hostname, host.port, host.protocol, host.sftpSudo, host.username);
-        const sharedHostCacheCandidate = getSharedRemoteHostCache(hostCacheKey);
+        const initialPath = options?.initialPath?.trim();
+        const sharedHostCacheCandidate = options?.ignoreSharedCache
+          ? null
+          : getSharedRemoteHostCache(hostCacheKey);
         const sharedHostCache =
           sharedHostCacheCandidate?.filenameEncoding === filenameEncoding
+            && (!initialPath || sharedHostCacheCandidate.path === initialPath)
             ? sharedHostCacheCandidate
             : null;
-        const cachedStartPath = sharedHostCache?.path ?? "/";
+        const cachedStartPath = initialPath || sharedHostCache?.path || "/";
 
         const connection: SftpConnection = {
           id: connectionId,
@@ -393,6 +407,10 @@ export const useSftpConnections = ({
                 }
               }
             }
+          }
+
+          if (initialPath) {
+            startPath = initialPath;
           }
 
           const provisionalCacheKey = sharedHostCache

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -6,6 +6,7 @@ import type { SftpPane } from "./types";
 import { useSftpDirectoryListing } from "./useSftpDirectoryListing";
 import { useSftpHostCredentials } from "./useSftpHostCredentials";
 import { buildCacheKey, getSharedRemoteHostCache, setSharedRemoteHostCache } from "./sharedRemoteHostCache";
+import { resolveRemoteSftpStartState } from "./sftpConnectStartPath";
 
 interface UseSftpConnectionsParams {
   hosts: Host[];
@@ -109,6 +110,33 @@ export const useSftpConnections = ({
 
       navSeqRef.current[side] += 1;
       const connectRequestId = navSeqRef.current[side];
+      const getTargetPane = () => {
+        const tabs = side === "left" ? leftTabsRef.current.tabs : rightTabsRef.current.tabs;
+        return tabs.find((tab) => tab.id === activeTabId) ?? null;
+      };
+      const isTargetConnectionCurrent = () => {
+        const pane = getTargetPane();
+        if (!pane) return false;
+        if (pane.connection?.id === connectionId) return true;
+        return !pane.connection && navSeqRef.current[side] === connectRequestId;
+      };
+      const isTargetConnectionAtPath = (path: string) => {
+        const connection = getTargetPane()?.connection;
+        if (!connection) return navSeqRef.current[side] === connectRequestId;
+        return connection?.id === connectionId && connection.currentPath === path;
+      };
+      const closeSftpSessionForConnection = async () => {
+        const sftpId = sftpSessionsRef.current.get(connectionId);
+        sftpSessionsRef.current.delete(connectionId);
+        connectionCacheKeyMapRef.current.delete(connectionId);
+        clearCacheForConnection(connectionId);
+        if (!sftpId) return;
+        try {
+          await netcattyBridge.get()?.closeSftp(sftpId);
+        } catch {
+          // Ignore errors when closing stale SFTP sessions
+        }
+      };
 
       lastConnectedHostRef.current[side] = host;
       // Store the cache key for this connection so pane actions can look it up
@@ -179,7 +207,7 @@ export const useSftpConnections = ({
 
         try {
           const files = await listLocalFiles(startPath);
-          if (navSeqRef.current[side] !== connectRequestId) return;
+          if (!isTargetConnectionAtPath(startPath)) return;
           dirCacheRef.current.set(makeCacheKey(connectionId, startPath, filenameEncoding), {
             files,
             timestamp: Date.now(),
@@ -192,7 +220,7 @@ export const useSftpConnections = ({
             reconnecting: false,
           }));
         } catch (err) {
-          if (navSeqRef.current[side] !== connectRequestId) return;
+          if (!isTargetConnectionAtPath(startPath)) return;
           reconnectingRef.current[side] = false;
           updateTab(side, activeTabId, (prev) => ({
             ...prev,
@@ -203,16 +231,15 @@ export const useSftpConnections = ({
         }
       } else {
         const hostCacheKey = buildCacheKey(host.id, host.hostname, host.port, host.protocol, host.sftpSudo, host.username);
-        const initialPath = options?.initialPath?.trim();
         const sharedHostCacheCandidate = options?.ignoreSharedCache
           ? null
           : getSharedRemoteHostCache(hostCacheKey);
-        const sharedHostCache =
-          sharedHostCacheCandidate?.filenameEncoding === filenameEncoding
-            && (!initialPath || sharedHostCacheCandidate.path === initialPath)
-            ? sharedHostCacheCandidate
-            : null;
-        const cachedStartPath = initialPath || sharedHostCache?.path || "/";
+        const { initialPath, sharedHostCache, cachedStartPath } = resolveRemoteSftpStartState({
+          filenameEncoding,
+          ignoreSharedCache: options?.ignoreSharedCache,
+          initialPath: options?.initialPath,
+          sharedHostCacheCandidate,
+        });
 
         const connection: SftpConnection = {
           id: connectionId,
@@ -278,7 +305,7 @@ export const useSftpConnections = ({
                 logLine = `${label} - ${status}${detail ? `: ${detail}` : ''}`;
             }
             // Only update if this is still the active request (avoids stale logs leaking)
-            if (navSeqRef.current[side] !== connectRequestId) return;
+            if (!isTargetConnectionCurrent()) return;
             updateTab(side, activeTabId, (prev) => ({
               ...prev,
               connectionLogs: [...prev.connectionLogs, logLine],
@@ -345,6 +372,10 @@ export const useSftpConnections = ({
           if (!sftpId) throw new Error("Failed to open SFTP session");
 
           sftpSessionsRef.current.set(connectionId, sftpId);
+          if (!isTargetConnectionCurrent()) {
+            await closeSftpSessionForConnection();
+            return;
+          }
 
           let startPath = sharedHostCache?.path ?? "/";
           let homeDir = sharedHostCache?.homeDir ?? startPath;
@@ -456,7 +487,10 @@ export const useSftpConnections = ({
               throw new Error("Cannot list any remote directory");
             }
           }
-          if (navSeqRef.current[side] !== connectRequestId) return;
+          if (!isTargetConnectionCurrent()) {
+            await closeSftpSessionForConnection();
+            return;
+          }
           dirCacheRef.current.set(makeCacheKey(connectionId, startPath, filenameEncoding), {
             files,
             timestamp: Date.now(),
@@ -487,7 +521,10 @@ export const useSftpConnections = ({
             connectionLogs: [], // Clear after successful connect to avoid replay during navigation
           }));
         } catch (err) {
-          if (navSeqRef.current[side] !== connectRequestId) return;
+          if (!isTargetConnectionCurrent()) {
+            await closeSftpSessionForConnection();
+            return;
+          }
           reconnectingRef.current[side] = false;
           updateTab(side, activeTabId, (prev) => ({
             ...prev,

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -374,9 +374,11 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
     handleReorderTabsRight,
     handleMoveTabFromLeftToRight,
     handleMoveTabFromRightToLeft,
+    handleDuplicateTabLeft,
+    handleDuplicateTabRight,
     handleHostSelectLeft,
     handleHostSelectRight,
-  } = useSftpViewTabs({ sftp, sftpRef });
+  } = useSftpViewTabs({ sftp, sftpRef, hosts: effectiveHosts });
 
   const handleAddTabLeftWithFocus = useCallback(() => {
     const tabId = handleAddTabLeft();
@@ -397,6 +399,26 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
     handleSelectTabRight(tabId);
     handlePaneFocus("right", tabId);
   }, [handlePaneFocus, handleSelectTabRight]);
+
+  const handleDuplicateTabLeftWithFocus = useCallback(
+    async (...args: Parameters<typeof handleDuplicateTabLeft>) => {
+      const tabId = await handleDuplicateTabLeft(...args);
+      if (tabId) {
+        handlePaneFocus("left", tabId);
+      }
+    },
+    [handleDuplicateTabLeft, handlePaneFocus],
+  );
+
+  const handleDuplicateTabRightWithFocus = useCallback(
+    async (...args: Parameters<typeof handleDuplicateTabRight>) => {
+      const tabId = await handleDuplicateTabRight(...args);
+      if (tabId) {
+        handlePaneFocus("right", tabId);
+      }
+    },
+    [handleDuplicateTabRight, handlePaneFocus],
+  );
 
   return (
     <SftpContextProvider
@@ -444,6 +466,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
                 onAddTab={handleAddTabLeftWithFocus}
                 onReorderTabs={handleReorderTabsLeft}
                 onMoveTabToOtherSide={handleMoveTabFromRightToLeft}
+                onDuplicateTab={handleDuplicateTabLeftWithFocus}
               />
             )}
             <div className="relative flex-1 min-h-0">
@@ -504,6 +527,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
                 onAddTab={handleAddTabRightWithFocus}
                 onReorderTabs={handleReorderTabsRight}
                 onMoveTabToOtherSide={handleMoveTabFromLeftToRight}
+                onDuplicateTab={handleDuplicateTabRightWithFocus}
               />
             )}
             <div className="relative flex-1 min-h-0">

--- a/components/sftp/SftpTabBar.tsx
+++ b/components/sftp/SftpTabBar.tsx
@@ -31,7 +31,14 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "../ui/context-menu";
-import type { SftpTabDuplicateMode } from "./sftpTabDuplication";
+import {
+  canDuplicateSftpTab,
+  isSftpTabKeyboardContextMenuShortcut,
+  isSftpTabKeyboardSelectShortcut,
+  shouldHandleSftpTabKeyboardEvent,
+  SFTP_TAB_DUPLICATE_MENU_ITEMS,
+  type SftpTabDuplicateMode,
+} from "./sftpTabDuplication";
 
 export interface SftpTab {
   id: string;
@@ -245,6 +252,35 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
     [onAddTab],
   );
 
+  const handleTabKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>, tabId: string) => {
+      if (!shouldHandleSftpTabKeyboardEvent(e.target, e.currentTarget)) {
+        return;
+      }
+
+      if (isSftpTabKeyboardSelectShortcut(e.key)) {
+        e.preventDefault();
+        onSelectTab(tabId);
+        return;
+      }
+
+      if (isSftpTabKeyboardContextMenuShortcut(e.key, e.shiftKey)) {
+        e.preventDefault();
+        const rect = e.currentTarget.getBoundingClientRect();
+        e.currentTarget.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            cancelable: true,
+            button: 2,
+            clientX: rect.left + Math.min(rect.width / 2, 24),
+            clientY: rect.bottom,
+          }),
+        );
+      }
+    },
+    [onSelectTab],
+  );
+
   // Cross-pane drag handlers
   const handleCrossPaneDragOver = useCallback(
     (e: React.DragEvent) => {
@@ -320,7 +356,7 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
         >
           {tabs.map((tab) => {
             const isActive = activeTabId === tab.id;
-            const canDuplicateTab = !!onDuplicateTab && !!tab.canDuplicate;
+            const canDuplicateTab = canDuplicateSftpTab(tab, !!onDuplicateTab);
             const isBeingDragged =
               isDragging && draggedTabIdRef.current === tab.id;
             const showDropIndicatorBefore =
@@ -337,7 +373,11 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
                     data-tab-id={tab.id}
                     data-tab-type="sftp"
                     data-state={isActive ? 'active' : 'inactive'}
+                    tabIndex={0}
+                    aria-haspopup="menu"
+                    aria-label={tab.label}
                     onClick={(e) => handleSelectTabClick(e, tab.id)}
+                    onKeyDown={(e) => handleTabKeyDown(e, tab.id)}
                     onMouseDown={handleTabMiddleMouseDown}
                     onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseTab(tab.id))}
                     draggable
@@ -347,7 +387,7 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
                     onDrop={(e) => handleTabDrop(e, tab.id)}
                     className={cn(
                       "netcatty-tab relative px-3 min-w-[100px] max-w-[180px] text-xs font-medium cursor-pointer flex items-center justify-between gap-2 flex-shrink-0 border-r border-border/40",
-                      "transition-[color,opacity,transform] duration-100 ease-out",
+                      "transition-[color,opacity,transform] duration-100 ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50 focus-visible:ring-inset",
                       isActive
                         ? "text-foreground border-b-2"
                         : "text-muted-foreground hover:text-foreground",
@@ -399,24 +439,18 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
                   </div>
                 </ContextMenuTrigger>
                 <ContextMenuContent>
-                  <ContextMenuItem
-                    disabled={!canDuplicateTab}
-                    onClick={() => {
-                      void onDuplicateTab?.(tab.id, "defaultPath");
-                    }}
-                  >
-                    <Copy size={14} className="mr-2" />
-                    {t("sftp.tabs.copyDefaultPath")}
-                  </ContextMenuItem>
-                  <ContextMenuItem
-                    disabled={!canDuplicateTab}
-                    onClick={() => {
-                      void onDuplicateTab?.(tab.id, "currentPath");
-                    }}
-                  >
-                    <Copy size={14} className="mr-2" />
-                    {t("sftp.tabs.copyCurrentPath")}
-                  </ContextMenuItem>
+                  {SFTP_TAB_DUPLICATE_MENU_ITEMS.map((item) => (
+                    <ContextMenuItem
+                      key={item.mode}
+                      disabled={!canDuplicateTab}
+                      onClick={() => {
+                        void onDuplicateTab?.(tab.id, item.mode);
+                      }}
+                    >
+                      <Copy size={14} className="mr-2" />
+                      {t(item.labelKey)}
+                    </ContextMenuItem>
+                  ))}
                 </ContextMenuContent>
               </ContextMenu>
             );

--- a/components/sftp/SftpTabBar.tsx
+++ b/components/sftp/SftpTabBar.tsx
@@ -9,7 +9,7 @@
  * - Drag-and-drop reordering of tabs
  */
 
-import { HardDrive, Monitor, Plus, X } from "lucide-react";
+import { Copy, HardDrive, Monitor, Plus, X } from "lucide-react";
 import React, {
   memo,
   useCallback,
@@ -25,12 +25,20 @@ import { useRenderTracker } from "../../lib/useRenderTracker";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "../../lib/utils";
 import { useActiveTabId } from "./SftpContext";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "../ui/context-menu";
+import type { SftpTabDuplicateMode } from "./sftpTabDuplication";
 
 export interface SftpTab {
   id: string;
   label: string;
   isLocal: boolean;
   hostId: string | null;
+  canDuplicate?: boolean;
 }
 
 interface SftpTabBarProps {
@@ -46,6 +54,10 @@ interface SftpTabBarProps {
   ) => void;
   /** Called when a tab is dragged to the other side */
   onMoveTabToOtherSide?: (tabId: string) => void;
+  onDuplicateTab?: (
+    tabId: string,
+    mode: SftpTabDuplicateMode,
+  ) => void | Promise<void>;
 }
 
 const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
@@ -56,6 +68,7 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
   onAddTab,
   onReorderTabs,
   onMoveTabToOtherSide,
+  onDuplicateTab,
 }) => {
   // Subscribe to activeTabId from store (isolated subscription)
   const activeTabId = useActiveTabId(side);
@@ -307,6 +320,7 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
         >
           {tabs.map((tab) => {
             const isActive = activeTabId === tab.id;
+            const canDuplicateTab = !!onDuplicateTab && !!tab.canDuplicate;
             const isBeingDragged =
               isDragging && draggedTabIdRef.current === tab.id;
             const showDropIndicatorBefore =
@@ -317,71 +331,94 @@ const SftpTabBarInner: React.FC<SftpTabBarProps> = ({
               dropIndicator.position === "after";
 
             return (
-              <div
-                key={tab.id}
-                data-tab-id={tab.id}
-                data-tab-type="sftp"
-                data-state={isActive ? 'active' : 'inactive'}
-                onClick={(e) => handleSelectTabClick(e, tab.id)}
-                onMouseDown={handleTabMiddleMouseDown}
-                onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseTab(tab.id))}
-                draggable
-                onDragStart={(e) => handleTabDragStart(e, tab.id)}
-                onDragEnd={handleTabDragEnd}
-                onDragOver={(e) => handleTabDragOver(e, tab.id)}
-                onDrop={(e) => handleTabDrop(e, tab.id)}
-                className={cn(
-                  "netcatty-tab relative px-3 min-w-[100px] max-w-[180px] text-xs font-medium cursor-pointer flex items-center justify-between gap-2 flex-shrink-0 border-r border-border/40",
-                  "transition-[color,opacity,transform] duration-100 ease-out",
-                  isActive
-                    ? "text-foreground border-b-2"
-                    : "text-muted-foreground hover:text-foreground",
-                  isBeingDragged && "opacity-50",
-                )}
-                style={
-                  isActive
-                    ? { borderBottomColor: "hsl(var(--accent))" }
-                    : undefined
-                }
-              >
-                {/* Drop indicator line - before */}
-                {showDropIndicatorBefore && isDragging && (
-                  <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-primary shadow-[0_0_8px_2px] shadow-primary/50 animate-pulse" />
-                )}
-                {/* Drop indicator line - after */}
-                {showDropIndicatorAfter && isDragging && (
-                  <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-primary shadow-[0_0_8px_2px] shadow-primary/50 animate-pulse" />
-                )}
+              <ContextMenu key={tab.id}>
+                <ContextMenuTrigger asChild>
+                  <div
+                    data-tab-id={tab.id}
+                    data-tab-type="sftp"
+                    data-state={isActive ? 'active' : 'inactive'}
+                    onClick={(e) => handleSelectTabClick(e, tab.id)}
+                    onMouseDown={handleTabMiddleMouseDown}
+                    onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseTab(tab.id))}
+                    draggable
+                    onDragStart={(e) => handleTabDragStart(e, tab.id)}
+                    onDragEnd={handleTabDragEnd}
+                    onDragOver={(e) => handleTabDragOver(e, tab.id)}
+                    onDrop={(e) => handleTabDrop(e, tab.id)}
+                    className={cn(
+                      "netcatty-tab relative px-3 min-w-[100px] max-w-[180px] text-xs font-medium cursor-pointer flex items-center justify-between gap-2 flex-shrink-0 border-r border-border/40",
+                      "transition-[color,opacity,transform] duration-100 ease-out",
+                      isActive
+                        ? "text-foreground border-b-2"
+                        : "text-muted-foreground hover:text-foreground",
+                      isBeingDragged && "opacity-50",
+                    )}
+                    style={
+                      isActive
+                        ? { borderBottomColor: "hsl(var(--accent))" }
+                        : undefined
+                    }
+                  >
+                    {/* Drop indicator line - before */}
+                    {showDropIndicatorBefore && isDragging && (
+                      <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-primary shadow-[0_0_8px_2px] shadow-primary/50 animate-pulse" />
+                    )}
+                    {/* Drop indicator line - after */}
+                    {showDropIndicatorAfter && isDragging && (
+                      <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-primary shadow-[0_0_8px_2px] shadow-primary/50 animate-pulse" />
+                    )}
 
-                <div className="flex items-center gap-1.5 min-w-0 flex-1">
-                  {tab.isLocal ? (
-                    <Monitor
-                      size={12}
-                      className={cn(
-                        "shrink-0",
-                        isActive ? "text-primary" : "text-muted-foreground",
+                    <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                      {tab.isLocal ? (
+                        <Monitor
+                          size={12}
+                          className={cn(
+                            "shrink-0",
+                            isActive ? "text-primary" : "text-muted-foreground",
+                          )}
+                        />
+                      ) : (
+                        <HardDrive
+                          size={12}
+                          className={cn(
+                            "shrink-0",
+                            isActive ? "text-primary" : "text-muted-foreground",
+                          )}
+                        />
                       )}
-                    />
-                  ) : (
-                    <HardDrive
-                      size={12}
-                      className={cn(
-                        "shrink-0",
-                        isActive ? "text-primary" : "text-muted-foreground",
-                      )}
-                    />
-                  )}
-                  <span className="truncate">{tab.label}</span>
-                </div>
+                      <span className="truncate">{tab.label}</span>
+                    </div>
 
-                <button
-                  onClick={(e) => handleCloseTab(e, tab.id)}
-                  className="p-0.5 hover:bg-destructive/10 hover:text-destructive transition-colors shrink-0"
-                  aria-label={t("common.close")}
-                >
-                  <X size={12} />
-                </button>
-              </div>
+                    <button
+                      onClick={(e) => handleCloseTab(e, tab.id)}
+                      className="p-0.5 hover:bg-destructive/10 hover:text-destructive transition-colors shrink-0"
+                      aria-label={t("common.close")}
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem
+                    disabled={!canDuplicateTab}
+                    onClick={() => {
+                      void onDuplicateTab?.(tab.id, "defaultPath");
+                    }}
+                  >
+                    <Copy size={14} className="mr-2" />
+                    {t("sftp.tabs.copyDefaultPath")}
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    disabled={!canDuplicateTab}
+                    onClick={() => {
+                      void onDuplicateTab?.(tab.id, "currentPath");
+                    }}
+                  >
+                    <Copy size={14} className="mr-2" />
+                    {t("sftp.tabs.copyCurrentPath")}
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
             );
           })}
         </div>
@@ -432,7 +469,8 @@ const sftpTabBarAreEqual = (
       prevTab.id !== nextTab.id ||
       prevTab.label !== nextTab.label ||
       prevTab.isLocal !== nextTab.isLocal ||
-      prevTab.hostId !== nextTab.hostId
+      prevTab.hostId !== nextTab.hostId ||
+      prevTab.canDuplicate !== nextTab.canDuplicate
     ) {
       return false;
     }

--- a/components/sftp/hooks/useSftpViewTabs.ts
+++ b/components/sftp/hooks/useSftpViewTabs.ts
@@ -6,17 +6,22 @@ import { editorTabStore } from "../../../application/state/editorTabStore";
 import type { EditorTab, EditorTabId } from "../../../application/state/editorTabStore";
 import { releaseEditorTabSaveCoordinator, saveEditorTab } from "../../../application/state/editorTabSave";
 import { promptUnsavedChanges } from "../../editor/UnsavedChangesDialog";
+import {
+  getSftpTabDuplicateRequest,
+  type SftpTabDuplicateMode,
+} from "../sftpTabDuplication";
 
 interface UseSftpViewTabsParams {
   sftp: SftpStateApi;
   sftpRef: MutableRefObject<SftpStateApi>;
+  hosts?: Host[];
 }
 
 interface UseSftpViewTabsResult {
   leftPanes: SftpStateApi["leftPane"][];
   rightPanes: SftpStateApi["rightPane"][];
-  leftTabsInfo: { id: string; label: string; isLocal: boolean; hostId: string | null }[];
-  rightTabsInfo: { id: string; label: string; isLocal: boolean; hostId: string | null }[];
+  leftTabsInfo: { id: string; label: string; isLocal: boolean; hostId: string | null; canDuplicate: boolean }[];
+  rightTabsInfo: { id: string; label: string; isLocal: boolean; hostId: string | null; canDuplicate: boolean }[];
   showHostPickerLeft: boolean;
   showHostPickerRight: boolean;
   hostSearchLeft: string;
@@ -35,15 +40,19 @@ interface UseSftpViewTabsResult {
   handleReorderTabsRight: (draggedId: string, targetId: string, position: "before" | "after") => void;
   handleMoveTabFromLeftToRight: (tabId: string) => void;
   handleMoveTabFromRightToLeft: (tabId: string) => void;
+  handleDuplicateTabLeft: (tabId: string, mode: SftpTabDuplicateMode) => Promise<string | null>;
+  handleDuplicateTabRight: (tabId: string, mode: SftpTabDuplicateMode) => Promise<string | null>;
   handleHostSelectLeft: (host: Host | "local") => void;
   handleHostSelectRight: (host: Host | "local") => void;
 }
 
-export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSftpViewTabsResult => {
+export const useSftpViewTabs = ({ sftp, sftpRef, hosts = [] }: UseSftpViewTabsParams): UseSftpViewTabsResult => {
   const [showHostPickerLeft, setShowHostPickerLeft] = useState(false);
   const [showHostPickerRight, setShowHostPickerRight] = useState(false);
   const [hostSearchLeft, setHostSearchLeft] = useState("");
   const [hostSearchRight, setHostSearchRight] = useState("");
+  const hostsRef = React.useRef(hosts);
+  hostsRef.current = hosts;
 
   const handleAddTabLeft = useCallback(() => {
     const tabId = sftpRef.current.addTab("left");
@@ -132,6 +141,43 @@ export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSf
     sftpRef.current.moveTabToOtherSide("right", tabId);
   }, [sftpRef]);
 
+  const handleDuplicateTab = useCallback(
+    async (side: "left" | "right", tabId: string, mode: SftpTabDuplicateMode) => {
+      const sideTabs = side === "left" ? sftpRef.current.leftTabs : sftpRef.current.rightTabs;
+      const pane = sideTabs.tabs.find((tab) => tab.id === tabId);
+      const request = getSftpTabDuplicateRequest(pane, mode);
+      if (!request) return null;
+
+      const host = request.kind === "local"
+        ? "local"
+        : hostsRef.current.find((item) => item.id === request.hostId);
+      if (!host) return null;
+
+      let duplicatedTabId: string | null = null;
+      await sftpRef.current.connect(side, host, {
+        forceNewTab: true,
+        ignoreSharedCache: mode === "defaultPath",
+        initialPath: request.path,
+        onTabCreated: (createdTabId) => {
+          duplicatedTabId = createdTabId;
+        },
+      });
+
+      return duplicatedTabId;
+    },
+    [sftpRef],
+  );
+
+  const handleDuplicateTabLeft = useCallback(
+    (tabId: string, mode: SftpTabDuplicateMode) => handleDuplicateTab("left", tabId, mode),
+    [handleDuplicateTab],
+  );
+
+  const handleDuplicateTabRight = useCallback(
+    (tabId: string, mode: SftpTabDuplicateMode) => handleDuplicateTab("right", tabId, mode),
+    [handleDuplicateTab],
+  );
+
   const handleHostSelectLeft = useCallback((host: Host | "local") => {
     sftpRef.current.connect("left", host);
     setShowHostPickerLeft(false);
@@ -149,6 +195,7 @@ export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSf
         label: pane.connection?.hostLabel || "New Tab",
         isLocal: pane.connection?.isLocal || false,
         hostId: pane.connection?.hostId || null,
+        canDuplicate: pane.connection?.status === "connected",
       })),
     [sftp.leftTabs.tabs],
   );
@@ -160,6 +207,7 @@ export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSf
         label: pane.connection?.hostLabel || "New Tab",
         isLocal: pane.connection?.isLocal || false,
         hostId: pane.connection?.hostId || null,
+        canDuplicate: pane.connection?.status === "connected",
       })),
     [sftp.rightTabs.tabs],
   );
@@ -187,6 +235,8 @@ export const useSftpViewTabs = ({ sftp, sftpRef }: UseSftpViewTabsParams): UseSf
     handleReorderTabsRight,
     handleMoveTabFromLeftToRight,
     handleMoveTabFromRightToLeft,
+    handleDuplicateTabLeft,
+    handleDuplicateTabRight,
     handleHostSelectLeft,
     handleHostSelectRight,
   };

--- a/components/sftp/sftpTabDuplication.test.ts
+++ b/components/sftp/sftpTabDuplication.test.ts
@@ -2,7 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { SftpPane } from "../../application/state/sftp/types.ts";
-import { getSftpTabDuplicateRequest } from "./sftpTabDuplication.ts";
+import {
+  canDuplicateSftpTab,
+  getSftpTabDuplicateRequest,
+  isSftpTabKeyboardContextMenuShortcut,
+  isSftpTabKeyboardSelectShortcut,
+  shouldHandleSftpTabKeyboardEvent,
+  SFTP_TAB_DUPLICATE_MENU_ITEMS,
+} from "./sftpTabDuplication.ts";
 
 const connectedPane = (overrides: Partial<NonNullable<SftpPane["connection"]>> = {}): SftpPane => ({
   id: "tab-1",
@@ -68,4 +75,40 @@ test("SFTP tab duplication is unavailable before a tab is connected", () => {
     getSftpTabDuplicateRequest(connectedPane({ status: "connecting" }), "currentPath"),
     null,
   );
+});
+
+test("SFTP tab duplicate menu exposes separate default and current path actions", () => {
+  assert.deepEqual(
+    SFTP_TAB_DUPLICATE_MENU_ITEMS.map((item) => item.mode),
+    ["defaultPath", "currentPath"],
+  );
+  assert.deepEqual(
+    SFTP_TAB_DUPLICATE_MENU_ITEMS.map((item) => item.labelKey),
+    ["sftp.tabs.copyDefaultPath", "sftp.tabs.copyCurrentPath"],
+  );
+});
+
+test("SFTP tab duplicate menu is disabled without a connected tab and handler", () => {
+  assert.equal(canDuplicateSftpTab({ canDuplicate: true }, true), true);
+  assert.equal(canDuplicateSftpTab({ canDuplicate: true }, false), false);
+  assert.equal(canDuplicateSftpTab({ canDuplicate: false }, true), false);
+  assert.equal(canDuplicateSftpTab(connectedPane(), true), true);
+  assert.equal(canDuplicateSftpTab(connectedPane({ status: "connecting" }), true), false);
+});
+
+test("SFTP tab duplicate menu has keyboard shortcuts for selection and menu access", () => {
+  assert.equal(isSftpTabKeyboardSelectShortcut("Enter"), true);
+  assert.equal(isSftpTabKeyboardSelectShortcut(" "), true);
+  assert.equal(isSftpTabKeyboardSelectShortcut("Escape"), false);
+  assert.equal(isSftpTabKeyboardContextMenuShortcut("ContextMenu"), true);
+  assert.equal(isSftpTabKeyboardContextMenuShortcut("F10", true), true);
+  assert.equal(isSftpTabKeyboardContextMenuShortcut("F10", false), false);
+});
+
+test("SFTP tab keyboard shortcuts do not intercept nested close button events", () => {
+  const tab = new EventTarget();
+  const closeButton = new EventTarget();
+
+  assert.equal(shouldHandleSftpTabKeyboardEvent(tab, tab), true);
+  assert.equal(shouldHandleSftpTabKeyboardEvent(closeButton, tab), false);
 });

--- a/components/sftp/sftpTabDuplication.test.ts
+++ b/components/sftp/sftpTabDuplication.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { SftpPane } from "../../application/state/sftp/types.ts";
+import { getSftpTabDuplicateRequest } from "./sftpTabDuplication.ts";
+
+const connectedPane = (overrides: Partial<NonNullable<SftpPane["connection"]>> = {}): SftpPane => ({
+  id: "tab-1",
+  connection: {
+    id: "conn-1",
+    hostId: "host-1",
+    hostLabel: "Prod",
+    isLocal: false,
+    status: "connected",
+    currentPath: "/var/www/app",
+    homeDir: "/home/deploy",
+    ...overrides,
+  },
+  files: [],
+  loading: false,
+  reconnecting: false,
+  error: null,
+  connectionLogs: [],
+  selectedFiles: new Set(),
+  filter: "",
+  filenameEncoding: "auto",
+  showHiddenFiles: false,
+  transferMutationToken: 0,
+});
+
+test("default-path SFTP tab duplication keeps only the remote host identity", () => {
+  assert.deepEqual(getSftpTabDuplicateRequest(connectedPane(), "defaultPath"), {
+    kind: "remote",
+    hostId: "host-1",
+  });
+});
+
+test("current-path SFTP tab duplication carries the active directory", () => {
+  assert.deepEqual(getSftpTabDuplicateRequest(connectedPane(), "currentPath"), {
+    kind: "remote",
+    hostId: "host-1",
+    path: "/var/www/app",
+  });
+});
+
+test("local SFTP tab duplication targets the local filesystem", () => {
+  assert.deepEqual(
+    getSftpTabDuplicateRequest(
+      connectedPane({
+        hostId: "local",
+        hostLabel: "Local",
+        isLocal: true,
+        currentPath: "/Users/damao/projects",
+        homeDir: "/Users/damao",
+      }),
+      "currentPath",
+    ),
+    {
+      kind: "local",
+      path: "/Users/damao/projects",
+    },
+  );
+});
+
+test("SFTP tab duplication is unavailable before a tab is connected", () => {
+  assert.equal(getSftpTabDuplicateRequest({ ...connectedPane(), connection: null }, "defaultPath"), null);
+  assert.equal(
+    getSftpTabDuplicateRequest(connectedPane({ status: "connecting" }), "currentPath"),
+    null,
+  );
+});

--- a/components/sftp/sftpTabDuplication.ts
+++ b/components/sftp/sftpTabDuplication.ts
@@ -6,6 +6,41 @@ export type SftpTabDuplicateRequest =
   | { kind: "local"; path?: string }
   | { kind: "remote"; hostId: string; path?: string };
 
+export const SFTP_TAB_DUPLICATE_MENU_ITEMS: ReadonlyArray<{
+  mode: SftpTabDuplicateMode;
+  labelKey: "sftp.tabs.copyDefaultPath" | "sftp.tabs.copyCurrentPath";
+}> = Object.freeze([
+  { mode: "defaultPath", labelKey: "sftp.tabs.copyDefaultPath" },
+  { mode: "currentPath", labelKey: "sftp.tabs.copyCurrentPath" },
+]);
+
+export function canDuplicateSftpTab(
+  tab: Pick<SftpPane, "connection"> | { canDuplicate?: boolean } | null | undefined,
+  hasDuplicateHandler: boolean,
+): boolean {
+  if (!hasDuplicateHandler || !tab) return false;
+  if ("connection" in tab) return tab.connection?.status === "connected";
+  return !!tab.canDuplicate;
+}
+
+export function isSftpTabKeyboardContextMenuShortcut(
+  key: string,
+  shiftKey = false,
+): boolean {
+  return key === "ContextMenu" || (shiftKey && key === "F10");
+}
+
+export function isSftpTabKeyboardSelectShortcut(key: string): boolean {
+  return key === "Enter" || key === " ";
+}
+
+export function shouldHandleSftpTabKeyboardEvent(
+  target: EventTarget | null,
+  currentTarget: EventTarget | null,
+): boolean {
+  return target === currentTarget;
+}
+
 export function getSftpTabDuplicateRequest(
   pane: Pick<SftpPane, "connection"> | null | undefined,
   mode: SftpTabDuplicateMode,

--- a/components/sftp/sftpTabDuplication.ts
+++ b/components/sftp/sftpTabDuplication.ts
@@ -1,0 +1,38 @@
+import type { SftpPane } from "../../application/state/sftp/types";
+
+export type SftpTabDuplicateMode = "defaultPath" | "currentPath";
+
+export type SftpTabDuplicateRequest =
+  | { kind: "local"; path?: string }
+  | { kind: "remote"; hostId: string; path?: string };
+
+export function getSftpTabDuplicateRequest(
+  pane: Pick<SftpPane, "connection"> | null | undefined,
+  mode: SftpTabDuplicateMode,
+): SftpTabDuplicateRequest | null {
+  const connection = pane?.connection;
+  if (!connection || connection.status !== "connected") {
+    return null;
+  }
+
+  const path = mode === "currentPath" && connection.currentPath
+    ? { path: connection.currentPath }
+    : {};
+
+  if (connection.isLocal) {
+    return {
+      kind: "local",
+      ...path,
+    };
+  }
+
+  if (!connection.hostId) {
+    return null;
+  }
+
+  return {
+    kind: "remote",
+    hostId: connection.hostId,
+    ...path,
+  };
+}


### PR DESCRIPTION
## Summary
- Add SFTP tab context menu actions to copy a tab using the default path or the current path
- Wire duplicated tabs to open fresh connections with the requested starting path
- Add focused tests for duplicated tab creation

Fixes #1423

## Verification
- node --test --import tsx components/sftp/sftpTabDuplication.test.ts
- npx eslint application/i18n/locales/en/vault.ts application/i18n/locales/ru/vault.ts application/i18n/locales/zh-CN/vault.ts application/state/sftp/useSftpConnections.ts components/SftpView.tsx components/sftp/SftpTabBar.tsx components/sftp/hooks/useSftpViewTabs.ts components/sftp/sftpTabDuplication.ts components/sftp/sftpTabDuplication.test.ts
- node --test --import tsx $(rg --files components/sftp application/state/sftp | rg "\.test\.tsx?$")
- npm run build
- Browser smoke test: SFTP tab context menu shows both actions and creates duplicated tabs as expected

Note: full npm test still has unrelated existing failures in AI bridge and SSH compatibility tests; no SFTP tests failed.