### PR TITLE
[codex] Fix CentOS 7 process listing

### DIFF
--- a/electron/bridges/systemManagerBridge.cjs
+++ b/electron/bridges/systemManagerBridge.cjs
@@ -16,7 +16,7 @@ const CAPABILITY_SCRIPT_POSIX = [
 const PROCESS_LIST_SCRIPT_POSIX = [
   "exec sh -c ",
   "'",
-  "ps -eo pid=,ppid=,user=,stat=,pcpu=,pmem=,rss=,vsz=,etime=,args= 2>/dev/null | head -n 200",
+  "ps -eo pid= -o ppid= -o user= -o stat= -o pcpu= -o pmem= -o rss= -o vsz= -o etime= -o args= 2>/dev/null | head -n 200",
   "'",
 ].join("");
 

--- a/electron/bridges/systemManagerBridge.processes.test.cjs
+++ b/electron/bridges/systemManagerBridge.processes.test.cjs
@@ -16,6 +16,7 @@ function createFakeExecStream(stdout) {
 }
 
 test("listProcesses uses a ps format that works on CentOS 7 procps", async () => {
+  const compatiblePsFormat = "ps -eo pid= -o ppid= -o user= -o stat= -o pcpu= -o pmem= -o rss= -o vsz= -o etime= -o args=";
   const badCentos7Output = [
     ",ppid=,user=,stat=,pcpu=,pmem=,rss=,vsz=,etime=,args=",
     "                                                    1",
@@ -26,9 +27,9 @@ test("listProcesses uses a ps format that works on CentOS 7 procps", async () =>
 
   const conn = {
     exec(command, callback) {
-      const stdout = command.includes("pid=,ppid=")
-        ? badCentos7Output
-        : compatibleOutput;
+      const stdout = command.includes(compatiblePsFormat)
+        ? compatibleOutput
+        : badCentos7Output;
       callback(null, createFakeExecStream(stdout));
     },
   };

--- a/electron/bridges/systemManagerBridge.processes.test.cjs
+++ b/electron/bridges/systemManagerBridge.processes.test.cjs
@@ -1,0 +1,47 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { createSystemManagerBridge } = require("./systemManagerBridge.cjs");
+
+function createFakeExecStream(stdout) {
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  process.nextTick(() => {
+    stream.emit("data", stdout);
+    stream.emit("close", 0);
+  });
+  return stream;
+}
+
+test("listProcesses uses a ps format that works on CentOS 7 procps", async () => {
+  const badCentos7Output = [
+    ",ppid=,user=,stat=,pcpu=,pmem=,rss=,vsz=,etime=,args=",
+    "                                                    1",
+  ].join("\n");
+  const compatibleOutput = [
+    "     1      0 root     Ss    0.0  0.0  4060 191024  2-19:23:42 /usr/lib/systemd/systemd --switched-root --system --deserialize 21",
+  ].join("\n");
+
+  const conn = {
+    exec(command, callback) {
+      const stdout = command.includes("pid=,ppid=")
+        ? badCentos7Output
+        : compatibleOutput;
+      callback(null, createFakeExecStream(stdout));
+    },
+  };
+  const sessions = new Map([["s1", { conn, type: "ssh" }]]);
+  const bridge = createSystemManagerBridge({
+    getSessions: () => sessions,
+    process,
+  });
+
+  const result = await bridge.listProcesses(null, { sessionId: "s1" });
+
+  assert.equal(result.success, true);
+  assert.equal(result.processes.length, 1);
+  assert.equal(result.processes[0].pid, 1);
+  assert.equal(result.processes[0].command, "/usr/lib/systemd/systemd --switched-root --system --deserialize 21");
+});


### PR DESCRIPTION
## Summary
- Fix process list collection on CentOS 7 by using a compatible ps format.
- Add and tighten a regression test for the CentOS 7 procps output issue.

## Root Cause
CentOS 7 procps misinterprets the combined comma-separated ps format and returns malformed rows, so Netcatty parses zero processes.

## Validation
- npm run lint
- npm test
- node --test --import tsx electron/bridges/systemManagerBridge.processes.test.cjs electron/bridges/systemManager/execConnHealth.test.cjs electron/bridges/systemManager/tmuxEnv.test.cjs
- Verified the fixed ps command and parser against the CentOS 7 host 10.2.0.32
- Multi-agent review run; feedback addressed and re-review requested