### PR TITLE
[codex] Simplify SFTP conflict dialog

### DIFF
--- a/components/sftp/SftpConflictDialog.tsx
+++ b/components/sftp/SftpConflictDialog.tsx
@@ -37,6 +37,40 @@ interface SftpConflictDialogProps {
     formatFileSize: (size: number) => string;
 }
 
+interface ConflictFileSummaryProps {
+    title: string;
+    sizeLabel: string;
+    modifiedLabel: string;
+    size: string;
+    modified: string;
+}
+
+const ConflictFileSummary: React.FC<ConflictFileSummaryProps> = ({
+    title,
+    sizeLabel,
+    modifiedLabel,
+    size,
+    modified,
+}) => (
+    <div className="rounded-md border border-border/60 bg-secondary/25 px-4 py-3">
+        <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="text-sm font-medium text-foreground">
+                {title}
+            </div>
+        </div>
+        <dl className="space-y-2 text-sm">
+            <div className="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-3">
+                <dt className="text-muted-foreground">{sizeLabel}</dt>
+                <dd className="min-w-0 text-foreground">{size}</dd>
+            </div>
+            <div className="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-3">
+                <dt className="text-muted-foreground">{modifiedLabel}</dt>
+                <dd className="min-w-0 break-words leading-relaxed text-foreground">{modified}</dd>
+            </div>
+        </dl>
+    </div>
+);
+
 const SftpConflictDialogInner: React.FC<SftpConflictDialogProps> = ({ conflicts, onResolve, formatFileSize }) => {
     const { t } = useI18n();
     const [applyToAll, setApplyToAll] = useState(false);
@@ -62,55 +96,46 @@ const SftpConflictDialogInner: React.FC<SftpConflictDialogProps> = ({ conflicts,
 
     return (
         <Dialog open={!!conflict} onOpenChange={() => handleAction('skip')}>
-            <DialogContent className="sm:max-w-[480px]">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
-                        <AlertCircle className="h-5 w-5 text-yellow-500" />
+            <DialogContent className="gap-5 p-5 sm:max-w-[520px] sm:p-6">
+                <DialogHeader className="space-y-2 pr-8">
+                    <DialogTitle className="flex items-center gap-3 text-xl leading-tight">
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/70 text-muted-foreground">
+                            <AlertCircle className="h-5 w-5" />
+                        </span>
                         {t('sftp.conflict.title')}
                     </DialogTitle>
-                    <DialogDescription>
+                    <DialogDescription className="text-[15px] leading-6">
                         {t('sftp.conflict.desc')}
                     </DialogDescription>
                 </DialogHeader>
 
-                <div className="space-y-4 py-4">
-                    <div className="text-sm">
-                        <span className="font-medium">{conflict.fileName}</span>
-                        <span className="text-muted-foreground ml-1">{t('sftp.conflict.alreadyExistsSuffix')}</span>
+                <div className="space-y-4">
+                    <div className="rounded-md border border-border/60 bg-muted/25 px-4 py-3 text-sm leading-6">
+                        <div className="min-w-0 break-words">
+                            <span className="font-medium text-foreground">{conflict.fileName}</span>
+                            <span className="ml-1 text-muted-foreground">{t('sftp.conflict.alreadyExistsSuffix')}</span>
+                        </div>
                     </div>
 
-                    <div className="grid grid-cols-2 gap-4 text-xs">
-                        <div className="p-3 rounded-lg bg-secondary/50 border border-border/60">
-                            <div className="font-medium mb-2 text-muted-foreground">{t('sftp.conflict.existingFile')}</div>
-                            <div className="space-y-1">
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">{t('sftp.conflict.size')}</span>
-                                    <span>{formatFileSize(conflict.existingSize)}</span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">{t('sftp.conflict.modified')}</span>
-                                    <span>{formatDate(conflict.existingModified)}</span>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className="p-3 rounded-lg bg-primary/10 border border-primary/30">
-                            <div className="font-medium mb-2 text-primary">{t('sftp.conflict.newFile')}</div>
-                            <div className="space-y-1">
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">{t('sftp.conflict.size')}</span>
-                                    <span>{formatFileSize(conflict.newSize)}</span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">{t('sftp.conflict.modified')}</span>
-                                    <span>{formatDate(conflict.newModified)}</span>
-                                </div>
-                            </div>
-                        </div>
+                    <div className="space-y-3">
+                        <ConflictFileSummary
+                            title={t('sftp.conflict.existingFile')}
+                            sizeLabel={t('sftp.conflict.size')}
+                            modifiedLabel={t('sftp.conflict.modified')}
+                            size={formatFileSize(conflict.existingSize)}
+                            modified={formatDate(conflict.existingModified)}
+                        />
+                        <ConflictFileSummary
+                            title={t('sftp.conflict.newFile')}
+                            sizeLabel={t('sftp.conflict.size')}
+                            modifiedLabel={t('sftp.conflict.modified')}
+                            size={formatFileSize(conflict.newSize)}
+                            modified={formatDate(conflict.newModified)}
+                        />
                     </div>
 
                     {sameTypeConflictCount > 1 && (
-                        <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+                        <label className="flex cursor-pointer items-center gap-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
                             <input
                                 type="checkbox"
                                 checked={applyToAll}
@@ -122,25 +147,25 @@ const SftpConflictDialogInner: React.FC<SftpConflictDialogProps> = ({ conflicts,
                     )}
                 </div>
 
-                <DialogFooter className="flex flex-wrap gap-2 sm:justify-end sm:space-x-0">
+                <DialogFooter className="flex flex-wrap gap-2 sm:items-center sm:justify-end sm:space-x-0">
                     <Button
-                        variant="destructive"
+                        variant="outline"
                         onClick={() => handleAction('stop')}
-                        className="flex-1"
+                        className="min-w-24 border-border/70 text-muted-foreground hover:text-destructive sm:mr-auto"
                     >
                         {t('sftp.conflict.action.stop')}
                     </Button>
                     <Button
                         variant="outline"
                         onClick={() => handleAction('skip')}
-                        className="flex-1"
+                        className="min-w-24"
                     >
                         {t('sftp.conflict.action.skip')}
                     </Button>
                     <Button
                         variant="outline"
                         onClick={() => handleAction('duplicate')}
-                        className="flex-1"
+                        className="min-w-24"
                     >
                         {t('sftp.conflict.action.duplicate')}
                     </Button>
@@ -149,7 +174,7 @@ const SftpConflictDialogInner: React.FC<SftpConflictDialogProps> = ({ conflicts,
                             variant="outline"
                             onClick={() => handleAction('merge')}
                             disabled={!canMerge}
-                            className="flex-1"
+                            className="min-w-24"
                         >
                             {t('sftp.conflict.action.merge')}
                         </Button>
@@ -158,7 +183,7 @@ const SftpConflictDialogInner: React.FC<SftpConflictDialogProps> = ({ conflicts,
                         <Button
                             variant="default"
                             onClick={() => handleAction('replace')}
-                            className="flex-1"
+                            className="min-w-28"
                         >
                             {t('sftp.conflict.action.replace')}
                         </Button>


### PR DESCRIPTION
## Summary
- Simplifies the SFTP file conflict dialog layout.
- Uses stacked file detail sections so dates and file metadata have more room.
- Reduces competing accent colors while keeping the primary replace action clear.

## Test Plan
- node --test --import tsx components/sftp/SftpConflictDialog.test.ts
- npm run build
