### PR TITLE
feat: auto-poll Docker capabilities while Docker tab is active

### DIFF
--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -75,6 +75,13 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     }
   }, [resolvedTab, capabilities, refreshCapabilities]);
 
+  // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
+  React.useEffect(() => {
+    if (!isVisible || activeTab !== 'docker' || capabilities?.hasDocker === true) return;
+    const interval = setInterval(() => refreshCapabilities(), capabilitiesTtlMs);
+    return () => clearInterval(interval);
+  }, [isVisible, activeTab, capabilities?.hasDocker, refreshCapabilities, capabilitiesTtlMs]);
+
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader
       host={sessionHost}

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -94,6 +94,7 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     }
   }, [capabilitiesTtlMs]);
   React.useEffect(() => {
+    cancelledRef.current = false;
     if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
     dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
     return () => {

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -78,12 +78,18 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
   // Use setTimeout recursion so the next probe only starts after the previous one finishes,
   // avoiding overlapping probes (e.g. SSH timeout 8s vs user-configured interval 2s).
+  //
+  // Use a ref to store refreshCapabilities so that if its reference changes on every render,
+  // the useEffect below is NOT re-run (which would cancel the timer and bypass the interval).
+  const refreshRef = React.useRef(refreshCapabilities);
+  refreshRef.current = refreshCapabilities;
+
   const dockerPollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   React.useEffect(() => {
     if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
     let cancelled = false;
     async function pollOnce() {
-      await refreshCapabilities();
+      await refreshRef.current();
       if (!cancelled) {
         dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
       }
@@ -96,7 +102,7 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
         dockerPollTimerRef.current = null;
       }
     };
-  }, [isVisible, resolvedTab, capabilities?.hasDocker, refreshCapabilities, capabilitiesTtlMs]);
+  }, [isVisible, resolvedTab, capabilities?.hasDocker, refreshRef, capabilitiesTtlMs]);
 
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -102,7 +102,7 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     const pollOnce = async () => {
       if (cancelled) return;
       if (probingRef.current) {
-        // probe 还在跑（如 tab-switch probe），等下一轮再试
+        // probe is in-flight, reschedule for next cycle
         timerId = setTimeout(pollOnce, capabilitiesTtlMs);
         return;
       }
@@ -110,7 +110,7 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
       try {
         await refreshRef.current();
       } catch {
-        // Transient error — keep polling next round
+        // Transient error - keep polling next round
       }
       probingRef.current = false;
       if (cancelled) return;

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -77,10 +77,10 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
 
   // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
   React.useEffect(() => {
-    if (!isVisible || activeTab !== 'docker' || capabilities?.hasDocker === true) return;
+    if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
     const interval = setInterval(() => refreshCapabilities(), capabilitiesTtlMs);
     return () => clearInterval(interval);
-  }, [isVisible, activeTab, capabilities?.hasDocker, refreshCapabilities, capabilitiesTtlMs]);
+  }, [isVisible, resolvedTab, capabilities?.hasDocker, refreshCapabilities, capabilitiesTtlMs]);
 
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -97,7 +97,11 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
 
     const pollOnce = async () => {
       if (cancelled) return;
-      await refreshRef.current();
+      try {
+        await refreshRef.current();
+      } catch {
+        // Transient error — keep polling next round
+      }
       if (cancelled) return;
       timerId = setTimeout(pollOnce, capabilitiesTtlMs);
     };

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -100,7 +100,12 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     let timerId: ReturnType<typeof setTimeout>;
 
     const pollOnce = async () => {
-      if (cancelled || probingRef.current) return;
+      if (cancelled) return;
+      if (probingRef.current) {
+        // probe 还在跑（如 tab-switch probe），等下一轮再试
+        timerId = setTimeout(pollOnce, capabilitiesTtlMs);
+        return;
+      }
       probingRef.current = true;
       try {
         await refreshRef.current();

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -64,12 +64,16 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
 
   // Must be defined before early returns to comply with React rules of hooks.
   const prevTabRef = React.useRef(resolvedTab);
+  const probingRef = React.useRef(false);
   React.useEffect(() => {
     const prev = prevTabRef.current;
     prevTabRef.current = resolvedTab;
     if (prev === resolvedTab) return;
     if (resolvedTab === 'docker' && capabilities?.hasDocker !== true) {
-      void refreshCapabilities();
+      if (!probingRef.current) {
+        probingRef.current = true;
+        refreshCapabilities().finally(() => { probingRef.current = false; });
+      }
     } else if (resolvedTab === 'tmux' && capabilities?.hasTmux !== true) {
       void refreshCapabilities();
     }
@@ -96,12 +100,14 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
     let timerId: ReturnType<typeof setTimeout>;
 
     const pollOnce = async () => {
-      if (cancelled) return;
+      if (cancelled || probingRef.current) return;
+      probingRef.current = true;
       try {
         await refreshRef.current();
       } catch {
         // Transient error — keep polling next round
       }
+      probingRef.current = false;
       if (cancelled) return;
       timerId = setTimeout(pollOnce, capabilitiesTtlMs);
     };

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -76,10 +76,26 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   }, [resolvedTab, capabilities, refreshCapabilities]);
 
   // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
+  // Use setTimeout recursion so the next probe only starts after the previous one finishes,
+  // avoiding overlapping probes (e.g. SSH timeout 8s vs user-configured interval 2s).
+  const dockerPollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   React.useEffect(() => {
     if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
-    const interval = setInterval(() => refreshCapabilities(), capabilitiesTtlMs);
-    return () => clearInterval(interval);
+    let cancelled = false;
+    async function pollOnce() {
+      await refreshCapabilities();
+      if (!cancelled) {
+        dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
+      }
+    }
+    void pollOnce();
+    return () => {
+      cancelled = true;
+      if (dockerPollTimerRef.current !== null) {
+        clearTimeout(dockerPollTimerRef.current);
+        dockerPollTimerRef.current = null;
+      }
+    };
   }, [isVisible, resolvedTab, capabilities?.hasDocker, refreshCapabilities, capabilitiesTtlMs]);
 
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -78,31 +78,32 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
   // Use setTimeout recursion so the next probe only starts after the previous one finishes,
   // avoiding overlapping probes (e.g. SSH timeout 8s vs user-configured interval 2s).
+  // First poll is delayed by one interval to avoid overlapping with the tab-switch probe above.
   //
   // Use a ref to store refreshCapabilities so that if its reference changes on every render,
   // the useEffect below is NOT re-run (which would cancel the timer and bypass the interval).
   const refreshRef = React.useRef(refreshCapabilities);
   refreshRef.current = refreshCapabilities;
-
   const dockerPollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelledRef = React.useRef(false);
+  const pollOnce = React.useCallback(async () => {
+    if (cancelledRef.current) return;
+    await refreshRef.current();
+    if (!cancelledRef.current) {
+      dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
+    }
+  }, [capabilitiesTtlMs]);
   React.useEffect(() => {
     if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
-    let cancelled = false;
-    async function pollOnce() {
-      await refreshRef.current();
-      if (!cancelled) {
-        dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
-      }
-    }
-    void pollOnce();
+    dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       if (dockerPollTimerRef.current !== null) {
         clearTimeout(dockerPollTimerRef.current);
         dockerPollTimerRef.current = null;
       }
     };
-  }, [isVisible, resolvedTab, capabilities?.hasDocker, refreshRef, capabilitiesTtlMs]);
+  }, [isVisible, resolvedTab, capabilities?.hasDocker, pollOnce, capabilitiesTtlMs]);
 
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader

--- a/components/systemManager/SystemManagerSidePanel.tsx
+++ b/components/systemManager/SystemManagerSidePanel.tsx
@@ -84,27 +84,31 @@ export const SystemManagerSidePanel = memo(function SystemManagerSidePanel({
   // the useEffect below is NOT re-run (which would cancel the timer and bypass the interval).
   const refreshRef = React.useRef(refreshCapabilities);
   refreshRef.current = refreshCapabilities;
-  const dockerPollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelledRef = React.useRef(false);
-  const pollOnce = React.useCallback(async () => {
-    if (cancelledRef.current) return;
-    await refreshRef.current();
-    if (!cancelledRef.current) {
-      dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
-    }
-  }, [capabilitiesTtlMs]);
+
+  // Auto-poll for Docker capabilities while Docker tab is active and Docker not yet detected.
+  // Each effect generation gets its own cancelled flag and timerId via closure,
+  // preventing stale probes from surviving cleanup (unlike cancelledRef which is shared).
+  // First poll is delayed by one interval to avoid overlapping with the tab-switch probe.
   React.useEffect(() => {
-    cancelledRef.current = false;
     if (!isVisible || resolvedTab !== 'docker' || capabilities?.hasDocker === true) return;
-    dockerPollTimerRef.current = setTimeout(pollOnce, capabilitiesTtlMs);
-    return () => {
-      cancelledRef.current = true;
-      if (dockerPollTimerRef.current !== null) {
-        clearTimeout(dockerPollTimerRef.current);
-        dockerPollTimerRef.current = null;
-      }
+
+    let cancelled = false;
+    let timerId: ReturnType<typeof setTimeout>;
+
+    const pollOnce = async () => {
+      if (cancelled) return;
+      await refreshRef.current();
+      if (cancelled) return;
+      timerId = setTimeout(pollOnce, capabilitiesTtlMs);
     };
-  }, [isVisible, resolvedTab, capabilities?.hasDocker, pollOnce, capabilitiesTtlMs]);
+
+    timerId = setTimeout(pollOnce, capabilitiesTtlMs);
+
+    return () => {
+      cancelled = true;
+      if (timerId) clearTimeout(timerId);
+    };
+  }, [isVisible, resolvedTab, capabilities?.hasDocker, capabilitiesTtlMs]);
 
   const workspaceHostHeader = showWorkspaceHostHeader && sessionHost ? (
     <WorkspaceSidebarHostHeader


### PR DESCRIPTION
## Summary

When the Docker tab is visible and `hasDocker` is not yet `true`, automatically poll `refreshCapabilities()` at the process refresh interval (default 3s). This way, after installing Docker, the panel discovers it within one refresh cycle without requiring a manual tab switch.

## Changes

- Added a new `useEffect` in `SystemManagerSidePanel.tsx` that starts a polling interval when:
  - `activeTab === 'docker'`
  - `capabilities?.hasDocker !== true`
  - `isVisible` is `true`
- Automatically stops when `hasDocker` becomes `true`, tab switches away, or panel becomes hidden.
- Reuses the existing `capabilitiesTtlMs` (`systemManagerProcessRefreshInterval * 1000`) as the polling interval.
- Reuses the existing `refreshCapabilities()` function.

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`).
- Test suite: pre-existing failures unrelated to this change.
- Logic: interval clears on unmount via cleanup function; dependencies correctly reflect all inputs.