### PR TITLE
fix: let Ctrl+C send SIGINT when no text is selected in terminal

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -61,6 +61,7 @@ import {
   shouldHandleTerminalFontSizeAction,
   terminalFontSizeWheelListenerOptions,
 } from "./terminalFontZoom";
+import { shouldPassThroughCopyShortcut } from "./terminalCopyShortcut";
 import {
   markExpectedTerminalCursorPositionReport,
   pasteTextIntoTerminal,
@@ -704,20 +705,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           ) {
             return true;
           }
-          // When copy is bound specifically to Ctrl+C / ⌃C (the ETX/SIGINT
-          // chord) and there is no text selected, pass the event through to
-          // xterm so it encodes the key as \x03. For any other copy binding
-          // (F5, Ctrl+L, etc.) we must NOT forward the key to the remote
-          // process — just consume it as a no-op.
-          if (
-            action === "copy"
-            && !term.hasSelection()
-            && e.key.toLowerCase() === "c"
-            && e.ctrlKey
-            && !e.shiftKey
-            && !e.altKey
-            && !e.metaKey
-          ) {
+          // When copy is bound specifically to Ctrl+C and there is no text
+          // selected, pass the event through so xterm can send SIGINT.
+          if (shouldPassThroughCopyShortcut(action, term.hasSelection(), e)) {
             return true;
           }
           e.preventDefault();

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -704,6 +704,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           ) {
             return true;
           }
+          // When copy is bound to Ctrl+C and there is no text selected,
+          // pass the event through to xterm so it encodes Ctrl+C as \x03
+          // (ETX → SIGINT). This preserves the standard terminal interrupt
+          // behaviour while still allowing copy when text is selected.
+          if (action === "copy" && !term.hasSelection()) {
+            return true;
+          }
           e.preventDefault();
           e.stopPropagation();
           switch (action) {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -704,11 +704,20 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           ) {
             return true;
           }
-          // When copy is bound to Ctrl+C and there is no text selected,
-          // pass the event through to xterm so it encodes Ctrl+C as \x03
-          // (ETX → SIGINT). This preserves the standard terminal interrupt
-          // behaviour while still allowing copy when text is selected.
-          if (action === "copy" && !term.hasSelection()) {
+          // When copy is bound specifically to Ctrl+C / ⌃C (the ETX/SIGINT
+          // chord) and there is no text selected, pass the event through to
+          // xterm so it encodes the key as \x03. For any other copy binding
+          // (F5, Ctrl+L, etc.) we must NOT forward the key to the remote
+          // process — just consume it as a no-op.
+          if (
+            action === "copy"
+            && !term.hasSelection()
+            && e.key.toLowerCase() === "c"
+            && e.ctrlKey
+            && !e.shiftKey
+            && !e.altKey
+            && !e.metaKey
+          ) {
             return true;
           }
           e.preventDefault();

--- a/components/terminal/runtime/terminalCopyShortcut.test.ts
+++ b/components/terminal/runtime/terminalCopyShortcut.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isPlainCtrlCInterruptChord,
+  shouldPassThroughCopyShortcut,
+} from "./terminalCopyShortcut.ts";
+
+const keyboardEvent = (
+  key: string,
+  code: string,
+  modifiers: Partial<KeyboardEvent> = {},
+): KeyboardEvent => ({
+  key,
+  code,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  metaKey: false,
+  ...modifiers,
+}) as KeyboardEvent;
+
+test("plain Ctrl+C copy with no selection passes through for SIGINT", () => {
+  const event = keyboardEvent("c", "KeyC", { ctrlKey: true });
+
+  assert.equal(isPlainCtrlCInterruptChord(event), true);
+  assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
+});
+
+test("copy shortcut does not pass through when text is selected", () => {
+  const event = keyboardEvent("c", "KeyC", { ctrlKey: true });
+
+  assert.equal(shouldPassThroughCopyShortcut("copy", true, event), false);
+});
+
+test("copy shortcut does not pass through for shifted or alternate chords", () => {
+  assert.equal(
+    shouldPassThroughCopyShortcut("copy", false, keyboardEvent("C", "KeyC", { ctrlKey: true, shiftKey: true })),
+    false,
+  );
+  assert.equal(
+    shouldPassThroughCopyShortcut("copy", false, keyboardEvent("l", "KeyL", { ctrlKey: true })),
+    false,
+  );
+  assert.equal(
+    shouldPassThroughCopyShortcut("paste", false, keyboardEvent("c", "KeyC", { ctrlKey: true })),
+    false,
+  );
+});
+
+test("plain Ctrl+C copy passthrough follows the physical C key on non-Latin layouts", () => {
+  const event = keyboardEvent("\u0441", "KeyC", { ctrlKey: true });
+
+  assert.equal(isPlainCtrlCInterruptChord(event), true);
+  assert.equal(shouldPassThroughCopyShortcut("copy", false, event), true);
+});

--- a/components/terminal/runtime/terminalCopyShortcut.ts
+++ b/components/terminal/runtime/terminalCopyShortcut.ts
@@ -1,0 +1,20 @@
+type CopyShortcutKeyEvent = Pick<
+  KeyboardEvent,
+  "key" | "code" | "ctrlKey" | "shiftKey" | "altKey" | "metaKey"
+>;
+
+export function isPlainCtrlCInterruptChord(e: CopyShortcutKeyEvent): boolean {
+  return e.ctrlKey
+    && !e.shiftKey
+    && !e.altKey
+    && !e.metaKey
+    && (e.key.toLowerCase() === "c" || e.code === "KeyC");
+}
+
+export function shouldPassThroughCopyShortcut(
+  action: string,
+  hasSelection: boolean,
+  e: CopyShortcutKeyEvent,
+): boolean {
+  return action === "copy" && !hasSelection && isPlainCtrlCInterruptChord(e);
+}


### PR DESCRIPTION
## Problem

When the user customizes the "Copy from Terminal" shortcut to `Ctrl+C`
(default is `Ctrl+Shift+C`), pressing Ctrl+C in the terminal always
triggers the copy action — even when no text is selected. This prevents
the standard Ctrl+C → SIGINT (interrupt) signal from reaching the shell.

## Root Cause

In `createXTermRuntime.ts`, the `attachCustomKeyEventHandler` handles
terminal actions by calling `e.preventDefault()` and `e.stopPropagation()`
unconditionally before checking whether text is actually selected. When
copy is bound to Ctrl+C, the event is always consumed, so xterm.js never
encodes it as `\x03` (ETX), and the SIGINT signal is never sent.

## Fix

Added a guard before `preventDefault`/`stopPropagation`: when the matched
action is `copy` and the terminal has no selection (`!term.hasSelection()`),
return `true` to pass the event through to xterm.js for normal processing.
This restores the standard Ctrl+C → `\x03` → SIGINT behavior while
preserving copy-when-selected.

```typescript
if (action === "copy" && !term.hasSelection()) {
  return true; // pass through to xterm → \x03 → SIGINT
}