### PR TITLE
fix: preserve double curly braces in shell template parsing (#1474)

### DIFF
--- a/domain/snippetVariables.ts
+++ b/domain/snippetVariables.ts
@@ -2,11 +2,15 @@
  * Parse and substitute {{variable}} / {{variable:default}} placeholders in snippet commands.
  */
 
-/** Non-global: safe to reuse; avoids lastIndex side effects across calls. */
-const VARIABLE_TOKEN = /\{\{([^}:]+)(?::([^}]*))?\}\}/;
+/** Non-global: safe to reuse; avoids lastIndex side effects across calls.
+ * Matches {{variable}} / {{variable:default}} placeholders.
+ * Excludes Go-template syntax like {{.Field}} or {{.}} (dot-prefixed names)
+ * so that commands like `docker inspect --format='{{.LogPath}}'` pass through
+ * without being treated as snippet variables. */
+const VARIABLE_TOKEN = /\{\{(?!\.)([^}:]+)(?::([^}]*))?\}\}/;
 
 function variablePattern(): RegExp {
-  return /\{\{([^}:]+)(?::([^}]*))?\}\}/g;
+  return /\{\{(?!\.)([^}:]+)(?::([^}]*))?\}\}/g;
 }
 
 export interface SnippetVariableDef {


### PR DESCRIPTION
## Description

Fixes #1474 — Shell command template parsing bug where `{{.LogPath}}` gets truncated to just `.`

### Root Cause

The snippet variable regex patterns in `domain/snippetVariables.ts` used `/\{\{([^}:]+)(?::([^}]*))?\}\}/` which matches **any** `{{...}}` pattern, including Go template expressions like `{{.LogPath}}`, `{{.Name}}`, `{{.}}`, etc.

When a user stores a script like:

```
ls -lh $(docker inspect --format='{{.LogPath}}' moviepilot)
```

The system incorrectly detected `{{.LogPath}}` as a snippet variable named `.LogPath`, popping up the variable prompt dialog. If the user provided a value (or no value), the Go template expression would be replaced/damaged.

### Fix

Added a negative lookahead `(?!\\.)` to both regex patterns (`VARIABLE_TOKEN` and `variablePattern()`) to exclude variable names that start with a dot (`.`). Dot-prefixed names like `{{.LogPath}}`, `{{.Name}}`, `{{.}}` are Go template field access expressions and should never be treated as snippet variables.

**Before:** `/\{\{([^}:]+)(?::([^}]*))?\}\}/`
**After:** `/\{\{(?!\.)([^}:]+)(?::([^}]*))?\}\}/`

### Testing

- All 10 existing snippet variable unit tests continue to pass
- Manually verified that `{{.LogPath}}`, `{{.Name}}`, `{{.}}`, and mixed Go-template + snippet variable commands are handled correctly
- Legitimate snippet variables like `{{name}}`, `{{password:secret}}` are unaffected
