### PR TITLE
fix: preserve cursor visibility when AI chat input is cleared (#1485)

### DIFF
--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -159,6 +159,18 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setSlashRange(null);
   }, []);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Track previous value to detect empty transitions
+  const prevValueRef = useRef(value);
+  useEffect(() => {
+    if (prevValueRef.current.length > 0 && value.length === 0) {
+      // Input was just cleared to empty — ensure the textarea keeps focus
+      // so the blinking cursor remains visible. React's controlled-input
+      // reconciliation may lose the cursor when the value goes to empty
+      // during a batch of parent state updates (draft + panel view).
+      textareaRef.current?.focus();
+    }
+    prevValueRef.current = value;
+  }, [value]);
   const inputShellRef = useRef<HTMLDivElement>(null);
   const modelBtnRef = useRef<HTMLButtonElement>(null);
   const permBtnRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
## Description

Fixes an issue where the cursor (blinking caret) disappears from the AI chat input textarea after the user clears the input box by backspacing to empty. Switching to another conversation and back does not restore it.

## Root Cause

When the user backspaces to empty the AI chat input, the `ChatInput` component's `handleInputChange` fires `onChange('')` which calls `setInputValue('')` on the parent `AIChatSidePanelActive`. This triggers `enterScopeDraftMode` (which calls `showDraftView`, updating panel view state) followed by `updateScopeDraft` (which updates the draft text to empty). The cascade of state updates causes React to re-render the component tree, and during this re-render, the controlled `<textarea>`'s cursor position can be lost when the value transitions to an empty string.

The issue specifically manifests because:
1. Every keystroke calls both `enterScopeDraftMode` and `updateScopeDraft`, causing multiple state updates to batch  
2. When the final character is backspaced, the value goes from `'h'` to `''`, and React's controlled-input reconciliation may not properly restore the cursor in this edge case
3. `React.memo` on ChatInput with default shallow comparison can prevent proper re-initialization when switching between sessions with empty drafts

## Fix

Added a `useEffect` in `ChatInput` that re-focuses the textarea when `value` becomes empty after being non-empty. This ensures the cursor remains visible when the user clears the input.

## Testing

- [x] Verified the fix handles the clear-to-empty edge case
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] No regressions to normal typing, @-mention, or slash-command flows
