### PR TITLE
fix: ensure credential delete button is visible for long names (#1482)

### DIFF
--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -135,7 +135,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-6 w-6"
+                  className="h-6 w-6 shrink-0"
                   onClick={() => {
                     update("identityFileId", undefined);
                     update("authMethod", undefined);

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -375,7 +375,7 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-6 w-6"
+                  className="h-6 w-6 shrink-0"
                   onClick={() => {
                     update("identityFileId", undefined);
                     update("authMethod", "password");

--- a/components/keychain/IdentityPanel.tsx
+++ b/components/keychain/IdentityPanel.tsx
@@ -135,7 +135,7 @@ export const IdentityPanel: React.FC<IdentityPanelProps> = ({
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-6 w-6"
+                                className="h-6 w-6 shrink-0"
                                 onClick={clearSelectedKey}
                             >
                                 <X size={12} />


### PR DESCRIPTION
Fix #1482 - Long credential names hide the delete button

**Root cause:** Three credential display components (`HostDetailsConnectionSections`, `GroupSshSettingsSection`, `IdentityPanel`) show selected SSH keys/credentials in a flex row with a name label and an X (clear/delete) button. The X button was missing `shrink-0`, so when the credential name is very long, the flex layout compresses the button, and the parent container's `overflow-hidden` clips it off-screen.

**Fix:** Added `shrink-0` to the X button in all three components, ensuring the button maintains its intrinsic width and is always visible regardless of name length.
