### PR TITLE
[codex] Fix SSH Ctrl+C interrupt handling

### DIFF
--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -685,6 +685,15 @@ function cancelActiveYmodemSession(session) {
   session.ymodemAbortController?.abort();
 }
 
+function signalSshInterruptIfNeeded(session, data) {
+  if (data !== '\x03' || !session?.stream || typeof session.stream.signal !== "function") return;
+  try {
+    session.stream.signal("INT");
+  } catch {
+    // Keep the legacy Ctrl+C byte write as the compatibility fallback.
+  }
+}
+
 function writeToSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   if (!session) return;
@@ -720,6 +729,7 @@ function writeToSession(event, payload) {
     const outgoing = encodeTerminalInput(payload.data, session.encoding);
 
     if (session.stream) {
+      signalSshInterruptIfNeeded(session, payload.data);
       session.stream.write(outgoing);
     } else if (session.proc) {
       session.proc.write(outgoing);

--- a/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
+++ b/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
@@ -116,3 +116,21 @@ test("telnet Ctrl+C behavior is unchanged", () => {
 
   assert.deepEqual(calls, [["write", "\x03"]]);
 });
+
+test("serial Ctrl+C behavior is unchanged", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("serial-1", {
+    type: "serial",
+    serialPort: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "serial-1", data: "\x03" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});

--- a/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
+++ b/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
@@ -1,0 +1,118 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const terminalBridge = require("./terminalBridge.cjs");
+
+function initBridge(sessions) {
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({ send() {} }),
+      },
+    },
+  });
+}
+
+test("SSH Ctrl+C signals INT immediately and still writes the original byte", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: {
+      signal(signalName) {
+        calls.push(["signal", signalName]);
+      },
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x03" });
+
+  assert.deepEqual(calls, [
+    ["signal", "INT"],
+    ["write", "\x03"],
+  ]);
+});
+
+test("SSH Ctrl+C still writes when the server does not support channel signals", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: {
+      signal(signalName) {
+        calls.push(["signal", signalName]);
+        throw new Error("signals unsupported");
+      },
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x03" });
+
+  assert.deepEqual(calls, [
+    ["signal", "INT"],
+    ["write", "\x03"],
+  ]);
+});
+
+test("SSH ordinary input is written without sending INT", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: {
+      signal(signalName) {
+        calls.push(["signal", signalName]);
+      },
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "cat\r" });
+
+  assert.deepEqual(calls, [["write", "cat\r"]]);
+});
+
+test("local Ctrl+C behavior is unchanged", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("local-1", {
+    type: "local",
+    proc: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "local-1", data: "\x03" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});
+
+test("telnet Ctrl+C behavior is unchanged", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("telnet-1", {
+    type: "telnet-native",
+    socket: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "telnet-1", data: "\x03" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});


### PR DESCRIPTION
## Summary
- Send an immediate SSH interrupt when a terminal session receives Ctrl+C.
- Keep the original Ctrl+C byte write as a fallback for servers that do not support SSH channel signals.
- Add main-process coverage for SSH Ctrl+C, fallback behavior, ordinary input, and non-SSH protocols.

Fixes #1480

## Verification
- `node --test --import tsx electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs`
- `node --test --import tsx electron/bridges/terminalBridge.*.test.cjs electron/bridges/terminalBridge/*.test.cjs`
- `npm run lint -- --quiet`
- `npm run build`
- `npm test`

Manual SSH long-output verification was not possible in this worktree because localhost SSH rejected non-interactive login.
