### PR TITLE
[codex] Fix long credential name removal

### DIFF
--- a/components/HostDetailsConnectionSections.test.tsx
+++ b/components/HostDetailsConnectionSections.test.tsx
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { SSHKey } from "../types.ts";
+import { HostDetailsConnectionSections } from "./HostDetailsConnectionSections.tsx";
+import { TooltipProvider } from "./ui/tooltip.tsx";
+
+const longCredentialLabel =
+  "D:\\download\\acdrOgxses_wuzh02.hpccube.com_really_really_long_private_key_name.pem";
+
+const availableKey: SSHKey = {
+  id: "key-1",
+  label: longCredentialLabel,
+  type: "ED25519",
+  privateKey: "",
+  publicKey: "",
+  source: "imported",
+  category: "key",
+  created: 1,
+};
+
+const renderConnectionSections = () =>
+  renderToStaticMarkup(
+    React.createElement(
+      TooltipProvider,
+      null,
+      React.createElement(HostDetailsConnectionSections, {
+        t: (key: string) => key,
+        form: {
+          id: "host-1",
+          label: "Host",
+          hostname: "example.com",
+          username: "root",
+          port: 22,
+          protocol: "ssh",
+          os: "linux",
+          authMethod: "key",
+          identityFileId: availableKey.id,
+        },
+        update: () => {},
+        groupDefaults: undefined,
+        selectedIdentity: undefined,
+        clearIdentity: () => {},
+        identities: [],
+        identitySuggestionsOpen: false,
+        filteredIdentitySuggestions: [],
+        setIdentitySuggestionsOpen: () => {},
+        availableKeys: [availableKey],
+        applyIdentity: () => {},
+        showPassword: false,
+        setShowPassword: () => {},
+        pendingReferenceKeyPath: null,
+        setPendingReferenceKeyPath: () => {},
+        selectedCredentialType: null,
+        setSelectedCredentialType: () => {},
+        credentialPopoverOpen: false,
+        setCredentialPopoverOpen: () => {},
+        keysByCategory: { key: [availableKey], certificate: [] },
+        newKeyFilePath: "",
+        setNewKeyFilePath: () => {},
+        addLocalKeyFilePath: () => {},
+        handleDistroModeChange: () => {},
+        distroOptions: [],
+        effectiveFormDistro: undefined,
+        getDistroOptionLabel: () => "",
+      }),
+    ),
+  );
+
+test("selected host credential keeps the remove button visible with a long name", () => {
+  const markup = renderConnectionSections();
+
+  assert.match(markup, new RegExp(longCredentialLabel.replaceAll("\\", "\\\\")));
+  assert.match(
+    markup,
+    /class="flex items-center gap-2 min-w-0 overflow-hidden p-2 rounded-md bg-secondary\/50 border border-border\/60"/,
+  );
+  assert.match(markup, /class="text-sm min-w-0 flex-1 truncate"/);
+  assert.match(markup, /class="[^"]*h-6 w-6 shrink-0[^"]*"/);
+});

--- a/components/HostDetailsConnectionSections.tsx
+++ b/components/HostDetailsConnectionSections.tsx
@@ -362,20 +362,20 @@ export const HostDetailsConnectionSections: React.FC<HostDetailsConnectionSectio
 
             {/* Selected credential display */}
             {!selectedIdentity && form.identityFileId && (
-              <div className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60">
+              <div className="flex items-center gap-2 min-w-0 overflow-hidden p-2 rounded-md bg-secondary/50 border border-border/60">
                 {form.authMethod === "certificate" ? (
-                  <Shield size={14} className="text-primary" />
+                  <Shield size={14} className="text-primary shrink-0" />
                 ) : (
-                  <Key size={14} className="text-primary" />
+                  <Key size={14} className="text-primary shrink-0" />
                 )}
-                <span className="text-sm flex-1 truncate">
+                <span className="text-sm min-w-0 flex-1 truncate">
                   {availableKeys.find((k) => k.id === form.identityFileId)
                     ?.label || "Key"}
                 </span>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-6 w-6"
+                  className="h-6 w-6 shrink-0"
                   onClick={() => {
                     update("identityFileId", undefined);
                     update("authMethod", "password");

--- a/components/KeychainCardLayout.test.tsx
+++ b/components/KeychainCardLayout.test.tsx
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { I18nProvider } from "../application/i18n/I18nProvider.tsx";
+import { STORAGE_KEY_VAULT_KEYS_VIEW_MODE } from "../infrastructure/config/storageKeys.ts";
+import type { Identity, SSHKey } from "../types.ts";
+import KeychainManager from "./KeychainManager.tsx";
+import { IdentityCard } from "./keychain/IdentityCard.tsx";
+import { KeyCard } from "./keychain/KeyCard.tsx";
+
+const longLabel =
+  "sdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijssdakdjkasjakjskajskaijs";
+
+const renderWithI18n = (node: React.ReactElement) =>
+  renderToStaticMarkup(
+    React.createElement(I18nProvider, { locale: "en" }, node),
+  );
+
+const installStorageStub = (viewMode: string | null = null) => {
+  const values = new Map<string, string>();
+  if (viewMode) {
+    values.set(STORAGE_KEY_VAULT_KEYS_VIEW_MODE, viewMode);
+  }
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+      removeItem: (key: string) => {
+        values.delete(key);
+      },
+    },
+  });
+};
+
+const installNavigatorStub = () => {
+  const currentNavigator = globalThis.navigator;
+  if (
+    typeof currentNavigator?.platform === "string" &&
+    typeof currentNavigator?.userAgent === "string"
+  ) {
+    return;
+  }
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      platform: "MacIntel",
+      userAgent: "Mac OS",
+    },
+  });
+};
+
+const identity: Identity = {
+  id: "identity-1",
+  label: longLabel,
+  username: "root",
+  authMethod: "password",
+  password: "pw",
+  created: 1,
+};
+
+const keyItem: SSHKey = {
+  id: "key-1",
+  label: longLabel,
+  type: "ED25519",
+  privateKey: "",
+  publicKey: "",
+  source: "imported",
+  category: "key",
+  created: 1,
+};
+
+test("IdentityCard list layout constrains long labels", () => {
+  const markup = renderWithI18n(
+    React.createElement(IdentityCard, {
+      identity,
+      viewMode: "list",
+      isSelected: false,
+      onClick: () => {},
+    }),
+  );
+
+  assert.match(markup, /group cursor-pointer min-w-0 w-full max-w-full/);
+  assert.doesNotMatch(markup, /group cursor-pointer min-w-0 w-full max-w-full overflow-hidden/);
+  assert.match(markup, /flex items-center gap-3 h-full min-w-0/);
+  assert.doesNotMatch(markup, /flex items-center gap-3 h-full min-w-0 overflow-hidden/);
+  assert.match(markup, /min-w-0 flex-1 basis-0 overflow-hidden/);
+  assert.match(markup, /block max-w-full truncate text-sm font-semibold/);
+});
+
+test("KeyCard list layout constrains long labels", () => {
+  const markup = renderWithI18n(
+    React.createElement(KeyCard, {
+      keyItem,
+      viewMode: "list",
+      isSelected: false,
+      isMac: false,
+      onClick: () => {},
+      onEdit: () => {},
+      onExport: () => {},
+      onCopyPublicKey: () => {},
+      onDelete: () => {},
+    }),
+  );
+
+  assert.match(markup, /group cursor-pointer min-w-0 w-full max-w-full/);
+  assert.doesNotMatch(markup, /group cursor-pointer min-w-0 w-full max-w-full overflow-hidden/);
+  assert.match(markup, /flex items-center gap-3 h-full min-w-0/);
+  assert.doesNotMatch(markup, /flex items-center gap-3 h-full min-w-0 overflow-hidden/);
+  assert.match(markup, /min-w-0 flex-1 basis-0 overflow-hidden/);
+  assert.match(markup, /block max-w-full truncate text-sm font-semibold/);
+});
+
+test("KeychainManager list layout constrains long key and identity rows", () => {
+  installNavigatorStub();
+  installStorageStub("list");
+
+  const markup = renderWithI18n(
+    React.createElement(KeychainManager, {
+      keys: [keyItem],
+      identities: [identity],
+      hosts: [],
+      proxyProfiles: [],
+      customGroups: [],
+      groupConfigs: [],
+      managedSources: [],
+      onSave: () => {},
+      onUpdate: () => {},
+      onReorderKeys: () => {},
+      onDelete: () => {},
+      onSaveIdentity: () => {},
+      onReorderIdentities: () => {},
+      onDeleteIdentity: () => {},
+    }),
+  );
+
+  assert.match(markup, /h-full min-w-0 w-full overflow-hidden flex relative/);
+  assert.match(markup, /flex-1 min-w-0 w-full overflow-y-auto/);
+  assert.doesNotMatch(markup, /flex-1 min-w-0 w-full overflow-y-auto overflow-x-hidden/);
+  assert.match(markup, /flex min-w-0 w-full max-w-full flex-col gap-0/);
+  assert.match(markup, /block min-w-0 w-full max-w-full/);
+  assert.match(markup, /Keys/);
+  assert.match(markup, /Identities/);
+});

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -540,7 +540,7 @@ echo $3 >> "$FILE"`);
   );
 
   return (
-    <div className="h-full flex relative">
+    <div className="h-full min-w-0 w-full overflow-hidden flex relative">
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -553,7 +553,7 @@ echo $3 >> "$FILE"`);
       {/* Main Content */}
       <div
         className={cn(
-          "flex-1 flex flex-col min-h-0 transition-all duration-200",
+          "flex-1 min-w-0 flex flex-col min-h-0 transition-all duration-200",
           panel.type !== "closed" && "mr-[380px]",
         )}
       >
@@ -705,7 +705,7 @@ echo $3 >> "$FILE"`);
         {/* Scrollable Content */}
         <div
           ref={listRef}
-          className="flex-1 overflow-y-auto"
+          className="flex-1 min-w-0 w-full overflow-y-auto"
           onDragOverCapture={(event) => {
             keyReorder.handleDragOverCapture(event);
             identityReorder.handleDragOverCapture(event);
@@ -724,15 +724,15 @@ echo $3 >> "$FILE"`);
           }}
         >
           {/* Keys Section */}
-          <div className="space-y-3 p-3">
-          <div className="flex items-center justify-between">
-            <h2 className={vaultSectionTitleClass}>
-              {t("keychain.section.keys")}
-            </h2>
-            <span className="text-xs text-muted-foreground">
-              {t("keychain.count.items", { count: filteredKeys.length })}
-            </span>
-          </div>
+          <div className="min-w-0 w-full space-y-3 p-3">
+            <div className="flex items-center justify-between">
+              <h2 className={vaultSectionTitleClass}>
+                {t("keychain.section.keys")}
+              </h2>
+              <span className="text-xs text-muted-foreground">
+                {t("keychain.count.items", { count: filteredKeys.length })}
+              </span>
+            </div>
 
           {filteredKeys.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
@@ -762,8 +762,8 @@ echo $3 >> "$FILE"`);
             <div
               className={
                 viewMode === "grid"
-                  ? "grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                  : "flex flex-col gap-0"
+                  ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                  : "flex min-w-0 w-full max-w-full flex-col gap-0"
               }
             >
               {filteredKeys.map((key) => (
@@ -790,7 +790,7 @@ echo $3 >> "$FILE"`);
 
         {/* Identities Section */}
         {activeFilter === "key" && filteredIdentities.length > 0 && (
-          <div className="space-y-3 px-3 pb-3">
+          <div className="min-w-0 w-full space-y-3 px-3 pb-3">
             <div className="flex items-center justify-between">
               <h2 className={vaultSectionTitleClass}>
                 {t("keychain.section.identities")}
@@ -802,13 +802,13 @@ echo $3 >> "$FILE"`);
             <div
               className={
                 viewMode === "grid"
-                  ? "grid gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                  : "flex flex-col gap-0"
+                  ? "grid min-w-0 w-full max-w-full gap-3 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                  : "flex min-w-0 w-full max-w-full flex-col gap-0"
               }
             >
               {filteredIdentities.map((identity) => (
                 <ContextMenu key={identity.id}>
-                  <ContextMenuTrigger>
+                  <ContextMenuTrigger className="block min-w-0 w-full max-w-full">
                     <IdentityCard
                       identity={identity}
                       viewMode={viewMode}

--- a/components/keychain/IdentityCard.tsx
+++ b/components/keychain/IdentityCard.tsx
@@ -48,7 +48,7 @@ export const IdentityCard: React.FC<IdentityCardProps> = ({
             {...reorderProps}
             className={cn(
                 reorderProps && "vault-drop-indicator-row",
-                "group cursor-pointer",
+                "group cursor-pointer min-w-0 w-full max-w-full",
                 viewMode === 'grid'
                     ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                     : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
@@ -57,14 +57,14 @@ export const IdentityCard: React.FC<IdentityCardProps> = ({
             )}
             onClick={onClick}
         >
-            <div className="flex items-center gap-3 h-full">
+            <div className="flex items-center gap-3 h-full min-w-0">
                 <VaultEntityIcon
                     className={vaultIdentityIconClass}
                     icon={<User size={18} />}
                 />
-                <div className="min-w-0 flex-1">
-                    <div className="text-sm font-semibold truncate">{identity.label || 'Add a label...'}</div>
-                    <div className="text-[11px] font-mono text-muted-foreground truncate">
+                <div className="min-w-0 flex-1 basis-0 overflow-hidden">
+                    <div className="block max-w-full truncate text-sm font-semibold">{identity.label || 'Add a label...'}</div>
+                    <div className="block max-w-full truncate text-[11px] font-mono text-muted-foreground">
                         {summary}
                     </div>
                 </div>

--- a/components/keychain/KeyCard.tsx
+++ b/components/keychain/KeyCard.tsx
@@ -55,7 +55,7 @@ export const KeyCard: React.FC<KeyCardProps> = ({
                     {...reorderProps}
                     className={cn(
                         reorderProps && "vault-drop-indicator-row",
-                        "group cursor-pointer",
+                        "group cursor-pointer min-w-0 w-full max-w-full",
                         viewMode === 'grid'
                             ? "soft-card elevate rounded-xl h-[68px] px-3 py-2"
                             : "h-14 px-3 py-2 hover:bg-secondary/60 rounded-lg transition-colors",
@@ -64,16 +64,16 @@ export const KeyCard: React.FC<KeyCardProps> = ({
                     )}
                     onClick={onClick}
                 >
-                    <div className="flex items-center gap-3 h-full">
+                    <div className="flex items-center gap-3 h-full min-w-0">
                         <VaultEntityIcon
                             className={keyItem.certificate
                               ? vaultCertificateIconClass
                               : vaultKeyIconClass}
                             icon={getKeyIcon(keyItem)}
                         />
-                        <div className="min-w-0 flex-1">
-                            <div className="text-sm font-semibold truncate">{keyItem.label}</div>
-                            <div className="text-[11px] font-mono text-muted-foreground truncate">
+                        <div className="min-w-0 flex-1 basis-0 overflow-hidden">
+                            <div className="block max-w-full truncate text-sm font-semibold">{keyItem.label}</div>
+                            <div className="block max-w-full truncate text-[11px] font-mono text-muted-foreground">
                                 Type {getKeyTypeDisplay(keyItem, isMac)}
                             </div>
                         </div>


### PR DESCRIPTION
## What changed

- Long credential names are shortened visually instead of stretching rows past the visible area.
- The host connection selected credential can still be removed even when its name is very long.
- Keychain List mode now keeps long key and identity names inside the row, with icons intact and row actions still reachable.
- Added coverage for both host connection selection and Keychain List rows.
- Addressed the remote Codex review note by stubbing the browser navigator in the Node-only KeychainManager layout test.

## Root cause

Long credential labels were allowed to take their full natural width in some rows, which pushed delete/remove entries out of view.

Fixes #1482

## Validation

- `node --test --import tsx components/KeychainCardLayout.test.tsx components/HostDetailsConnectionSections.test.tsx`
- `node --import "data:text/javascript,Object.defineProperty(globalThis%2C'navigator'%2C%7Bconfigurable%3Atrue%2Cvalue%3Aundefined%7D)%3B" --test --import tsx components/KeychainCardLayout.test.tsx`
- `npm run lint`
- `npm run build`
- `npm test`
- Browser check for host connection selected credential with a very long name: no horizontal overflow, remove button visible.
- Browser check for Keychain List mode with very long key and identity names at 2048px and 411px widths: no horizontal overflow, icons stayed 44x44, row action stayed within the viewport.
- Right-click check on the long identity row: Edit and Delete menu items opened correctly.
- Follow-up review agent pass: Critical/Important/Minor all clean.
