### PR TITLE
[codex] Fix AI new chat input focus

### DIFF
--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
+import { I18nProvider } from '../application/i18n/I18nProvider.tsx';
 import type { AIDraft, AISession } from '../infrastructure/ai/types';
+import { TooltipProvider } from './ui/tooltip.tsx';
 import {
   aiChatSidePanelPropsAreEqual,
+  AIChatSidePanel,
   hasAIChatSidePanelRetainedContent,
   shouldKeepAIChatSidePanelMounted,
 } from './AIChatSidePanel.tsx';
@@ -100,6 +105,32 @@ test('hidden AI side panel is retained when it has session messages', () => {
 
 test('visible AI side panel is always mounted even when empty', () => {
   assert.equal(shouldKeepAIChatSidePanelMounted(baseProps({ isVisible: true })), true);
+});
+
+test('visible empty draft renders the input immediately without preparing state', () => {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      I18nProvider,
+      { locale: 'en' },
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(AIChatSidePanel, baseProps({
+          isVisible: true,
+          sessions: [session({ id: 'session-history' })],
+          draftsByScope: {
+            'terminal:terminal-1': draft(),
+          },
+          panelViewByScope: {
+            'terminal:terminal-1': { mode: 'draft' },
+          },
+        })),
+      ),
+    ),
+  );
+
+  assert.match(markup, /textarea/);
+  assert.doesNotMatch(markup, /data-section="ai-chat-panel-preparing"/);
 });
 
 test('AI side panel re-renders when retained content becomes visible again', () => {

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -166,6 +166,9 @@ export function shouldKeepAIChatSidePanelMounted(props: AIChatSidePanelProps): b
 function shouldDelayAIChatSidePanelActivation(props: AIChatSidePanelProps): boolean {
   if (!(props.isVisible ?? true)) return false;
   const scopeKey = `${props.scopeType}:${props.scopeTargetId ?? ''}`;
+  if (props.draftsByScope[scopeKey] || props.panelViewByScope[scopeKey]?.mode === 'draft') {
+    return false;
+  }
   const sessionId = props.activeSessionIdMap[scopeKey] ?? null;
   if (isAIChatSessionStreaming(sessionId)) return false;
   return !hasAIChatSidePanelRetainedContent(props);


### PR DESCRIPTION
## Summary

- Keep visible AI draft panels mounted as the real chat input instead of briefly switching them to the preparing state when the draft becomes empty.
- Add a regression test covering a visible empty draft with chat history so the input renders immediately.

Fixes #1485

## Validation

- `node --test --import tsx components/AIChatSidePanel.mountRetention.test.ts components/ai/aiPanelViewState.test.ts application/state/aiDraftState.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`

## Notes

I also attempted rendered browser validation. The full app route loaded, but the normal browser lacks Netcatty's Electron terminal backend, and the Browser plugin runtime became unavailable after the sandbox transition before I could complete the temporary component harness interaction. The regression test renders the actual AI side panel and verifies the empty draft shows the textarea instead of the preparing state, which covers the focus-loss root cause.