### PR TITLE
Fix snippet Go template literals

### DIFF
--- a/domain/snippetVariables.test.ts
+++ b/domain/snippetVariables.test.ts
@@ -82,6 +82,41 @@ test("applySnippetVariables preserves Docker Go template assignment action block
   if (result.ok) assert.equal(result.command, command);
 });
 
+test("applySnippetVariables preserves Docker Go template assigned variables", () => {
+  const cases = [
+    "docker inspect --format='{{$p := .LogPath}}{{$p}}' moviepilot",
+    "docker inspect --format='{{$p := .LogPath}}{{printf \"%s\" $p}}' moviepilot",
+    "docker inspect --format='{{$p := .LogPath}}{{if $p}}{{$p}}{{end}}' moviepilot",
+    "docker inspect --format='{{range $k, $v := .NetworkSettings.Networks}}{{$k}}={{$v.IPAddress}}{{end}}' moviepilot",
+  ];
+
+  for (const command of cases) {
+    const result = applySnippetVariables(command, {});
+
+    assert.equal(snippetHasVariables(command), false);
+    assert.deepEqual(parseSnippetVariables(command), []);
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.command, command);
+  }
+});
+
+test("applySnippetVariables preserves Docker Go template helper actions", () => {
+  const cases = [
+    "docker inspect --format='{{json .}}' moviepilot",
+    "docker inspect --format='{{printf \"%s\" .}}' moviepilot",
+    "docker inspect --format='{{println .}}' moviepilot",
+  ];
+
+  for (const command of cases) {
+    const result = applySnippetVariables(command, {});
+
+    assert.equal(snippetHasVariables(command), false);
+    assert.deepEqual(parseSnippetVariables(command), []);
+    assert.equal(result.ok, true);
+    if (result.ok) assert.equal(result.command, command);
+  }
+});
+
 test("applySnippetVariables can mix script variables with Docker Go template field literals", () => {
   const result = applySnippetVariables(
     "ls -lh $(docker inspect --format='{{.LogPath}}' {{container:moviepilot}})",
@@ -132,6 +167,18 @@ test("applySnippetVariables keeps regular variables named like Go template contr
   const result = applySnippetVariables(
     "docker inspect --format='{{.LogPath}}' {{end:done}}",
     {},
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.command, "docker inspect --format='{{.LogPath}}' done");
+  }
+});
+
+test("applySnippetVariables keeps required variables named like Go template controls near Go template context", () => {
+  const result = applySnippetVariables(
+    "docker inspect --format='{{.LogPath}}' {{end}}",
+    { end: "done" },
   );
 
   assert.equal(result.ok, true);

--- a/domain/snippetVariables.test.ts
+++ b/domain/snippetVariables.test.ts
@@ -32,6 +32,137 @@ test("parseSnippetVariables reads default after colon", () => {
   ]);
 });
 
+test("parseSnippetVariables ignores Docker Go template field literals", () => {
+  const command = "ls -lh $(docker inspect --format='{{.LogPath}}' moviepilot)";
+
+  assert.equal(snippetHasVariables(command), false);
+  assert.deepEqual(parseSnippetVariables(command), []);
+});
+
+test("parseSnippetVariables ignores Docker Go template field literals with trim markers", () => {
+  const command = "ls -lh $(docker inspect --format='{{- .LogPath -}}' moviepilot)";
+
+  assert.equal(snippetHasVariables(command), false);
+  assert.deepEqual(parseSnippetVariables(command), []);
+});
+
+test("applySnippetVariables preserves Docker Go template field literals", () => {
+  const command = "ls -lh $(docker inspect --format='{{.LogPath}}' moviepilot)";
+  const result = applySnippetVariables(command, {});
+
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.command, command);
+});
+
+test("applySnippetVariables preserves Docker Go template field literals with trim markers", () => {
+  const command = "ls -lh $(docker inspect --format='{{- .LogPath -}}' moviepilot)";
+  const result = applySnippetVariables(command, {});
+
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.command, command);
+});
+
+test("applySnippetVariables preserves Docker Go template action blocks", () => {
+  const command = "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' moviepilot";
+  const result = applySnippetVariables(command, {});
+
+  assert.equal(snippetHasVariables(command), false);
+  assert.deepEqual(parseSnippetVariables(command), []);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.command, command);
+});
+
+test("applySnippetVariables preserves Docker Go template assignment action blocks", () => {
+  const command = "docker inspect --format='{{range $k, $v := .NetworkSettings.Networks}}{{$v.IPAddress}}{{end}}' moviepilot";
+  const result = applySnippetVariables(command, {});
+
+  assert.equal(snippetHasVariables(command), false);
+  assert.deepEqual(parseSnippetVariables(command), []);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.command, command);
+});
+
+test("applySnippetVariables can mix script variables with Docker Go template field literals", () => {
+  const result = applySnippetVariables(
+    "ls -lh $(docker inspect --format='{{.LogPath}}' {{container:moviepilot}})",
+    {},
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(
+      result.command,
+      "ls -lh $(docker inspect --format='{{.LogPath}}' moviepilot)",
+    );
+  }
+});
+
+test("applySnippetVariables can mix script variables with Docker Go template action blocks", () => {
+  const result = applySnippetVariables(
+    "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{container:moviepilot}}",
+    {},
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(
+      result.command,
+      "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' moviepilot",
+    );
+  }
+});
+
+test("snippetHasVariables detects script variables after Docker Go template field literals", () => {
+  assert.equal(
+    snippetHasVariables("docker inspect --format='{{.LogPath}}' {{container}}"),
+    true,
+  );
+});
+
+test("parseSnippetVariables keeps regular variables named like Go template controls outside Go template context", () => {
+  const result = applySnippetVariables("echo {{end}}", { end: "done" });
+
+  assert.equal(snippetHasVariables("echo {{end}}"), true);
+  assert.deepEqual(parseSnippetVariables("echo {{end}}"), [{ name: "end" }]);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.command, "echo done");
+});
+
+test("applySnippetVariables keeps regular variables named like Go template controls near Go template context", () => {
+  const result = applySnippetVariables(
+    "docker inspect --format='{{.LogPath}}' {{end:done}}",
+    {},
+  );
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.command, "docker inspect --format='{{.LogPath}}' done");
+  }
+});
+
+test("applySnippetVariables does not replace Go template actions when a script variable has the same name", () => {
+  const command = "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{end:done}}";
+  const result = applySnippetVariables(command, {});
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(
+      result.command,
+      "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' done",
+    );
+  }
+});
+
+test("previewSnippetCommand does not replace Go template actions when a script variable has the same name", () => {
+  assert.equal(
+    previewSnippetCommand(
+      "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {{end:done}}",
+      {},
+    ),
+    "docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' done",
+  );
+});
+
 test("applySnippetVariables replaces all occurrences", () => {
   const result = applySnippetVariables(
     "fallocate -l {{内存大小:4}}G\nswapon {{内存大小:4}}",

--- a/domain/snippetVariables.ts
+++ b/domain/snippetVariables.ts
@@ -2,11 +2,78 @@
  * Parse and substitute {{variable}} / {{variable:default}} placeholders in snippet commands.
  */
 
-/** Non-global: safe to reuse; avoids lastIndex side effects across calls. */
-const VARIABLE_TOKEN = /\{\{([^}:]+)(?::([^}]*))?\}\}/;
-
 function variablePattern(): RegExp {
   return /\{\{([^}:]+)(?::([^}]*))?\}\}/g;
+}
+
+const GO_TEMPLATE_CONTROL_ACTIONS = new Set([
+  "break",
+  "continue",
+  "else",
+  "end",
+  "if",
+  "range",
+  "with",
+]);
+
+function normalizeGoTemplateAction(name: string): string {
+  return name.trim().replace(/^-/, "").replace(/-$/, "").trim();
+}
+
+function templateActionBody(match: RegExpMatchArray): string {
+  return (match[0] ?? "").slice(2, -2);
+}
+
+function collectVariableMatches(text: string): {
+  matches: RegExpMatchArray[];
+  hasGoTemplateContext: boolean;
+} {
+  const matches = Array.from(text.matchAll(variablePattern()));
+  const hasGoTemplateContext = matches.some((match) => (
+    hasGoTemplateFieldReference(templateActionBody(match))
+  ));
+  return { matches, hasGoTemplateContext };
+}
+
+function hasGoTemplateFieldReference(name: string): boolean {
+  const action = normalizeGoTemplateAction(name);
+  return action === "."
+    || /(?:^|[\s(])\.[A-Za-z_]/.test(action)
+    || /(?:^|[\s(])\$[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]/.test(action);
+}
+
+function isGoTemplateControlAction(name: string): boolean {
+  const action = normalizeGoTemplateAction(name);
+  if (action === "break" || action === "continue" || action === "else" || action === "end") {
+    return true;
+  }
+  const firstWord = action.split(/\s+/, 1)[0] ?? "";
+  return GO_TEMPLATE_CONTROL_ACTIONS.has(firstWord) && action.startsWith(`${firstWord} `);
+}
+
+function isSnippetVariableName(
+  name: string,
+  tokenBody: string,
+  hasGoTemplateContext = false,
+): boolean {
+  return name !== ""
+    && !hasGoTemplateFieldReference(tokenBody)
+    && !(hasGoTemplateContext && isGoTemplateControlAction(tokenBody));
+}
+
+function replaceSnippetVariableTokens(
+  command: string,
+  replacementFor: (name: string, token: string) => string,
+): string {
+  const text = String(command ?? "");
+  const { hasGoTemplateContext } = collectVariableMatches(text);
+  return text.replace(variablePattern(), (token: string, rawName: string) => {
+    const name = String(rawName ?? "").trim();
+    if (!isSnippetVariableName(name, token.slice(2, -2), hasGoTemplateContext)) {
+      return token;
+    }
+    return replacementFor(name, token);
+  });
 }
 
 export interface SnippetVariableDef {
@@ -15,17 +82,18 @@ export interface SnippetVariableDef {
 }
 
 export function snippetHasVariables(command: string): boolean {
-  return VARIABLE_TOKEN.test(String(command ?? ""));
+  return parseSnippetVariables(command).length > 0;
 }
 
 export function parseSnippetVariables(command: string): SnippetVariableDef[] {
   const text = String(command ?? "");
   const seen = new Set<string>();
   const result: SnippetVariableDef[] = [];
+  const { matches, hasGoTemplateContext } = collectVariableMatches(text);
 
-  for (const match of text.matchAll(variablePattern())) {
+  for (const match of matches) {
     const name = match[1]?.trim() ?? "";
-    if (!name || seen.has(name)) continue;
+    if (!isSnippetVariableName(name, templateActionBody(match), hasGoTemplateContext) || seen.has(name)) continue;
     seen.add(name);
     const defaultRaw = match[2];
     result.push({
@@ -80,18 +148,10 @@ export function applySnippetVariables(
     return { ok: false, missing };
   }
 
-  let output = String(command ?? "");
-  for (const def of defs) {
-    const value = resolved[def.name];
-    const escapedName = def.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const pattern = new RegExp(
-      `\\{\\{${escapedName}(?::[^}]*)?\\}\\}`,
-      "g",
-    );
-    output = output.replace(pattern, value);
-  }
-
-  return { ok: true, command: output };
+  return {
+    ok: true,
+    command: replaceSnippetVariableTokens(command, (name, token) => resolved[name] ?? token),
+  };
 }
 
 /** Preview resolved command for UI; unfilled required vars stay as placeholders. */
@@ -102,16 +162,9 @@ export function previewSnippetCommand(
   const defs = parseSnippetVariables(command);
   if (defs.length === 0) return String(command ?? "");
 
-  let output = String(command ?? "");
-  for (const def of defs) {
-    const value = resolveVariableValue(def, values);
-    const replacement = value ?? `{{${def.name}}}`;
-    const escapedName = def.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const pattern = new RegExp(
-      `\\{\\{${escapedName}(?::[^}]*)?\\}\\}`,
-      "g",
-    );
-    output = output.replace(pattern, replacement);
-  }
-  return output;
+  return replaceSnippetVariableTokens(command, (name) => {
+    const def = defs.find((candidate) => candidate.name === name);
+    if (!def) return `{{${name}}}`;
+    return resolveVariableValue(def, values) ?? `{{${def.name}}}`;
+  });
 }

--- a/domain/snippetVariables.ts
+++ b/domain/snippetVariables.ts
@@ -26,20 +26,64 @@ function templateActionBody(match: RegExpMatchArray): string {
 
 function collectVariableMatches(text: string): {
   matches: RegExpMatchArray[];
-  hasGoTemplateContext: boolean;
+  goTemplateOffsets: Set<number>;
 } {
   const matches = Array.from(text.matchAll(variablePattern()));
-  const hasGoTemplateContext = matches.some((match) => (
-    hasGoTemplateFieldReference(templateActionBody(match))
-  ));
-  return { matches, hasGoTemplateContext };
+  const goTemplateOffsets = new Set<number>();
+  const goTemplateVariables = new Set<string>();
+  let blockDepth = 0;
+
+  for (const match of matches) {
+    const action = normalizeGoTemplateAction(templateActionBody(match));
+    const firstWord = action.split(/\s+/, 1)[0] ?? "";
+    const hasFieldReference = hasGoTemplateFieldReference(action);
+    const hasKnownVariableReference = hasGoTemplateVariableReference(action, goTemplateVariables);
+    const insideBlock = blockDepth > 0;
+    const isBlockStart = (firstWord === "if" || firstWord === "range" || firstWord === "with")
+      && (hasFieldReference || hasKnownVariableReference);
+    const isBlockEnd = action === "end";
+    const isGoTemplateToken = hasFieldReference
+      || hasKnownVariableReference
+      || isBlockStart
+      || (insideBlock && isGoTemplateControlAction(action));
+
+    if (isGoTemplateToken && match.index !== undefined) {
+      goTemplateOffsets.add(match.index);
+    }
+    if (isGoTemplateToken) {
+      for (const variable of action.matchAll(/\$[A-Za-z_][A-Za-z0-9_]*(?=\s*(?:,|:?=))/g)) {
+        goTemplateVariables.add(variable[0]);
+      }
+    }
+    if (isBlockStart) {
+      blockDepth += 1;
+    } else if (isBlockEnd && insideBlock) {
+      blockDepth -= 1;
+    }
+  }
+
+  return { matches, goTemplateOffsets };
 }
 
 function hasGoTemplateFieldReference(name: string): boolean {
   const action = normalizeGoTemplateAction(name);
   return action === "."
     || /(?:^|[\s(])\.[A-Za-z_]/.test(action)
+    || /(?:^|[\s(])\.(?:$|[\s),|])/.test(action)
     || /(?:^|[\s(])\$[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]/.test(action);
+}
+
+function hasGoTemplateVariableReference(action: string, variables: Set<string>): boolean {
+  for (const variable of variables) {
+    if (new RegExp(`(?:^|[^A-Za-z0-9_])${escapeRegExp(variable)}(?:$|[^A-Za-z0-9_])`).test(action)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function isGoTemplateControlAction(name: string): boolean {
@@ -53,12 +97,8 @@ function isGoTemplateControlAction(name: string): boolean {
 
 function isSnippetVariableName(
   name: string,
-  tokenBody: string,
-  hasGoTemplateContext = false,
 ): boolean {
-  return name !== ""
-    && !hasGoTemplateFieldReference(tokenBody)
-    && !(hasGoTemplateContext && isGoTemplateControlAction(tokenBody));
+  return name !== "";
 }
 
 function replaceSnippetVariableTokens(
@@ -66,10 +106,10 @@ function replaceSnippetVariableTokens(
   replacementFor: (name: string, token: string) => string,
 ): string {
   const text = String(command ?? "");
-  const { hasGoTemplateContext } = collectVariableMatches(text);
-  return text.replace(variablePattern(), (token: string, rawName: string) => {
+  const { goTemplateOffsets } = collectVariableMatches(text);
+  return text.replace(variablePattern(), (token: string, rawName: string, _defaultRaw: string | undefined, offset: number) => {
     const name = String(rawName ?? "").trim();
-    if (!isSnippetVariableName(name, token.slice(2, -2), hasGoTemplateContext)) {
+    if (goTemplateOffsets.has(offset) || !isSnippetVariableName(name)) {
       return token;
     }
     return replacementFor(name, token);
@@ -89,11 +129,11 @@ export function parseSnippetVariables(command: string): SnippetVariableDef[] {
   const text = String(command ?? "");
   const seen = new Set<string>();
   const result: SnippetVariableDef[] = [];
-  const { matches, hasGoTemplateContext } = collectVariableMatches(text);
+  const { matches, goTemplateOffsets } = collectVariableMatches(text);
 
   for (const match of matches) {
     const name = match[1]?.trim() ?? "";
-    if (!isSnippetVariableName(name, templateActionBody(match), hasGoTemplateContext) || seen.has(name)) continue;
+    if ((match.index !== undefined && goTemplateOffsets.has(match.index)) || !isSnippetVariableName(name) || seen.has(name)) continue;
     seen.add(name);
     const defaultRaw = match[2];
     result.push({


### PR DESCRIPTION
## Summary
- Preserve Docker and Go template expressions in saved snippet commands.
- Keep Netcatty snippet variables and defaults working, including mixed commands.

Fixes #1474

## Verification
- node --test --import tsx domain/snippetVariables.test.ts
- npm run lint
- npm run build
- npm test

## Review
- Multi-agent review completed; Critical and Important findings addressed; final review clean.