### PR TITLE
Fix docker command popups for Mosh hosts

### DIFF
--- a/components/TerminalPopupPage.test.ts
+++ b/components/TerminalPopupPage.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { Host, TerminalSession } from '../types';
+import type { TerminalPopupPayload } from '../domain/systemManager/types';
+import { resolveTerminalPopupHost, resolveTerminalPopupReuseId } from './TerminalPopupPage';
+
+const vaultHost = (overrides: Partial<Host> = {}): Host => ({
+  id: 'host-1',
+  label: 'Prod',
+  hostname: 'prod.example.com',
+  username: 'deploy',
+  port: 22,
+  protocol: 'ssh',
+  tags: [],
+  os: 'linux',
+  moshEnabled: true,
+  ...overrides,
+});
+
+const sourceSession = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
+  id: 'session-1',
+  hostId: 'host-1',
+  hostLabel: 'Prod',
+  hostname: 'prod.example.com',
+  username: 'deploy',
+  status: 'connected',
+  protocol: 'ssh',
+  port: 22,
+  moshEnabled: false,
+  ...overrides,
+});
+
+const popupPayload = (source: TerminalSession): TerminalPopupPayload => ({
+  title: 'Prod · docker: api',
+  parentSessionId: source.id,
+  sourceSession: source,
+  startupCommand: 'docker exec -it abc123 sh',
+});
+
+test('resolveTerminalPopupHost honors source session transport over saved Mosh host settings', () => {
+  const host = resolveTerminalPopupHost(popupPayload(sourceSession()), [vaultHost()]);
+
+  assert.equal(host.id, 'host-1');
+  assert.equal(host.hostname, 'prod.example.com');
+  assert.equal(host.protocol, 'ssh');
+  assert.equal(host.moshEnabled, false);
+  assert.equal(host.etEnabled, false);
+});
+
+test('resolveTerminalPopupHost still falls back to source session details when the host is missing', () => {
+  const host = resolveTerminalPopupHost(popupPayload(sourceSession({ hostId: 'missing' })), []);
+
+  assert.equal(host.id, 'missing');
+  assert.equal(host.label, 'Prod');
+  assert.equal(host.protocol, 'ssh');
+  assert.equal(host.moshEnabled, false);
+});
+
+test('resolveTerminalPopupHost does not turn command popups into serial sessions without serial config', () => {
+  const host = resolveTerminalPopupHost(
+    popupPayload(sourceSession({ protocol: 'serial' })),
+    [vaultHost({ protocol: 'serial' })],
+  );
+
+  assert.equal(host.protocol, 'ssh');
+  assert.equal(host.moshEnabled, false);
+});
+
+test('resolveTerminalPopupReuseId uses the explicit reuse id from the prepared source session', () => {
+  assert.equal(
+    resolveTerminalPopupReuseId(popupPayload(sourceSession({ reuseConnectionFromSessionId: 'session-1' }))),
+    'session-1',
+  );
+
+  assert.equal(
+    resolveTerminalPopupReuseId(popupPayload(sourceSession({ reuseConnectionFromSessionId: undefined }))),
+    undefined,
+  );
+});

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -1,7 +1,6 @@
 import { Copy, Minus, Square, Unplug, X } from 'lucide-react';
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { I18nProvider, useI18n } from '../application/i18n/I18nProvider';
-import { canReuseTerminalConnection } from '../application/state/terminalConnectionReuse';
 import { useSettingsState } from '../application/state/useSettingsState';
 import { useTerminalPopupWindow } from '../application/state/useTerminalPopupWindow';
 import { useVaultState } from '../application/state/useVaultState';
@@ -177,19 +176,58 @@ function TerminalPopupTitleIcon({ icon }: { icon: TerminalPopupPayload['icon'] }
 
 /** Fallback when the parent session's host is no longer in the vault (e.g. quick connect). */
 function buildHostFromSession(source: TerminalPopupPayload['sourceSession']): Host {
+  const protocol = resolveHostProtocolFromSourceSession(source);
   return {
     id: source.hostId,
     label: source.hostLabel,
     hostname: source.hostname,
     username: source.username,
-    port: source.port ?? (source.protocol === 'local' ? undefined : 22),
-    protocol: source.protocol === 'local' ? 'local' : 'ssh',
+    port: source.port ?? (protocol === 'local' ? undefined : 22),
+    protocol,
     tags: [],
     os: 'linux',
-    moshEnabled: source.moshEnabled,
-    etEnabled: source.etEnabled,
+    moshEnabled: source.moshEnabled === true,
+    etEnabled: source.etEnabled === true,
     charset: source.charset,
   };
+}
+
+function resolveHostProtocolFromSourceSession(source: TerminalPopupPayload['sourceSession']): Host['protocol'] {
+  if (
+    source.protocol === 'local' ||
+    source.protocol === 'telnet'
+  ) {
+    return source.protocol;
+  }
+  return 'ssh';
+}
+
+function applySourceSessionConnectionOverrides(
+  host: Host,
+  source: TerminalPopupPayload['sourceSession'],
+): Host {
+  return {
+    ...host,
+    hostname: source.hostname || host.hostname,
+    username: source.username || host.username,
+    port: source.port ?? host.port,
+    protocol: resolveHostProtocolFromSourceSession(source),
+    moshEnabled: source.moshEnabled === true,
+    etEnabled: source.etEnabled === true,
+    charset: source.charset ?? host.charset,
+  };
+}
+
+export function resolveTerminalPopupHost(config: TerminalPopupPayload, hosts: Host[]): Host {
+  const vaultHost = hosts.find((h) => h.id === config.sourceSession.hostId);
+  return applySourceSessionConnectionOverrides(
+    vaultHost ?? buildHostFromSession(config.sourceSession),
+    config.sourceSession,
+  );
+}
+
+export function resolveTerminalPopupReuseId(config: TerminalPopupPayload): string | undefined {
+  return config.sourceSession.reuseConnectionFromSessionId;
 }
 
 function TerminalPopupPageInner() {
@@ -240,15 +278,12 @@ function TerminalPopupPageInner() {
 
   const host = useMemo(() => {
     if (!config) return null;
-    const vaultHost = hosts.find((h) => h.id === config.sourceSession.hostId);
-    return vaultHost ?? buildHostFromSession(config.sourceSession);
+    return resolveTerminalPopupHost(config, hosts);
   }, [config, hosts]);
 
   const reuseId = useMemo(() => {
     if (!config) return undefined;
-    return canReuseTerminalConnection(config.sourceSession)
-      ? config.parentSessionId
-      : undefined;
+    return resolveTerminalPopupReuseId(config);
   }, [config]);
 
   const ready = Boolean(config && host && vaultInitialized);

--- a/components/systemManager/openInteractiveTerminal.test.ts
+++ b/components/systemManager/openInteractiveTerminal.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { TerminalSession } from '../../types';
+import { openInteractiveTerminal } from './openInteractiveTerminal';
+
+const parentSession = (overrides: Partial<TerminalSession> = {}): TerminalSession => ({
+  id: 'session-1',
+  hostId: 'host-1',
+  hostLabel: 'Prod',
+  hostname: 'prod.example.com',
+  username: 'deploy',
+  status: 'connected',
+  protocol: 'ssh',
+  port: 22,
+  ...overrides,
+});
+
+test('openInteractiveTerminal opens command popups over SSH even when the source host uses Mosh', async () => {
+  const payloads: unknown[] = [];
+  const backend = {
+    openTerminalPopup: async (payload: unknown) => {
+      payloads.push(payload);
+      return { success: true };
+    },
+  };
+
+  await openInteractiveTerminal(
+    backend as never,
+    parentSession({ moshEnabled: true }),
+    'docker: api',
+    'docker exec -it abc123 sh',
+  );
+
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(payloads[0], {
+    title: 'Prod · docker: api',
+    icon: undefined,
+    parentSessionId: 'session-1',
+    startupCommand: 'docker exec -it abc123 sh',
+    sourceSession: {
+      ...parentSession({ moshEnabled: true }),
+      protocol: 'ssh',
+      moshEnabled: false,
+      startupCommand: 'docker exec -it abc123 sh',
+      reuseConnectionFromSessionId: undefined,
+    },
+  });
+});
+
+test('openInteractiveTerminal keeps SSH connection reuse for ordinary connected SSH parents', async () => {
+  const payloads: unknown[] = [];
+  const backend = {
+    openTerminalPopup: async (payload: unknown) => {
+      payloads.push(payload);
+      return { success: true };
+    },
+  };
+
+  await openInteractiveTerminal(
+    backend as never,
+    parentSession(),
+    'logs: api',
+    'docker logs -f abc123',
+  );
+
+  const payload = payloads[0] as { sourceSession: TerminalSession };
+  assert.equal(payload.sourceSession.moshEnabled, false);
+  assert.equal(payload.sourceSession.protocol, 'ssh');
+  assert.equal(payload.sourceSession.reuseConnectionFromSessionId, 'session-1');
+});

--- a/components/systemManager/openInteractiveTerminal.ts
+++ b/components/systemManager/openInteractiveTerminal.ts
@@ -14,6 +14,33 @@ function buildPopupTitle(parentSession: TerminalSession, title: string): string 
   return `${hostLabel} · ${cleanTitle}`;
 }
 
+function buildCommandPopupSourceSession(
+  parentSession: TerminalSession,
+  startupCommand: string,
+  canReuseConnection: boolean,
+): TerminalSession {
+  const runtimeProtocol = parentSession.protocol as TerminalSession['protocol'] | 'mosh' | 'et' | undefined;
+  const shouldUseSshShell =
+    runtimeProtocol === undefined ||
+    runtimeProtocol === 'ssh' ||
+    runtimeProtocol === 'mosh' ||
+    parentSession.moshEnabled === true;
+
+  return {
+    ...parentSession,
+    ...(shouldUseSshShell
+      ? {
+        protocol: 'ssh' as const,
+        moshEnabled: false,
+      }
+      : {}),
+    startupCommand,
+    reuseConnectionFromSessionId: canReuseConnection
+      ? parentSession.id
+      : undefined,
+  };
+}
+
 export async function openInteractiveTerminal(
   backend: Backend,
   parentSession: TerminalSession,
@@ -37,13 +64,7 @@ export async function openInteractiveTerminal(
     icon: options?.icon,
     parentSessionId: parentSession.id,
     startupCommand,
-    sourceSession: {
-      ...parentSession,
-      startupCommand,
-      reuseConnectionFromSessionId: canReuseConnection
-        ? parentSession.id
-        : undefined,
-    },
+    sourceSession: buildCommandPopupSourceSession(parentSession, startupCommand, canReuseConnection),
   });
   await writeSystemManagerDiagnostic('openInteractiveTerminal result', {
     title: popupTitle,


### PR DESCRIPTION
## Summary
- Force Docker/tmux command popups opened from Mosh-enabled hosts to use the SSH shell path so startup commands actually run.
- Keep normal SSH parent sessions eligible for connection reuse, while Mosh parents open a fresh SSH shell instead of trying to reuse Mosh.
- Make terminal popup host resolution honor the prepared source session over saved vault Mosh settings.

Fixes #1468

## Validation
- `node --test --import tsx components/systemManager/openInteractiveTerminal.test.ts components/TerminalPopupPage.test.ts application/state/terminalConnectionReuse.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts`
- `npx eslint components/systemManager/openInteractiveTerminal.ts components/systemManager/openInteractiveTerminal.test.ts components/TerminalPopupPage.tsx components/TerminalPopupPage.test.ts`
- `npm run build`
- `npm test` was also attempted. The targeted path passed, but the full local suite hit unrelated environment-dependent failures around WebDAV/OAuth local port binding, Telnet bridge cases, and binary fetch script tests in this sandbox.
