### PR TITLE
[codex] Remove AI slash command toolbar button

### DIFF
--- a/components/ai/ChatInput.test.tsx
+++ b/components/ai/ChatInput.test.tsx
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ChatInput from './ChatInput';
+import { TooltipProvider } from '../ui/tooltip';
+
+test('does not render a standalone slash command toolbar button', () => {
+  const html = renderToStaticMarkup(
+    <TooltipProvider>
+      <ChatInput
+        value=""
+        onChange={() => {}}
+        onSend={() => {}}
+        isStreaming={false}
+        disabled={false}
+        agentName="Catty Agent"
+        quickMessages={[{
+          id: 'qm-1',
+          slug: 'hello',
+          name: 'Hello',
+          description: 'Greeting',
+          content: 'Say hello',
+        }]}
+      />
+    </TooltipProvider>,
+  );
+
+  assert.match(html, /textarea/);
+  assert.doesNotMatch(html, /aria-label="ai\.chat\.slashCommands"/);
+});

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -163,7 +163,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const modelBtnRef = useRef<HTMLButtonElement>(null);
   const permBtnRef = useRef<HTMLButtonElement>(null);
   const attachBtnRef = useRef<HTMLButtonElement>(null);
-  const quickMsgBtnRef = useRef<HTMLButtonElement>(null);
   const slashPickerListRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -257,28 +256,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }
     setActiveMenu(menu);
   }, [findSlashTrigger, getInputPanelMenuPos, value]);
-
-  const openSlashCommandPicker = useCallback((anchor?: 'toolbar') => {
-    if (anchor === 'toolbar') {
-      const rect = quickMsgBtnRef.current?.getBoundingClientRect();
-      if (rect) {
-        setMenuPos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 });
-      }
-      setInputPanelPos(null);
-      const caret = textareaRef.current?.selectionStart ?? value.length;
-      const trigger = findSlashTrigger(value, caret);
-      if (trigger) {
-        setSlashQuery(trigger.query);
-        setSlashRange({ start: trigger.start, end: trigger.end });
-      } else {
-        setSlashQuery('');
-        setSlashRange(null);
-      }
-      setActiveMenu('slashCommand');
-      return;
-    }
-    openInputPanelMenu('slashCommand');
-  }, [findSlashTrigger, openInputPanelMenu, value]);
 
   const userSkillOptions = useMemo<UserSkillSlashOption[]>(
     () => userSkills.map((skill) => ({
@@ -1068,30 +1045,6 @@ const ChatInput: React.FC<ChatInputProps> = ({
           <div className="flex-1 min-w-0" />
 
           <div className="flex items-center gap-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  ref={quickMsgBtnRef}
-                  type="button"
-                  onClick={() => {
-                    if (!showSlashCommandPicker) {
-                      openSlashCommandPicker('toolbar');
-                    } else {
-                      closeAllMenus();
-                    }
-                  }}
-                  className={[
-                    iconButtonClassName,
-                    isSlashCatalogEmpty ? 'opacity-45 hover:opacity-80' : '',
-                  ].filter(Boolean).join(' ')}
-                  aria-label={t('ai.chat.slashCommands')}
-                  aria-expanded={showSlashCommandPicker}
-                >
-                  <MessageSquare size={13} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{t('ai.chat.slashCommands')}</TooltipContent>
-            </Tooltip>
             <PromptInputSubmit
               status={status}
               onStop={onStop}


### PR DESCRIPTION
## Summary
- Remove the standalone slash-command button next to the AI chat send button.
- Keep slash commands available by typing `/` in the chat input.
- Add a regression check so the extra toolbar button does not come back unnoticed.

## Validation
- node --test --import tsx components/ai/ChatInput.test.tsx infrastructure/ai/quickMessages.test.ts
- npx eslint components/ai/ChatInput.tsx components/ai/ChatInput.test.tsx
- npm run build
