### PR TITLE
[codex] Fix terminal history scrolling in fullscreen apps

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -62,6 +62,14 @@ import {
   shouldHandleTerminalFontSizeAction,
   terminalFontSizeWheelListenerOptions,
 } from "./terminalFontZoom";
+import {
+  getHistoryPreviewLines,
+  forcedHistoryScrollLinesForWheel,
+  forcedHistoryScrollPageToLines,
+  forcedHistoryScrollPagesForKey,
+  forcedHistoryScrollWheelListenerOptions,
+  nextHistoryPreviewTop,
+} from "./terminalHistoryScrollOverride";
 import { shouldPassThroughCopyShortcut } from "./terminalCopyShortcut";
 import {
   markExpectedTerminalCursorPositionReport,
@@ -581,11 +589,83 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     event.stopPropagation();
     applyTerminalFontSize(nextFontSize);
   };
+  let historyPreviewOverlay: HTMLPreElement | null = null;
+  let historyPreviewTop: number | null = null;
+  const hideHistoryPreview = () => {
+    historyPreviewOverlay?.remove();
+    historyPreviewOverlay = null;
+    historyPreviewTop = null;
+  };
+  const ensureHistoryPreviewOverlay = () => {
+    if (historyPreviewOverlay) return historyPreviewOverlay;
+    const overlay = document.createElement("pre");
+    overlay.setAttribute("aria-hidden", "true");
+    Object.assign(overlay.style, {
+      position: "absolute",
+      inset: "0",
+      zIndex: "8",
+      margin: "0",
+      padding: "0 6px",
+      overflow: "hidden",
+      pointerEvents: "none",
+      whiteSpace: "pre",
+      fontFamily: String(term.options.fontFamily ?? fontFamily),
+      fontSize: `${currentTerminalFontSize()}px`,
+      lineHeight: String(term.options.lineHeight ?? lineHeight),
+      color: ctx.terminalTheme.colors.foreground,
+      background: ctx.terminalTheme.colors.background,
+    } satisfies Partial<CSSStyleDeclaration>);
+    ctx.container.appendChild(overlay);
+    historyPreviewOverlay = overlay;
+    return overlay;
+  };
+  const showAlternateScreenHistoryPreview = (lines: number) => {
+    if (term.buffer.active.type !== "alternate") return false;
+    const normalBuffer = term.buffer.normal;
+    historyPreviewTop = nextHistoryPreviewTop({
+      buffer: normalBuffer,
+      currentTop: historyPreviewTop,
+      lines,
+    });
+    const overlay = ensureHistoryPreviewOverlay();
+    overlay.style.fontSize = `${currentTerminalFontSize()}px`;
+    overlay.style.fontFamily = String(term.options.fontFamily ?? fontFamily);
+    overlay.style.lineHeight = String(term.options.lineHeight ?? lineHeight);
+    overlay.textContent = getHistoryPreviewLines({
+      buffer: normalBuffer,
+      rows: term.rows,
+      top: historyPreviewTop,
+    }).join("\n");
+    return true;
+  };
+  const scrollForcedHistoryLines = (lines: number) => {
+    if (showAlternateScreenHistoryPreview(lines)) return;
+    hideHistoryPreview();
+    term.scrollLines(lines);
+  };
+  const handleForcedHistoryScrollWheel = (event: WheelEvent) => {
+    const lines = forcedHistoryScrollLinesForWheel(event);
+    if (lines === null) {
+      hideHistoryPreview();
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    scrollForcedHistoryLines(lines);
+  };
+  ctx.container.addEventListener(
+    "wheel",
+    handleForcedHistoryScrollWheel,
+    forcedHistoryScrollWheelListenerOptions,
+  );
   ctx.container.addEventListener(
     "wheel",
     handleFontSizeWheel,
     terminalFontSizeWheelListenerOptions,
   );
+  const historyPreviewBufferChangeDisposable = term.buffer.onBufferChange(() => {
+    hideHistoryPreview();
+  });
 
   term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
     // Preserve mouse selection across keystrokes when enabled. xterm.js
@@ -633,6 +713,20 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (e.type !== "keydown") {
       return true;
     }
+
+    const forcedHistoryScrollPages = forcedHistoryScrollPagesForKey(e);
+    if (forcedHistoryScrollPages !== null) {
+      e.preventDefault();
+      e.stopPropagation();
+      const lines = forcedHistoryScrollPageToLines(forcedHistoryScrollPages, term.rows);
+      if (showAlternateScreenHistoryPreview(lines)) {
+        return false;
+      }
+      hideHistoryPreview();
+      term.scrollPages(forcedHistoryScrollPages);
+      return false;
+    }
+    hideHistoryPreview();
 
     // Sudo password hint: while a hint is pending, Enter confirms (paste the
     // saved password + submit); any other visible key dismisses it so the user
@@ -839,6 +933,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   ctx.container.addEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
   ctx.container.addEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
+  ctx.container.addEventListener("mousedown", hideHistoryPreview, true);
   ctx.container.addEventListener("auxclick", handleMiddleClick);
 
   fitAddon.fit();
@@ -1124,12 +1219,20 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     dispose: () => {
       ctx.container.removeEventListener(
         "wheel",
+        handleForcedHistoryScrollWheel,
+        forcedHistoryScrollWheelListenerOptions,
+      );
+      ctx.container.removeEventListener(
+        "wheel",
         handleFontSizeWheel,
         terminalFontSizeWheelListenerOptions,
       );
       ctx.container.removeEventListener("auxclick", handleMiddleClick);
       ctx.container.removeEventListener("mousedown", captureMiddleClickTerminalMouseEvent, true);
       ctx.container.removeEventListener("mouseup", captureMiddleClickTerminalMouseEvent, true);
+      ctx.container.removeEventListener("mousedown", hideHistoryPreview, true);
+      hideHistoryPreview();
+      historyPreviewBufferChangeDisposable.dispose();
       stopDprWatch();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();

--- a/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getHistoryPreviewLines,
+  forcedHistoryScrollLinesForWheel,
+  forcedHistoryScrollPageToLines,
+  forcedHistoryScrollPagesForKey,
+  forcedHistoryScrollWheelListenerOptions,
+  nextHistoryPreviewTop,
+} from "./terminalHistoryScrollOverride.ts";
+
+const wheel = (
+  over: Partial<Parameters<typeof forcedHistoryScrollLinesForWheel>[0]> = {},
+) => ({
+  altKey: false,
+  ctrlKey: false,
+  deltaMode: 0,
+  deltaY: -100,
+  metaKey: false,
+  shiftKey: true,
+  ...over,
+});
+
+const key = (
+  over: Partial<Parameters<typeof forcedHistoryScrollPagesForKey>[0]> = {},
+) => ({
+  altKey: false,
+  ctrlKey: false,
+  key: "PageUp",
+  metaKey: false,
+  shiftKey: true,
+  type: "keydown",
+  ...over,
+});
+
+test("Shift+wheel maps to explicit history scrolling before mouse tracking can consume it", () => {
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ deltaY: -100 })), -3);
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ deltaY: 100 })), 3);
+});
+
+test("forced history wheel listener can run before xterm mouse tracking and cancel scrolling", () => {
+  assert.equal(forcedHistoryScrollWheelListenerOptions.capture, true);
+  assert.equal(forcedHistoryScrollWheelListenerOptions.passive, false);
+});
+
+test("Shift+PageUp and Shift+PageDown map to one-page history scrolling", () => {
+  assert.equal(forcedHistoryScrollPagesForKey(key({ key: "PageUp" })), -1);
+  assert.equal(forcedHistoryScrollPagesForKey(key({ key: "PageDown" })), 1);
+});
+
+test("history scroll override stays out of unmodified TUI mouse and paging input", () => {
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ shiftKey: false })), null);
+  assert.equal(forcedHistoryScrollPagesForKey(key({ shiftKey: false })), null);
+});
+
+test("history scroll override does not steal existing modified shortcuts", () => {
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ ctrlKey: true })), null);
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ metaKey: true })), null);
+  assert.equal(forcedHistoryScrollLinesForWheel(wheel({ altKey: true })), null);
+
+  assert.equal(forcedHistoryScrollPagesForKey(key({ ctrlKey: true })), null);
+  assert.equal(forcedHistoryScrollPagesForKey(key({ metaKey: true })), null);
+  assert.equal(forcedHistoryScrollPagesForKey(key({ altKey: true })), null);
+});
+
+test("PageUp/PageDown history preview uses xterm's page size", () => {
+  assert.equal(forcedHistoryScrollPageToLines(-1, 24), -23);
+  assert.equal(forcedHistoryScrollPageToLines(1, 24), 23);
+  assert.equal(forcedHistoryScrollPageToLines(-1, 1), -1);
+});
+
+test("alternate-screen history preview reads normal-buffer history", () => {
+  const normalLines = ["old 1", "old 2", "prompt before codex", "bottom"];
+  const normalBuffer = {
+    baseY: 2,
+    length: normalLines.length,
+    type: "normal" as const,
+    viewportY: 2,
+    getLine(y: number) {
+      const text = normalLines[y];
+      if (text === undefined) return undefined;
+      return {
+        translateToString() {
+          return text;
+        },
+      };
+    },
+  };
+  const alternateBuffer = {
+    baseY: 0,
+    length: 2,
+    type: "alternate" as const,
+    viewportY: 0,
+    getLine(y: number) {
+      return {
+        translateToString() {
+          return `codex frame ${y}`;
+        },
+      };
+    },
+  };
+
+  const top = nextHistoryPreviewTop({
+    buffer: normalBuffer,
+    currentTop: null,
+    lines: -2,
+  });
+
+  assert.equal(top, 0);
+  assert.deepEqual(getHistoryPreviewLines({ buffer: normalBuffer, rows: 3, top }), [
+    "old 1",
+    "old 2",
+    "prompt before codex",
+  ]);
+  assert.notDeepEqual(getHistoryPreviewLines({ buffer: normalBuffer, rows: 2, top }), [
+    alternateBuffer.getLine(0)?.translateToString(),
+    alternateBuffer.getLine(1)?.translateToString(),
+  ]);
+});

--- a/components/terminal/runtime/terminalHistoryScrollOverride.ts
+++ b/components/terminal/runtime/terminalHistoryScrollOverride.ts
@@ -1,0 +1,98 @@
+type WheelLike = Pick<
+  WheelEvent,
+  "altKey" | "ctrlKey" | "deltaMode" | "deltaY" | "metaKey" | "shiftKey"
+>;
+
+type KeyLike = Pick<
+  KeyboardEvent,
+  "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey" | "type"
+>;
+
+type BufferLineLike = {
+  translateToString(trimRight?: boolean): string;
+};
+
+type BufferLike = {
+  baseY: number;
+  length: number;
+  type: "normal" | "alternate";
+  viewportY: number;
+  getLine(y: number): BufferLineLike | undefined;
+};
+
+const DOM_DELTA_LINE = 1;
+const DOM_DELTA_PAGE = 2;
+const DEFAULT_WHEEL_SCROLL_LINES = 3;
+const PAGE_WHEEL_SCROLL_LINES = 24;
+
+export const forcedHistoryScrollWheelListenerOptions = {
+  passive: false,
+  capture: true,
+} as const satisfies AddEventListenerOptions;
+
+const hasOnlyShiftModifier = (event: {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}): boolean => event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+
+export const forcedHistoryScrollLinesForWheel = (event: WheelLike): number | null => {
+  if (!hasOnlyShiftModifier(event) || event.deltaY === 0) return null;
+
+  const direction = event.deltaY < 0 ? -1 : 1;
+  if (event.deltaMode === DOM_DELTA_LINE) {
+    return direction * Math.max(1, Math.round(Math.abs(event.deltaY)));
+  }
+  if (event.deltaMode === DOM_DELTA_PAGE) {
+    return direction * PAGE_WHEEL_SCROLL_LINES;
+  }
+  return direction * DEFAULT_WHEEL_SCROLL_LINES;
+};
+
+export const forcedHistoryScrollPagesForKey = (event: KeyLike): number | null => {
+  if (event.type !== "keydown" || !hasOnlyShiftModifier(event)) return null;
+
+  if (event.key === "PageUp") return -1;
+  if (event.key === "PageDown") return 1;
+  return null;
+};
+
+export const forcedHistoryScrollPageToLines = (pageCount: number, rows: number): number =>
+  pageCount * Math.max(1, rows - 1);
+
+export const clampHistoryPreviewTop = (top: number, buffer: Pick<BufferLike, "baseY">): number => {
+  const maxTop = Math.max(0, buffer.baseY);
+  return Math.max(0, Math.min(maxTop, top));
+};
+
+export const nextHistoryPreviewTop = ({
+  buffer,
+  currentTop,
+  lines,
+}: {
+  buffer: Pick<BufferLike, "baseY" | "viewportY">;
+  currentTop: number | null;
+  lines: number;
+}): number => clampHistoryPreviewTop(
+  clampHistoryPreviewTop(currentTop ?? buffer.viewportY ?? buffer.baseY, buffer) + lines,
+  buffer,
+);
+
+export const getHistoryPreviewLines = ({
+  buffer,
+  rows,
+  top,
+}: {
+  buffer: BufferLike;
+  rows: number;
+  top: number;
+}): string[] => {
+  const clampedTop = clampHistoryPreviewTop(top, buffer);
+  const visibleRows = Math.max(1, rows);
+  const lines: string[] = [];
+  for (let row = 0; row < visibleRows; row += 1) {
+    lines.push(buffer.getLine(clampedTop + row)?.translateToString(true) ?? "");
+  }
+  return lines;
+};


### PR DESCRIPTION
## Summary
- Add a Shift-based terminal history escape hatch for fullscreen and mouse-tracking terminal apps.
- Support `Shift + wheel` and `Shift + PageUp/PageDown` without stealing normal TUI mouse or paging input.
- Show normal-buffer history while an alternate-screen app such as Codex is active.

## Why
Fullscreen terminal apps can enable mouse tracking and consume wheel/PageUp/PageDown input. In that state users had no reliable way to temporarily inspect terminal history, especially when the app was using the alternate screen.

Fixes #1494.

## Verification
- `node --test --import tsx components/terminal/runtime/terminalHistoryScrollOverride.test.ts components/terminal/runtime/terminalFontZoom.test.ts components/terminal/runtime/createXTermRuntime.test.ts components/terminal/runtime/middleClickBehavior.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (2497 tests, 0 failures)