### PR TITLE
[codex] Reduce SFTP transfer pressure

### DIFF
--- a/application/state/sftp/transferConcurrency.test.ts
+++ b/application/state/sftp/transferConcurrency.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY,
+  resolveSftpTransferConcurrency,
+  runSftpTransferWorkers,
+} from "./transferConcurrency";
+
+test("defaults folder file transfers to two concurrent files", () => {
+  assert.equal(resolveSftpTransferConcurrency(() => null), DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY);
+  assert.equal(DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY, 2);
+});
+
+test("keeps explicit folder transfer concurrency within the supported range", () => {
+  assert.equal(resolveSftpTransferConcurrency(() => 1), 1);
+  assert.equal(resolveSftpTransferConcurrency(() => 16), 16);
+  assert.equal(resolveSftpTransferConcurrency(() => 0), DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY);
+  assert.equal(resolveSftpTransferConcurrency(() => 17), DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY);
+});
+
+test("limits default multi-file transfer scheduling to two concurrent workers", async () => {
+  let active = 0;
+  let maxActive = 0;
+
+  await runSftpTransferWorkers([1, 2, 3, 4], () => null, async () => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    active -= 1;
+  });
+
+  assert.equal(maxActive, 2);
+});

--- a/application/state/sftp/transferConcurrency.ts
+++ b/application/state/sftp/transferConcurrency.ts
@@ -1,0 +1,34 @@
+export const DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY = 2;
+export const MIN_SFTP_FILE_TRANSFER_CONCURRENCY = 1;
+export const MAX_SFTP_FILE_TRANSFER_CONCURRENCY = 16;
+
+export function resolveSftpTransferConcurrency(readStoredValue: () => number | null | undefined): number {
+  const stored = readStoredValue();
+  return stored != null &&
+    stored >= MIN_SFTP_FILE_TRANSFER_CONCURRENCY &&
+    stored <= MAX_SFTP_FILE_TRANSFER_CONCURRENCY
+    ? stored
+    : DEFAULT_SFTP_FILE_TRANSFER_CONCURRENCY;
+}
+
+export async function runSftpTransferWorkers<T>(
+  items: T[],
+  readStoredConcurrency: () => number | null | undefined,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  const concurrency = resolveSftpTransferConcurrency(readStoredConcurrency);
+  let nextIndex = 0;
+
+  const runNext = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      await worker(items[index], index);
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => runNext(),
+  );
+  await Promise.all(workers);
+}

--- a/application/state/sftp/transferDirectoryOps.ts
+++ b/application/state/sftp/transferDirectoryOps.ts
@@ -304,8 +304,8 @@ export function useSftpDirectoryTransferOps({
 
     // Process subdirectories sequentially to avoid unbounded concurrent SFTP
     // requests from nested Promise.all + worker pools across the tree.
-    // File-level concurrency within each directory is still governed by
-    // getTransferConcurrency().
+    // File-level concurrency within each directory is still governed by the
+    // shared SFTP transfer worker scheduler below.
     for (const dir of dirs) {
       if (cancelledTasksRef.current.has(task.id) || cancelledTasksRef.current.has(rootTaskId)) {
         throw new Error("Transfer cancelled");

--- a/application/state/sftp/transferDirectoryOps.ts
+++ b/application/state/sftp/transferDirectoryOps.ts
@@ -4,6 +4,7 @@ import { STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY } from "../../../infrastructure/c
 import { localStorageAdapter } from "../../../infrastructure/persistence/localStorageAdapter";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { logger } from "../../../lib/logger";
+import { runSftpTransferWorkers } from "./transferConcurrency";
 import { joinPath } from "./utils";
 
 interface UseSftpDirectoryTransferOpsParams {
@@ -185,11 +186,6 @@ export function useSftpDirectoryTransferOps({
     });
   };
 
-  const getTransferConcurrency = () => {
-    const stored = localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY);
-    return stored != null && stored >= 1 && stored <= 16 ? stored : 4;
-  };
-
   /** Recursively count all files under a directory (for progress display). */
   const countDirectoryFiles = async (
     sourcePath: string,
@@ -346,17 +342,16 @@ export function useSftpDirectoryTransferOps({
 
     // Transfer files in parallel with concurrency limit
     if (regularFiles.length > 0) {
-      let fileIndex = 0;
       const errors: Error[] = [];
 
-      const worker = async () => {
-        while (fileIndex < regularFiles.length) {
+      await runSftpTransferWorkers(
+        regularFiles,
+        () => localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY),
+        async (file) => {
           if (cancelledTasksRef.current.has(task.id) || cancelledTasksRef.current.has(rootTaskId)) {
             throw new Error("Transfer cancelled");
           }
 
-          const idx = fileIndex++;
-          const file = regularFiles[idx];
           const fileId = crypto.randomUUID();
           const fileSize = getEntrySize(file);
 
@@ -431,15 +426,8 @@ export function useSftpDirectoryTransferOps({
             if (err instanceof Error && err.message === "Transfer cancelled") throw err;
             errors.push(err instanceof Error ? err : new Error(String(err)));
           }
-        }
-      };
-
-      const concurrency = getTransferConcurrency();
-      const workers = Array.from(
-        { length: Math.min(concurrency, regularFiles.length) },
-        () => worker(),
+        },
       );
-      await Promise.all(workers);
 
       totalErrors += errors.length;
       if (errors.length > 0) {

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -67,6 +67,7 @@ import { DEFAULT_UI_FONT_ID } from '../../infrastructure/config/uiFonts';
 import { uiFontStore, useUIFontsLoaded } from './uiFontStore';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
+import { resolveSftpTransferConcurrency } from './sftp/transferConcurrency';
 import {
   DEFAULT_ACCENT_MODE,
   DEFAULT_CUSTOM_ACCENT,
@@ -251,8 +252,9 @@ export const useSettingsState = () => {
     return stored ?? DEFAULT_DISABLE_TERMINAL_FONT_ZOOM;
   });
   const [sftpTransferConcurrency, setSftpTransferConcurrencyState] = useState<number>(() => {
-    const stored = localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY);
-    return stored != null && stored >= 1 && stored <= 16 ? stored : 4;
+    return resolveSftpTransferConcurrency(() =>
+      localStorageAdapter.readNumber(STORAGE_KEY_SFTP_TRANSFER_CONCURRENCY),
+    );
   });
 
   // Editor Settings

--- a/electron/bridges/registerBridgesTransferLimits.test.cjs
+++ b/electron/bridges/registerBridgesTransferLimits.test.cjs
@@ -1,0 +1,133 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { createBridgeRegistrar } = require("../main/registerBridges.cjs");
+const sftpBridge = require("./sftpBridge.cjs");
+const {
+  TRANSFER_CHUNK_SIZE,
+  TRANSFER_CONCURRENCY,
+} = require("./transferLimits.cjs");
+
+function createNoopBridge() {
+  return {
+    init() {},
+    registerHandlers() {},
+  };
+}
+
+function createIpcMainStub() {
+  return {
+    handlers: new Map(),
+    handle(channel, handler) {
+      this.handlers.set(channel, handler);
+    },
+    on() {},
+  };
+}
+
+test("downloadToTemp applies shared SFTP transfer limits to direct fastGet downloads", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-download-temp-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const ipcMain = createIpcMainStub();
+  const observed = {};
+  const sftpClients = new Map([
+    [
+      "sftp-1",
+      {
+        fastGet(_remotePath, localPath, options) {
+          observed.options = options;
+          return fs.promises.writeFile(localPath, "downloaded");
+        },
+      },
+    ],
+  ]);
+  const noopBridge = createNoopBridge();
+  const tempDirBridge = {
+    ensureTempDir() {},
+    registerHandlers() {},
+    getTempDir: () => tempDir,
+    getTempFilePath: (fileName) => Promise.resolve(path.join(tempDir, fileName)),
+  };
+
+  const registerBridges = createBridgeRegistrar({
+    electronModule: {
+      ipcMain,
+      safeStorage: {
+        isEncryptionAvailable: () => false,
+      },
+      dialog: {},
+    },
+    app: {
+      getPath: () => tempDir,
+      getVersion: () => "0.0.0",
+      getName: () => "Netcatty",
+    },
+    BrowserWindow: { getAllWindows: () => [] },
+    shell: { openExternal() {}, openPath() {} },
+    clipboard: { readText: () => "", writeText() {} },
+    path,
+    fs,
+    os,
+    preload: "",
+    effectiveDevServerUrl: null,
+    isDev: false,
+    appIcon: null,
+    isMac: false,
+    electronDir: __dirname,
+    sessions: new Map(),
+    sftpClients,
+    CLOUD_SYNC_PASSWORD_FILE: "cloud-sync-password",
+    getCliDiscoveryFilePath: () => path.join(tempDir, "cli-discovery.json"),
+    sshBridge: { ...noopBridge, ensureMoshStatsConnection() {} },
+    sftpBridge,
+    localFsBridge: noopBridge,
+    transferBridge: noopBridge,
+    portForwardingBridge: noopBridge,
+    terminalBridge: { ...noopBridge, execOnEtSession() {} },
+    crashLogBridge: noopBridge,
+    ptyProcessTree: { getChildProcesses: () => [] },
+    getOauthBridge: () => ({ setupOAuthBridge() {} }),
+    getGithubAuthBridge: () => noopBridge,
+    getGoogleAuthBridge: () => noopBridge,
+    getOnedriveAuthBridge: () => noopBridge,
+    getCloudSyncBridge: () => noopBridge,
+    getFileWatcherBridge: () => noopBridge,
+    getTempDirBridge: () => tempDirBridge,
+    getSessionLogsBridge: () => noopBridge,
+    getCompressUploadBridge: () => noopBridge,
+    getGlobalShortcutBridge: () => noopBridge,
+    getCredentialBridge: () => noopBridge,
+    getAutoUpdateBridge: () => noopBridge,
+    getAiBridge: () => noopBridge,
+    getWindowManager: () => ({}),
+    getVaultBackupBridge: () => noopBridge,
+    isPathInside: () => true,
+  });
+
+  registerBridges({});
+
+  const handler = ipcMain.handlers.get("netcatty:sftp:downloadToTemp");
+  assert.equal(typeof handler, "function");
+
+  const localPath = await handler(
+    { sender: { id: 1 } },
+    {
+      sftpId: "sftp-1",
+      remotePath: "/remote/report.bin",
+      fileName: "report.bin",
+      encoding: "utf-8",
+    },
+  );
+
+  assert.equal(localPath, path.join(tempDir, "report.bin"));
+  assert.deepEqual(observed.options, {
+    chunkSize: TRANSFER_CHUNK_SIZE,
+    concurrency: TRANSFER_CONCURRENCY,
+  });
+});

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -7,6 +7,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const os = require("node:os");
 const { encodePathForSession, ensureRemoteDirForSession, requireSftpChannel, resolveEncodingForRequest } = require("./sftpBridge.cjs");
+const { TRANSFER_CHUNK_SIZE, TRANSFER_CONCURRENCY } = require("./transferLimits.cjs");
 
 /**
  * Safely ensure a local directory exists.
@@ -27,13 +28,6 @@ async function ensureLocalDir(dir) {
 }
 
 // ── Transfer performance tuning ──────────────────────────────────────────────
-// ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel,
-// dramatically improving throughput over sequential stream piping.
-// Note: High concurrency (e.g. 64) can overwhelm SFTP servers, causing
-// extreme delays before the first chunk arrives. 8 balances throughput
-// on fast connections with responsiveness on slower servers.
-const TRANSFER_CHUNK_SIZE = 512 * 1024;   // 512KB per SFTP request
-const TRANSFER_CONCURRENCY = 8;           // 8 parallel SFTP requests
 // Progress IPC throttle: sending too many IPC messages bogs down the event loop
 const PROGRESS_THROTTLE_MS = 100;         // Send IPC at most every 100ms
 const PROGRESS_THROTTLE_BYTES = 256 * 1024; // Or every 256KB of progress

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+
+const transferBridge = require("./transferBridge.cjs");
+
+function createSender() {
+  return {
+    sent: [],
+    send(channel, payload) {
+      this.sent.push({ channel, payload });
+    },
+  };
+}
+
+function createFastSftp(overrides) {
+  const sftp = new EventEmitter();
+  sftp.readdir = (_path, callback) => callback(null, []);
+  sftp.stat = (_path, callback) => callback(null, { size: 1024 * 1024 });
+  sftp.mkdir = (_path, callback) => callback(null);
+  sftp.unlink = (_path, callback) => callback(null);
+  sftp.end = () => {};
+  Object.assign(sftp, overrides);
+  return sftp;
+}
+
+test("SFTP uploads use conservative per-file request concurrency", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "large.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024));
+
+  let observedConcurrency = 0;
+  const fastSftp = createFastSftp({
+    fastPut(_localPath, _remotePath, options, done) {
+      observedConcurrency = options.concurrency;
+      options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
+      queueMicrotask(() => done());
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const result = await transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "upload-large",
+      sourcePath: localPath,
+      targetPath: "/tmp/large.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(observedConcurrency, 4);
+});
+
+test("SFTP downloads use conservative per-file request concurrency", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  let observedConcurrency = 0;
+  const fastSftp = createFastSftp({
+    fastGet(_remotePath, localPath, options, done) {
+      observedConcurrency = options.concurrency;
+      options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
+      fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024)).then(
+        () => done(),
+        (err) => done(err),
+      );
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat(_path) {
+      return Promise.resolve({ size: 1024 * 1024 });
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["source", client]]) });
+
+  const sender = createSender();
+  const result = await transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "download-large",
+      sourcePath: "/tmp/large.bin",
+      targetPath: path.join(tempDir, "large.bin"),
+      sourceType: "sftp",
+      targetType: "local",
+      sourceSftpId: "source",
+    },
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(observedConcurrency, 4);
+});

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -1,0 +1,12 @@
+"use strict";
+
+// ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel.
+// Keep defaults conservative so one file transfer does not monopolize a shared
+// SSH/SFTP path used by interactive terminals.
+const TRANSFER_CHUNK_SIZE = 512 * 1024;
+const TRANSFER_CONCURRENCY = 4;
+
+module.exports = {
+  TRANSFER_CHUNK_SIZE,
+  TRANSFER_CONCURRENCY,
+};

--- a/electron/bridges/transferLimits.test.cjs
+++ b/electron/bridges/transferLimits.test.cjs
@@ -1,0 +1,12 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  TRANSFER_CONCURRENCY,
+  TRANSFER_CHUNK_SIZE,
+} = require("./transferLimits.cjs");
+
+test("SFTP transfer limits keep default per-file request fanout conservative", () => {
+  assert.equal(TRANSFER_CONCURRENCY, 4);
+  assert.equal(TRANSFER_CHUNK_SIZE, 512 * 1024);
+});

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -765,7 +765,7 @@ function createBridgeRegistrar(context) {
       console.log(`[Main]   Remote path: ${remotePath}`);
       console.log(`[Main]   File name: ${fileName}`);
       
-      const client = require("./bridges/sftpBridge.cjs");
+      const client = require("../bridges/sftpBridge.cjs");
       // Use tempDirBridge for dedicated Netcatty temp directory
       const localPath = await getTempDirBridge().getTempFilePath(fileName);
       

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -3,6 +3,7 @@
 let bridgesRegistered = false;
 let cloudSyncSessionPassword = null;
 const { readClipboardFiles, readClipboardImage } = require("../bridges/clipboardFiles.cjs");
+const { TRANSFER_CHUNK_SIZE, TRANSFER_CONCURRENCY } = require("../bridges/transferLimits.cjs");
 
 const excludedFigSpecPrefixes = ["aws", "gcloud", "az"];
 
@@ -794,7 +795,10 @@ function createBridgeRegistrar(context) {
       const encodedPath = client.encodePathForSession
         ? client.encodePathForSession(sftpId, remotePath, encoding)
         : remotePath;
-      await sftpClient.fastGet(encodedPath, localPath);
+      await sftpClient.fastGet(encodedPath, localPath, {
+        chunkSize: TRANSFER_CHUNK_SIZE,
+        concurrency: TRANSFER_CONCURRENCY,
+      });
       console.log(`[Main]   File downloaded successfully`);
       return localPath;
     });


### PR DESCRIPTION
## Summary
- Lower the default SFTP folder transfer fanout so multi-file transfers start fewer files at once.
- Share conservative per-file SFTP request limits across the main transfer bridge and temp download path.
- Add regression coverage for upload/download request concurrency, temp downloads, and default multi-file scheduling.

## Why
SFTP transfers could multiply file-level concurrency by per-file SFTP request concurrency and saturate the shared SSH/network path, making terminal switching and input laggy during large transfers. This keeps the mitigation small and focused on #1507 without rewriting the transfer architecture.

Fixes #1507.

## Validation
- `node --test electron/bridges/registerBridgesTransferLimits.test.cjs`
- `node --test --import tsx application/state/sftp/transferConcurrency.test.ts electron/bridges/registerBridgesTransferLimits.test.cjs electron/bridges/transferLimits.test.cjs electron/bridges/transferBridge.test.cjs`
- `node --test --import tsx application/state/sftp/*.test.ts components/sftp/*.test.ts electron/bridges/registerBridgesTransferLimits.test.cjs electron/bridges/transferLimits.test.cjs electron/bridges/transferBridge.test.cjs`
- `npm run lint`

## Notes
- Full `npm test` still has unrelated Cursor SDK discovery failures in this Linux environment because the matching `@cursor/sdk-linux-*` optional platform package is not installed.