### PR TITLE
[codex] Fix Agent history persistence

### DIFF
--- a/application/state/aiScopeCleanup.test.ts
+++ b/application/state/aiScopeCleanup.test.ts
@@ -65,7 +65,7 @@ test("pruneInactiveScopedTransientState removes closed workspace and terminal sc
   });
 });
 
-test("pruneInactiveScopedSessions preserves restorable terminal external session ids across reconnects", () => {
+test("pruneInactiveScopedSessions reports inactive targets without deleting persisted history", () => {
   const sessions = [
     createSession("terminal-restorable", {
       type: "terminal",
@@ -98,10 +98,32 @@ test("pruneInactiveScopedSessions preserves restorable terminal external session
     "terminal-local",
     "workspace-closed",
   ]);
-  assert.deepEqual(next.sessions, [
-    sessions[0],
-    sessions[3],
+  assert.equal(next.sessions, sessions);
+});
+
+test("pruneInactiveScopedSessions preserves inactive workspace and local terminal history after restart", () => {
+  const sessions = [
+    createSession("terminal-local", {
+      type: "terminal",
+      targetId: "closed-local",
+      hostIds: ["local-shell"],
+    }, "ext-local"),
+    createSession("workspace-closed", {
+      type: "workspace",
+      targetId: "closed-workspace",
+    }, "ext-workspace"),
+  ];
+
+  const next = pruneInactiveScopedSessions(
+    sessions,
+    new Set(),
+  );
+
+  assert.deepEqual(next.orphanedSessionIds, [
+    "terminal-local",
+    "workspace-closed",
   ]);
+  assert.equal(next.sessions, sessions);
 });
 
 test("pruneInactiveScopedSessions preserves original sessions when orphaned restorable chats are already detached", () => {

--- a/application/state/aiScopeCleanup.ts
+++ b/application/state/aiScopeCleanup.ts
@@ -90,12 +90,6 @@ export function pruneInactiveScopedTransientState(
   };
 }
 
-function isRestorableTerminalSession(session: AISession): boolean {
-  return session.scope.type === "terminal"
-    && !!session.scope.hostIds?.length
-    && session.scope.hostIds.some((id) => !id.startsWith("local-") && !id.startsWith("serial-"));
-}
-
 export function pruneInactiveScopedSessions(
   sessions: AISession[],
   activeTargetIds: Set<string>,
@@ -123,23 +117,8 @@ export function pruneInactiveScopedSessions(
     };
   }
 
-  const orphanedSessionIdSet = new Set(orphanedSessionIds);
-  let sessionsChanged = false;
-
-  const nextSessions = sessions.flatMap((session) => {
-    if (!orphanedSessionIdSet.has(session.id)) {
-      return [session];
-    }
-
-    if (!isRestorableTerminalSession(session)) {
-      sessionsChanged = true;
-      return [];
-    }
-    return [session];
-  });
-
   return {
-    sessions: sessionsChanged ? nextSessions : sessions,
+    sessions,
     orphanedSessionIds,
   };
 }

--- a/components/ai/scopedHistorySessions.test.ts
+++ b/components/ai/scopedHistorySessions.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AISession } from "../../infrastructure/ai/types.ts";
+import { getScopedHistorySessions } from "./scopedHistorySessions.ts";
+
+function createSession(
+  id: string,
+  scope: AISession["scope"],
+  updatedAt: number,
+): AISession {
+  return {
+    id,
+    title: id,
+    agentId: "catty",
+    scope,
+    messages: [],
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+test("workspace history remains visible after the original workspace target is gone", () => {
+  const staleWorkspaceSession = createSession(
+    "workspace-stale",
+    { type: "workspace", targetId: "workspace-before-restart" },
+    2,
+  );
+
+  const sessions = [
+    staleWorkspaceSession,
+    createSession("terminal-session", { type: "terminal", targetId: "terminal-1" }, 3),
+  ];
+
+  assert.deepEqual(
+    getScopedHistorySessions(
+      sessions,
+      "workspace",
+      "workspace-after-restart",
+      undefined,
+      new Set(),
+    ),
+    [staleWorkspaceSession],
+  );
+});
+
+test("terminal history without host ids remains visible after the original terminal target is gone", () => {
+  const staleLocalSession = createSession(
+    "terminal-local-stale",
+    { type: "terminal", targetId: "terminal-before-restart" },
+    2,
+  );
+
+  assert.deepEqual(
+    getScopedHistorySessions(
+      [staleLocalSession],
+      "terminal",
+      "terminal-after-restart",
+      undefined,
+      new Set(),
+    ),
+    [staleLocalSession],
+  );
+});
+
+test("scoped history orders exact, host-matched, then older same-scope sessions", () => {
+  const staleSameScopeSession = createSession(
+    "same-scope-stale",
+    { type: "terminal", targetId: "terminal-closed" },
+    100,
+  );
+  const hostMatchedSession = createSession(
+    "host-match",
+    { type: "terminal", targetId: "terminal-other", hostIds: ["host-a"] },
+    2,
+  );
+  const exactSession = createSession(
+    "exact",
+    { type: "terminal", targetId: "terminal-current" },
+    1,
+  );
+
+  assert.deepEqual(
+    getScopedHistorySessions(
+      [staleSameScopeSession, hostMatchedSession, exactSession],
+      "terminal",
+      "terminal-current",
+      ["host-a"],
+      new Set(),
+    ).map((session) => session.id),
+    ["exact", "host-match", "same-scope-stale"],
+  );
+});
+
+test("same-scope fallback excludes sessions already displayed by another terminal", () => {
+  const displayedElsewhere = createSession(
+    "displayed-elsewhere",
+    { type: "terminal", targetId: "terminal-before-restart" },
+    2,
+  );
+
+  assert.deepEqual(
+    getScopedHistorySessions(
+      [displayedElsewhere],
+      "terminal",
+      "terminal-after-restart",
+      undefined,
+      new Set(["displayed-elsewhere"]),
+    ),
+    [],
+  );
+});

--- a/components/ai/sessionScopeMatch.test.ts
+++ b/components/ai/sessionScopeMatch.test.ts
@@ -46,7 +46,7 @@ test("host-matched terminal session remains resumable when no terminal is displa
       ["host-a"],
       new Set(["session-other"]),
     ),
-    1,
+    2,
   );
 });
 
@@ -71,7 +71,7 @@ test("ownership is tracked by session id, not scope.targetId", () => {
   );
 });
 
-test("session targeting the current scope is an exact match (rank 2)", () => {
+test("session targeting the current scope is an exact match (rank 3)", () => {
   const session = createSession("session-1", "terminal-current", ["host-a"]);
 
   assert.equal(
@@ -82,7 +82,7 @@ test("session targeting the current scope is an exact match (rank 2)", () => {
       ["host-a"],
       new Set(),
     ),
-    2,
+    3,
   );
 });
 

--- a/components/ai/sessionScopeMatch.test.ts
+++ b/components/ai/sessionScopeMatch.test.ts
@@ -50,6 +50,21 @@ test("host-matched terminal session remains resumable when no terminal is displa
   );
 });
 
+test("host-mismatched terminal session is not resumable for the current terminal", () => {
+  const session = createSession("session-1", "terminal-closed", ["host-b"]);
+
+  assert.equal(
+    getSessionScopeMatchRank(
+      session,
+      "terminal",
+      "terminal-current",
+      ["host-a"],
+      new Set(),
+    ),
+    0,
+  );
+});
+
 test("ownership is tracked by session id, not scope.targetId", () => {
   // Session was created in terminal-A but a different terminal (B) is now
   // displaying it after the user resumed it from history. Opening a third

--- a/components/ai/sessionScopeMatch.ts
+++ b/components/ai/sessionScopeMatch.ts
@@ -14,15 +14,15 @@ export function getSessionScopeMatchRank(
   activeTerminalSessionIds?: Set<string>,
 ): number {
   if (session.scope.type !== scopeType) return 0;
-  if (session.scope.targetId === scopeTargetId) return 2;
+  if (session.scope.targetId === scopeTargetId) return 3;
 
-  if (scopeType !== "terminal" || !scopeHostIds?.length || !session.scope.hostIds?.length) {
+  if (scopeType === "terminal" && activeTerminalSessionIds?.has(session.id)) {
     return 0;
   }
 
-  if (activeTerminalSessionIds?.has(session.id)) {
-    return 0;
+  if (scopeType === "terminal" && scopeHostIds?.length && session.scope.hostIds?.length) {
+    return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 2 : 1;
   }
 
-  return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 1 : 0;
+  return 1;
 }

--- a/components/ai/sessionScopeMatch.ts
+++ b/components/ai/sessionScopeMatch.ts
@@ -21,7 +21,7 @@ export function getSessionScopeMatchRank(
   }
 
   if (scopeType === "terminal" && scopeHostIds?.length && session.scope.hostIds?.length) {
-    return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 2 : 1;
+    return session.scope.hostIds.some((hostId) => scopeHostIds.includes(hostId)) ? 2 : 0;
   }
 
   return 1;


### PR DESCRIPTION
## Summary
- Keep saved Agent chat sessions available after the original terminal or workspace target disappears.
- Expand the Agent history drawer fallback so restarted sessions can still surface prior same-scope history.
- Add regression coverage for restart/session-missing history access and cleanup that must not delete persisted history.

## Root cause
Agent sessions were persisted, but the history entry filtered too tightly against the current scope/session. Cleanup also removed saved sessions whose temporary terminal/workspace target no longer existed, so after closing tabs or restarting the app the user could no longer find some Agent history.

## Validation
- `npm test` — 2492 passed, 0 failed, 3 skipped
- `npm run lint`
- `npx tsc --noEmit --skipLibCheck --allowImportingTsExtensions --module ESNext --moduleResolution Bundler --target ES2022 --resolveJsonModule --jsx react-jsx --types node application/state/aiScopeCleanup.ts application/state/aiScopeCleanup.test.ts components/ai/sessionScopeMatch.ts components/ai/sessionScopeMatch.test.ts components/ai/scopedHistorySessions.ts components/ai/scopedHistorySessions.test.ts`

Fixes #1077