### PR TITLE
Clear SFTP filter on directory navigation

### DIFF
--- a/application/state/sftp/useSftpPaneActions.ts
+++ b/application/state/sftp/useSftpPaneActions.ts
@@ -3,7 +3,18 @@ import type { Host, SftpFileEntry, SftpFilenameEncoding } from "../../../domain/
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import { logger } from "../../../lib/logger";
 import { SftpPane } from "./types";
-import { getFileName, getParentPath, isNavigableDirectory, isWindowsRoot, joinPath } from "./utils";
+import {
+  getFileName,
+  getParentPath,
+  getSftpFilterAfterPathChange,
+  getSftpFilterAfterPathChangeError,
+  isNavigableDirectory,
+  isSameSftpPath,
+  isWindowsRoot,
+  joinPath,
+  normalizeSftpPathForCompare,
+  shouldClearSftpFilterForPathChange,
+} from "./utils";
 import { buildCacheKey, setSharedRemoteHostCache } from "./sharedRemoteHostCache";
 
 /** Shared empty set for navigation resets — never mutate this. */
@@ -83,17 +94,12 @@ export const useSftpPaneActions = ({
   dirCacheTtlMs,
 }: UseSftpPaneActionsParams): UseSftpPaneActionsResult => {
   const normalizePathForCompare = useCallback((path: string): string => {
-    if (isWindowsRoot(path)) return path.replace(/\//g, "\\").toLowerCase();
-    if (/^[A-Za-z]:/.test(path)) {
-      return path.replace(/\//g, "\\").replace(/[\\]+$/, "").toLowerCase();
-    }
-    if (path === "/") return "/";
-    return path.replace(/\/+$/, "");
+    return normalizeSftpPathForCompare(path);
   }, []);
 
   const isSamePath = useCallback((a: string, b: string): boolean => {
-    return normalizePathForCompare(a) === normalizePathForCompare(b);
-  }, [normalizePathForCompare]);
+    return isSameSftpPath(a, b);
+  }, []);
 
   const isDescendantPath = useCallback((candidate: string, parent: string): boolean => {
     const normalizedCandidate = normalizePathForCompare(candidate);
@@ -146,7 +152,7 @@ export const useSftpPaneActions = ({
   // than an intermediate optimistic state from another in-flight navigation.
   // Includes connectionId so stale entries from a previous host are ignored.
   const lastConfirmedRef = useRef(
-    new Map<string, { connectionId: string; path: string; files: SftpFileEntry[]; selectedFiles: Set<string> }>(),
+    new Map<string, { connectionId: string; path: string; files: SftpFileEntry[]; selectedFiles: Set<string>; filter: string }>(),
   );
 
   const navigateTo = useCallback(
@@ -171,6 +177,8 @@ export const useSftpPaneActions = ({
       const connectionId = pane.connection.id;
       const requestId = ++navSeqRef.current[side];
       const cacheKey = makeCacheKey(connectionId, path, pane.filenameEncoding);
+      const clearFilterForPathChange = shouldClearSftpFilterForPathChange(pane.connection.currentPath, path);
+      const nextConfirmedFilter = getSftpFilterAfterPathChange(pane.connection.currentPath, path, pane.filter);
       const cached = options?.force
         ? undefined
         : dirCacheRef.current.get(cacheKey);
@@ -186,6 +194,7 @@ export const useSftpPaneActions = ({
           path,
           files: cached.files,
           selectedFiles: EMPTY_SET,
+          filter: nextConfirmedFilter,
         });
         updateTab(side, targetTabId, (prev) => ({
           ...prev,
@@ -196,6 +205,7 @@ export const useSftpPaneActions = ({
           loading: false,
           error: null,
           selectedFiles: EMPTY_SET,
+          filter: clearFilterForPathChange ? "" : prev.filter,
         }));
         if (!pane.connection.isLocal) {
           // Use hostId as the shared cache key — this is safe because the
@@ -224,12 +234,14 @@ export const useSftpPaneActions = ({
           path: pane.connection.currentPath,
           files: pane.files,
           selectedFiles: pane.selectedFiles,
+          filter: pane.filter,
         });
       }
       const confirmed = lastConfirmedRef.current.get(targetTabId)!;
       const previousPath = confirmed.path;
       const previousFiles = confirmed.files;
       const previousSelection = confirmed.selectedFiles;
+      const previousFilter = confirmed.filter;
       tabNavSeqRef.current.set(targetTabId, requestId);
       // Keep existing files visible during loading — the loading overlay
       // (pointer-events-none) prevents interaction. This avoids blanking a tab
@@ -240,6 +252,7 @@ export const useSftpPaneActions = ({
           ? { ...prev.connection, currentPath: path }
           : null,
         selectedFiles: EMPTY_SET,
+        filter: clearFilterForPathChange ? "" : prev.filter,
         loading: true,
         error: null,
       }));
@@ -310,6 +323,7 @@ export const useSftpPaneActions = ({
           path,
           files,
           selectedFiles: EMPTY_SET,
+          filter: nextConfirmedFilter,
         });
 
         updateTab(side, targetTabId, (prev) => ({
@@ -320,6 +334,7 @@ export const useSftpPaneActions = ({
           files,
           loading: false,
           selectedFiles: EMPTY_SET,
+          filter: clearFilterForPathChange ? "" : prev.filter,
         }));
         if (!pane.connection.isLocal) {
           setSharedRemoteHostCache(getActivePaneCacheKey(side, pane.connection.hostId, pane.connection.id), {
@@ -346,6 +361,7 @@ export const useSftpPaneActions = ({
             connection: { ...prev.connection, currentPath: previousPath },
             files: previousFiles,
             selectedFiles: previousSelection,
+            filter: getSftpFilterAfterPathChangeError(previousFilter),
             error:
               err instanceof Error ? err.message : "Failed to list directory",
             loading: false,

--- a/application/state/sftp/useSftpPaneActions.ts
+++ b/application/state/sftp/useSftpPaneActions.ts
@@ -361,7 +361,7 @@ export const useSftpPaneActions = ({
             connection: { ...prev.connection, currentPath: previousPath },
             files: previousFiles,
             selectedFiles: previousSelection,
-            filter: getSftpFilterAfterPathChangeError(previousFilter),
+            filter: getSftpFilterAfterPathChangeError(clearFilterForPathChange, previousFilter, prev.filter),
             error:
               err instanceof Error ? err.message : "Failed to list directory",
             loading: false,

--- a/application/state/sftp/utils.test.ts
+++ b/application/state/sftp/utils.test.ts
@@ -1,11 +1,40 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { isConcreteTransferTargetPath } from "./utils";
+import {
+  getParentPath,
+  getSftpFilterAfterPathChange,
+  getSftpFilterAfterPathChangeError,
+  isConcreteTransferTargetPath,
+  shouldClearSftpFilterForPathChange,
+} from "./utils";
 
 test("concrete transfer target paths exclude temporary placeholders", () => {
   assert.equal(isConcreteTransferTargetPath({ targetPath: "/Users/alice/Downloads/report.pdf" }), true);
   assert.equal(isConcreteTransferTargetPath({ targetPath: "C:\\Users\\alice\\Downloads\\report.pdf" }), true);
   assert.equal(isConcreteTransferTargetPath({ targetPath: "(temp)" }), false);
   assert.equal(isConcreteTransferTargetPath({ targetPath: "   " }), false);
+});
+
+test("SFTP filter clears when entering a different directory", () => {
+  assert.equal(shouldClearSftpFilterForPathChange("/srv", "/srv/app"), true);
+  assert.equal(getSftpFilterAfterPathChange("/srv", "/srv/app", "log"), "");
+});
+
+test("SFTP filter clears when navigating to the parent directory", () => {
+  assert.equal(shouldClearSftpFilterForPathChange("/srv/app", getParentPath("/srv/app")), true);
+  assert.equal(getSftpFilterAfterPathChange("/srv/app", getParentPath("/srv/app"), "dist"), "");
+});
+
+test("SFTP filter stays when refreshing the same directory", () => {
+  assert.equal(shouldClearSftpFilterForPathChange("/srv/app", "/srv/app"), false);
+  assert.equal(shouldClearSftpFilterForPathChange("/srv/app", "/srv/app/"), false);
+  assert.equal(shouldClearSftpFilterForPathChange("C:\\Users\\alice", "c:/Users/alice"), false);
+  assert.equal(getSftpFilterAfterPathChange("/srv/app", "/srv/app", "log"), "log");
+  assert.equal(getSftpFilterAfterPathChange("/srv/app", "/srv/app/", "log"), "log");
+  assert.equal(getSftpFilterAfterPathChange("C:\\Users\\alice", "c:/Users/alice", "docs"), "docs");
+});
+
+test("SFTP filter restores when directory navigation fails", () => {
+  assert.equal(getSftpFilterAfterPathChangeError("log"), "log");
 });

--- a/application/state/sftp/utils.test.ts
+++ b/application/state/sftp/utils.test.ts
@@ -35,6 +35,10 @@ test("SFTP filter stays when refreshing the same directory", () => {
   assert.equal(getSftpFilterAfterPathChange("C:\\Users\\alice", "c:/Users/alice", "docs"), "docs");
 });
 
-test("SFTP filter restores when directory navigation fails", () => {
-  assert.equal(getSftpFilterAfterPathChangeError("log"), "log");
+test("SFTP filter restores when changed-directory navigation fails", () => {
+  assert.equal(getSftpFilterAfterPathChangeError(true, "log", "typed-while-loading"), "log");
+});
+
+test("SFTP filter preserves in-flight edits when same-directory refresh fails", () => {
+  assert.equal(getSftpFilterAfterPathChangeError(false, "log", "typed-while-loading"), "typed-while-loading");
 });

--- a/application/state/sftp/utils.ts
+++ b/application/state/sftp/utils.ts
@@ -114,6 +114,10 @@ export const getSftpFilterAfterPathChange = (
   return shouldClearSftpFilterForPathChange(currentPath, nextPath) ? "" : currentFilter;
 };
 
-export const getSftpFilterAfterPathChangeError = (previousFilter: string): string => {
-  return previousFilter;
+export const getSftpFilterAfterPathChangeError = (
+  clearFilterForPathChange: boolean,
+  previousFilter: string,
+  currentFilter: string,
+): string => {
+  return clearFilterForPathChange ? previousFilter : currentFilter;
 };

--- a/application/state/sftp/utils.ts
+++ b/application/state/sftp/utils.ts
@@ -85,3 +85,35 @@ export const getFileName = (path: string): string => {
   const parts = path.split(/[\\/]/).filter(Boolean);
   return parts[parts.length - 1] || "";
 };
+
+export const normalizeSftpPathForCompare = (path: string): string => {
+  if (isWindowsRoot(path)) return path.replace(/\//g, "\\").toLowerCase();
+  if (/^[A-Za-z]:/.test(path)) {
+    return path.replace(/\//g, "\\").replace(/[\\]+$/, "").toLowerCase();
+  }
+  if (path === "/") return "/";
+  return path.replace(/\/+$/, "");
+};
+
+export const isSameSftpPath = (a: string, b: string): boolean => {
+  return normalizeSftpPathForCompare(a) === normalizeSftpPathForCompare(b);
+};
+
+export const shouldClearSftpFilterForPathChange = (
+  currentPath: string,
+  nextPath: string,
+): boolean => {
+  return !isSameSftpPath(currentPath, nextPath);
+};
+
+export const getSftpFilterAfterPathChange = (
+  currentPath: string,
+  nextPath: string,
+  currentFilter: string,
+): string => {
+  return shouldClearSftpFilterForPathChange(currentPath, nextPath) ? "" : currentFilter;
+};
+
+export const getSftpFilterAfterPathChangeError = (previousFilter: string): string => {
+  return previousFilter;
+};


### PR DESCRIPTION
## Summary
- Clear the SFTP file filter when navigation lands on a different directory.
- Keep the filter when refreshing the same directory, including forced refreshes.
- Restore the previous filter if a directory navigation fails and rolls back.

Fixes #1471

## Testing
- `node --test --import tsx application/state/sftp/utils.test.ts application/state/sftp/*.test.ts components/sftp/*.test.ts components/SftpPaneFileList.test.tsx components/SftpClipboardUpload.test.ts components/SftpTransferItem.test.tsx`
- `npm run lint`
- `npm test`
- `npm run build`

## Review
- Independent reviewer checked the diff once, flagged missing failed-navigation coverage.
- Added that coverage and requested a second review; no clear issues remained.