### PR TITLE
[codex] Fix autocomplete cwd after user switch

### DIFF
--- a/components/terminal/autocomplete/completionEngine.ts
+++ b/components/terminal/autocomplete/completionEngine.ts
@@ -32,6 +32,7 @@ import {
 } from "./remotePathCompleter";
 import { getSnippetSuggestions } from "./snippetCompleter";
 import type { Snippet } from "../../../domain/models";
+import type { AutocompleteCwdSource } from "./terminalAutocompleteLayout";
 
 /** Source indicator for where a suggestion came from */
 export type SuggestionSource = "history" | "command" | "subcommand" | "option" | "arg" | "path" | "snippet";
@@ -172,6 +173,7 @@ export async function getCompletions(
     protocol?: string;
     /** Current working directory (from OSC 7) */
     cwd?: string;
+    cwdSource?: AutocompleteCwdSource;
     /** Custom snippets to surface at the command position */
     snippets?: Snippet[];
   } = {},
@@ -246,6 +248,7 @@ export async function getCompletions(
       protocol: options.protocol,
       os: options.os,
       cwd: options.cwd,
+      cwdSource: options.cwdSource,
       foldersOnly: pathCheck.foldersOnly,
     })
     : [];

--- a/components/terminal/autocomplete/remotePathCompleter.ts
+++ b/components/terminal/autocomplete/remotePathCompleter.ts
@@ -6,6 +6,7 @@
 
 import type { CompletionContext } from "./completionEngine";
 import type { FigArg } from "./figSpecLoader";
+import type { AutocompleteCwdSource } from "./terminalAutocompleteLayout";
 
 /** Directory entry returned from IPC */
 export interface DirEntry {
@@ -201,12 +202,13 @@ export async function getPathSuggestions(
     protocol?: string;
     os?: "linux" | "windows" | "macos";
     cwd?: string;
+    cwdSource?: AutocompleteCwdSource;
     foldersOnly: boolean;
   },
 ): Promise<{ name: string; type: DirEntry["type"] }[]> {
-  const { sessionId, protocol, os, cwd, foldersOnly } = options;
+  const { sessionId, protocol, os, cwd, cwdSource, foldersOnly } = options;
   const { dirToList, filterPrefix } = resolvePathComponents(ctx.currentWord, cwd, {
-    preferRelativeCwd: shouldUseRemoteShellCwd(protocol, sessionId, os),
+    preferRelativeCwd: shouldPreferRemoteShellCwd(protocol, sessionId, os, cwd, cwdSource),
   });
 
   const entries = await listDirectoryEntries(dirToList, {
@@ -348,11 +350,14 @@ function resolveDirLookup(pathToken: string, cwd: string | undefined, preferRela
   return normalizePosixLikePath(pathToken);
 }
 
-function shouldUseRemoteShellCwd(
+export function shouldPreferRemoteShellCwd(
   protocol: string | undefined,
   sessionId: string | undefined,
   os?: "linux" | "windows" | "macos",
+  cwd?: string,
+  cwdSource?: AutocompleteCwdSource,
 ): boolean {
+  if (cwdSource === "prompt" && cwd?.startsWith("/")) return false;
   return Boolean(sessionId && protocol !== "local" && os === "linux");
 }
 
@@ -362,7 +367,7 @@ function shouldBypassCache(
   os: "linux" | "windows" | "macos" | undefined,
   dirPath: string,
 ): boolean {
-  if (!shouldUseRemoteShellCwd(protocol, sessionId, os)) return false;
+  if (!shouldPreferRemoteShellCwd(protocol, sessionId, os)) return false;
   return !dirPath.startsWith("/") && dirPath !== "~" && !dirPath.startsWith("~/");
 }
 

--- a/components/terminal/autocomplete/terminalAutocompleteLayout.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteLayout.ts
@@ -10,39 +10,50 @@ export function resolveAutocompleteCwd(
   fallbackCwd: string | undefined,
   os: "linux" | "windows" | "macos",
 ): string | undefined {
-  if (os === "windows") return fallbackCwd;
+  return resolveAutocompleteCwdWithSource(promptText, currentWord, fallbackCwd, os).cwd;
+}
+
+export type AutocompleteCwdSource = "prompt" | "fallback" | "none";
+
+export function resolveAutocompleteCwdWithSource(
+  promptText: string,
+  currentWord: string,
+  fallbackCwd: string | undefined,
+  os: "linux" | "windows" | "macos",
+): { cwd: string | undefined; source: AutocompleteCwdSource } {
+  if (os === "windows") return { cwd: fallbackCwd, source: fallbackCwd ? "fallback" : "none" };
 
   const normalizedWord = currentWord.trim().replace(/^['"]/, "");
 
   // Absolute or home-relative paths don't depend on cwd
   if (normalizedWord.startsWith("/") || normalizedWord.startsWith("~/")) {
-    return fallbackCwd;
+    return { cwd: fallbackCwd, source: fallbackCwd ? "fallback" : "none" };
   }
 
   // For empty word (e.g. "cd ") and relative paths, try prompt-based cwd
   // extraction which reflects the current visible prompt — more up-to-date
   // than fallbackCwd when OSC 7 is not supported.
   const promptCwd = extractPosixCwdFromPrompt(promptText);
-  return chooseAutocompleteCwd(promptCwd, fallbackCwd);
+  return chooseAutocompleteCwdWithSource(promptCwd, fallbackCwd);
 }
 
-function chooseAutocompleteCwd(
+function chooseAutocompleteCwdWithSource(
   promptCwd: string | undefined,
   fallbackCwd: string | undefined,
-): string | undefined {
-  if (!promptCwd) return fallbackCwd;
-  if (!fallbackCwd) return promptCwd;
+): { cwd: string | undefined; source: AutocompleteCwdSource } {
+  if (!promptCwd) return { cwd: fallbackCwd, source: fallbackCwd ? "fallback" : "none" };
+  if (!fallbackCwd) return { cwd: promptCwd, source: "prompt" };
 
   // Prompt cwd is extracted from the currently visible prompt, so it tracks
   // directory changes even when OSC 7 is not supported. Prefer it over
   // fallbackCwd (which may be stale from initial connection) whenever it
   // looks like a usable path.
   if (promptCwd.startsWith("/") || promptCwd === "~" || promptCwd.startsWith("~/")) {
-    return promptCwd;
+    return { cwd: promptCwd, source: "prompt" };
   }
 
   // Bare directory name (e.g. "xunlong") can't be used as a path — fallback
-  return fallbackCwd;
+  return { cwd: fallbackCwd, source: fallbackCwd ? "fallback" : "none" };
 }
 
 function extractPosixCwdFromPrompt(promptText: string): string | undefined {

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -20,7 +20,11 @@ import type { Snippet } from "../../../domain/models";
 import { recordCommand } from "./commandHistoryStore";
 import { shellEscape } from "./completionEngine";
 import { preloadCommonSpecs } from "./figSpecLoader";
-import { listDirectoryEntries, normalizePathTokenForLookup } from "./remotePathCompleter";
+import {
+  listDirectoryEntries,
+  normalizePathTokenForLookup,
+  shouldPreferRemoteShellCwd,
+} from "./remotePathCompleter";
 import { decideGhostSuggestion } from "./ghostSuggestionPolicy";
 import { computeLivePreviewWrite } from "./livePreviewSequence";
 import {
@@ -28,7 +32,7 @@ import {
   areSuggestionsEqual,
   resolveAutocompleteAnchorInViewport,
   resolveAutocompleteCursorColumn,
-  resolveAutocompleteCwd,
+  resolveAutocompleteCwdWithSource,
 } from "./terminalAutocompleteLayout";
 import { handleTerminalAutocompleteInput } from "./terminalAutocompleteInput";
 import { handleTerminalAutocompleteKeyEvent } from "./terminalAutocompleteKeyEvent";
@@ -345,15 +349,19 @@ export function useTerminalAutocomplete(
     const activeWord = activePrompt?.isAtPrompt
       ? parseCommandLine(activePrompt.userInput).currentWord
       : parseCommandLine(item.text).currentWord;
-    const cwd = resolveAutocompleteCwd(
+    const cwdResolution = resolveAutocompleteCwdWithSource(
       activePrompt?.promptText ?? "",
       activeWord,
       getCwdRef.current?.(),
       hostOsRef.current,
     );
-    const dirPath = normalizePathTokenForLookup(parseCommandLine(item.text).currentWord, cwd, {
-      preferRelativeCwd: Boolean(
-        sessionIdRef.current && protocolRef.current !== "local" && hostOsRef.current === "linux",
+    const dirPath = normalizePathTokenForLookup(parseCommandLine(item.text).currentWord, cwdResolution.cwd, {
+      preferRelativeCwd: shouldPreferRemoteShellCwd(
+        protocolRef.current,
+        sessionIdRef.current,
+        hostOsRef.current,
+        cwdResolution.cwd,
+        cwdResolution.source,
       ),
     });
     if (!dirPath) return;
@@ -625,7 +633,7 @@ export function useTerminalAutocomplete(
 
     const input = prompt.userInput;
     const parsedInput = parseCommandLine(input);
-    const cwd = resolveAutocompleteCwd(
+    const cwdResolution = resolveAutocompleteCwdWithSource(
       prompt.promptText,
       parsedInput.currentWord,
       getCwdRef.current?.(),
@@ -639,7 +647,8 @@ export function useTerminalAutocomplete(
       maxResults: settingsRef.current.maxSuggestions,
       sessionId: sessionIdRef.current,
       protocol: protocolRef.current,
-      cwd,
+      cwd: cwdResolution.cwd,
+      cwdSource: cwdResolution.source,
       snippets: snippetsRef.current,
     });
 

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -103,6 +103,10 @@ Object.defineProperty(globalThis, "window", {
 
 const { getCompletions } = await import("./autocomplete/completionEngine.ts");
 const { clearHistory, recordCommand } = await import("./autocomplete/commandHistoryStore.ts");
+const {
+  normalizePathTokenForLookup,
+  shouldPreferRemoteShellCwd,
+} = await import("./autocomplete/remotePathCompleter.ts");
 
 test.beforeEach(() => {
   localStorage.clear();
@@ -162,6 +166,54 @@ test("getCompletions uses the remote shell cwd for relative path arguments inste
   assert.equal(completions[0]?.source, "path");
   assert.equal(completions[0]?.text, "cat worktree.txt");
   assert.equal(completions.some((entry) => entry.text.includes("~")), false);
+});
+
+test("getCompletions uses absolute prompt cwd for remote relative path arguments", async () => {
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "old-user-file.txt", type: "file" }]);
+  bridgeState.remoteEntriesByPath.set("/etc", [{ name: "passwd", type: "file" }]);
+
+  const completions = await getCompletions("cat pa", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+    cwd: "/etc",
+    cwdSource: "prompt",
+  });
+
+  assert.deepEqual(bridgeState.remoteCalls, ["/etc"]);
+  assert.equal(completions[0]?.source, "path");
+  assert.equal(completions[0]?.text, "cat passwd");
+  assert.equal(completions.some((entry) => entry.text === "cat old-user-file.txt"), false);
+});
+
+test("remote subdirectory lookups keep absolute prompt cwd", () => {
+  const preferRelativeCwd = shouldPreferRemoteShellCwd("ssh", "session-1", "linux", "/etc", "prompt");
+
+  assert.equal(preferRelativeCwd, false);
+  assert.equal(
+    normalizePathTokenForLookup("pam.d/", "/etc", { preferRelativeCwd }),
+    "/etc/pam.d/",
+  );
+});
+
+test("getCompletions keeps remote shell cwd when absolute cwd is only a fallback", async () => {
+  bridgeState.remoteEntriesByPath.set("/old", [{ name: "old-user-file.txt", type: "file" }]);
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "worktree.txt", type: "file" }]);
+
+  const completions = await getCompletions("cat wo", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+    cwd: "/old",
+    cwdSource: "fallback",
+  });
+
+  assert.deepEqual(bridgeState.remoteCalls, ["."]);
+  assert.equal(completions[0]?.source, "path");
+  assert.equal(completions[0]?.text, "cat worktree.txt");
+  assert.equal(completions.some((entry) => entry.text === "cat old-user-file.txt"), false);
 });
 
 test("getCompletions does not reuse cached remote relative listings after cwd changes", async () => {


### PR DESCRIPTION
## Summary
- Fix remote path autocomplete so an absolute cwd detected from the visible prompt is used for relative path suggestions.
- Keep the existing backend cwd fallback when the renderer does not know a reliable absolute cwd.
- Add a regression test for stale remote cwd suggestions after the prompt shows a newer directory.

## Root cause
For SSH/Linux path completion, relative paths always asked the backend to resolve the interactive shell cwd with `.`. After `sudo` or `su`, that backend probe can keep resolving to the original login shell cwd, so both inline and popup suggestions could keep showing entries from the previous directory even when the visible prompt had moved elsewhere.

## Validation
- `node --test --import tsx components/terminal/completionEngine.test.ts`
- `node --test --import tsx components/terminal/terminalAutocompleteLayout.test.ts components/terminal/GhostSuggestionPolicy.test.ts components/terminal/ghostTextConsistency.test.ts components/terminal/completionGate.test.ts components/terminal/snippetCompleter.test.ts components/terminal/completionEngineSnippets.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (reran after an initial flaky full-suite failure; second full run passed)

Fixes #1530
