### PR TITLE
[codex] Fix host keyword highlight enablement

### DIFF
--- a/components/terminal/HostKeywordHighlightPopover.test.ts
+++ b/components/terminal/HostKeywordHighlightPopover.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host, KeywordHighlightRule } from "../../types.ts";
+import { addHostKeywordHighlightRule } from "./HostKeywordHighlightPopover.tsx";
+
+const baseHost: Host = {
+  id: "host-1",
+  label: "Production",
+  hostname: "prod.example.com",
+  username: "root",
+  tags: [],
+  os: "linux",
+  keywordHighlightEnabled: false,
+  keywordHighlightRules: [
+    {
+      id: "old-rule",
+      label: "Old rule",
+      patterns: ["OLD"],
+      color: "#FBBF24",
+      enabled: true,
+    },
+  ],
+};
+
+const newRule: KeywordHighlightRule = {
+  id: "new-rule",
+  label: "Deploy",
+  patterns: ["DEPLOY"],
+  color: "#F87171",
+  enabled: true,
+};
+
+test("adding a host keyword highlight rule enables host highlighting", () => {
+  const updated = addHostKeywordHighlightRule(baseHost, newRule);
+
+  assert.equal(updated.keywordHighlightEnabled, true);
+  assert.deepEqual(updated.keywordHighlightRules, [
+    ...(baseHost.keywordHighlightRules ?? []),
+    newRule,
+  ]);
+});

--- a/components/terminal/HostKeywordHighlightPopover.tsx
+++ b/components/terminal/HostKeywordHighlightPopover.tsx
@@ -23,6 +23,14 @@ export interface HostKeywordHighlightPopoverProps {
 
 const DEFAULT_NEW_RULE_COLOR = '#F87171';
 
+export function addHostKeywordHighlightRule(host: Host, rule: KeywordHighlightRule): Host {
+  return {
+    ...host,
+    keywordHighlightRules: [...(host.keywordHighlightRules ?? []), rule],
+    keywordHighlightEnabled: true,
+  };
+}
+
 export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverProps> = ({
   host,
   onUpdateHost,
@@ -76,19 +84,16 @@ export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverPr
       enabled: true,
     };
 
-    updateRules([...rules, newRule]);
+    if (host && onUpdateHost) {
+      onUpdateHost(addHostKeywordHighlightRule(host, newRule));
+    }
 
     // Reset form
     setNewRuleLabel('');
     setNewRulePattern('');
     setNewRuleColor(DEFAULT_NEW_RULE_COLOR);
     setPatternError(null);
-
-    // Auto-enable if adding the first rule and not enabled
-    if (rules.length === 0 && !enabled && host && onUpdateHost) {
-      onUpdateHost({ ...host, keywordHighlightRules: [newRule], keywordHighlightEnabled: true });
-    }
-  }, [newRuleLabel, newRulePattern, newRuleColor, rules, updateRules, enabled, host, onUpdateHost, t]);
+  }, [newRuleLabel, newRulePattern, newRuleColor, host, onUpdateHost, t]);
 
   const handleDeleteRule = useCallback((ruleId: string) => {
     updateRules(rules.filter((r) => r.id !== ruleId));


### PR DESCRIPTION
## What changed

- Ensures adding a keyword highlight rule from the current connection panel also enables host keyword highlighting.
- Adds a regression test for adding a new rule when the host already has saved rules but the host-level highlight switch is off.

## Why

A code review found one concrete path matching the issue symptoms for current-connection rules: the rule could be saved successfully while the host-level highlight switch stayed disabled, so the new rule appeared configured but never ran. Existing rules could still appear to work through other enabled/global rules, making the behavior confusing.

I did not find a corresponding code path where global setting rules are saved but dropped. Existing global normalization tests still pass.

Related to #1502.

## Validation

- `node --test --import tsx components/terminal/HostKeywordHighlightPopover.test.ts domain/keywordHighlight.test.ts`
- `npx eslint components/terminal/HostKeywordHighlightPopover.tsx components/terminal/HostKeywordHighlightPopover.test.ts`
- `npm test` (rerun passed after one non-reproducible flaky run)
- `npm run build`