### PR TITLE
[codex] Sync AI API keys across devices

### DIFF
--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -20,7 +20,7 @@ import { mergeSyncPayloads } from '../../domain/syncMerge';
 import { resolveCloudSyncConflictAction } from '../../domain/syncStrategy';
 import {
   SYNCABLE_SETTING_STORAGE_KEYS,
-  collectSyncableSettings,
+  collectCloudSyncableSettings,
   getEffectivePortForwardingRulesForSync,
   hasMeaningfulCloudSyncData,
   shouldPromptCloudVaultRecovery,
@@ -199,17 +199,17 @@ export const useAutoSync = (config: AutoSyncConfig) => {
   ]);
 
   // Build sync payload
-  const buildPayload = useCallback((): SyncPayload => {
+  const buildPayload = useCallback(async (): Promise<SyncPayload> => {
     return {
       ...getSyncSnapshot(),
-      settings: collectSyncableSettings(),
+      settings: await collectCloudSyncableSettings(),
       syncedAt: Date.now(),
     };
   }, [getSyncSnapshot]);
   
   // Create a hash of current data for comparison (includes settings)
-  const getDataHash = useCallback(() => {
-    return JSON.stringify({ ...getSyncSnapshot(), settings: collectSyncableSettings() });
+  const getDataHash = useCallback(async () => {
+    return JSON.stringify({ ...getSyncSnapshot(), settings: await collectCloudSyncableSettings() });
   }, [getSyncSnapshot]);
   
   // Sync now handler - get fresh state directly from manager
@@ -298,8 +298,8 @@ export const useAutoSync = (config: AutoSyncConfig) => {
         throw new Error(t('sync.autoSync.vaultLocked'));
       }
 
-      const dataHash = getDataHash();
-      const payload = buildPayload();
+      const dataHash = await getDataHash();
+      const payload = await buildPayload();
       const encryptedCredentialPaths = findSyncPayloadEncryptedCredentialPaths(payload);
       if (encryptedCredentialPaths.length > 0) {
         console.warn('[AutoSync] Blocked: encrypted credential placeholders found at:', encryptedCredentialPaths.join(', '));
@@ -494,7 +494,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
 
       const remoteFile = inspection.remoteFile;
       const remotePayload = inspection.payload;
-      const localPayload = buildPayloadRef.current();
+      const localPayload = await buildPayloadRef.current();
 
       // If local vault is empty but cloud has data, this almost certainly
       // means the user's data was lost (update, storage corruption, etc.).
@@ -666,7 +666,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
           isInitializedRef.current = true;
         }
         if (markCurrentDataSynced) {
-          lastSyncedDataRef.current = getDataHashRef.current();
+          lastSyncedDataRef.current = await getDataHashRef.current();
         } else {
           lastSyncedDataRef.current = '';
         }
@@ -713,62 +713,67 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       return;
     }
 
-    // Skip initial render
-    if (!isInitializedRef.current) {
-      isInitializedRef.current = true;
-      lastSyncedDataRef.current = getDataHash();
-      return;
-    }
-    
-    const currentHash = getDataHash();
+    let cancelled = false;
+    void (async () => {
+      const currentHash = await getDataHash();
+      if (cancelled) return;
 
-    // After a merge, onApplyPayload changes local state which triggers
-    // this effect. Skip that cycle and just update the hash baseline.
-    if (skipNextSyncRef.current) {
-      skipNextSyncRef.current = false;
-      lastSyncedDataRef.current = currentHash;
-      return;
-    }
+      // Skip initial render
+      if (!isInitializedRef.current) {
+        isInitializedRef.current = true;
+        lastSyncedDataRef.current = currentHash;
+        return;
+      }
 
-    // Skip if data hasn't changed
-    if (currentHash === lastSyncedDataRef.current) {
-      return;
-    }
+      // After a merge, onApplyPayload changes local state which triggers
+      // this effect. Skip that cycle and just update the hash baseline.
+      if (skipNextSyncRef.current) {
+        skipNextSyncRef.current = false;
+        lastSyncedDataRef.current = currentHash;
+        return;
+      }
 
-    // Wait for the current sync to finish, then this effect will re-run
-    // because sync.isSyncing changed.
-    if (sync.isSyncing || isSyncRunningRef.current) {
-      return;
-    }
+      // Skip if data hasn't changed
+      if (currentHash === lastSyncedDataRef.current) {
+        return;
+      }
 
-    // Hold off on scheduling a new push while another window is applying
-    // a restore — the restore is about to land via localStorage and the
-    // debounce-fired syncNow would otherwise race it. The next data-
-    // change tick after the restore barrier clears will re-enter here.
-    if (isRestoreInProgress()) {
-      return;
-    }
+      // Wait for the current sync to finish, then this effect will re-run
+      // because sync.isSyncing changed.
+      if (sync.isSyncing || isSyncRunningRef.current) {
+        return;
+      }
 
-    // Don't even schedule a push while the apply-in-progress sentinel
-    // is held. The syncNow path re-checks and refuses too, but dropping
-    // the debounced schedule here avoids spinning a 3-second timer for
-    // every keystroke while the user is in the Restore UI working
-    // through recovery.
-    if (readInterruptedVaultApply()) {
-      return;
-    }
-    
-    // Clear existing timeout
-    if (syncTimeoutRef.current) {
-      clearTimeout(syncTimeoutRef.current);
-    }
-    
-    // Debounce sync by 3 seconds
-    syncTimeoutRef.current = setTimeout(() => {
-      syncNow();
-    }, 3000);
+      // Hold off on scheduling a new push while another window is applying
+      // a restore — the restore is about to land via localStorage and the
+      // debounce-fired syncNow would otherwise race it. The next data-
+      // change tick after the restore barrier clears will re-enter here.
+      if (isRestoreInProgress()) {
+        return;
+      }
+
+      // Don't even schedule a push while the apply-in-progress sentinel
+      // is held. The syncNow path re-checks and refuses too, but dropping
+      // the debounced schedule here avoids spinning a 3-second timer for
+      // every keystroke while the user is in the Restore UI working
+      // through recovery.
+      if (readInterruptedVaultApply()) {
+        return;
+      }
+
+      // Clear existing timeout
+      if (syncTimeoutRef.current) {
+        clearTimeout(syncTimeoutRef.current);
+      }
+
+      // Debounce sync by 3 seconds
+      syncTimeoutRef.current = setTimeout(() => {
+        void syncNow();
+      }, 3000);
+    })();
     
     return () => {
+      cancelled = true;
       if (syncTimeoutRef.current) {
         clearTimeout(syncTimeoutRef.current);
       }

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -40,6 +40,7 @@ const {
   applyLocalVaultPayload,
   applySyncPayload,
   buildLocalVaultPayload,
+  buildCloudSyncPayload,
   buildSyncPayload,
   hasCloudSyncEntityData,
   hasMeaningfulCloudSyncData,
@@ -70,6 +71,12 @@ const vault = (knownHosts: KnownHost[] = [knownHost()]): SyncableVaultData => ({
 
 test.beforeEach(() => {
   localStorage.clear();
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      dispatchEvent: () => true,
+    },
+    configurable: true,
+  });
 });
 
 test("buildSyncPayload treats known hosts as local-only data", () => {
@@ -192,6 +199,39 @@ test("buildSyncPayload omits device-bound encrypted AI API keys", () => {
   assert.equal("apiKey" in (payload.settings?.ai?.webSearchConfig ?? {}), false);
 });
 
+test("buildCloudSyncPayload includes decrypted AI API keys for portable cloud sync", async () => {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      netcatty: {
+        credentialsDecrypt: async (value: string) => {
+          if (value === "enc:v1:djEwPROVIDER") return "sk-provider";
+          if (value === "enc:v1:djEwWEB") return "sk-web";
+          return value;
+        },
+      },
+    },
+    configurable: true,
+  });
+
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify([{
+    id: "openai-main",
+    providerId: "openai",
+    name: "OpenAI",
+    apiKey: "enc:v1:djEwPROVIDER",
+    enabled: true,
+  }]));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify({
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwWEB",
+    enabled: true,
+  }));
+
+  const payload = await buildCloudSyncPayload(vault([]));
+
+  assert.equal(payload.settings?.ai?.providers?.[0]?.apiKey, "sk-provider");
+  assert.equal(payload.settings?.ai?.webSearchConfig?.apiKey, "sk-web");
+});
+
 test("applySyncPayload restores AI configuration settings", async () => {
   const providers = [{
     id: "anthropic-main",
@@ -247,6 +287,42 @@ test("applySyncPayload restores AI configuration settings", async () => {
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_AGENT_PROVIDER_MAP)!), { catty: "anthropic-main" });
   assert.deepEqual(JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!), webSearch);
   assert.equal(localStorage.getItem(storageKeys.STORAGE_KEY_AI_SHOW_TERMINAL_SELECTION_ACTION), "false");
+});
+
+test("applySyncPayload encrypts synced plaintext AI API keys before saving locally", async () => {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      netcatty: {
+        credentialsEncrypt: async (value: string) => `enc:v1:djEwLOCAL_${value}`,
+      },
+      dispatchEvent: () => true,
+    },
+    configurable: true,
+  });
+
+  const payload: SyncPayload = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    snippets: [],
+    customGroups: [],
+    settings: {
+      ai: {
+        providers: [
+          { id: "openai-main", providerId: "openai", name: "OpenAI", apiKey: "sk-provider", enabled: true },
+        ],
+        webSearchConfig: { providerId: "tavily", apiKey: "sk-web", enabled: true },
+      },
+    },
+    syncedAt: 1,
+  } as SyncPayload;
+
+  await applySyncPayload(payload, { importVaultData: () => {} });
+
+  const provider = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_PROVIDERS)!)[0];
+  const webSearch = JSON.parse(localStorage.getItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH)!);
+  assert.equal(provider.apiKey, "enc:v1:djEwLOCAL_sk-provider");
+  assert.equal(webSearch.apiKey, "enc:v1:djEwLOCAL_sk-web");
 });
 
 test("applySyncPayload restores host tree sidebar visibility setting", async () => {

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -691,6 +691,26 @@ test("buildLocalVaultPayload preserves known hosts for local backups", () => {
   assert.deepEqual(payload.knownHosts, [knownHost("kh-local")]);
 });
 
+test("buildLocalVaultPayload preserves local AI API keys for protective backups", () => {
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify([{
+    id: "openai-main",
+    providerId: "openai",
+    name: "OpenAI",
+    apiKey: "enc:v1:djEwPROVIDER",
+    enabled: true,
+  }]));
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_WEB_SEARCH, JSON.stringify({
+    providerId: "tavily",
+    apiKey: "enc:v1:djEwWEB",
+    enabled: true,
+  }));
+
+  const payload = buildLocalVaultPayload(vault([]));
+
+  assert.equal(payload.settings?.ai?.providers?.[0]?.apiKey, "enc:v1:djEwPROVIDER");
+  assert.equal(payload.settings?.ai?.webSearchConfig?.apiKey, "enc:v1:djEwWEB");
+});
+
 test("applySyncPayload ignores legacy cloud known hosts", async () => {
   let imported: Record<string, unknown> | null = null;
   const proxyProfiles = [

--- a/application/syncPayload.test.ts
+++ b/application/syncPayload.test.ts
@@ -232,6 +232,30 @@ test("buildCloudSyncPayload includes decrypted AI API keys for portable cloud sy
   assert.equal(payload.settings?.ai?.webSearchConfig?.apiKey, "sk-web");
 });
 
+test("buildCloudSyncPayload fails instead of deleting API keys when decrypt fails", async () => {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      netcatty: {
+        credentialsDecrypt: async (value: string) => value,
+      },
+    },
+    configurable: true,
+  });
+
+  localStorage.setItem(storageKeys.STORAGE_KEY_AI_PROVIDERS, JSON.stringify([{
+    id: "openai-main",
+    providerId: "openai",
+    name: "OpenAI",
+    apiKey: "enc:v1:djEwPROVIDER",
+    enabled: true,
+  }]));
+
+  await assert.rejects(
+    () => buildCloudSyncPayload(vault([])),
+    /Unable to decrypt AI API key/,
+  );
+});
+
 test("applySyncPayload restores AI configuration settings", async () => {
   const providers = [{
     id: "anthropic-main",

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -512,6 +512,29 @@ export async function collectCloudSyncableSettings(): Promise<SyncPayload['setti
   return Object.keys(nextSettings).length > 0 ? nextSettings : undefined;
 }
 
+function collectLocalBackupSettings(): SyncPayload['settings'] {
+  const settings = collectSyncableSettings();
+
+  const providers = readArraySetting(STORAGE_KEY_AI_PROVIDERS);
+  const webSearchConfig = readRecordSetting(STORAGE_KEY_AI_WEB_SEARCH);
+  if (!providers && !webSearchConfig) return settings;
+
+  const nextSettings: SyncPayload['settings'] = settings ? { ...settings } : {};
+  const ai: NonNullable<SyncPayload['settings']>['ai'] = {
+    ...(settings?.ai ?? {}),
+  };
+
+  if (providers) {
+    ai.providers = providers;
+  }
+  if (webSearchConfig) {
+    ai.webSearchConfig = webSearchConfig;
+  }
+
+  nextSettings.ai = ai;
+  return Object.keys(nextSettings).length > 0 ? nextSettings : undefined;
+}
+
 /**
  * Apply synced settings to localStorage. Merges terminal settings
  * to preserve platform-specific fields.
@@ -811,6 +834,7 @@ export function buildLocalVaultPayload(
 ): SyncPayload {
   return {
     ...buildSyncPayload(vault, portForwardingRules),
+    settings: collectLocalBackupSettings(),
     knownHosts: vault.knownHosts,
   };
 }

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -32,6 +32,7 @@ import {
 } from '../domain/customKeyBindings';
 import { isEncryptedCredentialPlaceholder } from '../domain/credentials';
 import { localStorageAdapter } from '../infrastructure/persistence/localStorageAdapter';
+import { decryptField, encryptField } from '../infrastructure/persistence/secureFieldAdapter';
 import { sanitizeQuickMessages } from '../infrastructure/ai/quickMessages';
 import { emitAIStateChanged } from './state/aiStateEvents';
 import { rehydrateGlobalSftpBookmarks } from './state/sftp/globalSftpBookmarks';
@@ -276,6 +277,23 @@ const stripDeviceBoundApiKey = <T extends Record<string, unknown>>(value: T): T 
   return next;
 };
 
+const withPortableApiKey = async <T extends Record<string, unknown>>(value: T): Promise<T> => {
+  const apiKey = value.apiKey;
+  if (typeof apiKey !== 'string' || !isEncryptedCredentialPlaceholder(apiKey)) return value;
+
+  const decrypted = await decryptField(apiKey).catch(() => undefined);
+  if (!decrypted || decrypted === apiKey) return stripDeviceBoundApiKey(value);
+  return { ...value, apiKey: decrypted };
+};
+
+const withLocalEncryptedApiKey = async <T extends Record<string, unknown>>(value: T): Promise<T> => {
+  const apiKey = value.apiKey;
+  if (typeof apiKey !== 'string' || isEncryptedCredentialPlaceholder(apiKey)) return value;
+
+  const encrypted = await encryptField(apiKey).catch(() => undefined);
+  return { ...value, apiKey: encrypted ?? apiKey };
+};
+
 /**
  * `collectSyncableSettings` strips device-bound encrypted apiKeys before upload,
  * so an incoming providers array typically has no apiKey for providers that
@@ -461,7 +479,7 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   const webSearchConfig = readRecordSetting(STORAGE_KEY_AI_WEB_SEARCH);
   if (webSearchConfig) ai.webSearchConfig = stripDeviceBoundApiKey(webSearchConfig);
   const quickMessages = readArraySetting(STORAGE_KEY_AI_QUICK_MESSAGES);
-  if (quickMessages) ai.quickMessages = sanitizeQuickMessages(quickMessages);
+  if (quickMessages) ai.quickMessages = sanitizeQuickMessages(quickMessages) as unknown as Array<Record<string, unknown>>;
   const showTerminalSelectionAction = localStorageAdapter.readBoolean(STORAGE_KEY_AI_SHOW_TERMINAL_SELECTION_ACTION);
   if (showTerminalSelectionAction != null) {
     ai.showTerminalSelectionAction = showTerminalSelectionAction;
@@ -471,11 +489,34 @@ export function collectSyncableSettings(): SyncPayload['settings'] {
   return Object.keys(settings).length > 0 ? settings : undefined;
 }
 
+export async function collectCloudSyncableSettings(): Promise<SyncPayload['settings']> {
+  const settings = collectSyncableSettings();
+
+  const providers = readArraySetting(STORAGE_KEY_AI_PROVIDERS);
+  const webSearchConfig = readRecordSetting(STORAGE_KEY_AI_WEB_SEARCH);
+  if (!providers && !webSearchConfig) return settings;
+
+  const nextSettings: SyncPayload['settings'] = settings ? { ...settings } : {};
+  const ai: NonNullable<SyncPayload['settings']>['ai'] = {
+    ...(settings?.ai ?? {}),
+  };
+
+  if (providers) {
+    ai.providers = await Promise.all(providers.map(withPortableApiKey));
+  }
+  if (webSearchConfig) {
+    ai.webSearchConfig = await withPortableApiKey(webSearchConfig);
+  }
+
+  nextSettings.ai = ai;
+  return Object.keys(nextSettings).length > 0 ? nextSettings : undefined;
+}
+
 /**
  * Apply synced settings to localStorage. Merges terminal settings
  * to preserve platform-specific fields.
  */
-function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): void {
+async function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): Promise<void> {
   // Theme & Appearance
   if (settings.theme != null) localStorageAdapter.writeString(STORAGE_KEY_THEME, settings.theme);
   if (settings.lightUiThemeId != null) localStorageAdapter.writeString(STORAGE_KEY_UI_THEME_LIGHT, settings.lightUiThemeId);
@@ -591,9 +632,10 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
   const ai = settings.ai;
   if (ai) {
     if (ai.providers != null) {
+      const providers = await Promise.all(ai.providers.map(withLocalEncryptedApiKey));
       localStorageAdapter.write(
         STORAGE_KEY_AI_PROVIDERS,
-        mergeAiProvidersPreservingLocalApiKeys(ai.providers),
+        mergeAiProvidersPreservingLocalApiKeys(providers),
       );
     }
     if (ai.activeProviderId != null) localStorageAdapter.writeString(STORAGE_KEY_AI_ACTIVE_PROVIDER, ai.activeProviderId);
@@ -613,9 +655,10 @@ function applySyncableSettings(settings: NonNullable<SyncPayload['settings']>): 
       if (ai.webSearchConfig === null) {
         localStorageAdapter.remove(STORAGE_KEY_AI_WEB_SEARCH);
       } else {
+        const webSearchConfig = await withLocalEncryptedApiKey(ai.webSearchConfig);
         localStorageAdapter.write(
           STORAGE_KEY_AI_WEB_SEARCH,
-          mergeWebSearchConfigPreservingLocalApiKey(ai.webSearchConfig),
+          mergeWebSearchConfigPreservingLocalApiKey(webSearchConfig),
         );
       }
     }
@@ -742,6 +785,25 @@ export function buildSyncPayload(
   };
 }
 
+export async function buildCloudSyncPayload(
+  vault: SyncableVaultData,
+  portForwardingRules?: PortForwardingRule[],
+): Promise<SyncPayload> {
+  return {
+    hosts: vault.hosts,
+    keys: vault.keys,
+    identities: vault.identities,
+    proxyProfiles: vault.proxyProfiles,
+    snippets: vault.snippets,
+    customGroups: vault.customGroups,
+    snippetPackages: vault.snippetPackages,
+    groupConfigs: vault.groupConfigs,
+    portForwardingRules: sanitizePortForwardingRulesForSync(portForwardingRules),
+    settings: await collectCloudSyncableSettings(),
+    syncedAt: Date.now(),
+  };
+}
+
 /** Build a local backup/restore payload, including local-only trust records. */
 export function buildLocalVaultPayload(
   vault: SyncableVaultData,
@@ -785,7 +847,7 @@ function applyPayload(
     vaultImport.groupConfigs = payload.groupConfigs;
   }
 
-  return Promise.resolve(importers.importVaultData(JSON.stringify(vaultImport))).then(() => {
+  return Promise.resolve(importers.importVaultData(JSON.stringify(vaultImport))).then(async () => {
     // Only import port-forwarding rules when the payload explicitly carries
     // them.  Absent field = "payload was created before this feature existed",
     // so local rules are preserved.  Explicitly present [] = "remote has no
@@ -796,7 +858,7 @@ function applyPayload(
 
     // Apply synced settings
     if (payload.settings) {
-      applySyncableSettings(payload.settings);
+      await applySyncableSettings(payload.settings);
       // Rehydrate in-memory bookmark snapshot after localStorage was updated
       if (payload.settings.sftpGlobalBookmarks != null) rehydrateGlobalSftpBookmarks();
       importers.onSettingsApplied?.();

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -277,12 +277,21 @@ const stripDeviceBoundApiKey = <T extends Record<string, unknown>>(value: T): T 
   return next;
 };
 
+const getApiKeyLabel = (value: Record<string, unknown>): string => {
+  if (typeof value.name === 'string' && value.name.trim()) return value.name;
+  if (typeof value.id === 'string' && value.id.trim()) return value.id;
+  if (typeof value.providerId === 'string' && value.providerId.trim()) return value.providerId;
+  return 'configured provider';
+};
+
 const withPortableApiKey = async <T extends Record<string, unknown>>(value: T): Promise<T> => {
   const apiKey = value.apiKey;
   if (typeof apiKey !== 'string' || !isEncryptedCredentialPlaceholder(apiKey)) return value;
 
   const decrypted = await decryptField(apiKey).catch(() => undefined);
-  if (!decrypted || decrypted === apiKey) return stripDeviceBoundApiKey(value);
+  if (!decrypted || decrypted === apiKey || isEncryptedCredentialPlaceholder(decrypted)) {
+    throw new Error(`Unable to decrypt AI API key for ${getApiKeyLabel(value)}. Sync was stopped to avoid removing the key from cloud sync.`);
+  }
   return { ...value, apiKey: decrypted };
 };
 

--- a/components/CloudSyncSettings.tsx
+++ b/components/CloudSyncSettings.tsx
@@ -32,7 +32,7 @@ import { LocalBackupsPanel } from './cloud-sync/CloudSyncLocalBackupsPanel';
 import { CloudSyncDialogs } from './cloud-sync/CloudSyncDialogs';
 import { CloudSyncDashboardTabs } from './cloud-sync/CloudSyncDashboardTabs';
 interface SyncDashboardProps {
-    onBuildPayload: () => SyncPayload;
+    onBuildPayload: () => SyncPayload | Promise<SyncPayload>;
     onApplyPayload: (payload: SyncPayload) => void | Promise<void>;
     onApplyLocalPayload?: (payload: SyncPayload) => void | Promise<void>;
     onClearLocalData?: () => void;
@@ -519,7 +519,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
     // Sync to provider
     const handleSync = async (provider: CloudProvider) => {
         try {
-            const payload = onBuildPayload();
+            const payload = await onBuildPayload();
             if (!ensureSyncablePayload(payload)) return;
             const result = await sync.syncToProvider(provider, payload);
 
@@ -572,7 +572,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
                 // renderer's in-memory state (no onApplyPayload call), so
                 // the barrier is belt-and-suspenders against the other
                 // window's push, not ours.
-                const localPayload = onBuildPayload();
+                const localPayload = await onBuildPayload();
                 if (!ensureSyncablePayload(localPayload)) return;
 
                 let results: Map<CloudProvider, SyncResult> | null = null;
@@ -858,7 +858,7 @@ const SyncDashboard: React.FC<SyncDashboardProps> = ({
 // ============================================================================
 
 interface CloudSyncSettingsProps {
-    onBuildPayload: () => SyncPayload;
+    onBuildPayload: () => SyncPayload | Promise<SyncPayload>;
     onApplyPayload: (payload: SyncPayload) => void | Promise<void>;
     onApplyLocalPayload?: (payload: SyncPayload) => void | Promise<void>;
     onClearLocalData?: () => void;

--- a/components/cloud-sync/CloudSyncDialogs.tsx
+++ b/components/cloud-sync/CloudSyncDialogs.tsx
@@ -126,7 +126,7 @@ interface CloudSyncDialogsProps {
   setIsUnlocking: BooleanSetter;
   showClearLocalDialog: boolean;
   setShowClearLocalDialog: BooleanSetter;
-  onBuildPayload: () => SyncPayload;
+  onBuildPayload: () => SyncPayload | Promise<SyncPayload>;
   onApplyPayload: (payload: SyncPayload) => void | Promise<void>;
   onClearLocalData?: () => void;
   ensureSyncablePayload: (payload: SyncPayload) => boolean;
@@ -687,7 +687,7 @@ export const CloudSyncDialogs: React.FC<CloudSyncDialogsProps> = ({
 
                                 let payloadForReencrypt: SyncPayload | null = null;
                                 if (sync.hasAnyConnectedProvider) {
-                                    const payload = onBuildPayload();
+                                    const payload = await onBuildPayload();
                                     if (!ensureSyncablePayload(payload)) {
                                         setChangeKeyError(t('sync.credentialsUnavailable'));
                                         return;
@@ -857,7 +857,7 @@ export const CloudSyncDialogs: React.FC<CloudSyncDialogsProps> = ({
                             <Button
                                 variant="destructive"
                                 onClick={async () => {
-                                    const localPayload = onBuildPayload();
+                                    const localPayload = await onBuildPayload();
                                     if (!ensureSyncablePayload(localPayload)) {
                                         setShowForcePushConfirm(false);
                                         return;

--- a/components/settings/tabs/SettingsSyncTab.tsx
+++ b/components/settings/tabs/SettingsSyncTab.tsx
@@ -3,8 +3,8 @@ import type { PortForwardingRule } from "../../../domain/models";
 import type { SyncPayload } from "../../../domain/sync";
 import {
   applyLocalVaultPayload,
+  buildCloudSyncPayload,
   buildLocalVaultPayload,
-  buildSyncPayload,
   applySyncPayload,
   getEffectivePortForwardingRulesForSync,
 } from "../../../application/syncPayload";
@@ -37,8 +37,8 @@ export default function SettingsSyncTab(props: {
     return getEffectivePortForwardingRulesForSync(portForwardingRules) ?? [];
   }, [portForwardingRules]);
 
-  const onBuildPayload = useCallback((): SyncPayload => {
-    return buildSyncPayload(vault, getEffectivePortForwardingRules());
+  const onBuildPayload = useCallback((): Promise<SyncPayload> => {
+    return buildCloudSyncPayload(vault, getEffectivePortForwardingRules());
   }, [vault, getEffectivePortForwardingRules]);
 
   const onBuildLocalPayload = useCallback((): SyncPayload => {


### PR DESCRIPTION
## Summary
- include AI provider and web search API keys in the encrypted cloud sync payload
- re-save synced API keys through the receiving device credential storage
- keep external agent/tool path configuration device-local

## Validation
- npx eslint application/syncPayload.ts application/syncPayload.test.ts application/state/useAutoSync.ts components/CloudSyncSettings.tsx components/cloud-sync/CloudSyncDialogs.tsx components/settings/tabs/SettingsSyncTab.tsx
- npx tsx --test application/syncPayload.test.ts
- npm run build
- npm test