### PR TITLE
[codex] Support ssh deep links

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,7 @@ import { matchesKeyBinding } from './domain/models';
 import { resolveGroupDefaults, applyGroupDefaults } from './domain/groupConfig';
 import { upsertKnownHost } from './domain/knownHosts';
 import { materializeHostProxyProfile } from './domain/proxyProfiles';
+import { buildSshDeepLinkHostDraft, findSshDeepLinkHost, parseSshDeepLink } from './domain/sshDeepLink';
 import { resolveHostAuth } from './domain/sshAuth';
 import { isEncryptedCredentialPlaceholder } from './domain/credentials';
 import {
@@ -100,6 +101,7 @@ function App({ settings }: { settings: SettingsState }) {
   const [protocolSelectHost, setProtocolSelectHost] = useState<Host | null>(null);
   // Navigation state for VaultView sections
   const [navigateToSection, setNavigateToSection] = useState<VaultSection | null>(null);
+  const [deepLinkHostDraft, setDeepLinkHostDraft] = useState<Host | null>(null);
   // Keyboard-interactive authentication queue (2FA/MFA) - queue-based to handle multiple concurrent sessions
   const [keyboardInteractiveQueue, setKeyboardInteractiveQueue] = useState<KeyboardInteractiveRequest[]>([]);
   // Passphrase request queue for encrypted SSH keys
@@ -872,6 +874,45 @@ function App({ settings }: { settings: SettingsState }) {
   // Wrapper to connect to host with logging
   const handleConnectToHost = useCallback((host: Host) => { return handleConnectToHostImpl(() => ({ addConnectionLog, connectToHost, host, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef }), host); }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
+  const _handleSshDeepLink = useEffectEvent((payload: { url?: string }) => {
+    const target = parseSshDeepLink(payload?.url || '');
+    if (!target) {
+      toast.warning(t('deepLink.ssh.invalid'));
+      return;
+    }
+
+    const effectiveHosts = hosts.map((host) => {
+      const effectiveHost = resolveEffectiveHost(host);
+      const resolvedAuth = resolveHostAuth({ host: effectiveHost, keys, identities });
+      return {
+        ...effectiveHost,
+        username: resolvedAuth.username || effectiveHost.username,
+      };
+    });
+    const matchedEffectiveHost = findSshDeepLinkHost(effectiveHosts, target);
+    if (matchedEffectiveHost) {
+      const originalHost = hosts.find((host) => host.id === matchedEffectiveHost.id) ?? matchedEffectiveHost;
+      handleConnectToHost(originalHost);
+      return;
+    }
+
+    setDeepLinkHostDraft(buildSshDeepLinkHostDraft(target, {
+      id: crypto.randomUUID(),
+      now: Date.now(),
+    }));
+    setNavigateToSection('hosts');
+    setActiveTabId('vault');
+  });
+
+  useEffect(() => {
+    if (isPeerSessionWindow) return;
+    const bridge = netcattyBridge.get();
+    if (!bridge?.onSshDeepLink) return;
+    return bridge.onSshDeepLink((payload) => {
+      _handleSshDeepLink(payload);
+    });
+  }, [isPeerSessionWindow]);
+
   // Wrap updateSessionStatus to track lastConnectedAt on successful connection
   const handleSessionStatusChange = useCallback((sessionId: string, status: TerminalSession['status']) => {
     updateSessionStatus(sessionId, status);
@@ -996,7 +1037,7 @@ function App({ settings }: { settings: SettingsState }) {
         logViews={logViews}
         t={t}
       />
-      <AppView ctx={{ accentMode, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace, clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, clearSessionFontSizeOverride, closeLogView, closeSession, closeTabsBatch, copySessionWithCurrentShell, copySessionToNewWindowWithCurrentShell, closeWorkspace, connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets, createWorkspaceWithHosts, customAccent, customGroups, currentTerminalTheme, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict, followAppTerminalTheme, groupConfigs, handleAddKnownHost, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDeleteHost, handleEndSessionDrag, handleHostConnectWithProtocolCheck, handleHotkeyAction, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit, handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect, handleRequestCloseEditorTabRef, handleSessionStatusChange, handleSyncNowManual, handleTerminalDataCapture, handleToggleTheme, handleUpdateHostFromTerminal, hostById, hosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen, keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, openLogView, orderedTabsWithEditors, orphanSessions, passphraseQueue, protocolSelectHost, proxyProfiles, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions, resetSessionRename, resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet: handleRunSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen, setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior, sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, sshDebugLogsEnabled: settings.sshDebugLogsEnabled, startSessionRename, renameSessionInline, startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, themeById, toggleBroadcast, toggleConnectionLogSaved, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, unmanageSource, updateConnectionLog, updateCustomGroups, updateGroupConfigs, updateHostDistro, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources, updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateSessionFontSize, updateSessionRestoreCwd, updateTerminalSetting, workspaceRenameTarget, workspaceRenameValue, workspaces, VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper }} />
+      <AppView ctx={{ accentMode, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace, clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, clearSessionFontSizeOverride, closeLogView, closeSession, closeTabsBatch, copySessionWithCurrentShell, copySessionToNewWindowWithCurrentShell, closeWorkspace, connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets, createWorkspaceWithHosts, customAccent, customGroups, currentTerminalTheme, deepLinkHostDraft, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict, followAppTerminalTheme, groupConfigs, handleAddKnownHost, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDeleteHost, handleEndSessionDrag, handleHostConnectWithProtocolCheck, handleHotkeyAction, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit, handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect, handleRequestCloseEditorTabRef, handleSessionStatusChange, handleSyncNowManual, handleTerminalDataCapture, handleToggleTheme, handleUpdateHostFromTerminal, hostById, hosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen, keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, openLogView, orderedTabsWithEditors, orphanSessions, passphraseQueue, protocolSelectHost, proxyProfiles, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions, resetSessionRename, resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet: handleRunSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen, setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior, sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, sshDebugLogsEnabled: settings.sshDebugLogsEnabled, startSessionRename, renameSessionInline, startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, themeById, toggleBroadcast, toggleConnectionLogSaved, toggleScriptsSidePanelRef, toggleSidePanelRef, toggleWorkspaceViewMode, unmanageSource, updateConnectionLog, updateCustomGroups, updateGroupConfigs, updateHostDistro, updateHosts, updateIdentities, updateKeys, updateKnownHosts, updateManagedSources, updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateSessionFontSize, updateSessionRestoreCwd, updateTerminalSetting, workspaceRenameTarget, workspaceRenameValue, workspaces, VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper }} />
     </>
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -24,7 +24,7 @@ import { matchesKeyBinding } from './domain/models';
 import { resolveGroupDefaults, applyGroupDefaults } from './domain/groupConfig';
 import { upsertKnownHost } from './domain/knownHosts';
 import { materializeHostProxyProfile } from './domain/proxyProfiles';
-import { buildSshDeepLinkHostDraft, findSshDeepLinkHost, parseSshDeepLink } from './domain/sshDeepLink';
+import { buildSshDeepLinkConnectionHost, buildSshDeepLinkHostDraft, findSshDeepLinkHost, parseSshDeepLink } from './domain/sshDeepLink';
 import { resolveHostAuth } from './domain/sshAuth';
 import { isEncryptedCredentialPlaceholder } from './domain/credentials';
 import {
@@ -876,7 +876,6 @@ function App({ settings }: { settings: SettingsState }) {
 
   const _handleSshDeepLink = useEffectEvent((payload: { url?: string }) => {
     const rawUrl = payload?.url || '';
-    if (!settings.sshDeepLinkEnabled) return;
     const target = parseSshDeepLink(rawUrl);
     if (!target) {
       toast.warning(t('deepLink.ssh.invalid'));
@@ -894,7 +893,7 @@ function App({ settings }: { settings: SettingsState }) {
     const matchedEffectiveHost = findSshDeepLinkHost(effectiveHosts, target);
     if (matchedEffectiveHost) {
       const originalHost = hosts.find((host) => host.id === matchedEffectiveHost.id) ?? matchedEffectiveHost;
-      handleConnectToHost(originalHost);
+      handleConnectToHost(buildSshDeepLinkConnectionHost(originalHost));
       return;
     }
 

--- a/App.tsx
+++ b/App.tsx
@@ -875,7 +875,9 @@ function App({ settings }: { settings: SettingsState }) {
   const handleConnectToHost = useCallback((host: Host) => { return handleConnectToHostImpl(() => ({ addConnectionLog, connectToHost, host, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef }), host); }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
   const _handleSshDeepLink = useEffectEvent((payload: { url?: string }) => {
-    const target = parseSshDeepLink(payload?.url || '');
+    const rawUrl = payload?.url || '';
+    if (!settings.sshDeepLinkEnabled) return;
+    const target = parseSshDeepLink(rawUrl);
     if (!target) {
       toast.warning(t('deepLink.ssh.invalid'));
       return;

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -35,7 +35,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     accentMode, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace,
     clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, closeLogView, closeSession, closeTabsBatch, closeWorkspace, copySessionToNewWindowWithCurrentShell, copySessionWithCurrentShell,
     connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets, createWorkspaceWithHosts, customAccent,
-    customGroups, currentTerminalTheme, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict,
+    customGroups, currentTerminalTheme, deepLinkHostDraft, deleteConnectionLog, draggingSessionId, effectiveKnownHosts, editorTabs, editorWordWrap, emptyVaultConflict,
     followAppTerminalTheme, groupConfigs, handleAddKnownHost, handleConnectSerial, handleConnectToHost, handleCreateLocalTerminal, handleDeleteHost,
     handleEndSessionDrag, handleHostConnectWithProtocolCheck, handleHotkeyAction, handleKeyboardInteractiveCancel, handleKeyboardInteractiveSubmit,
     handleOpenQuickSwitcher, handleOpenSettings, handleRootContextMenu, handlePassphraseCancel, handlePassphraseSkip, handlePassphraseSubmit, handleProtocolSelect,
@@ -44,7 +44,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, openLogView, orderedTabsWithEditors, orphanSessions,
     passphraseQueue, protocolSelectHost, proxyProfiles, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions, resetSessionRename,
     resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sshDebugLogsEnabled,
-    sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen,
+    sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen,
     setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, updateSessionFontSize, updateSessionRestoreCwd, clearSessionFontSizeOverride,
     setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior,
     sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, startSessionRename,
@@ -212,6 +212,8 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
             showOnlyUngroupedHostsInRoot={settings.showOnlyUngroupedHostsInRoot}
             navigateToSection={navigateToSection}
             onNavigateToSectionHandled={() => setNavigateToSection(null)}
+            deepLinkHostDraft={deepLinkHostDraft}
+            onDeepLinkHostDraftHandled={() => setDeepLinkHostDraft(null)}
             terminalSettings={terminalSettings}
           />
         </VaultViewContainer>

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -709,5 +709,6 @@ export const enCoreMessages: Messages = {
   'vault.hosts.errors.nameRequired': 'Host name is required.',
   'vault.hosts.empty.title': 'Set up your hosts',
   'vault.hosts.empty.desc': 'Save hosts to quickly connect to your servers, VMs, and containers.',
+  'deepLink.ssh.invalid': 'Invalid ssh:// link',
 
 };

--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -348,6 +348,9 @@ export const enVaultMessages: Messages = {
   'settings.sftp.doubleClickBehavior.transfer': 'Transfer to other pane',
   'settings.sftp.doubleClickBehavior.openDesc': 'Open the file in the default application',
   'settings.sftp.doubleClickBehavior.transferDesc': 'Transfer the file to the other pane\'s active host',
+  'settings.sshDeepLink.title': 'SSH links',
+  'settings.sshDeepLink.enable': 'Open ssh:// links with Netcatty',
+  'settings.sshDeepLink.enableDesc': 'Allow Netcatty to handle ssh:// links from browsers and other apps.',
 
   // Settings > SFTP Auto Sync
   'settings.sftp.autoSync': 'Auto-sync to remote',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -703,5 +703,6 @@ export const ruCoreMessages: Messages = {
 
   'vault.hosts.header.entries': 'Записей: {count}',
   'vault.hosts.header.live': 'Активных: {count}',
+  'deepLink.ssh.invalid': 'Недопустимая ссылка ssh://',
 
 };

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -383,6 +383,9 @@ export const ruVaultMessages: Messages = {
   'settings.sftp.doubleClickBehavior.transfer': 'Передать в другую панель',
   'settings.sftp.doubleClickBehavior.openDesc': 'Открыть файл в приложении по умолчанию',
   'settings.sftp.doubleClickBehavior.transferDesc': 'Передать файл на активный хост другой панели',
+  'settings.sshDeepLink.title': 'SSH-ссылки',
+  'settings.sshDeepLink.enable': 'Открывать ssh:// ссылки в Netcatty',
+  'settings.sshDeepLink.enableDesc': 'Разрешить Netcatty обрабатывать ssh:// ссылки из браузеров и других приложений.',
 
   // Settings > SFTP Auto Sync
   'settings.sftp.autoSync': 'Автосинхронизация с удалённым сервером',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -458,6 +458,7 @@ export const zhCNCoreMessages: Messages = {
   'vault.hosts.errors.nameRequired': '主机名称不能为空。',
   'vault.hosts.empty.title': '设置你的主机',
   'vault.hosts.empty.desc': '保存主机以快速连接到你的服务器、虚拟机和容器。',
+  'deepLink.ssh.invalid': '无效的 ssh:// 链接',
 
   // Vault import
   'vault.import.title': '添加数据到你的 Vault',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -88,6 +88,9 @@ export const zhCNTerminalMessages: Messages = {
   'settings.sftp.doubleClickBehavior.transfer': '传输到另一侧',
   'settings.sftp.doubleClickBehavior.openDesc': '使用默认应用程序打开文件',
   'settings.sftp.doubleClickBehavior.transferDesc': '将文件传输到另一窗格的活动主机',
+  'settings.sshDeepLink.title': 'SSH 链接',
+  'settings.sshDeepLink.enable': '用 Netcatty 打开 ssh:// 链接',
+  'settings.sshDeepLink.enableDesc': '允许 Netcatty 接管来自浏览器和其他应用的 ssh:// 链接。',
 
   // Settings > SFTP Auto Sync
   'settings.sftp.autoSync': '自动同步到远程',

--- a/application/state/settingsIpcSync.ts
+++ b/application/state/settingsIpcSync.ts
@@ -20,6 +20,7 @@ import {
   STORAGE_KEY_SESSION_LOGS_FORMAT,
   STORAGE_KEY_SESSION_LOGS_TIMESTAMPS_ENABLED,
   STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED,
+  STORAGE_KEY_SSH_DEEP_LINK_ENABLED,
   STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR,
   STORAGE_KEY_SFTP_FOLLOW_TERMINAL_CWD,
   STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE,
@@ -66,6 +67,7 @@ interface UseSettingsIpcSyncParams {
   setSessionLogsFormat: Dispatch<SetStateAction<SessionLogFormat>>;
   setSessionLogsTimestampsEnabled: Dispatch<SetStateAction<boolean>>;
   setSshDebugLogsEnabled: Dispatch<SetStateAction<boolean>>;
+  setSshDeepLinkEnabledState: (enabled: boolean) => void;
   setHotkeyScheme: Dispatch<SetStateAction<HotkeyScheme>>;
   applyIncomingCustomKeyBindings: (incoming: { bindings: CustomKeyBindings; version: number; origin: string }) => void;
   setIsHotkeyRecordingState: Dispatch<SetStateAction<boolean>>;
@@ -102,6 +104,7 @@ export function useSettingsIpcSync({
   setSessionLogsFormat,
   setSessionLogsTimestampsEnabled,
   setSshDebugLogsEnabled,
+  setSshDeepLinkEnabledState,
   setHotkeyScheme,
   applyIncomingCustomKeyBindings,
   setIsHotkeyRecordingState,
@@ -201,6 +204,9 @@ export function useSettingsIpcSync({
       if (key === STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED && typeof value === 'boolean') {
         setSshDebugLogsEnabled((prev) => (prev === value ? prev : value));
       }
+      if (key === STORAGE_KEY_SSH_DEEP_LINK_ENABLED && typeof value === 'boolean') {
+        setSshDeepLinkEnabledState(value);
+      }
       if (key === STORAGE_KEY_HOTKEY_SCHEME && (value === 'disabled' || value === 'mac' || value === 'pc')) {
         setHotkeyScheme(value);
       }
@@ -275,6 +281,7 @@ export function useSettingsIpcSync({
     setSessionLogsEnabled,
     setSessionLogsFormat,
     setSessionLogsTimestampsEnabled,
+    setSshDeepLinkEnabledState,
     setSshDebugLogsEnabled,
     setSftpAutoOpenSidebar,
     setSftpFollowTerminalCwd,

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -76,6 +76,7 @@ export const DEFAULT_SESSION_LOGS_ENABLED = false;
 export const DEFAULT_SESSION_LOGS_FORMAT: SessionLogFormat = 'txt';
 export const DEFAULT_SESSION_LOGS_TIMESTAMPS_ENABLED = false;
 export const DEFAULT_SSH_DEBUG_LOGS_ENABLED = false;
+export const DEFAULT_SSH_DEEP_LINK_ENABLED = true;
 
 export const readStoredString = (key: string): string | null => {
   const raw = localStorageAdapter.readString(key);

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -16,6 +16,7 @@ import {
   STORAGE_KEY_SESSION_LOGS_FORMAT,
   STORAGE_KEY_SESSION_LOGS_TIMESTAMPS_ENABLED,
   STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED,
+  STORAGE_KEY_SSH_DEEP_LINK_ENABLED,
   STORAGE_KEY_RESTORE_PREVIOUS_SESSION,
   STORAGE_KEY_RESTORE_TERMINAL_CWD,
   STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR,
@@ -92,6 +93,7 @@ interface UseSettingsStorageSyncParams {
   sessionLogsFormat: SessionLogFormat;
   sessionLogsTimestampsEnabled: boolean;
   sshDebugLogsEnabled: boolean;
+  sshDeepLinkEnabled: boolean;
   globalHotkeyEnabled: boolean;
   autoUpdateEnabled: boolean;
   windowOpacity: number;
@@ -131,6 +133,7 @@ interface UseSettingsStorageSyncParams {
   setSessionLogsFormat: Dispatch<SetStateAction<SessionLogFormat>>;
   setSessionLogsTimestampsEnabled: Dispatch<SetStateAction<boolean>>;
   setSshDebugLogsEnabled: Dispatch<SetStateAction<boolean>>;
+  setSshDeepLinkEnabledState: (enabled: boolean) => void;
   setGlobalHotkeyEnabled: Dispatch<SetStateAction<boolean>>;
   setWindowOpacity: Dispatch<SetStateAction<number>>;
   setAutoUpdateEnabled: Dispatch<SetStateAction<boolean>>;
@@ -148,7 +151,7 @@ export function useSettingsStorageSync({
   sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
   sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
   showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts, disableTerminalFontZoom, restorePreviousSession, restoreTerminalCwd,
-  editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
+  editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled, sshDeepLinkEnabled,
   globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
   setCustomCSS, setUiFontFamilyId, setHotkeyScheme, setUiLanguage,
@@ -157,7 +160,7 @@ export function useSettingsStorageSync({
   setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
   setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
   setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState, setShellOnlyTabNumberShortcutsState, setDisableTerminalFontZoomState, setRestorePreviousSessionState, setRestoreTerminalCwdState,
-  setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
+  setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled, setSshDeepLinkEnabledState,
   setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
   setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
 }: UseSettingsStorageSyncParams) {
@@ -171,7 +174,7 @@ export function useSettingsStorageSync({
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts, disableTerminalFontZoom, restorePreviousSession, restoreTerminalCwd,
-    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
+    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled, sshDeepLinkEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   });
   settingsSnapshotRef.current = {
@@ -181,7 +184,7 @@ export function useSettingsStorageSync({
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts, disableTerminalFontZoom, restorePreviousSession, restoreTerminalCwd,
-    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
+    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled, sshDeepLinkEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
   };
 
@@ -345,6 +348,12 @@ export function useSettingsStorageSync({
           setSshDebugLogsEnabled(newValue);
         }
       }
+      if (e.key === STORAGE_KEY_SSH_DEEP_LINK_ENABLED && e.newValue !== null) {
+        const newValue = e.newValue === 'true';
+        if (newValue !== s.sshDeepLinkEnabled) {
+          setSshDeepLinkEnabledState(newValue);
+        }
+      }
       // Sync SFTP compressed upload setting from other windows
       if (e.key === STORAGE_KEY_SFTP_USE_COMPRESSED_UPLOAD && e.newValue !== null) {
         const newValue = e.newValue === 'true' || e.newValue === 'enabled';
@@ -475,6 +484,7 @@ export function useSettingsStorageSync({
     setSessionLogsEnabled,
     setSessionLogsFormat,
     setSessionLogsTimestampsEnabled,
+    setSshDeepLinkEnabledState,
     setSshDebugLogsEnabled,
     setSftpAutoOpenSidebar,
     setSftpFollowTerminalCwd,

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -38,6 +38,7 @@ import {
   STORAGE_KEY_SESSION_LOGS_FORMAT,
   STORAGE_KEY_SESSION_LOGS_TIMESTAMPS_ENABLED,
   STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED,
+  STORAGE_KEY_SSH_DEEP_LINK_ENABLED,
   STORAGE_KEY_TOGGLE_WINDOW_HOTKEY,
   STORAGE_KEY_CLOSE_TO_TRAY,
   STORAGE_KEY_GLOBAL_HOTKEY_ENABLED,
@@ -95,6 +96,7 @@ import {
   DEFAULT_SHELL_ONLY_TAB_NUMBER_SHORTCUTS,
   DEFAULT_DISABLE_TERMINAL_FONT_ZOOM,
   DEFAULT_SSH_DEBUG_LOGS_ENABLED,
+  DEFAULT_SSH_DEEP_LINK_ENABLED,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
   DEFAULT_WINDOW_OPACITY,
@@ -298,6 +300,10 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     const stored = readStoredString(STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED);
     return stored === 'true' ? true : DEFAULT_SSH_DEBUG_LOGS_ENABLED;
   });
+  const [sshDeepLinkEnabled, setSshDeepLinkEnabledState] = useState<boolean>(() => {
+    const stored = localStorageAdapter.readBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED);
+    return stored ?? DEFAULT_SSH_DEEP_LINK_ENABLED;
+  });
 
   // Global Toggle Window Settings (Quake Mode)
   const [toggleWindowHotkey, setToggleWindowHotkey] = useState<string>(() => {
@@ -344,6 +350,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   const customKeyBindingsOriginRef = useRef(initialCustomKeyBindingsRecord?.origin || 'legacy');
   const customKeyBindingsLocalOriginRef = useRef(createCustomKeyBindingsSyncOrigin());
   const customKeyBindingsMutationSourceRef = useRef<'local' | 'incoming'>('local');
+  const sshDeepLinkMutationSourceRef = useRef<'local' | 'incoming'>('local');
 
   // Fix 1: Mount guard — skip redundant IPC broadcasts & localStorage writes on initial mount.
   // Set to true by the LAST useEffect declaration; all persist effects see false on first render.
@@ -424,6 +431,14 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
         return prev;
       }
       return incoming.bindings;
+    });
+  }, []);
+
+  const applyIncomingSshDeepLinkEnabled = useCallback((enabled: boolean) => {
+    setSshDeepLinkEnabledState((prev) => {
+      if (prev === enabled) return prev;
+      sshDeepLinkMutationSourceRef.current = 'incoming';
+      return enabled;
     });
   }, []);
 
@@ -546,6 +561,8 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     if (storedSshDebugLogsEnabled === 'true' || storedSshDebugLogsEnabled === 'false') {
       setSshDebugLogsEnabled(storedSshDebugLogsEnabled === 'true');
     }
+    const storedSshDeepLinkEnabled = localStorageAdapter.readBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED);
+    applyIncomingSshDeepLinkEnabled(storedSshDeepLinkEnabled ?? DEFAULT_SSH_DEEP_LINK_ENABLED);
 
     // SFTP
     const storedDblClick = readStoredString(STORAGE_KEY_SFTP_DOUBLE_CLICK_BEHAVIOR);
@@ -587,7 +604,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
 
     // Custom terminal themes
     customThemeStore.loadFromStorage();
-  }, [applyIncomingCustomKeyBindings, syncAppearanceFromStorage, syncCustomCssFromStorage, setTerminalSettings]);
+  }, [applyIncomingCustomKeyBindings, applyIncomingSshDeepLinkEnabled, syncAppearanceFromStorage, syncCustomCssFromStorage, setTerminalSettings]);
 
   useLayoutEffect(() => {
     const tokens = getUiThemeById(resolvedTheme, resolvedTheme === 'dark' ? darkUiThemeId : lightUiThemeId).tokens;
@@ -661,6 +678,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     setSessionLogsFormat,
     setSessionLogsTimestampsEnabled,
     setSshDebugLogsEnabled,
+    setSshDeepLinkEnabledState: applyIncomingSshDeepLinkEnabled,
     setHotkeyScheme,
     applyIncomingCustomKeyBindings,
     setIsHotkeyRecordingState,
@@ -704,7 +722,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles,
     sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
     showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts, disableTerminalFontZoom, restorePreviousSession, restoreTerminalCwd,
-    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
+    editorWordWrap, sessionLogsEnabled, sessionLogsDir, sessionLogsFormat, sessionLogsTimestampsEnabled, sshDebugLogsEnabled, sshDeepLinkEnabled,
     globalHotkeyEnabled, autoUpdateEnabled, windowOpacity,
     setTheme, setLightUiThemeId, setDarkUiThemeId, setAccentMode, setCustomAccent,
     setCustomCSS, setUiFontFamilyId, setHotkeyScheme, setUiLanguage,
@@ -713,7 +731,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     setSftpDoubleClickBehavior, setSftpAutoSync, setSftpShowHiddenFiles,
     setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
     setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState, setShellOnlyTabNumberShortcutsState, setDisableTerminalFontZoomState, setRestorePreviousSessionState, setRestoreTerminalCwdState,
-    setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled,
+    setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled, setSshDeepLinkEnabledState: applyIncomingSshDeepLinkEnabled,
     setGlobalHotkeyEnabled, setWindowOpacity, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
     setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
   });
@@ -946,6 +964,22 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     notifySettingsChanged(STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED, sshDebugLogsEnabled);
   }, [sshDebugLogsEnabled, notifySettingsChanged]);
 
+  const setSshDeepLinkEnabled = useCallback((enabled: boolean) => {
+    sshDeepLinkMutationSourceRef.current = 'local';
+    setSshDeepLinkEnabledState(enabled);
+  }, []);
+
+  useEffect(() => {
+    localStorageAdapter.writeBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, sshDeepLinkEnabled);
+    if (sshDeepLinkMutationSourceRef.current === 'incoming') {
+      sshDeepLinkMutationSourceRef.current = 'local';
+      return;
+    }
+    void netcattyBridge.get()?.setSshDeepLinkEnabled?.(sshDeepLinkEnabled);
+    if (!persistMountedRef.current) return;
+    notifySettingsChanged(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, sshDeepLinkEnabled);
+  }, [sshDeepLinkEnabled, notifySettingsChanged]);
+
   useSystemSettingsEffects({
     enabled: enableSystemEffects,
     toggleWindowHotkey,
@@ -1124,6 +1158,8 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     setSessionLogsTimestampsEnabled,
     sshDebugLogsEnabled,
     setSshDebugLogsEnabled,
+    sshDeepLinkEnabled,
+    setSshDeepLinkEnabled,
     // Global Toggle Window (Quake Mode)
     toggleWindowHotkey,
     setToggleWindowHotkey,
@@ -1149,7 +1185,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
       customKeyBindings, editorWordWrap,
       sftpDoubleClickBehavior, sftpAutoSync, sftpShowHiddenFiles, sftpUseCompressedUpload, sftpAutoOpenSidebar, sftpFollowTerminalCwd, sftpDefaultViewMode,
       showRecentHosts, showOnlyUngroupedHostsInRoot, showSftpTab, showHostTreeSidebar, shellOnlyTabNumberShortcuts, disableTerminalFontZoom,
-      customThemes, workspaceFocusStyle, sessionLogsTimestampsEnabled, sshDebugLogsEnabled,
+      customThemes, workspaceFocusStyle, sessionLogsTimestampsEnabled, sshDebugLogsEnabled, sshDeepLinkEnabled,
     ]),
   };
 };

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -351,6 +351,8 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   const customKeyBindingsLocalOriginRef = useRef(createCustomKeyBindingsSyncOrigin());
   const customKeyBindingsMutationSourceRef = useRef<'local' | 'incoming'>('local');
   const sshDeepLinkMutationSourceRef = useRef<'local' | 'incoming'>('local');
+  const sshDeepLinkEnabledRef = useRef(sshDeepLinkEnabled);
+  const sshDeepLinkSetRequestIdRef = useRef(0);
 
   // Fix 1: Mount guard — skip redundant IPC broadcasts & localStorage writes on initial mount.
   // Set to true by the LAST useEffect declaration; all persist effects see false on first render.
@@ -435,6 +437,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   }, []);
 
   const applyIncomingSshDeepLinkEnabled = useCallback((enabled: boolean) => {
+    sshDeepLinkSetRequestIdRef.current += 1;
     setSshDeepLinkEnabledState((prev) => {
       if (prev === enabled) return prev;
       sshDeepLinkMutationSourceRef.current = 'incoming';
@@ -964,9 +967,54 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     notifySettingsChanged(STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED, sshDebugLogsEnabled);
   }, [sshDebugLogsEnabled, notifySettingsChanged]);
 
+  useEffect(() => {
+    sshDeepLinkEnabledRef.current = sshDeepLinkEnabled;
+  }, [sshDeepLinkEnabled]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const requestIdAtStart = sshDeepLinkSetRequestIdRef.current;
+    const bridge = netcattyBridge.get();
+    if (!bridge?.getSshDeepLinkEnabled) return;
+    void bridge.getSshDeepLinkEnabled().then((enabled) => {
+      if (cancelled || typeof enabled !== 'boolean') return;
+      if (sshDeepLinkSetRequestIdRef.current !== requestIdAtStart) return;
+      sshDeepLinkMutationSourceRef.current = 'incoming';
+      setSshDeepLinkEnabledState((prev) => (prev === enabled ? prev : enabled));
+      localStorageAdapter.writeBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, enabled);
+    }).catch(() => {
+      // The renderer can still use its cached setting when the bridge is unavailable.
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const setSshDeepLinkEnabled = useCallback((enabled: boolean) => {
+    const previous = sshDeepLinkEnabledRef.current;
+    const requestId = sshDeepLinkSetRequestIdRef.current + 1;
+    sshDeepLinkSetRequestIdRef.current = requestId;
     sshDeepLinkMutationSourceRef.current = 'local';
     setSshDeepLinkEnabledState(enabled);
+
+    const bridge = netcattyBridge.get();
+    if (!bridge?.setSshDeepLinkEnabled) return;
+    void bridge.setSshDeepLinkEnabled(enabled).then((result) => {
+      if (sshDeepLinkSetRequestIdRef.current !== requestId) return;
+      const success = typeof result === 'object' ? result.success : result;
+      if (success !== false) return;
+      const finalEnabled = typeof result === 'object' && typeof result.enabled === 'boolean'
+        ? result.enabled
+        : previous;
+      sshDeepLinkMutationSourceRef.current = 'incoming';
+      setSshDeepLinkEnabledState(finalEnabled);
+      localStorageAdapter.writeBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, finalEnabled);
+    }).catch(() => {
+      if (sshDeepLinkSetRequestIdRef.current !== requestId) return;
+      sshDeepLinkMutationSourceRef.current = 'incoming';
+      setSshDeepLinkEnabledState(previous);
+      localStorageAdapter.writeBoolean(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, previous);
+    });
   }, []);
 
   useEffect(() => {
@@ -975,7 +1023,6 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
       sshDeepLinkMutationSourceRef.current = 'local';
       return;
     }
-    void netcattyBridge.get()?.setSshDeepLinkEnabled?.(sshDeepLinkEnabled);
     if (!persistMountedRef.current) return;
     notifySettingsChanged(STORAGE_KEY_SSH_DEEP_LINK_ENABLED, sshDeepLinkEnabled);
   }, [sshDeepLinkEnabled, notifySettingsChanged]);

--- a/application/state/useSettingsStateSshDeepLink.test.ts
+++ b/application/state/useSettingsStateSshDeepLink.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("ssh deep link native startup sync cannot overwrite a later setting change", () => {
+  const source = readFileSync(new URL("./useSettingsState.ts", import.meta.url), "utf8");
+  const getEnabledIndex = source.indexOf("bridge.getSshDeepLinkEnabled()");
+  const requestIdCaptureIndex = source.lastIndexOf(
+    "const requestIdAtStart = sshDeepLinkSetRequestIdRef.current",
+    getEnabledIndex,
+  );
+  const staleGuardIndex = source.indexOf(
+    "if (sshDeepLinkSetRequestIdRef.current !== requestIdAtStart) return;",
+    getEnabledIndex,
+  );
+
+  assert.notEqual(getEnabledIndex, -1);
+  assert.notEqual(requestIdCaptureIndex, -1);
+  assert.notEqual(staleGuardIndex, -1);
+  assert.ok(requestIdCaptureIndex < getEnabledIndex);
+  assert.ok(staleGuardIndex > getEnabledIndex);
+});
+
+test("incoming ssh deep link setting changes invalidate pending local responses", () => {
+  const source = readFileSync(new URL("./useSettingsState.ts", import.meta.url), "utf8");
+  const setterIndex = source.indexOf("const applyIncomingSshDeepLinkEnabled = useCallback");
+  const incrementIndex = source.indexOf("sshDeepLinkSetRequestIdRef.current += 1;", setterIndex);
+  const stateUpdateIndex = source.indexOf("setSshDeepLinkEnabledState((prev)", setterIndex);
+
+  assert.notEqual(setterIndex, -1);
+  assert.notEqual(incrementIndex, -1);
+  assert.notEqual(stateUpdateIndex, -1);
+  assert.ok(incrementIndex < stateUpdateIndex);
+});

--- a/components/SettingsApplicationTab.tsx
+++ b/components/SettingsApplicationTab.tsx
@@ -6,7 +6,7 @@ import { cn } from "../lib/utils";
 import { useApplicationBackend } from "../application/state/useApplicationBackend";
 import type { UpdateState, UseUpdateCheckResult } from "../application/state/useUpdateCheck";
 import { useI18n } from "../application/i18n/I18nProvider";
-import { SettingsTabContent } from "./settings/settings-ui";
+import { SectionHeader, SettingCard, SettingRow, SettingsTabContent, Toggle } from "./settings/settings-ui";
 import { toast } from "./ui/toast";
 
 type AppInfo = {
@@ -91,9 +91,11 @@ interface SettingsApplicationTabProps {
   installUpdate: UseUpdateCheckResult['installUpdate'];
   startDownload: UseUpdateCheckResult['startDownload'];
   isUpdateDemoMode: boolean;
+  sshDeepLinkEnabled: boolean;
+  setSshDeepLinkEnabled: (enabled: boolean) => void;
 }
 
-export default function SettingsApplicationTab({ updateState, checkNow, openReleasePage, installUpdate, startDownload, isUpdateDemoMode }: SettingsApplicationTabProps) {
+export default function SettingsApplicationTab({ updateState, checkNow, openReleasePage, installUpdate, startDownload, isUpdateDemoMode, sshDeepLinkEnabled, setSshDeepLinkEnabled }: SettingsApplicationTabProps) {
   const { t } = useI18n();
   const { openExternal, getApplicationInfo } = useApplicationBackend();
   const [appInfo, setAppInfo] = useState<AppInfo>({ name: "Netcatty", version: "" });
@@ -260,6 +262,22 @@ export default function SettingsApplicationTab({ updateState, checkNow, openRele
             />
           </div>
         </div>
+      </div>
+
+      <div>
+        <SectionHeader title={t('settings.sshDeepLink.title')} />
+        <SettingCard>
+          <SettingRow
+            label={t('settings.sshDeepLink.enable')}
+            description={t('settings.sshDeepLink.enableDesc')}
+          >
+            <Toggle
+              checked={sshDeepLinkEnabled}
+              onChange={setSshDeepLinkEnabled}
+              ariaLabel={t('settings.sshDeepLink.enable')}
+            />
+          </SettingRow>
+        </SettingCard>
       </div>
     </SettingsTabContent>
   );

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -340,6 +340,8 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
                             installUpdate={installUpdate}
                             startDownload={startDownload}
                             isUpdateDemoMode={isUpdateDemoMode}
+                            sshDeepLinkEnabled={settings.sshDeepLinkEnabled}
+                            setSshDeepLinkEnabled={settings.setSshDeepLinkEnabled}
                         />
                     )}
 

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -215,6 +215,8 @@ interface VaultViewProps {
   // Optional: navigate to a specific section on mount or when changed
   navigateToSection?: VaultSection | null;
   onNavigateToSectionHandled?: () => void;
+  deepLinkHostDraft?: Host | null;
+  onDeepLinkHostDraftHandled?: () => void;
   terminalSettings?: { keepaliveInterval: number; keepaliveCountMax: number };
 }
 
@@ -266,6 +268,8 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   showOnlyUngroupedHostsInRoot,
   navigateToSection,
   onNavigateToSectionHandled,
+  deepLinkHostDraft,
+  onDeepLinkHostDraftHandled,
   terminalSettings,
 }) => {
   const { t } = useI18n();
@@ -347,6 +351,16 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
   const [isHostPanelOpen, setIsHostPanelOpen] = useState(false);
   const [editingHost, setEditingHost] = useState<Host | null>(null);
   const [newHostGroupPath, setNewHostGroupPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!deepLinkHostDraft) return;
+    setCurrentSection("hosts");
+    setSelectedGroupPath(null);
+    setNewHostGroupPath(null);
+    setEditingHost(deepLinkHostDraft);
+    setIsHostPanelOpen(true);
+    onDeepLinkHostDraftHandled?.();
+  }, [deepLinkHostDraft, onDeepLinkHostDraftHandled]);
 
   // When the side panel is open, Tailwind's viewport-based grid-cols-* can't
   // react to the narrowed content area, so we drive the host-grid column count
@@ -1158,6 +1172,7 @@ export const vaultViewAreEqual = (
     prev.terminalThemeId === next.terminalThemeId &&
     prev.terminalFontSize === next.terminalFontSize &&
     prev.navigateToSection === next.navigateToSection &&
+    prev.deepLinkHostDraft === next.deepLinkHostDraft &&
     // Only the keepalive fields of terminalSettings are forwarded to
     // PortForwarding inside the vault, so compare them directly. Other
     // terminal settings (fonts, themes, etc.) don't affect this subtree

--- a/components/settings/tabs/SettingsFileAssociationsTab.tsx
+++ b/components/settings/tabs/SettingsFileAssociationsTab.tsx
@@ -16,7 +16,6 @@ import {
   SettingsTabContent,
   SettingRow,
   Select,
-  Toggle,
 } from "../settings-ui";
 
 const getOpenerLabel = (

--- a/domain/sshDeepLink.test.ts
+++ b/domain/sshDeepLink.test.ts
@@ -5,6 +5,7 @@ import {
   buildSshDeepLinkHostDraft,
   findSshDeepLinkHost,
   parseSshDeepLink,
+  shouldHandleSshDeepLink,
 } from "./sshDeepLink";
 
 const host = (overrides: Partial<Host>): Host => ({
@@ -42,6 +43,12 @@ test("parseSshDeepLink rejects unsupported or incomplete links", () => {
   assert.equal(parseSshDeepLink("https://example.com"), null);
   assert.equal(parseSshDeepLink("ssh://"), null);
   assert.equal(parseSshDeepLink("ssh://example.com:99999"), null);
+});
+
+test("shouldHandleSshDeepLink respects the user setting", () => {
+  assert.equal(shouldHandleSshDeepLink("ssh://alice@example.com", true), true);
+  assert.equal(shouldHandleSshDeepLink("ssh://alice@example.com", false), false);
+  assert.equal(shouldHandleSshDeepLink("https://example.com", true), false);
 });
 
 test("findSshDeepLinkHost matches saved ssh hosts by username hostname and port", () => {

--- a/domain/sshDeepLink.test.ts
+++ b/domain/sshDeepLink.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Host } from "./models";
+import {
+  buildSshDeepLinkHostDraft,
+  findSshDeepLinkHost,
+  parseSshDeepLink,
+} from "./sshDeepLink";
+
+const host = (overrides: Partial<Host>): Host => ({
+  id: overrides.id || "host-1",
+  label: overrides.label || "Example",
+  hostname: overrides.hostname || "example.com",
+  username: overrides.username ?? "root",
+  port: overrides.port,
+  group: "",
+  tags: [],
+  os: "linux",
+  protocol: overrides.protocol ?? "ssh",
+  ...overrides,
+});
+
+test("parseSshDeepLink accepts username host and port", () => {
+  assert.deepEqual(parseSshDeepLink("ssh://alice@example.com:2200"), {
+    rawUrl: "ssh://alice@example.com:2200",
+    username: "alice",
+    hostname: "example.com",
+    port: 2200,
+  });
+});
+
+test("parseSshDeepLink accepts IPv6 hosts", () => {
+  assert.deepEqual(parseSshDeepLink("ssh://bob@[2001:db8::10]:2222"), {
+    rawUrl: "ssh://bob@[2001:db8::10]:2222",
+    username: "bob",
+    hostname: "2001:db8::10",
+    port: 2222,
+  });
+});
+
+test("parseSshDeepLink rejects unsupported or incomplete links", () => {
+  assert.equal(parseSshDeepLink("https://example.com"), null);
+  assert.equal(parseSshDeepLink("ssh://"), null);
+  assert.equal(parseSshDeepLink("ssh://example.com:99999"), null);
+});
+
+test("findSshDeepLinkHost matches saved ssh hosts by username hostname and port", () => {
+  const hosts = [
+    host({ id: "wrong-port", hostname: "example.com", username: "alice", port: 22 }),
+    host({ id: "match", hostname: "example.com", username: "alice", port: 2200 }),
+    host({ id: "telnet", hostname: "example.com", username: "alice", port: 2200, protocol: "telnet" }),
+  ];
+
+  const match = findSshDeepLinkHost(hosts, parseSshDeepLink("ssh://alice@example.com:2200")!);
+
+  assert.equal(match?.id, "match");
+});
+
+test("findSshDeepLinkHost avoids ambiguous saved hosts", () => {
+  const hosts = [
+    host({ id: "one", hostname: "example.com", username: "alice", port: 2200 }),
+    host({ id: "two", hostname: "example.com", username: "alice", port: 2222 }),
+  ];
+
+  const match = findSshDeepLinkHost(hosts, parseSshDeepLink("ssh://alice@example.com")!);
+
+  assert.equal(match, null);
+});
+
+test("buildSshDeepLinkHostDraft prepares an editable new ssh host", () => {
+  const draft = buildSshDeepLinkHostDraft(
+    parseSshDeepLink("ssh://alice@example.com:2200")!,
+    { id: "new-id", now: 123 },
+  );
+
+  assert.deepEqual(draft, {
+    id: "new-id",
+    label: "alice@example.com",
+    hostname: "example.com",
+    username: "alice",
+    port: 2200,
+    group: "",
+    tags: [],
+    os: "linux",
+    protocol: "ssh",
+    createdAt: 123,
+  });
+});

--- a/domain/sshDeepLink.test.ts
+++ b/domain/sshDeepLink.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { Host } from "./models";
 import {
+  buildSshDeepLinkConnectionHost,
   buildSshDeepLinkHostDraft,
   findSshDeepLinkHost,
   parseSshDeepLink,
@@ -72,6 +73,35 @@ test("findSshDeepLinkHost avoids ambiguous saved hosts", () => {
   const match = findSshDeepLinkHost(hosts, parseSshDeepLink("ssh://alice@example.com")!);
 
   assert.equal(match, null);
+});
+
+test("findSshDeepLinkHost treats omitted ports as the ssh default", () => {
+  const hosts = [
+    host({ id: "custom-port", hostname: "example.com", username: "alice", port: 2200 }),
+    host({ id: "default-port", hostname: "example.com", username: "alice" }),
+  ];
+
+  const match = findSshDeepLinkHost(hosts, parseSshDeepLink("ssh://alice@example.com")!);
+
+  assert.equal(match?.id, "default-port");
+});
+
+test("buildSshDeepLinkConnectionHost forces a saved host to open with ssh", () => {
+  const savedHost = host({
+    id: "saved",
+    hostname: "example.com",
+    username: "alice",
+    moshEnabled: true,
+    etEnabled: true,
+  });
+
+  const connectionHost = buildSshDeepLinkConnectionHost(savedHost);
+
+  assert.equal(connectionHost.protocol, "ssh");
+  assert.equal(connectionHost.moshEnabled, false);
+  assert.equal(connectionHost.etEnabled, false);
+  assert.equal(savedHost.moshEnabled, true);
+  assert.equal(savedHost.etEnabled, true);
 });
 
 test("buildSshDeepLinkHostDraft prepares an editable new ssh host", () => {

--- a/domain/sshDeepLink.ts
+++ b/domain/sshDeepLink.ts
@@ -1,0 +1,98 @@
+import type { Host } from "./models";
+
+export interface SshDeepLinkTarget {
+  rawUrl: string;
+  username?: string;
+  hostname: string;
+  port?: number;
+}
+
+export interface SshDeepLinkDraftOptions {
+  id: string;
+  now: number;
+}
+
+const DEFAULT_SSH_PORT = 22;
+
+const normalizeHostname = (value: string): string =>
+  value.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+
+const decodeUrlComponent = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const getHostPort = (host: Host): number => host.port ?? DEFAULT_SSH_PORT;
+
+const isPrimarySshHost = (host: Host): boolean =>
+  host.protocol === undefined || host.protocol === "ssh";
+
+export const parseSshDeepLink = (rawUrl: string): SshDeepLinkTarget | null => {
+  if (typeof rawUrl !== "string") return null;
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "ssh:") return null;
+
+  const hostname = normalizeHostname(parsed.hostname);
+  if (!hostname) return null;
+
+  const portText = parsed.port;
+  const port = portText ? Number(portText) : undefined;
+  if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) {
+    return null;
+  }
+
+  const username = parsed.username
+    ? decodeUrlComponent(parsed.username).trim()
+    : undefined;
+
+  return {
+    rawUrl: trimmed,
+    ...(username ? { username } : {}),
+    hostname,
+    ...(port ? { port } : {}),
+  };
+};
+
+export const findSshDeepLinkHost = (
+  hosts: Host[],
+  target: SshDeepLinkTarget,
+): Host | null => {
+  const targetHost = normalizeHostname(target.hostname);
+  const candidates = hosts.filter((host) => {
+    if (!isPrimarySshHost(host)) return false;
+    if (normalizeHostname(host.hostname) !== targetHost) return false;
+    if (target.username && (host.username || "").trim() !== target.username) return false;
+    if (target.port !== undefined && getHostPort(host) !== target.port) return false;
+    return true;
+  });
+
+  return candidates.length === 1 ? candidates[0] : null;
+};
+
+export const buildSshDeepLinkHostDraft = (
+  target: SshDeepLinkTarget,
+  options: SshDeepLinkDraftOptions,
+): Host => ({
+  id: options.id,
+  label: target.username ? `${target.username}@${target.hostname}` : target.hostname,
+  hostname: target.hostname,
+  username: target.username || "",
+  ...(target.port !== undefined ? { port: target.port } : {}),
+  group: "",
+  tags: [],
+  os: "linux",
+  protocol: "ssh",
+  createdAt: options.now,
+});

--- a/domain/sshDeepLink.ts
+++ b/domain/sshDeepLink.ts
@@ -73,16 +73,24 @@ export const findSshDeepLinkHost = (
   target: SshDeepLinkTarget,
 ): Host | null => {
   const targetHost = normalizeHostname(target.hostname);
+  const targetPort = target.port ?? DEFAULT_SSH_PORT;
   const candidates = hosts.filter((host) => {
     if (!isPrimarySshHost(host)) return false;
     if (normalizeHostname(host.hostname) !== targetHost) return false;
     if (target.username && (host.username || "").trim() !== target.username) return false;
-    if (target.port !== undefined && getHostPort(host) !== target.port) return false;
+    if (getHostPort(host) !== targetPort) return false;
     return true;
   });
 
   return candidates.length === 1 ? candidates[0] : null;
 };
+
+export const buildSshDeepLinkConnectionHost = (host: Host): Host => ({
+  ...host,
+  protocol: "ssh",
+  moshEnabled: false,
+  etEnabled: false,
+});
 
 export const buildSshDeepLinkHostDraft = (
   target: SshDeepLinkTarget,

--- a/domain/sshDeepLink.ts
+++ b/domain/sshDeepLink.ts
@@ -65,6 +65,9 @@ export const parseSshDeepLink = (rawUrl: string): SshDeepLinkTarget | null => {
   };
 };
 
+export const shouldHandleSshDeepLink = (rawUrl: string, enabled: boolean): boolean =>
+  enabled && parseSshDeepLink(rawUrl) !== null;
+
 export const findSshDeepLinkHost = (
   hosts: Host[],
   target: SshDeepLinkTarget,

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -8,6 +8,12 @@ module.exports = {
     appId: 'com.netcatty.app',
     productName: 'Netcatty',
     artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
+    protocols: [
+        {
+            name: 'SSH URL',
+            schemes: ['ssh']
+        }
+    ],
     electronLanguages: ['en', 'en-US', 'zh_CN', 'zh-CN', 'ru'],
     // Give the macOS build a unique Mach-O LC_UUID before signing, so macOS
     // Local Network privacy treats Netcatty distinctly from every other

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -796,10 +796,18 @@ function waitForRendererReady(win, { timeoutMs = 15000 } = {}) {
  * existing error path instead.
  */
 async function sendWhenRendererReady(win, channel, payload, options = {}) {
-  const { timeoutMs = 8000, waitForReady = waitForRendererReady } = options;
+  const {
+    timeoutMs = 8000,
+    waitForReady = waitForRendererReady,
+    shouldSend,
+    cancelReason = "cancelled",
+  } = options;
   try {
     await waitForReady(win, { timeoutMs });
   } catch (err) {
+    if (typeof shouldSend === "function" && shouldSend() === false) {
+      return { success: false, reason: cancelReason };
+    }
     return {
       success: false,
       error: "New window did not become ready in time",
@@ -808,6 +816,9 @@ async function sendWhenRendererReady(win, channel, payload, options = {}) {
   }
   if (win?.isDestroyed?.() || win?.webContents?.isDestroyed?.()) {
     return { success: false, error: "Window closed before message could be delivered" };
+  }
+  if (typeof shouldSend === "function" && shouldSend() === false) {
+    return { success: false, reason: cancelReason };
   }
   win.webContents.send(channel, payload);
   return { success: true };

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -1488,3 +1488,43 @@ test("sendWhenRendererReady reports failure without sending when the window is g
   assert.equal(result.success, false);
   assert.equal(sent.length, 0);
 });
+
+test("sendWhenRendererReady can cancel after readiness before sending", async () => {
+  const { win, sent } = createSendableWindowStub();
+
+  const result = await sendWhenRendererReady(
+    win,
+    "netcatty:window:openSession",
+    { title: "Prod" },
+    {
+      timeoutMs: 8000,
+      waitForReady: async () => {},
+      shouldSend: () => false,
+      cancelReason: "disabled",
+    },
+  );
+
+  assert.deepEqual(result, { success: false, reason: "disabled" });
+  assert.equal(sent.length, 0);
+});
+
+test("sendWhenRendererReady reports cancellation instead of timeout after cancellation", async () => {
+  const { win, sent } = createSendableWindowStub();
+
+  const result = await sendWhenRendererReady(
+    win,
+    "netcatty:window:openSession",
+    { title: "Prod" },
+    {
+      timeoutMs: 5,
+      waitForReady: async () => {
+        throw new Error("Renderer did not report ready before timeout.");
+      },
+      shouldSend: () => false,
+      cancelReason: "disabled",
+    },
+  );
+
+  assert.deepEqual(result, { success: false, reason: "disabled" });
+  assert.equal(sent.length, 0);
+});

--- a/electron/deepLink.cjs
+++ b/electron/deepLink.cjs
@@ -83,13 +83,70 @@ function applySshProtocolClientPreference(options = {}) {
   return registerSshProtocolClient(options);
 }
 
+function updateSshDeepLinkEnabledPreference({
+  currentEnabled = true,
+  enabled = true,
+  applyPreference = () => false,
+  writePreference = () => false,
+  clearPending,
+} = {}) {
+  const nextEnabled = enabled !== false;
+  if (nextEnabled === currentEnabled) {
+    return { enabled: currentEnabled, success: true };
+  }
+
+  const success = applyPreference(nextEnabled) === true;
+  if (!success) {
+    return { enabled: currentEnabled, success: false };
+  }
+
+  const writeSucceeded = writePreference(nextEnabled) === true;
+  if (!writeSucceeded) {
+    const rolledBack = applyPreference(currentEnabled) === true;
+    const finalEnabled = rolledBack ? currentEnabled : nextEnabled;
+    if (!finalEnabled) {
+      clearPending?.();
+    }
+    return { enabled: finalEnabled, success: false };
+  }
+  if (!nextEnabled) {
+    clearPending?.();
+  }
+  return { enabled: nextEnabled, success: true };
+}
+
+function shouldDeliverSshDeepLink({ enabled = true, deliveryGeneration = 0, expectedGeneration = 0 } = {}) {
+  return enabled !== false && deliveryGeneration === expectedGeneration;
+}
+
+function applyInitialSshDeepLinkPreference({
+  enabled = true,
+  applyPreference = () => false,
+  clearPending,
+  logWarn = console.warn,
+} = {}) {
+  const requestedEnabled = enabled !== false;
+  const success = applyPreference(requestedEnabled) === true;
+  if (success) {
+    return { enabled: requestedEnabled, success: true };
+  }
+  logWarn("[Main] Failed to apply saved ssh:// deep link preference.");
+  if (requestedEnabled) {
+    clearPending?.();
+  }
+  return { enabled: false, success: false };
+}
+
 module.exports = {
   SSH_DEEP_LINK_CHANNEL,
+  applyInitialSshDeepLinkPreference,
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
   applySshProtocolClientPreference,
   registerSshProtocolClient,
   removeSshProtocolClient,
   readSshDeepLinkEnabledPreference,
+  shouldDeliverSshDeepLink,
+  updateSshDeepLinkEnabledPreference,
   writeSshDeepLinkEnabledPreference,
 };

--- a/electron/deepLink.cjs
+++ b/electron/deepLink.cjs
@@ -1,0 +1,36 @@
+const SSH_DEEP_LINK_CHANNEL = "netcatty:deepLink:ssh";
+const SSH_PROTOCOL = "ssh";
+
+function isSshDeepLinkUrl(rawUrl) {
+  if (typeof rawUrl !== "string" || !rawUrl.trim()) return false;
+  try {
+    return new URL(rawUrl).protocol.toLowerCase() === `${SSH_PROTOCOL}:`;
+  } catch {
+    return false;
+  }
+}
+
+function collectSshDeepLinkUrls(argv) {
+  if (!Array.isArray(argv)) return [];
+  return argv.filter(isSshDeepLinkUrl);
+}
+
+function registerSshProtocolClient({ app, isDev, argv = process.argv, execPath = process.execPath, logWarn = console.warn } = {}) {
+  if (!app || typeof app.setAsDefaultProtocolClient !== "function") return false;
+  try {
+    if (isDev && process.defaultApp && argv[1]) {
+      return app.setAsDefaultProtocolClient(SSH_PROTOCOL, execPath, [argv[1]]);
+    }
+    return app.setAsDefaultProtocolClient(SSH_PROTOCOL);
+  } catch (err) {
+    logWarn("[Main] Failed to register ssh:// protocol handler:", err);
+    return false;
+  }
+}
+
+module.exports = {
+  SSH_DEEP_LINK_CHANNEL,
+  collectSshDeepLinkUrls,
+  isSshDeepLinkUrl,
+  registerSshProtocolClient,
+};

--- a/electron/deepLink.cjs
+++ b/electron/deepLink.cjs
@@ -1,13 +1,13 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
 const SSH_DEEP_LINK_CHANNEL = "netcatty:deepLink:ssh";
 const SSH_PROTOCOL = "ssh";
+const SSH_DEEP_LINK_PREFERENCES_FILE = "ssh-deep-link-preferences.json";
 
 function isSshDeepLinkUrl(rawUrl) {
   if (typeof rawUrl !== "string" || !rawUrl.trim()) return false;
-  try {
-    return new URL(rawUrl).protocol.toLowerCase() === `${SSH_PROTOCOL}:`;
-  } catch {
-    return false;
-  }
+  return rawUrl.trim().toLowerCase().startsWith(`${SSH_PROTOCOL}://`);
 }
 
 function collectSshDeepLinkUrls(argv) {
@@ -28,9 +28,68 @@ function registerSshProtocolClient({ app, isDev, argv = process.argv, execPath =
   }
 }
 
+function removeSshProtocolClient({ app, isDev, argv = process.argv, execPath = process.execPath, logWarn = console.warn } = {}) {
+  if (!app || typeof app.removeAsDefaultProtocolClient !== "function") return false;
+  try {
+    if (isDev && process.defaultApp && argv[1]) {
+      return app.removeAsDefaultProtocolClient(SSH_PROTOCOL, execPath, [argv[1]]);
+    }
+    return app.removeAsDefaultProtocolClient(SSH_PROTOCOL);
+  } catch (err) {
+    logWarn("[Main] Failed to remove ssh:// protocol handler:", err);
+    return false;
+  }
+}
+
+function getSshDeepLinkPreferencePath({ app, pathModule = path } = {}) {
+  if (!app || typeof app.getPath !== "function") return null;
+  try {
+    return pathModule.join(app.getPath("userData"), SSH_DEEP_LINK_PREFERENCES_FILE);
+  } catch {
+    return null;
+  }
+}
+
+function readSshDeepLinkEnabledPreference({ app, fsModule = fs, pathModule = path, logWarn = console.warn } = {}) {
+  const filePath = getSshDeepLinkPreferencePath({ app, pathModule });
+  if (!filePath) return true;
+  try {
+    if (!fsModule.existsSync(filePath)) return true;
+    const parsed = JSON.parse(fsModule.readFileSync(filePath, "utf8"));
+    return parsed?.enabled !== false;
+  } catch (err) {
+    logWarn("[Main] Failed to read ssh:// deep link preference:", err);
+    return true;
+  }
+}
+
+function writeSshDeepLinkEnabledPreference({ app, enabled, fsModule = fs, pathModule = path, logWarn = console.warn } = {}) {
+  const filePath = getSshDeepLinkPreferencePath({ app, pathModule });
+  if (!filePath) return false;
+  try {
+    fsModule.mkdirSync(pathModule.dirname(filePath), { recursive: true });
+    fsModule.writeFileSync(filePath, JSON.stringify({ enabled: enabled !== false }, null, 2));
+    return true;
+  } catch (err) {
+    logWarn("[Main] Failed to write ssh:// deep link preference:", err);
+    return false;
+  }
+}
+
+function applySshProtocolClientPreference(options = {}) {
+  if (options.enabled === false) {
+    return removeSshProtocolClient(options);
+  }
+  return registerSshProtocolClient(options);
+}
+
 module.exports = {
   SSH_DEEP_LINK_CHANNEL,
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
+  applySshProtocolClientPreference,
   registerSshProtocolClient,
+  removeSshProtocolClient,
+  readSshDeepLinkEnabledPreference,
+  writeSshDeepLinkEnabledPreference,
 };

--- a/electron/deepLink.test.cjs
+++ b/electron/deepLink.test.cjs
@@ -2,10 +2,13 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  applyInitialSshDeepLinkPreference,
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
   applySshProtocolClientPreference,
   readSshDeepLinkEnabledPreference,
+  shouldDeliverSshDeepLink,
+  updateSshDeepLinkEnabledPreference,
   writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
 
@@ -63,4 +66,113 @@ test("ssh deep link enabled preference persists outside renderer localStorage", 
   assert.equal(readSshDeepLinkEnabledPreference({ app }), false);
   assert.equal(writeSshDeepLinkEnabledPreference({ app, enabled: true }), true);
   assert.equal(readSshDeepLinkEnabledPreference({ app }), true);
+});
+
+test("updateSshDeepLinkEnabledPreference keeps the previous state when the system change fails", () => {
+  const writes = [];
+  const result = updateSshDeepLinkEnabledPreference({
+    currentEnabled: true,
+    enabled: false,
+    applyPreference: () => false,
+    writePreference: (enabled) => {
+      writes.push(enabled);
+      return true;
+    },
+  });
+
+  assert.deepEqual(result, { enabled: true, success: false });
+  assert.deepEqual(writes, []);
+});
+
+test("updateSshDeepLinkEnabledPreference clears queued links after disabling succeeds", () => {
+  const writes = [];
+  let cleared = false;
+  const result = updateSshDeepLinkEnabledPreference({
+    currentEnabled: true,
+    enabled: false,
+    applyPreference: () => true,
+    writePreference: (enabled) => {
+      writes.push(enabled);
+      return true;
+    },
+    clearPending: () => {
+      cleared = true;
+    },
+  });
+
+  assert.deepEqual(result, { enabled: false, success: true });
+  assert.deepEqual(writes, [false]);
+  assert.equal(cleared, true);
+});
+
+test("updateSshDeepLinkEnabledPreference rolls back when saving the setting fails", () => {
+  const applied = [];
+  const result = updateSshDeepLinkEnabledPreference({
+    currentEnabled: true,
+    enabled: false,
+    applyPreference: (enabled) => {
+      applied.push(enabled);
+      return true;
+    },
+    writePreference: () => false,
+  });
+
+  assert.deepEqual(result, { enabled: true, success: false });
+  assert.deepEqual(applied, [false, true]);
+});
+
+test("updateSshDeepLinkEnabledPreference clears links when save and rollback both fail disabled", () => {
+  const applied = [];
+  let cleared = false;
+  const result = updateSshDeepLinkEnabledPreference({
+    currentEnabled: true,
+    enabled: false,
+    applyPreference: (enabled) => {
+      applied.push(enabled);
+      return enabled === false;
+    },
+    writePreference: () => false,
+    clearPending: () => {
+      cleared = true;
+    },
+  });
+
+  assert.deepEqual(result, { enabled: false, success: false });
+  assert.deepEqual(applied, [false, true]);
+  assert.equal(cleared, true);
+});
+
+test("shouldDeliverSshDeepLink drops stale deliveries after the setting changes", () => {
+  assert.equal(shouldDeliverSshDeepLink({
+    enabled: true,
+    deliveryGeneration: 1,
+    expectedGeneration: 1,
+  }), true);
+  assert.equal(shouldDeliverSshDeepLink({
+    enabled: false,
+    deliveryGeneration: 1,
+    expectedGeneration: 1,
+  }), false);
+  assert.equal(shouldDeliverSshDeepLink({
+    enabled: true,
+    deliveryGeneration: 2,
+    expectedGeneration: 1,
+  }), false);
+});
+
+test("applyInitialSshDeepLinkPreference disables handling when startup registration fails", () => {
+  let cleared = false;
+  const warnings = [];
+  const result = applyInitialSshDeepLinkPreference({
+    enabled: true,
+    applyPreference: () => false,
+    clearPending: () => {
+      cleared = true;
+    },
+    logWarn: (message) => warnings.push(message),
+  });
+
+  assert.deepEqual(result, { enabled: false, success: false });
+  assert.equal(cleared, true);
+  assert.equal(warnings.length, 1);
 });

--- a/electron/deepLink.test.cjs
+++ b/electron/deepLink.test.cjs
@@ -1,0 +1,27 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  collectSshDeepLinkUrls,
+  isSshDeepLinkUrl,
+} = require("./deepLink.cjs");
+
+test("isSshDeepLinkUrl accepts only ssh URLs", () => {
+  assert.equal(isSshDeepLinkUrl("ssh://alice@example.com:2200"), true);
+  assert.equal(isSshDeepLinkUrl("SSH://alice@example.com"), true);
+  assert.equal(isSshDeepLinkUrl("https://example.com"), false);
+  assert.equal(isSshDeepLinkUrl("--flag"), false);
+});
+
+test("collectSshDeepLinkUrls extracts ssh URLs from process arguments", () => {
+  assert.deepEqual(
+    collectSshDeepLinkUrls([
+      "/Applications/Netcatty.app/Contents/MacOS/Netcatty",
+      "--flag",
+      "ssh://alice@example.com",
+      "file:///tmp/example",
+      "ssh://bob@example.net:2222",
+    ]),
+    ["ssh://alice@example.com", "ssh://bob@example.net:2222"],
+  );
+});

--- a/electron/deepLink.test.cjs
+++ b/electron/deepLink.test.cjs
@@ -4,11 +4,15 @@ const assert = require("node:assert/strict");
 const {
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
+  applySshProtocolClientPreference,
+  readSshDeepLinkEnabledPreference,
+  writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
 
 test("isSshDeepLinkUrl accepts only ssh URLs", () => {
   assert.equal(isSshDeepLinkUrl("ssh://alice@example.com:2200"), true);
   assert.equal(isSshDeepLinkUrl("SSH://alice@example.com"), true);
+  assert.equal(isSshDeepLinkUrl("ssh://example.com:99999"), true);
   assert.equal(isSshDeepLinkUrl("https://example.com"), false);
   assert.equal(isSshDeepLinkUrl("--flag"), false);
 });
@@ -24,4 +28,39 @@ test("collectSshDeepLinkUrls extracts ssh URLs from process arguments", () => {
     ]),
     ["ssh://alice@example.com", "ssh://bob@example.net:2222"],
   );
+});
+
+test("applySshProtocolClientPreference registers or removes the ssh handler", () => {
+  const calls = [];
+  const app = {
+    setAsDefaultProtocolClient: (...args) => {
+      calls.push(["set", ...args]);
+      return true;
+    },
+    removeAsDefaultProtocolClient: (...args) => {
+      calls.push(["remove", ...args]);
+      return true;
+    },
+  };
+
+  assert.equal(applySshProtocolClientPreference({ app, enabled: true, isDev: false }), true);
+  assert.equal(applySshProtocolClientPreference({ app, enabled: false, isDev: false }), true);
+  assert.deepEqual(calls, [
+    ["set", "ssh"],
+    ["remove", "ssh"],
+  ]);
+});
+
+test("ssh deep link enabled preference persists outside renderer localStorage", () => {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-deeplink-"));
+  const app = { getPath: () => userDataDir };
+
+  assert.equal(readSshDeepLinkEnabledPreference({ app }), true);
+  assert.equal(writeSshDeepLinkEnabledPreference({ app, enabled: false }), true);
+  assert.equal(readSshDeepLinkEnabledPreference({ app }), false);
+  assert.equal(writeSshDeepLinkEnabledPreference({ app, enabled: true }), true);
+  assert.equal(readSshDeepLinkEnabledPreference({ app }), true);
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -65,10 +65,13 @@ const fs = require("node:fs");
 const { getCliDiscoveryFilePath } = require("./cli/discoveryPath.cjs");
 const {
   SSH_DEEP_LINK_CHANNEL,
+  applyInitialSshDeepLinkPreference,
   applySshProtocolClientPreference,
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
   readSshDeepLinkEnabledPreference,
+  shouldDeliverSshDeepLink,
+  updateSshDeepLinkEnabledPreference,
   writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
 
@@ -499,6 +502,7 @@ async function createAndShowMainWindow() {
 let sshDeepLinkEnabled = readSshDeepLinkEnabledPreference({ app });
 const pendingSshDeepLinkUrls = sshDeepLinkEnabled ? collectSshDeepLinkUrls(process.argv) : [];
 let flushingSshDeepLinks = false;
+let sshDeepLinkDeliveryGeneration = 0;
 
 function queueSshDeepLink(rawUrl) {
   if (!sshDeepLinkEnabled) return;
@@ -511,24 +515,51 @@ function queueSshDeepLink(rawUrl) {
 
 ipcMain?.handle?.("netcatty:deepLink:ssh:setEnabled", async (_event, payload) => {
   const enabled = payload?.enabled !== false;
-  sshDeepLinkEnabled = enabled;
-  writeSshDeepLinkEnabledPreference({ app, enabled });
-  return applySshProtocolClientPreference({ app, enabled, isDev });
+  const result = updateSshDeepLinkEnabledPreference({
+    currentEnabled: sshDeepLinkEnabled,
+    enabled,
+    applyPreference: (nextEnabled) => applySshProtocolClientPreference({ app, enabled: nextEnabled, isDev }),
+    writePreference: (nextEnabled) => writeSshDeepLinkEnabledPreference({ app, enabled: nextEnabled }),
+    clearPending: () => {
+      pendingSshDeepLinkUrls.length = 0;
+      sshDeepLinkDeliveryGeneration += 1;
+    },
+  });
+  sshDeepLinkEnabled = result.enabled;
+  return result;
 });
 
 ipcMain?.handle?.("netcatty:deepLink:ssh:getEnabled", async () => sshDeepLinkEnabled);
 
-async function deliverSshDeepLink(rawUrl) {
+async function deliverSshDeepLink(rawUrl, expectedGeneration = sshDeepLinkDeliveryGeneration) {
+  if (!shouldDeliverSshDeepLink({
+    enabled: sshDeepLinkEnabled,
+    deliveryGeneration: sshDeepLinkDeliveryGeneration,
+    expectedGeneration,
+  })) return;
   const win = await createAndShowMainWindow();
+  if (!shouldDeliverSshDeepLink({
+    enabled: sshDeepLinkEnabled,
+    deliveryGeneration: sshDeepLinkDeliveryGeneration,
+    expectedGeneration,
+  })) return;
   focusMainWindow();
   const windowManager = getWindowManager();
   const result = await windowManager.sendWhenRendererReady?.(
     win,
     SSH_DEEP_LINK_CHANNEL,
     { url: rawUrl },
-    { timeoutMs: isDev ? 30000 : 15000 },
+    {
+      timeoutMs: isDev ? 30000 : 15000,
+      shouldSend: () => shouldDeliverSshDeepLink({
+        enabled: sshDeepLinkEnabled,
+        deliveryGeneration: sshDeepLinkDeliveryGeneration,
+        expectedGeneration,
+      }),
+      cancelReason: "ssh-deep-link-disabled",
+    },
   );
-  if (result && result.success === false) {
+  if (result && result.success === false && result.reason !== "ssh-deep-link-disabled") {
     console.warn("[Main] Failed to deliver ssh:// deep link:", result.error || result.reason);
   }
 }
@@ -537,16 +568,16 @@ async function flushPendingSshDeepLinks() {
   if (flushingSshDeepLinks) return;
   flushingSshDeepLinks = true;
   try {
-    while (pendingSshDeepLinkUrls.length > 0) {
+    while (sshDeepLinkEnabled && pendingSshDeepLinkUrls.length > 0) {
       const rawUrl = pendingSshDeepLinkUrls.shift();
       if (!rawUrl) continue;
-      await deliverSshDeepLink(rawUrl);
+      await deliverSshDeepLink(rawUrl, sshDeepLinkDeliveryGeneration);
     }
   } catch (err) {
     console.warn("[Main] Failed to process ssh:// deep link:", err);
   } finally {
     flushingSshDeepLinks = false;
-    if (pendingSshDeepLinkUrls.length > 0) {
+    if (sshDeepLinkEnabled && pendingSshDeepLinkUrls.length > 0) {
       void flushPendingSshDeepLinks();
     }
   }
@@ -612,7 +643,15 @@ if (!gotLock) {
   // Application lifecycle
   app.whenReady().then(() => {
     registerAppProtocol();
-    applySshProtocolClientPreference({ app, enabled: sshDeepLinkEnabled, isDev });
+    const initialSshDeepLinkPreference = applyInitialSshDeepLinkPreference({
+      enabled: sshDeepLinkEnabled,
+      applyPreference: (enabled) => applySshProtocolClientPreference({ app, enabled, isDev }),
+      clearPending: () => {
+        pendingSshDeepLinkUrls.length = 0;
+        sshDeepLinkDeliveryGeneration += 1;
+      },
+    });
+    sshDeepLinkEnabled = initialSshDeepLinkPreference.enabled;
 
     // Grant only the Chromium permissions the app actually uses, and only
     // to the app's own origin. The default session is shared with in-app

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -54,7 +54,7 @@ try {
   electronModule = require("electron");
 }
 
-const { app, BrowserWindow, Menu, protocol, shell, clipboard, session } = electronModule || {};
+const { app, BrowserWindow, Menu, protocol, shell, clipboard, session, ipcMain } = electronModule || {};
 if (!app || !BrowserWindow) {
   throw new Error("Failed to load Electron runtime. Ensure the app is launched with the Electron binary.");
 }
@@ -65,9 +65,11 @@ const fs = require("node:fs");
 const { getCliDiscoveryFilePath } = require("./cli/discoveryPath.cjs");
 const {
   SSH_DEEP_LINK_CHANNEL,
+  applySshProtocolClientPreference,
   collectSshDeepLinkUrls,
   isSshDeepLinkUrl,
-  registerSshProtocolClient,
+  readSshDeepLinkEnabledPreference,
+  writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
 
 try {
@@ -494,16 +496,27 @@ async function createAndShowMainWindow() {
   return mainWindowStartupPromise;
 }
 
-const pendingSshDeepLinkUrls = collectSshDeepLinkUrls(process.argv);
+let sshDeepLinkEnabled = readSshDeepLinkEnabledPreference({ app });
+const pendingSshDeepLinkUrls = sshDeepLinkEnabled ? collectSshDeepLinkUrls(process.argv) : [];
 let flushingSshDeepLinks = false;
 
 function queueSshDeepLink(rawUrl) {
+  if (!sshDeepLinkEnabled) return;
   if (!isSshDeepLinkUrl(rawUrl)) return;
   pendingSshDeepLinkUrls.push(rawUrl);
   if (app.isReady?.()) {
     void flushPendingSshDeepLinks();
   }
 }
+
+ipcMain?.handle?.("netcatty:deepLink:ssh:setEnabled", async (_event, payload) => {
+  const enabled = payload?.enabled !== false;
+  sshDeepLinkEnabled = enabled;
+  writeSshDeepLinkEnabledPreference({ app, enabled });
+  return applySshProtocolClientPreference({ app, enabled, isDev });
+});
+
+ipcMain?.handle?.("netcatty:deepLink:ssh:getEnabled", async () => sshDeepLinkEnabled);
 
 async function deliverSshDeepLink(rawUrl) {
   const win = await createAndShowMainWindow();
@@ -579,7 +592,9 @@ if (!gotLock) {
   app.on("second-instance", (_event, argv) => {
     const deepLinkUrls = collectSshDeepLinkUrls(argv);
     if (deepLinkUrls.length > 0) {
-      deepLinkUrls.forEach(queueSshDeepLink);
+      if (sshDeepLinkEnabled) {
+        deepLinkUrls.forEach(queueSshDeepLink);
+      }
       return;
     }
     if (!focusMainWindow()) {
@@ -597,7 +612,7 @@ if (!gotLock) {
   // Application lifecycle
   app.whenReady().then(() => {
     registerAppProtocol();
-    registerSshProtocolClient({ app, isDev });
+    applySshProtocolClientPreference({ app, enabled: sshDeepLinkEnabled, isDev });
 
     // Grant only the Chromium permissions the app actually uses, and only
     // to the app's own origin. The default session is shared with in-app

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -63,6 +63,12 @@ const path = require("node:path");
 const os = require("node:os");
 const fs = require("node:fs");
 const { getCliDiscoveryFilePath } = require("./cli/discoveryPath.cjs");
+const {
+  SSH_DEEP_LINK_CHANNEL,
+  collectSshDeepLinkUrls,
+  isSshDeepLinkUrl,
+  registerSshProtocolClient,
+} = require("./deepLink.cjs");
 
 try {
   protocol?.registerSchemesAsPrivileged?.([
@@ -488,6 +494,51 @@ async function createAndShowMainWindow() {
   return mainWindowStartupPromise;
 }
 
+const pendingSshDeepLinkUrls = collectSshDeepLinkUrls(process.argv);
+let flushingSshDeepLinks = false;
+
+function queueSshDeepLink(rawUrl) {
+  if (!isSshDeepLinkUrl(rawUrl)) return;
+  pendingSshDeepLinkUrls.push(rawUrl);
+  if (app.isReady?.()) {
+    void flushPendingSshDeepLinks();
+  }
+}
+
+async function deliverSshDeepLink(rawUrl) {
+  const win = await createAndShowMainWindow();
+  focusMainWindow();
+  const windowManager = getWindowManager();
+  const result = await windowManager.sendWhenRendererReady?.(
+    win,
+    SSH_DEEP_LINK_CHANNEL,
+    { url: rawUrl },
+    { timeoutMs: isDev ? 30000 : 15000 },
+  );
+  if (result && result.success === false) {
+    console.warn("[Main] Failed to deliver ssh:// deep link:", result.error || result.reason);
+  }
+}
+
+async function flushPendingSshDeepLinks() {
+  if (flushingSshDeepLinks) return;
+  flushingSshDeepLinks = true;
+  try {
+    while (pendingSshDeepLinkUrls.length > 0) {
+      const rawUrl = pendingSshDeepLinkUrls.shift();
+      if (!rawUrl) continue;
+      await deliverSshDeepLink(rawUrl);
+    }
+  } catch (err) {
+    console.warn("[Main] Failed to process ssh:// deep link:", err);
+  } finally {
+    flushingSshDeepLinks = false;
+    if (pendingSshDeepLinkUrls.length > 0) {
+      void flushPendingSshDeepLinks();
+    }
+  }
+}
+
 function hasUsableWindow() {
   try {
     const windowManager = getWindowManager();
@@ -520,7 +571,17 @@ const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
+  app.on("open-url", (event, rawUrl) => {
+    event.preventDefault();
+    queueSshDeepLink(rawUrl);
+  });
+
+  app.on("second-instance", (_event, argv) => {
+    const deepLinkUrls = collectSshDeepLinkUrls(argv);
+    if (deepLinkUrls.length > 0) {
+      deepLinkUrls.forEach(queueSshDeepLink);
+      return;
+    }
     if (!focusMainWindow()) {
       // Window is missing or crashed — try to recreate it
       void createAndShowMainWindow().catch((err) => {
@@ -536,6 +597,7 @@ if (!gotLock) {
   // Application lifecycle
   app.whenReady().then(() => {
     registerAppProtocol();
+    registerSshProtocolClient({ app, isDev });
 
     // Grant only the Chromium permissions the app actually uses, and only
     // to the app's own origin. The default session is shared with in-app
@@ -639,6 +701,8 @@ if (!gotLock) {
 
     // Create the main window
     void createAndShowMainWindow().then(() => {
+      void flushPendingSshDeepLinks();
+
       // Trigger auto-update check 5 s after window creation.
       // startAutoCheck() is a no-op on unsupported platforms (Linux deb/rpm/snap).
       getAutoUpdateBridge().startAutoCheck(5000);

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -555,6 +555,10 @@ function createPreloadApi(ctx) {
     ipcRenderer.on("netcatty:deepLink:ssh", handler);
     return () => ipcRenderer.removeListener("netcatty:deepLink:ssh", handler);
   },
+  setSshDeepLinkEnabled: (enabled) =>
+    ipcRenderer.invoke("netcatty:deepLink:ssh:setEnabled", { enabled }),
+  getSshDeepLinkEnabled: () =>
+    ipcRenderer.invoke("netcatty:deepLink:ssh:getEnabled"),
 
   // Quit guard: main process asks whether any editor tabs have unsaved changes.
   // Returns an unsubscribe function so React effects can clean up on unmount.

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -550,6 +550,12 @@ function createPreloadApi(ctx) {
   // Tell main process the renderer has mounted/painted (used to avoid initial blank screen).
   rendererReady: () => ipcRenderer.send("netcatty:renderer:ready"),
 
+  onSshDeepLink: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on("netcatty:deepLink:ssh", handler);
+    return () => ipcRenderer.removeListener("netcatty:deepLink:ssh", handler);
+  },
+
   // Quit guard: main process asks whether any editor tabs have unsaved changes.
   // Returns an unsubscribe function so React effects can clean up on unmount.
   onCheckDirtyEditors: (listener) => {

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -116,6 +116,7 @@ export const STORAGE_KEY_SESSION_LOGS_DIR = 'netcatty_session_logs_dir_v1';
 export const STORAGE_KEY_SESSION_LOGS_FORMAT = 'netcatty_session_logs_format_v1';
 export const STORAGE_KEY_SESSION_LOGS_TIMESTAMPS_ENABLED = 'netcatty_session_logs_timestamps_enabled_v1';
 export const STORAGE_KEY_SSH_DEBUG_LOGS_ENABLED = 'netcatty_ssh_debug_logs_enabled_v1';
+export const STORAGE_KEY_SSH_DEEP_LINK_ENABLED = 'netcatty_ssh_deep_link_enabled_v1';
 
 // Archived legacy key records that are no longer supported by the app (e.g. biometric/WebAuthn/FIDO2 experiments).
 export const STORAGE_KEY_LEGACY_KEYS = 'netcatty_legacy_keys_v1';

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -67,6 +67,15 @@ test("beforePack installs missing Cursor SDK platform runtime packages", () => {
   assert.equal(config.beforePack, "./scripts/beforePackCursorSdk.cjs");
 });
 
+test("packaged app declares ssh URL protocol support", () => {
+  assert.deepEqual(config.protocols, [
+    {
+      name: "SSH URL",
+      schemes: ["ssh"],
+    },
+  ]);
+});
+
 test("build.files trims release-only dependency payloads", () => {
   const files = config.files;
   for (const glob of [

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -32,7 +32,7 @@ declare global {
     // Fired when an install was requested but blocked by unsaved editors (#1215).
     onUpdateNeedsSave?(cb: () => void): () => void;
     onSshDeepLink?(cb: (payload: { url?: string }) => void): () => void;
-    setSshDeepLinkEnabled?(enabled: boolean): Promise<boolean>;
+    setSshDeepLinkEnabled?(enabled: boolean): Promise<boolean | { success: boolean; enabled: boolean }>;
     getSshDeepLinkEnabled?(): Promise<boolean>;
 
     // Global Toggle Hotkey (Quake Mode)

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -32,6 +32,8 @@ declare global {
     // Fired when an install was requested but blocked by unsaved editors (#1215).
     onUpdateNeedsSave?(cb: () => void): () => void;
     onSshDeepLink?(cb: (payload: { url?: string }) => void): () => void;
+    setSshDeepLinkEnabled?(enabled: boolean): Promise<boolean>;
+    getSshDeepLinkEnabled?(): Promise<boolean>;
 
     // Global Toggle Hotkey (Quake Mode)
     registerGlobalHotkey?(hotkey: string): Promise<{ success: boolean; enabled?: boolean; error?: string; accelerator?: string }>;

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -31,6 +31,7 @@ declare global {
     onUpdateError?(cb: (payload: { error: string }) => void): () => void;
     // Fired when an install was requested but blocked by unsaved editors (#1215).
     onUpdateNeedsSave?(cb: () => void): () => void;
+    onSshDeepLink?(cb: (payload: { url?: string }) => void): () => void;
 
     // Global Toggle Hotkey (Quake Mode)
     registerGlobalHotkey?(hotkey: string): Promise<{ success: boolean; enabled?: boolean; error?: string; accelerator?: string }>;


### PR DESCRIPTION
## Summary
- Support ssh:// links from browsers and the OS
- Connect directly when a unique saved host matches the link
- Open a prefilled new-host panel when no saved host matches
- Add a Settings > Application switch to enable or disable ssh:// link handling

Fixes #1512

## Validation
- node --test --import tsx domain/sshDeepLink.test.ts electron/deepLink.test.cjs
- node --test --import tsx domain/sshDeepLink.test.ts electron/deepLink.test.cjs application/i18n/locales/settingsLocales.test.ts application/state/sessionRestoreSettings.test.ts
- npm run lint
- npm run build
- npm test
- local multi-agent review/fix loop completed with no remaining findings
