### PR TITLE
[codex] Fix SSH prompt stalling after login

### DIFF
--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -73,6 +73,31 @@ test("does not create timestamp markers for alternate screen output", () => {
   ]);
 });
 
+test("preserves OSC prompt prefixes terminated by C1 string terminator", () => {
+  const segmenter = createTerminalLineTimestampSegmenter({
+    now: () => new Date(2026, 5, 6, 9, 8, 7),
+  });
+
+  assert.deepEqual(segmenter.append("\x1b]0;server\u009calice@server:~$ "), [
+    { kind: "data", data: "\x1b]0;server\u009c" },
+    { kind: "timestamp", label: "09:08:07" },
+    { kind: "data", data: "alice@server:~$ " },
+  ]);
+});
+
+test("preserves split OSC prompt prefixes terminated by C1 string terminator", () => {
+  const segmenter = createTerminalLineTimestampSegmenter({
+    now: () => new Date(2026, 5, 6, 9, 8, 7),
+  });
+
+  assert.deepEqual(segmenter.append("\x1b]7;file://server/home/alice"), []);
+  assert.deepEqual(segmenter.append("\u009calice@server:~$ "), [
+    { kind: "data", data: "\x1b]7;file://server/home/alice\u009c" },
+    { kind: "timestamp", label: "09:08:07" },
+    { kind: "data", data: "alice@server:~$ " },
+  ]);
+});
+
 test("resolves visible timestamp rows from marker lines", () => {
   assert.deepEqual(
     resolveTerminalTimestampGutterRows({
@@ -132,4 +157,92 @@ test("keeps recording and preserves existing timestamps when the gutter is hidde
 
   assert.deepEqual(markerLines, [0, 1, 2]);
   assert.deepEqual(disposedMarkerLines, []);
+});
+
+test("does not withhold output when an OSC sequence is split across chunks", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  const callbacks: string[] = [];
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "\x1b]7;file://server/home/alice",
+    () => callbacks.push("first"),
+  );
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "\u009calice@server:~$ ",
+    () => callbacks.push("second"),
+  );
+
+  assert.equal(writes.join(""), "\x1b]7;file://server/home/alice\u009calice@server:~$ ");
+  assert.deepEqual(callbacks, ["first", "second"]);
+  assert.deepEqual(markerLines, [0]);
+});
+
+test("keeps timestamps for visible text before a split OSC sequence", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "hello \x1b]7;file://server/home/alice",
+    () => {},
+  );
+
+  assert.equal(writes.join(""), "hello \x1b]7;file://server/home/alice");
+  assert.deepEqual(markerLines, [0]);
+});
+
+test("keeps fallback timestamps on the matching multiline rows", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "one\r\ntwo \x1b]7;file://server/home/alice",
+    () => {},
+  );
+
+  assert.equal(writes.join(""), "one\r\ntwo \x1b]7;file://server/home/alice");
+  assert.deepEqual(markerLines, [0, 1]);
+});
+
+test("does not duplicate a line timestamp after a split OSC fallback", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "hello \x1b]7;file://server/home/alice",
+    () => {},
+  );
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "\u009cworld",
+    () => {},
+  );
+
+  assert.equal(writes.join(""), "hello \x1b]7;file://server/home/alice\u009cworld");
+  assert.deepEqual(markerLines, [0]);
+});
+
+test("does not timestamp the next chunk after a split alternate-screen sequence", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+
+  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049", () => {});
+  writeTerminalDataWithLineTimestamps(term as never, "hvim screen", () => {});
+
+  assert.equal(writes.join(""), "\x1b[?1049hvim screen");
+  assert.deepEqual(markerLines, []);
+});
+
+test("timestamps a prompt after split alternate-screen enter and leave in one chunk", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+
+  writeTerminalDataWithLineTimestamps(term as never, "\x1b[?1049", () => {});
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    "hvim screen\x1b[?1049lprompt",
+    () => {},
+  );
+
+  assert.equal(writes.join(""), "\x1b[?1049hvim screen\x1b[?1049lprompt");
+  assert.deepEqual(markerLines, [0]);
 });

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -7,6 +7,7 @@ export type TerminalLineTimestampSegment =
 export type TerminalLineTimestampSegmenter = {
   append: (data: string) => TerminalLineTimestampSegment[];
   reset: () => void;
+  flushPendingEscapeSequence: () => string;
   setAlternateScreenActive: (active: boolean) => void;
 };
 
@@ -31,6 +32,7 @@ type TimestampStore = {
   segmenter: TerminalLineTimestampSegmenter;
   entries: TimestampEntry[];
   listeners: Set<() => void>;
+  timestampOnlyPrefix: string;
 };
 
 export type TerminalTimestampGutterEntry = {
@@ -52,6 +54,34 @@ export const formatTerminalLineTimestamp = (date: Date): string => (
 );
 
 const isCsiFinalByte = (char: string): boolean => char >= "@" && char <= "~";
+const STRING_TERMINATOR = "\u009c";
+
+const readStringTerminatedSequence = (
+  data: string,
+  startIndex: number,
+): { sequence: string; endIndex: number; complete: boolean } => {
+  for (let index = startIndex + 2; index < data.length; index += 1) {
+    if (data[index] === "\u0007" || data[index] === STRING_TERMINATOR) {
+      return {
+        sequence: data.slice(startIndex, index + 1),
+        endIndex: index,
+        complete: true,
+      };
+    }
+    if (data[index] === "\x1b" && data[index + 1] === "\\") {
+      return {
+        sequence: data.slice(startIndex, index + 2),
+        endIndex: index + 1,
+        complete: true,
+      };
+    }
+  }
+  return {
+    sequence: data.slice(startIndex),
+    endIndex: data.length - 1,
+    complete: false,
+  };
+};
 
 const readEscapeSequence = (
   data: string,
@@ -81,44 +111,11 @@ const readEscapeSequence = (
   }
 
   if (next === "]") {
-    for (let index = startIndex + 2; index < data.length; index += 1) {
-      if (data[index] === "\u0007") {
-        return {
-          sequence: data.slice(startIndex, index + 1),
-          endIndex: index,
-          complete: true,
-        };
-      }
-      if (data[index] === "\x1b" && data[index + 1] === "\\") {
-        return {
-          sequence: data.slice(startIndex, index + 2),
-          endIndex: index + 1,
-          complete: true,
-        };
-      }
-    }
-    return {
-      sequence: data.slice(startIndex),
-      endIndex: data.length - 1,
-      complete: false,
-    };
+    return readStringTerminatedSequence(data, startIndex);
   }
 
   if (next === "P" || next === "^" || next === "_" || next === "X") {
-    for (let index = startIndex + 2; index < data.length; index += 1) {
-      if (data[index] === "\x1b" && data[index + 1] === "\\") {
-        return {
-          sequence: data.slice(startIndex, index + 2),
-          endIndex: index + 1,
-          complete: true,
-        };
-      }
-    }
-    return {
-      sequence: data.slice(startIndex),
-      endIndex: data.length - 1,
-      complete: false,
-    };
+    return readStringTerminatedSequence(data, startIndex);
   }
 
   return {
@@ -153,10 +150,24 @@ const getAlternateScreenAction = (sequence: string): "enter" | "leave" | null =>
   return final === "h" ? "enter" : "leave";
 };
 
+const isPotentialAlternateScreenSequence = (sequence: string): boolean => {
+  if (!sequence.startsWith("\x1b[?")) return false;
+
+  const params = sequence.slice(3).split(";");
+  const alternateScreenModes = ["47", "1047", "1049"];
+  return params.some((part) => (
+    part === ""
+    || alternateScreenModes.some((mode) => mode.startsWith(part) || part.startsWith(mode))
+  ));
+};
+
 const isPrintableOutput = (char: string): boolean => {
   if (char === "\t") return true;
   const code = char.codePointAt(0);
-  return code !== undefined && code >= 0x20 && code !== 0x7f;
+  return code !== undefined
+    && code >= 0x20
+    && code !== 0x7f
+    && (code < 0x80 || code > 0x9f);
 };
 
 const pushDataSegment = (
@@ -257,6 +268,11 @@ export const createTerminalLineTimestampSegmenter = (
       pendingEscapeSequence = "";
       suspendedForAlternateScreen = false;
     },
+    flushPendingEscapeSequence() {
+      const sequence = pendingEscapeSequence;
+      pendingEscapeSequence = "";
+      return sequence;
+    },
     setAlternateScreenActive(active: boolean) {
       suspendedForAlternateScreen = active;
       if (active) {
@@ -279,6 +295,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       segmenter: createTerminalLineTimestampSegmenter(),
       entries: [],
       listeners: new Set(),
+      timestampOnlyPrefix: "",
     };
     stores.set(term, store);
   }
@@ -296,6 +313,7 @@ const resetTimestampStore = (store: TimestampStore) => {
   }
   store.entries = [];
   store.segmenter.reset();
+  store.timestampOnlyPrefix = "";
   notifyTimestampStore(store);
 };
 
@@ -406,31 +424,70 @@ export const writeTerminalDataWithLineTimestamps = (
   store.segmenter.setAlternateScreenActive(
     ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
   );
-  const segments = store.segmenter.append(data);
-  let index = 0;
+  const timestampOnlyPrefix = store.timestampOnlyPrefix;
+  store.timestampOnlyPrefix = "";
+  const dataForTimestamps = `${timestampOnlyPrefix}${data}`;
+  const segments = store.segmenter.append(dataForTimestamps);
+  const parsedData = segments
+    .filter((segment): segment is { kind: "data"; data: string } => segment.kind === "data")
+    .map((segment) => segment.data)
+    .join("");
+  const writeSegments = (
+    onComplete: () => void,
+    skipLeadingDataLength = 0,
+  ) => {
+    let index = 0;
+    let remainingSkipLength = skipLeadingDataLength;
 
-  const writeNext = () => {
-    const segment = segments[index];
-    index += 1;
+    const writeNext = () => {
+      const segment = segments[index];
+      index += 1;
 
-    if (!segment) {
-      done();
-      return;
-    }
+      if (!segment) {
+        onComplete();
+        return;
+      }
 
-    if (segment.kind === "timestamp") {
-      recordTerminalLineTimestamp(term, store, segment.label);
-      writeNext();
-      return;
-    }
+      if (segment.kind === "timestamp") {
+        recordTerminalLineTimestamp(term, store, segment.label);
+        writeNext();
+        return;
+      }
 
-    if (!segment.data) {
-      writeNext();
-      return;
-    }
+      let segmentData = segment.data;
+      if (remainingSkipLength > 0) {
+        const skippedLength = Math.min(remainingSkipLength, segmentData.length);
+        segmentData = segmentData.slice(skippedLength);
+        remainingSkipLength -= skippedLength;
+      }
 
-    term.write(segment.data, writeNext);
+      if (!segmentData) {
+        writeNext();
+        return;
+      }
+
+      term.write(segmentData, writeNext);
+    };
+
+    writeNext();
   };
 
-  writeNext();
+  if (parsedData !== dataForTimestamps) {
+    const pendingEscapeSequence = store.segmenter.flushPendingEscapeSequence();
+    if (isPotentialAlternateScreenSequence(pendingEscapeSequence)) {
+      store.timestampOnlyPrefix = pendingEscapeSequence;
+    }
+    if (!parsedData || !dataForTimestamps.startsWith(parsedData)) {
+      term.write(data, done);
+      return;
+    }
+
+    const parsedCurrentDataLength = Math.max(0, parsedData.length - timestampOnlyPrefix.length);
+    writeSegments(
+      () => term.write(data.slice(parsedCurrentDataLength), done),
+      timestampOnlyPrefix.length,
+    );
+    return;
+  }
+  writeSegments(done, timestampOnlyPrefix.length);
 };

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -73,12 +73,12 @@ test("writeSessionData records terminal output timestamps without changing outpu
   assert.deepEqual(markerLines, [0, 1]);
 });
 
-test("writeSessionData records timestamps independently of display settings", () => {
+test("writeSessionData skips timestamps when the host gutter is disabled", () => {
   const { term, writes, markerLines } = createFakeTerm();
   writeSessionData(createContext(true, { showLineTimestamps: false }) as never, term, "hello");
 
   assert.deepEqual(writes, ["hello"]);
-  assert.deepEqual(markerLines, [0]);
+  assert.deepEqual(markerLines, []);
 });
 
 test("writeSessionData records timestamps for hosts with timestamps enabled", () => {
@@ -113,7 +113,7 @@ test("writeSessionData resumes timestamps after leaving alternate screen in the 
   assert.deepEqual(markerLines, [0]);
 });
 
-test("writeSessionData keeps recording while the latest host display setting changes", () => {
+test("writeSessionData records timestamps only while the latest host setting is enabled", () => {
   const { term, writes, markerLines, disposedMarkerLines } = createFakeTerm();
   const ctx = createContext(false, { showLineTimestamps: false });
 
@@ -124,7 +124,7 @@ test("writeSessionData keeps recording while the latest host display setting cha
   writeSessionData(ctx as never, term, "disabled");
 
   assert.equal(writes.join(""), "before\r\nenabled\r\ndisabled");
-  assert.deepEqual(markerLines, [0, 1, 2]);
+  assert.deepEqual(markerLines, [1]);
   assert.deepEqual(disposedMarkerLines, []);
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -180,7 +180,12 @@ export const writeSessionData = (
       flow.written(data.length);
     };
 
-    writeTerminalDataWithLineTimestamps(term, displayData, afterWrite);
+    if (ctx.host?.showLineTimestamps === true) {
+      writeTerminalDataWithLineTimestamps(term, displayData, afterWrite);
+      return;
+    }
+
+    term.write(displayData, afterWrite);
   });
 };
 


### PR DESCRIPTION
## What changed

- Keep terminal output on the raw write path unless a host explicitly enables the left-side output timestamp gutter.
- When the timestamp gutter is enabled, fall back safely if timestamp parsing cannot account for the full chunk, without withholding terminal output.
- Teach the timestamp parser about the C1 string terminator used by OSC/string-control sequences.
- Preserve correct timestamp rows around split prompt/control sequences, including alternate-screen enter/leave sequences.

## Why

Issue #1492 shows SSH reaching the Ubuntu login banner and `Last login`, then stopping before the shell prompt. This can happen when the remote prompt starts with an invisible OSC sequence that uses the C1 string terminator. The timestamp parser previously kept that sequence open, so the prompt and later echoed input could be buffered instead of shown.

The safer behavior is that timestamp parsing must never be able to block terminal output. If parsing cannot safely timestamp a chunk, Netcatty now shows the output and simply skips or delays timestamping only where needed.

## Impact

Normal SSH sessions that do not enable output timestamps no longer go through timestamp parsing at all. Sessions with timestamps enabled should still show prompt/input normally; edge cases may miss a timestamp marker rather than blocking output or stamping full-screen content incorrectly.

Closes #1492

## Validation

- `node --test --import tsx components/terminal/runtime/terminalLineTimestamps.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts`
- `node --test --import tsx components/terminal/runtime/*.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
