### PR TITLE
[codex] Restore terminal mode after auto-run snippets

### DIFF
--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -892,6 +892,7 @@ export const useSessionState = ({
       // Store the command to run after connection
       startupCommand: resolvedCommand,
       noAutoRun: snippet.noAutoRun,
+      protectStartupCommandTerminalMode: true,
     }));
 
 	    setSessions(prev => [...prev, ...sessionsWithWorkspace]);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -87,6 +87,7 @@ import {
 import {
   forceSyncRenderAfterResize,
   MAX_CONNECTION_LOG_DATA_CHARS,
+  prepareAutoRunSnippetCommand,
   shouldHideConnectingDialogForConnectionReuse,
   shouldShowTerminalConnectionDialog,
   type TerminalProps,
@@ -124,6 +125,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   restoreTerminalCwd = false,
   startupCommand,
   noAutoRun,
+  protectStartupCommandTerminalMode,
   reuseConnectionFromSessionId,
   serialConfig,
   hotkeyScheme = "disabled",
@@ -697,6 +699,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     reuseConnectionFromSessionId,
     startupCommand,
     noAutoRun,
+    protectStartupCommandTerminalMode,
+    shellType,
     suppressHostStartupCommandRef,
     terminalSettings,
     terminalSettingsRef,
@@ -875,13 +879,23 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const executeSnippetCommand = useCallback((
     command: string,
     noAutoRun?: boolean,
-    options?: { broadcast?: boolean },
+    options?: { broadcast?: boolean; protectTerminalMode?: boolean },
   ) => {
     const term = termRef.current;
     const id = sessionRef.current;
     if (!term || !id) return;
 
-    let data = normalizeLineEndings(command);
+    let fallbackBroadcastData = normalizeLineEndings(command);
+    const fallbackBroadcastIsMultiLine = fallbackBroadcastData.includes('\n');
+    if (fallbackBroadcastIsMultiLine && term.modes.bracketedPasteMode && !disableBracketedPasteRef.current) {
+      fallbackBroadcastData = wrapBracketedPaste(fallbackBroadcastData);
+    }
+    if (!noAutoRun) fallbackBroadcastData = `${fallbackBroadcastData}\r`;
+
+    const commandToSend = options?.protectTerminalMode
+      ? prepareAutoRunSnippetCommand(command, { host, noAutoRun, shellType })
+      : command;
+    let data = normalizeLineEndings(commandToSend);
     const isMultiLine = data.includes('\n');
     // Wrap in bracketed paste BEFORE appending \r so the Enter is sent
     // outside the paste markers — otherwise shells treat it as pasted text
@@ -899,19 +913,26 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     // broadcast mode would clear peer input (the clear keystrokes already go
     // through the broadcast-aware path) but never send the command.
     if (options?.broadcast !== false && isBroadcastEnabledRef.current && onBroadcastInputRef.current) {
-      onBroadcastInputRef.current(data, sessionId);
+      onBroadcastInputRef.current(data, sessionId, options?.protectTerminalMode
+        ? {
+            protectTerminalMode: true,
+            rawCommand: command,
+            fallbackData: fallbackBroadcastData,
+            noAutoRun,
+          }
+        : undefined);
     }
 
     data = prepareProgrammaticSudoInput(data);
     terminalBackend.writeToSession(id, data);
     scrollToBottomAfterProgrammaticInput(data);
     term.focus();
-  }, [prepareProgrammaticSudoInput, scrollToBottomAfterProgrammaticInput, terminalBackend, sessionId]);
+  }, [host, prepareProgrammaticSudoInput, scrollToBottomAfterProgrammaticInput, shellType, terminalBackend, sessionId]);
 
   const executeSnippet = useCallback(async (snippet: Snippet) => {
     const command = await resolveSnippetCommand(snippet);
     if (command === null) return;
-    executeSnippetCommand(command, snippet.noAutoRun);
+    executeSnippetCommand(command, snippet.noAutoRun, { protectTerminalMode: true });
   }, [executeSnippetCommand]);
 
   const onSnippetShortkeyRef = useRef(executeSnippet);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -43,6 +43,11 @@ import type { Snippet } from '../types';
 import { ThemeSidePanel } from './terminal/ThemeSidePanel';
 import { focusTerminalSessionInput } from './terminal/focusTerminalSession';
 import { TerminalComposeBar } from './terminal/TerminalComposeBar';
+import {
+  prepareAutoRunSnippetCommand,
+  prepareProtectedBroadcastSnippetData,
+  type TerminalBroadcastInputOptions,
+} from './terminal/terminalHelpers';
 import { Button } from './ui/button';
 import { setupMcpApprovalBridge } from '../infrastructure/ai/shared/approvalGate';
 import { resolveScriptsSidePanelShortcutIntent } from '../application/state/resolveSnippetsShortcutIntent';
@@ -319,20 +324,6 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const onSetWorkspaceFocusedSessionRef = useRef(onSetWorkspaceFocusedSession);
   onSetWorkspaceFocusedSessionRef.current = onSetWorkspaceFocusedSession;
 
-  // Handle broadcast input - write to all other sessions in the source workspace.
-  const handleBroadcastInput = useCallback((data: string, sourceSessionId: string) => {
-    const sourceSession = sessionsRef.current.find((session) => session.id === sourceSessionId);
-    const workspaceId = sourceSession?.workspaceId;
-    if (!workspaceId) return;
-
-    for (const session of sessionsRef.current) {
-      if (session.workspaceId === workspaceId && session.id !== sourceSessionId) {
-        if (!canUseDirectSessionWriteFallback(session)) continue;
-        terminalBackend.writeToSession(session.id, data);
-      }
-    }
-  }, [terminalBackend]);
-
   // Side panel state - per-tab tracking of which sub-panel is active
   // Maps tab IDs to the active sub-panel type (sftp/scripts/theme), absent = closed
   const [sidePanelOpenTabs, setSidePanelOpenTabs] = useState<Map<string, SidePanelTab>>(new Map());
@@ -539,6 +530,38 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [sessions, sessionHostsMap, hosts, groupConfigs, proxyProfileIdSet, proxyProfiles]);
   const sessionHostsMapRef = useRef(sessionHostsMap);
   sessionHostsMapRef.current = sessionHostsMap;
+
+  // Handle broadcast input - write to all other sessions in the source workspace.
+  const handleBroadcastInput = useCallback((
+    data: string,
+    sourceSessionId: string,
+    options?: TerminalBroadcastInputOptions,
+  ) => {
+    const sourceSession = sessionsRef.current.find((session) => session.id === sourceSessionId);
+    const workspaceId = sourceSession?.workspaceId;
+    if (!workspaceId) return;
+
+    for (const session of sessionsRef.current) {
+      if (session.workspaceId !== workspaceId || session.id === sourceSessionId) continue;
+      if (!canUseDirectSessionWriteFallback(session)) continue;
+
+      let targetData = data;
+      if (options?.protectTerminalMode && options.rawCommand !== undefined) {
+        const host = sessionHostsMapRef.current.get(session.id);
+        if (host) {
+          targetData = prepareProtectedBroadcastSnippetData({
+            rawCommand: options.rawCommand,
+            fallbackData: options.fallbackData ?? data,
+            host,
+            noAutoRun: options.noAutoRun,
+            shellType: session.shellType,
+          });
+        }
+      }
+
+      terminalBackend.writeToSession(session.id, targetData);
+    }
+  }, [terminalBackend]);
 
   const handleCommandSubmitted = useCallback((_command: string, _hostId: string, _hostLabel: string, sessionId: string) => {
     const tabId = activeTabIdRef.current;
@@ -925,19 +948,27 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   }, [handleCloseSidePanel, handleSwitchSidePanelTab]);
 
   // Execute snippet on the focused terminal session
-  const handleSnippetClickForFocusedSession = useCallback((command: string, noAutoRun?: boolean) => {
+  const handleSnippetClickForFocusedSession = useCallback((
+    command: string,
+    noAutoRun?: boolean,
+    options?: { protectTerminalMode?: boolean },
+  ) => {
     const sessionId = activeWorkspaceRef.current?.focusedSessionId ?? activeSessionRef.current?.id;
     if (!sessionId) return;
     const executor = snippetExecutorsRef.current.get(sessionId);
     if (executor) {
-      executor(command, noAutoRun);
+      executor(command, noAutoRun, { protectTerminalMode: options?.protectTerminalMode });
       return;
     }
 
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     if (!session || !canUseDirectSessionWriteFallback(session)) return;
 
-    let data = normalizeLineEndings(command);
+    const host = sessionHostsMapRef.current.get(sessionId);
+    const commandToSend = options?.protectTerminalMode && host
+      ? prepareAutoRunSnippetCommand(command, { host, noAutoRun, shellType: session.shellType })
+      : command;
+    let data = normalizeLineEndings(commandToSend);
     if (!noAutoRun) data = `${data}\r`;
     terminalBackend.writeToSession(sessionId, data);
     // Re-focus the terminal so the user can interact immediately
@@ -959,7 +990,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const handleSnippetFromPanel = useCallback(async (snippet: Snippet) => {
     const command = await resolveSnippetCommand(snippet);
     if (command === null) return;
-    handleSnippetClickForFocusedSession(command, snippet.noAutoRun);
+    handleSnippetClickForFocusedSession(command, snippet.noAutoRun, { protectTerminalMode: true });
   }, [handleSnippetClickForFocusedSession]);
 
   const handleComposeSend = useCallback((text: string) => {

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -731,6 +731,58 @@ test("local session runs startup command after attaching", async () => {
   }]);
 });
 
+test("ssh snippet startup command restores terminal mode after attaching", async () => {
+  const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: (id: string, data: string, options?: { automated?: boolean }) => {
+      sessionWrites.push({ id, data, automated: options?.automated });
+    },
+    resizeSession: noop,
+  };
+
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "CentOS",
+      hostname: "centos.example.test",
+      username: "alice",
+      protocol: "ssh",
+      os: "linux",
+      distro: "centos",
+    },
+    terminalSettings: { startupCommandDelayMs: 0 },
+    terminalBackend,
+    startupCommand: "bash <(curl -sSL https://linuxmirrors.cn/docker.sh)",
+    protectStartupCommandTerminalMode: true,
+    promptLineBreakStateRef: undefined,
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(sessionWrites.length, 1);
+  assert.equal(sessionWrites[0].id, "ssh-session");
+  assert.equal(sessionWrites[0].automated, true);
+  assert.match(sessionWrites[0].data, /netcatty-stty/);
+  assert.equal(sessionWrites[0].data.endsWith("\r"), true);
+});
+
 test("startup command suppression is consumed only when scheduling", () => {
   const suppressHostStartupCommandRef = { current: true };
   const ctx = createStarterContext({

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -103,6 +103,8 @@ export type TerminalSessionStartersContext = {
   reuseConnectionFromSessionId?: string;
   startupCommand?: string;
   noAutoRun?: boolean;
+  protectStartupCommandTerminalMode?: boolean;
+  shellType?: TerminalSession["shellType"];
   suppressHostStartupCommandRef?: RefObject<boolean>;
   terminalSettings?: TerminalSettings;
   terminalSettingsRef?: RefObject<TerminalSettings | undefined>;

--- a/components/terminal/runtime/terminalStartupCommands.ts
+++ b/components/terminal/runtime/terminalStartupCommands.ts
@@ -1,4 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { prepareAutoRunSnippetCommand } from "../terminalHelpers";
 import { markPromptLineBreakCommandPending } from "./promptLineBreak";
 import type { TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
 
@@ -73,10 +74,18 @@ export const scheduleStartupCommand = (
     };
   }
 
+  const preparedCommandToRun = ctx.protectStartupCommandTerminalMode
+    ? prepareAutoRunSnippetCommand(commandToRun, {
+        host: ctx.host,
+        noAutoRun: ctx.noAutoRun,
+        shellType: ctx.shellType,
+      })
+    : commandToRun;
+
   // Auto-run: send each non-empty line in sequence, waiting delayMs before the
   // first and between each, so a line runs inside any sub-shell opened by a
   // previous line (e.g. `sudo -i` then `alias ...`).
-  const lines = splitStartupCommandLines(commandToRun);
+  const lines = splitStartupCommandLines(preparedCommandToRun);
   if (lines.length === 0) {
     onSettled?.();
     return undefined;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -1,8 +1,10 @@
 import type { DragEvent, PointerEvent } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 
+import { classifyDistroId } from "../../domain/host";
 import { logger } from "../../lib/logger";
 import { getPathForFile, type DropEntry } from "../../lib/sftpFileUtils";
+import { normalizeLineEndings } from "../../lib/utils";
 import type {
   Host,
   Identity,
@@ -17,6 +19,13 @@ import type {
 } from "../../types";
 
 export const MAX_CONNECTION_LOG_DATA_CHARS = 1_000_000;
+
+export interface TerminalBroadcastInputOptions {
+  protectTerminalMode?: boolean;
+  rawCommand?: string;
+  fallbackData?: string;
+  noAutoRun?: boolean;
+}
 
 /**
  * Get the display name for a terminal session.
@@ -126,6 +135,7 @@ export interface TerminalProps {
   restoreTerminalCwd?: boolean;
   startupCommand?: string;
   noAutoRun?: boolean;
+  protectStartupCommandTerminalMode?: boolean;
   // When this tab was created from a connected SSH session, the id of the
   // source session whose authenticated connection should be reused for a new
   // shell channel — skipping a second MFA prompt (issue #1204).
@@ -173,10 +183,18 @@ export interface TerminalProps {
   onToggleBroadcast?: () => void;
   onToggleComposeBar?: () => void;
   isWorkspaceComposeBarOpen?: boolean;
-  onBroadcastInput?: (data: string, sourceSessionId: string) => void;
+  onBroadcastInput?: (
+    data: string,
+    sourceSessionId: string,
+    options?: TerminalBroadcastInputOptions,
+  ) => void;
   onSnippetExecutorChange?: (
     sessionId: string,
-    executor: ((command: string, noAutoRun?: boolean) => void) | null,
+    executor: ((
+      command: string,
+      noAutoRun?: boolean,
+      options?: { broadcast?: boolean; protectTerminalMode?: boolean },
+    ) => void) | null,
   ) => void;
   sessionLog?: { enabled: boolean; directory: string; format: string; timestampsEnabled?: boolean };
   sshDebugLogEnabled?: boolean;
@@ -225,6 +243,158 @@ export function shouldShowTerminalConnectionDialog({
     && !(!!hideConnectingDialogForConnectionReuse && status === "connecting")
     && !((isLocalConnection || isSerialConnection) && status === "connecting")
     && !(status === "disconnected" && isDisconnectedDialogDismissed);
+}
+
+type SnippetRestoreHost = Pick<Host, "protocol" | "deviceType" | "distro" | "os">;
+
+function shouldUseSnippetRestoreShell(shellType?: TerminalSession["shellType"]): boolean {
+  return shellType === undefined || shellType === "posix";
+}
+
+function shouldRestoreTerminalModeAfterSnippet({
+  host,
+  noAutoRun,
+  shellType,
+}: {
+  host: SnippetRestoreHost;
+  noAutoRun?: boolean;
+  shellType?: TerminalSession["shellType"];
+}): boolean {
+  if (noAutoRun) return false;
+  if (!shouldUseSnippetRestoreShell(shellType)) return false;
+  const protocol = host.protocol ?? "ssh";
+  if (protocol !== "ssh") return false;
+
+  const detectedDeviceClass = classifyDistroId(host.distro);
+  if (host.deviceType === "network" || detectedDeviceClass === "network-device") return false;
+
+  return host.os === "macos" || detectedDeviceClass === "linux-like";
+}
+
+function encodeUtf8Base64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+function hasMultipleCommandLines(command: string): boolean {
+  return command.includes("\n") || command.includes("\r");
+}
+
+function doubleQuoteFishAndPosix(value: string): string {
+  return `"${value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\"", "\\\"")
+    .replaceAll("$", "\\$")
+    .replaceAll("`", "\\`")}"`;
+}
+
+function buildPosixSnippetRestoreCommand(encodedCommand: string): string {
+  return [
+    "__netcatty_stty_state=\"$(stty -g 2>/dev/null || true)\"",
+    "__netcatty_restore(){ if [ -n \"$__netcatty_stty_state\" ]; then stty \"$__netcatty_stty_state\" 2>/dev/null || stty sane 2>/dev/null || true; else stty sane 2>/dev/null || true; fi; }",
+    "trap __netcatty_restore INT TERM EXIT",
+    `__netcatty_cmd_b64='${encodedCommand}'`,
+    "__netcatty_cmd=\"$(printf %s \"$__netcatty_cmd_b64\" | base64 -d 2>/dev/null || printf %s \"$__netcatty_cmd_b64\" | base64 -D 2>/dev/null)\"",
+    "__netcatty_decode_status=$?",
+    "if [ \"$__netcatty_decode_status\" -eq 0 ]; then eval \"$__netcatty_cmd\"; __netcatty_status=$?; else printf '%s\\n' 'Netcatty: failed to decode protected snippet command' >&2; __netcatty_status=127; fi",
+    "__netcatty_restore",
+    "trap - INT TERM EXIT",
+    "unset __netcatty_stty_state __netcatty_cmd_b64 __netcatty_cmd __netcatty_decode_status",
+    "unset -f __netcatty_restore 2>/dev/null || true",
+    "( exit $__netcatty_status )",
+  ].join("; ");
+}
+
+function buildPortableCurrentShellSnippetRestoreCommand(command: string): string | null {
+  const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const stateFile = `/tmp/.netcatty-stty-${suffix}`;
+  const statusFile = `/tmp/.netcatty-status-${suffix}`;
+  const commandFile = `/tmp/.netcatty-cmd-${suffix}`;
+  const encodedCommand = encodeUtf8Base64(command);
+  const writeCommand = `sh -c 'printf %s "$1" | base64 -d > ${commandFile} 2>/dev/null || printf %s "$1" | base64 -D > ${commandFile} 2>/dev/null' sh '${encodedCommand}'`;
+  const saveState = `sh -c 'stty -g > ${stateFile} 2>/dev/null || true'`;
+  const restoreState = `sh -c 'xargs stty < ${stateFile} 2>/dev/null || stty sane 2>/dev/null || true'; rm -f ${stateFile}`;
+  const trapCleanup = `${restoreState}; rm -f ${statusFile} ${commandFile}`;
+  const exitWithStatus = `sh -c 'code=$(cat ${statusFile} 2>/dev/null || printf 1); rm -f ${statusFile}; exit "$code"'`;
+  const fishRunner = [
+    `source ${commandFile}`,
+    "set __netcatty_status $status",
+    `sh -c 'printf %s "$1" > ${statusFile}' sh "$__netcatty_status"`,
+    "set -e __netcatty_status",
+    "true",
+  ].join("; ");
+  const posixRunner = [
+    `. ${commandFile}`,
+    "__netcatty_status=$?",
+    `sh -c 'printf %s "$1" > ${statusFile}' sh "$__netcatty_status"`,
+    "unset __netcatty_status",
+    "true",
+  ].join("; ");
+  const runInCurrentShell = [
+    `sh -c 'test -n "$1"' sh "$FISH_VERSION" && eval ${doubleQuoteFishAndPosix(fishRunner)}`,
+    `eval ${doubleQuoteFishAndPosix(posixRunner)}`,
+  ].join(" || ");
+
+  return [
+    writeCommand,
+    saveState,
+    `trap ${doubleQuoteFishAndPosix(trapCleanup)} INT TERM EXIT`,
+    runInCurrentShell,
+    restoreState,
+    "trap - INT TERM EXIT",
+    `rm -f ${commandFile}`,
+    exitWithStatus,
+  ].join("; ");
+}
+
+export function prepareAutoRunSnippetCommand(
+  command: string,
+  opts: {
+    host: SnippetRestoreHost;
+    noAutoRun?: boolean;
+    shellType?: TerminalSession["shellType"];
+  },
+): string {
+  const rawCommand = String(command ?? "");
+  if (!shouldRestoreTerminalModeAfterSnippet(opts)) {
+    return rawCommand;
+  }
+  if (hasMultipleCommandLines(rawCommand)) {
+    return rawCommand;
+  }
+
+  const encodedCommand = encodeUtf8Base64(rawCommand);
+  return opts.shellType === undefined
+    ? (buildPortableCurrentShellSnippetRestoreCommand(rawCommand) ?? rawCommand)
+    : buildPosixSnippetRestoreCommand(encodedCommand);
+}
+
+export function prepareProtectedBroadcastSnippetData({
+  rawCommand,
+  fallbackData,
+  host,
+  noAutoRun,
+  shellType,
+}: {
+  rawCommand: string;
+  fallbackData: string;
+  host: SnippetRestoreHost;
+  noAutoRun?: boolean;
+  shellType?: TerminalSession["shellType"];
+}): string {
+  const prepared = prepareAutoRunSnippetCommand(rawCommand, { host, noAutoRun, shellType });
+  if (prepared === String(rawCommand ?? "")) {
+    return fallbackData;
+  }
+  let data = normalizeLineEndings(prepared);
+  if (!noAutoRun) data = `${data}\r`;
+  return data;
 }
 
 export function shouldHideConnectingDialogForConnectionReuse({

--- a/components/terminalHelpers.test.ts
+++ b/components/terminalHelpers.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 
 import type { Host } from "../domain/models";
 import {
+  prepareAutoRunSnippetCommand,
+  prepareProtectedBroadcastSnippetData,
   shouldHideConnectingDialogForConnectionReuse,
   shouldShowTerminalConnectionDialog,
 } from "./terminal/terminalHelpers";
@@ -125,4 +128,158 @@ test("connection reuse hides connecting dialog only while reuse is still possibl
     }),
     false,
   );
+});
+
+test("auto-run snippets on Linux-like SSH hosts restore terminal mode afterwards", () => {
+  const command = "bash <(curl -sSL https://linuxmirrors.cn/docker.sh)";
+
+  const wrapped = prepareAutoRunSnippetCommand(command, {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+    shellType: "posix",
+  });
+
+  assert.match(wrapped, /__netcatty_stty_state=/);
+  assert.match(wrapped, /__netcatty_cmd_b64='/);
+  assert.equal(wrapped.includes("\n"), false);
+  assert.match(wrapped, /stty "\$__netcatty_stty_state"/);
+  assert.match(wrapped, /trap __netcatty_restore INT TERM EXIT/);
+  assert.match(wrapped, /trap - INT TERM EXIT/);
+  assert.match(wrapped, /stty sane/);
+  assert.match(wrapped, /\( exit \$__netcatty_status \)/);
+
+  const encoded = wrapped.match(/__netcatty_cmd_b64='([^']+)'/)?.[1];
+  assert.equal(Buffer.from(encoded ?? "", "base64").toString("utf8"), command);
+});
+
+test("auto-run snippets with unknown remote shell use a portable current-shell wrapper", () => {
+  const command = "bash <(curl -sSL https://linuxmirrors.cn/docker.sh)";
+
+  const wrapped = prepareAutoRunSnippetCommand(command, {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+  });
+
+  assert.match(wrapped, /^sh -c 'printf %s "\$1" \| base64 -d > \/tmp\/\.netcatty-cmd-/);
+  assert.match(wrapped, /sh -c 'stty -g > \/tmp\/\.netcatty-stty-/);
+  assert.match(wrapped, /trap "sh -c 'xargs stty < \/tmp\/\.netcatty-stty-/);
+  assert.match(wrapped, /source \/tmp\/\.netcatty-cmd-/);
+  assert.match(wrapped, /\. \/tmp\/\.netcatty-cmd-/);
+  assert.match(wrapped, /set __netcatty_status/);
+  assert.match(wrapped, /__netcatty_status=\\\$\?/);
+  assert.match(wrapped, /\/tmp\/\.netcatty-status-/);
+  assert.match(wrapped, /trap - INT TERM EXIT/);
+  assert.doesNotMatch(wrapped, /\$[{]SHELL:-sh[}]/);
+});
+
+test("auto-run snippets with unknown remote shell preserve failure status", () => {
+  const wrapped = prepareAutoRunSnippetCommand("sh -c 'exit 42'", {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+  });
+
+  const result = spawnSync("bash", ["-lc", wrapped], { encoding: "utf8" });
+  assert.equal(result.status, 42);
+});
+
+test("auto-run snippets keep multi-line commands as terminal input", () => {
+  const command = "echo one\necho two";
+
+  assert.equal(prepareAutoRunSnippetCommand(command, {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+  }), command);
+
+  assert.equal(prepareAutoRunSnippetCommand(command, {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+    shellType: "posix",
+  }), command);
+});
+
+test("snippet terminal mode restore is skipped for paste-only and non-shell targets", () => {
+  const command = "show version";
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+      noAutoRun: true,
+    }),
+    command,
+  );
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "ssh", deviceType: "network", distro: "cisco" }),
+      noAutoRun: false,
+    }),
+    command,
+  );
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "serial" }),
+      noAutoRun: false,
+    }),
+    command,
+  );
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "ssh", os: "linux", distro: undefined }),
+      noAutoRun: false,
+    }),
+    command,
+  );
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+      noAutoRun: false,
+      shellType: "fish",
+    }),
+    command,
+  );
+
+  assert.equal(
+    prepareAutoRunSnippetCommand(command, {
+      host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+      noAutoRun: false,
+      shellType: "unknown",
+    }),
+    command,
+  );
+});
+
+test("protected snippet broadcast is prepared per target host", () => {
+  const command = "bash <(curl -sSL https://linuxmirrors.cn/docker.sh)";
+  const fallbackData = `${command}\r`;
+
+  const linuxData = prepareProtectedBroadcastSnippetData({
+    rawCommand: command,
+    fallbackData,
+    host: host({ protocol: "ssh", os: "linux", distro: "rocky" }),
+    noAutoRun: false,
+    shellType: "posix",
+  });
+  assert.match(linuxData, /__netcatty_stty_state=/);
+  assert.match(linuxData, /stty "\$__netcatty_stty_state"/);
+  assert.equal(linuxData.endsWith("\r"), true);
+
+  const fishData = prepareProtectedBroadcastSnippetData({
+    rawCommand: command,
+    fallbackData,
+    host: host({ protocol: "ssh", os: "linux", distro: "rocky" }),
+    noAutoRun: false,
+    shellType: "fish",
+  });
+  assert.equal(fishData, fallbackData);
+
+  const networkDeviceData = prepareProtectedBroadcastSnippetData({
+    rawCommand: command,
+    fallbackData,
+    host: host({ protocol: "ssh", deviceType: "network", distro: "cisco" }),
+    noAutoRun: false,
+  });
+  assert.equal(networkDeviceData, fallbackData);
 });

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -17,6 +17,7 @@ import type { ExecutorContext } from '../../infrastructure/ai/cattyAgent/executo
 import { AIChatSidePanel } from '../AIChatSidePanel';
 import Terminal from '../Terminal';
 import { removePaneVisible, setPaneVisible } from '../terminal/paneVisibilityStore';
+import type { TerminalBroadcastInputOptions } from '../terminal/terminalHelpers';
 import {
   getTerminalPaneRenderSnapshot,
   parseTerminalPaneRenderSnapshot,
@@ -54,7 +55,7 @@ export type PendingSftpUpload = {
 export type SnippetExecutor = (
   command: string,
   noAutoRun?: boolean,
-  options?: { broadcast?: boolean },
+  options?: { broadcast?: boolean; protectTerminalMode?: boolean },
 ) => void;
 
 export type PendingTerminalSelectionForAI = {
@@ -604,7 +605,11 @@ interface TerminalPaneProps {
   onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
   onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
   isBroadcastEnabled?: (workspaceId: string) => boolean;
-  onBroadcastInput: (data: string, sourceSessionId: string) => void;
+  onBroadcastInput: (
+    data: string,
+    sourceSessionId: string,
+    options?: TerminalBroadcastInputOptions,
+  ) => void;
   onToggleWorkspaceComposeBar: () => void;
   onSnippetExecutorChange: (
     sessionId: string,
@@ -1124,6 +1129,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
         restoreTerminalCwd={restoreTerminalCwd && sessionHostResolved}
         startupCommand={session.startupCommand}
         noAutoRun={session.noAutoRun}
+        protectStartupCommandTerminalMode={session.protectStartupCommandTerminalMode}
         reuseConnectionFromSessionId={session.reuseConnectionFromSessionId}
         serialConfig={session.serialConfig}
         hotkeyScheme={hotkeyScheme}
@@ -1228,7 +1234,11 @@ interface TerminalPanesHostProps {
   onSetWorkspaceFocusedSession?: (workspaceId: string, sessionId: string) => void;
   onSplitSession?: (sessionId: string, direction: SplitDirection) => void;
   isBroadcastEnabled?: (workspaceId: string) => boolean;
-  onBroadcastInput: (data: string, sourceSessionId: string) => void;
+  onBroadcastInput: (
+    data: string,
+    sourceSessionId: string,
+    options?: TerminalBroadcastInputOptions,
+  ) => void;
   onToggleWorkspaceComposeBar: () => void;
   onSnippetExecutorChange: (
     sessionId: string,

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -368,6 +368,7 @@ export interface TerminalSession {
   workspaceId?: string;
   startupCommand?: string; // Command to run after connection (for snippet runner)
   noAutoRun?: boolean;     // If true, paste command without auto-executing
+  protectStartupCommandTerminalMode?: boolean;
   // Connection-time protocol overrides (used instead of looking up from hosts)
   protocol?: 'ssh' | 'telnet' | 'local' | 'serial';
   port?: number;


### PR DESCRIPTION
## Summary
- restore remote terminal mode after eligible SSH auto-run snippets
- keep paste-only snippets, multi-line snippets, network devices, serial/telnet/local sessions, unknown fallback sessions, and explicit non-POSIX shells out of the wrapper
- prepare protected broadcast and snippet-created startup commands per target host/session

## Root Cause
CentOS 7 can leave the remote TTY in no-echo/non-canonical mode when an interactive shell script is interrupted while reading single-key input. The session remains connected, but subsequent input appears invisible until the user runs stty sane. This reproduces with ordinary OpenSSH too, so the root cause is not Netcatty itself.

## Validation
- git diff --check
- node --test --import tsx components/terminalHelpers.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts
- npm run lint
- npm run build
- npm test
- Generated unknown-shell wrapper returns status 42 in fish
- Reproduced the issue on the supplied CentOS 7 host and verified the generated protected command restores normal terminal echo after Ctrl+C
- Two read-only sub-agent review rounds ended with no actionable findings

Fixes #1498
