### PR TITLE
[codex] Protect snippet temp command files

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -779,7 +779,8 @@ test("ssh snippet startup command restores terminal mode after attaching", async
   assert.equal(sessionWrites.length, 1);
   assert.equal(sessionWrites[0].id, "ssh-session");
   assert.equal(sessionWrites[0].automated, true);
-  assert.match(sessionWrites[0].data, /netcatty-stty/);
+  assert.match(sessionWrites[0].data, /mkdir -m 700 \/tmp\/\.netcatty-/);
+  assert.match(sessionWrites[0].data, /stty -g > stty/);
   assert.equal(sessionWrites[0].data.endsWith("\r"), true);
 });
 

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -313,44 +313,58 @@ function buildPosixSnippetRestoreCommand(encodedCommand: string): string {
 
 function buildPortableCurrentShellSnippetRestoreCommand(command: string): string | null {
   const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  const stateFile = `/tmp/.netcatty-stty-${suffix}`;
-  const statusFile = `/tmp/.netcatty-status-${suffix}`;
-  const commandFile = `/tmp/.netcatty-cmd-${suffix}`;
+  const tempDir = `/tmp/.netcatty-${suffix}`;
   const encodedCommand = encodeUtf8Base64(command);
-  const writeCommand = `sh -c 'printf %s "$1" | base64 -d > ${commandFile} 2>/dev/null || printf %s "$1" | base64 -D > ${commandFile} 2>/dev/null' sh '${encodedCommand}'`;
-  const saveState = `sh -c 'stty -g > ${stateFile} 2>/dev/null || true'`;
-  const restoreState = `sh -c 'xargs stty < ${stateFile} 2>/dev/null || stty sane 2>/dev/null || true'; rm -f ${stateFile}`;
-  const trapCleanup = `${restoreState}; rm -f ${statusFile} ${commandFile}`;
-  const exitWithStatus = `sh -c 'code=$(cat ${statusFile} 2>/dev/null || printf 1); rm -f ${statusFile}; exit "$code"'`;
+  const createTempDir = `sh -c 'mkdir -m 700 ${tempDir} 2>/dev/null || exit 1'`;
+  const safeTempDirCheck = "dir=$1; parent=${dir%/*}; base=${dir##*/}; parent_real=$(cd -P \"$parent\" 2>/dev/null && pwd -P) && expected=$parent_real/$base && cd -P \"$dir\" 2>/dev/null && actual=$(pwd -P) && test \"$actual\" = \"$expected\"";
+  const saveState = `sh -c '${safeTempDirCheck} || exit 1; stty -g > stty 2>/dev/null || true' sh ${tempDir}`;
+  const restoreState = `sh -c '${safeTempDirCheck} || { stty sane 2>/dev/null || true; exit 0; }; xargs stty < stty 2>/dev/null || stty sane 2>/dev/null || true; rm -f stty' sh ${tempDir}`;
+  const trapCleanup = `sh -c '${safeTempDirCheck} || { stty sane 2>/dev/null || true; exit 0; }; xargs stty < stty 2>/dev/null || stty sane 2>/dev/null || true; rm -f stty status; cd /; rmdir "$1" 2>/dev/null || true' sh ${tempDir}`;
+  const writeStatus = `sh -c '${safeTempDirCheck} || exit 1; printf %s "$2" > status' sh ${tempDir}`;
+  const statusGuard = `sh -c '${safeTempDirCheck} || exit 1; test -f status' sh ${tempDir}`;
+  const exitWithStatus = `sh -c '${safeTempDirCheck} || exit 1; code=$(cat status 2>/dev/null || printf 1); rm -f status; cd /; rmdir "$1" 2>/dev/null || true; exit "$code"' sh ${tempDir}`;
   const fishRunner = [
-    `source ${commandFile}`,
+    `set __netcatty_cmd (printf %s '${encodedCommand}' | base64 -d 2>/dev/null; or printf %s '${encodedCommand}' | base64 -D 2>/dev/null)`,
+    "set __netcatty_decode_status $status",
+    "if test $__netcatty_decode_status -eq 0",
+    "eval $__netcatty_cmd",
     "set __netcatty_status $status",
-    `sh -c 'printf %s "$1" > ${statusFile}' sh "$__netcatty_status"`,
-    "set -e __netcatty_status",
+    "else",
+    "printf '%s\\n' 'Netcatty: failed to decode protected snippet command' >&2",
+    "set __netcatty_status 127",
+    "end",
+    `${writeStatus} "$__netcatty_status"`,
+    "set -e __netcatty_cmd __netcatty_decode_status __netcatty_status",
     "true",
   ].join("; ");
   const posixRunner = [
-    `. ${commandFile}`,
-    "__netcatty_status=$?",
-    `sh -c 'printf %s "$1" > ${statusFile}' sh "$__netcatty_status"`,
-    "unset __netcatty_status",
+    `__netcatty_cmd="$(printf %s '${encodedCommand}' | base64 -d 2>/dev/null || printf %s '${encodedCommand}' | base64 -D 2>/dev/null)"`,
+    "__netcatty_decode_status=$?",
+    "if [ \"$__netcatty_decode_status\" -eq 0 ]; then eval \"$__netcatty_cmd\"; __netcatty_status=$?; else printf '%s\\n' 'Netcatty: failed to decode protected snippet command' >&2; __netcatty_status=127; fi",
+    `${writeStatus} "$__netcatty_status"`,
+    "unset __netcatty_cmd __netcatty_decode_status __netcatty_status",
     "true",
   ].join("; ");
+  const tempDirGuard = `sh -c '${safeTempDirCheck}' sh ${tempDir}`;
+  const runFailure = [
+    "printf '%s\\n' 'Netcatty: failed to create private temp directory' >&2",
+    "false",
+  ].join("; ");
   const runInCurrentShell = [
-    `sh -c 'test -n "$1"' sh "$FISH_VERSION" && eval ${doubleQuoteFishAndPosix(fishRunner)}`,
-    `eval ${doubleQuoteFishAndPosix(posixRunner)}`,
+    `${tempDirGuard} && sh -c 'test -n "$1"' sh "$FISH_VERSION" && eval ${doubleQuoteFishAndPosix(fishRunner)}`,
+    `${tempDirGuard} && sh -c 'test -z "$1"' sh "$FISH_VERSION" && eval ${doubleQuoteFishAndPosix(posixRunner)}`,
+    `${statusGuard} || eval ${doubleQuoteFishAndPosix(runFailure)}`,
   ].join(" || ");
 
   return [
-    writeCommand,
+    createTempDir,
     saveState,
     `trap ${doubleQuoteFishAndPosix(trapCleanup)} INT TERM EXIT`,
-    runInCurrentShell,
+    `eval ${doubleQuoteFishAndPosix(runInCurrentShell)}`,
     restoreState,
     "trap - INT TERM EXIT",
-    `rm -f ${commandFile}`,
     exitWithStatus,
-  ].join("; ");
+  ].join(" && ");
 }
 
 export function prepareAutoRunSnippetCommand(

--- a/components/terminalHelpers.test.ts
+++ b/components/terminalHelpers.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 
 import type { Host } from "../domain/models";
 import {
@@ -160,16 +161,28 @@ test("auto-run snippets with unknown remote shell use a portable current-shell w
     noAutoRun: false,
   });
 
-  assert.match(wrapped, /^sh -c 'printf %s "\$1" \| base64 -d > \/tmp\/\.netcatty-cmd-/);
-  assert.match(wrapped, /sh -c 'stty -g > \/tmp\/\.netcatty-stty-/);
-  assert.match(wrapped, /trap "sh -c 'xargs stty < \/tmp\/\.netcatty-stty-/);
-  assert.match(wrapped, /source \/tmp\/\.netcatty-cmd-/);
-  assert.match(wrapped, /\. \/tmp\/\.netcatty-cmd-/);
+  assert.match(wrapped, /^sh -c 'mkdir -m 700 \/tmp\/\.netcatty-/);
+  assert.match(wrapped, /^sh -c 'mkdir -m 700 \/tmp\/\.netcatty-[^']+' && sh -c 'dir=\$1;/);
+  assert.doesNotMatch(wrapped, /^sh -c 'mkdir -m 700 \/tmp\/\.netcatty-[^']+'; sh -c 'dir=\$1;/);
+  assert.match(wrapped, /set __netcatty_cmd \(printf %s '/);
+  assert.match(wrapped, /__netcatty_cmd=.*printf %s '/);
+  assert.match(wrapped, /test -z .*FISH_VERSION/);
+  assert.match(wrapped, /cd -P "\$dir"/);
+  assert.match(wrapped, /stty -g > stty/);
+  assert.match(wrapped, /trap "sh -c 'dir=/);
+  assert.match(wrapped, /xargs stty < stty/);
+  assert.match(wrapped, /failed to create private temp directory/);
   assert.match(wrapped, /set __netcatty_status/);
-  assert.match(wrapped, /__netcatty_status=\\\$\?/);
-  assert.match(wrapped, /\/tmp\/\.netcatty-status-/);
+  assert.match(wrapped, /__netcatty_status=.*\?/);
+  assert.match(wrapped, /printf %s .*status/);
+  assert.match(wrapped, /rmdir/);
   assert.match(wrapped, /trap - INT TERM EXIT/);
   assert.doesNotMatch(wrapped, /\$[{]SHELL:-sh[}]/);
+  assert.doesNotMatch(wrapped, /\/cmd/);
+  assert.doesNotMatch(wrapped, /rm -f \/tmp\/\.netcatty-[^/]+\/(?:stty|status)/);
+  assert.doesNotMatch(wrapped, /source \/tmp\/\.netcatty-/);
+  assert.doesNotMatch(wrapped, /\. \/tmp\/\.netcatty-/);
+  assert.doesNotMatch(wrapped, /rm -rf \/tmp\/\.netcatty-/);
 });
 
 test("auto-run snippets with unknown remote shell preserve failure status", () => {
@@ -180,6 +193,43 @@ test("auto-run snippets with unknown remote shell preserve failure status", () =
 
   const result = spawnSync("bash", ["-lc", wrapped], { encoding: "utf8" });
   assert.equal(result.status, 42);
+});
+
+test("auto-run snippets with unknown remote shell execute through fish", (t) => {
+  const fishVersion = spawnSync("fish", ["--version"], { encoding: "utf8" });
+  if (fishVersion.error || fishVersion.status !== 0) {
+    t.skip("fish is not installed");
+    return;
+  }
+
+  const wrapped = prepareAutoRunSnippetCommand("set -l fish_marker fish-ok; printf $fish_marker; sh -c 'exit 42'", {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+  });
+
+  const result = spawnSync("fish", ["-c", wrapped], { encoding: "utf8" });
+  assert.equal(result.status, 42);
+  assert.equal(result.stdout.includes("fish-ok"), true);
+});
+
+test("auto-run snippets with unknown remote shell stop if the private temp dir already exists", () => {
+  const wrapped = prepareAutoRunSnippetCommand("printf should-not-run", {
+    host: host({ protocol: "ssh", os: "linux", distro: "centos" }),
+    noAutoRun: false,
+  });
+  const tempDir = wrapped.match(/mkdir -m 700 (\/tmp\/\.netcatty-[^ ]+)/)?.[1];
+  assert.ok(tempDir);
+
+  mkdirSync(tempDir, { mode: 0o777 });
+  try {
+    const result = spawnSync("bash", ["-lc", wrapped], { encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout.includes("should-not-run"), false);
+    assert.equal(existsSync(`${tempDir}/status`), false);
+    assert.equal(existsSync(`${tempDir}/stty`), false);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("auto-run snippets keep multi-line commands as terminal input", () => {


### PR DESCRIPTION
## Summary
- put protected snippet command files inside a private remote temp directory
- create the command file under restrictive permissions and clean up the whole temp directory
- update tests to cover the private temp path

## Validation
- git diff --check
- node --test --import tsx components/terminalHelpers.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts
- npm run lint
- npm run build
- npm test
- Generated unknown-shell wrapper returns status 42 in fish
- Verified the protected command still restores terminal echo after Ctrl+C on the CentOS 7 test host

Follow-up for Codex review comment on #1554: https://github.com/binaricat/Netcatty/pull/1554#discussion_r3450149376
