### PR TITLE
[codex] Polish vault UI state and contrast

### DIFF
--- a/application/state/settingsStateDefaults.test.ts
+++ b/application/state/settingsStateDefaults.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getContrastRatio,
+  getHslTokenRelativeLuminance,
+  resolveReadableForegroundForHsl,
+  resolveThemeAccentForeground,
+} from "./settingsStateDefaults.ts";
+import type { UiThemeTokens } from "../../infrastructure/config/uiThemes.ts";
+
+test("readable foreground picks white text for dark accent colors", () => {
+  assert.equal(resolveReadableForegroundForHsl("270 70% 45%"), "0 0% 100%");
+});
+
+test("readable foreground picks black text for light accent colors", () => {
+  assert.equal(resolveReadableForegroundForHsl("48 95% 72%"), "0 0% 0%");
+});
+
+test("computed contrast chooses the stronger black or white foreground", () => {
+  const purpleLuminance = getHslTokenRelativeLuminance("270 70% 45%");
+  assert.equal(typeof purpleLuminance, "number");
+  assert.ok(getContrastRatio(1, purpleLuminance as number) > getContrastRatio(0, purpleLuminance as number));
+
+  const yellowLuminance = getHslTokenRelativeLuminance("48 95% 72%");
+  assert.equal(typeof yellowLuminance, "number");
+  assert.ok(getContrastRatio(0, yellowLuminance as number) > getContrastRatio(1, yellowLuminance as number));
+});
+
+test("theme accent foreground uses the computed color for preset accent buttons", () => {
+  const tokens: UiThemeTokens = {
+    background: "0 0% 100%",
+    foreground: "222 47% 12%",
+    card: "0 0% 100%",
+    cardForeground: "222 47% 12%",
+    popover: "0 0% 100%",
+    popoverForeground: "222 47% 12%",
+    primary: "270 70% 45%",
+    primaryForeground: "0 0% 0%",
+    secondary: "220 12% 95%",
+    secondaryForeground: "222 47% 12%",
+    muted: "220 12% 95%",
+    mutedForeground: "220 10% 45%",
+    accent: "270 70% 45%",
+    accentForeground: "0 0% 0%",
+    destructive: "0 70% 50%",
+    destructiveForeground: "0 0% 100%",
+    border: "220 12% 88%",
+    input: "220 12% 88%",
+    ring: "270 70% 45%",
+  };
+
+  assert.equal(resolveThemeAccentForeground(tokens, "theme", "48 95% 72%"), "0 0% 100%");
+  assert.equal(resolveThemeAccentForeground(tokens, "custom", "48 95% 72%"), "0 0% 0%");
+});

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -99,6 +99,84 @@ export const isValidHslToken = (value: string): boolean => {
   return /^\s*\d+(\.\d+)?\s+\d+(\.\d+)?%\s+\d+(\.\d+)?%\s*$/.test(value);
 };
 
+type ParsedHslToken = {
+  hue: number;
+  saturation: number;
+  lightness: number;
+};
+
+const BLACK_HSL = '0 0% 0%';
+const WHITE_HSL = '0 0% 100%';
+
+const parseHslToken = (value: string): ParsedHslToken | null => {
+  const match = /^\s*(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%\s*$/.exec(value);
+  if (!match) return null;
+  const hue = Number(match[1]);
+  const saturation = Number(match[2]);
+  const lightness = Number(match[3]);
+  if (![hue, saturation, lightness].every(Number.isFinite)) return null;
+  return {
+    hue: ((hue % 360) + 360) % 360,
+    saturation: Math.min(100, Math.max(0, saturation)) / 100,
+    lightness: Math.min(100, Math.max(0, lightness)) / 100,
+  };
+};
+
+const hslToRgb = ({ hue, saturation, lightness }: ParsedHslToken): [number, number, number] => {
+  if (saturation === 0) return [lightness, lightness, lightness];
+
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const huePrime = hue / 60;
+  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const [red, green, blue] =
+    huePrime < 1 ? [chroma, x, 0] :
+    huePrime < 2 ? [x, chroma, 0] :
+    huePrime < 3 ? [0, chroma, x] :
+    huePrime < 4 ? [0, x, chroma] :
+    huePrime < 5 ? [x, 0, chroma] :
+    [chroma, 0, x];
+  const match = lightness - chroma / 2;
+  return [red + match, green + match, blue + match];
+};
+
+const toLinearSrgb = (channel: number): number => (
+  channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+);
+
+export const getHslTokenRelativeLuminance = (value: string): number | null => {
+  const parsed = parseHslToken(value);
+  if (!parsed) return null;
+  const [red, green, blue] = hslToRgb(parsed).map(toLinearSrgb);
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+};
+
+export const getContrastRatio = (foregroundLuminance: number, backgroundLuminance: number): number => {
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+export const resolveReadableForegroundForHsl = (
+  backgroundHsl: string,
+  fallback: string = WHITE_HSL,
+): string => {
+  const backgroundLuminance = getHslTokenRelativeLuminance(backgroundHsl);
+  if (backgroundLuminance == null) return fallback;
+
+  const blackContrast = getContrastRatio(0, backgroundLuminance);
+  const whiteContrast = getContrastRatio(1, backgroundLuminance);
+  return whiteContrast >= blackContrast ? WHITE_HSL : BLACK_HSL;
+};
+
+export const resolveThemeAccentForeground = (
+  tokens: UiThemeTokens,
+  accentMode: 'theme' | 'custom',
+  accentOverride: string,
+): string => {
+  const accentToken = accentMode === 'custom' ? accentOverride : tokens.accent;
+  return resolveReadableForegroundForHsl(accentToken, tokens.primaryForeground);
+};
+
 export const isValidUiThemeId = (theme: 'light' | 'dark', value: string): boolean => {
   const list = theme === 'dark' ? DARK_UI_THEMES : LIGHT_UI_THEMES;
   return list.some((preset) => preset.id === value);
@@ -143,19 +221,16 @@ export const applyThemeTokens = (
   root.style.setProperty('--popover', tokens.popover);
   root.style.setProperty('--popover-foreground', tokens.popoverForeground);
   const accentToken = accentMode === 'custom' ? accentOverride : tokens.accent;
-  const accentLightness = parseFloat(accentToken.split(/\s+/)[2]?.replace('%', '') || '');
-  const computedAccentForeground = resolvedTheme === 'dark'
-    ? '220 40% 96%'
-    : (!Number.isNaN(accentLightness) && accentLightness < 55 ? '0 0% 98%' : '222 47% 12%');
+  const computedAccentForeground = resolveThemeAccentForeground(tokens, accentMode, accentOverride);
 
   root.style.setProperty('--primary', accentToken);
-  root.style.setProperty('--primary-foreground', accentMode === 'custom' ? computedAccentForeground : tokens.primaryForeground);
+  root.style.setProperty('--primary-foreground', computedAccentForeground);
   root.style.setProperty('--secondary', tokens.secondary);
   root.style.setProperty('--secondary-foreground', tokens.secondaryForeground);
   root.style.setProperty('--muted', tokens.muted);
   root.style.setProperty('--muted-foreground', tokens.mutedForeground);
   root.style.setProperty('--accent', accentToken);
-  root.style.setProperty('--accent-foreground', accentMode === 'custom' ? computedAccentForeground : tokens.accentForeground);
+  root.style.setProperty('--accent-foreground', computedAccentForeground);
   root.style.setProperty('--destructive', tokens.destructive);
   root.style.setProperty('--destructive-foreground', tokens.destructiveForeground);
   root.style.setProperty('--border', tokens.border);

--- a/components/VaultHostListSection.test.ts
+++ b/components/VaultHostListSection.test.ts
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("host tree list keeps slight top padding", () => {
+  const source = readFileSync(new URL("./vault/VaultHostListSection.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /viewMode === "tree"\s*\?\s*"pt-1\.5"\s*:\s*"pt-0"/);
+});

--- a/components/VaultViewLayout.test.ts
+++ b/components/VaultViewLayout.test.ts
@@ -8,3 +8,9 @@ test("vault stage aligns its content to the top tab bar", () => {
   assert.match(vaultViewLayoutSource, /className="flex min-w-0 flex-1 py-0 pr-2 pb-2 pl-0"/);
   assert.doesNotMatch(vaultViewLayoutSource, /className="flex min-w-0 flex-1 p-2 pl-0"/);
 });
+
+test("vault notes stay mounted while switching sections", () => {
+  assert.match(vaultViewLayoutSource, /data-section="vault-notes-retained"/);
+  assert.match(vaultViewLayoutSource, /currentSection !== "notes" && "hidden"/);
+  assert.doesNotMatch(vaultViewLayoutSource, /currentSection === "notes" && \(\s*<NotesManager/);
+});

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -49,7 +49,8 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
   return <div
           ref={hostListScrollRef}
           className={cn(
-            "flex-1 overflow-auto px-4 pt-0 pb-4 space-y-3",
+            "flex-1 overflow-auto px-4 pb-4 space-y-3",
+            viewMode === "tree" ? "pt-1.5" : "pt-0",
             !isHostsSectionActive && "hidden",
           )}
           data-section="vault-host-list"

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -585,7 +585,10 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             }
           />
         )}
-        {currentSection === "notes" && (
+        <div
+          className={cn("min-h-0 flex-1", currentSection !== "notes" && "hidden")}
+          data-section="vault-notes-retained"
+        >
           <NotesManager
             notes={notes}
             noteGroups={noteGroups}
@@ -600,7 +603,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
               handleHostConnect(host);
             }}
           />
-        )}
+        </div>
         {currentSection === "keys" && (
           <KeychainManager
             keys={keys}


### PR DESCRIPTION
## What changed

- Keep the Vault notes page mounted while switching subpages so the selected note and local page state are preserved.
- Improve accent button text contrast by choosing black or white text based on the accent color.
- Add a small top gap to the host tree view so the list no longer feels glued to the header.
- Add focused tests for the retained notes page, host tree spacing, and accent contrast behavior.

## Why

These changes address UI polish regressions seen while navigating Vault pages and using light-mode themed buttons.

## Validation

- `node --test --import tsx components/VaultViewLayout.test.ts components/notes/NotesManager.test.tsx components/VaultHostListSection.test.ts application/state/settingsStateDefaults.test.ts`
- `npx eslint components/vault/VaultViewLayout.tsx components/VaultViewLayout.test.ts components/notes/NotesManager.tsx components/notes/NotesManager.test.tsx components/vault/VaultHostListSection.tsx components/VaultHostListSection.test.ts application/state/settingsStateDefaults.ts application/state/settingsStateDefaults.test.ts`
- `npm run build`