### PR TITLE
[codex] Fix tooltip theme contrast

### DIFF
--- a/application/app/topTabsChromeTheme.test.ts
+++ b/application/app/topTabsChromeTheme.test.ts
@@ -9,10 +9,22 @@ test("active chrome theme applies top tab vars and clears them before vault rest
   const effectsSource = readFileSync(new URL("../../components/terminalLayer/useTerminalLayerEffects.ts", import.meta.url), "utf8");
 
   assert.match(chromeThemeSource, /applyTopTabsChromeThemeVars\(theme\)/);
+  assert.match(chromeThemeSource, /resolveReadableForegroundForHsl\(cursor\)/);
   const restoreBlock = chromeThemeSource.match(
     /clearTopTabsChromeThemeVars\(\);\s*runThemeTransition\(\(\) => \{\s*removeActiveChromeTheme\(\);/,
   )?.[0] ?? "";
   assert.notEqual(restoreBlock, "", "top tab vars must clear before the vault restore transition starts");
   assert.match(syncSource, /activeTabId === 'vault' \|\| activeTabId === 'sftp'\)[\s\S]*clearTopTabsChromeThemeVars\(\)/);
   assert.match(effectsSource, /if \(!isTerminalLayerVisible\) \{[\s\S]*clearTopTabsPreviewVars\(\)/);
+});
+
+test("top tabs chrome theme keeps accent foreground in sync", () => {
+  const source = readFileSync(new URL("./topTabsChromeTheme.ts", import.meta.url), "utf8");
+  const supportSource = readFileSync(new URL("../../components/terminalLayer/TerminalLayerSupport.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /--primary-foreground/);
+  assert.match(source, /--accent-foreground/);
+  assert.match(source, /resolveReadableForegroundForHsl\(accent\)/);
+  assert.match(supportSource, /removeStylePropertyIfSet\(tabsRoot, '--primary-foreground'\)/);
+  assert.match(supportSource, /removeStylePropertyIfSet\(tabsRoot, '--accent-foreground'\)/);
 });

--- a/application/app/topTabsChromeTheme.ts
+++ b/application/app/topTabsChromeTheme.ts
@@ -1,4 +1,5 @@
 import type { TerminalTheme } from '../../types';
+import { resolveReadableForegroundForHsl } from '../../domain/colorContrast';
 
 function hexToHslToken(hex: string): string {
   const normalized = hex.startsWith('#') ? hex : `#${hex}`;
@@ -61,7 +62,9 @@ const TOP_TABS_THEME_PROPERTIES = [
   '--background',
   '--foreground',
   '--accent',
+  '--accent-foreground',
   '--primary',
+  '--primary-foreground',
   '--secondary',
   '--border',
   '--muted-foreground',
@@ -84,6 +87,7 @@ export function applyTopTabsChromeThemeVars(theme: TerminalTheme): void {
   const bg = hexToHslToken(theme.colors.background);
   const fg = hexToHslToken(theme.colors.foreground);
   const accent = hexToHslToken(theme.colors.cursor);
+  const accentForeground = resolveReadableForegroundForHsl(accent);
   const isDark = theme.type === 'dark';
   const secondary = adjustLightnessToken(bg, isDark ? 6 : -5);
   const border = adjustLightnessToken(bg, isDark ? 12 : -10);
@@ -92,7 +96,9 @@ export function applyTopTabsChromeThemeVars(theme: TerminalTheme): void {
   setStylePropertyIfChanged(tabsRoot, '--background', bg);
   setStylePropertyIfChanged(tabsRoot, '--foreground', fg);
   setStylePropertyIfChanged(tabsRoot, '--accent', accent);
+  setStylePropertyIfChanged(tabsRoot, '--accent-foreground', accentForeground);
   setStylePropertyIfChanged(tabsRoot, '--primary', accent);
+  setStylePropertyIfChanged(tabsRoot, '--primary-foreground', accentForeground);
   setStylePropertyIfChanged(tabsRoot, '--secondary', secondary);
   setStylePropertyIfChanged(tabsRoot, '--border', border);
   setStylePropertyIfChanged(tabsRoot, '--muted-foreground', mutedFg);

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -6,6 +6,13 @@ import { UI_FONTS } from '../../infrastructure/config/uiFonts';
 import { uiFontStore } from './uiFontStore';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
+import { resolveReadableForegroundForHsl } from '../../domain/colorContrast';
+
+export {
+  getContrastRatio,
+  getHslTokenRelativeLuminance,
+  resolveReadableForegroundForHsl,
+} from '../../domain/colorContrast';
 
 export const DEFAULT_THEME: 'light' | 'dark' | 'system' = 'dark';
 export const DEFAULT_WINDOW_OPACITY = 1;
@@ -97,75 +104,6 @@ export const isValidTheme = (value: unknown): value is 'light' | 'dark' | 'syste
 export const isValidHslToken = (value: string): boolean => {
   // Expect: "<h> <s>% <l>%", e.g. "221.2 83.2% 53.3%"
   return /^\s*\d+(\.\d+)?\s+\d+(\.\d+)?%\s+\d+(\.\d+)?%\s*$/.test(value);
-};
-
-type ParsedHslToken = {
-  hue: number;
-  saturation: number;
-  lightness: number;
-};
-
-const BLACK_HSL = '0 0% 0%';
-const WHITE_HSL = '0 0% 100%';
-
-const parseHslToken = (value: string): ParsedHslToken | null => {
-  const match = /^\s*(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%\s*$/.exec(value);
-  if (!match) return null;
-  const hue = Number(match[1]);
-  const saturation = Number(match[2]);
-  const lightness = Number(match[3]);
-  if (![hue, saturation, lightness].every(Number.isFinite)) return null;
-  return {
-    hue: ((hue % 360) + 360) % 360,
-    saturation: Math.min(100, Math.max(0, saturation)) / 100,
-    lightness: Math.min(100, Math.max(0, lightness)) / 100,
-  };
-};
-
-const hslToRgb = ({ hue, saturation, lightness }: ParsedHslToken): [number, number, number] => {
-  if (saturation === 0) return [lightness, lightness, lightness];
-
-  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
-  const huePrime = hue / 60;
-  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
-  const [red, green, blue] =
-    huePrime < 1 ? [chroma, x, 0] :
-    huePrime < 2 ? [x, chroma, 0] :
-    huePrime < 3 ? [0, chroma, x] :
-    huePrime < 4 ? [0, x, chroma] :
-    huePrime < 5 ? [x, 0, chroma] :
-    [chroma, 0, x];
-  const match = lightness - chroma / 2;
-  return [red + match, green + match, blue + match];
-};
-
-const toLinearSrgb = (channel: number): number => (
-  channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
-);
-
-export const getHslTokenRelativeLuminance = (value: string): number | null => {
-  const parsed = parseHslToken(value);
-  if (!parsed) return null;
-  const [red, green, blue] = hslToRgb(parsed).map(toLinearSrgb);
-  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
-};
-
-export const getContrastRatio = (foregroundLuminance: number, backgroundLuminance: number): number => {
-  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
-  const darker = Math.min(foregroundLuminance, backgroundLuminance);
-  return (lighter + 0.05) / (darker + 0.05);
-};
-
-export const resolveReadableForegroundForHsl = (
-  backgroundHsl: string,
-  fallback: string = WHITE_HSL,
-): string => {
-  const backgroundLuminance = getHslTokenRelativeLuminance(backgroundHsl);
-  if (backgroundLuminance == null) return fallback;
-
-  const blackContrast = getContrastRatio(0, backgroundLuminance);
-  const whiteContrast = getContrastRatio(1, backgroundLuminance);
-  return whiteContrast >= blackContrast ? WHITE_HSL : BLACK_HSL;
 };
 
 export const resolveThemeAccentForeground = (

--- a/application/state/useActiveChromeTheme.test.ts
+++ b/application/state/useActiveChromeTheme.test.ts
@@ -7,6 +7,7 @@ import {
   themeFingerprint,
 } from "./useActiveChromeTheme.ts";
 import { TERMINAL_THEMES } from "../../infrastructure/config/terminalThemes.ts";
+import { readFileSync } from "node:fs";
 
 function createInlineStyle() {
   const values = new Map<string, string>();
@@ -92,4 +93,11 @@ test("syncActiveChromeTheme refreshes top tabs when the active theme fingerprint
       delete globalWithDocument.document;
     }
   }
+});
+
+test("active chrome theme foreground uses contrast calculation", () => {
+  const source = readFileSync(new URL("./useActiveChromeTheme.ts", import.meta.url), "utf8");
+
+  assert.match(source, /resolveReadableForegroundForHsl\(cursor\)/);
+  assert.doesNotMatch(source, /cursorLightness > 55/);
 });

--- a/application/state/useActiveChromeTheme.ts
+++ b/application/state/useActiveChromeTheme.ts
@@ -7,6 +7,7 @@ import {
 import { runThemeTransition } from "./themeTransition";
 import { TERMINAL_THEMES } from "../../infrastructure/config/terminalThemes";
 import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
+import { resolveReadableForegroundForHsl } from "../../domain/colorContrast";
 
 function hexToHsl(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16) / 255;
@@ -79,8 +80,7 @@ function buildChromeCss(theme: TerminalTheme): string {
   const muted = adjustLightness(bg, isDark ? 10 : -8);
   const mutedFg = adjustSaturation(adjustLightness(fg, isDark ? -20 : 20), 0.5);
   const border = adjustLightness(bg, isDark ? 12 : -10);
-  const cursorLightness = parseFloat(cursor.split(" ")[2] ?? "50");
-  const primaryFg = cursorLightness > 55 ? "0 0% 0%" : "0 0% 100%";
+  const primaryFg = resolveReadableForegroundForHsl(cursor);
 
   const values = [
     bg, fg, card, fg,

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -190,7 +190,9 @@ export const clearTopTabsPreviewVars = () => {
   removeStylePropertyIfSet(tabsRoot, '--background');
   removeStylePropertyIfSet(tabsRoot, '--foreground');
   removeStylePropertyIfSet(tabsRoot, '--accent');
+  removeStylePropertyIfSet(tabsRoot, '--accent-foreground');
   removeStylePropertyIfSet(tabsRoot, '--primary');
+  removeStylePropertyIfSet(tabsRoot, '--primary-foreground');
   removeStylePropertyIfSet(tabsRoot, '--secondary');
   removeStylePropertyIfSet(tabsRoot, '--border');
   removeStylePropertyIfSet(tabsRoot, '--muted-foreground');

--- a/domain/colorContrast.ts
+++ b/domain/colorContrast.ts
@@ -1,0 +1,68 @@
+type ParsedHslToken = {
+  hue: number;
+  saturation: number;
+  lightness: number;
+};
+
+const BLACK_HSL = '0 0% 0%';
+const WHITE_HSL = '0 0% 100%';
+
+const parseHslToken = (value: string): ParsedHslToken | null => {
+  const match = /^\s*(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%\s*$/.exec(value);
+  if (!match) return null;
+  const hue = Number(match[1]);
+  const saturation = Number(match[2]);
+  const lightness = Number(match[3]);
+  if (![hue, saturation, lightness].every(Number.isFinite)) return null;
+  return {
+    hue: ((hue % 360) + 360) % 360,
+    saturation: Math.min(100, Math.max(0, saturation)) / 100,
+    lightness: Math.min(100, Math.max(0, lightness)) / 100,
+  };
+};
+
+const hslToRgb = ({ hue, saturation, lightness }: ParsedHslToken): [number, number, number] => {
+  if (saturation === 0) return [lightness, lightness, lightness];
+
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const huePrime = hue / 60;
+  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const [red, green, blue] =
+    huePrime < 1 ? [chroma, x, 0] :
+    huePrime < 2 ? [x, chroma, 0] :
+    huePrime < 3 ? [0, chroma, x] :
+    huePrime < 4 ? [0, x, chroma] :
+    huePrime < 5 ? [x, 0, chroma] :
+    [chroma, 0, x];
+  const match = lightness - chroma / 2;
+  return [red + match, green + match, blue + match];
+};
+
+const toLinearSrgb = (channel: number): number => (
+  channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+);
+
+export const getHslTokenRelativeLuminance = (value: string): number | null => {
+  const parsed = parseHslToken(value);
+  if (!parsed) return null;
+  const [red, green, blue] = hslToRgb(parsed).map(toLinearSrgb);
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+};
+
+export const getContrastRatio = (foregroundLuminance: number, backgroundLuminance: number): number => {
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+export const resolveReadableForegroundForHsl = (
+  backgroundHsl: string,
+  fallback: string = WHITE_HSL,
+): string => {
+  const backgroundLuminance = getHslTokenRelativeLuminance(backgroundHsl);
+  if (backgroundLuminance == null) return fallback;
+
+  const blackContrast = getContrastRatio(0, backgroundLuminance);
+  const whiteContrast = getContrastRatio(1, backgroundLuminance);
+  return whiteContrast >= blackContrast ? WHITE_HSL : BLACK_HSL;
+};


### PR DESCRIPTION
## What changed

- Share the accent foreground contrast helper across app theme and active terminal theme paths.
- Use the same black/white contrast choice for active chrome theme tooltip foreground colors.
- Keep top tab accent foreground variables in sync when terminal theme previews override accent colors.

## Why

Some side bar tooltips in light mode used terminal-theme accent colors without updating the matching foreground color, leaving dark text on dark purple backgrounds.

## Validation

- `node --test --import tsx application/state/settingsStateDefaults.test.ts application/state/useActiveChromeTheme.test.ts application/app/topTabsChromeTheme.test.ts components/terminalLayer/useTerminalLayerEffects.test.ts`
- `npx eslint domain/colorContrast.ts application/state/settingsStateDefaults.ts application/state/settingsStateDefaults.test.ts application/state/useActiveChromeTheme.ts application/state/useActiveChromeTheme.test.ts application/app/topTabsChromeTheme.ts application/app/topTabsChromeTheme.test.ts components/terminalLayer/TerminalLayerSupport.tsx components/terminalLayer/useTerminalLayerEffects.test.ts`
- `npm run build`