### PR TITLE
[codex] Polish notes and terminal UI

### DIFF
--- a/application/state/terminalSidePanelTabs.ts
+++ b/application/state/terminalSidePanelTabs.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from 'react';
+
+import { STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_ORDER } from '../../infrastructure/config/storageKeys';
+import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
+
+export type TerminalSidePanelTabId = 'sftp' | 'scripts' | 'history' | 'theme' | 'system' | 'notes' | 'ai';
+
+export const TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER: TerminalSidePanelTabId[] = [
+  'sftp',
+  'scripts',
+  'history',
+  'theme',
+  'system',
+  'notes',
+  'ai',
+];
+
+export const TERMINAL_SIDE_PANEL_TAB_IDS = new Set<TerminalSidePanelTabId>(TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER);
+
+export function normalizeTerminalSidePanelTabOrder(value: unknown): TerminalSidePanelTabId[] {
+  if (!Array.isArray(value) || value.length !== TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER.length) {
+    return [...TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER];
+  }
+
+  const seen = new Set<TerminalSidePanelTabId>();
+  const normalized: TerminalSidePanelTabId[] = [];
+  for (const candidate of value) {
+    if (typeof candidate !== 'string') return [...TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER];
+    if (!TERMINAL_SIDE_PANEL_TAB_IDS.has(candidate as TerminalSidePanelTabId)) {
+      return [...TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER];
+    }
+    const tab = candidate as TerminalSidePanelTabId;
+    if (seen.has(tab)) return [...TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER];
+    seen.add(tab);
+    normalized.push(tab);
+  }
+
+  return normalized;
+}
+
+export function reorderTerminalSidePanelTab(
+  order: TerminalSidePanelTabId[],
+  draggedTab: TerminalSidePanelTabId,
+  targetTab: TerminalSidePanelTabId,
+  placement: 'before' | 'after' = 'before',
+): TerminalSidePanelTabId[] {
+  if (draggedTab === targetTab) return order;
+  if (!order.includes(draggedTab) || !order.includes(targetTab)) return order;
+
+  const withoutDragged = order.filter((tab) => tab !== draggedTab);
+  const targetIndex = withoutDragged.indexOf(targetTab);
+  if (targetIndex === -1) return order;
+  const insertionIndex = placement === 'after' ? targetIndex + 1 : targetIndex;
+  return [
+    ...withoutDragged.slice(0, insertionIndex),
+    draggedTab,
+    ...withoutDragged.slice(insertionIndex),
+  ];
+}
+
+function readTerminalSidePanelTabOrder(): TerminalSidePanelTabId[] {
+  try {
+    return normalizeTerminalSidePanelTabOrder(
+      localStorageAdapter.read<TerminalSidePanelTabId[]>(STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_ORDER),
+    );
+  } catch {
+    return [...TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER];
+  }
+}
+
+function persistTerminalSidePanelTabOrder(order: TerminalSidePanelTabId[]): void {
+  try {
+    localStorageAdapter.write(STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_ORDER, order);
+  } catch {
+    // Best effort only; the toolbar still works with the in-memory order.
+  }
+}
+
+export function useTerminalSidePanelTabOrder(): {
+  sidePanelTabOrder: TerminalSidePanelTabId[];
+  setSidePanelTabOrder: (order: TerminalSidePanelTabId[]) => void;
+} {
+  const [sidePanelTabOrder, setSidePanelTabOrderRaw] = useState<TerminalSidePanelTabId[]>(
+    readTerminalSidePanelTabOrder,
+  );
+
+  const setSidePanelTabOrder = useCallback((order: TerminalSidePanelTabId[]) => {
+    setSidePanelTabOrderRaw(order);
+    persistTerminalSidePanelTabOrder(order);
+  }, []);
+
+  return { sidePanelTabOrder, setSidePanelTabOrder };
+}

--- a/components/DistroAvatar.test.tsx
+++ b/components/DistroAvatar.test.tsx
@@ -35,6 +35,19 @@ test("DistroAvatar keeps serial hosts on the USB icon", () => {
   assert.doesNotMatch(markup, /background-color:#2563EB/i);
 });
 
+test("DistroAvatar tree size uses compact host icon corners", () => {
+  const markup = renderToStaticMarkup(
+    <DistroAvatar
+      host={{ ...baseHost, distro: "ubuntu" }}
+      fallback="U"
+      size="tree"
+    />,
+  );
+
+  assert.match(markup, /h-6 w-6 rounded/);
+  assert.doesNotMatch(markup, /rounded-md/);
+});
+
 test("DistroAvatar keeps distro icon and applies custom palette color when icon mode is automatic", () => {
   const markup = renderToStaticMarkup(
     <DistroAvatar

--- a/components/DistroAvatar.tsx
+++ b/components/DistroAvatar.tsx
@@ -96,7 +96,7 @@ const DistroAvatarInner: React.FC<DistroAvatarProps> = ({
     xs: "h-4 w-4 rounded",
     sm: "h-5 w-5 rounded",
     md: "h-8 w-8 rounded",
-    tree: "h-6 w-6 rounded-md",
+    tree: "h-6 w-6 rounded",
     log: "h-9 w-9 rounded-xl",
     lg: "h-11 w-11 rounded-xl",
   };

--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -12,6 +12,7 @@ import {
   getNoteGroupSelectionState,
   getNotesGroupDropAction,
   getNoteSelectionState,
+  getValidatedNoteSelectionState,
   getSelectedVaultNote,
   isNoteFolderTreeSelected,
   NotesManager,
@@ -65,6 +66,13 @@ test("NotesManager marks selected notebook rows with shared tree state", () => {
   assert.equal(markup.match(/data-selected="true"/g)?.length, 1);
   assert.match(markup, /data-vault-tree-row="group"[^>]*data-selected="false"/);
   assert.match(markup, /data-vault-tree-row="item"[^>]*data-selected="true"/);
+});
+
+test("NotesManager balances folder and note tree icon sizes", () => {
+  const markup = renderNotes();
+
+  assert.match(markup, /width="16" height="16"[^>]*class="lucide lucide-folder/);
+  assert.match(markup, /width="16" height="16"[^>]*class="lucide lucide-file-text/);
 });
 
 test("NotesManager selection helpers keep note and folder selection exclusive", () => {
@@ -125,6 +133,20 @@ test("NotesManager note creation, duplicate, and delete fallback selections stay
   });
 });
 
+test("NotesManager selects the first loaded note when full mode has no selection", () => {
+  const notes = [
+    note({ id: "note-2", title: "Loaded note", group: "Ops", order: 2000 }),
+  ];
+
+  assert.deepEqual(getValidatedNoteSelectionState(notes, null, null, false), {
+    selectedNoteId: "note-2",
+    selectedGroup: null,
+    overlayNoteId: null,
+  });
+  assert.equal(getValidatedNoteSelectionState(notes, null, "Ops", false), null);
+  assert.equal(getValidatedNoteSelectionState(notes, null, null, true), null);
+});
+
 test("NotesManager group drop helper separates reorder, inside, and ignored drops", () => {
   assert.equal(getNotesGroupDropAction("Ops", "Deploy", "before"), "reorder");
   assert.equal(getNotesGroupDropAction("Ops", "Deploy", "after"), "reorder");
@@ -180,6 +202,7 @@ test("NotesManager renders empty state", () => {
 
   assert.match(markup, /No notes yet/);
   assert.match(markup, /New Note/);
+  assert.doesNotMatch(markup, /data-notes-drop-zone="root"/);
 });
 
 test("NotesManager sidebar mode renders list without editor by default", () => {

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -263,6 +263,19 @@ export const getFallbackNoteSelectionState = (
   overlayNoteId: null,
 });
 
+export const getValidatedNoteSelectionState = (
+  notes: VaultNote[],
+  selectedNoteId: string | null,
+  selectedGroup: string | null,
+  isSidebarMode: boolean,
+): { selectedNoteId: string | null; selectedGroup: null; overlayNoteId: null } | null => {
+  if (selectedNoteId && notes.some((note) => note.id === selectedNoteId)) return null;
+  if (selectedNoteId || (!isSidebarMode && !selectedGroup && notes.length > 0)) {
+    return getFallbackNoteSelectionState(notes, isSidebarMode);
+  }
+  return null;
+};
+
 export const getNotesGroupDropAction = (
   sourceGroup: string | null,
   targetGroup: string,
@@ -334,12 +347,12 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     !queryLower || node.name.toLowerCase().includes(queryLower) || node.path.toLowerCase().includes(queryLower);
 
   useEffect(() => {
-    if (!selectedNoteId || sortedNotes.some((note) => note.id === selectedNoteId)) return;
-    const nextSelection = getFallbackNoteSelectionState(sortedNotes, isSidebarMode);
+    const nextSelection = getValidatedNoteSelectionState(sortedNotes, selectedNoteId, selectedGroup, isSidebarMode);
+    if (!nextSelection) return;
     setSelectedNoteId(nextSelection.selectedNoteId);
     setSelectedGroup(nextSelection.selectedGroup);
     setOverlayNoteId(nextSelection.overlayNoteId);
-  }, [isSidebarMode, selectedNoteId, sortedNotes]);
+  }, [isSidebarMode, selectedGroup, selectedNoteId, sortedNotes]);
 
   useEffect(() => {
     if (!overlayNoteId || sortedNotes.some((note) => note.id === overlayNoteId)) return;
@@ -751,7 +764,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
       >
         <div className="mr-1 h-5 w-4 shrink-0" />
         <div className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center text-current">
-          <Folder size={18} strokeWidth={1.9} />
+          <Folder size={16} strokeWidth={1.9} />
         </div>
         <VaultTreeInlineRenameInput
           initialName={t("notes.action.newGroup")}
@@ -780,7 +793,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               saveNote({ ...note, title, updatedAt: Date.now() });
             }}
             onRenameCancel={() => setEditingNoteId(null)}
-            icon={<FileText size={14} className="mr-2 shrink-0 text-muted-foreground" />}
+            icon={<FileText size={16} className="mr-2 shrink-0 text-muted-foreground" />}
             data-note-id={note.id}
             data-notes-drag-kind="note"
             data-notes-context-menu="note"
@@ -856,6 +869,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               expanded={expanded}
               selected={isNoteFolderTreeSelected(selectedGroup, selectedNoteId, node.path)}
               hasChildren={hasChildren}
+              iconSize={16}
               editing={editingGroupPath === node.path}
               editingInitialName={node.name}
               onRenameCommit={(name) => renameGroup(node.path, name)}
@@ -950,6 +964,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
   const treeIsEmpty = visibleRootNotes.length === 0 && visibleTree.length === 0;
   const hasSearch = query.trim().length > 0;
   const canExpandCollapse = allGroupPaths.length > 0 && !hasSearch;
+  const shouldShowNotesTree = isSidebarMode || sortedNotes.length > 0;
 
   const handleTreeResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -991,13 +1006,14 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
       <div className="flex min-h-0 flex-1">
-        <aside
-          className={cn(
-            "relative flex flex-col bg-background",
-            isSidebarMode ? "min-w-0 flex-1" : "shrink-0 border-r border-border/60",
-          )}
-          style={isSidebarMode ? undefined : { width: treeWidth }}
-        >
+        {shouldShowNotesTree && (
+          <aside
+            className={cn(
+              "relative flex flex-col bg-background",
+              isSidebarMode ? "min-w-0 flex-1" : "shrink-0 border-r border-border/60",
+            )}
+            style={isSidebarMode ? undefined : { width: treeWidth }}
+          >
           <div className="flex-shrink-0">
             <div className="flex h-9 shrink-0 items-center gap-1 border-b border-border/60 px-1.5 py-1">
               <Tooltip>
@@ -1150,7 +1166,8 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               onPointerDown={handleTreeResizeStart}
             />
           )}
-        </aside>
+          </aside>
+        )}
 
         {!isSidebarMode && (
         <main className="flex min-w-0 flex-1 flex-col bg-background">

--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -56,6 +56,19 @@ test("keeps SFTP visible before the terminal overflow menu for SSH sessions", ()
   assert.ok(sftpIndex < moreIndex);
 });
 
+test("keeps Scripts visible before the terminal overflow menu", () => {
+  const markup = renderToolbar(sshHost);
+
+  const scriptsIndex = markup.indexOf('aria-label="Scripts"');
+  const moreIndex = markup.indexOf('aria-label="More actions"');
+
+  assert.notEqual(scriptsIndex, -1);
+  assert.notEqual(moreIndex, -1);
+  assert.ok(scriptsIndex < moreIndex);
+  assert.equal(markup.match(/Scripts/g)?.length, 1);
+  assert.match(markup, /type="button"[^>]*aria-label="Scripts"/);
+});
+
 test("hides SFTP for local terminal sessions", () => {
   const markup = renderToolbar({
     ...sshHost,

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -242,6 +242,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             <Tooltip>
                 <TooltipTrigger asChild>
                     <Button
+                        type="button"
                         variant="secondary"
                         size="icon"
                         className={buttonBase}
@@ -259,6 +260,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
             <Tooltip>
                 <TooltipTrigger asChild>
                     <Button
+                        type="button"
                         variant="secondary"
                         size="icon"
                         className={buttonBase}
@@ -273,10 +275,26 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                 <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
             </Tooltip>
 
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        className={buttonBase}
+                        aria-label={t("terminal.toolbar.scripts")}
+                        onClick={onOpenScripts}
+                    >
+                        <Zap size={12} />
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("terminal.toolbar.scripts")}</TooltipContent>
+            </Tooltip>
+
             {/* Overflow menu — keeps lower-frequency opener-style actions
-                (Encoding / Scripts / Terminal Settings) behind a single
+                (Encoding / Terminal Settings) behind a single
                 trigger so the toolbar doesn't feel crowded.
-                Highlight / Compose / Search stay visible because they
+                Highlight / Compose / Search / Scripts stay visible because they
                 are toggled mid-session, not just once. */}
             <Popover
                 open={overflowOpen}
@@ -313,12 +331,6 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                         }
                     }}
                 >
-                    <PopoverClose asChild>
-                        <button type="button" className={menuItemClass} onClick={onOpenScripts}>
-                            <Zap size={12} className="shrink-0" />
-                            <span className="flex-1 text-left truncate">{t("terminal.toolbar.scripts")}</span>
-                        </button>
-                    </PopoverClose>
                     {historySupported && (
                         <PopoverClose asChild>
                             <button

--- a/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import {
+  normalizeTerminalSidePanelTabOrder,
+  reorderTerminalSidePanelTab,
+  TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER,
+} from '../../application/state/terminalSidePanelTabs.ts';
 import { getTerminalSidePanelShellWidth } from './TerminalLayerSidePanelSection.tsx';
 
 test('AI side panel shell can be force-hidden for layout isolation', () => {
@@ -41,4 +46,38 @@ test('closed side panel shell has no width', () => {
     resizePreviewWidth: null,
     sidePanelWidth: 420,
   }), 0);
+});
+
+test('side panel tab order falls back to the default order', () => {
+  assert.deepEqual(normalizeTerminalSidePanelTabOrder(null), TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER);
+  assert.deepEqual(normalizeTerminalSidePanelTabOrder(['scripts', 'bad-tab']), TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER);
+});
+
+test('side panel tab order accepts a stored permutation', () => {
+  const stored = ['scripts', 'sftp', 'history', 'theme', 'system', 'notes', 'ai'];
+
+  assert.deepEqual(normalizeTerminalSidePanelTabOrder(stored), stored);
+});
+
+test('side panel tab order moves the dragged tab before the target tab', () => {
+  assert.deepEqual(
+    reorderTerminalSidePanelTab(
+      TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER,
+      'notes',
+      'scripts',
+    ),
+    ['sftp', 'notes', 'scripts', 'history', 'theme', 'system', 'ai'],
+  );
+});
+
+test('side panel tab order can move the dragged tab after the target tab', () => {
+  assert.deepEqual(
+    reorderTerminalSidePanelTab(
+      TERMINAL_SIDE_PANEL_TAB_DEFAULT_ORDER,
+      'scripts',
+      'ai',
+      'after',
+    ),
+    ['sftp', 'history', 'theme', 'system', 'notes', 'ai', 'scripts'],
+  );
 });

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Activity, FolderTree, History, MessageSquare, NotebookText, Palette, PanelLeft, PanelRight, X, Zap } from 'lucide-react';
 import { SystemManagerSidePanel } from '../systemManager/SystemManagerSidePanel';
-import React, { memo, useCallback, useState } from 'react';
+import React, { memo, useCallback, useRef, useState } from 'react';
 
 import { useActiveTabId } from '../../application/state/activeTabStore';
+import {
+  reorderTerminalSidePanelTab,
+  TERMINAL_SIDE_PANEL_TAB_IDS,
+  type TerminalSidePanelTabId,
+  useTerminalSidePanelTabOrder,
+} from '../../application/state/terminalSidePanelTabs';
 import { terminalLayoutSuppressStore } from '../../application/state/terminalLayoutSuppressStore';
 import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
 
@@ -12,6 +18,7 @@ import type { SidePanelTab } from './TerminalLayerSupport';
 import { terminalLayerSidePanelCtxEqual } from './terminalLayerViewMemo';
 
 type SidePanelContext = Record<string, any>;
+const SIDE_PANEL_TAB_DRAG_MIME = 'application/x-netcatty-sidepanel-tab';
 
 export function getTerminalSidePanelShellWidth({
   activeSidePanelTab,
@@ -178,6 +185,12 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
   } = ctx;
 
   const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
+  const { sidePanelTabOrder, setSidePanelTabOrder } = useTerminalSidePanelTabOrder();
+  const [dragOverSidePanelTab, setDragOverSidePanelTab] = useState<{
+    tab: TerminalSidePanelTabId;
+    placement: 'before' | 'after';
+  } | null>(null);
+  const draggedSidePanelTabRef = useRef<TerminalSidePanelTabId | null>(null);
   const isAiShellForceHidden = AI_PANEL_FORCE_HIDE_SHELL && activeSidePanelTab === 'ai';
   const shouldRenderAiPanels = mountedAiTabIds.length > 0 && !isAiShellForceHidden;
   const shellWidth = getTerminalSidePanelShellWidth({
@@ -227,6 +240,104 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
     sidePanelPosition,
     sidePanelWidth,
   ]);
+
+  const handleSidePanelTabDragStart = useCallback((event: React.DragEvent, tab: TerminalSidePanelTabId) => {
+    draggedSidePanelTabRef.current = tab;
+    setDragOverSidePanelTab(null);
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(SIDE_PANEL_TAB_DRAG_MIME, tab);
+    event.dataTransfer.setData('text/plain', tab);
+  }, []);
+
+  const handleSidePanelTabDrop = useCallback((event: React.DragEvent, targetTab: TerminalSidePanelTabId) => {
+    if (!Array.from(event.dataTransfer.types).includes(SIDE_PANEL_TAB_DRAG_MIME)) return;
+    event.preventDefault();
+    const transferredTab = event.dataTransfer.getData(SIDE_PANEL_TAB_DRAG_MIME) as TerminalSidePanelTabId;
+    const draggedTab = draggedSidePanelTabRef.current ?? transferredTab;
+    draggedSidePanelTabRef.current = null;
+    setDragOverSidePanelTab(null);
+    if (!TERMINAL_SIDE_PANEL_TAB_IDS.has(draggedTab)) return;
+
+    const nextOrder = reorderTerminalSidePanelTab(
+      sidePanelTabOrder,
+      draggedTab,
+      targetTab,
+      dragOverSidePanelTab?.tab === targetTab ? dragOverSidePanelTab.placement : 'before',
+    );
+    if (nextOrder !== sidePanelTabOrder) {
+      setSidePanelTabOrder(nextOrder);
+    }
+  }, [dragOverSidePanelTab, setSidePanelTabOrder, sidePanelTabOrder]);
+
+  const handleSidePanelTabDragOver = useCallback((event: React.DragEvent, targetTab: TerminalSidePanelTabId) => {
+    if (!Array.from(event.dataTransfer.types).includes(SIDE_PANEL_TAB_DRAG_MIME)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    const rect = event.currentTarget.getBoundingClientRect();
+    const placement = event.clientX > rect.left + (rect.width / 2) ? 'after' : 'before';
+    setDragOverSidePanelTab((current) => {
+      if (current?.tab === targetTab && current.placement === placement) return current;
+      return { tab: targetTab, placement };
+    });
+  }, []);
+
+  const handleSidePanelTabDragLeave = useCallback((event: React.DragEvent, targetTab: TerminalSidePanelTabId) => {
+    if (dragOverSidePanelTab?.tab !== targetTab) return;
+    const nextTarget = event.relatedTarget as Node | null;
+    if (nextTarget && event.currentTarget.contains(nextTarget)) return;
+    setDragOverSidePanelTab(null);
+  }, [dragOverSidePanelTab]);
+
+  const sidePanelTabItems: Array<{
+    id: TerminalSidePanelTabId;
+    label: string;
+    icon: React.ReactNode;
+    onClick: () => void;
+  }> = [
+    {
+      id: 'sftp',
+      label: t('terminal.layer.sftp'),
+      icon: <FolderTree size={15} />,
+      onClick: handleToggleSftpFromBar,
+    },
+    {
+      id: 'scripts',
+      label: t('terminal.layer.scripts'),
+      icon: <Zap size={15} />,
+      onClick: handleOpenScripts,
+    },
+    {
+      id: 'history',
+      label: t('terminal.layer.history'),
+      icon: <History size={15} />,
+      onClick: handleOpenHistory,
+    },
+    {
+      id: 'theme',
+      label: t('terminal.layer.theme'),
+      icon: <Palette size={15} />,
+      onClick: handleOpenTheme,
+    },
+    {
+      id: 'system',
+      label: t('terminal.layer.system'),
+      icon: <Activity size={15} />,
+      onClick: handleOpenSystem,
+    },
+    {
+      id: 'notes',
+      label: t('terminal.layer.notes'),
+      icon: <NotebookText size={15} />,
+      onClick: handleOpenNotes,
+    },
+    {
+      id: 'ai',
+      label: t('terminal.layer.aiChat'),
+      icon: <MessageSquare size={15} />,
+      onClick: handleOpenAI,
+    },
+  ];
+  const sidePanelTabItemById = new Map(sidePanelTabItems.map((item) => [item.id, item]));
 
   return (
     <>
@@ -279,174 +390,59 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                 borderBottom: '1px solid var(--terminal-sidepanel-border)',
               }}
             >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="sftp"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'sftp' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'sftp'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'sftp'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleToggleSftpFromBar}
-                  >
-                    <FolderTree size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.sftp')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="scripts"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'scripts' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'scripts'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'scripts'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenScripts}
-                  >
-                    <Zap size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.scripts')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="history"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'history' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'history'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'history'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenHistory}
-                  >
-                    <History size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.history')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="theme"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'theme' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'theme'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'theme'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenTheme}
-                  >
-                    <Palette size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.theme')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="system"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'system' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'system'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'system'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenSystem}
-                  >
-                    <Activity size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.system')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="notes"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'notes' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'notes'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'notes'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenNotes}
-                  >
-                    <NotebookText size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.notes')}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    data-tab-id="ai"
-                    data-tab-type="sidepanel"
-                    data-state={activeSidePanelTab === 'ai' ? 'active' : 'inactive'}
-                    className="netcatty-tab h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      backgroundColor: activeSidePanelTab === 'ai'
-                        ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
-                        : 'transparent',
-                      color: activeSidePanelTab === 'ai'
-                        ? 'var(--terminal-sidepanel-fg)'
-                        : 'var(--terminal-sidepanel-muted)',
-                    }}
-                    onClick={handleOpenAI}
-                  >
-                    <MessageSquare size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.aiChat')}</TooltipContent>
-              </Tooltip>
+              {sidePanelTabOrder.map((tabId) => {
+                const item = sidePanelTabItemById.get(tabId);
+                if (!item) return null;
+                const isActive = activeSidePanelTab === item.id;
+                const showDropIndicator = dragOverSidePanelTab?.tab === item.id
+                  && draggedSidePanelTabRef.current !== null
+                  && draggedSidePanelTabRef.current !== item.id;
+                return (
+                  <Tooltip key={item.id}>
+                    <TooltipTrigger asChild>
+                      <Btn
+                        variant="ghost"
+                        size="icon"
+                        draggable
+                        data-tab-id={item.id}
+                        data-tab-type="sidepanel"
+                        data-state={isActive ? 'active' : 'inactive'}
+                        className="netcatty-tab relative h-7 w-7 rounded-md p-0 hover:bg-transparent"
+                        style={{
+                          backgroundColor: isActive
+                            ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
+                            : 'transparent',
+                          color: isActive
+                            ? 'var(--terminal-sidepanel-fg)'
+                            : 'var(--terminal-sidepanel-muted)',
+                        }}
+                        onClick={item.onClick}
+                        onDragStart={(event: React.DragEvent) => handleSidePanelTabDragStart(event, item.id)}
+                        onDragOver={(event: React.DragEvent) => handleSidePanelTabDragOver(event, item.id)}
+                        onDragLeave={(event: React.DragEvent) => handleSidePanelTabDragLeave(event, item.id)}
+                        onDrop={(event: React.DragEvent) => handleSidePanelTabDrop(event, item.id)}
+                        onDragEnd={() => {
+                          draggedSidePanelTabRef.current = null;
+                          setDragOverSidePanelTab(null);
+                        }}
+                      >
+                        {showDropIndicator && (
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              'pointer-events-none absolute top-1 bottom-1 w-0.5 rounded-none',
+                              dragOverSidePanelTab?.placement === 'after' ? 'right-0' : 'left-0',
+                            )}
+                            style={{ backgroundColor: 'var(--terminal-sidepanel-accent)' }}
+                          />
+                        )}
+                        {item.icon}
+                      </Btn>
+                    </TooltipTrigger>
+                    <TooltipContent>{item.label}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
               <div className="flex-1" />
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/components/vault/VaultTreeRow.tsx
+++ b/components/vault/VaultTreeRow.tsx
@@ -95,6 +95,7 @@ type VaultTreeGroupRowProps = Omit<React.HTMLAttributes<HTMLDivElement>, "childr
   onRenameCancel?: () => void;
   actions?: React.ReactNode;
   icon?: React.ReactNode;
+  iconSize?: number;
   meta?: React.ReactNode;
   rowRef?: React.Ref<HTMLDivElement>;
   onToggle?: () => void;
@@ -113,6 +114,7 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
   onRenameCancel,
   actions,
   icon,
+  iconSize = 18,
   meta,
   rowRef,
   className,
@@ -146,9 +148,9 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
       </div>
       <div className="mr-2 flex h-5 w-5 shrink-0 items-center justify-center text-current transition-colors">
         {icon ?? (expanded ? (
-          <FolderOpen size={18} strokeWidth={1.9} />
+          <FolderOpen size={iconSize} strokeWidth={1.9} />
         ) : (
-          <Folder size={18} strokeWidth={1.9} />
+          <Folder size={iconSize} strokeWidth={1.9} />
         ))}
       </div>
       {editing && onRenameCommit && onRenameCancel ? (

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -182,6 +182,7 @@ export const STORAGE_KEY_GROUP_CONFIGS = 'netcatty_group_configs_v1';
 
 // Side Panel
 export const STORAGE_KEY_SIDE_PANEL_WIDTH = 'netcatty_side_panel_width';
+export const STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_ORDER = 'netcatty_terminal_side_panel_tab_order_v1';
 export const STORAGE_KEY_WORKSPACE_FOCUS_SIDEBAR_WIDTH = 'netcatty_workspace_focus_sidebar_width';
 export const STORAGE_KEY_TERMINAL_HOST_TREE_WIDTH = 'netcatty_terminal_host_tree_width_v1';
 export const STORAGE_KEY_TERMINAL_HOST_TREE_COLLAPSED = 'netcatty_terminal_host_tree_collapsed_v1';


### PR DESCRIPTION
## Summary
- Follow up on the Codex review comment from #1565.
- Ensure Notes selects the first loaded note when the full Notes view mounted before saved notes were available.
- Hide the Notes tree sidebar when there are no notes, leaving the main empty state as the only prompt.
- Balance Notes tree folder and note icons at the same size without changing the host tree default.
- Tighten the host tree avatar corner radius so host icons read less pill-like.
- Let terminal side-panel top buttons be reordered by drag and drop, with a straight before/after drop indicator.
- Move the terminal Scripts button out of the More menu and show it directly in the top-right toolbar.

## Checks
- `node --test --import tsx components/DistroAvatar.test.tsx components/vault/VaultTreeRow.test.tsx components/notes/NotesManager.test.tsx`
- `npx eslint components/DistroAvatar.tsx components/DistroAvatar.test.tsx components/HostTreeView.tsx components/vault/VaultTreeRow.tsx components/notes/NotesManager.tsx components/notes/NotesManager.test.tsx`
- `node --test --import tsx components/terminal/TerminalToolbar.test.ts components/terminalLayer/TerminalLayerSidePanelSection.test.ts`
- `npx eslint application/state/terminalSidePanelTabs.ts components/terminal/TerminalToolbar.tsx components/terminal/TerminalToolbar.test.ts components/terminalLayer/TerminalLayerSidePanelSection.tsx components/terminalLayer/TerminalLayerSidePanelSection.test.ts infrastructure/config/storageKeys.ts`
- `git diff --check`
- `npm test`
- `npm run build`