### PR TITLE
[codex] Fix vault theme flash

### DIFF
--- a/application/app/AppMounts.test.ts
+++ b/application/app/AppMounts.test.ts
@@ -14,6 +14,9 @@ Object.defineProperty(globalThis, 'localStorage', {
 
 const { getLogViewWrapperStyle, shouldRenderTerminalLayerMount } = await import('./AppMounts.tsx');
 const activeTabChromeSource = readFileSync(new URL('./AppActiveTabChrome.tsx', import.meta.url), 'utf8');
+const appViewSource = readFileSync(new URL('./AppView.tsx', import.meta.url), 'utf8');
+const appMountsSource = readFileSync(new URL('./AppMounts.tsx', import.meta.url), 'utf8');
+const globalCssSource = readFileSync(new URL('../../index.css', import.meta.url), 'utf8');
 
 test('visible log view leaves room for the terminal host sidebar', () => {
   assert.deepEqual(getLogViewWrapperStyle(true, 220), {
@@ -35,6 +38,25 @@ test('terminal layer renders only after terminal content is visible or mounted',
   assert.equal(shouldRenderTerminalLayerMount(true, false), true);
   assert.equal(shouldRenderTerminalLayerMount(false, true), true);
   assert.equal(shouldRenderTerminalLayerMount(false, false), false);
+});
+
+test('inactive app surfaces suppress background color transitions', () => {
+  assert.match(appMountsSource, /data-inactive-app-surface=\{isActive \? undefined : "true"\}/);
+  assert.match(appMountsSource, /data-inactive-app-surface=\{isVisible \? undefined : "true"\}/);
+  assert.match(globalCssSource, /\[data-inactive-app-surface\][\s\S]*transition: none !important;/);
+});
+
+test('vault activation suppresses inherited text color transitions', () => {
+  assert.match(appMountsSource, /data-app-surface-transition-suppressed/);
+  assert.match(appMountsSource, /setSuppressActiveTransition\(false\)/);
+  assert.match(globalCssSource, /\[data-app-surface-transition-suppressed\][\s\S]*transition: none !important;/);
+});
+
+test('vault surface carries app theme vars while terminal chrome is active', () => {
+  assert.match(appMountsSource, /appThemeStyle\?: React\.CSSProperties/);
+  assert.match(appMountsSource, /style=\{\{ \.\.\.appThemeStyle, \.\.\.containerStyle \}\}/);
+  assert.match(appViewSource, /buildAppThemeCssVars\(tokens, accentMode, customAccent\)/);
+  assert.match(appViewSource, /<VaultViewContainer appThemeStyle=\{appThemeStyle\}>/);
 });
 
 test('active tab chrome keeps removed theme side effects unmounted', () => {

--- a/application/app/AppMounts.tsx
+++ b/application/app/AppMounts.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useActiveTabId, useIsSftpActive, useIsVaultActive } from '../state/activeTabStore';
 import { useTerminalHostTreeLayoutWidth } from '../state/terminalHostTreeStore';
 import { isTerminalContentTabSurface } from './workTabSurface';
@@ -9,14 +9,47 @@ import type { SftpView as SftpViewComponent } from '../../components/SftpView';
 import type { TerminalLayer as TerminalLayerComponent } from '../../components/TerminalLayer';
 
 // Visibility container for VaultView - isolates isActive subscription
-export const VaultViewContainer: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const VaultViewContainer: React.FC<{
+  children: React.ReactNode;
+  appThemeStyle?: React.CSSProperties;
+}> = ({ children, appThemeStyle }) => {
   const isActive = useIsVaultActive();
+  const wasActiveRef = useRef(isActive);
+  const [suppressActiveTransition, setSuppressActiveTransition] = useState(false);
+  const isActivating = isActive && !wasActiveRef.current;
+  const shouldSuppressTransition = isActivating || suppressActiveTransition;
   const containerStyle: React.CSSProperties = isActive
     ? {}
     : { visibility: 'hidden', pointerEvents: 'none', position: 'absolute', zIndex: -1 };
 
+  useLayoutEffect(() => {
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+    if (!isActive || wasActive) return;
+
+    setSuppressActiveTransition(true);
+    const view = window;
+    let firstFrame = 0;
+    let secondFrame = 0;
+    firstFrame = view.requestAnimationFrame(() => {
+      secondFrame = view.requestAnimationFrame(() => {
+        setSuppressActiveTransition(false);
+      });
+    });
+
+    return () => {
+      view.cancelAnimationFrame(firstFrame);
+      view.cancelAnimationFrame(secondFrame);
+    };
+  }, [isActive]);
+
   return (
-    <div className={cn("absolute inset-0", isActive ? "z-20" : "")} style={containerStyle}>
+    <div
+      className={cn("absolute inset-0", isActive ? "z-20" : "")}
+      data-inactive-app-surface={isActive ? undefined : "true"}
+      data-app-surface-transition-suppressed={shouldSuppressTransition ? "true" : undefined}
+      style={{ ...appThemeStyle, ...containerStyle }}
+    >
       {children}
     </div>
   );
@@ -51,7 +84,11 @@ export const LogViewWrapper: React.FC<LogViewWrapperProps> = ({ logView, default
   const containerStyle = getLogViewWrapperStyle(isVisible, hostTreeLayoutWidth);
 
   return (
-    <div className={cn("absolute inset-0", isVisible ? "z-20" : "")} style={containerStyle}>
+    <div
+      className={cn("absolute inset-0", isVisible ? "z-20" : "")}
+      data-inactive-app-surface={isVisible ? undefined : "true"}
+      style={containerStyle}
+    >
       <Suspense fallback={null}>
         <LazyLogView
           log={logView.log}

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useMemo } from 'react';
 import { AlertTriangle, Download, Trash2 } from 'lucide-react';
 import { activeTabStore, toEditorTabId } from '../state/activeTabStore';
 import { editorTabStore } from '../state/editorTabStore';
@@ -19,6 +19,8 @@ import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import { toast } from '../../components/ui/toast';
 import { AppHostTreeLayer } from './AppHostTreeLayer';
+import { getUiThemeById } from '../../infrastructure/config/uiThemes';
+import { buildAppThemeCssVars } from '../state/settingsStateDefaults';
 
 const LazyProtocolSelectDialog = lazy(() => import('../../components/ProtocolSelectDialog'));
 const LazyQuickSwitcher = lazy(() =>
@@ -54,6 +56,17 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     updateNoteGroups, updateNotes, updateProxyProfiles, updateSnippetPackages, updateSnippets, updateSplitSizes, updateTerminalSetting, workspaceRenameTarget, workspaceRenameValue, workspaces,
     VaultViewContainer, SftpViewMount, TerminalLayerMount, LogViewWrapper,
   } = ctx;
+
+  const appThemeStyle = useMemo(() => {
+    const tokens = getUiThemeById(
+      resolvedTheme,
+      resolvedTheme === 'dark' ? settings.darkUiThemeId : settings.lightUiThemeId,
+    ).tokens;
+    return {
+      ...buildAppThemeCssVars(tokens, accentMode, customAccent),
+      colorScheme: resolvedTheme,
+    } as React.CSSProperties;
+  }, [accentMode, customAccent, resolvedTheme, settings.darkUiThemeId, settings.lightUiThemeId]);
 
   return (
     <SnippetExecutionProvider>
@@ -163,7 +176,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
           onCreateLocalTerminal={handleCreateLocalTerminal}
         />
 
-        <VaultViewContainer>
+        <VaultViewContainer appThemeStyle={appThemeStyle}>
           <VaultView
             hosts={hosts}
             keys={keys}

--- a/application/state/settingsStateDefaults.test.ts
+++ b/application/state/settingsStateDefaults.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   getContrastRatio,
+  buildAppThemeCssVars,
   getHslTokenRelativeLuminance,
   resolveReadableForegroundForHsl,
   resolveThemeAccentForeground,
@@ -52,4 +53,50 @@ test("theme accent foreground uses the computed color for preset accent buttons"
 
   assert.equal(resolveThemeAccentForeground(tokens, "theme", "48 95% 72%"), "0 0% 100%");
   assert.equal(resolveThemeAccentForeground(tokens, "custom", "48 95% 72%"), "0 0% 0%");
+});
+
+test("app surface theme vars isolate non-terminal pages from active terminal chrome", () => {
+  const tokens: UiThemeTokens = {
+    background: "0 0% 100%",
+    foreground: "222 47% 12%",
+    card: "0 0% 100%",
+    cardForeground: "222 47% 12%",
+    popover: "0 0% 100%",
+    popoverForeground: "222 47% 12%",
+    primary: "270 70% 45%",
+    primaryForeground: "0 0% 0%",
+    secondary: "220 12% 95%",
+    secondaryForeground: "222 47% 12%",
+    muted: "220 12% 95%",
+    mutedForeground: "220 10% 45%",
+    accent: "270 70% 45%",
+    accentForeground: "0 0% 0%",
+    destructive: "0 70% 50%",
+    destructiveForeground: "0 0% 100%",
+    border: "220 12% 88%",
+    input: "220 12% 88%",
+    ring: "270 70% 45%",
+  };
+
+  assert.deepEqual(buildAppThemeCssVars(tokens, "theme", "48 95% 72%"), {
+    "--background": "0 0% 100%",
+    "--foreground": "222 47% 12%",
+    "--card": "0 0% 100%",
+    "--card-foreground": "222 47% 12%",
+    "--popover": "0 0% 100%",
+    "--popover-foreground": "222 47% 12%",
+    "--primary": "270 70% 45%",
+    "--primary-foreground": "0 0% 100%",
+    "--secondary": "220 12% 95%",
+    "--secondary-foreground": "222 47% 12%",
+    "--muted": "220 12% 95%",
+    "--muted-foreground": "220 10% 45%",
+    "--accent": "270 70% 45%",
+    "--accent-foreground": "0 0% 100%",
+    "--destructive": "0 70% 50%",
+    "--destructive-foreground": "0 0% 100%",
+    "--border": "220 12% 88%",
+    "--input": "220 12% 88%",
+    "--ring": "270 70% 45%",
+  });
 });

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -115,6 +115,37 @@ export const resolveThemeAccentForeground = (
   return resolveReadableForegroundForHsl(accentToken, tokens.primaryForeground);
 };
 
+export const buildAppThemeCssVars = (
+  tokens: UiThemeTokens,
+  accentMode: 'theme' | 'custom',
+  accentOverride: string,
+): Record<string, string> => {
+  const accentToken = accentMode === 'custom' ? accentOverride : tokens.accent;
+  const computedAccentForeground = resolveThemeAccentForeground(tokens, accentMode, accentOverride);
+
+  return {
+    '--background': tokens.background,
+    '--foreground': tokens.foreground,
+    '--card': tokens.card,
+    '--card-foreground': tokens.cardForeground,
+    '--popover': tokens.popover,
+    '--popover-foreground': tokens.popoverForeground,
+    '--primary': accentToken,
+    '--primary-foreground': computedAccentForeground,
+    '--secondary': tokens.secondary,
+    '--secondary-foreground': tokens.secondaryForeground,
+    '--muted': tokens.muted,
+    '--muted-foreground': tokens.mutedForeground,
+    '--accent': accentToken,
+    '--accent-foreground': computedAccentForeground,
+    '--destructive': tokens.destructive,
+    '--destructive-foreground': tokens.destructiveForeground,
+    '--border': tokens.border,
+    '--input': tokens.input,
+    '--ring': accentToken,
+  };
+};
+
 export const isValidUiThemeId = (theme: 'light' | 'dark', value: string): boolean => {
   const list = theme === 'dark' ? DARK_UI_THEMES : LIGHT_UI_THEMES;
   return list.some((preset) => preset.id === value);
@@ -152,28 +183,10 @@ export const applyThemeTokens = (
   const root = window.document.documentElement;
   root.classList.remove('light', 'dark');
   root.classList.add(resolvedTheme);
-  root.style.setProperty('--background', tokens.background);
-  root.style.setProperty('--foreground', tokens.foreground);
-  root.style.setProperty('--card', tokens.card);
-  root.style.setProperty('--card-foreground', tokens.cardForeground);
-  root.style.setProperty('--popover', tokens.popover);
-  root.style.setProperty('--popover-foreground', tokens.popoverForeground);
-  const accentToken = accentMode === 'custom' ? accentOverride : tokens.accent;
-  const computedAccentForeground = resolveThemeAccentForeground(tokens, accentMode, accentOverride);
-
-  root.style.setProperty('--primary', accentToken);
-  root.style.setProperty('--primary-foreground', computedAccentForeground);
-  root.style.setProperty('--secondary', tokens.secondary);
-  root.style.setProperty('--secondary-foreground', tokens.secondaryForeground);
-  root.style.setProperty('--muted', tokens.muted);
-  root.style.setProperty('--muted-foreground', tokens.mutedForeground);
-  root.style.setProperty('--accent', accentToken);
-  root.style.setProperty('--accent-foreground', computedAccentForeground);
-  root.style.setProperty('--destructive', tokens.destructive);
-  root.style.setProperty('--destructive-foreground', tokens.destructiveForeground);
-  root.style.setProperty('--border', tokens.border);
-  root.style.setProperty('--input', tokens.input);
-  root.style.setProperty('--ring', accentToken);
+  const cssVars = buildAppThemeCssVars(tokens, accentMode, accentOverride);
+  for (const [property, value] of Object.entries(cssVars)) {
+    root.style.setProperty(property, value);
+  }
 
   // Sync with native window title bar (Electron)
   netcattyBridge.get()?.setTheme?.(themeSource);

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -81,3 +81,10 @@ test("terminal body keeps a slight inset from the surrounding chrome", () => {
   assert.match(source, /left=\{terminalBodyInset\}/);
   assert.match(source, /bottom=\{terminalBodyInset\}/);
 });
+
+test("terminal theme updates force xterm renderer to repaint immediately", () => {
+  const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+
+  assert.match(source, /term\.options\.theme = \{/);
+  assert.match(source, /forceSyncRenderAfterResize\(term\)/);
+});

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -437,17 +437,19 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   }, [status]);
 
 
-  // Sync xterm theme before browser paint so canvas + DOM CSS vars update in the same frame
+  // Sync xterm theme before browser paint and force the renderer to catch up so
+  // split panes do not visibly repaint one after another.
   useLayoutEffect(() => {
-    if (termRef.current) {
-      termRef.current.options.theme = {
-        ...effectiveTheme.colors,
-        selectionBackground: effectiveTheme.colors.selection,
-        scrollbarSliderBackground: effectiveTheme.colors.foreground + '33',
-        scrollbarSliderHoverBackground: effectiveTheme.colors.foreground + '66',
-        scrollbarSliderActiveBackground: effectiveTheme.colors.foreground + '80',
-      };
-    }
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = {
+      ...effectiveTheme.colors,
+      selectionBackground: effectiveTheme.colors.selection,
+      scrollbarSliderBackground: effectiveTheme.colors.foreground + '33',
+      scrollbarSliderHoverBackground: effectiveTheme.colors.foreground + '66',
+      scrollbarSliderActiveBackground: effectiveTheme.colors.foreground + '80',
+    };
+    forceSyncRenderAfterResize(term);
   }, [effectiveTheme]);
 
 

--- a/components/terminalLayer/useTerminalThemePanelState.test.ts
+++ b/components/terminalLayer/useTerminalThemePanelState.test.ts
@@ -9,6 +9,22 @@ test("follow-app side panel theme changes update the global terminal theme", () 
   assert.match(source, /if \(followAppTerminalTheme\) \{/);
 });
 
+test("follow-app side panel theme changes skip focused-only terminal preview", () => {
+  const followAppBranch = source.match(/if \(followAppTerminalTheme\) \{[\s\S]*?return;[\s\S]*?\n\s+\}/)?.[0] ?? "";
+
+  assert.notEqual(followAppBranch, "", "follow-app theme changes should have an immediate branch");
+  assert.doesNotMatch(followAppBranch, /applyTerminalPreviewVars/);
+  assert.doesNotMatch(followAppBranch, /applyTopTabsPreviewVars/);
+  assert.doesNotMatch(followAppBranch, /applyHostTreePreviewVars/);
+  assert.match(followAppBranch, /clearTerminalPreviewVars\(previewTargetSessionId\)/);
+  assert.match(followAppBranch, /clearHostTreePreviewVars\(\)/);
+  assert.match(followAppBranch, /clearTopTabsPreviewVars\(\)/);
+  assert.match(
+    source,
+    /if \(followAppTerminalTheme\) \{[\s\S]*setThemePreview\(\{ targetSessionId: null, themeId: null \}\);[\s\S]*onUpdateFollowAppTerminalThemeId\?\.\(themeId\);[\s\S]*return;[\s\S]*\}\s+applyTopTabsPreviewVars\(themeId\);[\s\S]*applyHostTreePreviewVars\(themeId\);[\s\S]*applyTerminalPreviewVars\(previewTargetSessionId, themeId\);/,
+  );
+});
+
 test("theme previews update the host tree sidebar in the same pass", () => {
   assert.match(source, /applyHostTreePreviewVars\(themeId\)/);
   assert.match(source, /clearHostTreePreviewVars\(\)/);

--- a/components/terminalLayer/useTerminalThemePanelState.ts
+++ b/components/terminalLayer/useTerminalThemePanelState.ts
@@ -228,19 +228,25 @@ export function useTerminalThemePanelState({
   const handleThemeChangeForFocusedSession = useCallback((themeId: string) => {
       if (themeId === previewedOrVisibleThemeId) return;
       if (!focusedHost && !followAppTerminalTheme) return;
-      applyTerminalPreviewVars(previewTargetSessionId, themeId);
-      applyTopTabsPreviewVars(themeId);
-      applyHostTreePreviewVars(themeId);
-      setThemePreview({ targetSessionId: previewTargetSessionId, themeId });
       if (themeCommitTimerRef.current) {
         clearTimeout(themeCommitTimerRef.current);
+        themeCommitTimerRef.current = null;
       }
+      if (followAppTerminalTheme) {
+        clearTerminalPreviewVars(previewTargetSessionId);
+        clearHostTreePreviewVars();
+        clearTopTabsPreviewVars();
+        setThemePreview({ targetSessionId: null, themeId: null });
+        onUpdateFollowAppTerminalThemeId?.(themeId);
+        return;
+      }
+
+      applyTopTabsPreviewVars(themeId);
+      applyHostTreePreviewVars(themeId);
+      applyTerminalPreviewVars(previewTargetSessionId, themeId);
+      setThemePreview({ targetSessionId: previewTargetSessionId, themeId });
       themeCommitTimerRef.current = setTimeout(() => {
         startTransition(() => {
-          if (followAppTerminalTheme) {
-            onUpdateFollowAppTerminalThemeId?.(themeId);
-            return;
-          }
           if (isFocusedHostEphemeral) {
             onUpdateTerminalThemeId?.(themeId);
             return;

--- a/index.css
+++ b/index.css
@@ -367,6 +367,20 @@ html[data-theme-transition] *::after {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+[data-inactive-app-surface],
+[data-inactive-app-surface] *,
+[data-inactive-app-surface] *::before,
+[data-inactive-app-surface] *::after {
+  transition: none !important;
+}
+
+[data-app-surface-transition-suppressed],
+[data-app-surface-transition-suppressed] *,
+[data-app-surface-transition-suppressed] *::before,
+[data-app-surface-transition-suppressed] *::after {
+  transition: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(root),
   ::view-transition-new(root) {


### PR DESCRIPTION
## Summary
- Prevent Vault from inheriting terminal theme colors while switching tabs.
- Keep follow-mode terminal theme changes synchronized across workspace panes.
- Preserve readable theme button text and add regressions for the flash paths.

## Test Plan
- node --test --import tsx application/app/AppMounts.test.ts application/state/settingsStateDefaults.test.ts application/state/activeChromeThemeSync.test.ts application/state/useActiveChromeTheme.test.ts application/app/topTabsChromeTheme.test.ts components/terminalLayer/useTerminalThemePanelState.test.ts components/terminal/TerminalView.test.tsx
- npx eslint application/app/AppMounts.tsx application/app/AppMounts.test.ts application/app/AppView.tsx application/state/settingsStateDefaults.ts application/state/settingsStateDefaults.test.ts components/terminalLayer/useTerminalThemePanelState.ts components/terminal/useTerminalEffects.ts
- git diff --check
- npm run build