### PR TITLE
[codex] Auto reconnect restored terminal sessions

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -293,7 +293,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   // isScriptsOpen state removed - scripts now handled by side panel
   const [status, setStatus] = useState<TerminalSession["status"]>(() => (
-    getInitialTerminalStatus({ status: "disconnected", restoreState })
+    getInitialTerminalStatus()
   ));
   const [error, setError] = useState<string | null>(null);
   const lastToastedErrorRef = useRef<string | null>(null);
@@ -673,6 +673,38 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     hasConnectedRef.current = next === "connected";
     onStatusChange?.(sessionId, next);
   };
+
+  const prepareRestoredReconnect = useCallback(() => {
+    if (restoreState !== "restored-disconnected") {
+      suppressHostStartupCommandRef.current = false;
+      restoreCwdIntentRef.current = null;
+      return;
+    }
+
+    suppressHostStartupCommandRef.current = true;
+    restoreCwdIntentRef.current = resolveRestoreCwdIntent({
+      enabled: restoreTerminalCwd,
+      session: {
+        status: "disconnected",
+        restoreState,
+        protocol: host.protocol,
+        shellType,
+        lastCwd,
+        moshEnabled: host.moshEnabled,
+        etEnabled: host.etEnabled,
+      },
+      isNetworkDevice,
+    });
+  }, [
+    host.etEnabled,
+    host.moshEnabled,
+    host.protocol,
+    isNetworkDevice,
+    lastCwd,
+    restoreState,
+    restoreTerminalCwd,
+    shellType,
+  ]);
 
   const handleTerminalDataCaptureOnce = useCallback((capturedSessionId: string, data: string) => {
     const captureHandler = onTerminalDataCaptureRef.current;
@@ -1153,22 +1185,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const handleRetry = () => {
     if (!termRef.current) return;
-    suppressHostStartupCommandRef.current = restoreState === "restored-disconnected";
+    prepareRestoredReconnect();
     cleanupSession();
-    const restoreCwdIntent = resolveRestoreCwdIntent({
-      enabled: restoreTerminalCwd,
-      session: {
-        status,
-        restoreState,
-        protocol: host.protocol,
-        shellType,
-        lastCwd,
-        moshEnabled: host.moshEnabled,
-        etEnabled: host.etEnabled,
-      },
-      isNetworkDevice,
-    });
-    restoreCwdIntentRef.current = restoreCwdIntent;
     const term = termRef.current;
     // Claim a fresh retry token. If the user cancels / closes / unmounts /
     // kicks off another retry while the chained writes below are still
@@ -1358,7 +1376,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const effectiveComposeBarOpen = inWorkspace ? !!isWorkspaceComposeBarOpen : isComposeBarOpen;
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return <TerminalView ctx={{ Activity, ArrowDownToLine, ArrowUpFromLine, Button, Clock3, Copy, Cpu, HardDrive, HoverCard, HoverCardContent, HoverCardTrigger, Maximize2, MemoryStick, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onAddSelectionToAI, onBroadcastInput, onCloseSession, onDetach, onDetachDragEnd, onDetachDragStart, onDetachPointerDown, onEndSessionDrag, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onStartSessionDrag, onToggleBroadcast, onUpdateHost: handleUpdateHostFromTerminal, osc52ReadPromptVisible, osc7SetupCommand, osc7SetupOpen, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scrollToBottomAfterProgrammaticInput, searchMatchCount, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, statusDotTone, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />;
 };

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -7,36 +7,44 @@ import {
   shouldStartTerminalBackend,
 } from "./restoredSessionGate.ts";
 
-test("restored disconnected sessions initialize as disconnected", () => {
+test("restored disconnected sessions initialize as connecting", () => {
   assert.equal(
-    getInitialTerminalStatus({ status: "disconnected", restoreState: "restored-disconnected" }),
-    "disconnected",
+    getInitialTerminalStatus(),
+    "connecting",
   );
 });
 
 test("normal sessions initialize as connecting", () => {
-  assert.equal(getInitialTerminalStatus({ status: "connecting" }), "connecting");
-  assert.equal(getInitialTerminalStatus({ status: "disconnected" }), "connecting");
+  assert.equal(getInitialTerminalStatus(), "connecting");
 });
 
-test("restored disconnected sessions do not start terminal backend", () => {
-  assert.equal(
-    shouldStartTerminalBackend({ status: "disconnected", restoreState: "restored-disconnected" }),
-    false,
-  );
-  assert.equal(shouldStartTerminalBackend({ status: "connecting" }), true);
+test("restored disconnected sessions start terminal backend", () => {
+  assert.equal(shouldStartTerminalBackend(), true);
 });
 
-test("restored disconnected sessions still create a terminal runtime before skipping backend startup", () => {
+test("restored disconnected sessions still create a terminal runtime before backend startup", () => {
   const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
   const runtimeIndex = source.indexOf("const runtime = createXTermRuntime");
-  const backendGateIndex = source.indexOf("if (!shouldStartTerminalBackend({ status, restoreState }))");
+  const backendGateIndex = source.indexOf("if (!shouldStartTerminalBackend())");
 
   assert.notEqual(runtimeIndex, -1);
   assert.notEqual(backendGateIndex, -1);
   assert.ok(
     runtimeIndex < backendGateIndex,
-    "restored placeholders need an xterm runtime so manual reconnect has a terminal to reuse",
+    "restored sessions need an xterm runtime before the backend starts",
+  );
+});
+
+test("auto reconnect prepares restored session state before clearing the restore marker", () => {
+  const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+  const prepareIndex = source.indexOf("prepareRestoredReconnect?.()");
+  const updateConnectingIndex = source.indexOf('updateStatus("connecting")', prepareIndex);
+
+  assert.notEqual(prepareIndex, -1);
+  assert.notEqual(updateConnectingIndex, -1);
+  assert.ok(
+    prepareIndex < updateConnectingIndex,
+    "auto reconnect must capture restore details before the restored marker is cleared",
   );
 });
 
@@ -45,22 +53,28 @@ test("manual reconnect captures restore cwd intent before clearing restored stat
   const importIndex = source.indexOf("resolveRestoreCwdIntent");
   const refIndex = source.indexOf("const restoreCwdIntentRef = useRef");
   const contextIndex = source.indexOf("restoreCwdIntentRef,");
-  const captureCallIndex = source.indexOf("const restoreCwdIntent = resolveRestoreCwdIntent");
-  const captureAssignIndex = source.indexOf("restoreCwdIntentRef.current = restoreCwdIntent", captureCallIndex);
-  const bootActiveIndex = source.indexOf("isBootActiveRef.current = true", captureAssignIndex);
+  const prepareDefinitionIndex = source.indexOf("const prepareRestoredReconnect = useCallback");
+  const captureAssignIndex = source.indexOf("restoreCwdIntentRef.current =", prepareDefinitionIndex);
+  const captureCallIndex = source.indexOf("resolveRestoreCwdIntent", captureAssignIndex);
+  const manualRetryIndex = source.indexOf("const handleRetry = () =>");
+  const manualPrepareIndex = source.indexOf("prepareRestoredReconnect();", manualRetryIndex);
+  const bootActiveIndex = source.indexOf("isBootActiveRef.current = true", manualPrepareIndex);
   const connectingIndex = source.indexOf('updateStatus("connecting")');
   const startNewSessionIndex = source.indexOf("const startNewSession = () =>", connectingIndex);
 
   assert.notEqual(importIndex, -1);
   assert.notEqual(refIndex, -1);
   assert.notEqual(contextIndex, -1);
+  assert.notEqual(prepareDefinitionIndex, -1);
   assert.notEqual(captureCallIndex, -1);
   assert.notEqual(captureAssignIndex, -1);
+  assert.notEqual(manualRetryIndex, -1);
+  assert.notEqual(manualPrepareIndex, -1);
   assert.notEqual(bootActiveIndex, -1);
   assert.notEqual(connectingIndex, -1);
   assert.notEqual(startNewSessionIndex, -1);
   assert.ok(
-    captureCallIndex < captureAssignIndex && captureAssignIndex < connectingIndex,
+    captureAssignIndex < captureCallIndex && manualPrepareIndex < connectingIndex,
     "manual retry must capture cwd intent while restoreState is still available",
   );
   assert.ok(

--- a/components/terminal/restoredSessionGate.ts
+++ b/components/terminal/restoredSessionGate.ts
@@ -1,17 +1,7 @@
 import type { TerminalSession } from "../../domain/models";
 
-type RestoredGateSession = Pick<TerminalSession, "status"> & {
-  restoreState?: string;
-};
-
-export const isRestoredDisconnectedTerminal = (session: RestoredGateSession): boolean =>
-  session.status === "disconnected" && session.restoreState === "restored-disconnected";
-
-export const getInitialTerminalStatus = (
-  session: RestoredGateSession,
-): TerminalSession["status"] => (
-  isRestoredDisconnectedTerminal(session) ? "disconnected" : "connecting"
+export const getInitialTerminalStatus = (): TerminalSession["status"] => (
+  "connecting"
 );
 
-export const shouldStartTerminalBackend = (session: RestoredGateSession): boolean =>
-  !isRestoredDisconnectedTerminal(session);
+export const shouldStartTerminalBackend = (): boolean => true;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -50,7 +50,7 @@ export function resolveSelectionOverlayPosition(term: any, container: HTMLElemen
 }
 
 export function useTerminalEffects(ctx: TerminalEffectsContext) {
-  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
+  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
 
   // Remember the last layout we successfully refit while visible so revisiting
   // the same workspace tab does not replay expensive force-fit/WebGL recovery.
@@ -312,34 +312,45 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         runtime.keywordHighlighter.setRules(mergedRules, isEnabled);
 
         const term = runtime.term;
+        const restoredReconnect = restoreState === "restored-disconnected";
+        if (restoredReconnect) {
+          prepareRestoredReconnect?.();
+        }
+        const setBackendConnectingStatus = () => {
+          if (restoredReconnect) {
+            updateStatus("connecting");
+          } else {
+            setStatus("connecting");
+          }
+        };
 
-        if (!shouldStartTerminalBackend({ status, restoreState })) {
+        if (!shouldStartTerminalBackend()) {
           isBootActiveRef.current = false;
           return;
         }
 
         if (host.protocol === "serial") {
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing serial connection..."]);
           await sessionStarters.startSerial(term);
           if (disposed) return;
         } else if (host.protocol === "local" || host.hostname === "localhost") {
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing local shell..."]);
           await sessionStarters.startLocal(term);
           if (disposed) return;
         } else if (host.protocol === "telnet") {
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing Telnet connection..."]);
           await sessionStarters.startTelnet(term);
           if (disposed) return;
         } else if (host.moshEnabled) {
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing Mosh connection..."]);
           await sessionStarters.startMosh(term);
           if (disposed) return;
         } else if (host.etEnabled) {
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing EternalTerminal connection..."]);
           await sessionStarters.startEt(term);
           if (disposed) return;
@@ -360,7 +371,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
             return;
           }
 
-          setStatus("connecting");
+          setBackendConnectingStatus();
           setProgressLogs(["Initializing secure channel..."]);
           await sessionStarters.startSSH(term);
           if (disposed) return;


### PR DESCRIPTION
## Summary
- Automatically reconnect restored terminal sessions instead of leaving them on the manual reconnect prompt.
- Preserve the restored-session safeguards that skip host startup commands and restore the last working directory before clearing the restored marker.
- Update restored-session tests for the new default reconnect behavior.

## Test Plan
- npm run lint
- npm test
- npm run build
- node --test --import tsx components/terminal/restoredSessionGate.test.ts domain/sessionRestore.test.ts application/state/sessionRestoreState.test.ts components/terminalLayer/terminalLayerSessionRouting.test.ts components/terminal/TerminalConnectionDialog.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts

## Review
- Parallel read-only review found no behavior blockers.
- Review feedback about stale no-arg helper call sites was fixed before publishing.
