### PR TITLE
Improve notes markdown editing

### DIFF
--- a/application/state/useStoredString.test.ts
+++ b/application/state/useStoredString.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createStoredStringSyncHandlers,
+  readStoredStringValue,
+  resolveStoredStringUpdate,
+} from "./useStoredString.ts";
+
+type TestMode = "edit" | "preview";
+
+const isTestMode = (value: string | null): value is TestMode =>
+  value === "edit" || value === "preview";
+
+function installLocalStorage() {
+  const previousLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const backing = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return backing.size;
+    },
+    clear() {
+      backing.clear();
+    },
+    getItem(key: string) {
+      return backing.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(backing.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      backing.delete(key);
+    },
+    setItem(key: string, value: string) {
+      backing.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+  });
+
+  return {
+    storage,
+    restore() {
+      if (previousLocalStorage) {
+        Object.defineProperty(globalThis, "localStorage", previousLocalStorage);
+        return;
+      }
+      Reflect.deleteProperty(globalThis, "localStorage");
+    },
+  };
+}
+
+test("stored string sync handlers refresh from same-window and browser storage events", (t) => {
+  const env = installLocalStorage();
+  t.after(() => env.restore());
+
+  const storageKey = "netcatty:test-mode";
+  const syncedValues: TestMode[] = [];
+  const handlers = createStoredStringSyncHandlers<TestMode>({
+    storageKey,
+    fallback: "edit",
+    isAllowedValue: isTestMode,
+    onValue: (value) => syncedValues.push(value),
+  });
+
+  env.storage.setItem(storageKey, "preview");
+  handlers.handleAdapterChange({ detail: { key: storageKey } } as CustomEvent<{ key: string }>);
+  assert.deepEqual(syncedValues, ["preview"]);
+
+  env.storage.setItem(storageKey, "invalid");
+  handlers.handleBrowserStorage({ type: "storage", key: storageKey } as StorageEvent);
+  assert.deepEqual(syncedValues, ["preview", "edit"]);
+
+  env.storage.setItem(storageKey, "preview");
+  handlers.handleAdapterChange({ detail: { key: "other-key" } } as CustomEvent<{ key: string }>);
+  assert.deepEqual(syncedValues, ["preview", "edit"]);
+});
+
+test("stored string helpers read fallback and resolve updater-style toggles", (t) => {
+  const env = installLocalStorage();
+  t.after(() => env.restore());
+
+  const storageKey = "netcatty:test-mode";
+  assert.equal(readStoredStringValue(storageKey, "edit", isTestMode), "edit");
+
+  env.storage.setItem(storageKey, "preview");
+  assert.equal(readStoredStringValue(storageKey, "edit", isTestMode), "preview");
+
+  env.storage.setItem(storageKey, "invalid");
+  assert.equal(readStoredStringValue(storageKey, "edit", isTestMode), "edit");
+
+  assert.equal(resolveStoredStringUpdate<TestMode>("edit", "preview"), "preview");
+  assert.equal(
+    resolveStoredStringUpdate<TestMode>("preview", (currentValue) => (
+      currentValue === "edit" ? "preview" : "edit"
+    )),
+    "edit",
+  );
+});

--- a/application/state/useStoredString.ts
+++ b/application/state/useStoredString.ts
@@ -1,28 +1,105 @@
-import { useEffect, useState } from "react";
-import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
+import { useCallback, useEffect, useState } from "react";
+import {
+  LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+  localStorageAdapter,
+} from "../../infrastructure/persistence/localStorageAdapter";
 
-/**
- * Hook for persisting a string value to localStorage.
- * @param storageKey - The key to use for localStorage
- * @param fallback - The default value if no stored value exists
- * @param validate - Optional function to validate stored value; returns fallback if invalid
- * @returns A tuple of [value, setValue] similar to useState
- */
-export const useStoredString = <T extends string = string>(
-    storageKey: string,
-    fallback: T,
-    validate?: (value: string) => value is T,
+type StoredStringSetter<T extends string> = (nextValue: T | ((currentValue: T) => T)) => void;
+
+const canUseLocalStorage = () => typeof globalThis.localStorage !== "undefined";
+
+export const readStoredStringValue = <T extends string>(
+  storageKey: string,
+  fallback: T,
+  isAllowedValue: (value: string | null) => value is T,
+): T => {
+  if (!canUseLocalStorage()) return fallback;
+  const stored = localStorageAdapter.readString(storageKey);
+  return isAllowedValue(stored) ? stored : fallback;
+};
+
+export const resolveStoredStringUpdate = <T extends string>(
+  currentValue: T,
+  nextValue: T | ((currentValue: T) => T),
+): T => (typeof nextValue === "function" ? nextValue(currentValue) : nextValue);
+
+export const shouldSyncStoredStringEvent = (storageKey: string, event: Event): boolean => {
+  const changedKey = event.type === "storage"
+    ? (event as StorageEvent).key
+    : (event as CustomEvent<{ key?: string }>).detail?.key;
+  return changedKey === storageKey;
+};
+
+export const createStoredStringSyncHandlers = <T extends string>({
+  storageKey,
+  fallback,
+  isAllowedValue,
+  onValue,
+}: {
+  storageKey: string;
+  fallback: T;
+  isAllowedValue: (value: string | null) => value is T;
+  onValue: (value: T) => void;
+}) => {
+  const syncFromStorage = () => {
+    onValue(readStoredStringValue(storageKey, fallback, isAllowedValue));
+  };
+
+  return {
+    handleAdapterChange(event: Event) {
+      if (shouldSyncStoredStringEvent(storageKey, event)) syncFromStorage();
+    },
+    handleBrowserStorage(event: Event) {
+      if (shouldSyncStoredStringEvent(storageKey, event)) syncFromStorage();
+    },
+  };
+};
+
+export const useStoredString = <T extends string>(
+  storageKey: string,
+  fallback: T,
+  isAllowedValue: (value: string | null) => value is T,
 ) => {
-    const [value, setValue] = useState<T>(() => {
-        const stored = localStorageAdapter.readString(storageKey);
-        if (stored === null) return fallback;
-        if (validate) return validate(stored) ? stored : fallback;
-        return stored as T;
+  const [value, setValue] = useState<T>(() => readStoredStringValue(
+    storageKey,
+    fallback,
+    isAllowedValue,
+  ));
+
+  const setAndPersist = useCallback<StoredStringSetter<T>>((nextValue) => {
+    setValue((currentValue) => {
+      const resolvedValue = resolveStoredStringUpdate(currentValue, nextValue);
+      if (canUseLocalStorage()) {
+        localStorageAdapter.writeString(storageKey, resolvedValue);
+      }
+      return resolvedValue;
+    });
+  }, [storageKey]);
+
+  useEffect(() => {
+    const target = globalThis as typeof globalThis & {
+      addEventListener?: (type: string, listener: EventListener) => void;
+      removeEventListener?: (type: string, listener: EventListener) => void;
+    };
+    if (typeof target.addEventListener !== "function") return;
+
+    const {
+      handleAdapterChange,
+      handleBrowserStorage,
+    } = createStoredStringSyncHandlers({
+      storageKey,
+      fallback,
+      isAllowedValue,
+      onValue: setValue,
     });
 
-    useEffect(() => {
-        localStorageAdapter.writeString(storageKey, value);
-    }, [storageKey, value]);
+    target.addEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleAdapterChange);
+    target.addEventListener("storage", handleBrowserStorage);
+    return () => {
+      target.removeEventListener?.(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleAdapterChange);
+      target.removeEventListener?.("storage", handleBrowserStorage);
+    };
+  }, [fallback, isAllowedValue, storageKey]);
 
-    return [value, setValue] as const;
+  return [value, setAndPersist] as const;
 };

--- a/components/notes/InlineMarkdownEditor.test.tsx
+++ b/components/notes/InlineMarkdownEditor.test.tsx
@@ -1,10 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   getHostPickerTriggerRange,
+  isSupportedNoteExternalHref,
   isPointerInsideLinkActionHoverZone,
   resolveHostPickerPopupPosition,
+  shouldInsertClipboardTextAsMarkdown,
   shouldHandleHostPickerNavigationKey,
 } from "./InlineMarkdownEditor.tsx";
 
@@ -79,4 +82,194 @@ test("host picker stays below the caret when there is enough room", () => {
 
   assert.equal(position.left, 120);
   assert.equal(position.top, 150);
+});
+
+test("pasted markdown is detected only when it has renderable structure", () => {
+  assert.equal(shouldInsertClipboardTextAsMarkdown("# Runbook\n\n- restart sshd"), true);
+  assert.equal(shouldInsertClipboardTextAsMarkdown("Open [docs](https://example.com)"), true);
+  assert.equal(shouldInsertClipboardTextAsMarkdown("```sh\nuptime\n```"), true);
+  assert.equal(shouldInsertClipboardTextAsMarkdown("plain text from clipboard"), false);
+  assert.equal(shouldInsertClipboardTextAsMarkdown("https://example.com/path_(x)"), false);
+  assert.equal(shouldInsertClipboardTextAsMarkdown("![logo](https://example.com/logo.png)"), false);
+});
+
+test("note editor registers a code block editor for pasted fenced code", () => {
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /codeBlockPlugin\([^)]*\),\s*codeMirrorPlugin\(\{\s*codeBlockLanguages:/s,
+  );
+  assert.match(source, /codeMirrorExtensions:\s*NOTE_CODE_MIRROR_EXTENSIONS/);
+  assert.match(source, /syntaxHighlighting\(noteCodeHighlightStyle\)/);
+});
+
+test("note editor exposes preview and edit modes with a markdown toolbar in edit mode", () => {
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+  const managerSource = readFileSync(new URL("./NotesManager.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /type NoteEditorMode = "edit" \| "preview"/);
+  assert.match(source, /toolbarPlugin\(\{\s*toolbarContents:/s);
+  assert.match(source, /readOnly=\{editorMode === "preview"\}/);
+  assert.match(source, /<BlockTypeSelect \/>/);
+  assert.match(source, /<BoldItalicUnderlineToggles /);
+  assert.match(source, /<ListsToggle /);
+  assert.match(source, /<InsertCodeBlock \/>/);
+  assert.match(source, /<InsertTable \/>/);
+  assert.match(source, /editorMode = controlledEditorMode \?\? "edit"/);
+  assert.doesNotMatch(source, /data-note-mode-switch/);
+  assert.doesNotMatch(source, /absolute -top-9/);
+  assert.match(managerSource, /data-note-title-row/);
+  assert.match(managerSource, /data-note-mode-switch/);
+  assert.match(managerSource, /Glasses/);
+  assert.match(managerSource, /PencilLine/);
+  assert.match(managerSource, /setNoteEditorMode\(\(currentMode\) => \(/);
+  assert.match(managerSource, /currentMode === "edit" \? "preview" : "edit"/);
+  assert.match(managerSource, /editorMode=\{noteEditorMode\}/);
+  assert.match(managerSource, /className="app-no-drag h-8 w-8 shrink-0 rounded-md p-0 text-muted-foreground transition-colors hover:bg-secondary\/70 hover:text-foreground"/);
+  assert.doesNotMatch(managerSource, /data-note-mode-switch[\s\S]{0,500}border/);
+  assert.doesNotMatch(`${source}\n${managerSource}`, /role="tablist"|role="tab"|renderModeButton/);
+  assert.doesNotMatch(`${source}\n${managerSource}`, /className="mb-2 flex shrink-0 items-center justify-end"/);
+});
+
+test("note markdown toolbar remains usable in narrow panes", () => {
+  const styles = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+
+  assert.doesNotMatch(source, /MoreHorizontal|data-note-toolbar-more|netcatty-note-toolbar-more/);
+
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s*\{[^}]*container-type:\s*inline-size;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-note-markdown-toolbar\s*\{[^}]*max-width:\s*100%;[^}]*height:\s*auto\s*!important;[^}]*overflow:\s*visible\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-note-markdown-toolbar\s*\{[^}]*box-sizing:\s*border-box;[^}]*display:\s*flex\s*!important;[^}]*flex-wrap:\s*wrap\s*!important;[^}]*align-content:\s*flex-start\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-note-markdown-toolbar\s*>\s*\*\s*\{[^}]*flex-shrink:\s*0;/s,
+  );
+  assert.match(
+    styles,
+    /@container\s*\(max-width:\s*34rem\)\s*\{[\s\S]*\.netcatty-note-markdown-toolbar\s*\{[^}]*gap:\s*0\.125rem\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /@container\s*\(max-width:\s*34rem\)\s*\{[\s\S]*\.netcatty-note-markdown-toolbar\s*\{[^}]*flex-wrap:\s*wrap\s*!important;[^}]*align-content:\s*flex-start\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /@container\s*\(max-width:\s*34rem\)\s*\{[\s\S]*\.netcatty-note-markdown-toolbar\s+button,[\s\S]*\.netcatty-note-markdown-toolbar\s+\[role="button"\][\s\S]*height:\s*1\.75rem\s*!important;/s,
+  );
+});
+
+test("preview mode opens links directly without showing the edit hover action", () => {
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /const handleClickCapture = useCallback/);
+  assert.match(source, /if \(editorMode !== "preview"\) \{[\s\S]*scheduleHostPickerUpdate\(\);[\s\S]*return;/);
+  assert.match(source, /const handled = openLink\(href, label\);[\s\S]*if \(!handled\) return;[\s\S]*event\.preventDefault\(\);/);
+  assert.match(source, /onClickCapture=\{handleClickCapture\}/);
+  assert.match(source, /if \(editorMode !== "edit"\) \{[\s\S]*setLinkAction\(null\);[\s\S]*return;/);
+  assert.match(source, /\{editorMode === "edit" && linkAction && \(/);
+});
+
+test("preview mode only intercepts links netcatty can open", () => {
+  assert.equal(isSupportedNoteExternalHref("https://example.com/docs"), true);
+  assert.equal(isSupportedNoteExternalHref("http://example.com/docs"), true);
+  assert.equal(isSupportedNoteExternalHref("mailto:support@example.com"), true);
+  assert.equal(isSupportedNoteExternalHref("#section"), false);
+  assert.equal(isSupportedNoteExternalHref("/docs"), false);
+  assert.equal(isSupportedNoteExternalHref("file:///tmp/readme.md"), false);
+});
+
+test("pasting inside code blocks keeps CodeMirror in control", () => {
+  const source = readFileSync(new URL("./InlineMarkdownEditor.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /export const isNotePasteInsideCodeBlock/);
+  assert.match(source, /element\?\.closest/);
+  assert.match(source, /\.cm-editor/);
+  assert.match(source, /_codeMirrorWrapper_/);
+  assert.match(source, /if \(isNotePasteInsideCodeBlock\(event\.target\)\) return;/);
+});
+
+test("note code block editor colors follow the app theme", () => {
+  const styles = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+
+  assert.match(styles, /\.netcatty-mdx-editor\s+\.cm-editor/);
+  assert.match(styles, /\.netcatty-mdx-editor\s+\.cm-gutters/);
+  assert.match(styles, /background:\s*hsl\(var\(--secondary\)/);
+  assert.match(styles, /color:\s*hsl\(var\(--foreground\)/);
+  assert.match(styles, /--note-code-token-keyword:\s*color-mix\(in oklab,\s*hsl\(var\(--primary\)\)/);
+  assert.match(styles, /\.netcatty-mdx-editor\s+\.cm-content\s+\.netcatty-code-token-keyword/);
+  assert.match(styles, /\.netcatty-mdx-editor\s+\.cm-content\s+\.netcatty-code-token-string/);
+  assert.doesNotMatch(styles, /span\[class\*="ͼ"\]/);
+  assert.doesNotMatch(styles, /\.netcatty-mdx-editor\s+\.cm-line\s+span/);
+});
+
+test("note code block active line is highlighted only while focused", () => {
+  const styles = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-activeLine,\s*\.netcatty-mdx-editor\s+\.cm-activeLineGutter\s*\{[^}]*background:\s*transparent/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-editor:focus-within\s+\.cm-activeLine,\s*\.netcatty-mdx-editor\s+\.cm-editor:focus-within\s+\.cm-activeLineGutter\s*\{[^}]*background:\s*hsl\(var\(--primary\)\s*\/\s*0\.08\)/s,
+  );
+});
+
+test("note code block frame is borderless and language picker is compact", () => {
+  const styles = readFileSync(new URL("../../index.css", import.meta.url), "utf8");
+
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\[class\*="_codeMirrorWrapper_"\]\s*\{[^}]*border:\s*0\s*!important;[^}]*padding:\s*0\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-editor\s*\{[^}]*border:\s*0\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\[class\*="_codeMirrorToolbar_"\]\s*\{[^}]*position:\s*static\s*!important;[^}]*padding:\s*0\.125rem;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\[class\*="_codeMirrorToolbar_"\]\s+\[class\*="_toolbarCodeBlockLanguageSelectTrigger_"\]\s*\{[^}]*height:\s*1\.45rem\s*!important;[^}]*font-size:\s*11px\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\[class\*="_toolbarCodeBlockLanguageSelectContent_"\]\s*\{[^}]*font-size:\s*11px\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-editor\s*\{[^}]*font-size:\s*13px\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-line\s*\{[^}]*line-height:\s*1\.45\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-gutterElement\s*\{[^}]*font-size:\s*13px\s*!important;[^}]*line-height:\s*1\.45\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-content\s*\{[^}]*padding:\s*0\.25rem\s+0\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor\s+\.cm-gutters\s*\{[^}]*padding:\s*0\s*!important;/s,
+  );
+  assert.match(
+    styles,
+    /\.netcatty-mdx-editor--preview\s+\[class\*="_codeMirrorToolbar_"\]\s*\{[^}]*display:\s*none\s*!important;/s,
+  );
 });

--- a/components/notes/InlineMarkdownEditor.tsx
+++ b/components/notes/InlineMarkdownEditor.tsx
@@ -1,15 +1,30 @@
 import {
+  BlockTypeSelect,
+  BoldItalicUnderlineToggles,
+  CodeToggle,
+  CreateLink,
+  InsertCodeBlock,
+  InsertTable,
+  InsertThematicBreak,
+  ListsToggle,
   codeBlockPlugin,
+  codeMirrorPlugin,
   headingsPlugin,
+  linkDialogPlugin,
   linkPlugin,
   listsPlugin,
   markdownShortcutPlugin,
   MDXEditor,
   type MDXEditorMethods,
   quotePlugin,
+  Separator,
   tablePlugin,
   thematicBreakPlugin,
+  toolbarPlugin,
+  UndoRedo,
 } from "@mdxeditor/editor";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
 import { ExternalLink } from "lucide-react";
 import {
   $createRangeSelection,
@@ -29,9 +44,13 @@ export interface InlineMarkdownEditorProps {
   placeholder: string;
   onChange: (value: string) => void;
   hosts?: Host[];
+  editorMode?: NoteEditorMode;
   onOpenHost?: (host: Host) => void;
   onOpenExternalLink?: (url: string) => void | Promise<void>;
+  previewEmptyLabel?: string;
 }
+
+export type NoteEditorMode = "edit" | "preview";
 
 type HostPickerState = {
   open: boolean;
@@ -60,8 +79,82 @@ const HOST_PICKER_ROW_HEIGHT = 34;
 const HOST_PICKER_EMPTY_HEIGHT = 40;
 const HOST_PICKER_LIST_VERTICAL_PADDING = 8;
 const HOST_PICKER_LIST_MAX_HEIGHT = 256;
+const NOTE_CODE_BLOCK_LANGUAGES = {
+  bash: "Bash",
+  c: "C",
+  conf: "Config",
+  cpp: "C++",
+  csharp: "C#",
+  css: "CSS",
+  dockerfile: "Dockerfile",
+  env: "Env",
+  go: "Go",
+  html: "HTML",
+  ini: "INI",
+  java: "Java",
+  javascript: "JavaScript",
+  js: "JavaScript",
+  json: "JSON",
+  jsx: "JavaScript (React)",
+  markdown: "Markdown",
+  md: "Markdown",
+  nginx: "Nginx",
+  plaintext: "Plain text",
+  python: "Python",
+  rust: "Rust",
+  sh: "Shell",
+  shell: "Shell",
+  sql: "SQL",
+  toml: "TOML",
+  ts: "TypeScript",
+  tsx: "TypeScript (React)",
+  typescript: "TypeScript",
+  yaml: "YAML",
+  yml: "YAML",
+  zsh: "Zsh",
+} satisfies Record<string, string>;
+
+const noteCodeHighlightStyle = HighlightStyle.define([
+  { tag: tags.meta, class: "netcatty-code-token-muted" },
+  { tag: tags.link, class: "netcatty-code-token-link" },
+  { tag: tags.heading, class: "netcatty-code-token-heading" },
+  { tag: tags.emphasis, class: "netcatty-code-token-emphasis" },
+  { tag: tags.strong, class: "netcatty-code-token-strong" },
+  { tag: [tags.keyword, tags.regexp, tags.escape, tags.special(tags.string)], class: "netcatty-code-token-keyword" },
+  { tag: [tags.atom, tags.bool, tags.url, tags.labelName], class: "netcatty-code-token-name" },
+  { tag: [tags.literal, tags.inserted, tags.number], class: "netcatty-code-token-value" },
+  { tag: [tags.string, tags.deleted], class: "netcatty-code-token-string" },
+  { tag: [tags.variableName, tags.propertyName], class: "netcatty-code-token-variable" },
+  { tag: [tags.definition(tags.variableName), tags.local(tags.variableName)], class: "netcatty-code-token-variable" },
+  { tag: [tags.typeName, tags.namespace, tags.className, tags.macroName], class: "netcatty-code-token-type" },
+  { tag: [tags.definition(tags.propertyName), tags.special(tags.variableName)], class: "netcatty-code-token-property" },
+  { tag: tags.comment, class: "netcatty-code-token-muted" },
+  { tag: tags.invalid, class: "netcatty-code-token-invalid" },
+]);
+
+const NOTE_CODE_MIRROR_EXTENSIONS = [syntaxHighlighting(noteCodeHighlightStyle)];
 
 type RectLike = Pick<DOMRect, "bottom" | "height" | "left" | "top" | "width">;
+
+const NoteMarkdownToolbar = React.memo(function NoteMarkdownToolbar() {
+  return (
+    <>
+      <UndoRedo />
+      <Separator />
+      <BlockTypeSelect />
+      <Separator />
+      <BoldItalicUnderlineToggles options={["Bold", "Italic"]} />
+      <CodeToggle />
+      <Separator />
+      <ListsToggle options={["bullet", "number", "check"]} />
+      <Separator />
+      <CreateLink />
+      <InsertCodeBlock />
+      <InsertTable />
+      <InsertThematicBreak />
+    </>
+  );
+});
 
 const isSshCandidateHost = (host: Host): boolean =>
   Boolean(host.hostname?.trim()) && (host.protocol === undefined || host.protocol === "ssh");
@@ -96,6 +189,34 @@ const getEstimatedHostPickerHeight = (availableHostCount: number): number => {
     ? availableHostCount * HOST_PICKER_ROW_HEIGHT + HOST_PICKER_LIST_VERTICAL_PADDING
     : HOST_PICKER_EMPTY_HEIGHT;
   return HOST_PICKER_HEADER_HEIGHT + Math.min(HOST_PICKER_LIST_MAX_HEIGHT, listHeight);
+};
+
+const PASTED_MARKDOWN_PATTERNS = [
+  /^ {0,3}#{1,6}\s+\S/m,
+  /^ {0,3}(?:[-+*]|\d+[.)])\s+\S/m,
+  /^ {0,3}>\s+\S/m,
+  /^ {0,3}(?:```|~~~)/m,
+  /^ {0,3}[-*_](?:\s*[-*_]){2,}\s*$/m,
+  /^ {0,3}\|?.+\|.+\n {0,3}\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/m,
+  /(^|[^!])\[[^\]\n]+\]\([^) \n]+(?:\s+"[^"\n]*")?\)/,
+  /(^|[\s([{])(?:\*\*|__)\S[\s\S]*?\S(?:\*\*|__)(?=$|[\s\])}.,;:!?])/,
+  /(^|[\s([{])`[^`\n]+`(?=$|[\s\])}.,;:!?])/,
+];
+
+export const shouldInsertClipboardTextAsMarkdown = (text: string): boolean => {
+  const markdown = text.replace(/\r\n?/g, "\n").trim();
+  if (!markdown) return false;
+  return PASTED_MARKDOWN_PATTERNS.some((pattern) => pattern.test(markdown));
+};
+
+export const isNotePasteInsideCodeBlock = (target: EventTarget | null): boolean => {
+  if (typeof Element === "undefined") return false;
+  const element = target instanceof Element
+    ? target
+    : typeof Node !== "undefined" && target instanceof Node
+      ? target.parentElement
+      : null;
+  return Boolean(element?.closest(".cm-editor, [class*=\"_codeMirrorWrapper_\"]"));
 };
 
 export const resolveHostPickerPopupPosition = ({
@@ -136,24 +257,32 @@ export const resolveHostPickerPopupPosition = ({
   return { left, top };
 };
 
+const SUPPORTED_NOTE_EXTERNAL_LINK_PROTOCOL_PATTERN = /^(?:https?:|mailto:)/i;
+
+export const isSupportedNoteExternalHref = (href: string): boolean => {
+  const trimmed = href.trim();
+  if (!SUPPORTED_NOTE_EXTERNAL_LINK_PROTOCOL_PATTERN.test(trimmed)) return false;
+  try {
+    const url = new URL(trimmed);
+    return ["http:", "https:", "mailto:"].includes(url.protocol);
+  } catch {
+    return false;
+  }
+};
+
 const openExternalLink = async (
   href: string,
   onOpenExternalLink?: (url: string) => void | Promise<void>,
-) => {
-  let url: URL;
-  try {
-    url = new URL(href, window.location.href);
-  } catch {
-    return;
-  }
-
-  if (!["http:", "https:", "mailto:"].includes(url.protocol)) return;
+): Promise<boolean> => {
+  if (!isSupportedNoteExternalHref(href)) return false;
+  const url = new URL(href.trim());
 
   if (onOpenExternalLink) {
     await onOpenExternalLink(url.toString());
-    return;
+    return true;
   }
   window.open(url.toString(), "_blank", "noopener,noreferrer");
+  return true;
 };
 
 export const shouldHandleHostPickerNavigationKey = (
@@ -224,8 +353,10 @@ export function InlineMarkdownEditor({
   placeholder,
   onChange,
   hosts = [],
+  editorMode: controlledEditorMode,
   onOpenHost,
   onOpenExternalLink,
+  previewEmptyLabel,
 }: InlineMarkdownEditorProps) {
   const editorRef = useRef<MDXEditorMethods>(null);
   const latestMarkdownRef = useRef(value);
@@ -240,6 +371,7 @@ export function InlineMarkdownEditor({
     top: 32,
   });
   const [linkAction, setLinkAction] = useState<LinkActionState | null>(null);
+  const editorMode = controlledEditorMode ?? "edit";
   const hostPickerRangeRef = useRef<Range | null>(null);
   const plugins = useMemo(() => [
     headingsPlugin(),
@@ -247,10 +379,21 @@ export function InlineMarkdownEditor({
     quotePlugin(),
     thematicBreakPlugin(),
     linkPlugin(),
+    linkDialogPlugin(),
     tablePlugin(),
     codeBlockPlugin({ defaultCodeBlockLanguage: "" }),
+    codeMirrorPlugin({
+      codeBlockLanguages: NOTE_CODE_BLOCK_LANGUAGES,
+      codeMirrorExtensions: NOTE_CODE_MIRROR_EXTENSIONS,
+    }),
+    ...(editorMode === "edit" ? [
+      toolbarPlugin({
+        toolbarContents: () => <NoteMarkdownToolbar />,
+        toolbarClassName: "netcatty-note-markdown-toolbar",
+      }),
+    ] : []),
     markdownShortcutPlugin(),
-  ], []);
+  ], [editorMode]);
   const hostCandidates = useMemo(
     () => hosts.filter(isSshCandidateHost),
     [hosts],
@@ -273,6 +416,16 @@ export function InlineMarkdownEditor({
       selectedIndex: Math.max(0, filteredHosts.length - 1),
     }));
   }, [filteredHosts.length, hostPicker.open, hostPicker.selectedIndex]);
+
+  useEffect(() => {
+    if (editorMode === "edit") return;
+    hostPickerRangeRef.current = null;
+    setHostPicker((current) => ({ ...current, open: false, query: "", selectedIndex: 0 }));
+  }, [editorMode]);
+
+  useEffect(() => {
+    setLinkAction(null);
+  }, [editorMode]);
 
   const getHostPickerContext = useCallback(() => {
     const container = containerRef.current;
@@ -336,8 +489,9 @@ export function InlineMarkdownEditor({
   }, [getHostPickerContext]);
 
   const scheduleHostPickerUpdate = useCallback(() => {
+    if (editorMode !== "edit") return;
     window.requestAnimationFrame(updateHostPickerFromSelection);
-  }, [updateHostPickerFromSelection]);
+  }, [editorMode, updateHostPickerFromSelection]);
 
   const annotateHostLinks = useCallback(() => {
     const container = containerRef.current;
@@ -400,6 +554,7 @@ export function InlineMarkdownEditor({
   }, [commitMarkdown, getHostPickerContext]);
 
   const handleKeyDownCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (editorMode !== "edit") return;
     if (!shouldHandleHostPickerNavigationKey(hostPicker.open, event.key, filteredHosts.length)) return;
     event.preventDefault();
     event.stopPropagation();
@@ -434,19 +589,21 @@ export function InlineMarkdownEditor({
     }
   }, [
     filteredHosts,
+    editorMode,
     hostPicker.open,
     hostPicker.selectedIndex,
     insertHostLink,
   ]);
 
   const handleKeyUpCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (editorMode !== "edit") return;
     if (event.metaKey || event.ctrlKey || event.altKey) return;
     if (hostCandidates.length === 0) return;
     if (["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(event.key)) return;
     scheduleHostPickerUpdate();
-  }, [hostCandidates.length, scheduleHostPickerUpdate]);
+  }, [editorMode, hostCandidates.length, scheduleHostPickerUpdate]);
 
-  const openLink = useCallback((href: string, label?: string) => {
+  const openLink = useCallback((href: string, label?: string): boolean => {
     const host = buildSshNoteLinkOpenHost(hosts, href, label, {
       id: crypto.randomUUID(),
       now: Date.now(),
@@ -455,11 +612,39 @@ export function InlineMarkdownEditor({
       if (onOpenHost) {
         onOpenHost(host);
       }
+      return true;
+    }
+
+    if (!isSupportedNoteExternalHref(href)) return false;
+    void openExternalLink(href, onOpenExternalLink);
+    return true;
+  }, [hosts, onOpenExternalLink, onOpenHost]);
+
+  const handleClickCapture = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (editorMode !== "preview") {
+      scheduleHostPickerUpdate();
       return;
     }
 
-    void openExternalLink(href, onOpenExternalLink);
-  }, [hosts, onOpenExternalLink, onOpenHost]);
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const link = target.closest<HTMLAnchorElement>("a[href]");
+    const renderedHref = link?.getAttribute("href") || link?.href;
+    if (!link || !renderedHref || !containerRef.current?.contains(link)) return;
+
+    const label = link.textContent?.trim() || renderedHref;
+    const href = resolveRenderedMarkdownLinkHref(
+      latestMarkdownRef.current,
+      label,
+      renderedHref,
+    );
+    const handled = openLink(href, label);
+    if (!handled) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation?.();
+  }, [editorMode, openLink, scheduleHostPickerUpdate]);
 
   const activateLinkAction = useCallback((
     event: React.SyntheticEvent<HTMLElement>,
@@ -478,6 +663,11 @@ export function InlineMarkdownEditor({
   }, [openLink]);
 
   const handleMouseMoveCapture = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (editorMode !== "edit") {
+      setLinkAction(null);
+      return;
+    }
+
     const target = event.target;
     if (!(target instanceof Element)) return;
     if (target.closest("[data-note-link-action]")) return;
@@ -503,6 +693,14 @@ export function InlineMarkdownEditor({
       label,
       renderedHref,
     );
+    const canOpenLink = Boolean(buildSshNoteLinkOpenHost(hosts, href, label, {
+      id: "note-link-hover",
+      now: 0,
+    })) || isSupportedNoteExternalHref(href);
+    if (!canOpenLink) {
+      setLinkAction(null);
+      return;
+    }
     const linkRect = link.getBoundingClientRect();
     setLinkAction({
       href,
@@ -510,7 +708,7 @@ export function InlineMarkdownEditor({
       left: Math.max(0, Math.min(containerRect.width - LINK_ACTION_SIZE - 6, linkRect.right - containerRect.left + 2)),
       top: Math.max(0, linkRect.top - containerRect.top - 2),
     });
-  }, [linkAction]);
+  }, [editorMode, hosts, linkAction]);
 
   const handleBlurCapture = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
     const nextTarget = event.relatedTarget;
@@ -518,19 +716,37 @@ export function InlineMarkdownEditor({
     setHostPicker((current) => ({ ...current, open: false, query: "", selectedIndex: 0 }));
   }, []);
 
+  const handlePasteCapture = useCallback((event: React.ClipboardEvent<HTMLDivElement>) => {
+    if (editorMode !== "edit") return;
+    if (isNotePasteInsideCodeBlock(event.target)) return;
+    const markdown = event.clipboardData.getData("text/plain");
+    if (!shouldInsertClipboardTextAsMarkdown(markdown)) return;
+
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation?.();
+    setHostPicker((current) => ({ ...current, open: false, query: "", selectedIndex: 0 }));
+    setLinkAction(null);
+    editor.insertMarkdown(markdown);
+  }, [editorMode]);
+
   return (
     <div
       ref={containerRef}
-      className="relative h-full"
+      className="relative flex h-full flex-col"
       onBlurCapture={handleBlurCapture}
-      onClickCapture={scheduleHostPickerUpdate}
+      onClickCapture={handleClickCapture}
       onInputCapture={scheduleHostPickerUpdate}
       onKeyDownCapture={handleKeyDownCapture}
       onKeyUpCapture={handleKeyUpCapture}
       onMouseLeave={() => setLinkAction(null)}
       onMouseMoveCapture={handleMouseMoveCapture}
+      onPasteCapture={handlePasteCapture}
     >
-      {linkAction && (
+      {editorMode === "edit" && linkAction && (
         <button
           type="button"
           data-note-link-action="true"
@@ -575,15 +791,23 @@ export function InlineMarkdownEditor({
           </div>
         </div>
       )}
-      <MDXEditor
-        ref={editorRef}
-        markdown={value}
-        placeholder={placeholder}
-        plugins={plugins}
-        className="netcatty-mdx-editor"
-        contentEditableClassName="netcatty-mdx-content"
-        onChange={commitMarkdown}
-      />
+      {editorMode === "preview" && !value.trim() ? (
+        <div className="netcatty-note-preview-empty">
+          {previewEmptyLabel ?? placeholder}
+        </div>
+      ) : (
+        <MDXEditor
+          key={editorMode}
+          ref={editorRef}
+          markdown={value}
+          placeholder={placeholder}
+          plugins={plugins}
+          readOnly={editorMode === "preview"}
+          className={cn("netcatty-mdx-editor", editorMode === "preview" && "netcatty-mdx-editor--preview")}
+          contentEditableClassName="netcatty-mdx-content"
+          onChange={commitMarkdown}
+        />
+      )}
     </div>
   );
 }

--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
@@ -167,6 +168,15 @@ test("NotesManager exposes shared tree drag targets and context menus", () => {
   assert.match(markup, /draggable="true"/);
   assert.match(markup, /data-open="false"/);
   assert.match(markup, /role="separator"/);
+});
+
+test("NotesManager restores and persists the note editor mode without resetting on note switch", () => {
+  const source = readFileSync(new URL("./NotesManager.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /STORAGE_KEY_VAULT_NOTES_EDITOR_MODE/);
+  assert.match(source, /useStoredString<NoteEditorMode>\(\s*STORAGE_KEY_VAULT_NOTES_EDITOR_MODE,\s*"edit",\s*isNoteEditorMode/s);
+  assert.doesNotMatch(source, /localStorageAdapter/);
+  assert.doesNotMatch(source, /setNoteEditorMode\("edit"\)/);
 });
 
 test("NotesManager renders nested notebook folders", () => {

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -5,8 +5,10 @@ import {
   FileText,
   Folder,
   FolderPlus,
+  Glasses,
   MoreHorizontal,
   Minimize2,
+  PencilLine,
   Plus,
   Search,
   X,
@@ -15,6 +17,7 @@ import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useStat
 import { useI18n } from "../../application/i18n/I18nProvider";
 import { useApplicationBackend } from "../../application/state/useApplicationBackend";
 import { useStoredNumber } from "../../application/state/useStoredNumber";
+import { useStoredString } from "../../application/state/useStoredString";
 import {
   ancestorNoteGroupPaths,
   cleanNoteGroupPath,
@@ -29,7 +32,10 @@ import {
   resolveMovedNoteGroupPath,
 } from "../../domain/notes";
 import { getNextVaultOrder, reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from "../../domain/vaultOrder";
-import { STORAGE_KEY_VAULT_NOTES_TREE_WIDTH } from "../../infrastructure/config/storageKeys";
+import {
+  STORAGE_KEY_VAULT_NOTES_EDITOR_MODE,
+  STORAGE_KEY_VAULT_NOTES_TREE_WIDTH,
+} from "../../infrastructure/config/storageKeys";
 import { cn } from "../../lib/utils";
 import type { Host, VaultNote } from "../../types";
 import { Button } from "../ui/button";
@@ -58,6 +64,7 @@ import {
   markVaultDropIndicator,
   markVaultInsideDropIndicator,
 } from "../vault/vaultReorderDrag";
+import type { NoteEditorMode } from "./InlineMarkdownEditor";
 
 const InlineMarkdownEditor = lazy(() =>
   import("./InlineMarkdownEditor").then((module) => ({ default: module.InlineMarkdownEditor })),
@@ -79,6 +86,12 @@ const NOTES_TREE_MIN_WIDTH = 220;
 const NOTES_TREE_MAX_WIDTH = 520;
 const NOTE_DRAG_TYPE = "application/x-netcatty-note-id";
 const NOTE_GROUP_DRAG_TYPE = "application/x-netcatty-note-group-path";
+
+export const normalizeNoteEditorMode = (value: string | null): NoteEditorMode | null =>
+  value === "edit" || value === "preview" ? value : null;
+
+const isNoteEditorMode = (value: string | null): value is NoteEditorMode =>
+  normalizeNoteEditorMode(value) !== null;
 
 const InlineMarkdownEditorFallback = () => (
   <div
@@ -318,6 +331,11 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
   const [query, setQuery] = useState("");
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(() => initialOpenNoteId ?? (isSidebarMode ? null : notes[0]?.id ?? null));
+  const [noteEditorMode, setNoteEditorMode] = useStoredString<NoteEditorMode>(
+    STORAGE_KEY_VAULT_NOTES_EDITOR_MODE,
+    "edit",
+    isNoteEditorMode,
+  );
   const [overlayNoteId, setOverlayNoteId] = useState<string | null>(() => initialOpenNoteId);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
     () => new Set(notes.flatMap((note) => note.group ? ancestorNoteGroupPaths(note.group) : [])),
@@ -438,6 +456,32 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
   const handleOpenHostFromNote = useCallback((host: Host, noteId: string) => {
     onOpenHost?.(host, { noteId });
   }, [onOpenHost]);
+
+  const renderNoteModeToggle = () => {
+    const label = noteEditorMode === "edit" ? t("notes.mode.preview") : t("notes.mode.edit");
+    const Icon = noteEditorMode === "edit" ? Glasses : PencilLine;
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            data-note-mode-switch
+            aria-label={label}
+            className="app-no-drag h-8 w-8 shrink-0 rounded-md p-0 text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+            onClick={() => setNoteEditorMode((currentMode) => (
+              currentMode === "edit" ? "preview" : "edit"
+            ))}
+          >
+            <Icon size={16} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
+    );
+  };
 
   const addNoteToGroup = (group: string | null) => {
     const note = createNote(group, getNextVaultOrder(sortedNotes));
@@ -1185,7 +1229,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         <main className="flex min-w-0 flex-1 flex-col bg-background">
           {selectedNote ? (
             <>
-              <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-8 pt-6 pb-1">
+              <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-8 pt-6 pb-1" data-note-title-row>
                 <div className="min-w-0 flex-1">
                   <input
                     className="h-7 w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
@@ -1198,6 +1242,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
                     })}
                   />
                 </div>
+                {renderNoteModeToggle()}
               </div>
               <ScrollArea className="min-h-0 flex-1">
                 <div className="min-h-full w-full px-8 pt-2 pb-6">
@@ -1207,6 +1252,8 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
                         key={selectedNote.id}
                         value={selectedNote.content}
                         placeholder={t("notes.editor.placeholder")}
+                        editorMode={noteEditorMode}
+                        previewEmptyLabel={t("notes.preview.empty")}
                         onChange={(content) => saveNote({
                           ...selectedNote,
                           content,
@@ -1261,17 +1308,20 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
             </div>
           </div>
           <div className="flex min-h-0 flex-1 flex-col bg-background">
-            <div className="flex min-h-[54px] shrink-0 items-center px-4 pt-5 pb-1">
-              <input
-                className="h-7 w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
-                value={overlayNote.title}
-                placeholder={t("notes.title.placeholder")}
-                onChange={(event) => saveNote({
-                  ...overlayNote,
-                  title: event.target.value,
-                  updatedAt: Date.now(),
-                })}
-              />
+            <div className="flex min-h-[54px] shrink-0 items-center gap-3 px-4 pt-5 pb-1" data-note-title-row>
+              <div className="min-w-0 flex-1">
+                <input
+                  className="h-7 w-full bg-transparent text-lg font-semibold outline-none placeholder:text-muted-foreground"
+                  value={overlayNote.title}
+                  placeholder={t("notes.title.placeholder")}
+                  onChange={(event) => saveNote({
+                    ...overlayNote,
+                    title: event.target.value,
+                    updatedAt: Date.now(),
+                  })}
+                />
+              </div>
+              {renderNoteModeToggle()}
             </div>
             <ScrollArea className="min-h-0 flex-1">
               <div className="min-h-full w-full px-4 pt-2 pb-6">
@@ -1281,11 +1331,13 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
                       key={overlayNote.id}
                       value={overlayNote.content}
                       placeholder={t("notes.editor.placeholder")}
+                      editorMode={noteEditorMode}
                       onChange={(content) => saveNote({
                         ...overlayNote,
                         content,
                         updatedAt: Date.now(),
                       })}
+                      previewEmptyLabel={t("notes.preview.empty")}
                       hosts={hosts}
                       onOpenHost={(host) => handleOpenHostFromNote(host, overlayNote.id)}
                       onOpenExternalLink={openExternal}

--- a/domain/sshDeepLink.test.ts
+++ b/domain/sshDeepLink.test.ts
@@ -168,6 +168,28 @@ test("buildSshNoteLinkOpenHost treats a bare host link as an existing ssh host r
   assert.equal(openHost?.protocol, "ssh");
 });
 
+test("buildSshNoteLinkOpenHost leaves document-relative note links alone", () => {
+  const hosts = [
+    host({ id: "docs", label: "docs", hostname: "docs.example.com" }),
+    host({ id: "section", label: "section", hostname: "section.example.com" }),
+  ];
+
+  for (const [href, label] of [
+    ["/docs", "docs"],
+    ["#section", "section"],
+    ["./docs", "docs"],
+    ["../docs", "docs"],
+    ["docs/page", "docs"],
+    ["docs?tab=install", "docs"],
+    ["docs#install", "docs"],
+  ] as const) {
+    assert.equal(
+      buildSshNoteLinkOpenHost(hosts, href, label, { id: "draft-id", now: 456 }),
+      null,
+    );
+  }
+});
+
 test("buildSshNoteLinkOpenHost does not treat sanitized editor links as hosts", () => {
   const openHost = buildSshNoteLinkOpenHost(
     [host({ id: "match", hostname: "10.2.0.32", username: "root" })],

--- a/domain/sshDeepLink.ts
+++ b/domain/sshDeepLink.ts
@@ -124,6 +124,17 @@ const normalizeBareHostReference = (value: string): string | null => {
   return decoded;
 };
 
+const isDocumentRelativeLink = (value: string): boolean => {
+  const trimmed = value.trim();
+  return trimmed.startsWith("#")
+    || trimmed.startsWith("/")
+    || trimmed.startsWith("./")
+    || trimmed.startsWith("../")
+    || trimmed.includes("/")
+    || trimmed.includes("?")
+    || trimmed.includes("#");
+};
+
 const parseBareHostReference = (value: string): SshDeepLinkTarget | null => {
   const reference = normalizeBareHostReference(value);
   if (!reference) return null;
@@ -152,6 +163,9 @@ export const buildSshNoteLinkOpenHost = (
   }
 
   if (URL_SCHEME_PATTERN.test(normalizedHref)) {
+    return null;
+  }
+  if (isDocumentRelativeLink(normalizedHref)) {
     return null;
   }
 

--- a/index.css
+++ b/index.css
@@ -826,6 +826,8 @@ html[data-theme-transition] *::after {
 }
 
 .netcatty-mdx-editor {
+  container-type: inline-size;
+  min-width: 0;
   --basePageBg: hsl(var(--background));
   --baseBase: hsl(var(--background));
   --baseBgSubtle: hsl(var(--secondary) / 0.45);
@@ -843,6 +845,90 @@ html[data-theme-transition] *::after {
   --accentSolidHover: hsl(var(--primary) / 0.9);
   background: transparent;
   color: hsl(var(--foreground));
+}
+
+.netcatty-note-preview-empty {
+  min-height: calc(100vh - 15rem);
+  color: hsl(var(--muted-foreground));
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.netcatty-note-markdown-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-content: flex-start !important;
+  height: auto !important;
+  overflow: visible !important;
+  align-items: center !important;
+  min-height: 2rem !important;
+  margin-bottom: 0.75rem;
+  border: 1px solid hsl(var(--border) / 0.6) !important;
+  border-radius: 6px !important;
+  background: hsl(var(--background) / 0.96) !important;
+  color: hsl(var(--foreground)) !important;
+  box-shadow: none !important;
+}
+
+.netcatty-note-markdown-toolbar > * {
+  flex-shrink: 0;
+}
+
+.netcatty-note-markdown-toolbar button,
+.netcatty-note-markdown-toolbar [role="button"],
+.netcatty-note-markdown-toolbar [role="combobox"] {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.netcatty-note-markdown-toolbar button:hover,
+.netcatty-note-markdown-toolbar [role="button"]:hover,
+.netcatty-note-markdown-toolbar [role="combobox"]:hover,
+.netcatty-note-markdown-toolbar button[data-state="on"],
+.netcatty-note-markdown-toolbar button[data-state="open"] {
+  background: hsl(var(--secondary)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.netcatty-note-markdown-toolbar [role="separator"] {
+  flex-shrink: 0;
+  background: hsl(var(--border) / 0.7) !important;
+}
+
+@container (max-width: 34rem) {
+  .netcatty-note-markdown-toolbar {
+    gap: 0.125rem !important;
+    row-gap: 0.125rem !important;
+    flex-wrap: wrap !important;
+    align-content: flex-start !important;
+    min-height: 1.9rem !important;
+    padding: 0.125rem !important;
+  }
+
+  .netcatty-note-markdown-toolbar button,
+  .netcatty-note-markdown-toolbar [role="button"] {
+    width: 1.75rem !important;
+    min-width: 1.75rem !important;
+    height: 1.75rem !important;
+    padding: 0 !important;
+  }
+
+  .netcatty-note-markdown-toolbar [role="combobox"] {
+    min-width: 7.25rem !important;
+    max-width: 8.5rem !important;
+    height: 1.75rem !important;
+    padding: 0 0.45rem !important;
+  }
+
+  .netcatty-note-markdown-toolbar [role="separator"] {
+    margin: 0 0.125rem !important;
+  }
 }
 
 .netcatty-mdx-editor,
@@ -943,10 +1029,177 @@ html[data-theme-transition] *::after {
 }
 
 .netcatty-mdx-content pre {
-  border: 1px solid hsl(var(--border) / 0.45);
+  border: 0;
   border-radius: 6px;
   background: hsl(var(--secondary) / 0.35);
   padding: 0.75rem;
+}
+
+.netcatty-mdx-editor [class*="_codeMirrorWrapper_"] {
+  margin: 0.85rem 0 1rem;
+  border: 0 !important;
+  border-radius: 6px;
+  background: transparent !important;
+  padding: 0 !important;
+  overflow: hidden;
+}
+
+.netcatty-mdx-editor [class*="_codeMirrorToolbar_"] {
+  position: static !important;
+  right: auto !important;
+  top: auto !important;
+  z-index: auto !important;
+  gap: 0.125rem;
+  padding: 0.125rem;
+  border-bottom-left-radius: 0 !important;
+  background: transparent !important;
+}
+
+.netcatty-mdx-editor--preview [class*="_codeMirrorToolbar_"] {
+  display: none !important;
+}
+
+.netcatty-mdx-editor [class*="_codeMirrorToolbar_"] [class*="_toolbarCodeBlockLanguageSelectTrigger_"] {
+  height: 1.45rem !important;
+  width: auto !important;
+  min-width: 3.75rem;
+  padding: 0 0.4rem !important;
+  font-size: 11px !important;
+  line-height: 1 !important;
+}
+
+.netcatty-mdx-editor [class*="_codeMirrorToolbar_"] button {
+  min-height: 1.45rem !important;
+  height: 1.45rem !important;
+  min-width: 1.45rem !important;
+  width: auto !important;
+  padding: 0 0.35rem !important;
+  background: hsl(var(--background) / 0.88) !important;
+}
+
+.netcatty-mdx-editor [class*="_codeMirrorToolbar_"] [class*="_toolbarCodeBlockLanguageSelectTrigger_"] span {
+  font-size: inherit !important;
+  line-height: inherit !important;
+}
+
+.netcatty-mdx-editor [class*="_toolbarCodeBlockLanguageSelectContent_"] {
+  width: 9.5rem !important;
+  font-size: 11px !important;
+}
+
+.netcatty-mdx-editor [class*="_toolbarCodeBlockLanguageSelectContent_"] [class*="_selectItem_"] {
+  font-size: 11px !important;
+}
+
+.netcatty-mdx-editor .cm-editor {
+  --note-code-token-muted: hsl(var(--muted-foreground) / 0.9);
+  --note-code-token-keyword: color-mix(in oklab, hsl(var(--primary)) 82%, hsl(var(--foreground)));
+  --note-code-token-name: color-mix(in oklab, hsl(var(--primary)) 50%, hsl(var(--foreground)));
+  --note-code-token-value: color-mix(in oklab, hsl(var(--primary)) 38%, hsl(var(--foreground)));
+  --note-code-token-string: color-mix(in oklab, hsl(var(--primary)) 24%, hsl(var(--foreground)));
+  overflow: hidden;
+  border: 0 !important;
+  border-radius: 6px;
+  background: hsl(var(--secondary) / 0.35) !important;
+  color: hsl(var(--foreground) / 0.9) !important;
+  font-family: var(--font-mono);
+  font-size: 13px !important;
+}
+
+.netcatty-mdx-editor .cm-scroller {
+  background: transparent !important;
+  color: hsl(var(--foreground) / 0.9) !important;
+  font-family: var(--font-mono);
+}
+
+.netcatty-mdx-editor .cm-content {
+  background: transparent !important;
+  color: hsl(var(--foreground) / 0.9) !important;
+  font-family: var(--font-mono);
+  padding: 0.25rem 0 !important;
+}
+
+.netcatty-mdx-editor .cm-line {
+  color: inherit !important;
+  line-height: 1.45 !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-muted {
+  color: var(--note-code-token-muted) !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-keyword {
+  color: var(--note-code-token-keyword) !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-name,
+.netcatty-mdx-editor .cm-content .netcatty-code-token-variable,
+.netcatty-mdx-editor .cm-content .netcatty-code-token-type,
+.netcatty-mdx-editor .cm-content .netcatty-code-token-property {
+  color: var(--note-code-token-name) !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-value {
+  color: var(--note-code-token-value) !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-string {
+  color: var(--note-code-token-string) !important;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-link {
+  color: hsl(var(--primary)) !important;
+  text-decoration: underline;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-heading,
+.netcatty-mdx-editor .cm-content .netcatty-code-token-strong {
+  font-weight: 600;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-emphasis {
+  font-style: italic;
+}
+
+.netcatty-mdx-editor .cm-content .netcatty-code-token-invalid {
+  color: hsl(var(--destructive)) !important;
+}
+
+.netcatty-mdx-editor .cm-gutters {
+  border-right: 1px solid hsl(var(--border) / 0.35) !important;
+  background: hsl(var(--secondary) / 0.24) !important;
+  color: hsl(var(--muted-foreground) / 0.75) !important;
+  font-family: var(--font-mono);
+  font-size: 13px !important;
+  line-height: 1.45 !important;
+  padding: 0 !important;
+}
+
+.netcatty-mdx-editor .cm-gutterElement {
+  font-size: 13px !important;
+  line-height: 1.45 !important;
+}
+
+.netcatty-mdx-editor .cm-lineNumbers .cm-gutterElement {
+  padding: 0 0.45rem 0 0.55rem !important;
+}
+
+.netcatty-mdx-editor .cm-activeLine,
+.netcatty-mdx-editor .cm-activeLineGutter {
+  background: transparent !important;
+}
+
+.netcatty-mdx-editor .cm-editor:focus-within .cm-activeLine,
+.netcatty-mdx-editor .cm-editor:focus-within .cm-activeLineGutter {
+  background: hsl(var(--primary) / 0.08) !important;
+}
+
+.netcatty-mdx-editor .cm-selectionBackground {
+  background: hsl(var(--primary) / 0.22) !important;
+}
+
+.netcatty-mdx-editor .cm-cursor {
+  border-left-color: hsl(var(--foreground)) !important;
 }
 
 .netcatty-mdx-content blockquote {

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -47,6 +47,7 @@ export const STORAGE_KEY_VAULT_KEYS_VIEW_MODE = 'netcatty_vault_keys_view_mode_v
 export const STORAGE_KEY_VAULT_PROXY_PROFILES_VIEW_MODE = 'netcatty_vault_proxy_profiles_view_mode_v1';
 export const STORAGE_KEY_VAULT_SNIPPETS_VIEW_MODE = 'netcatty_vault_snippets_view_mode_v1';
 export const STORAGE_KEY_VAULT_NOTES_VIEW_MODE = 'netcatty_vault_notes_view_mode_v1';
+export const STORAGE_KEY_VAULT_NOTES_EDITOR_MODE = 'netcatty_vault_notes_editor_mode_v1';
 export const STORAGE_KEY_VAULT_NOTES_SELECTED_GROUP = 'netcatty_vault_notes_selected_group_v1';
 export const STORAGE_KEY_VAULT_NOTES_TREE_WIDTH = 'netcatty_vault_notes_tree_width_v1';
 /** Inline snippet script editor height (px) in vault edit panel. */


### PR DESCRIPTION
## Summary
- render pasted Markdown in notes instead of keeping raw Markdown text
- add edit/preview modes with a compact Markdown toolbar
- improve code block styling, link behavior, mode persistence, and narrow toolbar wrapping

## Validation
- node --test --import tsx components/notes/InlineMarkdownEditor.test.tsx components/notes/NotesManager.test.tsx domain/notes.test.ts
- npm run lint
- git diff --check
- Browser check: verified notes toolbar wrapping across 900, 1100, 1300, and 1450 px viewports without button overflow
