### PR TITLE
修复设置窗口按钮悬停时不显示手型光标

### DIFF
--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -303,7 +303,7 @@ const SettingsPageContent: React.FC<{ settings: SettingsState }> = ({ settings }
     }, [closeSettingsWindow]);
 
     return (
-        <div className="h-screen flex flex-col bg-background text-foreground font-sans">
+        <div className="settings-window h-screen flex flex-col bg-background text-foreground font-sans">
             <div className="shrink-0 border-b border-border app-drag">
                 <div className="flex items-center justify-between px-4 pt-3">
                     {isMac && <div className="h-6" />}

--- a/index.css
+++ b/index.css
@@ -155,6 +155,14 @@
   animation: netcatty-lazy-fade-in 160ms ease-out both;
 }
 
+.settings-window button:not(:disabled),
+.settings-window [role="button"]:not([aria-disabled="true"]),
+.settings-window [role="switch"]:not([aria-disabled="true"]),
+.settings-window [data-slot="tabs-trigger"]:not([data-disabled]),
+.settings-window [data-slot="select-trigger"]:not([data-disabled]) {
+  cursor: pointer;
+}
+
 .top-tab-root-label {
   display: inline-block;
   overflow: hidden;


### PR DESCRIPTION
## 概要
- 将手型光标样式限定在设置窗口根节点作用域内
- 恢复设置页中按钮、标签页切换、开关和下拉触发器等可点击控件的手型光标

## 验证
- npm run build
