### PR TITLE
[codex] Bind SFTP follow directory to hosts

### DIFF
--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -60,6 +60,7 @@ import {
 } from './terminalLayer/terminalLayerSessionRouting';
 import { resolvePreferredTerminalCwd, scheduleBackendCwdProbeAfterCommand } from './terminal/sftpCwd';
 import { classifyDistroId, shouldProbeSessionCwd } from '../domain/host';
+import { resolveHostFollowTerminalCwd } from './sftp/sftpFollowTerminalCwd';
 
 import {
   AIChatPanelsHost,
@@ -576,10 +577,12 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
   const handleCommandSubmitted = useCallback((_command: string, _hostId: string, _hostLabel: string, sessionId: string) => {
     const tabId = activeTabIdRef.current;
-    if (!sftpFollowTerminalCwdRef.current || !tabId || sidePanelOpenTabsRef.current.get(tabId) !== 'sftp') return;
+    if (!tabId || sidePanelOpenTabsRef.current.get(tabId) !== 'sftp') return;
 
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     if (!session || !canReuseTerminalConnection(session)) return;
+    const sessionHost = sessionHostsMapRef.current.get(sessionId);
+    if (!resolveHostFollowTerminalCwd(sessionHost?.sftpFollowTerminalCwd, sftpFollowTerminalCwdRef.current)) return;
 
     const revisionAtCommand = terminalCwdRevisionRef.current;
     const probeGeneration = (cwdProbeGenerationRef.current.get(sessionId) ?? 0) + 1;

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { shouldFollowTerminalCwdNavigate } from "./sftpFollowTerminalCwd";
+import {
+  resolveHostFollowTerminalCwd,
+  shouldFollowTerminalCwdNavigate,
+} from "./sftpFollowTerminalCwd";
 
 const base = {
   followEnabled: true,
@@ -32,4 +35,11 @@ test("shouldFollowTerminalCwdNavigate returns false while interactive work is ac
 
 test("shouldFollowTerminalCwdNavigate returns false without a known terminal cwd", () => {
   assert.equal(shouldFollowTerminalCwdNavigate({ ...base, terminalCwd: null }), false);
+});
+
+test("resolveHostFollowTerminalCwd inherits the global setting until the host overrides it", () => {
+  assert.equal(resolveHostFollowTerminalCwd(undefined, true), true);
+  assert.equal(resolveHostFollowTerminalCwd(undefined, false), false);
+  assert.equal(resolveHostFollowTerminalCwd(true, false), true);
+  assert.equal(resolveHostFollowTerminalCwd(false, true), false);
 });

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -7,6 +7,11 @@ export type SftpFollowTerminalCwdContext = {
   isConnected: boolean;
 };
 
+export const resolveHostFollowTerminalCwd = (
+  hostFollowTerminalCwd: boolean | undefined,
+  globalFollowTerminalCwd: boolean,
+): boolean => hostFollowTerminalCwd ?? globalFollowTerminalCwd;
+
 /** Whether SFTP should auto-navigate to match the linked terminal cwd. */
 export const shouldFollowTerminalCwdNavigate = ({
   followEnabled,

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -16,6 +16,8 @@ import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { SidePanelTab } from './TerminalLayerSupport';
 import { terminalLayerSidePanelCtxEqual } from './terminalLayerViewMemo';
+import { resolveHostFollowTerminalCwd } from '../sftp/sftpFollowTerminalCwd';
+import type { Host } from '../../types';
 
 type SidePanelContext = Record<string, any>;
 const SIDE_PANEL_TAB_DRAG_MIME = 'application/x-netcatty-sidepanel-tab';
@@ -487,6 +489,27 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
               const panelActiveHost = isVisibleSftpPanel
                 ? (sftpActiveHost ?? storedSftpHost)
                 : storedSftpHost;
+              const panelFollowTerminalCwd = resolveHostFollowTerminalCwd(
+                panelActiveHost?.sftpFollowTerminalCwd,
+                sftpFollowTerminalCwd,
+              );
+              const handlePanelFollowTerminalCwdChange = (enabled: boolean) => {
+                if (!panelActiveHost?.id) {
+                  setSftpFollowTerminalCwd(enabled);
+                  return;
+                }
+                let updated = false;
+                const nextHosts = (hosts as Host[]).map((host) => {
+                  if (host.id !== panelActiveHost.id) return host;
+                  updated = true;
+                  return { ...host, sftpFollowTerminalCwd: enabled };
+                });
+                if (updated) {
+                  updateHosts(nextHosts);
+                } else {
+                  setSftpFollowTerminalCwd(enabled);
+                }
+              };
               return (
                 <div
                   key={tabId}
@@ -523,9 +546,9 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                   editorWordWrap={editorWordWrap}
                   setEditorWordWrap={setEditorWordWrap}
                   onGetTerminalCwd={getTerminalCwd}
-                  activeTerminalCwd={isVisibleSftpPanel && sftpFollowTerminalCwd ? activeTerminalCwd : null}
-                  sftpFollowTerminalCwd={sftpFollowTerminalCwd}
-                  onSftpFollowTerminalCwdChange={setSftpFollowTerminalCwd}
+                  activeTerminalCwd={isVisibleSftpPanel && panelFollowTerminalCwd ? activeTerminalCwd : null}
+                  sftpFollowTerminalCwd={panelFollowTerminalCwd}
+                  onSftpFollowTerminalCwdChange={handlePanelFollowTerminalCwdChange}
                   onRequestTerminalFocus={refocusActiveTerminalSession}
                   terminalSettings={terminalSettings}
                 />

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -522,6 +522,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     sessions,
     showHostTreeSidebar,
     sftpActiveHost,
+    s.sftpFollowTerminalCwd,
     themeState,
     workspaceById,
     workspaceInnerRef,

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -195,6 +195,28 @@ test("keeps host details timestamp value when the details form edits it", () => 
   );
 });
 
+test("preserves a concurrent SFTP follow-terminal-directory toggle when host details did not edit it", () => {
+  const openedHost = makeHost({ sftpFollowTerminalCwd: undefined });
+  const latestHost = makeHost({ sftpFollowTerminalCwd: true });
+  const draft = makeHost({ label: "Edited label", sftpFollowTerminalCwd: undefined });
+
+  assert.deepEqual(
+    preserveConcurrentHostLineTimestampUpdate({ draft, openedHost, latestHost }),
+    { ...draft, sftpFollowTerminalCwd: true },
+  );
+});
+
+test("keeps host details SFTP follow-terminal-directory value when the details form edits it", () => {
+  const openedHost = makeHost({ sftpFollowTerminalCwd: false });
+  const latestHost = makeHost({ sftpFollowTerminalCwd: false });
+  const draft = makeHost({ sftpFollowTerminalCwd: true });
+
+  assert.equal(
+    preserveConcurrentHostLineTimestampUpdate({ draft, openedHost, latestHost }).sftpFollowTerminalCwd,
+    true,
+  );
+});
+
 test("normalizePrimaryTelnetState preserves an explicit telnet port", () => {
   const result = normalizePrimaryTelnetState(makeHost({
     protocol: "telnet",

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -271,9 +271,20 @@ export const preserveConcurrentHostLineTimestampUpdate = ({
 }): Host => {
   if (!openedHost || !latestHost) return draft;
   if (draft.id !== openedHost.id || draft.id !== latestHost.id) return draft;
-  if (draft.showLineTimestamps !== openedHost.showLineTimestamps) return draft;
-  if (latestHost.showLineTimestamps === openedHost.showLineTimestamps) return draft;
-  return { ...draft, showLineTimestamps: latestHost.showLineTimestamps };
+  let next = draft;
+  if (
+    draft.showLineTimestamps === openedHost.showLineTimestamps &&
+    latestHost.showLineTimestamps !== openedHost.showLineTimestamps
+  ) {
+    next = { ...next, showLineTimestamps: latestHost.showLineTimestamps };
+  }
+  if (
+    draft.sftpFollowTerminalCwd === openedHost.sftpFollowTerminalCwd &&
+    latestHost.sftpFollowTerminalCwd !== openedHost.sftpFollowTerminalCwd
+  ) {
+    next = { ...next, sftpFollowTerminalCwd: latestHost.sftpFollowTerminalCwd };
+  }
+  return next;
 };
 
 export const upsertHostById = (hosts: Host[], host: Host): Host[] => {

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -188,6 +188,7 @@ export interface Host {
   sftpSudo?: boolean; // Use sudo for SFTP operations (requires password)
   sftpEncoding?: SftpFilenameEncoding; // Filename encoding for SFTP operations
   sftpBookmarks?: SftpBookmark[]; // Bookmarked SFTP paths for quick navigation
+  sftpFollowTerminalCwd?: boolean; // Overrides global SFTP follow-terminal-directory setting
   // Managed source: if this host is managed by an external file (e.g., ~/.ssh/config)
   managedSourceId?: string; // Reference to ManagedSource.id
   // Host-level keyword highlighting (overrides/extends global settings)


### PR DESCRIPTION
## Summary
- Store the SFTP follow-terminal-directory toggle on the current host while keeping the global setting as the default for hosts without an override.
- Apply the per-host value when probing terminal cwd changes and when refreshing the SFTP side panel.
- Preserve concurrent sidebar changes when saving an already-open host details form.

Closes #1413

## Test Plan
- npm test
- npm run lint
- npm run build
