### PR TITLE
[codex] Save SFTP follow toggle on visible host

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -40,7 +40,7 @@ import { useSftpKeyboardShortcuts } from "./sftp/hooks/useSftpKeyboardShortcuts"
 import { sftpFocusStore } from "./sftp/hooks/useSftpFocusedPane";
 import { keepOnlyPaneSelections } from "./sftp/hooks/selectionScope";
 import { KeyBinding, HotkeyScheme } from "../domain/models";
-import { shouldFollowTerminalCwdNavigate } from "./sftp/sftpFollowTerminalCwd";
+import { resolveHostFollowTerminalCwd, shouldFollowTerminalCwdNavigate } from "./sftp/sftpFollowTerminalCwd";
 
 interface SftpSidePanelProps {
   hosts: Host[];
@@ -79,7 +79,7 @@ interface SftpSidePanelProps {
   onGetTerminalCwd?: (options?: { preferFreshBackend?: boolean }) => Promise<string | null>;
   activeTerminalCwd?: string | null;
   sftpFollowTerminalCwd?: boolean;
-  onSftpFollowTerminalCwdChange?: (enabled: boolean) => void;
+  onSftpFollowTerminalCwdChange?: (enabled: boolean, host?: Host | null) => void;
   onRequestTerminalFocus?: () => void;
   terminalSettings?: { keepaliveInterval: number; keepaliveCountMax: number };
 }
@@ -473,7 +473,7 @@ type SftpSidePanelInteractiveBodyProps = {
   onGetTerminalCwd?: (options?: { preferFreshBackend?: boolean }) => Promise<string | null>;
   activeTerminalCwd?: string | null;
   sftpFollowTerminalCwd: boolean;
-  onSftpFollowTerminalCwdChange?: (enabled: boolean) => void;
+  onSftpFollowTerminalCwdChange?: (enabled: boolean, host?: Host | null) => void;
   onRequestTerminalFocus?: () => void;
   isVisible: boolean;
   behaviorRef: MutableRefObject<"open" | "transfer">;
@@ -653,13 +653,38 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     onInteractiveWorkChange(showTextEditor || !!permissionsState || showFileOpenerDialog);
   }, [onInteractiveWorkChange, permissionsState, showFileOpenerDialog, showTextEditor]);
 
+  // When a host switch is deferred or the picker connects a different host,
+  // actions should follow the visible SFTP connection, not the incoming default.
+  const displayHost = useMemo(() => {
+    const conn = sftp.leftPane.connection;
+    if (conn && !conn.isLocal) {
+      // Prefer the stored Host object from connect time — it preserves
+      // session-time overrides that the vault host may lack.
+      if (connectedHostObjRef.current && connectedHostObjRef.current.id === conn.hostId) {
+        return connectedHostObjRef.current;
+      }
+      return hosts.find((h) => h.id === conn.hostId) ?? activeHost;
+    }
+    return activeHost;
+  }, [activeHost, connectedHostObjRef, hosts, sftp.leftPane.connection]);
+
+  const followTerminalCwdHost = useMemo(() => {
+    if (sftp.leftPane.connection?.isLocal) return null;
+    return displayHost;
+  }, [displayHost, sftp.leftPane.connection?.isLocal]);
+
+  const effectiveFollowTerminalCwd = resolveHostFollowTerminalCwd(
+    followTerminalCwdHost?.sftpFollowTerminalCwd,
+    sftpFollowTerminalCwd,
+  );
+
   const canFollowTerminalCwd = useMemo(() => {
-    if (!onGetTerminalCwd || !activeHost) return false;
-    const proto = activeHost.protocol;
+    if (!onGetTerminalCwd || !followTerminalCwdHost) return false;
+    const proto = followTerminalCwdHost.protocol;
     if (proto === "local" || proto === "serial") return false;
-    if (activeHost.id?.startsWith("local-") || activeHost.id?.startsWith("serial-")) return false;
+    if (followTerminalCwdHost.id?.startsWith("local-") || followTerminalCwdHost.id?.startsWith("serial-")) return false;
     return true;
-  }, [activeHost, onGetTerminalCwd]);
+  }, [followTerminalCwdHost, onGetTerminalCwd]);
 
   const hasActiveWork = showTextEditor || !!permissionsState || showFileOpenerDialog
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
@@ -673,7 +698,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   }, [onGetTerminalCwd, sftpRef]);
 
   const syncFollowToTerminalCwd = useCallback(async () => {
-    if (!onGetTerminalCwd || !sftpFollowTerminalCwd || !canFollowTerminalCwd) {
+    if (!onGetTerminalCwd || !effectiveFollowTerminalCwd || !canFollowTerminalCwd) {
       return;
     }
 
@@ -685,7 +710,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
 
     const connection = sftpRef.current.leftPane.connection;
     if (!shouldFollowTerminalCwdNavigate({
-      followEnabled: sftpFollowTerminalCwd,
+      followEnabled: effectiveFollowTerminalCwd,
       isVisible,
       terminalCwd,
       currentPath: connection?.currentPath,
@@ -699,26 +724,26 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   }, [
     activeTerminalCwd,
     canFollowTerminalCwd,
+    effectiveFollowTerminalCwd,
     hasActiveWork,
     isVisible,
     onGetTerminalCwd,
     sftpRef,
-    sftpFollowTerminalCwd,
   ]);
 
   const handleToggleFollowTerminalCwd = useCallback(() => {
-    onSftpFollowTerminalCwdChange?.(!sftpFollowTerminalCwd);
-  }, [onSftpFollowTerminalCwdChange, sftpFollowTerminalCwd]);
+    onSftpFollowTerminalCwdChange?.(!effectiveFollowTerminalCwd, followTerminalCwdHost);
+  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, onSftpFollowTerminalCwdChange]);
 
   useEffect(() => {
-    if (!sftpFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;
+    if (!effectiveFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;
     void syncFollowToTerminalCwd();
   }, [
     activeTerminalCwd,
     canFollowTerminalCwd,
+    effectiveFollowTerminalCwd,
     hasActiveWork,
     isVisible,
-    sftpFollowTerminalCwd,
     sftp.leftPane.connection?.currentPath,
     sftp.leftPane.connection?.status,
     sftp.leftPane.connection?.isLocal,
@@ -810,23 +835,6 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     [t],
   );
 
-  // When the auto-connect effect defers a switch (active transfers or open
-  // editor), the panel still operates on the current connection, not
-  // activeHost.  Use the connected host for the header so the label matches
-  // what browse/edit/delete actions actually target.
-  const displayHost = useMemo(() => {
-    const conn = sftp.leftPane.connection;
-    if (conn && !conn.isLocal) {
-      // Prefer the stored Host object from connect time — it preserves
-      // session-time overrides that the vault host may lack.
-      if (connectedHostObjRef.current && connectedHostObjRef.current.id === conn.hostId) {
-        return connectedHostObjRef.current;
-      }
-      return hosts.find((h) => h.id === conn.hostId) ?? activeHost;
-    }
-    return activeHost;
-  }, [activeHost, connectedHostObjRef, hosts, sftp.leftPane.connection]);
-
   // Determine the active pane to render (without using global activeTabStore)
   const activeLeftPaneId = sftp.leftTabs.activeTabId;
 
@@ -899,7 +907,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
                   forceActive
                   onToggleShowHiddenFiles={() => handleToggleHiddenFiles(pane.id)}
                   onGoToTerminalCwd={onGetTerminalCwd ? handleGoToTerminalCwd : undefined}
-                  followTerminalCwd={canFollowTerminalCwd ? sftpFollowTerminalCwd : undefined}
+                  followTerminalCwd={canFollowTerminalCwd ? effectiveFollowTerminalCwd : undefined}
                   onToggleFollowTerminalCwd={canFollowTerminalCwd ? handleToggleFollowTerminalCwd : undefined}
                 />
               </div>

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   resolveHostFollowTerminalCwd,
+  resolveSftpFollowTerminalCwdTargetHost,
   shouldFollowTerminalCwdNavigate,
 } from "./sftpFollowTerminalCwd";
 
@@ -42,4 +43,18 @@ test("resolveHostFollowTerminalCwd inherits the global setting until the host ov
   assert.equal(resolveHostFollowTerminalCwd(undefined, false), false);
   assert.equal(resolveHostFollowTerminalCwd(true, false), true);
   assert.equal(resolveHostFollowTerminalCwd(false, true), false);
+});
+
+test("resolveSftpFollowTerminalCwdTargetHost prefers the visible SFTP host", () => {
+  const terminalHost = { id: "terminal-host" };
+  const visibleHost = { id: "visible-sftp-host" };
+
+  assert.equal(
+    resolveSftpFollowTerminalCwdTargetHost(visibleHost, terminalHost),
+    visibleHost,
+  );
+  assert.equal(
+    resolveSftpFollowTerminalCwdTargetHost(null, terminalHost),
+    terminalHost,
+  );
 });

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -12,6 +12,11 @@ export const resolveHostFollowTerminalCwd = (
   globalFollowTerminalCwd: boolean,
 ): boolean => hostFollowTerminalCwd ?? globalFollowTerminalCwd;
 
+export const resolveSftpFollowTerminalCwdTargetHost = <T>(
+  visibleHost: T | null | undefined,
+  fallbackHost: T | null | undefined,
+): T | null => visibleHost ?? fallbackHost ?? null;
+
 /** Whether SFTP should auto-navigate to match the linked terminal cwd. */
 export const shouldFollowTerminalCwdNavigate = ({
   followEnabled,

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -16,7 +16,7 @@ import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { SidePanelTab } from './TerminalLayerSupport';
 import { terminalLayerSidePanelCtxEqual } from './terminalLayerViewMemo';
-import { resolveHostFollowTerminalCwd } from '../sftp/sftpFollowTerminalCwd';
+import { resolveSftpFollowTerminalCwdTargetHost } from '../sftp/sftpFollowTerminalCwd';
 import type { Host } from '../../types';
 
 type SidePanelContext = Record<string, any>;
@@ -489,18 +489,15 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
               const panelActiveHost = isVisibleSftpPanel
                 ? (sftpActiveHost ?? storedSftpHost)
                 : storedSftpHost;
-              const panelFollowTerminalCwd = resolveHostFollowTerminalCwd(
-                panelActiveHost?.sftpFollowTerminalCwd,
-                sftpFollowTerminalCwd,
-              );
-              const handlePanelFollowTerminalCwdChange = (enabled: boolean) => {
-                if (!panelActiveHost?.id) {
+              const handlePanelFollowTerminalCwdChange = (enabled: boolean, visibleHost?: Host | null) => {
+                const targetHost = resolveSftpFollowTerminalCwdTargetHost(visibleHost, panelActiveHost);
+                if (!targetHost?.id) {
                   setSftpFollowTerminalCwd(enabled);
                   return;
                 }
                 let updated = false;
                 const nextHosts = (hosts as Host[]).map((host) => {
-                  if (host.id !== panelActiveHost.id) return host;
+                  if (host.id !== targetHost.id) return host;
                   updated = true;
                   return { ...host, sftpFollowTerminalCwd: enabled };
                 });
@@ -546,8 +543,8 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                   editorWordWrap={editorWordWrap}
                   setEditorWordWrap={setEditorWordWrap}
                   onGetTerminalCwd={getTerminalCwd}
-                  activeTerminalCwd={isVisibleSftpPanel && panelFollowTerminalCwd ? activeTerminalCwd : null}
-                  sftpFollowTerminalCwd={panelFollowTerminalCwd}
+                  activeTerminalCwd={isVisibleSftpPanel ? activeTerminalCwd : null}
+                  sftpFollowTerminalCwd={sftpFollowTerminalCwd}
                   onSftpFollowTerminalCwdChange={handlePanelFollowTerminalCwdChange}
                   onRequestTerminalFocus={refocusActiveTerminalSession}
                   terminalSettings={terminalSettings}


### PR DESCRIPTION
## Summary
- Use the actually visible SFTP connection host when resolving the follow-terminal-directory toggle state.
- Save follow-toggle changes to the visible SFTP host instead of the focused terminal host.
- Keep the global setting as the fallback for hosts without their own override.

Addresses Codex feedback from #1580.

## Test Plan
- node --test --import tsx components/sftp/sftpFollowTerminalCwd.test.ts
- npm run lint
- npm run build
- npm test
