### PR TITLE
[codex] Refresh SFTP follow toggle from latest host

### DIFF
--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -40,7 +40,11 @@ import { useSftpKeyboardShortcuts } from "./sftp/hooks/useSftpKeyboardShortcuts"
 import { sftpFocusStore } from "./sftp/hooks/useSftpFocusedPane";
 import { keepOnlyPaneSelections } from "./sftp/hooks/selectionScope";
 import { KeyBinding, HotkeyScheme } from "../domain/models";
-import { resolveHostFollowTerminalCwd, shouldFollowTerminalCwdNavigate } from "./sftp/sftpFollowTerminalCwd";
+import {
+  mergeLatestFollowTerminalCwdHostSetting,
+  resolveHostFollowTerminalCwd,
+  shouldFollowTerminalCwdNavigate,
+} from "./sftp/sftpFollowTerminalCwd";
 
 interface SftpSidePanelProps {
   hosts: Host[];
@@ -658,12 +662,13 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const displayHost = useMemo(() => {
     const conn = sftp.leftPane.connection;
     if (conn && !conn.isLocal) {
+      const latestHost = hosts.find((h) => h.id === conn.hostId) ?? null;
       // Prefer the stored Host object from connect time — it preserves
       // session-time overrides that the vault host may lack.
       if (connectedHostObjRef.current && connectedHostObjRef.current.id === conn.hostId) {
-        return connectedHostObjRef.current;
+        return mergeLatestFollowTerminalCwdHostSetting(connectedHostObjRef.current, latestHost);
       }
-      return hosts.find((h) => h.id === conn.hostId) ?? activeHost;
+      return latestHost ?? activeHost;
     }
     return activeHost;
   }, [activeHost, connectedHostObjRef, hosts, sftp.leftPane.connection]);

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  mergeLatestFollowTerminalCwdHostSetting,
   resolveHostFollowTerminalCwd,
   resolveSftpFollowTerminalCwdTargetHost,
   shouldFollowTerminalCwdNavigate,
@@ -56,5 +57,27 @@ test("resolveSftpFollowTerminalCwdTargetHost prefers the visible SFTP host", () 
   assert.equal(
     resolveSftpFollowTerminalCwdTargetHost(null, terminalHost),
     terminalHost,
+  );
+});
+
+test("mergeLatestFollowTerminalCwdHostSetting refreshes the follow flag without losing display overrides", () => {
+  const connectedHost = {
+    id: "host-1",
+    hostname: "session.example.com",
+    sftpFollowTerminalCwd: false,
+  };
+  const latestHost = {
+    id: "host-1",
+    hostname: "vault.example.com",
+    sftpFollowTerminalCwd: true,
+  };
+
+  assert.deepEqual(
+    mergeLatestFollowTerminalCwdHostSetting(connectedHost, latestHost),
+    {
+      id: "host-1",
+      hostname: "session.example.com",
+      sftpFollowTerminalCwd: true,
+    },
   );
 });

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -17,6 +17,22 @@ export const resolveSftpFollowTerminalCwdTargetHost = <T>(
   fallbackHost: T | null | undefined,
 ): T | null => visibleHost ?? fallbackHost ?? null;
 
+export const mergeLatestFollowTerminalCwdHostSetting = <
+  T extends { id?: string; sftpFollowTerminalCwd?: boolean },
+>(
+  displayHost: T | null | undefined,
+  latestHost: T | null | undefined,
+): T | null => {
+  if (!displayHost) return latestHost ?? null;
+  if (!latestHost || latestHost.id !== displayHost.id) return displayHost;
+
+  return {
+    ...latestHost,
+    ...displayHost,
+    sftpFollowTerminalCwd: latestHost.sftpFollowTerminalCwd,
+  };
+};
+
 /** Whether SFTP should auto-navigate to match the linked terminal cwd. */
 export const shouldFollowTerminalCwdNavigate = ({
   followEnabled,


### PR DESCRIPTION
## Summary
- Refresh the SFTP follow-directory flag from the latest saved host record even when the visible connection uses a connection-time host object.
- Preserve connection-time display/endpoint overrides while keeping the follow toggle state current after save.

Addresses Codex feedback from #1581.

## Test Plan
- node --test --import tsx components/sftp/sftpFollowTerminalCwd.test.ts
- npm run lint
- npm run build
- npm test
