### PR TITLE
Add OpenCode SDK integration

### DIFF
--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -160,6 +160,18 @@ export const enAiMessages: Messages = {
   'ai.codebuddy.envVars.placeholder': 'CODEBUDDY_API_KEY=...\nCODEBUDDY_AUTH_TOKEN=...\nOTHER_VAR=...',
   'ai.codebuddy.envVars.hint': 'One KEY=VALUE per line, passed to the CodeBuddy agent. Set CODEBUDDY_API_KEY or CODEBUDDY_AUTH_TOKEN here for authentication. Stored locally in plaintext.',
 
+  // AI OpenCode
+  'ai.opencode.title': 'OpenCode',
+  'ai.opencode.description': 'Uses OpenCode via the official SDK. Configure providers and keys in OpenCode, then select it as an external coding agent.',
+  'ai.opencode.detecting': 'Detecting...',
+  'ai.opencode.detected': 'Detected',
+  'ai.opencode.notFound': 'Not found',
+  'ai.opencode.path': 'Path:',
+  'ai.opencode.notFoundHint': 'Could not find opencode in PATH. Install it or specify the executable path below.',
+  'ai.opencode.customPathPlaceholder': 'e.g. /usr/local/bin/opencode',
+  'ai.opencode.check': 'Check',
+  'ai.opencode.resetPath': 'Reset',
+
   // AI Default Agent
   'ai.defaultAgent': 'Default Agent',
   'ai.defaultAgent.description': 'Agent to use when starting a new AI session',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -160,6 +160,18 @@ export const zhCNAiMessages: Messages = {
   'ai.codebuddy.envVars.placeholder': 'CODEBUDDY_API_KEY=...\nCODEBUDDY_AUTH_TOKEN=...\nOTHER_VAR=...',
   'ai.codebuddy.envVars.hint': '每行一个 KEY=VALUE，传给 CodeBuddy agent。可在此设置 CODEBUDDY_API_KEY 或 CODEBUDDY_AUTH_TOKEN 完成认证。明文存在本地。',
 
+  // AI OpenCode
+  'ai.opencode.title': 'OpenCode',
+  'ai.opencode.description': '通过官方 SDK 接入 OpenCode。先在 OpenCode 里配置 provider 和密钥，检测到后即可作为外部编程 Agent 使用。',
+  'ai.opencode.detecting': '检测中...',
+  'ai.opencode.detected': '已检测到',
+  'ai.opencode.notFound': '未找到',
+  'ai.opencode.path': '路径：',
+  'ai.opencode.notFoundHint': '在 PATH 中未找到 opencode。请安装或在下方指定可执行文件路径。',
+  'ai.opencode.customPathPlaceholder': '例如 /usr/local/bin/opencode',
+  'ai.opencode.check': '检查',
+  'ai.opencode.resetPath': '重置',
+
   // AI Default Agent
   'ai.defaultAgent': '默认 Agent',
   'ai.defaultAgent.description': '创建新 AI 会话时使用的 Agent',

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -51,7 +51,13 @@ import { canSendWithAgent, findEnabledExternalAgent } from './ai/agentSendEligib
 import { clearAllPendingApprovals } from '../infrastructure/ai/shared/approvalGate';
 import { useConversationExport } from './ai/hooks/useConversationExport';
 import type { AIChatSidePanelProps } from './AIChatSidePanel.types';
-import { generateId, modelPresetsContainId, shouldLoadSdkRuntimeModels } from './AIChatSidePanelHelpers';
+import {
+  generateId,
+  normalizeSdkRuntimeModelPresets,
+  shouldAdoptSdkCurrentModel,
+  shouldLoadSdkRuntimeModels,
+  shouldUseStoredAgentModel,
+} from './AIChatSidePanelHelpers';
 import { AIChatPanelContent } from './AIChatPanelContent';
 import {
   getAIPanelProfilerProps,
@@ -664,21 +670,24 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       getManualAgentCommand(currentAgentConfig),
     ).then((result) => {
       if (cancelled || !result?.ok || !Array.isArray(result.models)) return;
-      if (result.models.length === 0) {
+      const runtimePresets = normalizeSdkRuntimeModelPresets(result.models, result.currentModelId);
+      const storedModelId = agentModelMapRef.current[currentAgentId];
+      if (runtimePresets.length === 0) {
         setRuntimeAgentModelPresets((prev) => {
           if (!(currentAgentId in prev)) return prev;
           const { [currentAgentId]: _removed, ...rest } = prev;
           return rest;
         });
+        if (shouldAdoptSdkCurrentModel(result.currentModelId, storedModelId, runtimePresets)) {
+          setAgentModel(currentAgentId, result.currentModelId!);
+        }
         return;
       }
-      const runtimePresets = result.models ?? [];
       setRuntimeAgentModelPresets((prev) => ({
         ...prev,
         [currentAgentId]: runtimePresets,
       }));
-      const storedModelId = agentModelMapRef.current[currentAgentId];
-      if (result.currentModelId && (!storedModelId || !modelPresetsContainId(runtimePresets, storedModelId))) {
+      if (shouldAdoptSdkCurrentModel(result.currentModelId, storedModelId, runtimePresets)) {
         setAgentModel(currentAgentId, result.currentModelId);
       }
     }).catch((err) => {
@@ -710,7 +719,9 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
 
   const selectedAgentModel = useMemo(() => {
     const stored = agentModelMap[currentAgentId];
-    if (stored && modelPresetsContainId(agentModelPresets, stored)) {
+    if (shouldUseStoredAgentModel(stored, agentModelPresets, currentAgentConfig, {
+      runtimeModelsLoaded: currentAgentId in runtimeAgentModelPresets,
+    })) {
       return stored;
     }
     if (agentModelPresets.length > 0) {
@@ -721,7 +732,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       return first.id;
     }
     return undefined;
-  }, [currentAgentId, agentModelMap, agentModelPresets]);
+  }, [currentAgentConfig, currentAgentId, agentModelMap, agentModelPresets, runtimeAgentModelPresets]);
 
   const inputAgentId = activeSession?.agentId ?? currentDraft?.agentId ?? currentAgentId;
   const canSendCurrentAgent = useMemo(

--- a/components/AIChatSidePanelHelpers.test.tsx
+++ b/components/AIChatSidePanelHelpers.test.tsx
@@ -3,7 +3,10 @@ import assert from 'node:assert/strict';
 
 import {
   modelPresetsContainId,
+  normalizeSdkRuntimeModelPresets,
+  shouldAdoptSdkCurrentModel,
   shouldLoadSdkRuntimeModels,
+  shouldUseStoredAgentModel,
 } from './AIChatSidePanelHelpers';
 import type { AgentModelPreset, ExternalAgentConfig } from '../infrastructure/ai/types';
 
@@ -30,6 +33,68 @@ test('shouldLoadSdkRuntimeModels includes SDK agents with model catalogs', () =>
   assert.equal(shouldLoadSdkRuntimeModels(agent('claude')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('copilot')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('codebuddy')), true);
+  assert.equal(shouldLoadSdkRuntimeModels(agent('opencode')), true);
   assert.equal(shouldLoadSdkRuntimeModels(agent('codex')), false);
   assert.equal(shouldLoadSdkRuntimeModels(undefined), false);
+});
+
+test('shouldAdoptSdkCurrentModel keeps SDK defaults when no runtime list is returned', () => {
+  assert.equal(shouldAdoptSdkCurrentModel('openai/gpt-5.1', undefined, []), true);
+  assert.equal(shouldAdoptSdkCurrentModel('openai/gpt-5.1', 'openai/gpt-5.1', []), true);
+  assert.equal(
+    shouldAdoptSdkCurrentModel('openai/gpt-5.1', 'anthropic/claude-sonnet', [
+      { id: 'anthropic/claude-sonnet', name: 'Claude' },
+    ]),
+    false,
+  );
+  assert.equal(shouldAdoptSdkCurrentModel(null, undefined, []), false);
+});
+
+test('normalizeSdkRuntimeModelPresets preserves SDK current model without a catalog', () => {
+  assert.deepEqual(normalizeSdkRuntimeModelPresets([], 'custom/provider-model'), [
+    { id: 'custom/provider-model', name: 'custom/provider-model' },
+  ]);
+  assert.deepEqual(normalizeSdkRuntimeModelPresets([], null), []);
+  assert.deepEqual(
+    normalizeSdkRuntimeModelPresets([{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }], 'custom/provider-model'),
+    [
+      { id: 'custom/provider-model', name: 'custom/provider-model' },
+      { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+    ],
+  );
+  assert.deepEqual(
+    normalizeSdkRuntimeModelPresets([{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }], 'openai/gpt-5.1'),
+    [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  );
+});
+
+test('shouldUseStoredAgentModel trusts SDK defaults when no runtime list is returned', () => {
+  const opencodeAgent: ExternalAgentConfig = {
+    id: 'managed_opencode',
+    name: 'OpenCode',
+    command: 'opencode',
+    enabled: true,
+    sdkBackend: 'opencode',
+  };
+
+  assert.equal(shouldUseStoredAgentModel('openai/gpt-5.1', [], opencodeAgent), true);
+  assert.equal(shouldUseStoredAgentModel('openai/gpt-5.1', [], undefined), false);
+  assert.equal(
+    shouldUseStoredAgentModel('anthropic/claude-sonnet', [
+      { id: 'anthropic/claude-sonnet', name: 'Claude' },
+    ], opencodeAgent),
+    true,
+  );
+  assert.equal(
+    shouldUseStoredAgentModel('openai/gpt-5.1', [
+      { id: 'anthropic/claude-sonnet', name: 'Claude' },
+    ], opencodeAgent),
+    true,
+  );
+  assert.equal(
+    shouldUseStoredAgentModel('openai/gpt-5.1', [
+      { id: 'anthropic/claude-sonnet', name: 'Claude' },
+    ], opencodeAgent, { runtimeModelsLoaded: true }),
+    false,
+  );
 });

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -30,7 +30,42 @@ export function isCopilotAgentConfig(agent?: ExternalAgentConfig): boolean {
 
 export function shouldLoadSdkRuntimeModels(agent?: ExternalAgentConfig): boolean {
   const sdkBackend = getExternalAgentSdkBackend(agent);
-  return sdkBackend === 'claude' || sdkBackend === 'copilot' || sdkBackend === 'codebuddy';
+  return sdkBackend === 'claude'
+    || sdkBackend === 'copilot'
+    || sdkBackend === 'codebuddy'
+    || sdkBackend === 'opencode';
+}
+
+export function shouldAdoptSdkCurrentModel(
+  currentModelId: string | null | undefined,
+  storedModelId: string | null | undefined,
+  runtimePresets: AgentModelPreset[],
+): boolean {
+  if (!currentModelId) return false;
+  return !storedModelId
+    || runtimePresets.length === 0
+    || !modelPresetsContainId(runtimePresets, storedModelId);
+}
+
+export function normalizeSdkRuntimeModelPresets(
+  models: AgentModelPreset[],
+  currentModelId: string | null | undefined,
+): AgentModelPreset[] {
+  if (!currentModelId) return models;
+  if (modelPresetsContainId(models, currentModelId)) return models;
+  return [{ id: currentModelId, name: currentModelId }, ...models];
+}
+
+export function shouldUseStoredAgentModel(
+  storedModelId: string | null | undefined,
+  presets: AgentModelPreset[],
+  agent?: ExternalAgentConfig,
+  options: { runtimeModelsLoaded?: boolean } = {},
+): boolean {
+  if (!storedModelId) return false;
+  if (modelPresetsContainId(presets, storedModelId)) return true;
+  if (!shouldLoadSdkRuntimeModels(agent)) return false;
+  return options.runtimeModelsLoaded !== true;
 }
 
 export function generateId(): string {

--- a/components/ai/managedAgentState.test.ts
+++ b/components/ai/managedAgentState.test.ts
@@ -195,6 +195,23 @@ test('buildManagedAgentState stores CODEBUDDY_CODE_PATH for codebuddy', () => {
   });
 });
 
+test('buildManagedAgentState stores OPENCODE_BIN for opencode', () => {
+  const state = buildManagedAgentState(
+    [],
+    'catty',
+    'opencode',
+    { path: '/opt/homebrew/bin/opencode', version: '1.0.0', available: true },
+  );
+
+  assert.equal(state.agents.length, 1);
+  assert.equal(state.agents[0].id, 'discovered_opencode');
+  assert.equal(state.agents[0].command, '/opt/homebrew/bin/opencode');
+  assert.equal(state.agents[0].sdkBackend, 'opencode');
+  assert.deepEqual(state.agents[0].env, {
+    OPENCODE_BIN: '/opt/homebrew/bin/opencode',
+  });
+});
+
 test('updateCodebuddyManagedEnv creates a disabled managed entry before CLI detection', () => {
   const state = updateCodebuddyManagedEnv([], 'internal', 'CODEBUDDY_API_KEY=secret');
 

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -199,6 +199,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     copilot: string;
     cursor: string;
     codebuddy: string;
+    opencode: string;
   } | null>(null);
   if (!initialManagedPathsRef.current) {
     initialManagedPathsRef.current = getInitialManagedAgentPaths(externalAgents);
@@ -258,6 +259,12 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const [codebuddyCustomPath, setCodebuddyCustomPath] = useState(() => initialManagedPathsRef.current?.codebuddy ?? "");
   const [isResolvingCodebuddy, setIsResolvingCodebuddy] = useState(false);
 
+  const [opencodePathInfo, setOpencodePathInfo] = useState<AgentPathInfo | null>(
+    () => getSavedManagedAgentPathInfo(externalAgents, "opencode"),
+  );
+  const [opencodeCustomPath, setOpencodeCustomPath] = useState(() => initialManagedPathsRef.current?.opencode ?? "");
+  const [isResolvingOpencode, setIsResolvingOpencode] = useState(false);
+
   const codebuddyManagedEnv = useMemo(
     () => externalAgents.find((a) => a.id === "discovered_codebuddy")?.env,
     [externalAgents],
@@ -295,7 +302,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   useEffect(() => () => {
     mountedRef.current = false;
     codexRequestIdRef.current += 1;
-    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy"] as ManagedAgentKey[]) {
+    for (const key of ["codex", "claude", "copilot", "cursor", "codebuddy", "opencode"] as ManagedAgentKey[]) {
       agentPathRequestIdRef.current[key] = (agentPathRequestIdRef.current[key] ?? 0) + 1;
     }
   }, []);
@@ -313,7 +320,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
           ? setCopilotPathInfo
           : agentKey === "cursor"
             ? setCursorPathInfo
-            : setCodebuddyPathInfo;
+            : agentKey === "codebuddy"
+              ? setCodebuddyPathInfo
+              : setOpencodePathInfo;
 
     setInfo(result);
 
@@ -352,7 +361,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
           ? setIsResolvingCopilot
           : agentKey === "cursor"
             ? setIsResolvingCursor
-            : setIsResolvingCodebuddy;
+            : agentKey === "codebuddy"
+              ? setIsResolvingCodebuddy
+              : setIsResolvingOpencode;
 
     setResolving(true);
     const requestId = (agentPathRequestIdRef.current[agentKey] ?? 0) + 1;
@@ -383,7 +394,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               ? setCopilotPathInfo
               : agentKey === "cursor"
                 ? setCursorPathInfo
-                : setCodebuddyPathInfo;
+                : agentKey === "codebuddy"
+                  ? setCodebuddyPathInfo
+                  : setOpencodePathInfo;
         setInfo(result);
         return result;
       }
@@ -420,6 +433,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         options: { apiKeyPresent: Boolean(cursorApiKeyEncrypted) },
       },
       { key: "codebuddy", delayMs: 1280, path: initialPaths?.codebuddy ?? "" },
+      { key: "opencode", delayMs: 1560, path: initialPaths?.opencode ?? "" },
     ];
     const cancelTasks = tasks
       .filter((task) => !autoResolvedAgentStateRef.current[task.key])
@@ -570,7 +584,9 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
           ? copilotCustomPath
           : agentKey === "codebuddy"
             ? codebuddyCustomPath
-            : "";
+            : agentKey === "opencode"
+              ? opencodeCustomPath
+              : "";
     const result = await resolveAgentPath(agentKey, customPath, {
       refreshShellEnv: true,
       commandSource: customPath.trim() ? "manual" : "auto",
@@ -582,7 +598,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
         codexPath: result?.path || customPath.trim() || undefined,
       });
     }
-  }, [claudeCustomPath, codexCustomPath, copilotCustomPath, codebuddyCustomPath, resolveAgentPath, refreshCodexIntegration]);
+  }, [claudeCustomPath, codexCustomPath, copilotCustomPath, codebuddyCustomPath, opencodeCustomPath, resolveAgentPath, refreshCodexIntegration]);
 
   const handleResetCustomPath = useCallback(async (agentKey: ManagedAgentKey) => {
     if (agentKey === "codex") {
@@ -593,6 +609,8 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
       setCopilotCustomPath("");
     } else if (agentKey === "codebuddy") {
       setCodebuddyCustomPath("");
+    } else if (agentKey === "opencode") {
+      setOpencodeCustomPath("");
     }
 
     const result = await resolveAgentPath(agentKey, "", {
@@ -951,6 +969,21 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
               onInternetEnvChange={(v) => updateCodebuddyEnv(v, codebuddyEnvText)}
               envText={codebuddyEnvText}
               onEnvTextChange={(v) => updateCodebuddyEnv(codebuddyInternetEnv, v)}
+            />
+          </SettingsSection>
+
+          <SettingsSection
+            title={t('ai.opencode.title')}
+            leading={<AgentIconBadge agent={{ id: "opencode", icon: "opencode", name: "OpenCode" }} variant="plain" className="h-5 w-5 text-muted-foreground/90" />}
+          >
+            <CopilotCliCard
+              pathInfo={opencodePathInfo}
+              isResolvingPath={isResolvingOpencode}
+              customPath={opencodeCustomPath}
+              onCustomPathChange={setOpencodeCustomPath}
+              onRecheckPath={() => void handleCheckCustomPath("opencode")}
+              onResetPath={() => void handleResetCustomPath("opencode")}
+              i18nPrefix="ai.opencode"
             />
           </SettingsSection>
 

--- a/components/settings/tabs/ai/CopilotCliCard.tsx
+++ b/components/settings/tabs/ai/CopilotCliCard.tsx
@@ -12,7 +12,7 @@ export const CopilotCliCard: React.FC<{
   onCustomPathChange: (path: string) => void;
   onRecheckPath: () => void;
   onResetPath?: () => void;
-  i18nPrefix?: "ai.copilot" | "ai.cursor";
+  i18nPrefix?: "ai.copilot" | "ai.cursor" | "ai.opencode";
   allowEmptyCheck?: boolean;
   showCustomPathInput?: boolean;
 }> = ({

--- a/components/settings/tabs/ai/managedAgentState.ts
+++ b/components/settings/tabs/ai/managedAgentState.ts
@@ -101,7 +101,9 @@ export function buildManagedAgentState(
       ? { ...(existingManaged?.env ?? {}), CLAUDE_CODE_EXECUTABLE: pathInfo.path }
       : agentKey === "codebuddy"
         ? { ...(existingManaged?.env ?? {}), CODEBUDDY_CODE_PATH: pathInfo.path }
-        : existingManaged?.env;
+        : agentKey === "opencode"
+          ? { ...(existingManaged?.env ?? {}), OPENCODE_BIN: pathInfo.path }
+          : existingManaged?.env;
   const nextManagedAgent: ExternalAgentConfig = {
     ...existingManagedWithoutLegacy,
     ...defaults,
@@ -165,5 +167,6 @@ export function getInitialManagedAgentPaths(agents: ExternalAgentConfig[]) {
     copilot: getAutoManagedAgentStoredPath(agents, "copilot") ?? "",
     cursor: getAutoManagedAgentStoredPath(agents, "cursor") ?? "",
     codebuddy: getAutoManagedAgentStoredPath(agents, "codebuddy") ?? "",
+    opencode: getAutoManagedAgentStoredPath(agents, "opencode") ?? "",
   };
 }

--- a/components/settings/tabs/ai/types.ts
+++ b/components/settings/tabs/ai/types.ts
@@ -149,6 +149,12 @@ export const AGENT_DEFAULTS: Record<string, Omit<ExternalAgentConfig, "id" | "co
     icon: "codebuddy",
     sdkBackend: "codebuddy",
   },
+  opencode: {
+    name: "OpenCode",
+    args: [],
+    icon: "opencode",
+    sdkBackend: "opencode",
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -175,7 +181,7 @@ export function normalizeCodexBridgeError(error: unknown): string {
 // Provider icon helper
 // ---------------------------------------------------------------------------
 
-export type SettingsIconId = AIProviderId | "claude" | "copilot" | "codebuddy";
+export type SettingsIconId = AIProviderId | "claude" | "copilot" | "codebuddy" | "opencode";
 
 export const SETTINGS_ICON_PATHS: Record<SettingsIconId, string> = {
   openai: "/ai/providers/openai.svg",
@@ -183,6 +189,7 @@ export const SETTINGS_ICON_PATHS: Record<SettingsIconId, string> = {
   claude: "/ai/agents/claude.svg",
   copilot: "/ai/agents/copilot.svg",
   codebuddy: "/ai/agents/codebuddy.svg",
+  opencode: "/ai/agents/opencode.svg",
   google: "/ai/providers/google.svg",
   ollama: "/ai/providers/ollama.svg",
   openrouter: "/ai/providers/openrouter.svg",
@@ -201,6 +208,7 @@ export const SETTINGS_ICON_COLORS: Record<SettingsIconId, string> = {
   claude: "bg-orange-600",
   copilot: "border border-zinc-300 bg-white",
   codebuddy: "bg-indigo-600",
+  opencode: "bg-teal-600",
   google: "bg-blue-600",
   ollama: "bg-purple-600",
   openrouter: "bg-pink-600",

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -109,6 +109,8 @@ module.exports = {
         '!node_modules/@openai/codex-{darwin,linux,linuxmusl,win32}-*/**/*',
         '!node_modules/@github/copilot-{darwin,linux,linuxmusl,win32}-*/**/*',
         '!node_modules/@github/copilot/**/*',
+        '!node_modules/opencode-{darwin,linux,linuxmusl,windows}-*/**/*',
+        '!node_modules/opencode-ai/**/*',
         // CodeBuddy follows the same first-party integration model as the
         // other coding agents: Netcatty discovers and passes the user's
         // installed CLI path to the SDK. Keep the small SDK wrapper, but do not

--- a/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
+++ b/electron/bridges/aiBridge/agentDiscoveryHandlers.cjs
@@ -50,6 +50,8 @@ function registerAgentDiscoveryHandlers(ctx) {
         description: "Cursor's coding agent via Cursor SDK", sdkBackend: "cursor", args: [] },
       { command: "codebuddy", name: "CodeBuddy Code", icon: "codebuddy",
         description: "Tencent's coding agent CLI (Agent SDK)", sdkBackend: "codebuddy", args: [] },
+      { command: "opencode", name: "OpenCode", icon: "opencode",
+        description: "Open source coding agent via the official OpenCode SDK", sdkBackend: "opencode", args: [] },
     ];
 
     const shellEnv = await getShellEnv();
@@ -93,6 +95,8 @@ function registerAgentDiscoveryHandlers(ctx) {
           };
         } else if (agent.command === "codebuddy") {
           auth = probeCodebuddyAuth({ env: shellEnv });
+        } else if (agent.command === "opencode") {
+          auth = { authenticated: true, authSource: "opencode-config" };
         }
       } catch { /* auth probe is best-effort */ }
 

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -14,6 +14,7 @@ const codex = require("./codexDriver.cjs");
 const copilot = require("./copilotDriver.cjs");
 const cursor = require("./cursorDriver.cjs");
 const codebuddy = require("./codebuddyDriver.cjs");
+const opencode = require("./opencodeDriver.cjs");
 
 const DRIVER_REGISTRY = {
   claude: {
@@ -123,6 +124,26 @@ const DRIVER_REGISTRY = {
     },
     async listModels(ctx) {
       return codebuddy.listCodebuddyModels({ pathToCodebuddyCode: ctx.binPath, env: ctx.env });
+    },
+  },
+  opencode: {
+    async runTurn(ctx) {
+      return opencode.runOpenCodeTurn({
+        prompt: ctx.prompt,
+        attachments: ctx.attachments,
+        cwd: ctx.cwd,
+        model: ctx.model,
+        env: ctx.env,
+        binPath: ctx.binPath,
+        injectedMcpServers: ctx.injectedMcpServers,
+        toolIntegrationMode: ctx.toolIntegrationMode,
+        resumeSessionId: ctx.resumeSessionId,
+        emitter: ctx.emitter,
+        abortController: ctx.abortController,
+      });
+    },
+    async listModels(ctx) {
+      return opencode.listOpenCodeModels({ env: ctx.env, binPath: ctx.binPath });
     },
   },
 };

--- a/electron/bridges/aiBridge/sdk/index.test.cjs
+++ b/electron/bridges/aiBridge/sdk/index.test.cjs
@@ -3,11 +3,11 @@ const assert = require("node:assert/strict");
 const { getDriver, listBackends, DRIVER_REGISTRY } = require("./index.cjs");
 
 test("registry exposes SDK backends", () => {
-  assert.deepEqual(listBackends().sort(), ["claude", "codebuddy", "codex", "copilot", "cursor"]);
+  assert.deepEqual(listBackends().sort(), ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]);
 });
 
 test("getDriver returns a driver with runTurn", () => {
-  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor"]) {
+  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]) {
     const d = getDriver(key);
     assert.equal(typeof d.runTurn, "function", `${key} must expose runTurn`);
   }
@@ -18,7 +18,7 @@ test("getDriver throws on unknown backend", () => {
 });
 
 test("SDK drivers expose listModels; codex returns [] (no catalog)", async () => {
-  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor"]) {
+  for (const key of ["claude", "codebuddy", "codex", "copilot", "cursor", "opencode"]) {
     assert.equal(typeof getDriver(key).listModels, "function", `${key} must expose listModels`);
   }
   assert.deepEqual(await getDriver("codex").listModels({}), []);

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -1,0 +1,678 @@
+"use strict";
+
+const net = require("node:net");
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
+
+const OPENCODE_IMAGE_MEDIA_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+const DEFAULT_OPENCODE_PORT = 4096;
+
+function isOpenCodeImageAttachment(attachment) {
+  return Boolean(
+    attachment &&
+    OPENCODE_IMAGE_MEDIA_TYPES.has(String(attachment.mediaType || "").toLowerCase()) &&
+    attachment.filePath,
+  );
+}
+
+function parseOpenCodeModel(model) {
+  const raw = String(model || "").trim();
+  const slash = raw.indexOf("/");
+  if (slash <= 0 || slash === raw.length - 1) return undefined;
+  return {
+    providerID: raw.slice(0, slash),
+    modelID: raw.slice(slash + 1),
+  };
+}
+
+function toOpenCodeMcpConfig(injectedMcpServers) {
+  const mcp = {};
+  for (const cfg of injectedMcpServers || []) {
+    if (!cfg || !cfg.name) continue;
+    mcp[cfg.name] = {
+      type: "local",
+      command: [cfg.command, ...(cfg.args || [])],
+      environment: mcpEnvPairsToObject(cfg.env),
+      enabled: true,
+    };
+  }
+  return mcp;
+}
+
+function buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode } = {}) {
+  const allowBash = toolIntegrationMode === "skills";
+  const config = {
+    share: "disabled",
+    autoupdate: false,
+    permission: {
+      edit: "deny",
+      bash: allowBash ? "allow" : "deny",
+      webfetch: "deny",
+      external_directory: "deny",
+    },
+    mcp: toOpenCodeMcpConfig(injectedMcpServers),
+  };
+  if (model) config.model = model;
+  return config;
+}
+
+function buildOpenCodePromptParts(prompt, attachments) {
+  const parts = [{ type: "text", text: String(prompt || "") }];
+  for (const attachment of Array.isArray(attachments) ? attachments : []) {
+    if (!isOpenCodeImageAttachment(attachment)) continue;
+    parts.push({
+      type: "file",
+      mime: String(attachment.mediaType).toLowerCase(),
+      filename: attachment.filename,
+      url: pathToFileURL(attachment.filePath).href,
+    });
+  }
+  return parts;
+}
+
+function extractOpenCodeErrorMessage(error) {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  return String(
+    error.data?.message ||
+    error.message ||
+    error.name ||
+    "",
+  );
+}
+
+function getOpenCodeResultError(result) {
+  if (!result || typeof result !== "object") return null;
+  return result.error || null;
+}
+
+function getOpenCodeEventPayload(event) {
+  if (event?.payload && typeof event.payload === "object") return event.payload;
+  if (event?.type && event?.properties) return event;
+  return null;
+}
+
+function getOpenCodeSessionIdFromEvent(event) {
+  const properties = getOpenCodeEventPayload(event)?.properties;
+  return properties?.sessionID
+    || properties?.sessionId
+    || properties?.part?.sessionID
+    || properties?.part?.sessionId
+    || properties?.info?.sessionID
+    || properties?.info?.sessionId
+    || properties?.info?.id
+    || null;
+}
+
+function getOpenCodePartId(part) {
+  return part?.id || part?.partID || part?.partId || null;
+}
+
+function rememberOpenCodePartType(state, part) {
+  const partId = getOpenCodePartId(part);
+  if (!partId || !part?.type) return;
+  state.partTypes = state.partTypes || new Map();
+  state.partTypes.set(partId, part.type);
+}
+
+function getOpenCodeDeltaKind(properties, state) {
+  const partId = properties?.partID || properties?.partId || null;
+  const knownType = partId && state.partTypes?.get(partId);
+  if (knownType === "reasoning" || knownType === "text") return knownType;
+  const field = String(properties?.field || "").toLowerCase();
+  if (field.includes("reason") || field.includes("thinking")) return "reasoning";
+  if (field === "text" || field === "content" || field.endsWith(".text") || field.endsWith(".content")) return "text";
+  return null;
+}
+
+function emitOpenCodePartChunk({ emitter, state, partId, kind, text, isDelta }) {
+  if (typeof text !== "string" || text.length === 0) return false;
+  let chunk = text;
+  if (partId) {
+    state.partOffsets = state.partOffsets || new Map();
+    const emittedLength = state.partOffsets.get(partId) || 0;
+    if (isDelta) {
+      state.partOffsets.set(partId, emittedLength + text.length);
+    } else {
+      chunk = text.slice(emittedLength);
+      state.partOffsets.set(partId, Math.max(emittedLength, text.length));
+    }
+  }
+  if (!chunk) return false;
+  if (kind === "reasoning") {
+    emitter.reasoning(chunk);
+    state.reasoningOpen = true;
+  } else {
+    emitter.text(chunk);
+  }
+  return true;
+}
+
+function translateOpenCodeEvent(event, emitter, state = {}) {
+  const payload = getOpenCodeEventPayload(event);
+  if (!payload || typeof payload !== "object") return { idle: false, error: false, content: false };
+
+  if (payload.type === "message.part.updated") {
+    const part = payload.properties?.part;
+    if (!part || typeof part !== "object") return { idle: false, error: false, content: false };
+    rememberOpenCodePartType(state, part);
+
+    if (part.type === "text") {
+      const delta = payload.properties?.delta;
+      if (emitOpenCodePartChunk({
+        emitter,
+        state,
+        partId: getOpenCodePartId(part),
+        kind: "text",
+        text: typeof delta === "string" ? delta : part.text,
+        isDelta: typeof delta === "string",
+      })) {
+        return { idle: false, error: false, content: true };
+      }
+      return { idle: false, error: false, content: false };
+    }
+
+    if (part.type === "reasoning") {
+      const delta = payload.properties?.delta;
+      if (emitOpenCodePartChunk({
+        emitter,
+        state,
+        partId: getOpenCodePartId(part),
+        kind: "reasoning",
+        text: typeof delta === "string" ? delta : part.text,
+        isDelta: typeof delta === "string",
+      })) {
+        return { idle: false, error: false, content: true };
+      }
+      return { idle: false, error: false, content: false };
+    }
+
+    if (part.type === "tool") {
+      if (state.reasoningOpen) {
+        emitter.reasoningEnd?.();
+        state.reasoningOpen = false;
+      }
+      const callId = part.callID || part.id || "";
+      const toolName = part.tool || "tool";
+      const input = part.state?.input || {};
+      if (part.state?.status === "running" || part.state?.status === "pending") {
+        state.toolCalls = state.toolCalls || new Set();
+        if (!state.toolCalls.has(callId)) {
+          state.toolCalls.add(callId);
+          emitter.toolCall(toolName, input, callId);
+        }
+      } else if (part.state?.status === "completed") {
+        state.toolCalls = state.toolCalls || new Set();
+        if (!state.toolCalls.has(callId)) {
+          state.toolCalls.add(callId);
+          emitter.toolCall(toolName, input, callId);
+        }
+        state.toolResults = state.toolResults || new Set();
+        if (!state.toolResults.has(callId)) {
+          state.toolResults.add(callId);
+          emitter.toolResult(callId, part.state.output || "", toolName);
+        }
+      } else if (part.state?.status === "error") {
+        emitter.emitError(part.state.error || "OpenCode tool failed");
+        return { idle: false, error: true, content: false };
+      }
+    }
+    return { idle: false, error: false, content: part.type === "tool" };
+  }
+
+  if (payload.type === "message.part.delta") {
+    const properties = payload.properties || {};
+    const delta = typeof properties.delta === "string" ? properties.delta : "";
+    const kind = getOpenCodeDeltaKind(properties, state);
+    if (!delta || !kind) return { idle: false, error: false, content: false };
+    if (emitOpenCodePartChunk({
+      emitter,
+      state,
+      partId: properties.partID || properties.partId || null,
+      kind,
+      text: delta,
+      isDelta: true,
+    })) {
+      return { idle: false, error: false, content: true };
+    }
+    return { idle: false, error: false, content: false };
+  }
+
+  if (payload.type === "session.error") {
+    emitter.emitError(extractOpenCodeErrorMessage(payload.properties?.error) || "OpenCode session failed");
+    return { idle: false, error: true, content: false };
+  }
+
+  if (payload.type === "session.idle") {
+    if (state.reasoningOpen) {
+      emitter.reasoningEnd?.();
+      state.reasoningOpen = false;
+    }
+    emitter.status("OpenCode session idle");
+    return { idle: true, error: false, content: false };
+  }
+
+  if (payload.type === "session.status" && payload.properties?.status?.type) {
+    emitter.status(`OpenCode session ${payload.properties.status.type}`);
+  }
+
+  return { idle: false, error: false, content: false };
+}
+
+function classifyOpenCodeSpawnError(error) {
+  const code = error && error.code;
+  const msg = String((error && error.message) || error || "");
+  return {
+    isSpawnEnoent: code === "ENOENT" || /ENOENT/i.test(msg) || /not found/i.test(msg),
+    message: msg,
+  };
+}
+
+function shellQuotePosix(value) {
+  return `"${String(value).replace(/(["\\$`])/g, "\\$1")}"`;
+}
+
+function createOpenCodeShim(binPath, options = {}) {
+  if (!binPath) return null;
+  const platform = options.platform || process.platform;
+  const tempDirBridge = options.tempDirBridge || require("../../tempDirBridge.cjs");
+  const getTempFilePath = options.getTempFilePath || tempDirBridge.getTempFilePath;
+  const shimParent = getTempFilePath("opencode-sdk-shim");
+  const uniqueId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  const shimRoot = path.join(shimParent, uniqueId);
+  fs.mkdirSync(shimRoot, { recursive: true });
+  const shimName = platform === "win32" ? "opencode.cmd" : "opencode";
+  const shimPath = path.join(shimRoot, shimName);
+  if (platform === "win32") {
+    fs.writeFileSync(shimPath, `@echo off\r\n"${binPath}" %*\r\n`);
+  } else {
+    fs.writeFileSync(shimPath, `#!/bin/sh\nexec ${shellQuotePosix(binPath)} "$@"\n`);
+    fs.chmodSync(shimPath, 0o755);
+  }
+  return {
+    dir: shimRoot,
+    path: shimPath,
+    cleanup() {
+      try { fs.rmSync(shimRoot, { recursive: true, force: true }); } catch {}
+      try { fs.rmdirSync(shimParent); } catch {}
+    },
+  };
+}
+
+function createOpenCodeProcessEnv(env, binPath, options = {}) {
+  const next = { ...(env || {}) };
+  let shim = null;
+  if (binPath) {
+    shim = createOpenCodeShim(binPath, options);
+    next.OPENCODE_BIN = binPath;
+    next.PATH = [shim?.dir || path.dirname(binPath), next.PATH || process.env.PATH || ""]
+      .filter(Boolean)
+      .join(path.delimiter);
+  }
+  return {
+    env: next,
+    cleanup() {
+      shim?.cleanup?.();
+    },
+  };
+}
+
+function attachOpenCodeCleanup(opencode, cleanup) {
+  if (!opencode || typeof cleanup !== "function") return opencode;
+  const server = opencode.server;
+  if (!server || typeof server.close !== "function") {
+    cleanup();
+    return opencode;
+  }
+  const originalClose = server.close;
+  let cleaned = false;
+  server.close = function wrappedOpenCodeClose(...args) {
+    try {
+      return originalClose.apply(this, args);
+    } finally {
+      if (!cleaned) {
+        cleaned = true;
+        cleanup();
+      }
+    }
+  };
+  return opencode;
+}
+
+function withOpenCodeProcessEnv(env, binPath, fn, options = {}) {
+  const previous = {};
+  const { env: next, cleanup } = createOpenCodeProcessEnv(env, binPath, options);
+  const restoreEnv = () => {
+    for (const key of Object.keys(next)) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+  };
+  for (const [key, value] of Object.entries(next)) {
+    previous[key] = process.env[key];
+    process.env[key] = String(value);
+  }
+  let result;
+  try {
+    result = fn();
+  } catch (error) {
+    restoreEnv();
+    cleanup();
+    throw error;
+  }
+  restoreEnv();
+  if (result && typeof result.then === "function") {
+    return result.then(
+      (opencode) => attachOpenCodeCleanup(opencode, cleanup),
+      (error) => {
+        cleanup();
+        throw error;
+      },
+    );
+  }
+  return attachOpenCodeCleanup(result, cleanup);
+}
+
+function getAvailablePort(host = "127.0.0.1") {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port === DEFAULT_OPENCODE_PORT ? getAvailablePort(host) : port);
+      });
+    });
+  });
+}
+
+async function withOpenCodeServerPort(options = {}) {
+  if (options.port != null) return options;
+  return { ...options, port: await getAvailablePort(options.hostname || "127.0.0.1") };
+}
+
+async function createDefaultOpenCode(options, env, binPath) {
+  let sdk;
+  try { sdk = await import("@opencode-ai/sdk"); } catch {
+    throw new Error("OpenCode SDK not installed. Run: npm install @opencode-ai/sdk");
+  }
+  return withOpenCodeProcessEnv(env, binPath, () => sdk.createOpencode(options));
+}
+
+function createAbortWait(signal) {
+  if (!signal) return { promise: new Promise(() => {}), dispose() {} };
+  if (signal.aborted) return { promise: Promise.resolve(), dispose() {} };
+  let resolveAbort;
+  const promise = new Promise((resolve) => { resolveAbort = resolve; });
+  const onAbort = () => resolveAbort();
+  signal.addEventListener("abort", onAbort, { once: true });
+  return {
+    promise,
+    dispose() {
+      signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+function createStopWait() {
+  let stopped = false;
+  let resolveStop;
+  const promise = new Promise((resolve) => { resolveStop = resolve; });
+  return {
+    promise,
+    get stopped() { return stopped; },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      resolveStop();
+    },
+  };
+}
+
+function createStreamReadyWait() {
+  let ready = false;
+  let resolveReady;
+  const promise = new Promise((resolve) => { resolveReady = resolve; });
+  return {
+    promise,
+    markReady() {
+      if (ready) return;
+      ready = true;
+      resolveReady();
+    },
+  };
+}
+
+async function runOpenCodeTurn({
+  prompt, attachments, cwd, model, injectedMcpServers, toolIntegrationMode,
+  resumeSessionId, env, binPath, emitter, abortController, openCodeFactory,
+}) {
+  const config = buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode });
+  let opencode = null;
+  let sessionId = resumeSessionId || null;
+  let hasContent = false;
+  let failed = false;
+  let abortSent = false;
+  let removeAbortListener = null;
+  const state = { reasoningOpen: false };
+  const directoryQuery = cwd ? { directory: cwd } : undefined;
+
+  try {
+    const factory = openCodeFactory || ((options) => createDefaultOpenCode(options, env, binPath));
+    opencode = await factory(await withOpenCodeServerPort({ config, signal: abortController?.signal }));
+    const { client } = opencode;
+    const abortOpenCode = async () => {
+      if (abortSent) return;
+      abortSent = true;
+      if (sessionId) {
+        try { await client.session.abort({ path: { id: sessionId }, query: directoryQuery }); } catch {}
+      }
+      try { opencode?.server?.close?.(); } catch {}
+    };
+    if (abortController?.signal) {
+      const onAbort = () => { void abortOpenCode(); };
+      abortController.signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => abortController.signal.removeEventListener("abort", onAbort);
+    }
+    const events = await client.global.event({ signal: abortController?.signal });
+
+    if (!sessionId) {
+      const created = await client.session.create({
+        body: { title: "Netcatty OpenCode" },
+        query: directoryQuery,
+      });
+      sessionId = created?.data?.id || created?.id || null;
+    }
+    if (!sessionId) throw new Error("OpenCode did not create a session");
+    emitter.sessionId(sessionId);
+
+    const stopEventLoopWait = createStopWait();
+    const streamReadyWait = createStreamReadyWait();
+    const eventLoop = (async () => {
+      const iterator = events.stream?.[Symbol.asyncIterator]?.();
+      if (!iterator) {
+        streamReadyWait.markReady();
+        return;
+      }
+      const abortWait = createAbortWait(abortController?.signal);
+      try {
+        while (true) {
+          const nextEvent = iterator.next();
+          const raced = await Promise.race([
+            nextEvent.then(
+              (value) => ({ type: "event", value }),
+              (error) => ({ type: "error", error }),
+            ),
+            abortWait.promise.then(() => ({ type: "abort" })),
+            stopEventLoopWait.promise.then(() => ({ type: "stop" })),
+          ]);
+          if (raced.type === "abort") break;
+          if (raced.type === "stop") break;
+          if (raced.type === "error") throw raced.error;
+          const { value: event, done } = raced.value;
+          streamReadyWait.markReady();
+          if (done) break;
+          if (abortController?.signal?.aborted) break;
+          const eventSessionId = getOpenCodeSessionIdFromEvent(event);
+          if (eventSessionId && eventSessionId !== sessionId) continue;
+          const result = translateOpenCodeEvent(event, emitter, state);
+          if (result.content) hasContent = true;
+          if (result.error) {
+            failed = true;
+            break;
+          }
+          if (result.idle) break;
+        }
+      } finally {
+        abortWait.dispose();
+        if (abortController?.signal?.aborted || stopEventLoopWait.stopped) {
+          try { void iterator.return?.(); } catch {}
+        }
+      }
+    })();
+
+    const body = {
+      parts: buildOpenCodePromptParts(prompt, attachments),
+    };
+    const parsedModel = parseOpenCodeModel(model);
+    if (parsedModel) body.model = parsedModel;
+
+    const streamReadyAbortWait = createAbortWait(abortController?.signal);
+    const streamReadyResult = await Promise.race([
+      streamReadyWait.promise.then(() => ({ type: "ready" })),
+      streamReadyAbortWait.promise.then(() => ({ type: "abort" })),
+      eventLoop.then(
+        () => ({ type: "closed" }),
+        (error) => ({ type: "error", error }),
+      ),
+    ]);
+    streamReadyAbortWait.dispose();
+    if (streamReadyResult.type === "error") throw streamReadyResult.error;
+    if (streamReadyResult.type === "abort") {
+      await abortOpenCode();
+      stopEventLoopWait.stop();
+      await eventLoop.catch(() => {});
+      return { sessionId };
+    }
+    if (streamReadyResult.type === "closed" && !abortController?.signal?.aborted) {
+      throw new Error("OpenCode event stream closed before the prompt was sent");
+    }
+
+    const promptAbortWait = createAbortWait(abortController?.signal);
+    const promptResult = await Promise.race([
+      client.session.promptAsync({
+        path: { id: sessionId },
+        query: directoryQuery,
+        body,
+        signal: abortController?.signal,
+        throwOnError: true,
+      }).then(
+        (result) => {
+          const error = getOpenCodeResultError(result);
+          return error ? { type: "error", error } : { type: "prompt" };
+        },
+        (error) => ({ type: "error", error }),
+      ),
+      promptAbortWait.promise.then(() => ({ type: "abort" })),
+    ]);
+    promptAbortWait.dispose();
+    if (promptResult.type === "error") {
+      failed = true;
+      await abortOpenCode();
+      stopEventLoopWait.stop();
+      await eventLoop.catch(() => {});
+      throw promptResult.error;
+    }
+
+    if (promptResult.type === "abort") {
+      await abortOpenCode();
+    } else {
+      await eventLoop;
+    }
+
+    if (abortController?.signal?.aborted) {
+      await abortOpenCode();
+    }
+
+    if (!hasContent && !failed && !abortController?.signal?.aborted) {
+      emitter.emitError("OpenCode returned an empty response. Run `opencode` in a terminal to configure authentication and models.");
+      return { sessionId };
+    }
+    if (!failed && !abortController?.signal?.aborted) emitter.emitDone();
+    return { sessionId };
+  } catch (error) {
+    const classified = classifyOpenCodeSpawnError(error);
+    if (classified.isSpawnEnoent) {
+      emitter.emitError("OpenCode CLI not found or not runnable. Install OpenCode and ensure `opencode` is on PATH, or set a custom path in Settings.");
+    } else {
+      emitter.emitError(extractOpenCodeErrorMessage(error) || classified.message || "OpenCode turn failed");
+    }
+    return { sessionId };
+  } finally {
+    removeAbortListener?.();
+    try { opencode?.server?.close?.(); } catch {}
+  }
+}
+
+function mapOpenCodeModels(response) {
+  const providers = Array.isArray(response?.providers) ? response.providers : [];
+  const models = [];
+  for (const provider of providers) {
+    const providerId = provider?.id || provider?.providerID;
+    if (!providerId || !provider?.models || typeof provider.models !== "object") continue;
+    for (const [modelId, info] of Object.entries(provider.models)) {
+      models.push({
+        id: `${providerId}/${modelId}`,
+        name: `${provider.name || providerId} ${info?.name || modelId}`,
+      });
+    }
+  }
+  return models;
+}
+
+async function listOpenCodeModels({ env, binPath, openCodeFactory } = {}) {
+  let opencode = null;
+  try {
+    const factory = openCodeFactory || ((options) => createDefaultOpenCode(options, env, binPath));
+    opencode = await factory(await withOpenCodeServerPort({ config: { autoupdate: false }, timeout: 10000 }));
+    let currentModelId = null;
+    if (typeof opencode.client.config.get === "function") {
+      try {
+        const configResponse = await opencode.client.config.get();
+        const configData = configResponse?.data || configResponse;
+        currentModelId = typeof configData?.model === "string" && configData.model.includes("/")
+          ? configData.model
+          : null;
+      } catch {}
+    }
+    const response = await opencode.client.config.providers();
+    const data = response?.data || response;
+    return {
+      currentModelId,
+      models: mapOpenCodeModels(data),
+    };
+  } catch {
+    return { currentModelId: null, models: [] };
+  } finally {
+    try { opencode?.server?.close?.(); } catch {}
+  }
+}
+
+module.exports = {
+  buildOpenCodeConfig,
+  buildOpenCodePromptParts,
+  classifyOpenCodeSpawnError,
+  createOpenCodeProcessEnv,
+  withOpenCodeProcessEnv,
+  listOpenCodeModels,
+  mapOpenCodeModels,
+  parseOpenCodeModel,
+  runOpenCodeTurn,
+  toOpenCodeMcpConfig,
+  translateOpenCodeEvent,
+};

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -1,0 +1,742 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  buildOpenCodeConfig,
+  buildOpenCodePromptParts,
+  classifyOpenCodeSpawnError,
+  createOpenCodeProcessEnv,
+  mapOpenCodeModels,
+  parseOpenCodeModel,
+  runOpenCodeTurn,
+  translateOpenCodeEvent,
+  withOpenCodeProcessEnv,
+} = require("./opencodeDriver.cjs");
+
+function collector() {
+  const events = [];
+  const emitter = {
+    text: (t) => events.push({ k: "text", t }),
+    reasoning: (d) => events.push({ k: "reasoning", d }),
+    toolCall: (name, args, id) => events.push({ k: "toolCall", name, args, id }),
+    toolResult: (id, out, name) => events.push({ k: "toolResult", id, out, name }),
+    status: (m) => events.push({ k: "status", m }),
+    sessionId: (s) => events.push({ k: "sessionId", s }),
+    emitDone: () => events.push({ k: "done" }),
+    emitError: (m) => events.push({ k: "error", m }),
+  };
+  return { events, emitter };
+}
+
+test("parseOpenCodeModel splits provider/model ids", () => {
+  assert.deepEqual(parseOpenCodeModel("openai/gpt-5.1"), { providerID: "openai", modelID: "gpt-5.1" });
+  assert.deepEqual(parseOpenCodeModel("anthropic/claude-sonnet-4-6"), { providerID: "anthropic", modelID: "claude-sonnet-4-6" });
+  assert.equal(parseOpenCodeModel("gpt-5.1"), undefined);
+  assert.equal(parseOpenCodeModel(""), undefined);
+});
+
+test("buildOpenCodeConfig isolates local tools and injects Netcatty MCP", () => {
+  const cfg = buildOpenCodeConfig({
+    model: "openai/gpt-5.1",
+    injectedMcpServers: [{
+      name: "netcatty-remote-hosts",
+      command: "/abs/electron",
+      args: ["/abs/server.cjs"],
+      env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
+    }],
+  });
+
+  assert.equal(cfg.model, "openai/gpt-5.1");
+  assert.deepEqual(cfg.permission, {
+    edit: "deny",
+    bash: "deny",
+    webfetch: "deny",
+    external_directory: "deny",
+  });
+  assert.deepEqual(cfg.mcp["netcatty-remote-hosts"], {
+    type: "local",
+    command: ["/abs/electron", "/abs/server.cjs"],
+    environment: { NETCATTY_MCP_PORT: "1" },
+    enabled: true,
+  });
+});
+
+test("buildOpenCodePromptParts includes supported images as file parts", () => {
+  assert.deepEqual(buildOpenCodePromptParts("describe", [
+    { filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" },
+    { filename: "bad.svg", mediaType: "image/svg+xml", filePath: "/tmp/bad.svg", base64Data: "def" },
+  ]), [
+    { type: "text", text: "describe" },
+    { type: "file", mime: "image/png", filename: "shot.png", url: "file:///tmp/shot.png" },
+  ]);
+});
+
+test("createOpenCodeProcessEnv creates an opencode shim for arbitrary custom binary paths", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-opencode-test-"));
+  const fakeBin = path.join(tempRoot, "my-opencode-wrapper");
+  fs.writeFileSync(fakeBin, "#!/bin/sh\n");
+  fs.chmodSync(fakeBin, 0o755);
+
+  const { env, cleanup } = createOpenCodeProcessEnv(
+    { PATH: "/usr/bin" },
+    fakeBin,
+    {
+      platform: "linux",
+      getTempFilePath: (name) => path.join(tempRoot, name),
+    },
+  );
+
+  try {
+    const shimDir = env.PATH.split(path.delimiter)[0];
+    const shim = path.join(shimDir, "opencode");
+    assert.equal(env.OPENCODE_BIN, fakeBin);
+    assert.equal(fs.existsSync(shim), true);
+    assert.match(fs.readFileSync(shim, "utf8"), new RegExp(`exec "${fakeBin.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`));
+  } finally {
+    cleanup();
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("createOpenCodeProcessEnv uses a unique shim directory per launch", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-opencode-test-"));
+  const fakeBin = path.join(tempRoot, "my-opencode-wrapper");
+  fs.writeFileSync(fakeBin, "#!/bin/sh\n");
+  fs.chmodSync(fakeBin, 0o755);
+
+  const first = createOpenCodeProcessEnv(
+    { PATH: "/usr/bin" },
+    fakeBin,
+    {
+      platform: "linux",
+      getTempFilePath: (name) => path.join(tempRoot, name),
+    },
+  );
+  const second = createOpenCodeProcessEnv(
+    { PATH: "/usr/bin" },
+    fakeBin,
+    {
+      platform: "linux",
+      getTempFilePath: (name) => path.join(tempRoot, name),
+    },
+  );
+
+  try {
+    const firstShimDir = first.env.PATH.split(path.delimiter)[0];
+    const secondShimDir = second.env.PATH.split(path.delimiter)[0];
+    const shimParent = path.dirname(firstShimDir);
+    assert.notEqual(firstShimDir, secondShimDir);
+    assert.equal(path.dirname(secondShimDir), shimParent);
+    assert.equal(fs.existsSync(path.join(firstShimDir, "opencode")), true);
+    assert.equal(fs.existsSync(path.join(secondShimDir, "opencode")), true);
+
+    first.cleanup();
+    assert.equal(fs.existsSync(path.join(firstShimDir, "opencode")), false);
+    assert.equal(fs.existsSync(path.join(secondShimDir, "opencode")), true);
+    assert.equal(fs.existsSync(shimParent), true);
+
+    second.cleanup();
+    assert.equal(fs.existsSync(shimParent), false);
+  } finally {
+    second.cleanup();
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("withOpenCodeProcessEnv launches before another call can overwrite process env", async () => {
+  const previousOpenCodeBin = process.env.OPENCODE_BIN;
+  const previousPath = process.env.PATH;
+  const observed = [];
+
+  try {
+    const first = withOpenCodeProcessEnv(
+      { OPENCODE_BIN: "/tmp/opencode-one", PATH: "/tmp/one" },
+      null,
+      () => {
+        observed.push({ bin: process.env.OPENCODE_BIN, path: process.env.PATH });
+        return new Promise((resolve) => setImmediate(resolve));
+      },
+    );
+    const second = withOpenCodeProcessEnv(
+      { OPENCODE_BIN: "/tmp/opencode-two", PATH: "/tmp/two" },
+      null,
+      () => {
+        observed.push({ bin: process.env.OPENCODE_BIN, path: process.env.PATH });
+        return Promise.resolve();
+      },
+    );
+
+    await Promise.all([first, second]);
+
+    assert.deepEqual(observed, [
+      { bin: "/tmp/opencode-one", path: "/tmp/one" },
+      { bin: "/tmp/opencode-two", path: "/tmp/two" },
+    ]);
+  } finally {
+    if (previousOpenCodeBin === undefined) delete process.env.OPENCODE_BIN;
+    else process.env.OPENCODE_BIN = previousOpenCodeBin;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+});
+
+test("withOpenCodeProcessEnv restores process env before async startup settles", async () => {
+  const previousOpenCodeBin = process.env.OPENCODE_BIN;
+  const previousPath = process.env.PATH;
+  let releaseStartup;
+
+  try {
+    const pending = withOpenCodeProcessEnv(
+      { OPENCODE_BIN: "/tmp/opencode-starting", PATH: "/tmp/opencode-shim" },
+      null,
+      () => {
+        assert.equal(process.env.OPENCODE_BIN, "/tmp/opencode-starting");
+        return new Promise((resolve) => { releaseStartup = resolve; });
+      },
+    );
+
+    assert.equal(process.env.OPENCODE_BIN, previousOpenCodeBin);
+    assert.equal(process.env.PATH, previousPath);
+    releaseStartup();
+    await pending;
+  } finally {
+    if (previousOpenCodeBin === undefined) delete process.env.OPENCODE_BIN;
+    else process.env.OPENCODE_BIN = previousOpenCodeBin;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+});
+
+test("withOpenCodeProcessEnv keeps the opencode shim until the server closes", async () => {
+  const previousOpenCodeBin = process.env.OPENCODE_BIN;
+  const previousPath = process.env.PATH;
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-opencode-test-"));
+  const fakeBin = path.join(tempRoot, "my-opencode-wrapper");
+  fs.writeFileSync(fakeBin, "#!/bin/sh\n");
+  fs.chmodSync(fakeBin, 0o755);
+  let releaseStartup;
+  let shimDir;
+  let closeCount = 0;
+
+  try {
+    const pending = withOpenCodeProcessEnv(
+      { PATH: "/usr/bin" },
+      fakeBin,
+      () => {
+        shimDir = process.env.PATH.split(path.delimiter)[0];
+        return new Promise((resolve) => {
+          releaseStartup = () => resolve({
+            server: {
+              close() {
+                closeCount += 1;
+              },
+            },
+          });
+        });
+      },
+      {
+        platform: "linux",
+        getTempFilePath: (name) => path.join(tempRoot, name),
+      },
+    );
+
+    const shimPath = path.join(shimDir, "opencode");
+    assert.equal(process.env.OPENCODE_BIN, previousOpenCodeBin);
+    assert.equal(process.env.PATH, previousPath);
+    assert.equal(fs.existsSync(shimPath), true);
+
+    releaseStartup();
+    const opencode = await pending;
+    assert.equal(fs.existsSync(shimPath), true);
+
+    opencode.server.close();
+    assert.equal(closeCount, 1);
+    assert.equal(fs.existsSync(shimPath), false);
+  } finally {
+    if (previousOpenCodeBin === undefined) delete process.env.OPENCODE_BIN;
+    else process.env.OPENCODE_BIN = previousOpenCodeBin;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("translateOpenCodeEvent maps text, reasoning, tools, errors, and idle", () => {
+  const { events, emitter } = collector();
+  const state = {};
+  translateOpenCodeEvent(
+    { directory: "/tmp", payload: { type: "message.part.updated", properties: { part: { type: "text", id: "p1", text: "hello" }, delta: "he" } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { payload: { type: "message.part.updated", properties: { part: { type: "reasoning", id: "r1", text: "thinking" }, delta: "think" } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { payload: { type: "message.part.updated", properties: { part: { type: "tool", callID: "tool-1", tool: "netcatty_run", state: { status: "running", input: { command: "uptime" } } } } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { payload: { type: "message.part.updated", properties: { part: { type: "tool", callID: "tool-1", tool: "netcatty_run", state: { status: "completed", input: { command: "uptime" }, output: "ok" } } } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { payload: { type: "session.error", properties: { error: { data: { message: "bad key" } } } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { payload: { type: "session.idle", properties: { sessionID: "sess-1" } } },
+    emitter,
+    state,
+  );
+
+  assert.deepEqual(events, [
+    { k: "text", t: "he" },
+    { k: "reasoning", d: "think" },
+    { k: "toolCall", name: "netcatty_run", args: { command: "uptime" }, id: "tool-1" },
+    { k: "toolResult", id: "tool-1", out: "ok", name: "netcatty_run" },
+    { k: "error", m: "bad key" },
+    { k: "status", m: "OpenCode session idle" },
+  ]);
+});
+
+test("translateOpenCodeEvent maps OpenCode part delta text and reasoning events", () => {
+  const { events, emitter } = collector();
+  const state = {};
+
+  assert.equal(
+    translateOpenCodeEvent(
+      { type: "message.part.delta", properties: { sessionID: "sess-1", messageID: "msg-1", partID: "p1", field: "text", delta: "he" } },
+      emitter,
+      state,
+    ).content,
+    true,
+  );
+  translateOpenCodeEvent(
+    { type: "message.part.updated", properties: { part: { type: "text", id: "p1", sessionID: "sess-1", text: "hello" } } },
+    emitter,
+    state,
+  );
+  translateOpenCodeEvent(
+    { type: "message.part.updated", properties: { part: { type: "reasoning", id: "r1", sessionID: "sess-1", text: "" } } },
+    emitter,
+    state,
+  );
+  assert.equal(
+    translateOpenCodeEvent(
+      { type: "message.part.delta", properties: { sessionID: "sess-1", messageID: "msg-1", partID: "r1", field: "text", delta: "think" } },
+      emitter,
+      state,
+    ).content,
+    true,
+  );
+  translateOpenCodeEvent(
+    { type: "message.part.updated", properties: { part: { type: "reasoning", id: "r1", sessionID: "sess-1", text: "thinking" } } },
+    emitter,
+    state,
+  );
+
+  assert.deepEqual(events, [
+    { k: "text", t: "he" },
+    { k: "text", t: "llo" },
+    { k: "reasoning", d: "think" },
+    { k: "reasoning", d: "ing" },
+  ]);
+});
+
+test("translateOpenCodeEvent also accepts direct OpenCode SDK events", () => {
+  const { events, emitter } = collector();
+  translateOpenCodeEvent(
+    { type: "message.part.updated", properties: { part: { type: "text", sessionID: "sess-1", id: "p1", text: "hello" }, delta: "he" } },
+    emitter,
+  );
+  translateOpenCodeEvent(
+    { type: "session.idle", properties: { sessionID: "sess-1" } },
+    emitter,
+  );
+
+  assert.deepEqual(events, [
+    { k: "text", t: "he" },
+    { k: "status", m: "OpenCode session idle" },
+  ]);
+});
+
+test("translateOpenCodeEvent emits a tool call before a result when only completion arrives", () => {
+  const { events, emitter } = collector();
+  translateOpenCodeEvent(
+    { type: "message.part.updated", properties: { part: { type: "tool", callID: "tool-1", tool: "netcatty_run", state: { status: "completed", input: { command: "whoami" }, output: "me" } } } },
+    emitter,
+  );
+
+  assert.deepEqual(events, [
+    { k: "toolCall", name: "netcatty_run", args: { command: "whoami" }, id: "tool-1" },
+    { k: "toolResult", id: "tool-1", out: "me", name: "netcatty_run" },
+  ]);
+});
+
+test("mapOpenCodeModels flattens providers", () => {
+  assert.deepEqual(mapOpenCodeModels({
+    providers: [
+      { id: "openai", name: "OpenAI", models: { "gpt-5.1": { name: "GPT-5.1" } } },
+      { id: "anthropic", models: { "claude-sonnet": {} } },
+    ],
+  }), [
+    { id: "openai/gpt-5.1", name: "OpenAI GPT-5.1" },
+    { id: "anthropic/claude-sonnet", name: "anthropic claude-sonnet" },
+  ]);
+  assert.deepEqual(mapOpenCodeModels(null), []);
+});
+
+test("runOpenCodeTurn ignores events from other OpenCode sessions", async () => {
+  const { events, emitter } = collector();
+  const abortController = new AbortController();
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "server.connected", properties: {} };
+      yield { type: "message.part.updated", properties: { part: { type: "text", sessionID: "other", id: "p0", text: "wrong" }, delta: "wrong" } };
+      yield { type: "message.part.updated", properties: { part: { type: "text", sessionID: "sess-1", id: "p1", text: "right" }, delta: "right" } };
+      yield { type: "session.idle", properties: { sessionID: "sess-1" } };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => ({ data: true }),
+    },
+  };
+
+  await runOpenCodeTurn({
+    prompt: "hello",
+    emitter,
+    abortController,
+    openCodeFactory: async () => ({ client, server: { close() {} } }),
+  });
+
+  assert.deepEqual(events.filter((event) => event.k === "text"), [
+    { k: "text", t: "right" },
+  ]);
+});
+
+test("runOpenCodeTurn creates a session, streams event deltas, and returns session id", async () => {
+  const { events, emitter } = collector();
+  const abortController = new AbortController();
+  let eventController;
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      yield { payload: { type: "server.connected", properties: {} } };
+      await new Promise((resolve) => { eventController = resolve; });
+      yield { payload: { type: "message.part.updated", properties: { part: { type: "text", id: "p1", text: "hi" }, delta: "hi" } } };
+      yield { payload: { type: "session.idle", properties: { sessionID: "sess-1" } } };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async (args) => {
+        assert.equal(args.query.directory, "/repo");
+        return { data: { id: "sess-1" } };
+      },
+      promptAsync: async (args) => {
+        assert.equal(args.path.id, "sess-1");
+        assert.deepEqual(args.body.model, { providerID: "openai", modelID: "gpt-5.1" });
+        eventController();
+        return { data: true };
+      },
+    },
+  };
+
+  const result = await runOpenCodeTurn({
+    prompt: "hello",
+    cwd: "/repo",
+    model: "openai/gpt-5.1",
+    emitter,
+    abortController,
+    openCodeFactory: async () => ({ client, server: { close() {} } }),
+  });
+
+  assert.deepEqual(result, { sessionId: "sess-1" });
+  assert.deepEqual(events, [
+    { k: "sessionId", s: "sess-1" },
+    { k: "text", t: "hi" },
+    { k: "status", m: "OpenCode session idle" },
+    { k: "done" },
+  ]);
+});
+
+test("runOpenCodeTurn treats OpenCode part delta events as streamed content", async () => {
+  const { events, emitter } = collector();
+  const abortController = new AbortController();
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "server.connected", properties: {} };
+      yield { type: "message.part.delta", properties: { sessionID: "sess-1", messageID: "msg-1", partID: "p1", field: "text", delta: "hi" } };
+      yield { type: "session.idle", properties: { sessionID: "sess-1" } };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => ({ data: true }),
+    },
+  };
+
+  const result = await runOpenCodeTurn({
+    prompt: "hello",
+    emitter,
+    abortController,
+    openCodeFactory: async () => ({ client, server: { close() {} } }),
+  });
+
+  assert.deepEqual(result, { sessionId: "sess-1" });
+  assert.deepEqual(events, [
+    { k: "sessionId", s: "sess-1" },
+    { k: "text", t: "hi" },
+    { k: "status", m: "OpenCode session idle" },
+    { k: "done" },
+  ]);
+});
+
+test("runOpenCodeTurn surfaces promptAsync error results without waiting for events", async () => {
+  const { events, emitter } = collector();
+  const abortController = new AbortController();
+  let closeCount = 0;
+  let abortCount = 0;
+  let iteratorReturnCount = 0;
+  const stream = {
+    [Symbol.asyncIterator]() {
+      let connected = false;
+      return {
+        next: async () => {
+          if (!connected) {
+            connected = true;
+            return { value: { type: "server.connected", properties: {} }, done: false };
+          }
+          return new Promise(() => {});
+        },
+        return: async () => {
+          iteratorReturnCount += 1;
+          return { done: true };
+        },
+      };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => ({ error: { data: { message: "bad model" } } }),
+      abort: async () => { abortCount += 1; },
+    },
+  };
+
+  const result = await Promise.race([
+    runOpenCodeTurn({
+      prompt: "hello",
+      emitter,
+      abortController,
+      openCodeFactory: async () => ({ client, server: { close() { closeCount += 1; } } }),
+    }),
+    new Promise((resolve) => setTimeout(() => resolve("timed-out"), 50)),
+  ]);
+
+  assert.notEqual(result, "timed-out");
+  assert.deepEqual(result, { sessionId: "sess-1" });
+  assert.equal(events.some((event) => event.k === "error" && event.m === "bad model"), true);
+  assert.equal(events.some((event) => event.k === "done"), false);
+  assert.equal(abortCount, 1);
+  assert.equal(closeCount >= 1, true);
+  assert.equal(iteratorReturnCount, 1);
+});
+
+test("runOpenCodeTurn returns promptly when aborted while the event stream is quiet", async () => {
+  const { events, emitter } = collector();
+  const abortController = new AbortController();
+  let closeCount = 0;
+  let abortCount = 0;
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      await new Promise(() => {});
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => ({ data: true }),
+      abort: async () => { abortCount += 1; },
+    },
+  };
+
+  const running = runOpenCodeTurn({
+    prompt: "hello",
+    emitter,
+    abortController,
+    openCodeFactory: async () => ({ client, server: { close() { closeCount += 1; } } }),
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  abortController.abort();
+
+  const result = await Promise.race([
+    running,
+    new Promise((resolve) => setTimeout(() => resolve("timed-out"), 50)),
+  ]);
+
+  assert.notEqual(result, "timed-out");
+  assert.deepEqual(result, { sessionId: "sess-1" });
+  assert.equal(abortCount, 1);
+  assert.equal(closeCount >= 1, true);
+  assert.equal(events.some((event) => event.k === "done"), false);
+});
+
+test("runOpenCodeTurn passes an explicit non-default port to the OpenCode SDK factory", async () => {
+  const { emitter } = collector();
+  const abortController = new AbortController();
+  let capturedPort;
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "server.connected", properties: {} };
+      yield { type: "message.part.updated", properties: { part: { type: "text", sessionID: "sess-1", id: "p1", text: "ok" }, delta: "ok" } };
+      yield { type: "session.idle", properties: { sessionID: "sess-1" } };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => ({ data: true }),
+    },
+  };
+
+  await runOpenCodeTurn({
+    prompt: "hello",
+    emitter,
+    abortController,
+    openCodeFactory: async (options) => {
+      capturedPort = options.port;
+      return { client, server: { close() {} } };
+    },
+  });
+
+  assert.equal(typeof capturedPort, "number");
+  assert.notEqual(capturedPort, 4096);
+});
+
+test("runOpenCodeTurn waits for the OpenCode event stream before prompting", async () => {
+  const { emitter } = collector();
+  const abortController = new AbortController();
+  let releaseServerConnected;
+  let serverConnectedSeen = false;
+  let promptStarted = false;
+  const stream = {
+    async *[Symbol.asyncIterator]() {
+      await new Promise((resolve) => { releaseServerConnected = resolve; });
+      yield { payload: { type: "server.connected", properties: {} } };
+      serverConnectedSeen = true;
+      yield { payload: { type: "message.part.updated", properties: { part: { type: "text", sessionID: "sess-1", id: "p1", text: "ok" }, delta: "ok" } } };
+      yield { payload: { type: "session.idle", properties: { sessionID: "sess-1" } } };
+    },
+  };
+  const client = {
+    global: { event: async () => ({ stream }) },
+    session: {
+      create: async () => ({ data: { id: "sess-1" } }),
+      promptAsync: async () => {
+        promptStarted = true;
+        assert.equal(serverConnectedSeen, true);
+        return { data: true };
+      },
+    },
+  };
+
+  const running = runOpenCodeTurn({
+    prompt: "hello",
+    model: "openai/gpt-5.1",
+    emitter,
+    abortController,
+    openCodeFactory: async () => ({ client, server: { close() {} } }),
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(promptStarted, false);
+  releaseServerConnected();
+  const result = await running;
+
+  assert.deepEqual(result, { sessionId: "sess-1" });
+  assert.equal(promptStarted, true);
+});
+
+test("listOpenCodeModels passes an explicit non-default port to the OpenCode SDK factory", async () => {
+  let capturedPort;
+  const models = await require("./opencodeDriver.cjs").listOpenCodeModels({
+    openCodeFactory: async (options) => {
+      capturedPort = options.port;
+      return {
+        client: {
+          config: {
+            get: async () => ({ model: "openai/gpt-5.1" }),
+            providers: async () => ({ providers: [] }),
+          },
+        },
+        server: { close() {} },
+      };
+    },
+  });
+
+  assert.deepEqual(models, { currentModelId: "openai/gpt-5.1", models: [] });
+  assert.equal(typeof capturedPort, "number");
+  assert.notEqual(capturedPort, 4096);
+});
+
+test("listOpenCodeModels preserves provider for nested configured model ids", async () => {
+  const models = await require("./opencodeDriver.cjs").listOpenCodeModels({
+    openCodeFactory: async () => ({
+      client: {
+        config: {
+          get: async () => ({ data: { model: "openrouter/openai/gpt-5.1" } }),
+          providers: async () => ({ providers: [] }),
+        },
+      },
+      server: { close() {} },
+    }),
+  });
+
+  assert.deepEqual(models, { currentModelId: "openrouter/openai/gpt-5.1", models: [] });
+});
+
+test("listOpenCodeModels does not adopt provider defaults as the current model", async () => {
+  const models = await require("./opencodeDriver.cjs").listOpenCodeModels({
+    openCodeFactory: async () => ({
+      client: {
+        config: {
+          get: async () => ({}),
+          providers: async () => ({
+            providers: [
+              { id: "openai", name: "OpenAI", models: { "gpt-5.1": { name: "GPT-5.1" } } },
+            ],
+            default: { openai: "gpt-5.1", openrouter: "openai/gpt-5.1" },
+          }),
+        },
+      },
+      server: { close() {} },
+    }),
+  });
+
+  assert.deepEqual(models, {
+    currentModelId: null,
+    models: [{ id: "openai/gpt-5.1", name: "OpenAI GPT-5.1" }],
+  });
+});
+
+test("classifyOpenCodeSpawnError recognizes missing opencode CLI", () => {
+  assert.equal(classifyOpenCodeSpawnError(Object.assign(new Error("spawn opencode ENOENT"), { code: "ENOENT" })).isSpawnEnoent, true);
+  assert.equal(classifyOpenCodeSpawnError(new Error("other")).isSpawnEnoent, false);
+});

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -28,6 +28,17 @@ function buildSdkModelCacheKey(backendKey, binPath) {
   return [String(backendKey || ""), String(binPath || "")].join("\u0000");
 }
 
+function shouldCacheSdkRuntimeModels(backendKey) {
+  return backendKey !== "opencode";
+}
+
+function normalizeSdkListModelsResult(raw) {
+  const rawModels = Array.isArray(raw) ? raw : raw?.models;
+  const currentModelId = Array.isArray(raw) ? null : raw?.currentModelId || null;
+  const models = Array.isArray(rawModels) ? rawModels.filter((m) => m && m.id) : [];
+  return { currentModelId, models };
+}
+
 function isPathLikeCommand(command) {
   const raw = String(command || "").trim();
   return Boolean(raw && (raw.includes("/") || raw.includes("\\") || /^[a-z]:/i.test(raw)));
@@ -192,6 +203,11 @@ function resolveSdkBackendBinPath({
       ? resolveCodebuddyExecutableForSdk(realPath)
       : realPath;
     return sdkPath || undefined;
+  }
+  if (backendKey === "opencode") {
+    const configuredEnvPath = normalizeCliPathForPlatform?.(env?.OPENCODE_BIN);
+    const rawPath = configuredEnvPath || resolveCliFromPath(backendKey, shellEnv) || undefined;
+    return rawPath ? resolveRealCliPath(rawPath, realpath) : undefined;
   }
   return resolveSdkBinPath?.(backendKey, shellEnv) || undefined;
 }
@@ -445,15 +461,18 @@ function registerSdkStreamHandlers(ctx) {
         });
         // claude/copilot enumerate models via the SDK; codex has no catalog (its
         // driver returns []), so the renderer falls back to curated presets.
+        // OpenCode model catalogs are user-config driven and can change outside
+        // Netcatty, so do not cache them behind the generic SDK cache.
         const cacheKey = buildSdkModelCacheKey(backendKey, binPath);
-        const cached = sdkModelCache.get(cacheKey);
+        const shouldCacheModels = shouldCacheSdkRuntimeModels(backendKey);
+        const cached = shouldCacheModels ? sdkModelCache.get(cacheKey) : null;
         if (cached && Date.now() - cached.at < MODEL_CACHE_TTL_MS) {
-          return { ok: true, currentModelId: null, models: cached.models };
+          return { ok: true, currentModelId: cached.currentModelId || null, models: cached.models };
         }
         const raw = await withTimeout(driver.listModels({ binPath, env }), MODEL_LIST_TIMEOUT_MS);
-        const models = Array.isArray(raw) ? raw.filter((m) => m && m.id) : [];
-        sdkModelCache.set(cacheKey, { at: Date.now(), models });
-        return { ok: true, currentModelId: null, models };
+        const { currentModelId, models } = normalizeSdkListModelsResult(raw);
+        if (shouldCacheModels) sdkModelCache.set(cacheKey, { at: Date.now(), currentModelId, models });
+        return { ok: true, currentModelId, models };
       } catch (err) {
         // Degrade to [] so the renderer keeps its curated presets (never empty).
         console.debug(`[sdk] list-models(${backendKey}) unavailable, using curated presets`);
@@ -496,7 +515,9 @@ module.exports = {
   resolveSdkBackendBinPath,
   buildSdkSessionKey,
   buildSdkModelCacheKey,
+  normalizeSdkListModelsResult,
   resolveSdkResumeSessionId,
+  shouldCacheSdkRuntimeModels,
   normalizeHistoryMessages,
   buildSdkTurnPrompt,
 };

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -4,9 +4,11 @@ const {
   buildSdkTurnPrompt,
   buildSdkModelCacheKey,
   buildSdkSessionKey,
+  normalizeSdkListModelsResult,
   resolveSdkResumeSessionId,
   resolveBackendKey,
   resolveSdkBackendBinPath,
+  shouldCacheSdkRuntimeModels,
 } = require("./sdkStreamHandlers.cjs");
 
 test("resolveBackendKey maps backend command/value to registry key", () => {
@@ -14,6 +16,7 @@ test("resolveBackendKey maps backend command/value to registry key", () => {
   assert.equal(resolveBackendKey("codex"), "codex");
   assert.equal(resolveBackendKey("copilot"), "copilot");
   assert.equal(resolveBackendKey("codebuddy"), "codebuddy");
+  assert.equal(resolveBackendKey("opencode"), "opencode");
 });
 
 test("resolveBackendKey returns null for unknown", () => {
@@ -38,6 +41,26 @@ test("SDK model cache keys include resolved CLI path", () => {
     buildSdkModelCacheKey("claude", "/usr/local/bin/claude"),
     buildSdkModelCacheKey("claude", "/opt/homebrew/bin/claude"),
   );
+});
+
+test("normalizeSdkListModelsResult preserves current model ids from object results", () => {
+  assert.deepEqual(normalizeSdkListModelsResult({
+    currentModelId: "openai/gpt-5.1",
+    models: [{ id: "openai/gpt-5.1" }, null, { name: "missing-id" }],
+  }), {
+    currentModelId: "openai/gpt-5.1",
+    models: [{ id: "openai/gpt-5.1" }],
+  });
+  assert.deepEqual(normalizeSdkListModelsResult([{ id: "claude-sonnet" }]), {
+    currentModelId: null,
+    models: [{ id: "claude-sonnet" }],
+  });
+});
+
+test("shouldCacheSdkRuntimeModels skips OpenCode model catalogs", () => {
+  assert.equal(shouldCacheSdkRuntimeModels("opencode"), false);
+  assert.equal(shouldCacheSdkRuntimeModels("claude"), true);
+  assert.equal(shouldCacheSdkRuntimeModels("codebuddy"), true);
 });
 
 test("SDK resume only uses the current backend/path session key", () => {

--- a/infrastructure/ai/managedAgents.ts
+++ b/infrastructure/ai/managedAgents.ts
@@ -1,6 +1,6 @@
 import type { DiscoveredAgent, ExternalAgentConfig } from './types';
 
-export type ManagedAgentKey = 'codex' | 'claude' | 'copilot' | 'cursor' | 'codebuddy';
+export type ManagedAgentKey = 'codex' | 'claude' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode';
 
 const MANAGED_AGENT_META: Record<ManagedAgentKey, { commandNames: string[]; sdkBackend: string }> = {
   codex: { commandNames: ['codex'], sdkBackend: 'codex' },
@@ -8,6 +8,7 @@ const MANAGED_AGENT_META: Record<ManagedAgentKey, { commandNames: string[]; sdkB
   copilot: { commandNames: ['copilot'], sdkBackend: 'copilot' },
   cursor: { commandNames: ['cursor'], sdkBackend: 'cursor' },
   codebuddy: { commandNames: ['codebuddy'], sdkBackend: 'codebuddy' },
+  opencode: { commandNames: ['opencode'], sdkBackend: 'opencode' },
 };
 
 function getCommandBasename(command: string | undefined): string {
@@ -34,7 +35,8 @@ export function isSettingsManagedDiscoveredAgent(
     || agent.command === 'claude'
     || agent.command === 'copilot'
     || agent.command === 'cursor'
-    || agent.command === 'codebuddy';
+    || agent.command === 'codebuddy'
+    || agent.command === 'opencode';
 }
 
 export function matchesManagedAgentConfig(

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -233,7 +233,7 @@ export interface ExternalAgentConfig {
   icon?: string;
   enabled: boolean;
   available?: boolean;
-  /** SDK backend key for managed agents (claude|codex|copilot|cursor|codebuddy). */
+  /** SDK backend key for managed agents (claude|codex|copilot|cursor|codebuddy|opencode). */
   sdkBackend?: string;
   /** Internal: whether the managed command was set manually or auto-detected. */
   commandSource?: "manual" | "auto";
@@ -258,8 +258,8 @@ export interface DiscoveredAgent {
   /** @deprecated Legacy discovery field from the pre-SDK migration. */
   acpCommand?: string;
   acpArgs?: string[];
-  /** SDK backend key (claude|codex|copilot|cursor|codebuddy) — the routing value. */
-  sdkBackend?: 'claude' | 'codex' | 'copilot' | 'cursor' | 'codebuddy';
+  /** SDK backend key (claude|codex|copilot|cursor|codebuddy|opencode) — the routing value. */
+  sdkBackend?: 'claude' | 'codex' | 'copilot' | 'cursor' | 'codebuddy' | 'opencode';
   /** Absolute resolved CLI path (preferred over `path`). */
   binPath?: string;
   installed?: boolean;
@@ -477,6 +477,14 @@ export const CODEBUDDY_MODEL_PRESETS: AgentModelPreset[] = [
   { id: 'hy3-preview', name: 'Hy3 Preview' },
 ];
 
+export const OPENCODE_MODEL_PRESETS: AgentModelPreset[] = [
+  { id: 'openai/gpt-5.1', name: 'OpenAI GPT-5.1' },
+  { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
+  { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat' },
+  { id: 'openrouter/openai/gpt-5.1', name: 'OpenRouter GPT-5.1' },
+  { id: 'ollama/llama3.3', name: 'Ollama Llama 3.3' },
+];
+
 export function getAgentModelPresets(agentCommand?: string): AgentModelPreset[] {
   if (!agentCommand) return [];
   // Split on both POSIX (/) and Windows (\) separators so command paths like
@@ -488,6 +496,7 @@ export function getAgentModelPresets(agentCommand?: string): AgentModelPreset[] 
   if (basename.startsWith('codex')) return CODEX_MODEL_PRESETS;
   if (basename.startsWith('cursor')) return CURSOR_MODEL_PRESETS;
   if (basename.startsWith('codebuddy')) return CODEBUDDY_MODEL_PRESETS;
+  if (basename.startsWith('opencode')) return OPENCODE_MODEL_PRESETS;
   return [];
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.161",
         "@cursor/sdk": "^1.0.18",
         "@github/copilot-sdk": "1.0.0",
+        "@opencode-ai/sdk": "^1.17.9",
         "@tencent-ai/agent-sdk": "^0.3.173",
         "@vscode/windows-process-tree": "^0.7.0"
       }
@@ -4445,6 +4446,16 @@
       ],
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.9.tgz",
+      "integrity": "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.161",
     "@cursor/sdk": "^1.0.18",
     "@github/copilot-sdk": "1.0.0",
+    "@opencode-ai/sdk": "^1.17.9",
     "@tencent-ai/agent-sdk": "^0.3.173",
     "@vscode/windows-process-tree": "^0.7.0"
   },

--- a/public/ai/agents/NOTICE.md
+++ b/public/ai/agents/NOTICE.md
@@ -15,3 +15,8 @@
   `Factory.factory-vscode-extension` marketplace package
   (`extension/resources/icons/droid.svg`). The mark remains the property of
   Factory.ai and is used here only to identify Droid CLI sessions in the UI.
+
+## From [opencode](https://github.com/sst/opencode)
+
+- `opencode.svg` — copied from the official OpenCode brand asset
+  `packages/console/app/src/asset/brand/opencode-logo-light-square.svg`.

--- a/public/ai/agents/opencode.svg
+++ b/public/ai/agents/opencode.svg
@@ -1,4 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="444.00 174.00 312.00 312.00" fill="currentColor">
-  <path d="M520,180h200v300h-240V180h40ZM540,300v120h120v-180h-120v60Z"/>
-  <path d="M660,300v120h-120v-120h120Z" fill-opacity="0.5"/>
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(30, 0)">
+<g clip-path="url(#clip0_1401_86274)">
+<mask id="mask0_1401_86274" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="240" height="300">
+<path d="M240 0H0V300H240V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_1401_86274)">
+<path d="M180 240H60V120H180V240Z" fill="#CFCECD"/>
+<path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#211E1E"/>
+</g>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_1401_86274">
+<rect width="240" height="300" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -26,6 +26,8 @@ test("build.files excludes per-platform agent binaries", () => {
     "!node_modules/@openai/codex-{darwin,linux,linuxmusl,win32}-*/**/*",
     "!node_modules/@github/copilot-{darwin,linux,linuxmusl,win32}-*/**/*",
     "!node_modules/@github/copilot/**/*",
+    "!node_modules/opencode-{darwin,linux,linuxmusl,windows}-*/**/*",
+    "!node_modules/opencode-ai/**/*",
   ];
   for (const glob of expectExclusions) {
     assert.ok(


### PR DESCRIPTION
## Summary
- Add OpenCode as a managed SDK agent with CLI discovery and custom path support
- Load OpenCode models from the SDK while preserving selected custom/current models
- Use the official OpenCode SVG asset and exclude OpenCode CLI platform packages from app packaging

Closes #1563

## Verification
- node --test electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs electron/bridges/aiBridge/sdk/index.test.cjs scripts/electron-builder-config.test.cjs
- node --test --import tsx components/AIChatSidePanelHelpers.test.tsx components/ai/managedAgentState.test.ts
- npm run lint
- npm run build
- codex review --uncommitted: no actionable findings