### PR TITLE
fix: Docker panel NOPASSWD sudo fallback (#1595)

### DIFF
--- a/electron/bridges/systemManager/dockerOps.cjs
+++ b/electron/bridges/systemManager/dockerOps.cjs
@@ -46,6 +46,10 @@ function buildDockerCommand(args) {
   return `docker ${args}`.trim();
 }
 
+function buildPasswordlessSudoDockerCommand(args) {
+  return `sudo ${buildDockerCommand(args)}`;
+}
+
 function buildSudoDockerCommand(args) {
   return `sudo -S -p '' ${buildDockerCommand(args)}`;
 }
@@ -169,21 +173,35 @@ function createDockerOpsApi({ execOnSession, getSession }) {
     const result = await execOnSession(event, sessionId, cmd, timeoutMs);
     if (isSuccessfulCommandResult(result)) return result;
 
-    const sudoPassword = getSessionSudoPassword(getSession?.(sessionId));
+    if (isDockerSocketPermissionError(result)) {
+      const sudoPassword = getSessionSudoPassword(getSession?.(sessionId));
+      let lastSudoResult = null;
 
-    if (sudoPassword && isDockerSocketPermissionError(result)) {
-      const sudoResult = await execOnSession(
+      const nopasswdResult = await execOnSession(
         event,
         sessionId,
-        buildSudoDockerCommand(args),
+        buildPasswordlessSudoDockerCommand(args),
         timeoutMs,
-        { stdin: `${sudoPassword}\n` },
       );
-      if (isSuccessfulCommandResult(sudoResult)) return sudoResult;
+      if (isSuccessfulCommandResult(nopasswdResult)) return nopasswdResult;
+      lastSudoResult = nopasswdResult;
+
+      if (sudoPassword) {
+        const sudoResult = await execOnSession(
+          event,
+          sessionId,
+          buildSudoDockerCommand(args),
+          timeoutMs,
+          { stdin: `${sudoPassword}\n` },
+        );
+        if (isSuccessfulCommandResult(sudoResult)) return sudoResult;
+        lastSudoResult = sudoResult;
+      }
+
       return {
         success: false,
-        error: dockerCommandError(sudoResult, `sudo docker exited with code ${sudoResult?.code}`),
-        stderr: sudoResult?.stderr,
+        error: dockerCommandError(lastSudoResult, `sudo docker exited with code ${lastSudoResult?.code}`),
+        stderr: lastSudoResult?.stderr,
       };
     }
 

--- a/electron/bridges/systemManager/dockerOps.test.cjs
+++ b/electron/bridges/systemManager/dockerOps.test.cjs
@@ -45,6 +45,56 @@ test("listContainers falls back to sudo when plain docker hits socket permission
           code: 1,
         };
       }
+      if (calls.length === 2) {
+        return {
+          success: true,
+          stdout: "",
+          stderr: "sudo: a password is required",
+          code: 1,
+        };
+      }
+      return {
+        success: true,
+        stdout: '{"ID":"abc123","Names":"web","Image":"nginx","State":"running"}\n',
+        stderr: "",
+        code: 0,
+      };
+    },
+  });
+
+  const result = await dockerOps.listContainers(null, "s1");
+
+  assert.equal(result.success, true);
+  assert.equal(result.containers.length, 1);
+  assert.equal(calls.length, 3);
+  assert.equal(calls[0].command, "docker ps -a --format '{{json .}}'");
+  assert.equal(calls[0].execOptions, undefined);
+  assert.equal(
+    calls[1].command,
+    "sudo docker ps -a --format '{{json .}}'",
+  );
+  assert.equal(calls[1].execOptions, undefined);
+  assert.equal(
+    calls[2].command,
+    "sudo -S -p '' docker ps -a --format '{{json .}}'",
+  );
+  assert.deepEqual(calls[2].execOptions, { stdin: "host-secret\n" });
+});
+
+test("listContainers falls back to passwordless sudo when no saved password exists", async () => {
+  const calls = [];
+  const dockerOps = createDockerOpsApi({
+    getSession: () => ({}),
+    execOnSession: async (_event, sessionId, command, timeoutMs, execOptions) => {
+      calls.push({ sessionId, command, timeoutMs, execOptions });
+      if (calls.length === 1) {
+        return {
+          success: true,
+          stdout: "",
+          stderr: "Got permission denied while trying to connect to the Docker daemon socket",
+          code: 1,
+        };
+      }
       return {
         success: true,
         stdout: '{"ID":"abc123","Names":"web","Image":"nginx","State":"running"}\n',
@@ -60,34 +110,11 @@ test("listContainers falls back to sudo when plain docker hits socket permission
   assert.equal(result.containers.length, 1);
   assert.equal(calls.length, 2);
   assert.equal(calls[0].command, "docker ps -a --format '{{json .}}'");
-  assert.equal(calls[0].execOptions, undefined);
   assert.equal(
     calls[1].command,
-    "sudo -S -p '' docker ps -a --format '{{json .}}'",
+    "sudo docker ps -a --format '{{json .}}'",
   );
-  assert.deepEqual(calls[1].execOptions, { stdin: "host-secret\n" });
-});
-
-test("listContainers uses plain docker when no saved password exists", async () => {
-  const calls = [];
-  const dockerOps = createDockerOpsApi({
-    getSession: () => ({}),
-    execOnSession: async (_event, sessionId, command, timeoutMs, execOptions) => {
-      calls.push({ sessionId, command, timeoutMs, execOptions });
-      return {
-        success: true,
-        stdout: "",
-        stderr: "Got permission denied while trying to connect to the Docker daemon socket",
-        code: 1,
-      };
-    },
-  });
-
-  const result = await dockerOps.listContainers(null, "s1");
-
-  assert.equal(result.success, false);
-  assert.match(result.error, /permission denied/i);
-  assert.equal(calls.length, 1);
+  assert.equal(calls[1].execOptions, undefined);
 });
 
 test("listContainers does not retry with transport auth passwords that were not saved for sudo autofill", async () => {
@@ -112,7 +139,12 @@ test("listContainers does not retry with transport auth passwords that were not 
 
   assert.equal(result.success, false);
   assert.match(result.error, /permission denied/i);
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 2);
+  assert.equal(
+    calls[1].command,
+    "sudo docker ps -a --format '{{json .}}'",
+  );
+  assert.equal(calls[1].execOptions, undefined);
 });
 
 test("listContainers retries with explicit sudo autofill password on mosh or et sessions", async () => {
@@ -132,6 +164,14 @@ test("listContainers retries with explicit sudo autofill password on mosh or et 
           code: 1,
         };
       }
+      if (calls.length === 2) {
+        return {
+          success: true,
+          stdout: "",
+          stderr: "sudo: a password is required",
+          code: 1,
+        };
+      }
       return {
         success: true,
         stdout: '{"ID":"abc123","Names":"web","Image":"nginx","State":"running"}\n',
@@ -144,12 +184,12 @@ test("listContainers retries with explicit sudo autofill password on mosh or et 
   const result = await dockerOps.listContainers(null, "s1");
 
   assert.equal(result.success, true);
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
   assert.equal(
-    calls[1].command,
+    calls[2].command,
     "sudo -S -p '' docker ps -a --format '{{json .}}'",
   );
-  assert.deepEqual(calls[1].execOptions, { stdin: "saved-secret\n" });
+  assert.deepEqual(calls[2].execOptions, { stdin: "saved-secret\n" });
 });
 
 test("docker image actions retry with sudo and send saved passwords through stdin", async () => {
@@ -166,6 +206,14 @@ test("docker image actions retry with sudo and send saved passwords through stdi
           code: 1,
         };
       }
+      if (calls.length === 2) {
+        return {
+          success: true,
+          stdout: "",
+          stderr: "sudo: a password is required",
+          code: 1,
+        };
+      }
       return { success: true, stdout: "deleted\n", stderr: "", code: 0 };
     },
   });
@@ -177,10 +225,10 @@ test("docker image actions retry with sudo and send saved passwords through stdi
   });
 
   assert.equal(result.success, true);
-  assert.equal(calls.length, 2);
+  assert.equal(calls.length, 3);
   assert.equal(
-    calls[1].command,
+    calls[2].command,
     "sudo -S -p '' docker rmi sha256abc123",
   );
-  assert.deepEqual(calls[1].execOptions, { stdin: "pa'ss\n" });
+  assert.deepEqual(calls[2].execOptions, { stdin: "pa'ss\n" });
 });


### PR DESCRIPTION
## Summary
- Fixes #1595 by retrying Docker panel commands with passwordless `sudo docker` when plain `docker` hits socket permission errors.
- Keeps the existing `sudo -S` path for hosts that require a saved sudo password, tried only after passwordless sudo fails.
- Aligns Docker panel behavior with the Docker Shell/Logs popup terminals, which already use plain `sudo`.

## Test plan
- [x] `node --test electron/bridges/systemManager/dockerOps.test.cjs`
- [ ] Verify on a host with NOPASSWD sudo and no login password: Docker panel lists containers/images
- [ ] Verify on a host with password-required sudo and saved autofill password: Docker panel still works


Made with [Cursor](https://cursor.com)