### PR TITLE
fix(ui): render flag emoji in host labels on Windows (#1589)

### DIFF
--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -66,7 +66,7 @@ import { TERMINAL_THEME_AUTO } from '../../domain/terminalAppearance';
 import { customThemeStore, useCustomThemes } from '../state/customThemeStore';
 import { DEFAULT_FONT_SIZE } from '../../infrastructure/config/fonts';
 import { getUiThemeById } from '../../infrastructure/config/uiThemes';
-import { DEFAULT_UI_FONT_ID } from '../../infrastructure/config/uiFonts';
+import { DEFAULT_UI_FONT_ID, withWindowsEmojiFallback } from '../../infrastructure/config/uiFonts';
 import { uiFontStore, useUIFontsLoaded } from './uiFontStore';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
@@ -654,7 +654,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   // Re-run when fonts finish loading to get correct family for local fonts
   useLayoutEffect(() => {
     const font = uiFontStore.getFontById(uiFontFamilyId);
-    document.documentElement.style.setProperty('--font-sans', font.family);
+    document.documentElement.style.setProperty('--font-sans', withWindowsEmojiFallback(font.family));
     localStorageAdapter.writeString(STORAGE_KEY_UI_FONT_FAMILY, uiFontFamilyId);
     // Fix 1: Skip IPC broadcast on initial mount
     if (persistMountedRef.current) {

--- a/index.css
+++ b/index.css
@@ -123,6 +123,12 @@
 
 }
 
+/* Windows: Space Grotesk includes regional-indicator letters that block
+   composed flag emoji unless a color emoji font is tried first (#1589). */
+html.platform-win32 {
+  --font-sans: "Segoe UI Emoji", "Segoe UI Symbol", "Space Grotesk", system-ui, sans-serif;
+}
+
 @keyframes top-tab-enter {
   from {
     opacity: 0;

--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
       color: hsl(var(--foreground));
     }
 
+    html.platform-win32 body {
+      font-family: 'Segoe UI Emoji', 'Segoe UI Symbol', 'Space Grotesk', system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    }
+
     /* Global Modern Scrollbar */
     ::-webkit-scrollbar {
       width: 10px;
@@ -182,6 +186,11 @@
         }
 
         if (lang) root.lang = lang;
+
+        var ua = navigator.userAgent || '';
+        if (/Win/i.test(ua)) {
+          root.classList.add('platform-win32');
+        }
       } catch (e) {
         // ignore
       }

--- a/infrastructure/config/uiFonts.test.ts
+++ b/infrastructure/config/uiFonts.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  detectUiPlatform,
+  withWindowsEmojiFallback,
+  WINDOWS_UI_EMOJI_FONTS,
+  withUiCjkFallback,
+} from './uiFonts';
+
+describe('detectUiPlatform', () => {
+  it('detects Windows user agents', () => {
+    assert.equal(
+      detectUiPlatform('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'),
+      'win32',
+    );
+  });
+
+  it('detects macOS user agents', () => {
+    assert.equal(
+      detectUiPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36'),
+      'darwin',
+    );
+  });
+
+  it('falls back to linux for other platforms', () => {
+    assert.equal(
+      detectUiPlatform('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'),
+      'linux',
+    );
+  });
+});
+
+describe('withWindowsEmojiFallback', () => {
+  const sampleFamily = '"Space Grotesk", system-ui, sans-serif';
+
+  it('prepends Windows emoji fonts so host labels can render flag emoji', () => {
+    const stack = withWindowsEmojiFallback(sampleFamily, 'win32');
+    assert.ok(stack.startsWith(WINDOWS_UI_EMOJI_FONTS));
+    assert.match(stack, /Space Grotesk/);
+  });
+
+  it('keeps the stack unchanged on non-Windows platforms', () => {
+    assert.equal(withWindowsEmojiFallback(sampleFamily, 'darwin'), sampleFamily);
+    assert.equal(withWindowsEmojiFallback(sampleFamily, 'linux'), sampleFamily);
+  });
+
+  it('does not double-prepend when emoji fonts are already present', () => {
+    const alreadyPrefixed = `${WINDOWS_UI_EMOJI_FONTS}, ${sampleFamily}`;
+    assert.equal(withWindowsEmojiFallback(alreadyPrefixed, 'win32'), alreadyPrefixed);
+  });
+});
+
+describe('withUiCjkFallback', () => {
+  it('still appends CJK fallbacks for UI font stacks', () => {
+    const stack = withUiCjkFallback('"Space Grotesk", system-ui');
+    assert.match(stack, /PingFang SC/);
+    assert.match(stack, /Space Grotesk/);
+  });
+});

--- a/infrastructure/config/uiFonts.ts
+++ b/infrastructure/config/uiFonts.ts
@@ -9,6 +9,15 @@ export interface UIFont {
   family: string;
 }
 
+export type UiPlatform = 'darwin' | 'win32' | 'linux';
+
+/**
+ * Windows bundles UI fonts via @font-face. Their regional-indicator glyphs
+ * render as separate letters instead of composed flag emoji unless a color
+ * emoji font is consulted first — see #1589.
+ */
+export const WINDOWS_UI_EMOJI_FONTS = '"Segoe UI Emoji", "Segoe UI Symbol"';
+
 /**
  * Fallback fonts for CJK (Chinese, Japanese, Korean) support
  */
@@ -32,6 +41,24 @@ export const withUiCjkFallback = (family: string) => {
   }
   return `${trimmed}, ${CJK_FALLBACK_STACK}`;
 };
+
+export function detectUiPlatform(userAgent: string): UiPlatform {
+  if (/Win/i.test(userAgent)) return 'win32';
+  if (/Mac|iPod|iPhone|iPad/i.test(userAgent)) return 'darwin';
+  return 'linux';
+}
+
+export function withWindowsEmojiFallback(
+  family: string,
+  platform: UiPlatform = typeof navigator !== 'undefined'
+    ? detectUiPlatform(navigator.userAgent)
+    : 'linux',
+): string {
+  if (platform !== 'win32') return family;
+  const trimmed = family.trim();
+  if (trimmed.includes('Segoe UI Emoji')) return trimmed;
+  return `${WINDOWS_UI_EMOJI_FONTS}, ${trimmed}`;
+}
 
 const BASE_UI_FONTS: UIFont[] = [
   {


### PR DESCRIPTION
## Summary
- On Windows, prepend `Segoe UI Emoji` / `Segoe UI Symbol` to the UI sans font stack so regional-indicator pairs in host labels compose into flag emoji instead of separate letters.
- Apply the emoji prefix both at initial paint (`platform-win32` CSS class) and when settings update `--font-sans` at runtime.

## Test plan
- [x] `node --test --import tsx infrastructure/config/uiFonts.test.ts`
- [ ] On Windows, create a host with label `🇭🇰 prod` and verify the vault/tree/tab show a flag emoji
- [ ] Change UI font in Settings and confirm flag emoji still renders
- [ ] On macOS/Linux, confirm labels and fonts are unchanged

Fixes #1589

Made with [Cursor](https://cursor.com)