### PR TITLE
Fix tmux detach focus regression on Windows (#1587)

### DIFF
--- a/components/systemManager/SystemPanelConfirmDialog.tsx
+++ b/components/systemManager/SystemPanelConfirmDialog.tsx
@@ -1,0 +1,69 @@
+import React, { memo } from 'react';
+import { useI18n } from '../../application/i18n/I18nProvider';
+import { cn } from '../../lib/utils';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
+
+interface SystemPanelConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  busy?: boolean;
+  destructive?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+/**
+ * In-app confirm dialog. Prefer this over window.confirm() in Electron side panels:
+ * native confirms can leave focus/modal state broken on Windows, which blocks
+ * subsequent Radix dialogs (e.g. tmux "new session" right after detach).
+ */
+export const SystemPanelConfirmDialog = memo(function SystemPanelConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  busy = false,
+  destructive = false,
+  onOpenChange,
+  onConfirm,
+}: SystemPanelConfirmDialogProps) {
+  const { t } = useI18n();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[380px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground whitespace-pre-wrap">{message}</p>
+
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+            className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className={cn(
+              'px-3 py-1.5 text-sm rounded-md transition-colors disabled:opacity-50',
+              destructive
+                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                : 'bg-primary text-primary-foreground hover:bg-primary/90',
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});

--- a/components/systemManager/TmuxSessionCard.tsx
+++ b/components/systemManager/TmuxSessionCard.tsx
@@ -22,6 +22,7 @@ import {
   SystemPanelStatusBadge,
 } from './SystemPanelUi';
 import { SystemPanelPromptDialog } from './SystemPanelPromptDialog';
+import { SystemPanelConfirmDialog } from './SystemPanelConfirmDialog';
 import { openInteractiveTerminal } from './openInteractiveTerminal';
 import { showSystemManagerError } from './systemManagerToast';
 import { runTmuxSessionAction } from './tmuxActionFocus';
@@ -86,6 +87,7 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
   const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const [renamePrompt, setRenamePrompt] = useState<RenamePromptTarget | null>(null);
+  const [detachConfirmOpen, setDetachConfirmOpen] = useState(false);
   const [newWindowOpen, setNewWindowOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -194,14 +196,7 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
                 title={t('systemManager.tmux.detach')}
                 disabled={busy}
                 loading={isPending('detachSession')}
-                onClick={() => {
-                  void runConfirmedTmuxDetachAction({
-                    sessionName: session.name,
-                    confirmMessage: t('systemManager.tmux.confirmDetachSession', { name: session.name }),
-                    confirm: globalThis.confirm,
-                    runAction,
-                  });
-                }}
+                onClick={() => setDetachConfirmOpen(true)}
               >
                 <Unplug size={12} />
               </SystemPanelRoundButton>
@@ -312,6 +307,20 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
           </div>
         )}
       </SystemPanelCollapsible>
+
+      <SystemPanelConfirmDialog
+        open={detachConfirmOpen}
+        title={t('systemManager.tmux.detach')}
+        message={t('systemManager.tmux.confirmDetachSession', { name: session.name })}
+        confirmLabel={t('systemManager.tmux.detach')}
+        destructive
+        busy={busy}
+        onOpenChange={setDetachConfirmOpen}
+        onConfirm={() => {
+          setDetachConfirmOpen(false);
+          void runAction({ action: 'detachSession', sessionName: session.name });
+        }}
+      />
 
       <SystemPanelPromptDialog
         open={renamePrompt !== null}

--- a/components/systemManager/tmuxActionFocus.test.ts
+++ b/components/systemManager/tmuxActionFocus.test.ts
@@ -3,46 +3,30 @@ import assert from "node:assert/strict";
 
 import type { TmuxManageAction } from "../../domain/systemManager/types.ts";
 import { runConfirmedTmuxDetachAction } from "./TmuxSessionCard.tsx";
-import { runTmuxSessionAction } from "./tmuxActionFocus.ts";
+import { runTmuxSessionAction, scheduleDeferredTerminalFocus } from "./tmuxActionFocus.ts";
 
 test("tmux detach action requests terminal focus after a successful action", async () => {
   const calls: string[] = [];
   const action: TmuxManageAction = { action: "detachSession", sessionName: "work" };
+  const timeouts: Array<{ delay: number; callback: () => void }> = [];
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
 
-  const result = await runTmuxSessionAction({
-    sessionId: "session-1",
-    action,
-    tmuxAction: async (payload) => {
-      assert.deepEqual(payload, { sessionId: "session-1", ...action });
-      calls.push("tmuxAction");
-      return { success: true };
-    },
-    onSessionsChanged: async () => {
-      calls.push("sessionsChanged");
-    },
-    onRequestTerminalFocus: () => {
-      calls.push("focus");
-    },
-  });
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+    timeouts.push({ delay: delay ?? 0, callback });
+    return timeouts.length;
+  }) as typeof globalThis.setTimeout;
 
-  assert.deepEqual(result, { success: true });
-  assert.deepEqual(calls, ["tmuxAction", "sessionsChanged", "focus"]);
-});
-
-test("tmux detach confirmation runs the action path that requests terminal focus", async () => {
-  const calls: string[] = [];
-
-  const handled = await runConfirmedTmuxDetachAction({
-    sessionName: "work",
-    confirmMessage: "detach work?",
-    confirm: (message) => {
-      calls.push(`confirm:${message}`);
-      return true;
-    },
-    runAction: (action) => runTmuxSessionAction({
+  try {
+    const result = await runTmuxSessionAction({
       sessionId: "session-1",
       action,
-      tmuxAction: async () => {
+      tmuxAction: async (payload) => {
+        assert.deepEqual(payload, { sessionId: "session-1", ...action });
         calls.push("tmuxAction");
         return { success: true };
       },
@@ -52,11 +36,92 @@ test("tmux detach confirmation runs the action path that requests terminal focus
       onRequestTerminalFocus: () => {
         calls.push("focus");
       },
-    }).then(() => undefined),
-  });
+    });
 
-  assert.equal(handled, true);
-  assert.deepEqual(calls, ["confirm:detach work?", "tmuxAction", "sessionsChanged", "focus"]);
+    assert.deepEqual(result, { success: true });
+    assert.deepEqual(calls, ["tmuxAction", "sessionsChanged"]);
+    assert.deepEqual(timeouts.map(({ delay }) => delay), [0, 50, 150]);
+    for (const { callback } of timeouts) callback();
+    assert.deepEqual(calls, ["tmuxAction", "sessionsChanged", "focus", "focus", "focus"]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test("scheduleDeferredTerminalFocus runs the callback on deferred timers", () => {
+  const calls: string[] = [];
+  const timeouts: Array<{ delay: number; callback: () => void }> = [];
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+    timeouts.push({ delay: delay ?? 0, callback });
+    return timeouts.length;
+  }) as typeof globalThis.setTimeout;
+
+  try {
+    scheduleDeferredTerminalFocus(() => calls.push("focus"));
+    assert.deepEqual(timeouts.map(({ delay }) => delay), [0, 50, 150]);
+    for (const { callback } of timeouts) callback();
+    assert.deepEqual(calls, ["focus", "focus", "focus"]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test("tmux detach confirmation runs the action path that requests terminal focus", async () => {
+  const calls: string[] = [];
+  const timeouts: Array<{ delay: number; callback: () => void }> = [];
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+    timeouts.push({ delay: delay ?? 0, callback });
+    return timeouts.length;
+  }) as typeof globalThis.setTimeout;
+
+  try {
+    const handled = await runConfirmedTmuxDetachAction({
+      sessionName: "work",
+      confirmMessage: "detach work?",
+      confirm: (message) => {
+        calls.push(`confirm:${message}`);
+        return true;
+      },
+      runAction: (action) => runTmuxSessionAction({
+        sessionId: "session-1",
+        action,
+        tmuxAction: async () => {
+          calls.push("tmuxAction");
+          return { success: true };
+        },
+        onSessionsChanged: async () => {
+          calls.push("sessionsChanged");
+        },
+        onRequestTerminalFocus: () => {
+          calls.push("focus");
+        },
+      }).then(() => undefined),
+    });
+
+    assert.equal(handled, true);
+    assert.deepEqual(calls, ["confirm:detach work?", "tmuxAction", "sessionsChanged"]);
+    for (const { callback } of timeouts) callback();
+    assert.deepEqual(calls, ["confirm:detach work?", "tmuxAction", "sessionsChanged", "focus", "focus", "focus"]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+  }
 });
 
 test("tmux detach action does not request terminal focus when the action fails", async () => {

--- a/components/systemManager/tmuxActionFocus.ts
+++ b/components/systemManager/tmuxActionFocus.ts
@@ -19,6 +19,32 @@ interface RunTmuxSessionActionOptions {
 const shouldRequestTerminalFocusAfterAction = (action: TmuxManageAction): boolean =>
   action.action === 'detachSession';
 
+const DEFERRED_TERMINAL_FOCUS_DELAYS_MS = [0, 50, 150] as const;
+
+export function scheduleDeferredTerminalFocus(onRequestTerminalFocus?: () => void): void {
+  if (!onRequestTerminalFocus) return;
+
+  const run = () => onRequestTerminalFocus();
+  const schedule = typeof globalThis.setTimeout === 'function'
+    ? globalThis.setTimeout.bind(globalThis)
+    : (callback: () => void) => {
+      callback();
+      return 0;
+    };
+  const raf = typeof globalThis.requestAnimationFrame === 'function'
+    ? globalThis.requestAnimationFrame.bind(globalThis)
+    : (callback: () => void) => {
+      callback();
+      return 0;
+    };
+
+  raf(() => {
+    for (const delayMs of DEFERRED_TERMINAL_FOCUS_DELAYS_MS) {
+      schedule(run, delayMs);
+    }
+  });
+}
+
 export async function runTmuxSessionAction({
   sessionId,
   action,
@@ -35,7 +61,7 @@ export async function runTmuxSessionAction({
     await onSessionsChanged();
   } finally {
     if (shouldRequestTerminalFocusAfterAction(action)) {
-      onRequestTerminalFocus?.();
+      scheduleDeferredTerminalFocus(onRequestTerminalFocus);
     }
   }
 

--- a/components/terminal/focusTerminalSession.test.ts
+++ b/components/terminal/focusTerminalSession.test.ts
@@ -44,6 +44,49 @@ test("focusTerminalSessionInput focuses the xterm helper textarea immediately an
   assert.deepEqual(focusCalls, ["focus", "focus"]);
 });
 
+test("focusTerminalSessionInput dispatches a terminal restore focus event", () => {
+  const events: string[] = [];
+  const handler = (event: Event) => {
+    events.push((event as CustomEvent<{ sessionId: string }>).detail.sessionId);
+  };
+  const originalWindow = globalThis.window;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      dispatchEvent: (event: Event) => {
+        handler(event);
+        return true;
+      },
+    },
+  });
+
+  try {
+    focusTerminalSessionInput("session-1", {
+      document: {
+        querySelector: () => ({
+          querySelector: () => ({ focus: () => undefined }),
+        }),
+      },
+      requestAnimationFrame: (callback) => {
+        callback();
+        return 1;
+      },
+      setTimeout: (callback) => {
+        callback();
+        return 0;
+      },
+    });
+
+    assert.deepEqual(events, ["session-1", "session-1"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  }
+});
+
 test("focusTerminalSessionInput ignores empty or unavailable targets", () => {
   assert.doesNotThrow(() => {
     focusTerminalSessionInput(null, {

--- a/components/terminal/focusTerminalSession.test.ts
+++ b/components/terminal/focusTerminalSession.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { focusTerminalSessionInput } from "./focusTerminalSession";
+import { focusTerminalSessionInput, hasOpenAppDialog } from "./focusTerminalSession";
 
 test("focusTerminalSessionInput focuses the xterm helper textarea immediately and after scheduled retries", () => {
   const focusCalls: string[] = [];
@@ -18,6 +18,7 @@ test("focusTerminalSessionInput focuses the xterm helper textarea immediately an
   const doc = {
     querySelector: (selector: string) => {
       queriedSelectors.push(selector);
+      if (selector === '[role="dialog"][data-state="open"]') return null;
       return pane;
     },
   };
@@ -37,11 +38,75 @@ test("focusTerminalSessionInput focuses the xterm helper textarea immediately an
   });
 
   assert.deepEqual(queriedSelectors, [
+    '[role="dialog"][data-state="open"]',
     '[data-session-id="session-1"]',
+    '[role="dialog"][data-state="open"]',
     '[data-session-id="session-1"]',
   ]);
   assert.deepEqual(timeouts, [50]);
   assert.deepEqual(focusCalls, ["focus", "focus"]);
+});
+
+test("hasOpenAppDialog detects open Radix dialogs", () => {
+  assert.equal(hasOpenAppDialog(null), false);
+  assert.equal(hasOpenAppDialog({ querySelector: () => null }), false);
+  assert.equal(
+    hasOpenAppDialog({
+      querySelector: (selector) => (
+        selector === '[role="dialog"][data-state="open"]' ? {} : null
+      ),
+    }),
+    true,
+  );
+});
+
+test("focusTerminalSessionInput skips textarea focus while an app dialog is open", () => {
+  const focusCalls: string[] = [];
+  const events: string[] = [];
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      dispatchEvent: (event: Event) => {
+        events.push((event as CustomEvent<{ sessionId: string }>).detail.sessionId);
+        return true;
+      },
+    },
+  });
+
+  try {
+    focusTerminalSessionInput("session-1", {
+      document: {
+        querySelector: (selector) => {
+          if (selector === '[role="dialog"][data-state="open"]') return {};
+          if (selector === '[data-session-id="session-1"]') {
+            return {
+              querySelector: () => ({
+                focus: () => focusCalls.push("focus"),
+              }),
+            };
+          }
+          return null;
+        },
+      },
+      requestAnimationFrame: (callback) => {
+        callback();
+        return 1;
+      },
+      setTimeout: (callback) => {
+        callback();
+        return 0;
+      },
+    });
+
+    assert.deepEqual(focusCalls, []);
+    assert.deepEqual(events, ["session-1", "session-1"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: undefined,
+    });
+  }
 });
 
 test("focusTerminalSessionInput dispatches a terminal restore focus event", () => {
@@ -64,9 +129,12 @@ test("focusTerminalSessionInput dispatches a terminal restore focus event", () =
   try {
     focusTerminalSessionInput("session-1", {
       document: {
-        querySelector: () => ({
-          querySelector: () => ({ focus: () => undefined }),
-        }),
+        querySelector: (selector) => {
+          if (selector === '[role="dialog"][data-state="open"]') return null;
+          return {
+            querySelector: () => ({ focus: () => undefined }),
+          };
+        },
       },
       requestAnimationFrame: (callback) => {
         callback();

--- a/components/terminal/focusTerminalSession.ts
+++ b/components/terminal/focusTerminalSession.ts
@@ -16,6 +16,20 @@ interface FocusTerminalSessionInputOptions {
 const escapeAttributeValue = (value: string): string =>
   value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
+export const TERMINAL_SESSION_RESTORE_FOCUS_EVENT = "netcatty:terminal-session-restore-focus";
+
+export type TerminalSessionRestoreFocusDetail = {
+  sessionId: string;
+};
+
+const dispatchTerminalSessionRestoreFocus = (sessionId: string): void => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<TerminalSessionRestoreFocusDetail>(
+    TERMINAL_SESSION_RESTORE_FOCUS_EVENT,
+    { detail: { sessionId } },
+  ));
+};
+
 export const focusTerminalSessionInput = (
   sessionId: string | null | undefined,
   options: FocusTerminalSessionInputOptions = {},
@@ -46,6 +60,7 @@ export const focusTerminalSessionInput = (
     const pane = doc.querySelector(paneSelector) as QueryTarget | null;
     const textarea = pane?.querySelector("textarea.xterm-helper-textarea") as FocusableTarget | null;
     textarea?.focus?.();
+    dispatchTerminalSessionRestoreFocus(sessionId);
   };
 
   raf(() => {

--- a/components/terminal/focusTerminalSession.ts
+++ b/components/terminal/focusTerminalSession.ts
@@ -1,9 +1,21 @@
-type QueryTarget = {
+type QueryRoot = {
+  querySelector: (selector: string) => unknown | null;
+};
+
+type QueryTarget = QueryRoot & {
   querySelector: (selector: string) => QueryTarget | FocusableTarget | null;
 };
 
 type FocusableTarget = {
   focus?: () => void;
+};
+
+/** Skip terminal refocus while a Radix dialog is open so deferred tmux actions do not steal modal focus. */
+export const hasOpenAppDialog = (
+  doc: QueryRoot | null = typeof document !== "undefined" ? document : null,
+): boolean => {
+  if (!doc) return false;
+  return doc.querySelector('[role="dialog"][data-state="open"]') !== null;
 };
 
 interface FocusTerminalSessionInputOptions {
@@ -57,6 +69,11 @@ export const focusTerminalSessionInput = (
   const paneSelector = `[data-session-id="${escapeAttributeValue(sessionId)}"]`;
 
   const focusTarget = () => {
+    if (hasOpenAppDialog(doc)) {
+      dispatchTerminalSessionRestoreFocus(sessionId);
+      return;
+    }
+
     const pane = doc.querySelector(paneSelector) as QueryTarget | null;
     const textarea = pane?.querySelector("textarea.xterm-helper-textarea") as FocusableTarget | null;
     textarea?.focus?.();

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -4,6 +4,7 @@ import { resolveFontWeightBold } from '../../lib/fontWeightAvailability';
 import { resolveXTermScrollback } from '../../infrastructure/config/xtermPerformance';
 import { shouldInterceptMouseTrackingContextMenu } from './runtime/middleClickBehavior';
 import {
+  hasOpenAppDialog,
   TERMINAL_SESSION_RESTORE_FOCUS_EVENT,
   type TerminalSessionRestoreFocusDetail,
 } from './focusTerminalSession';
@@ -604,6 +605,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       if (!term) return;
 
       applyUserCursorBlinkPreference(term, terminalSettingsRef.current);
+      if (hasOpenAppDialog()) return;
       term.focus();
       scheduleLayoutRecoveryRefit([0, 100]);
     };

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -3,6 +3,11 @@ import { useRef } from 'react';
 import { resolveFontWeightBold } from '../../lib/fontWeightAvailability';
 import { resolveXTermScrollback } from '../../infrastructure/config/xtermPerformance';
 import { shouldInterceptMouseTrackingContextMenu } from './runtime/middleClickBehavior';
+import {
+  TERMINAL_SESSION_RESTORE_FOCUS_EVENT,
+  type TerminalSessionRestoreFocusDetail,
+} from './focusTerminalSession';
+import { applyUserCursorBlinkPreference } from './runtime/cursorPreference';
 
 type TerminalEffectsContext = Record<string, any>;
 
@@ -588,6 +593,24 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       layoutRecoveryTimersRef.current.push(timerId);
     }
   };
+
+  useEffect(() => {
+    const handleRestoreFocus = (event: Event) => {
+      const detail = (event as CustomEvent<TerminalSessionRestoreFocusDetail>).detail;
+      if (detail?.sessionId !== sessionId) return;
+      if (!isVisibleRef.current) return;
+
+      const term = termRef.current;
+      if (!term) return;
+
+      applyUserCursorBlinkPreference(term, terminalSettingsRef.current);
+      term.focus();
+      scheduleLayoutRecoveryRefit([0, 100]);
+    };
+
+    window.addEventListener(TERMINAL_SESSION_RESTORE_FOCUS_EVENT, handleRestoreFocus);
+    return () => window.removeEventListener(TERMINAL_SESSION_RESTORE_FOCUS_EVENT, handleRestoreFocus);
+  }, [sessionId]);
 
   const shouldRefitImmediatelyOnShow = () => (
     !inWorkspace || isFocusMode || isFocused


### PR DESCRIPTION
## Summary
- Replace native `window.confirm()` with an in-app confirm dialog for tmux detach, avoiding broken Radix modal/focus state on Windows Electron
- Defer terminal refocus after detach and restore cursor blink plus xterm focus via a session restore event
- Fixes sidebar tmux "new session" becoming unusable and terminal cursor blink stopping after detach

## Test plan
- [ ] On Windows, connect SSH and create a tmux session
- [ ] Use sidebar System → tmux → Detach all
- [ ] Verify terminal cursor blinks and input works
- [ ] Click sidebar tmux New (+) and create another session successfully
- [ ] Run `npm test` for `tmuxActionFocus.test.ts` and `focusTerminalSession.test.ts`

Fixes #1587

Made with [Cursor](https://cursor.com)