### PR TITLE
fix: add missing useCallback deps in TerminalLayerSupport

### DIFF
--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1162,15 +1162,13 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
     document.addEventListener('pointerup', handlePointerUp, true);
     document.addEventListener('pointercancel', handlePointerCancel, true);
   }, [
+    host,
     inActiveWorkspace,
     onEndSessionDrag,
     onRemoveSessionFromWorkspace,
     onReorderTabs,
     onStartSessionDrag,
-    session.customName,
-    session.hostLabel,
-    session.id,
-    session.workspaceId,
+    session,
     workspaceById,
   ]);
   const handleTerminalFontSizeChange = useCallback((nextFontSize: number) => {


### PR DESCRIPTION
## Summary
- Fix `react-hooks/exhaustive-deps` warning in `handleDetachPointerDown` by adding `host` and `session` to the dependency array
- Replace granular `session.*` fields with the full `session` object since drag label resolution depends on dynamic title and host settings

## Test plan
- [x] `npm run lint` passes with no warnings
- [ ] Drag a terminal tab out of workspace and confirm ghost label still shows the correct title


Made with [Cursor](https://cursor.com)