### PR TITLE
feat(terminal): hibernate hidden tabs to reduce renderer memory

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -479,6 +479,10 @@ export const enCoreMessages: Messages = {
   'settings.terminal.rendering.renderer': 'Renderer',
   'settings.terminal.rendering.renderer.desc': 'Choose the terminal rendering technology. Auto will use DOM on low-memory devices. Changes take effect on new terminal sessions.',
   'settings.terminal.rendering.auto': 'Auto',
+  'settings.terminal.rendering.hibernateHiddenTabs': 'Hibernate hidden tabs',
+  'settings.terminal.rendering.hibernateHiddenTabs.desc': 'Dispose the terminal renderer for off-screen tabs to save memory while keeping the SSH session connected. Skipped during file transfers.',
+  'settings.terminal.rendering.hibernateHiddenTabsDelay': 'Hibernate delay',
+  'settings.terminal.rendering.hibernateHiddenTabsDelay.desc': 'How long a tab must stay off-screen before its renderer is released (5–600 seconds).',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': 'Workspace Focus Indicator',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -351,6 +351,10 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.rendering.renderer': '渲染器',
   'settings.terminal.rendering.renderer.desc': '选择终端渲染技术。自动模式会在低内存设备上使用 DOM 渲染。更改将在新终端会话中生效。',
   'settings.terminal.rendering.auto': '自动',
+  'settings.terminal.rendering.hibernateHiddenTabs': '隐藏标签页休眠',
+  'settings.terminal.rendering.hibernateHiddenTabs.desc': '标签页离开视野后释放终端渲染器以节省内存，SSH 连接保持不断。文件传输期间不会休眠。',
+  'settings.terminal.rendering.hibernateHiddenTabsDelay': '休眠延迟',
+  'settings.terminal.rendering.hibernateHiddenTabsDelay.desc': '标签页离开视野多久后释放渲染器（5–600 秒）。',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': '工作区焦点提示',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1603,11 +1603,19 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     wakeInProgressRef.current = true;
 
+    const stopHibernateListeners = () => {
+      disposeDataRef.current?.();
+      disposeDataRef.current = null;
+      disposeExitRef.current?.();
+      disposeExitRef.current = null;
+    };
+
     return wakeTerminalFromHibernate({
       refs: terminalRuntimeRefs,
       runtimeContext,
       container,
       getPayload,
+      stopHibernateListeners,
       sessionConnected: options.sessionConnected,
       getSessionConnected: () => getSessionConnectedRef.current(),
       reattachSession: (term) => {
@@ -1620,15 +1628,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       isBootActiveRef,
       sessionId,
       updateStatus: (next) => updateStatusRef.current(next),
-    }).then((ok) => {
-      if (ok && !options.sessionConnected) {
-        disposeDataRef.current?.();
-        disposeDataRef.current = null;
-        disposeExitRef.current?.();
-        disposeExitRef.current = null;
-      }
-      return ok;
-    }).catch((err) => {
+    }).then((ok) => ok).catch((err) => {
       logger.error("[Terminal] Failed to resume from hibernate", err);
       return false;
     }).finally(() => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1552,36 +1552,43 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const safeFitRef = useRef(safeFit);
   safeFitRef.current = safeFit;
 
-  const wakeFromHibernateRuntime = useCallback((payload: TerminalHibernateWakePayload) => {
+  const wakeFromHibernateRuntime = useCallback((
+    payload: TerminalHibernateWakePayload,
+    options: { sessionConnected: boolean },
+  ): boolean | Promise<boolean> => {
     if (wakeInProgressRef.current || hasRuntimeRef.current) {
       logger.warn("[Terminal] Wake skipped", {
         sessionId,
         wakeInProgress: wakeInProgressRef.current,
         hasRuntime: hasRuntimeRef.current,
       });
-      return;
+      return false;
     }
     const container = containerRef.current;
     const runtimeContext = xTermRuntimeContextRef.current;
-    if (!container || !runtimeContext || !sessionRef.current) {
+    if (!container || !runtimeContext) {
       logger.warn("[Terminal] Wake skipped: missing mount prerequisites", {
         sessionId,
         hasContainer: !!container,
         hasRuntimeContext: !!runtimeContext,
-        hasSession: !!sessionRef.current,
       });
-      return;
+      return false;
+    }
+    if (options.sessionConnected && !sessionRef.current) {
+      logger.warn("[Terminal] Wake skipped: missing backend session", { sessionId });
+      return false;
     }
 
     wakeInProgressRef.current = true;
     disposeDataRef.current?.();
     disposeDataRef.current = null;
 
-    void wakeTerminalFromHibernate({
+    return wakeTerminalFromHibernate({
       refs: terminalRuntimeRefs,
       runtimeContext,
       container,
       payload,
+      sessionConnected: options.sessionConnected,
       reattachSession: (term) => {
         sessionStartersRef.current?.reattachSession(term);
       },
@@ -1594,6 +1601,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       updateStatus: (next) => updateStatusRef.current(next),
     }).catch((err) => {
       logger.error("[Terminal] Failed to resume from hibernate", err);
+      return false;
     }).finally(() => {
       wakeInProgressRef.current = false;
     });

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -85,6 +85,22 @@ import {
 } from "./terminal/clipboardImagePaste";
 import { createTerminalCwdTracker, resolvePreferredTerminalCwd } from "./terminal/sftpCwd";
 import { useTerminalEffects } from "./terminal/useTerminalEffects";
+import { useTerminalHibernateEffect } from "./terminal/useTerminalHibernateEffect";
+import {
+  appendHibernatePendingBuffer,
+  serializeTerminalForHibernate,
+} from "./terminal/terminalHibernateRuntime";
+import {
+  isTerminalFileTransferActive,
+  resolveTerminalHibernateDelayMs,
+  resolveTerminalHibernateEnabled,
+  type TerminalHibernateWakePayload,
+} from "../domain/terminalHibernate";
+import {
+  wakeTerminalFromHibernate,
+  type TerminalRuntimeRefs,
+} from "./terminal/terminalRuntimeMount";
+import type { CreateXTermRuntimeContext } from "./terminal/runtime/createXTermRuntime";
 import { TerminalView } from "./terminal/TerminalView";
 import {
   getInitialTerminalStatus,
@@ -200,6 +216,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const knownCwdRef = useRef<string | undefined>(undefined);
   const disposeDataRef = useRef<(() => void) | null>(null);
   const disposeExitRef = useRef<(() => void) | null>(null);
+  const hibernatedRef = useRef(false);
+  const hasRuntimeRef = useRef(false);
+  const hibernateSnapshotRef = useRef("");
+  const hibernatePendingBufferRef = useRef("");
+  const hibernateAlternateScreenRef = useRef(false);
+  const wakeInProgressRef = useRef(false);
   const sessionRef = useRef<string | null>(null);
   const isBootActiveRef = useRef(false);
   const hasConnectedRef = useRef(false);
@@ -558,6 +580,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   // terminal. We just forward `isSupportedOs` via ctx.
 
   const zmodem = useZmodemTransfer(sessionId);
+  const [ymodemInProgress, setYmodemInProgress] = useState(false);
 
   const zmodemToastedRef = useRef(false);
 
@@ -700,6 +723,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     hasConnectedRef.current = next === "connected";
     onStatusChange?.(sessionId, next);
   };
+  const updateStatusRef = useRef(updateStatus);
+  updateStatusRef.current = updateStatus;
 
   const prepareRestoredReconnect = useCallback(() => {
     if (restoreState !== "restored-disconnected") {
@@ -758,18 +783,89 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sessionRef.current = null;
   };
 
-  const teardown = () => {
-    isBootActiveRef.current = false;
-    retryTokenRef.current = null;
-    restoreCwdIntentRef.current = null;
-    suppressHostStartupCommandRef.current = false;
-    cleanupSession();
+  const disposeRuntimeOnly = () => {
     xtermRuntimeRef.current?.dispose();
     xtermRuntimeRef.current = null;
     termRef.current = null;
     fitAddonRef.current = null;
     serializeAddonRef.current = null;
     searchAddonRef.current = null;
+    hasRuntimeRef.current = false;
+  };
+
+  const forceCloseHibernatedSession = useCallback(() => {
+    disposeDataRef.current?.();
+    disposeDataRef.current = null;
+    disposeExitRef.current?.();
+    disposeExitRef.current = null;
+    if (sessionRef.current) {
+      try {
+        terminalBackend.closeSession(sessionRef.current);
+      } catch (err) {
+        logger.warn("Failed to close hibernated session", err);
+      }
+    }
+    sessionRef.current = null;
+    hibernatedRef.current = false;
+    hibernateSnapshotRef.current = "";
+    hibernatePendingBufferRef.current = "";
+    hibernateAlternateScreenRef.current = false;
+  }, [terminalBackend]);
+
+  const hibernateRuntime = useCallback(() => {
+    if (hibernatedRef.current || !termRef.current || !serializeAddonRef.current) return;
+    const backendId = sessionRef.current;
+    if (!backendId) return;
+
+    const { snapshot, alternateScreen } = serializeTerminalForHibernate(
+      termRef.current,
+      serializeAddonRef.current,
+    );
+    if (alternateScreen && snapshot.length === 0) {
+      logger.info("[Terminal] Skipping hibernate: alternate screen snapshot unavailable", { sessionId });
+      return;
+    }
+
+    hibernateSnapshotRef.current = snapshot;
+    hibernateAlternateScreenRef.current = alternateScreen;
+    isBootActiveRef.current = false;
+    disposeRuntimeOnly();
+
+    disposeDataRef.current?.();
+    hibernatePendingBufferRef.current = "";
+    disposeDataRef.current = terminalBackend.onSessionData(backendId, (chunk) => {
+      hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
+        hibernatePendingBufferRef.current,
+        chunk,
+      );
+    });
+
+    hibernatedRef.current = true;
+    logger.info("[Terminal] Hibernated runtime", {
+      sessionId,
+      snapshotChars: hibernateSnapshotRef.current.length,
+      alternateScreen,
+    });
+  }, [sessionId, terminalBackend]);
+
+  const terminalRuntimeRefs = useMemo<TerminalRuntimeRefs>(() => ({
+    xtermRuntimeRef,
+    termRef,
+    fitAddonRef,
+    serializeAddonRef,
+    searchAddonRef,
+    hasRuntimeRef,
+  }), []);
+
+  const xTermRuntimeContextRef = useRef<Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible"> | null>(null);
+
+  const teardown = () => {
+    isBootActiveRef.current = false;
+    retryTokenRef.current = null;
+    restoreCwdIntentRef.current = null;
+    suppressHostStartupCommandRef.current = false;
+    cleanupSession();
+    disposeRuntimeOnly();
   };
 
   const sessionStarters = createTerminalSessionStarters({
@@ -1091,6 +1187,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
       const fileName = filePath.split(/[\\/]/).pop() || filePath;
       toast.info(t("terminal.ymodem.started", { fileName }));
+      setYmodemInProgress(true);
       const result = await sendSerialYmodem(sessionRef.current || sessionId, filePath);
       if (result.success) {
         toast.success(t("terminal.ymodem.complete", { fileName: result.fileName || fileName }));
@@ -1099,6 +1196,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t("terminal.ymodem.failed"));
+    } finally {
+      setYmodemInProgress(false);
     }
   }, [isSerialConnection, selectFile, selectFileAvailable, sendSerialYmodem, serialYmodemAvailable, sessionId, t]);
 
@@ -1114,6 +1213,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if (!destinationDir) return;
 
       toast.info(t("terminal.ymodem.receiveStarted"));
+      setYmodemInProgress(true);
       const result = await receiveSerialYmodem(sessionRef.current || sessionId, destinationDir);
       if (result.success) {
         if (result.fileCount && result.fileCount > 1) {
@@ -1128,6 +1228,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
     } catch {
       toast.error(t("terminal.ymodem.receiveFailed"));
+    } finally {
+      setYmodemInProgress(false);
     }
   }, [
     isSerialConnection,
@@ -1399,7 +1501,126 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const effectiveComposeBarOpen = inWorkspace ? !!isWorkspaceComposeBarOpen : isComposeBarOpen;
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  xTermRuntimeContextRef.current = {
+    host,
+    fontFamilyId,
+    resolvedFontFamily,
+    fontSize: effectiveFontSize,
+    terminalTheme: effectiveTheme,
+    terminalSettingsRef,
+    terminalBackend,
+    sessionRef,
+    hotkeySchemeRef,
+    disableTerminalFontZoomRef,
+    keyBindingsRef,
+    onHotkeyActionRef,
+    onTerminalFontSizeChange,
+    isBroadcastEnabledRef,
+    onBroadcastInputRef,
+    snippetsRef,
+    onSnippetShortkeyRef,
+    sessionId,
+    statusRef,
+    onCommandExecuted,
+    onCommandSubmitted,
+    commandBufferRef,
+    promptLineBreakStateRef,
+    sudoAutofillRef,
+    setIsSearchOpen,
+    serialLocalEcho: serialConfig?.localEcho,
+    serialLineMode: serialConfig?.lineMode,
+    serialLineBufferRef,
+    onTerminalLogData: captureTerminalLogData,
+    onCwdChange: (cwd: string) => {
+      terminalCwdTracker.setRendererCwd(cwd);
+      knownCwdRef.current = cwd;
+      onTerminalCwdChange?.(sessionId, cwd);
+    },
+    onTitleChange: (title: string | null) => {
+      onTerminalTitleChange?.(sessionId, title);
+    },
+    onBell: () => {
+      onTerminalBell?.(sessionId);
+    },
+    onOsc52ReadRequest: handleOsc52ReadRequest,
+    onAutocompleteKeyEvent: (e: KeyboardEvent) => autocompleteKeyEventRef.current?.(e) ?? true,
+    onAutocompleteInput: (data: string) => autocompleteInputRef.current?.(data),
+    terminalContextActionsRef,
+    isRestoringSelectionRef,
+  };
+
+  const safeFitRef = useRef(safeFit);
+  safeFitRef.current = safeFit;
+
+  const wakeFromHibernateRuntime = useCallback((payload: TerminalHibernateWakePayload) => {
+    if (wakeInProgressRef.current || hasRuntimeRef.current) {
+      logger.warn("[Terminal] Wake skipped", {
+        sessionId,
+        wakeInProgress: wakeInProgressRef.current,
+        hasRuntime: hasRuntimeRef.current,
+      });
+      return;
+    }
+    const container = containerRef.current;
+    const runtimeContext = xTermRuntimeContextRef.current;
+    if (!container || !runtimeContext || !sessionRef.current) {
+      logger.warn("[Terminal] Wake skipped: missing mount prerequisites", {
+        sessionId,
+        hasContainer: !!container,
+        hasRuntimeContext: !!runtimeContext,
+        hasSession: !!sessionRef.current,
+      });
+      return;
+    }
+
+    wakeInProgressRef.current = true;
+    disposeDataRef.current?.();
+    disposeDataRef.current = null;
+
+    void wakeTerminalFromHibernate({
+      refs: terminalRuntimeRefs,
+      runtimeContext,
+      container,
+      payload,
+      reattachSession: (term) => {
+        sessionStartersRef.current?.reattachSession(term);
+      },
+      safeFit: (...args) => safeFitRef.current(...args),
+      resizeSession,
+      forceSyncRenderAfterResize,
+      lastFittedSizeRef,
+      isBootActiveRef,
+      sessionId,
+      updateStatus: (next) => updateStatusRef.current(next),
+    }).catch((err) => {
+      logger.error("[Terminal] Failed to resume from hibernate", err);
+    }).finally(() => {
+      wakeInProgressRef.current = false;
+    });
+  }, [sessionId, terminalRuntimeRefs, resizeSession]);
+
+  useTerminalHibernateEffect({
+    sessionId,
+    isVisibleRef,
+    status,
+    isSearchOpen,
+    hibernateEnabled: resolveTerminalHibernateEnabled(terminalSettings),
+    hibernateDelayMs: resolveTerminalHibernateDelayMs(terminalSettings),
+    fileTransferActive: isTerminalFileTransferActive({
+      zmodemActive: zmodem.active,
+      ymodemInProgress,
+      isDraggingOver,
+    }),
+    hibernatedRef,
+    hibernatePendingBufferRef,
+    hibernateSnapshotRef,
+    hibernateAlternateScreenRef,
+    hasRuntimeRef,
+    onHibernate: hibernateRuntime,
+    onWake: wakeFromHibernateRuntime,
+  });
+
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return <TerminalView ctx={{ Activity, ArrowDownToLine, ArrowUpFromLine, Button, Clock3, Copy, Cpu, HardDrive, HoverCard, HoverCardContent, HoverCardTrigger, Maximize2, MemoryStick, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onAddSelectionToAI, onBroadcastInput, onCloseSession, onDetach, onDetachDragEnd, onDetachDragStart, onDetachPointerDown, onEndSessionDrag, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onStartSessionDrag, onToggleBroadcast, onUpdateHost: handleUpdateHostFromTerminal, osc52ReadPromptVisible, osc7SetupCommand, osc7SetupOpen, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scrollToBottomAfterProgrammaticInput, searchMatchCount, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, statusDotTone, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />;
 };

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -359,6 +359,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const statusRef = useRef<TerminalSession["status"]>(status);
   statusRef.current = status;
+  const getSessionConnectedRef = useRef(() => statusRef.current === "connected" && Boolean(sessionRef.current));
+  getSessionConnectedRef.current = () => statusRef.current === "connected" && Boolean(sessionRef.current);
   const sudoAutofillRef = useRef<SudoPasswordAutofill | null>(null);
   const sudoAutofillPasswordRef = useRef(sudoAutofillPassword);
   sudoAutofillPasswordRef.current = sudoAutofillPassword;
@@ -794,6 +796,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   };
 
   const forceCloseHibernatedSession = useCallback(() => {
+    if (!terminalDataCapturedRef.current) {
+      const hibernatedData = hibernateSnapshotRef.current + hibernatePendingBufferRef.current;
+      if (hibernatedData) {
+        handleTerminalDataCaptureOnce(sessionId, hibernatedData);
+      }
+    }
     disposeDataRef.current?.();
     disposeDataRef.current = null;
     disposeExitRef.current?.();
@@ -810,7 +818,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     hibernateSnapshotRef.current = "";
     hibernatePendingBufferRef.current = "";
     hibernateAlternateScreenRef.current = false;
-  }, [terminalBackend]);
+  }, [handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
 
   const hibernateRuntime = useCallback(() => {
     if (hibernatedRef.current || !termRef.current || !serializeAddonRef.current) return;
@@ -1630,6 +1638,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useTerminalHibernateEffect({
     sessionId,
     isVisibleRef,
+    getSessionConnectedRef,
     status,
     isSearchOpen,
     hibernateEnabled: resolveTerminalHibernateEnabled(terminalSettings),

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -840,13 +840,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       );
     });
 
+    disposeExitRef.current?.();
+    disposeExitRef.current = terminalBackend.onSessionExit(backendId, (evt) => {
+      updateStatusRef.current("disconnected");
+      if (evt.error) {
+        setError(evt.error);
+      }
+      const exitMessage = `\r\n[session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`;
+      hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
+        hibernatePendingBufferRef.current,
+        exitMessage,
+      );
+      onSessionExit?.(sessionId, evt);
+    });
+
     hibernatedRef.current = true;
     logger.info("[Terminal] Hibernated runtime", {
       sessionId,
       snapshotChars: hibernateSnapshotRef.current.length,
       alternateScreen,
     });
-  }, [sessionId, terminalBackend]);
+  }, [onSessionExit, sessionId, terminalBackend]);
 
   const terminalRuntimeRefs = useMemo<TerminalRuntimeRefs>(() => ({
     xtermRuntimeRef,
@@ -1580,8 +1594,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     wakeInProgressRef.current = true;
-    disposeDataRef.current?.();
-    disposeDataRef.current = null;
 
     return wakeTerminalFromHibernate({
       refs: terminalRuntimeRefs,
@@ -1599,6 +1611,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       isBootActiveRef,
       sessionId,
       updateStatus: (next) => updateStatusRef.current(next),
+    }).then((ok) => {
+      if (ok && !options.sessionConnected) {
+        disposeDataRef.current?.();
+        disposeDataRef.current = null;
+        disposeExitRef.current?.();
+        disposeExitRef.current = null;
+      }
+      return ok;
     }).catch((err) => {
       logger.error("[Terminal] Failed to resume from hibernate", err);
       return false;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1575,7 +1575,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   safeFitRef.current = safeFit;
 
   const wakeFromHibernateRuntime = useCallback((
-    payload: TerminalHibernateWakePayload,
+    getPayload: () => TerminalHibernateWakePayload,
     options: { sessionConnected: boolean },
   ): boolean | Promise<boolean> => {
     if (wakeInProgressRef.current || hasRuntimeRef.current) {
@@ -1607,8 +1607,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       refs: terminalRuntimeRefs,
       runtimeContext,
       container,
-      payload,
+      getPayload,
       sessionConnected: options.sessionConnected,
+      getSessionConnected: () => getSessionConnectedRef.current(),
       reattachSession: (term) => {
         sessionStartersRef.current?.reattachSession(term);
       },

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -979,6 +979,38 @@ function SettingsTerminalTab(props: {
             className="w-32"
           />
         </SettingRow>
+        <SettingRow
+          label={t("settings.terminal.rendering.hibernateHiddenTabs")}
+          description={t("settings.terminal.rendering.hibernateHiddenTabs.desc")}
+        >
+          <Toggle
+            checked={terminalSettings.hibernateHiddenTabs}
+            onChange={(v) => updateTerminalSetting("hibernateHiddenTabs", v)}
+          />
+        </SettingRow>
+        {terminalSettings.hibernateHiddenTabs && (
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernateHiddenTabsDelay")}
+            description={t("settings.terminal.rendering.hibernateHiddenTabsDelay.desc")}
+          >
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={5}
+                max={600}
+                value={terminalSettings.hibernateHiddenTabsDelaySec}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  if (!Number.isNaN(val) && val >= 5 && val <= 600) {
+                    updateTerminalSetting("hibernateHiddenTabsDelaySec", val);
+                  }
+                }}
+                className="w-20"
+              />
+              <span className="text-sm text-muted-foreground">{t("settings.terminal.serverStats.seconds")}</span>
+            </div>
+          </SettingRow>
+        )}
       </div>
       {/* Autocomplete */}
       <SectionHeader title={t("settings.terminal.section.workspaceFocus")} />

--- a/components/terminal/paneVisibilityStore.ts
+++ b/components/terminal/paneVisibilityStore.ts
@@ -28,6 +28,23 @@ export function removePaneVisible(sessionId: string): void {
   listenersBySession.get(sessionId)?.forEach((listener) => listener());
 }
 
+export function getPaneVisible(sessionId: string): boolean {
+  return visibleBySession.get(sessionId) ?? false;
+}
+
+export function subscribePaneVisible(sessionId: string, listener: Listener): () => void {
+  let set = listenersBySession.get(sessionId);
+  if (!set) {
+    set = new Set();
+    listenersBySession.set(sessionId, set);
+  }
+  set.add(listener);
+  return () => {
+    set!.delete(listener);
+    if (set!.size === 0) listenersBySession.delete(sessionId);
+  };
+}
+
 export function usePaneVisible(sessionId: string): boolean {
   const subscribe = useCallback((listener: Listener) => {
     let set = listenersBySession.get(sessionId);

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -5,6 +5,7 @@ import type { TerminalSessionStartersContext } from "./createTerminalSessionStar
 export type { PendingAuth, SessionLogConfig, TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
 export { normalizeStartupCommandDelay, splitStartupCommandLines } from "./terminalStartupCommands";
 import {
+  attachSessionToTerminal,
   buildTermEnv,
   closeOrphanBackendSession,
   getFlowController,
@@ -1202,5 +1203,21 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     }
   };
 
-  return { startSSH, startTelnet, startMosh, startEt, startLocal, startSerial };
+  const reattachSession = (term: XTerm) => {
+    const id = ctx.sessionRef.current;
+    if (!id) return false;
+    ctx.disposeDataRef.current?.();
+    ctx.disposeDataRef.current = null;
+    ctx.disposeExitRef.current?.();
+    ctx.disposeExitRef.current = null;
+    const isSerial = ctx.host.protocol === "serial" || ctx.host.id?.startsWith("serial-");
+    attachSessionToTerminal(ctx, term, id, {
+      convertLfToCrlf: isSerial,
+      sudoAutofillPassword: ctx.sudoAutofillPassword,
+    });
+    ctx.hasConnectedRef.current = true;
+    return true;
+  };
+
+  return { startSSH, startTelnet, startMosh, startEt, startLocal, startSerial, reattachSession };
 };

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -218,6 +218,13 @@ export const tryAttachSessionToTerminal = (
   return true;
 };
 
+export const detachSessionDataListeners = (ctx: Pick<TerminalSessionStartersContext, "disposeDataRef" | "disposeExitRef">) => {
+  ctx.disposeDataRef.current?.();
+  ctx.disposeDataRef.current = null;
+  ctx.disposeExitRef.current?.();
+  ctx.disposeExitRef.current = null;
+};
+
 export const attachSessionToTerminal = (
   ctx: TerminalSessionStartersContext,
   term: XTerm,

--- a/components/terminal/terminalHibernateRuntime.test.ts
+++ b/components/terminal/terminalHibernateRuntime.test.ts
@@ -5,6 +5,7 @@ import {
   isTerminalAlternateScreenActive,
   refreshTerminalViewport,
   resolveHibernateSerializeOptions,
+  serializeTerminalForHibernate,
 } from "./terminalHibernateRuntime.ts";
 
 const createFakeTerm = (bufferType: "normal" | "alternate") => ({
@@ -53,4 +54,17 @@ test("refreshTerminalViewport refreshes the full viewport", () => {
   };
   refreshTerminalViewport(term as never);
   assert.deepEqual(refreshed, [0, 23]);
+});
+
+test("serializeTerminalForHibernate preserves alternate screen when serialize throws", () => {
+  const term = createFakeTerm("alternate");
+  const serializeAddon = {
+    serialize: () => {
+      throw new Error("serialize failed");
+    },
+  };
+  assert.deepEqual(serializeTerminalForHibernate(term as never, serializeAddon as never), {
+    snapshot: "",
+    alternateScreen: true,
+  });
 });

--- a/components/terminal/terminalHibernateRuntime.test.ts
+++ b/components/terminal/terminalHibernateRuntime.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isTerminalAlternateScreenActive,
+  refreshTerminalViewport,
+  resolveHibernateSerializeOptions,
+} from "./terminalHibernateRuntime.ts";
+
+const createFakeTerm = (bufferType: "normal" | "alternate") => ({
+  buffer: {
+    active: { type: bufferType },
+  },
+});
+
+test("resolveHibernateSerializeOptions keeps alt buffer and modes for full-screen apps", () => {
+  const term = createFakeTerm("alternate");
+  assert.equal(isTerminalAlternateScreenActive(term as never), true);
+  assert.deepEqual(resolveHibernateSerializeOptions(term as never), {
+    excludeAltBuffer: false,
+    excludeModes: false,
+    alternateScreen: true,
+  });
+});
+
+test("resolveHibernateSerializeOptions excludes alt buffer on the normal screen", () => {
+  const term = createFakeTerm("normal");
+  assert.equal(isTerminalAlternateScreenActive(term as never), false);
+  assert.deepEqual(resolveHibernateSerializeOptions(term as never), {
+    excludeAltBuffer: true,
+    excludeModes: true,
+    alternateScreen: false,
+  });
+});
+
+test("refreshTerminalViewport skips refresh when the terminal has no rows", () => {
+  const term = {
+    rows: 0,
+    refresh: () => {
+      throw new Error("refresh should not be called");
+    },
+  };
+  refreshTerminalViewport(term as never);
+});
+
+test("refreshTerminalViewport refreshes the full viewport", () => {
+  let refreshed: [number, number] | null = null;
+  const term = {
+    rows: 24,
+    refresh: (start: number, end: number) => {
+      refreshed = [start, end];
+    },
+  };
+  refreshTerminalViewport(term as never);
+  assert.deepEqual(refreshed, [0, 23]);
+});

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -41,7 +41,10 @@ export function serializeTerminalForHibernate(term: XTerm, serializeAddon: Seria
       alternateScreen,
     };
   } catch {
-    return { snapshot: "", alternateScreen: false };
+    return {
+      snapshot: "",
+      alternateScreen: isTerminalAlternateScreenActive(term),
+    };
   }
 }
 

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -65,6 +65,10 @@ export function refreshTerminalViewport(term: XTerm): void {
   term.refresh(0, endRow);
 }
 
+export async function appendTerminalReplayData(term: XTerm, data: string): Promise<void> {
+  return writeTerminalPayload(term, data);
+}
+
 export async function applyHibernateWakeToTerminal(
   term: XTerm,
   runtime: XTermRuntime,

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -1,0 +1,88 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { SerializeAddon } from "@xterm/addon-serialize";
+
+import {
+  capHibernateBuffer,
+  capHibernateBufferByLines,
+  TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES,
+  type TerminalHibernateWakePayload,
+} from "../../domain/terminalHibernate";
+import type { XTermRuntime } from "./runtime/createXTermRuntime";
+
+export function isTerminalAlternateScreenActive(term: XTerm): boolean {
+  return (term.buffer.active as { type?: string }).type === "alternate";
+}
+
+export function resolveHibernateSerializeOptions(term: XTerm): {
+  excludeAltBuffer: boolean;
+  excludeModes: boolean;
+  alternateScreen: boolean;
+} {
+  const alternateScreen = isTerminalAlternateScreenActive(term);
+  return {
+    excludeAltBuffer: !alternateScreen,
+    excludeModes: !alternateScreen,
+    alternateScreen,
+  };
+}
+
+export function serializeTerminalForHibernate(term: XTerm, serializeAddon: SerializeAddon): {
+  snapshot: string;
+  alternateScreen: boolean;
+} {
+  try {
+    const { excludeAltBuffer, excludeModes, alternateScreen } = resolveHibernateSerializeOptions(term);
+    const raw = serializeAddon.serialize({
+      excludeAltBuffer,
+      excludeModes,
+    });
+    return {
+      snapshot: capHibernateBufferByLines(raw, TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES),
+      alternateScreen,
+    };
+  } catch {
+    return { snapshot: "", alternateScreen: false };
+  }
+}
+
+export function appendHibernatePendingBuffer(current: string, chunk: string): string {
+  return capHibernateBuffer(current + chunk);
+}
+
+const writeTerminalPayload = (term: XTerm, data: string): Promise<void> => {
+  if (!data) return Promise.resolve();
+  return new Promise((resolve) => {
+    term.write(data, () => resolve());
+  });
+};
+
+export function refreshTerminalViewport(term: XTerm): void {
+  const endRow = term.rows - 1;
+  if (endRow < 0) return;
+  term.refresh(0, endRow);
+}
+
+export async function applyHibernateWakeToTerminal(
+  term: XTerm,
+  runtime: XTermRuntime,
+  payload: TerminalHibernateWakePayload,
+): Promise<void> {
+  await writeTerminalPayload(term, payload.snapshot);
+  await writeTerminalPayload(term, payload.pendingBuffer);
+  runtime.ensureWebglRenderer();
+  runtime.clearTextureAtlas();
+  if (payload.alternateScreen) {
+    refreshTerminalViewport(term);
+  }
+}
+
+export function nudgeAlternateScreenRedraw(term: XTerm): void {
+  refreshTerminalViewport(term);
+  const cols = term.cols;
+  const rows = term.rows;
+  if (cols > 0 && rows > 0) {
+    // Many full-screen TUIs (htop, vim) repaint on a size "change" even when dimensions match.
+    term.resize(cols, rows);
+    refreshTerminalViewport(term);
+  }
+}

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -62,6 +62,8 @@ export type WakeTerminalFromHibernateOptions = {
   runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible">;
   container: HTMLDivElement;
   getPayload: () => TerminalHibernateWakePayload;
+  /** Stop hibernate IPC listeners before reading the final replay payload. */
+  stopHibernateListeners: () => void;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
   resizeSession: () => void;
@@ -83,6 +85,7 @@ export async function wakeTerminalFromHibernate(
     runtimeContext,
     container,
     getPayload,
+    stopHibernateListeners,
     reattachSession,
     safeFit,
     resizeSession,
@@ -120,9 +123,11 @@ export async function wakeTerminalFromHibernate(
   applyTerminalKeywordHighlightRules(runtime, runtimeContext.terminalSettingsRef, runtimeContext.host);
 
   const term = runtime.term;
+  stopHibernateListeners();
   const payload = getPayload();
   await applyHibernateWakeToTerminal(term, runtime, payload);
-  if (sessionConnected && (getSessionConnected?.() ?? true)) {
+  const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
+  if (shouldReattach) {
     reattachSession(term);
     updateStatus("connected");
   }

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -70,6 +70,8 @@ export type WakeTerminalFromHibernateOptions = {
   isBootActiveRef: MutableRefObject<boolean>;
   sessionId: string;
   updateStatus: (status: "connected") => void;
+  /** When false, recreate xterm and replay output without reattaching or forcing connected status. */
+  sessionConnected?: boolean;
 };
 
 export async function wakeTerminalFromHibernate(
@@ -88,6 +90,7 @@ export async function wakeTerminalFromHibernate(
     isBootActiveRef,
     sessionId,
     updateStatus,
+    sessionConnected = true,
   } = options;
 
   if (refs.hasRuntimeRef.current) {
@@ -116,8 +119,10 @@ export async function wakeTerminalFromHibernate(
 
   const term = runtime.term;
   await applyHibernateWakeToTerminal(term, runtime, payload);
-  reattachSession(term);
-  updateStatus("connected");
+  if (sessionConnected) {
+    reattachSession(term);
+    updateStatus("connected");
+  }
 
   safeFit({ force: true });
   resizeSession();

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -13,6 +13,7 @@ import {
   type XTermRuntime,
 } from "./runtime/createXTermRuntime";
 import {
+  appendTerminalReplayData,
   applyHibernateWakeToTerminal,
   nudgeAlternateScreenRedraw,
 } from "./terminalHibernateRuntime";
@@ -123,9 +124,17 @@ export async function wakeTerminalFromHibernate(
   applyTerminalKeywordHighlightRules(runtime, runtimeContext.terminalSettingsRef, runtimeContext.host);
 
   const term = runtime.term;
+  const initialPayload = getPayload();
+  const pendingAtApplyStart = initialPayload.pendingBuffer;
+  await applyHibernateWakeToTerminal(term, runtime, initialPayload);
+  const afterApply = getPayload();
+  if (afterApply.pendingBuffer.length > pendingAtApplyStart.length) {
+    await appendTerminalReplayData(
+      term,
+      afterApply.pendingBuffer.slice(pendingAtApplyStart.length),
+    );
+  }
   stopHibernateListeners();
-  const payload = getPayload();
-  await applyHibernateWakeToTerminal(term, runtime, payload);
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
   if (shouldReattach) {
     reattachSession(term);
@@ -135,7 +144,7 @@ export async function wakeTerminalFromHibernate(
   safeFit({ force: true });
   resizeSession();
   forceSyncRenderAfterResize(term);
-  if (payload.alternateScreen) {
+  if (initialPayload.alternateScreen) {
     nudgeAlternateScreenRedraw(term);
   } else {
     term.scrollToBottom();
@@ -145,23 +154,23 @@ export async function wakeTerminalFromHibernate(
   window.setTimeout(() => {
     safeFit({ force: true });
     forceSyncRenderAfterResize(term);
-    if (payload.alternateScreen) {
+    if (initialPayload.alternateScreen) {
       nudgeAlternateScreenRedraw(term);
     }
   }, 100);
   window.setTimeout(() => {
     safeFit({ force: true });
     forceSyncRenderAfterResize(term);
-    if (payload.alternateScreen) {
+    if (initialPayload.alternateScreen) {
       nudgeAlternateScreenRedraw(term);
     }
   }, 350);
 
   logger.info("[Terminal] Resumed from hibernate", {
     sessionId,
-    snapshotChars: payload.snapshot.length,
-    pendingChars: payload.pendingBuffer.length,
-    alternateScreen: payload.alternateScreen,
+    snapshotChars: initialPayload.snapshot.length,
+    pendingChars: afterApply.pendingBuffer.length,
+    alternateScreen: initialPayload.alternateScreen,
   });
   return true;
 }

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -1,0 +1,153 @@
+import type { MutableRefObject, RefObject } from "react";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { SearchAddon } from "@xterm/addon-search";
+import type { SerializeAddon } from "@xterm/addon-serialize";
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import type { Host, TerminalSettings } from "../../types";
+import { logger } from "../../lib/logger";
+import type { TerminalHibernateWakePayload } from "../../domain/terminalHibernate";
+import {
+  createXTermRuntime,
+  type CreateXTermRuntimeContext,
+  type XTermRuntime,
+} from "./runtime/createXTermRuntime";
+import {
+  applyHibernateWakeToTerminal,
+  nudgeAlternateScreenRedraw,
+} from "./terminalHibernateRuntime";
+
+export type TerminalRuntimeRefs = {
+  xtermRuntimeRef: MutableRefObject<XTermRuntime | null>;
+  termRef: MutableRefObject<XTerm | null>;
+  fitAddonRef: MutableRefObject<FitAddon | null>;
+  serializeAddonRef: MutableRefObject<SerializeAddon | null>;
+  searchAddonRef: MutableRefObject<SearchAddon | null>;
+  hasRuntimeRef: MutableRefObject<boolean>;
+};
+
+export function assignTerminalRuntimeRefs(
+  refs: TerminalRuntimeRefs,
+  runtime: XTermRuntime,
+): void {
+  refs.xtermRuntimeRef.current = runtime;
+  refs.termRef.current = runtime.term;
+  refs.fitAddonRef.current = runtime.fitAddon;
+  refs.serializeAddonRef.current = runtime.serializeAddon;
+  refs.searchAddonRef.current = runtime.searchAddon;
+  refs.hasRuntimeRef.current = true;
+}
+
+export function applyTerminalKeywordHighlightRules(
+  runtime: XTermRuntime,
+  terminalSettingsRef: RefObject<TerminalSettings | undefined>,
+  host: Host,
+): void {
+  const globalRules = terminalSettingsRef.current?.keywordHighlightRules ?? [];
+  const hostRules = host?.keywordHighlightRules ?? [];
+  const globalEnabled = terminalSettingsRef.current?.keywordHighlightEnabled ?? false;
+  const hostEnabled = host?.keywordHighlightEnabled;
+  const effectiveGlobalEnabled = globalEnabled;
+  const effectiveHostEnabled = hostEnabled ?? false;
+  const mergedRules = [
+    ...(effectiveGlobalEnabled ? globalRules : []),
+    ...(effectiveHostEnabled ? hostRules : []),
+  ];
+  const isEnabled = effectiveGlobalEnabled || effectiveHostEnabled;
+  runtime.keywordHighlighter.setRules(mergedRules, isEnabled);
+}
+
+export type WakeTerminalFromHibernateOptions = {
+  refs: TerminalRuntimeRefs;
+  runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible">;
+  container: HTMLDivElement;
+  payload: TerminalHibernateWakePayload;
+  reattachSession: (term: XTerm) => void;
+  safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
+  resizeSession: () => void;
+  forceSyncRenderAfterResize: (term: XTerm) => void;
+  lastFittedSizeRef: MutableRefObject<{ width: number; height: number } | null>;
+  isBootActiveRef: MutableRefObject<boolean>;
+  sessionId: string;
+  updateStatus: (status: "connected") => void;
+};
+
+export async function wakeTerminalFromHibernate(
+  options: WakeTerminalFromHibernateOptions,
+): Promise<boolean> {
+  const {
+    refs,
+    runtimeContext,
+    container,
+    payload,
+    reattachSession,
+    safeFit,
+    resizeSession,
+    forceSyncRenderAfterResize,
+    lastFittedSizeRef,
+    isBootActiveRef,
+    sessionId,
+    updateStatus,
+  } = options;
+
+  if (refs.hasRuntimeRef.current) {
+    return true;
+  }
+
+  await new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      return;
+    }
+    window.setTimeout(resolve, 0);
+  });
+
+  isBootActiveRef.current = true;
+  lastFittedSizeRef.current = null;
+
+  const runtime = createXTermRuntime({
+    ...runtimeContext,
+    container,
+    initiallyVisible: true,
+  });
+
+  assignTerminalRuntimeRefs(refs, runtime);
+  applyTerminalKeywordHighlightRules(runtime, runtimeContext.terminalSettingsRef, runtimeContext.host);
+
+  const term = runtime.term;
+  await applyHibernateWakeToTerminal(term, runtime, payload);
+  reattachSession(term);
+  updateStatus("connected");
+
+  safeFit({ force: true });
+  resizeSession();
+  forceSyncRenderAfterResize(term);
+  if (payload.alternateScreen) {
+    nudgeAlternateScreenRedraw(term);
+  }
+  term.scrollToBottom();
+
+  window.setTimeout(() => safeFit({ force: true }), 0);
+  window.setTimeout(() => {
+    safeFit({ force: true });
+    forceSyncRenderAfterResize(term);
+    if (payload.alternateScreen) {
+      nudgeAlternateScreenRedraw(term);
+    }
+  }, 100);
+  window.setTimeout(() => {
+    safeFit({ force: true });
+    forceSyncRenderAfterResize(term);
+    if (payload.alternateScreen) {
+      nudgeAlternateScreenRedraw(term);
+    }
+  }, 350);
+
+  logger.info("[Terminal] Resumed from hibernate", {
+    sessionId,
+    snapshotChars: payload.snapshot.length,
+    pendingChars: payload.pendingBuffer.length,
+    alternateScreen: payload.alternateScreen,
+  });
+  return true;
+}

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -129,8 +129,9 @@ export async function wakeTerminalFromHibernate(
   forceSyncRenderAfterResize(term);
   if (payload.alternateScreen) {
     nudgeAlternateScreenRedraw(term);
+  } else {
+    term.scrollToBottom();
   }
-  term.scrollToBottom();
 
   window.setTimeout(() => safeFit({ force: true }), 0);
   window.setTimeout(() => {

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -127,12 +127,17 @@ export async function wakeTerminalFromHibernate(
   const initialPayload = getPayload();
   const pendingAtApplyStart = initialPayload.pendingBuffer;
   await applyHibernateWakeToTerminal(term, runtime, initialPayload);
-  const afterApply = getPayload();
-  if (afterApply.pendingBuffer.length > pendingAtApplyStart.length) {
-    await appendTerminalReplayData(
-      term,
-      afterApply.pendingBuffer.slice(pendingAtApplyStart.length),
-    );
+  let replayedPendingLength = pendingAtApplyStart.length;
+  for (let drainPass = 0; drainPass < 16; drainPass += 1) {
+    const pending = getPayload().pendingBuffer;
+    if (pending.length <= replayedPendingLength) break;
+    await appendTerminalReplayData(term, pending.slice(replayedPendingLength));
+    replayedPendingLength = pending.length;
+  }
+  const finalPending = getPayload().pendingBuffer;
+  if (finalPending.length > replayedPendingLength) {
+    await appendTerminalReplayData(term, finalPending.slice(replayedPendingLength));
+    replayedPendingLength = finalPending.length;
   }
   stopHibernateListeners();
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
@@ -169,7 +174,7 @@ export async function wakeTerminalFromHibernate(
   logger.info("[Terminal] Resumed from hibernate", {
     sessionId,
     snapshotChars: initialPayload.snapshot.length,
-    pendingChars: afterApply.pendingBuffer.length,
+    pendingChars: replayedPendingLength,
     alternateScreen: initialPayload.alternateScreen,
   });
   return true;

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -61,7 +61,7 @@ export type WakeTerminalFromHibernateOptions = {
   refs: TerminalRuntimeRefs;
   runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible">;
   container: HTMLDivElement;
-  payload: TerminalHibernateWakePayload;
+  getPayload: () => TerminalHibernateWakePayload;
   reattachSession: (term: XTerm) => void;
   safeFit: (options?: { force?: boolean; requireVisible?: boolean }) => void;
   resizeSession: () => void;
@@ -72,6 +72,7 @@ export type WakeTerminalFromHibernateOptions = {
   updateStatus: (status: "connected") => void;
   /** When false, recreate xterm and replay output without reattaching or forcing connected status. */
   sessionConnected?: boolean;
+  getSessionConnected?: () => boolean;
 };
 
 export async function wakeTerminalFromHibernate(
@@ -81,7 +82,7 @@ export async function wakeTerminalFromHibernate(
     refs,
     runtimeContext,
     container,
-    payload,
+    getPayload,
     reattachSession,
     safeFit,
     resizeSession,
@@ -91,6 +92,7 @@ export async function wakeTerminalFromHibernate(
     sessionId,
     updateStatus,
     sessionConnected = true,
+    getSessionConnected,
   } = options;
 
   if (refs.hasRuntimeRef.current) {
@@ -118,8 +120,9 @@ export async function wakeTerminalFromHibernate(
   applyTerminalKeywordHighlightRules(runtime, runtimeContext.terminalSettingsRef, runtimeContext.host);
 
   const term = runtime.term;
+  const payload = getPayload();
   await applyHibernateWakeToTerminal(term, runtime, payload);
-  if (sessionConnected) {
+  if (sessionConnected && (getSessionConnected?.() ?? true)) {
     reattachSession(term);
     updateStatus("connected");
   }

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -65,7 +65,7 @@ export function resolveSelectionOverlayPosition(term: any, container: HTMLElemen
 }
 
 export function useTerminalEffects(ctx: TerminalEffectsContext) {
-  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, host, hotkeySchemeRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
+  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, onBroadcastInputRef, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, setIsSearchOpen, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
 
   // Remember the last layout we successfully refit while visible so revisiting
   // the same workspace tab does not replay expensive force-fit/WebGL recovery.
@@ -309,6 +309,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         fitAddonRef.current = runtime.fitAddon;
         serializeAddonRef.current = runtime.serializeAddon;
         searchAddonRef.current = runtime.searchAddon;
+        hasRuntimeRef.current = true;
         // xterm boots asynchronously; ResizeObserver may have already run without
         // fitAddon and will not re-attach until isVisible/isResizing changes.
         setTimeout(() => {
@@ -410,6 +411,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     return () => {
       disposed = true;
       isBootActiveRef.current = false;
+      if (hibernatedRef?.current) {
+        forceCloseHibernatedSession?.();
+        return;
+      }
       if (!terminalDataCapturedRef.current && serializeAddonRef.current) {
         try {
           const terminalData = serializeAddonRef.current.serialize();
@@ -422,7 +427,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       teardown();
     };
      
-  }, [handleTerminalDataCaptureOnce, host.id, sessionId]);
+  }, [forceCloseHibernatedSession, handleTerminalDataCaptureOnce, host.id, sessionId]);
 
 
   // Connection timeline and timeout visuals

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -24,7 +24,10 @@ type UseTerminalHibernateEffectOptions = {
   hibernateAlternateScreenRef: React.MutableRefObject<boolean>;
   hasRuntimeRef: React.MutableRefObject<boolean>;
   onHibernate: () => void;
-  onWake: (payload: TerminalHibernateWakePayload) => void;
+  onWake: (
+    payload: TerminalHibernateWakePayload,
+    options: { sessionConnected: boolean },
+  ) => boolean | Promise<boolean>;
 };
 
 export function useTerminalHibernateEffect({
@@ -59,29 +62,38 @@ export function useTerminalHibernateEffect({
       }
     };
 
+    const clearHibernateState = () => {
+      hibernateSnapshotRef.current = "";
+      hibernatePendingBufferRef.current = "";
+      hibernateAlternateScreenRef.current = false;
+      hibernatedRef.current = false;
+    };
+
     const tryWake = () => {
       if (!hibernatedRef.current) return;
 
+      const sessionConnected = status === "connected";
       const payload: TerminalHibernateWakePayload = {
         snapshot: hibernateSnapshotRef.current,
         pendingBuffer: hibernatePendingBufferRef.current,
         alternateScreen: hibernateAlternateScreenRef.current,
       };
-      hibernateSnapshotRef.current = "";
-      hibernatePendingBufferRef.current = "";
-      hibernateAlternateScreenRef.current = false;
-      hibernatedRef.current = false;
       logger.info("[Terminal] Waking from hibernate", {
         sessionId,
         snapshotChars: payload.snapshot.length,
         pendingChars: payload.pendingBuffer.length,
+        sessionConnected,
       });
-      onWakeRef.current(payload);
+      void Promise.resolve(onWakeRef.current(payload, { sessionConnected })).then((accepted) => {
+        if (accepted !== false) {
+          clearHibernateState();
+        }
+      });
     };
 
     if (!hibernateEnabled) {
       clearHibernateTimer();
-      if (hibernatedRef.current && getPaneVisible(sessionId)) {
+      if (hibernatedRef.current) {
         tryWake();
       }
       const unsubscribeDisabled = subscribePaneVisible(sessionId, () => {

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -71,6 +71,24 @@ export function useTerminalHibernateEffect({
       hibernatedRef.current = false;
     };
 
+    const scheduleHibernate = () => {
+      if (!hibernateEnabled) return;
+      clearHibernateTimer();
+      if (hibernatedRef.current || !hasRuntimeRef.current) return;
+      if (status !== "connected") return;
+      if (isSearchOpen) return;
+      if (fileTransferActive) return;
+
+      hiddenSinceRef.current = Date.now();
+      const hiddenAt = hiddenSinceRef.current;
+      hibernateTimerRef.current = window.setTimeout(() => {
+        hibernateTimerRef.current = null;
+        if (hiddenSinceRef.current !== hiddenAt) return;
+        if (getPaneVisible(sessionId)) return;
+        onHibernateRef.current();
+      }, hibernateDelayMs);
+    };
+
     const tryWake = () => {
       if (!hibernatedRef.current) return;
 
@@ -89,6 +107,9 @@ export function useTerminalHibernateEffect({
       void Promise.resolve(onWakeRef.current(getPayload, { sessionConnected })).then((accepted) => {
         if (accepted !== false) {
           clearHibernateState();
+          if (!getPaneVisible(sessionId)) {
+            scheduleHibernate();
+          }
         }
       });
     };
@@ -107,23 +128,6 @@ export function useTerminalHibernateEffect({
         unsubscribeDisabled();
       };
     }
-
-    const scheduleHibernate = () => {
-      clearHibernateTimer();
-      if (hibernatedRef.current || !hasRuntimeRef.current) return;
-      if (status !== "connected") return;
-      if (isSearchOpen) return;
-      if (fileTransferActive) return;
-
-      hiddenSinceRef.current = Date.now();
-      const hiddenAt = hiddenSinceRef.current;
-      hibernateTimerRef.current = window.setTimeout(() => {
-        hibernateTimerRef.current = null;
-        if (hiddenSinceRef.current !== hiddenAt) return;
-        if (getPaneVisible(sessionId)) return;
-        onHibernateRef.current();
-      }, hibernateDelayMs);
-    };
 
     const applyVisibility = (visible: boolean) => {
       paneVisibleRef.current = visible;

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -13,6 +13,7 @@ import type { TerminalSession } from "../../types";
 type UseTerminalHibernateEffectOptions = {
   sessionId: string;
   isVisibleRef: React.MutableRefObject<boolean>;
+  getSessionConnectedRef: React.MutableRefObject<() => boolean>;
   status: TerminalSession["status"];
   isSearchOpen: boolean;
   hibernateEnabled: boolean;
@@ -33,6 +34,7 @@ type UseTerminalHibernateEffectOptions = {
 export function useTerminalHibernateEffect({
   sessionId,
   isVisibleRef,
+  getSessionConnectedRef,
   status,
   isSearchOpen,
   hibernateEnabled,
@@ -72,7 +74,7 @@ export function useTerminalHibernateEffect({
     const tryWake = () => {
       if (!hibernatedRef.current) return;
 
-      const sessionConnected = status === "connected";
+      const sessionConnected = getSessionConnectedRef.current();
       const payload: TerminalHibernateWakePayload = {
         snapshot: hibernateSnapshotRef.current,
         pendingBuffer: hibernatePendingBufferRef.current,
@@ -151,6 +153,7 @@ export function useTerminalHibernateEffect({
     };
   }, [
     fileTransferActive,
+    getSessionConnectedRef,
     hasRuntimeRef,
     hibernateDelayMs,
     hibernateEnabled,

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -1,0 +1,154 @@
+import { useEffect, useRef } from "react";
+
+import {
+  type TerminalHibernateWakePayload,
+} from "../../domain/terminalHibernate";
+import { logger } from "../../lib/logger";
+import {
+  getPaneVisible,
+  subscribePaneVisible,
+} from "./paneVisibilityStore";
+import type { TerminalSession } from "../../types";
+
+type UseTerminalHibernateEffectOptions = {
+  sessionId: string;
+  isVisibleRef: React.MutableRefObject<boolean>;
+  status: TerminalSession["status"];
+  isSearchOpen: boolean;
+  hibernateEnabled: boolean;
+  hibernateDelayMs: number;
+  fileTransferActive: boolean;
+  hibernatedRef: React.MutableRefObject<boolean>;
+  hibernatePendingBufferRef: React.MutableRefObject<string>;
+  hibernateSnapshotRef: React.MutableRefObject<string>;
+  hibernateAlternateScreenRef: React.MutableRefObject<boolean>;
+  hasRuntimeRef: React.MutableRefObject<boolean>;
+  onHibernate: () => void;
+  onWake: (payload: TerminalHibernateWakePayload) => void;
+};
+
+export function useTerminalHibernateEffect({
+  sessionId,
+  isVisibleRef,
+  status,
+  isSearchOpen,
+  hibernateEnabled,
+  hibernateDelayMs,
+  fileTransferActive,
+  hibernatedRef,
+  hibernatePendingBufferRef,
+  hibernateSnapshotRef,
+  hibernateAlternateScreenRef,
+  hasRuntimeRef,
+  onHibernate,
+  onWake,
+}: UseTerminalHibernateEffectOptions): void {
+  const hiddenSinceRef = useRef<number | null>(null);
+  const hibernateTimerRef = useRef<number | null>(null);
+  const paneVisibleRef = useRef(getPaneVisible(sessionId));
+  const onHibernateRef = useRef(onHibernate);
+  const onWakeRef = useRef(onWake);
+  onHibernateRef.current = onHibernate;
+  onWakeRef.current = onWake;
+
+  useEffect(() => {
+    const clearHibernateTimer = () => {
+      if (hibernateTimerRef.current !== null) {
+        window.clearTimeout(hibernateTimerRef.current);
+        hibernateTimerRef.current = null;
+      }
+    };
+
+    const tryWake = () => {
+      if (!hibernatedRef.current) return;
+
+      const payload: TerminalHibernateWakePayload = {
+        snapshot: hibernateSnapshotRef.current,
+        pendingBuffer: hibernatePendingBufferRef.current,
+        alternateScreen: hibernateAlternateScreenRef.current,
+      };
+      hibernateSnapshotRef.current = "";
+      hibernatePendingBufferRef.current = "";
+      hibernateAlternateScreenRef.current = false;
+      hibernatedRef.current = false;
+      logger.info("[Terminal] Waking from hibernate", {
+        sessionId,
+        snapshotChars: payload.snapshot.length,
+        pendingChars: payload.pendingBuffer.length,
+      });
+      onWakeRef.current(payload);
+    };
+
+    if (!hibernateEnabled) {
+      clearHibernateTimer();
+      if (hibernatedRef.current && getPaneVisible(sessionId)) {
+        tryWake();
+      }
+      const unsubscribeDisabled = subscribePaneVisible(sessionId, () => {
+        if (hibernatedRef.current && getPaneVisible(sessionId)) {
+          tryWake();
+        }
+      });
+      return () => {
+        unsubscribeDisabled();
+      };
+    }
+
+    const scheduleHibernate = () => {
+      clearHibernateTimer();
+      if (hibernatedRef.current || !hasRuntimeRef.current) return;
+      if (status !== "connected") return;
+      if (isSearchOpen) return;
+      if (fileTransferActive) return;
+
+      hiddenSinceRef.current = Date.now();
+      const hiddenAt = hiddenSinceRef.current;
+      hibernateTimerRef.current = window.setTimeout(() => {
+        hibernateTimerRef.current = null;
+        if (hiddenSinceRef.current !== hiddenAt) return;
+        if (getPaneVisible(sessionId)) return;
+        onHibernateRef.current();
+      }, hibernateDelayMs);
+    };
+
+    const applyVisibility = (visible: boolean) => {
+      paneVisibleRef.current = visible;
+      isVisibleRef.current = visible;
+
+      if (visible) {
+        hiddenSinceRef.current = null;
+        clearHibernateTimer();
+        tryWake();
+        return;
+      }
+
+      scheduleHibernate();
+    };
+
+    applyVisibility(getPaneVisible(sessionId));
+
+    const unsubscribe = subscribePaneVisible(sessionId, () => {
+      const visible = getPaneVisible(sessionId);
+      if (visible === paneVisibleRef.current) return;
+      applyVisibility(visible);
+    });
+
+    return () => {
+      clearHibernateTimer();
+      unsubscribe();
+    };
+  }, [
+    fileTransferActive,
+    hasRuntimeRef,
+    hibernateDelayMs,
+    hibernateEnabled,
+    hibernatePendingBufferRef,
+    hibernateSnapshotRef,
+    hibernateAlternateScreenRef,
+    hibernatedRef,
+    isSearchOpen,
+    isVisibleRef,
+    sessionId,
+    status,
+  ]);
+}

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -26,7 +26,7 @@ type UseTerminalHibernateEffectOptions = {
   hasRuntimeRef: React.MutableRefObject<boolean>;
   onHibernate: () => void;
   onWake: (
-    payload: TerminalHibernateWakePayload,
+    getPayload: () => TerminalHibernateWakePayload,
     options: { sessionConnected: boolean },
   ) => boolean | Promise<boolean>;
 };
@@ -75,18 +75,18 @@ export function useTerminalHibernateEffect({
       if (!hibernatedRef.current) return;
 
       const sessionConnected = getSessionConnectedRef.current();
-      const payload: TerminalHibernateWakePayload = {
+      const getPayload = (): TerminalHibernateWakePayload => ({
         snapshot: hibernateSnapshotRef.current,
         pendingBuffer: hibernatePendingBufferRef.current,
         alternateScreen: hibernateAlternateScreenRef.current,
-      };
+      });
       logger.info("[Terminal] Waking from hibernate", {
         sessionId,
-        snapshotChars: payload.snapshot.length,
-        pendingChars: payload.pendingBuffer.length,
+        snapshotChars: hibernateSnapshotRef.current.length,
+        pendingChars: hibernatePendingBufferRef.current.length,
         sessionConnected,
       });
-      void Promise.resolve(onWakeRef.current(payload, { sessionConnected })).then((accepted) => {
+      void Promise.resolve(onWakeRef.current(getPayload, { sessionConnected })).then((accepted) => {
         if (accepted !== false) {
           clearHibernateState();
         }

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -1,5 +1,6 @@
 import type { SerialConfig } from './connection';
 import type { CodingCliProviderId } from '../codingCliProviders';
+import { normalizeHibernateHiddenTabsDelaySec } from '../terminalHibernate';
 
 // Terminal appearance settings
 export type CursorShape = 'block' | 'bar' | 'underline';
@@ -117,6 +118,10 @@ export interface TerminalSettings {
 
   // Rendering
   rendererType: 'auto' | 'webgl' | 'dom'; // Terminal renderer: auto (detect based on hardware), webgl, or dom
+  /** Dispose xterm for hidden tabs after a delay to save renderer memory; SSH stays connected. */
+  hibernateHiddenTabs: boolean;
+  /** Seconds after a tab leaves view before hibernating (see hibernateHiddenTabs). */
+  hibernateHiddenTabsDelaySec: number;
   showLineTimestamps: boolean; // Show output timestamps in a side gutter
 
   // Autocomplete
@@ -261,6 +266,9 @@ export const normalizeTerminalSettings = (
   return {
     ...mergedSettings,
     rendererType,
+    hibernateHiddenTabsDelaySec: normalizeHibernateHiddenTabsDelaySec(
+      mergedSettings.hibernateHiddenTabsDelaySec,
+    ),
     autocompleteGhostText: mergedSettings.autocompletePopupMenu
       ? false
       : mergedSettings.autocompleteGhostText,
@@ -323,6 +331,8 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   forcePromptNewLine: false, // Opt-in: keep the next shell prompt visually separated from unterminated final output lines
   osc52Clipboard: 'write-only', // OSC-52: allow remote programs to write clipboard by default
   rendererType: 'auto', // Auto-detect best renderer based on hardware
+  hibernateHiddenTabs: true,
+  hibernateHiddenTabsDelaySec: 5,
   showLineTimestamps: false, // Opt-in: shows output timestamps beside terminal lines
   autocompleteEnabled: true, // Autocomplete enabled by default
   autocompleteGhostText: false, // Mutually exclusive with popup menu

--- a/domain/terminalHibernate.test.ts
+++ b/domain/terminalHibernate.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  capHibernateBuffer,
+  capHibernateBufferByLines,
+  isTerminalFileTransferActive,
+  normalizeHibernateHiddenTabsDelaySec,
+  resolveTerminalHibernateDelayMs,
+  resolveTerminalHibernateEnabled,
+  TERMINAL_HIBERNATE_BUFFER_MAX_CHARS,
+  TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT,
+  TERMINAL_HIBERNATE_DELAY_SEC_MAX,
+  TERMINAL_HIBERNATE_DELAY_SEC_MIN,
+} from "./terminalHibernate.ts";
+
+test("capHibernateBuffer trims from the front when over the char limit", () => {
+  const input = "a".repeat(TERMINAL_HIBERNATE_BUFFER_MAX_CHARS + 10);
+  const capped = capHibernateBuffer(input);
+  assert.equal(capped.length, TERMINAL_HIBERNATE_BUFFER_MAX_CHARS);
+  assert.equal(capped, "a".repeat(TERMINAL_HIBERNATE_BUFFER_MAX_CHARS));
+});
+
+test("capHibernateBufferByLines keeps the most recent lines", () => {
+  const input = ["line-1", "line-2", "line-3", "line-4"].join("\n");
+  assert.equal(capHibernateBufferByLines(input, 2), "line-3\nline-4");
+});
+
+test("resolveTerminalHibernateEnabled defaults to enabled", () => {
+  assert.equal(resolveTerminalHibernateEnabled(), true);
+  assert.equal(resolveTerminalHibernateEnabled({ hibernateHiddenTabs: true }), true);
+  assert.equal(resolveTerminalHibernateEnabled({ hibernateHiddenTabs: false }), false);
+});
+
+test("isTerminalFileTransferActive is true when any transfer signal is active", () => {
+  assert.equal(
+    isTerminalFileTransferActive({ zmodemActive: false, ymodemInProgress: false, isDraggingOver: false }),
+    false,
+  );
+  assert.equal(
+    isTerminalFileTransferActive({ zmodemActive: true, ymodemInProgress: false, isDraggingOver: false }),
+    true,
+  );
+  assert.equal(
+    isTerminalFileTransferActive({ zmodemActive: false, ymodemInProgress: true, isDraggingOver: false }),
+    true,
+  );
+  assert.equal(
+    isTerminalFileTransferActive({ zmodemActive: false, ymodemInProgress: false, isDraggingOver: true }),
+    true,
+  );
+});
+
+test("normalizeHibernateHiddenTabsDelaySec clamps to the allowed range", () => {
+  assert.equal(normalizeHibernateHiddenTabsDelaySec(undefined), TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT);
+  assert.equal(normalizeHibernateHiddenTabsDelaySec(45), 45);
+  assert.equal(normalizeHibernateHiddenTabsDelaySec(1), TERMINAL_HIBERNATE_DELAY_SEC_MIN);
+  assert.equal(normalizeHibernateHiddenTabsDelaySec(9999), TERMINAL_HIBERNATE_DELAY_SEC_MAX);
+});
+
+test("resolveTerminalHibernateDelayMs converts seconds to milliseconds", () => {
+  assert.equal(resolveTerminalHibernateDelayMs(), TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT * 1000);
+  assert.equal(resolveTerminalHibernateDelayMs({ hibernateHiddenTabsDelaySec: 10 }), 10_000);
+});

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -1,0 +1,72 @@
+import type { TerminalSettings } from "./models/terminal";
+
+/** Compile-time kill switch for terminal hibernate (Settings > Terminal still controls user default). */
+export const TERMINAL_HIBERNATE_ENABLED = true;
+
+/** Default delay before hibernating a hidden tab (seconds). */
+export const TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT = 5;
+
+export const TERMINAL_HIBERNATE_DELAY_SEC_MIN = 5;
+
+export const TERMINAL_HIBERNATE_DELAY_SEC_MAX = 600;
+
+/** Default delay in milliseconds (legacy constant for tests). */
+export const TERMINAL_HIBERNATE_DELAY_MS = TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT * 1000;
+
+export function normalizeHibernateHiddenTabsDelaySec(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return TERMINAL_HIBERNATE_DELAY_SEC_DEFAULT;
+  }
+  return Math.min(
+    TERMINAL_HIBERNATE_DELAY_SEC_MAX,
+    Math.max(TERMINAL_HIBERNATE_DELAY_SEC_MIN, Math.round(value)),
+  );
+}
+
+export function resolveTerminalHibernateDelayMs(
+  settings?: Pick<TerminalSettings, "hibernateHiddenTabsDelaySec"> | null,
+): number {
+  return normalizeHibernateHiddenTabsDelaySec(settings?.hibernateHiddenTabsDelaySec) * 1000;
+}
+
+export function resolveTerminalHibernateEnabled(
+  settings?: Pick<TerminalSettings, "hibernateHiddenTabs"> | null,
+): boolean {
+  if (!TERMINAL_HIBERNATE_ENABLED) return false;
+  return settings?.hibernateHiddenTabs !== false;
+}
+
+/** Block hibernate while a file transfer or drag-drop session is in progress. */
+export function isTerminalFileTransferActive(options: {
+  zmodemActive: boolean;
+  ymodemInProgress: boolean;
+  isDraggingOver: boolean;
+}): boolean {
+  return options.zmodemActive || options.ymodemInProgress || options.isDraggingOver;
+}
+
+/** Lines kept when snapshotting xterm scrollback before hibernate. */
+export const TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES = 3_000;
+
+/** Max chars buffered in renderer while xterm is hibernated (post-snapshot output). */
+export const TERMINAL_HIBERNATE_BUFFER_MAX_CHARS = 512 * 1024;
+
+export function capHibernateBuffer(buffer: string, maxChars = TERMINAL_HIBERNATE_BUFFER_MAX_CHARS): string {
+  if (buffer.length <= maxChars) return buffer;
+  return buffer.slice(buffer.length - maxChars);
+}
+
+export function capHibernateBufferByLines(text: string, maxLines: number): string {
+  if (maxLines <= 0 || text.length === 0) return text;
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  return lines.slice(lines.length - maxLines).join("\n");
+}
+
+/** Snapshot + buffered output to replay when recreating xterm after hibernate. */
+export type TerminalHibernateWakePayload = {
+  snapshot: string;
+  pendingBuffer: string;
+  /** True when the pane was hibernated while a full-screen app owned the alt buffer. */
+  alternateScreen: boolean;
+};

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -17,6 +17,16 @@ test("normalizeTerminalSettings enables font smoothing by default", () => {
   assert.equal(normalizeTerminalSettings().fontSmoothing, true);
 });
 
+test("normalizeTerminalSettings enables hibernate for hidden tabs by default", () => {
+  assert.equal(normalizeTerminalSettings().hibernateHiddenTabs, true);
+  assert.equal(normalizeTerminalSettings().hibernateHiddenTabsDelaySec, 5);
+});
+
+test("normalizeTerminalSettings clamps hibernate delay seconds", () => {
+  assert.equal(normalizeTerminalSettings({ hibernateHiddenTabsDelaySec: 120 }).hibernateHiddenTabsDelaySec, 120);
+  assert.equal(normalizeTerminalSettings({ hibernateHiddenTabsDelaySec: 2 }).hibernateHiddenTabsDelaySec, 5);
+});
+
 test("normalizeTerminalSettings preserves disabled font smoothing", () => {
   assert.equal(normalizeTerminalSettings({ fontSmoothing: false }).fontSmoothing, false);
 });


### PR DESCRIPTION
## Summary
- Dispose xterm for off-screen terminal tabs after a configurable delay while keeping SSH sessions connected
- Replay serialized scrollback and capped pending output on wake, including alternate-screen apps (htop/vim)
- Add Settings toggle and delay (5–600s, default 5s); skip hibernate during Zmodem/Ymodem transfers and file drag-drop

## Test plan
- [ ] Open 2+ SSH tabs, switch away for >5s, confirm Activity Monitor/renderer memory drops on background tab
- [ ] Switch back: terminal restores output, htop/vim alt-screen renders correctly
- [ ] Run `sz`/`rz` or serial Ymodem on background tab path: hibernate should not trigger during transfer
- [ ] Disable "Hibernate hidden tabs" in Settings > Terminal > Rendering and confirm tabs stay live
- [ ] Adjust hibernate delay in settings and verify timer respects new value


Made with [Cursor](https://cursor.com)