### PR TITLE
fix: stop SFTP cwd toggling when OSC 7 tracking is active (#1602)

### DIFF
--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -215,6 +215,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     meta?: { source?: 'osc7' },
   ) => {
     if (meta?.source === 'osc7') {
+      // Bump on every OSC 7 report, even when the decoded path is unchanged.
+      // PROMPT_COMMAND/precmd emits OSC 7 after each command; skipping the
+      // backend pwd probe in that case prevents SFTP follow from toggling
+      // between OSC 7 cwd and login-shell fallback pwd (notably after sudo).
       const nextSignal = (terminalOsc7SignalBySessionRef.current.get(sessionId) ?? 0) + 1;
       terminalOsc7SignalBySessionRef.current.set(sessionId, nextSignal);
     }

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -195,6 +195,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const focusedSessionIdRef = useRef<string | undefined>(undefined);
   const terminalCwdRevisionRef = useRef(0);
   const [terminalCwdRevision, setTerminalCwdRevision] = useState(0);
+  const terminalOsc7SignalBySessionRef = useRef<Map<string, number>>(new Map());
   const cwdProbeCancelersRef = useRef<Map<string, () => void>>(new Map());
   const cwdProbeGenerationRef = useRef<Map<string, number>>(new Map());
 
@@ -208,7 +209,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     return () => window.clearTimeout(timeoutId);
   }, []);
 
-  const handleTerminalCwdChange = useCallback((sessionId: string, cwd: string | null) => {
+  const handleTerminalCwdChange = useCallback((
+    sessionId: string,
+    cwd: string | null,
+    meta?: { source?: 'osc7' },
+  ) => {
+    if (meta?.source === 'osc7') {
+      const nextSignal = (terminalOsc7SignalBySessionRef.current.get(sessionId) ?? 0) + 1;
+      terminalOsc7SignalBySessionRef.current.set(sessionId, nextSignal);
+    }
+
     const currentCwd = terminalRendererCwdBySessionRef.current.get(sessionId) ?? null;
     const nextCwd = cwd && cwd.trim().length > 0 ? cwd : null;
     if (currentCwd === nextCwd) return;
@@ -707,14 +717,14 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     const followHost = resolveSftpFollowTerminalCwdTargetHost(visibleSftpHost, sessionHost);
     if (!resolveHostFollowTerminalCwd(followHost?.sftpFollowTerminalCwd, sftpFollowTerminalCwdRef.current)) return;
 
-    const revisionAtCommand = terminalCwdRevisionRef.current;
+    const osc7SignalAtCommand = terminalOsc7SignalBySessionRef.current.get(sessionId) ?? 0;
     const probeGeneration = (cwdProbeGenerationRef.current.get(sessionId) ?? 0) + 1;
     cwdProbeGenerationRef.current.set(sessionId, probeGeneration);
     cwdProbeCancelersRef.current.get(sessionId)?.();
     const cancelProbe = scheduleBackendCwdProbeAfterCommand({
       sessionId,
-      cwdRevisionAtCommand: revisionAtCommand,
-      getCwdRevision: () => terminalCwdRevisionRef.current,
+      osc7SignalAtCommand,
+      getOsc7Signal: () => terminalOsc7SignalBySessionRef.current.get(sessionId) ?? 0,
       getSessionPwd: (id, options) => terminalBackend.getSessionPwd(id, options),
       canProbe: async () => {
         if (cwdProbeGenerationRef.current.get(sessionId) !== probeGeneration) return false;

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -79,7 +79,7 @@ __netcatty_osc7_url_path() {
 mkdir -p "$(dirname "$config")"
 touch "$config"
 if grep -F "$marker" "$config" >/dev/null 2>&1; then
-  printf "Netcatty OSC 7 cwd tracking is already configured in %s\n" "$config"
+  :
 else
   case "$shell_name" in
     bash)
@@ -141,12 +141,10 @@ end
 NETCATTY_OSC7_FISH
       ;;
   esac
-  printf "Netcatty OSC 7 cwd tracking configured in %s\n" "$config"
 fi
 
 host=$(hostname 2>/dev/null || printf localhost)
-printf '\033]7;file://%s%s\a' "$host" "$(__netcatty_osc7_url_path "$PWD")"
-printf "\nRestart this shell, or open a new one, to keep tracking future directory changes.\n"`;
+printf '\033]7;file://%s%s\a' "$host" "$(__netcatty_osc7_url_path "$PWD")"`;
 
 export const buildOsc7SetupCommand = (): string =>
   `set +u 2>/dev/null || true; printf "%s\\n" ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)} | env NETCATTY_ZDOTDIR="$ZDOTDIR" NETCATTY_XDG_CONFIG_HOME="$XDG_CONFIG_HOME" sh\n`;

--- a/components/terminal/sftpCwd.test.ts
+++ b/components/terminal/sftpCwd.test.ts
@@ -123,6 +123,22 @@ test("probeBackendSessionCwdAfterCommand probes backend when OSC 7 did not repor
   assert.equal(cwd, "/var/log");
 });
 
+test("probeBackendSessionCwdAfterCommand skips when OSC 7 confirms unchanged cwd after command", async () => {
+  let backendCalls = 0;
+  const cwd = await probeBackendSessionCwdAfterCommand({
+    sessionId: "session-1",
+    osc7SignalAtCommand: 2,
+    getOsc7Signal: () => 3,
+    getSessionPwd: async () => {
+      backendCalls += 1;
+      return { success: true, cwd: "/home/user" };
+    },
+  });
+
+  assert.equal(cwd, null);
+  assert.equal(backendCalls, 0);
+});
+
 test("probeBackendSessionCwdAfterCommand still probes when cwd path is unchanged but OSC 7 did not fire", async () => {
   const cwd = await probeBackendSessionCwdAfterCommand({
     sessionId: "session-1",

--- a/components/terminal/sftpCwd.test.ts
+++ b/components/terminal/sftpCwd.test.ts
@@ -93,12 +93,12 @@ test("terminal cwd tracker clears stale renderer cwd before falling back to back
   assert.equal(cwd, "/home/fresh-session");
 });
 
-test("probeBackendSessionCwdAfterCommand skips when cwd revision already advanced", async () => {
+test("probeBackendSessionCwdAfterCommand skips when OSC 7 already reported after command", async () => {
   let backendCalls = 0;
   const cwd = await probeBackendSessionCwdAfterCommand({
     sessionId: "session-1",
-    cwdRevisionAtCommand: 1,
-    getCwdRevision: () => 2,
+    osc7SignalAtCommand: 1,
+    getOsc7Signal: () => 2,
     getSessionPwd: async () => {
       backendCalls += 1;
       return { success: true, cwd: "/tmp" };
@@ -109,11 +109,11 @@ test("probeBackendSessionCwdAfterCommand skips when cwd revision already advance
   assert.equal(backendCalls, 0);
 });
 
-test("probeBackendSessionCwdAfterCommand probes backend when revision is unchanged", async () => {
+test("probeBackendSessionCwdAfterCommand probes backend when OSC 7 did not report", async () => {
   const cwd = await probeBackendSessionCwdAfterCommand({
     sessionId: "session-1",
-    cwdRevisionAtCommand: 3,
-    getCwdRevision: () => 3,
+    osc7SignalAtCommand: 3,
+    getOsc7Signal: () => 3,
     getSessionPwd: async (sessionId) => {
       assert.equal(sessionId, "session-1");
       return { success: true, cwd: "/var/log" };
@@ -121,4 +121,15 @@ test("probeBackendSessionCwdAfterCommand probes backend when revision is unchang
   });
 
   assert.equal(cwd, "/var/log");
+});
+
+test("probeBackendSessionCwdAfterCommand still probes when cwd path is unchanged but OSC 7 did not fire", async () => {
+  const cwd = await probeBackendSessionCwdAfterCommand({
+    sessionId: "session-1",
+    osc7SignalAtCommand: 5,
+    getOsc7Signal: () => 5,
+    getSessionPwd: async () => ({ success: true, cwd: "/srv/app" }),
+  });
+
+  assert.equal(cwd, "/srv/app");
 });

--- a/components/terminal/sftpCwd.ts
+++ b/components/terminal/sftpCwd.ts
@@ -67,27 +67,27 @@ export const PROBE_SESSION_CWD_AFTER_COMMAND_MS = 150;
 
 export type ProbeBackendSessionCwdAfterCommandOptions = {
   sessionId: string;
-  cwdRevisionAtCommand: number;
-  getCwdRevision: () => number;
+  osc7SignalAtCommand: number;
+  getOsc7Signal: () => number;
   getSessionPwd: (sessionId: string, options?: SessionPwdOptions) => Promise<SessionPwdResult>;
   canProbe?: () => boolean | Promise<boolean>;
 };
 
-/** Probe backend pwd when OSC 7 did not update cwd after a command. */
+/** Probe backend pwd when OSC 7 did not report after a command. */
 export const probeBackendSessionCwdAfterCommand = async ({
   sessionId,
-  cwdRevisionAtCommand,
-  getCwdRevision,
+  osc7SignalAtCommand,
+  getOsc7Signal,
   getSessionPwd,
   canProbe = () => true,
 }: ProbeBackendSessionCwdAfterCommandOptions): Promise<string | null> => {
-  if (getCwdRevision() !== cwdRevisionAtCommand) return null;
+  if (getOsc7Signal() !== osc7SignalAtCommand) return null;
   const allowed = await canProbe();
-  if (!allowed || getCwdRevision() !== cwdRevisionAtCommand) return null;
+  if (!allowed || getOsc7Signal() !== osc7SignalAtCommand) return null;
 
   try {
     const result = await getSessionPwd(sessionId);
-    if (getCwdRevision() !== cwdRevisionAtCommand) return null;
+    if (getOsc7Signal() !== osc7SignalAtCommand) return null;
     return result.success ? normalizeCwd(result.cwd) : null;
   } catch {
     return null;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -174,7 +174,7 @@ export interface TerminalProps {
     pendingUploadEntries?: DropEntry[],
     sourceSessionId?: string,
   ) => void;
-  onTerminalCwdChange?: (sessionId: string, cwd: string | null) => void;
+  onTerminalCwdChange?: (sessionId: string, cwd: string | null, meta?: { source?: 'osc7' }) => void;
   onTerminalTitleChange?: (sessionId: string, title: string | null) => void;
   onTerminalBell?: (sessionId: string) => void;
   onTerminalOutput?: (sessionId: string, chunk: string) => void;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -280,7 +280,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
           onCwdChange: (cwd: string) => {
             terminalCwdTracker.setRendererCwd(cwd);
             knownCwdRef.current = cwd;
-            onTerminalCwdChange?.(sessionId, cwd);
+            onTerminalCwdChange?.(sessionId, cwd, { source: 'osc7' });
           },
           onTitleChange: (title: string | null) => {
             onTerminalTitleChange?.(sessionId, title);

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -663,7 +663,7 @@ interface TerminalPaneProps {
     pendingUploadEntries?: DropEntry[],
     sourceSessionId?: string,
   ) => void;
-  onTerminalCwdChange: (sessionId: string, cwd: string | null) => void;
+  onTerminalCwdChange: (sessionId: string, cwd: string | null, meta?: { source?: 'osc7' }) => void;
   onTerminalTitleChange?: (sessionId: string, title: string | null) => void;
   onTerminalBell?: (sessionId: string) => void;
   onTerminalOutput?: (sessionId: string, chunk: string) => void;


### PR DESCRIPTION
## Summary
- Track per-session OSC 7 activity separately from cwd path changes, and skip backend pwd probes after commands once the shell has reported OSC 7 (even when the path is unchanged).
- This prevents SFTP follow mode from alternating between OSC 7 cwd and login-shell fallback pwd after `sudo -s` / `sudo -i`.
- Silence OSC 7 setup script status text in the terminal; the existing toast already confirms success.

Fixes #1602

## Test plan
- [x] `node --import tsx --test components/terminal/sftpCwd.test.ts components/terminal/osc7Setup.test.ts`
- [ ] SSH as a normal user, enable SFTP follow + OSC 7 setup, `sudo -s`, run non-`cd` commands and confirm SFTP no longer toggles paths on Enter
- [ ] Configure OSC 7 tracking and confirm the terminal shows no setup status text (only the toast)
- [ ] Verify `cd` still updates SFTP path correctly without OSC 7 configured (backend probe fallback)


Made with [Cursor](https://cursor.com)