### PR TITLE
fix(terminal): fall back to isVisible for popup hibernate

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1638,6 +1638,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   useTerminalHibernateEffect({
     sessionId,
+    isVisible,
     isVisibleRef,
     getSessionConnectedRef,
     status,

--- a/components/terminal/paneVisibilityStore.test.ts
+++ b/components/terminal/paneVisibilityStore.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getPaneVisible,
+  hasPaneVisibilityEntry,
+  removePaneVisible,
+  resolvePaneVisible,
+  setPaneVisible,
+} from "./paneVisibilityStore.ts";
+
+const SESSION_ID = "test-session-popup-fallback";
+
+test("resolvePaneVisible falls back to the prop when the store has no entry", () => {
+  removePaneVisible(SESSION_ID);
+  assert.equal(hasPaneVisibilityEntry(SESSION_ID), false);
+  assert.equal(getPaneVisible(SESSION_ID), false);
+  assert.equal(resolvePaneVisible(SESSION_ID, true), true);
+  assert.equal(resolvePaneVisible(SESSION_ID, false), false);
+});
+
+test("resolvePaneVisible prefers the store when an entry exists", () => {
+  setPaneVisible(SESSION_ID, false);
+  assert.equal(resolvePaneVisible(SESSION_ID, true), false);
+  setPaneVisible(SESSION_ID, true);
+  assert.equal(resolvePaneVisible(SESSION_ID, false), true);
+  removePaneVisible(SESSION_ID);
+});

--- a/components/terminal/paneVisibilityStore.ts
+++ b/components/terminal/paneVisibilityStore.ts
@@ -32,6 +32,17 @@ export function getPaneVisible(sessionId: string): boolean {
   return visibleBySession.get(sessionId) ?? false;
 }
 
+/** True when a workspace pane (or similar) publishes visibility for this session. */
+export function hasPaneVisibilityEntry(sessionId: string): boolean {
+  return visibleBySession.has(sessionId);
+}
+
+/** Prefer the store when present; otherwise fall back to the Terminal `isVisible` prop. */
+export function resolvePaneVisible(sessionId: string, fallbackVisible: boolean): boolean {
+  if (!visibleBySession.has(sessionId)) return fallbackVisible;
+  return visibleBySession.get(sessionId)!;
+}
+
 export function subscribePaneVisible(sessionId: string, listener: Listener): () => void {
   let set = listenersBySession.get(sessionId);
   if (!set) {

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -5,13 +5,14 @@ import {
 } from "../../domain/terminalHibernate";
 import { logger } from "../../lib/logger";
 import {
-  getPaneVisible,
+  resolvePaneVisible,
   subscribePaneVisible,
 } from "./paneVisibilityStore";
 import type { TerminalSession } from "../../types";
 
 type UseTerminalHibernateEffectOptions = {
   sessionId: string;
+  isVisible: boolean;
   isVisibleRef: React.MutableRefObject<boolean>;
   getSessionConnectedRef: React.MutableRefObject<() => boolean>;
   status: TerminalSession["status"];
@@ -33,6 +34,7 @@ type UseTerminalHibernateEffectOptions = {
 
 export function useTerminalHibernateEffect({
   sessionId,
+  isVisible,
   isVisibleRef,
   getSessionConnectedRef,
   status,
@@ -50,13 +52,15 @@ export function useTerminalHibernateEffect({
 }: UseTerminalHibernateEffectOptions): void {
   const hiddenSinceRef = useRef<number | null>(null);
   const hibernateTimerRef = useRef<number | null>(null);
-  const paneVisibleRef = useRef(getPaneVisible(sessionId));
+  const paneVisibleRef = useRef(resolvePaneVisible(sessionId, isVisible));
   const onHibernateRef = useRef(onHibernate);
   const onWakeRef = useRef(onWake);
   onHibernateRef.current = onHibernate;
   onWakeRef.current = onWake;
 
   useEffect(() => {
+    const resolveVisible = () => resolvePaneVisible(sessionId, isVisibleRef.current);
+
     const clearHibernateTimer = () => {
       if (hibernateTimerRef.current !== null) {
         window.clearTimeout(hibernateTimerRef.current);
@@ -84,7 +88,7 @@ export function useTerminalHibernateEffect({
       hibernateTimerRef.current = window.setTimeout(() => {
         hibernateTimerRef.current = null;
         if (hiddenSinceRef.current !== hiddenAt) return;
-        if (getPaneVisible(sessionId)) return;
+        if (resolveVisible()) return;
         onHibernateRef.current();
       }, hibernateDelayMs);
     };
@@ -107,7 +111,7 @@ export function useTerminalHibernateEffect({
       void Promise.resolve(onWakeRef.current(getPayload, { sessionConnected })).then((accepted) => {
         if (accepted !== false) {
           clearHibernateState();
-          if (!getPaneVisible(sessionId)) {
+          if (!resolveVisible()) {
             scheduleHibernate();
           }
         }
@@ -120,7 +124,7 @@ export function useTerminalHibernateEffect({
         tryWake();
       }
       const unsubscribeDisabled = subscribePaneVisible(sessionId, () => {
-        if (hibernatedRef.current && getPaneVisible(sessionId)) {
+        if (hibernatedRef.current && resolveVisible()) {
           tryWake();
         }
       });
@@ -143,10 +147,10 @@ export function useTerminalHibernateEffect({
       scheduleHibernate();
     };
 
-    applyVisibility(getPaneVisible(sessionId));
+    applyVisibility(resolveVisible());
 
     const unsubscribe = subscribePaneVisible(sessionId, () => {
-      const visible = getPaneVisible(sessionId);
+      const visible = resolveVisible();
       if (visible === paneVisibleRef.current) return;
       applyVisibility(visible);
     });
@@ -166,6 +170,7 @@ export function useTerminalHibernateEffect({
     hibernateAlternateScreenRef,
     hibernatedRef,
     isSearchOpen,
+    isVisible,
     isVisibleRef,
     sessionId,
     status,


### PR DESCRIPTION
## Summary
- Fixes Codex P1 on #1603: standalone `Terminal` mounts (e.g. `TerminalPopupPage`) no longer hibernate after 5s because `paneVisibilityStore` has no entry
- Add `resolvePaneVisible()` to prefer store state when published, otherwise use the `isVisible` prop
- Hibernate effect re-runs when `isVisible` changes for non-store terminals

## Test plan
- [ ] Open a session in Terminal Popup window — stays live after 5+ seconds
- [ ] Workspace tabs still hibernate hidden panes after delay
- [ ] Switching workspace tabs still wakes/hibernates correctly


Made with [Cursor](https://cursor.com)