### PR TITLE
add improved host search matching

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -59,6 +59,7 @@ import { VaultSection } from './components/VaultView';
 import { KeyboardInteractiveRequest } from './components/KeyboardInteractiveModal';
 import { PassphraseRequest } from './components/PassphraseModal';
 import { classifyLocalShellType } from './lib/localShell';
+import { getHostSearchMatch } from './lib/searchMatcher';
 import { useDiscoveredShells, resolveShellSetting } from './lib/useDiscoveredShells';
 import { Host, HostProtocol, KnownHost, SerialConfig, Snippet, SSHKey, TerminalSession } from './types';
 import { resolveSnippetCommand } from './components/SnippetExecutionProvider';
@@ -825,15 +826,18 @@ function App({ settings }: { settings: SettingsState }) {
 
   const quickResults = useMemo(() => {
     if (!isQuickSwitcherOpen) return [];
-    const term = quickSearch.trim().toLowerCase();
-    const filtered = term
-      ? hosts.filter(h =>
-        h.label.toLowerCase().includes(term) ||
-        h.hostname.toLowerCase().includes(term) ||
-        (h.group || '').toLowerCase().includes(term)
-      )
-      : hosts;
-    return filtered;
+    const term = quickSearch.trim();
+    if (!term) return hosts;
+    return hosts
+      .map((host) => ({ host, match: getHostSearchMatch(term, host) }))
+      .filter((entry) => entry.match.matched)
+      .sort((left, right) => {
+        if (left.match.score !== right.match.score) {
+          return right.match.score - left.match.score;
+        }
+        return left.host.label.localeCompare(right.host.label);
+      })
+      .map((entry) => entry.host);
   }, [quickSearch, hosts, isQuickSwitcherOpen]);
 
   const handleDeleteHost = useCallback((hostId: string) => {

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -490,7 +490,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
                   );
                 })}
               </div>
-            ) : onCreateLocalTerminal && (
+            ) : shouldShowLocalTerminalFallback && (
               <div>
                 <div className="px-4 py-1.5">
                   <span className="text-xs font-medium text-muted-foreground">

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -11,6 +11,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "
 import { useI18n } from "../application/i18n/I18nProvider";
 import { Host, TerminalSession, Workspace } from "../types";
 import { KeyBinding } from "../domain/models";
+import { matchesSearchQuery } from "../lib/searchMatcher";
 import { useDiscoveredShells, getShellIconPath, isMonochromeShellIcon } from "../lib/useDiscoveredShells";
 
 type QuickSwitcherItem = {
@@ -96,7 +97,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     const list = !query.trim()
       ? discoveredShells
       : discoveredShells.filter(
-          (s) => s.name.toLowerCase().includes(query.toLowerCase()) || s.id.toLowerCase().includes(query.toLowerCase())
+          (s) => matchesSearchQuery(query, s.name, s.id)
         );
     // Default shell first
     return [...list].sort((a, b) => (a.isDefault === b.isDefault ? 0 : a.isDefault ? -1 : 1));
@@ -150,6 +151,36 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     () => sessions.filter((s) => !s.workspaceId),
     [sessions]
   );
+  const trimmedQuery = query.trim();
+  const builtInTabs = useMemo(() => {
+    if (!trimmedQuery) return showSftpTab ? ["vault", "sftp"] : ["vault"];
+    const matched: string[] = [];
+    if (matchesSearchQuery(trimmedQuery, "Vaults", "vault", "hosts", "connections")) {
+      matched.push("vault");
+    }
+    if (showSftpTab && matchesSearchQuery(trimmedQuery, "SFTP", "files", "transfer", "sftp")) {
+      matched.push("sftp");
+    }
+    return matched;
+  }, [showSftpTab, trimmedQuery]);
+  const filteredOrphanSessions = useMemo(() => {
+    if (!trimmedQuery) return orphanSessions;
+    return orphanSessions.filter((session) =>
+      matchesSearchQuery(
+        trimmedQuery,
+        session.hostLabel || "",
+        session.hostname || "",
+        session.id,
+      ),
+    );
+  }, [orphanSessions, trimmedQuery]);
+  const filteredWorkspaces = useMemo(() => {
+    if (!trimmedQuery) return workspaces;
+    return workspaces.filter((workspace) =>
+      matchesSearchQuery(trimmedQuery, workspace.title, workspace.id),
+    );
+  }, [trimmedQuery, workspaces]);
+  const shouldShowLocalTerminalFallback = filteredShells.length === 0 && !!onCreateLocalTerminal && !trimmedQuery;
 
   // Always show categorized view (Hosts/Tabs/Quick connect)
   const showCategorized = true;
@@ -164,12 +195,13 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
         items.push({ type: "host", id: host.id, data: host }),
       );
       // Tabs (built-in + sessions + workspaces)
-      items.push({ type: "tab", id: "vault" });
-      if (showSftpTab) items.push({ type: "tab", id: "sftp" });
-      orphanSessions.forEach((s) =>
+      builtInTabs.forEach((tabId) => {
+        items.push({ type: "tab", id: tabId });
+      });
+      filteredOrphanSessions.forEach((s) =>
         items.push({ type: "tab", id: s.id, data: s }),
       );
-      workspaces.forEach((w) =>
+      filteredWorkspaces.forEach((w) =>
         items.push({ type: "workspace", id: w.id, data: w }),
       );
       // Local shells (or fallback action if discovery not ready)
@@ -177,7 +209,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
         filteredShells.forEach((shell) =>
           items.push({ type: "shell", id: shell.id }),
         );
-      } else {
+      } else if (shouldShowLocalTerminalFallback) {
         items.push({ type: "action", id: "local-terminal" });
       }
     } else {
@@ -198,7 +230,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
     });
 
     return { flatItems: items, itemIndexMap: indexMap };
-  }, [showCategorized, results, orphanSessions, workspaces, filteredShells, showSftpTab]);
+  }, [showCategorized, results, builtInTabs, filteredOrphanSessions, filteredWorkspaces, filteredShells, shouldShowLocalTerminalFallback]);
 
   // O(1) index lookup
   const getItemIndex = useCallback((type: string, id: string) => {
@@ -334,7 +366,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
               </div>
 
               {/* Built-in tabs */}
-              {(showSftpTab ? ["vault", "sftp"] : ["vault"]).map((tabId) => {
+              {builtInTabs.map((tabId) => {
                 const idx = getItemIndex("tab", tabId);
                 const isSelected = idx === selectedIndex;
                 const icon =
@@ -365,7 +397,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
               })}
 
               {/* Workspaces */}
-              {workspaces.map((workspace) => {
+              {filteredWorkspaces.map((workspace) => {
                 const idx = getItemIndex("workspace", workspace.id);
                 const isSelected = idx === selectedIndex;
 
@@ -391,7 +423,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
               })}
 
               {/* Orphan sessions */}
-              {orphanSessions.map((session) => {
+              {filteredOrphanSessions.map((session) => {
                 const idx = getItemIndex("tab", session.id);
                 const isSelected = idx === selectedIndex;
 

--- a/components/SelectHostPanel.tsx
+++ b/components/SelectHostPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { cn } from "../lib/utils";
+import { matchesHostSearchQuery, matchesSearchQuery } from "../lib/searchMatcher";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { Host, ProxyProfile, SSHKey } from "../types";
 import { ManagedSource } from "../domain/models";
@@ -169,13 +170,10 @@ const SelectHostPanel: React.FC<SelectHostPanelProps> = ({
 
     // Filter by search
     if (searchQuery) {
-      const q = searchQuery.toLowerCase();
       result = result.filter(
         (h) =>
-          h.label.toLowerCase().includes(q) ||
-          h.hostname.toLowerCase().includes(q) ||
-          h.username.toLowerCase().includes(q) ||
-          (h.notes?.toLowerCase().includes(q) ?? false),
+          matchesHostSearchQuery(searchQuery, h) ||
+          matchesSearchQuery(searchQuery, h.username, h.notes),
       );
     }
 

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -37,6 +37,7 @@ import {
   STORAGE_KEY_VAULT_HOSTS_TREE_EXPANDED,
 } from '../../infrastructure/config/storageKeys';
 import { cn } from '../../lib/utils';
+import { matchesHostSearchQuery, matchesSearchQuery } from '../../lib/searchMatcher';
 import type { GroupConfig, GroupNode, Host, TerminalTheme } from '../../types';
 import { HostTreeGroupContextMenuContent, HostTreeHostContextMenuContent } from '../host/HostTreeContextMenus';
 import { HostTreeGroupInlineRenameInput } from '../host/HostTreeGroupInlineRenameInput';
@@ -199,13 +200,8 @@ export function getTerminalHostTreeMeasuredLayoutWidth(
 }
 
 function hostMatchesSearch(host: Host, search: string): boolean {
-  const s = search.toLowerCase();
-  return (
-    host.label.toLowerCase().includes(s)
-    || host.hostname.toLowerCase().includes(s)
-    || host.tags.some((tag) => tag.toLowerCase().includes(s))
-    || (host.notes?.toLowerCase().includes(s) ?? false)
-  );
+  return matchesHostSearchQuery(search, host)
+    || matchesSearchQuery(search, host.username, host.notes);
 }
 
 function filterGroupNode(

--- a/components/vault/useVaultHostCollections.tsx
+++ b/components/vault/useVaultHostCollections.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react";
 
 import { upsertKnownHost } from "../../domain/knownHosts";
 import { sortByVaultOrder, sortVaultStringsByOrder } from "../../domain/vaultOrder";
+import { matchesHostSearchQuery, matchesSearchQuery } from "../../lib/searchMatcher";
 import type { GroupConfig, GroupNode, Host, KnownHost } from "../../types";
 import KnownHostsManager from "../KnownHostsManager";
 import type { SortMode } from "../ui/sort-dropdown";
@@ -47,17 +48,15 @@ export function useVaultHostCollections({
     );
   }, [groupConfigs]);
 
-  const searchTerm = useMemo(() => search.trim().toLowerCase(), [search]);
+  const searchTerm = useMemo(() => search.trim(), [search]);
   const selectedTagSet = useMemo(() => new Set(selectedTags), [selectedTags]);
   const hasSelectedTags = selectedTags.length > 0;
 
   const hostMatchesSearchAndTags = useCallback((host: Host): boolean => {
     if (searchTerm) {
       const matchesSearch =
-        host.label.toLowerCase().includes(searchTerm) ||
-        host.hostname.toLowerCase().includes(searchTerm) ||
-        host.tags.some((tag) => tag.toLowerCase().includes(searchTerm)) ||
-        (host.notes?.toLowerCase().includes(searchTerm) ?? false);
+        matchesHostSearchQuery(searchTerm, host) ||
+        matchesSearchQuery(searchTerm, host.username, host.notes);
       if (!matchesSearch) return false;
     }
     if (hasSelectedTags && !host.tags?.some((tag) => selectedTagSet.has(tag))) {

--- a/domain/searchMatcher.test.ts
+++ b/domain/searchMatcher.test.ts
@@ -51,6 +51,18 @@ test("host search does not mix human tokens with hostname IP tokens", () => {
   );
 });
 
+test("host search treats equivalent dash separators as strict punctuation matches", () => {
+  const match = getHostSearchMatch("山东 6-1", {
+    label: "山东—业务交换机6—1",
+    hostname: "10.6.1.88",
+    group: "铁塔/山东",
+    tags: [],
+  });
+
+  assert.equal(match.matched, true);
+  assert.equal(match.phase, "strict");
+});
+
 test("host search still supports direct IP matching", () => {
   assert.equal(
     matchesHostSearchQuery("10.6.1.88", {

--- a/domain/searchMatcher.test.ts
+++ b/domain/searchMatcher.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getHostSearchMatch,
+  matchesHostSearchQuery,
+  matchesSearchQuery,
+} from "../lib/searchMatcher.ts";
+
+test("matches mixed Chinese and dash-separated numeric suffix with spaced query", () => {
+  assert.equal(
+    matchesSearchQuery("山东 6-1", "山东-业务交换机6-1"),
+    true,
+  );
+});
+
+test("matches mixed Chinese and em-dash separator with spaced query", () => {
+  assert.equal(
+    matchesSearchQuery("山东 6-1", "山东—业务交换机6—1"),
+    true,
+  );
+});
+
+test("matches IPv4-like query only on contiguous dotted address", () => {
+  assert.equal(
+    matchesSearchQuery("192.168.6.1", "192.168.6.1"),
+    true,
+  );
+  assert.equal(
+    matchesSearchQuery("192.168.6.1", "192.168.16.10"),
+    false,
+  );
+});
+
+test("matches compact form across separators", () => {
+  assert.equal(
+    matchesSearchQuery("prod api 01", "prod-api-01"),
+    true,
+  );
+});
+
+test("host search does not mix human tokens with hostname IP tokens", () => {
+  assert.equal(
+    matchesHostSearchQuery("山东 6-1", {
+      label: "山东-业务交换机2-2",
+      hostname: "10.6.1.88",
+      group: "铁塔网络设备/山东",
+      tags: [],
+    }),
+    false,
+  );
+});
+
+test("host search still supports direct IP matching", () => {
+  assert.equal(
+    matchesHostSearchQuery("10.6.1.88", {
+      label: "山东-业务交换机2-2",
+      hostname: "10.6.1.88",
+      group: "铁塔网络设备/山东",
+      tags: [],
+    }),
+    true,
+  );
+});
+
+test("host search keeps trailing dash semantic and avoids loose numeric fallback", () => {
+  assert.equal(
+    matchesHostSearchQuery("山东 6-", {
+      label: "山东-IPMI交换机6",
+      hostname: "10.6.1.88",
+      group: "铁塔/山东",
+      tags: [],
+    }),
+    false,
+  );
+  assert.equal(
+    matchesHostSearchQuery("山东 6-", {
+      label: "山东-管理交换机6-1",
+      hostname: "10.6.1.81",
+      group: "铁塔/山东",
+      tags: [],
+    }),
+    true,
+  );
+});
+
+test("host search scoring prefers strict punctuation match over loose compact match", () => {
+  const strict = getHostSearchMatch("山东 6-", {
+    label: "山东-管理交换机6-1",
+    hostname: "10.6.1.81",
+    group: "铁塔/山东",
+    tags: [],
+  });
+  const loose = getHostSearchMatch("山东 61", {
+    label: "山东-管理交换机6-1",
+    hostname: "10.6.1.81",
+    group: "铁塔/山东",
+    tags: [],
+  });
+  assert.equal(strict.matched, true);
+  assert.equal(loose.matched, true);
+  assert.equal(strict.phase, "strict");
+  assert.equal(loose.phase, "loose");
+  assert.equal(strict.score > loose.score, true);
+});
+
+test("host search scoring favors label over group when both match", () => {
+  const labelHit = getHostSearchMatch("山东 6-1", {
+    label: "山东-业务交换机6-1",
+    hostname: "10.8.2.10",
+    group: "网络设备/核心",
+    tags: [],
+  });
+  const groupHit = getHostSearchMatch("山东 6-1", {
+    label: "核心交换机",
+    hostname: "10.8.2.11",
+    group: "山东/业务交换机6-1",
+    tags: [],
+  });
+  assert.equal(labelHit.matched, true);
+  assert.equal(groupHit.matched, true);
+  assert.equal(labelHit.score > groupHit.score, true);
+});

--- a/lib/searchMatcher.ts
+++ b/lib/searchMatcher.ts
@@ -4,6 +4,7 @@ const SEARCH_SPLIT_REGEX = /[\s\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<
 const SEARCH_REMOVE_REGEX = /[\s\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<>《》、"'`~·]+/gu;
 const SEARCH_QUERY_SEGMENT_SPLIT_REGEX = /\s+/u;
 const SEARCH_QUERY_PUNCT_REGEX = /[\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<>《》、"'`~·]/u;
+const DASH_SEPARATOR_REGEX = /[\u2010-\u2015\u2212\uFE58\uFE63\uFF0D]/gu;
 const PINYIN_CACHE = new Map<string, { full: string; initials: string }>();
 const IPV4_LIKE_REGEX = /^\d{1,3}(?:\.\d{1,3})+$/;
 const HOST_PHASE_SCORE_BONUS = {
@@ -24,7 +25,7 @@ const HOST_METHOD_SCORE = {
 } as const;
 
 function normalizeText(input: string): string {
-  return input.normalize("NFKC").toLowerCase().trim();
+  return input.normalize("NFKC").replace(DASH_SEPARATOR_REGEX, "-").toLowerCase().trim();
 }
 
 function compactText(input: string): string {

--- a/lib/searchMatcher.ts
+++ b/lib/searchMatcher.ts
@@ -1,0 +1,352 @@
+import { pinyin } from "pinyin-pro";
+
+const SEARCH_SPLIT_REGEX = /[\s\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<>《》、"'`~·]+/u;
+const SEARCH_REMOVE_REGEX = /[\s\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<>《》、"'`~·]+/gu;
+const SEARCH_QUERY_SEGMENT_SPLIT_REGEX = /\s+/u;
+const SEARCH_QUERY_PUNCT_REGEX = /[\p{Pd}_/\\|.,，。;；:：!！?？()（）[\]{}<>《》、"'`~·]/u;
+const PINYIN_CACHE = new Map<string, { full: string; initials: string }>();
+const IPV4_LIKE_REGEX = /^\d{1,3}(?:\.\d{1,3})+$/;
+const HOST_PHASE_SCORE_BONUS = {
+  strict: 1_000_000,
+  loose: 100_000,
+} as const;
+const HOST_FIELD_SCORE = {
+  label: 500,
+  hostname: 380,
+  group: 280,
+  tag: 220,
+} as const;
+const HOST_METHOD_SCORE = {
+  literal: 50,
+  compact: 25,
+  pinyinFull: 12,
+  pinyinInitials: 8,
+} as const;
+
+function normalizeText(input: string): string {
+  return input.normalize("NFKC").toLowerCase().trim();
+}
+
+function compactText(input: string): string {
+  return normalizeText(input).replace(SEARCH_REMOVE_REGEX, "");
+}
+
+function getPinyinVariants(sourceText: string): { full: string; initials: string } {
+  const cacheKey = normalizeText(sourceText);
+  const cached = PINYIN_CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  let full = "";
+  let initials = "";
+
+  try {
+    full = compactText(
+      pinyin(sourceText, {
+        toneType: "none",
+      }),
+    );
+    initials = compactText(
+      pinyin(sourceText, {
+        pattern: "first",
+        toneType: "none",
+      }),
+    );
+  } catch {
+    // ignore conversion failures
+  }
+
+  const next = { full, initials };
+  PINYIN_CACHE.set(cacheKey, next);
+  return next;
+}
+
+export function tokenizeSearchQuery(query: string): string[] {
+  const normalized = normalizeText(query);
+  if (!normalized) return [];
+  return normalized.split(SEARCH_SPLIT_REGEX).filter(Boolean);
+}
+
+export function matchesSearchQuery(
+  query: string,
+  ...fields: Array<string | null | undefined>
+): boolean {
+  const normalizedQuery = normalizeText(query);
+  if (!normalizedQuery) return true;
+
+  const normalizedFields = fields
+    .filter((field): field is string => typeof field === "string" && field.trim().length > 0)
+    .map((field) => normalizeText(field));
+  if (normalizedFields.length === 0) return false;
+
+  // For dotted numeric input (IPv4-like), require contiguous literal match.
+  if (IPV4_LIKE_REGEX.test(normalizedQuery)) {
+    return normalizedFields.some((field) => field.includes(normalizedQuery));
+  }
+
+  const sourceText = normalizedFields.join(" ");
+  const haystack = sourceText;
+  if (haystack.includes(normalizedQuery)) {
+    return true;
+  }
+
+  const haystackCompact = compactText(sourceText);
+  const compactQuery = compactText(normalizedQuery);
+  if (compactQuery && haystackCompact.includes(compactQuery)) {
+    return true;
+  }
+
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (tokens.length === 0) return true;
+
+  if (tokens.every((token) => haystack.includes(token))) {
+    return true;
+  }
+
+  const hasLatinToken = tokens.some((token) => /[a-z]/i.test(token));
+  if (!hasLatinToken) return false;
+
+  const { full, initials } = getPinyinVariants(sourceText);
+  if (!full && !initials) return false;
+
+  return tokens.every((token) => {
+    if (haystack.includes(token)) return true;
+    const compactToken = compactText(token);
+    return (
+      (full && full.includes(compactToken)) ||
+      (initials && initials.includes(compactToken))
+    );
+  });
+}
+
+/**
+ * Host search should avoid mixing label/group tokens with hostname/IP tokens.
+ * Otherwise queries like "山东 6-1" can accidentally match:
+ * - "山东" from group/label
+ * - "6" / "1" from hostname IP
+ * across different fields.
+ */
+export function matchesHostSearchQuery(
+  query: string,
+  hostLike: {
+    label?: string | null;
+    hostname?: string | null;
+    group?: string | null;
+    tags?: Array<string | null | undefined> | null;
+  },
+): boolean {
+  return getHostSearchMatch(query, hostLike).matched;
+}
+
+type HostMatchField = "label" | "hostname" | "group" | "tag";
+type HostMatchMethod = "literal" | "compact" | "pinyinFull" | "pinyinInitials";
+type HostMatchPhase = "strict" | "loose";
+
+export type HostSearchMatchDetail = {
+  segment: string;
+  field: HostMatchField;
+  method: HostMatchMethod;
+  phase: HostMatchPhase;
+};
+
+export type HostSearchMatchResult = {
+  matched: boolean;
+  phase: HostMatchPhase | "none";
+  score: number;
+  details: HostSearchMatchDetail[];
+};
+
+type HostSearchFieldSource = {
+  field: HostMatchField;
+  allowPinyin: boolean;
+  text: string;
+  compact: string;
+};
+
+function scoreHostMatch(detail: HostSearchMatchDetail): number {
+  return HOST_FIELD_SCORE[detail.field] + HOST_METHOD_SCORE[detail.method];
+}
+
+function selectBetterHostMatch(
+  left: HostSearchMatchResult,
+  right: HostSearchMatchResult,
+): HostSearchMatchResult {
+  if (!left.matched) return right;
+  if (!right.matched) return left;
+  if (left.score !== right.score) {
+    return left.score > right.score ? left : right;
+  }
+  if (left.details.length !== right.details.length) {
+    return left.details.length < right.details.length ? left : right;
+  }
+  return left;
+}
+
+function matchSegmentAgainstSource(
+  segment: string,
+  source: HostSearchFieldSource,
+): HostSearchMatchDetail | null {
+  if (source.text.includes(segment)) {
+    return {
+      segment,
+      field: source.field,
+      method: "literal",
+      phase: "strict",
+    };
+  }
+
+  // Keep punctuation semantic (e.g. 6-, 6-1, 10.6.1.8): no compact fallback.
+  if (SEARCH_QUERY_PUNCT_REGEX.test(segment)) return null;
+
+  const compactSegment = compactText(segment);
+  if (compactSegment && source.compact.includes(compactSegment)) {
+    return {
+      segment,
+      field: source.field,
+      method: "compact",
+      phase: "loose",
+    };
+  }
+
+  if (!source.allowPinyin || !/[a-z]/i.test(segment)) return null;
+
+  const { full, initials } = getPinyinVariants(source.text);
+  if (full && full.includes(compactSegment)) {
+    return {
+      segment,
+      field: source.field,
+      method: "pinyinFull",
+      phase: "loose",
+    };
+  }
+  if (initials && initials.includes(compactSegment)) {
+    return {
+      segment,
+      field: source.field,
+      method: "pinyinInitials",
+      phase: "loose",
+    };
+  }
+
+  return null;
+}
+
+function evaluateHostFieldGroup(
+  segments: string[],
+  sources: HostSearchFieldSource[],
+): HostSearchMatchResult {
+  if (sources.length === 0) {
+    return { matched: false, phase: "none", score: 0, details: [] };
+  }
+
+  const details: HostSearchMatchDetail[] = [];
+  let isStrict = true;
+
+  for (const segment of segments) {
+    let best: HostSearchMatchDetail | null = null;
+    let bestScore = -1;
+
+    for (const source of sources) {
+      const detail = matchSegmentAgainstSource(segment, source);
+      if (!detail) continue;
+
+      const score = scoreHostMatch(detail);
+      if (score > bestScore) {
+        best = detail;
+        bestScore = score;
+      }
+    }
+
+    if (!best) {
+      return { matched: false, phase: "none", score: 0, details: [] };
+    }
+    if (best.phase !== "strict") {
+      isStrict = false;
+    }
+    details.push(best);
+  }
+
+  const phase: HostMatchPhase = isStrict ? "strict" : "loose";
+  const baseScore = details.reduce((sum, detail) => sum + scoreHostMatch(detail), 0);
+  return {
+    matched: true,
+    phase,
+    score: baseScore + HOST_PHASE_SCORE_BONUS[phase],
+    details,
+  };
+}
+
+export function getHostSearchMatch(
+  query: string,
+  hostLike: {
+    label?: string | null;
+    hostname?: string | null;
+    group?: string | null;
+    tags?: Array<string | null | undefined> | null;
+  },
+): HostSearchMatchResult {
+  const normalizedQuery = normalizeText(query);
+  if (!normalizedQuery) {
+    return { matched: true, phase: "strict", score: HOST_PHASE_SCORE_BONUS.strict, details: [] };
+  }
+
+  const querySegments = normalizedQuery
+    .split(SEARCH_QUERY_SEGMENT_SPLIT_REGEX)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (querySegments.length === 0) {
+    return { matched: true, phase: "strict", score: HOST_PHASE_SCORE_BONUS.strict, details: [] };
+  }
+
+  const label = normalizeText(hostLike.label ?? "");
+  const group = normalizeText(hostLike.group ?? "");
+  const hostname = normalizeText(hostLike.hostname ?? "");
+  const tags = (hostLike.tags ?? [])
+    .filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+    .map((tag) => normalizeText(tag));
+
+  const humanSources: HostSearchFieldSource[] = [];
+  if (label) {
+    humanSources.push({
+      field: "label",
+      allowPinyin: true,
+      text: label,
+      compact: compactText(label),
+    });
+  }
+  if (group) {
+    humanSources.push({
+      field: "group",
+      allowPinyin: true,
+      text: group,
+      compact: compactText(group),
+    });
+  }
+  for (const tag of tags) {
+    humanSources.push({
+      field: "tag",
+      allowPinyin: true,
+      text: tag,
+      compact: compactText(tag),
+    });
+  }
+
+  const networkSources: HostSearchFieldSource[] = hostname
+    ? [{
+      field: "hostname",
+      allowPinyin: false,
+      text: hostname,
+      compact: compactText(hostname),
+    }]
+    : [];
+
+  const humanResult = evaluateHostFieldGroup(querySegments, humanSources);
+  const networkResult = evaluateHostFieldGroup(querySegments, networkSources);
+  return selectBetterHostMatch(humanResult, networkResult);
+}
+
+export function getHostSearchReason(match: HostSearchMatchResult): string {
+  if (!match.matched || match.details.length === 0) return "";
+  const uniqueFields = Array.from(new Set(match.details.map((detail) => detail.field)));
+  const phaseLabel = match.phase === "strict" ? "strict" : "loose";
+  return `${phaseLabel}:${uniqueFields.join("/")}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "lucide-react": "0.560.0",
         "monaco-editor": "^0.55.1",
         "node-pty": "1.1.0",
+        "pinyin-pro": "^3.28.1",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "serialport": "^13.0.0",
@@ -15882,6 +15883,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pinyin-pro": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.1.tgz",
+      "integrity": "sha512-oqz8ulwRgtUXRi0vbqEfGNly19zpyCxYrjhkk5TibGcgSW6eNwS5woajCXRwqURi8Ehc2yOFTiB4uNoZ+NJOnA==",
+      "license": "MIT"
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lucide-react": "0.560.0",
     "monaco-editor": "^0.55.1",
     "node-pty": "1.1.0",
+    "pinyin-pro": "^3.28.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "serialport": "^13.0.0",


### PR DESCRIPTION
## Summary
- add shared host search matcher with Chinese/pinyin, separator-aware, and IPv4-safe matching
- use the matcher in vault host lists, terminal host tree, select-host panel, and quick switcher
- rank quick switcher host results by match quality

## Tests
- node --test --import tsx domain/searchMatcher.test.ts
- npm run build
- npx eslint App.tsx components/QuickSwitcher.tsx components/SelectHostPanel.tsx components/terminalLayer/TerminalHostTreeSidebar.tsx components/vault/useVaultHostCollections.tsx lib/searchMatcher.ts domain/searchMatcher.test.ts
