### PR TITLE
fix: 修复终端主机列表窄宽度布局

### DIFF
--- a/application/state/terminalHostTreeStore.test.ts
+++ b/application/state/terminalHostTreeStore.test.ts
@@ -39,8 +39,8 @@ test('opening host tree state does not jump the layout width', () => {
 });
 
 test('host tree restored layout width is clamped', () => {
-  assert.equal(clampTerminalHostTreeWidth(80), 160);
+  assert.equal(clampTerminalHostTreeWidth(80), 132);
   assert.equal(clampTerminalHostTreeWidth(999), 360);
-  assert.equal(clampTerminalHostTreeWidth(0), 160);
+  assert.equal(clampTerminalHostTreeWidth(0), 132);
   assert.equal(TERMINAL_HOST_TREE_DEFAULT_WIDTH, 220);
 });

--- a/application/state/terminalHostTreeStore.ts
+++ b/application/state/terminalHostTreeStore.ts
@@ -5,7 +5,7 @@ import { localStorageAdapter } from '../../infrastructure/persistence/localStora
 
 type Listener = () => void;
 
-export const TERMINAL_HOST_TREE_MIN_WIDTH = 160;
+export const TERMINAL_HOST_TREE_MIN_WIDTH = 132;
 export const TERMINAL_HOST_TREE_DEFAULT_WIDTH = 220;
 export const TERMINAL_HOST_TREE_MAX_WIDTH = 360;
 

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(globalThis, "requestAnimationFrame", {
 const {
   computeHostTreeTabGutter,
   resolveWorkspaceSessionTabDropTarget,
+  shouldHideRootTabsForNarrowHostTree,
   shouldKeepHostTreeToggleSurface,
   shouldShowHostTreeToggle,
 } = await import("./TopTabs.tsx");
@@ -42,6 +43,14 @@ test("host tree tab gutter fills the remaining sidebar width", () => {
 
 test("host tree tab gutter never goes negative", () => {
   assert.equal(computeHostTreeTabGutter(120, 280), 0);
+});
+
+test("root tabs hide only when an open host tree is at the narrow edge", () => {
+  assert.equal(shouldHideRootTabsForNarrowHostTree(true, 132), true);
+  assert.equal(shouldHideRootTabsForNarrowHostTree(true, 156), true);
+  assert.equal(shouldHideRootTabsForNarrowHostTree(true, 184), false);
+  assert.equal(shouldHideRootTabsForNarrowHostTree(true, 220), false);
+  assert.equal(shouldHideRootTabsForNarrowHostTree(false, 132), false);
 });
 
 test("host tree tab surface stays mounted when root pages are active", () => {

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -9,6 +9,7 @@ import { resolveSessionTabTitle } from '../domain/sessionTabTitle';
 import { useSessionActivityMap } from '../application/state/sessionActivityStore';
 import { getTopTabInsertionTarget, getWorkspaceSessionDragId, hasWorkspaceSessionDrag } from '../application/state/terminalDragData';
 import {
+  TERMINAL_HOST_TREE_MIN_WIDTH,
   useTerminalHostTreeLayoutWidth,
   useTerminalHostTreeOpen,
   useToggleTerminalHostTree,
@@ -48,6 +49,15 @@ const emptyTabStyle: React.CSSProperties = {};
 
 export function computeHostTreeTabGutter(hostTreeLayoutWidth: number, toggleRight: number): number {
   return Math.max(0, hostTreeLayoutWidth - toggleRight);
+}
+
+export function shouldHideRootTabsForNarrowHostTree(
+  isHostTreeOpen: boolean,
+  hostTreeLayoutWidth: number,
+): boolean {
+  return isHostTreeOpen
+    && hostTreeLayoutWidth > 0
+    && hostTreeLayoutWidth <= TERMINAL_HOST_TREE_MIN_WIDTH + 24;
 }
 
 export function shouldShowHostTreeToggle({
@@ -191,6 +201,10 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   const isHostTreeOpen = useTerminalHostTreeOpen();
   const hostTreeLayoutWidth = useTerminalHostTreeLayoutWidth();
   const toggleHostTree = useToggleTerminalHostTree();
+  const hideRootTabsForNarrowHostTree = shouldHideRootTabsForNarrowHostTree(
+    isHostTreeOpen,
+    hostTreeLayoutWidth,
+  );
   const activeTabId = useActiveTabId();
   const { getTabAnimationClass } = useTopTabLifecycleAnimations(orderedTabs);
   const fixedLeftTabsRef = useRef<HTMLDivElement>(null);
@@ -876,7 +890,13 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
         }}
       >
         {/* Fixed left tabs: Vaults and SFTP */}
-        <div ref={fixedLeftTabsRef} className="flex items-end gap-0 flex-shrink-0 app-drag">
+        <div
+          ref={fixedLeftTabsRef}
+          className={cn(
+            'flex items-end gap-0 flex-shrink-0 app-drag overflow-hidden transition-[width,opacity] duration-200 ease-out',
+            hideRootTabsForNarrowHostTree && 'w-0 opacity-0 pointer-events-none',
+          )}
+        >
           <RootTopTab
             tabId="vault"
             label="Vaults"

--- a/components/terminalLayer/TerminalHostTreeSidebar.test.ts
+++ b/components/terminalLayer/TerminalHostTreeSidebar.test.ts
@@ -20,9 +20,12 @@ const {
   getTerminalHostTreeInitialLayoutWidth,
   getTerminalHostTreeLayoutTargetWidth,
   getTerminalHostTreeMeasuredLayoutWidth,
+  getTerminalHostTreeReservedLayoutWidth,
   getTerminalHostTreeSidebarPanelStyle,
   getTerminalHostTreeSidebarShellStyle,
+  shouldCompactTerminalHostTreeToolbar,
   isTerminalHostTreeSidebarVisible,
+  shouldShowTerminalHostTreeExpandCollapseControls,
 } = await import('./TerminalHostTreeSidebar.tsx');
 const { TERMINAL_HOST_TREE_WIDTH_TRANSITION } = await import('../../application/state/terminalHostTreeAnimation.ts');
 
@@ -74,6 +77,34 @@ test('host tree layout sync can sample the current shell width before targeting'
     getBoundingClientRect: () => ({ width: -12 }),
   } as unknown as HTMLElement, 240), 0);
   assert.equal(getTerminalHostTreeMeasuredLayoutWidth(null, 240), 240);
+});
+
+test('host tree layout reserves target width while opening to keep content out of the sidebar', () => {
+  assert.equal(getTerminalHostTreeReservedLayoutWidth({
+    getBoundingClientRect: () => ({ width: 84 }),
+  } as unknown as HTMLElement, 240, true), 240);
+  assert.equal(getTerminalHostTreeReservedLayoutWidth({
+    getBoundingClientRect: () => ({ width: 260 }),
+  } as unknown as HTMLElement, 240, true), 260);
+  assert.equal(getTerminalHostTreeReservedLayoutWidth({
+    getBoundingClientRect: () => ({ width: 84 }),
+  } as unknown as HTMLElement, 0, false), 84);
+});
+
+test('host tree expand and collapse controls only render when they can act', () => {
+  assert.equal(shouldShowTerminalHostTreeExpandCollapseControls(1, false, false, false), true);
+  assert.equal(shouldShowTerminalHostTreeExpandCollapseControls(0, false, false, false), false);
+  assert.equal(shouldShowTerminalHostTreeExpandCollapseControls(1, true, false, false), false);
+  assert.equal(shouldShowTerminalHostTreeExpandCollapseControls(1, false, true, false), false);
+  assert.equal(shouldShowTerminalHostTreeExpandCollapseControls(1, false, false, true), false);
+});
+
+test('host tree toolbar compacts low-priority actions near the minimum width', () => {
+  assert.equal(shouldCompactTerminalHostTreeToolbar(132), true);
+  assert.equal(shouldCompactTerminalHostTreeToolbar(156), true);
+  assert.equal(shouldCompactTerminalHostTreeToolbar(184), false);
+  assert.equal(shouldCompactTerminalHostTreeToolbar(220), false);
+  assert.equal(shouldCompactTerminalHostTreeToolbar(0), false);
 });
 
 test('host tree layout width follows the animated shell via ResizeObserver', () => {

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -198,6 +198,30 @@ export function getTerminalHostTreeMeasuredLayoutWidth(
     : Math.max(0, fallbackWidth);
 }
 
+export function getTerminalHostTreeReservedLayoutWidth(
+  element: Pick<HTMLElement, 'getBoundingClientRect'> | null,
+  targetLayoutWidth: number,
+  isVisible: boolean,
+): number {
+  const measuredWidth = getTerminalHostTreeMeasuredLayoutWidth(element, targetLayoutWidth);
+  return isVisible
+    ? Math.max(measuredWidth, Math.max(0, targetLayoutWidth))
+    : measuredWidth;
+}
+
+export function shouldShowTerminalHostTreeExpandCollapseControls(
+  groupPathCount: number,
+  searchActive: boolean,
+  tagsActive: boolean,
+  compactToolbar: boolean,
+): boolean {
+  return groupPathCount > 0 && !searchActive && !tagsActive && !compactToolbar;
+}
+
+export function shouldCompactTerminalHostTreeToolbar(displayWidth: number): boolean {
+  return displayWidth > 0 && displayWidth <= TERMINAL_HOST_TREE_MIN_WIDTH + 24;
+}
+
 function hostMatchesSearch(host: Host, search: string): boolean {
   const s = search.toLowerCase();
   return (
@@ -745,8 +769,6 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
     collapseAll();
   }, [collapseAll]);
 
-  const canExpandCollapse = allGroupPaths.length > 0 && !searchActive && !tagsActive;
-
   const handleCollapse = useCallback(() => {
     terminalHostTreeStore.setIsOpen(false);
   }, []);
@@ -961,6 +983,13 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
   }, [isVisible, persistSidebarWidth, setSidebarWidth, sidebarWidth]);
 
   const displayWidth = resizePreviewWidth ?? sidebarWidth;
+  const compactToolbarActions = shouldCompactTerminalHostTreeToolbar(displayWidth);
+  const showExpandCollapseControls = shouldShowTerminalHostTreeExpandCollapseControls(
+    allGroupPaths.length,
+    searchActive,
+    tagsActive,
+    compactToolbarActions,
+  );
   const targetLayoutWidth = getTerminalHostTreeLayoutTargetWidth(isVisible, displayWidth);
   const hiddenSurfaceShellWidth = getTerminalHostTreeHiddenSurfaceShellWidth(isOpen, enabled, displayWidth);
   const [shellWidth, setShellWidth] = useState(getTerminalHostTreeInitialLayoutWidth);
@@ -969,9 +998,9 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
 
   const syncLayoutWidthFromShell = useCallback((fallbackWidth = targetLayoutWidth) => {
     terminalHostTreeStore.setLayoutWidth(
-      getTerminalHostTreeMeasuredLayoutWidth(shellRef.current, fallbackWidth),
+      getTerminalHostTreeReservedLayoutWidth(shellRef.current, fallbackWidth, isVisible),
     );
-  }, [targetLayoutWidth]);
+  }, [isVisible, targetLayoutWidth]);
 
   useEffect(() => {
     const el = shellRef.current;
@@ -1097,9 +1126,10 @@ const TerminalHostTreeSidebarInner: React.FC<TerminalHostTreeSidebarProps> = ({
           canNewGroup={Boolean(menuActions)}
           onCreateLocalTerminal={handleCreateLocalTerminal}
           canCreateLocalTerminal={Boolean(onCreateLocalTerminal)}
+          compactActions={compactToolbarActions}
           onExpandAll={handleExpandAll}
           onCollapseAll={handleCollapseAll}
-          canExpandCollapse={canExpandCollapse}
+          showExpandCollapseControls={showExpandCollapseControls}
           onCollapse={handleCollapse}
         />
 

--- a/components/terminalLayer/TerminalHostTreeToolbar.tsx
+++ b/components/terminalLayer/TerminalHostTreeToolbar.tsx
@@ -29,9 +29,10 @@ interface TerminalHostTreeToolbarProps {
   canNewGroup?: boolean;
   onCreateLocalTerminal: () => void;
   canCreateLocalTerminal?: boolean;
+  compactActions?: boolean;
   onExpandAll: () => void;
   onCollapseAll: () => void;
-  canExpandCollapse?: boolean;
+  showExpandCollapseControls?: boolean;
   onCollapse: () => void;
 }
 
@@ -50,9 +51,10 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
   canNewGroup = true,
   onCreateLocalTerminal,
   canCreateLocalTerminal = true,
+  compactActions = false,
   onExpandAll,
   onCollapseAll,
-  canExpandCollapse = true,
+  showExpandCollapseControls = true,
   onCollapse,
 }) => {
   const { t } = useI18n();
@@ -117,69 +119,75 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
           <TooltipContent side="bottom">{t('terminal.layer.hostTree.tagsButton')}</TooltipContent>
         </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={iconButtonClass}
-              style={{ color: theme.mutedFg }}
-              disabled={!canNewGroup}
-              onClick={onNewRootGroup}
-            >
-              <FolderPlus size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{t('terminal.layer.hostTree.newGroup')}</TooltipContent>
-        </Tooltip>
+        {!compactActions && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClass}
+                  style={{ color: theme.mutedFg }}
+                  disabled={!canNewGroup}
+                  onClick={onNewRootGroup}
+                >
+                  <FolderPlus size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('terminal.layer.hostTree.newGroup')}</TooltipContent>
+            </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={iconButtonClass}
-              style={{ color: theme.mutedFg }}
-              disabled={!canCreateLocalTerminal}
-              onClick={onCreateLocalTerminal}
-            >
-              <TerminalSquare size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{t('terminal.layer.hostTree.localShell')}</TooltipContent>
-        </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClass}
+                  style={{ color: theme.mutedFg }}
+                  disabled={!canCreateLocalTerminal}
+                  onClick={onCreateLocalTerminal}
+                >
+                  <TerminalSquare size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('terminal.layer.hostTree.localShell')}</TooltipContent>
+            </Tooltip>
+          </>
+        )}
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={iconButtonClass}
-              style={{ color: theme.mutedFg }}
-              disabled={!canExpandCollapse}
-              onClick={onExpandAll}
-            >
-              <Expand size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{t('vault.tree.expandAll')}</TooltipContent>
-        </Tooltip>
+        {showExpandCollapseControls && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClass}
+                  style={{ color: theme.mutedFg }}
+                  onClick={onExpandAll}
+                >
+                  <Expand size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('vault.tree.expandAll')}</TooltipContent>
+            </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={iconButtonClass}
-              style={{ color: theme.mutedFg }}
-              disabled={!canExpandCollapse}
-              onClick={onCollapseAll}
-            >
-              <Minimize2 size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{t('vault.tree.collapseAll')}</TooltipContent>
-        </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={iconButtonClass}
+                  style={{ color: theme.mutedFg }}
+                  onClick={onCollapseAll}
+                >
+                  <Minimize2 size={14} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('vault.tree.collapseAll')}</TooltipContent>
+            </Tooltip>
+          </>
+        )}
 
         <div className="flex-1 min-w-0" />
 
@@ -188,7 +196,7 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
             <Button
               variant="ghost"
               size="icon"
-              className={iconButtonClass}
+              className={cn(iconButtonClass, 'mr-1')}
               style={{ color: theme.mutedFg }}
               onClick={onCollapse}
             >


### PR DESCRIPTION
## 变更说明

- 修复终端主机列表打开或拖拽宽度时，右侧终端/标签区域侵入侧栏导致关闭按钮被遮挡的问题。
- 主机列表接近最小宽度时隐藏低优先级工具栏按钮，保留搜索、标签和关闭按钮的可用空间。
- 展开/折叠按钮在不可触发或窄宽度下隐藏，避免挤压关闭按钮。
- 顶部标签栏在主机列表窄宽度时收起 Vault/SFTP 根标签，避免 SSH 标签挤到主机列表关闭按钮。
- 主机列表最小宽度调整为 132px，允许比之前更窄的收起宽度。

## 验证

- `node --test --import tsx components/terminalLayer/TerminalHostTreeSidebar.test.ts components/TopTabs.test.ts application/state/terminalHostTreeStore.test.ts application/app/AppHostTreeLayer.test.ts`
- `npm run lint`