### PR TITLE
Fix GB18030 terminal decoding for locale charsets

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -95,6 +95,19 @@ import {
 } from "./terminal/terminalHelpers";
 import { terminalPropsAreEqual } from "./terminal/terminalMemo";
 
+const resolveInitialTerminalEncoding = (charset?: string): 'utf-8' | 'gb18030' => {
+  if (!charset) return 'utf-8';
+  const raw = String(charset).trim().toLowerCase();
+  const localeCodeset = raw.match(/\.([^@]+)(?:@.*)?$/)?.[1];
+  const candidates = [raw, localeCodeset].filter((value): value is string => Boolean(value));
+  return candidates.some((candidate) => {
+    const normalized = candidate.replace(/[^a-z0-9]/g, "");
+    return ["gb18030", "gbk", "gb2312", "cp936", "ms936"].includes(normalized);
+  })
+    ? 'gb18030'
+    : 'utf-8';
+};
+
 const TerminalComponent: React.FC<TerminalProps> = ({
   host,
   keys,
@@ -319,8 +332,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   // pendingUploadEntries removed - drag-drop uploads now handled by SftpSidePanel
   const [isComposeBarOpen, setIsComposeBarOpen] = useState(false);
   const [terminalEncoding, setTerminalEncoding] = useState<'utf-8' | 'gb18030'>(() => {
-    if (host?.charset && /^gb/i.test(String(host.charset).trim())) return 'gb18030';
-    return 'utf-8';
+    return resolveInitialTerminalEncoding(host?.charset);
   });
   const terminalEncodingRef = useRef(terminalEncoding);
   terminalEncodingRef.current = terminalEncoding;

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -392,7 +392,7 @@ const sessionEncodings = new Map();
 // Per-session stateful iconv decoders (keyed by sessionId, value: { stdout, stderr })
 const sessionDecoders = new Map();
 const iconv = require("iconv-lite");
-const { encodeTerminalInput } = require("./terminalEncoding.cjs");
+const { encodeTerminalInput, normalizeTerminalEncoding } = require("./terminalEncoding.cjs");
 
 function getSessionDecoder(sessionId, stream) {
   let decoders = sessionDecoders.get(sessionId);
@@ -446,6 +446,9 @@ function resolveLangFromCharset(charset) {
   const trimmed = String(charset).trim();
   if (/^utf-?8$/i.test(trimmed) || /^utf8$/i.test(trimmed)) {
     return "en_US.UTF-8";
+  }
+  if (normalizeTerminalEncoding(trimmed) === "gb18030" && !trimmed.includes(".")) {
+    return "zh_CN.GB18030";
   }
   return trimmed;
 }
@@ -802,6 +805,7 @@ const startSessionApi = createStartSessionApi({
   createProxySocket, attachX11Forwarding, createPtyOutputBuffer, sessionLogStreamManager,
   trackSessionIdlePrompt, looksLikeIdleAutoLogout, createZmodemSentry, enableSshNoDelay, enableTcpNoDelay,
   iconv, getSessionDecoder, resetSessionDecoders, sessionEncodings, sessionDecoders, encodeTerminalInput,
+  normalizeTerminalEncoding,
   connectThroughChain, getAvailableAgentSocket, getCachedAuthMethod, setCachedAuthMethod, clearCachedAuthMethod,
   attachSshDebugLogger, logSshAlgorithms, resolveLangFromCharset, safeSend, zmodemOverwritePending,
   shouldLogSshDebugMessage, log, createSshDiagnosticLogger,
@@ -1010,7 +1014,8 @@ const sessionOpsApi = createSessionOpsApi({
   get sessions() { return sessions; },
   get electronModule() { return electronModule; },
   fs, path, os, exec, randomUUID, iconv, Buffer, process, console, setTimeout, clearTimeout,
-  getSessionDecoder, resetSessionDecoders, sessionEncodings, resolveLangFromCharset, safeSend,
+  getSessionDecoder, resetSessionDecoders, sessionEncodings, normalizeTerminalEncoding,
+  resolveLangFromCharset, safeSend,
   quoteShellArg, log, ensureMoshStatsConnection, ensureEtStatsConnection,
   execOnEtSession: (...args) => require("./terminalBridge.cjs").execOnEtSession(...args),
   getServerStats: undefined,

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -1102,7 +1102,7 @@ function createSessionOpsApi(ctx) {
       if (!session || !session.stream) {
         return { ok: false, encoding: encoding || "utf-8" };
       }
-      const enc = String(encoding || "utf-8").toLowerCase();
+      const enc = normalizeTerminalEncoding(encoding);
       if (!iconv.encodingExists(enc)) {
         return { ok: false, encoding: enc };
       }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -231,8 +231,8 @@ function createStartSessionApi(ctx) {
       // (Terminal.tsx) so behavior for other/arbitrary charsets is unchanged:
       // the renderer pushes the effective encoding via setEncoding on attach,
       // and that handler keeps both halves in sync.
-      const gbCharset = options.charset && /^gb/i.test(String(options.charset).trim());
-      if (gbCharset) {
+      const initialEncoding = normalizeTerminalEncoding(options.charset);
+      if (initialEncoding === "gb18030") {
         sessionEncodings.set(sessionId, "gb18030");
         session.encoding = "gb18030";
       }

--- a/electron/bridges/terminalEncoding.cjs
+++ b/electron/bridges/terminalEncoding.cjs
@@ -23,10 +23,19 @@ const iconv = require("iconv-lite");
 function normalizeTerminalEncoding(charset) {
   if (!charset) return "utf-8";
   const raw = String(charset).trim().toLowerCase();
-  const normalized = raw.replace(/[^a-z0-9]/g, "");
-  if (["utf8", "utf-8"].includes(normalized)) return "utf-8";
-  if (normalized === "gb18030" || normalized === "gbk" || normalized === "gb2312") return "gb18030";
-  return iconv.encodingExists(raw) ? raw : "utf-8";
+  const localeCodeset = raw.match(/\.([^@]+)(?:@.*)?$/)?.[1];
+  const candidates = [raw, localeCodeset].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const normalized = candidate.replace(/[^a-z0-9]/g, "");
+    if (normalized === "utf8") return "utf-8";
+    if (["gb18030", "gbk", "gb2312", "cp936", "ms936"].includes(normalized)) {
+      return "gb18030";
+    }
+    if (iconv.encodingExists(candidate)) return candidate;
+  }
+
+  return "utf-8";
 }
 
 // True when the encoding is UTF-8 (the JS/Node default for string → bytes).

--- a/electron/bridges/terminalEncoding.test.cjs
+++ b/electron/bridges/terminalEncoding.test.cjs
@@ -12,6 +12,10 @@ test("normalizeTerminalEncoding maps GB variants onto the gb18030 superset", () 
   assert.equal(normalizeTerminalEncoding("gbk"), "gb18030");
   assert.equal(normalizeTerminalEncoding("GB2312"), "gb18030");
   assert.equal(normalizeTerminalEncoding("gb-18030"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("zh_CN.GB18030"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("zh_CN.GBK"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("zh_CN.cp936"), "gb18030");
+  assert.equal(normalizeTerminalEncoding("zh_CN.GB18030@custom"), "gb18030");
 });
 
 test("normalizeTerminalEncoding normalizes utf-8 spellings and defaults", () => {


### PR DESCRIPTION
## Summary
- normalize GB-family terminal charset values such as `GBK`, `cp936`, and `zh_CN.GB18030` to the `gb18030` decoder
- pre-seed SSH session output/input encoding from normalized host charset values
- keep the renderer terminal encoding state aligned so SSH sessions are not reset back to UTF-8 after attach

## Testing
- `node --test electron/bridges/terminalEncoding.test.cjs`
- `node --check electron/bridges/terminalEncoding.cjs; node --check electron/bridges/sshBridge.cjs; node --check electron/bridges/sshBridge/startSession.cjs; node --check electron/bridges/sshBridge/sessionOps.cjs`
- `git diff --check`