### PR TITLE
feat(copilot): Skills CLI mode for Copilot backend

### DIFF
--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -115,6 +115,11 @@ function findExecPayloadSeparatorIndex(command) {
   return lastIndex;
 }
 
+function matchesShellMetacharAt(text, index) {
+  const match = LOCAL_SHELL_METACHAR_PATTERN.exec(String(text || "").slice(index));
+  return Boolean(match && match.index === 0);
+}
+
 function containsUnsafeShellMetachar(text) {
   let inSingle = false;
   let inDouble = false;
@@ -143,7 +148,7 @@ function containsUnsafeShellMetachar(text) {
       if (text.startsWith("$(", i) || ch === "`") return true;
       continue;
     }
-    if (LOCAL_SHELL_METACHAR_PATTERN.test(text.slice(i))) return true;
+    if (matchesShellMetacharAt(text, i)) return true;
   }
   return false;
 }
@@ -194,6 +199,9 @@ function isLikelyNetcattyCliShellCommand(fullCommandText) {
   if (remotePayload) {
     if (!hasExecPayloadSubcommand(localPart)) return false;
     if (containsUnsafeShellMetachar(localPart)) return false;
+    // The runtime executes fullCommandText in a local shell; scan all of it so
+    // tokens after `--` cannot chain additional local commands unless quoted.
+    if (containsUnsafeShellMetachar(command)) return false;
     return true;
   }
 
@@ -516,6 +524,7 @@ module.exports = {
   getLocalNetcattyCliPrefix,
   findExecPayloadSeparatorIndex,
   containsUnsafeShellMetachar,
+  matchesShellMetacharAt,
   hasExecPayloadSubcommand,
   copilotBuiltinTools,
   toCopilotMcpServers,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -115,7 +115,7 @@ function findExecPayloadSeparatorIndex(command) {
   return lastIndex;
 }
 
-function containsUnquotedShellMetachar(text) {
+function containsUnsafeShellMetachar(text) {
   let inSingle = false;
   let inDouble = false;
   let escape = false;
@@ -138,7 +138,11 @@ function containsUnquotedShellMetachar(text) {
       inDouble = !inDouble;
       continue;
     }
-    if (inSingle || inDouble) continue;
+    if (inSingle) continue;
+    if (inDouble) {
+      if (text.startsWith("$(", i) || ch === "`") return true;
+      continue;
+    }
     if (LOCAL_SHELL_METACHAR_PATTERN.test(text.slice(i))) return true;
   }
   return false;
@@ -157,8 +161,16 @@ function getLocalNetcattyCliPrefix(fullCommandText) {
 function isNetcattyCliInvocationPrefix(localPart) {
   const text = String(localPart || "").trim();
   if (!text) return false;
+  const pathPrefix = String.raw`(?:\.\./|\./|/|[A-Za-z]:[\\/])[\w. \\-]*[\\/]`;
   const invocation = new RegExp(
-    String.raw`^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|'[^']*${NETCATTY_CLI_PATH_SUFFIX}'|${NETCATTY_CLI_TOKEN}(?=\s|$)|\S*${NETCATTY_CLI_PATH_SUFFIX}(?=\s|$)|node\s+(?:"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|'[^']*${NETCATTY_CLI_PATH_SUFFIX}'|\S*${NETCATTY_CLI_PATH_SUFFIX})(?=\s|$))`,
+    String.raw`^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:` +
+    String.raw`"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|` +
+    String.raw `'[^']*${NETCATTY_CLI_PATH_SUFFIX}'|` +
+    String.raw `${NETCATTY_CLI_TOKEN}(?=\s|$)|` +
+    String.raw `${pathPrefix}${NETCATTY_CLI_TOKEN}(?=\s|$)|` +
+    String.raw `node\s+(?:${NETCATTY_CLI_TOKEN}(?=\s|$)|${pathPrefix}${NETCATTY_CLI_TOKEN}(?=\s|$)|` +
+    String.raw `(?:[\w.-]+(?:[\\/][\w.-]+)*[\\/])?${NETCATTY_CLI_TOKEN}(?=\s|$)|` +
+    String.raw `"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|'[^']*${NETCATTY_CLI_PATH_SUFFIX}'))`,
     "i",
   );
   return invocation.test(text);
@@ -181,11 +193,11 @@ function isLikelyNetcattyCliShellCommand(fullCommandText) {
 
   if (remotePayload) {
     if (!hasExecPayloadSubcommand(localPart)) return false;
-    if (containsUnquotedShellMetachar(localPart)) return false;
+    if (containsUnsafeShellMetachar(localPart)) return false;
     return true;
   }
 
-  return !containsUnquotedShellMetachar(command);
+  return !containsUnsafeShellMetachar(command);
 }
 
 function approveNetcattyMcpOnly(request) {
@@ -503,6 +515,7 @@ module.exports = {
   isLikelyNetcattyCliShellCommand,
   getLocalNetcattyCliPrefix,
   findExecPayloadSeparatorIndex,
+  containsUnsafeShellMetachar,
   hasExecPayloadSubcommand,
   copilotBuiltinTools,
   toCopilotMcpServers,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -11,9 +11,12 @@
  *   (bring-your-own-CLI), so we MUST point `connection` at the user's system
  *   `copilot` binary via RuntimeConnection.forStdio({ path }) — otherwise the SDK
  *   falls back to the (absent) bundled runtime in the shipped app.
- * - Side effects route through the injected netcatty MCP server (stdio). The
- *   SDK-level permission handler rejects local Copilot tools and allows only
- *   MCP requests; netcatty MCP then enforces approval/scope/blocklist.
+ * - MCP mode: side effects route through the injected netcatty MCP server
+ *   (stdio). The permission handler rejects local Copilot tools and allows
+ *   only MCP requests; netcatty MCP then enforces approval/scope/blocklist.
+ * - Skills mode: only builtin bash (+ skill) are exposed. Shell permission
+ *   requests are approved only for Netcatty CLI invocations; discovery env is
+ *   passed to the Copilot runtime so `netcatty-tool-cli` can reach the host.
  *
  * 🔬 SMOKE-CALIBRATE [copilot-stream]: sendAndWait returns only the final
  *   assistant text. A follow-up can subscribe via session.on(handler) to stream
@@ -48,7 +51,13 @@ function toCopilotMcpServers(injectedMcpServers) {
   return map;
 }
 
-function buildCopilotSessionOptions({ model, injectedMcpServers }) {
+const COPILOT_SKILLS_AVAILABLE_TOOLS = ["builtin:bash", "builtin:skill"];
+
+function copilotBuiltinTools(toolIntegrationMode) {
+  return toolIntegrationMode === "skills" ? [...COPILOT_SKILLS_AVAILABLE_TOOLS] : null;
+}
+
+function buildCopilotSessionOptions({ model, injectedMcpServers, toolIntegrationMode }) {
   // onPermissionRequest is wired in runCopilotTurn (it needs the SDK's approveAll).
   const options = {
     mcpServers: toCopilotMcpServers(injectedMcpServers),
@@ -58,8 +67,14 @@ function buildCopilotSessionOptions({ model, injectedMcpServers }) {
     // has live reasoning to render.
     streaming: true,
   };
+  const availableTools = copilotBuiltinTools(toolIntegrationMode);
+  if (availableTools) options.availableTools = availableTools;
   if (model) options.model = model;
   return options;
+}
+
+function isLikelyNetcattyCliShellCommand(fullCommandText) {
+  return /netcatty-tool-cli/i.test(String(fullCommandText || ""));
 }
 
 function approveNetcattyMcpOnly(request) {
@@ -70,6 +85,28 @@ function approveNetcattyMcpOnly(request) {
     kind: "reject",
     feedback: "Only Netcatty MCP tools are allowed from this integration.",
   };
+}
+
+function approveNetcattyCliShellOnly(request) {
+  if (request?.kind === "shell") {
+    const fullCommandText = request.fullCommandText || "";
+    if (isLikelyNetcattyCliShellCommand(fullCommandText)) {
+      return { kind: "approve-once" };
+    }
+    return {
+      kind: "reject",
+      feedback:
+        "Only Netcatty CLI shell commands are allowed. Invoke the netcatty-tool-cli launcher or script prefix provided in the host context, and include --chat-session on every call.",
+    };
+  }
+  return {
+    kind: "reject",
+    feedback: "Only Netcatty CLI shell commands are allowed from this integration.",
+  };
+}
+
+function buildCopilotPermissionHandler(toolIntegrationMode) {
+  return toolIntegrationMode === "skills" ? approveNetcattyCliShellOnly : approveNetcattyMcpOnly;
 }
 
 function extractCopilotContent(response) {
@@ -178,7 +215,18 @@ function translateCopilotEvent(event, emitter, state) {
  * @param {AbortSignal} [args.signal]
  * @param {object} [args.sdkModule] inject the @github/copilot-sdk module (for tests)
  */
-async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptions, resumeSessionId, emitter, signal, sdkModule }) {
+async function runCopilotTurn({
+  prompt,
+  attachments,
+  clientOptions,
+  sessionOptions,
+  resumeSessionId,
+  toolIntegrationMode,
+  runtimeEnv,
+  emitter,
+  signal,
+  sdkModule,
+}) {
   let resolvedModule = sdkModule;
   if (!resolvedModule) {
     try { resolvedModule = await import("@github/copilot-sdk"); } catch { emitter.emitError("GitHub Copilot SDK not installed. Run: npm install @github/copilot-sdk"); return { sessionId: null }; }
@@ -190,6 +238,9 @@ async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptio
   // (the bundled runtime is excluded from packaging) and authenticate as the
   // logged-in user (gh CLI / stored OAuth).
   const realClientOptions = { useLoggedInUser: true };
+  if (runtimeEnv && typeof runtimeEnv === "object") {
+    realClientOptions.env = runtimeEnv;
+  }
   if (clientOptions?.cliPath && RuntimeConnection?.forStdio) {
     realClientOptions.connection = RuntimeConnection.forStdio({ path: clientOptions.cliPath });
   }
@@ -202,8 +253,8 @@ async function runCopilotTurn({ prompt, attachments, clientOptions, sessionOptio
     const sessionConfig = {
       ...sessionOptions,
       streaming: true,
-      // Allow only MCP calls; netcatty MCP performs scope/approval/blocklist checks.
-      onPermissionRequest: approveNetcattyMcpOnly,
+      // MCP mode: only netcatty MCP. Skills mode: only Netcatty CLI shell commands.
+      onPermissionRequest: buildCopilotPermissionHandler(toolIntegrationMode),
     };
     // Resume the prior conversation so context carries ACROSS turns (incl. after
     // a Stop). Always (re)apply sessionConfig so the FRESH netcatty MCP server
@@ -335,7 +386,11 @@ module.exports = {
   buildCopilotClientOptions,
   buildCopilotSessionOptions,
   buildCopilotMessageOptions,
+  buildCopilotPermissionHandler,
   approveNetcattyMcpOnly,
+  approveNetcattyCliShellOnly,
+  isLikelyNetcattyCliShellCommand,
+  copilotBuiltinTools,
   toCopilotMcpServers,
   extractCopilotContent,
   extractCopilotResultText,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -79,12 +79,75 @@ function buildCopilotSessionOptions({ model, injectedMcpServers, toolIntegration
 const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|`]|&&|\|\||\$\(|\$\{|<<?|\r?\n)/;
 const LOCAL_SHELL_WRAPPER_PATTERN = /^(?:\/[^\s]+\/)?(?:ba|z|fi)?sh(?:\.exe)?\s+-c\b/i;
 
-/** Split before exec/job-start remote payload (` -- cmd`), not before `--session` flags. */
+/** Find the last exec/job-start payload separator outside shell quotes. */
+function findExecPayloadSeparatorIndex(command) {
+  const text = String(command || "");
+  let inSingle = false;
+  let inDouble = false;
+  let escape = false;
+  let lastIndex = -1;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\" && (inSingle || inDouble)) {
+      escape = true;
+      continue;
+    }
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && text.startsWith(" -- ", i)) {
+      lastIndex = i;
+      i += 3;
+    }
+  }
+  return lastIndex;
+}
+
+function containsUnquotedShellMetachar(text) {
+  let inSingle = false;
+  let inDouble = false;
+  let escape = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\" && (inSingle || inDouble)) {
+      escape = true;
+      continue;
+    }
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (inSingle || inDouble) continue;
+    if (LOCAL_SHELL_METACHAR_PATTERN.test(text.slice(i))) return true;
+  }
+  return false;
+}
+
+/** Split before the final exec/job-start remote payload (` -- cmd`), not flag values. */
 function getLocalNetcattyCliPrefix(fullCommandText) {
   const command = String(fullCommandText || "").trim();
-  const match = command.match(/\s--\s/);
-  if (match && match.index != null) {
-    return command.slice(0, match.index).trim();
+  const splitAt = findExecPayloadSeparatorIndex(command);
+  if (splitAt >= 0) {
+    return command.slice(0, splitAt).trim();
   }
   return command;
 }
@@ -92,14 +155,14 @@ function getLocalNetcattyCliPrefix(fullCommandText) {
 function isNetcattyCliInvocationPrefix(localPart) {
   const text = String(localPart || "").trim();
   if (!text) return false;
-  return /^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*netcatty-tool-cli(?:\.cjs)?[^"]*"|'[^']*netcatty-tool-cli(?:\.cjs)?[^']*'|(?:\S*\/)?netcatty-tool-cli(?:\.cjs)?(?:\b|\s)|node\s+\S*netcatty-tool-cli(?:\.cjs)?\b)/i.test(text);
+  return /^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*\/netcatty-tool-cli(?:\.cjs)?"|'[^']*\/netcatty-tool-cli(?:\.cjs)?'|netcatty-tool-cli(?:\.cjs)?(?=\s|$)|\S*\/netcatty-tool-cli(?:\.cjs)?(?=\s|$)|node\s+(?:"[^"]*netcatty-tool-cli(?:\.cjs)?"|'[^']*netcatty-tool-cli(?:\.cjs)?'|\S*\/netcatty-tool-cli(?:\.cjs)?)(?=\s|$))/i.test(text);
 }
 
 function isLikelyNetcattyCliShellCommand(fullCommandText) {
   const localPart = getLocalNetcattyCliPrefix(fullCommandText);
   if (!localPart) return false;
   if (LOCAL_SHELL_WRAPPER_PATTERN.test(localPart)) return false;
-  if (LOCAL_SHELL_METACHAR_PATTERN.test(localPart)) return false;
+  if (containsUnquotedShellMetachar(localPart)) return false;
   return isNetcattyCliInvocationPrefix(localPart);
 }
 
@@ -417,6 +480,8 @@ module.exports = {
   approveNetcattyCliShellOnly,
   isLikelyNetcattyCliShellCommand,
   getLocalNetcattyCliPrefix,
+  findExecPayloadSeparatorIndex,
+  containsUnquotedShellMetachar,
   copilotBuiltinTools,
   toCopilotMcpServers,
   extractCopilotContent,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -75,9 +75,11 @@ function buildCopilotSessionOptions({ model, injectedMcpServers, toolIntegration
   return options;
 }
 
-// Shell chaining/redirection in the local Netcatty CLI prefix (not after `--`).
-const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|`]|&&|\|\||\$\(|\$\{|<<?|\r?\n)/;
+// Shell chaining/redirection in the local Netcatty CLI prefix (not after exec `--`).
+const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|`]|&&|\|\||\$\(|\$\{|<<?|>{1,2}|\r?\n)/;
 const LOCAL_SHELL_WRAPPER_PATTERN = /^(?:\/[^\s]+\/)?(?:ba|z|fi)?sh(?:\.exe)?\s+-c\b/i;
+const NETCATTY_CLI_TOKEN = String.raw`netcatty-tool-cli(?:\.(?:cjs|cmd))?`;
+const NETCATTY_CLI_PATH_SUFFIX = String.raw`(?:[\\/]|^)${NETCATTY_CLI_TOKEN}`;
 
 /** Find the last exec/job-start payload separator outside shell quotes. */
 function findExecPayloadSeparatorIndex(command) {
@@ -155,15 +157,35 @@ function getLocalNetcattyCliPrefix(fullCommandText) {
 function isNetcattyCliInvocationPrefix(localPart) {
   const text = String(localPart || "").trim();
   if (!text) return false;
-  return /^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*\/netcatty-tool-cli(?:\.cjs)?"|'[^']*\/netcatty-tool-cli(?:\.cjs)?'|netcatty-tool-cli(?:\.cjs)?(?=\s|$)|\S*\/netcatty-tool-cli(?:\.cjs)?(?=\s|$)|node\s+(?:"[^"]*netcatty-tool-cli(?:\.cjs)?"|'[^']*netcatty-tool-cli(?:\.cjs)?'|\S*\/netcatty-tool-cli(?:\.cjs)?)(?=\s|$))/i.test(text);
+  const invocation = new RegExp(
+    String.raw`^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|'[^']*${NETCATTY_CLI_PATH_SUFFIX}'|${NETCATTY_CLI_TOKEN}(?=\s|$)|\S*${NETCATTY_CLI_PATH_SUFFIX}(?=\s|$)|node\s+(?:"[^"]*${NETCATTY_CLI_PATH_SUFFIX}"|'[^']*${NETCATTY_CLI_PATH_SUFFIX}'|\S*${NETCATTY_CLI_PATH_SUFFIX})(?=\s|$))`,
+    "i",
+  );
+  return invocation.test(text);
+}
+
+function hasExecPayloadSubcommand(localPart) {
+  return /\b(?:exec|job-start)\b/i.test(String(localPart || ""));
 }
 
 function isLikelyNetcattyCliShellCommand(fullCommandText) {
-  const localPart = getLocalNetcattyCliPrefix(fullCommandText);
-  if (!localPart) return false;
-  if (LOCAL_SHELL_WRAPPER_PATTERN.test(localPart)) return false;
-  if (containsUnquotedShellMetachar(localPart)) return false;
-  return isNetcattyCliInvocationPrefix(localPart);
+  const command = String(fullCommandText || "").trim();
+  if (!command) return false;
+
+  const splitAt = findExecPayloadSeparatorIndex(command);
+  const localPart = splitAt >= 0 ? command.slice(0, splitAt).trim() : command;
+  const remotePayload = splitAt >= 0 ? command.slice(splitAt + 4).trim() : "";
+
+  if (!localPart || LOCAL_SHELL_WRAPPER_PATTERN.test(localPart)) return false;
+  if (!isNetcattyCliInvocationPrefix(localPart)) return false;
+
+  if (remotePayload) {
+    if (!hasExecPayloadSubcommand(localPart)) return false;
+    if (containsUnquotedShellMetachar(localPart)) return false;
+    return true;
+  }
+
+  return !containsUnquotedShellMetachar(command);
 }
 
 function approveNetcattyMcpOnly(request) {
@@ -481,7 +503,7 @@ module.exports = {
   isLikelyNetcattyCliShellCommand,
   getLocalNetcattyCliPrefix,
   findExecPayloadSeparatorIndex,
-  containsUnquotedShellMetachar,
+  hasExecPayloadSubcommand,
   copilotBuiltinTools,
   toCopilotMcpServers,
   extractCopilotContent,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -73,8 +73,32 @@ function buildCopilotSessionOptions({ model, injectedMcpServers, toolIntegration
   return options;
 }
 
+// Shell chaining/redirection in the local Netcatty CLI prefix (not after `--`).
+const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|]|&&|\|\||\$\(|\$\{|<<?|\r?\n)/;
+const LOCAL_SHELL_WRAPPER_PATTERN = /^(?:\/[^\s]+\/)?(?:ba|z|fi)?sh(?:\.exe)?\s+-c\b/i;
+
+/** Split before exec/job-start remote payload (` -- cmd`), not before `--session` flags. */
+function getLocalNetcattyCliPrefix(fullCommandText) {
+  const command = String(fullCommandText || "").trim();
+  const match = command.match(/\s--\s/);
+  if (match && match.index != null) {
+    return command.slice(0, match.index).trim();
+  }
+  return command;
+}
+
+function isNetcattyCliInvocationPrefix(localPart) {
+  const text = String(localPart || "").trim();
+  if (!text) return false;
+  return /^(?:(?:[A-Za-z_][\w.-]*=[^\s]+\s+)*)?(?:"[^"]*netcatty-tool-cli(?:\.cjs)?[^"]*"|'[^']*netcatty-tool-cli(?:\.cjs)?[^']*'|(?:\S*\/)?netcatty-tool-cli(?:\.cjs)?(?:\b|\s)|node\s+\S*netcatty-tool-cli(?:\.cjs)?\b)/i.test(text);
+}
+
 function isLikelyNetcattyCliShellCommand(fullCommandText) {
-  return /netcatty-tool-cli/i.test(String(fullCommandText || ""));
+  const localPart = getLocalNetcattyCliPrefix(fullCommandText);
+  if (!localPart) return false;
+  if (LOCAL_SHELL_WRAPPER_PATTERN.test(localPart)) return false;
+  if (LOCAL_SHELL_METACHAR_PATTERN.test(localPart)) return false;
+  return isNetcattyCliInvocationPrefix(localPart);
 }
 
 function approveNetcattyMcpOnly(request) {
@@ -390,6 +414,7 @@ module.exports = {
   approveNetcattyMcpOnly,
   approveNetcattyCliShellOnly,
   isLikelyNetcattyCliShellCommand,
+  getLocalNetcattyCliPrefix,
   copilotBuiltinTools,
   toCopilotMcpServers,
   extractCopilotContent,

--- a/electron/bridges/aiBridge/sdk/copilotDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.cjs
@@ -14,7 +14,9 @@
  * - MCP mode: side effects route through the injected netcatty MCP server
  *   (stdio). The permission handler rejects local Copilot tools and allows
  *   only MCP requests; netcatty MCP then enforces approval/scope/blocklist.
- * - Skills mode: only builtin bash (+ skill) are exposed. Shell permission
+ * - Skills mode: only builtin bash is exposed (CLI instructions are injected via
+ *   the host prompt; the skill builtin is omitted because its read/custom-tool
+ *   permission kinds are not shell-safe to auto-approve). Shell permission
  *   requests are approved only for Netcatty CLI invocations; discovery env is
  *   passed to the Copilot runtime so `netcatty-tool-cli` can reach the host.
  *
@@ -51,7 +53,7 @@ function toCopilotMcpServers(injectedMcpServers) {
   return map;
 }
 
-const COPILOT_SKILLS_AVAILABLE_TOOLS = ["builtin:bash", "builtin:skill"];
+const COPILOT_SKILLS_AVAILABLE_TOOLS = ["builtin:bash"];
 
 function copilotBuiltinTools(toolIntegrationMode) {
   return toolIntegrationMode === "skills" ? [...COPILOT_SKILLS_AVAILABLE_TOOLS] : null;
@@ -74,7 +76,7 @@ function buildCopilotSessionOptions({ model, injectedMcpServers, toolIntegration
 }
 
 // Shell chaining/redirection in the local Netcatty CLI prefix (not after `--`).
-const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|]|&&|\|\||\$\(|\$\{|<<?|\r?\n)/;
+const LOCAL_SHELL_METACHAR_PATTERN = /(?:[;&|`]|&&|\|\||\$\(|\$\{|<<?|\r?\n)/;
 const LOCAL_SHELL_WRAPPER_PATTERN = /^(?:\/[^\s]+\/)?(?:ba|z|fi)?sh(?:\.exe)?\s+-c\b/i;
 
 /** Split before exec/job-start remote payload (` -- cmd`), not before `--session` flags. */

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -329,6 +329,9 @@ test("isLikelyNetcattyCliShellCommand rejects impostor binaries and quoted -- by
     isLikelyNetcattyCliShellCommand('netcatty-tool-cli sftp read --remote-path "a -- b" --session s1 --json'),
     true,
   );
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json  --  ; rm -rf /"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json > /tmp/out"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand('"C:\\Apps\\Netcatty\\netcatty-tool-cli.cmd" status --json'), true);
 });
 
 test("runCopilotTurn passes runtime env and skills permission handler", async () => {

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -263,9 +263,9 @@ test("runCopilotTurn aborts the active Copilot session when the signal aborts", 
   assert.equal(events.some((event) => event.k === "done"), false);
 });
 
-test("copilotBuiltinTools exposes bash+skill only in skills mode", () => {
+test("copilotBuiltinTools exposes bash only in skills mode", () => {
   assert.equal(copilotBuiltinTools("mcp"), null);
-  assert.deepEqual(copilotBuiltinTools("skills"), ["builtin:bash", "builtin:skill"]);
+  assert.deepEqual(copilotBuiltinTools("skills"), ["builtin:bash"]);
 });
 
 test("buildCopilotSessionOptions whitelists bash in skills mode", () => {
@@ -274,7 +274,7 @@ test("buildCopilotSessionOptions whitelists bash in skills mode", () => {
     injectedMcpServers: [],
     toolIntegrationMode: "skills",
   });
-  assert.deepEqual(skills.availableTools, ["builtin:bash", "builtin:skill"]);
+  assert.deepEqual(skills.availableTools, ["builtin:bash"]);
   assert.deepEqual(skills.mcpServers, {});
 });
 
@@ -308,6 +308,7 @@ test("isLikelyNetcattyCliShellCommand rejects chained or wrapped local commands"
   assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json && curl evil"), false);
   assert.equal(isLikelyNetcattyCliShellCommand('bash -c "netcatty-tool-cli status --json"'), false);
   assert.equal(isLikelyNetcattyCliShellCommand("malicious netcatty-tool-cli status --json"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status `id` --json"), false);
 });
 
 test("isLikelyNetcattyCliShellCommand allows remote exec payloads after --", () => {

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -1,37 +1,274 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const {
-  buildCopilotSessionOptions,
-  buildCopilotPermissionHandler,
-  approveNetcattyMcpOnly,
-  approveNetcattyCliShellOnly,
-  isLikelyNetcattyCliShellCommand,
-  copilotBuiltinTools,
-} = require("./copilotDriver.cjs");
+const { approveNetcattyMcpOnly, approveNetcattyCliShellOnly, buildCopilotClientOptions, buildCopilotPermissionHandler, buildCopilotSessionOptions, buildCopilotMessageOptions, copilotBuiltinTools, extractCopilotContent, isLikelyNetcattyCliShellCommand, mapCopilotModels, runCopilotTurn, translateCopilotEvent } = require("./copilotDriver.cjs");
+
+function collector() {
+  const events = [];
+  return {
+    events,
+    emitter: {
+      text: (t) => events.push({ k: "text", t }),
+      reasoning: (d) => events.push({ k: "reasoning", d }),
+      reasoningEnd: () => events.push({ k: "reasoningEnd" }),
+      toolCall: (n, a, id) => events.push({ k: "toolCall", n, a, id }),
+      toolResult: (id, o, n) => events.push({ k: "toolResult", id, o, n }),
+      sessionId: (s) => events.push({ k: "sessionId", s }),
+      emitError: (e) => events.push({ k: "error", e }),
+      emitDone: () => events.push({ k: "done" }),
+    },
+  };
+}
+
+/** Minimal @github/copilot-sdk mock; records create vs resume + returns a session. */
+function makeSdk(captured) {
+  const makeSession = (sessionId) => ({
+    sessionId,
+    async sendAndWait({ prompt }) { captured.prompt = prompt; return { data: { content: "reply:" + sessionId } }; },
+  });
+  class CopilotClient {
+    constructor(options) { captured.clientOptions = options; }
+    async createSession(cfg) { captured.created = cfg; return makeSession("sess-new"); }
+    async resumeSession(id, cfg) { captured.resumed = { id, cfg }; return makeSession(id); }
+    async stop() {}
+  }
+  return { CopilotClient, RuntimeConnection: { forStdio: () => ({}) }, approveAll: () => {} };
+}
+
+test("buildCopilotClientOptions pins cliPath", () => {
+  const o = buildCopilotClientOptions({ cliPath: "/abs/copilot" });
+  assert.equal(o.cliPath, "/abs/copilot");
+});
+
+test("buildCopilotSessionOptions maps injected MCP to local stdio servers", () => {
+  const o = buildCopilotSessionOptions({
+    model: "claude-sonnet-4.5",
+    injectedMcpServers: [{
+      name: "netcatty-remote-hosts", command: "/abs/electron",
+      args: ["/abs/server.cjs"], env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
+    }],
+  });
+  assert.equal(o.model, "claude-sonnet-4.5");
+  assert.equal(o.streaming, true);
+  const srv = o.mcpServers["netcatty-remote-hosts"];
+  assert.equal(srv.type, "stdio");
+  assert.equal(srv.command, "/abs/electron");
+  assert.deepEqual(srv.env, { NETCATTY_MCP_PORT: "1" });
+  assert.deepEqual(srv.tools, ["*"]);
+  // onPermissionRequest is wired in runCopilotTurn via the SDK's approveAll,
+  // not in buildCopilotSessionOptions.
+});
+
+test("approveNetcattyMcpOnly approves MCP permission requests and rejects local tools", () => {
+  assert.deepEqual(
+    approveNetcattyMcpOnly({ kind: "mcp", toolName: "terminal_execute" }),
+    { kind: "approve-once" },
+  );
+  assert.deepEqual(
+    approveNetcattyMcpOnly({ kind: "shell", fullCommandText: "rm -rf /tmp/x" }),
+    { kind: "reject", feedback: "Only Netcatty MCP tools are allowed from this integration." },
+  );
+  assert.deepEqual(
+    approveNetcattyMcpOnly({ kind: "read", fileName: "/etc/passwd" }),
+    { kind: "reject", feedback: "Only Netcatty MCP tools are allowed from this integration." },
+  );
+});
+
+test("extractCopilotContent reads response data.content", () => {
+  assert.equal(extractCopilotContent({ data: { content: "hi" } }), "hi");
+  assert.equal(extractCopilotContent(null), "");
+  assert.equal(extractCopilotContent({ data: {} }), "");
+});
+
+test("buildCopilotMessageOptions sends pasted images/files as native attachments", () => {
+  const opts = buildCopilotMessageOptions({
+    prompt: "inspect these",
+    attachments: [
+      { filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" },
+      { filename: "note.txt", mediaType: "text/plain", filePath: "/tmp/note.txt" },
+    ],
+  });
+  assert.equal(opts.prompt, "inspect these");
+  assert.equal("streamDeltas" in opts, false);
+  assert.deepEqual(opts.attachments, [
+    { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
+    { type: "file", path: "/tmp/note.txt", displayName: "note.txt" },
+  ]);
+});
+
+test("mapCopilotModels maps {id,name} and drops entries without id", () => {
+  const out = mapCopilotModels([
+    { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    { id: "gpt-5" },
+    { name: "no id -> dropped" },
+  ]);
+  assert.deepEqual(out, [
+    { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    { id: "gpt-5", name: "gpt-5" },
+  ]);
+  assert.deepEqual(mapCopilotModels(undefined), []);
+});
+
+test("runCopilotTurn (fresh) creates a session, emits its id early, returns it for resume", async () => {
+  const { events, emitter } = collector();
+  const captured = {};
+  const result = await runCopilotTurn({
+    prompt: "hi", clientOptions: { cliPath: "/c" }, sessionOptions: { model: "m" },
+    emitter, sdkModule: makeSdk(captured),
+  });
+  assert.ok(captured.created, "used createSession when there's no resume id");
+  assert.equal(captured.created.model, "m");
+  assert.deepEqual(events.filter((e) => e.k === "sessionId"), [{ k: "sessionId", s: "sess-new" }]);
+  assert.equal(result.sessionId, "sess-new");
+});
+
+test("runCopilotTurn resumes the prior session (carry context) and re-applies fresh config", async () => {
+  const { events, emitter } = collector();
+  const captured = {};
+  const result = await runCopilotTurn({
+    prompt: "what did we say", clientOptions: {}, sessionOptions: { model: "m" },
+    resumeSessionId: "sess-existing", emitter, sdkModule: makeSdk(captured),
+  });
+  assert.equal(captured.resumed.id, "sess-existing", "used resumeSession, not createSession");
+  assert.equal(captured.created, undefined);
+  // fresh netcatty MCP/session config re-applied on resume (not the stale one)
+  assert.equal(captured.resumed.cfg.model, "m");
+  assert.equal(result.sessionId, "sess-existing");
+  assert.ok(events.some((e) => e.k === "sessionId" && e.s === "sess-existing"));
+});
+
+test("translateCopilotEvent: deltas -> text/reasoning, tool start/complete -> tool card", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false, streamedText: false };
+  translateCopilotEvent({ type: "assistant.reasoning_delta", data: { deltaContent: "thinking" } }, emitter, state);
+  translateCopilotEvent({ type: "assistant.message_delta", data: { deltaContent: "hello" } }, emitter, state);
+  translateCopilotEvent({ type: "tool.execution_start", data: { toolName: "shell", arguments: { command: "ls" }, toolCallId: "t1" } }, emitter, state);
+  translateCopilotEvent({ type: "tool.execution_complete", data: { toolCallId: "t1", result: { content: [{ type: "text", text: "files" }] } } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "thinking" },
+    { k: "reasoningEnd" }, // message_delta closes the thinking block
+    { k: "text", t: "hello" },
+    { k: "toolCall", n: "shell", a: { command: "ls" }, id: "t1" },
+    { k: "toolResult", id: "t1", o: "files", n: undefined },
+  ]);
+  assert.equal(state.streamedText, true);
+});
+
+test("translateCopilotEvent: final reasoning is shown when no reasoning deltas streamed", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
+  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "complete thinking" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "complete thinking" },
+    { k: "reasoningEnd" },
+  ]);
+  assert.equal(state.reasoningOpen, false);
+});
+
+test("translateCopilotEvent: final reasoning is ignored after streamed reasoning deltas", () => {
+  const { events, emitter } = collector();
+  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
+  translateCopilotEvent({ type: "assistant.reasoning_delta", data: { deltaContent: "thinking" } }, emitter, state);
+  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "thinking" } }, emitter, state);
+  translateCopilotEvent({ type: "assistant.message_delta", data: { deltaContent: "hello" } }, emitter, state);
+  assert.deepEqual(events, [
+    { k: "reasoning", d: "thinking" },
+    { k: "reasoningEnd" },
+    { k: "text", t: "hello" },
+  ]);
+});
+
+test("runCopilotTurn streams tool calls + deltas via session.on (no final-text dup)", async () => {
+  const { events, emitter } = collector();
+  const captured = {};
+  let handler = null;
+  const sdkModule = {
+    RuntimeConnection: { forStdio: () => ({}) },
+    approveAll: () => {},
+    CopilotClient: class {
+      async createSession(cfg) {
+        captured.created = cfg;
+        return {
+          sessionId: "sess-x",
+          on(h) { handler = h; return () => { handler = null; }; },
+          async sendAndWait(opts) {
+            captured.opts = opts;
+            handler({ type: "assistant.message_delta", data: { deltaContent: "hi " } });
+            handler({ type: "tool.execution_start", data: { toolName: "shell", arguments: {}, toolCallId: "t1" } });
+            handler({ type: "tool.execution_complete", data: { toolCallId: "t1", result: { content: [{ type: "text", text: "ok" }] } } });
+            handler({ type: "assistant.message_delta", data: { deltaContent: "there" } });
+            return { data: { content: "hi there" } };
+          },
+          async stop() {},
+        };
+      }
+      async stop() {}
+    },
+  };
+  const result = await runCopilotTurn({
+    prompt: "go",
+    attachments: [{ filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" }],
+    clientOptions: {},
+    sessionOptions: {},
+    emitter,
+    sdkModule,
+  });
+  assert.equal(captured.created.streaming, true, "requested session streaming");
+  assert.equal("streamDeltas" in captured.opts, false, "does not send unsupported message streaming flag");
+  assert.deepEqual(captured.opts.attachments, [
+    { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
+  ]);
+  // streamed deltas shown, NOT the duplicated final consolidated text
+  assert.deepEqual(events.filter((e) => e.k === "text"), [{ k: "text", t: "hi " }, { k: "text", t: "there" }]);
+  assert.ok(events.some((e) => e.k === "toolCall" && e.id === "t1"), "tool card streamed");
+  assert.ok(events.some((e) => e.k === "toolResult" && e.o === "ok"), "tool result streamed");
+  assert.equal(result.sessionId, "sess-x");
+});
+
+test("runCopilotTurn aborts the active Copilot session when the signal aborts", async () => {
+  const { events, emitter } = collector();
+  const controller = new AbortController();
+  let abortCalled = false;
+  const sdkModule = {
+    RuntimeConnection: { forStdio: () => ({}) },
+    approveAll: () => {},
+    CopilotClient: class {
+      async createSession() {
+        return {
+          sessionId: "sess-abort",
+          on() { return () => {}; },
+          async sendAndWait() {
+            controller.abort();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return { data: { content: "late text" } };
+          },
+          async abort() { abortCalled = true; },
+        };
+      }
+      async stop() {}
+    },
+  };
+
+  const result = await runCopilotTurn({
+    prompt: "stop me",
+    clientOptions: {},
+    sessionOptions: {},
+    emitter,
+    signal: controller.signal,
+    sdkModule,
+  });
+
+  assert.equal(abortCalled, true);
+  assert.equal(result.sessionId, "sess-abort");
+  assert.equal(events.some((event) => event.k === "text" && event.t === "late text"), false);
+  assert.equal(events.some((event) => event.k === "done"), false);
+});
 
 test("copilotBuiltinTools exposes bash+skill only in skills mode", () => {
   assert.equal(copilotBuiltinTools("mcp"), null);
   assert.deepEqual(copilotBuiltinTools("skills"), ["builtin:bash", "builtin:skill"]);
 });
 
-test("buildCopilotSessionOptions whitelists bash in skills mode and keeps MCP servers in mcp mode", () => {
-  const mcpServers = [{
-    name: "netcatty-remote-hosts",
-    command: "/abs/electron",
-    args: ["/abs/server.cjs"],
-    env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
-  }];
-
-  const mcp = buildCopilotSessionOptions({
-    model: "gpt-5",
-    injectedMcpServers: mcpServers,
-    toolIntegrationMode: "mcp",
-  });
-  assert.equal(mcp.model, "gpt-5");
-  assert.equal(mcp.streaming, true);
-  assert.ok(mcp.mcpServers["netcatty-remote-hosts"]);
-  assert.equal(mcp.availableTools, undefined);
-
+test("buildCopilotSessionOptions whitelists bash in skills mode", () => {
   const skills = buildCopilotSessionOptions({
     model: "gpt-5",
     injectedMcpServers: [],
@@ -41,35 +278,16 @@ test("buildCopilotSessionOptions whitelists bash in skills mode and keeps MCP se
   assert.deepEqual(skills.mcpServers, {});
 });
 
-test("approveNetcattyMcpOnly allows MCP and rejects shell", () => {
-  assert.deepEqual(
-    approveNetcattyMcpOnly({ kind: "mcp", toolName: "terminal_execute" }),
-    { kind: "approve-once" },
-  );
-  assert.equal(
-    approveNetcattyCliShellOnly({ kind: "shell", fullCommandText: "pwd" }).kind,
-    "reject",
-  );
-  assert.equal(
-    approveNetcattyMcpOnly({ kind: "shell", fullCommandText: "netcatty-tool-cli status --json" }).kind,
-    "reject",
-  );
-});
-
 test("approveNetcattyCliShellOnly allows Netcatty CLI shell commands only", () => {
   assert.deepEqual(
     approveNetcattyCliShellOnly({
       kind: "shell",
-      fullCommandText: 'node "/Applications/Netcatty.app/.../netcatty-tool-cli.cjs" env --chat-session abc --json',
+      fullCommandText: 'node "/Applications/Netcatty.app/netcatty-tool-cli.cjs" env --chat-session abc --json',
     }),
     { kind: "approve-once" },
   );
   assert.equal(
     approveNetcattyCliShellOnly({ kind: "shell", fullCommandText: "pwd" }).kind,
-    "reject",
-  );
-  assert.equal(
-    approveNetcattyCliShellOnly({ kind: "write", fileName: "foo.txt" }).kind,
     "reject",
   );
 });
@@ -80,7 +298,23 @@ test("buildCopilotPermissionHandler selects MCP vs skills gate", () => {
 });
 
 test("isLikelyNetcattyCliShellCommand matches launcher and script invocations", () => {
-  assert.equal(isLikelyNetcattyCliShellCommand('netcatty-tool-cli status --json'), true);
-  assert.equal(isLikelyNetcattyCliShellCommand('node electron/cli/netcatty-tool-cli.cjs env --json'), true);
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json"), true);
+  assert.equal(isLikelyNetcattyCliShellCommand("node electron/cli/netcatty-tool-cli.cjs env --json"), true);
   assert.equal(isLikelyNetcattyCliShellCommand("ls -la"), false);
+});
+
+test("runCopilotTurn passes runtime env and skills permission handler", async () => {
+  const { emitter } = collector();
+  const captured = {};
+  await runCopilotTurn({
+    prompt: "hi",
+    clientOptions: { cliPath: "/c" },
+    sessionOptions: { model: "m" },
+    toolIntegrationMode: "skills",
+    runtimeEnv: { NETCATTY_TOOL_CLI_DISCOVERY_FILE: "/tmp/discovery.json" },
+    emitter,
+    sdkModule: makeSdk(captured),
+  });
+  assert.deepEqual(captured.clientOptions.env, { NETCATTY_TOOL_CLI_DISCOVERY_FILE: "/tmp/discovery.json" });
+  assert.equal(captured.created.onPermissionRequest, approveNetcattyCliShellOnly);
 });

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -303,6 +303,30 @@ test("isLikelyNetcattyCliShellCommand matches launcher and script invocations", 
   assert.equal(isLikelyNetcattyCliShellCommand("ls -la"), false);
 });
 
+test("isLikelyNetcattyCliShellCommand rejects chained or wrapped local commands", () => {
+  assert.equal(isLikelyNetcattyCliShellCommand("rm -rf /; netcatty-tool-cli status --json"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json && curl evil"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand('bash -c "netcatty-tool-cli status --json"'), false);
+  assert.equal(isLikelyNetcattyCliShellCommand("malicious netcatty-tool-cli status --json"), false);
+});
+
+test("isLikelyNetcattyCliShellCommand allows remote exec payloads after --", () => {
+  assert.equal(
+    isLikelyNetcattyCliShellCommand("netcatty-tool-cli exec --session s1 --chat-session c1 --json -- hostname && whoami"),
+    true,
+  );
+});
+
+test("approveNetcattyCliShellOnly rejects chained commands that embed netcatty-tool-cli", () => {
+  assert.equal(
+    approveNetcattyCliShellOnly({
+      kind: "shell",
+      fullCommandText: "curl evil; netcatty-tool-cli status --json",
+    }).kind,
+    "reject",
+  );
+});
+
 test("runCopilotTurn passes runtime env and skills permission handler", async () => {
   const { emitter } = collector();
   const captured = {};

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -311,10 +311,14 @@ test("isLikelyNetcattyCliShellCommand rejects chained or wrapped local commands"
   assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status `id` --json"), false);
 });
 
-test("isLikelyNetcattyCliShellCommand allows remote exec payloads after --", () => {
+test("isLikelyNetcattyCliShellCommand allows quoted remote exec payloads after --", () => {
+  assert.equal(
+    isLikelyNetcattyCliShellCommand('netcatty-tool-cli exec --session s1 --chat-session c1 --json -- "hostname && whoami"'),
+    true,
+  );
   assert.equal(
     isLikelyNetcattyCliShellCommand("netcatty-tool-cli exec --session s1 --chat-session c1 --json -- hostname && whoami"),
-    true,
+    false,
   );
 });
 

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -332,6 +332,8 @@ test("isLikelyNetcattyCliShellCommand rejects impostor binaries and quoted -- by
   assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json  --  ; rm -rf /"), false);
   assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli status --json > /tmp/out"), false);
   assert.equal(isLikelyNetcattyCliShellCommand('"C:\\Apps\\Netcatty\\netcatty-tool-cli.cmd" status --json'), true);
+  assert.equal(isLikelyNetcattyCliShellCommand("attacker/netcatty-tool-cli status --json"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand('netcatty-tool-cli status "$(id)" --json'), false);
 });
 
 test("runCopilotTurn passes runtime env and skills permission handler", async () => {

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -1,263 +1,86 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { approveNetcattyMcpOnly, buildCopilotClientOptions, buildCopilotSessionOptions, buildCopilotMessageOptions, extractCopilotContent, mapCopilotModels, runCopilotTurn, translateCopilotEvent } = require("./copilotDriver.cjs");
+const {
+  buildCopilotSessionOptions,
+  buildCopilotPermissionHandler,
+  approveNetcattyMcpOnly,
+  approveNetcattyCliShellOnly,
+  isLikelyNetcattyCliShellCommand,
+  copilotBuiltinTools,
+} = require("./copilotDriver.cjs");
 
-function collector() {
-  const events = [];
-  return {
-    events,
-    emitter: {
-      text: (t) => events.push({ k: "text", t }),
-      reasoning: (d) => events.push({ k: "reasoning", d }),
-      reasoningEnd: () => events.push({ k: "reasoningEnd" }),
-      toolCall: (n, a, id) => events.push({ k: "toolCall", n, a, id }),
-      toolResult: (id, o, n) => events.push({ k: "toolResult", id, o, n }),
-      sessionId: (s) => events.push({ k: "sessionId", s }),
-      emitError: (e) => events.push({ k: "error", e }),
-      emitDone: () => events.push({ k: "done" }),
-    },
-  };
-}
-
-/** Minimal @github/copilot-sdk mock; records create vs resume + returns a session. */
-function makeSdk(captured) {
-  const makeSession = (sessionId) => ({
-    sessionId,
-    async sendAndWait({ prompt }) { captured.prompt = prompt; return { data: { content: "reply:" + sessionId } }; },
-  });
-  class CopilotClient {
-    async createSession(cfg) { captured.created = cfg; return makeSession("sess-new"); }
-    async resumeSession(id, cfg) { captured.resumed = { id, cfg }; return makeSession(id); }
-    async stop() {}
-  }
-  return { CopilotClient, RuntimeConnection: { forStdio: () => ({}) }, approveAll: () => {} };
-}
-
-test("buildCopilotClientOptions pins cliPath", () => {
-  const o = buildCopilotClientOptions({ cliPath: "/abs/copilot" });
-  assert.equal(o.cliPath, "/abs/copilot");
+test("copilotBuiltinTools exposes bash+skill only in skills mode", () => {
+  assert.equal(copilotBuiltinTools("mcp"), null);
+  assert.deepEqual(copilotBuiltinTools("skills"), ["builtin:bash", "builtin:skill"]);
 });
 
-test("buildCopilotSessionOptions maps injected MCP to local stdio servers", () => {
-  const o = buildCopilotSessionOptions({
-    model: "claude-sonnet-4.5",
-    injectedMcpServers: [{
-      name: "netcatty-remote-hosts", command: "/abs/electron",
-      args: ["/abs/server.cjs"], env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
-    }],
+test("buildCopilotSessionOptions whitelists bash in skills mode and keeps MCP servers in mcp mode", () => {
+  const mcpServers = [{
+    name: "netcatty-remote-hosts",
+    command: "/abs/electron",
+    args: ["/abs/server.cjs"],
+    env: [{ name: "NETCATTY_MCP_PORT", value: "1" }],
+  }];
+
+  const mcp = buildCopilotSessionOptions({
+    model: "gpt-5",
+    injectedMcpServers: mcpServers,
+    toolIntegrationMode: "mcp",
   });
-  assert.equal(o.model, "claude-sonnet-4.5");
-  assert.equal(o.streaming, true);
-  const srv = o.mcpServers["netcatty-remote-hosts"];
-  assert.equal(srv.type, "stdio");
-  assert.equal(srv.command, "/abs/electron");
-  assert.deepEqual(srv.env, { NETCATTY_MCP_PORT: "1" });
-  assert.deepEqual(srv.tools, ["*"]);
-  // onPermissionRequest is wired in runCopilotTurn via the SDK's approveAll,
-  // not in buildCopilotSessionOptions.
+  assert.equal(mcp.model, "gpt-5");
+  assert.equal(mcp.streaming, true);
+  assert.ok(mcp.mcpServers["netcatty-remote-hosts"]);
+  assert.equal(mcp.availableTools, undefined);
+
+  const skills = buildCopilotSessionOptions({
+    model: "gpt-5",
+    injectedMcpServers: [],
+    toolIntegrationMode: "skills",
+  });
+  assert.deepEqual(skills.availableTools, ["builtin:bash", "builtin:skill"]);
+  assert.deepEqual(skills.mcpServers, {});
 });
 
-test("approveNetcattyMcpOnly approves MCP permission requests and rejects local tools", () => {
+test("approveNetcattyMcpOnly allows MCP and rejects shell", () => {
   assert.deepEqual(
     approveNetcattyMcpOnly({ kind: "mcp", toolName: "terminal_execute" }),
     { kind: "approve-once" },
   );
-  assert.deepEqual(
-    approveNetcattyMcpOnly({ kind: "shell", fullCommandText: "rm -rf /tmp/x" }),
-    { kind: "reject", feedback: "Only Netcatty MCP tools are allowed from this integration." },
+  assert.equal(
+    approveNetcattyCliShellOnly({ kind: "shell", fullCommandText: "pwd" }).kind,
+    "reject",
   );
-  assert.deepEqual(
-    approveNetcattyMcpOnly({ kind: "read", fileName: "/etc/passwd" }),
-    { kind: "reject", feedback: "Only Netcatty MCP tools are allowed from this integration." },
+  assert.equal(
+    approveNetcattyMcpOnly({ kind: "shell", fullCommandText: "netcatty-tool-cli status --json" }).kind,
+    "reject",
   );
 });
 
-test("extractCopilotContent reads response data.content", () => {
-  assert.equal(extractCopilotContent({ data: { content: "hi" } }), "hi");
-  assert.equal(extractCopilotContent(null), "");
-  assert.equal(extractCopilotContent({ data: {} }), "");
+test("approveNetcattyCliShellOnly allows Netcatty CLI shell commands only", () => {
+  assert.deepEqual(
+    approveNetcattyCliShellOnly({
+      kind: "shell",
+      fullCommandText: 'node "/Applications/Netcatty.app/.../netcatty-tool-cli.cjs" env --chat-session abc --json',
+    }),
+    { kind: "approve-once" },
+  );
+  assert.equal(
+    approveNetcattyCliShellOnly({ kind: "shell", fullCommandText: "pwd" }).kind,
+    "reject",
+  );
+  assert.equal(
+    approveNetcattyCliShellOnly({ kind: "write", fileName: "foo.txt" }).kind,
+    "reject",
+  );
 });
 
-test("buildCopilotMessageOptions sends pasted images/files as native attachments", () => {
-  const opts = buildCopilotMessageOptions({
-    prompt: "inspect these",
-    attachments: [
-      { filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" },
-      { filename: "note.txt", mediaType: "text/plain", filePath: "/tmp/note.txt" },
-    ],
-  });
-  assert.equal(opts.prompt, "inspect these");
-  assert.equal("streamDeltas" in opts, false);
-  assert.deepEqual(opts.attachments, [
-    { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
-    { type: "file", path: "/tmp/note.txt", displayName: "note.txt" },
-  ]);
+test("buildCopilotPermissionHandler selects MCP vs skills gate", () => {
+  assert.equal(buildCopilotPermissionHandler("mcp"), approveNetcattyMcpOnly);
+  assert.equal(buildCopilotPermissionHandler("skills"), approveNetcattyCliShellOnly);
 });
 
-test("mapCopilotModels maps {id,name} and drops entries without id", () => {
-  const out = mapCopilotModels([
-    { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
-    { id: "gpt-5" },
-    { name: "no id -> dropped" },
-  ]);
-  assert.deepEqual(out, [
-    { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
-    { id: "gpt-5", name: "gpt-5" },
-  ]);
-  assert.deepEqual(mapCopilotModels(undefined), []);
-});
-
-test("runCopilotTurn (fresh) creates a session, emits its id early, returns it for resume", async () => {
-  const { events, emitter } = collector();
-  const captured = {};
-  const result = await runCopilotTurn({
-    prompt: "hi", clientOptions: { cliPath: "/c" }, sessionOptions: { model: "m" },
-    emitter, sdkModule: makeSdk(captured),
-  });
-  assert.ok(captured.created, "used createSession when there's no resume id");
-  assert.equal(captured.created.model, "m");
-  assert.deepEqual(events.filter((e) => e.k === "sessionId"), [{ k: "sessionId", s: "sess-new" }]);
-  assert.equal(result.sessionId, "sess-new");
-});
-
-test("runCopilotTurn resumes the prior session (carry context) and re-applies fresh config", async () => {
-  const { events, emitter } = collector();
-  const captured = {};
-  const result = await runCopilotTurn({
-    prompt: "what did we say", clientOptions: {}, sessionOptions: { model: "m" },
-    resumeSessionId: "sess-existing", emitter, sdkModule: makeSdk(captured),
-  });
-  assert.equal(captured.resumed.id, "sess-existing", "used resumeSession, not createSession");
-  assert.equal(captured.created, undefined);
-  // fresh netcatty MCP/session config re-applied on resume (not the stale one)
-  assert.equal(captured.resumed.cfg.model, "m");
-  assert.equal(result.sessionId, "sess-existing");
-  assert.ok(events.some((e) => e.k === "sessionId" && e.s === "sess-existing"));
-});
-
-test("translateCopilotEvent: deltas -> text/reasoning, tool start/complete -> tool card", () => {
-  const { events, emitter } = collector();
-  const state = { reasoningOpen: false, streamedText: false };
-  translateCopilotEvent({ type: "assistant.reasoning_delta", data: { deltaContent: "thinking" } }, emitter, state);
-  translateCopilotEvent({ type: "assistant.message_delta", data: { deltaContent: "hello" } }, emitter, state);
-  translateCopilotEvent({ type: "tool.execution_start", data: { toolName: "shell", arguments: { command: "ls" }, toolCallId: "t1" } }, emitter, state);
-  translateCopilotEvent({ type: "tool.execution_complete", data: { toolCallId: "t1", result: { content: [{ type: "text", text: "files" }] } } }, emitter, state);
-  assert.deepEqual(events, [
-    { k: "reasoning", d: "thinking" },
-    { k: "reasoningEnd" }, // message_delta closes the thinking block
-    { k: "text", t: "hello" },
-    { k: "toolCall", n: "shell", a: { command: "ls" }, id: "t1" },
-    { k: "toolResult", id: "t1", o: "files", n: undefined },
-  ]);
-  assert.equal(state.streamedText, true);
-});
-
-test("translateCopilotEvent: final reasoning is shown when no reasoning deltas streamed", () => {
-  const { events, emitter } = collector();
-  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
-  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "complete thinking" } }, emitter, state);
-  assert.deepEqual(events, [
-    { k: "reasoning", d: "complete thinking" },
-    { k: "reasoningEnd" },
-  ]);
-  assert.equal(state.reasoningOpen, false);
-});
-
-test("translateCopilotEvent: final reasoning is ignored after streamed reasoning deltas", () => {
-  const { events, emitter } = collector();
-  const state = { reasoningOpen: false, streamedText: false, streamedReasoning: false };
-  translateCopilotEvent({ type: "assistant.reasoning_delta", data: { deltaContent: "thinking" } }, emitter, state);
-  translateCopilotEvent({ type: "assistant.reasoning", data: { content: "thinking" } }, emitter, state);
-  translateCopilotEvent({ type: "assistant.message_delta", data: { deltaContent: "hello" } }, emitter, state);
-  assert.deepEqual(events, [
-    { k: "reasoning", d: "thinking" },
-    { k: "reasoningEnd" },
-    { k: "text", t: "hello" },
-  ]);
-});
-
-test("runCopilotTurn streams tool calls + deltas via session.on (no final-text dup)", async () => {
-  const { events, emitter } = collector();
-  const captured = {};
-  let handler = null;
-  const sdkModule = {
-    RuntimeConnection: { forStdio: () => ({}) },
-    approveAll: () => {},
-    CopilotClient: class {
-      async createSession(cfg) {
-        captured.created = cfg;
-        return {
-          sessionId: "sess-x",
-          on(h) { handler = h; return () => { handler = null; }; },
-          async sendAndWait(opts) {
-            captured.opts = opts;
-            handler({ type: "assistant.message_delta", data: { deltaContent: "hi " } });
-            handler({ type: "tool.execution_start", data: { toolName: "shell", arguments: {}, toolCallId: "t1" } });
-            handler({ type: "tool.execution_complete", data: { toolCallId: "t1", result: { content: [{ type: "text", text: "ok" }] } } });
-            handler({ type: "assistant.message_delta", data: { deltaContent: "there" } });
-            return { data: { content: "hi there" } };
-          },
-          async stop() {},
-        };
-      }
-      async stop() {}
-    },
-  };
-  const result = await runCopilotTurn({
-    prompt: "go",
-    attachments: [{ filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" }],
-    clientOptions: {},
-    sessionOptions: {},
-    emitter,
-    sdkModule,
-  });
-  assert.equal(captured.created.streaming, true, "requested session streaming");
-  assert.equal("streamDeltas" in captured.opts, false, "does not send unsupported message streaming flag");
-  assert.deepEqual(captured.opts.attachments, [
-    { type: "blob", data: "abc", mimeType: "image/png", displayName: "shot.png" },
-  ]);
-  // streamed deltas shown, NOT the duplicated final consolidated text
-  assert.deepEqual(events.filter((e) => e.k === "text"), [{ k: "text", t: "hi " }, { k: "text", t: "there" }]);
-  assert.ok(events.some((e) => e.k === "toolCall" && e.id === "t1"), "tool card streamed");
-  assert.ok(events.some((e) => e.k === "toolResult" && e.o === "ok"), "tool result streamed");
-  assert.equal(result.sessionId, "sess-x");
-});
-
-test("runCopilotTurn aborts the active Copilot session when the signal aborts", async () => {
-  const { events, emitter } = collector();
-  const controller = new AbortController();
-  let abortCalled = false;
-  const sdkModule = {
-    RuntimeConnection: { forStdio: () => ({}) },
-    approveAll: () => {},
-    CopilotClient: class {
-      async createSession() {
-        return {
-          sessionId: "sess-abort",
-          on() { return () => {}; },
-          async sendAndWait() {
-            controller.abort();
-            await new Promise((resolve) => setTimeout(resolve, 0));
-            return { data: { content: "late text" } };
-          },
-          async abort() { abortCalled = true; },
-        };
-      }
-      async stop() {}
-    },
-  };
-
-  const result = await runCopilotTurn({
-    prompt: "stop me",
-    clientOptions: {},
-    sessionOptions: {},
-    emitter,
-    signal: controller.signal,
-    sdkModule,
-  });
-
-  assert.equal(abortCalled, true);
-  assert.equal(result.sessionId, "sess-abort");
-  assert.equal(events.some((event) => event.k === "text" && event.t === "late text"), false);
-  assert.equal(events.some((event) => event.k === "done"), false);
+test("isLikelyNetcattyCliShellCommand matches launcher and script invocations", () => {
+  assert.equal(isLikelyNetcattyCliShellCommand('netcatty-tool-cli status --json'), true);
+  assert.equal(isLikelyNetcattyCliShellCommand('node electron/cli/netcatty-tool-cli.cjs env --json'), true);
+  assert.equal(isLikelyNetcattyCliShellCommand("ls -la"), false);
 });

--- a/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/copilotDriver.test.cjs
@@ -318,13 +318,16 @@ test("isLikelyNetcattyCliShellCommand allows remote exec payloads after --", () 
   );
 });
 
-test("approveNetcattyCliShellOnly rejects chained commands that embed netcatty-tool-cli", () => {
+test("isLikelyNetcattyCliShellCommand rejects impostor binaries and quoted -- bypasses", () => {
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli-backup status --json"), false);
+  assert.equal(isLikelyNetcattyCliShellCommand("netcatty-tool-cli.evil status --json"), false);
   assert.equal(
-    approveNetcattyCliShellOnly({
-      kind: "shell",
-      fullCommandText: "curl evil; netcatty-tool-cli status --json",
-    }).kind,
-    "reject",
+    isLikelyNetcattyCliShellCommand('netcatty-tool-cli sftp read --remote-path "a -- b" ; rm -rf /'),
+    false,
+  );
+  assert.equal(
+    isLikelyNetcattyCliShellCommand('netcatty-tool-cli sftp read --remote-path "a -- b" --session s1 --json'),
+    true,
   );
 });
 

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -65,6 +65,7 @@ const DRIVER_REGISTRY = {
       const sessionOptions = copilot.buildCopilotSessionOptions({
         model: ctx.model,
         injectedMcpServers: ctx.injectedMcpServers,
+        toolIntegrationMode: ctx.toolIntegrationMode,
       });
       return copilot.runCopilotTurn({
         prompt: ctx.prompt,
@@ -72,6 +73,8 @@ const DRIVER_REGISTRY = {
         clientOptions,
         sessionOptions,
         resumeSessionId: ctx.resumeSessionId,
+        toolIntegrationMode: ctx.toolIntegrationMode,
+        runtimeEnv: ctx.env,
         emitter: ctx.emitter,
         signal: ctx.signal,
       });


### PR DESCRIPTION
## Summary
- Teach the Copilot SDK driver to respect `toolIntegrationMode`: MCP mode keeps the existing netcatty-mcp-only permission gate; Skills mode exposes `builtin:bash` + `builtin:skill`, passes CLI discovery env to the Copilot runtime, and approves shell commands that invoke `netcatty-tool-cli`.
- Wire `ctx.env` and `ctx.toolIntegrationMode` through the copilot driver registry entry.

## Context
Previously Copilot always rejected non-MCP tool calls with "Only Netcatty MCP tools are allowed", so Settings → Skills + CLI did not work with the Copilot backend even though Claude/Codex already supported it.

## Test plan
- [x] `node --test electron/bridges/aiBridge/sdk/copilotDriver.test.cjs`
- [ ] Dev smoke: Settings → AI → Skills + CLI + Copilot backend → ask agent to run `netcatty-tool-cli env --chat-session <id> --json`


Made with [Cursor](https://cursor.com)