### PR TITLE
fix(notes): allow clearing default note title (#1610)

### DIFF
--- a/components/notes/NotesManager.test.tsx
+++ b/components/notes/NotesManager.test.tsx
@@ -228,6 +228,20 @@ test("NotesManager exposes markdown import controls", () => {
   assert.match(source, /multiple/);
 });
 
+test("NotesManager shows placeholder label for notes without titles", () => {
+  const markup = renderNotes([note({ title: "" })]);
+
+  assert.match(markup, /Note title/);
+});
+
+test("NotesManager tree rename allows clearing note titles", () => {
+  const source = readFileSync(new URL("./NotesManager.tsx", import.meta.url), "utf8");
+  const renameBlock = source.match(/onRenameCommit=\{\(name\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
+
+  assert.match(renameBlock, /saveNote\(\{ \.\.\.note, title: name\.trim\(\)/);
+  assert.doesNotMatch(renameBlock, /if \(!title\) return/);
+});
+
 test("NotesManager sidebar mode renders list without editor by default", () => {
   const markup = renderNotes([note()], "sidebar");
 

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -181,7 +181,7 @@ const createNote = (group: string | null, order: number): VaultNote => {
   const now = Date.now();
   return {
     id: crypto.randomUUID(),
-    title: "Untitled note",
+    title: "",
     content: "",
     group: group || undefined,
     createdAt: now,
@@ -934,13 +934,15 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     );
   };
 
+  const noteDisplayTitle = (title: string) => title || t("notes.title.placeholder");
+
   const renderNoteRow = (note: VaultNote, depth: number) => {
     if (!noteMatches(note)) return null;
     return (
       <ContextMenu key={note.id}>
         <ContextMenuTrigger asChild>
           <VaultTreeItemRow
-            label={note.title}
+            label={noteDisplayTitle(note.title)}
             depth={depth}
             selected={selectedNoteId === note.id}
             editing={editingNoteId === note.id}

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -949,9 +949,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
             editingInitialName={note.title}
             onRenameCommit={(name) => {
               setEditingNoteId(null);
-              const title = name.trim();
-              if (!title) return;
-              saveNote({ ...note, title, updatedAt: Date.now() });
+              saveNote({ ...note, title: name.trim(), updatedAt: Date.now() });
             }}
             onRenameCancel={() => setEditingNoteId(null)}
             icon={<FileText size={16} className="mr-2 shrink-0 text-muted-foreground" />}

--- a/domain/notes.test.ts
+++ b/domain/notes.test.ts
@@ -11,15 +11,23 @@ import {
   remapExpandedNoteGroupPaths,
   resolveMovedNoteGroupPath,
   resolveRenderedMarkdownLinkHref,
+  sanitizeNoteTitle,
   sanitizeVaultNote,
 } from "./notes";
 
 test("sanitizeVaultNote supplies safe defaults", () => {
   const note = sanitizeVaultNote({ title: "  ", content: 123 as never });
-  assert.equal(note.title, "Untitled note");
+  assert.equal(note.title, "");
   assert.equal(note.content, "");
   assert.equal(typeof note.id, "string");
   assert.equal(typeof note.createdAt, "number");
+});
+
+test("sanitizeNoteTitle preserves non-empty titles and allows empty titles", () => {
+  assert.equal(sanitizeNoteTitle("  My note  "), "My note");
+  assert.equal(sanitizeNoteTitle(""), "");
+  assert.equal(sanitizeNoteTitle("   "), "");
+  assert.equal(sanitizeNoteTitle(undefined), "");
 });
 
 test("normalizeVaultNotes trims group and de-duplicates tags", () => {

--- a/domain/notes.ts
+++ b/domain/notes.ts
@@ -14,10 +14,8 @@ const cleanStringArray = (values: unknown): string[] | undefined => {
   return cleaned.length ? cleaned : undefined;
 };
 
-export const sanitizeNoteTitle = (title: unknown): string => {
-  const value = typeof title === "string" ? title.trim() : "";
-  return value || "Untitled note";
-};
+export const sanitizeNoteTitle = (title: unknown): string =>
+  typeof title === "string" ? title.trim() : "";
 
 export const sanitizeVaultNote = (note: Partial<VaultNote>): VaultNote => {
   const now = Date.now();


### PR DESCRIPTION
## Summary

- Fixes #1610 — new notes can now have their title fully cleared and replaced with custom text instead of snapping back to "Untitled note".
- Root cause: `sanitizeNoteTitle` forced any empty/whitespace title back to `"Untitled note"` on every save via `normalizeVaultNotes`, so clearing the title input immediately restored the default.
- New notes now start with an empty title and show the localized placeholder (`notes.title.placeholder`); the sidebar tree uses the same placeholder when a note has no title.

## Test plan

- [x] `node --test --import tsx domain/notes.test.ts components/notes/NotesManager.test.tsx`
- [ ] Create a new note, select all title text, delete it, and confirm the field stays empty
- [ ] Type a custom title and confirm it persists after switching notes
- [ ] Confirm the sidebar tree shows the placeholder label for notes without a title


Made with [Cursor](https://cursor.com)