### PR TITLE
[Bug] 选择 Keychain 引用密钥后不再尝试默认 SSH key

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -484,6 +484,22 @@ async function getAvailableAgentSocket() {
 }
 
 /**
+ * True when the session options carry an explicit user key choice — either
+ * inline private key material or identity file paths from a Keychain reference
+ * key (issue #1614).
+ * @param {Object} options
+ * @param {string} [options.privateKey]
+ * @param {string[]} [options.identityFilePaths]
+ * @returns {boolean}
+ */
+function hasUserConfiguredKey(options) {
+  if (typeof options?.privateKey === "string" && options.privateKey.trim().length > 0) {
+    return true;
+  }
+  return Array.isArray(options?.identityFilePaths) && options.identityFilePaths.length > 0;
+}
+
+/**
  * Build authentication handler with default key fallback support
  * @param {Object} options
  * @param {string} [options.privateKey] - Explicitly configured private key
@@ -1012,6 +1028,7 @@ module.exports = {
   preparePrivateKeyForAuth,
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
+  hasUserConfiguredKey,
   PassphraseCancelledError,
   isPassphraseCancelledError,
 };

--- a/electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs
+++ b/electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs
@@ -1,0 +1,38 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { hasUserConfiguredKey } = require("./sshAuthHelper.cjs");
+
+test("hasUserConfiguredKey is true for inline private key material", () => {
+  assert.equal(hasUserConfiguredKey({ privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----" }), true);
+});
+
+test("hasUserConfiguredKey is false for empty or whitespace inline keys", () => {
+  assert.equal(hasUserConfiguredKey({ privateKey: "" }), false);
+  assert.equal(hasUserConfiguredKey({ privateKey: "   " }), false);
+  assert.equal(hasUserConfiguredKey({}), false);
+});
+
+test("hasUserConfiguredKey is true for Keychain reference identity file paths", () => {
+  assert.equal(
+    hasUserConfiguredKey({ identityFilePaths: ["/Users/alice/.ssh/id_ed25519"] }),
+    true,
+  );
+});
+
+test("hasUserConfiguredKey is false for empty identity file path lists", () => {
+  assert.equal(hasUserConfiguredKey({ identityFilePaths: [] }), false);
+  assert.equal(hasUserConfiguredKey({ identityFilePaths: null }), false);
+});
+
+test("hasUserConfiguredKey prefers explicit inline key over empty paths", () => {
+  assert.equal(
+    hasUserConfiguredKey({
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----",
+      identityFilePaths: [],
+    }),
+    true,
+  );
+});

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -32,6 +32,7 @@ const {
   preparePrivateKeyForAuth,
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
+  hasUserConfiguredKey,
   PassphraseCancelledError,
   isPassphraseCancelledError,
 } = require("./sshAuthHelper.cjs");
@@ -810,7 +811,7 @@ const startSessionApi = createStartSessionApi({
   attachSshDebugLogger, logSshAlgorithms, resolveLangFromCharset, safeSend, zmodemOverwritePending,
   shouldLogSshDebugMessage, log, createSshDiagnosticLogger,
   buildAlgorithms, randomUUID, findDefaultPrivateKey, findAllDefaultPrivateKeys,
-  preparePrivateKeyForAuth, loadFirstIdentityFileForAuth, createKeyboardInteractiveHandler,
+  preparePrivateKeyForAuth, loadFirstIdentityFileForAuth, hasUserConfiguredKey, createKeyboardInteractiveHandler,
   createConnectionRef, acquireConnectionRef, releaseConnectionRef, findReusableSession,
   get probeReceiveConflicts() { return probeReceiveConflicts; },
   get removeRemoteFiles() { return removeRemoteFiles; },

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -656,7 +656,7 @@ function createStartSessionApi(ctx) {
           if (connectOpts.password) order.push("password");
           // Add default key fallback if available and no user key configured
           // Must also set connectOpts.privateKey for ssh2 to actually try publickey auth
-          if (defaultKeyInfo && !options.privateKey) {
+          if (defaultKeyInfo && !hasUserConfiguredKey(options)) {
             connectOpts.privateKey = defaultKeyInfo.privateKey;
             order.push("publickey");
           }
@@ -693,7 +693,7 @@ function createStartSessionApi(ctx) {
                 id: `publickey-default-${keyInfo.keyName}`
               });
             }
-          } else if (defaultKeyInfo && !options.privateKey && !usedDefaultKeyAsPrimary) {
+          } else if (defaultKeyInfo && !hasUserConfiguredKey(options) && !usedDefaultKeyAsPrimary) {
             // Single default key fallback (when user has configured other auth methods)
             authMethods.push({ type: "publickey", key: defaultKeyInfo.privateKey, isDefault: true, id: "publickey-default" });
           }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -601,7 +601,9 @@ function createStartSessionApi(ctx) {
           });
         }
 
-        // If no primary auth method configured, try ssh-agent first, then ALL default keys
+        // If no primary auth method configured, try ssh-agent first, then ALL default keys.
+        // Skip default-key primaries when the user explicitly chose a key (inline or
+        // identityFilePaths) even if loading that key failed (issue #1614).
         if (!connectOpts.privateKey && !connectOpts.password && !connectOpts.agent) {
           // First, try to use ssh-agent if available (this is what regular SSH does)
           const sshAgentSocket = await getAvailableAgentSocket();
@@ -612,12 +614,12 @@ function createStartSessionApi(ctx) {
           }
 
           // Mark that we need to try all default keys (handled in authMethods below)
-          if (allDefaultKeys.length > 0) {
+          if (!hasUserConfiguredKey(options) && allDefaultKeys.length > 0) {
             log("Will try all default SSH keys as fallback", { count: allDefaultKeys.length, keyNames: allDefaultKeys.map(k => k.keyName) });
             // Set first key for connectOpts.privateKey (required for ssh2 to allow publickey auth)
             connectOpts.privateKey = allDefaultKeys[0].privateKey;
             usedDefaultKeyAsPrimary = true;
-          } else {
+          } else if (allDefaultKeys.length === 0) {
             log("No default SSH key found in ~/.ssh directory");
           }
         }


### PR DESCRIPTION
## Summary
- 修复 issue #1614：当主机明确选择了 Keychain 中「引用本地文件」的 SSH 密钥时，终端 SSH 连接不再在认证失败后自动 fallback 到 `~/.ssh/id_*` 默认密钥
- 新增 `hasUserConfiguredKey()` 辅助函数，将 `identityFilePaths` 与 `privateKey` 同等视为用户显式指定的密钥
- 在 `startSession.cjs` 的两处默认 key fallback 判断中使用该函数，使引用型密钥与内联私钥行为一致

## Root cause
引用文件型 Keychain key 通过 `identityFilePaths` 传给后端（而非 `privateKey`）。后端会先加载并尝试用户选择的密钥，但构造 fallback auth methods 时判断的是 `!options.privateKey`，导致即使用户已指定密钥，仍会把默认 `~/.ssh/id_*` 加入认证流程。

## Test plan
- [x] `node --test electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs` 全部通过
- [ ] 在 Keychain 添加引用 `~/.ssh/id_ed25519` 的密钥，为主机选择该密钥后连接
- [ ] 确认所选密钥认证失败后，不再弹出默认 `~/.ssh/id_*` 密钥的 passphrase 提示
- [ ] 确认未指定密钥的主机仍可正常 fallback 到默认 SSH key

Fixes #1614

Made with [Cursor](https://cursor.com)