### PR TITLE
fix(sftp): reconnect terminal side panel after SSH session loss (#1608)

### DIFF
--- a/application/state/sftp/useSftpPaneActions.ts
+++ b/application/state/sftp/useSftpPaneActions.ts
@@ -43,8 +43,10 @@ interface UseSftpPaneActionsParams {
   dirCacheTtlMs: number;
 }
 
+export type SftpNavigateResult = "reached" | "failed" | "aborted";
+
 interface UseSftpPaneActionsResult {
-  navigateTo: (side: "left" | "right", path: string, options?: { force?: boolean; tabId?: string }) => Promise<void>;
+  navigateTo: (side: "left" | "right", path: string, options?: { force?: boolean; tabId?: string }) => Promise<SftpNavigateResult>;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   navigateUp: (side: "left" | "right") => Promise<void>;
   openEntry: (side: "left" | "right", entry: SftpFileEntry) => Promise<void>;
@@ -160,7 +162,7 @@ export const useSftpPaneActions = ({
       side: "left" | "right",
       path: string,
       options?: { force?: boolean; tabId?: string },
-    ) => {
+    ): Promise<SftpNavigateResult> => {
       const sideTabs = side === "left" ? leftTabsRef.current : rightTabsRef.current;
       // When tabId is specified, target that specific tab instead of the active one.
       // This allows refreshing a background tab (e.g. after a transfer completes
@@ -171,7 +173,7 @@ export const useSftpPaneActions = ({
         : getActivePane(side);
 
       if (!pane?.connection || !targetTabId) {
-        return;
+        return "aborted";
       }
 
       const connectionId = pane.connection.id;
@@ -220,7 +222,7 @@ export const useSftpPaneActions = ({
             filenameEncoding: pane.filenameEncoding,
           });
         }
-        return;
+        return "reached";
       }
 
       // Re-seed confirmed state whenever the pane is settled (not loading), or
@@ -277,7 +279,7 @@ export const useSftpPaneActions = ({
             } else {
               handleSessionError(side, new Error("SFTP session lost"));
             }
-            return;
+            return "aborted";
           }
 
           try {
@@ -295,7 +297,7 @@ export const useSftpPaneActions = ({
               } else {
                 handleSessionError(side, err as Error);
               }
-              return;
+              return "aborted";
             }
             throw err as Error;
           }
@@ -306,7 +308,7 @@ export const useSftpPaneActions = ({
           // a connect/disconnect. Check if THIS tab's request is still current.
           if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
             // This tab also has a newer navigation — drop completely.
-            return;
+            return "aborted";
           }
           // Side was superseded by another tab, but this tab's request is
           // still current. The fetched files are valid — fall through to
@@ -344,18 +346,21 @@ export const useSftpPaneActions = ({
             filenameEncoding: pane.filenameEncoding,
           });
         }
+        return "reached";
       } catch (err) {
         if (navSeqRef.current[side] !== requestId) {
           if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
-            return;
+            return "aborted";
           }
           // Side superseded by another tab, but this tab's request is
           // current — fall through to show the error on this tab.
         }
+        let navigationFailed = false;
         updateTab(side, targetTabId, (prev) => {
           if (prev.connection?.id !== connectionId) {
             return prev;
           }
+          navigationFailed = true;
           return {
             ...prev,
             connection: { ...prev.connection, currentPath: previousPath },
@@ -367,6 +372,7 @@ export const useSftpPaneActions = ({
             loading: false,
           };
         });
+        return navigationFailed ? "failed" : "aborted";
       }
     },
     [

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -45,6 +45,11 @@ import {
   resolveHostFollowTerminalCwd,
   shouldFollowTerminalCwdNavigate,
 } from "./sftp/sftpFollowTerminalCwd";
+import {
+  findReusableSftpSidePanelTab,
+  shouldResetSftpSidePanelSourceSession,
+  shouldSkipSftpSidePanelAutoConnect,
+} from "./sftp/sftpSidePanelAutoConnect";
 
 interface SftpSidePanelProps {
   hosts: Host[];
@@ -211,6 +216,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
 
   const connectedKeyRef = useRef<string | null>(null);
   const connectedHostObjRef = useRef<Host | null>(null);
+  const lastSourceSessionIdRef = useRef<string | null>(null);
+  const lastFailedFollowCwdRef = useRef<string | null>(null);
   const lastAppliedInitialLocationKeyRef = useRef<string | null>(null);
   const handledPendingUploadIdRef = useRef<string | null>(null);
   const tabConnectionKeyMapRef = useRef<Map<string, string>>(new Map());
@@ -264,7 +271,26 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       activeHost.sftpSudo,
       activeHost.username,
     );
-    if (connectedKeyRef.current === connectionKey) return;
+    if (shouldResetSftpSidePanelSourceSession(lastSourceSessionIdRef.current, activeSessionId)) {
+      connectedKeyRef.current = null;
+    }
+    if (activeSessionId) {
+      lastSourceSessionIdRef.current = activeSessionId;
+    }
+
+    const hasBackendSession = (connectionId: string) => !!s.getSftpIdForConnection(connectionId);
+    const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
+    const activeConnectionId = activeTab?.connection?.id;
+    if (
+      shouldSkipSftpSidePanelAutoConnect(
+        connectionKey,
+        connectedKeyRef.current,
+        activeTab,
+        activeConnectionId ? hasBackendSession(activeConnectionId) : false,
+      )
+    ) {
+      return;
+    }
     if (hasActiveWork) return;
 
     logger.info("[SftpSidePanel] Auto-connect triggered", {
@@ -275,11 +301,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     });
 
     const tabs = s.leftTabs.tabs;
-    const existingTab = tabs.find((tab) => {
-      if (!tab.connection || tab.connection.hostId !== activeHost.id) return false;
-      if (tab.connection.status === "error" || tab.connection.status === "disconnected") return false;
-      return tabConnectionKeyMapRef.current.get(tab.id) === connectionKey;
-    });
+    const existingTab = findReusableSftpSidePanelTab(
+      tabs,
+      activeHost.id,
+      connectionKey,
+      tabConnectionKeyMapRef.current,
+      hasBackendSession,
+    );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;
@@ -712,6 +740,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       terminalCwd = await onGetTerminalCwd({ preferFreshBackend: true });
     }
     if (!terminalCwd) return;
+    if (lastFailedFollowCwdRef.current === terminalCwd) return;
 
     const connection = sftpRef.current.leftPane.connection;
     if (!shouldFollowTerminalCwdNavigate({
@@ -726,6 +755,16 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     }
 
     await sftpRef.current.navigateTo("left", terminalCwd);
+    const pane = sftpRef.current.leftPane;
+    if (
+      pane.error
+      && pane.connection?.currentPath !== terminalCwd
+      && !pane.loading
+    ) {
+      lastFailedFollowCwdRef.current = terminalCwd;
+    } else if (pane.connection?.currentPath === terminalCwd) {
+      lastFailedFollowCwdRef.current = null;
+    }
   }, [
     activeTerminalCwd,
     canFollowTerminalCwd,
@@ -739,6 +778,10 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const handleToggleFollowTerminalCwd = useCallback(() => {
     onSftpFollowTerminalCwdChange?.(!effectiveFollowTerminalCwd, followTerminalCwdHost);
   }, [effectiveFollowTerminalCwd, followTerminalCwdHost, onSftpFollowTerminalCwdChange]);
+
+  useEffect(() => {
+    lastFailedFollowCwdRef.current = null;
+  }, [activeTerminalCwd]);
 
   useEffect(() => {
     if (!effectiveFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -217,7 +217,6 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   const connectedKeyRef = useRef<string | null>(null);
   const connectedHostObjRef = useRef<Host | null>(null);
   const lastSourceSessionIdRef = useRef<string | null>(null);
-  const lastFailedFollowCwdRef = useRef<string | null>(null);
   const lastAppliedInitialLocationKeyRef = useRef<string | null>(null);
   const handledPendingUploadIdRef = useRef<string | null>(null);
   const tabConnectionKeyMapRef = useRef<Map<string, string>>(new Map());
@@ -271,7 +270,11 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       activeHost.sftpSudo,
       activeHost.username,
     );
-    if (shouldResetSftpSidePanelSourceSession(lastSourceSessionIdRef.current, activeSessionId)) {
+    const sessionChanged = shouldResetSftpSidePanelSourceSession(
+      lastSourceSessionIdRef.current,
+      activeSessionId,
+    );
+    if (sessionChanged) {
       connectedKeyRef.current = null;
     }
     if (activeSessionId) {
@@ -282,7 +285,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
     const activeConnectionId = activeTab?.connection?.id;
     if (
-      shouldSkipSftpSidePanelAutoConnect(
+      !sessionChanged
+      && shouldSkipSftpSidePanelAutoConnect(
         connectionKey,
         connectedKeyRef.current,
         activeTab,
@@ -301,13 +305,15 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     });
 
     const tabs = s.leftTabs.tabs;
-    const existingTab = findReusableSftpSidePanelTab(
-      tabs,
-      activeHost.id,
-      connectionKey,
-      tabConnectionKeyMapRef.current,
-      hasBackendSession,
-    );
+    const existingTab = sessionChanged
+      ? null
+      : findReusableSftpSidePanelTab(
+        tabs,
+        activeHost.id,
+        connectionKey,
+        tabConnectionKeyMapRef.current,
+        hasBackendSession,
+      );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;
@@ -722,6 +728,12 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const hasActiveWork = showTextEditor || !!permissionsState || showFileOpenerDialog
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
 
+  const lastFailedFollowCwdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    lastFailedFollowCwdRef.current = null;
+  }, [sftp.leftPane.connection?.id]);
+
   const handleGoToTerminalCwd = useCallback(async () => {
     if (!onGetTerminalCwd) return;
     const cwd = await onGetTerminalCwd({ preferFreshBackend: true });
@@ -754,15 +766,10 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       return;
     }
 
-    await sftpRef.current.navigateTo("left", terminalCwd);
-    const pane = sftpRef.current.leftPane;
-    if (
-      pane.error
-      && pane.connection?.currentPath !== terminalCwd
-      && !pane.loading
-    ) {
+    const navigateResult = await sftpRef.current.navigateTo("left", terminalCwd);
+    if (navigateResult === "failed") {
       lastFailedFollowCwdRef.current = terminalCwd;
-    } else if (pane.connection?.currentPath === terminalCwd) {
+    } else if (navigateResult === "reached") {
       lastFailedFollowCwdRef.current = null;
     }
   }, [

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { SftpPane } from "../../application/state/sftp/types";
+import {
+  findReusableSftpSidePanelTab,
+  isRemoteSftpTabHealthy,
+  shouldResetSftpSidePanelSourceSession,
+  shouldSkipSftpSidePanelAutoConnect,
+} from "./sftpSidePanelAutoConnect";
+
+const remoteConnectedTab = (overrides: Partial<SftpPane> = {}): SftpPane => ({
+  id: "tab-1",
+  connection: {
+    id: "conn-1",
+    hostId: "host-1",
+    hostLabel: "server",
+    isLocal: false,
+    status: "connected",
+    currentPath: "/var/www",
+  },
+  files: [],
+  loading: false,
+  reconnecting: false,
+  error: null,
+  connectionLogs: [],
+  selectedFiles: new Set(),
+  filter: "",
+  filenameEncoding: "auto",
+  showHiddenFiles: false,
+  transferMutationToken: 0,
+  ...overrides,
+});
+
+test("isRemoteSftpTabHealthy rejects loading tabs", () => {
+  const tab = remoteConnectedTab({ loading: true });
+  assert.equal(isRemoteSftpTabHealthy(tab, true), false);
+});
+
+test("isRemoteSftpTabHealthy rejects tabs without a backend SFTP session", () => {
+  const tab = remoteConnectedTab();
+  assert.equal(isRemoteSftpTabHealthy(tab, false), false);
+});
+
+test("isRemoteSftpTabHealthy rejects connecting tabs", () => {
+  const tab = remoteConnectedTab({
+    connection: {
+      ...remoteConnectedTab().connection!,
+      status: "connecting",
+    },
+  });
+  assert.equal(isRemoteSftpTabHealthy(tab, true), false);
+});
+
+test("shouldSkipSftpSidePanelAutoConnect returns false for stale connected keys", () => {
+  const tab = remoteConnectedTab({ loading: true });
+  assert.equal(
+    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true),
+    false,
+  );
+});
+
+test("findReusableSftpSidePanelTab ignores tabs stuck in loading after SSH disconnect", () => {
+  const tab = remoteConnectedTab({ loading: true });
+  const map = new Map([[tab.id, "host-key"]]);
+  assert.equal(
+    findReusableSftpSidePanelTab([tab], "host-1", "host-key", map, () => true),
+    null,
+  );
+});
+
+test("findReusableSftpSidePanelTab returns healthy tabs", () => {
+  const tab = remoteConnectedTab();
+  const map = new Map([[tab.id, "host-key"]]);
+  assert.equal(
+    findReusableSftpSidePanelTab([tab], "host-1", "host-key", map, () => true),
+    tab,
+  );
+});
+
+test("shouldResetSftpSidePanelSourceSession detects terminal session changes", () => {
+  assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"), true);
+  assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-a"), false);
+  assert.equal(shouldResetSftpSidePanelSourceSession(null, "sess-a"), false);
+  assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", null), false);
+});

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -83,3 +83,16 @@ test("shouldResetSftpSidePanelSourceSession detects terminal session changes", (
   assert.equal(shouldResetSftpSidePanelSourceSession(null, "sess-a"), false);
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", null), false);
 });
+
+test("shouldSkipSftpSidePanelAutoConnect returns false after terminal session changes", () => {
+  const tab = remoteConnectedTab();
+  assert.equal(
+    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true),
+    true,
+  );
+  // Caller gates on sessionChanged before invoking skip — stale reuse must not win.
+  assert.equal(
+    shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"),
+    true,
+  );
+});

--- a/components/sftp/sftpSidePanelAutoConnect.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.ts
@@ -1,0 +1,57 @@
+import type { SftpPane } from "../../application/state/sftp/types";
+
+export type SftpSidePanelTabHealth = Pick<SftpPane, "connection" | "loading" | "reconnecting">;
+
+/** Whether a remote SFTP tab is safe to reuse without reconnecting. */
+export function isRemoteSftpTabHealthy(
+  tab: SftpSidePanelTabHealth,
+  hasBackendSession: boolean,
+): boolean {
+  const conn = tab.connection;
+  if (!conn || conn.isLocal) return true;
+  if (conn.status !== "connected") return false;
+  if (tab.loading || tab.reconnecting) return false;
+  if (!hasBackendSession) return false;
+  return true;
+}
+
+/** Skip auto-connect only when the active tab is already bound to this endpoint and healthy. */
+export function shouldSkipSftpSidePanelAutoConnect(
+  connectionKey: string,
+  connectedKey: string | null,
+  activeTab: SftpSidePanelTabHealth | null | undefined,
+  hasBackendSession: boolean,
+): boolean {
+  if (connectedKey !== connectionKey) return false;
+  if (!activeTab) return false;
+  return isRemoteSftpTabHealthy(activeTab, hasBackendSession);
+}
+
+export function findReusableSftpSidePanelTab(
+  tabs: SftpPane[],
+  hostId: string,
+  connectionKey: string,
+  tabConnectionKeyMap: ReadonlyMap<string, string>,
+  hasBackendSession: (connectionId: string) => boolean,
+): SftpPane | null {
+  const candidate = tabs.find((tab) => {
+    if (!tab.connection || tab.connection.hostId !== hostId) return false;
+    if (tab.connection.status === "error" || tab.connection.status === "disconnected") return false;
+    return tabConnectionKeyMap.get(tab.id) === connectionKey;
+  });
+  if (!candidate?.connection) return null;
+  if (!isRemoteSftpTabHealthy(candidate, hasBackendSession(candidate.connection.id))) {
+    return null;
+  }
+  return candidate;
+}
+
+/** True when the linked terminal SSH session changed and SFTP must rebind. */
+export function shouldResetSftpSidePanelSourceSession(
+  previousSessionId: string | null | undefined,
+  nextSessionId: string | null | undefined,
+): boolean {
+  if (!nextSessionId) return false;
+  if (!previousSessionId) return false;
+  return nextSessionId !== previousSessionId;
+}


### PR DESCRIPTION
## Summary
- 修复终端侧栏 SFTP 在 SSH 断开后重连时卡在「加载中」的问题：根因是 `SftpSidePanel` 的 `runAutoConnect` 通过 `connectedKeyRef` / `existingTab` 短路复用了已失效的 tab（`loading: true` 或后端 SFTP session 已丢失），却不再发起新的 `connect()`。
- SSH 会话 ID 变化时强制重新绑定 SFTP（`sourceSessionId`），并仅在 tab 真正健康（`connected`、非 loading、后端 session 存在）时才复用。
- 追随终端目录模式下，对已确认不存在的 cwd 停止无限重试导航，避免在已删除目录上反复 loading。

## Root cause
侧栏 SFTP 与独立 SFTP 视图共用 `useSftpState`，但侧栏额外有 `runAutoConnect` 自动连接逻辑。终端断开连接后侧栏 panel 仍保持挂载（#c331b15d），tab 状态可能停留在 `loading: true` 或 `connected` 但 SFTP session 已死。重连 SSH 后 `activeSessionId` 变化，但 auto-connect 认为「已连接同一主机」直接 return，不再调用 `connect()`，界面永久停在加载态。独立 SFTP 栏无此短路逻辑，因此正常。

## Test plan
- [x] `node --import tsx --test components/sftp/sftpSidePanelAutoConnect.test.ts`
- [ ] 打开终端 + SFTP 侧栏，进入某目录后通过 SSH 删除该目录并断开连接
- [ ] 重新连接同一主机，确认侧栏 SFTP 能正常加载（不再永久 loading）
- [ ] 确认独立 SFTP 视图行为未受影响
- [ ] 若开启「追随终端目录」，确认对已删除 cwd 不会无限重试

Fixes #1608

Made with [Cursor](https://cursor.com)