### PR TITLE
fix host search punctuation-only and hostname compact false positives

### DIFF
--- a/domain/searchMatcher.test.ts
+++ b/domain/searchMatcher.test.ts
@@ -116,6 +116,23 @@ test("host search scoring prefers strict punctuation match over loose compact ma
   assert.equal(strict.score > loose.score, true);
 });
 
+test("punctuation-only query does not match every field", () => {
+  assert.equal(matchesSearchQuery("---", "prod-api-01"), false);
+  assert.equal(matchesSearchQuery("-", "some-host"), false);
+});
+
+test("host search avoids compact hostname false positives on numeric segments", () => {
+  assert.equal(
+    matchesHostSearchQuery("61", {
+      label: "核心交换机",
+      hostname: "10.6.1.88",
+      group: "网络设备",
+      tags: [],
+    }),
+    false,
+  );
+});
+
 test("host search scoring favors label over group when both match", () => {
   const labelHit = getHostSearchMatch("山东 6-1", {
     label: "山东-业务交换机6-1",

--- a/lib/searchMatcher.ts
+++ b/lib/searchMatcher.ts
@@ -84,6 +84,9 @@ export function matchesSearchQuery(
     return normalizedFields.some((field) => field.includes(normalizedQuery));
   }
 
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (tokens.length === 0) return false;
+
   const sourceText = normalizedFields.join(" ");
   const haystack = sourceText;
   if (haystack.includes(normalizedQuery)) {
@@ -95,9 +98,6 @@ export function matchesSearchQuery(
   if (compactQuery && haystackCompact.includes(compactQuery)) {
     return true;
   }
-
-  const tokens = tokenizeSearchQuery(normalizedQuery);
-  if (tokens.length === 0) return true;
 
   if (tokens.every((token) => haystack.includes(token))) {
     return true;
@@ -199,7 +199,11 @@ function matchSegmentAgainstSource(
   if (SEARCH_QUERY_PUNCT_REGEX.test(segment)) return null;
 
   const compactSegment = compactText(segment);
-  if (compactSegment && source.compact.includes(compactSegment)) {
+  if (
+    compactSegment
+    && source.field !== "hostname"
+    && source.compact.includes(compactSegment)
+  ) {
     return {
       segment,
       field: source.field,


### PR DESCRIPTION
## Summary
- reject separator-only search queries before substring matching (fixes punctuation-only queries matching all rows)
- skip compact matching on hostname fields to avoid IP digit false positives (e.g. `61` matching `10.6.1.88`)

Follow-up to #1611 after local bugbot review.

## Test plan
- [x] `node --test --import tsx domain/searchMatcher.test.ts`

Made with [Cursor](https://cursor.com)