### PR TITLE
fix(sftp): stop follow-terminal-cwd retry loop on unreachable paths

### DIFF
--- a/application/state/sftp/useSftpPaneActions.ts
+++ b/application/state/sftp/useSftpPaneActions.ts
@@ -44,7 +44,7 @@ interface UseSftpPaneActionsParams {
 }
 
 interface UseSftpPaneActionsResult {
-  navigateTo: (side: "left" | "right", path: string, options?: { force?: boolean; tabId?: string }) => Promise<void>;
+  navigateTo: (side: "left" | "right", path: string, options?: { force?: boolean; tabId?: string }) => Promise<boolean>;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   navigateUp: (side: "left" | "right") => Promise<void>;
   openEntry: (side: "left" | "right", entry: SftpFileEntry) => Promise<void>;
@@ -171,7 +171,7 @@ export const useSftpPaneActions = ({
         : getActivePane(side);
 
       if (!pane?.connection || !targetTabId) {
-        return;
+        return false;
       }
 
       const connectionId = pane.connection.id;
@@ -220,7 +220,7 @@ export const useSftpPaneActions = ({
             filenameEncoding: pane.filenameEncoding,
           });
         }
-        return;
+        return true;
       }
 
       // Re-seed confirmed state whenever the pane is settled (not loading), or
@@ -277,7 +277,7 @@ export const useSftpPaneActions = ({
             } else {
               handleSessionError(side, new Error("SFTP session lost"));
             }
-            return;
+            return false;
           }
 
           try {
@@ -295,7 +295,7 @@ export const useSftpPaneActions = ({
               } else {
                 handleSessionError(side, err as Error);
               }
-              return;
+              return false;
             }
             throw err as Error;
           }
@@ -306,7 +306,7 @@ export const useSftpPaneActions = ({
           // a connect/disconnect. Check if THIS tab's request is still current.
           if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
             // This tab also has a newer navigation — drop completely.
-            return;
+            return true;
           }
           // Side was superseded by another tab, but this tab's request is
           // still current. The fetched files are valid — fall through to
@@ -344,10 +344,11 @@ export const useSftpPaneActions = ({
             filenameEncoding: pane.filenameEncoding,
           });
         }
+        return true;
       } catch (err) {
         if (navSeqRef.current[side] !== requestId) {
           if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
-            return;
+            return true;
           }
           // Side superseded by another tab, but this tab's request is
           // current — fall through to show the error on this tab.
@@ -367,6 +368,7 @@ export const useSftpPaneActions = ({
             loading: false,
           };
         });
+        return false;
       }
     },
     [

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -572,6 +572,10 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const panelRootRef = useRef<HTMLDivElement>(null);
   const dialogActionScopeIdRef = useRef(`sftp-side-panel:${crypto.randomUUID()}`);
   const [hasPaneFocus, setHasPaneFocus] = useState(false);
+  const [pendingFollowOverride, setPendingFollowOverride] = useState<{
+    hostId: string;
+    value: boolean;
+  } | null>(null);
 
   useSftpKeyboardShortcuts({
     keyBindings,
@@ -699,15 +703,34 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     const conn = sftp.leftPane.connection;
     if (conn && !conn.isLocal) {
       const latestHost = hosts.find((h) => h.id === conn.hostId) ?? null;
+      const pendingFollowValue = pendingFollowOverride?.hostId === conn.hostId
+        ? pendingFollowOverride.value
+        : undefined;
       // Prefer the stored Host object from connect time — it preserves
       // session-time overrides that the vault host may lack.
       if (connectedHostObjRef.current && connectedHostObjRef.current.id === conn.hostId) {
-        return mergeLatestFollowTerminalCwdHostSetting(connectedHostObjRef.current, latestHost);
+        return mergeLatestFollowTerminalCwdHostSetting(
+          connectedHostObjRef.current,
+          latestHost,
+          pendingFollowValue,
+        );
       }
       return latestHost ?? activeHost;
     }
     return activeHost;
-  }, [activeHost, connectedHostObjRef, hosts, sftp.leftPane.connection]);
+  }, [activeHost, connectedHostObjRef, hosts, pendingFollowOverride, sftp.leftPane.connection]);
+
+  useEffect(() => {
+    if (!pendingFollowOverride) return;
+    const latestHost = hosts.find((host) => host.id === pendingFollowOverride.hostId);
+    if (latestHost?.sftpFollowTerminalCwd === pendingFollowOverride.value) {
+      setPendingFollowOverride(null);
+    }
+  }, [hosts, pendingFollowOverride]);
+
+  useEffect(() => {
+    setPendingFollowOverride(null);
+  }, [sftp.leftPane.connection?.id]);
 
   const followTerminalCwdHost = useMemo(() => {
     if (sftp.leftPane.connection?.isLocal) return null;
@@ -816,17 +839,11 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     if (!nextEnabled) {
       blockedFollowRef.current = null;
     }
-    if (
-      connectedHostObjRef.current
-      && followTerminalCwdHost?.id === connectedHostObjRef.current.id
-    ) {
-      connectedHostObjRef.current = {
-        ...connectedHostObjRef.current,
-        sftpFollowTerminalCwd: nextEnabled,
-      };
+    if (followTerminalCwdHost?.id) {
+      setPendingFollowOverride({ hostId: followTerminalCwdHost.id, value: nextEnabled });
     }
     onSftpFollowTerminalCwdChange?.(nextEnabled, followTerminalCwdHost);
-  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, connectedHostObjRef, onSftpFollowTerminalCwdChange]);
+  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, onSftpFollowTerminalCwdChange]);
 
   useEffect(() => {
     if (!effectiveFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -694,6 +694,17 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const hasActiveWork = showTextEditor || !!permissionsState || showFileOpenerDialog
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
 
+  const blockedFollowTerminalCwdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    blockedFollowTerminalCwdRef.current = null;
+  }, [activeTerminalCwd]);
+
+  useEffect(() => {
+    if (effectiveFollowTerminalCwd) return;
+    blockedFollowTerminalCwdRef.current = null;
+  }, [effectiveFollowTerminalCwd]);
+
   const handleGoToTerminalCwd = useCallback(async () => {
     if (!onGetTerminalCwd) return;
     const cwd = await onGetTerminalCwd({ preferFreshBackend: true });
@@ -721,11 +732,26 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       currentPath: connection?.currentPath,
       hasActiveWork,
       isConnected: Boolean(connection && !connection.isLocal && connection.status === "connected"),
+      blockedTerminalCwd: blockedFollowTerminalCwdRef.current,
     })) {
       return;
     }
 
     await sftpRef.current.navigateTo("left", terminalCwd);
+
+    const updatedConnection = sftpRef.current.leftPane.connection;
+    if (updatedConnection?.currentPath === terminalCwd) {
+      blockedFollowTerminalCwdRef.current = null;
+      return;
+    }
+
+    if (
+      updatedConnection
+      && !updatedConnection.isLocal
+      && updatedConnection.status === "connected"
+    ) {
+      blockedFollowTerminalCwdRef.current = terminalCwd;
+    }
   }, [
     activeTerminalCwd,
     canFollowTerminalCwd,
@@ -737,8 +763,21 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   ]);
 
   const handleToggleFollowTerminalCwd = useCallback(() => {
-    onSftpFollowTerminalCwdChange?.(!effectiveFollowTerminalCwd, followTerminalCwdHost);
-  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, onSftpFollowTerminalCwdChange]);
+    const nextEnabled = !effectiveFollowTerminalCwd;
+    if (!nextEnabled) {
+      blockedFollowTerminalCwdRef.current = null;
+    }
+    if (
+      connectedHostObjRef.current
+      && followTerminalCwdHost?.id === connectedHostObjRef.current.id
+    ) {
+      connectedHostObjRef.current = {
+        ...connectedHostObjRef.current,
+        sftpFollowTerminalCwd: nextEnabled,
+      };
+    }
+    onSftpFollowTerminalCwdChange?.(nextEnabled, followTerminalCwdHost);
+  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, connectedHostObjRef, onSftpFollowTerminalCwdChange]);
 
   useEffect(() => {
     if (!effectiveFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -754,8 +754,18 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
 
   const blockedFollowRef = useRef<SftpFollowTerminalCwdBlock | null>(null);
+  const followSyncGenerationRef = useRef(0);
+  const effectiveFollowTerminalCwdRef = useRef(effectiveFollowTerminalCwd);
+  const canFollowTerminalCwdRef = useRef(canFollowTerminalCwd);
+  effectiveFollowTerminalCwdRef.current = effectiveFollowTerminalCwd;
+  canFollowTerminalCwdRef.current = canFollowTerminalCwd;
   const connectionId = sftp.leftPane.connection?.id ?? null;
   const connectionPath = sftp.leftPane.connection?.currentPath ?? null;
+
+  const invalidateInFlightFollowSync = useCallback(() => {
+    followSyncGenerationRef.current += 1;
+    blockedFollowRef.current = null;
+  }, []);
 
   useEffect(() => {
     blockedFollowRef.current = null;
@@ -767,8 +777,8 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
 
   useEffect(() => {
     if (effectiveFollowTerminalCwd) return;
-    blockedFollowRef.current = null;
-  }, [effectiveFollowTerminalCwd]);
+    invalidateInFlightFollowSync();
+  }, [effectiveFollowTerminalCwd, invalidateInFlightFollowSync]);
 
   useEffect(() => {
     if (
@@ -798,15 +808,24 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       return;
     }
 
+    const syncGeneration = followSyncGenerationRef.current;
+
     let terminalCwd = activeTerminalCwd;
     if (!terminalCwd) {
       terminalCwd = await onGetTerminalCwd({ preferFreshBackend: true });
     }
     if (!terminalCwd) return;
+    if (
+      syncGeneration !== followSyncGenerationRef.current
+      || !effectiveFollowTerminalCwdRef.current
+      || !canFollowTerminalCwdRef.current
+    ) {
+      return;
+    }
 
     const connection = sftpRef.current.leftPane.connection;
     if (!shouldFollowTerminalCwdNavigate({
-      followEnabled: effectiveFollowTerminalCwd,
+      followEnabled: effectiveFollowTerminalCwdRef.current,
       isVisible,
       terminalCwd,
       currentPath: connection?.currentPath,
@@ -819,8 +838,21 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     }
 
     const navigateResult = await sftpRef.current.navigateTo("left", terminalCwd);
-    if (navigateResult === "failed" && connection?.id) {
-      blockedFollowRef.current = { connectionId: connection.id, terminalCwd };
+    if (
+      syncGeneration !== followSyncGenerationRef.current
+      || !effectiveFollowTerminalCwdRef.current
+      || !canFollowTerminalCwdRef.current
+    ) {
+      return;
+    }
+
+    const currentConnection = sftpRef.current.leftPane.connection;
+    if (!currentConnection || currentConnection.id !== connection?.id) {
+      return;
+    }
+
+    if (navigateResult === "failed" && currentConnection.id) {
+      blockedFollowRef.current = { connectionId: currentConnection.id, terminalCwd };
     } else if (navigateResult === "reached") {
       blockedFollowRef.current = null;
     }
@@ -837,13 +869,13 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const handleToggleFollowTerminalCwd = useCallback(() => {
     const nextEnabled = !effectiveFollowTerminalCwd;
     if (!nextEnabled) {
-      blockedFollowRef.current = null;
+      invalidateInFlightFollowSync();
     }
     if (followTerminalCwdHost?.id) {
       setPendingFollowOverride({ hostId: followTerminalCwdHost.id, value: nextEnabled });
     }
     onSftpFollowTerminalCwdChange?.(nextEnabled, followTerminalCwdHost);
-  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, onSftpFollowTerminalCwdChange]);
+  }, [effectiveFollowTerminalCwd, followTerminalCwdHost, invalidateInFlightFollowSync, onSftpFollowTerminalCwdChange]);
 
   useEffect(() => {
     if (!effectiveFollowTerminalCwd || !canFollowTerminalCwd || !isVisible || hasActiveWork) return;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -713,8 +713,10 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const handleGoToTerminalCwd = useCallback(async () => {
     if (!onGetTerminalCwd) return;
     const cwd = await onGetTerminalCwd({ preferFreshBackend: true });
-    if (cwd) {
-      sftpRef.current.navigateTo("left", cwd);
+    if (!cwd) return;
+    const navigated = await sftpRef.current.navigateTo("left", cwd);
+    if (navigated) {
+      blockedFollowRef.current = null;
     }
   }, [onGetTerminalCwd, sftpRef]);
 

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -44,6 +44,7 @@ import {
   mergeLatestFollowTerminalCwdHostSetting,
   resolveHostFollowTerminalCwd,
   shouldFollowTerminalCwdNavigate,
+  type SftpFollowTerminalCwdBlock,
 } from "./sftp/sftpFollowTerminalCwd";
 
 interface SftpSidePanelProps {
@@ -694,15 +695,19 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const hasActiveWork = showTextEditor || !!permissionsState || showFileOpenerDialog
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
 
-  const blockedFollowTerminalCwdRef = useRef<string | null>(null);
+  const blockedFollowRef = useRef<SftpFollowTerminalCwdBlock | null>(null);
 
   useEffect(() => {
-    blockedFollowTerminalCwdRef.current = null;
-  }, [activeTerminalCwd]);
+    blockedFollowRef.current = null;
+  }, [
+    activeTerminalCwd,
+    followTerminalCwdHost?.id,
+    sftp.leftPane.connection?.id,
+  ]);
 
   useEffect(() => {
     if (effectiveFollowTerminalCwd) return;
-    blockedFollowTerminalCwdRef.current = null;
+    blockedFollowRef.current = null;
   }, [effectiveFollowTerminalCwd]);
 
   const handleGoToTerminalCwd = useCallback(async () => {
@@ -730,27 +735,22 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       isVisible,
       terminalCwd,
       currentPath: connection?.currentPath,
+      connectionId: connection?.id,
       hasActiveWork,
       isConnected: Boolean(connection && !connection.isLocal && connection.status === "connected"),
-      blockedTerminalCwd: blockedFollowTerminalCwdRef.current,
+      blockedFollow: blockedFollowRef.current,
     })) {
       return;
     }
 
-    await sftpRef.current.navigateTo("left", terminalCwd);
-
-    const updatedConnection = sftpRef.current.leftPane.connection;
-    if (updatedConnection?.currentPath === terminalCwd) {
-      blockedFollowTerminalCwdRef.current = null;
+    const navigated = await sftpRef.current.navigateTo("left", terminalCwd);
+    if (navigated) {
+      blockedFollowRef.current = null;
       return;
     }
 
-    if (
-      updatedConnection
-      && !updatedConnection.isLocal
-      && updatedConnection.status === "connected"
-    ) {
-      blockedFollowTerminalCwdRef.current = terminalCwd;
+    if (connection?.id) {
+      blockedFollowRef.current = { connectionId: connection.id, terminalCwd };
     }
   }, [
     activeTerminalCwd,
@@ -765,7 +765,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   const handleToggleFollowTerminalCwd = useCallback(() => {
     const nextEnabled = !effectiveFollowTerminalCwd;
     if (!nextEnabled) {
-      blockedFollowTerminalCwdRef.current = null;
+      blockedFollowRef.current = null;
     }
     if (
       connectedHostObjRef.current

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -39,6 +39,27 @@ test("shouldFollowTerminalCwdNavigate returns false without a known terminal cwd
   assert.equal(shouldFollowTerminalCwdNavigate({ ...base, terminalCwd: null }), false);
 });
 
+test("shouldFollowTerminalCwdNavigate returns false when cwd is blocked after a failed follow", () => {
+  assert.equal(
+    shouldFollowTerminalCwdNavigate({
+      ...base,
+      blockedTerminalCwd: "/home/user/project",
+    }),
+    false,
+  );
+});
+
+test("shouldFollowTerminalCwdNavigate ignores blocked cwd when terminal cwd changed", () => {
+  assert.equal(
+    shouldFollowTerminalCwdNavigate({
+      ...base,
+      terminalCwd: "/home/user/other",
+      blockedTerminalCwd: "/home/user/project",
+    }),
+    true,
+  );
+});
+
 test("resolveHostFollowTerminalCwd inherits the global setting until the host overrides it", () => {
   assert.equal(resolveHostFollowTerminalCwd(undefined, true), true);
   assert.equal(resolveHostFollowTerminalCwd(undefined, false), false);
@@ -86,6 +107,27 @@ test("mergeLatestFollowTerminalCwdHostSetting refreshes the follow flag without 
       id: "host-1",
       hostname: "session.example.com",
       sftpFollowTerminalCwd: true,
+    },
+  );
+});
+
+test("mergeLatestFollowTerminalCwdHostSetting keeps optimistic session override until vault updates", () => {
+  const connectedHost = {
+    id: "host-1",
+    hostname: "session.example.com",
+    sftpFollowTerminalCwd: false,
+  };
+  const latestHost = {
+    id: "host-1",
+    hostname: "vault.example.com",
+  };
+
+  assert.deepEqual(
+    mergeLatestFollowTerminalCwdHostSetting(connectedHost, latestHost),
+    {
+      id: "host-1",
+      hostname: "session.example.com",
+      sftpFollowTerminalCwd: false,
     },
   );
 });

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -136,11 +136,32 @@ test("mergeLatestFollowTerminalCwdHostSetting keeps optimistic session override 
   };
 
   assert.deepEqual(
-    mergeLatestFollowTerminalCwdHostSetting(connectedHost, latestHost),
+    mergeLatestFollowTerminalCwdHostSetting(connectedHost, latestHost, false),
     {
       id: "host-1",
       hostname: "session.example.com",
       sftpFollowTerminalCwd: false,
+    },
+  );
+});
+
+test("mergeLatestFollowTerminalCwdHostSetting drops stale session override when vault clears the follow flag", () => {
+  const connectedHost = {
+    id: "host-1",
+    hostname: "session.example.com",
+    sftpFollowTerminalCwd: true,
+  };
+  const latestHost = {
+    id: "host-1",
+    hostname: "vault.example.com",
+  };
+
+  assert.deepEqual(
+    mergeLatestFollowTerminalCwdHostSetting(connectedHost, latestHost),
+    {
+      id: "host-1",
+      hostname: "session.example.com",
+      sftpFollowTerminalCwd: undefined,
     },
   );
 });

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -12,6 +12,7 @@ const base = {
   isVisible: true,
   terminalCwd: "/home/user/project",
   currentPath: "/home/user",
+  connectionId: "conn-1",
   hasActiveWork: false,
   isConnected: true,
 };
@@ -43,9 +44,20 @@ test("shouldFollowTerminalCwdNavigate returns false when cwd is blocked after a 
   assert.equal(
     shouldFollowTerminalCwdNavigate({
       ...base,
-      blockedTerminalCwd: "/home/user/project",
+      blockedFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
     }),
     false,
+  );
+});
+
+test("shouldFollowTerminalCwdNavigate ignores blocked cwd for a different connection", () => {
+  assert.equal(
+    shouldFollowTerminalCwdNavigate({
+      ...base,
+      connectionId: "conn-2",
+      blockedFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
+    }),
+    true,
   );
 });
 
@@ -54,7 +66,7 @@ test("shouldFollowTerminalCwdNavigate ignores blocked cwd when terminal cwd chan
     shouldFollowTerminalCwdNavigate({
       ...base,
       terminalCwd: "/home/user/other",
-      blockedTerminalCwd: "/home/user/project",
+      blockedFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
     }),
     true,
   );

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -30,6 +30,7 @@ export const mergeLatestFollowTerminalCwdHostSetting = <
 >(
   displayHost: T | null | undefined,
   latestHost: T | null | undefined,
+  pendingFollowOverride?: boolean,
 ): T | null => {
   if (!displayHost) return latestHost ?? null;
   if (!latestHost || latestHost.id !== displayHost.id) return displayHost;
@@ -40,7 +41,7 @@ export const mergeLatestFollowTerminalCwdHostSetting = <
     sftpFollowTerminalCwd:
       latestHost.sftpFollowTerminalCwd !== undefined
         ? latestHost.sftpFollowTerminalCwd
-        : displayHost.sftpFollowTerminalCwd,
+        : pendingFollowOverride,
   };
 };
 

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -1,12 +1,18 @@
+export type SftpFollowTerminalCwdBlock = {
+  connectionId: string;
+  terminalCwd: string;
+};
+
 export type SftpFollowTerminalCwdContext = {
   followEnabled: boolean;
   isVisible: boolean;
   terminalCwd?: string | null;
   currentPath?: string | null;
+  connectionId?: string | null;
   hasActiveWork: boolean;
   isConnected: boolean;
   /** Skip auto-follow while this terminal cwd cannot be reached on SFTP. */
-  blockedTerminalCwd?: string | null;
+  blockedFollow?: SftpFollowTerminalCwdBlock | null;
 };
 
 export const resolveHostFollowTerminalCwd = (
@@ -44,14 +50,22 @@ export const shouldFollowTerminalCwdNavigate = ({
   isVisible,
   terminalCwd,
   currentPath,
+  connectionId,
   hasActiveWork,
   isConnected,
-  blockedTerminalCwd,
+  blockedFollow,
 }: SftpFollowTerminalCwdContext): boolean => {
   if (!followEnabled || !isVisible || !isConnected) return false;
   if (hasActiveWork) return false;
   if (!terminalCwd || terminalCwd.trim().length === 0) return false;
-  if (blockedTerminalCwd && blockedTerminalCwd === terminalCwd) return false;
+  if (
+    blockedFollow
+    && connectionId
+    && blockedFollow.connectionId === connectionId
+    && blockedFollow.terminalCwd === terminalCwd
+  ) {
+    return false;
+  }
   if (!currentPath || currentPath === terminalCwd) return false;
   return true;
 };

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -5,6 +5,8 @@ export type SftpFollowTerminalCwdContext = {
   currentPath?: string | null;
   hasActiveWork: boolean;
   isConnected: boolean;
+  /** Skip auto-follow while this terminal cwd cannot be reached on SFTP. */
+  blockedTerminalCwd?: string | null;
 };
 
 export const resolveHostFollowTerminalCwd = (
@@ -29,7 +31,10 @@ export const mergeLatestFollowTerminalCwdHostSetting = <
   return {
     ...latestHost,
     ...displayHost,
-    sftpFollowTerminalCwd: latestHost.sftpFollowTerminalCwd,
+    sftpFollowTerminalCwd:
+      latestHost.sftpFollowTerminalCwd !== undefined
+        ? latestHost.sftpFollowTerminalCwd
+        : displayHost.sftpFollowTerminalCwd,
   };
 };
 
@@ -41,10 +46,12 @@ export const shouldFollowTerminalCwdNavigate = ({
   currentPath,
   hasActiveWork,
   isConnected,
+  blockedTerminalCwd,
 }: SftpFollowTerminalCwdContext): boolean => {
   if (!followEnabled || !isVisible || !isConnected) return false;
   if (hasActiveWork) return false;
   if (!terminalCwd || terminalCwd.trim().length === 0) return false;
+  if (blockedTerminalCwd && blockedTerminalCwd === terminalCwd) return false;
   if (!currentPath || currentPath === terminalCwd) return false;
   return true;
 };


### PR DESCRIPTION
## Summary
- Block repeated SFTP auto-navigation when follow-terminal-cwd targets a path that cannot be reached, fixing perpetual loading on incompatible servers (e.g. Synology NAS).
- Clear the block when terminal cwd changes or follow is disabled, and apply optimistic host toggle state so the toolbar switch responds immediately.
- Add unit tests for blocked-path and optimistic merge behavior.

Fixes follow-up from #1413 (https://github.com/binaricat/Netcatty/issues/1413#issuecomment-4787843603)

## Test plan
- [x] `node --test --import tsx components/sftp/sftpFollowTerminalCwd.test.ts`
- [ ] Enable global/per-host follow on an SFTP host whose terminal cwd is unreachable → SFTP loads once, stops spinning, toggle can disable follow
- [ ] `cd` terminal to a new reachable path → follow retries for the new cwd
- [ ] Disable follow via toolbar or global setting → no further auto-navigation


Made with [Cursor](https://cursor.com)