### PR TITLE
fix(terminal): preserve scrollback for Codex/Claude Code full-screen redraws

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1031,6 +1031,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         const term = termRef.current;
         if (!term) return;
 
+        const buffer = term.buffer.active;
+        const wasPinnedToBottom = buffer.viewportY >= buffer.baseY;
+        const savedViewportY = buffer.viewportY;
+
         const dimensions = fitAddon.proposeDimensions();
         if (!dimensions || Number.isNaN(dimensions.cols) || Number.isNaN(dimensions.rows)) return;
 
@@ -1043,6 +1047,18 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           term.resize(dimensions.cols, dimensions.rows);
           forceSyncRenderAfterResize(term);
         }
+
+        // Preserve scroll position across resize (superset/Tabby pattern).
+        if (wasPinnedToBottom) {
+          term.scrollToBottom();
+        } else {
+          const targetY = Math.min(savedViewportY, term.buffer.active.baseY);
+          if (term.buffer.active.viewportY !== targetY) {
+            term.scrollToLine(targetY);
+          }
+        }
+        term.refresh(0, Math.max(0, term.rows - 1));
+
         if (typeof requestAnimationFrame === "function") {
           requestAnimationFrame(() => {
             autocompleteRepositionRef.current?.();

--- a/components/terminal/clearTerminalViewport.test.ts
+++ b/components/terminal/clearTerminalViewport.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldPreserveViewportBeforeFullErase } from "./clearTerminalViewport.ts";
+
+const createMockTerm = (bufferType: "normal" | "alternate"): { buffer: { active: { type: "normal" | "alternate" } } } => ({
+  buffer: {
+    active: {
+      type: bufferType,
+    },
+  },
+});
+
+test("preserves viewport before full erase on the normal screen outside sync blocks", () => {
+  const term = createMockTerm("normal");
+  assert.equal(shouldPreserveViewportBeforeFullErase(term as never, false), true);
+});
+
+test("skips viewport preservation inside DEC 2026 sync blocks", () => {
+  const term = createMockTerm("normal");
+  assert.equal(shouldPreserveViewportBeforeFullErase(term as never, true), false);
+});
+
+test("skips viewport preservation on the alternate screen", () => {
+  const term = createMockTerm("alternate");
+  assert.equal(shouldPreserveViewportBeforeFullErase(term as never, false), false);
+});

--- a/components/terminal/clearTerminalViewport.ts
+++ b/components/terminal/clearTerminalViewport.ts
@@ -83,3 +83,18 @@ export const isEraseScrollbackSequence = (params: CsiParam[]): boolean =>
 
 export const isEraseViewportSequence = (params: CsiParam[]): boolean =>
   params.length > 0 && params[0] === 2;
+
+/**
+ * Netcatty preserves visible rows in scrollback before CSI 2 J so shell `clear`
+ * does not discard history. TUIs inside DEC 2026 sync blocks or the alternate
+ * screen expect an in-place erase instead.
+ */
+export const shouldPreserveViewportBeforeFullErase = (
+  term: XTerm,
+  inDec2026SyncBlock: boolean,
+): boolean => {
+  if (inDec2026SyncBlock) {
+    return false;
+  }
+  return term.buffer.active.type === "normal";
+};

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -15,6 +15,7 @@ import {
   writeSessionData,
   writeTerminalLine,
 } from "./terminalSessionAttachment";
+import { resetTerminalSyncBlockFilter } from "./terminalSyncBlockFilter";
 import { isConnectionTokenCurrent, registerConnectionToken, runDistroDetection } from "./terminalDistroDetection";
 import { resolveStartupCommand, scheduleStartupCommand } from "./terminalStartupCommands";
 import { markPromptLineBreakCommandPending } from "./promptLineBreak";
@@ -1096,6 +1097,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
 
       ctx.sessionRef.current = id;
       getFlowController(ctx, term).reset();
+      resetTerminalSyncBlockFilter(term);
       resetTerminalLineTimestampState(term);
       ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {
         writeSessionData(ctx, term, chunk);

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -16,6 +16,7 @@ import {
   writeTerminalLine,
 } from "./terminalSessionAttachment";
 import { resetTerminalSyncBlockFilter } from "./terminalSyncBlockFilter";
+import { resetTerminalWriteCoalescer } from "./terminalWriteCoalescer";
 import { isConnectionTokenCurrent, registerConnectionToken, runDistroDetection } from "./terminalDistroDetection";
 import { resolveStartupCommand, scheduleStartupCommand } from "./terminalStartupCommands";
 import { markPromptLineBreakCommandPending } from "./promptLineBreak";
@@ -1097,6 +1098,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
 
       ctx.sessionRef.current = id;
       getFlowController(ctx, term).reset();
+      resetTerminalWriteCoalescer(term);
       resetTerminalSyncBlockFilter(term);
       resetTerminalLineTimestampState(term);
       ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -35,9 +35,10 @@ import { isMacPlatform } from "../../../lib/utils";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import {
   clearTerminalViewport,
-  isEraseViewportSequence,
   isEraseScrollbackSequence,
+  isEraseViewportSequence,
   preserveTerminalViewportInScrollback,
+  shouldPreserveViewportBeforeFullErase,
 } from "../clearTerminalViewport";
 import {
   createKittyKeyboardModeState,
@@ -1058,9 +1059,30 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   // OSC 7 format: \x1b]7;file://hostname/path\x07 or \x1b]7;file://hostname/path\x1b\\
   let currentCwd: string | undefined = undefined;
 
+  // Track DEC 2026 synchronized-output blocks so CSI 2 J can erase in place for
+  // Codex/Claude Code TUIs instead of pushing visible rows into scrollback.
+  let inDec2026SyncBlock = false;
+
+  const dec2026SyncStartDisposable = term.parser.registerCsiHandler(
+    { prefix: "?", final: "h", params: [2026] },
+    () => {
+      inDec2026SyncBlock = true;
+      return false;
+    },
+  );
+  const dec2026SyncEndDisposable = term.parser.registerCsiHandler(
+    { prefix: "?", final: "l", params: [2026] },
+    () => {
+      inDec2026SyncBlock = false;
+      return false;
+    },
+  );
+
   const eraseScrollbackDisposable = term.parser.registerCsiHandler({ final: "J" }, (params) => {
     if (isEraseViewportSequence(params)) {
-      preserveTerminalViewportInScrollback(term);
+      if (shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock)) {
+        preserveTerminalViewportInScrollback(term);
+      }
       return false;
     }
     if (!isEraseScrollbackSequence(params)) {
@@ -1251,6 +1273,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       stopDprWatch();
       keywordHighlighter.dispose();
       eraseScrollbackDisposable.dispose();
+      dec2026SyncStartDisposable.dispose();
+      dec2026SyncEndDisposable.dispose();
       for (const disposable of cursorPositionReportRequestDisposables) {
         disposable.dispose();
       }

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { Terminal as XTerm } from "@xterm/xterm";
+
 import {
   createSyncBlockFilterState,
   filterSyncBlockClears,
@@ -10,65 +12,96 @@ import {
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
+const ALT_SCREEN_ENTER = "\x1b[?1049h";
+
+const createMockTerm = ({
+  type = "normal",
+  viewportY = 10,
+  baseY = 76,
+  length = 100,
+  rows = 24,
+}: {
+  type?: "normal" | "alternate";
+  viewportY?: number;
+  baseY?: number;
+  length?: number;
+  rows?: number;
+} = {}): XTerm => ({
+  rows,
+  buffer: {
+    active: {
+      type,
+      baseY,
+      length,
+      viewportY,
+    },
+  },
+} as unknown as XTerm);
+
+const scrolledUpTerm = createMockTerm();
+const bottomTerm = createMockTerm({ viewportY: 76, baseY: 76 });
 
 test("passes through data with no synchronized-output sequences", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const input = "hello\r\n\x1b[2Jworld\r\n";
 
-  assert.equal(filterSyncBlockClears(input, state), input);
+  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
   assert.equal(state.inSyncBlock, false);
 });
 
 test("strips clear-screen inside a synchronized-output block", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
 
-  assert.equal(filterSyncBlockClears(input, state), `${SYNC_START}frame${SYNC_END}`);
+  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), `${SYNC_START}frame${SYNC_END}`);
   assert.equal(state.inSyncBlock, false);
 });
 
 test("does not strip clear-screen outside synchronized-output blocks", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
 
-  assert.equal(filterSyncBlockClears(CLEAR, state), CLEAR);
+  assert.equal(filterSyncBlockClears(CLEAR, state, scrolledUpTerm), CLEAR);
   assert.equal(state.inSyncBlock, false);
 });
 
 test("tracks synchronized-output state across chunks", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
 
-  assert.equal(filterSyncBlockClears(SYNC_START, state), SYNC_START);
+  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm), SYNC_START);
   assert.equal(state.inSyncBlock, true);
 
-  assert.equal(filterSyncBlockClears(`${CLEAR}partial`, state), "partial");
+  assert.equal(filterSyncBlockClears(`${CLEAR}partial`, state, scrolledUpTerm), "partial");
   assert.equal(state.inSyncBlock, true);
 
-  assert.equal(filterSyncBlockClears(`${CLEAR}done${SYNC_END}`, state), `done${SYNC_END}`);
+  assert.equal(
+    filterSyncBlockClears(`${CLEAR}done${SYNC_END}`, state, scrolledUpTerm),
+    `done${SYNC_END}`,
+  );
   assert.equal(state.inSyncBlock, false);
 });
 
 test("leaves non-clear redraw sequences inside synchronized-output blocks intact", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const cursorHome = "\x1b[H";
   const input = `${SYNC_START}${cursorHome}${CLEAR}text${SYNC_END}`;
 
   assert.equal(
-    filterSyncBlockClears(input, state),
+    filterSyncBlockClears(input, state, scrolledUpTerm),
     `${SYNC_START}${cursorHome}text${SYNC_END}`,
   );
 });
 
 test("handles sync start marker split across chunks", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const startPrefix = SYNC_START.slice(0, -1);
   const startSuffix = SYNC_START.slice(-1);
 
-  assert.equal(filterSyncBlockClears(startPrefix, state), "");
+  assert.equal(filterSyncBlockClears(startPrefix, state, scrolledUpTerm), "");
   assert.equal(state.pending, startPrefix);
   assert.equal(state.inSyncBlock, false);
 
   assert.equal(
-    filterSyncBlockClears(`${startSuffix}${CLEAR}frame${SYNC_END}`, state),
+    filterSyncBlockClears(`${startSuffix}${CLEAR}frame${SYNC_END}`, state, scrolledUpTerm),
     `${SYNC_START}frame${SYNC_END}`,
   );
   assert.equal(state.inSyncBlock, false);
@@ -76,53 +109,64 @@ test("handles sync start marker split across chunks", () => {
 });
 
 test("handles clear-screen marker split across chunks inside sync block", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const clearPrefix = CLEAR.slice(0, -1);
   const clearSuffix = CLEAR.slice(-1);
 
-  assert.equal(filterSyncBlockClears(SYNC_START, state), SYNC_START);
+  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm), SYNC_START);
   assert.equal(state.inSyncBlock, true);
 
-  assert.equal(filterSyncBlockClears(`${clearPrefix}`, state), "");
+  assert.equal(filterSyncBlockClears(`${clearPrefix}`, state, scrolledUpTerm), "");
   assert.equal(state.pending, clearPrefix);
 
-  assert.equal(filterSyncBlockClears(`${clearSuffix}frame${SYNC_END}`, state), `frame${SYNC_END}`);
+  assert.equal(
+    filterSyncBlockClears(`${clearSuffix}frame${SYNC_END}`, state, scrolledUpTerm),
+    `frame${SYNC_END}`,
+  );
   assert.equal(state.inSyncBlock, false);
   assert.equal(state.pending, "");
 });
 
 test("handles sync end marker split across chunks", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
   const endPrefix = SYNC_END.slice(0, -1);
   const endSuffix = SYNC_END.slice(-1);
 
-  assert.equal(filterSyncBlockClears(`${SYNC_START}frame${endPrefix}`, state), `${SYNC_START}frame`);
+  assert.equal(
+    filterSyncBlockClears(`${SYNC_START}frame${endPrefix}`, state, scrolledUpTerm),
+    `${SYNC_START}frame`,
+  );
   assert.equal(state.inSyncBlock, true);
   assert.equal(state.pending, endPrefix);
 
-  assert.equal(filterSyncBlockClears(endSuffix, state), SYNC_END);
+  assert.equal(filterSyncBlockClears(endSuffix, state, scrolledUpTerm), SYNC_END);
   assert.equal(state.inSyncBlock, false);
   assert.equal(state.pending, "");
 });
 
 test("releases a trailing ESC when the next chunk is ordinary text", () => {
-  const state = createSyncBlockFilterState();
+  const state = createSyncBlockFilterState(scrolledUpTerm);
 
-  assert.equal(filterSyncBlockClears("prompt\x1b", state), "prompt");
+  assert.equal(filterSyncBlockClears("prompt\x1b", state, scrolledUpTerm), "prompt");
   assert.equal(state.pending, "\x1b");
 
-  assert.equal(filterSyncBlockClears("more output", state), "\x1bmore output");
+  assert.equal(filterSyncBlockClears("more output", state, scrolledUpTerm), "\x1bmore output");
   assert.equal(state.pending, "");
 });
 
-test("keeps clear-screen inside sync blocks when stripping is disabled", () => {
-  const state = createSyncBlockFilterState();
+test("preserves clear-screen when alternate-screen entry precedes sync redraw", () => {
+  const state = createSyncBlockFilterState(scrolledUpTerm);
+  const input = `${ALT_SCREEN_ENTER}${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
+  assert.equal(state.inAlternateScreen, true);
+});
+
+test("preserves clear-screen inside sync blocks when viewport is at bottom", () => {
+  const state = createSyncBlockFilterState(bottomTerm);
   const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
 
-  assert.equal(
-    filterSyncBlockClears(input, state, { stripClearsInSyncBlock: false }),
-    input,
-  );
+  assert.equal(filterSyncBlockClears(input, state, bottomTerm), input);
 });
 
 test("isTerminalViewportScrolledUp is false when buffer state is unavailable", () => {
@@ -130,24 +174,10 @@ test("isTerminalViewportScrolledUp is false when buffer state is unavailable", (
 });
 
 test("isTerminalViewportScrolledUp is false on alternate-screen buffers", () => {
-  const term = {
-    rows: 24,
-    buffer: { active: { type: "alternate", baseY: 0, length: 24 } },
-  } as never;
-
-  assert.equal(isTerminalViewportScrolledUp(term), false);
+  assert.equal(isTerminalViewportScrolledUp(createMockTerm({ type: "alternate", viewportY: 0, baseY: 0, length: 24 })), false);
 });
 
 test("isTerminalViewportScrolledUp detects normal-buffer scrollback", () => {
-  const atBottom = {
-    rows: 24,
-    buffer: { active: { type: "normal", viewportY: 76, baseY: 76, length: 100 } },
-  } as never;
-  const scrolledUp = {
-    rows: 24,
-    buffer: { active: { type: "normal", viewportY: 10, baseY: 76, length: 100 } },
-  } as never;
-
-  assert.equal(isTerminalViewportScrolledUp(atBottom), false);
-  assert.equal(isTerminalViewportScrolledUp(scrolledUp), true);
+  assert.equal(isTerminalViewportScrolledUp(bottomTerm), false);
+  assert.equal(isTerminalViewportScrolledUp(scrolledUpTerm), true);
 });

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSyncBlockFilterState,
+  filterSyncBlockClears,
+} from "./filterSyncBlockClears.ts";
+
+const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
+const CLEAR = "\x1b[2J";
+
+test("passes through data with no synchronized-output sequences", () => {
+  const state = createSyncBlockFilterState();
+  const input = "hello\r\n\x1b[2Jworld\r\n";
+
+  assert.equal(filterSyncBlockClears(input, state), input);
+  assert.equal(state.inSyncBlock, false);
+});
+
+test("strips clear-screen inside a synchronized-output block", () => {
+  const state = createSyncBlockFilterState();
+  const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state), `${SYNC_START}frame${SYNC_END}`);
+  assert.equal(state.inSyncBlock, false);
+});
+
+test("does not strip clear-screen outside synchronized-output blocks", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears(CLEAR, state), CLEAR);
+  assert.equal(state.inSyncBlock, false);
+});
+
+test("tracks synchronized-output state across chunks", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears(SYNC_START, state), SYNC_START);
+  assert.equal(state.inSyncBlock, true);
+
+  assert.equal(filterSyncBlockClears(`${CLEAR}partial`, state), "partial");
+  assert.equal(state.inSyncBlock, true);
+
+  assert.equal(filterSyncBlockClears(`${CLEAR}done${SYNC_END}`, state), `done${SYNC_END}`);
+  assert.equal(state.inSyncBlock, false);
+});
+
+test("leaves non-clear redraw sequences inside synchronized-output blocks intact", () => {
+  const state = createSyncBlockFilterState();
+  const cursorHome = "\x1b[H";
+  const input = `${SYNC_START}${cursorHome}${CLEAR}text${SYNC_END}`;
+
+  assert.equal(
+    filterSyncBlockClears(input, state),
+    `${SYNC_START}${cursorHome}text${SYNC_END}`,
+  );
+});

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { Terminal as XTerm } from "@xterm/xterm";
-
 import {
   createSyncBlockFilterState,
   filterSyncBlockClears,
@@ -12,205 +10,135 @@ import {
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
-const ALT_SCREEN_ENTER = "\x1b[?1049h";
+const CURSOR_HOME = "\x1b[H";
 
-const createMockTerm = ({
-  type = "normal",
-  viewportY = 10,
-  baseY = 76,
-  length = 100,
-  rows = 24,
-}: {
-  type?: "normal" | "alternate";
-  viewportY?: number;
-  baseY?: number;
-  length?: number;
-  rows?: number;
-} = {}): XTerm => ({
-  rows,
-  buffer: {
-    active: {
-      type,
-      baseY,
-      length,
-      viewportY,
-    },
-  },
-} as unknown as XTerm);
+const scrolledUpTerm = {
+  rows: 24,
+  buffer: { active: { type: "normal" as const, viewportY: 0, baseY: 5 } },
+};
 
-const scrolledUpTerm = createMockTerm();
-const bottomTerm = createMockTerm({ viewportY: 76, baseY: 76 });
+const liveBottomTerm = {
+  rows: 24,
+  buffer: { active: { type: "normal" as const, viewportY: 10, baseY: 10 } },
+};
 
 test("passes through data with no synchronized-output sequences", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
+  const state = createSyncBlockFilterState();
   const input = "hello\r\n\x1b[2Jworld\r\n";
 
-  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
+  assert.equal(filterSyncBlockClears(input, state), input);
   assert.equal(state.inSyncBlock, false);
 });
 
-test("strips clear-screen inside a synchronized-output block", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
-
-  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), `${SYNC_START}frame${SYNC_END}`);
-  assert.equal(state.inSyncBlock, false);
-});
-
-test("does not strip clear-screen outside synchronized-output blocks", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-
-  assert.equal(filterSyncBlockClears(CLEAR, state, scrolledUpTerm), CLEAR);
-  assert.equal(state.inSyncBlock, false);
-});
-
-test("tracks synchronized-output state across chunks", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-
-  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm), SYNC_START);
-  assert.equal(state.inSyncBlock, true);
-
-  assert.equal(filterSyncBlockClears(`${CLEAR}partial`, state, scrolledUpTerm), "partial");
-  assert.equal(state.inSyncBlock, true);
+test("strips home and clear for full-screen redraw sync blocks", () => {
+  const state = createSyncBlockFilterState();
+  const input = `${SYNC_START}${CURSOR_HOME}${CLEAR}frame${SYNC_END}`;
 
   assert.equal(
-    filterSyncBlockClears(`${CLEAR}done${SYNC_END}`, state, scrolledUpTerm),
-    `done${SYNC_END}`,
-  );
-  assert.equal(state.inSyncBlock, false);
-});
-
-test("leaves non-clear redraw sequences inside synchronized-output blocks intact", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const cursorHome = "\x1b[H";
-  const input = `${SYNC_START}${cursorHome}${CLEAR}text${SYNC_END}`;
-
-  assert.equal(
-    filterSyncBlockClears(input, state, scrolledUpTerm),
-    `${SYNC_START}${cursorHome}text${SYNC_END}`,
-  );
-});
-
-test("handles sync start marker split across chunks", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const startPrefix = SYNC_START.slice(0, -1);
-  const startSuffix = SYNC_START.slice(-1);
-
-  assert.equal(filterSyncBlockClears(startPrefix, state, scrolledUpTerm), "");
-  assert.equal(state.pending, startPrefix);
-  assert.equal(state.inSyncBlock, false);
-
-  assert.equal(
-    filterSyncBlockClears(`${startSuffix}${CLEAR}frame${SYNC_END}`, state, scrolledUpTerm),
+    filterSyncBlockClears(input, state, scrolledUpTerm as never),
     `${SYNC_START}frame${SYNC_END}`,
   );
   assert.equal(state.inSyncBlock, false);
-  assert.equal(state.pending, "");
 });
 
-test("handles clear-screen marker split across chunks inside sync block", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
+test("passes full-screen redraw clears through at the live bottom", () => {
+  const state = createSyncBlockFilterState();
+  const input = `${SYNC_START}${CURSOR_HOME}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state, liveBottomTerm as never), input);
+});
+
+test("passes incremental sync blocks through unchanged", () => {
+  const state = createSyncBlockFilterState();
+  const rowMove = "\x1b[5;1H";
+  const input = `${SYNC_START}${rowMove}partial${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state), input);
+});
+
+test("passes clear-screen outside synchronized-output blocks", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears(CLEAR, state), CLEAR);
+});
+
+test("passes standalone clear inside sync blocks that are not full redraws", () => {
+  const state = createSyncBlockFilterState();
+  const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state), input);
+});
+
+test("tracks full redraw state across chunks", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm as never), SYNC_START);
+  assert.equal(filterSyncBlockClears(CURSOR_HOME, state, scrolledUpTerm as never), "");
+  assert.equal(state.pendingCursorHome, CURSOR_HOME);
+
+  assert.equal(filterSyncBlockClears(CLEAR, state, scrolledUpTerm as never), "");
+  assert.equal(
+    filterSyncBlockClears(`frame${SYNC_END}`, state, scrolledUpTerm as never),
+    `frame${SYNC_END}`,
+  );
+});
+
+test("releases held cursor-home when sync block ends without clear", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm as never), SYNC_START);
+  assert.equal(filterSyncBlockClears(CURSOR_HOME, state, scrolledUpTerm as never), "");
+  assert.equal(
+    filterSyncBlockClears(`partial${SYNC_END}`, state, scrolledUpTerm as never),
+    `${CURSOR_HOME}partial${SYNC_END}`,
+  );
+});
+
+test("handles sync markers split across chunks", () => {
+  const state = createSyncBlockFilterState();
+  const startPrefix = SYNC_START.slice(0, -1);
+  const startSuffix = SYNC_START.slice(-1);
+
+  assert.equal(filterSyncBlockClears(startPrefix, state, scrolledUpTerm as never), "");
+  assert.equal(
+    filterSyncBlockClears(
+      `${startSuffix}${CURSOR_HOME}${CLEAR}frame${SYNC_END}`,
+      state,
+      scrolledUpTerm as never,
+    ),
+    `${SYNC_START}frame${SYNC_END}`,
+  );
+});
+
+test("handles clear-screen marker split across chunks inside full redraw block", () => {
+  const state = createSyncBlockFilterState();
   const clearPrefix = CLEAR.slice(0, -1);
   const clearSuffix = CLEAR.slice(-1);
 
-  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm), SYNC_START);
-  assert.equal(state.inSyncBlock, true);
-
-  assert.equal(filterSyncBlockClears(`${clearPrefix}`, state, scrolledUpTerm), "");
-  assert.equal(state.pending, clearPrefix);
-
+  assert.equal(filterSyncBlockClears(SYNC_START, state, scrolledUpTerm as never), SYNC_START);
+  assert.equal(filterSyncBlockClears(CURSOR_HOME, state, scrolledUpTerm as never), "");
+  assert.equal(filterSyncBlockClears(clearPrefix, state, scrolledUpTerm as never), "");
   assert.equal(
-    filterSyncBlockClears(`${clearSuffix}frame${SYNC_END}`, state, scrolledUpTerm),
+    filterSyncBlockClears(`${clearSuffix}frame${SYNC_END}`, state, scrolledUpTerm as never),
     `frame${SYNC_END}`,
   );
-  assert.equal(state.inSyncBlock, false);
-  assert.equal(state.pending, "");
 });
 
-test("handles sync end marker split across chunks", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const endPrefix = SYNC_END.slice(0, -1);
-  const endSuffix = SYNC_END.slice(-1);
+test("leaves non-home redraw sequences inside full redraw blocks intact", () => {
+  const state = createSyncBlockFilterState();
+  const cursorHome = "\x1b[1;1H";
+  const input = `${SYNC_START}${cursorHome}${CLEAR}text${SYNC_END}`;
 
   assert.equal(
-    filterSyncBlockClears(`${SYNC_START}frame${endPrefix}`, state, scrolledUpTerm),
-    `${SYNC_START}frame`,
+    filterSyncBlockClears(input, state, scrolledUpTerm as never),
+    `${SYNC_START}text${SYNC_END}`,
   );
-  assert.equal(state.inSyncBlock, true);
-  assert.equal(state.pending, endPrefix);
-
-  assert.equal(filterSyncBlockClears(endSuffix, state, scrolledUpTerm), SYNC_END);
-  assert.equal(state.inSyncBlock, false);
-  assert.equal(state.pending, "");
 });
 
-test("releases a trailing ESC when the next chunk is ordinary text", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-
-  assert.equal(filterSyncBlockClears("prompt\x1b", state, scrolledUpTerm), "prompt");
-  assert.equal(state.pending, "\x1b");
-
-  assert.equal(filterSyncBlockClears("more output", state, scrolledUpTerm), "\x1bmore output");
-  assert.equal(state.pending, "");
+test("isTerminalViewportScrolledUp is false at the live bottom", () => {
+  assert.equal(isTerminalViewportScrolledUp(liveBottomTerm as never), false);
 });
 
-test("preserves clear-screen when alternate-screen entry precedes sync redraw", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const input = `${ALT_SCREEN_ENTER}${SYNC_START}${CLEAR}frame${SYNC_END}`;
-
-  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
-  assert.equal(state.inAlternateScreen, true);
-});
-
-test("preserves clear-screen for combined alternate-screen private-mode sequences", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const input = `\x1b[?1049;1000h${SYNC_START}${CLEAR}frame${SYNC_END}`;
-
-  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
-  assert.equal(state.inAlternateScreen, true);
-});
-
-test("handles split combined alternate-screen sequences across chunks", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-  const prefix = "\x1b[?1049;";
-  const suffix = `1000h${SYNC_START}${CLEAR}frame${SYNC_END}`;
-
-  assert.equal(filterSyncBlockClears(prefix, state, scrolledUpTerm), "");
-  assert.equal(state.pending, prefix);
-
-  assert.equal(
-    filterSyncBlockClears(suffix, state, scrolledUpTerm),
-    `\x1b[?1049;1000h${SYNC_START}${CLEAR}frame${SYNC_END}`,
-  );
-  assert.equal(state.inAlternateScreen, true);
-});
-
-test("does not treat later text as part of a private-mode CSI", () => {
-  const state = createSyncBlockFilterState(scrolledUpTerm);
-
-  assert.equal(
-    filterSyncBlockClears("\x1b[?1049shello", state, scrolledUpTerm),
-    "\x1b[?1049shello",
-  );
-  assert.equal(state.inAlternateScreen, false);
-});
-
-test("preserves clear-screen inside sync blocks when viewport is at bottom", () => {
-  const state = createSyncBlockFilterState(bottomTerm);
-  const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
-
-  assert.equal(filterSyncBlockClears(input, state, bottomTerm), input);
-});
-
-test("isTerminalViewportScrolledUp is false when buffer state is unavailable", () => {
-  assert.equal(isTerminalViewportScrolledUp({} as never), false);
-});
-
-test("isTerminalViewportScrolledUp is false on alternate-screen buffers", () => {
-  assert.equal(isTerminalViewportScrolledUp(createMockTerm({ type: "alternate", viewportY: 0, baseY: 0, length: 24 })), false);
-});
-
-test("isTerminalViewportScrolledUp detects normal-buffer scrollback", () => {
-  assert.equal(isTerminalViewportScrolledUp(bottomTerm), false);
-  assert.equal(isTerminalViewportScrolledUp(scrolledUpTerm), true);
+test("isTerminalViewportScrolledUp is true when reading scrollback", () => {
+  assert.equal(isTerminalViewportScrolledUp(scrolledUpTerm as never), true);
 });

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -56,3 +56,36 @@ test("leaves non-clear redraw sequences inside synchronized-output blocks intact
     `${SYNC_START}${cursorHome}text${SYNC_END}`,
   );
 });
+
+test("handles sync start marker split across chunks", () => {
+  const state = createSyncBlockFilterState();
+  const startPrefix = SYNC_START.slice(0, -1);
+  const startSuffix = SYNC_START.slice(-1);
+
+  assert.equal(filterSyncBlockClears(startPrefix, state), "");
+  assert.equal(state.pending, startPrefix);
+  assert.equal(state.inSyncBlock, false);
+
+  assert.equal(
+    filterSyncBlockClears(`${startSuffix}${CLEAR}frame${SYNC_END}`, state),
+    `${SYNC_START}frame${SYNC_END}`,
+  );
+  assert.equal(state.inSyncBlock, false);
+  assert.equal(state.pending, "");
+});
+
+test("handles clear-screen marker split across chunks inside sync block", () => {
+  const state = createSyncBlockFilterState();
+  const clearPrefix = CLEAR.slice(0, -1);
+  const clearSuffix = CLEAR.slice(-1);
+
+  assert.equal(filterSyncBlockClears(SYNC_START, state), SYNC_START);
+  assert.equal(state.inSyncBlock, true);
+
+  assert.equal(filterSyncBlockClears(`${clearPrefix}`, state), "");
+  assert.equal(state.pending, clearPrefix);
+
+  assert.equal(filterSyncBlockClears(`${clearSuffix}frame${SYNC_END}`, state), `frame${SYNC_END}`);
+  assert.equal(state.inSyncBlock, false);
+  assert.equal(state.pending, "");
+});

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   createSyncBlockFilterState,
   filterSyncBlockClears,
+  isTerminalViewportScrolledUp,
 } from "./filterSyncBlockClears.ts";
 
 const SYNC_START = "\x1b[?2026h";
@@ -112,4 +113,37 @@ test("releases a trailing ESC when the next chunk is ordinary text", () => {
 
   assert.equal(filterSyncBlockClears("more output", state), "\x1bmore output");
   assert.equal(state.pending, "");
+});
+
+test("keeps clear-screen inside sync blocks when stripping is disabled", () => {
+  const state = createSyncBlockFilterState();
+  const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(
+    filterSyncBlockClears(input, state, { stripClearsInSyncBlock: false }),
+    input,
+  );
+});
+
+test("isTerminalViewportScrolledUp is false on alternate-screen buffers", () => {
+  const term = {
+    rows: 24,
+    buffer: { active: { type: "alternate", baseY: 0, length: 24 } },
+  } as never;
+
+  assert.equal(isTerminalViewportScrolledUp(term), false);
+});
+
+test("isTerminalViewportScrolledUp detects normal-buffer scrollback", () => {
+  const atBottom = {
+    rows: 24,
+    buffer: { active: { type: "normal", baseY: 76, length: 100 } },
+  } as never;
+  const scrolledUp = {
+    rows: 24,
+    buffer: { active: { type: "normal", baseY: 10, length: 100 } },
+  } as never;
+
+  assert.equal(isTerminalViewportScrolledUp(atBottom), false);
+  assert.equal(isTerminalViewportScrolledUp(scrolledUp), true);
 });

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -170,6 +170,31 @@ test("preserves clear-screen for combined alternate-screen private-mode sequence
   assert.equal(state.inAlternateScreen, true);
 });
 
+test("handles split combined alternate-screen sequences across chunks", () => {
+  const state = createSyncBlockFilterState(scrolledUpTerm);
+  const prefix = "\x1b[?1049;";
+  const suffix = `1000h${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(prefix, state, scrolledUpTerm), "");
+  assert.equal(state.pending, prefix);
+
+  assert.equal(
+    filterSyncBlockClears(suffix, state, scrolledUpTerm),
+    `\x1b[?1049;1000h${SYNC_START}${CLEAR}frame${SYNC_END}`,
+  );
+  assert.equal(state.inAlternateScreen, true);
+});
+
+test("does not treat later text as part of a private-mode CSI", () => {
+  const state = createSyncBlockFilterState(scrolledUpTerm);
+
+  assert.equal(
+    filterSyncBlockClears("\x1b[?1049shello", state, scrolledUpTerm),
+    "\x1b[?1049shello",
+  );
+  assert.equal(state.inAlternateScreen, false);
+});
+
 test("preserves clear-screen inside sync blocks when viewport is at bottom", () => {
   const state = createSyncBlockFilterState(bottomTerm);
   const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -125,6 +125,10 @@ test("keeps clear-screen inside sync blocks when stripping is disabled", () => {
   );
 });
 
+test("isTerminalViewportScrolledUp is false when buffer state is unavailable", () => {
+  assert.equal(isTerminalViewportScrolledUp({} as never), false);
+});
+
 test("isTerminalViewportScrolledUp is false on alternate-screen buffers", () => {
   const term = {
     rows: 24,

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -137,11 +137,11 @@ test("isTerminalViewportScrolledUp is false on alternate-screen buffers", () => 
 test("isTerminalViewportScrolledUp detects normal-buffer scrollback", () => {
   const atBottom = {
     rows: 24,
-    buffer: { active: { type: "normal", baseY: 76, length: 100 } },
+    buffer: { active: { type: "normal", viewportY: 76, baseY: 76, length: 100 } },
   } as never;
   const scrolledUp = {
     rows: 24,
-    buffer: { active: { type: "normal", baseY: 10, length: 100 } },
+    buffer: { active: { type: "normal", viewportY: 10, baseY: 76, length: 100 } },
   } as never;
 
   assert.equal(isTerminalViewportScrolledUp(atBottom), false);

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -89,3 +89,27 @@ test("handles clear-screen marker split across chunks inside sync block", () => 
   assert.equal(state.inSyncBlock, false);
   assert.equal(state.pending, "");
 });
+
+test("handles sync end marker split across chunks", () => {
+  const state = createSyncBlockFilterState();
+  const endPrefix = SYNC_END.slice(0, -1);
+  const endSuffix = SYNC_END.slice(-1);
+
+  assert.equal(filterSyncBlockClears(`${SYNC_START}frame${endPrefix}`, state), `${SYNC_START}frame`);
+  assert.equal(state.inSyncBlock, true);
+  assert.equal(state.pending, endPrefix);
+
+  assert.equal(filterSyncBlockClears(endSuffix, state), SYNC_END);
+  assert.equal(state.inSyncBlock, false);
+  assert.equal(state.pending, "");
+});
+
+test("releases a trailing ESC when the next chunk is ordinary text", () => {
+  const state = createSyncBlockFilterState();
+
+  assert.equal(filterSyncBlockClears("prompt\x1b", state), "prompt");
+  assert.equal(state.pending, "\x1b");
+
+  assert.equal(filterSyncBlockClears("more output", state), "\x1bmore output");
+  assert.equal(state.pending, "");
+});

--- a/components/terminal/runtime/filterSyncBlockClears.test.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.test.ts
@@ -162,6 +162,14 @@ test("preserves clear-screen when alternate-screen entry precedes sync redraw", 
   assert.equal(state.inAlternateScreen, true);
 });
 
+test("preserves clear-screen for combined alternate-screen private-mode sequences", () => {
+  const state = createSyncBlockFilterState(scrolledUpTerm);
+  const input = `\x1b[?1049;1000h${SYNC_START}${CLEAR}frame${SYNC_END}`;
+
+  assert.equal(filterSyncBlockClears(input, state, scrolledUpTerm), input);
+  assert.equal(state.inAlternateScreen, true);
+});
+
 test("preserves clear-screen inside sync blocks when viewport is at bottom", () => {
   const state = createSyncBlockFilterState(bottomTerm);
   const input = `${SYNC_START}${CLEAR}frame${SYNC_END}`;

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -11,8 +11,9 @@ import type { Terminal as XTerm } from "@xterm/xterm";
  * position and makes earlier output appear "eaten".
  *
  * Alternate-screen TUIs still need the clear to remove stale cells from shorter
- * redraw frames, so callers should only enable stripping while the viewport is
- * scrolled up in the normal buffer.
+ * redraw frames. Because PTY chunks can enter alternate screen before xterm has
+ * applied the switch, this filter tracks alternate-screen transitions in-band
+ * and only strips clears while the normal buffer is scrolled up.
  *
  * PTY/IPC chunks can split escape sequences at arbitrary byte boundaries, so a
  * trailing partial marker is held in `pending` until the next chunk completes it.
@@ -23,12 +24,9 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 export type SyncBlockFilterState = {
   inSyncBlock: boolean;
+  inAlternateScreen: boolean;
   /** Trailing bytes that may complete a marker in the next chunk. */
   pending: string;
-};
-
-export type SyncBlockClearFilterOptions = {
-  stripClearsInSyncBlock: boolean;
 };
 
 export type SyncBlockClearFilterResult = {
@@ -39,8 +37,16 @@ export type SyncBlockClearFilterResult = {
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
+const ALT_SCREEN_ENTER = ["\x1b[?1049h", "\x1b[?1047h", "\x1b[?47h"] as const;
+const ALT_SCREEN_LEAVE = ["\x1b[?1049l", "\x1b[?1047l", "\x1b[?47l"] as const;
 
-const MARKERS = [SYNC_START, SYNC_END, CLEAR] as const;
+const MARKERS = [
+  SYNC_START,
+  SYNC_END,
+  CLEAR,
+  ...ALT_SCREEN_ENTER,
+  ...ALT_SCREEN_LEAVE,
+] as const;
 
 const maxMarkerPrefixLength = Math.max(...MARKERS.map((marker) => marker.length)) - 1;
 
@@ -58,16 +64,51 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
   return { emit: input, pending: "" };
 };
 
+const matchMarker = (input: string, index: number, markers: readonly string[]): string | null => {
+  for (const marker of markers) {
+    if (input.startsWith(marker, index)) {
+      return marker;
+    }
+  }
+  return null;
+};
+
+const shouldStripClearInSyncBlock = (
+  state: SyncBlockFilterState,
+  term: XTerm,
+): boolean => {
+  if (state.inAlternateScreen) {
+    return false;
+  }
+  return isTerminalViewportScrolledUp(term);
+};
+
 const scanSyncBlockClears = (
   input: string,
   state: SyncBlockFilterState,
-  stripClearsInSyncBlock: boolean,
+  term: XTerm,
 ): SyncBlockClearFilterResult => {
   let result = "";
   let startedSyncBlock = false;
   let index = 0;
 
   while (index < input.length) {
+    const alternateEnter = matchMarker(input, index, ALT_SCREEN_ENTER);
+    if (alternateEnter) {
+      state.inAlternateScreen = true;
+      result += alternateEnter;
+      index += alternateEnter.length;
+      continue;
+    }
+
+    const alternateLeave = matchMarker(input, index, ALT_SCREEN_LEAVE);
+    if (alternateLeave) {
+      state.inAlternateScreen = false;
+      result += alternateLeave;
+      index += alternateLeave.length;
+      continue;
+    }
+
     if (input.startsWith(SYNC_START, index)) {
       state.inSyncBlock = true;
       startedSyncBlock = true;
@@ -84,8 +125,8 @@ const scanSyncBlockClears = (
     }
 
     if (
-      stripClearsInSyncBlock
-      && state.inSyncBlock
+      state.inSyncBlock
+      && shouldStripClearInSyncBlock(state, term)
       && input.startsWith(CLEAR, index)
     ) {
       index += CLEAR.length;
@@ -102,7 +143,7 @@ const scanSyncBlockClears = (
 export const filterSyncBlockClearsWithMeta = (
   data: string,
   state: SyncBlockFilterState,
-  options: SyncBlockClearFilterOptions = { stripClearsInSyncBlock: true },
+  term: XTerm,
 ): SyncBlockClearFilterResult => {
   const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
   state.pending = pending;
@@ -110,17 +151,20 @@ export const filterSyncBlockClearsWithMeta = (
     return { output: "", startedSyncBlock: false };
   }
 
-  return scanSyncBlockClears(emit, state, options.stripClearsInSyncBlock);
+  return scanSyncBlockClears(emit, state, term);
 };
 
 export const filterSyncBlockClears = (
   data: string,
   state: SyncBlockFilterState,
-  options: SyncBlockClearFilterOptions = { stripClearsInSyncBlock: true },
-): string => filterSyncBlockClearsWithMeta(data, state, options).output;
+  term: XTerm,
+): string => filterSyncBlockClearsWithMeta(data, state, term).output;
 
-export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
+export const createSyncBlockFilterState = (
+  term?: Pick<XTerm, "buffer">,
+): SyncBlockFilterState => ({
   inSyncBlock: false,
+  inAlternateScreen: term?.buffer?.active?.type === "alternate",
   pending: "",
 });
 

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -1,11 +1,18 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
 /**
  * Strip `\x1b[2J` (ED — erase display) inside DEC Mode 2026 synchronized-output
  * blocks before data reaches xterm.js.
  *
  * Coding CLIs such as Codex and Claude Code wrap full-screen redraws in
  * `\x1b[?2026h` … `\x1b[?2026l`. Native terminals treat the enclosed clear as
- * part of the atomic update, but xterm.js resets viewportY on every `\x1b[2J`,
- * which yanks scroll position and makes earlier output appear "eaten".
+ * part of the atomic update, but xterm.js resets viewportY on every `\x1b[2J`
+ * when the user has scrolled up in the normal buffer, which yanks scroll
+ * position and makes earlier output appear "eaten".
+ *
+ * Alternate-screen TUIs still need the clear to remove stale cells from shorter
+ * redraw frames, so callers should only enable stripping while the viewport is
+ * scrolled up in the normal buffer.
  *
  * PTY/IPC chunks can split escape sequences at arbitrary byte boundaries, so a
  * trailing partial marker is held in `pending` until the next chunk completes it.
@@ -18,6 +25,10 @@ export type SyncBlockFilterState = {
   inSyncBlock: boolean;
   /** Trailing bytes that may complete a marker in the next chunk. */
   pending: string;
+};
+
+export type SyncBlockClearFilterOptions = {
+  stripClearsInSyncBlock: boolean;
 };
 
 const SYNC_START = "\x1b[?2026h";
@@ -42,7 +53,11 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
   return { emit: input, pending: "" };
 };
 
-const scanSyncBlockClears = (input: string, state: SyncBlockFilterState): string => {
+const scanSyncBlockClears = (
+  input: string,
+  state: SyncBlockFilterState,
+  stripClearsInSyncBlock: boolean,
+): string => {
   let result = "";
   let index = 0;
 
@@ -61,7 +76,11 @@ const scanSyncBlockClears = (input: string, state: SyncBlockFilterState): string
       continue;
     }
 
-    if (state.inSyncBlock && input.startsWith(CLEAR, index)) {
+    if (
+      stripClearsInSyncBlock
+      && state.inSyncBlock
+      && input.startsWith(CLEAR, index)
+    ) {
       index += CLEAR.length;
       continue;
     }
@@ -76,6 +95,7 @@ const scanSyncBlockClears = (input: string, state: SyncBlockFilterState): string
 export const filterSyncBlockClears = (
   data: string,
   state: SyncBlockFilterState,
+  options: SyncBlockClearFilterOptions = { stripClearsInSyncBlock: true },
 ): string => {
   const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
   state.pending = pending;
@@ -83,10 +103,23 @@ export const filterSyncBlockClears = (
     return "";
   }
 
-  return scanSyncBlockClears(emit, state);
+  return scanSyncBlockClears(emit, state, options.stripClearsInSyncBlock);
 };
 
 export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
   inSyncBlock: false,
   pending: "",
 });
+
+export const isTerminalViewportScrolledUp = (term: XTerm): boolean => {
+  const buffer = term.buffer.active;
+  if (buffer.type === "alternate") {
+    return false;
+  }
+
+  const maxBaseY = Math.max(0, buffer.length - term.rows);
+  return buffer.baseY < maxBaseY;
+};
+
+export const shouldStripSyncBlockClears = (term: XTerm): boolean =>
+  isTerminalViewportScrolledUp(term);

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -1,32 +1,30 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 /**
- * Strip `\x1b[2J` (ED — erase display) inside DEC Mode 2026 synchronized-output
+ * Strip full-screen redraw sequences inside DEC Mode 2026 synchronized-output
  * blocks before data reaches xterm.js.
  *
- * Coding CLIs such as Codex and Claude Code wrap full-screen redraws in
- * `\x1b[?2026h` … `\x1b[?2026l`. Native terminals treat the enclosed clear as
- * part of the atomic update, but xterm.js resets viewportY on every `\x1b[2J`
- * when the user has scrolled up in the normal buffer, which yanks scroll
- * position and makes earlier output appear "eaten".
+ * Codex and Claude Code emit `\x1b[H` + `\x1b[2J` inside sync blocks for
+ * full-screen frames. xterm.js resets viewportY on `\x1b[2J`, which yanks
+ * scroll position. Incremental sync blocks must pass through untouched.
  *
- * Alternate-screen TUIs still need the clear to remove stale cells from shorter
- * redraw frames. Because PTY chunks can enter alternate screen before xterm has
- * applied the switch, this filter tracks alternate-screen transitions in-band
- * and only strips clears while the normal buffer is scrolled up.
+ * Detection follows anthropics/claude-code#35580: only blocks that contain
+ * both cursor-home and erase-display are treated as full redraws. Pane (#120)
+ * strips `\x1b[2J`; we also hold the leading `\x1b[H` until `\x1b[2J` confirms
+ * the redraw so incremental blocks that never emit `\x1b[2J` still work.
  *
- * PTY/IPC chunks can split escape sequences at arbitrary byte boundaries, so a
- * trailing partial marker is held in `pending` until the next chunk completes it.
- *
+ * @see https://github.com/Dcouple-Inc/Pane/pull/120
+ * @see https://github.com/anthropics/claude-code/issues/35580
  * @see https://github.com/xtermjs/xterm.js/issues/5801
- * @see https://github.com/openai/codex/issues/14277
  */
 
 export type SyncBlockFilterState = {
   inSyncBlock: boolean;
-  inAlternateScreen: boolean;
-  /** Trailing bytes that may complete a marker in the next chunk. */
   pending: string;
+  /** Leading `\x1b[H` held until `\x1b[2J` confirms a full redraw. */
+  pendingCursorHome: string | null;
+  /** null = unknown; true = strip home+clear; false = pass block through. */
+  fullRedrawBlock: boolean | null;
 };
 
 export type SyncBlockClearFilterResult = {
@@ -37,18 +35,19 @@ export type SyncBlockClearFilterResult = {
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
+const CURSOR_HOME = "\x1b[H";
+const CURSOR_HOME_EXPLICIT = "\x1b[1;1H";
 
-const MARKERS = [SYNC_START, SYNC_END, CLEAR] as const;
-const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
+const MARKERS = [SYNC_START, SYNC_END, CLEAR, CURSOR_HOME, CURSOR_HOME_EXPLICIT] as const;
 
 const maxMarkerPrefixLength = Math.max(...MARKERS.map((marker) => marker.length)) - 1;
-
-const isCsiFinal = (ch: string): boolean => ch >= "@" && ch <= "~";
 
 const isIncompleteEscapePrefix = (suffix: string): boolean => {
   if (!suffix.startsWith("\x1b")) {
     return false;
   }
+
+  const isCsiFinal = (ch: string): boolean => ch >= "@" && ch <= "~";
 
   let index = 0;
   while (index < suffix.length) {
@@ -106,61 +105,50 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
   return { emit: input, pending: "" };
 };
 
-const readPrivateModeCsi = (
+const readBlockCursorHome = (
   input: string,
   index: number,
-): { raw: string; end: number; setsAlternate: boolean | null } | null => {
-  if (!input.startsWith("\x1b[?", index)) {
-    return null;
+): { raw: string; end: number } | null => {
+  if (input.startsWith(CURSOR_HOME_EXPLICIT, index)) {
+    return { raw: CURSOR_HOME_EXPLICIT, end: index + CURSOR_HOME_EXPLICIT.length };
   }
-
-  for (let end = index + 3; end < input.length; end += 1) {
-    const final = input[end];
-    if (!isCsiFinal(final)) {
-      continue;
-    }
-
-    if (final !== "h" && final !== "l") {
-      return {
-        raw: input.slice(index, end + 1),
-        end: end + 1,
-        setsAlternate: null,
-      };
-    }
-
-    const params = input.slice(index + 3, end).split(";");
-    let setsAlternate: boolean | null = null;
-    for (const param of params) {
-      const mode = Number.parseInt(param, 10);
-      if (ALTERNATE_SCREEN_MODES.has(mode)) {
-        setsAlternate = final === "h";
-      }
-    }
-
-    return {
-      raw: input.slice(index, end + 1),
-      end: end + 1,
-      setsAlternate,
-    };
+  if (input.startsWith(CURSOR_HOME, index)) {
+    return { raw: CURSOR_HOME, end: index + CURSOR_HOME.length };
   }
-
   return null;
 };
 
-const shouldStripClearInSyncBlock = (
-  state: SyncBlockFilterState,
-  term: XTerm,
-): boolean => {
-  if (state.inAlternateScreen) {
+const releasePendingCursorHome = (state: SyncBlockFilterState, result: string): string => {
+  if (!state.pendingCursorHome) {
+    return result;
+  }
+  const released = `${result}${state.pendingCursorHome}`;
+  state.pendingCursorHome = null;
+  return released;
+};
+
+const resetSyncBlockState = (state: SyncBlockFilterState): void => {
+  state.inSyncBlock = false;
+  state.pendingCursorHome = null;
+  state.fullRedrawBlock = null;
+};
+
+/** True when the user has scrolled up into scrollback history. */
+export const isTerminalViewportScrolledUp = (term: XTerm): boolean => {
+  const buffer = term.buffer.active;
+  if (buffer.type !== "normal") {
     return false;
   }
-  return isTerminalViewportScrolledUp(term);
+  return buffer.viewportY < buffer.baseY;
 };
+
+const shouldStripFullRedrawClear = (term?: XTerm): boolean =>
+  term !== undefined && isTerminalViewportScrolledUp(term);
 
 const scanSyncBlockClears = (
   input: string,
   state: SyncBlockFilterState,
-  term: XTerm,
+  term?: XTerm,
 ): SyncBlockClearFilterResult => {
   let result = "";
   let startedSyncBlock = false;
@@ -168,6 +156,7 @@ const scanSyncBlockClears = (
 
   while (index < input.length) {
     if (input.startsWith(SYNC_START, index)) {
+      resetSyncBlockState(state);
       state.inSyncBlock = true;
       startedSyncBlock = true;
       result += SYNC_START;
@@ -176,31 +165,66 @@ const scanSyncBlockClears = (
     }
 
     if (input.startsWith(SYNC_END, index)) {
-      state.inSyncBlock = false;
+      result = releasePendingCursorHome(state, result);
+      resetSyncBlockState(state);
       result += SYNC_END;
       index += SYNC_END.length;
       continue;
     }
 
-    const privateMode = readPrivateModeCsi(input, index);
-    if (privateMode) {
-      if (privateMode.setsAlternate === true) {
-        state.inAlternateScreen = true;
-      } else if (privateMode.setsAlternate === false) {
-        state.inAlternateScreen = false;
-      }
-      result += privateMode.raw;
-      index = privateMode.end;
+    if (!state.inSyncBlock) {
+      result += input[index];
+      index += 1;
       continue;
     }
 
-    if (
-      state.inSyncBlock
-      && shouldStripClearInSyncBlock(state, term)
-      && input.startsWith(CLEAR, index)
-    ) {
+    if (state.fullRedrawBlock === false) {
+      result += input[index];
+      index += 1;
+      continue;
+    }
+
+    const cursorHome = readBlockCursorHome(input, index);
+    if (cursorHome) {
+      if (state.fullRedrawBlock === true) {
+        index = cursorHome.end;
+        continue;
+      }
+      if (!shouldStripFullRedrawClear(term)) {
+        result += cursorHome.raw;
+        index = cursorHome.end;
+        continue;
+      }
+      state.pendingCursorHome = cursorHome.raw;
+      index = cursorHome.end;
+      continue;
+    }
+
+    if (input.startsWith(CLEAR, index)) {
+      if (state.pendingCursorHome !== null) {
+        state.pendingCursorHome = null;
+        state.fullRedrawBlock = true;
+        index += CLEAR.length;
+        continue;
+      }
+      if (state.fullRedrawBlock === true) {
+        index += CLEAR.length;
+        continue;
+      }
+      if (!shouldStripFullRedrawClear(term)) {
+        result += CLEAR;
+        index += CLEAR.length;
+        continue;
+      }
+      state.fullRedrawBlock = false;
+      result += CLEAR;
       index += CLEAR.length;
       continue;
+    }
+
+    if (state.pendingCursorHome !== null) {
+      result += state.pendingCursorHome;
+      state.pendingCursorHome = null;
     }
 
     result += input[index];
@@ -213,8 +237,12 @@ const scanSyncBlockClears = (
 export const filterSyncBlockClearsWithMeta = (
   data: string,
   state: SyncBlockFilterState,
-  term: XTerm,
+  term?: XTerm,
 ): SyncBlockClearFilterResult => {
+  if (!state.inSyncBlock && !state.pending && !data.includes("\x1b")) {
+    return { output: data, startedSyncBlock: false };
+  }
+
   const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
   state.pending = pending;
   if (!emit) {
@@ -227,25 +255,12 @@ export const filterSyncBlockClearsWithMeta = (
 export const filterSyncBlockClears = (
   data: string,
   state: SyncBlockFilterState,
-  term: XTerm,
+  term?: XTerm,
 ): string => filterSyncBlockClearsWithMeta(data, state, term).output;
 
-export const createSyncBlockFilterState = (
-  term?: Pick<XTerm, "buffer">,
-): SyncBlockFilterState => ({
+export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
   inSyncBlock: false,
-  inAlternateScreen: term?.buffer?.active?.type === "alternate",
   pending: "",
+  pendingCursorHome: null,
+  fullRedrawBlock: null,
 });
-
-export const isTerminalViewportScrolledUp = (term: XTerm): boolean => {
-  const buffer = term.buffer?.active;
-  if (!buffer || buffer.type === "alternate") {
-    return false;
-  }
-
-  return buffer.viewportY < buffer.baseY;
-};
-
-export const shouldStripSyncBlockClears = (term: XTerm): boolean =>
-  isTerminalViewportScrolledUp(term);

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -1,0 +1,62 @@
+/**
+ * Strip `\x1b[2J` (ED — erase display) inside DEC Mode 2026 synchronized-output
+ * blocks before data reaches xterm.js.
+ *
+ * Coding CLIs such as Codex and Claude Code wrap full-screen redraws in
+ * `\x1b[?2026h` … `\x1b[?2026l`. Native terminals treat the enclosed clear as
+ * part of the atomic update, but xterm.js resets viewportY on every `\x1b[2J`,
+ * which yanks scroll position and makes earlier output appear "eaten".
+ *
+ * @see https://github.com/xtermjs/xterm.js/issues/5801
+ * @see https://github.com/openai/codex/issues/14277
+ */
+
+export type SyncBlockFilterState = {
+  inSyncBlock: boolean;
+};
+
+const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
+const CLEAR = "\x1b[2J";
+
+export const filterSyncBlockClears = (
+  data: string,
+  state: SyncBlockFilterState,
+): string => {
+  if (!state.inSyncBlock && !data.includes(SYNC_START)) {
+    return data;
+  }
+
+  let result = "";
+  let index = 0;
+
+  while (index < data.length) {
+    if (data.startsWith(SYNC_START, index)) {
+      state.inSyncBlock = true;
+      result += SYNC_START;
+      index += SYNC_START.length;
+      continue;
+    }
+
+    if (data.startsWith(SYNC_END, index)) {
+      state.inSyncBlock = false;
+      result += SYNC_END;
+      index += SYNC_END.length;
+      continue;
+    }
+
+    if (state.inSyncBlock && data.startsWith(CLEAR, index)) {
+      index += CLEAR.length;
+      continue;
+    }
+
+    result += data[index];
+    index += 1;
+  }
+
+  return result;
+};
+
+export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
+  inSyncBlock: false,
+});

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -7,56 +7,86 @@
  * part of the atomic update, but xterm.js resets viewportY on every `\x1b[2J`,
  * which yanks scroll position and makes earlier output appear "eaten".
  *
+ * PTY/IPC chunks can split escape sequences at arbitrary byte boundaries, so a
+ * trailing partial marker is held in `pending` until the next chunk completes it.
+ *
  * @see https://github.com/xtermjs/xterm.js/issues/5801
  * @see https://github.com/openai/codex/issues/14277
  */
 
 export type SyncBlockFilterState = {
   inSyncBlock: boolean;
+  /** Trailing bytes that may complete a marker in the next chunk. */
+  pending: string;
 };
 
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
 
-export const filterSyncBlockClears = (
-  data: string,
-  state: SyncBlockFilterState,
-): string => {
-  if (!state.inSyncBlock && !data.includes(SYNC_START)) {
-    return data;
-  }
+const MARKERS = [SYNC_START, SYNC_END, CLEAR] as const;
 
+const maxMarkerPrefixLength = Math.max(...MARKERS.map((marker) => marker.length)) - 1;
+
+const splitPendingMarkerSuffix = (input: string): { emit: string; pending: string } => {
+  const maxLength = Math.min(input.length, maxMarkerPrefixLength);
+  for (let length = maxLength; length > 0; length -= 1) {
+    const suffix = input.slice(-length);
+    if (MARKERS.some((marker) => marker.startsWith(suffix) && marker.length > suffix.length)) {
+      return {
+        emit: input.slice(0, -length),
+        pending: suffix,
+      };
+    }
+  }
+  return { emit: input, pending: "" };
+};
+
+const scanSyncBlockClears = (input: string, state: SyncBlockFilterState): string => {
   let result = "";
   let index = 0;
 
-  while (index < data.length) {
-    if (data.startsWith(SYNC_START, index)) {
+  while (index < input.length) {
+    if (input.startsWith(SYNC_START, index)) {
       state.inSyncBlock = true;
       result += SYNC_START;
       index += SYNC_START.length;
       continue;
     }
 
-    if (data.startsWith(SYNC_END, index)) {
+    if (input.startsWith(SYNC_END, index)) {
       state.inSyncBlock = false;
       result += SYNC_END;
       index += SYNC_END.length;
       continue;
     }
 
-    if (state.inSyncBlock && data.startsWith(CLEAR, index)) {
+    if (state.inSyncBlock && input.startsWith(CLEAR, index)) {
       index += CLEAR.length;
       continue;
     }
 
-    result += data[index];
+    result += input[index];
     index += 1;
   }
 
   return result;
 };
 
+export const filterSyncBlockClears = (
+  data: string,
+  state: SyncBlockFilterState,
+): string => {
+  const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
+  state.pending = pending;
+  if (!emit) {
+    return "";
+  }
+
+  return scanSyncBlockClears(emit, state);
+};
+
 export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
   inSyncBlock: false,
+  pending: "",
 });

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -125,8 +125,8 @@ export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
 });
 
 export const isTerminalViewportScrolledUp = (term: XTerm): boolean => {
-  const buffer = term.buffer.active;
-  if (buffer.type === "alternate") {
+  const buffer = term.buffer?.active;
+  if (!buffer || buffer.type === "alternate") {
     return false;
   }
 

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -49,19 +49,41 @@ const isIncompleteEscapePrefix = (suffix: string): boolean => {
   if (!suffix.startsWith("\x1b")) {
     return false;
   }
-  if (suffix === "\x1b") {
-    return true;
+
+  let index = 0;
+  while (index < suffix.length) {
+    if (suffix.startsWith("\x1b[", index)) {
+      let hasFinal = false;
+      for (let i = index + 2; i < suffix.length; i += 1) {
+        if (isCsiFinal(suffix[i])) {
+          index = i + 1;
+          hasFinal = true;
+          break;
+        }
+      }
+      if (!hasFinal) {
+        return true;
+      }
+      continue;
+    }
+
+    if (suffix[index] === "\x1b") {
+      if (index === suffix.length - 1) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+
+    index += 1;
   }
-  if (!suffix.startsWith("\x1b[")) {
-    return false;
-  }
-  const final = suffix[suffix.length - 1];
-  return !isCsiFinal(final);
+
+  return false;
 };
 
 const splitPendingMarkerSuffix = (input: string): { emit: string; pending: string } => {
-  const maxLength = Math.min(input.length, maxMarkerPrefixLength);
-  for (let length = maxLength; length > 0; length -= 1) {
+  const markerMax = Math.min(input.length, maxMarkerPrefixLength);
+  for (let length = markerMax; length > 0; length -= 1) {
     const suffix = input.slice(-length);
     if (MARKERS.some((marker) => marker.startsWith(suffix) && marker.length > suffix.length)) {
       return {
@@ -69,6 +91,10 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
         pending: suffix,
       };
     }
+  }
+
+  for (let length = input.length; length > 0; length -= 1) {
+    const suffix = input.slice(-length);
     if (isIncompleteEscapePrefix(suffix)) {
       return {
         emit: input.slice(0, -length),
@@ -76,6 +102,7 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
       };
     }
   }
+
   return { emit: input, pending: "" };
 };
 
@@ -89,8 +116,16 @@ const readPrivateModeCsi = (
 
   for (let end = index + 3; end < input.length; end += 1) {
     const final = input[end];
-    if (final !== "h" && final !== "l") {
+    if (!isCsiFinal(final)) {
       continue;
+    }
+
+    if (final !== "h" && final !== "l") {
+      return {
+        raw: input.slice(index, end + 1),
+        end: end + 1,
+        setsAlternate: null,
+      };
     }
 
     const params = input.slice(index + 3, end).split(";");

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -31,6 +31,11 @@ export type SyncBlockClearFilterOptions = {
   stripClearsInSyncBlock: boolean;
 };
 
+export type SyncBlockClearFilterResult = {
+  output: string;
+  startedSyncBlock: boolean;
+};
+
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
@@ -57,13 +62,15 @@ const scanSyncBlockClears = (
   input: string,
   state: SyncBlockFilterState,
   stripClearsInSyncBlock: boolean,
-): string => {
+): SyncBlockClearFilterResult => {
   let result = "";
+  let startedSyncBlock = false;
   let index = 0;
 
   while (index < input.length) {
     if (input.startsWith(SYNC_START, index)) {
       state.inSyncBlock = true;
+      startedSyncBlock = true;
       result += SYNC_START;
       index += SYNC_START.length;
       continue;
@@ -89,22 +96,28 @@ const scanSyncBlockClears = (
     index += 1;
   }
 
-  return result;
+  return { output: result, startedSyncBlock };
+};
+
+export const filterSyncBlockClearsWithMeta = (
+  data: string,
+  state: SyncBlockFilterState,
+  options: SyncBlockClearFilterOptions = { stripClearsInSyncBlock: true },
+): SyncBlockClearFilterResult => {
+  const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
+  state.pending = pending;
+  if (!emit) {
+    return { output: "", startedSyncBlock: false };
+  }
+
+  return scanSyncBlockClears(emit, state, options.stripClearsInSyncBlock);
 };
 
 export const filterSyncBlockClears = (
   data: string,
   state: SyncBlockFilterState,
   options: SyncBlockClearFilterOptions = { stripClearsInSyncBlock: true },
-): string => {
-  const { emit, pending } = splitPendingMarkerSuffix(`${state.pending}${data}`);
-  state.pending = pending;
-  if (!emit) {
-    return "";
-  }
-
-  return scanSyncBlockClears(emit, state, options.stripClearsInSyncBlock);
-};
+): string => filterSyncBlockClearsWithMeta(data, state, options).output;
 
 export const createSyncBlockFilterState = (): SyncBlockFilterState => ({
   inSyncBlock: false,
@@ -117,8 +130,7 @@ export const isTerminalViewportScrolledUp = (term: XTerm): boolean => {
     return false;
   }
 
-  const maxBaseY = Math.max(0, buffer.length - term.rows);
-  return buffer.baseY < maxBaseY;
+  return buffer.viewportY < buffer.baseY;
 };
 
 export const shouldStripSyncBlockClears = (term: XTerm): boolean =>

--- a/components/terminal/runtime/filterSyncBlockClears.ts
+++ b/components/terminal/runtime/filterSyncBlockClears.ts
@@ -37,18 +37,27 @@ export type SyncBlockClearFilterResult = {
 const SYNC_START = "\x1b[?2026h";
 const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
-const ALT_SCREEN_ENTER = ["\x1b[?1049h", "\x1b[?1047h", "\x1b[?47h"] as const;
-const ALT_SCREEN_LEAVE = ["\x1b[?1049l", "\x1b[?1047l", "\x1b[?47l"] as const;
 
-const MARKERS = [
-  SYNC_START,
-  SYNC_END,
-  CLEAR,
-  ...ALT_SCREEN_ENTER,
-  ...ALT_SCREEN_LEAVE,
-] as const;
+const MARKERS = [SYNC_START, SYNC_END, CLEAR] as const;
+const ALTERNATE_SCREEN_MODES = new Set([47, 1047, 1049]);
 
 const maxMarkerPrefixLength = Math.max(...MARKERS.map((marker) => marker.length)) - 1;
+
+const isCsiFinal = (ch: string): boolean => ch >= "@" && ch <= "~";
+
+const isIncompleteEscapePrefix = (suffix: string): boolean => {
+  if (!suffix.startsWith("\x1b")) {
+    return false;
+  }
+  if (suffix === "\x1b") {
+    return true;
+  }
+  if (!suffix.startsWith("\x1b[")) {
+    return false;
+  }
+  const final = suffix[suffix.length - 1];
+  return !isCsiFinal(final);
+};
 
 const splitPendingMarkerSuffix = (input: string): { emit: string; pending: string } => {
   const maxLength = Math.min(input.length, maxMarkerPrefixLength);
@@ -60,16 +69,46 @@ const splitPendingMarkerSuffix = (input: string): { emit: string; pending: strin
         pending: suffix,
       };
     }
+    if (isIncompleteEscapePrefix(suffix)) {
+      return {
+        emit: input.slice(0, -length),
+        pending: suffix,
+      };
+    }
   }
   return { emit: input, pending: "" };
 };
 
-const matchMarker = (input: string, index: number, markers: readonly string[]): string | null => {
-  for (const marker of markers) {
-    if (input.startsWith(marker, index)) {
-      return marker;
-    }
+const readPrivateModeCsi = (
+  input: string,
+  index: number,
+): { raw: string; end: number; setsAlternate: boolean | null } | null => {
+  if (!input.startsWith("\x1b[?", index)) {
+    return null;
   }
+
+  for (let end = index + 3; end < input.length; end += 1) {
+    const final = input[end];
+    if (final !== "h" && final !== "l") {
+      continue;
+    }
+
+    const params = input.slice(index + 3, end).split(";");
+    let setsAlternate: boolean | null = null;
+    for (const param of params) {
+      const mode = Number.parseInt(param, 10);
+      if (ALTERNATE_SCREEN_MODES.has(mode)) {
+        setsAlternate = final === "h";
+      }
+    }
+
+    return {
+      raw: input.slice(index, end + 1),
+      end: end + 1,
+      setsAlternate,
+    };
+  }
+
   return null;
 };
 
@@ -93,22 +132,6 @@ const scanSyncBlockClears = (
   let index = 0;
 
   while (index < input.length) {
-    const alternateEnter = matchMarker(input, index, ALT_SCREEN_ENTER);
-    if (alternateEnter) {
-      state.inAlternateScreen = true;
-      result += alternateEnter;
-      index += alternateEnter.length;
-      continue;
-    }
-
-    const alternateLeave = matchMarker(input, index, ALT_SCREEN_LEAVE);
-    if (alternateLeave) {
-      state.inAlternateScreen = false;
-      result += alternateLeave;
-      index += alternateLeave.length;
-      continue;
-    }
-
     if (input.startsWith(SYNC_START, index)) {
       state.inSyncBlock = true;
       startedSyncBlock = true;
@@ -121,6 +144,18 @@ const scanSyncBlockClears = (
       state.inSyncBlock = false;
       result += SYNC_END;
       index += SYNC_END.length;
+      continue;
+    }
+
+    const privateMode = readPrivateModeCsi(input, index);
+    if (privateMode) {
+      if (privateMode.setsAlternate === true) {
+        state.inAlternateScreen = true;
+      } else if (privateMode.setsAlternate === false) {
+        state.inAlternateScreen = false;
+      }
+      result += privateMode.raw;
+      index = privateMode.end;
       continue;
     }
 

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -22,6 +22,11 @@ import {
   filterTerminalSessionData,
   resetTerminalSyncBlockFilter,
 } from "./terminalSyncBlockFilter";
+import {
+  enqueueCoalescedTerminalWrite,
+  flushTerminalWriteCoalescer,
+  resetTerminalWriteCoalescer,
+} from "./terminalWriteCoalescer";
 
 export const buildTermEnv = (host: Host, terminalSettings?: TerminalSettings) => {
   const env: Record<string, string> = {
@@ -145,10 +150,20 @@ export const writeSessionData = (
   term: XTerm,
   data: string,
 ) => {
-  const displayData = filterTerminalSessionData(term, data);
+  enqueueCoalescedTerminalWrite(term, data, (batch) => {
+    writeSessionDataImmediate(ctx, term, batch);
+  });
+};
+
+const writeSessionDataImmediate = (
+  ctx: TerminalSessionStartersContext,
+  term: XTerm,
+  data: string,
+) => {
   const flow = getFlowController(ctx, term);
-  flow.received(displayData.length);
+  flow.received(data.length);
   enqueueTerminalWrite(term, (done) => {
+    const displayData = filterTerminalSessionData(term, data);
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
     if (!forcePromptNewLine && ctx.promptLineBreakStateRef?.current) {
@@ -251,6 +266,8 @@ export const attachSessionToTerminal = (
   ctx.sessionRef.current = id;
   // Clear any stale back-pressure accounting from a prior session on this term.
   getFlowController(ctx, term).reset();
+  flushTerminalWriteCoalescer(term);
+  resetTerminalWriteCoalescer(term);
   resetTerminalSyncBlockFilter(term);
   resetTerminalLineTimestamps(term);
   ctx.onSessionAttached?.(id);

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -18,6 +18,10 @@ import {
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps";
 import { createSudoPasswordAutofill } from "./terminalSudoAutofill";
+import {
+  filterTerminalSessionData,
+  resetTerminalSyncBlockFilter,
+} from "./terminalSyncBlockFilter";
 
 export const buildTermEnv = (host: Host, terminalSettings?: TerminalSettings) => {
   const env: Record<string, string> = {
@@ -141,8 +145,9 @@ export const writeSessionData = (
   term: XTerm,
   data: string,
 ) => {
+  const displayData = filterTerminalSessionData(term, data);
   const flow = getFlowController(ctx, term);
-  flow.received(data.length);
+  flow.received(displayData.length);
   enqueueTerminalWrite(term, (done) => {
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
@@ -150,8 +155,8 @@ export const writeSessionData = (
       ctx.promptLineBreakStateRef.current.pendingCommand = false;
       ctx.promptLineBreakStateRef.current.suppressNextPromptCache = false;
     }
-    const pasteDisplayData = prepareTerminalDataForUserPasteDisplay(term, data);
-    const displayData = prepareTerminalDataForPromptLineBreak(
+    const pasteDisplayData = prepareTerminalDataForUserPasteDisplay(term, displayData);
+    const preparedDisplayData = prepareTerminalDataForPromptLineBreak(
       term,
       pasteDisplayData,
       ctx.promptLineBreakStateRef?.current,
@@ -177,10 +182,10 @@ export const writeSessionData = (
       }
       done();
       // Acknowledge the chunk so back-pressure can ease once xterm catches up.
-      flow.written(data.length);
+      flow.written(displayData.length);
     };
 
-    writeTerminalDataWithLineTimestamps(term, displayData, afterWrite);
+    writeTerminalDataWithLineTimestamps(term, preparedDisplayData, afterWrite);
   });
 };
 
@@ -246,6 +251,7 @@ export const attachSessionToTerminal = (
   ctx.sessionRef.current = id;
   // Clear any stale back-pressure accounting from a prior session on this term.
   getFlowController(ctx, term).reset();
+  resetTerminalSyncBlockFilter(term);
   resetTerminalLineTimestamps(term);
   ctx.onSessionAttached?.(id);
   const sudoAutofill = createSudoPasswordAutofill({

--- a/components/terminal/runtime/terminalSyncBlockFilter.test.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.test.ts
@@ -10,39 +10,29 @@ import {
 } from "./terminalSyncBlockFilter.ts";
 
 const SYNC_START = "\x1b[?2026h";
+const SYNC_END = "\x1b[?2026l";
 const CLEAR = "\x1b[2J";
+const CURSOR_HOME = "\x1b[H";
 
-const createMockTerm = ({
-  type = "normal",
-  viewportY = 10,
-  baseY = 76,
-  length = 100,
-  rows = 24,
-}: {
-  type?: "normal" | "alternate";
-  viewportY?: number;
-  baseY?: number;
-  length?: number;
-  rows?: number;
-} = {}): XTerm => ({
-  rows,
+const createMockTerm = (): XTerm => ({
+  rows: 24,
   buffer: {
     active: {
-      type,
-      baseY,
-      length,
-      viewportY,
+      type: "normal",
+      viewportY: 0,
+      baseY: 5,
     },
   },
-} as unknown as XTerm);
+} as XTerm);
 
-test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
+test("abandoned sync blocks stop stripping full redraw clears after timeout", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ viewportY: 10, baseY: 76 });
+  const term = createMockTerm();
 
   try {
     resetTerminalSyncBlockFilter(term);
     assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
+    assert.equal(filterTerminalSessionData(term, CURSOR_HOME), "");
     assert.equal(filterTerminalSessionData(term, CLEAR), "");
 
     mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
@@ -55,13 +45,13 @@ test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
 
 test("completed sync blocks clear the timeout without waiting", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ viewportY: 10, baseY: 76 });
+  const term = createMockTerm();
 
   try {
     resetTerminalSyncBlockFilter(term);
     assert.equal(
-      filterTerminalSessionData(term, `${SYNC_START}frame\x1b[?2026l`),
-      `${SYNC_START}frame\x1b[?2026l`,
+      filterTerminalSessionData(term, `${SYNC_START}${CURSOR_HOME}${CLEAR}frame${SYNC_END}`),
+      `${SYNC_START}frame${SYNC_END}`,
     );
 
     mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
@@ -72,30 +62,19 @@ test("completed sync blocks clear the timeout without waiting", () => {
   }
 });
 
-test("sync block timeout is armed once even when output keeps streaming", () => {
-  mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ viewportY: 10, baseY: 76 });
+test("passes incremental sync blocks through unchanged", () => {
+  const term = createMockTerm();
+  resetTerminalSyncBlockFilter(term);
 
-  try {
-    resetTerminalSyncBlockFilter(term);
-    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
-    assert.equal(filterTerminalSessionData(term, "frame-1"), "frame-1");
-    assert.equal(filterTerminalSessionData(term, "frame-2"), "frame-2");
-
-    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS - 1);
-    assert.equal(filterTerminalSessionData(term, CLEAR), "");
-
-    mock.timers.tick(1);
-    assert.equal(filterTerminalSessionData(term, CLEAR), CLEAR);
-  } finally {
-    resetTerminalSyncBlockFilter(term);
-    mock.timers.reset();
-  }
+  assert.equal(
+    filterTerminalSessionData(term, `${SYNC_START}\x1b[5;1Hframe${SYNC_END}`),
+    `${SYNC_START}\x1b[5;1Hframe${SYNC_END}`,
+  );
 });
 
 test("sync block timeout preserves pending partial marker bytes", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ viewportY: 10, baseY: 76 });
+  const term = createMockTerm();
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -104,48 +83,6 @@ test("sync block timeout preserves pending partial marker bytes", () => {
 
     mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
     assert.equal(filterTerminalSessionData(term, "[31mtext"), "\x1b[31mtext");
-  } finally {
-    resetTerminalSyncBlockFilter(term);
-    mock.timers.reset();
-  }
-});
-
-test("preserves clear-screen redraws on alternate-screen buffers", () => {
-  const term = createMockTerm({ type: "alternate", viewportY: 0, baseY: 0, length: 24 });
-  resetTerminalSyncBlockFilter(term);
-
-  assert.equal(
-    filterTerminalSessionData(term, `${SYNC_START}${CLEAR}frame\x1b[?2026l`),
-    `${SYNC_START}${CLEAR}frame\x1b[?2026l`,
-  );
-});
-
-test("preserves clear-screen redraws when the viewport is at the bottom", () => {
-  const term = createMockTerm({ viewportY: 76, baseY: 76, length: 100 });
-  resetTerminalSyncBlockFilter(term);
-
-  assert.equal(
-    filterTerminalSessionData(term, `${SYNC_START}${CLEAR}frame\x1b[?2026l`),
-    `${SYNC_START}${CLEAR}frame\x1b[?2026l`,
-  );
-});
-
-test("restarts sync timeout when back-to-back blocks arrive in one chunk", () => {
-  mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ viewportY: 10, baseY: 76 });
-
-  try {
-    resetTerminalSyncBlockFilter(term);
-    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
-
-    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS - 1);
-    assert.equal(
-      filterTerminalSessionData(term, `\x1b[?2026l${SYNC_START}${CLEAR}`),
-      `\x1b[?2026l${SYNC_START}`,
-    );
-
-    mock.timers.tick(1);
-    assert.equal(filterTerminalSessionData(term, CLEAR), "");
   } finally {
     resetTerminalSyncBlockFilter(term);
     mock.timers.reset();

--- a/components/terminal/runtime/terminalSyncBlockFilter.test.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.test.ts
@@ -12,10 +12,31 @@ import {
 const SYNC_START = "\x1b[?2026h";
 const CLEAR = "\x1b[2J";
 
-const term = {} as XTerm;
+const createMockTerm = ({
+  type = "normal",
+  baseY = 76,
+  length = 100,
+  rows = 24,
+}: {
+  type?: "normal" | "alternate";
+  baseY?: number;
+  length?: number;
+  rows?: number;
+} = {}): XTerm => ({
+  rows,
+  buffer: {
+    active: {
+      type,
+      baseY,
+      length,
+      viewportY: baseY,
+    },
+  },
+} as unknown as XTerm);
 
 test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
+  const term = createMockTerm({ baseY: 10 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -32,6 +53,7 @@ test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
 
 test("completed sync blocks clear the timeout without waiting", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
+  const term = createMockTerm({ baseY: 10 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -50,6 +72,7 @@ test("completed sync blocks clear the timeout without waiting", () => {
 
 test("sync block timeout is armed once even when output keeps streaming", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
+  const term = createMockTerm({ baseY: 10 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -70,6 +93,7 @@ test("sync block timeout is armed once even when output keeps streaming", () => 
 
 test("sync block timeout preserves pending partial marker bytes", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
+  const term = createMockTerm({ baseY: 10 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -82,4 +106,24 @@ test("sync block timeout preserves pending partial marker bytes", () => {
     resetTerminalSyncBlockFilter(term);
     mock.timers.reset();
   }
+});
+
+test("preserves clear-screen redraws on alternate-screen buffers", () => {
+  const term = createMockTerm({ type: "alternate", baseY: 0, length: 24 });
+  resetTerminalSyncBlockFilter(term);
+
+  assert.equal(
+    filterTerminalSessionData(term, `${SYNC_START}${CLEAR}frame\x1b[?2026l`),
+    `${SYNC_START}${CLEAR}frame\x1b[?2026l`,
+  );
+});
+
+test("preserves clear-screen redraws when the viewport is at the bottom", () => {
+  const term = createMockTerm({ baseY: 76, length: 100 });
+  resetTerminalSyncBlockFilter(term);
+
+  assert.equal(
+    filterTerminalSessionData(term, `${SYNC_START}${CLEAR}frame\x1b[?2026l`),
+    `${SYNC_START}${CLEAR}frame\x1b[?2026l`,
+  );
 });

--- a/components/terminal/runtime/terminalSyncBlockFilter.test.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.test.ts
@@ -47,3 +47,39 @@ test("completed sync blocks clear the timeout without waiting", () => {
     mock.timers.reset();
   }
 });
+
+test("sync block timeout is armed once even when output keeps streaming", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  try {
+    resetTerminalSyncBlockFilter(term);
+    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
+    assert.equal(filterTerminalSessionData(term, "frame-1"), "frame-1");
+    assert.equal(filterTerminalSessionData(term, "frame-2"), "frame-2");
+
+    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS - 1);
+    assert.equal(filterTerminalSessionData(term, CLEAR), "");
+
+    mock.timers.tick(1);
+    assert.equal(filterTerminalSessionData(term, CLEAR), CLEAR);
+  } finally {
+    resetTerminalSyncBlockFilter(term);
+    mock.timers.reset();
+  }
+});
+
+test("sync block timeout preserves pending partial marker bytes", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  try {
+    resetTerminalSyncBlockFilter(term);
+    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
+    assert.equal(filterTerminalSessionData(term, "color\x1b"), "color");
+
+    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
+    assert.equal(filterTerminalSessionData(term, "[31mtext"), "\x1b[31mtext");
+  } finally {
+    resetTerminalSyncBlockFilter(term);
+    mock.timers.reset();
+  }
+});

--- a/components/terminal/runtime/terminalSyncBlockFilter.test.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import {
+  filterTerminalSessionData,
+  resetTerminalSyncBlockFilter,
+  SYNC_BLOCK_TIMEOUT_MS,
+} from "./terminalSyncBlockFilter.ts";
+
+const SYNC_START = "\x1b[?2026h";
+const CLEAR = "\x1b[2J";
+
+const term = {} as XTerm;
+
+test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  try {
+    resetTerminalSyncBlockFilter(term);
+    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
+    assert.equal(filterTerminalSessionData(term, CLEAR), "");
+
+    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
+    assert.equal(filterTerminalSessionData(term, CLEAR), CLEAR);
+  } finally {
+    resetTerminalSyncBlockFilter(term);
+    mock.timers.reset();
+  }
+});
+
+test("completed sync blocks clear the timeout without waiting", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+
+  try {
+    resetTerminalSyncBlockFilter(term);
+    assert.equal(
+      filterTerminalSessionData(term, `${SYNC_START}frame\x1b[?2026l`),
+      `${SYNC_START}frame\x1b[?2026l`,
+    );
+
+    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS);
+    assert.equal(filterTerminalSessionData(term, CLEAR), CLEAR);
+  } finally {
+    resetTerminalSyncBlockFilter(term);
+    mock.timers.reset();
+  }
+});

--- a/components/terminal/runtime/terminalSyncBlockFilter.test.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.test.ts
@@ -14,11 +14,13 @@ const CLEAR = "\x1b[2J";
 
 const createMockTerm = ({
   type = "normal",
+  viewportY = 10,
   baseY = 76,
   length = 100,
   rows = 24,
 }: {
   type?: "normal" | "alternate";
+  viewportY?: number;
   baseY?: number;
   length?: number;
   rows?: number;
@@ -29,14 +31,14 @@ const createMockTerm = ({
       type,
       baseY,
       length,
-      viewportY: baseY,
+      viewportY,
     },
   },
 } as unknown as XTerm);
 
 test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ baseY: 10 });
+  const term = createMockTerm({ viewportY: 10, baseY: 76 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -53,7 +55,7 @@ test("abandoned sync blocks stop stripping clear-screen after timeout", () => {
 
 test("completed sync blocks clear the timeout without waiting", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ baseY: 10 });
+  const term = createMockTerm({ viewportY: 10, baseY: 76 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -72,7 +74,7 @@ test("completed sync blocks clear the timeout without waiting", () => {
 
 test("sync block timeout is armed once even when output keeps streaming", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ baseY: 10 });
+  const term = createMockTerm({ viewportY: 10, baseY: 76 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -93,7 +95,7 @@ test("sync block timeout is armed once even when output keeps streaming", () => 
 
 test("sync block timeout preserves pending partial marker bytes", () => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  const term = createMockTerm({ baseY: 10 });
+  const term = createMockTerm({ viewportY: 10, baseY: 76 });
 
   try {
     resetTerminalSyncBlockFilter(term);
@@ -109,7 +111,7 @@ test("sync block timeout preserves pending partial marker bytes", () => {
 });
 
 test("preserves clear-screen redraws on alternate-screen buffers", () => {
-  const term = createMockTerm({ type: "alternate", baseY: 0, length: 24 });
+  const term = createMockTerm({ type: "alternate", viewportY: 0, baseY: 0, length: 24 });
   resetTerminalSyncBlockFilter(term);
 
   assert.equal(
@@ -119,11 +121,33 @@ test("preserves clear-screen redraws on alternate-screen buffers", () => {
 });
 
 test("preserves clear-screen redraws when the viewport is at the bottom", () => {
-  const term = createMockTerm({ baseY: 76, length: 100 });
+  const term = createMockTerm({ viewportY: 76, baseY: 76, length: 100 });
   resetTerminalSyncBlockFilter(term);
 
   assert.equal(
     filterTerminalSessionData(term, `${SYNC_START}${CLEAR}frame\x1b[?2026l`),
     `${SYNC_START}${CLEAR}frame\x1b[?2026l`,
   );
+});
+
+test("restarts sync timeout when back-to-back blocks arrive in one chunk", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  const term = createMockTerm({ viewportY: 10, baseY: 76 });
+
+  try {
+    resetTerminalSyncBlockFilter(term);
+    assert.equal(filterTerminalSessionData(term, SYNC_START), SYNC_START);
+
+    mock.timers.tick(SYNC_BLOCK_TIMEOUT_MS - 1);
+    assert.equal(
+      filterTerminalSessionData(term, `\x1b[?2026l${SYNC_START}${CLEAR}`),
+      `\x1b[?2026l${SYNC_START}`,
+    );
+
+    mock.timers.tick(1);
+    assert.equal(filterTerminalSessionData(term, CLEAR), "");
+  } finally {
+    resetTerminalSyncBlockFilter(term);
+    mock.timers.reset();
+  }
 });

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -3,7 +3,6 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import {
   createSyncBlockFilterState,
   filterSyncBlockClearsWithMeta,
-  shouldStripSyncBlockClears,
   type SyncBlockFilterState,
 } from "./filterSyncBlockClears.ts";
 
@@ -29,13 +28,13 @@ const expireSyncBlock = (term: XTerm, state: SyncBlockFilterState): void => {
 
 export const resetTerminalSyncBlockFilter = (term: XTerm): void => {
   clearSyncBlockTimer(term);
-  syncBlockFilterStates.set(term, createSyncBlockFilterState());
+  syncBlockFilterStates.set(term, createSyncBlockFilterState(term));
 };
 
 const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
   let state = syncBlockFilterStates.get(term);
   if (!state) {
-    state = createSyncBlockFilterState();
+    state = createSyncBlockFilterState(term);
     syncBlockFilterStates.set(term, state);
   }
   return state;
@@ -57,9 +56,7 @@ const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): voi
 
 export const filterTerminalSessionData = (term: XTerm, data: string): string => {
   const state = getSyncBlockFilterState(term);
-  const { output, startedSyncBlock } = filterSyncBlockClearsWithMeta(data, state, {
-    stripClearsInSyncBlock: shouldStripSyncBlockClears(term),
-  });
+  const { output, startedSyncBlock } = filterSyncBlockClearsWithMeta(data, state, term);
 
   if (startedSyncBlock) {
     clearSyncBlockTimer(term);

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -21,31 +21,13 @@ const clearSyncBlockTimer = (term: XTerm): void => {
   syncBlockTimers.delete(term);
 };
 
-const abandonSyncBlock = (term: XTerm, state: SyncBlockFilterState): void => {
+const expireSyncBlock = (term: XTerm, state: SyncBlockFilterState): void => {
   state.inSyncBlock = false;
-  state.pending = "";
   clearSyncBlockTimer(term);
-};
-
-const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): void => {
-  clearSyncBlockTimer(term);
-  if (!state.inSyncBlock) {
-    return;
-  }
-  syncBlockTimers.set(
-    term,
-    setTimeout(() => {
-      syncBlockTimers.delete(term);
-      abandonSyncBlock(term, state);
-    }, SYNC_BLOCK_TIMEOUT_MS),
-  );
 };
 
 export const resetTerminalSyncBlockFilter = (term: XTerm): void => {
-  const state = syncBlockFilterStates.get(term);
-  if (state) {
-    abandonSyncBlock(term, state);
-  }
+  clearSyncBlockTimer(term);
   syncBlockFilterStates.set(term, createSyncBlockFilterState());
 };
 
@@ -58,13 +40,30 @@ const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
   return state;
 };
 
+const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): void => {
+  if (syncBlockTimers.has(term) || !state.inSyncBlock) {
+    return;
+  }
+
+  syncBlockTimers.set(
+    term,
+    setTimeout(() => {
+      syncBlockTimers.delete(term);
+      expireSyncBlock(term, state);
+    }, SYNC_BLOCK_TIMEOUT_MS),
+  );
+};
+
 export const filterTerminalSessionData = (term: XTerm, data: string): string => {
   const state = getSyncBlockFilterState(term);
+  const wasInSyncBlock = state.inSyncBlock;
   const filtered = filterSyncBlockClears(data, state);
-  if (state.inSyncBlock) {
+
+  if (state.inSyncBlock && !wasInSyncBlock) {
     scheduleSyncBlockTimeout(term, state);
-  } else {
+  } else if (!state.inSyncBlock) {
     clearSyncBlockTimer(term);
   }
+
   return filtered;
 };

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -3,6 +3,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import {
   createSyncBlockFilterState,
   filterSyncBlockClears,
+  shouldStripSyncBlockClears,
   type SyncBlockFilterState,
 } from "./filterSyncBlockClears.ts";
 
@@ -57,7 +58,9 @@ const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): voi
 export const filterTerminalSessionData = (term: XTerm, data: string): string => {
   const state = getSyncBlockFilterState(term);
   const wasInSyncBlock = state.inSyncBlock;
-  const filtered = filterSyncBlockClears(data, state);
+  const filtered = filterSyncBlockClears(data, state, {
+    stripClearsInSyncBlock: shouldStripSyncBlockClears(term),
+  });
 
   if (state.inSyncBlock && !wasInSyncBlock) {
     scheduleSyncBlockTimeout(term, state);

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -23,18 +23,20 @@ const clearSyncBlockTimer = (term: XTerm): void => {
 
 const expireSyncBlock = (term: XTerm, state: SyncBlockFilterState): void => {
   state.inSyncBlock = false;
+  state.pendingCursorHome = null;
+  state.fullRedrawBlock = null;
   clearSyncBlockTimer(term);
 };
 
 export const resetTerminalSyncBlockFilter = (term: XTerm): void => {
   clearSyncBlockTimer(term);
-  syncBlockFilterStates.set(term, createSyncBlockFilterState(term));
+  syncBlockFilterStates.set(term, createSyncBlockFilterState());
 };
 
 const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
   let state = syncBlockFilterStates.get(term);
   if (!state) {
-    state = createSyncBlockFilterState(term);
+    state = createSyncBlockFilterState();
     syncBlockFilterStates.set(term, state);
   }
   return state;

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -1,0 +1,25 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import {
+  createSyncBlockFilterState,
+  filterSyncBlockClears,
+  type SyncBlockFilterState,
+} from "./filterSyncBlockClears.ts";
+
+const syncBlockFilterStates = new WeakMap<XTerm, SyncBlockFilterState>();
+
+export const resetTerminalSyncBlockFilter = (term: XTerm): void => {
+  syncBlockFilterStates.set(term, createSyncBlockFilterState());
+};
+
+const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
+  let state = syncBlockFilterStates.get(term);
+  if (!state) {
+    state = createSyncBlockFilterState();
+    syncBlockFilterStates.set(term, state);
+  }
+  return state;
+};
+
+export const filterTerminalSessionData = (term: XTerm, data: string): string =>
+  filterSyncBlockClears(data, getSyncBlockFilterState(term));

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -6,9 +6,46 @@ import {
   type SyncBlockFilterState,
 } from "./filterSyncBlockClears.ts";
 
+/** Matches @xterm/xterm RenderService SYNCHRONIZED_OUTPUT_TIMEOUT_MS. */
+export const SYNC_BLOCK_TIMEOUT_MS = 1000;
+
 const syncBlockFilterStates = new WeakMap<XTerm, SyncBlockFilterState>();
+const syncBlockTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
+
+const clearSyncBlockTimer = (term: XTerm): void => {
+  const timer = syncBlockTimers.get(term);
+  if (timer === undefined) {
+    return;
+  }
+  clearTimeout(timer);
+  syncBlockTimers.delete(term);
+};
+
+const abandonSyncBlock = (term: XTerm, state: SyncBlockFilterState): void => {
+  state.inSyncBlock = false;
+  state.pending = "";
+  clearSyncBlockTimer(term);
+};
+
+const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): void => {
+  clearSyncBlockTimer(term);
+  if (!state.inSyncBlock) {
+    return;
+  }
+  syncBlockTimers.set(
+    term,
+    setTimeout(() => {
+      syncBlockTimers.delete(term);
+      abandonSyncBlock(term, state);
+    }, SYNC_BLOCK_TIMEOUT_MS),
+  );
+};
 
 export const resetTerminalSyncBlockFilter = (term: XTerm): void => {
+  const state = syncBlockFilterStates.get(term);
+  if (state) {
+    abandonSyncBlock(term, state);
+  }
   syncBlockFilterStates.set(term, createSyncBlockFilterState());
 };
 
@@ -21,5 +58,13 @@ const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
   return state;
 };
 
-export const filterTerminalSessionData = (term: XTerm, data: string): string =>
-  filterSyncBlockClears(data, getSyncBlockFilterState(term));
+export const filterTerminalSessionData = (term: XTerm, data: string): string => {
+  const state = getSyncBlockFilterState(term);
+  const filtered = filterSyncBlockClears(data, state);
+  if (state.inSyncBlock) {
+    scheduleSyncBlockTimeout(term, state);
+  } else {
+    clearSyncBlockTimer(term);
+  }
+  return filtered;
+};

--- a/components/terminal/runtime/terminalSyncBlockFilter.ts
+++ b/components/terminal/runtime/terminalSyncBlockFilter.ts
@@ -2,7 +2,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
   createSyncBlockFilterState,
-  filterSyncBlockClears,
+  filterSyncBlockClearsWithMeta,
   shouldStripSyncBlockClears,
   type SyncBlockFilterState,
 } from "./filterSyncBlockClears.ts";
@@ -42,7 +42,7 @@ const getSyncBlockFilterState = (term: XTerm): SyncBlockFilterState => {
 };
 
 const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): void => {
-  if (syncBlockTimers.has(term) || !state.inSyncBlock) {
+  if (!state.inSyncBlock) {
     return;
   }
 
@@ -57,16 +57,16 @@ const scheduleSyncBlockTimeout = (term: XTerm, state: SyncBlockFilterState): voi
 
 export const filterTerminalSessionData = (term: XTerm, data: string): string => {
   const state = getSyncBlockFilterState(term);
-  const wasInSyncBlock = state.inSyncBlock;
-  const filtered = filterSyncBlockClears(data, state, {
+  const { output, startedSyncBlock } = filterSyncBlockClearsWithMeta(data, state, {
     stripClearsInSyncBlock: shouldStripSyncBlockClears(term),
   });
 
-  if (state.inSyncBlock && !wasInSyncBlock) {
+  if (startedSyncBlock) {
+    clearSyncBlockTimer(term);
     scheduleSyncBlockTimeout(term, state);
   } else if (!state.inSyncBlock) {
     clearSyncBlockTimer(term);
   }
 
-  return filtered;
+  return output;
 };

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -1,0 +1,27 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { createWriteCoalescer, type WriteCoalescer } from "./writeCoalescer.ts";
+
+const terminalWriteCoalescers = new WeakMap<XTerm, WriteCoalescer>();
+
+export const enqueueCoalescedTerminalWrite = (
+  term: XTerm,
+  data: string,
+  writeNow: (data: string) => void,
+): void => {
+  let coalescer = terminalWriteCoalescers.get(term);
+  if (!coalescer) {
+    coalescer = createWriteCoalescer(writeNow);
+    terminalWriteCoalescers.set(term, coalescer);
+  }
+  coalescer.push(data);
+};
+
+export const flushTerminalWriteCoalescer = (term: XTerm): void => {
+  terminalWriteCoalescers.get(term)?.flushSync();
+};
+
+export const resetTerminalWriteCoalescer = (term: XTerm): void => {
+  terminalWriteCoalescers.get(term)?.dispose();
+  terminalWriteCoalescers.delete(term);
+};

--- a/components/terminal/runtime/writeCoalescer.test.ts
+++ b/components/terminal/runtime/writeCoalescer.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+
+import {
+  createWriteCoalescer,
+  MAX_PENDING_WRITE_COALESCE_BYTES,
+} from "./writeCoalescer.ts";
+
+type FrameCallback = (time: number) => void;
+
+let frameCallbacks: Map<number, FrameCallback>;
+let nextFrameId: number;
+let originalRaf: typeof requestAnimationFrame;
+let originalCancelRaf: typeof cancelAnimationFrame;
+
+const fireFrame = (): void => {
+  const callbacks = [...frameCallbacks.values()];
+  frameCallbacks.clear();
+  for (const callback of callbacks) {
+    callback(performance.now());
+  }
+};
+
+beforeEach(() => {
+  frameCallbacks = new Map();
+  nextFrameId = 1;
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  globalThis.requestAnimationFrame = (callback: FrameCallback) => {
+    const id = nextFrameId;
+    nextFrameId += 1;
+    frameCallbacks.set(id, callback);
+    return id;
+  };
+  globalThis.cancelAnimationFrame = (id: number) => {
+    frameCallbacks.delete(id);
+  };
+});
+
+afterEach(() => {
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+});
+
+test("coalesces chunks in the same frame into one write", () => {
+  const writes: string[] = [];
+  const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+  coalescer.push("foo");
+  coalescer.push("bar");
+  coalescer.push("baz");
+  assert.equal(writes.length, 0);
+
+  fireFrame();
+  assert.deepEqual(writes, ["foobarbaz"]);
+});
+
+test("schedules a new frame for data arriving after a flush", () => {
+  const writes: string[] = [];
+  const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+  coalescer.push("first");
+  fireFrame();
+  coalescer.push("second");
+  fireFrame();
+
+  assert.deepEqual(writes, ["first", "second"]);
+});
+
+test("flushSync writes pending bytes immediately and cancels the scheduled frame", () => {
+  const writes: string[] = [];
+  const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+  coalescer.push("pending");
+  coalescer.flushSync();
+  assert.deepEqual(writes, ["pending"]);
+
+  fireFrame();
+  assert.deepEqual(writes, ["pending"]);
+});
+
+test("flushes synchronously when pending bytes exceed the cap", () => {
+  const writes: string[] = [];
+  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const chunk = "x".repeat(MAX_PENDING_WRITE_COALESCE_BYTES);
+
+  coalescer.push(chunk);
+  coalescer.push("y");
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.length, MAX_PENDING_WRITE_COALESCE_BYTES + 1);
+});
+
+test("dispose flushes remaining bytes and stops accepting new chunks", () => {
+  const writes: string[] = [];
+  const coalescer = createWriteCoalescer((data) => writes.push(data));
+
+  coalescer.push("tail");
+  coalescer.dispose();
+  assert.deepEqual(writes, ["tail"]);
+
+  coalescer.push("ignored");
+  fireFrame();
+  assert.deepEqual(writes, ["tail"]);
+});

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -1,0 +1,72 @@
+/**
+ * Coalesces PTY output chunks into one xterm.write() per animation frame.
+ *
+ * Agent CLIs (Codex, Claude Code) emit full-screen repaints as many small PTY
+ * chunks. Writing each chunk individually triggers an xterm parse/render cycle
+ * per chunk, which can tear TUI frames (missing box borders, clipped bottom
+ * rows). Batching to the display refresh rate keeps rendering atomic per frame.
+ *
+ * Ported from superset-sh/superset (issues #2241 / #2244):
+ * apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
+ */
+
+/** Pending-byte ceiling when rAF is throttled (hidden window). */
+export const MAX_PENDING_WRITE_COALESCE_BYTES = 1024 * 1024;
+
+export type WriteCoalescer = {
+  push(chunk: string): void;
+  /** Flush pending bytes synchronously before ordered writes (exit notices). */
+  flushSync(): void;
+  dispose(): void;
+};
+
+export const createWriteCoalescer = (write: (data: string) => void): WriteCoalescer => {
+  let pending: string[] = [];
+  let pendingBytes = 0;
+  let frameId: number | null = null;
+  let disposed = false;
+
+  const flushSync = (): void => {
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (pendingBytes === 0) {
+      return;
+    }
+    const batch = pending.length === 1 ? pending[0]! : pending.join("");
+    pending = [];
+    pendingBytes = 0;
+    write(batch);
+  };
+
+  const push = (chunk: string): void => {
+    if (disposed || chunk.length === 0) {
+      return;
+    }
+    pending.push(chunk);
+    pendingBytes += chunk.length;
+    if (pendingBytes > MAX_PENDING_WRITE_COALESCE_BYTES) {
+      flushSync();
+      return;
+    }
+    if (frameId === null) {
+      frameId = requestAnimationFrame(() => {
+        frameId = null;
+        flushSync();
+      });
+    }
+  };
+
+  return {
+    push,
+    flushSync,
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      flushSync();
+      disposed = true;
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Filter `\x1b[2J` (erase display) inside DEC Mode 2026 synchronized-output blocks (`\x1b[?2026h` … `\x1b[?2026l`) at the PTY→xterm boundary before session data is written.
- Keep per-terminal sync-block state across chunked PTY output and reset it on session attach.
- Add unit tests for passthrough, in-block stripping, cross-chunk state, and unaffected non-clear sequences.

## Why
Codex and Claude Code wrap full-screen TUI redraws in DEC 2026 sync blocks. Native terminals treat the enclosed clear as part of an atomic update, but xterm.js resets `viewportY` on every `\x1b[2J`, which yanks scroll position and makes earlier output appear "eaten" during long sessions.

This follows the same approach as [Pane PR #120](https://github.com/dcouple/Pane/pull/120) and addresses reports in [openai/codex#14277](https://github.com/openai/codex/issues/14277) / [xtermjs/xterm.js#5801](https://github.com/xtermjs/xterm.js/issues/5801).

Fixes #1612

## Notes
- Only `\x1b[2J` inside active sync blocks is stripped; standalone `clear`, vim, and other TUIs are unaffected.
- Shift+wheel history preview (#1532) still applies for alternate-screen apps; this change improves in-session scroll stability while output streams.

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/filterSyncBlockClears.test.ts`
- [ ] Run Codex in Netcatty, generate multi-screen output, scroll up mid-stream — viewport should stay put while new frames render
- [ ] Run `clear` outside a coding CLI — should still clear the screen normally
- [ ] Open vim/htop — alternate-screen behavior should be unchanged


Made with [Cursor](https://cursor.com)