### PR TITLE
fix(telnet): allow input on silent no-auth sessions (#1632)

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts
@@ -237,6 +237,76 @@ test("startTelnet preserves an explicitly cleared telnet password", async () => 
   assert.equal(capturedOptions.password, "");
 });
 
+test("startTelnet marks the session connected before the server sends output", async () => {
+  let status = "connecting";
+  let progressValue = 0;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      telnetPort: 23,
+    },
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: (next: string) => { status = next; },
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: (value: number) => { progressValue = value; },
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+
+  assert.equal(status, "connected");
+  assert.equal(progressValue, 100);
+  assert.equal(ctx.sessionRef.current, "telnet-session");
+});
+
 test("startTelnet rejects unreadable saved telnet passwords before connecting", async () => {
   let started = false;
   let error = "";

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -649,6 +649,14 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         cleanupTelnetStartupWait();
         disposeTelnetExit?.();
       };
+
+      // Many telnet endpoints (especially no-auth devices) stay silent until
+      // the client sends data. Mark connected once the socket session is
+      // attached so the connection overlay dismisses and keyboard input works
+      // (issue #1632).
+      ctx.updateStatus("connected");
+      ctx.setProgressValue(100);
+
       if (waitsForAutoLogin) {
         return;
       }


### PR DESCRIPTION
## Summary
- Mark Telnet sessions as connected immediately after the socket attaches, matching the existing serial connection behavior
- Dismiss the connecting overlay without waiting for the first server output, so silent no-auth devices no longer block keyboard input
- Add regression test covering the no-output-before-input case

Fixes #1632

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts`
- [ ] Connect to a Telnet host with no login prompt and verify the overlay closes and keyboard input works
- [ ] Connect to a Telnet host with saved credentials + startup command and verify auto-login still runs before the startup command


Made with [Cursor](https://cursor.com)