### PR TITLE
fix(ui): defer terminal layout suppress notifications to avoid render warnings

### DIFF
--- a/application/state/terminalLayoutSuppressStore.test.ts
+++ b/application/state/terminalLayoutSuppressStore.test.ts
@@ -14,3 +14,26 @@ test('terminalLayoutSuppressStore tracks nested begin/end', () => {
   terminalLayoutSuppressStore.end();
   assert.equal(terminalLayoutSuppressStore.getActive(), false);
 });
+
+test('terminalLayoutSuppressStore defers subscriber notifications', async () => {
+  let notifyCount = 0;
+  const unsubscribe = terminalLayoutSuppressStore.subscribe(() => {
+    notifyCount += 1;
+  });
+
+  terminalLayoutSuppressStore.begin();
+  assert.equal(notifyCount, 0, 'begin should not notify synchronously');
+  assert.equal(terminalLayoutSuppressStore.getActive(), true);
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.equal(notifyCount, 1, 'begin should notify after the current turn');
+
+  terminalLayoutSuppressStore.end();
+  assert.equal(notifyCount, 1, 'end should not notify synchronously');
+  assert.equal(terminalLayoutSuppressStore.getActive(), false);
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  assert.equal(notifyCount, 2, 'end should notify after the current turn');
+
+  unsubscribe();
+});

--- a/application/state/terminalLayoutSuppressStore.ts
+++ b/application/state/terminalLayoutSuppressStore.ts
@@ -4,9 +4,19 @@ type Listener = () => void;
 
 let suppressDepth = 0;
 const listeners = new Set<Listener>();
+let notifyRafId: number | null = null;
 
-function emit() {
-  listeners.forEach((listener) => listener());
+const scheduleFrame =
+  typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : (cb: () => void) => setTimeout(cb, 0) as unknown as number;
+
+function scheduleEmit() {
+  if (notifyRafId !== null) return;
+  notifyRafId = scheduleFrame(() => {
+    notifyRafId = null;
+    listeners.forEach((listener) => listener());
+  });
 }
 
 export const terminalLayoutSuppressStore = {
@@ -19,14 +29,14 @@ export const terminalLayoutSuppressStore = {
 
   begin: () => {
     suppressDepth += 1;
-    emit();
+    scheduleEmit();
   },
 
   end: () => {
     const wasActive = suppressDepth > 0;
     suppressDepth = Math.max(0, suppressDepth - 1);
     if (wasActive) {
-      emit();
+      scheduleEmit();
     }
   },
 };


### PR DESCRIPTION
## Summary
- Defer `terminalLayoutSuppressStore` subscriber notifications to the next animation frame, matching the existing `activeTabStore` pattern
- Keep `getActive()` synchronous so tab switches and resize suppression behavior stay immediate
- Add a test verifying subscribers are not notified synchronously on `begin`/`end`

## Test plan
- [x] `node --test --import tsx application/state/terminalLayoutSuppressStore.test.ts`
- [ ] Switch top tabs and confirm the React warning no longer appears in devtools
- [ ] Drag terminal host tree / side panel resizers and confirm terminals still suppress resize during drag


Made with [Cursor](https://cursor.com)