### PR TITLE
feat(terminal): optimize hibernate wake for large buffers

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -483,6 +483,16 @@ export const enCoreMessages: Messages = {
   'settings.terminal.rendering.hibernateHiddenTabs.desc': 'Dispose the terminal renderer for off-screen tabs to save memory while keeping the SSH session connected. Skipped during file transfers.',
   'settings.terminal.rendering.hibernateHiddenTabsDelay': 'Hibernate delay',
   'settings.terminal.rendering.hibernateHiddenTabsDelay.desc': 'How long a tab must stay off-screen before its renderer is released (5–600 seconds).',
+  'settings.terminal.rendering.hibernateSkipAltScreen': 'Skip hibernate on full-screen apps',
+  'settings.terminal.rendering.hibernateSkipAltScreen.desc': 'Keep the terminal renderer alive while vim, htop, or agent TUIs own the alternate screen buffer.',
+  'settings.terminal.rendering.hibernateKeepRendererCount': 'Keep hidden renderers',
+  'settings.terminal.rendering.hibernateKeepRendererCount.desc': 'How many off-screen tabs keep their renderer alive (WebGL suspended) before full hibernate.',
+  'settings.terminal.rendering.hibernateUseHeadlessMirror': 'Main-process terminal mirror',
+  'settings.terminal.rendering.hibernateUseHeadlessMirror.desc': 'Mirror PTY output in a headless xterm on the main process for faster wake snapshots.',
+  'settings.terminal.rendering.hibernateReplayChunkBytes': 'Wake replay chunk size',
+  'settings.terminal.rendering.hibernateReplayChunkBytes.desc': 'Bytes replayed per animation frame when restoring a hibernated terminal (4–64 KB).',
+  'settings.terminal.rendering.hibernatePreferWasmSerialize': 'Prefer WASM serialize',
+  'settings.terminal.rendering.hibernatePreferWasmSerialize.desc': 'Use WASM terminal serialization when available; falls back to the JS serializer.',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': 'Workspace Focus Indicator',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -355,6 +355,16 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.rendering.hibernateHiddenTabs.desc': '标签页离开视野后释放终端渲染器以节省内存，SSH 连接保持不断。文件传输期间不会休眠。',
   'settings.terminal.rendering.hibernateHiddenTabsDelay': '休眠延迟',
   'settings.terminal.rendering.hibernateHiddenTabsDelay.desc': '标签页离开视野多久后释放渲染器（5–600 秒）。',
+  'settings.terminal.rendering.hibernateSkipAltScreen': '全屏 TUI 跳过休眠',
+  'settings.terminal.rendering.hibernateSkipAltScreen.desc': 'vim、htop 或 Agent TUI 占用 alternate screen 时保持终端渲染器，避免慢恢复。',
+  'settings.terminal.rendering.hibernateKeepRendererCount': '保留隐藏渲染器数量',
+  'settings.terminal.rendering.hibernateKeepRendererCount.desc': '多少个不可见标签页仅暂停 WebGL、不销毁 xterm，超出后才完整休眠。',
+  'settings.terminal.rendering.hibernateUseHeadlessMirror': '主进程终端镜像',
+  'settings.terminal.rendering.hibernateUseHeadlessMirror.desc': '在主进程用 headless xterm 镜像 PTY 输出，加快休眠唤醒时的快照获取。',
+  'settings.terminal.rendering.hibernateReplayChunkBytes': '唤醒分片大小',
+  'settings.terminal.rendering.hibernateReplayChunkBytes.desc': '恢复休眠终端时每帧回放的 ANSI 字节数（4–64 KB）。',
+  'settings.terminal.rendering.hibernatePreferWasmSerialize': '优先 WASM 序列化',
+  'settings.terminal.rendering.hibernatePreferWasmSerialize.desc': '在可用时使用 WASM 终端序列化，否则回退到 JS SerializeAddon。',
 
   // Settings > Terminal > Workspace Focus Indicator
   'settings.terminal.section.workspaceFocus': '工作区焦点提示',

--- a/application/state/terminalHiddenRendererStore.test.ts
+++ b/application/state/terminalHiddenRendererStore.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { terminalHiddenRendererStore } from "./terminalHiddenRendererStore.ts";
+
+test("terminalHiddenRendererStore evicts oldest soft-hidden session", () => {
+  terminalHiddenRendererStore.clearSoftHidden("a");
+  terminalHiddenRendererStore.clearSoftHidden("b");
+  terminalHiddenRendererStore.markSoftHidden("a");
+  terminalHiddenRendererStore.markSoftHidden("b");
+  assert.equal(terminalHiddenRendererStore.pickEvictionCandidate(2), "a");
+  terminalHiddenRendererStore.clearSoftHidden("a");
+  terminalHiddenRendererStore.clearSoftHidden("b");
+});

--- a/application/state/terminalHiddenRendererStore.ts
+++ b/application/state/terminalHiddenRendererStore.ts
@@ -1,0 +1,55 @@
+type Listener = () => void;
+
+const softHiddenSessions = new Map<string, number>();
+const listeners = new Set<Listener>();
+let evictionRequestSessionId: string | null = null;
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export const terminalHiddenRendererStore = {
+  getSoftHiddenCount: () => softHiddenSessions.size,
+
+  isSoftHidden: (sessionId: string) => softHiddenSessions.has(sessionId),
+
+  markSoftHidden: (sessionId: string) => {
+    softHiddenSessions.set(sessionId, Date.now());
+    emit();
+  },
+
+  clearSoftHidden: (sessionId: string) => {
+    if (!softHiddenSessions.delete(sessionId)) return;
+    emit();
+  },
+
+  /** Returns the oldest soft-hidden session id when over the keep limit. */
+  pickEvictionCandidate: (keepCount: number): string | null => {
+    if (softHiddenSessions.size < keepCount) return null;
+    let oldestId: string | null = null;
+    let oldestTs = Number.POSITIVE_INFINITY;
+    for (const [sessionId, ts] of softHiddenSessions) {
+      if (ts < oldestTs) {
+        oldestTs = ts;
+        oldestId = sessionId;
+      }
+    }
+    return oldestId;
+  },
+
+  requestEviction: (sessionId: string) => {
+    evictionRequestSessionId = sessionId;
+    emit();
+  },
+
+  consumeEvictionRequest: (sessionId: string): boolean => {
+    if (evictionRequestSessionId !== sessionId) return false;
+    evictionRequestSessionId = null;
+    return true;
+  },
+
+  subscribe: (listener: Listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};

--- a/application/state/terminalMirrorSnapshot.ts
+++ b/application/state/terminalMirrorSnapshot.ts
@@ -1,0 +1,12 @@
+import type { TerminalHibernateSnapshot } from "../../components/terminal/terminalHibernateRuntime";
+
+export function mirrorSnapshotToHibernateSnapshot(
+  mirror: { snapshot: string; alternateScreen: boolean },
+): TerminalHibernateSnapshot {
+  return {
+    snapshot: mirror.snapshot,
+    viewportSnapshot: mirror.snapshot,
+    scrollbackSnapshot: "",
+    alternateScreen: mirror.alternateScreen,
+  };
+}

--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -100,6 +100,16 @@ export const useTerminalBackend = () => {
     return bridge.setSessionEncoding(sessionId, encoding);
   }, []);
 
+  const getTerminalMirrorSnapshot = useCallback(async (sessionId: string) => {
+    const bridge = netcattyBridge.get();
+    if (!bridge?.getTerminalMirrorSnapshot) return null;
+    try {
+      return await bridge.getTerminalMirrorSnapshot(sessionId);
+    } catch {
+      return null;
+    }
+  }, []);
+
   const onSessionData = useCallback((sessionId: string, cb: (data: string) => void) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.onSessionData) throw new Error("onSessionData unavailable");
@@ -328,6 +338,7 @@ export const useTerminalBackend = () => {
       setSessionFlowPaused,
       closeSession,
       setSessionEncoding,
+      getTerminalMirrorSnapshot,
       onSessionData,
       onSessionExit,
       onTelnetAutoLoginComplete,
@@ -376,6 +387,7 @@ export const useTerminalBackend = () => {
       setSessionFlowPaused,
       closeSession,
       setSessionEncoding,
+      getTerminalMirrorSnapshot,
       onSessionData,
       onSessionExit,
       onTelnetAutoLoginComplete,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -88,14 +88,22 @@ import { useTerminalEffects } from "./terminal/useTerminalEffects";
 import { useTerminalHibernateEffect } from "./terminal/useTerminalHibernateEffect";
 import {
   appendHibernatePendingBuffer,
+  isTerminalAlternateScreenActive,
   serializeTerminalForHibernate,
 } from "./terminal/terminalHibernateRuntime";
 import {
   isTerminalFileTransferActive,
+  resolveHibernateKeepRendererCount,
+  resolveHibernatePreferWasmSerialize,
+  resolveHibernateSkipAltScreen,
+  resolveHibernateUseHeadlessMirror,
   resolveTerminalHibernateDelayMs,
   resolveTerminalHibernateEnabled,
+  resolveTerminalHibernateReplayChunkBytes,
   type TerminalHibernateWakePayload,
 } from "../domain/terminalHibernate";
+import { terminalHiddenRendererStore } from "../application/state/terminalHiddenRendererStore";
+import { mirrorSnapshotToHibernateSnapshot } from "../application/state/terminalMirrorSnapshot";
 import {
   wakeTerminalFromHibernate,
   type TerminalRuntimeRefs,
@@ -230,8 +238,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const disposeDataRef = useRef<(() => void) | null>(null);
   const disposeExitRef = useRef<(() => void) | null>(null);
   const hibernatedRef = useRef(false);
+  const softHiddenRef = useRef(false);
   const hasRuntimeRef = useRef(false);
   const hibernateSnapshotRef = useRef("");
+  const hibernateViewportSnapshotRef = useRef("");
+  const hibernateScrollbackSnapshotRef = useRef("");
+  const hibernateMirrorPreferredRef = useRef(false);
   const hibernatePendingBufferRef = useRef("");
   const hibernateAlternateScreenRef = useRef(false);
   const wakeInProgressRef = useRef(false);
@@ -827,30 +839,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
     sessionRef.current = null;
     hibernatedRef.current = false;
+    softHiddenRef.current = false;
     hibernateSnapshotRef.current = "";
+    hibernateViewportSnapshotRef.current = "";
+    hibernateScrollbackSnapshotRef.current = "";
+    hibernateMirrorPreferredRef.current = false;
     hibernatePendingBufferRef.current = "";
     hibernateAlternateScreenRef.current = false;
+    terminalHiddenRendererStore.clearSoftHidden(sessionId);
   }, [handleTerminalDataCaptureOnce, sessionId, terminalBackend]);
 
-  const hibernateRuntime = useCallback(() => {
-    if (hibernatedRef.current || !termRef.current || !serializeAddonRef.current) return;
-    const backendId = sessionRef.current;
-    if (!backendId) return;
-
-    const { snapshot, alternateScreen } = serializeTerminalForHibernate(
-      termRef.current,
-      serializeAddonRef.current,
-    );
-    if (alternateScreen && snapshot.length === 0) {
-      logger.info("[Terminal] Skipping hibernate: alternate screen snapshot unavailable", { sessionId });
-      return;
-    }
-
-    hibernateSnapshotRef.current = snapshot;
-    hibernateAlternateScreenRef.current = alternateScreen;
-    isBootActiveRef.current = false;
-    disposeRuntimeOnly();
-
+  const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
     hibernatePendingBufferRef.current = "";
     disposeDataRef.current = terminalBackend.onSessionData(backendId, (chunk) => {
@@ -873,14 +872,107 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       );
       onSessionExit?.(sessionId, evt);
     });
+  }, [onSessionExit, sessionId, terminalBackend]);
 
+  const applyHibernateSnapshot = useCallback((
+    snapshot: {
+      snapshot: string;
+      viewportSnapshot: string;
+      scrollbackSnapshot: string;
+      alternateScreen: boolean;
+    },
+    mirrorPreferred: boolean,
+  ) => {
+    hibernateSnapshotRef.current = snapshot.snapshot;
+    hibernateViewportSnapshotRef.current = snapshot.viewportSnapshot;
+    hibernateScrollbackSnapshotRef.current = snapshot.scrollbackSnapshot;
+    hibernateAlternateScreenRef.current = snapshot.alternateScreen;
+    hibernateMirrorPreferredRef.current = mirrorPreferred;
+  }, []);
+
+  const fullHibernateRuntime = useCallback(async () => {
+    if (hibernatedRef.current || softHiddenRef.current || !termRef.current || !serializeAddonRef.current) return;
+    const backendId = sessionRef.current;
+    if (!backendId) return;
+
+    terminalHiddenRendererStore.clearSoftHidden(sessionId);
+    softHiddenRef.current = false;
+
+    let snapshot = await serializeTerminalForHibernate(
+      termRef.current,
+      serializeAddonRef.current,
+      { preferWasm: resolveHibernatePreferWasmSerialize(terminalSettings) },
+    );
+    let mirrorPreferred = false;
+
+    if (resolveHibernateUseHeadlessMirror(terminalSettings)) {
+      const mirror = await terminalBackend.getTerminalMirrorSnapshot(backendId);
+      if (mirror && mirror.snapshot.length > 0) {
+        snapshot = mirrorSnapshotToHibernateSnapshot(mirror);
+        mirrorPreferred = true;
+      }
+    }
+
+    if (snapshot.alternateScreen && snapshot.snapshot.length === 0) {
+      logger.info("[Terminal] Skipping hibernate: alternate screen snapshot unavailable", { sessionId });
+      return;
+    }
+
+    applyHibernateSnapshot(snapshot, mirrorPreferred);
+    isBootActiveRef.current = false;
+    disposeRuntimeOnly();
+    beginHibernatedSessionListeners(backendId);
     hibernatedRef.current = true;
     logger.info("[Terminal] Hibernated runtime", {
       sessionId,
       snapshotChars: hibernateSnapshotRef.current.length,
-      alternateScreen,
+      viewportChars: hibernateViewportSnapshotRef.current.length,
+      scrollbackChars: hibernateScrollbackSnapshotRef.current.length,
+      alternateScreen: snapshot.alternateScreen,
+      mirrorPreferred,
     });
-  }, [onSessionExit, sessionId, terminalBackend]);
+  }, [
+    applyHibernateSnapshot,
+    beginHibernatedSessionListeners,
+    sessionId,
+    terminalBackend,
+    terminalSettings,
+  ]);
+
+  const hideRuntimeOnly = useCallback(() => {
+    if (hibernatedRef.current || softHiddenRef.current || !hasRuntimeRef.current) return;
+    xtermRuntimeRef.current?.suspendWebglRenderer();
+    terminalHiddenRendererStore.markSoftHidden(sessionId);
+    softHiddenRef.current = true;
+    logger.info("[Terminal] Soft-hidden runtime", { sessionId });
+  }, [sessionId]);
+
+  const hibernateRuntime = useCallback(() => {
+    if (hibernatedRef.current || softHiddenRef.current || !termRef.current) return;
+
+    if (
+      isTerminalAlternateScreenActive(termRef.current)
+      && resolveHibernateSkipAltScreen(terminalSettings)
+    ) {
+      logger.info("[Terminal] Skipping hibernate: alternate screen active", { sessionId });
+      return;
+    }
+
+    const keepCount = resolveHibernateKeepRendererCount(terminalSettings);
+    if (keepCount > 0 && terminalHiddenRendererStore.getSoftHiddenCount() < keepCount) {
+      hideRuntimeOnly();
+      return;
+    }
+
+    if (keepCount > 0) {
+      const victim = terminalHiddenRendererStore.pickEvictionCandidate(keepCount);
+      if (victim && victim !== sessionId) {
+        terminalHiddenRendererStore.requestEviction(victim);
+      }
+    }
+
+    void fullHibernateRuntime();
+  }, [fullHibernateRuntime, hideRuntimeOnly, sessionId, terminalSettings]);
 
   const terminalRuntimeRefs = useMemo<TerminalRuntimeRefs>(() => ({
     xtermRuntimeRef,
@@ -1602,6 +1694,25 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const safeFitRef = useRef(safeFit);
   safeFitRef.current = safeFit;
 
+  const wakeSoftHiddenRuntime = useCallback(() => {
+    if (!softHiddenRef.current) return;
+    terminalHiddenRendererStore.clearSoftHidden(sessionId);
+    softHiddenRef.current = false;
+    xtermRuntimeRef.current?.ensureWebglRenderer();
+    xtermRuntimeRef.current?.clearTextureAtlas();
+    safeFitRef.current({ force: true });
+  }, [sessionId]);
+
+  useEffect(() => {
+    return terminalHiddenRendererStore.subscribe(() => {
+      if (!terminalHiddenRendererStore.consumeEvictionRequest(sessionId)) return;
+      if (!softHiddenRef.current || hibernatedRef.current) return;
+      softHiddenRef.current = false;
+      terminalHiddenRendererStore.clearSoftHidden(sessionId);
+      void fullHibernateRuntime();
+    });
+  }, [fullHibernateRuntime, sessionId]);
+
   const wakeFromHibernateRuntime = useCallback((
     getPayload: () => TerminalHibernateWakePayload,
     options: { sessionConnected: boolean },
@@ -1656,13 +1767,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       isBootActiveRef,
       sessionId,
       updateStatus: (next) => updateStatusRef.current(next),
+      replayChunkBytes: resolveTerminalHibernateReplayChunkBytes(terminalSettings),
     }).then((ok) => ok).catch((err) => {
       logger.error("[Terminal] Failed to resume from hibernate", err);
       return false;
     }).finally(() => {
       wakeInProgressRef.current = false;
     });
-  }, [sessionId, terminalRuntimeRefs, resizeSession]);
+  }, [sessionId, terminalRuntimeRefs, resizeSession, terminalSettings]);
 
   useTerminalHibernateEffect({
     sessionId,
@@ -1679,11 +1791,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       isDraggingOver,
     }),
     hibernatedRef,
+    softHiddenRef,
     hibernatePendingBufferRef,
     hibernateSnapshotRef,
+    hibernateViewportSnapshotRef,
+    hibernateScrollbackSnapshotRef,
+    hibernateMirrorPreferredRef,
     hibernateAlternateScreenRef,
     hasRuntimeRef,
     onHibernate: hibernateRuntime,
+    onSoftHideWake: wakeSoftHiddenRuntime,
     onWake: wakeFromHibernateRuntime,
   });
 

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -989,6 +989,7 @@ function SettingsTerminalTab(props: {
           />
         </SettingRow>
         {terminalSettings.hibernateHiddenTabs && (
+          <>
           <SettingRow
             label={t("settings.terminal.rendering.hibernateHiddenTabsDelay")}
             description={t("settings.terminal.rendering.hibernateHiddenTabsDelay.desc")}
@@ -1010,6 +1011,71 @@ function SettingsTerminalTab(props: {
               <span className="text-sm text-muted-foreground">{t("settings.terminal.serverStats.seconds")}</span>
             </div>
           </SettingRow>
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernateSkipAltScreen")}
+            description={t("settings.terminal.rendering.hibernateSkipAltScreen.desc")}
+          >
+            <Toggle
+              checked={terminalSettings.hibernateSkipAltScreen}
+              onChange={(v) => updateTerminalSetting("hibernateSkipAltScreen", v)}
+            />
+          </SettingRow>
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernateKeepRendererCount")}
+            description={t("settings.terminal.rendering.hibernateKeepRendererCount.desc")}
+          >
+            <Input
+              type="number"
+              min={0}
+              max={12}
+              value={terminalSettings.hibernateKeepRendererCount}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!Number.isNaN(val) && val >= 0 && val <= 12) {
+                  updateTerminalSetting("hibernateKeepRendererCount", val);
+                }
+              }}
+              className="w-20"
+            />
+          </SettingRow>
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernateUseHeadlessMirror")}
+            description={t("settings.terminal.rendering.hibernateUseHeadlessMirror.desc")}
+          >
+            <Toggle
+              checked={terminalSettings.hibernateUseHeadlessMirror}
+              onChange={(v) => updateTerminalSetting("hibernateUseHeadlessMirror", v)}
+            />
+          </SettingRow>
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernateReplayChunkBytes")}
+            description={t("settings.terminal.rendering.hibernateReplayChunkBytes.desc")}
+          >
+            <Input
+              type="number"
+              min={4096}
+              max={65536}
+              step={1024}
+              value={terminalSettings.hibernateReplayChunkBytes}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!Number.isNaN(val) && val >= 4096 && val <= 65536) {
+                  updateTerminalSetting("hibernateReplayChunkBytes", val);
+                }
+              }}
+              className="w-28"
+            />
+          </SettingRow>
+          <SettingRow
+            label={t("settings.terminal.rendering.hibernatePreferWasmSerialize")}
+            description={t("settings.terminal.rendering.hibernatePreferWasmSerialize.desc")}
+          >
+            <Toggle
+              checked={terminalSettings.hibernatePreferWasmSerialize}
+              onChange={(v) => updateTerminalSetting("hibernatePreferWasmSerialize", v)}
+            />
+          </SettingRow>
+          </>
         )}
       </div>
       {/* Autocomplete */}

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -126,6 +126,8 @@ export type XTermRuntime = {
    * active. Called when a deferred pane first becomes visible.
    */
   ensureWebglRenderer: () => void;
+  /** Drop the WebGL addon while keeping the terminal alive (soft-hide). */
+  suspendWebglRenderer: () => void;
 };
 
 export type CreateXTermRuntimeContext = {
@@ -212,6 +214,8 @@ export type CreateXTermRuntimeContext = {
   // background tabs) to avoid spinning up many WebGL contexts at once. Defaults
   // to visible (immediate WebGL) when omitted.
   initiallyVisible?: boolean;
+  /** When true, keep the DOM renderer until replay completes (hibernate wake). */
+  deferWebglUntilReplayComplete?: boolean;
 };
 
 const detectPlatform = (): XTermPlatform => {
@@ -439,6 +443,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       webglAddon.onContextLoss(() => {
         logger.warn("[XTerm] WebGL context loss detected, disposing addon");
         webglAddon?.dispose();
+        webglAddon = null;
+        webglLoaded = false;
       });
       term.loadAddon(webglAddon);
       webglLoaded = true;
@@ -451,6 +457,22 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     scopedWindow.__xtermWebGLLoaded = webglLoaded;
   };
 
+  const suspendWebglRenderer = () => {
+    if (!webglAddon) {
+      webglLoaded = false;
+      scopedWindow.__xtermWebGLLoaded = false;
+      return;
+    }
+    try {
+      webglAddon.dispose();
+    } catch (webglErr) {
+      logger.warn("[XTerm] Failed to suspend WebGL renderer", webglErr);
+    }
+    webglAddon = null;
+    webglLoaded = false;
+    scopedWindow.__xtermWebGLLoaded = false;
+  };
+
   if (!performanceConfig.useWebGLAddon) {
     logger.info(
       "[XTerm] Skipping WebGL addon (DOM preferred for low-memory devices)",
@@ -459,9 +481,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     shouldDeferWebglUntilVisible({
       useWebGLAddon: performanceConfig.useWebGLAddon,
       initiallyVisible: ctx.initiallyVisible ?? true,
-    })
+    }) || ctx.deferWebglUntilReplayComplete
   ) {
-    logger.info("[XTerm] Deferring WebGL addon until pane becomes visible");
+    logger.info("[XTerm] Deferring WebGL addon until pane becomes visible or replay completes");
   } else {
     loadWebglRenderer();
   }
@@ -1253,6 +1275,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     keywordHighlighter,
     clearTextureAtlas: clearWebglTextureAtlas,
     ensureWebglRenderer: loadWebglRenderer,
+    suspendWebglRenderer,
     dispose: () => {
       ctx.container.removeEventListener(
         "wheel",

--- a/components/terminal/terminalHibernateRuntime.test.ts
+++ b/components/terminal/terminalHibernateRuntime.test.ts
@@ -8,9 +8,13 @@ import {
   serializeTerminalForHibernate,
 } from "./terminalHibernateRuntime.ts";
 
-const createFakeTerm = (bufferType: "normal" | "alternate") => ({
+const createFakeTerm = (bufferType: "normal" | "alternate", rows = 24, length = 30) => ({
+  rows,
   buffer: {
-    active: { type: bufferType },
+    active: {
+      type: bufferType,
+      length,
+    },
   },
 });
 
@@ -56,15 +60,31 @@ test("refreshTerminalViewport refreshes the full viewport", () => {
   assert.deepEqual(refreshed, [0, 23]);
 });
 
-test("serializeTerminalForHibernate preserves alternate screen when serialize throws", () => {
+test("serializeTerminalForHibernate preserves alternate screen when serialize throws", async () => {
   const term = createFakeTerm("alternate");
   const serializeAddon = {
     serialize: () => {
       throw new Error("serialize failed");
     },
   };
-  assert.deepEqual(serializeTerminalForHibernate(term as never, serializeAddon as never), {
+  assert.deepEqual(await serializeTerminalForHibernate(term as never, serializeAddon as never), {
     snapshot: "",
+    viewportSnapshot: "",
+    scrollbackSnapshot: "",
     alternateScreen: true,
   });
+});
+
+test("serializeTerminalForHibernate requests viewport-only range on alternate screen", async () => {
+  let capturedOptions: Record<string, unknown> | undefined;
+  const term = createFakeTerm("alternate", 24);
+  const serializeAddon = {
+    serialize: (options?: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "alt-viewport";
+    },
+  };
+  const result = await serializeTerminalForHibernate(term as never, serializeAddon as never);
+  assert.equal(result.snapshot, "alt-viewport");
+  assert.deepEqual(capturedOptions?.range, { start: 0, end: 23 });
 });

--- a/components/terminal/terminalHibernateRuntime.ts
+++ b/components/terminal/terminalHibernateRuntime.ts
@@ -8,6 +8,12 @@ import {
   type TerminalHibernateWakePayload,
 } from "../../domain/terminalHibernate";
 import type { XTermRuntime } from "./runtime/createXTermRuntime";
+import { serializeTerminalBuffer } from "./terminalSerialize";
+import {
+  writeTerminalPayloadChunked,
+  writeTerminalReplaySequence,
+  type TerminalReplayOptions,
+} from "./terminalReplay";
 
 export function isTerminalAlternateScreenActive(term: XTerm): boolean {
   return (term.buffer.active as { type?: string }).type === "alternate";
@@ -26,23 +32,104 @@ export function resolveHibernateSerializeOptions(term: XTerm): {
   };
 }
 
-export function serializeTerminalForHibernate(term: XTerm, serializeAddon: SerializeAddon): {
+export type TerminalHibernateSnapshot = {
   snapshot: string;
+  viewportSnapshot: string;
+  scrollbackSnapshot: string;
   alternateScreen: boolean;
-} {
+};
+
+function resolveActiveBufferLength(term: XTerm): number {
+  return term.buffer.active.length;
+}
+
+async function serializeWithOptions(
+  term: XTerm,
+  serializeAddon: SerializeAddon,
+  options: Record<string, unknown>,
+  preferWasm: boolean,
+): Promise<string> {
   try {
-    const { excludeAltBuffer, excludeModes, alternateScreen } = resolveHibernateSerializeOptions(term);
-    const raw = serializeAddon.serialize({
+    return await serializeTerminalBuffer({
+      term,
+      serializeAddon,
+      options,
+      preferWasm,
+    });
+  } catch {
+    return "";
+  }
+}
+
+export async function serializeTerminalForHibernate(
+  term: XTerm,
+  serializeAddon: SerializeAddon,
+  options: { preferWasm?: boolean } = {},
+): Promise<TerminalHibernateSnapshot> {
+  const { excludeAltBuffer, excludeModes, alternateScreen } = resolveHibernateSerializeOptions(term);
+  const preferWasm = options.preferWasm === true;
+  const rows = Math.max(1, term.rows);
+  const bufferLength = resolveActiveBufferLength(term);
+
+  try {
+    if (alternateScreen) {
+      const endRow = Math.max(0, rows - 1);
+      const viewportSnapshot = capHibernateBufferByLines(
+        await serializeWithOptions(term, serializeAddon, {
+          excludeAltBuffer: false,
+          excludeModes: false,
+          range: { start: 0, end: endRow },
+        }, preferWasm),
+        rows,
+      );
+      return {
+        snapshot: viewportSnapshot,
+        viewportSnapshot,
+        scrollbackSnapshot: "",
+        alternateScreen: true,
+      };
+    }
+
+    const viewportStart = Math.max(0, bufferLength - rows);
+    const viewportEnd = Math.max(0, bufferLength - 1);
+    const viewportSnapshot = await serializeWithOptions(term, serializeAddon, {
       excludeAltBuffer,
       excludeModes,
-    });
+      range: { start: viewportStart, end: viewportEnd },
+    }, preferWasm);
+
+    let scrollbackSnapshot = "";
+    if (viewportStart > 0) {
+      const scrollbackStart = Math.max(0, viewportStart - TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES);
+      scrollbackSnapshot = capHibernateBufferByLines(
+        await serializeWithOptions(term, serializeAddon, {
+          excludeAltBuffer,
+          excludeModes,
+          range: { start: scrollbackStart, end: viewportStart - 1 },
+        }, preferWasm),
+        TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES,
+      );
+    }
+
+    const snapshot = capHibernateBufferByLines(
+      await serializeWithOptions(term, serializeAddon, {
+        excludeAltBuffer,
+        excludeModes,
+      }, preferWasm),
+      TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES,
+    );
+
     return {
-      snapshot: capHibernateBufferByLines(raw, TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES),
-      alternateScreen,
+      snapshot,
+      viewportSnapshot,
+      scrollbackSnapshot,
+      alternateScreen: false,
     };
   } catch {
     return {
       snapshot: "",
+      viewportSnapshot: "",
+      scrollbackSnapshot: "",
       alternateScreen: isTerminalAlternateScreenActive(term),
     };
   }
@@ -52,34 +139,58 @@ export function appendHibernatePendingBuffer(current: string, chunk: string): st
   return capHibernateBuffer(current + chunk);
 }
 
-const writeTerminalPayload = (term: XTerm, data: string): Promise<void> => {
-  if (!data) return Promise.resolve();
-  return new Promise((resolve) => {
-    term.write(data, () => resolve());
-  });
-};
-
 export function refreshTerminalViewport(term: XTerm): void {
   const endRow = term.rows - 1;
   if (endRow < 0) return;
   term.refresh(0, endRow);
 }
 
-export async function appendTerminalReplayData(term: XTerm, data: string): Promise<void> {
-  return writeTerminalPayload(term, data);
+export async function appendTerminalReplayData(
+  term: XTerm,
+  data: string,
+  replayOptions?: TerminalReplayOptions,
+): Promise<void> {
+  return writeTerminalPayloadChunked(term, data, replayOptions);
 }
+
+export type ApplyHibernateWakeOptions = {
+  replayOptions?: TerminalReplayOptions;
+  deferWebgl?: boolean;
+};
+
+const scheduleIdle = (callback: () => void): void => {
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(() => callback(), { timeout: 500 });
+    return;
+  }
+  setTimeout(callback, 0);
+};
 
 export async function applyHibernateWakeToTerminal(
   term: XTerm,
   runtime: XTermRuntime,
   payload: TerminalHibernateWakePayload,
+  options: ApplyHibernateWakeOptions = {},
 ): Promise<void> {
-  await writeTerminalPayload(term, payload.snapshot);
-  await writeTerminalPayload(term, payload.pendingBuffer);
-  runtime.ensureWebglRenderer();
-  runtime.clearTextureAtlas();
+  const replayOptions = options.replayOptions;
+  const viewport = payload.viewportSnapshot ?? payload.snapshot;
+  const scrollback = payload.scrollbackSnapshot ?? "";
+
+  await writeTerminalReplaySequence(term, [viewport, payload.pendingBuffer], replayOptions);
+
+  if (!options.deferWebgl) {
+    runtime.ensureWebglRenderer();
+    runtime.clearTextureAtlas();
+  }
+
   if (payload.alternateScreen) {
     refreshTerminalViewport(term);
+  }
+
+  if (scrollback) {
+    scheduleIdle(() => {
+      void writeTerminalPayloadChunked(term, scrollback, replayOptions);
+    });
   }
 }
 
@@ -92,4 +203,19 @@ export function nudgeAlternateScreenRedraw(term: XTerm): void {
     term.resize(cols, rows);
     refreshTerminalViewport(term);
   }
+}
+
+export function buildHibernateWakePayload(
+  snapshot: TerminalHibernateSnapshot,
+  pendingBuffer: string,
+  mirrorPreferred = false,
+): TerminalHibernateWakePayload {
+  return {
+    snapshot: snapshot.snapshot,
+    viewportSnapshot: snapshot.viewportSnapshot,
+    scrollbackSnapshot: snapshot.scrollbackSnapshot,
+    pendingBuffer,
+    alternateScreen: snapshot.alternateScreen,
+    mirrorPreferred,
+  };
 }

--- a/components/terminal/terminalReplay.test.ts
+++ b/components/terminal/terminalReplay.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { writeTerminalPayloadChunked } from "./terminalReplay.ts";
+
+test("writeTerminalPayloadChunked writes large payloads in multiple chunks", async () => {
+  const writes: string[] = [];
+  const term = {
+    write: (data: string, cb: () => void) => {
+      writes.push(data);
+      cb();
+    },
+  } as unknown as XTerm;
+
+  const payload = "x".repeat(40_000);
+  await writeTerminalPayloadChunked(term, payload, { chunkBytes: 16_384 });
+
+  assert.ok(writes.length >= 2);
+  assert.equal(writes.join(""), payload);
+});

--- a/components/terminal/terminalReplay.ts
+++ b/components/terminal/terminalReplay.ts
@@ -1,0 +1,54 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+export type TerminalReplayOptions = {
+  chunkBytes?: number;
+};
+
+const scheduleFrame = (): Promise<void> => new Promise((resolve) => {
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(() => resolve());
+    return;
+  }
+  setTimeout(resolve, 0);
+});
+
+const writeChunk = (term: XTerm, data: string): Promise<void> => {
+  if (!data) return Promise.resolve();
+  return new Promise((resolve) => {
+    term.write(data, () => resolve());
+  });
+};
+
+export async function writeTerminalPayloadChunked(
+  term: XTerm,
+  data: string,
+  options: TerminalReplayOptions = {},
+): Promise<void> {
+  const chunkBytes = Math.max(1024, options.chunkBytes ?? 16 * 1024);
+  if (!data) return;
+  if (data.length <= chunkBytes) {
+    await writeChunk(term, data);
+    return;
+  }
+
+  let offset = 0;
+  while (offset < data.length) {
+    const end = Math.min(data.length, offset + chunkBytes);
+    await writeChunk(term, data.slice(offset, end));
+    offset = end;
+    if (offset < data.length) {
+      await scheduleFrame();
+    }
+  }
+}
+
+export async function writeTerminalReplaySequence(
+  term: XTerm,
+  segments: string[],
+  options: TerminalReplayOptions = {},
+): Promise<void> {
+  for (const segment of segments) {
+    if (!segment) continue;
+    await writeTerminalPayloadChunked(term, segment, options);
+  }
+}

--- a/components/terminal/terminalRuntimeMount.ts
+++ b/components/terminal/terminalRuntimeMount.ts
@@ -60,7 +60,7 @@ export function applyTerminalKeywordHighlightRules(
 
 export type WakeTerminalFromHibernateOptions = {
   refs: TerminalRuntimeRefs;
-  runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible">;
+  runtimeContext: Omit<CreateXTermRuntimeContext, "container" | "initiallyVisible" | "deferWebglUntilReplayComplete">;
   container: HTMLDivElement;
   getPayload: () => TerminalHibernateWakePayload;
   /** Stop hibernate IPC listeners before reading the final replay payload. */
@@ -76,6 +76,7 @@ export type WakeTerminalFromHibernateOptions = {
   /** When false, recreate xterm and replay output without reattaching or forcing connected status. */
   sessionConnected?: boolean;
   getSessionConnected?: () => boolean;
+  replayChunkBytes?: number;
 };
 
 export async function wakeTerminalFromHibernate(
@@ -97,6 +98,7 @@ export async function wakeTerminalFromHibernate(
     updateStatus,
     sessionConnected = true,
     getSessionConnected,
+    replayChunkBytes = 16 * 1024,
   } = options;
 
   if (refs.hasRuntimeRef.current) {
@@ -118,6 +120,7 @@ export async function wakeTerminalFromHibernate(
     ...runtimeContext,
     container,
     initiallyVisible: true,
+    deferWebglUntilReplayComplete: true,
   });
 
   assignTerminalRuntimeRefs(refs, runtime);
@@ -126,25 +129,43 @@ export async function wakeTerminalFromHibernate(
   const term = runtime.term;
   const initialPayload = getPayload();
   const pendingAtApplyStart = initialPayload.pendingBuffer;
-  await applyHibernateWakeToTerminal(term, runtime, initialPayload);
+  const replayOptions = { chunkBytes: replayChunkBytes };
+
+  await applyHibernateWakeToTerminal(term, runtime, initialPayload, {
+    replayOptions,
+    deferWebgl: true,
+  });
+
   let replayedPendingLength = pendingAtApplyStart.length;
   for (let drainPass = 0; drainPass < 16; drainPass += 1) {
     const pending = getPayload().pendingBuffer;
     if (pending.length <= replayedPendingLength) break;
-    await appendTerminalReplayData(term, pending.slice(replayedPendingLength));
+    await appendTerminalReplayData(
+      term,
+      pending.slice(replayedPendingLength),
+      replayOptions,
+    );
     replayedPendingLength = pending.length;
   }
   const finalPending = getPayload().pendingBuffer;
   if (finalPending.length > replayedPendingLength) {
-    await appendTerminalReplayData(term, finalPending.slice(replayedPendingLength));
+    await appendTerminalReplayData(
+      term,
+      finalPending.slice(replayedPendingLength),
+      replayOptions,
+    );
     replayedPendingLength = finalPending.length;
   }
+
   stopHibernateListeners();
   const shouldReattach = sessionConnected && (getSessionConnected?.() ?? true);
   if (shouldReattach) {
     reattachSession(term);
     updateStatus("connected");
   }
+
+  runtime.ensureWebglRenderer();
+  runtime.clearTextureAtlas();
 
   safeFit({ force: true });
   resizeSession();
@@ -174,8 +195,11 @@ export async function wakeTerminalFromHibernate(
   logger.info("[Terminal] Resumed from hibernate", {
     sessionId,
     snapshotChars: initialPayload.snapshot.length,
+    viewportChars: initialPayload.viewportSnapshot?.length ?? initialPayload.snapshot.length,
+    scrollbackChars: initialPayload.scrollbackSnapshot?.length ?? 0,
     pendingChars: replayedPendingLength,
     alternateScreen: initialPayload.alternateScreen,
+    mirrorPreferred: initialPayload.mirrorPreferred === true,
   });
   return true;
 }

--- a/components/terminal/terminalSerialize.ts
+++ b/components/terminal/terminalSerialize.ts
@@ -1,0 +1,21 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { SerializeAddon } from "@xterm/addon-serialize";
+
+import { resolveTerminalSerializeFn } from "./terminalSerializeWasm";
+
+export type TerminalSerializeRequest = {
+  term: XTerm;
+  serializeAddon: SerializeAddon;
+  options?: Record<string, unknown>;
+  preferWasm?: boolean;
+};
+
+export async function serializeTerminalBuffer(
+  request: TerminalSerializeRequest,
+): Promise<string> {
+  const serialize = await resolveTerminalSerializeFn(
+    (options) => request.serializeAddon.serialize(options),
+    request.preferWasm === true,
+  );
+  return serialize(request.options);
+}

--- a/components/terminal/terminalSerializeWasm.ts
+++ b/components/terminal/terminalSerializeWasm.ts
@@ -1,0 +1,33 @@
+/**
+ * Optional WASM-backed terminal serialize hook.
+ *
+ * xterm.js upstream is exploring a WASM serialize addon (~10x faster for large
+ * scrollback). Until a stable package ships alongside @xterm/addon-serialize,
+ * this module feature-detects and falls back to the JS SerializeAddon.
+ */
+
+export type TerminalSerializeFn = (options?: Record<string, unknown>) => string;
+
+let wasmSerializeLoader: (() => Promise<TerminalSerializeFn | null>) | null = null;
+
+export function registerWasmSerializeLoader(
+  loader: () => Promise<TerminalSerializeFn | null>,
+): void {
+  wasmSerializeLoader = loader;
+}
+
+export async function resolveTerminalSerializeFn(
+  jsSerialize: TerminalSerializeFn,
+  preferWasm: boolean,
+): Promise<TerminalSerializeFn> {
+  if (!preferWasm || !wasmSerializeLoader) {
+    return jsSerialize;
+  }
+  try {
+    const wasmSerialize = await wasmSerializeLoader();
+    if (wasmSerialize) return wasmSerialize;
+  } catch {
+    // Fall back to JS serialize below.
+  }
+  return jsSerialize;
+}

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -21,11 +21,16 @@ type UseTerminalHibernateEffectOptions = {
   hibernateDelayMs: number;
   fileTransferActive: boolean;
   hibernatedRef: React.MutableRefObject<boolean>;
+  softHiddenRef: React.MutableRefObject<boolean>;
   hibernatePendingBufferRef: React.MutableRefObject<string>;
   hibernateSnapshotRef: React.MutableRefObject<string>;
+  hibernateViewportSnapshotRef: React.MutableRefObject<string>;
+  hibernateScrollbackSnapshotRef: React.MutableRefObject<string>;
+  hibernateMirrorPreferredRef: React.MutableRefObject<boolean>;
   hibernateAlternateScreenRef: React.MutableRefObject<boolean>;
   hasRuntimeRef: React.MutableRefObject<boolean>;
   onHibernate: () => void;
+  onSoftHideWake: () => void;
   onWake: (
     getPayload: () => TerminalHibernateWakePayload,
     options: { sessionConnected: boolean },
@@ -43,19 +48,26 @@ export function useTerminalHibernateEffect({
   hibernateDelayMs,
   fileTransferActive,
   hibernatedRef,
+  softHiddenRef,
   hibernatePendingBufferRef,
   hibernateSnapshotRef,
+  hibernateViewportSnapshotRef,
+  hibernateScrollbackSnapshotRef,
+  hibernateMirrorPreferredRef,
   hibernateAlternateScreenRef,
   hasRuntimeRef,
   onHibernate,
+  onSoftHideWake,
   onWake,
 }: UseTerminalHibernateEffectOptions): void {
   const hiddenSinceRef = useRef<number | null>(null);
   const hibernateTimerRef = useRef<number | null>(null);
   const paneVisibleRef = useRef(resolvePaneVisible(sessionId, isVisible));
   const onHibernateRef = useRef(onHibernate);
+  const onSoftHideWakeRef = useRef(onSoftHideWake);
   const onWakeRef = useRef(onWake);
   onHibernateRef.current = onHibernate;
+  onSoftHideWakeRef.current = onSoftHideWake;
   onWakeRef.current = onWake;
 
   useEffect(() => {
@@ -70,8 +82,11 @@ export function useTerminalHibernateEffect({
 
     const clearHibernateState = () => {
       hibernateSnapshotRef.current = "";
+      hibernateViewportSnapshotRef.current = "";
+      hibernateScrollbackSnapshotRef.current = "";
       hibernatePendingBufferRef.current = "";
       hibernateAlternateScreenRef.current = false;
+      hibernateMirrorPreferredRef.current = false;
       hibernatedRef.current = false;
     };
 
@@ -94,17 +109,27 @@ export function useTerminalHibernateEffect({
     };
 
     const tryWake = () => {
+      if (softHiddenRef.current) {
+        softHiddenRef.current = false;
+        onSoftHideWakeRef.current();
+        return;
+      }
       if (!hibernatedRef.current) return;
 
       const sessionConnected = getSessionConnectedRef.current();
       const getPayload = (): TerminalHibernateWakePayload => ({
         snapshot: hibernateSnapshotRef.current,
+        viewportSnapshot: hibernateViewportSnapshotRef.current || hibernateSnapshotRef.current,
+        scrollbackSnapshot: hibernateScrollbackSnapshotRef.current,
         pendingBuffer: hibernatePendingBufferRef.current,
         alternateScreen: hibernateAlternateScreenRef.current,
+        mirrorPreferred: hibernateMirrorPreferredRef.current,
       });
       logger.info("[Terminal] Waking from hibernate", {
         sessionId,
         snapshotChars: hibernateSnapshotRef.current.length,
+        viewportChars: hibernateViewportSnapshotRef.current.length,
+        scrollbackChars: hibernateScrollbackSnapshotRef.current.length,
         pendingChars: hibernatePendingBufferRef.current.length,
         sessionConnected,
       });
@@ -120,11 +145,11 @@ export function useTerminalHibernateEffect({
 
     if (!hibernateEnabled) {
       clearHibernateTimer();
-      if (hibernatedRef.current) {
+      if (hibernatedRef.current || softHiddenRef.current) {
         tryWake();
       }
       const unsubscribeDisabled = subscribePaneVisible(sessionId, () => {
-        if (hibernatedRef.current && resolveVisible()) {
+        if ((hibernatedRef.current || softHiddenRef.current) && resolveVisible()) {
           tryWake();
         }
       });
@@ -163,16 +188,20 @@ export function useTerminalHibernateEffect({
     fileTransferActive,
     getSessionConnectedRef,
     hasRuntimeRef,
+    hibernateAlternateScreenRef,
     hibernateDelayMs,
     hibernateEnabled,
+    hibernateMirrorPreferredRef,
     hibernatePendingBufferRef,
+    hibernateScrollbackSnapshotRef,
     hibernateSnapshotRef,
-    hibernateAlternateScreenRef,
+    hibernateViewportSnapshotRef,
     hibernatedRef,
     isSearchOpen,
     isVisible,
     isVisibleRef,
     sessionId,
+    softHiddenRef,
     status,
   ]);
 }

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -1,6 +1,10 @@
 import type { SerialConfig } from './connection';
 import type { CodingCliProviderId } from '../codingCliProviders';
-import { normalizeHibernateHiddenTabsDelaySec } from '../terminalHibernate';
+import {
+  normalizeHibernateHiddenTabsDelaySec,
+  normalizeHibernateKeepRendererCount,
+  normalizeHibernateReplayChunkBytes,
+} from '../terminalHibernate';
 
 // Terminal appearance settings
 export type CursorShape = 'block' | 'bar' | 'underline';
@@ -122,6 +126,16 @@ export interface TerminalSettings {
   hibernateHiddenTabs: boolean;
   /** Seconds after a tab leaves view before hibernating (see hibernateHiddenTabs). */
   hibernateHiddenTabsDelaySec: number;
+  /** Skip full hibernate while a full-screen TUI owns the alternate screen buffer. */
+  hibernateSkipAltScreen: boolean;
+  /** Hidden tabs whose renderer is kept alive (WebGL suspended) before full hibernate. */
+  hibernateKeepRendererCount: number;
+  /** Mirror PTY output in a main-process headless xterm for faster wake snapshots. */
+  hibernateUseHeadlessMirror: boolean;
+  /** Bytes per animation frame when replaying hibernate snapshots in the renderer. */
+  hibernateReplayChunkBytes: number;
+  /** Prefer WASM terminal serialize when available (falls back to JS). */
+  hibernatePreferWasmSerialize: boolean;
   showLineTimestamps: boolean; // Show output timestamps in a side gutter
 
   // Autocomplete
@@ -269,6 +283,12 @@ export const normalizeTerminalSettings = (
     hibernateHiddenTabsDelaySec: normalizeHibernateHiddenTabsDelaySec(
       mergedSettings.hibernateHiddenTabsDelaySec,
     ),
+    hibernateKeepRendererCount: normalizeHibernateKeepRendererCount(
+      mergedSettings.hibernateKeepRendererCount,
+    ),
+    hibernateReplayChunkBytes: normalizeHibernateReplayChunkBytes(
+      mergedSettings.hibernateReplayChunkBytes,
+    ),
     autocompleteGhostText: mergedSettings.autocompletePopupMenu
       ? false
       : mergedSettings.autocompleteGhostText,
@@ -333,6 +353,11 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   rendererType: 'auto', // Auto-detect best renderer based on hardware
   hibernateHiddenTabs: true,
   hibernateHiddenTabsDelaySec: 5,
+  hibernateSkipAltScreen: true,
+  hibernateKeepRendererCount: 2,
+  hibernateUseHeadlessMirror: true,
+  hibernateReplayChunkBytes: 16 * 1024,
+  hibernatePreferWasmSerialize: false,
   showLineTimestamps: false, // Opt-in: shows output timestamps beside terminal lines
   autocompleteEnabled: true, // Autocomplete enabled by default
   autocompleteGhostText: false, // Mutually exclusive with popup menu

--- a/domain/terminalHibernate.optimizations.test.ts
+++ b/domain/terminalHibernate.optimizations.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeHibernateKeepRendererCount,
+  normalizeHibernateReplayChunkBytes,
+  resolveHibernateSkipAltScreen,
+  resolveHibernateUseHeadlessMirror,
+} from "./terminalHibernate.ts";
+
+test("normalizeHibernateReplayChunkBytes clamps to allowed range", () => {
+  assert.equal(normalizeHibernateReplayChunkBytes(undefined), 16 * 1024);
+  assert.equal(normalizeHibernateReplayChunkBytes(8 * 1024), 8 * 1024);
+  assert.equal(normalizeHibernateReplayChunkBytes(1), 4 * 1024);
+  assert.equal(normalizeHibernateReplayChunkBytes(999_999), 64 * 1024);
+});
+
+test("normalizeHibernateKeepRendererCount clamps to allowed range", () => {
+  assert.equal(normalizeHibernateKeepRendererCount(undefined), 2);
+  assert.equal(normalizeHibernateKeepRendererCount(4), 4);
+  assert.equal(normalizeHibernateKeepRendererCount(-1), 0);
+  assert.equal(normalizeHibernateKeepRendererCount(99), 12);
+});
+
+test("resolveHibernateSkipAltScreen defaults to enabled", () => {
+  assert.equal(resolveHibernateSkipAltScreen(), true);
+  assert.equal(resolveHibernateSkipAltScreen({ hibernateSkipAltScreen: false }), false);
+});
+
+test("resolveHibernateUseHeadlessMirror defaults to enabled", () => {
+  assert.equal(resolveHibernateUseHeadlessMirror(), true);
+  assert.equal(resolveHibernateUseHeadlessMirror({ hibernateUseHeadlessMirror: false }), false);
+});

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -48,6 +48,20 @@ export function isTerminalFileTransferActive(options: {
 /** Lines kept when snapshotting xterm scrollback before hibernate. */
 export const TERMINAL_HIBERNATE_SNAPSHOT_MAX_LINES = 3_000;
 
+/** Default chunk size for replaying hibernate snapshots without blocking the main thread. */
+export const TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_DEFAULT = 16 * 1024;
+
+export const TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_MIN = 4 * 1024;
+
+export const TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_MAX = 64 * 1024;
+
+/** Hidden tabs whose xterm runtime is kept alive (WebGL suspended) before full hibernate. */
+export const TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_DEFAULT = 2;
+
+export const TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_MIN = 0;
+
+export const TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_MAX = 12;
+
 /** Max chars buffered in renderer while xterm is hibernated (post-snapshot output). */
 export const TERMINAL_HIBERNATE_BUFFER_MAX_CHARS = 512 * 1024;
 
@@ -63,10 +77,74 @@ export function capHibernateBufferByLines(text: string, maxLines: number): strin
   return lines.slice(lines.length - maxLines).join("\n");
 }
 
+export function normalizeHibernateReplayChunkBytes(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_DEFAULT;
+  }
+  return Math.min(
+    TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_MAX,
+    Math.max(TERMINAL_HIBERNATE_REPLAY_CHUNK_BYTES_MIN, Math.round(value)),
+  );
+}
+
+export function normalizeHibernateKeepRendererCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_DEFAULT;
+  }
+  return Math.min(
+    TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_MAX,
+    Math.max(TERMINAL_HIBERNATE_KEEP_RENDERER_COUNT_MIN, Math.round(value)),
+  );
+}
+
+export function resolveTerminalHibernateReplayChunkBytes(
+  settings?: Pick<TerminalSettings, "hibernateReplayChunkBytes"> | null,
+): number {
+  return normalizeHibernateReplayChunkBytes(settings?.hibernateReplayChunkBytes);
+}
+
+export function resolveHibernateKeepRendererCount(
+  settings?: Pick<TerminalSettings, "hibernateKeepRendererCount"> | null,
+): number {
+  return normalizeHibernateKeepRendererCount(settings?.hibernateKeepRendererCount);
+}
+
+export function resolveHibernateSkipAltScreen(
+  settings?: Pick<TerminalSettings, "hibernateSkipAltScreen"> | null,
+): boolean {
+  return settings?.hibernateSkipAltScreen !== false;
+}
+
+export function resolveHibernateUseHeadlessMirror(
+  settings?: Pick<TerminalSettings, "hibernateUseHeadlessMirror"> | null,
+): boolean {
+  return settings?.hibernateUseHeadlessMirror !== false;
+}
+
+export function resolveHibernatePreferWasmSerialize(
+  settings?: Pick<TerminalSettings, "hibernatePreferWasmSerialize"> | null,
+): boolean {
+  return settings?.hibernatePreferWasmSerialize === true;
+}
+
+export function shouldSkipHibernateForAltScreen(
+  alternateScreen: boolean,
+  settings?: Pick<TerminalSettings, "hibernateSkipAltScreen"> | null,
+): boolean {
+  return alternateScreen && resolveHibernateSkipAltScreen(settings);
+}
+
 /** Snapshot + buffered output to replay when recreating xterm after hibernate. */
 export type TerminalHibernateWakePayload = {
+  /** Full serialized terminal state (legacy combined snapshot). */
   snapshot: string;
+  /** Visible viewport rows for fast first paint during wake. */
+  viewportSnapshot?: string;
+  /** Older scrollback rows replayed lazily after viewport + pending. */
+  scrollbackSnapshot?: string;
   pendingBuffer: string;
   /** True when the pane was hibernated while a full-screen app owned the alt buffer. */
   alternateScreen: boolean;
+  /** When true, snapshot was sourced from the main-process headless mirror. */
+  mirrorPreferred?: boolean;
 };

--- a/electron/bridges/emitTerminalSessionData.cjs
+++ b/electron/bridges/emitTerminalSessionData.cjs
@@ -1,0 +1,48 @@
+"use strict";
+
+const {
+  writeMirror,
+  resizeMirror,
+  serializeMirror,
+  disposeMirror,
+} = require("./terminalHeadlessMirror.cjs");
+
+/**
+ * Deliver terminal output to the renderer and optionally mirror it in a
+ * headless xterm on the main process for fast hibernate snapshots.
+ */
+function emitTerminalSessionData(contents, sessionId, data, options = {}) {
+  const { cols, rows, mirrorEnabled = true } = options;
+  if (mirrorEnabled && data) {
+    writeMirror(sessionId, data, cols, rows);
+  }
+  contents?.send("netcatty:data", { sessionId, data });
+}
+
+function registerTerminalMirrorHandlers(ipcMain) {
+  ipcMain.handle("netcatty:mirror:snapshot", (_event, payload = {}) => {
+    const sessionId = payload.sessionId;
+    if (!sessionId) return { snapshot: "", alternateScreen: false };
+    return serializeMirror(sessionId);
+  });
+
+  ipcMain.handle("netcatty:mirror:resize", (_event, payload = {}) => {
+    const { sessionId, cols, rows } = payload;
+    if (!sessionId || !cols || !rows) return { ok: false };
+    resizeMirror(sessionId, cols, rows);
+    return { ok: true };
+  });
+
+  ipcMain.handle("netcatty:mirror:dispose", (_event, payload = {}) => {
+    const sessionId = payload.sessionId;
+    if (!sessionId) return { ok: false };
+    disposeMirror(sessionId);
+    return { ok: true };
+  });
+}
+
+module.exports = {
+  emitTerminalSessionData,
+  registerTerminalMirrorHandlers,
+  disposeMirror,
+};

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
+
 function createStartSessionApi(ctx) {
   with (ctx) {
     /**
@@ -61,6 +63,8 @@ function createStartSessionApi(ctx) {
           port: options.port || 22,
           username: options.username || 'root',
         },
+        cols: options.cols || 80,
+        rows: options.rows || 24,
       };
       sessions.set(sessionId, session);
 
@@ -95,7 +99,11 @@ function createStartSessionApi(ctx) {
       // cap still forces an immediate flush for bursts of output.
       const { bufferData, flush: flushBuffer } = createPtyOutputBuffer((data) => {
         const contents = event.sender;
-        safeSend(contents, "netcatty:data", { sessionId, data });
+        const current = sessions.get(sessionId);
+        emitTerminalSessionData(contents, sessionId, data, {
+          cols: current?.cols,
+          rows: current?.rows,
+        });
       });
 
       const sshZmodemSentry = createZmodemSentry({
@@ -1017,7 +1025,11 @@ function createStartSessionApi(ctx) {
             sendProgress(totalHops, totalHops, options.hostname, 'shell');
 
             const sendTerminalMessage = (data) => {
-              safeSend(event.sender, "netcatty:data", { sessionId, data });
+              const current = sessions.get(sessionId);
+              emitTerminalSessionData(event.sender, sessionId, data, {
+                cols: current?.cols,
+                rows: current?.rows,
+              });
             };
 
             const x11FakeCookie = options.x11Forwarding

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -13,6 +13,8 @@ const { promisify } = require("node:util");
 const { StringDecoder } = require("node:string_decoder");
 const pty = require("node-pty");
 const { SerialPort } = require("serialport");
+const { emitTerminalSessionData, disposeMirror } = require("./emitTerminalSessionData.cjs");
+const { resizeMirror } = require("./terminalHeadlessMirror.cjs");
 const iconv = require("iconv-lite");
 const ptyProcessTree = require("./ptyProcessTree.cjs");
 
@@ -404,7 +406,10 @@ function startLocalSession(event, payload) {
 
   const { bufferData: bufferLocalData, flush: flushLocal } = createPtyOutputBuffer((data) => {
     const contents = electronModule.webContents.fromId(session.webContentsId);
-    contents?.send("netcatty:data", { sessionId, data });
+    emitTerminalSessionData(contents, sessionId, data, {
+      cols: session.cols,
+      rows: session.rows,
+    });
   });
   session.flushPendingData = flushLocal;
 
@@ -626,7 +631,10 @@ async function startSerialSession(event, options) {
             const decoded = serialDecoderRef.current.write(buf);
             if (!decoded) return;
             const contents = electronModule.webContents.fromId(session.webContentsId);
-            contents?.send("netcatty:data", { sessionId, data: decoded });
+            emitTerminalSessionData(contents, sessionId, decoded, {
+              cols: session.cols,
+              rows: session.rows,
+            });
             sessionLogStreamManager.appendData(sessionId, decoded);
           },
           writeToRemote(buf) {
@@ -944,6 +952,9 @@ function resizeSession(event, payload) {
   if (!session) return;
   if (Number.isFinite(payload.cols)) session.cols = payload.cols;
   if (Number.isFinite(payload.rows)) session.rows = payload.rows;
+  if (Number.isFinite(payload.cols) && Number.isFinite(payload.rows)) {
+    resizeMirror(payload.sessionId, payload.cols, payload.rows);
+  }
   
   try {
     if (session.stream) {
@@ -980,6 +991,7 @@ function resizeSession(event, payload) {
 function closeSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   if (!session) return;
+  disposeMirror(payload.sessionId);
   session.closed = true;
   
   try {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 const crypto = require("node:crypto");
 const { createSystemKnownHostsApi } = require("../sshBridge/systemKnownHosts.cjs");
+const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
 
 //
 // EternalTerminal session backend, factored into the createXxxSessionApi
@@ -818,7 +819,10 @@ main();
 
         const { bufferData: bufferEtData, flush: flushEt } = createPtyOutputBuffer((data) => {
           const contents = electronModule.webContents.fromId(session.webContentsId);
-          contents?.send("netcatty:data", { sessionId, data });
+          emitTerminalSessionData(contents, sessionId, data, {
+            cols: session.cols,
+            rows: session.rows,
+          });
         });
         session.flushPendingData = flushEt;
 

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
+
 function createMoshSessionApi(ctx) {
   with (ctx) {
     function resolveBareMoshClient(_options, opts = {}) {
@@ -425,7 +427,10 @@ function createMoshSessionApi(ctx) {
     
       const { bufferData, flush } = createPtyOutputBuffer((data) => {
         const contents = electronModule.webContents.fromId(session.webContentsId);
-        contents?.send("netcatty:data", { sessionId, data });
+        emitTerminalSessionData(contents, sessionId, data, {
+          cols: session.cols,
+          rows: session.rows,
+        });
       });
       session.flushPendingData = flush;
     

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
+
 function createTelnetSessionApi(ctx) {
   with (ctx) {
     async function startTelnetSession(event, options) {
@@ -154,7 +156,7 @@ function createTelnetSessionApi(ctx) {
         const telnetWebContentsId = event.sender.id;
         const { bufferData: bufferTelnetData, flush: flushTelnet } = createPtyOutputBuffer((data) => {
           const contents = electronModule.webContents.fromId(telnetWebContentsId);
-          contents?.send("netcatty:data", { sessionId, data });
+          emitTerminalSessionData(contents, sessionId, data, { cols, rows });
         });
     
         const telnetZmodemSentry = createZmodemSentry({

--- a/electron/bridges/terminalHeadlessMirror.cjs
+++ b/electron/bridges/terminalHeadlessMirror.cjs
@@ -1,0 +1,100 @@
+"use strict";
+
+const { SerializeAddon } = require("@xterm/addon-serialize");
+const { Terminal: HeadlessTerminal } = require("@xterm/headless");
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const DEFAULT_SCROLLBACK = 3000;
+
+/** @type {Map<string, { headless: import("@xterm/headless").Terminal, serializer: SerializeAddon, cols: number, rows: number }>} */
+const mirrors = new Map();
+
+function isAlternateScreenActive(headless) {
+  return headless.buffer.active.type === "alternate";
+}
+
+function createMirror(cols, rows) {
+  const headless = new HeadlessTerminal({
+    cols,
+    rows,
+    scrollback: DEFAULT_SCROLLBACK,
+    allowProposedApi: true,
+  });
+  const serializer = new SerializeAddon();
+  headless.loadAddon(serializer);
+  return { headless, serializer, cols, rows };
+}
+
+function ensureMirror(sessionId, cols = DEFAULT_COLS, rows = DEFAULT_ROWS) {
+  let mirror = mirrors.get(sessionId);
+  if (!mirror) {
+    mirror = createMirror(cols, rows);
+    mirrors.set(sessionId, mirror);
+    return mirror;
+  }
+  if (mirror.cols !== cols || mirror.rows !== rows) {
+    try {
+      mirror.headless.resize(cols, rows);
+    } catch {
+      // Ignore resize failures on disposed mirrors.
+    }
+    mirror.cols = cols;
+    mirror.rows = rows;
+  }
+  return mirror;
+}
+
+function writeMirror(sessionId, data, cols, rows) {
+  if (!data) return;
+  const mirror = ensureMirror(sessionId, cols, rows);
+  mirror.headless.write(data);
+}
+
+function resizeMirror(sessionId, cols, rows) {
+  if (!mirrors.has(sessionId)) return;
+  const mirror = ensureMirror(sessionId, cols, rows);
+  try {
+    mirror.headless.resize(cols, rows);
+  } catch {
+    mirrors.delete(sessionId);
+  }
+}
+
+function serializeMirror(sessionId) {
+  const mirror = mirrors.get(sessionId);
+  if (!mirror) {
+    return { snapshot: "", alternateScreen: false };
+  }
+  const alternateScreen = isAlternateScreenActive(mirror.headless);
+  try {
+    const snapshot = mirror.serializer.serialize({
+      excludeAltBuffer: !alternateScreen,
+      excludeModes: !alternateScreen,
+      ...(alternateScreen
+        ? { range: { start: 0, end: Math.max(0, mirror.rows - 1) } }
+        : {}),
+    });
+    return { snapshot, alternateScreen };
+  } catch {
+    return { snapshot: "", alternateScreen };
+  }
+}
+
+function disposeMirror(sessionId) {
+  const mirror = mirrors.get(sessionId);
+  if (!mirror) return;
+  try {
+    mirror.headless.dispose();
+  } catch {
+    // Ignore dispose failures.
+  }
+  mirrors.delete(sessionId);
+}
+
+module.exports = {
+  writeMirror,
+  resizeMirror,
+  serializeMirror,
+  disposeMirror,
+};

--- a/electron/bridges/terminalHeadlessMirror.test.cjs
+++ b/electron/bridges/terminalHeadlessMirror.test.cjs
@@ -1,0 +1,21 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  writeMirror,
+  serializeMirror,
+  disposeMirror,
+} = require("./terminalHeadlessMirror.cjs");
+
+test("terminalHeadlessMirror tracks output and serializes snapshot", async () => {
+  const sessionId = "mirror-test-session";
+  disposeMirror(sessionId);
+  writeMirror(sessionId, "hello\r\n", 80, 24);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const { snapshot, alternateScreen } = serializeMirror(sessionId);
+  assert.equal(alternateScreen, false);
+  assert.match(snapshot, /hello/);
+  disposeMirror(sessionId);
+});

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -170,6 +170,8 @@ function createBridgeRegistrar(context) {
     transferBridge.registerHandlers(ipcMain);
     portForwardingBridge.registerHandlers(ipcMain);
     terminalBridge.registerHandlers(ipcMain);
+    const { registerTerminalMirrorHandlers } = require("../bridges/emitTerminalSessionData.cjs");
+    registerTerminalMirrorHandlers(ipcMain);
 
     const { createSystemManagerBridge } = require("../bridges/systemManagerBridge.cjs");
     const systemManagerBridge = createSystemManagerBridge({

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -172,6 +172,9 @@ function createPreloadApi(ctx) {
   resizeSession: (sessionId, cols, rows) => {
     ipcRenderer.send("netcatty:resize", { sessionId, cols, rows });
   },
+  getTerminalMirrorSnapshot: (sessionId) => {
+    return ipcRenderer.invoke("netcatty:mirror:snapshot", { sessionId });
+  },
   setSessionFlowPaused: (sessionId, paused) => {
     ipcRenderer.send("netcatty:flow", { sessionId, paused: Boolean(paused) });
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@xterm/addon-unicode-graphemes": "0.5.0-beta.220",
         "@xterm/addon-web-links": "0.13.0-beta.220",
         "@xterm/addon-webgl": "0.20.0-beta.219",
+        "@xterm/headless": "^6.1.0-beta.220",
         "@xterm/xterm": "6.1.0-beta.220",
         "ai": "^6.0.116",
         "clsx": "2.1.1",
@@ -339,29 +340,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.99.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.99.0.tgz",
-      "integrity": "sha512-vdicFA9YjtvgpG8rxp39hqW4oxpkdRGPTq0QEts5TZhr2GkLozDduK/GiXrLQ7PzrKYBtIkQFdRW+QBjzlsABg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1292,6 +1270,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1571,13 +1550,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
-      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "optional": true
     },
     "node_modules/@buttercup/fetch": {
       "version": "0.2.1",
@@ -1897,6 +1869,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1986,6 +1959,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1995,21 +1969,12 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
       "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@connectrpc/connect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
-      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
@@ -2146,6 +2111,13 @@
       "bin": {
         "rg": "bin/rg.exe"
       }
+    },
+    "node_modules/@cursor/sdk/node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "optional": true
     },
     "node_modules/@cursor/sdk/node_modules/zod": {
       "version": "3.25.76",
@@ -2452,7 +2424,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2474,7 +2445,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3884,6 +3854,7 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -4166,6 +4137,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -7588,8 +7560,7 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -8213,6 +8184,7 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -8242,6 +8214,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8590,11 +8563,21 @@
         "@xterm/xterm": "^6.1.0-beta.220"
       }
     },
+    "node_modules/@xterm/headless": {
+      "version": "6.1.0-beta.220",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.1.0-beta.220.tgz",
+      "integrity": "sha512-oc+cI28eP/ktv91ddk1MxsEdfS41dnNvB3eMjNxfP7v+SaM7aXgXAL8Kj0/zzbpX/dG0nbA9wi3YvsybzCN3OQ==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/@xterm/xterm": {
       "version": "6.1.0-beta.220",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.220.tgz",
       "integrity": "sha512-rwEKE75wfwfNWeGnjl0iQRA1W50HigKoGcGMeF3o5CqDSdI9IjmwzpV9xHXqLH6CYj6s9N1g6bbKFVDou9dJ/A==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "addons/*"
       ]
@@ -8659,6 +8642,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9360,6 +9344,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10185,8 +10170,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10483,6 +10467,7 @@
       "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.2",
         "builder-util": "26.15.0",
@@ -10764,7 +10749,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10785,7 +10769,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10801,7 +10784,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10812,7 +10794,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -11037,6 +11018,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11490,8 +11472,7 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -12428,6 +12409,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12884,7 +12866,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -13006,7 +12987,6 @@
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -13164,7 +13144,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14110,6 +14089,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -15230,7 +15210,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -15250,6 +15229,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -16000,7 +15980,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -16018,7 +15997,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -16323,6 +16301,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16332,6 +16311,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17669,7 +17649,6 @@
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -17975,7 +17954,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -18002,7 +17980,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18077,6 +18054,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18171,8 +18149,7 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -18199,6 +18176,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -18310,6 +18288,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18350,6 +18329,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -18725,6 +18705,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18818,6 +18799,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19105,6 +19087,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@xterm/addon-unicode-graphemes": "0.5.0-beta.220",
     "@xterm/addon-web-links": "0.13.0-beta.220",
     "@xterm/addon-webgl": "0.20.0-beta.219",
+    "@xterm/headless": "^6.1.0-beta.220",
     "@xterm/xterm": "6.1.0-beta.220",
     "ai": "^6.0.116",
     "clsx": "2.1.1",

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -274,6 +274,10 @@ declare global {
       action: "overwrite" | "skip" | "cancel";
       applyToRest: boolean;
     }): void;
+    getTerminalMirrorSnapshot?(sessionId: string): Promise<{
+      snapshot: string;
+      alternateScreen: boolean;
+    }>;
     onSessionData(sessionId: string, cb: (data: string) => void): () => void;
     onSessionExit(
       sessionId: string,


### PR DESCRIPTION
## Summary
- **Chunked replay**: wake restores snapshot/pending output in configurable 4–64 KB frames via `requestAnimationFrame`, avoiding long main-thread blocks on large buffers
- **Deferred WebGL**: hibernate wake keeps the DOM renderer until replay completes, then enables WebGL and clears the texture atlas
- **Smarter hibernate policy**: skip hibernate on alternate-screen TUIs by default; soft-hide up to N hidden tabs (WebGL suspended) with LRU eviction before full hibernate
- **Two-phase snapshots**: serialize viewport separately from scrollback; viewport + pending replay first, scrollback lazy-replays on idle
- **Main-process headless mirror** (`@xterm/headless`): PTY output mirrored in Electron main for faster wake snapshots (Superset-style)
- **WASM serialize hook**: optional prefer-WASM setting with JS SerializeAddon fallback until upstream WASM addon ships

## Plan
See `docs/superpowers/plans/2026-06-24-terminal-hibernate-optimizations.md`

## Test plan
- [x] `node --test --import tsx domain/terminalHibernate*.test.ts application/state/terminalHiddenRendererStore.test.ts components/terminal/terminalHibernateRuntime.test.ts components/terminal/terminalReplay.test.ts`
- [x] `node --test electron/bridges/terminalHeadlessMirror.test.cjs`
- [x] `npm run lint`
- [ ] Switch between tabs with large scrollback / full-screen TUI and confirm faster wake + no UI freeze
- [ ] Verify Settings > Terminal hibernate tuning controls persist
- [ ] Confirm soft-hide keeps up to N hidden renderers before full hibernate


Made with [Cursor](https://cursor.com)