### PR TITLE
fix(terminal): disable hibernate hidden tabs by default

### DIFF
--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -351,7 +351,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   forcePromptNewLine: false, // Opt-in: keep the next shell prompt visually separated from unterminated final output lines
   osc52Clipboard: 'write-only', // OSC-52: allow remote programs to write clipboard by default
   rendererType: 'auto', // Auto-detect best renderer based on hardware
-  hibernateHiddenTabs: true,
+  hibernateHiddenTabs: false,
   hibernateHiddenTabsDelaySec: 5,
   hibernateSkipAltScreen: true,
   hibernateKeepRendererCount: 2,

--- a/domain/terminalHibernate.test.ts
+++ b/domain/terminalHibernate.test.ts
@@ -26,8 +26,8 @@ test("capHibernateBufferByLines keeps the most recent lines", () => {
   assert.equal(capHibernateBufferByLines(input, 2), "line-3\nline-4");
 });
 
-test("resolveTerminalHibernateEnabled defaults to enabled", () => {
-  assert.equal(resolveTerminalHibernateEnabled(), true);
+test("resolveTerminalHibernateEnabled defaults to disabled", () => {
+  assert.equal(resolveTerminalHibernateEnabled(), false);
   assert.equal(resolveTerminalHibernateEnabled({ hibernateHiddenTabs: true }), true);
   assert.equal(resolveTerminalHibernateEnabled({ hibernateHiddenTabs: false }), false);
 });

--- a/domain/terminalHibernate.ts
+++ b/domain/terminalHibernate.ts
@@ -33,7 +33,7 @@ export function resolveTerminalHibernateEnabled(
   settings?: Pick<TerminalSettings, "hibernateHiddenTabs"> | null,
 ): boolean {
   if (!TERMINAL_HIBERNATE_ENABLED) return false;
-  return settings?.hibernateHiddenTabs !== false;
+  return settings?.hibernateHiddenTabs === true;
 }
 
 /** Block hibernate while a file transfer or drag-drop session is in progress. */

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -17,8 +17,8 @@ test("normalizeTerminalSettings enables font smoothing by default", () => {
   assert.equal(normalizeTerminalSettings().fontSmoothing, true);
 });
 
-test("normalizeTerminalSettings enables hibernate for hidden tabs by default", () => {
-  assert.equal(normalizeTerminalSettings().hibernateHiddenTabs, true);
+test("normalizeTerminalSettings disables hibernate for hidden tabs by default", () => {
+  assert.equal(normalizeTerminalSettings().hibernateHiddenTabs, false);
   assert.equal(normalizeTerminalSettings().hibernateHiddenTabsDelaySec, 5);
 });
 


### PR DESCRIPTION
## Summary
- Change the default for `hibernateHiddenTabs` from enabled to disabled so tab hibernation is opt-in.
- Update `resolveTerminalHibernateEnabled` to only return true when the setting is explicitly enabled.

## Test plan
- [x] `node --test --import tsx domain/terminalHibernate.test.ts domain/terminalSettings.test.ts`
- [ ] Fresh install / reset terminal settings: "Hibernate hidden tabs" is off by default
- [ ] Manually enabling the setting still activates hibernate behavior for off-screen tabs


Made with [Cursor](https://cursor.com)