### PR TITLE
fix(ai): allow Netcatty CLI paths for OpenCode skills mode

### DIFF
--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -141,6 +141,7 @@ const DRIVER_REGISTRY = {
         binPath: ctx.binPath,
         injectedMcpServers: ctx.injectedMcpServers,
         toolIntegrationMode: ctx.toolIntegrationMode,
+        skillsPathAllowlist: ctx.skillsPathAllowlist,
         resumeSessionId: ctx.resumeSessionId,
         emitter: ctx.emitter,
         abortController: ctx.abortController,

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
@@ -43,14 +43,21 @@ function buildNetcattySkillsOpenCodePathAllowlist({
   discoveryFilePath,
   cliStateDir,
   runtimeBinaryPath,
+  tempDir,
+  extraFilePaths,
 } = {}) {
+  const filePaths = [
+    launcherPath,
+    cliScriptPath,
+    skillPath,
+    discoveryFilePath,
+    runtimeBinaryPath,
+    ...(Array.isArray(extraFilePaths) ? extraFilePaths : []),
+  ];
   return dedupePatterns([
-    launcherPath && toOpenCodeFileParentGlob(launcherPath),
-    cliScriptPath && toOpenCodeFileParentGlob(cliScriptPath),
-    skillPath && toOpenCodeFileParentGlob(skillPath),
-    discoveryFilePath && toOpenCodeFileParentGlob(discoveryFilePath),
+    ...filePaths.map((filePath) => filePath && toOpenCodeFileParentGlob(filePath)),
     cliStateDir && toOpenCodeDirectoryGlob(cliStateDir),
-    runtimeBinaryPath && toOpenCodeFileParentGlob(runtimeBinaryPath),
+    tempDir && toOpenCodeDirectoryGlob(tempDir),
   ]);
 }
 

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
@@ -1,0 +1,81 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function normalizeOpenCodePath(targetPath) {
+  return process.platform === "win32"
+    ? targetPath.replace(/\\/g, "/")
+    : targetPath;
+}
+
+function toOpenCodeDirectoryGlob(dirPath) {
+  if (!dirPath || typeof dirPath !== "string") return null;
+  try {
+    const resolved = path.resolve(dirPath);
+    let baseDir = resolved;
+    if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
+      baseDir = path.dirname(resolved);
+    }
+    return `${normalizeOpenCodePath(baseDir)}/**`;
+  } catch {
+    return null;
+  }
+}
+
+function toOpenCodeFileParentGlob(filePath) {
+  if (!filePath || typeof filePath !== "string") return null;
+  try {
+    return toOpenCodeDirectoryGlob(path.dirname(path.resolve(filePath)));
+  } catch {
+    return null;
+  }
+}
+
+function dedupePatterns(patterns) {
+  return [...new Set(patterns.filter(Boolean))];
+}
+
+function buildNetcattySkillsOpenCodePathAllowlist({
+  launcherPath,
+  cliScriptPath,
+  skillPath,
+  discoveryFilePath,
+  cliStateDir,
+  runtimeBinaryPath,
+} = {}) {
+  return dedupePatterns([
+    launcherPath && toOpenCodeFileParentGlob(launcherPath),
+    cliScriptPath && toOpenCodeFileParentGlob(cliScriptPath),
+    skillPath && toOpenCodeFileParentGlob(skillPath),
+    discoveryFilePath && toOpenCodeFileParentGlob(discoveryFilePath),
+    cliStateDir && toOpenCodeDirectoryGlob(cliStateDir),
+    runtimeBinaryPath && toOpenCodeFileParentGlob(runtimeBinaryPath),
+  ]);
+}
+
+function buildOpenCodeSkillsPermissionRules(pathAllowlist = []) {
+  const external_directory = { "*": "deny" };
+  const read = {};
+  for (const pattern of pathAllowlist) {
+    external_directory[pattern] = "allow";
+    read[pattern] = "allow";
+  }
+
+  return {
+    bash: "allow",
+    read,
+    list: "deny",
+    glob: "deny",
+    grep: "deny",
+    skill: "allow",
+    external_directory,
+  };
+}
+
+module.exports = {
+  buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeSkillsPermissionRules,
+  toOpenCodeDirectoryGlob,
+  toOpenCodeFileParentGlob,
+};

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
@@ -46,6 +46,19 @@ test("buildNetcattySkillsOpenCodePathAllowlist dedupes launcher and script roots
   ]);
 });
 
+test("buildNetcattySkillsOpenCodePathAllowlist includes temp dir and extra attachment paths", () => {
+  const patterns = buildNetcattySkillsOpenCodePathAllowlist({
+    discoveryFilePath: "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/discovery.json",
+    tempDir: "/var/folders/tmp/Netcatty",
+    extraFilePaths: ["/var/folders/tmp/Netcatty/ai-attachment-1.png"],
+  });
+
+  assert.deepEqual(patterns, [
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+    "/var/folders/tmp/Netcatty/**",
+  ]);
+});
+
 test("buildOpenCodeSkillsPermissionRules allowlists Netcatty CLI paths and denies other external access", () => {
   const rules = buildOpenCodeSkillsPermissionRules([
     "/Applications/Netcatty.app/Contents/MacOS/**",

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeSkillsPermissionRules,
+  toOpenCodeDirectoryGlob,
+  toOpenCodeFileParentGlob,
+} = require("./netcattySkillsOpenCodePermissions.cjs");
+
+test("toOpenCodeFileParentGlob maps files to parent directory globs", () => {
+  assert.equal(
+    toOpenCodeFileParentGlob("/Applications/Netcatty.app/Contents/MacOS/netcatty-tool-cli"),
+    "/Applications/Netcatty.app/Contents/MacOS/**",
+  );
+  assert.equal(
+    toOpenCodeFileParentGlob("/tmp/netcatty/skills/netcatty-tool-cli/SKILL.md"),
+    "/tmp/netcatty/skills/netcatty-tool-cli/**",
+  );
+});
+
+test("toOpenCodeDirectoryGlob keeps directory roots stable when missing on disk", () => {
+  assert.equal(
+    toOpenCodeDirectoryGlob("/Users/me/Library/Application Support/netcatty/netcatty-tool-cli"),
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+  );
+});
+
+test("buildNetcattySkillsOpenCodePathAllowlist dedupes launcher and script roots", () => {
+  const launcher = "/Applications/Netcatty.app/Contents/MacOS/netcatty-tool-cli";
+  const script = "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli/netcatty-tool-cli.cjs";
+  const skill = "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/skills/netcatty-tool-cli/SKILL.md";
+  const patterns = buildNetcattySkillsOpenCodePathAllowlist({
+    launcherPath: launcher,
+    cliScriptPath: script,
+    skillPath: skill,
+    discoveryFilePath: "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/discovery.json",
+    cliStateDir: "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli",
+  });
+
+  assert.deepEqual(patterns, [
+    "/Applications/Netcatty.app/Contents/MacOS/**",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli/**",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/skills/netcatty-tool-cli/**",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+  ]);
+});
+
+test("buildOpenCodeSkillsPermissionRules allowlists Netcatty CLI paths and denies other external access", () => {
+  const rules = buildOpenCodeSkillsPermissionRules([
+    "/Applications/Netcatty.app/Contents/MacOS/**",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+  ]);
+
+  assert.equal(rules.bash, "allow");
+  assert.equal(rules.skill, "allow");
+  assert.equal(rules.list, "deny");
+  assert.deepEqual(rules.external_directory, {
+    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
+    "*": "deny",
+  });
+  assert.deepEqual(rules.read, {
+    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
+  });
+});

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -5,6 +5,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
+const {
+  buildOpenCodeSkillsPermissionRules,
+} = require("./netcattySkillsOpenCodePermissions.cjs");
 
 const OPENCODE_IMAGE_MEDIA_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
 const DEFAULT_OPENCODE_PORT = 4096;
@@ -55,17 +58,21 @@ function toOpenCodeMcpConfig(injectedMcpServers) {
   return mcp;
 }
 
-function buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode } = {}) {
+function buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode, skillsPathAllowlist } = {}) {
   const allowBash = toolIntegrationMode === "skills";
+  const permission = {
+    edit: "deny",
+    bash: allowBash ? "allow" : "deny",
+    webfetch: "deny",
+    external_directory: "deny",
+  };
+  if (allowBash && Array.isArray(skillsPathAllowlist) && skillsPathAllowlist.length > 0) {
+    Object.assign(permission, buildOpenCodeSkillsPermissionRules(skillsPathAllowlist));
+  }
   const config = {
     share: "disabled",
     autoupdate: false,
-    permission: {
-      edit: "deny",
-      bash: allowBash ? "allow" : "deny",
-      webfetch: "deny",
-      external_directory: "deny",
-    },
+    permission,
     mcp: toOpenCodeMcpConfig(injectedMcpServers),
   };
   if (model) config.model = model;
@@ -505,9 +512,9 @@ function createStopWait() {
 
 async function runOpenCodeTurn({
   prompt, systemPrompt, attachments, cwd, model, injectedMcpServers, toolIntegrationMode,
-  resumeSessionId, env, binPath, emitter, abortController, openCodeFactory,
+  skillsPathAllowlist, resumeSessionId, env, binPath, emitter, abortController, openCodeFactory,
 }) {
-  const config = buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode });
+  const config = buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode, skillsPathAllowlist });
   let opencode = null;
   let sessionId = resumeSessionId || null;
   let hasContent = false;

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -64,6 +64,25 @@ test("buildOpenCodeConfig isolates local tools and injects Netcatty MCP", () => 
   });
 });
 
+test("buildOpenCodeConfig allowlists Netcatty CLI paths in skills mode", () => {
+  const cfg = buildOpenCodeConfig({
+    toolIntegrationMode: "skills",
+    skillsPathAllowlist: [
+      "/Applications/Netcatty.app/Contents/MacOS/**",
+      "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+    ],
+  });
+
+  assert.equal(cfg.permission.bash, "allow");
+  assert.equal(cfg.permission.skill, "allow");
+  assert.equal(cfg.permission.list, "deny");
+  assert.deepEqual(cfg.permission.external_directory, {
+    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
+    "*": "deny",
+  });
+});
+
 test("buildOpenCodePromptParts includes supported images as file parts", () => {
   assert.deepEqual(buildOpenCodePromptParts("describe", [
     { filename: "shot.png", mediaType: "image/png", filePath: "/tmp/shot.png", base64Data: "abc" },

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -5,7 +5,7 @@ const { buildSdkAgentEnv } = require("./env.cjs");
 const { buildInjectedMcpServers } = require("./injectMcp.cjs");
 const { createStreamEmitter } = require("./emit.cjs");
 const { buildNetcattySkillsOpenCodePathAllowlist } = require("./netcattySkillsOpenCodePermissions.cjs");
-const { getToolCliStateDir } = require("../../cli/discoveryPath.cjs");
+const { getToolCliStateDir } = require("../../../cli/discoveryPath.cjs");
 const { realpathSync } = require("node:fs");
 
 const VALID_BACKENDS = new Set(listBackends());

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -6,6 +6,7 @@ const { buildInjectedMcpServers } = require("./injectMcp.cjs");
 const { createStreamEmitter } = require("./emit.cjs");
 const { buildNetcattySkillsOpenCodePathAllowlist } = require("./netcattySkillsOpenCodePermissions.cjs");
 const { getToolCliStateDir } = require("../../../cli/discoveryPath.cjs");
+const tempDirBridge = require("../../tempDirBridge.cjs");
 const { realpathSync } = require("node:fs");
 
 const VALID_BACKENDS = new Set(listBackends());
@@ -411,9 +412,15 @@ function registerSdkStreamHandlers(ctx) {
               launcherPath: NETCATTY_TOOL_LAUNCHER_PATH,
               cliScriptPath: NETCATTY_TOOL_CLI_PATH,
               skillPath: NETCATTY_TOOL_SKILL_PATH,
-              discoveryFilePath: cliDiscoveryFilePath,
-              cliStateDir: getToolCliStateDir(),
+              discoveryFilePath: cliDiscoveryFilePath || undefined,
+              cliStateDir: cliDiscoveryFilePath
+                ? undefined
+                : getToolCliStateDir({ userDataDir: electronModule?.getPath?.("userData") }),
               runtimeBinaryPath: process.execPath,
+              tempDir: tempDirBridge.getTempDir(),
+              extraFilePaths: stagedAttachments
+                .map((attachment) => attachment?.filePath)
+                .filter(Boolean),
             })
             : undefined;
           const result = await driver.runTurn({

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -4,6 +4,8 @@ const { getDriver, listBackends } = require("./index.cjs");
 const { buildSdkAgentEnv } = require("./env.cjs");
 const { buildInjectedMcpServers } = require("./injectMcp.cjs");
 const { createStreamEmitter } = require("./emit.cjs");
+const { buildNetcattySkillsOpenCodePathAllowlist } = require("./netcattySkillsOpenCodePermissions.cjs");
+const { getToolCliStateDir } = require("../../cli/discoveryPath.cjs");
 const { realpathSync } = require("node:fs");
 
 const VALID_BACKENDS = new Set(listBackends());
@@ -404,6 +406,16 @@ function registerSdkStreamHandlers(ctx) {
               }
             },
           };
+          const skillsPathAllowlist = effectiveMode === "skills" && backendKey === "opencode"
+            ? buildNetcattySkillsOpenCodePathAllowlist({
+              launcherPath: NETCATTY_TOOL_LAUNCHER_PATH,
+              cliScriptPath: NETCATTY_TOOL_CLI_PATH,
+              skillPath: NETCATTY_TOOL_SKILL_PATH,
+              discoveryFilePath: cliDiscoveryFilePath,
+              cliStateDir: getToolCliStateDir(),
+              runtimeBinaryPath: process.execPath,
+            })
+            : undefined;
           const result = await driver.runTurn({
             prompt: backendKey === "opencode" ? turnPrompt : contextualPrompt,
             systemPrompt: backendKey === "opencode" ? systemContext : undefined,
@@ -414,6 +426,7 @@ function registerSdkStreamHandlers(ctx) {
             injectedMcpServers,
             claudeSettings,
             toolIntegrationMode: effectiveMode,
+            skillsPathAllowlist,
             emitter: driverEmitter,
             signal: abortController.signal,
             abortController,


### PR DESCRIPTION
## Summary
- Add OpenCode skills-mode permission allowlist for Netcatty CLI launcher, script, skill file, discovery/state directories, and runtime binary paths.
- Keep unrelated external directory access denied and disable list/glob/grep so the agent routes remote work through bash + netcatty-tool-cli instead of native file tools.

## Problem
OpenCode + Skills + CLI failed because Netcatty injected `external_directory: deny`, which blocked bash invocations of `netcatty-tool-cli` and skill reads outside the OpenCode workspace.

## Test plan
- [x] `node --test electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs`
- [ ] Settings → AI → Skills + CLI, OpenCode agent: ask to check machine config on scoped SSH session
- [ ] Confirm netcatty-tool-cli bash calls succeed without external_directory permission errors


Made with [Cursor](https://cursor.com)