### PR TITLE
fix: guard terminal write coalescing without raf

### DIFF
--- a/components/terminal/runtime/writeCoalescer.test.ts
+++ b/components/terminal/runtime/writeCoalescer.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { afterEach, beforeEach, test } from "node:test";
+import { beforeEach, test } from "node:test";
 
 import {
   createWriteCoalescer,
@@ -10,8 +10,18 @@ type FrameCallback = (time: number) => void;
 
 let frameCallbacks: Map<number, FrameCallback>;
 let nextFrameId: number;
-let originalRaf: typeof requestAnimationFrame;
-let originalCancelRaf: typeof cancelAnimationFrame;
+
+const createTestCoalescer = (write: (data: string) => void) =>
+  createWriteCoalescer(write, {
+    scheduleFrame(callback) {
+      const id = nextFrameId;
+      nextFrameId += 1;
+      frameCallbacks.set(id, callback);
+      return () => {
+        frameCallbacks.delete(id);
+      };
+    },
+  });
 
 const fireFrame = (): void => {
   const callbacks = [...frameCallbacks.values()];
@@ -24,27 +34,11 @@ const fireFrame = (): void => {
 beforeEach(() => {
   frameCallbacks = new Map();
   nextFrameId = 1;
-  originalRaf = globalThis.requestAnimationFrame;
-  originalCancelRaf = globalThis.cancelAnimationFrame;
-  globalThis.requestAnimationFrame = (callback: FrameCallback) => {
-    const id = nextFrameId;
-    nextFrameId += 1;
-    frameCallbacks.set(id, callback);
-    return id;
-  };
-  globalThis.cancelAnimationFrame = (id: number) => {
-    frameCallbacks.delete(id);
-  };
-});
-
-afterEach(() => {
-  globalThis.requestAnimationFrame = originalRaf;
-  globalThis.cancelAnimationFrame = originalCancelRaf;
 });
 
 test("coalesces chunks in the same frame into one write", () => {
   const writes: string[] = [];
-  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const coalescer = createTestCoalescer((data) => writes.push(data));
 
   coalescer.push("foo");
   coalescer.push("bar");
@@ -57,7 +51,7 @@ test("coalesces chunks in the same frame into one write", () => {
 
 test("schedules a new frame for data arriving after a flush", () => {
   const writes: string[] = [];
-  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const coalescer = createTestCoalescer((data) => writes.push(data));
 
   coalescer.push("first");
   fireFrame();
@@ -69,7 +63,7 @@ test("schedules a new frame for data arriving after a flush", () => {
 
 test("flushSync writes pending bytes immediately and cancels the scheduled frame", () => {
   const writes: string[] = [];
-  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const coalescer = createTestCoalescer((data) => writes.push(data));
 
   coalescer.push("pending");
   coalescer.flushSync();
@@ -81,7 +75,7 @@ test("flushSync writes pending bytes immediately and cancels the scheduled frame
 
 test("flushes synchronously when pending bytes exceed the cap", () => {
   const writes: string[] = [];
-  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const coalescer = createTestCoalescer((data) => writes.push(data));
   const chunk = "x".repeat(MAX_PENDING_WRITE_COALESCE_BYTES);
 
   coalescer.push(chunk);
@@ -92,7 +86,7 @@ test("flushes synchronously when pending bytes exceed the cap", () => {
 
 test("dispose flushes remaining bytes and stops accepting new chunks", () => {
   const writes: string[] = [];
-  const coalescer = createWriteCoalescer((data) => writes.push(data));
+  const coalescer = createTestCoalescer((data) => writes.push(data));
 
   coalescer.push("tail");
   coalescer.dispose();

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -20,16 +20,35 @@ export type WriteCoalescer = {
   dispose(): void;
 };
 
-export const createWriteCoalescer = (write: (data: string) => void): WriteCoalescer => {
+type ScheduleWriteFrame = (callback: () => void) => (() => void) | null;
+
+const scheduleWriteFrame = (callback: () => void): (() => void) | null => {
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    const frameId = globalThis.requestAnimationFrame(callback);
+    return () => {
+      if (typeof globalThis.cancelAnimationFrame === "function") {
+        globalThis.cancelAnimationFrame(frameId);
+      }
+    };
+  }
+
+  return null;
+};
+
+export const createWriteCoalescer = (
+  write: (data: string) => void,
+  options: { scheduleFrame?: ScheduleWriteFrame } = {},
+): WriteCoalescer => {
   let pending: string[] = [];
   let pendingBytes = 0;
-  let frameId: number | null = null;
+  let cancelPendingFrame: (() => void) | null = null;
   let disposed = false;
+  const scheduleFrame = options.scheduleFrame ?? scheduleWriteFrame;
 
   const flushSync = (): void => {
-    if (frameId !== null) {
-      cancelAnimationFrame(frameId);
-      frameId = null;
+    if (cancelPendingFrame !== null) {
+      cancelPendingFrame();
+      cancelPendingFrame = null;
     }
     if (pendingBytes === 0) {
       return;
@@ -50,11 +69,16 @@ export const createWriteCoalescer = (write: (data: string) => void): WriteCoales
       flushSync();
       return;
     }
-    if (frameId === null) {
-      frameId = requestAnimationFrame(() => {
-        frameId = null;
+    if (cancelPendingFrame === null) {
+      const cancelFrame = scheduleFrame(() => {
+        cancelPendingFrame = null;
         flushSync();
       });
+      if (cancelFrame === null) {
+        flushSync();
+        return;
+      }
+      cancelPendingFrame = cancelFrame;
     }
   };
 


### PR DESCRIPTION
## Summary
- Adds a non-browser fallback for terminal write coalescing so Node tests do not crash when requestAnimationFrame is absent.
- Keeps renderer behavior on requestAnimationFrame.
- Removes global requestAnimationFrame mutation from the coalescer unit test to avoid cross-test interference.

## Validation
- node --test --import tsx components/terminal/runtime/writeCoalescer.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/createTerminalSessionStarters.et.test.ts components/terminal/runtime/createTerminalSessionStarters.mosh.test.ts components/terminal/runtime/createTerminalSessionStarters.ssh.test.ts
- npm run lint
- npm run build
- npm test (remaining local-only failures are pre-existing SSH/telnet environment differences; the requestAnimationFrame failures are gone)
