### PR TITLE
fix: route port forward jump auth externally

### DIFF
--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -241,6 +241,7 @@ async function startPortForward(event, payload) {
           _connectionsRef: chainConnections,
           _tunnelRef: tunnelState,
           _passphraseSignal: passphraseAbortController.signal,
+          _keyboardInteractiveScope: "external",
         },
         jumpHosts,
         hostname,

--- a/electron/bridges/portForwardingBridge.jumpScope.test.cjs
+++ b/electron/bridges/portForwardingBridge.jumpScope.test.cjs
@@ -1,0 +1,111 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { Duplex } = require("node:stream");
+const Module = require("node:module");
+
+function createSender() {
+  return {
+    id: 1,
+    isDestroyed: () => false,
+    send() {},
+  };
+}
+
+function loadBridgeWithMocks(t) {
+  const originalLoad = Module._load;
+  let capturedChainOptions = null;
+
+  class MockSshClient extends EventEmitter {
+    connect(options) {
+      this.options = options;
+      setImmediate(() => this.emit("ready"));
+    }
+
+    forwardOut(_srcIP, _srcPort, _dstHost, _dstPort, callback) {
+      callback(null, new Duplex({
+        read() {},
+        write(_chunk, _encoding, done) {
+          done();
+        },
+      }));
+    }
+
+    end() {
+      this.emit("close");
+    }
+  }
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "ssh2") {
+      return {
+        Client: MockSshClient,
+        utils: {
+          parseKey: () => null,
+        },
+      };
+    }
+    if (request === "./sshBridge.cjs") {
+      return {
+        buildAlgorithms: () => ({}),
+        connectThroughChain: async (_event, options) => {
+          capturedChainOptions = options;
+          return {
+            socket: new Duplex({
+              read() {},
+              write(_chunk, _encoding, done) {
+                done();
+              },
+            }),
+            connections: [],
+          };
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const bridgePath = require.resolve("./portForwardingBridge.cjs");
+  delete require.cache[bridgePath];
+  const bridge = require("./portForwardingBridge.cjs");
+
+  t.after(() => {
+    Module._load = originalLoad;
+    delete require.cache[bridgePath];
+  });
+
+  return { bridge, getCapturedChainOptions: () => capturedChainOptions };
+}
+
+test("port forwarding routes jump-host keyboard-interactive prompts through the external scope", async (t) => {
+  const { bridge, getCapturedChainOptions } = loadBridgeWithMocks(t);
+  const event = { sender: createSender() };
+
+  try {
+    const result = await bridge.startPortForward(event, {
+      tunnelId: "pf-jump-scope",
+      type: "local",
+      localPort: 0,
+      bindAddress: "127.0.0.1",
+      remoteHost: "127.0.0.1",
+      remotePort: 3306,
+      hostname: "db.internal",
+      port: 22,
+      username: "dbuser",
+      password: "target-password",
+      jumpHosts: [{
+        hostname: "jump.internal",
+        port: 22,
+        username: "jumpuser",
+        password: "jump-password",
+      }],
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(getCapturedChainOptions()?._keyboardInteractiveScope, "external");
+  } finally {
+    await bridge.stopPortForward(event, { tunnelId: "pf-jump-scope" });
+  }
+});

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -479,6 +479,7 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
   const sender = event.sender;
   const connections = options?._connectionsRef || [];
   const sshDiagnosticLogger = options?._sshDiagnosticLogger || log;
+  const keyboardInteractiveScope = options?._keyboardInteractiveScope || "terminal";
   let currentSocket = null;
 
   const sendProgress = (hop, total, label, status, error) => {
@@ -727,7 +728,7 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
           hostname: hopLabel,
           password: jump.password,
           logPrefix: `[Chain] Hop ${i + 1}/${totalHops}`,
-          scope: "terminal",
+          scope: keyboardInteractiveScope,
           onAutoFill: () => sendProgress(
             i + 1, totalHops + 1, hopLabel, 'auth-attempt', 'using saved password',
           ),


### PR DESCRIPTION
## Summary
- Fixes jump-host keyboard-interactive prompts for port forwarding by routing them through the external connection scope.
- Keeps normal terminal jump-host authentication on the terminal scope.
- Adds a regression test that reproduces the port-forwarding jump-host path.

## Root cause
Port forwarding uses the shared jump-host connection helper, but that helper hardcoded jump-host keyboard-interactive prompts to the terminal session scope. Port-forwarding tunnels do not have a terminal session, so jump-host password prompts could not be answered correctly.

## Validation
- node --test electron/bridges/portForwardingBridge.jumpScope.test.cjs electron/bridges/portForwardingBridge.cancel.test.cjs electron/bridges/sshBridge.hostKeyChain.test.cjs electron/bridges/sftpBridge.hostKeyVerification.test.cjs electron/bridges/sftpBridge.cleanup.test.cjs
- npm run lint
- npm run build

Fixes #1644
