### PR TITLE
Add manual session log toolbar button

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -32,6 +32,8 @@ export const enTerminalMessages: Messages = {
   'terminal.toolbar.terminalSettings': 'Terminal settings',
   'terminal.toolbar.searchTerminal': 'Search terminal',
   'terminal.toolbar.search': 'Search',
+  'terminal.toolbar.startSessionLog': 'Start session log',
+  'terminal.toolbar.stopSessionLog': 'Stop session log',
   'terminal.toolbar.timestampsEnable': 'Show timestamps',
   'terminal.toolbar.timestampsDisable': 'Hide timestamps',
   'terminal.toolbar.broadcast': 'Broadcast',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -53,6 +53,8 @@ export const ruTerminalMessages: Messages = {
   'terminal.toolbar.terminalSettings': 'Настройки терминала',
   'terminal.toolbar.searchTerminal': 'Поиск по терминалу',
   'terminal.toolbar.search': 'Поиск',
+  'terminal.toolbar.startSessionLog': 'Начать журнал сессии',
+  'terminal.toolbar.stopSessionLog': 'Остановить журнал сессии',
   'terminal.toolbar.timestampsEnable': 'Показать время',
   'terminal.toolbar.timestampsDisable': 'Скрыть время',
   'terminal.toolbar.broadcast': 'Трансляция',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -315,6 +315,8 @@ export const zhCNVaultMessages: Messages = {
   'terminal.toolbar.terminalSettings': '终端设置',
   'terminal.toolbar.searchTerminal': '搜索终端',
   'terminal.toolbar.search': '搜索',
+  'terminal.toolbar.startSessionLog': '开始会话日志',
+  'terminal.toolbar.stopSessionLog': '停止会话日志',
   'terminal.toolbar.broadcast': '广播',
   'terminal.toolbar.broadcastEnable': '启用广播模式',
   'terminal.toolbar.broadcastDisable': '关闭广播模式',

--- a/application/state/useSessionLogBackend.ts
+++ b/application/state/useSessionLogBackend.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
+
+type ManualStartPayload = {
+  sessionId: string;
+  sessionName?: string;
+  preferredDirectory?: string;
+  initialLine?: string;
+};
+
+type ManualStopPayload = {
+  sessionId: string;
+};
+
+type ManualStatusPayload = {
+  sessionId: string;
+};
+
+export const useSessionLogBackend = () => {
+  const startManualSessionLog = useCallback(async (payload: ManualStartPayload) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.startManualSessionLog?.(payload) ?? { success: false, started: false, error: "Session log bridge unavailable" };
+  }, []);
+
+  const stopManualSessionLog = useCallback(async (payload: ManualStopPayload) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.stopManualSessionLog?.(payload) ?? { success: false, stopped: false, error: "Session log bridge unavailable" };
+  }, []);
+
+  const getManualSessionLogStatus = useCallback(async (payload: ManualStatusPayload) => {
+    const bridge = netcattyBridge.get();
+    return bridge?.getManualSessionLogStatus?.(payload) ?? { success: false, isLogging: false, error: "Session log bridge unavailable" };
+  }, []);
+
+  return { startManualSessionLog, stopManualSessionLog, getManualSessionLogStatus };
+};

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -29,6 +29,7 @@ import { classifyDistroId, shouldProbeSessionCwd } from "../domain/host";
 import { supportsZmodemTerminalDragDrop } from "../lib/zmodemDragDrop";
 import { resolveHostAuth } from "../domain/sshAuth";
 import { useTerminalBackend } from "../application/state/useTerminalBackend";
+import { useSessionLogBackend } from "../application/state/useSessionLogBackend";
 import { useTerminalLayoutSuppressActive } from "../application/state/terminalLayoutSuppressStore";
 // SFTPModal removed - SFTP is now handled by SftpSidePanel in TerminalLayer
 import { Button } from "./ui/button";
@@ -52,6 +53,7 @@ import { ZmodemProgressIndicator } from "./terminal/ZmodemProgressIndicator";
 import { createReplaySafeTerminalLogSanitizer } from "./terminal/replaySafeTerminalLog";
 import { createConnectionLogBuffer } from "./terminal/connectionLogBuffer";
 import { createProgrammaticCommandLogRewriter, type ProgrammaticCommandLogRewrite } from "./terminal/programmaticCommandLog";
+import { getSessionLogInitialLine } from "./terminal/sessionLogInitialLine";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import { createTerminalSessionStarters, type PendingAuth } from "./terminal/runtime/createTerminalSessionStarters";
 import { createXTermRuntime, type XTermRuntime } from "./terminal/runtime/createXTermRuntime";
@@ -347,6 +349,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const sudoHintRef = useRef<((active: boolean) => boolean) | undefined>(undefined);
 
   const terminalBackend = useTerminalBackend();
+  const { startManualSessionLog, stopManualSessionLog, getManualSessionLogStatus } = useSessionLogBackend();
   const {
     resizeSession,
     receiveSerialYmodem,
@@ -373,6 +376,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const [timeLeft, setTimeLeft] = useState(CONNECTION_TIMEOUT / 1000);
   const [isCancelling, setIsCancelling] = useState(false);
   const [showSFTP, setShowSFTP] = useState(false);
+  const [isSessionLogging, setIsSessionLogging] = useState(false);
   const [progressValue, setProgressValue] = useState(15);
   const [hasSelection, setHasSelection] = useState(false);
   const [selectionOverlayPosition, setSelectionOverlayPosition] = useState<{ left: number; top: number } | null>(null);
@@ -1550,6 +1554,70 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     containerRef,
   });
 
+  const handleToggleSessionLog = useCallback(async () => {
+    const currentSessionId = sessionRef.current ?? sessionId;
+    if (!currentSessionId) {
+      toast.error("Session log bridge is unavailable");
+      return;
+    }
+
+    try {
+      const currentStatus = await getManualSessionLogStatus({ sessionId: currentSessionId });
+      if (currentStatus?.isLogging) {
+        const stopResult = await stopManualSessionLog({ sessionId: currentSessionId });
+        if (stopResult?.success) {
+          setIsSessionLogging(false);
+        } else {
+          toast.error(stopResult?.error || "Failed to stop session log");
+        }
+        return;
+      }
+
+      const startResult = await startManualSessionLog({
+        sessionId: currentSessionId,
+        sessionName: host.label || host.hostname || currentSessionId,
+        preferredDirectory: sessionLog?.directory,
+        initialLine: termRef.current ? getSessionLogInitialLine(termRef.current) : "",
+      });
+      if (startResult?.success) {
+        if (!startResult?.started && startResult?.canceled) return;
+        setIsSessionLogging(!!startResult?.started);
+      } else {
+        toast.error(startResult?.error || "Failed to start session log");
+      }
+    } catch (err) {
+      logger.error("[Terminal] Failed to toggle manual session log:", err);
+      toast.error("Failed to toggle session log");
+    }
+  }, [
+    getManualSessionLogStatus,
+    host.hostname,
+    host.label,
+    sessionId,
+    sessionLog?.directory,
+    startManualSessionLog,
+    stopManualSessionLog,
+  ]);
+
+  useEffect(() => {
+    const currentSessionId = sessionRef.current ?? sessionId;
+    if (!currentSessionId) {
+      setIsSessionLogging(false);
+      return;
+    }
+
+    let cancelled = false;
+    void getManualSessionLogStatus({ sessionId: currentSessionId }).then((result) => {
+      if (!cancelled) setIsSessionLogging(!!result?.isLogging);
+    }).catch(() => {
+      if (!cancelled) setIsSessionLogging(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getManualSessionLogStatus, sessionId, status]);
+
   const renderControls = useCallback((opts?: { showClose?: boolean }) => (
     <TerminalToolbar
       status={status}
@@ -1575,6 +1643,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       onClose={() => onCloseSession?.(sessionId)}
       isSearchOpen={isSearchOpen}
       onToggleSearch={handleToggleSearch}
+      showLogButton
+      onToggleSessionLog={handleToggleSessionLog}
+      isSessionLogging={isSessionLogging}
+      isSessionLogDisabled={status !== "connected" && !isSessionLogging}
       isComposeBarOpen={inWorkspace ? isWorkspaceComposeBarOpen : isComposeBarOpen}
       onToggleComposeBar={inWorkspace ? onToggleComposeBar : () => setIsComposeBarOpen(prev => !prev)}
       terminalEncoding={terminalEncoding}
@@ -1587,6 +1659,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     handleReceiveYmodem,
     handleSendYmodem,
     handleSetTerminalEncoding,
+    handleToggleSessionLog,
     handleToggleSearch,
     host,
     inWorkspace,
@@ -1595,6 +1668,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isSerialConnection,
     isComposeBarOpen,
     isSearchOpen,
+    isSessionLogging,
     isWorkspaceComposeBarOpen,
     onCloseSession,
     onOpenScripts,

--- a/components/terminal/TerminalToolbar.test.ts
+++ b/components/terminal/TerminalToolbar.test.ts
@@ -69,6 +69,33 @@ test("keeps Scripts visible before the terminal overflow menu", () => {
   assert.match(markup, /type="button"[^>]*aria-label="Scripts"/);
 });
 
+test("shows manual session log button when requested", () => {
+  const markup = renderToolbar(sshHost, "connected", {
+    showLogButton: true,
+    onToggleSessionLog: () => {},
+  });
+
+  const logIndex = markup.indexOf('aria-label="Start session log"');
+  const scriptsIndex = markup.indexOf('aria-label="Scripts"');
+
+  assert.notEqual(logIndex, -1);
+  assert.notEqual(scriptsIndex, -1);
+  assert.ok(logIndex < scriptsIndex);
+});
+
+test("marks manual session log button active while logging", () => {
+  const markup = renderToolbar(sshHost, "connected", {
+    showLogButton: true,
+    onToggleSessionLog: () => {},
+    isSessionLogging: true,
+  });
+
+  assert.match(
+    markup,
+    /aria-label="Stop session log"[^>]*aria-pressed="true"[^>]*style="background-color:var\(--terminal-toolbar-btn-active\)"/,
+  );
+});
+
 test("hides SFTP for local terminal sessions", () => {
   const markup = renderToolbar({
     ...sshHost,

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -2,7 +2,7 @@
  * Terminal Toolbar
  * Displays high-frequency terminal actions and close button in the terminal status bar.
  */
-import { Check, ChevronRight, Download, FolderInput, FolderSync, History, Languages, MoreVertical, X, Zap, Palette, Search, TextCursorInput, Upload } from 'lucide-react';
+import { Check, ChevronRight, Download, FileText, FolderInput, FolderSync, History, Languages, MoreVertical, X, Zap, Palette, Search, TextCursorInput, Upload } from 'lucide-react';
 import React, { useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { Host, Snippet } from '../../types';
@@ -34,6 +34,11 @@ export interface TerminalToolbarProps {
     // Search functionality
     isSearchOpen?: boolean;
     onToggleSearch?: () => void;
+    // Manual session log
+    showLogButton?: boolean;
+    onToggleSessionLog?: () => void;
+    isSessionLogging?: boolean;
+    isSessionLogDisabled?: boolean;
     // Compose bar
     isComposeBarOpen?: boolean;
     onToggleComposeBar?: () => void;
@@ -61,6 +66,10 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     onClose,
     isSearchOpen,
     onToggleSearch,
+    showLogButton = false,
+    onToggleSessionLog,
+    isSessionLogging = false,
+    isSessionLogDisabled = false,
     isComposeBarOpen,
     onToggleComposeBar,
     terminalEncoding,
@@ -274,6 +283,29 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                 </TooltipTrigger>
                 <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
             </Tooltip>
+
+            {showLogButton && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="icon"
+                            className={cn(buttonBase, isSessionLogDisabled && "opacity-50")}
+                            aria-label={isSessionLogging ? t("terminal.toolbar.stopSessionLog") : t("terminal.toolbar.startSessionLog")}
+                            aria-pressed={isSessionLogging}
+                            onClick={onToggleSessionLog}
+                            disabled={isSessionLogDisabled || !onToggleSessionLog}
+                            style={isSessionLogging ? activeButtonStyle : undefined}
+                        >
+                            <FileText size={12} />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        {isSessionLogging ? t("terminal.toolbar.stopSessionLog") : t("terminal.toolbar.startSessionLog")}
+                    </TooltipContent>
+                </Tooltip>
+            )}
 
             <Tooltip>
                 <TooltipTrigger asChild>

--- a/components/terminal/sessionLogInitialLine.test.ts
+++ b/components/terminal/sessionLogInitialLine.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSessionLogInitialLine } from "./sessionLogInitialLine.ts";
+
+const makeTerm = (rows: Array<{ text: string; isWrapped?: boolean }>, cursorY: number, cursorX: number) => ({
+  buffer: {
+    active: {
+      baseY: 0,
+      cursorY,
+      cursorX,
+      getLine: (line: number) => {
+        const row = rows[line];
+        if (!row) return undefined;
+        return {
+          isWrapped: row.isWrapped,
+          translateToString: () => row.text,
+        };
+      },
+    },
+  },
+});
+
+test("getSessionLogInitialLine captures the current prompt and typed command", () => {
+  const term = makeTerm([
+    { text: "root@MyNAS:~# show vlan" },
+  ], 0, "root@MyNAS:~# show vlan".length);
+
+  assert.equal(getSessionLogInitialLine(term), "root@MyNAS:~# show vlan");
+});
+
+test("getSessionLogInitialLine falls back to nearest trusted prompt line", () => {
+  const term = makeTerm([
+    { text: "root@MyNAS:~# " },
+    { text: "command output" },
+  ], 1, "command output".length);
+
+  assert.equal(getSessionLogInitialLine(term), "root@MyNAS:~# ");
+});

--- a/components/terminal/sessionLogInitialLine.ts
+++ b/components/terminal/sessionLogInitialLine.ts
@@ -1,0 +1,138 @@
+type BufferLineLike = {
+  isWrapped?: boolean;
+  translateToString(trimRight?: boolean): string;
+};
+
+type ActiveBufferLike = {
+  baseY: number;
+  cursorX: number;
+  cursorY: number;
+  getLine(line: number): BufferLineLike | undefined;
+};
+
+export type TerminalSessionLogInitialLineSource = {
+  buffer: {
+    active: ActiveBufferLike;
+  };
+};
+
+type PromptDetectionLike = {
+  isAtPrompt: boolean;
+  promptText: string;
+};
+
+const PROMPT_END_RE = /(?:[$#%]\s|[❯❮→➜➤⟩»›]\s|[\uE000-\uF8FF]\s)$/u;
+const CMD_PROMPT_RE = /^[A-Za-z]:\\.*>$/;
+
+export function getSessionLogInitialLine(term: TerminalSessionLogInitialLineSource): string {
+  const buffer = term.buffer.active;
+  const cursorY = buffer.cursorY + buffer.baseY;
+  const currentPrefix = getLogicalLinePrefix(buffer, cursorY, buffer.cursorX);
+
+  if (looksLikeTrustedPrompt(detectPromptInText(currentPrefix))) {
+    return currentPrefix;
+  }
+
+  const promptLine = findNearestPromptLine(buffer, cursorY);
+  if (promptLine) {
+    return promptLine;
+  }
+
+  return currentPrefix;
+}
+
+function findNearestPromptLine(buffer: ActiveBufferLike, cursorY: number): string {
+  const visitedStartRows = new Set<number>();
+
+  for (let row = cursorY; row >= 0; row -= 1) {
+    const startRow = findLogicalLineStart(buffer, row);
+    if (visitedStartRows.has(startRow)) continue;
+    visitedStartRows.add(startRow);
+
+    const logicalLine = getLogicalLineText(buffer, row);
+    const prompt = detectPromptInText(logicalLine);
+    if (looksLikeTrustedPrompt(prompt)) {
+      return logicalLine;
+    }
+  }
+
+  return "";
+}
+
+function getLogicalLinePrefix(buffer: ActiveBufferLike, row: number, cursorX: number): string {
+  const startRow = findLogicalLineStart(buffer, row);
+  const currentLine = buffer.getLine(row);
+  if (!currentLine) return "";
+
+  let text = "";
+  for (let lineRow = startRow; lineRow < row; lineRow += 1) {
+    text += buffer.getLine(lineRow)?.translateToString(false) ?? "";
+  }
+
+  text += currentLine.translateToString(false).substring(0, Math.max(0, cursorX));
+  return text;
+}
+
+function getLogicalLineText(buffer: ActiveBufferLike, row: number): string {
+  const startRow = findLogicalLineStart(buffer, row);
+  const endRow = findLogicalLineEnd(buffer, row);
+
+  let text = "";
+  for (let lineRow = startRow; lineRow <= endRow; lineRow += 1) {
+    text += buffer.getLine(lineRow)?.translateToString(false) ?? "";
+  }
+  return text;
+}
+
+function findLogicalLineStart(buffer: ActiveBufferLike, row: number): number {
+  let startRow = row;
+  while (startRow > 0) {
+    const line = buffer.getLine(startRow);
+    if (!line?.isWrapped) break;
+    startRow -= 1;
+  }
+  return startRow;
+}
+
+function findLogicalLineEnd(buffer: ActiveBufferLike, row: number): number {
+  let endRow = row;
+  while (true) {
+    const nextLine = buffer.getLine(endRow + 1);
+    if (!nextLine?.isWrapped) break;
+    endRow += 1;
+  }
+  return endRow;
+}
+
+function detectPromptInText(text: string): PromptDetectionLike {
+  const promptText = findPromptText(text);
+  if (!promptText) {
+    return { isAtPrompt: false, promptText: "" };
+  }
+
+  return { isAtPrompt: true, promptText };
+}
+
+function findPromptText(text: string): string {
+  if (!text) return "";
+
+  const standardMatch = text.match(/^.*(?:[$#%]|[❯❮→➜➤⟩»›]|[\uE000-\uF8FF])\s/u);
+  if (standardMatch) {
+    return standardMatch[0];
+  }
+
+  const trimmed = text.trimEnd();
+  const cmdPromptMatch = trimmed.match(/^[A-Za-z]:\\.*>/);
+  if (cmdPromptMatch) {
+    return cmdPromptMatch[0];
+  }
+
+  return "";
+}
+
+function looksLikeTrustedPrompt(prompt: PromptDetectionLike): boolean {
+  if (!prompt.isAtPrompt) return false;
+  const { promptText } = prompt;
+  if (PROMPT_END_RE.test(promptText)) return true;
+  return CMD_PROMPT_RE.test(promptText.trimEnd());
+}

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -148,7 +148,7 @@ function sanitizeSudoAutofillLogData(entry, dataChunk, { final = false } = {}) {
 function startStream(sessionId, opts) {
   if (activeStreams.has(sessionId)) {
     console.warn(`[SessionLogStream] Stream already active for ${sessionId}, stopping old one`);
-    stopStream(sessionId);
+    stopStream(sessionId, activeStreams.get(sessionId)?.startToken);
   }
 
   const { hostLabel, hostname, directory, format, startTime } = opts;
@@ -231,6 +231,7 @@ function createStreamEntry(sessionId, opts) {
     closing: false,
     disabled: false,
     startToken,
+    stopRequiresToken: Boolean(opts.stopRequiresToken),
   };
 
   entry.flushTimer = setInterval(() => {
@@ -262,6 +263,7 @@ function startStreamToFile(sessionId, opts = {}) {
       startTime: startTime || Date.now(),
       timestampsEnabled: opts.timestampsEnabled,
       timestampProvider: opts.timestampProvider,
+      stopRequiresToken: opts.stopRequiresToken,
     });
     if (typeof initialLine === "string" && initialLine.length > 0) {
       appendData(sessionId, initialLine);
@@ -402,6 +404,9 @@ async function stopStream(sessionId, expectedToken) {
     // The current stream belongs to a fresh incarnation; leave it alone.
     return null;
   }
+  if (entry.stopRequiresToken && !expectedToken) {
+    return null;
+  }
   activeStreams.delete(sessionId);
   entry.closing = true;
 
@@ -455,8 +460,8 @@ function hasStream(sessionId) {
  */
 async function cleanupAll() {
   console.log(`[SessionLogStream] Cleaning up ${activeStreams.size} active streams`);
-  const ids = [...activeStreams.keys()];
-  await Promise.allSettled(ids.map(id => stopStream(id)));
+  const entries = [...activeStreams.entries()];
+  await Promise.allSettled(entries.map(([id, entry]) => stopStream(id, entry.startToken)));
 }
 
 module.exports = {

--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -173,59 +173,102 @@ function startStream(sessionId, opts) {
     const fileName = `${dateStr}.${ext}`;
     const filePath = path.join(hostDir, fileName);
 
-    const writeStream = isRaw
-      ? fs.createWriteStream(filePath, { flags: "w", encoding: "utf8" })
-      : null;
-
-    if (writeStream) {
-      writeStream.on("error", (err) => {
-        console.error(`[SessionLogStream] Write error for ${sessionId}:`, err.message);
-        // Disable this stream on error to avoid cascading failures
-        const entry = activeStreams.get(sessionId);
-        if (entry) {
-          entry.disabled = true;
-        }
-      });
-    }
-
-    const startToken = Symbol("session-log-stream");
-    const entry = {
-      writeStream,
+    return createStreamEntry(sessionId, {
       filePath,
       hostDir,
       format,
-      isRaw,
-      isHtml,
-      renderer: isRaw ? null : createTerminalTextRenderer(),
-      renderedTimestampPrefixer: !isRaw && opts.timestampsEnabled
-        ? createRenderedLineTimestampPrefixer({ timestampProvider: opts.timestampProvider })
-        : null,
       hostLabel: hostLabel || hostname || "unknown",
       startTime: startTime || Date.now(),
-      buffer: "",
-      programmaticCommandLogRewriter: createProgrammaticCommandLogRewriter(),
-      sudoAutofillRewrites: [],
-      sudoAutofillPending: "",
-      flushTimer: null,
-      snapshotPromise: null,
-      snapshotRequested: false,
-      snapshotDirty: false,
-      closing: false,
-      disabled: false,
-      startToken,
-    };
-
-    // Start periodic flush
-    entry.flushTimer = setInterval(() => {
-      flushBuffer(entry);
-    }, FLUSH_INTERVAL);
-
-    activeStreams.set(sessionId, entry);
-    console.log(`[SessionLogStream] Started stream for ${sessionId} -> ${filePath}`);
-    return startToken;
+      timestampsEnabled: opts.timestampsEnabled,
+      timestampProvider: opts.timestampProvider,
+    });
   } catch (err) {
     console.error(`[SessionLogStream] Failed to start stream for ${sessionId}:`, err.message);
     return null;
+  }
+}
+
+function createStreamEntry(sessionId, opts) {
+  const { filePath, hostDir, format, hostLabel, startTime } = opts;
+  const isRaw = format === "raw";
+  const isHtml = format === "html";
+  const writeStream = isRaw
+    ? fs.createWriteStream(filePath, { flags: "w", encoding: "utf8" })
+    : null;
+
+  if (writeStream) {
+    writeStream.on("error", (err) => {
+      console.error(`[SessionLogStream] Write error for ${sessionId}:`, err.message);
+      const entry = activeStreams.get(sessionId);
+      if (entry) {
+        entry.disabled = true;
+      }
+    });
+  }
+
+  const startToken = Symbol("session-log-stream");
+  const entry = {
+    writeStream,
+    filePath,
+    hostDir,
+    format,
+    isRaw,
+    isHtml,
+    renderer: isRaw ? null : createTerminalTextRenderer(),
+    renderedTimestampPrefixer: !isRaw && opts.timestampsEnabled
+      ? createRenderedLineTimestampPrefixer({ timestampProvider: opts.timestampProvider })
+      : null,
+    hostLabel,
+    startTime,
+    buffer: "",
+    programmaticCommandLogRewriter: createProgrammaticCommandLogRewriter(),
+    sudoAutofillRewrites: [],
+    sudoAutofillPending: "",
+    flushTimer: null,
+    snapshotPromise: null,
+    snapshotRequested: false,
+    snapshotDirty: false,
+    closing: false,
+    disabled: false,
+    startToken,
+  };
+
+  entry.flushTimer = setInterval(() => {
+    flushBuffer(entry);
+  }, FLUSH_INTERVAL);
+
+  activeStreams.set(sessionId, entry);
+  console.log(`[SessionLogStream] Started stream for ${sessionId} -> ${filePath}`);
+  return startToken;
+}
+
+function startStreamToFile(sessionId, opts = {}) {
+  if (activeStreams.has(sessionId)) {
+    return { ok: false, error: "Stream already active for this session" };
+  }
+
+  const { filePath, hostLabel, startTime, initialLine } = opts;
+  if (!filePath) {
+    return { ok: false, error: "Missing filePath" };
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const token = createStreamEntry(sessionId, {
+      filePath,
+      hostDir: path.dirname(filePath),
+      format: opts.format || "raw",
+      hostLabel: hostLabel || "session",
+      startTime: startTime || Date.now(),
+      timestampsEnabled: opts.timestampsEnabled,
+      timestampProvider: opts.timestampProvider,
+    });
+    if (typeof initialLine === "string" && initialLine.length > 0) {
+      appendData(sessionId, initialLine);
+    }
+    return { ok: true, token };
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) };
   }
 }
 
@@ -418,6 +461,7 @@ async function cleanupAll() {
 
 module.exports = {
   startStream,
+  startStreamToFile,
   appendData,
   registerSudoAutofillInput,
   registerProgrammaticCommandLogRewrite,

--- a/electron/bridges/sessionLogStreamManager.test.cjs
+++ b/electron/bridges/sessionLogStreamManager.test.cjs
@@ -142,6 +142,41 @@ test("stopStream without a token still tears down the current stream (back-compa
   }
 });
 
+test("token-required explicit file streams ignore tokenless stale stops", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-token-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let token;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      stopRequiresToken: true,
+    });
+    assert.equal(result.ok, true);
+    token = result.token;
+
+    appendData(sessionId, "before-stale\n");
+    const staleResult = await stopStream(sessionId);
+    assert.equal(staleResult, null);
+    assert.equal(hasStream(sessionId), true);
+
+    appendData(sessionId, "after-stale\n");
+    const finalPath = await stopStream(sessionId, token);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "before-stale\nafter-stale\n");
+  } finally {
+    if (hasStream(sessionId)) {
+      await stopStream(sessionId, token);
+    }
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("startStreamToFile writes to an explicit raw log file path", async () => {
   const directory = path.join(TEMP_ROOT, `manual-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const filePath = path.join(directory, "manual.log");

--- a/electron/bridges/sessionLogStreamManager.test.cjs
+++ b/electron/bridges/sessionLogStreamManager.test.cjs
@@ -8,6 +8,7 @@ const {
   registerProgrammaticCommandLogRewrite,
   registerSudoAutofillInput,
   startStream,
+  startStreamToFile,
   stopStream,
 } = require("./sessionLogStreamManager.cjs");
 
@@ -137,6 +138,63 @@ test("stopStream without a token still tears down the current stream (back-compa
     assert.equal(fs.readFileSync(finalPath, "utf8"), "data\n");
     assert.equal(hasStream(sessionId), false);
   } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile writes to an explicit raw log file path", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "header\n",
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "body\n");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "header\nbody\n");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile can write human-readable text logs from ANSI terminal output", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-txt-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "txt",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+    });
+
+    assert.equal(result.ok, true);
+    appendData(
+      sessionId,
+      "\x1b[01;32mroot@MyNAS\x1b[00m:\x1b[01;34m~\x1b[00m# ip a\r\n1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536\r\n\x1b[01;32mroot@MyNAS\x1b[00m:\x1b[01;34m~\x1b[00m# ",
+    );
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(
+      fs.readFileSync(filePath, "utf8"),
+      "root@MyNAS:~# ip a\n1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536\nroot@MyNAS:~#",
+    );
+  } finally {
+    await stopStream(sessionId);
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -13,6 +13,7 @@ const {
 
 const FILE_NAME_UNSAFE_CHARS = new Set(["<", ">", ":", "\"", "/", "\\", "|", "?", "*"]);
 const WINDOWS_RESERVED_DEVICE_NAME = /^(con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i;
+const manualSessionLogTokens = new Map();
 
 function isControlCharacter(char) {
   const code = char.codePointAt(0);
@@ -291,12 +292,14 @@ async function startManualSessionLog(event, payload = {}) {
       hostLabel: safeSessionName,
       startTime: Date.now(),
       initialLine: typeof initialLine === "string" ? initialLine : "",
+      stopRequiresToken: true,
     });
 
     if (!startResult.ok) {
       return { success: false, started: false, error: startResult.error || "Failed to start session log" };
     }
 
+    manualSessionLogTokens.set(sessionId, startResult.token);
     return { success: true, started: true, filePath };
   } catch (err) {
     return { success: false, started: false, error: err?.message || String(err) };
@@ -311,10 +314,19 @@ async function stopManualSessionLog(event, payload = {}) {
   }
 
   try {
-    const filePath = await sessionLogStreamManager.stopStream(sessionId);
-    if (!filePath) {
+    const token = manualSessionLogTokens.get(sessionId);
+    if (!token) {
       return { success: true, stopped: false };
     }
+
+    const filePath = await sessionLogStreamManager.stopStream(sessionId, token);
+    if (!filePath) {
+      if (!sessionLogStreamManager.hasStream(sessionId)) {
+        manualSessionLogTokens.delete(sessionId);
+      }
+      return { success: true, stopped: false };
+    }
+    manualSessionLogTokens.delete(sessionId);
     return { success: true, stopped: true, filePath };
   } catch (err) {
     return { success: false, stopped: false, error: err?.message || String(err) };

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -251,6 +251,85 @@ async function openSessionLogsDir(event, payload) {
   }
 }
 
+async function startManualSessionLog(event, payload = {}) {
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  const { sessionId, sessionName, preferredDirectory, initialLine } = payload;
+  if (!sessionId) {
+    return { success: false, started: false, error: "Missing sessionId" };
+  }
+
+  if (sessionLogStreamManager.hasStream(sessionId)) {
+    return { success: false, started: false, error: "Session log is already active" };
+  }
+
+  const targetDirectory = typeof preferredDirectory === "string" && preferredDirectory.trim()
+    ? preferredDirectory.trim()
+    : require("node:os").homedir();
+  const safeSessionName = safePathSegment(sessionName || sessionId, "session");
+  const defaultPath = path.join(targetDirectory, `${safeSessionName}_${toLocalISOString(new Date())}.log`);
+
+  try {
+    const result = await dialog.showSaveDialog({
+      defaultPath,
+      filters: [
+        { name: "Log Files", extensions: ["log"] },
+        { name: "Text Files", extensions: ["txt"] },
+        { name: "All Files", extensions: ["*"] },
+      ],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: true, started: false, canceled: true };
+    }
+
+    const filePath = path.extname(result.filePath)
+      ? result.filePath
+      : `${result.filePath}.log`;
+    const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
+      filePath,
+      format: "txt",
+      hostLabel: safeSessionName,
+      startTime: Date.now(),
+      initialLine: typeof initialLine === "string" ? initialLine : "",
+    });
+
+    if (!startResult.ok) {
+      return { success: false, started: false, error: startResult.error || "Failed to start session log" };
+    }
+
+    return { success: true, started: true, filePath };
+  } catch (err) {
+    return { success: false, started: false, error: err?.message || String(err) };
+  }
+}
+
+async function stopManualSessionLog(event, payload = {}) {
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  const { sessionId } = payload;
+  if (!sessionId) {
+    return { success: false, stopped: false, error: "Missing sessionId" };
+  }
+
+  try {
+    const filePath = await sessionLogStreamManager.stopStream(sessionId);
+    if (!filePath) {
+      return { success: true, stopped: false };
+    }
+    return { success: true, stopped: true, filePath };
+  } catch (err) {
+    return { success: false, stopped: false, error: err?.message || String(err) };
+  }
+}
+
+async function getManualSessionLogStatus(event, payload = {}) {
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+  const { sessionId } = payload;
+  if (!sessionId) {
+    return { success: false, isLogging: false, error: "Missing sessionId" };
+  }
+  return { success: true, isLogging: sessionLogStreamManager.hasStream(sessionId) };
+}
+
 /**
  * Register IPC handlers for session logs operations
  */
@@ -259,6 +338,9 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:sessionLogs:selectDir", selectSessionLogsDir);
   ipcMain.handle("netcatty:sessionLogs:autoSave", autoSaveSessionLog);
   ipcMain.handle("netcatty:sessionLogs:openDir", openSessionLogsDir);
+  ipcMain.handle("netcatty:sessionLog:manualStart", startManualSessionLog);
+  ipcMain.handle("netcatty:sessionLog:manualStop", stopManualSessionLog);
+  ipcMain.handle("netcatty:sessionLog:manualStatus", getManualSessionLogStatus);
 }
 
 module.exports = {
@@ -267,6 +349,9 @@ module.exports = {
   selectSessionLogsDir,
   autoSaveSessionLog,
   openSessionLogsDir,
+  startManualSessionLog,
+  stopManualSessionLog,
+  getManualSessionLogStatus,
   toLocalISOString,
   terminalDataToHtml,
   terminalPlainTextToHtml,

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -106,3 +106,48 @@ test("auto-save host directory falls back when the sanitized host label is empty
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("manual session logs survive tokenless stale stops and stop through the bridge", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-token-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "H3C switch",
+      preferredDirectory: directory,
+      initialLine: "started\n",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+
+    sessionLogStreamManager.appendData(sessionId, "before-stale\n");
+    const staleResult = await sessionLogStreamManager.stopStream(sessionId);
+    assert.equal(staleResult, null);
+    assert.equal(sessionLogStreamManager.hasStream(sessionId), true);
+
+    sessionLogStreamManager.appendData(sessionId, "after-stale\n");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+    assert.equal(stopResult.success, true);
+    assert.equal(stopResult.stopped, true);
+    assert.equal(stopResult.filePath, filePath);
+    assert.equal(sessionLogStreamManager.hasStream(sessionId), false);
+
+    const content = fs.readFileSync(filePath, "utf8");
+    assert.match(content, /started/);
+    assert.match(content, /before-stale/);
+    assert.match(content, /after-stale/);
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -751,6 +751,12 @@ function createPreloadApi(ctx) {
     ipcRenderer.invoke("netcatty:sessionLogs:autoSave", payload),
   openSessionLogsDir: (directory) =>
     ipcRenderer.invoke("netcatty:sessionLogs:openDir", { directory }),
+  startManualSessionLog: (payload) =>
+    ipcRenderer.invoke("netcatty:sessionLog:manualStart", payload),
+  stopManualSessionLog: (payload) =>
+    ipcRenderer.invoke("netcatty:sessionLog:manualStop", payload),
+  getManualSessionLogStatus: (payload) =>
+    ipcRenderer.invoke("netcatty:sessionLog:manualStatus", payload),
 
   // Crash Logs
   getCrashLogs: () =>

--- a/types/global/netcatty-bridge-files.d.ts
+++ b/types/global/netcatty-bridge-files.d.ts
@@ -82,6 +82,18 @@ declare global {
       directory: string;
     }): Promise<{ success: boolean; error?: string; filePath?: string }>;
     openSessionLogsDir?(directory: string): Promise<{ success: boolean; error?: string }>;
+    startManualSessionLog?(payload: {
+      sessionId: string;
+      sessionName?: string;
+      preferredDirectory?: string;
+      initialLine?: string;
+    }): Promise<{ success: boolean; started: boolean; canceled?: boolean; error?: string; filePath?: string }>;
+    stopManualSessionLog?(payload: {
+      sessionId: string;
+    }): Promise<{ success: boolean; stopped: boolean; error?: string; filePath?: string }>;
+    getManualSessionLogStatus?(payload: {
+      sessionId: string;
+    }): Promise<{ success: boolean; isLogging: boolean; error?: string }>;
 
     // Get file path from File object (for drag-and-drop, uses Electron's webUtils)
     getPathForFile?(file: File): string | undefined;


### PR DESCRIPTION
Summary
- add a terminal toolbar button to start/stop manual session logging
- let manual session logs write to a user-selected file as readable text
- include the current prompt/typed command when logging starts mid-session

Tests
- node --test --import tsx components/terminal/TerminalToolbar.test.ts components/terminal/sessionLogInitialLine.test.ts
- node --test electron/bridges/sessionLogStreamManager.test.cjs electron/bridges/sessionLogsBridge.test.cjs
- npm run lint
- npm run build
- Windows NSIS package build