### PR TITLE
Add snippet connect automation

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -648,6 +648,11 @@ export const enTerminalMessages: Messages = {
   'snippets.packageDialog.root': 'Root',
   'snippets.packageDialog.placeholder': 'e.g. ops/maintenance',
   'snippets.packageDialog.hint': 'Use "/" to create nested packages.',
+  'snippets.automation.runOnConnect': 'Run automatically on connect',
+  'snippets.automation.runOnConnectHelp': 'When a selected target opens, this script is appended to the host startup command and executed after the terminal connects.',
+  'snippets.automation.targetRequired': 'Add at least one target host to enable this automation.',
+  'snippets.automation.badge': 'Auto',
+  'snippets.automation.badgeTooltip': 'Runs automatically when a target host connects',
 
   // Snippets Rename Dialog
   'snippets.renameDialog.title': 'Rename Package',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -674,6 +674,11 @@ export const ruTerminalMessages: Messages = {
   'snippets.packageDialog.root': 'Корень',
   'snippets.packageDialog.placeholder': 'например, ops/maintenance',
   'snippets.packageDialog.hint': 'Используйте "/" для создания вложенных пакетов.',
+  'snippets.automation.runOnConnect': 'Запускать автоматически при подключении',
+  'snippets.automation.runOnConnectHelp': 'Когда выбранный целевой хост открывается, этот скрипт добавляется к стартовой команде хоста и выполняется после подключения терминала.',
+  'snippets.automation.targetRequired': 'Добавьте хотя бы один целевой хост, чтобы включить эту автоматизацию.',
+  'snippets.automation.badge': 'Авто',
+  'snippets.automation.badgeTooltip': 'Автоматически запускается при подключении целевого хоста',
 
   // Snippets Rename Dialog
   'snippets.renameDialog.title': 'Переименовать пакет',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -668,6 +668,11 @@ export const zhCNTerminalMessages: Messages = {
   'snippets.packageDialog.root': '根目录',
   'snippets.packageDialog.placeholder': '例如：ops/maintenance',
   'snippets.packageDialog.hint': '使用 "/" 创建嵌套代码包。',
+  'snippets.automation.runOnConnect': '连接时自动运行',
+  'snippets.automation.runOnConnectHelp': '打开已选择的目标主机时，此脚本会追加到主机启动命令之后，并在终端连接成功后执行。',
+  'snippets.automation.targetRequired': '请至少添加一个目标主机以启用此自动化。',
+  'snippets.automation.badge': '自动',
+  'snippets.automation.badgeTooltip': '目标主机连接时会自动运行',
 
   // Snippets Rename Dialog
   'snippets.renameDialog.title': '重命名代码包',

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -1,4 +1,4 @@
-import { CheckSquare, ChevronDown, Clock, Copy, Download, Edit2, FileCode, FolderPlus, LayoutGrid, List as ListIcon, Package, Play, Plus, Search, Square, Trash2, Upload, X } from 'lucide-react';
+import { CheckSquare, ChevronDown, Clock, Copy, Download, Edit2, FileCode, FolderPlus, LayoutGrid, List as ListIcon, Package, Play, Plus, Search, Square, Trash2, Upload, X, Zap } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { useStoredViewMode } from '../application/state/useStoredViewMode';
@@ -690,6 +690,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
         targets: targetSelection,
         shortkey: editingSnippet.shortkey,
         noAutoRun: editingSnippet.noAutoRun,
+        runOnConnect: editingSnippet.runOnConnect,
         order: editingSnippet.order,
       });
       setRightPanelMode('none');
@@ -1791,6 +1792,17 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                             <div className="shrink-0 px-2 py-1 text-[10px] font-mono rounded border border-border bg-muted/50 text-muted-foreground">
                               {snippet.shortkey}
                             </div>
+                          )}
+                          {snippet.runOnConnect && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <div className="shrink-0 px-2 py-1 text-[10px] rounded border border-primary/30 bg-primary/10 text-primary flex items-center gap-1">
+                                  <Zap size={11} />
+                                  {t('snippets.automation.badge')}
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent>{t('snippets.automation.badgeTooltip')}</TooltipContent>
+                            </Tooltip>
                           )}
                           {viewMode === 'list' && !isMultiSelectMode && (
                             <Button

--- a/components/SnippetsRightPanel.tsx
+++ b/components/SnippetsRightPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { parseSnippetVariables } from '../domain/snippetVariables';
-import { Check, Clock, Keyboard, Loader2, Package, RotateCcw, Trash2 } from 'lucide-react';
+import { Check, Clock, Keyboard, Loader2, Package, RotateCcw, Trash2, Zap } from 'lucide-react';
 import { cn } from '../lib/utils';
 import SelectHostPanel from './SelectHostPanel';
 import { AsidePanel, AsidePanelContent, AsidePanelFooter } from './ui/aside-panel';
@@ -206,6 +206,32 @@ export const SnippetsRightPanel: React.FC<SnippetsRightPanelProps> = ({
               />
               <span className="text-xs text-muted-foreground">{t('snippets.field.noAutoRun')}</span>
             </label>
+
+            {/* Automation */}
+            <Card className="p-3 space-y-2 bg-card border-border/80">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={editingSnippet.runOnConnect ?? false}
+                  onChange={(e) => setEditingSnippet({ ...editingSnippet, runOnConnect: e.target.checked || undefined })}
+                  className="mt-0.5 rounded border-input"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                    <Zap size={13} className="text-primary" />
+                    {t('snippets.automation.runOnConnect')}
+                  </span>
+                  <span className="block mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                    {t('snippets.automation.runOnConnectHelp')}
+                  </span>
+                  {targetHosts.length === 0 && (
+                    <span className="block mt-1 text-[11px] leading-relaxed text-amber-500">
+                      {t('snippets.automation.targetRequired')}
+                    </span>
+                  )}
+                </span>
+              </label>
+            </Card>
 
             {/* Shortkey */}
             <Card className="p-3 space-y-2 bg-card border-border/80">

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import React, { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import { activeTabStore } from '../../application/state/activeTabStore';
 import { useTerminalLayoutSuppressActive } from '../../application/state/terminalLayoutSuppressStore';
@@ -10,6 +10,11 @@ import { useStoredBoolean } from '../../application/state/useStoredBoolean';
 import { collectSessionIds, SplitDirection } from '../../domain/workspace';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
 import { KeyBinding, TerminalSettings } from '../../domain/models';
+import {
+  buildStartupCommandWithSnippetAutomation,
+  getHostConnectSnippetCommands,
+} from '../../domain/snippetAutomation';
+import { readSnippetVariableValuesForSnippet } from '../../application/state/snippetVariableValues';
 import { STORAGE_KEY_AI_SHOW_TERMINAL_SELECTION_ACTION } from '../../infrastructure/config/storageKeys';
 import { cn } from '../../lib/utils';
 import { LazyLoadBoundary } from '../ui/lazy-load-boundary';
@@ -904,6 +909,19 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   const inActiveWorkspace = !!activeWorkspaceId;
   const isFocusMode = paneState.mode === 'focus';
   const isSplitViewVisible = paneState.mode === 'split';
+  const startupCommand = useMemo(() => {
+    if (session.startupCommand || session.restoreState) return session.startupCommand;
+    const snippetCommands = getHostConnectSnippetCommands(
+      host,
+      snippets,
+      (snippet) => readSnippetVariableValuesForSnippet(snippet.id),
+    );
+    if (snippetCommands.length === 0) return undefined;
+    return buildStartupCommandWithSnippetAutomation({
+      hostStartupCommand: host.startupCommand,
+      snippetCommands,
+    });
+  }, [host, session.restoreState, session.startupCommand, snippets]);
   const rect = activeWorkspaceId && isSplitViewVisible
     ? workspaceRectsById.get(activeWorkspaceId)?.[session.id] ?? null
     : null;
@@ -1215,7 +1233,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
         shellType={session.shellType}
         lastCwd={session.lastCwd}
         restoreTerminalCwd={restoreTerminalCwd && sessionHostResolved}
-        startupCommand={session.startupCommand}
+        startupCommand={startupCommand}
         noAutoRun={session.noAutoRun}
         reuseConnectionFromSessionId={session.reuseConnectionFromSessionId}
         serialConfig={session.serialConfig}

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -283,6 +283,7 @@ export interface Snippet {
   targets?: string[]; // host ids
   shortkey?: string; // Keyboard shortcut to send this snippet in terminal (e.g., "F1", "Ctrl + F1")
   noAutoRun?: boolean; // If true, paste command without executing (no trailing Enter)
+  runOnConnect?: boolean; // If true, run automatically after connecting to matching targets
   order?: number;
 }
 

--- a/domain/snippetAutomation.test.ts
+++ b/domain/snippetAutomation.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host, Snippet } from "./models.ts";
+import {
+  applySnippetStartupAutomation,
+  buildStartupCommandWithSnippetAutomation,
+  getHostConnectSnippetCommands,
+  shouldRunSnippetOnHostConnect,
+} from "./snippetAutomation.ts";
+
+const host = (overrides: Partial<Host> = {}): Host => ({
+  id: "host-1",
+  label: "Prod",
+  hostname: "prod.example.com",
+  username: "root",
+  tags: [],
+  os: "linux",
+  ...overrides,
+});
+
+const snippet = (overrides: Partial<Snippet> = {}): Snippet => ({
+  id: "snippet-1",
+  label: "Check disk",
+  command: "df -h",
+  tags: [],
+  package: "",
+  targets: ["host-1"],
+  runOnConnect: true,
+  ...overrides,
+});
+
+test("shouldRunSnippetOnHostConnect requires opt-in and a matching target", () => {
+  assert.equal(shouldRunSnippetOnHostConnect(snippet(), "host-1"), true);
+  assert.equal(shouldRunSnippetOnHostConnect(snippet({ runOnConnect: false }), "host-1"), false);
+  assert.equal(shouldRunSnippetOnHostConnect(snippet({ targets: ["host-2"] }), "host-1"), false);
+  assert.equal(shouldRunSnippetOnHostConnect(snippet({ command: "   " }), "host-1"), false);
+});
+
+test("getHostConnectSnippetCommands resolves defaults and skips missing variables", () => {
+  const commands = getHostConnectSnippetCommands(host(), [
+    snippet({ id: "a", command: "echo {{name:netcatty}}" }),
+    snippet({ id: "b", command: "echo {{required}}" }),
+    snippet({ id: "c", command: "uptime", targets: ["host-2"] }),
+  ]);
+
+  assert.deepEqual(commands, ["echo netcatty"]);
+});
+
+test("getHostConnectSnippetCommands uses persisted variable values when provided", () => {
+  const commands = getHostConnectSnippetCommands(
+    host(),
+    [snippet({ id: "a", command: "deploy {{service}}" })],
+    () => ({ service: "api" }),
+  );
+
+  assert.deepEqual(commands, ["deploy api"]);
+});
+
+test("buildStartupCommandWithSnippetAutomation appends snippets after host startup command", () => {
+  assert.equal(
+    buildStartupCommandWithSnippetAutomation({
+      hostStartupCommand: "cd /srv",
+      snippetCommands: ["git status", "docker ps\n"],
+    }),
+    "cd /srv\ngit status\ndocker ps",
+  );
+});
+
+test("applySnippetStartupAutomation returns original host when no snippets apply", () => {
+  const original = host();
+  const result = applySnippetStartupAutomation(original, [snippet({ targets: ["other"] })]);
+
+  assert.equal(result, original);
+});
+
+test("applySnippetStartupAutomation appends matching snippet commands", () => {
+  const result = applySnippetStartupAutomation(
+    host({ startupCommand: "cd /srv" }),
+    [
+      snippet({ id: "a", command: "git status" }),
+      snippet({ id: "b", command: "echo done", runOnConnect: false }),
+    ],
+  );
+
+  assert.equal(result.startupCommand, "cd /srv\ngit status");
+});

--- a/domain/snippetAutomation.ts
+++ b/domain/snippetAutomation.ts
@@ -1,0 +1,67 @@
+import type { Host, Snippet } from "./models";
+import { applySnippetVariables } from "./snippetVariables";
+
+export type SnippetVariableValuesProvider = (snippet: Snippet) => Record<string, string>;
+
+const normalizeCommandBlock = (command: string | undefined): string | null => {
+  if (!command || command.trim().length === 0) return null;
+  return command.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n+$/g, "");
+};
+
+export const shouldRunSnippetOnHostConnect = (
+  snippet: Pick<Snippet, "command" | "runOnConnect" | "targets">,
+  hostId: string,
+): boolean => (
+  snippet.runOnConnect === true
+  && snippet.command.trim().length > 0
+  && Array.isArray(snippet.targets)
+  && snippet.targets.includes(hostId)
+);
+
+export const resolveSnippetAutomationCommand = (
+  snippet: Snippet,
+  values: Record<string, string> = {},
+): string | null => {
+  const result = applySnippetVariables(snippet.command, values);
+  if (!result.ok) return null;
+  return normalizeCommandBlock(result.command);
+};
+
+export const getHostConnectSnippetCommands = (
+  host: Pick<Host, "id">,
+  snippets: Snippet[],
+  valuesForSnippet?: SnippetVariableValuesProvider,
+): string[] => snippets
+  .filter((snippet) => shouldRunSnippetOnHostConnect(snippet, host.id))
+  .map((snippet) => resolveSnippetAutomationCommand(snippet, valuesForSnippet?.(snippet) ?? {}))
+  .filter((command): command is string => Boolean(command));
+
+export const buildStartupCommandWithSnippetAutomation = ({
+  hostStartupCommand,
+  snippetCommands,
+}: {
+  hostStartupCommand?: string;
+  snippetCommands: string[];
+}): string | undefined => {
+  const blocks = [
+    normalizeCommandBlock(hostStartupCommand),
+    ...snippetCommands.map(normalizeCommandBlock),
+  ].filter((block): block is string => Boolean(block));
+  if (blocks.length === 0) return undefined;
+  return blocks.join("\n");
+};
+
+export const applySnippetStartupAutomation = (
+  host: Host,
+  snippets: Snippet[],
+  options: { valuesForSnippet?: SnippetVariableValuesProvider } = {},
+): Host => {
+  const snippetCommands = getHostConnectSnippetCommands(host, snippets, options.valuesForSnippet);
+  if (snippetCommands.length === 0) return host;
+  const startupCommand = buildStartupCommandWithSnippetAutomation({
+    hostStartupCommand: host.startupCommand,
+    snippetCommands,
+  });
+  if (startupCommand === host.startupCommand) return host;
+  return { ...host, startupCommand };
+};

--- a/domain/snippetTransfer.test.ts
+++ b/domain/snippetTransfer.test.ts
@@ -40,6 +40,7 @@ test("buildSnippetExportPayload removes host target bindings", () => {
       tags: [],
       package: "ops/web",
       noAutoRun: undefined,
+      runOnConnect: undefined,
       shortkey: undefined,
     },
   ]);
@@ -142,6 +143,7 @@ test("mergeSnippetImportPayload overwrites duplicate commands while preserving l
         tags: ["linux"],
         shortkey: "F8",
         noAutoRun: true,
+        runOnConnect: true,
       },
     ],
   }));
@@ -170,6 +172,7 @@ test("mergeSnippetImportPayload overwrites duplicate commands while preserving l
       targets: [],
       shortkey: "F8",
       noAutoRun: true,
+      runOnConnect: true,
       order: 1000,
     },
   ]);

--- a/domain/snippetTransfer.ts
+++ b/domain/snippetTransfer.ts
@@ -13,6 +13,7 @@ export type SnippetExportItem = {
   package?: string;
   shortkey?: string;
   noAutoRun?: boolean;
+  runOnConnect?: boolean;
 };
 
 export type SnippetExportPayload = {
@@ -96,6 +97,7 @@ const toExportItem = (snippet: Snippet): SnippetExportItem => ({
   package: snippet.package || "",
   shortkey: snippet.shortkey,
   noAutoRun: snippet.noAutoRun,
+  runOnConnect: snippet.runOnConnect,
 });
 
 export const buildSnippetExportPayload = ({
@@ -139,6 +141,7 @@ const sanitizeImportItem = (value: unknown): SnippetExportItem | null => {
       ? value.shortkey.trim()
       : undefined,
     noAutoRun: value.noAutoRun === true ? true : undefined,
+    runOnConnect: value.runOnConnect === true ? true : undefined,
   };
 };
 
@@ -216,6 +219,7 @@ const toImportedSnippet = (item: SnippetExportItem, id: string, order?: number):
   targets: [],
   shortkey: item.shortkey,
   noAutoRun: item.noAutoRun,
+  runOnConnect: item.runOnConnect,
   order,
 });
 


### PR DESCRIPTION
## Summary
- Add a `runOnConnect` snippet option for target-bound scripts.
- Inject matching auto-run snippet commands into the terminal startup flow at render time, avoiding persistent session-restore side effects.
- Preserve the option through snippet import/export and add UI labels/badges.

## Testing
- `node --test --import tsx domain/snippetAutomation.test.ts domain/snippetTransfer.test.ts`
- `npm run lint`
- `npm run build`