### PR TITLE
fix(terminal): garbled font on Windows cold start (#1647)

### DIFF
--- a/application/state/settingsStateDefaults.test.ts
+++ b/application/state/settingsStateDefaults.test.ts
@@ -7,8 +7,43 @@ import {
   getHslTokenRelativeLuminance,
   resolveReadableForegroundForHsl,
   resolveThemeAccentForeground,
+  migrateIncomingTerminalFontId,
 } from "./settingsStateDefaults.ts";
+import { TERMINAL_FONT_AUTO } from "../../infrastructure/config/fonts.ts";
+import { STORAGE_KEY_TERM_FONT_FAMILY } from "../../infrastructure/config/storageKeys.ts";
 import type { UiThemeTokens } from "../../infrastructure/config/uiThemes.ts";
+
+function installMemoryLocalStorage(): Map<string, string> {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+  return store;
+}
+
+test("migrateIncomingTerminalFontId rewrites deprecated ids to the auto sentinel, not menlo", () => {
+  // menlo would put Windows/Linux upgrade users back into the #1647 path,
+  // and a concrete id would leak across OSes via sync; auto resolves per device.
+  const store = installMemoryLocalStorage();
+  try {
+    assert.equal(migrateIncomingTerminalFontId("pingfang-sc"), TERMINAL_FONT_AUTO);
+    // The rewrite is persisted as the platform-neutral sentinel, never a concrete id.
+    assert.equal(store.get(STORAGE_KEY_TERM_FONT_FAMILY), TERMINAL_FONT_AUTO);
+    assert.equal(migrateIncomingTerminalFontId("microsoft-yahei"), TERMINAL_FONT_AUTO);
+  } finally {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+});
+
+test("migrateIncomingTerminalFontId leaves valid ids and empty values untouched", () => {
+  assert.equal(migrateIncomingTerminalFontId("jetbrains-mono"), "jetbrains-mono");
+  assert.equal(migrateIncomingTerminalFontId(TERMINAL_FONT_AUTO), TERMINAL_FONT_AUTO);
+  assert.equal(migrateIncomingTerminalFontId(""), null);
+  assert.equal(migrateIncomingTerminalFontId(null), null);
+});
 
 test("readable foreground picks white text for dark accent colors", () => {
   assert.equal(resolveReadableForegroundForHsl("270 70% 45%"), "0 0% 100%");

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -2,8 +2,7 @@ import type { HotkeyScheme, SessionLogFormat, TerminalSettings } from '../../dom
 import { STORAGE_KEY_TERM_FONT_FAMILY } from '../../infrastructure/config/storageKeys';
 import {
   isDeprecatedPrimaryFontId,
-  detectFontPlatform,
-  getDefaultTerminalFontIdForPlatform,
+  TERMINAL_FONT_AUTO,
 } from '../../infrastructure/config/fonts';
 import { DARK_UI_THEMES, LIGHT_UI_THEMES, type UiThemeTokens } from '../../infrastructure/config/uiThemes';
 import { UI_FONTS } from '../../infrastructure/config/uiFonts';
@@ -39,19 +38,6 @@ export const DEFAULT_TERMINAL_THEME = 'netcatty-dark';
 export const DEFAULT_FONT_FAMILY = 'menlo';
 
 /**
- * The default terminal font id for the current OS. On Windows/Linux the
- * macOS-oriented `menlo` default isn't installed, so the primary Latin
- * glyphs fell through to a bundled webfont whose late swap garbled the
- * cell grid on cold start (#1647). Resolving a locally-installed font per
- * platform keeps the first paint correct. Falls back to DEFAULT_FONT_FAMILY
- * outside a browser (e.g. tests) where `navigator` is absent.
- */
-export function getDefaultTerminalFontFamily(): string {
-  if (typeof navigator === 'undefined') return DEFAULT_FONT_FAMILY;
-  return getDefaultTerminalFontIdForPlatform(detectFontPlatform(navigator.platform));
-}
-
-/**
  * Migrate any terminal font id arriving from storage / IPC / sync to a
  * safe value. If `raw` is a deprecated proportional id (pingfang-sc,
  * microsoft-yahei, comic-sans-ms), persist the rewrite back to
@@ -62,13 +48,18 @@ export function getDefaultTerminalFontFamily(): string {
  * single point of truth keeps deprecated ids from re-entering state.
  *
  * Returns null when there's nothing to apply (raw is empty); callers
- * fall back to DEFAULT_FONT_FAMILY in that case.
+ * fall back to the TERMINAL_FONT_AUTO sentinel in that case.
  */
 export function migrateIncomingTerminalFontId(raw: string | null | undefined): string | null {
   if (!raw) return null;
   if (isDeprecatedPrimaryFontId(raw)) {
-    localStorageAdapter.writeString(STORAGE_KEY_TERM_FONT_FAMILY, DEFAULT_FONT_FAMILY);
-    return DEFAULT_FONT_FAMILY;
+    // Rewrite to the platform-neutral auto sentinel rather than a concrete
+    // id: on Windows/Linux a hard-coded `menlo` would land these upgrade
+    // users right back in the missing-font / cold-start path (#1647), and
+    // syncing a concrete id would leak it across OSes. `auto` resolves to
+    // each device's local default at render time.
+    localStorageAdapter.writeString(STORAGE_KEY_TERM_FONT_FAMILY, TERMINAL_FONT_AUTO);
+    return TERMINAL_FONT_AUTO;
   }
   return raw;
 }

--- a/application/state/settingsStateDefaults.ts
+++ b/application/state/settingsStateDefaults.ts
@@ -1,6 +1,10 @@
 import type { HotkeyScheme, SessionLogFormat, TerminalSettings } from '../../domain/models';
 import { STORAGE_KEY_TERM_FONT_FAMILY } from '../../infrastructure/config/storageKeys';
-import { isDeprecatedPrimaryFontId } from '../../infrastructure/config/fonts';
+import {
+  isDeprecatedPrimaryFontId,
+  detectFontPlatform,
+  getDefaultTerminalFontIdForPlatform,
+} from '../../infrastructure/config/fonts';
 import { DARK_UI_THEMES, LIGHT_UI_THEMES, type UiThemeTokens } from '../../infrastructure/config/uiThemes';
 import { UI_FONTS } from '../../infrastructure/config/uiFonts';
 import { uiFontStore } from './uiFontStore';
@@ -33,6 +37,19 @@ export const DEFAULT_ACCENT_MODE: 'theme' | 'custom' = 'theme';
 export const DEFAULT_CUSTOM_ACCENT = '221.2 83.2% 53.3%';
 export const DEFAULT_TERMINAL_THEME = 'netcatty-dark';
 export const DEFAULT_FONT_FAMILY = 'menlo';
+
+/**
+ * The default terminal font id for the current OS. On Windows/Linux the
+ * macOS-oriented `menlo` default isn't installed, so the primary Latin
+ * glyphs fell through to a bundled webfont whose late swap garbled the
+ * cell grid on cold start (#1647). Resolving a locally-installed font per
+ * platform keeps the first paint correct. Falls back to DEFAULT_FONT_FAMILY
+ * outside a browser (e.g. tests) where `navigator` is absent.
+ */
+export function getDefaultTerminalFontFamily(): string {
+  if (typeof navigator === 'undefined') return DEFAULT_FONT_FAMILY;
+  return getDefaultTerminalFontIdForPlatform(detectFontPlatform(navigator.platform));
+}
 
 /**
  * Migrate any terminal font id arriving from storage / IPC / sync to a

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -76,7 +76,7 @@ import {
   DEFAULT_CUSTOM_ACCENT,
   DEFAULT_DARK_UI_THEME,
   DEFAULT_EDITOR_WORD_WRAP,
-  DEFAULT_FONT_FAMILY,
+  getDefaultTerminalFontFamily,
   DEFAULT_HOTKEY_SCHEME,
   DEFAULT_LIGHT_UI_THEME,
   DEFAULT_SESSION_LOGS_ENABLED,
@@ -178,7 +178,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   );
   const [terminalFontFamilyId, setTerminalFontFamilyId] = useState<string>(() => {
     const stored = localStorageAdapter.readString(STORAGE_KEY_TERM_FONT_FAMILY);
-    return migrateIncomingTerminalFontId(stored) ?? DEFAULT_FONT_FAMILY;
+    return migrateIncomingTerminalFontId(stored) ?? getDefaultTerminalFontFamily();
   });
   const [terminalFontSize, setTerminalFontSize] = useState<number>(() => localStorageAdapter.readNumber(STORAGE_KEY_TERM_FONT_SIZE) || DEFAULT_FONT_SIZE);
   const [uiLanguage, setUiLanguage] = useState<UILanguage>(() => {

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -64,7 +64,7 @@ import {
 } from '../../domain/customKeyBindings';
 import { TERMINAL_THEME_AUTO } from '../../domain/terminalAppearance';
 import { customThemeStore, useCustomThemes } from '../state/customThemeStore';
-import { DEFAULT_FONT_SIZE } from '../../infrastructure/config/fonts';
+import { DEFAULT_FONT_SIZE, TERMINAL_FONT_AUTO } from '../../infrastructure/config/fonts';
 import { getUiThemeById } from '../../infrastructure/config/uiThemes';
 import { DEFAULT_UI_FONT_ID, withWindowsEmojiFallback } from '../../infrastructure/config/uiFonts';
 import { uiFontStore, useUIFontsLoaded } from './uiFontStore';
@@ -76,7 +76,6 @@ import {
   DEFAULT_CUSTOM_ACCENT,
   DEFAULT_DARK_UI_THEME,
   DEFAULT_EDITOR_WORD_WRAP,
-  getDefaultTerminalFontFamily,
   DEFAULT_HOTKEY_SCHEME,
   DEFAULT_LIGHT_UI_THEME,
   DEFAULT_SESSION_LOGS_ENABLED,
@@ -178,7 +177,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   );
   const [terminalFontFamilyId, setTerminalFontFamilyId] = useState<string>(() => {
     const stored = localStorageAdapter.readString(STORAGE_KEY_TERM_FONT_FAMILY);
-    return migrateIncomingTerminalFontId(stored) ?? getDefaultTerminalFontFamily();
+    return migrateIncomingTerminalFontId(stored) ?? TERMINAL_FONT_AUTO;
   });
   const [terminalFontSize, setTerminalFontSize] = useState<number>(() => localStorageAdapter.readNumber(STORAGE_KEY_TERM_FONT_SIZE) || DEFAULT_FONT_SIZE);
   const [uiLanguage, setUiLanguage] = useState<UILanguage>(() => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -37,6 +37,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { toast } from "./ui/toast";
 import { useAvailableFonts } from "../application/state/fontStore";
 import { composeFontFamilyStack, type SupportedPlatform } from "../infrastructure/config/cjkFonts";
+import { resolveTerminalFontFamilyId } from "../infrastructure/config/fonts";
 import { TERMINAL_THEMES } from "../infrastructure/config/terminalThemes";
 import { useCustomThemes } from "../application/state/customThemeStore";
 
@@ -702,7 +703,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const hostFontId = hasFontFamilyOverride && host.fontFamily
       ? host.fontFamily
       : fontFamilyId;
-    const resolvedFontId = hostFontId || "menlo";
+    const resolvedFontId = resolveTerminalFontFamilyId(
+      hostFontId,
+      typeof navigator !== "undefined" ? navigator.platform : "",
+    );
     const selectedFont = availableFonts.find((f) => f.id === resolvedFontId) || availableFonts[0];
     const platform: SupportedPlatform =
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform)

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -6,7 +6,7 @@ import type {
   TerminalSettings,
 } from "../../../domain/models";
 import { useI18n } from "../../../application/i18n/I18nProvider";
-import { MAX_FONT_SIZE, MIN_FONT_SIZE, type TerminalFont } from "../../../infrastructure/config/fonts";
+import { MAX_FONT_SIZE, MIN_FONT_SIZE, resolveTerminalFontFamilyId, type TerminalFont } from "../../../infrastructure/config/fonts";
 import { TERMINAL_THEMES } from "../../../infrastructure/config/terminalThemes";
 import { customThemeStore, useCustomThemes } from "../../../application/state/customThemeStore";
 import { parseItermcolors } from "../../../infrastructure/parsers/itermcolorsParser";
@@ -495,7 +495,10 @@ function SettingsTerminalTab(props: {
           description={t("settings.terminal.font.family.desc")}
         >
           <TerminalFontSelect
-            value={terminalFontFamilyId}
+            value={resolveTerminalFontFamilyId(
+              terminalFontFamilyId,
+              typeof navigator !== "undefined" ? navigator.platform : "",
+            )}
             fonts={availableFonts}
             onChange={(id) => setTerminalFontFamilyId(id)}
             className="w-48"

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -30,6 +30,7 @@ import {
   resolveHostTerminalFontWeight,
 } from "../../../domain/terminalAppearance";
 import { resolveFontWeightBold } from "../../../lib/fontWeightAvailability";
+import { resolveTerminalFontFamilyId } from "../../../infrastructure/config/fonts";
 import { logger } from "../../../lib/logger";
 import { isMacPlatform } from "../../../lib/utils";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
@@ -281,7 +282,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     rendererType,
   });
 
-  const hostFontId = resolveHostTerminalFontFamilyId(ctx.host, ctx.fontFamilyId) || "menlo";
+  const hostFontId = resolveTerminalFontFamilyId(
+    resolveHostTerminalFontFamilyId(ctx.host, ctx.fontFamilyId),
+    typeof navigator !== "undefined" ? navigator.platform : "",
+  );
   // Use fontStore for font lookup - guarantees non-empty result
   const fontObj = fontStore.getFontById(hostFontId);
   const fontFamily = ctx.resolvedFontFamily || fontObj.family;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/exhaustive-deps */
 import { useRef } from 'react';
 import { resolveFontWeightBold } from '../../lib/fontWeightAvailability';
+import { bundledFamiliesInStack } from '../../lib/fontAvailability';
 import { resolveXTermScrollback } from '../../infrastructure/config/xtermPerformance';
 import { shouldInterceptMouseTrackingContextMenu } from './runtime/middleClickBehavior';
 import {
@@ -743,9 +744,90 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
   useEffect(() => {
     let cancelled = false;
+
+    // Re-derive cell metrics and repaint after a font finishes loading. xterm
+    // measures the cell grid once at open(); a webfont that swaps in later
+    // (font-display: swap on the bundled JetBrains Mono / Sarasa Mono SC, or
+    // any user-chosen webfont) leaves the grid sized to the fallback until a
+    // manual resize (#1647). This performs the same recovery a resize does.
+    const remeasureAfterFontLoad = () => {
+      const term = termRef.current as {
+        cols: number;
+        rows: number;
+        renderer?: { remeasureFont?: () => void };
+      } | null;
+      if (cancelled || !term) return;
+      const fitAddon = fitAddonRef.current;
+      try {
+        term.renderer?.remeasureFont?.();
+      } catch (err) {
+        logger.warn("Font remeasure failed", err);
+      }
+
+      // remeasureFont does not invalidate cells rasterized before fonts were ready.
+      xtermRuntimeRef.current?.clearTextureAtlas();
+      const visibleTerm = termRef.current;
+      if (visibleTerm) {
+        forceSyncRenderAfterResize(visibleTerm);
+      }
+
+      try {
+        fitAddon?.fit();
+      } catch (err) {
+        logger.warn("Fit after fonts ready failed", err);
+      }
+
+      if (terminalSettings && termRef.current) {
+        const resolvedBold = resolveFontWeightBold({
+          fontFamilyCss: termRef.current.options?.fontFamily || "",
+          normalWeight: effectiveFontWeight,
+          desiredBoldWeight: terminalSettings.fontWeightBold,
+          fontSize: effectiveFontSize,
+        });
+        termRef.current.options.fontWeightBold = resolvedBold as
+          | 100
+          | 200
+          | 300
+          | 400
+          | 500
+          | 600
+          | 700
+          | 800
+          | 900;
+      }
+
+      const id = sessionRef.current;
+      if (id) {
+        try {
+          resizeSession(id, term.cols, term.rows);
+        } catch (err) {
+          logger.warn("Resize session after fonts ready failed", err);
+        }
+      }
+    };
+
+    const fontFaceSet = document.fonts as FontFaceSet | undefined;
+
+    // Coalesce bursts of loadingdone events (a cold start loads several faces
+    // in quick succession) into a single remeasure.
+    let remeasureTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRemeasure = () => {
+      if (cancelled) return;
+      if (remeasureTimer) clearTimeout(remeasureTimer);
+      remeasureTimer = setTimeout(() => {
+        remeasureTimer = null;
+        remeasureAfterFontLoad();
+      }, 50);
+    };
+
+    // Any font finishing later than the initial measurement — including a
+    // user-chosen webfont primary — triggers a remeasure, so recovery no
+    // longer depends on the single document.fonts.ready resolution below.
+    const onLoadingDone = () => scheduleRemeasure();
+    fontFaceSet?.addEventListener?.("loadingdone", onLoadingDone);
+
     const waitForFonts = async () => {
       try {
-        const fontFaceSet = document.fonts as FontFaceSet | undefined;
         if (!fontFaceSet?.ready) return;
         await fontFaceSet.ready;
         if (cancelled) return;
@@ -758,60 +840,23 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         } catch (err) {
           logger.warn("Nerd Font preload failed", err);
         }
-        if (cancelled) return;
 
-        const term = termRef.current as {
-          cols: number;
-          rows: number;
-          renderer?: { remeasureFont?: () => void };
-        } | null;
-        const fitAddon = fitAddonRef.current;
-        try {
-          term?.renderer?.remeasureFont?.();
-        } catch (err) {
-          logger.warn("Font remeasure failed", err);
-        }
-
-        // remeasureFont does not invalidate cells rasterized before fonts were ready.
-        xtermRuntimeRef.current?.clearTextureAtlas();
-        const visibleTerm = termRef.current;
-        if (visibleTerm) {
-          forceSyncRenderAfterResize(visibleTerm);
-        }
-
-        try {
-          fitAddon?.fit();
-        } catch (err) {
-          logger.warn("Fit after fonts ready failed", err);
-        }
-
-        if (terminalSettings && termRef.current) {
-          const resolvedBold = resolveFontWeightBold({
-            fontFamilyCss: termRef.current.options?.fontFamily || "",
-            normalWeight: effectiveFontWeight,
-            desiredBoldWeight: terminalSettings.fontWeightBold,
-            fontSize: effectiveFontSize,
-          });
-          termRef.current.options.fontWeightBold = resolvedBold as
-            | 100
-            | 200
-            | 300
-            | 400
-            | 500
-            | 600
-            | 700
-            | 800
-            | 900;
-        }
-
-        const id = sessionRef.current;
-        if (id && term) {
+        // Explicitly load the bundled webfonts the terminal actually renders
+        // with (the Latin JetBrains Mono fallback, the Sarasa Mono SC CJK
+        // fallback). document.fonts.ready can resolve before these are even
+        // requested, so without this the cold-start grid stays mis-sized (#1647).
+        const fontFamilyCss = (termRef.current as { options?: { fontFamily?: string } } | null)
+          ?.options?.fontFamily || "";
+        for (const family of bundledFamiliesInStack(fontFamilyCss)) {
           try {
-            resizeSession(id, term.cols, term.rows);
+            await fontFaceSet.load(`${effectiveFontSize}px "${family}"`);
           } catch (err) {
-            logger.warn("Resize session after fonts ready failed", err);
+            logger.warn(`Bundled font preload failed: ${family}`, err);
           }
         }
+        if (cancelled) return;
+
+        remeasureAfterFontLoad();
       } catch (err) {
         logger.warn("Waiting for fonts failed", err);
       }
@@ -820,6 +865,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     waitForFonts();
     return () => {
       cancelled = true;
+      if (remeasureTimer) clearTimeout(remeasureTimer);
+      fontFaceSet?.removeEventListener?.("loadingdone", onLoadingDone);
     };
   }, [effectiveFontSize, effectiveFontWeight, resizeSession, terminalSettings]);
 

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -17,10 +17,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { SidePanelTab } from './TerminalLayerSupport';
 import { terminalLayerSidePanelCtxEqual } from './terminalLayerViewMemo';
 import { resolveSftpFollowTerminalCwdTargetHost } from '../sftp/sftpFollowTerminalCwd';
+import { resolveTerminalFontFamilyId } from '../../infrastructure/config/fonts';
 import type { Host } from '../../types';
 
 type SidePanelContext = Record<string, any>;
 const SIDE_PANEL_TAB_DRAG_MIME = 'application/x-netcatty-sidepanel-tab';
+const navigatorPlatform = typeof navigator !== 'undefined' ? navigator.platform : '';
 
 export function getTerminalSidePanelShellWidth({
   activeSidePanelTab,
@@ -619,8 +621,8 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                     followAppTerminalTheme={followAppTerminalTheme}
                     currentThemeId={previewedOrVisibleThemeId}
                     globalThemeId={terminalThemeId ?? terminalTheme.id}
-                    currentFontFamilyId={focusedFontFamilyId}
-                    globalFontFamilyId={terminalFontFamilyId}
+                    currentFontFamilyId={resolveTerminalFontFamilyId(focusedFontFamilyId, navigatorPlatform)}
+                    globalFontFamilyId={resolveTerminalFontFamilyId(terminalFontFamilyId, navigatorPlatform)}
                     currentFontSize={focusedFontSize}
                     currentFontWeight={focusedFontWeight}
                     canResetTheme={followAppTerminalTheme ? false : focusedThemeOverridden}

--- a/components/terminalLayer/useTerminalThemePanelState.ts
+++ b/components/terminalLayer/useTerminalThemePanelState.ts
@@ -16,6 +16,7 @@ import {
   resolveHostTerminalThemeId,
 } from '../../domain/terminalAppearance';
 import { TERMINAL_THEMES } from '../../infrastructure/config/terminalThemes';
+import { isSameResolvedTerminalFont } from '../../infrastructure/config/fonts';
 import type { Host, TerminalSession, TerminalTheme, Workspace } from '../../types';
 import { useCustomThemes } from '../../application/state/customThemeStore';
 import { applyTopTabsChromeThemeVars } from '../../application/app/topTabsChromeTheme';
@@ -28,6 +29,8 @@ import {
   setStylePropertyIfChanged,
   type SidePanelTab,
 } from './TerminalLayerSupport';
+
+const navigatorPlatform = typeof navigator !== 'undefined' ? navigator.platform : '';
 
 interface UseTerminalThemePanelStateOptions {
   accentMode: 'theme' | 'custom';
@@ -270,7 +273,10 @@ export function useTerminalThemePanelState({
     }, [focusedHost, isFocusedHostEphemeral, onUpdateHost, previewTargetSessionId, rawFocusedHost]);
   
   const handleFontFamilyChangeForFocusedSession = useCallback((fontFamilyId: string) => {
-      if (!focusedHost || fontFamilyId === focusedFontFamilyId) return;
+      // The panel shows the resolved concrete font for an `auto` default, so
+      // compare resolved ids — otherwise clicking the already-displayed default
+      // pins a per-OS font (and syncs it across devices). #1647 follow-up.
+      if (!focusedHost || isSameResolvedTerminalFont(fontFamilyId, focusedFontFamilyId, navigatorPlatform)) return;
       startTransition(() => {
         if (isFocusedHostEphemeral) {
           onUpdateTerminalFontFamilyId?.(fontFamilyId);

--- a/infrastructure/config/fonts.test.ts
+++ b/infrastructure/config/fonts.test.ts
@@ -5,6 +5,7 @@ import {
   getDefaultTerminalFontIdForPlatform,
   detectFontPlatform,
   resolveTerminalFontFamilyId,
+  isSameResolvedTerminalFont,
   TERMINAL_FONT_AUTO,
 } from './fonts';
 
@@ -118,6 +119,25 @@ describe('resolveTerminalFontFamilyId', () => {
   it('keeps an explicit font id regardless of platform', () => {
     assert.equal(resolveTerminalFontFamilyId('jetbrains-mono', 'Win32'), 'jetbrains-mono');
     assert.equal(resolveTerminalFontFamilyId('menlo', 'Win32'), 'menlo');
+  });
+});
+
+describe('isSameResolvedTerminalFont', () => {
+  it('treats clicking the displayed default while stored=auto as a no-op', () => {
+    // Prevents the side panel from pinning a concrete per-OS font (which would
+    // then sync across devices) on a no-op-looking click of the shown default.
+    assert.equal(isSameResolvedTerminalFont('consolas', TERMINAL_FONT_AUTO, 'Win32'), true);
+    assert.equal(isSameResolvedTerminalFont('menlo', TERMINAL_FONT_AUTO, 'MacIntel'), true);
+    assert.equal(isSameResolvedTerminalFont('dejavu-sans-mono', TERMINAL_FONT_AUTO, 'Linux'), true);
+  });
+
+  it('reports a real change when a different font is selected', () => {
+    assert.equal(isSameResolvedTerminalFont('jetbrains-mono', TERMINAL_FONT_AUTO, 'Win32'), false);
+  });
+
+  it('compares concrete ids directly', () => {
+    assert.equal(isSameResolvedTerminalFont('fira-code', 'fira-code', 'Win32'), true);
+    assert.equal(isSameResolvedTerminalFont('fira-code', 'menlo', 'Win32'), false);
   });
 });
 

--- a/infrastructure/config/fonts.test.ts
+++ b/infrastructure/config/fonts.test.ts
@@ -4,6 +4,8 @@ import {
   TERMINAL_FONTS,
   getDefaultTerminalFontIdForPlatform,
   detectFontPlatform,
+  resolveTerminalFontFamilyId,
+  TERMINAL_FONT_AUTO,
 } from './fonts';
 
 /**
@@ -97,6 +99,25 @@ describe('getDefaultTerminalFontIdForPlatform', () => {
         `default for ${platform} not in TERMINAL_FONTS`,
       );
     }
+  });
+});
+
+describe('resolveTerminalFontFamilyId', () => {
+  it('resolves the auto sentinel to the per-platform default', () => {
+    assert.equal(resolveTerminalFontFamilyId(TERMINAL_FONT_AUTO, 'Win32'), 'consolas');
+    assert.equal(resolveTerminalFontFamilyId(TERMINAL_FONT_AUTO, 'MacIntel'), 'menlo');
+    assert.equal(resolveTerminalFontFamilyId(TERMINAL_FONT_AUTO, 'Linux x86_64'), 'dejavu-sans-mono');
+  });
+
+  it('treats empty/nullish ids as auto (resolves per platform)', () => {
+    assert.equal(resolveTerminalFontFamilyId('', 'Win32'), 'consolas');
+    assert.equal(resolveTerminalFontFamilyId(null, 'MacIntel'), 'menlo');
+    assert.equal(resolveTerminalFontFamilyId(undefined, 'Linux'), 'dejavu-sans-mono');
+  });
+
+  it('keeps an explicit font id regardless of platform', () => {
+    assert.equal(resolveTerminalFontFamilyId('jetbrains-mono', 'Win32'), 'jetbrains-mono');
+    assert.equal(resolveTerminalFontFamilyId('menlo', 'Win32'), 'menlo');
   });
 });
 

--- a/infrastructure/config/fonts.test.ts
+++ b/infrastructure/config/fonts.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { TERMINAL_FONTS } from './fonts';
+import {
+  TERMINAL_FONTS,
+  getDefaultTerminalFontIdForPlatform,
+  detectFontPlatform,
+} from './fonts';
 
 /**
  * Proportional (non-monospace) fonts must never appear in the terminal
@@ -65,5 +69,50 @@ describe('TERMINAL_FONTS dropdown contents', () => {
       assert.equal(seen.has(font.id), false, `duplicate id: ${font.id}`);
       seen.add(font.id);
     }
+  });
+});
+
+describe('getDefaultTerminalFontIdForPlatform', () => {
+  it('uses a locally-installed Windows font (no webfont swap on cold start)', () => {
+    assert.equal(getDefaultTerminalFontIdForPlatform('win32'), 'consolas');
+  });
+
+  it('uses the most widely pre-installed Linux monospace font', () => {
+    assert.equal(getDefaultTerminalFontIdForPlatform('linux'), 'dejavu-sans-mono');
+  });
+
+  it('keeps the macOS system font default', () => {
+    assert.equal(getDefaultTerminalFontIdForPlatform('darwin'), 'menlo');
+  });
+
+  it('falls back to the macOS default for unknown platforms', () => {
+    assert.equal(getDefaultTerminalFontIdForPlatform('freebsd'), 'menlo');
+  });
+
+  it('only ever returns ids that exist in TERMINAL_FONTS', () => {
+    const ids = new Set(TERMINAL_FONTS.map((f) => f.id));
+    for (const platform of ['darwin', 'win32', 'linux', 'unknown']) {
+      assert.ok(
+        ids.has(getDefaultTerminalFontIdForPlatform(platform)),
+        `default for ${platform} not in TERMINAL_FONTS`,
+      );
+    }
+  });
+});
+
+describe('detectFontPlatform', () => {
+  it('maps navigator.platform Windows values to win32', () => {
+    assert.equal(detectFontPlatform('Win32'), 'win32');
+    assert.equal(detectFontPlatform('Windows'), 'win32');
+  });
+
+  it('maps macOS and iOS values to darwin', () => {
+    assert.equal(detectFontPlatform('MacIntel'), 'darwin');
+    assert.equal(detectFontPlatform('iPhone'), 'darwin');
+  });
+
+  it('treats everything else (incl. Linux) as linux', () => {
+    assert.equal(detectFontPlatform('Linux x86_64'), 'linux');
+    assert.equal(detectFontPlatform(''), 'linux');
   });
 });

--- a/infrastructure/config/fonts.ts
+++ b/infrastructure/config/fonts.ts
@@ -100,6 +100,28 @@ export function detectFontPlatform(navigatorPlatform: string): FontPlatform {
   return 'linux';
 }
 
+/**
+ * The stored sentinel meaning "follow the OS default font". It is
+ * persisted and cloud-synced as-is (platform-neutral), so each device
+ * resolves it to its own locally-installed default at render time —
+ * unlike a concrete platform id, which would leak one OS's font to
+ * another via sync and reintroduce #1647 on the receiving machine.
+ */
+export const TERMINAL_FONT_AUTO = 'auto';
+
+/**
+ * Resolve a stored terminal font id to a concrete font id. The `auto`
+ * sentinel (and any empty/nullish value) resolves to the per-platform
+ * default; an explicit user choice is returned unchanged.
+ */
+export function resolveTerminalFontFamilyId(
+  id: string | null | undefined,
+  navigatorPlatform: string,
+): string {
+  if (id && id !== TERMINAL_FONT_AUTO) return id;
+  return getDefaultTerminalFontIdForPlatform(detectFontPlatform(navigatorPlatform));
+}
+
 // Font ids that earlier versions of netcatty exposed in the primary font
 // dropdown but that are proportional (non-monospace) and produce broken
 // cell-grid alignment when used as a terminal font. Reads should migrate

--- a/infrastructure/config/fonts.ts
+++ b/infrastructure/config/fonts.ts
@@ -122,6 +122,25 @@ export function resolveTerminalFontFamilyId(
   return getDefaultTerminalFontIdForPlatform(detectFontPlatform(navigatorPlatform));
 }
 
+/**
+ * Whether two terminal font ids resolve to the same concrete font on this
+ * platform. Font pickers display the resolved concrete font for an `auto`
+ * value, so a click on the shown default arrives as that concrete id while
+ * the stored value is still `auto`; comparing raw would treat it as a
+ * change and pin a per-OS font (which then syncs across devices). Comparing
+ * resolved ids makes that click a correct no-op.
+ */
+export function isSameResolvedTerminalFont(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  navigatorPlatform: string,
+): boolean {
+  return (
+    resolveTerminalFontFamilyId(a, navigatorPlatform) ===
+    resolveTerminalFontFamilyId(b, navigatorPlatform)
+  );
+}
+
 // Font ids that earlier versions of netcatty exposed in the primary font
 // dropdown but that are proportional (non-monospace) and produce broken
 // cell-grid alignment when used as a terminal font. Reads should migrate

--- a/infrastructure/config/fonts.ts
+++ b/infrastructure/config/fonts.ts
@@ -65,6 +65,41 @@ export const DEFAULT_FONT_SIZE = 14;
 export const MIN_FONT_SIZE = 10;
 export const MAX_FONT_SIZE = 32;
 
+export type FontPlatform = 'darwin' | 'win32' | 'linux' | (string & {});
+
+/**
+ * The default terminal font id for a given OS. Chosen so the primary
+ * Latin glyphs render with a font that ships with the OS — avoiding the
+ * cold-start cell-misalignment in #1647, where a bundled webfont
+ * (JetBrains Mono, font-display: swap) swapped in *after* xterm measured
+ * the cell grid and left ASCII garbled until a manual window resize.
+ *
+ *   - darwin: Menlo is a macOS system font (instant, no swap).
+ *   - win32:  Consolas ships with every Windows since Vista.
+ *   - linux:  DejaVu Sans Mono is the most widely pre-installed Linux
+ *             monospace; if a given distro lacks it, the runtime font-ready
+ *             remeasure (useTerminalEffects) still recovers any swap.
+ *
+ * Unknown platforms fall back to the macOS default.
+ */
+export function getDefaultTerminalFontIdForPlatform(platform: FontPlatform): string {
+  if (platform === 'win32') return 'consolas';
+  if (platform === 'linux') return 'dejavu-sans-mono';
+  return 'menlo';
+}
+
+/**
+ * Normalize a `navigator.platform` string to the coarse OS buckets used
+ * by getDefaultTerminalFontIdForPlatform. Mirrors the detection already
+ * used for the CJK fallback stack in Terminal.tsx (Mac/Win regex on
+ * navigator.platform); anything else — including Linux — is `linux`.
+ */
+export function detectFontPlatform(navigatorPlatform: string): FontPlatform {
+  if (/Win/i.test(navigatorPlatform)) return 'win32';
+  if (/Mac|iPhone|iPad|iPod/i.test(navigatorPlatform)) return 'darwin';
+  return 'linux';
+}
+
 // Font ids that earlier versions of netcatty exposed in the primary font
 // dropdown but that are proportional (non-monospace) and produce broken
 // cell-grid alignment when used as a terminal font. Reads should migrate

--- a/lib/fontAvailability.test.ts
+++ b/lib/fontAvailability.test.ts
@@ -9,7 +9,28 @@ import {
   clearFontAvailabilityCache,
   subscribeFontAvailability,
   getFontAvailabilityVersion,
+  bundledFamiliesInStack,
 } from './fontAvailability';
+
+describe('bundledFamiliesInStack', () => {
+  it('returns bundled webfonts present in a composed stack, in order', () => {
+    const stack = 'Consolas, "JetBrains Mono", "Sarasa Mono SC", monospace';
+    assert.deepEqual(bundledFamiliesInStack(stack), ['JetBrains Mono', 'Sarasa Mono SC']);
+  });
+
+  it('returns nothing when only system fonts are referenced', () => {
+    assert.deepEqual(bundledFamiliesInStack('Menlo, monospace'), []);
+  });
+
+  it('ignores the generic monospace keyword and dedupes', () => {
+    const stack = '"JetBrains Mono", "JetBrains Mono", monospace';
+    assert.deepEqual(bundledFamiliesInStack(stack), ['JetBrains Mono']);
+  });
+
+  it('is case-insensitive on family names', () => {
+    assert.deepEqual(bundledFamiliesInStack('"jetbrains mono"'), ['JetBrains Mono']);
+  });
+});
 
 describe('extractPrimaryFamily', () => {
   it('strips quotes from a quoted name', () => {

--- a/lib/fontAvailability.ts
+++ b/lib/fontAvailability.ts
@@ -26,6 +26,33 @@ const KNOWN_BUNDLED_FAMILIES = new Set<string>([
   'Sarasa Mono SC',     // public/fonts/SarasaMonoSC-Regular.woff2 (OFL)
 ]);
 
+const KNOWN_BUNDLED_BY_LOWER = new Map<string, string>(
+  [...KNOWN_BUNDLED_FAMILIES].map((name) => [name.toLowerCase(), name]),
+);
+
+/**
+ * The bundled webfonts (shipped via @font-face / @fontsource) that appear
+ * in a composed font-family stack, in stack order and de-duplicated, with
+ * their canonical casing. Used to explicitly preload the fonts a terminal
+ * actually renders with so xterm can remeasure the cell grid once they
+ * load — these faces use `font-display: swap`, so without an explicit
+ * preload + remeasure their late swap garbles the grid until a manual
+ * resize (#1647). System fonts and the generic `monospace` keyword are
+ * skipped.
+ */
+export function bundledFamiliesInStack(fontFamilyCss: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const token of splitFontFamilyList(fontFamilyCss)) {
+    const bare = token.replace(/^["']|["']$/g, '').toLowerCase();
+    const canonical = KNOWN_BUNDLED_BY_LOWER.get(bare);
+    if (!canonical || seen.has(canonical)) continue;
+    seen.add(canonical);
+    result.push(canonical);
+  }
+  return result;
+}
+
 let systemFamilies: Set<string> | null = null;
 let availabilityVersion = 0;
 const listeners = new Set<() => void>();


### PR DESCRIPTION
## Background

Fixes #1647: on Windows, the first connection after a cold start renders garbled/misaligned ASCII (e.g. `ls` output); resizing the window restores it.

## Root cause

xterm measures the character cell grid once at `open()`. The default terminal font was `menlo` (platform-independent), which isn't installed on Windows/Linux, so the primary Latin glyphs fell through to the `"JetBrains Mono"` Latin fallback hard-wired into `composeFontFamilyStack` — a bundled `@fontsource` webfont with `font-display: swap`. It loads asynchronously and swaps in *after* xterm has measured the grid, so the glyph advance width no longer matches the locked cell grid → ASCII misaligns. A manual resize triggers `fitAddon.fit()`, which remeasures with the webfont loaded → it recovers. macOS is unaffected because Menlo is a system font (synchronously available, no swap).

The existing `waitForFonts` didn't catch it: it only explicitly preloaded the Nerd Font, not the actual primary font carrying ASCII, and it relied on a single `document.fonts.ready` resolution that can fire before the webfont is even requested — with no remeasure afterward.

## Changes

- **Platform-neutral `auto` font default.** The stored default becomes an `auto` sentinel, resolved to a locally-installed font per OS at render time (win32 → Consolas, linux → DejaVu Sans Mono, darwin → Menlo). `auto` is persisted/synced as-is, so it never leaks one OS's font to another device and never reintroduces #1647 on the receiving machine. Deprecated font ids also migrate to `auto`.
- **General font-ready recovery** (`useTerminalEffects`): explicitly preload the bundled webfonts the terminal actually renders with (JetBrains Mono / Sarasa Mono SC) before remeasuring, and add a `document.fonts` `loadingdone` listener that clears the texture atlas, remeasures, refits and resizes whenever any font finishes loading. Recovery no longer depends on the single `document.fonts.ready` resolution and also covers user-chosen webfonts.

The default change fixes the out-of-the-box Windows case; the font-ready recovery is the general fix.

## Testing

- `node --test --import tsx infrastructure/config/fonts.test.ts lib/fontAvailability.test.ts application/state/settingsStateDefaults.test.ts` — new unit tests for `getDefaultTerminalFontIdForPlatform`, `detectFontPlatform`, `resolveTerminalFontFamilyId`, `isSameResolvedTerminalFont`, `bundledFamiliesInStack`, and deprecated-id migration. All passing.
- `npm run lint` — clean.
- `npm run build` — passing.

Reviewed locally with Codex (multiple adversarial passes); findings on default persistence/sync and side-panel no-op writes were addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)