### PR TITLE
Add typed tool result handles

### DIFF
--- a/components/ai/cattyHistoryReplay.test.ts
+++ b/components/ai/cattyHistoryReplay.test.ts
@@ -8,6 +8,10 @@ import {
   buildHistoricalUserReplayContent,
 } from "./cattyHistoryReplay.ts";
 import type { ChatMessage } from "../../infrastructure/ai/types.ts";
+import {
+  buildTerminalExecuteResultForModel,
+  resetToolResultHandlesForTests,
+} from "../../infrastructure/ai/toolResultHandles.ts";
 
 test("buildHistoricalUserReplayContent replaces historical image data with a placeholder", () => {
   const attachment: ChatMessageAttachment = {
@@ -106,6 +110,39 @@ test("buildHistoricalToolResultReplayText can preserve terminal output for 413 r
     buildHistoricalToolResultReplayText(result, toolCall, { preserveTerminalOutput: true }),
     "real terminal output",
   );
+});
+
+test("buildHistoricalToolResultReplayText preserves compressed terminal handle metadata", () => {
+  resetToolResultHandlesForTests();
+  const toolCall: ToolCall = {
+    id: "call-1",
+    name: "terminal_execute",
+    arguments: { command: "npm run build" },
+  };
+  const compressed = buildTerminalExecuteResultForModel({
+    stdout: "BUILD\n".repeat(20_000),
+    stderr: "",
+    exitCode: 0,
+  }, {
+    chatSessionId: "chat-1",
+    toolCallId: "call-1",
+    sessionId: "session-1",
+    command: "npm run build",
+  });
+
+  assert.ok("outputCompression" in compressed);
+  const content = JSON.stringify(compressed);
+  const result: ToolResult = {
+    toolCallId: "call-1",
+    content,
+  };
+
+  const replay = buildHistoricalToolResultReplayText(result, toolCall);
+
+  assert.equal(replay, content);
+  assert.match(replay, /tool_result_read/);
+  assert.match(replay, /outputCompression/);
+  assert.doesNotMatch(replay, /Historical terminal output omitted/);
 });
 
 test("buildHistoricalToolReplayMaps pairs reused tool ids with the nearest preceding call", () => {

--- a/components/ai/cattyHistoryReplay.ts
+++ b/components/ai/cattyHistoryReplay.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ChatMessageAttachment, ToolCall, ToolResult } from "../../infrastructure/ai/types";
 import { isTerminalSelectionAttachment } from "../../application/state/terminalSelectionAttachment";
+import { isCompressedTerminalToolResultContent } from "../../infrastructure/ai/toolResultHandles";
 
 const MAX_ATTACHMENT_PLACEHOLDER_DETAIL_CHARS = 120;
 const MAX_TOOL_COMMAND_CHARS = 220;
@@ -120,6 +121,9 @@ export function buildHistoricalToolResultReplayText(
 ): string {
   const toolName = toolCall?.name ?? "unknown";
   if (!isTerminalToolName(toolName) || preserveTerminalOutput) {
+    return result.content;
+  }
+  if (isCompressedTerminalToolResultContent(result.content)) {
     return result.content;
   }
 

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -16,6 +16,10 @@ import {
 import { requestApproval } from '../shared/approvalGate';
 import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
 import { truncateTextWithHeadAndTail } from '../requestPayloadCompression';
+import {
+  buildTerminalExecuteResultForModel,
+  readToolResultHandle,
+} from '../toolResultHandles';
 
 const MAX_LIVE_TERMINAL_STDOUT_CHARS = 24_000;
 const MAX_LIVE_TERMINAL_STDERR_CHARS = 12_000;
@@ -122,13 +126,43 @@ export function createCattyTools(
           try {
             const result = await executeTerminalExecute(deps, { sessionId, command });
             if (result.ok === false) return unwrap(result);
-            return fitTerminalExecuteResultForModel(result.data);
+            return buildTerminalExecuteResultForModel(result.data, {
+              chatSessionId,
+              toolCallId,
+              sessionId,
+              command,
+            });
           } finally {
             abortSignal?.removeEventListener('abort', cancelOnAbort);
           }
         } finally {
           slot.release();
         }
+      },
+    }),
+
+    tool_result_read: tool({
+      description:
+        'Read an exact slice from a large tool result that was compressed into a handle. ' +
+        'Use this when terminal_execute returns outputCompression.handle and you need more exact stdout/stderr. ' +
+        'Repeated identical reads return a concise notice; change offset, length, or channel to inspect a different slice.',
+      inputSchema: z.object({
+        handle: z.string().describe('The outputCompression.handle returned by a compressed tool result.'),
+        channel: z.enum(['all', 'stdout', 'stderr']).optional().default('all')
+          .describe('Which part of the stored result to read. Defaults to all.'),
+        offset: z.number().int().min(0).optional().default(0)
+          .describe('Character offset to start reading from. Defaults to 0.'),
+        length: z.number().int().min(1).max(20000).optional().default(4000)
+          .describe('Maximum characters to return. Defaults to 4000, max 20000.'),
+      }),
+      execute: async ({ handle, channel, offset, length }) => {
+        return readToolResultHandle({
+          handle,
+          channel,
+          offset,
+          length,
+          chatSessionId,
+        });
       },
     }),
 

--- a/infrastructure/ai/toolResultHandles.test.ts
+++ b/infrastructure/ai/toolResultHandles.test.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildTerminalExecuteResultForModel,
+  readToolResultHandle,
+  resetToolResultHandlesForTests,
+} from "./toolResultHandles.ts";
+
+test("buildTerminalExecuteResultForModel compresses large terminal output into a readable handle", () => {
+  resetToolResultHandlesForTests();
+  const stdout = Array.from({ length: 2_000 }, (_, index) => `stdout line ${index}`).join("\n");
+  const stderr = "error: build failed\nstack trace line";
+
+  const result = buildTerminalExecuteResultForModel({
+    stdout,
+    stderr,
+    exitCode: 1,
+  }, {
+    chatSessionId: "chat-1",
+    toolCallId: "call-1",
+    sessionId: "session-1",
+    command: "npm test",
+  });
+
+  assert.equal("type" in result ? result.type : undefined, "netcatty.terminal_execute_result");
+  assert.ok("outputCompression" in result);
+  assert.equal(result.command, "npm test");
+  assert.equal(result.sessionId, "session-1");
+  assert.equal(result.status, "failed");
+  assert.match(result.outputCompression.handle, /^trh_call-1_/);
+  assert.equal(result.outputCompression.readTool, "tool_result_read");
+  assert.match(result.stdout.content, /stdout line 0/);
+  assert.match(result.stdout.content, /lines omitted/);
+  assert.match(result.stdout.content, /stdout line 1999/);
+  assert.doesNotMatch(JSON.stringify(result), /stdout line 1000/);
+  assert.match(result.errorSummary ?? "", /error: build failed/);
+});
+
+test("readToolResultHandle returns exact slices and concise notices for duplicate reads", () => {
+  resetToolResultHandlesForTests();
+  const stdout = `${"A".repeat(20_000)}TARGET${"B".repeat(5_000)}`;
+  const compressed = buildTerminalExecuteResultForModel({
+    stdout,
+    stderr: "",
+    exitCode: 0,
+  }, {
+    chatSessionId: "chat-1",
+    toolCallId: "call-2",
+    sessionId: "session-1",
+    command: "generate-output",
+  });
+
+  assert.ok("outputCompression" in compressed);
+  const firstRead = readToolResultHandle({
+    handle: compressed.outputCompression.handle,
+    chatSessionId: "chat-1",
+    channel: "stdout",
+    offset: 19_995,
+    length: 16,
+  });
+
+  assert.equal(firstRead.type, "netcatty.tool_result_slice");
+  assert.match(firstRead.content, /TARGET/);
+  assert.equal(firstRead.offset, 19_995);
+  assert.equal(firstRead.nextOffset, 20_011);
+
+  const duplicateRead = readToolResultHandle({
+    handle: compressed.outputCompression.handle,
+    chatSessionId: "chat-1",
+    channel: "stdout",
+    offset: 19_995,
+    length: 16,
+  });
+
+  assert.equal(duplicateRead.type, "netcatty.tool_result_repeat_notice");
+  assert.match(duplicateRead.message, /already returned/);
+  assert.ok(!("content" in duplicateRead));
+});
+
+test("readToolResultHandle rejects handles from another chat session", () => {
+  resetToolResultHandlesForTests();
+  const compressed = buildTerminalExecuteResultForModel({
+    stdout: "X".repeat(20_000),
+    stderr: "",
+    exitCode: 0,
+  }, {
+    chatSessionId: "chat-1",
+    toolCallId: "call-3",
+    sessionId: "session-1",
+    command: "print",
+  });
+
+  assert.ok("outputCompression" in compressed);
+  const result = readToolResultHandle({
+    handle: compressed.outputCompression.handle,
+    chatSessionId: "chat-2",
+  });
+
+  assert.deepEqual(result, { error: "Tool result handle is not available in this chat session." });
+});

--- a/infrastructure/ai/toolResultHandles.ts
+++ b/infrastructure/ai/toolResultHandles.ts
@@ -1,0 +1,296 @@
+const LARGE_TERMINAL_OUTPUT_CHARS = 16_000;
+const TERMINAL_PREVIEW_HEAD_LINES = 20;
+const TERMINAL_PREVIEW_TAIL_LINES = 40;
+const TERMINAL_PREVIEW_MAX_LINE_CHARS = 240;
+const DEFAULT_READ_LENGTH = 4_000;
+const MAX_READ_LENGTH = 20_000;
+const MAX_HANDLE_RECORDS = 200;
+
+export type ToolResultReadChannel = "all" | "stdout" | "stderr";
+
+export interface TerminalExecuteResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export interface TerminalToolResultMetadata {
+  chatSessionId?: string | null;
+  toolCallId: string;
+  sessionId: string;
+  command: string;
+}
+
+export interface TerminalOutputPreview {
+  chars: number;
+  lines: number;
+  truncated: boolean;
+  content: string;
+}
+
+export interface CompressedTerminalToolResult {
+  type: "netcatty.terminal_execute_result";
+  sessionId: string;
+  command: string;
+  exitCode: number | null;
+  status: "success" | "failed" | "unknown";
+  stdout: TerminalOutputPreview;
+  stderr: TerminalOutputPreview;
+  outputCompression: {
+    kind: "terminal_output";
+    handle: string;
+    readTool: "tool_result_read";
+    totalChars: number;
+    totalLines: number;
+    stdoutChars: number;
+    stderrChars: number;
+    note: string;
+  };
+  errorSummary?: string;
+}
+
+export interface ToolResultSlice {
+  type: "netcatty.tool_result_slice";
+  handle: string;
+  channel: ToolResultReadChannel;
+  offset: number;
+  length: number;
+  nextOffset: number | null;
+  totalChars: number;
+  content: string;
+}
+
+export interface ToolResultRepeatNotice {
+  type: "netcatty.tool_result_repeat_notice";
+  handle: string;
+  channel: ToolResultReadChannel;
+  offset: number;
+  length: number;
+  totalChars: number;
+  message: string;
+}
+
+export interface ToolResultReadError {
+  error: string;
+}
+
+interface ToolResultHandleRecord {
+  handle: string;
+  chatSessionId?: string | null;
+  toolCallId: string;
+  toolName: string;
+  createdAt: number;
+  stdout: string;
+  stderr: string;
+  combined: string;
+  reads: Map<string, number>;
+}
+
+const records = new Map<string, ToolResultHandleRecord>();
+let handleCounter = 0;
+
+export function buildTerminalExecuteResultForModel(
+  result: TerminalExecuteResult,
+  metadata: TerminalToolResultMetadata,
+): TerminalExecuteResult | CompressedTerminalToolResult {
+  const totalChars = result.stdout.length + result.stderr.length;
+  if (totalChars <= LARGE_TERMINAL_OUTPUT_CHARS) return result;
+
+  const handle = createHandle(metadata.toolCallId);
+  const combined = formatCombinedTerminalOutput(result);
+  records.set(handle, {
+    handle,
+    chatSessionId: metadata.chatSessionId,
+    toolCallId: metadata.toolCallId,
+    toolName: "terminal_execute",
+    createdAt: Date.now(),
+    stdout: result.stdout,
+    stderr: result.stderr,
+    combined,
+    reads: new Map(),
+  });
+  pruneOldRecords();
+
+  const stdout = buildTerminalOutputPreview(result.stdout);
+  const stderr = buildTerminalOutputPreview(result.stderr);
+  const errorSummary = buildErrorSummary(result);
+
+  return {
+    type: "netcatty.terminal_execute_result",
+    sessionId: metadata.sessionId,
+    command: metadata.command,
+    exitCode: result.exitCode,
+    status: getTerminalStatus(result.exitCode),
+    stdout,
+    stderr,
+    outputCompression: {
+      kind: "terminal_output",
+      handle,
+      readTool: "tool_result_read",
+      totalChars: combined.length,
+      totalLines: countLines(combined),
+      stdoutChars: result.stdout.length,
+      stderrChars: result.stderr.length,
+      note: "Large terminal output was compressed. Use tool_result_read with this handle, channel, offset, and length to inspect exact output slices.",
+    },
+    ...(errorSummary ? { errorSummary } : {}),
+  };
+}
+
+export function readToolResultHandle(args: {
+  handle: string;
+  chatSessionId?: string | null;
+  channel?: ToolResultReadChannel;
+  offset?: number;
+  length?: number;
+}): ToolResultSlice | ToolResultRepeatNotice | ToolResultReadError {
+  const record = records.get(args.handle);
+  if (!record) {
+    return { error: `Tool result handle not found: ${args.handle}` };
+  }
+  if (record.chatSessionId && args.chatSessionId && record.chatSessionId !== args.chatSessionId) {
+    return { error: "Tool result handle is not available in this chat session." };
+  }
+
+  const channel = args.channel ?? "all";
+  const content = selectRecordContent(record, channel);
+  const offset = clampInteger(args.offset ?? 0, 0, content.length);
+  const length = clampInteger(args.length ?? DEFAULT_READ_LENGTH, 1, MAX_READ_LENGTH);
+  const readKey = `${channel}:${offset}:${length}`;
+  const readCount = record.reads.get(readKey) ?? 0;
+  record.reads.set(readKey, readCount + 1);
+
+  if (readCount > 0) {
+    return {
+      type: "netcatty.tool_result_repeat_notice",
+      handle: record.handle,
+      channel,
+      offset,
+      length,
+      totalChars: content.length,
+      message: "This exact tool result slice was already returned. Request a different channel, offset, or length if more detail is needed.",
+    };
+  }
+
+  const slice = content.slice(offset, offset + length);
+  const nextOffset = offset + slice.length < content.length ? offset + slice.length : null;
+  return {
+    type: "netcatty.tool_result_slice",
+    handle: record.handle,
+    channel,
+    offset,
+    length: slice.length,
+    nextOffset,
+    totalChars: content.length,
+    content: slice,
+  };
+}
+
+export function isCompressedTerminalToolResultContent(content: string): boolean {
+  const parsed = parseJsonObject(content);
+  return parsed?.type === "netcatty.terminal_execute_result"
+    && typeof parsed.outputCompression === "object"
+    && parsed.outputCompression !== null;
+}
+
+export function resetToolResultHandlesForTests(): void {
+  records.clear();
+  handleCounter = 0;
+}
+
+function createHandle(toolCallId: string): string {
+  const safeToolCallId = toolCallId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 32) || "tool";
+  handleCounter += 1;
+  return `trh_${safeToolCallId}_${Date.now().toString(36)}_${handleCounter.toString(36)}`;
+}
+
+function pruneOldRecords(): void {
+  if (records.size <= MAX_HANDLE_RECORDS) return;
+  const sorted = [...records.values()].sort((a, b) => a.createdAt - b.createdAt);
+  for (const record of sorted.slice(0, records.size - MAX_HANDLE_RECORDS)) {
+    records.delete(record.handle);
+  }
+}
+
+function buildTerminalOutputPreview(value: string): TerminalOutputPreview {
+  const lines = splitLines(value);
+  const truncated = value.length > 0 && lines.length > TERMINAL_PREVIEW_HEAD_LINES + TERMINAL_PREVIEW_TAIL_LINES;
+  const previewLines = truncated
+    ? [
+      ...lines.slice(0, TERMINAL_PREVIEW_HEAD_LINES),
+      `[... ${Math.max(0, lines.length - TERMINAL_PREVIEW_HEAD_LINES - TERMINAL_PREVIEW_TAIL_LINES)} lines omitted; use tool_result_read for exact output ...]`,
+      ...lines.slice(-TERMINAL_PREVIEW_TAIL_LINES),
+    ]
+    : lines;
+
+  return {
+    chars: value.length,
+    lines: lines.length,
+    truncated,
+    content: previewLines.map(truncatePreviewLine).join("\n"),
+  };
+}
+
+function buildErrorSummary(result: TerminalExecuteResult): string | undefined {
+  const source = result.stderr.trim() || (result.exitCode && result.exitCode !== 0 ? result.stdout.trim() : "");
+  if (!source) return undefined;
+  return splitLines(source)
+    .filter((line) => line.trim())
+    .slice(0, 6)
+    .map(truncatePreviewLine)
+    .join("\n");
+}
+
+function formatCombinedTerminalOutput(result: TerminalExecuteResult): string {
+  const parts: string[] = [];
+  if (result.stdout) parts.push(`STDOUT:\n${result.stdout}`);
+  if (result.stderr) parts.push(`STDERR:\n${result.stderr}`);
+  if (result.exitCode != null) parts.push(`[exit code: ${result.exitCode}]`);
+  return parts.join("\n\n");
+}
+
+function selectRecordContent(record: ToolResultHandleRecord, channel: ToolResultReadChannel): string {
+  switch (channel) {
+    case "stdout":
+      return record.stdout;
+    case "stderr":
+      return record.stderr;
+    default:
+      return record.combined;
+  }
+}
+
+function getTerminalStatus(exitCode: number | null): "success" | "failed" | "unknown" {
+  if (exitCode == null || exitCode === -1) return "unknown";
+  return exitCode === 0 ? "success" : "failed";
+}
+
+function splitLines(value: string): string[] {
+  if (!value) return [];
+  return value.replace(/\r\n/g, "\n").split("\n");
+}
+
+function countLines(value: string): number {
+  return splitLines(value).length;
+}
+
+function truncatePreviewLine(line: string): string {
+  if (line.length <= TERMINAL_PREVIEW_MAX_LINE_CHARS) return line;
+  return `${line.slice(0, TERMINAL_PREVIEW_MAX_LINE_CHARS - 3)}...`;
+}
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function parseJsonObject(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(content);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add typed compression for large Catty terminal tool outputs with preview metadata and session-scoped result handles.
- Add `tool_result_read` so the agent can fetch exact stdout/stderr slices by handle without replaying full outputs.
- Preserve compressed handle metadata during historical terminal result replay and add focused tests.

## Testing
- `node --test --import tsx "infrastructure/ai/toolResultHandles.test.ts" "components/ai/cattyHistoryReplay.test.ts" "infrastructure/ai/sdk/tools.test.ts" "infrastructure/ai/requestPayloadCompression.test.ts"`
- `npm run lint`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b01584e-2aab-4f75-a67d-83ed4cc95d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b01584e-2aab-4f75-a67d-83ed4cc95d5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

