### PR TITLE
[codex] fix terminal dynamic tab title settings

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -170,6 +170,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
         onRemoveSessionFromWorkspace={removeSessionFromWorkspace}
         showSftpTab={settings.showSftpTab}
         showHostTreeSidebar={settings.showHostTreeSidebar}
+        dynamicTabTitleMode={settings.terminalSettings.dynamicTabTitleMode}
         editorTabs={editorTabs}
         onRequestCloseEditorTab={handleRequestCloseEditorTab}
         hostById={hostById}

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -380,6 +380,12 @@ export const enCoreMessages: Messages = {
   'settings.terminal.behavior.forcePromptNewLine': 'Prompt on a new line',
   'settings.terminal.behavior.forcePromptNewLine.desc':
     'When the final line of command output is not terminated by a newline, move the recognized shell prompt to the next visual line.',
+  'settings.terminal.behavior.dynamicTabTitle': 'Dynamic tab title',
+  'settings.terminal.behavior.dynamicTabTitle.desc':
+    'Choose when session tabs should follow shell-reported window titles.',
+  'settings.terminal.behavior.dynamicTabTitle.off': 'Disabled',
+  'settings.terminal.behavior.dynamicTabTitle.agent': 'Agents only',
+  'settings.terminal.behavior.dynamicTabTitle.all': 'All sessions',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 clipboard',
   'settings.terminal.behavior.osc52Clipboard.desc':
     'Allow remote programs (tmux, vim, etc.) to access the local clipboard via OSC-52 escape sequences.',

--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -628,8 +628,6 @@ export const enVaultMessages: Messages = {
   'hostDetails.section.terminalBehavior': 'Terminal Behavior',
   'hostDetails.lineTimestamps': 'Show output timestamps',
   'hostDetails.lineTimestamps.desc': 'Show local time beside visible output lines for this host without changing terminal text.',
-  'hostDetails.disableDynamicTabTitle': 'Disable dynamic tab title',
-  'hostDetails.disableDynamicTabTitle.desc': 'Keep the connection name on session tabs instead of following the shell-reported window title.',
   'hostDetails.legacyAlgorithms': 'Allow Legacy Algorithms',
   'hostDetails.legacyAlgorithms.desc': 'Enable deprecated SSH algorithms (diffie-hellman-group1, ssh-dss, 3des-cbc, etc.) for connecting to older network equipment.',
   'hostDetails.legacyAlgorithms.warning': 'These algorithms have known security weaknesses. Only enable for legacy devices that do not support modern cryptography.',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -369,6 +369,12 @@ export const ruCoreMessages: Messages = {
   'settings.terminal.behavior.forcePromptNewLine': 'Переносить приглашение на новую строку',
   'settings.terminal.behavior.forcePromptNewLine.desc':
     'Если последняя строка вывода команды не завершена переводом строки, переносить распознанное приглашение оболочки на следующую визуальную строку.',
+  'settings.terminal.behavior.dynamicTabTitle': 'Динамический заголовок вкладки',
+  'settings.terminal.behavior.dynamicTabTitle.desc':
+    'Выберите, когда вкладки сеансов должны следовать заголовкам окна, сообщаемым оболочкой.',
+  'settings.terminal.behavior.dynamicTabTitle.off': 'Отключено',
+  'settings.terminal.behavior.dynamicTabTitle.agent': 'Только агенты',
+  'settings.terminal.behavior.dynamicTabTitle.all': 'Все сеансы',
   'settings.terminal.behavior.osc52Clipboard': 'Буфер обмена OSC-52',
   'settings.terminal.behavior.osc52Clipboard.desc':
     'Разрешить удалённым программам (tmux, vim и т. д.) доступ к локальному буферу обмена через escape-последовательности OSC-52.',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -660,8 +660,6 @@ export const ruVaultMessages: Messages = {
   'hostDetails.section.terminalBehavior': 'Поведение терминала',
   'hostDetails.lineTimestamps': 'Показывать время вывода',
   'hostDetails.lineTimestamps.desc': 'Показывать локальное время рядом с видимыми строками вывода для этого хоста, не изменяя текст терминала.',
-  'hostDetails.disableDynamicTabTitle': 'Отключить динамический заголовок вкладки',
-  'hostDetails.disableDynamicTabTitle.desc': 'Показывать имя подключения на вкладках сессии вместо заголовка окна от shell.',
   'hostDetails.legacyAlgorithms': 'Разрешить устаревшие алгоритмы',
   'hostDetails.legacyAlgorithms.desc': 'Включить устаревшие SSH-алгоритмы (diffie-hellman-group1, ssh-dss, 3des-cbc и т. д.) для подключения к старому сетевому оборудованию.',
   'hostDetails.legacyAlgorithms.warning': 'У этих алгоритмов есть известные слабые места безопасности. Включайте только для устаревших устройств, которые не поддерживают современную криптографию.',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -256,6 +256,12 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.behavior.forcePromptNewLine': '提示符另起一行',
   'settings.terminal.behavior.forcePromptNewLine.desc':
     '当命令输出的最后一行未以换行符结束时，将识别到的 shell 提示符移动到下一行显示。',
+  'settings.terminal.behavior.dynamicTabTitle': '动态标签页标题',
+  'settings.terminal.behavior.dynamicTabTitle.desc':
+    '选择标签页什么时候跟随 Shell 报告的窗口标题。',
+  'settings.terminal.behavior.dynamicTabTitle.off': '关闭',
+  'settings.terminal.behavior.dynamicTabTitle.agent': '仅 Agent',
+  'settings.terminal.behavior.dynamicTabTitle.all': '全部会话',
   'settings.terminal.behavior.osc52Clipboard': 'OSC-52 剪贴板',
   'settings.terminal.behavior.osc52Clipboard.desc':
     '允许远程程序（tmux、vim 等）通过 OSC-52 转义序列访问本地剪贴板。',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -202,8 +202,6 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.section.terminalBehavior': '终端行为',
   'hostDetails.lineTimestamps': '显示输出时间',
   'hostDetails.lineTimestamps.desc': '在终端输出行旁边显示本地时间，不改变终端文本内容。',
-  'hostDetails.disableDynamicTabTitle': '禁用动态标签页标题',
-  'hostDetails.disableDynamicTabTitle.desc': '标签页始终显示连接名称，不跟随 Shell 报告的窗口标题变化。',
   'hostDetails.legacyAlgorithms': '允许旧版算法',
   'hostDetails.legacyAlgorithms.desc': '启用已弃用的 SSH 算法（diffie-hellman-group1、ssh-dss、3des-cbc 等）以连接老旧网络设备。',
   'hostDetails.legacyAlgorithms.warning': '这些算法存在已知安全漏洞，仅建议在老旧设备不支持现代加密时启用。',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -202,7 +202,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'rightClickBehavior', 'middleClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'keepaliveCountMax', 'disableBracketedPaste', 'clearWipesScrollback',
-  'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'showServerStats',
+  'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'dynamicTabTitleMode', 'showServerStats',
   'serverStatsRefreshInterval',
   'systemManagerProcessRefreshInterval', 'systemManagerTmuxRefreshInterval',
   'systemManagerDockerListRefreshInterval', 'systemManagerDockerStatsRefreshInterval',

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -376,12 +376,6 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
             enabled={!!form.showLineTimestamps}
             onToggle={() => update("showLineTimestamps", !form.showLineTimestamps)}
           />
-          <ToggleRow
-            label={t("hostDetails.disableDynamicTabTitle")}
-            hint={t("hostDetails.disableDynamicTabTitle.desc")}
-            enabled={!!form.disableDynamicTabTitle}
-            onToggle={() => update("disableDynamicTabTitle", !form.disableDynamicTabTitle)}
-          />
           <HostDetailsSettingRow label={t("hostDetails.backspaceBehavior")}>
             <Select
               value={form.backspaceBehavior ?? "default"}

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -264,15 +264,20 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const handleTerminalTitleChange = useCallback((sessionId: string, title: string | null) => {
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     if (!session) return;
-    const host = hostsRef.current.find((candidate) => candidate.id === session.hostId);
-    const isDynamicTitleDisabled = host?.disableDynamicTabTitle === true;
-    if (isDynamicTitleDisabled) {
-      onUpdateSessionDynamicTitle?.(sessionId, null);
-    } else {
-      onUpdateSessionDynamicTitle?.(sessionId, title);
-    }
+    const dynamicTabTitleMode = terminalSettings?.dynamicTabTitleMode ?? 'agent';
 
     const trimmedTitle = title?.trim();
+    const providerId = trimmedTitle
+      ? inferCodingCliProviderFromTitleSignals(trimmedTitle)
+      : undefined;
+    const shouldStoreDynamicTitle =
+      dynamicTabTitleMode === 'all' ||
+      (
+        dynamicTabTitleMode === 'agent' &&
+        Boolean(session.codingCliProviderId || providerId)
+      );
+    onUpdateSessionDynamicTitle?.(sessionId, shouldStoreDynamicTitle ? title : null);
+
     if (!trimmedTitle) {
       if (session.codingCliProviderId) {
         codingCliOutputScannersRef.current.delete(sessionId);
@@ -282,20 +287,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return;
     }
 
-    if (isDynamicTitleDisabled) {
-      if (
-        session.codingCliProviderId
-        && shouldClearCodingCliProviderForTitle(trimmedTitle, session.codingCliProviderId)
-      ) {
-        codingCliOutputScannersRef.current.delete(sessionId);
-        codingCliOutputScanDisabledRef.current.delete(sessionId);
-        onUpdateSessionCodingCliProvider?.(sessionId, null);
-      }
-      return;
-    }
-
-    const providerId = inferCodingCliProviderFromTitleSignals(trimmedTitle);
-    if (providerId) {
+    if (providerId && dynamicTabTitleMode !== 'off') {
       if (!session.codingCliProviderId || session.codingCliProviderId !== providerId) {
         codingCliOutputScannersRef.current.delete(sessionId);
         codingCliOutputScanDisabledRef.current.delete(sessionId);
@@ -312,7 +304,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       codingCliOutputScanDisabledRef.current.delete(sessionId);
       onUpdateSessionCodingCliProvider?.(sessionId, null);
     }
-  }, [applySessionCodingCliProvider, onUpdateSessionCodingCliProvider, onUpdateSessionDynamicTitle]);
+  }, [applySessionCodingCliProvider, onUpdateSessionCodingCliProvider, onUpdateSessionDynamicTitle, terminalSettings?.dynamicTabTitleMode]);
 
   const handleTerminalOutput = useCallback((sessionId: string, chunk: string) => {
     if (!chunk || codingCliOutputScanDisabledRef.current.has(sessionId)) return;

--- a/components/TopTabs.tsx
+++ b/components/TopTabs.tsx
@@ -6,6 +6,7 @@ import type { EditorTab } from '../application/state/editorTabStore';
 import { buildWorkspaceActivityMap } from '../application/state/sessionActivity';
 import { collectSessionIds } from '../domain/workspace';
 import { resolveSessionTabTitle } from '../domain/sessionTabTitle';
+import type { DynamicTabTitleMode } from '../domain/models';
 import { useSessionActivityMap } from '../application/state/sessionActivityStore';
 import { getTopTabInsertionTarget, getWorkspaceSessionDragId, hasWorkspaceSessionDrag } from '../application/state/terminalDragData';
 import {
@@ -146,6 +147,7 @@ interface TopTabsProps {
   ) => void;
   showSftpTab: boolean;
   showHostTreeSidebar: boolean;
+  dynamicTabTitleMode?: DynamicTabTitleMode;
   editorTabs: readonly EditorTab[];
   onRequestCloseEditorTab: (editorTabId: string) => void;
   hostById: Map<string, Host>;
@@ -181,6 +183,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
   onRemoveSessionFromWorkspace,
   showSftpTab,
   showHostTreeSidebar,
+  dynamicTabTitleMode,
   editorTabs,
   onRequestCloseEditorTab,
   hostById,
@@ -755,6 +758,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
             onCopySession={onCopySession}
             onCopySessionToNewWindow={onCopySessionToNewWindow}
             renderBulkCloseItems={renderBulkCloseItems}
+            dynamicTabTitleMode={dynamicTabTitleMode}
             t={t}
             tabAnimationClass={getTabAnimationClass(session.id)}
           />
@@ -776,7 +780,7 @@ const TopTabsInner: React.FC<TopTabsProps> = ({
           if (wsSession) {
             workspaceSessionLabels[sessionId] = resolveSessionTabTitle(
               wsSession,
-              hostMap.get(wsSession.hostId),
+              dynamicTabTitleMode,
             );
           }
         }
@@ -1127,7 +1131,8 @@ const topTabsAreEqual = (prev: TopTabsProps, next: TopTabsProps): boolean => {
     prev.onSyncNow === next.onSyncNow &&
     prev.onToggleTheme === next.onToggleTheme &&
     prev.showSftpTab === next.showSftpTab &&
-    prev.showHostTreeSidebar === next.showHostTreeSidebar
+    prev.showHostTreeSidebar === next.showHostTreeSidebar &&
+    prev.dynamicTabTitleMode === next.dynamicTabTitleMode
   );
 };
 

--- a/components/settings/TerminalBehaviorSettings.test.tsx
+++ b/components/settings/TerminalBehaviorSettings.test.tsx
@@ -9,10 +9,24 @@ const middleClickBehaviorOptions = (
   }
 ).MIDDLE_CLICK_BEHAVIOR_OPTIONS;
 
+const dynamicTabTitleModeOptions = (
+  terminalBehaviorSettings as {
+    DYNAMIC_TAB_TITLE_MODE_OPTIONS?: Array<{ value: string; labelKey: string }>;
+  }
+).DYNAMIC_TAB_TITLE_MODE_OPTIONS;
+
 test("middle-click settings expose only supported behaviors", () => {
   assert.ok(Array.isArray(middleClickBehaviorOptions));
   assert.deepEqual(
     middleClickBehaviorOptions.map((option) => option.value),
     ["context-menu", "paste", "disabled"],
+  );
+});
+
+test("dynamic tab title settings expose off, agent-only, and all modes", () => {
+  assert.ok(Array.isArray(dynamicTabTitleModeOptions));
+  assert.deepEqual(
+    dynamicTabTitleModeOptions.map((option) => option.value),
+    ["off", "agent", "all"],
   );
 });

--- a/components/settings/tabs/TerminalBehaviorSettings.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { LinkModifier, MiddleClickBehavior, RightClickBehavior, TerminalSettings } from "../../../domain/models";
+import type { DynamicTabTitleMode, LinkModifier, MiddleClickBehavior, RightClickBehavior, TerminalSettings } from "../../../domain/models";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
 import { SectionHeader, Select, SettingRow, Toggle } from "../settings-ui";
@@ -19,6 +19,15 @@ export const MIDDLE_CLICK_BEHAVIOR_OPTIONS: Array<{
   { value: "context-menu", labelKey: "settings.terminal.behavior.middleClick.menu" },
   { value: "paste", labelKey: "settings.terminal.behavior.middleClick.paste" },
   { value: "disabled", labelKey: "settings.terminal.behavior.middleClick.disabled" },
+];
+
+export const DYNAMIC_TAB_TITLE_MODE_OPTIONS: Array<{
+  value: DynamicTabTitleMode;
+  labelKey: string;
+}> = [
+  { value: "off", labelKey: "settings.terminal.behavior.dynamicTabTitle.off" },
+  { value: "agent", labelKey: "settings.terminal.behavior.dynamicTabTitle.agent" },
+  { value: "all", labelKey: "settings.terminal.behavior.dynamicTabTitle.all" },
 ];
 
 export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> = ({
@@ -93,6 +102,21 @@ export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> =
           description={t("settings.terminal.behavior.forcePromptNewLine.desc")}
         >
           <Toggle checked={terminalSettings.forcePromptNewLine ?? false} onChange={(v) => updateTerminalSetting("forcePromptNewLine", v)} />
+        </SettingRow>
+
+        <SettingRow
+          label={t("settings.terminal.behavior.dynamicTabTitle")}
+          description={t("settings.terminal.behavior.dynamicTabTitle.desc")}
+        >
+          <Select
+            value={terminalSettings.dynamicTabTitleMode ?? "agent"}
+            options={DYNAMIC_TAB_TITLE_MODE_OPTIONS.map((option) => ({
+              value: option.value,
+              label: t(option.labelKey),
+            }))}
+            onChange={(v) => updateTerminalSetting("dynamicTabTitleMode", v as DynamicTabTitleMode)}
+            className="w-44"
+          />
         </SettingRow>
 
         <SettingRow

--- a/components/terminalLayer/TerminalFocusSidebar.tsx
+++ b/components/terminalLayer/TerminalFocusSidebar.tsx
@@ -4,6 +4,7 @@ import React, { memo, useCallback, useMemo, useState, type DragEvent, type Mouse
 import { useStoredNumber } from '../../application/state/useStoredNumber';
 import { resolveWorkspaceFocusSessionOrder } from '../../domain/workspace';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
+import type { DynamicTabTitleMode } from '../../domain/models';
 import { STORAGE_KEY_WORKSPACE_FOCUS_SIDEBAR_WIDTH } from '../../infrastructure/config/storageKeys';
 import { cn } from '../../lib/utils';
 import type { Host, TerminalSession, TerminalTheme, Workspace } from '../../types';
@@ -31,6 +32,7 @@ interface TerminalFocusSidebarProps {
   resolvedPreviewTheme: TerminalTheme;
   sessionHostsMap: Map<string, Host>;
   sessions: TerminalSession[];
+  dynamicTabTitleMode?: DynamicTabTitleMode;
   t: (key: string) => string;
 }
 
@@ -66,6 +68,7 @@ type WorkspaceFocusSessionRowProps = {
   onDragOver: (event: DragEvent, sessionId: string) => void;
   onDrop: (event: DragEvent, sessionId: string) => void;
   onDragEnd: () => void;
+  dynamicTabTitleMode?: DynamicTabTitleMode;
   t: (key: string) => string;
 };
 
@@ -90,6 +93,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
   onDragOver,
   onDrop,
   onDragEnd,
+  dynamicTabTitleMode,
   t,
 }) => {
   const {
@@ -184,7 +188,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
                     onStartRename(session.id);
                   }}
                 >
-                  {resolveSessionTabTitle(session, host)}
+                  {resolveSessionTabTitle(session, dynamicTabTitleMode)}
                 </div>
                 <div className="mt-0.5 truncate text-[10px] leading-none" style={{ color: mutedFg }}>
                   {session.username}@{session.hostname}
@@ -245,6 +249,7 @@ const TerminalFocusSidebarInner: React.FC<TerminalFocusSidebarProps> = ({
   resolvedPreviewTheme,
   sessionHostsMap,
   sessions,
+  dynamicTabTitleMode,
   t,
 }) => {
   const [focusSidebarSearch, setFocusSidebarSearch] = useState('');
@@ -546,6 +551,7 @@ const TerminalFocusSidebarInner: React.FC<TerminalFocusSidebarProps> = ({
               onDragOver={handleFocusSidebarDragOver}
               onDrop={handleFocusSidebarDrop}
               onDragEnd={handleFocusSidebarDragEnd}
+              dynamicTabTitleMode={dynamicTabTitleMode}
               t={t}
             />
           ))}
@@ -568,6 +574,7 @@ function terminalFocusSidebarPropsEqual(
   if (prev.resolvedPreviewTheme !== next.resolvedPreviewTheme) return false;
   if (prev.sessionHostsMap !== next.sessionHostsMap) return false;
   if (prev.sessions !== next.sessions) return false;
+  if (prev.dynamicTabTitleMode !== next.dynamicTabTitleMode) return false;
   if (prev.t !== next.t) return false;
   if (prev.onReorderWorkspaceSessions !== next.onReorderWorkspaceSessions) return false;
   if (prev.onRequestAddToWorkspace !== next.onRequestAddToWorkspace) return false;

--- a/components/terminalLayer/TerminalLayerFocusSidebarSection.tsx
+++ b/components/terminalLayer/TerminalLayerFocusSidebarSection.tsx
@@ -25,6 +25,7 @@ function TerminalLayerFocusSidebarSectionInner({ ctx }: { ctx: FocusSidebarConte
       resolvedPreviewTheme={ctx.resolvedPreviewTheme}
       sessionHostsMap={ctx.sessionHostsMap}
       sessions={ctx.sessions}
+      dynamicTabTitleMode={ctx.terminalSettings?.dynamicTabTitleMode}
       t={ctx.t}
     />
   );

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1010,7 +1010,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
     e.stopPropagation();
 
     const startPoint = { clientX: e.clientX, clientY: e.clientY };
-    const dragLabel = resolveSessionTabTitle(session, host);
+    const dragLabel = resolveSessionTabTitle(session, terminalSettings?.dynamicTabTitleMode);
     let dragStarted = false;
     let ghostEl: HTMLDivElement | null = null;
     let insertEl: HTMLDivElement | null = null;
@@ -1162,13 +1162,13 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
     document.addEventListener('pointerup', handlePointerUp, true);
     document.addEventListener('pointercancel', handlePointerCancel, true);
   }, [
-    host,
     inActiveWorkspace,
     onEndSessionDrag,
     onRemoveSessionFromWorkspace,
     onReorderTabs,
     onStartSessionDrag,
     session,
+    terminalSettings?.dynamicTabTitleMode,
     workspaceById,
   ]);
   const handleTerminalFontSizeChange = useCallback((nextFontSize: number) => {
@@ -1255,7 +1255,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
         sessionLog={sessionLog}
         sshDebugLogEnabled={sshDebugLogEnabled}
         sudoAutofillPassword={sudoAutofillPassword}
-        sessionDisplayName={resolveSessionTabTitle(session, host)}
+        sessionDisplayName={resolveSessionTabTitle(session, terminalSettings?.dynamicTabTitleMode)}
         showSelectionAIAction={showSelectionAIAction}
         onAddSelectionToAI={onAddSelectionToAI}
         onRename={handleRename}

--- a/components/terminalLayer/TerminalLayerTabBridge.test.ts
+++ b/components/terminalLayer/TerminalLayerTabBridge.test.ts
@@ -20,3 +20,8 @@ test('terminal panes can gate cwd restore per session host resolution', () => {
   assert.match(supportSource, /restoreTerminalCwd=\{restoreTerminalCwd && sessionHostResolved\}/);
   assert.match(layerSource, /session\.protocol === 'local'/);
 });
+
+test('terminal layer bridge refreshes when terminal settings change', () => {
+  assert.match(source, /terminalSettings: s\.terminalSettings/);
+  assert.match(source, /\[\s*[\s\S]*s\.terminalSettings[\s\S]*\]\);/);
+});

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -526,6 +526,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     sessionHostsMap,
     s.resolvedSessionHostIds,
     sessions,
+    s.terminalSettings,
     showHostTreeSidebar,
     sftpActiveHost,
     s.sftpFollowTerminalCwd,

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import type { Workspace } from "../../types";
 import {
+  terminalLayerFocusSidebarPropsEqual,
   terminalLayerSidePanelCtxEqual,
   terminalLayerViewCtxEqual,
   terminalLayerWorkspaceCtxEqual,
@@ -138,6 +139,33 @@ test("terminal layer side panel re-renders when follow terminal cwd setting chan
     terminalLayerViewCtxEqual(
       baseCtx,
       { ...baseCtx, sftpFollowTerminalCwd: true },
+    ),
+    false,
+  );
+});
+
+test("terminal layer focus sidebar re-renders when dynamic tab title mode changes", () => {
+  const baseCtx = {
+    isFocusMode: true,
+    activeWorkspace: workspace(),
+    focusedSessionId: "session-1",
+    resolvedPreviewTheme: {},
+    sessionHostsMap: new Map(),
+    sessions: [],
+    terminalSettings: { dynamicTabTitleMode: "agent" },
+  };
+
+  assert.equal(
+    terminalLayerFocusSidebarPropsEqual(
+      baseCtx,
+      { ...baseCtx, terminalSettings: { dynamicTabTitleMode: "off" } },
+    ),
+    false,
+  );
+  assert.equal(
+    terminalLayerViewCtxEqual(
+      baseCtx,
+      { ...baseCtx, terminalSettings: { dynamicTabTitleMode: "off" } },
     ),
     false,
   );

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -354,6 +354,7 @@ export function terminalLayerFocusSidebarPropsEqual(prev: Ctx, next: Ctx): boole
     && eq(prev, next, 'resolvedPreviewTheme')
     && eq(prev, next, 'sessionHostsMap')
     && eq(prev, next, 'sessions')
+    && prev.terminalSettings?.dynamicTabTitleMode === next.terminalSettings?.dynamicTabTitleMode
     && eq(prev, next, 't')
     && eq(prev, next, 'onReorderWorkspaceSessions')
     && eq(prev, next, 'onRequestAddToWorkspace')

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -10,6 +10,7 @@ import { resolveHostIconAppearance, resolveHostIconColorAppearance } from '../..
 import { resolveSessionCodingCliProvider } from '../../domain/codingCliProviderMatch';
 import { resolveCodingCliActivityPhase } from '../../domain/codingCliTitleParse';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
+import type { DynamicTabTitleMode } from '../../domain/models';
 import { CodingCliProviderIcon } from '../icons/CodingCliProviderIcon';
 import { cn } from '../../lib/utils';
 import { Host, TerminalSession, Workspace } from '../../types';
@@ -503,6 +504,7 @@ interface SessionTopTabProps {
   onCopySession: (sessionId: string) => void;
   onCopySessionToNewWindow: (sessionId: string) => void;
   renderBulkCloseItems: RenderBulkCloseItems;
+  dynamicTabTitleMode?: DynamicTabTitleMode;
   t: TranslateFn;
   tabAnimationClass?: string;
 }
@@ -526,6 +528,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
   onCopySession,
   onCopySessionToNewWindow,
   renderBulkCloseItems,
+  dynamicTabTitleMode,
   t,
   tabAnimationClass,
 }) => {
@@ -592,7 +595,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
           )}
           <div className="flex items-center gap-2 min-w-0 flex-1">
             <SessionTabIcon host={host} session={session} isActive={isActive} protocol={session.protocol} shellIcon={session.localShellIcon} />
-            <span className="truncate">{resolveSessionTabTitle(session, host)}</span>
+            <span className="truncate">{resolveSessionTabTitle(session, dynamicTabTitleMode)}</span>
             <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
           </div>
           <button

--- a/domain/codingCliProviderMatch.test.ts
+++ b/domain/codingCliProviderMatch.test.ts
@@ -41,13 +41,12 @@ test('matchCodingCliProviderFromTitle detects Claude Code and Codex titles', () 
   );
 });
 
-test('resolveSessionCodingCliProvider honors disabled dynamic titles', () => {
+test('resolveSessionCodingCliProvider detects providers from dynamic titles', () => {
   assert.equal(
     resolveSessionCodingCliProvider(
       { dynamicTitle: 'Claude Code' },
-      { disableDynamicTabTitle: true },
-    ),
-    undefined,
+    )?.id,
+    'claude',
   );
 });
 

--- a/domain/codingCliProviderMatch.ts
+++ b/domain/codingCliProviderMatch.ts
@@ -4,7 +4,6 @@ import {
   titleIncludesPhrase,
 } from './codingCliTitleParse';
 import type { Host, TerminalSession } from '../types';
-import { isDynamicTabTitleDisabled } from './sessionTabTitle';
 
 export type SessionCodingCliSource = Pick<
   TerminalSession,
@@ -104,7 +103,7 @@ export function resolveCodingCliProviderFromCommandCandidates(
 
 export function resolveSessionCodingCliProvider(
   source: SessionCodingCliSource,
-  host?: Pick<Host, 'disableDynamicTabTitle' | 'startupCommand'>,
+  host?: Pick<Host, 'startupCommand'>,
 ): CodingCliProvider | undefined {
   if (source.codingCliProviderId) {
     const sticky = getCodingCliProvider(source.codingCliProviderId);
@@ -114,7 +113,7 @@ export function resolveSessionCodingCliProvider(
   const commandProvider = resolveCodingCliProviderFromCommandCandidates(source, host);
   if (commandProvider) return commandProvider;
 
-  if (!isDynamicTabTitleDisabled(host) && !source.customName) {
+  if (!source.customName) {
     const dynamicTitle = source.dynamicTitle?.trim();
     if (dynamicTitle) {
       const provider = matchCodingCliProviderFromTitle(dynamicTitle);
@@ -131,7 +130,7 @@ export function resolveSessionCodingCliProvider(
 
 export function resolveSessionCodingCliProviderId(
   source: SessionCodingCliSource,
-  host?: Pick<Host, 'disableDynamicTabTitle' | 'startupCommand'>,
+  host?: Pick<Host, 'startupCommand'>,
 ): CodingCliProviderId | undefined {
   return resolveSessionCodingCliProvider(source, host)?.id;
 }

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -13,6 +13,7 @@ export type RightClickBehavior = TerminalMouseClickBehavior;
 export type MiddleClickBehavior = 'context-menu' | 'paste' | 'disabled';
 export type LinkModifier = 'none' | 'ctrl' | 'alt' | 'meta';
 export type TerminalEmulationType = 'xterm-256color' | 'xterm-16color' | 'xterm';
+export type DynamicTabTitleMode = 'off' | 'agent' | 'all';
 
 // Keyword highlighting configuration
 export interface KeywordHighlightRule {
@@ -119,6 +120,9 @@ export interface TerminalSettings {
 
   // Clipboard
   osc52Clipboard: 'off' | 'write-only' | 'read-write' | 'prompt'; // OSC-52 clipboard access: off, write-only (default), read-write, or prompt on read
+
+  // Tab titles
+  dynamicTabTitleMode: DynamicTabTitleMode; // off, agent-only, or all shell-reported titles
 
   // Rendering
   rendererType: 'auto' | 'webgl' | 'dom'; // Terminal renderer: auto (detect based on hardware), webgl, or dom
@@ -259,6 +263,12 @@ const resolveMiddleClickBehavior = (
   return DEFAULT_TERMINAL_SETTINGS.middleClickBehavior;
 };
 
+const isDynamicTabTitleMode = (value: unknown): value is DynamicTabTitleMode => (
+  value === 'off' ||
+  value === 'agent' ||
+  value === 'all'
+);
+
 export const normalizeTerminalSettings = (
   settings?: Partial<TerminalSettings> | null,
 ): TerminalSettings => {
@@ -268,6 +278,9 @@ export const normalizeTerminalSettings = (
     ...(settings ?? {}),
     middleClickBehavior,
     middleClickPaste: middleClickBehavior === 'paste',
+    dynamicTabTitleMode: isDynamicTabTitleMode(settings?.dynamicTabTitleMode)
+      ? settings.dynamicTabTitleMode
+      : DEFAULT_TERMINAL_SETTINGS.dynamicTabTitleMode,
   };
 
   // Migrate legacy 'canvas' renderer to 'dom' (canvas removed in xterm.js 6.0)
@@ -348,6 +361,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   preserveSelectionOnInput: false, // Opt-in: keep selection alive when typing
   forcePromptNewLine: false, // Opt-in: keep the next shell prompt visually separated from unterminated final output lines
   osc52Clipboard: 'write-only', // OSC-52: allow remote programs to write clipboard by default
+  dynamicTabTitleMode: 'agent',
   rendererType: 'auto', // Auto-detect best renderer based on hardware
   hibernateHiddenTabs: false,
   hibernateHiddenTabsDelaySec: 5,

--- a/domain/sessionTabTitle.test.ts
+++ b/domain/sessionTabTitle.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   getSessionConnectionLabel,
-  isDynamicTabTitleDisabled,
   resolveSessionTabTitle,
 } from './sessionTabTitle';
 
@@ -17,19 +16,47 @@ test('getSessionConnectionLabel prefers customName over hostLabel', () => {
   );
 });
 
-test('resolveSessionTabTitle uses dynamic title by default', () => {
+test('resolveSessionTabTitle ignores dynamic title for non-agent sessions', () => {
   assert.equal(
     resolveSessionTabTitle(
-      { hostLabel: 'web-01', dynamicTitle: 'claude: refactor auth' },
-      undefined,
+      { hostLabel: 'web-01', dynamicTitle: 'root@v2022:/var/log' },
+    ),
+    'web-01',
+  );
+});
+
+test('resolveSessionTabTitle uses dynamic title for agent sessions', () => {
+  assert.equal(
+    resolveSessionTabTitle(
+      { hostLabel: 'web-01', dynamicTitle: 'claude: refactor auth', codingCliProviderId: 'claude' },
     ),
     'claude: refactor auth',
   );
 });
 
+test('resolveSessionTabTitle uses dynamic title for all sessions in all mode', () => {
+  assert.equal(
+    resolveSessionTabTitle(
+      { hostLabel: 'web-01', dynamicTitle: 'root@v2022:/var/log' },
+      'all',
+    ),
+    'root@v2022:/var/log',
+  );
+});
+
+test('resolveSessionTabTitle disables dynamic titles in off mode', () => {
+  assert.equal(
+    resolveSessionTabTitle(
+      { hostLabel: 'web-01', dynamicTitle: 'claude: refactor auth', codingCliProviderId: 'claude' },
+      'off',
+    ),
+    'web-01',
+  );
+});
+
 test('resolveSessionTabTitle falls back to connection label when dynamic title is empty', () => {
   assert.equal(
-    resolveSessionTabTitle({ hostLabel: 'web-01', dynamicTitle: '   ' }, undefined),
+    resolveSessionTabTitle({ hostLabel: 'web-01', dynamicTitle: '   ' }),
     'web-01',
   );
 });
@@ -38,34 +65,16 @@ test('resolveSessionTabTitle prefers user customName over dynamic title', () => 
   assert.equal(
     resolveSessionTabTitle(
       { customName: 'Prod deploy', hostLabel: 'web-01', dynamicTitle: 'claude: refactor auth' },
-      undefined,
     ),
     'Prod deploy',
-  );
-});
-
-test('resolveSessionTabTitle honors disableDynamicTabTitle host setting', () => {
-  assert.equal(
-    resolveSessionTabTitle(
-      { hostLabel: 'web-01', dynamicTitle: 'user@host:/var/log' },
-      { disableDynamicTabTitle: true },
-    ),
-    'web-01',
   );
 });
 
 test('resolveSessionTabTitle strips agent spinner prefixes from dynamic titles', () => {
   assert.equal(
     resolveSessionTabTitle(
-      { hostLabel: 'web-01', dynamicTitle: '⠋ Droid' },
-      undefined,
+      { hostLabel: 'web-01', dynamicTitle: '⠋ Droid', codingCliProviderId: 'droid' },
     ),
     'Droid',
   );
-});
-
-test('isDynamicTabTitleDisabled is false unless explicitly enabled', () => {
-  assert.equal(isDynamicTabTitleDisabled(undefined), false);
-  assert.equal(isDynamicTabTitleDisabled({}), false);
-  assert.equal(isDynamicTabTitleDisabled({ disableDynamicTabTitle: true }), true);
 });

--- a/domain/sessionTabTitle.ts
+++ b/domain/sessionTabTitle.ts
@@ -1,30 +1,29 @@
-import type { Host, TerminalSession } from '../types';
+import type { TerminalSession } from '../types';
 import { normalizeCodingCliTitle } from './codingCliTitleParse';
+import type { DynamicTabTitleMode } from './models/terminal';
 
 /** Static connection label: user rename or host label. */
 export const getSessionConnectionLabel = (session: Pick<TerminalSession, 'customName' | 'hostLabel'>): string => {
   return session.customName || session.hostLabel || '';
 };
 
-/** Whether the host opts out of shell-reported window titles. */
-export const isDynamicTabTitleDisabled = (host?: Pick<Host, 'disableDynamicTabTitle'>): boolean => {
-  return host?.disableDynamicTabTitle === true;
-};
-
 /**
  * Resolve the label shown on session tabs and pane headers.
- * Uses the shell-reported title when dynamic titles are enabled.
+ * Uses the shell-reported title according to the global dynamic title mode.
  */
 export const resolveSessionTabTitle = (
-  session: Pick<TerminalSession, 'customName' | 'hostLabel' | 'dynamicTitle'>,
-  host?: Pick<Host, 'disableDynamicTabTitle'>,
+  session: Pick<TerminalSession, 'customName' | 'hostLabel' | 'dynamicTitle' | 'codingCliProviderId'>,
+  dynamicTabTitleMode: DynamicTabTitleMode = 'agent',
 ): string => {
   const connectionLabel = getSessionConnectionLabel(session);
-  if (isDynamicTabTitleDisabled(host)) {
+  if (dynamicTabTitleMode === 'off') {
     return connectionLabel;
   }
   if (session.customName) {
     return session.customName;
+  }
+  if (dynamicTabTitleMode === 'agent' && !session.codingCliProviderId) {
+    return connectionLabel;
   }
   const dynamicTitle = session.dynamicTitle?.trim();
   if (!dynamicTitle) {

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -13,6 +13,23 @@ test("normalizeTerminalSettings defaults startupCommandDelayMs to 600", () => {
   assert.equal(normalizeTerminalSettings().startupCommandDelayMs, 600);
 });
 
+test("normalizeTerminalSettings defaults dynamic tab titles to agent mode", () => {
+  assert.equal(normalizeTerminalSettings().dynamicTabTitleMode, "agent");
+});
+
+test("normalizeTerminalSettings preserves supported dynamic tab title modes", () => {
+  assert.equal(normalizeTerminalSettings({ dynamicTabTitleMode: "off" }).dynamicTabTitleMode, "off");
+  assert.equal(normalizeTerminalSettings({ dynamicTabTitleMode: "agent" }).dynamicTabTitleMode, "agent");
+  assert.equal(normalizeTerminalSettings({ dynamicTabTitleMode: "all" }).dynamicTabTitleMode, "all");
+});
+
+test("normalizeTerminalSettings falls back for unsupported dynamic tab title modes", () => {
+  assert.equal(
+    normalizeTerminalSettings({ dynamicTabTitleMode: "legacy" as never }).dynamicTabTitleMode,
+    "agent",
+  );
+});
+
 test("normalizeTerminalSettings enables font smoothing by default", () => {
   assert.equal(normalizeTerminalSettings().fontSmoothing, true);
 });


### PR DESCRIPTION
Summary
- Add a global Dynamic tab title mode with Disabled / Agents only / All sessions.
- Default dynamic titles to Agents only so ordinary SSH sessions keep their saved connection names.
- Remove the per-host dynamic-title switch from host settings and sync the new global setting.

Fixes #1652

Validation
- node --test --import tsx domain/sessionTabTitle.test.ts domain/terminalSettings.test.ts components/settings/TerminalBehaviorSettings.test.tsx domain/codingCliProviderMatch.test.ts
- npm run lint
- npm run build
- npm test
- Browser check: Settings > Terminal shows Dynamic tab title with Disabled / Agents only / All sessions.