### PR TITLE
Add Catty long-running terminal tools

### DIFF
--- a/components/ai-elements/tool-call.test.tsx
+++ b/components/ai-elements/tool-call.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractDisplayCommand } from './tool-call';
+import { extractDisplayCommand, formatToolCallName } from './tool-call';
 
 // Codex (SDK) emits command_execution.command as a STRING that wraps the real
 // command in `<shell> -lc '<full>'`. Under Skills + CLI the real command is a
@@ -58,4 +58,10 @@ test('plain command passes through unchanged', () => {
 test('empty / missing args -> null', () => {
   assert.equal(extractDisplayCommand(undefined), null);
   assert.equal(extractDisplayCommand({ command: '' }), null);
+});
+
+test('formats Catty long-running terminal tool names', () => {
+  assert.equal(formatToolCallName('terminal_start', { command: 'npm run build' }), 'netcatty: start terminal job');
+  assert.equal(formatToolCallName('terminal_poll', { jobId: 'job_123' }), 'netcatty: poll job job_123');
+  assert.equal(formatToolCallName('terminal_stop', { jobId: 'job_123' }), 'netcatty: stop job job_123');
 });

--- a/components/ai-elements/tool-call.tsx
+++ b/components/ai-elements/tool-call.tsx
@@ -94,6 +94,20 @@ export function extractDisplayCommand(args: Record<string, unknown> | undefined)
   return cmdString;
 }
 
+export function formatToolCallName(name: string, args: Record<string, unknown> | undefined): string {
+  const jobId = typeof args?.jobId === 'string' ? args.jobId : '';
+  switch (name) {
+    case 'terminal_start':
+      return 'netcatty: start terminal job';
+    case 'terminal_poll':
+      return jobId ? `netcatty: poll job ${jobId}` : 'netcatty: poll job';
+    case 'terminal_stop':
+      return jobId ? `netcatty: stop job ${jobId}` : 'netcatty: stop job';
+    default:
+      return name;
+  }
+}
+
 /**
  * Format tool result for display. Extracts stdout/stderr from structured
  * command results for terminal-like output.
@@ -112,6 +126,19 @@ function formatToolResult(result: unknown): string {
 
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     const obj = parsed as Record<string, unknown>;
+    if (
+      typeof obj.output === 'string' ||
+      typeof obj.status === 'string' ||
+      typeof obj.jobId === 'string'
+    ) {
+      const parts: string[] = [];
+      if (typeof obj.status === 'string') parts.push(`status: ${obj.status}`);
+      if (typeof obj.jobId === 'string') parts.push(`job: ${obj.jobId}`);
+      if (typeof obj.output === 'string' && obj.output) parts.push(obj.output);
+      if (typeof obj.exitCode === 'number') parts.push(`exit code: ${obj.exitCode}`);
+      if (typeof obj.error === 'string' && obj.error) parts.push(`error: ${obj.error}`);
+      if (parts.length > 0) return parts.join('\n');
+    }
     if (typeof obj.stdout === 'string' || typeof obj.stderr === 'string') {
       const parts: string[] = [];
       if (typeof obj.stdout === 'string' && obj.stdout) parts.push(obj.stdout);
@@ -243,7 +270,7 @@ export const ToolCall = ({
               </Tooltip>
             );
           }
-          return <span className="font-mono text-muted-foreground/70 truncate">{name}</span>;
+          return <span className="font-mono text-muted-foreground/70 truncate">{formatToolCallName(name, args)}</span>;
         })()}
         <span className="flex-1" />
         {/* Approval badge for resolved approvals */}

--- a/electron/bridges/aiBridge/cattyExecHandlers.cjs
+++ b/electron/bridges/aiBridge/cattyExecHandlers.cjs
@@ -102,10 +102,9 @@ function registerCattyExecHandlers(ctx) {
               syntheticEcho: true,
             });
           },
-          // Catty Agent has no terminal_start fallback for long-running
-          // commands, so do NOT enforce a hard wall-clock timeout here.
-          // The inactivity timeout still applies, so genuinely hung
-          // processes are still terminated.
+          // Catty Agent now has terminal_start/terminal_poll for long-running
+          // commands, so keep terminal_execute on the short-command budget.
+          enforceWallTimeout: true,
         }));
       }
 
@@ -149,6 +148,50 @@ function registerCattyExecHandlers(ctx) {
       releaseLock();
       return { ok: false, error: err?.message || String(err) };
     }
+  });
+
+  ipcMain.handle("netcatty:ai:job-start", async (event, { sessionId, command, chatSessionId, scopedSessionIds }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    if (!mcpServerBridge.dispatchFromRendererTool) {
+      return { ok: false, error: "Background job dispatch is not available" };
+    }
+    return mcpServerBridge.dispatchFromRendererTool("netcatty/jobStart", {
+      sessionId,
+      command,
+      chatSessionId,
+      scopedSessionIds,
+    });
+  });
+
+  ipcMain.handle("netcatty:ai:job-poll", async (event, { jobId, offset, chatSessionId, scopedSessionIds }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    if (!mcpServerBridge.dispatchFromRendererTool) {
+      return { ok: false, error: "Background job dispatch is not available" };
+    }
+    return mcpServerBridge.dispatchFromRendererTool("netcatty/jobPoll", {
+      jobId,
+      offset,
+      chatSessionId,
+      scopedSessionIds,
+    });
+  });
+
+  ipcMain.handle("netcatty:ai:job-stop", async (event, { jobId, chatSessionId, scopedSessionIds }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    if (!mcpServerBridge.dispatchFromRendererTool) {
+      return { ok: false, error: "Background job dispatch is not available" };
+    }
+    return mcpServerBridge.dispatchFromRendererTool("netcatty/jobStop", {
+      jobId,
+      chatSessionId,
+      scopedSessionIds,
+    });
   });
 
   // Cancel in-flight Catty Agent command executions for a chat session

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -813,7 +813,7 @@ function validateSessionScope(sessionId, chatSessionId, explicitScopedIds = null
   return null;
 }
 
-async function dispatch(method, params) {
+async function dispatch(method, params, options = {}) {
   debugLog("dispatch", { method, params, permissionMode });
   const capability = getCapabilityByRpcMethod(method, CAPABILITY_SURFACES.BUILTIN);
   const sessionWriteLockId = (capability?.id === "terminal.execute" || capability?.id === "terminal.start")
@@ -863,7 +863,7 @@ async function dispatch(method, params) {
     // netcatty/jobStop bypasses approval — it's a stop/cancel action that
     // must remain available even if the renderer is unavailable; otherwise
     // a runaway terminal_start job could not be interrupted at all.
-    if (permission.requiresApproval) {
+    if (permission.requiresApproval && !options.approvalAlreadyGranted) {
       const { chatSessionId, ...toolArgs } = params || {};
       const approved = await requestApprovalFromRenderer(method, toolArgs, chatSessionId);
       if (!approved) {
@@ -919,6 +919,10 @@ async function dispatch(method, params) {
       pendingSessionWriteApprovals.delete(sessionWriteLockId);
     }
   }
+}
+
+function dispatchFromRendererTool(method, params) {
+  return dispatch(method, params, { approvalAlreadyGranted: true });
 }
 
 // ── Handler: getContext ──
@@ -1120,4 +1124,5 @@ module.exports = {
   reserveSessionExecution,
   releaseSessionExecution,
   getSessionBusyError,
+  dispatchFromRendererTool,
 };

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -923,6 +923,15 @@ function createPreloadApi(ctx) {
   aiExec: async (sessionId, command, chatSessionId) => {
     return ipcRenderer.invoke("netcatty:ai:exec", { sessionId, command, chatSessionId });
   },
+  aiJobStart: async (sessionId, command, chatSessionId, scopedSessionIds) => {
+    return ipcRenderer.invoke("netcatty:ai:job-start", { sessionId, command, chatSessionId, scopedSessionIds });
+  },
+  aiJobPoll: async (jobId, offset, chatSessionId, scopedSessionIds) => {
+    return ipcRenderer.invoke("netcatty:ai:job-poll", { jobId, offset, chatSessionId, scopedSessionIds });
+  },
+  aiJobStop: async (jobId, chatSessionId, scopedSessionIds) => {
+    return ipcRenderer.invoke("netcatty:ai:job-stop", { jobId, chatSessionId, scopedSessionIds });
+  },
   aiCattyCancelExec: async (chatSessionId) => {
     return ipcRenderer.invoke("netcatty:ai:catty:cancel", { chatSessionId });
   },

--- a/infrastructure/ai/cattyAgent/executor.ts
+++ b/infrastructure/ai/cattyAgent/executor.ts
@@ -1,6 +1,9 @@
 import type { ToolCall, ToolResult, AIPermissionMode, WebSearchConfig } from '../types';
 import {
   executeTerminalExecute,
+  executeTerminalPoll,
+  executeTerminalStart,
+  executeTerminalStop,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
   executeWebSearch,
@@ -24,6 +27,67 @@ export interface NetcattyBridge {
     stderr?: string;
     exitCode?: number;
     error?: string;
+  }>;
+  aiJobStart?(
+    sessionId: string,
+    command: string,
+    chatSessionId?: string,
+    scopedSessionIds?: string[],
+  ): Promise<{
+    ok: boolean;
+    jobId?: string;
+    sessionId?: string;
+    command?: string;
+    status?: string;
+    startedAt?: number;
+    outputMode?: string;
+    recommendedPollIntervalMs?: number;
+    error?: string;
+  }>;
+  aiJobPoll?(
+    jobId: string,
+    offset?: number,
+    chatSessionId?: string,
+    scopedSessionIds?: string[],
+  ): Promise<{
+    ok: boolean;
+    jobId?: string;
+    sessionId?: string;
+    command?: string;
+    status?: string;
+    completed?: boolean;
+    exitCode?: number | null;
+    error?: string | null;
+    startedAt?: number;
+    updatedAt?: number;
+    output?: string;
+    nextOffset?: number;
+    totalOutputChars?: number;
+    outputBaseOffset?: number;
+    outputTruncated?: boolean;
+    recommendedPollIntervalMs?: number;
+  }>;
+  aiJobStop?(
+    jobId: string,
+    chatSessionId?: string,
+    scopedSessionIds?: string[],
+  ): Promise<{
+    ok: boolean;
+    jobId?: string;
+    sessionId?: string;
+    command?: string;
+    status?: string;
+    completed?: boolean;
+    exitCode?: number | null;
+    error?: string | null;
+    startedAt?: number;
+    updatedAt?: number;
+    output?: string;
+    nextOffset?: number;
+    totalOutputChars?: number;
+    outputBaseOffset?: number;
+    outputTruncated?: boolean;
+    recommendedPollIntervalMs?: number;
   }>;
   /**
    * Cancel any in-flight Catty Agent command execution scoped to the
@@ -112,6 +176,29 @@ export function createToolExecutor(
           const r = await executeTerminalExecute(deps, {
             sessionId: String(args.sessionId || ''),
             command: String(args.command || ''),
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_start': {
+          const r = await executeTerminalStart(deps, {
+            sessionId: String(args.sessionId || ''),
+            command: String(args.command || ''),
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_poll': {
+          const r = await executeTerminalPoll(deps, {
+            jobId: String(args.jobId || ''),
+            offset: Number(args.offset) || 0,
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_stop': {
+          const r = await executeTerminalStop(deps, {
+            jobId: String(args.jobId || ''),
           });
           return toToolResult(toolCall.id, r);
         }

--- a/infrastructure/ai/cattyAgent/systemPrompt.ts
+++ b/infrastructure/ai/cattyAgent/systemPrompt.ts
@@ -42,7 +42,7 @@ ${permissionRules}
 
 1. **Plan before acting.** When a task involves multiple steps, present a brief numbered plan to the user before executing.
 
-2. **Use the right tool.** For normal shell commands, use \`terminal_execute\` so you receive the command output. When operating on multiple sessions, call \`terminal_execute\` for each target session.
+2. **Use the right terminal tool.** For short shell commands expected to finish within about 60 seconds, use \`terminal_execute\` so you receive the command output. For builds, scans, watch mode, log-following, ping, or anything likely to stream output for an extended period, use \`terminal_start\`, then poll with \`terminal_poll\` until \`completed\` is true. Reuse each poll's \`nextOffset\` value, avoid aggressive polling, and use \`terminal_stop\` if you need to interrupt the job. When operating on multiple sessions, call the appropriate terminal tool for each target session.
 
 3. **Never execute dangerous commands.** Commands matching the blocklist (e.g. \`rm -rf /\`, \`mkfs\`, \`dd\` to disk devices, \`shutdown\`, fork bombs, recursive chmod 777 on root) are strictly forbidden and will be automatically denied. Do not attempt to bypass these restrictions.
 
@@ -123,7 +123,7 @@ function buildPermissionRules(
     case 'confirm':
       return [
         'You are in **confirm** mode. The system will automatically show an approval prompt to the user for write and execute operations:',
-        '- Command execution (`terminal_execute`) will pause and show approval buttons in the UI automatically.',
+        '- Command execution (`terminal_execute`, `terminal_start`) will pause and show approval buttons in the UI automatically.',
         '',
         'You do NOT need to ask the user for confirmation in your text responses. Just call the tool directly — the approval system handles it. Read-only operations are allowed without any approval.',
       ].join('\n');

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -6,6 +6,9 @@ import type { WebSearchConfig } from '../types';
 import { isWebSearchReady } from '../types';
 import {
   executeTerminalExecute,
+  executeTerminalPoll,
+  executeTerminalStart,
+  executeTerminalStop,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
   executeWebSearch,
@@ -19,6 +22,7 @@ import { truncateTextWithHeadAndTail } from '../requestPayloadCompression';
 
 const MAX_LIVE_TERMINAL_STDOUT_CHARS = 24_000;
 const MAX_LIVE_TERMINAL_STDERR_CHARS = 12_000;
+const MAX_LIVE_TERMINAL_JOB_OUTPUT_CHARS = 24_000;
 
 /** Unwrap a shared ToolExecResult into the shape expected by Vercel AI SDK tool results. */
 function unwrap<T>(r: ToolExecResult<T>): T | { error: string } {
@@ -35,6 +39,13 @@ export function fitTerminalExecuteResultForModel(result: {
     ...result,
     stdout: truncateTextWithHeadAndTail(result.stdout, MAX_LIVE_TERMINAL_STDOUT_CHARS),
     stderr: truncateTextWithHeadAndTail(result.stderr, MAX_LIVE_TERMINAL_STDERR_CHARS),
+  };
+}
+
+export function fitTerminalJobResultForModel<T extends { output: string }>(result: T): T {
+  return {
+    ...result,
+    output: truncateTextWithHeadAndTail(result.output, MAX_LIVE_TERMINAL_JOB_OUTPUT_CHARS),
   };
 }
 
@@ -59,8 +70,8 @@ export function createCattyTools(
   return {
     terminal_execute: tool({
       description:
-        'Execute a shell command on the specified terminal session. ' +
-        "The command runs in the session's shell and output is returned when complete.",
+        'Execute a short shell command on the specified terminal session and wait for completion. ' +
+        "Use terminal_start for builds, watch commands, log-following, or commands likely to run longer than about 60 seconds.",
       inputSchema: z.object({
         sessionId: z.string().describe('The terminal session ID to execute the command on.'),
         command: z.string().describe('The shell command to execute in the target session.'),
@@ -129,6 +140,73 @@ export function createCattyTools(
         } finally {
           slot.release();
         }
+      },
+    }),
+
+    terminal_start: tool({
+      description:
+        'Start a long-running command on the specified terminal session without waiting for completion. ' +
+        'Use this for builds, scans, watch commands, log-following, or anything likely to stream output for an extended period. ' +
+        'After starting, use terminal_poll with the returned jobId and nextOffset values, and use terminal_stop to interrupt it.',
+      inputSchema: z.object({
+        sessionId: z.string().describe('The terminal session ID to execute the long-running command on.'),
+        command: z.string().describe('The shell command to start in the target session.'),
+      }),
+      execute: async ({ sessionId, command }, { toolCallId, abortSignal }) => {
+        const queueKey = `${chatSessionId ?? 'global'}:${sessionId}`;
+        const slot = reserveSessionSlot(queueKey);
+        try {
+          if (permissionMode === 'confirm') {
+            const approved = await requestApproval(toolCallId, 'terminal_start', { sessionId, command }, chatSessionId);
+            if (!approved) {
+              return { error: 'User denied command execution.' };
+            }
+          }
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          await slot.ready;
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          return unwrap(await executeTerminalStart(deps, { sessionId, command }));
+        } finally {
+          slot.release();
+        }
+      },
+    }),
+
+    terminal_poll: tool({
+      description:
+        'Poll a long-running terminal job that was started with terminal_start. ' +
+        'Returns incremental output since the provided offset plus status, completion, nextOffset, and truncation metadata. ' +
+        'Do not poll aggressively; normally wait roughly 30 seconds between polls unless the output justifies checking sooner.',
+      inputSchema: z.object({
+        jobId: z.string().describe('The background job ID returned by terminal_start.'),
+        offset: z
+          .number()
+          .optional()
+          .default(0)
+          .describe('The output offset to resume from. Use the previous terminal_poll nextOffset value.'),
+      }),
+      execute: async ({ jobId, offset }) => {
+        const result = await executeTerminalPoll(deps, { jobId, offset });
+        if (result.ok === false) return unwrap(result);
+        return fitTerminalJobResultForModel(result.data);
+      },
+    }),
+
+    terminal_stop: tool({
+      description:
+        'Stop a long-running terminal job that was started with terminal_start. ' +
+        'This sends an interrupt to the visible terminal job and returns the latest job state and output.',
+      inputSchema: z.object({
+        jobId: z.string().describe('The background job ID returned by terminal_start.'),
+      }),
+      execute: async ({ jobId }) => {
+        const result = await executeTerminalStop(deps, { jobId });
+        if (result.ok === false) return unwrap(result);
+        return fitTerminalJobResultForModel(result.data);
       },
     }),
 

--- a/infrastructure/ai/shared/toolExecutors.test.ts
+++ b/infrastructure/ai/shared/toolExecutors.test.ts
@@ -1,0 +1,156 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  executeTerminalPoll,
+  executeTerminalStart,
+  executeTerminalStop,
+} from './toolExecutors.ts';
+import type { ToolDeps } from './toolExecutors.ts';
+import type { ExecutorContext, NetcattyBridge } from '../cattyAgent/executor';
+
+const context: ExecutorContext = {
+  workspaceId: 'ws-1',
+  workspaceName: 'Workspace',
+  sessions: [
+    {
+      sessionId: 'sess-1',
+      hostId: 'host-1',
+      hostname: 'example.test',
+      label: 'Example',
+      protocol: 'ssh',
+      connected: true,
+    },
+  ],
+};
+
+function createDeps(bridge: Partial<NetcattyBridge>, overrides: Partial<ToolDeps> = {}): ToolDeps {
+  return {
+    bridge: {
+      aiExec: async () => ({ ok: true, stdout: '', stderr: '', exitCode: 0 }),
+      ...bridge,
+    } as NetcattyBridge,
+    context,
+    permissionMode: 'autonomous',
+    chatSessionId: 'chat-1',
+    ...overrides,
+  };
+}
+
+test('executeTerminalStart rejects observer mode before calling bridge', async () => {
+  let called = false;
+  const deps = createDeps({
+    aiJobStart: async () => {
+      called = true;
+      return { ok: true };
+    },
+  }, { permissionMode: 'observer' });
+
+  const result = await executeTerminalStart(deps, {
+    sessionId: 'sess-1',
+    command: 'npm run build',
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok === false) {
+    assert.match(result.error, /Observer mode/);
+  }
+  assert.equal(called, false);
+});
+
+test('executeTerminalStart passes chat and scoped session IDs to bridge', async () => {
+  let received: unknown[] | null = null;
+  const deps = createDeps({
+    aiJobStart: async (...args) => {
+      received = args;
+      return {
+        ok: true,
+        jobId: 'job-1',
+        sessionId: 'sess-1',
+        command: 'npm run build',
+        status: 'running',
+        startedAt: 123,
+        outputMode: 'foreground-mirrored',
+        recommendedPollIntervalMs: 30000,
+      };
+    },
+  });
+
+  const result = await executeTerminalStart(deps, {
+    sessionId: 'sess-1',
+    command: 'npm run build',
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(received, ['sess-1', 'npm run build', 'chat-1', ['sess-1']]);
+  if (result.ok) {
+    assert.equal(result.data.jobId, 'job-1');
+    assert.equal(result.data.status, 'running');
+  }
+});
+
+test('executeTerminalPoll passes offset and returns job snapshot', async () => {
+  let received: unknown[] | null = null;
+  const deps = createDeps({
+    aiJobPoll: async (...args) => {
+      received = args;
+      return {
+        ok: true,
+        jobId: 'job-1',
+        sessionId: 'sess-1',
+        command: 'npm run build',
+        status: 'running',
+        completed: false,
+        exitCode: null,
+        error: null,
+        startedAt: 123,
+        updatedAt: 456,
+        output: 'chunk',
+        nextOffset: 99,
+        totalOutputChars: 99,
+        outputBaseOffset: 0,
+        outputTruncated: false,
+      };
+    },
+  });
+
+  const result = await executeTerminalPoll(deps, { jobId: 'job-1', offset: 42 });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(received, ['job-1', 42, 'chat-1', ['sess-1']]);
+  if (result.ok) {
+    assert.equal(result.data.output, 'chunk');
+    assert.equal(result.data.nextOffset, 99);
+  }
+});
+
+test('executeTerminalStop is available even when permission mode is observer', async () => {
+  let called = false;
+  const deps = createDeps({
+    aiJobStop: async () => {
+      called = true;
+      return {
+        ok: true,
+        jobId: 'job-1',
+        sessionId: 'sess-1',
+        command: 'npm run build',
+        status: 'stopping',
+        completed: false,
+        exitCode: null,
+        error: 'Cancellation requested',
+        startedAt: 123,
+        updatedAt: 456,
+        output: '',
+        nextOffset: 0,
+        totalOutputChars: 0,
+        outputBaseOffset: 0,
+        outputTruncated: false,
+      };
+    },
+  }, { permissionMode: 'observer' });
+
+  const result = await executeTerminalStop(deps, { jobId: 'job-1' });
+
+  assert.equal(result.ok, true);
+  assert.equal(called, true);
+});

--- a/infrastructure/ai/shared/toolExecutors.ts
+++ b/infrastructure/ai/shared/toolExecutors.ts
@@ -21,6 +21,34 @@ export type ToolExecResult<T = unknown> =
   | { ok: true; data: T }
   | { ok: false; error: string };
 
+export interface TerminalJobStartData {
+  jobId: string;
+  sessionId: string;
+  command: string;
+  status: string;
+  startedAt: number;
+  outputMode?: string;
+  recommendedPollIntervalMs?: number;
+}
+
+export interface TerminalJobSnapshotData {
+  jobId: string;
+  sessionId: string;
+  command: string;
+  status: string;
+  completed: boolean;
+  exitCode: number | null;
+  error: string | null;
+  startedAt: number;
+  updatedAt: number;
+  output: string;
+  nextOffset: number;
+  totalOutputChars: number;
+  outputBaseOffset: number;
+  outputTruncated: boolean;
+  recommendedPollIntervalMs?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Dependencies bundle
 // ---------------------------------------------------------------------------
@@ -47,6 +75,10 @@ function validSessionIds(ctx: ToolDeps['context']): Set<string> {
   return new Set(resolved.sessions.map(s => s.sessionId));
 }
 
+function scopedSessionIds(ctx: ToolDeps['context']): string[] {
+  return [...validSessionIds(ctx)];
+}
+
 function validateSessionScope(ctx: ToolDeps['context'], sessionId: string): string | null {
   const ids = validSessionIds(ctx);
   if (!ids.has(sessionId)) {
@@ -59,15 +91,23 @@ function isObserver(mode: AIPermissionMode): boolean {
   return mode === 'observer';
 }
 
-// ---------------------------------------------------------------------------
-// Tool executors
-// ---------------------------------------------------------------------------
+function getSessionExecutionContext(ctx: ToolDeps['context'], sessionId: string): {
+  isNetworkDevice: boolean;
+} {
+  const resolved = resolveContext(ctx);
+  const targetSession = resolved.sessions.find(s => s.sessionId === sessionId);
+  const proto = targetSession?.protocol || '';
+  const isSshOrSerial = proto === 'ssh' || proto === 'serial';
+  return {
+    isNetworkDevice: proto === 'serial' || (targetSession?.deviceType === 'network' && isSshOrSerial),
+  };
+}
 
-export async function executeTerminalExecute(
+function validateTerminalCommand(
   deps: ToolDeps,
   args: { sessionId: string; command: string },
-): Promise<ToolExecResult<{ stdout: string; stderr: string; exitCode: number | null }>> {
-  const { bridge, context, commandBlocklist, permissionMode } = deps;
+): ToolExecResult<{ isNetworkDevice: boolean }> {
+  const { context, commandBlocklist, permissionMode } = deps;
   const { sessionId, command } = args;
 
   if (!sessionId || !command) {
@@ -78,20 +118,30 @@ export async function executeTerminalExecute(
   if (isObserver(permissionMode)) {
     return { ok: false, error: 'Observer mode: command execution is disabled. Switch to Confirm or Auto mode to execute commands.' };
   }
-  // Shell blocklist is meaningless on network device CLIs (e.g. "shutdown"
-  // disables an interface on Cisco). Skip for serial and network device sessions.
-  // The bridge layer (handleExec / netcatty:ai:exec) also has its own session-aware check.
-  const resolved = resolveContext(context);
-  const targetSession = resolved.sessions.find(s => s.sessionId === sessionId);
-  const proto = targetSession?.protocol || '';
-  const isSshOrSerial = proto === 'ssh' || proto === 'serial';
-  const isNetworkDevice = proto === 'serial' || (targetSession?.deviceType === 'network' && isSshOrSerial);
-  if (!isNetworkDevice) {
+
+  const executionContext = getSessionExecutionContext(context, sessionId);
+  if (!executionContext.isNetworkDevice) {
     const safety = checkCommandSafety(command, commandBlocklist);
     if (safety.blocked) {
       return { ok: false, error: `Command blocked by safety policy. Matched pattern: ${safety.matchedPattern}` };
     }
   }
+  return { ok: true, data: executionContext };
+}
+
+// ---------------------------------------------------------------------------
+// Tool executors
+// ---------------------------------------------------------------------------
+
+export async function executeTerminalExecute(
+  deps: ToolDeps,
+  args: { sessionId: string; command: string },
+): Promise<ToolExecResult<{ stdout: string; stderr: string; exitCode: number | null }>> {
+  const { bridge } = deps;
+  const { sessionId, command } = args;
+  const validated = validateTerminalCommand(deps, args);
+  if (validated.ok === false) return validated;
+  const { isNetworkDevice } = validated.data;
 
   const result = await bridge.aiExec(sessionId, command, deps.chatSessionId);
   // Real execution failures (timeout, disconnect, no stream) have an `error` field
@@ -113,6 +163,128 @@ export async function executeTerminalExecute(
       exitCode: isNetworkDevice ? (result.exitCode ?? null) : (result.exitCode ?? -1),
     },
   };
+}
+
+export async function executeTerminalStart(
+  deps: ToolDeps,
+  args: { sessionId: string; command: string },
+): Promise<ToolExecResult<TerminalJobStartData>> {
+  const { bridge } = deps;
+  const { sessionId, command } = args;
+  const validated = validateTerminalCommand(deps, args);
+  if (validated.ok === false) return validated;
+
+  if (!bridge.aiJobStart) {
+    return { ok: false, error: 'terminal_start is not available on the Netcatty bridge' };
+  }
+
+  const result = await bridge.aiJobStart(
+    sessionId,
+    command,
+    deps.chatSessionId,
+    scopedSessionIds(deps.context),
+  );
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'Failed to start background terminal job' };
+  }
+  if (!result.jobId || !result.sessionId || !result.command || !result.status || !result.startedAt) {
+    return { ok: false, error: 'Background terminal job start returned an incomplete response' };
+  }
+  return {
+    ok: true,
+    data: {
+      jobId: result.jobId,
+      sessionId: result.sessionId,
+      command: result.command,
+      status: result.status,
+      startedAt: result.startedAt,
+      outputMode: result.outputMode,
+      recommendedPollIntervalMs: result.recommendedPollIntervalMs,
+    },
+  };
+}
+
+function normalizeTerminalJobSnapshot(result: {
+  ok: boolean;
+  jobId?: string;
+  sessionId?: string;
+  command?: string;
+  status?: string;
+  completed?: boolean;
+  exitCode?: number | null;
+  error?: string | null;
+  startedAt?: number;
+  updatedAt?: number;
+  output?: string;
+  nextOffset?: number;
+  totalOutputChars?: number;
+  outputBaseOffset?: number;
+  outputTruncated?: boolean;
+  recommendedPollIntervalMs?: number;
+}): ToolExecResult<TerminalJobSnapshotData> {
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'Background terminal job request failed' };
+  }
+  if (!result.jobId || !result.sessionId || !result.command || !result.status) {
+    return { ok: false, error: 'Background terminal job returned an incomplete response' };
+  }
+  return {
+    ok: true,
+    data: {
+      jobId: result.jobId,
+      sessionId: result.sessionId,
+      command: result.command,
+      status: result.status,
+      completed: Boolean(result.completed),
+      exitCode: result.exitCode ?? null,
+      error: result.error ?? null,
+      startedAt: Number(result.startedAt) || 0,
+      updatedAt: Number(result.updatedAt) || 0,
+      output: result.output || '',
+      nextOffset: Number(result.nextOffset) || 0,
+      totalOutputChars: Number(result.totalOutputChars) || 0,
+      outputBaseOffset: Number(result.outputBaseOffset) || 0,
+      outputTruncated: Boolean(result.outputTruncated),
+      recommendedPollIntervalMs: result.recommendedPollIntervalMs,
+    },
+  };
+}
+
+export async function executeTerminalPoll(
+  deps: ToolDeps,
+  args: { jobId: string; offset?: number },
+): Promise<ToolExecResult<TerminalJobSnapshotData>> {
+  if (!args.jobId) {
+    return { ok: false, error: 'Missing jobId' };
+  }
+  if (!deps.bridge.aiJobPoll) {
+    return { ok: false, error: 'terminal_poll is not available on the Netcatty bridge' };
+  }
+  const result = await deps.bridge.aiJobPoll(
+    args.jobId,
+    args.offset ?? 0,
+    deps.chatSessionId,
+    scopedSessionIds(deps.context),
+  );
+  return normalizeTerminalJobSnapshot(result);
+}
+
+export async function executeTerminalStop(
+  deps: ToolDeps,
+  args: { jobId: string },
+): Promise<ToolExecResult<TerminalJobSnapshotData>> {
+  if (!args.jobId) {
+    return { ok: false, error: 'Missing jobId' };
+  }
+  if (!deps.bridge.aiJobStop) {
+    return { ok: false, error: 'terminal_stop is not available on the Netcatty bridge' };
+  }
+  const result = await deps.bridge.aiJobStop(
+    args.jobId,
+    deps.chatSessionId,
+    scopedSessionIds(deps.context),
+  );
+  return normalizeTerminalJobSnapshot(result);
 }
 
 export function executeWorkspaceGetInfo(

--- a/types/global/netcatty-bridge-ai.d.ts
+++ b/types/global/netcatty-bridge-ai.d.ts
@@ -8,6 +8,9 @@ declare global {
     aiFetch?(url: string, method?: string, headers?: Record<string, string>, body?: string, providerId?: string, skipHostCheck?: boolean, followRedirects?: boolean, skipTLSVerify?: boolean): Promise<{ ok: boolean; status?: number; data: string; error?: string }>;
     aiAllowlistAddHost?(baseURL: string): Promise<{ ok: boolean; error?: string }>;
     aiExec?(sessionId: string, command: string, chatSessionId?: string): Promise<{ ok: boolean; stdout?: string; stderr?: string; exitCode?: number | null; error?: string }>;
+    aiJobStart?(sessionId: string, command: string, chatSessionId?: string, scopedSessionIds?: string[]): Promise<{ ok: boolean; jobId?: string; sessionId?: string; command?: string; status?: string; startedAt?: number; outputMode?: string; recommendedPollIntervalMs?: number; error?: string }>;
+    aiJobPoll?(jobId: string, offset?: number, chatSessionId?: string, scopedSessionIds?: string[]): Promise<{ ok: boolean; jobId?: string; sessionId?: string; command?: string; status?: string; completed?: boolean; exitCode?: number | null; error?: string | null; startedAt?: number; updatedAt?: number; output?: string; nextOffset?: number; totalOutputChars?: number; outputBaseOffset?: number; outputTruncated?: boolean; recommendedPollIntervalMs?: number }>;
+    aiJobStop?(jobId: string, chatSessionId?: string, scopedSessionIds?: string[]): Promise<{ ok: boolean; jobId?: string; sessionId?: string; command?: string; status?: string; completed?: boolean; exitCode?: number | null; error?: string | null; startedAt?: number; updatedAt?: number; output?: string; nextOffset?: number; totalOutputChars?: number; outputBaseOffset?: number; outputTruncated?: boolean; recommendedPollIntervalMs?: number }>;
     aiCattyCancelExec?(chatSessionId: string): Promise<{ ok: boolean; error?: string }>;
     aiDiscoverAgents?(options?: { refreshShellEnv?: boolean; apiKeyPresent?: boolean }): Promise<Array<{
       command: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Catty `terminal_start`, `terminal_poll`, and `terminal_stop` tools for long-running terminal jobs.
- Route Catty job IPC through the MCP bridge job dispatcher so job state, offsets, stop handling, scope, and policy remain shared.
- Update Catty prompts and tool-card rendering for long-running job lifecycle visibility.
- Keep `terminal_execute` on the short-command wall-clock budget now that Catty has a long-running fallback.

## Validation
- `node --test --import tsx infrastructure/ai/shared/toolExecutors.test.ts infrastructure/ai/sdk/tools.test.ts components/ai-elements/tool-call.test.tsx`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a62c1cc9-621b-4d8e-9e1c-2646d50134d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a62c1cc9-621b-4d8e-9e1c-2646d50134d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

