### PR TITLE
Add context compaction trace and replay coverage

### DIFF
--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -27,6 +27,7 @@ import type {
 import { isWebSearchReady } from '../../../infrastructure/ai/types';
 import { buildSystemPrompt } from '../../../infrastructure/ai/cattyAgent/systemPrompt';
 import {
+  buildContextCompactionTrace,
   CONTEXT_COMPACTION_SYSTEM_PROMPT,
   DEFAULT_CONTEXT_WINDOW_TOKENS,
   DEFAULT_PROTECT_RECENT_MESSAGES,
@@ -35,6 +36,8 @@ import {
   keepRecentContextMessages,
   prepareContextCompaction,
   resolveContextWindow,
+  type ContextCompactionRequestTooLargeRetryInfo,
+  type ContextCompactionTrace,
 } from '../../../infrastructure/ai/contextCompaction';
 import {
   compressMessagesForRequestTooLargeRetry,
@@ -1046,6 +1049,23 @@ export function useAIChatStreaming({
         );
         return pruned;
       };
+      const recordContextCompactionTrace = (
+        messageId: string,
+        trace: ContextCompactionTrace,
+      ) => {
+        if (!trace.didCompact && !trace.requestTooLargeRetry) return;
+        console.info('[Catty] Context compaction trace:', trace);
+        updateMessageById(sessionId, messageId, msg => ({
+          ...msg,
+          diagnostics: {
+            ...msg.diagnostics,
+            contextCompaction: [
+              ...(msg.diagnostics?.contextCompaction ?? []),
+              trace,
+            ],
+          },
+        }));
+      };
       const compactMessages = async (
         messages: ModelMessage[],
         {
@@ -1054,28 +1074,46 @@ export function useAIChatStreaming({
           fallbackLog,
           compressForRequestTooLargeRetry = false,
           compressionLog,
+          traceTargetMessageId = assistantMsgId,
+          triggerReason = force ? 'http-413-retry' : 'context-window-threshold',
+          requestTooLargeRetry,
         }: {
           force?: boolean;
           statusText?: string;
           fallbackLog: string;
           compressForRequestTooLargeRetry?: boolean;
           compressionLog?: string;
+          traceTargetMessageId?: string;
+          triggerReason?: string;
+          requestTooLargeRetry?: ContextCompactionRequestTooLargeRetryInfo;
         },
       ): Promise<ModelMessage[]> => {
-        const compressRetryMessages = (candidateMessages: ModelMessage[], log?: string): ModelMessage[] => {
-          if (!compressForRequestTooLargeRetry) return candidateMessages;
+        const compressRetryMessages = (candidateMessages: ModelMessage[], log?: string): {
+          messages: ModelMessage[];
+          didAdjust: boolean;
+        } => {
+          if (!compressForRequestTooLargeRetry) {
+            return { messages: candidateMessages, didAdjust: false };
+          }
           const compressed = compressMessagesForRequestTooLargeRetry(candidateMessages);
           if (compressed.didAdjust && log) {
             console.warn(log);
           }
-          return compressed.messages;
+          return compressed;
         };
 
         try {
           if (statusText) {
             updateLastMessage(sessionId, msg => ({ ...msg, statusText }));
           }
-          const inputMessages = compressRetryMessages(messages, compressionLog);
+          const inputCompression = compressRetryMessages(messages, compressionLog);
+          const inputMessages = inputCompression.messages;
+          const retryTrace: ContextCompactionRequestTooLargeRetryInfo | undefined = requestTooLargeRetry
+            ? {
+                ...requestTooLargeRetry,
+                payloadCompressionAppliedBeforeCompaction: inputCompression.didAdjust,
+              }
+            : undefined;
           const compacted = await prepareContextCompaction({
             messages: inputMessages,
             contextWindow,
@@ -1083,22 +1121,76 @@ export function useAIChatStreaming({
             thresholdRatio: force ? 0 : undefined,
             protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
             summarize: summarizeForCompaction,
+            trace: {
+              triggerReason,
+              requestTooLargeRetry: retryTrace,
+            },
           });
           let nextMessages = force && !compacted.didCompact
             ? keepRecentContextMessages(inputMessages, DEFAULT_PROTECT_RECENT_MESSAGES)
             : compacted.messages;
-          return compressRetryMessages(nextMessages);
+          const outputCompression = compressRetryMessages(nextMessages);
+          nextMessages = outputCompression.messages;
+          const finalTrace: ContextCompactionTrace = outputCompression.didAdjust && compacted.trace.requestTooLargeRetry
+            ? {
+                ...compacted.trace,
+                requestTooLargeRetry: {
+                  ...compacted.trace.requestTooLargeRetry,
+                  payloadCompressionAppliedAfterCompaction: true,
+                },
+              }
+            : compacted.trace;
+          recordContextCompactionTrace(traceTargetMessageId, finalTrace);
+          return nextMessages;
         } catch (err) {
           if (abortController.signal.aborted) throw err;
           console.warn(fallbackLog, err);
           const fallbackMessages = keepRecentContextMessages(messages, DEFAULT_PROTECT_RECENT_MESSAGES);
+          const fallbackSplitAt = messages.length - fallbackMessages.length;
+          const fallbackRetryTrace = requestTooLargeRetry
+            ? {
+                ...requestTooLargeRetry,
+                payloadCompressionAppliedBeforeCompaction: false,
+              }
+            : undefined;
           if (!compressForRequestTooLargeRetry) {
+            recordContextCompactionTrace(traceTargetMessageId, buildContextCompactionTrace({
+              messagesBefore: messages,
+              messagesAfter: fallbackMessages,
+              contextWindow,
+              reservedTokens: getRequestReserveTokens(),
+              thresholdRatio: force ? 0 : undefined,
+              protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
+              splitAt: fallbackSplitAt,
+              mode: 'recent-tail-fallback',
+              skippedReason: 'summarizer-error',
+              triggerReason,
+              requestTooLargeRetry: fallbackRetryTrace,
+            }));
             return fallbackMessages;
           }
           const compressed = compressMessagesForRequestTooLargeRetry(fallbackMessages);
           if (compressed.didAdjust) {
             console.warn('[Catty] Request content compressed after compaction fallback.');
           }
+          recordContextCompactionTrace(traceTargetMessageId, buildContextCompactionTrace({
+            messagesBefore: messages,
+            messagesAfter: compressed.messages,
+            contextWindow,
+            reservedTokens: getRequestReserveTokens(),
+            thresholdRatio: force ? 0 : undefined,
+            protectRecentMessages: DEFAULT_PROTECT_RECENT_MESSAGES,
+            splitAt: fallbackSplitAt,
+            mode: 'recent-tail-fallback',
+            skippedReason: 'summarizer-error',
+            triggerReason,
+            requestTooLargeRetry: fallbackRetryTrace
+              ? {
+                  ...fallbackRetryTrace,
+                  payloadCompressionAppliedAfterCompaction: compressed.didAdjust,
+                }
+              : undefined,
+          }));
           return compressed.messages;
         }
       };
@@ -1171,6 +1263,12 @@ export function useAIChatStreaming({
           fallbackLog: '[Catty] Forced context compaction after 413 failed; falling back to recent messages only:',
           compressForRequestTooLargeRetry: true,
           compressionLog: '[Catty] Request content compressed after forced context compaction.',
+          traceTargetMessageId: retryAssistantMsgId,
+          triggerReason: 'http-413-retry',
+          requestTooLargeRetry: {
+            attempt: 1,
+            hadToolProgress,
+          },
         }));
 
         await processCattyStream(

--- a/infrastructure/ai/contextCompaction.test.ts
+++ b/infrastructure/ai/contextCompaction.test.ts
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 import type { ModelMessage } from "ai";
 
 import {
+  buildContextCompactionTrace,
   buildCompactedMessages,
+  estimateModelMessagesChars,
   estimateModelMessagesTokens,
   estimateUnknownTokens,
   findSafeCompactionSplitIndex,
@@ -105,6 +107,15 @@ test("prepareContextCompaction summarizes old messages and returns compacted con
   assert.equal(result.didCompact, true);
   assert.equal(result.summary, "Summary of old messages.");
   assert.deepEqual(result.messages.slice(-2), messages.slice(-2));
+  assert.equal(result.trace.mode, "llm-summary");
+  assert.equal(result.trace.triggerReason, "context-window-threshold");
+  assert.equal(result.trace.compactedMessageCount, 2);
+  assert.equal(result.trace.retainedTailMessageCount, 2);
+  assert.deepEqual(result.trace.ranges.summarizedMessages, { start: 0, endExclusive: 2 });
+  assert.deepEqual(result.trace.ranges.retainedTail, { start: 2, endExclusive: 4 });
+  assert.equal(result.trace.before.messageCount, 4);
+  assert.equal(result.trace.after.messageCount, 4);
+  assert.ok(result.trace.after.estimatedTokens < result.trace.before.estimatedTokens);
 });
 
 test("prepareContextCompaction includes reserved request tokens in the compaction check", async () => {
@@ -127,6 +138,76 @@ test("prepareContextCompaction includes reserved request tokens in the compactio
 
   assert.equal(result.didCompact, true);
   assert.equal(result.summary, "System prompt forced compaction.");
+  assert.ok(result.trace.reservedTokens > 0);
+  assert.ok(result.trace.before.estimatedPromptTokens > result.trace.before.estimatedTokens);
+});
+
+test("prepareContextCompaction returns a skipped trace below the threshold", async () => {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "short prompt" },
+    { role: "assistant", content: "short answer" },
+  ];
+
+  const result = await prepareContextCompaction({
+    messages,
+    contextWindow: 10_000,
+    summarize: async () => {
+      throw new Error("summarizer should not run");
+    },
+    trace: {
+      now: () => 123,
+    },
+  });
+
+  assert.equal(result.didCompact, false);
+  assert.equal(result.trace.createdAt, 123);
+  assert.equal(result.trace.mode, "skipped");
+  assert.equal(result.trace.skippedReason, "below-threshold");
+  assert.equal(result.trace.before.estimatedChars, estimateModelMessagesChars(messages));
+  assert.equal(result.trace.after.estimatedChars, result.trace.before.estimatedChars);
+});
+
+test("buildContextCompactionTrace records request-too-large retry metadata", () => {
+  const messagesBefore: ModelMessage[] = [
+    { role: "user", content: "old ".repeat(100) },
+    { role: "assistant", content: "recent answer" },
+  ];
+  const messagesAfter: ModelMessage[] = [
+    { role: "user", content: "recent answer" },
+  ];
+
+  const trace = buildContextCompactionTrace({
+    messagesBefore,
+    messagesAfter,
+    contextWindow: 100,
+    reservedTokens: 11.2,
+    thresholdRatio: 0,
+    protectRecentMessages: 1,
+    splitAt: 1,
+    mode: "recent-tail-fallback",
+    skippedReason: "summarizer-error",
+    triggerReason: "http-413-retry",
+    requestTooLargeRetry: {
+      attempt: 1,
+      hadToolProgress: true,
+      payloadCompressionAppliedBeforeCompaction: true,
+      payloadCompressionAppliedAfterCompaction: false,
+    },
+    now: () => 456,
+  });
+
+  assert.equal(trace.createdAt, 456);
+  assert.equal(trace.didCompact, true);
+  assert.equal(trace.mode, "recent-tail-fallback");
+  assert.equal(trace.skippedReason, "summarizer-error");
+  assert.equal(trace.reservedTokens, 12);
+  assert.equal(trace.requestTooLargeRetry?.attempt, 1);
+  assert.equal(trace.requestTooLargeRetry?.hadToolProgress, true);
+  assert.equal(trace.requestTooLargeRetry?.payloadCompressionAppliedBeforeCompaction, true);
+  assert.equal(trace.before.messageCount, 2);
+  assert.equal(trace.after.messageCount, 1);
+  assert.equal(trace.compactedMessageCount, 1);
+  assert.equal(trace.retainedTailMessageCount, 1);
 });
 
 test("prepareContextCompaction summarizes older tool results instead of dropping them first", async () => {
@@ -173,6 +254,52 @@ test("prepareContextCompaction summarizes older tool results instead of dropping
 
   assert.equal(result.didCompact, true);
   assert.match(result.messages[0]?.content as string, /81% full/);
+});
+
+test("prepareContextCompaction keeps tool call and result together when the split overlaps their boundary", async () => {
+  const messages: ModelMessage[] = [
+    { role: "user", content: "old setup ".repeat(80) },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "terminal_execute",
+          input: { command: "npm test" },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "terminal_execute",
+          output: { type: "text", value: "AssertionError: failed" },
+        },
+      ],
+    },
+    { role: "user", content: "recent follow-up" },
+    { role: "assistant", content: "recent answer" },
+  ];
+
+  const result = await prepareContextCompaction({
+    messages,
+    contextWindow: 90,
+    protectRecentMessages: 3,
+    summarize: async (messagesToSummarize) => {
+      assert.deepEqual(messagesToSummarize, messages.slice(0, 1));
+      return "Old setup happened.";
+    },
+  });
+
+  assert.equal(result.didCompact, true);
+  assert.equal(result.trace.splitIndex, 1);
+  assert.equal(result.trace.compactedMessageCount, 1);
+  assert.equal(result.trace.retainedTailMessageCount, 4);
+  assert.deepEqual(result.messages.slice(-4), messages.slice(1));
 });
 
 test("formatMessagesForCompaction redacts image and file payloads", () => {

--- a/infrastructure/ai/contextCompaction.ts
+++ b/infrastructure/ai/contextCompaction.ts
@@ -32,12 +32,72 @@ export interface PrepareContextCompactionInput {
   thresholdRatio?: number;
   protectRecentMessages?: number;
   summarize: (messagesToSummarize: ModelMessage[]) => Promise<string>;
+  trace?: ContextCompactionTraceOptions;
 }
 
 export interface PrepareContextCompactionResult {
   messages: ModelMessage[];
   summary?: string;
   didCompact: boolean;
+  trace: ContextCompactionTrace;
+}
+
+export interface ContextCompactionTraceOptions {
+  triggerReason?: string;
+  requestTooLargeRetry?: ContextCompactionRequestTooLargeRetryInfo;
+  now?: () => number;
+}
+
+export interface ContextCompactionRequestTooLargeRetryInfo {
+  attempt: number;
+  hadToolProgress: boolean;
+  payloadCompressionAppliedBeforeCompaction?: boolean;
+  payloadCompressionAppliedAfterCompaction?: boolean;
+}
+
+export type ContextCompactionTraceMode = "llm-summary" | "recent-tail-fallback" | "skipped";
+
+export type ContextCompactionSkippedReason =
+  | "below-threshold"
+  | "no-old-messages"
+  | "empty-summary"
+  | "summarizer-error";
+
+export interface ContextCompactionTraceSnapshot {
+  messageCount: number;
+  estimatedChars: number;
+  estimatedTokens: number;
+  estimatedPromptTokens: number;
+}
+
+export interface ContextCompactionTraceRange {
+  start: number;
+  endExclusive: number;
+}
+
+export interface ContextCompactionTrace {
+  type: "context_compaction";
+  createdAt: number;
+  triggerReason: string;
+  mode: ContextCompactionTraceMode;
+  didCompact: boolean;
+  skippedReason?: ContextCompactionSkippedReason;
+  contextWindow: number;
+  thresholdRatio: number;
+  reservedTokens: number;
+  protectRecentMessages: number;
+  splitIndex: number;
+  compactedMessageCount: number;
+  retainedTailMessageCount: number;
+  retainedTailTokenEstimate: number;
+  ranges: {
+    summarizedMessages: ContextCompactionTraceRange;
+    retainedTail: ContextCompactionTraceRange;
+  };
+  before: ContextCompactionTraceSnapshot;
+  after: ContextCompactionTraceSnapshot;
+  summary?: string;
+  requestTooLargeRetry?: ContextCompactionRequestTooLargeRetryInfo;
 }
 
 export interface ResolveContextWindowInput {
@@ -76,10 +136,14 @@ export function sanitizeContextWindow(value: unknown): number | undefined {
 }
 
 export function estimateModelMessagesTokens(messages: ModelMessage[]): number {
-  const chars = messages.reduce((total, message) => {
+  const chars = estimateModelMessagesChars(messages);
+  return Math.ceil(chars / TOKEN_CHARS);
+}
+
+export function estimateModelMessagesChars(messages: ModelMessage[]): number {
+  return messages.reduce((total, message) => {
     return total + estimateUnknownChars(message.role) + estimateUnknownChars(message.content);
   }, 0);
-  return Math.ceil(chars / TOKEN_CHARS);
 }
 
 export function estimateUnknownTokens(value: unknown): number {
@@ -123,6 +187,73 @@ export function buildCompactedMessages({
   ];
 }
 
+export function buildContextCompactionTrace({
+  messagesBefore,
+  messagesAfter,
+  contextWindow = DEFAULT_CONTEXT_WINDOW_TOKENS,
+  reservedTokens = 0,
+  thresholdRatio = DEFAULT_COMPACTION_RATIO,
+  protectRecentMessages = DEFAULT_PROTECT_RECENT_MESSAGES,
+  splitAt = messagesBefore.length,
+  mode,
+  skippedReason,
+  summary,
+  triggerReason = "context-window-threshold",
+  requestTooLargeRetry,
+  now = Date.now,
+}: {
+  messagesBefore: ModelMessage[];
+  messagesAfter: ModelMessage[];
+  contextWindow?: number;
+  reservedTokens?: number;
+  thresholdRatio?: number;
+  protectRecentMessages?: number;
+  splitAt?: number;
+  mode: ContextCompactionTraceMode;
+  skippedReason?: ContextCompactionSkippedReason;
+  summary?: string;
+  triggerReason?: string;
+  requestTooLargeRetry?: ContextCompactionRequestTooLargeRetryInfo;
+  now?: () => number;
+}): ContextCompactionTrace {
+  const safeReservedTokens = Math.max(0, Math.ceil(reservedTokens));
+  const safeSplitAt = Math.max(0, Math.min(messagesBefore.length, splitAt));
+  const retainedTail = messagesBefore.slice(safeSplitAt);
+  const before = buildTraceSnapshot(messagesBefore, safeReservedTokens);
+  const after = buildTraceSnapshot(messagesAfter, safeReservedTokens);
+
+  return {
+    type: "context_compaction",
+    createdAt: now(),
+    triggerReason,
+    mode,
+    didCompact: mode !== "skipped",
+    ...(skippedReason ? { skippedReason } : {}),
+    contextWindow,
+    thresholdRatio,
+    reservedTokens: safeReservedTokens,
+    protectRecentMessages,
+    splitIndex: safeSplitAt,
+    compactedMessageCount: safeSplitAt,
+    retainedTailMessageCount: retainedTail.length,
+    retainedTailTokenEstimate: estimateModelMessagesTokens(retainedTail),
+    ranges: {
+      summarizedMessages: {
+        start: 0,
+        endExclusive: safeSplitAt,
+      },
+      retainedTail: {
+        start: safeSplitAt,
+        endExclusive: messagesBefore.length,
+      },
+    },
+    before,
+    after,
+    ...(summary ? { summary } : {}),
+    ...(requestTooLargeRetry ? { requestTooLargeRetry } : {}),
+  };
+}
+
 export async function prepareContextCompaction({
   messages,
   contextWindow = DEFAULT_CONTEXT_WINDOW_TOKENS,
@@ -130,28 +261,96 @@ export async function prepareContextCompaction({
   thresholdRatio,
   protectRecentMessages = DEFAULT_PROTECT_RECENT_MESSAGES,
   summarize,
+  trace: traceOptions,
 }: PrepareContextCompactionInput): Promise<PrepareContextCompactionResult> {
-  const promptTokens = estimateModelMessagesTokens(messages) + Math.max(0, Math.ceil(reservedTokens));
-  if (!shouldCompactContext({ promptTokens, contextWindow, thresholdRatio })) {
-    return { messages, didCompact: false };
+  const effectiveThresholdRatio = thresholdRatio ?? DEFAULT_COMPACTION_RATIO;
+  const safeReservedTokens = Math.max(0, Math.ceil(reservedTokens));
+  const promptTokens = estimateModelMessagesTokens(messages) + safeReservedTokens;
+  if (!shouldCompactContext({ promptTokens, contextWindow, thresholdRatio: effectiveThresholdRatio })) {
+    return {
+      messages,
+      didCompact: false,
+      trace: buildContextCompactionTrace({
+        messagesBefore: messages,
+        messagesAfter: messages,
+        contextWindow,
+        reservedTokens: safeReservedTokens,
+        thresholdRatio: effectiveThresholdRatio,
+        protectRecentMessages,
+        mode: "skipped",
+        skippedReason: "below-threshold",
+        triggerReason: traceOptions?.triggerReason,
+        requestTooLargeRetry: traceOptions?.requestTooLargeRetry,
+        now: traceOptions?.now,
+      }),
+    };
   }
 
   const splitAt = findSafeCompactionSplitIndex(messages, protectRecentMessages);
   const oldMessages = messages.slice(0, splitAt);
   const recentMessages = messages.slice(splitAt);
   if (oldMessages.length === 0) {
-    return { messages, didCompact: false };
+    return {
+      messages,
+      didCompact: false,
+      trace: buildContextCompactionTrace({
+        messagesBefore: messages,
+        messagesAfter: messages,
+        contextWindow,
+        reservedTokens: safeReservedTokens,
+        thresholdRatio: effectiveThresholdRatio,
+        protectRecentMessages,
+        splitAt,
+        mode: "skipped",
+        skippedReason: "no-old-messages",
+        triggerReason: traceOptions?.triggerReason,
+        requestTooLargeRetry: traceOptions?.requestTooLargeRetry,
+        now: traceOptions?.now,
+      }),
+    };
   }
 
   const summary = (await summarize(oldMessages)).trim();
   if (!summary) {
-    return { messages, didCompact: false };
+    return {
+      messages,
+      didCompact: false,
+      trace: buildContextCompactionTrace({
+        messagesBefore: messages,
+        messagesAfter: messages,
+        contextWindow,
+        reservedTokens: safeReservedTokens,
+        thresholdRatio: effectiveThresholdRatio,
+        protectRecentMessages,
+        splitAt,
+        mode: "skipped",
+        skippedReason: "empty-summary",
+        triggerReason: traceOptions?.triggerReason,
+        requestTooLargeRetry: traceOptions?.requestTooLargeRetry,
+        now: traceOptions?.now,
+      }),
+    };
   }
+  const compactedMessages = buildCompactedMessages({ summary, recentMessages });
 
   return {
-    messages: buildCompactedMessages({ summary, recentMessages }),
+    messages: compactedMessages,
     summary,
     didCompact: true,
+    trace: buildContextCompactionTrace({
+      messagesBefore: messages,
+      messagesAfter: compactedMessages,
+      contextWindow,
+      reservedTokens: safeReservedTokens,
+      thresholdRatio: effectiveThresholdRatio,
+      protectRecentMessages,
+      splitAt,
+      mode: "llm-summary",
+      summary,
+      triggerReason: traceOptions?.triggerReason,
+      requestTooLargeRetry: traceOptions?.requestTooLargeRetry,
+      now: traceOptions?.now,
+    }),
   };
 }
 
@@ -169,6 +368,20 @@ export function keepRecentContextMessages(
 ): ModelMessage[] {
   const splitAt = findSafeCompactionSplitIndex(messages, protectRecentMessages);
   return messages.slice(splitAt);
+}
+
+function buildTraceSnapshot(
+  messages: ModelMessage[],
+  reservedTokens: number,
+): ContextCompactionTraceSnapshot {
+  const estimatedChars = estimateModelMessagesChars(messages);
+  const estimatedTokens = Math.ceil(estimatedChars / TOKEN_CHARS);
+  return {
+    messageCount: messages.length,
+    estimatedChars,
+    estimatedTokens,
+    estimatedPromptTokens: estimatedTokens + reservedTokens,
+  };
 }
 
 function estimateUnknownChars(value: unknown): number {

--- a/infrastructure/ai/contextCompactionReplay.test.ts
+++ b/infrastructure/ai/contextCompactionReplay.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ModelMessage } from "ai";
+
+import {
+  formatMessagesForCompaction,
+  prepareContextCompaction,
+} from "./contextCompaction.ts";
+
+test("context compaction replay preserves goal, command, path, error, and unfinished work", async () => {
+  const messages: ModelMessage[] = [
+    {
+      role: "user",
+      content: "用户目标：让上下文压缩可解释、可测试、可回放；保持最小改动。",
+    },
+    {
+      role: "assistant",
+      content: "我会先补 trace，再补边界和回放测试。",
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-ctx-test",
+          toolName: "terminal_execute",
+          input: {
+            command: "node --test --import tsx infrastructure/ai/contextCompaction.test.ts",
+          },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-ctx-test",
+          toolName: "terminal_execute",
+          output: {
+            type: "text",
+            value: [
+              "cwd=/workspace",
+              "path=/workspace/infrastructure/ai/contextCompaction.ts",
+              "error=AssertionError: orphaned tool result at split boundary",
+              "exitCode=1",
+            ].join("\n"),
+          },
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      content: "失败原因在 /workspace/infrastructure/ai/contextCompaction.ts 的 split 边界保护。",
+    },
+    {
+      role: "user",
+      content: "未完成事项：修复边界保护后继续补回放测试，并记录 413 retry 信息。",
+    },
+    {
+      role: "user",
+      content: "当前请求：继续实现 trace 并跑相关测试。",
+    },
+    {
+      role: "assistant",
+      content: "正在继续处理。",
+    },
+  ];
+
+  const result = await prepareContextCompaction({
+    messages,
+    contextWindow: 120,
+    protectRecentMessages: 2,
+    trace: {
+      triggerReason: "replay-quality-fixture",
+      now: () => 789,
+    },
+    summarize: async (messagesToSummarize) => {
+      const replayInput = formatMessagesForCompaction(messagesToSummarize);
+      assert.match(replayInput, /用户目标：让上下文压缩可解释、可测试、可回放/);
+      assert.match(replayInput, /node --test --import tsx infrastructure\/ai\/contextCompaction\.test\.ts/);
+      assert.match(replayInput, /\/workspace\/infrastructure\/ai\/contextCompaction\.ts/);
+      assert.match(replayInput, /AssertionError: orphaned tool result/);
+      assert.match(replayInput, /未完成事项：修复边界保护后继续补回放测试/);
+
+      return [
+        "用户目标：让上下文压缩可解释、可测试、可回放；保持最小改动。",
+        "已运行命令：node --test --import tsx infrastructure/ai/contextCompaction.test.ts。",
+        "关键路径：/workspace/infrastructure/ai/contextCompaction.ts。",
+        "关键错误：AssertionError: orphaned tool result at split boundary。",
+        "未完成事项：修复边界保护后继续补回放测试，并记录 413 retry 信息。",
+      ].join("\n");
+    },
+  });
+
+  assert.equal(result.didCompact, true);
+  assert.equal(result.trace.triggerReason, "replay-quality-fixture");
+  assert.equal(result.trace.summary, result.summary);
+
+  const replayText = result.messages.map((message) => {
+    return typeof message.content === "string"
+      ? message.content
+      : JSON.stringify(message.content);
+  }).join("\n");
+
+  assert.match(replayText, /用户目标：让上下文压缩可解释、可测试、可回放/);
+  assert.match(replayText, /node --test --import tsx infrastructure\/ai\/contextCompaction\.test\.ts/);
+  assert.match(replayText, /\/workspace\/infrastructure\/ai\/contextCompaction\.ts/);
+  assert.match(replayText, /AssertionError: orphaned tool result/);
+  assert.match(replayText, /未完成事项：修复边界保护后继续补回放测试/);
+  assert.match(replayText, /当前请求：继续实现 trace 并跑相关测试/);
+});

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -1,5 +1,6 @@
 // AI Provider types
 import defaultCommandBlocklist from '../../lib/commandBlocklist.json';
+import type { ContextCompactionTrace } from './contextCompaction';
 import type { ProviderContinuation } from './providerContinuation';
 
 export type AIProviderId =
@@ -141,6 +142,9 @@ export interface ChatMessage {
     toolName: string;
     toolArgs: Record<string, unknown>;
     status: 'pending' | 'approved' | 'denied';
+  };
+  diagnostics?: {
+    contextCompaction?: ContextCompactionTrace[];
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add structured context compaction traces with before/after size snapshots, split ranges, retained tail counts, summaries, and request-too-large retry metadata.
- Persist Catty compaction traces on assistant message diagnostics and log them for debugging.
- Add boundary and replay tests proving compaction preserves tool call/result integrity and key task context.

## Validation
- `node --test --import tsx infrastructure/ai/contextCompaction.test.ts infrastructure/ai/contextCompactionReplay.test.ts infrastructure/ai/requestPayloadCompression.test.ts components/ai/cattyHistoryReplay.test.ts`
- `npx eslint infrastructure/ai/contextCompaction.ts infrastructure/ai/contextCompaction.test.ts infrastructure/ai/contextCompactionReplay.test.ts infrastructure/ai/types.ts components/ai/hooks/useAIChatStreaming.ts`
- `npm test`

## Notes
- Full `./node_modules/.bin/tsc --noEmit` currently fails on pre-existing repository-wide type errors outside this change set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2ddd27f-362a-4fdb-b001-1cde1c71e98a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2ddd27f-362a-4fdb-b001-1cde1c71e98a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

