### PR TITLE
Unify terminal capability tool definitions

### DIFF
--- a/electron/bridges/aiBridge/cattyExecHandlers.cjs
+++ b/electron/bridges/aiBridge/cattyExecHandlers.cjs
@@ -151,6 +151,38 @@ function registerCattyExecHandlers(ctx) {
     }
   });
 
+  ipcMain.handle("netcatty:ai:job-start", async (event, { sessionId, command, chatSessionId }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    return mcpServerBridge.callCapabilityRpc("netcatty/jobStart", {
+      sessionId,
+      command,
+      chatSessionId,
+    }, { skipApproval: true });
+  });
+
+  ipcMain.handle("netcatty:ai:job-poll", async (event, { jobId, offset, chatSessionId }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    return mcpServerBridge.callCapabilityRpc("netcatty/jobPoll", {
+      jobId,
+      offset,
+      chatSessionId,
+    }, { skipApproval: true });
+  });
+
+  ipcMain.handle("netcatty:ai:job-stop", async (event, { jobId, chatSessionId }) => {
+    if (!validateSender(event)) {
+      return { ok: false, error: "Unauthorized IPC sender" };
+    }
+    return mcpServerBridge.callCapabilityRpc("netcatty/jobStop", {
+      jobId,
+      chatSessionId,
+    }, { skipApproval: true });
+  });
+
   // Cancel in-flight Catty Agent command executions for a chat session
   ipcMain.handle("netcatty:ai:catty:cancel", async (event, { chatSessionId }) => {
     if (!validateSender(event)) {

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -813,7 +813,7 @@ function validateSessionScope(sessionId, chatSessionId, explicitScopedIds = null
   return null;
 }
 
-async function dispatch(method, params) {
+async function dispatch(method, params, options = {}) {
   debugLog("dispatch", { method, params, permissionMode });
   const capability = getCapabilityByRpcMethod(method, CAPABILITY_SURFACES.BUILTIN);
   const sessionWriteLockId = (capability?.id === "terminal.execute" || capability?.id === "terminal.start")
@@ -863,7 +863,7 @@ async function dispatch(method, params) {
     // netcatty/jobStop bypasses approval — it's a stop/cancel action that
     // must remain available even if the renderer is unavailable; otherwise
     // a runaway terminal_start job could not be interrupted at all.
-    if (permission.requiresApproval) {
+    if (permission.requiresApproval && !options.skipApproval) {
       const { chatSessionId, ...toolArgs } = params || {};
       const approved = await requestApprovalFromRenderer(method, toolArgs, chatSessionId);
       if (!approved) {
@@ -919,6 +919,10 @@ async function dispatch(method, params) {
       pendingSessionWriteApprovals.delete(sessionWriteLockId);
     }
   }
+}
+
+function callCapabilityRpc(method, params, options = {}) {
+  return dispatch(method, params || {}, options);
 }
 
 // ── Handler: getContext ──
@@ -1120,4 +1124,5 @@ module.exports = {
   reserveSessionExecution,
   releaseSessionExecution,
   getSessionBusyError,
+  callCapabilityRpc,
 };

--- a/electron/capabilities/adapters/cliAdapter.cjs
+++ b/electron/capabilities/adapters/cliAdapter.cjs
@@ -24,9 +24,12 @@ function listCliCapabilities(options = {}) {
       domain: capability.domain,
       status: capability.status,
       description: capability.description,
+      parameters: capability.parameters || {},
       command: capability.surfaces[surface].command,
       rpcMethod: capability.surfaces?.[CAPABILITY_SURFACES.BUILTIN]?.rpcMethod || null,
       policy: capability.policy,
+      implementationStatus: capability.surfaces?.[surface]?.implementationStatus || "implemented",
+      notImplementedReason: capability.surfaces?.[surface]?.notImplementedReason || null,
     }));
 }
 

--- a/electron/capabilities/adapters/cliAdapter.test.cjs
+++ b/electron/capabilities/adapters/cliAdapter.test.cjs
@@ -14,7 +14,9 @@ test("getCliRpcMethod resolves implemented cli commands to builtin rpc methods",
 
 test("listCliCapabilities returns implemented commands by default", () => {
   const entries = listCliCapabilities();
-  assert.ok(entries.some((entry) => entry.id === "terminal.execute"));
+  const terminalExecute = entries.find((entry) => entry.id === "terminal.execute");
+  assert.ok(terminalExecute);
+  assert.equal(terminalExecute.parameters.command.type, "string");
   assert.ok(entries.every((entry) => entry.status === CAPABILITY_STATUS.IMPLEMENTED));
 });
 

--- a/electron/capabilities/adapters/mcpAdapter.cjs
+++ b/electron/capabilities/adapters/mcpAdapter.cjs
@@ -7,18 +7,81 @@ const {
   listCapabilities,
 } = require("../registry.cjs");
 
+function getSurfaceBinding(capability, surface) {
+  return capability?.surfaces?.[surface] || null;
+}
+
+function getSurfaceImplementationStatus(capability, surface) {
+  const binding = getSurfaceBinding(capability, surface);
+  return binding?.implementationStatus || "implemented";
+}
+
+function getSurfaceNotImplementedReason(capability, surface) {
+  const binding = getSurfaceBinding(capability, surface);
+  return binding?.notImplementedReason || null;
+}
+
+function buildZodField(parameter, zod) {
+  let field;
+  switch (parameter.type) {
+    case "number":
+      field = zod.number();
+      break;
+    case "integer":
+      field = zod.number().int();
+      break;
+    case "boolean":
+      field = zod.boolean();
+      break;
+    case "string":
+    default:
+      field = zod.string();
+      break;
+  }
+  if (typeof parameter.min === "number" && typeof field.min === "function") {
+    field = field.min(parameter.min);
+  }
+  if (parameter.description && typeof field.describe === "function") {
+    field = field.describe(parameter.description);
+  }
+  if (parameter.optional && typeof field.optional === "function") {
+    field = field.optional();
+  }
+  return field;
+}
+
+function buildMcpInputSchema(parameters = {}, zod) {
+  if (!zod) return {};
+  return Object.fromEntries(
+    Object.entries(parameters).map(([name, parameter]) => [
+      name,
+      buildZodField(parameter, zod),
+    ]),
+  );
+}
+
+function toMcpToolEntry(capability, surface, zod = null) {
+  const binding = getSurfaceBinding(capability, surface);
+  return {
+    id: capability.id,
+    toolName: binding.mcpTool,
+    rpcMethod: binding.rpcMethod,
+    description: capability.description,
+    parameters: capability.parameters || {},
+    inputSchema: buildMcpInputSchema(capability.parameters, zod),
+    policy: capability.policy,
+    status: capability.status,
+    implementationStatus: getSurfaceImplementationStatus(capability, surface),
+    notImplementedReason: getSurfaceNotImplementedReason(capability, surface),
+  };
+}
+
 function listMcpTools(surface = CAPABILITY_SURFACES.BUILTIN, options = {}) {
   const status = options.status || CAPABILITY_STATUS.IMPLEMENTED;
+  const zod = options.zod || null;
   return listCapabilities({ surface, status })
     .filter((capability) => capability.surfaces?.[surface]?.mcpTool)
-    .map((capability) => ({
-      id: capability.id,
-      toolName: capability.surfaces[surface].mcpTool,
-      rpcMethod: capability.surfaces[surface].rpcMethod,
-      description: capability.description,
-      policy: capability.policy,
-      status: capability.status,
-    }));
+    .map((capability) => toMcpToolEntry(capability, surface, zod));
 }
 
 function getMcpToolRpcMethod(toolName, surface = CAPABILITY_SURFACES.BUILTIN) {
@@ -31,8 +94,16 @@ function getMcpToolNameForRpcMethod(rpcMethod, surface = CAPABILITY_SURFACES.BUI
   return capability?.surfaces?.[surface]?.mcpTool || null;
 }
 
+function getMcpToolDefinition(toolName, surface = CAPABILITY_SURFACES.BUILTIN, zod = null) {
+  const capability = getCapabilityByMcpTool(toolName, surface);
+  if (!capability) return null;
+  return toMcpToolEntry(capability, surface, zod);
+}
+
 module.exports = {
   listMcpTools,
   getMcpToolRpcMethod,
   getMcpToolNameForRpcMethod,
+  getMcpToolDefinition,
+  buildMcpInputSchema,
 };

--- a/electron/capabilities/adapters/mcpAdapter.test.cjs
+++ b/electron/capabilities/adapters/mcpAdapter.test.cjs
@@ -7,8 +7,10 @@ const {
   listMcpTools,
   getMcpToolRpcMethod,
   getMcpToolNameForRpcMethod,
+  getMcpToolDefinition,
 } = require("./mcpAdapter.cjs");
 const { CAPABILITY_SURFACES } = require("../constants.cjs");
+const { z } = require("zod");
 
 test("listMcpTools exposes builtin terminal tools", () => {
   const tools = listMcpTools(CAPABILITY_SURFACES.BUILTIN);
@@ -23,9 +25,20 @@ test("getMcpToolRpcMethod resolves tool names", () => {
   );
 });
 
+test("getMcpToolDefinition derives zod input schema from catalog parameters", () => {
+  const definition = getMcpToolDefinition("terminal_poll", CAPABILITY_SURFACES.BUILTIN, z);
+  assert.equal(definition.toolName, "terminal_poll");
+  const schema = z.object(definition.inputSchema);
+  assert.deepEqual(schema.parse({ jobId: "job-1", offset: 3 }), { jobId: "job-1", offset: 3 });
+  assert.throws(() => schema.parse({ jobId: "job-1", offset: -1 }));
+});
+
 test("public surface includes sftp tools for future public mcp registration", () => {
   const tools = listMcpTools(CAPABILITY_SURFACES.PUBLIC);
-  assert.ok(tools.some((tool) => tool.toolName === "sftp_list"));
+  const sftpList = tools.find((tool) => tool.toolName === "sftp_list");
+  assert.ok(sftpList);
+  assert.equal(sftpList.implementationStatus, "not_implemented");
+  assert.match(sftpList.notImplementedReason, /not registered/);
   assert.equal(
     getMcpToolNameForRpcMethod("public/sftp/list", CAPABILITY_SURFACES.PUBLIC),
     "sftp_list",

--- a/electron/capabilities/catalog/sftp.cjs
+++ b/electron/capabilities/catalog/sftp.cjs
@@ -2,6 +2,11 @@
 
 const { CAPABILITY_STATUS } = require("../constants.cjs");
 
+const PUBLIC_MCP_NOT_IMPLEMENTED = Object.freeze({
+  implementationStatus: "not_implemented",
+  notImplementedReason: "Cataloged for the future public MCP surface, but not registered by the current Netcatty MCP server.",
+});
+
 function sftpCapability(id, description, policyOverrides, surfaces) {
   return {
     id,
@@ -30,7 +35,7 @@ const SFTP_CAPABILITIES = [
     { sensitiveRead: true },
     {
       builtin: { rpcMethod: "netcatty/sftp/list" },
-      public: { rpcMethod: "public/sftp/list", mcpTool: "sftp_list", confirmInConfirmMode: true },
+      public: { rpcMethod: "public/sftp/list", mcpTool: "sftp_list", confirmInConfirmMode: true, ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "list"] },
     },
   ),
@@ -40,7 +45,7 @@ const SFTP_CAPABILITIES = [
     { sensitiveRead: true },
     {
       builtin: { rpcMethod: "netcatty/sftp/read" },
-      public: { rpcMethod: "public/sftp/readFile", mcpTool: "sftp_read_file", confirmInConfirmMode: true },
+      public: { rpcMethod: "public/sftp/readFile", mcpTool: "sftp_read_file", confirmInConfirmMode: true, ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "read"] },
     },
   ),
@@ -50,7 +55,7 @@ const SFTP_CAPABILITIES = [
     { write: true, bypassesApproval: false, bypassesChatCancel: false },
     {
       builtin: { rpcMethod: "netcatty/sftp/write" },
-      public: { rpcMethod: "public/sftp/writeFile", mcpTool: "sftp_write_file" },
+      public: { rpcMethod: "public/sftp/writeFile", mcpTool: "sftp_write_file", ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "write"] },
     },
   ),
@@ -78,7 +83,7 @@ const SFTP_CAPABILITIES = [
     { sensitiveRead: true },
     {
       builtin: { rpcMethod: "netcatty/sftp/stat" },
-      public: { rpcMethod: "public/sftp/stat", mcpTool: "sftp_stat", confirmInConfirmMode: true },
+      public: { rpcMethod: "public/sftp/stat", mcpTool: "sftp_stat", confirmInConfirmMode: true, ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "stat"] },
     },
   ),
@@ -88,7 +93,7 @@ const SFTP_CAPABILITIES = [
     { sensitiveRead: true },
     {
       builtin: { rpcMethod: "netcatty/sftp/home" },
-      public: { rpcMethod: "public/sftp/home", mcpTool: "sftp_home", confirmInConfirmMode: true },
+      public: { rpcMethod: "public/sftp/home", mcpTool: "sftp_home", confirmInConfirmMode: true, ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "home"] },
     },
   ),
@@ -98,7 +103,7 @@ const SFTP_CAPABILITIES = [
     { write: true, bypassesApproval: false, bypassesChatCancel: false },
     {
       builtin: { rpcMethod: "netcatty/sftp/mkdir" },
-      public: { rpcMethod: "public/sftp/mkdir", mcpTool: "sftp_mkdir" },
+      public: { rpcMethod: "public/sftp/mkdir", mcpTool: "sftp_mkdir", ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "mkdir"] },
     },
   ),
@@ -108,7 +113,7 @@ const SFTP_CAPABILITIES = [
     { write: true, bypassesApproval: false, bypassesChatCancel: false },
     {
       builtin: { rpcMethod: "netcatty/sftp/delete" },
-      public: { rpcMethod: "public/sftp/delete", mcpTool: "sftp_delete" },
+      public: { rpcMethod: "public/sftp/delete", mcpTool: "sftp_delete", ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "delete"] },
     },
   ),
@@ -118,7 +123,7 @@ const SFTP_CAPABILITIES = [
     { write: true, bypassesApproval: false, bypassesChatCancel: false },
     {
       builtin: { rpcMethod: "netcatty/sftp/rename" },
-      public: { rpcMethod: "public/sftp/rename", mcpTool: "sftp_rename" },
+      public: { rpcMethod: "public/sftp/rename", mcpTool: "sftp_rename", ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "rename"] },
     },
   ),
@@ -128,7 +133,7 @@ const SFTP_CAPABILITIES = [
     { write: true, bypassesApproval: false, bypassesChatCancel: false },
     {
       builtin: { rpcMethod: "netcatty/sftp/chmod" },
-      public: { rpcMethod: "public/sftp/chmod", mcpTool: "sftp_chmod" },
+      public: { rpcMethod: "public/sftp/chmod", mcpTool: "sftp_chmod", ...PUBLIC_MCP_NOT_IMPLEMENTED },
       cli: { command: ["sftp", "chmod"] },
     },
   ),

--- a/electron/capabilities/catalog/terminal.cjs
+++ b/electron/capabilities/catalog/terminal.cjs
@@ -8,7 +8,17 @@ const TERMINAL_CAPABILITIES = [
     id: "terminal.execute",
     domain: "terminal",
     status: CAPABILITY_STATUS.IMPLEMENTED,
-    description: "Execute a short command in a terminal session and wait for completion.",
+    description: "Execute a short command on a Netcatty terminal session and wait for the full result. Use this only for commands expected to finish within about 60 seconds. For long-running commands such as builds, scans, log-following, or anything likely to exceed that budget, use terminal_start and then terminal_poll instead.",
+    parameters: {
+      sessionId: {
+        type: "string",
+        description: "The terminal session ID (from get_environment or workspace_get_info) to execute on.",
+      },
+      command: {
+        type: "string",
+        description: "The command to execute in the target session.",
+      },
+    },
     policy: {
       write: true,
       sensitiveRead: false,
@@ -28,7 +38,17 @@ const TERMINAL_CAPABILITIES = [
     id: "terminal.start",
     domain: "terminal",
     status: CAPABILITY_STATUS.IMPLEMENTED,
-    description: "Start a long-running command in a terminal session.",
+    description: "Start a long-running command on a Netcatty terminal session without waiting for final completion. The command still runs in the visible terminal/PTTY so the user can watch live output. Prefer this whenever the command may exceed about 2 minutes, or when it streams output for an extended period, such as builds, scans, watch commands, and log-follow commands. After starting, wait at least about 30 seconds before the first terminal_poll unless you have a strong reason to check sooner.",
+    parameters: {
+      sessionId: {
+        type: "string",
+        description: "The terminal session ID (from get_environment or workspace_get_info) to execute on.",
+      },
+      command: {
+        type: "string",
+        description: "The command to start in the target session.",
+      },
+    },
     policy: {
       write: true,
       sensitiveRead: false,
@@ -48,7 +68,19 @@ const TERMINAL_CAPABILITIES = [
     id: "terminal.poll",
     domain: "terminal",
     status: CAPABILITY_STATUS.IMPLEMENTED,
-    description: "Poll incremental output from a long-running terminal job.",
+    description: "Poll a long-running Netcatty command that was started with terminal_start. Returns incremental output since the given offset and the current status. Use the returned nextOffset for the next poll. If outputTruncated is true, only the retained tail starting at outputBaseOffset is still available. Do not poll aggressively: wait at least about 30 seconds between polls unless the tool output explicitly justifies checking sooner. As soon as completed is true, stop polling and analyze the final result immediately.",
+    parameters: {
+      jobId: {
+        type: "string",
+        description: "The background job ID returned by terminal_start.",
+      },
+      offset: {
+        type: "integer",
+        optional: true,
+        min: 0,
+        description: "Character offset previously returned as nextOffset. Omit or use 0 on the first poll.",
+      },
+    },
     policy: {
       write: false,
       sensitiveRead: false,
@@ -68,7 +100,13 @@ const TERMINAL_CAPABILITIES = [
     id: "terminal.stop",
     domain: "terminal",
     status: CAPABILITY_STATUS.IMPLEMENTED,
-    description: "Stop a long-running terminal job.",
+    description: "Stop a long-running Netcatty command that was started with terminal_start. This sends Ctrl+C to the running terminal job and returns its latest state.",
+    parameters: {
+      jobId: {
+        type: "string",
+        description: "The background job ID returned by terminal_start.",
+      },
+    },
     policy: {
       write: true,
       sensitiveRead: false,

--- a/electron/capabilities/types.cjs
+++ b/electron/capabilities/types.cjs
@@ -12,6 +12,14 @@
  * @property {string} [mcpTool]
  * @property {string[]} [command]
  * @property {boolean} [confirmInConfirmMode]
+ * @property {'implemented' | 'not_implemented'} [implementationStatus]
+ * @property {string} [notImplementedReason]
+ *
+ * @typedef {Object} CapabilityParameterDefinition
+ * @property {'string' | 'number' | 'integer' | 'boolean'} type
+ * @property {string} [description]
+ * @property {boolean} [optional]
+ * @property {number} [min]
  *
  * @typedef {Object} CapabilityPolicy
  * @property {boolean} write
@@ -27,6 +35,7 @@
  * @property {string} domain
  * @property {CapabilityStatus} status
  * @property {string} description
+ * @property {Record<string, CapabilityParameterDefinition>} [parameters]
  * @property {CapabilityPolicy} policy
  * @property {Partial<Record<CapabilitySurface, CapabilitySurfaceBinding>>} surfaces
  *

--- a/electron/cli/netcatty-tool-cli.capabilities.test.cjs
+++ b/electron/cli/netcatty-tool-cli.capabilities.test.cjs
@@ -13,5 +13,7 @@ test("netcatty-tool-cli capabilities lists implemented commands without app conn
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.ok, true);
-  assert.ok(payload.capabilities.some((entry) => entry.id === "terminal.execute"));
+  const terminalExecute = payload.capabilities.find((entry) => entry.id === "terminal.execute");
+  assert.ok(terminalExecute);
+  assert.equal(terminalExecute.parameters.sessionId.type, "string");
 });

--- a/electron/mcp/netcatty-mcp-server.cjs
+++ b/electron/mcp/netcatty-mcp-server.cjs
@@ -11,6 +11,8 @@ const net = require("node:net");
 const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
 const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
 const { z } = require("zod");
+const { CAPABILITY_SURFACES } = require("../capabilities/constants.cjs");
+const { getMcpToolDefinition } = require("../capabilities/adapters/mcpAdapter.cjs");
 
 const DEBUG_MCP = process.env.NETCATTY_MCP_DEBUG === "1";
 
@@ -180,6 +182,17 @@ const server = new McpServer({
   version: "1.0.0",
 });
 
+function registerBuiltinTool(toolName, handler) {
+  const definition = getMcpToolDefinition(toolName, CAPABILITY_SURFACES.BUILTIN, z);
+  if (!definition) {
+    throw new Error(`Missing builtin MCP capability definition for ${toolName}`);
+  }
+  if (definition.implementationStatus === "not_implemented") {
+    throw new Error(`Builtin MCP capability ${definition.id} is marked not implemented`);
+  }
+  server.tool(definition.toolName, definition.description, definition.inputSchema, handler);
+}
+
 // Scope params shared by all tool calls.
 // When chatSessionId is present, let the main process resolve the current
 // workspace membership dynamically so mid-session workspace changes are visible
@@ -269,14 +282,8 @@ server.tool(
   },
 );
 
-// Tool: terminal_execute
-server.tool(
+registerBuiltinTool(
   "terminal_execute",
-  "Execute a short command on a Netcatty terminal session and wait for the full result. Use this only for commands expected to finish within about 60 seconds. For long-running commands such as builds, scans, log-following, or anything likely to exceed that budget, use terminal_start and then terminal_poll instead.",
-  {
-    sessionId: z.string().describe("The terminal session ID (from get_environment) to execute on."),
-    command: z.string().describe("The command to execute in the target session."),
-  },
   async ({ sessionId, command }) => {
     debugLog("terminal_execute called", { sessionId, command });
     // skipBlocklist: bridge layer does session-aware blocklist (serial sessions skip shell patterns)
@@ -308,13 +315,8 @@ server.tool(
   },
 );
 
-server.tool(
+registerBuiltinTool(
   "terminal_start",
-  "Start a long-running command on a Netcatty terminal session without waiting for final completion. The command still runs in the visible terminal/PTTY so the user can watch live output. Prefer this whenever the command may exceed about 2 minutes, or when it streams output for an extended period, such as builds, scans, watch commands, and log-follow commands. After starting, wait at least about 30 seconds before the first terminal_poll unless you have a strong reason to check sooner.",
-  {
-    sessionId: z.string().describe("The terminal session ID (from get_environment) to execute on."),
-    command: z.string().describe("The command to start in the target session."),
-  },
   async ({ sessionId, command }) => {
     const guardErr = guardWriteOperation(command, { skipBlocklist: true });
     if (guardErr) {
@@ -340,13 +342,8 @@ server.tool(
   },
 );
 
-server.tool(
+registerBuiltinTool(
   "terminal_poll",
-  "Poll a long-running Netcatty command that was started with terminal_start. Returns incremental output since the given offset and the current status. Use the returned nextOffset for the next poll. If outputTruncated is true, only the retained tail starting at outputBaseOffset is still available. Do not poll aggressively: wait at least about 30 seconds between polls unless the tool output explicitly justifies checking sooner. As soon as completed is true, stop polling and analyze the final result immediately.",
-  {
-    jobId: z.string().describe("The background job ID returned by terminal_start."),
-    offset: z.number().int().min(0).optional().describe("Character offset previously returned as nextOffset. Omit or use 0 on the first poll."),
-  },
   async ({ jobId, offset }) => {
     const result = await rpcCall("netcatty/jobPoll", { ...scopeParams, jobId, offset: offset || 0 });
     if (!result.ok) {
@@ -356,12 +353,8 @@ server.tool(
   },
 );
 
-server.tool(
+registerBuiltinTool(
   "terminal_stop",
-  "Stop a long-running Netcatty command that was started with terminal_start. This sends Ctrl+C to the running terminal job and returns its latest state.",
-  {
-    jobId: z.string().describe("The background job ID returned by terminal_start."),
-  },
   async ({ jobId }) => {
     const result = await rpcCall("netcatty/jobStop", { ...scopeParams, jobId });
     if (!result.ok) {

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -923,6 +923,15 @@ function createPreloadApi(ctx) {
   aiExec: async (sessionId, command, chatSessionId) => {
     return ipcRenderer.invoke("netcatty:ai:exec", { sessionId, command, chatSessionId });
   },
+  aiJobStart: async (sessionId, command, chatSessionId) => {
+    return ipcRenderer.invoke("netcatty:ai:job-start", { sessionId, command, chatSessionId });
+  },
+  aiJobPoll: async (jobId, offset, chatSessionId) => {
+    return ipcRenderer.invoke("netcatty:ai:job-poll", { jobId, offset, chatSessionId });
+  },
+  aiJobStop: async (jobId, chatSessionId) => {
+    return ipcRenderer.invoke("netcatty:ai:job-stop", { jobId, chatSessionId });
+  },
   aiCattyCancelExec: async (chatSessionId) => {
     return ipcRenderer.invoke("netcatty:ai:catty:cancel", { chatSessionId });
   },

--- a/infrastructure/ai/cattyAgent/executor.ts
+++ b/infrastructure/ai/cattyAgent/executor.ts
@@ -1,6 +1,9 @@
 import type { ToolCall, ToolResult, AIPermissionMode, WebSearchConfig } from '../types';
 import {
   executeTerminalExecute,
+  executeTerminalPoll,
+  executeTerminalStart,
+  executeTerminalStop,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
   executeWebSearch,
@@ -25,6 +28,29 @@ export interface NetcattyBridge {
     exitCode?: number;
     error?: string;
   }>;
+  aiJobStart?(
+    sessionId: string,
+    command: string,
+    chatSessionId?: string,
+  ): Promise<{
+    ok: boolean;
+    jobId?: string;
+    sessionId?: string;
+    status?: string;
+    startedAt?: number;
+    outputMode?: string;
+    recommendedPollIntervalMs?: number;
+    error?: string;
+  }>;
+  aiJobPoll?(
+    jobId: string,
+    offset?: number,
+    chatSessionId?: string,
+  ): Promise<Record<string, unknown> & { ok: boolean; error?: string }>;
+  aiJobStop?(
+    jobId: string,
+    chatSessionId?: string,
+  ): Promise<Record<string, unknown> & { ok: boolean; error?: string }>;
   /**
    * Cancel any in-flight Catty Agent command execution scoped to the
    * given chat session. Idempotent — safe to call when nothing is
@@ -112,6 +138,29 @@ export function createToolExecutor(
           const r = await executeTerminalExecute(deps, {
             sessionId: String(args.sessionId || ''),
             command: String(args.command || ''),
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_start': {
+          const r = await executeTerminalStart(deps, {
+            sessionId: String(args.sessionId || ''),
+            command: String(args.command || ''),
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_poll': {
+          const r = await executeTerminalPoll(deps, {
+            jobId: String(args.jobId || ''),
+            offset: Number(args.offset) || 0,
+          });
+          return toToolResult(toolCall.id, r);
+        }
+
+        case 'terminal_stop': {
+          const r = await executeTerminalStop(deps, {
+            jobId: String(args.jobId || ''),
           });
           return toToolResult(toolCall.id, r);
         }

--- a/infrastructure/ai/cattyAgent/systemPrompt.ts
+++ b/infrastructure/ai/cattyAgent/systemPrompt.ts
@@ -42,7 +42,7 @@ ${permissionRules}
 
 1. **Plan before acting.** When a task involves multiple steps, present a brief numbered plan to the user before executing.
 
-2. **Use the right tool.** For normal shell commands, use \`terminal_execute\` so you receive the command output. When operating on multiple sessions, call \`terminal_execute\` for each target session.
+2. **Use the right terminal tool.** Use \`terminal_execute\` for commands likely to finish within about 60 seconds. For builds, scans, log-following, watch commands, or anything likely to run longer, use \`terminal_start\`, then \`terminal_poll\` with the returned \`nextOffset\` until \`completed\` is true. Use \`terminal_stop\` only when you need to interrupt a started long-running command. When operating on multiple sessions, call the appropriate terminal tool for each target session.
 
 3. **Never execute dangerous commands.** Commands matching the blocklist (e.g. \`rm -rf /\`, \`mkfs\`, \`dd\` to disk devices, \`shutdown\`, fork bombs, recursive chmod 777 on root) are strictly forbidden and will be automatically denied. Do not attempt to bypass these restrictions.
 

--- a/infrastructure/ai/sdk/capabilityToolDefinitions.test.ts
+++ b/infrastructure/ai/sdk/capabilityToolDefinitions.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+
+import { getSharedBuiltinMcpToolDefinition } from './capabilityToolDefinitions';
+
+test('Catty SDK reads terminal tool schema from shared capability catalog', () => {
+  const definition = getSharedBuiltinMcpToolDefinition('terminal_execute', z);
+  assert.equal(definition.toolName, 'terminal_execute');
+  assert.match(definition.description, /short command/);
+
+  const schema = z.object(definition.inputSchema);
+  assert.deepEqual(
+    schema.parse({ sessionId: 'session-1', command: 'pwd' }),
+    { sessionId: 'session-1', command: 'pwd' },
+  );
+  assert.throws(() => schema.parse({ sessionId: 'session-1' }));
+});
+
+test('Catty SDK can read long-running terminal tool schema from shared catalog', () => {
+  const definition = getSharedBuiltinMcpToolDefinition('terminal_poll', z);
+  const schema = z.object(definition.inputSchema);
+
+  assert.deepEqual(schema.parse({ jobId: 'job-1' }), { jobId: 'job-1' });
+  assert.throws(() => schema.parse({ jobId: 'job-1', offset: -1 }));
+});

--- a/infrastructure/ai/sdk/capabilityToolDefinitions.ts
+++ b/infrastructure/ai/sdk/capabilityToolDefinitions.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod';
+import mcpAdapter from '@/electron/capabilities/adapters/mcpAdapter.cjs';
+
+type ZodShape = Record<string, z.ZodType<unknown>>;
+
+interface SharedMcpToolDefinition {
+  toolName: string;
+  description: string;
+  inputSchema: ZodShape;
+  implementationStatus?: string;
+}
+
+const { getMcpToolDefinition } = mcpAdapter as unknown as {
+  getMcpToolDefinition: (
+    toolName: string,
+    surface: string,
+    zod: typeof z,
+  ) => SharedMcpToolDefinition | null;
+};
+
+export function getSharedBuiltinMcpToolDefinition(
+  toolName: string,
+  zod: typeof z,
+): SharedMcpToolDefinition {
+  const definition = getMcpToolDefinition(toolName, 'builtin', zod);
+  if (!definition) {
+    throw new Error(`Missing builtin MCP capability definition for ${toolName}`);
+  }
+  if (definition.implementationStatus === 'not_implemented') {
+    throw new Error(`Builtin MCP capability ${definition.toolName} is marked not implemented`);
+  }
+  return definition;
+}

--- a/infrastructure/ai/sdk/tools.ts
+++ b/infrastructure/ai/sdk/tools.ts
@@ -6,6 +6,9 @@ import type { WebSearchConfig } from '../types';
 import { isWebSearchReady } from '../types';
 import {
   executeTerminalExecute,
+  executeTerminalPoll,
+  executeTerminalStart,
+  executeTerminalStop,
   executeWorkspaceGetInfo,
   executeWorkspaceGetSessionInfo,
   executeWebSearch,
@@ -16,6 +19,7 @@ import {
 import { requestApproval } from '../shared/approvalGate';
 import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
 import { truncateTextWithHeadAndTail } from '../requestPayloadCompression';
+import { getSharedBuiltinMcpToolDefinition } from './capabilityToolDefinitions';
 
 const MAX_LIVE_TERMINAL_STDOUT_CHARS = 24_000;
 const MAX_LIVE_TERMINAL_STDERR_CHARS = 12_000;
@@ -55,16 +59,15 @@ export function createCattyTools(
   chatSessionId?: string,
 ) {
   const deps: ToolDeps = { bridge, context, commandBlocklist, permissionMode, webSearchConfig, chatSessionId };
+  const terminalExecuteDefinition = getSharedBuiltinMcpToolDefinition('terminal_execute', z);
+  const terminalStartDefinition = getSharedBuiltinMcpToolDefinition('terminal_start', z);
+  const terminalPollDefinition = getSharedBuiltinMcpToolDefinition('terminal_poll', z);
+  const terminalStopDefinition = getSharedBuiltinMcpToolDefinition('terminal_stop', z);
 
   return {
     terminal_execute: tool({
-      description:
-        'Execute a shell command on the specified terminal session. ' +
-        "The command runs in the session's shell and output is returned when complete.",
-      inputSchema: z.object({
-        sessionId: z.string().describe('The terminal session ID to execute the command on.'),
-        command: z.string().describe('The shell command to execute in the target session.'),
-      }),
+      description: terminalExecuteDefinition.description,
+      inputSchema: z.object(terminalExecuteDefinition.inputSchema),
       // No needsApproval — approval is handled inside execute via the approval gate.
       execute: async ({ sessionId, command }, { toolCallId, abortSignal }) => {
         // Snap our place in the per-session execution queue *first*,
@@ -129,6 +132,49 @@ export function createCattyTools(
         } finally {
           slot.release();
         }
+      },
+    }),
+
+    terminal_start: tool({
+      description: terminalStartDefinition.description,
+      inputSchema: z.object(terminalStartDefinition.inputSchema),
+      execute: async ({ sessionId, command }, { toolCallId, abortSignal }) => {
+        const queueKey = `${chatSessionId ?? 'global'}:${sessionId}`;
+        const slot = reserveSessionSlot(queueKey);
+        try {
+          if (permissionMode === 'confirm') {
+            const approved = await requestApproval(toolCallId, 'terminal_start', { sessionId, command }, chatSessionId);
+            if (!approved) {
+              return { error: 'User denied command execution.' };
+            }
+          }
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          await slot.ready;
+          if (abortSignal?.aborted) {
+            return { error: 'Command cancelled before it could start.' };
+          }
+          return unwrap(await executeTerminalStart(deps, { sessionId, command }));
+        } finally {
+          slot.release();
+        }
+      },
+    }),
+
+    terminal_poll: tool({
+      description: terminalPollDefinition.description,
+      inputSchema: z.object(terminalPollDefinition.inputSchema),
+      execute: async ({ jobId, offset }) => {
+        return unwrap(await executeTerminalPoll(deps, { jobId, offset }));
+      },
+    }),
+
+    terminal_stop: tool({
+      description: terminalStopDefinition.description,
+      inputSchema: z.object(terminalStopDefinition.inputSchema),
+      execute: async ({ jobId }) => {
+        return unwrap(await executeTerminalStop(deps, { jobId }));
       },
     }),
 

--- a/infrastructure/ai/shared/toolExecutors.ts
+++ b/infrastructure/ai/shared/toolExecutors.ts
@@ -115,6 +115,82 @@ export async function executeTerminalExecute(
   };
 }
 
+export async function executeTerminalStart(
+  deps: ToolDeps,
+  args: { sessionId: string; command: string },
+): Promise<ToolExecResult<{
+  jobId?: string;
+  sessionId?: string;
+  status?: string;
+  startedAt?: number;
+  outputMode?: string;
+  recommendedPollIntervalMs?: number;
+}>> {
+  const { bridge, context, permissionMode } = deps;
+  const { sessionId, command } = args;
+
+  if (!sessionId || !command) {
+    return { ok: false, error: 'Missing sessionId or command' };
+  }
+  const scopeErr = validateSessionScope(context, sessionId);
+  if (scopeErr) return { ok: false, error: scopeErr };
+  if (isObserver(permissionMode)) {
+    return { ok: false, error: 'Observer mode: command execution is disabled. Switch to Confirm or Auto mode to execute commands.' };
+  }
+  if (!bridge.aiJobStart) {
+    return { ok: false, error: 'terminal_start is not available on the Netcatty bridge' };
+  }
+
+  const result = await bridge.aiJobStart(sessionId, command, deps.chatSessionId);
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'Failed to start long-running command' };
+  }
+  return { ok: true, data: result };
+}
+
+export async function executeTerminalPoll(
+  deps: ToolDeps,
+  args: { jobId: string; offset?: number },
+): Promise<ToolExecResult<Record<string, unknown>>> {
+  const { bridge } = deps;
+  const { jobId } = args;
+
+  if (!jobId) {
+    return { ok: false, error: 'Missing jobId' };
+  }
+  if (!bridge.aiJobPoll) {
+    return { ok: false, error: 'terminal_poll is not available on the Netcatty bridge' };
+  }
+
+  const offset = Number.isFinite(args.offset) && (args.offset ?? 0) >= 0 ? args.offset : 0;
+  const result = await bridge.aiJobPoll(jobId, offset, deps.chatSessionId);
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'Failed to poll long-running command' };
+  }
+  return { ok: true, data: result };
+}
+
+export async function executeTerminalStop(
+  deps: ToolDeps,
+  args: { jobId: string },
+): Promise<ToolExecResult<Record<string, unknown>>> {
+  const { bridge } = deps;
+  const { jobId } = args;
+
+  if (!jobId) {
+    return { ok: false, error: 'Missing jobId' };
+  }
+  if (!bridge.aiJobStop) {
+    return { ok: false, error: 'terminal_stop is not available on the Netcatty bridge' };
+  }
+
+  const result = await bridge.aiJobStop(jobId, deps.chatSessionId);
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'Failed to stop long-running command' };
+  }
+  return { ok: true, data: result };
+}
+
 export function executeWorkspaceGetInfo(
   deps: ToolDeps,
 ): ToolExecResult<{

--- a/types/global/netcatty-bridge-ai.d.ts
+++ b/types/global/netcatty-bridge-ai.d.ts
@@ -8,6 +8,9 @@ declare global {
     aiFetch?(url: string, method?: string, headers?: Record<string, string>, body?: string, providerId?: string, skipHostCheck?: boolean, followRedirects?: boolean, skipTLSVerify?: boolean): Promise<{ ok: boolean; status?: number; data: string; error?: string }>;
     aiAllowlistAddHost?(baseURL: string): Promise<{ ok: boolean; error?: string }>;
     aiExec?(sessionId: string, command: string, chatSessionId?: string): Promise<{ ok: boolean; stdout?: string; stderr?: string; exitCode?: number | null; error?: string }>;
+    aiJobStart?(sessionId: string, command: string, chatSessionId?: string): Promise<{ ok: boolean; jobId?: string; sessionId?: string; status?: string; startedAt?: number; outputMode?: string; recommendedPollIntervalMs?: number; error?: string }>;
+    aiJobPoll?(jobId: string, offset?: number, chatSessionId?: string): Promise<{ ok: boolean; jobId?: string; sessionId?: string; status?: string; output?: string; nextOffset?: number; completed?: boolean; exitCode?: number | null; error?: string; outputTruncated?: boolean; outputBaseOffset?: number }>;
+    aiJobStop?(jobId: string, chatSessionId?: string): Promise<{ ok: boolean; jobId?: string; sessionId?: string; status?: string; output?: string; nextOffset?: number; completed?: boolean; exitCode?: number | null; error?: string; outputTruncated?: boolean; outputBaseOffset?: number }>;
     aiCattyCancelExec?(chatSessionId: string): Promise<{ ok: boolean; error?: string }>;
     aiDiscoverAgents?(options?: { refreshShellEnv?: boolean; apiKeyPresent?: boolean }): Promise<Array<{
       command: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- derive MCP terminal tool descriptions and zod schemas from the capability catalog
- expose shared terminal schemas to Catty and add Catty terminal_start/poll/stop tools
- mark future public SFTP MCP surfaces as explicitly not implemented in catalog metadata

## Validation
- `node --test --import tsx "electron/capabilities/adapters/mcpAdapter.test.cjs" "electron/capabilities/adapters/cliAdapter.test.cjs" "electron/cli/netcatty-tool-cli.capabilities.test.cjs" "infrastructure/ai/sdk/capabilityToolDefinitions.test.ts" "electron/bridges/mcpServerBridge.attachments.test.cjs"`
- `npm run lint`
- `npm run build`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3db67a2-7149-4a59-84ba-232ede48c87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3db67a2-7149-4a59-84ba-232ede48c87c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

