### PR TITLE
Define unified agent event trace

### DIFF
--- a/application/state/aiStateSnapshots.ts
+++ b/application/state/aiStateSnapshots.ts
@@ -3,6 +3,10 @@ import {
   STORAGE_KEY_AI_ACTIVE_SESSION_MAP,
   STORAGE_KEY_AI_SESSIONS,
 } from '../../infrastructure/config/storageKeys';
+import {
+  DEFAULT_MAX_AGENT_TRACE_EVENTS,
+  trimAgentTrace,
+} from '../../infrastructure/ai/traceStore';
 import type {
   AIDraft,
   AIPanelView,
@@ -160,6 +164,8 @@ export function cleanupOrphanedAISessions(activeTargetIds: Set<string>) {
 const MAX_STORED_SESSIONS = 50;
 /** Maximum number of messages per session when persisting to localStorage. */
 const MAX_SESSION_MESSAGES = 200;
+/** Maximum number of trace events per session when persisting to localStorage. */
+const MAX_SESSION_TRACE_EVENTS = DEFAULT_MAX_AGENT_TRACE_EVENTS;
 
 /**
  * Prune sessions before writing to localStorage to prevent hitting the
@@ -174,10 +180,15 @@ export function pruneSessionsForStorage(sessions: AISession[]): AISession[] {
   const sorted = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
   const limited = sorted.slice(0, MAX_STORED_SESSIONS);
   return limited.map(s => {
-    if (s.messages.length > MAX_SESSION_MESSAGES) {
-      return { ...s, messages: s.messages.slice(-MAX_SESSION_MESSAGES) };
-    }
-    return s;
+    const messages = s.messages.length > MAX_SESSION_MESSAGES
+      ? s.messages.slice(-MAX_SESSION_MESSAGES)
+      : s.messages;
+    const trace = s.trace?.length
+      ? trimAgentTrace(s.trace, MAX_SESSION_TRACE_EVENTS)
+      : s.trace;
+    return messages !== s.messages || trace !== s.trace
+      ? { ...s, messages, trace }
+      : s;
   });
 }
 

--- a/application/state/useAIState.ts
+++ b/application/state/useAIState.ts
@@ -21,6 +21,11 @@ import {
 } from '../../infrastructure/config/storageKeys';
 import type { AIQuickMessage } from '../../infrastructure/ai/quickMessages';
 import { sanitizeQuickMessages } from '../../infrastructure/ai/quickMessages';
+import type { AgentEvent } from '../../infrastructure/ai/agentEvent';
+import {
+  appendAgentEvent,
+  DEFAULT_MAX_AGENT_TRACE_EVENTS,
+} from '../../infrastructure/ai/traceStore';
 import type {
   AIDraft,
   AISession,
@@ -724,6 +729,22 @@ export function useAIState() {
     });
   }, [debouncedPersistSessions]);
 
+  const appendAgentEventToSession = useCallback((sessionId: string, event: AgentEvent) => {
+    setSessionsRaw(prev => {
+      const next = prev.map(s => {
+        if (s.id !== sessionId) return s;
+        return {
+          ...s,
+          trace: appendAgentEvent(s.trace, event, DEFAULT_MAX_AGENT_TRACE_EVENTS),
+          updatedAt: Date.now(),
+        };
+      });
+      setLatestAISessionsSnapshot(next);
+      debouncedPersistSessions();
+      return next;
+    });
+  }, [debouncedPersistSessions]);
+
   const updateLastMessage = useCallback((sessionId: string, updater: (msg: ChatMessage) => ChatMessage) => {
     setSessionsRaw(prev => {
       const next = prev.map(s => {
@@ -760,7 +781,7 @@ export function useAIState() {
       persistTimerRef.current = null;
     }
     setSessionsRaw(prev => {
-      const next = prev.map(s => s.id === sessionId ? { ...s, messages: [], updatedAt: Date.now() } : s);
+      const next = prev.map(s => s.id === sessionId ? { ...s, messages: [], trace: [], updatedAt: Date.now() } : s);
       setLatestAISessionsSnapshot(next);
       persistSessions(next);
       return next;
@@ -1046,6 +1067,7 @@ export function useAIState() {
     updateSessionTitle,
     updateSessionExternalSessionId,
     addMessageToSession,
+    appendAgentEventToSession,
     updateLastMessage,
     updateMessageById,
     clearSessionMessages,
@@ -1103,6 +1125,7 @@ export function useAIState() {
     updateSessionTitle,
     updateSessionExternalSessionId,
     addMessageToSession,
+    appendAgentEventToSession,
     updateLastMessage,
     updateMessageById,
     clearSessionMessages,

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -239,6 +239,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   updateSessionTitle,
   updateSessionExternalSessionId,
   addMessageToSession,
+  appendAgentEventToSession,
   updateLastMessage,
   updateMessageById,
   providers,
@@ -289,6 +290,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   } = useAIChatStreaming({
     maxIterations,
     addMessageToSession,
+    appendAgentEventToSession,
     updateLastMessage,
     updateMessageById,
   });
@@ -1149,6 +1151,7 @@ const AI_CHAT_SIDE_PANEL_AI_STATE_KEYS = [
   'updateSessionTitle',
   'updateSessionExternalSessionId',
   'addMessageToSession',
+  'appendAgentEventToSession',
   'updateLastMessage',
   'updateMessageById',
   'providers',

--- a/components/AIChatSidePanel.types.ts
+++ b/components/AIChatSidePanel.types.ts
@@ -11,6 +11,7 @@ import type {
   WebSearchConfig,
 } from '../infrastructure/ai/types';
 import type { AIQuickMessage } from '../infrastructure/ai/quickMessages';
+import type { AgentEvent } from '../infrastructure/ai/agentEvent';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
 
 // -------------------------------------------------------------------
@@ -40,6 +41,7 @@ export interface AIChatSidePanelProps {
   updateSessionTitle: (sessionId: string, title: string) => void;
   updateSessionExternalSessionId: (sessionId: string, externalSessionId: string | undefined) => void;
   addMessageToSession: (sessionId: string, message: ChatMessage) => void;
+  appendAgentEventToSession: (sessionId: string, event: AgentEvent) => void;
   updateLastMessage: (
     sessionId: string,
     updater: (msg: ChatMessage) => ChatMessage,

--- a/components/ai/hooks/useAIChatStreaming.ts
+++ b/components/ai/hooks/useAIChatStreaming.ts
@@ -39,6 +39,8 @@ import {
 import {
   compressMessagesForRequestTooLargeRetry,
 } from '../../../infrastructure/ai/requestPayloadCompression';
+import type { AgentEvent, AgentEventContext } from '../../../infrastructure/ai/agentEvent';
+import { createAgentEvent, createAgentEventFromContext } from '../../../infrastructure/ai/agentEvent';
 import {
   createCattyRequestTooLargeRetryError,
   hadToolProgressBeforeRequestTooLarge,
@@ -50,6 +52,7 @@ import { getExternalAgentSdkBackend } from '../../../infrastructure/ai/managedAg
 import { runSdkAgentTurn } from '../../../infrastructure/ai/sdkAgentAdapter';
 import { classifyError, isRequestTooLargeError } from '../../../infrastructure/ai/errorClassifier';
 import { isSdkStreamStateError } from '../../../infrastructure/ai/shared/streamStateErrors';
+import { onApprovalTraceEvent } from '../../../infrastructure/ai/shared/approvalGate';
 import {
   buildPromptWithTerminalSelectionAttachments,
   isTerminalSelectionAttachment,
@@ -163,6 +166,7 @@ function collectOpenAIChatAssistantFieldsForMessages(
 export interface UseAIChatStreamingParams {
   maxIterations: number;
   addMessageToSession: (sessionId: string, message: ChatMessage) => void;
+  appendAgentEventToSession: (sessionId: string, event: AgentEvent) => void;
   updateLastMessage: (sessionId: string, updater: (msg: ChatMessage) => ChatMessage) => void;
   updateMessageById: (sessionId: string, messageId: string, updater: (msg: ChatMessage) => ChatMessage) => void;
 }
@@ -189,6 +193,7 @@ export interface UseAIChatStreamingReturn {
     currentAssistantMsgId: string,
     advancedParams?: ProviderAdvancedParams,
     continuationContext?: CattyProviderContinuationContext,
+    turnId?: string,
   ) => Promise<void>;
   /** Send a message to the Catty agent (built-in). */
   sendToCattyAgent: (
@@ -251,6 +256,7 @@ export interface SendToExternalContext {
 export function useAIChatStreaming({
   maxIterations,
   addMessageToSession,
+  appendAgentEventToSession,
   updateLastMessage,
   updateMessageById,
 }: UseAIChatStreamingParams): UseAIChatStreamingReturn {
@@ -258,6 +264,12 @@ export function useAIChatStreaming({
   const [streamingSessionIds, setStreamingSessions] = useState<Set<string>>(
     () => new Set(sharedStreamingSessionIds),
   );
+
+  const appendTraceEvent = useCallback((event: AgentEvent) => {
+    appendAgentEventToSession(event.sessionId, event);
+  }, [appendAgentEventToSession]);
+
+  useEffect(() => onApprovalTraceEvent(appendTraceEvent), [appendTraceEvent]);
   useEffect(() => {
     const syncFromStore = () => {
       setStreamingSessions(new Set(sharedStreamingSessionIds));
@@ -329,7 +341,15 @@ export function useAIChatStreaming({
     currentAssistantMsgId: string,
     advancedParams?: ProviderAdvancedParams,
     continuationContext?: CattyProviderContinuationContext,
+    turnId?: string,
   ): Promise<void> => {
+    const traceContext: AgentEventContext = {
+      sessionId: streamSessionId,
+      turnId,
+      source: 'catty',
+      model: continuationContext?.source.modelId,
+      providerId: continuationContext?.source.providerType,
+    };
     const result = streamText({
       model,
       messages: sdkMessages,
@@ -448,6 +468,11 @@ export function useAIChatStreaming({
             updateAssistantContinuation(messageId, { textProviderOptions: providerOptions });
           }
           if (text) {
+            appendTraceEvent(createAgentEventFromContext(traceContext, {
+              type: 'model_delta',
+              delta: text,
+              messageId: activeMsgId,
+            }));
             pendingText += text;
             if (rafId === null) {
               rafId = requestAnimationFrame(flushText);
@@ -473,6 +498,21 @@ export function useAIChatStreaming({
             : undefined;
           if (continuation || rText) {
             const messageId = ensureAssistantMessage();
+            if (rText) {
+              appendTraceEvent(createAgentEventFromContext(traceContext, {
+                type: 'reasoning_delta',
+                delta: rText,
+                phase: chunk.type === 'reasoning-start' ? 'start' : 'delta',
+                messageId,
+              }));
+            } else if (chunk.type === 'reasoning-start') {
+              appendTraceEvent(createAgentEventFromContext(traceContext, {
+                type: 'reasoning_delta',
+                delta: '',
+                phase: 'start',
+                messageId,
+              }));
+            }
             updateAssistantContinuation(messageId, continuation, rText);
           }
           break;
@@ -489,13 +529,38 @@ export function useAIChatStreaming({
           break;
         }
         case 'reasoning-end':
+          appendTraceEvent(createAgentEventFromContext(traceContext, {
+            type: 'reasoning_delta',
+            delta: '',
+            phase: 'end',
+            messageId: activeMsgId,
+          }));
+          break;
         case 'text-start':
         case 'text-end':
         case 'start':
-        case 'finish':
         case 'start-step':
         case 'finish-step':
           break;
+        case 'finish': {
+          const usage = (chunk as { usage?: {
+            inputTokens?: number;
+            outputTokens?: number;
+            totalTokens?: number;
+            promptTokens?: number;
+            completionTokens?: number;
+          } }).usage;
+          if (usage) {
+            appendTraceEvent(createAgentEventFromContext(traceContext, {
+              type: 'usage',
+              promptTokens: usage.promptTokens ?? usage.inputTokens,
+              completionTokens: usage.completionTokens ?? usage.outputTokens,
+              totalTokens: usage.totalTokens,
+              raw: usage,
+            }));
+          }
+          break;
+        }
         case 'tool-call': {
           cancelPendingFlush();
           flushText();
@@ -503,6 +568,13 @@ export function useAIChatStreaming({
           hadToolProgress = true;
           const messageId = ensureAssistantMessage();
           const providerOptions = normalizeProviderContinuationOptions(typedChunk.providerMetadata);
+          appendTraceEvent(createAgentEventFromContext(traceContext, {
+            type: 'tool_call',
+            toolCallId: typedChunk.toolCallId,
+            toolName: typedChunk.toolName,
+            args: (typedChunk.input ?? typedChunk.args) as Record<string, unknown>,
+            messageId,
+          }));
           updateMessageById(streamSessionId, messageId, msg => ({
             ...msg,
             toolCalls: [...(msg.toolCalls || []), {
@@ -534,6 +606,14 @@ export function useAIChatStreaming({
           );
           const toolOutput = typedChunk.output ?? typedChunk.result;
           const toolError = isToolResultError(toolOutput);
+          appendTraceEvent(createAgentEventFromContext(traceContext, {
+            type: 'tool_result',
+            toolCallId: typedChunk.toolCallId,
+            output: typeof toolOutput === 'string'
+              ? toolOutput
+              : JSON.stringify(toolOutput),
+            isError: toolError,
+          }));
           addMessageToSession(streamSessionId, {
             id: generateId(),
             role: 'tool',
@@ -583,6 +663,12 @@ export function useAIChatStreaming({
           }
           cancelPendingFlush();
           flushText();
+          appendTraceEvent(createAgentEventFromContext(traceContext, {
+            type: 'error',
+            error: classifyError(typedChunk.error).message,
+            retryable: classifyError(typedChunk.error).retryable,
+            errorKind: classifyError(typedChunk.error).type,
+          }));
           updateMessageById(streamSessionId, activeMsgId, msg => ({
             ...msg,
             statusText: '',
@@ -610,7 +696,7 @@ export function useAIChatStreaming({
       reader.releaseLock();
     }
     return;
-  }, [maxIterations, addMessageToSession, updateMessageById]);
+  }, [maxIterations, addMessageToSession, updateMessageById, appendTraceEvent]);
 
   // -------------------------------------------------------------------
   // sendToExternalAgent
@@ -632,6 +718,22 @@ export function useAIChatStreaming({
     );
 
     const sdkBackend = getExternalAgentSdkBackend(agentConfig);
+    const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const turnStartedAt = Date.now();
+    appendTraceEvent(createAgentEvent({
+      type: 'turn_start',
+      sessionId,
+      turnId,
+      source: 'external_sdk',
+      agentId: agentConfig.id,
+      backend: sdkBackend,
+      model: context.selectedAgentModel || agentConfig.name || 'external',
+      prompt: trimmed,
+      attachments: attachedImages.map(attachment => ({
+        filename: attachment.filename,
+        mediaType: attachment.mediaType,
+      })),
+    }));
     if (sdkBackend && bridge) {
       const requestId = `sdk_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
 
@@ -651,14 +753,38 @@ export function useAIChatStreaming({
           });
         }
       };
+      let sawErrorEvent = false;
+      let turnEnded = false;
+      const endTurn = (status: Extract<AgentEvent, { type: 'turn_end' }>['status']) => {
+        if (turnEnded) return;
+        turnEnded = true;
+        appendTraceEvent(createAgentEvent({
+          type: 'turn_end',
+          sessionId,
+          turnId,
+          source: 'external_sdk',
+          requestId,
+          backend: sdkBackend,
+          model: context.selectedAgentModel,
+          status,
+          durationMs: Date.now() - turnStartedAt,
+        }));
+      };
 
-      await runSdkAgentTurn(
-        bridge,
-        requestId,
-        sessionId,
-        agentConfig,
-        trimmed,
-        {
+      try {
+        await runSdkAgentTurn(
+          bridge,
+          requestId,
+          sessionId,
+          agentConfig,
+          trimmed,
+          {
+          onAgentEvent: (event) => {
+            if (event.type === 'error') {
+              sawErrorEvent = true;
+            }
+            appendTraceEvent(event);
+          },
           onTextDelta: (text: string) => {
             maybeCreateAssistantMsg();
             updateLastMessage(sessionId, msg => ({
@@ -715,35 +841,92 @@ export function useAIChatStreaming({
             context.updateExternalSessionId?.(sessionId, externalSessionId);
           },
           onError: (error: string) => {
+            if (!sawErrorEvent) {
+              appendTraceEvent(createAgentEvent({
+                type: 'error',
+                sessionId,
+                turnId,
+                source: 'external_sdk',
+                requestId,
+                backend: sdkBackend,
+                model: context.selectedAgentModel,
+                error,
+                errorKind: 'agent',
+              }));
+            }
+            endTurn('error');
             reportStreamError(sessionId, abortController.signal, error);
             setStreamingForScope(sessionId, false);
           },
-          onDone: () => {},
-        },
-        abortController.signal,
-        // Managed SDK agents (codex, claude) must resolve auth from their own
-        // CLI config/login state, so we deliberately pass no providerId here.
-        // See issue #705 for Codex; same reasoning for Claude.
-        undefined,
-        context.selectedAgentModel,
-        context.existingSessionId,
-        context.historyMessages,
-        attachedImages.length > 0 ? attachedImages : undefined,
-        context.toolIntegrationMode,
-        context.defaultTargetSession,
-        userSkillsContext,
-      );
+          onDone: () => {
+            endTurn(abortController.signal.aborted ? 'aborted' : 'completed');
+          },
+          },
+          abortController.signal,
+          // Managed SDK agents (codex, claude) must resolve auth from their own
+          // CLI config/login state, so we deliberately pass no providerId here.
+          // See issue #705 for Codex; same reasoning for Claude.
+          undefined,
+          context.selectedAgentModel,
+          context.existingSessionId,
+          context.historyMessages,
+          attachedImages.length > 0 ? attachedImages : undefined,
+          context.toolIntegrationMode,
+          context.defaultTargetSession,
+          userSkillsContext,
+          turnId,
+        );
+      } catch (err) {
+        const errorInfo = classifyError(err);
+        if (!sawErrorEvent) {
+          appendTraceEvent(createAgentEvent({
+            type: 'error',
+            sessionId,
+            turnId,
+            source: 'external_sdk',
+            requestId,
+            backend: sdkBackend,
+            model: context.selectedAgentModel,
+            error: errorInfo.message,
+            retryable: errorInfo.retryable,
+            errorKind: errorInfo.type,
+          }));
+        }
+        endTurn(abortController.signal.aborted ? 'aborted' : 'error');
+        throw err;
+      }
     } else {
+      const error = 'This agent has no SDK backend configured. Re-discover it in Settings -> AI.';
+      appendTraceEvent(createAgentEvent({
+        type: 'error',
+        sessionId,
+        turnId,
+        source: 'external_sdk',
+        backend: sdkBackend,
+        model: context.selectedAgentModel,
+        error,
+        errorKind: 'agent',
+      }));
+      appendTraceEvent(createAgentEvent({
+        type: 'turn_end',
+        sessionId,
+        turnId,
+        source: 'external_sdk',
+        backend: sdkBackend,
+        model: context.selectedAgentModel,
+        status: 'error',
+        durationMs: Date.now() - turnStartedAt,
+      }));
       // Managed agents always route through the SDK path above.
       reportStreamError(
         sessionId,
         abortController.signal,
-        'This agent has no SDK backend configured. Re-discover it in Settings -> AI.',
+        error,
       );
       setStreamingForScope(sessionId, false);
     }
   }, [
-    addMessageToSession, updateLastMessage, setStreamingForScope, reportStreamError,
+    addMessageToSession, updateLastMessage, setStreamingForScope, reportStreamError, appendTraceEvent,
   ]);
 
   // -------------------------------------------------------------------
@@ -803,6 +986,30 @@ export function useAIChatStreaming({
     }
 
     const activeModelId = context.activeModelId || context.activeProvider.defaultModel || '';
+    const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const turnStartedAt = Date.now();
+    let turnStatus: Extract<AgentEvent, { type: 'turn_end' }>['status'] = 'completed';
+    appendTraceEvent(createAgentEvent({
+      type: 'turn_start',
+      sessionId,
+      turnId,
+      source: 'catty',
+      agentId: 'catty',
+      model: activeModelId,
+      providerId: context.activeProvider.providerId,
+      prompt: trimmed,
+      attachments: attachments?.map(attachment => ({
+        filename: attachment.filename,
+        mediaType: attachment.mediaType,
+        terminalSelection: attachment.terminalSelection,
+        lineCount: attachment.lineCount,
+      })),
+      scope: {
+        type: context.scopeType,
+        targetId: context.scopeTargetId,
+        label: context.scopeLabel,
+      },
+    }));
     const continuationContext: CattyProviderContinuationContext = {
       source: {
         providerConfigId: context.activeProvider.id,
@@ -1075,7 +1282,20 @@ export function useAIChatStreaming({
           if (statusText) {
             updateLastMessage(sessionId, msg => ({ ...msg, statusText }));
           }
+          const compactionReason: Extract<AgentEvent, { type: 'compaction' }>['reason'] =
+            force || compressForRequestTooLargeRetry ? 'request_too_large' : 'threshold';
           const inputMessages = compressRetryMessages(messages, compressionLog);
+          appendTraceEvent(createAgentEvent({
+            type: 'compaction',
+            sessionId,
+            turnId,
+            source: 'catty',
+            model: activeModelId,
+            providerId: context.activeProvider?.providerId,
+            phase: 'start',
+            reason: compactionReason,
+            messagesBefore: inputMessages.length,
+          }));
           const compacted = await prepareContextCompaction({
             messages: inputMessages,
             contextWindow,
@@ -1087,10 +1307,35 @@ export function useAIChatStreaming({
           let nextMessages = force && !compacted.didCompact
             ? keepRecentContextMessages(inputMessages, DEFAULT_PROTECT_RECENT_MESSAGES)
             : compacted.messages;
+          appendTraceEvent(createAgentEvent({
+            type: 'compaction',
+            sessionId,
+            turnId,
+            source: 'catty',
+            model: activeModelId,
+            providerId: context.activeProvider?.providerId,
+            phase: 'end',
+            reason: compactionReason,
+            messagesBefore: inputMessages.length,
+            messagesAfter: nextMessages.length,
+            didCompact: compacted.didCompact || (force && !compacted.didCompact),
+          }));
           return compressRetryMessages(nextMessages);
         } catch (err) {
           if (abortController.signal.aborted) throw err;
           console.warn(fallbackLog, err);
+          appendTraceEvent(createAgentEvent({
+            type: 'compaction',
+            sessionId,
+            turnId,
+            source: 'catty',
+            model: activeModelId,
+            providerId: context.activeProvider?.providerId,
+            phase: 'error',
+            reason: force || compressForRequestTooLargeRetry ? 'request_too_large' : 'threshold',
+            messagesBefore: messages.length,
+            error: err instanceof Error ? err.message : String(err),
+          }));
           const fallbackMessages = keepRecentContextMessages(messages, DEFAULT_PROTECT_RECENT_MESSAGES);
           if (!compressForRequestTooLargeRetry) {
             return fallbackMessages;
@@ -1120,6 +1365,7 @@ export function useAIChatStreaming({
           assistantMsgId,
           context.activeProvider?.advancedParams,
           continuationContext,
+          turnId,
         );
       } catch (streamErr) {
         if (abortController.signal.aborted || !isRequestTooLargeError(streamErr)) {
@@ -1183,12 +1429,39 @@ export function useAIChatStreaming({
           retryAssistantMsgId,
           context.activeProvider?.advancedParams,
           continuationContext,
+          turnId,
         );
       }
     } catch (err) {
       console.error('[Catty] streamText error:', err);
+      turnStatus = abortController.signal.aborted ? 'aborted' : 'error';
+      const errorInfo = classifyError(err);
+      appendTraceEvent(createAgentEvent({
+        type: 'error',
+        sessionId,
+        turnId,
+        source: 'catty',
+        model: activeModelId,
+        providerId: context.activeProvider?.providerId,
+        error: errorInfo.message,
+        retryable: errorInfo.retryable,
+        errorKind: errorInfo.type,
+      }));
       reportStreamError(sessionId, abortController.signal, err);
     } finally {
+      if (abortController.signal.aborted) {
+        turnStatus = 'aborted';
+      }
+      appendTraceEvent(createAgentEvent({
+        type: 'turn_end',
+        sessionId,
+        turnId,
+        source: 'catty',
+        model: activeModelId,
+        providerId: context.activeProvider?.providerId,
+        status: turnStatus,
+        durationMs: Date.now() - turnStartedAt,
+      }));
       // Clear any lingering statusText when the stream finishes
       updateLastMessage(sessionId, msg => msg.statusText ? { ...msg, statusText: '' } : msg);
       setStreamingForScope(sessionId, false);
@@ -1198,6 +1471,7 @@ export function useAIChatStreaming({
   }, [
     processCattyStream, reportStreamError, setStreamingForScope,
     addMessageToSession, updateLastMessage, updateMessageById,
+    appendTraceEvent,
   ]);
 
   return {

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -485,6 +485,7 @@ const AIChatPanelsHostInner: React.FC<AIChatPanelsHostProps> = ({
                     updateSessionTitle={aiState.updateSessionTitle}
                     updateSessionExternalSessionId={aiState.updateSessionExternalSessionId}
                     addMessageToSession={aiState.addMessageToSession}
+                    appendAgentEventToSession={aiState.appendAgentEventToSession}
                     updateLastMessage={aiState.updateLastMessage}
                     updateMessageById={aiState.updateMessageById}
                     providers={aiState.providers}

--- a/infrastructure/ai/agentEvent.ts
+++ b/infrastructure/ai/agentEvent.ts
@@ -1,0 +1,258 @@
+import type { AIProviderId, ChatMessageAttachment } from './types';
+
+export type AgentEventType =
+  | 'turn_start'
+  | 'model_delta'
+  | 'reasoning_delta'
+  | 'tool_call'
+  | 'tool_result'
+  | 'approval_requested'
+  | 'approval_resolved'
+  | 'compaction'
+  | 'usage'
+  | 'error'
+  | 'turn_end';
+
+export type AgentEventSource = 'catty' | 'external_sdk' | 'mcp' | 'skills' | 'system';
+
+export interface AgentEventBase {
+  id: string;
+  type: AgentEventType;
+  sessionId: string;
+  turnId?: string;
+  timestamp: number;
+  source: AgentEventSource;
+  requestId?: string;
+  backend?: string;
+  model?: string;
+  providerId?: AIProviderId | string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TurnStartAgentEvent extends AgentEventBase {
+  type: 'turn_start';
+  agentId: string;
+  prompt: string;
+  attachments?: Array<Pick<ChatMessageAttachment, 'filename' | 'mediaType' | 'terminalSelection' | 'lineCount'>>;
+  scope?: {
+    type: 'terminal' | 'workspace' | 'global';
+    targetId?: string;
+    label?: string;
+  };
+}
+
+export interface ModelDeltaAgentEvent extends AgentEventBase {
+  type: 'model_delta';
+  delta: string;
+  messageId?: string;
+}
+
+export interface ReasoningDeltaAgentEvent extends AgentEventBase {
+  type: 'reasoning_delta';
+  delta: string;
+  phase?: 'start' | 'delta' | 'end';
+  messageId?: string;
+}
+
+export interface ToolCallAgentEvent extends AgentEventBase {
+  type: 'tool_call';
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  messageId?: string;
+}
+
+export interface ToolResultAgentEvent extends AgentEventBase {
+  type: 'tool_result';
+  toolCallId: string;
+  toolName?: string;
+  output: string;
+  isError?: boolean;
+}
+
+export interface ApprovalRequestedAgentEvent extends AgentEventBase {
+  type: 'approval_requested';
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+export interface ApprovalResolvedAgentEvent extends AgentEventBase {
+  type: 'approval_resolved';
+  approvalId: string;
+  toolCallId: string;
+  approved: boolean;
+  resolution: 'approved' | 'denied' | 'timeout' | 'cleared' | 'cancelled';
+}
+
+export interface CompactionAgentEvent extends AgentEventBase {
+  type: 'compaction';
+  phase: 'start' | 'end' | 'error';
+  reason: 'threshold' | 'request_too_large' | 'fallback' | 'manual';
+  messagesBefore?: number;
+  messagesAfter?: number;
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  didCompact?: boolean;
+  summary?: string;
+  error?: string;
+}
+
+export interface UsageAgentEvent extends AgentEventBase {
+  type: 'usage';
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  raw?: unknown;
+}
+
+export interface ErrorAgentEvent extends AgentEventBase {
+  type: 'error';
+  error: string;
+  retryable?: boolean;
+  errorKind?: string;
+}
+
+export interface TurnEndAgentEvent extends AgentEventBase {
+  type: 'turn_end';
+  status: 'completed' | 'error' | 'aborted' | 'cancelled';
+  durationMs?: number;
+}
+
+export type AgentEvent =
+  | TurnStartAgentEvent
+  | ModelDeltaAgentEvent
+  | ReasoningDeltaAgentEvent
+  | ToolCallAgentEvent
+  | ToolResultAgentEvent
+  | ApprovalRequestedAgentEvent
+  | ApprovalResolvedAgentEvent
+  | CompactionAgentEvent
+  | UsageAgentEvent
+  | ErrorAgentEvent
+  | TurnEndAgentEvent;
+
+export type NewAgentEvent<T extends AgentEventType = AgentEventType> =
+  Omit<Extract<AgentEvent, { type: T }>, 'id' | 'timestamp'> & {
+    id?: string;
+    timestamp?: number;
+  };
+
+export interface AgentEventContext {
+  sessionId: string;
+  turnId?: string;
+  source: AgentEventSource;
+  requestId?: string;
+  backend?: string;
+  model?: string;
+  providerId?: AIProviderId | string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SdkStreamEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export function createAgentEvent<T extends AgentEventType>(
+  event: NewAgentEvent<T>,
+): Extract<AgentEvent, { type: T }> {
+  return {
+    ...event,
+    id: event.id ?? `agent-event-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: event.timestamp ?? Date.now(),
+  } as Extract<AgentEvent, { type: T }>;
+}
+
+export function createAgentEventFromContext<T extends AgentEventType>(
+  context: AgentEventContext,
+  event: Omit<NewAgentEvent<T>, keyof AgentEventContext>,
+): Extract<AgentEvent, { type: T }> {
+  return createAgentEvent({
+    ...context,
+    ...event,
+  } as NewAgentEvent<T>);
+}
+
+function stringifySdkOutput(output: unknown): string {
+  if (typeof output === 'string') return output;
+  if (output == null) return '';
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
+export function normalizeSdkStreamEventToAgentEvents(
+  event: SdkStreamEvent,
+  context: AgentEventContext,
+): AgentEvent[] {
+  switch (event.type) {
+    case 'text-delta': {
+      const delta = (event.textDelta as string) || (event.delta as string) || '';
+      return delta
+        ? [createAgentEventFromContext(context, { type: 'model_delta', delta })]
+        : [];
+    }
+    case 'reasoning-start':
+      return [createAgentEventFromContext(context, { type: 'reasoning_delta', delta: '', phase: 'start' })];
+    case 'reasoning-delta': {
+      const delta = (event.delta as string) || '';
+      return delta
+        ? [createAgentEventFromContext(context, { type: 'reasoning_delta', delta, phase: 'delta' })]
+        : [];
+    }
+    case 'reasoning-end':
+      return [createAgentEventFromContext(context, { type: 'reasoning_delta', delta: '', phase: 'end' })];
+    case 'tool-call': {
+      const toolName = (event.toolName as string) || 'unknown';
+      const args =
+        (event.input as Record<string, unknown>) ||
+        (event.args as Record<string, unknown>) ||
+        {};
+      const toolCallId = (event.toolCallId as string) || `sdk-tool-${Date.now()}`;
+      return [createAgentEventFromContext(context, {
+        type: 'tool_call',
+        toolCallId,
+        toolName,
+        args,
+      })];
+    }
+    case 'tool-result': {
+      const output = event.output ?? event.result;
+      const toolCallId = (event.toolCallId as string) || '';
+      return [createAgentEventFromContext(context, {
+        type: 'tool_result',
+        toolCallId,
+        toolName: (event.toolName as string) || undefined,
+        output: stringifySdkOutput(output),
+      })];
+    }
+    case 'usage': {
+      const promptTokens = typeof event.promptTokens === 'number' ? event.promptTokens : undefined;
+      const completionTokens = typeof event.completionTokens === 'number' ? event.completionTokens : undefined;
+      const totalTokens = typeof event.totalTokens === 'number'
+        ? event.totalTokens
+        : promptTokens != null && completionTokens != null
+          ? promptTokens + completionTokens
+          : undefined;
+      return [createAgentEventFromContext(context, {
+        type: 'usage',
+        promptTokens,
+        completionTokens,
+        totalTokens,
+        raw: event,
+      })];
+    }
+    case 'error':
+      return [createAgentEventFromContext(context, {
+        type: 'error',
+        error: stringifySdkOutput(event.error) || 'Unknown error',
+      })];
+    default:
+      return [];
+  }
+}

--- a/infrastructure/ai/approvalGateTrace.test.ts
+++ b/infrastructure/ai/approvalGateTrace.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  onApprovalTraceEvent,
+  requestApproval,
+  resolveApproval,
+} from './shared/approvalGate';
+import type { AgentEvent } from './agentEvent';
+
+test('approvalGate emits approval_requested and approval_resolved trace events', async () => {
+  const events: AgentEvent[] = [];
+  const unsubscribe = onApprovalTraceEvent(event => events.push(event));
+
+  const approval = requestApproval(
+    'tool-approval-1',
+    'terminal_execute',
+    { command: 'uptime' },
+    'session-1',
+  );
+  resolveApproval('tool-approval-1', true);
+
+  assert.equal(await approval, true);
+  unsubscribe();
+
+  assert.deepEqual(events.map(event => event.type), ['approval_requested', 'approval_resolved']);
+  assert.equal(events[0].sessionId, 'session-1');
+  assert.equal(events[0].source, 'catty');
+  assert.equal((events[0] as Extract<AgentEvent, { type: 'approval_requested' }>).toolName, 'terminal_execute');
+  assert.equal((events[1] as Extract<AgentEvent, { type: 'approval_resolved' }>).approved, true);
+  assert.equal((events[1] as Extract<AgentEvent, { type: 'approval_resolved' }>).resolution, 'approved');
+});
+
+test('approvalGate emits timeout trace events for unanswered approvals', async () => {
+  const events: AgentEvent[] = [];
+  const unsubscribe = onApprovalTraceEvent(event => events.push(event));
+
+  const approval = requestApproval(
+    'tool-approval-timeout',
+    'terminal_execute',
+    { command: 'sleep 1' },
+    'session-timeout',
+    1,
+  );
+
+  assert.equal(await approval, false);
+  unsubscribe();
+
+  assert.deepEqual(events.map(event => event.type), ['approval_requested', 'approval_resolved']);
+  const resolved = events[1] as Extract<AgentEvent, { type: 'approval_resolved' }>;
+  assert.equal(resolved.approved, false);
+  assert.equal(resolved.resolution, 'timeout');
+});

--- a/infrastructure/ai/sdkAgentAdapter.test.ts
+++ b/infrastructure/ai/sdkAgentAdapter.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import { formatSdkAgentErrorForDisplay, runSdkAgentTurn } from './sdkAgentAdapter';
 import type { SdkAgentCallbacks } from './sdkAgentAdapter';
+import type { AgentEvent } from './agentEvent';
 import type { ExternalAgentConfig } from './types';
 
 function createCallbacks(errors: string[]): SdkAgentCallbacks {
@@ -238,6 +239,73 @@ test('runSdkAgentTurn stores SDK session ids with backend and path metadata', as
     backend: 'codex',
     binPath: '/opt/homebrew/bin/codex',
   });
+});
+
+test('runSdkAgentTurn normalizes SDK stream events to AgentEvent callbacks', async () => {
+  const agentEvents: AgentEvent[] = [];
+  let onEvent: ((event: unknown) => void) | null = null;
+  let done: (() => void) | null = null;
+  const bridge: Record<string, (...args: unknown[]) => unknown> = {
+    aiSdkAgentStream: async () => {
+      queueMicrotask(() => {
+        onEvent?.({
+          type: 'tool-call',
+          toolName: 'terminal_execute',
+          args: { command: 'pwd' },
+          toolCallId: 'tc-1',
+        });
+        onEvent?.({
+          type: 'tool-result',
+          toolCallId: 'tc-1',
+          output: '/workspace',
+          toolName: 'terminal_execute',
+        });
+        done?.();
+      });
+      return { ok: true };
+    },
+    aiSdkAgentCancel: async () => ({ ok: true }),
+    onAiSdkAgentEvent: (_requestId: unknown, cb: unknown) => {
+      onEvent = cb as (event: unknown) => void;
+      return () => {};
+    },
+    onAiSdkAgentDone: (_requestId: unknown, cb: unknown) => {
+      done = cb as () => void;
+      return () => {};
+    },
+    onAiSdkAgentError: () => () => {},
+  };
+
+  await runSdkAgentTurn(
+    bridge,
+    'request-trace',
+    'chat-trace',
+    sdkConfig,
+    'hello',
+    {
+      ...createCallbacks([]),
+      onAgentEvent: (event) => agentEvents.push(event),
+    },
+    undefined,
+    undefined,
+    'gpt-5.5',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'turn-1',
+  );
+
+  assert.deepEqual(agentEvents.map(event => event.type), ['tool_call', 'tool_result']);
+  assert.equal(agentEvents[0].sessionId, 'chat-trace');
+  assert.equal(agentEvents[0].turnId, 'turn-1');
+  assert.equal(agentEvents[0].source, 'external_sdk');
+  assert.equal(agentEvents[0].backend, 'codex');
+  assert.equal(agentEvents[0].model, 'gpt-5.5');
+  assert.deepEqual((agentEvents[0] as Extract<AgentEvent, { type: 'tool_call' }>).args, { command: 'pwd' });
+  assert.equal((agentEvents[1] as Extract<AgentEvent, { type: 'tool_result' }>).output, '/workspace');
 });
 
 test('runSdkAgentTurn forwards Cursor API key as agent environment', async () => {

--- a/infrastructure/ai/sdkAgentAdapter.ts
+++ b/infrastructure/ai/sdkAgentAdapter.ts
@@ -6,6 +6,8 @@
  */
 
 import type { AIToolIntegrationMode, ExternalAgentConfig } from './types';
+import type { AgentEvent, AgentEventContext } from './agentEvent';
+import { normalizeSdkStreamEventToAgentEvents } from './agentEvent';
 import { getExternalAgentSdkBackend } from './managedAgents';
 import { decryptField } from '../persistence/secureFieldAdapter';
 
@@ -23,6 +25,7 @@ export interface DefaultTargetSessionHint {
 }
 
 export interface SdkAgentCallbacks {
+  onAgentEvent?: (event: AgentEvent) => void;
   onSessionId?: (sessionId: string) => void;
   onTextDelta: (text: string) => void;
   onThinkingDelta: (text: string) => void;
@@ -182,6 +185,7 @@ export async function runSdkAgentTurn(
   toolIntegrationMode?: AIToolIntegrationMode,
   defaultTargetSession?: DefaultTargetSessionHint,
   userSkillsContext?: string,
+  turnId?: string,
 ): Promise<void> {
   const sdkBridge = bridge as unknown as SdkAgentBridge;
   const sdkBackend = getExternalAgentSdkBackend(config);
@@ -210,7 +214,15 @@ export async function runSdkAgentTurn(
 
   // Set up event listeners before starting stream
   const unsubEvent = sdkBridge.onAiSdkAgentEvent(requestId, (event: StreamEvent) => {
-    const streamFailed = handleStreamEvent(event, callbacks);
+    const streamFailed = handleStreamEvent(event, callbacks, {
+      sessionId: chatSessionId,
+      source: 'external_sdk',
+      requestId,
+      turnId,
+      backend: sdkBackend,
+      model,
+      providerId,
+    });
     if (streamFailed) {
       settle();
     }
@@ -299,7 +311,15 @@ function cleanup(fns: (() => void)[]) {
  * Handle a single stream event from the AI SDK fullStream.
  * Events come from `streamText().fullStream` in the main process.
  */
-function handleStreamEvent(event: StreamEvent, callbacks: SdkAgentCallbacks): boolean {
+function handleStreamEvent(
+  event: StreamEvent,
+  callbacks: SdkAgentCallbacks,
+  context: AgentEventContext,
+): boolean {
+  for (const agentEvent of normalizeSdkStreamEventToAgentEvents(event, context)) {
+    callbacks.onAgentEvent?.(agentEvent);
+  }
+
   switch (event.type) {
     case 'text-delta': {
       const text = (event.textDelta as string) || (event.delta as string) || '';

--- a/infrastructure/ai/shared/approvalGate.ts
+++ b/infrastructure/ai/shared/approvalGate.ts
@@ -14,6 +14,8 @@
  * Approvals are scoped by optional chatSessionId to prevent cross-session
  * interference when stopping or cancelling sessions.
  */
+import type { AgentEvent } from '../agentEvent';
+import { createAgentEvent } from '../agentEvent';
 
 /** Default timeout for unanswered approval prompts (5 minutes). */
 const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
@@ -41,6 +43,50 @@ const listeners = new Set<ApprovalRequestListener>();
 // Subscribers for approval cleared/removed events (UI listens to clean up cards)
 type ApprovalClearedListener = (toolCallIds: string[]) => void;
 const clearedListeners = new Set<ApprovalClearedListener>();
+
+type ApprovalTraceListener = (event: AgentEvent) => void;
+const traceListeners = new Set<ApprovalTraceListener>();
+
+function approvalSource(toolCallId: string): AgentEvent['source'] {
+  return toolCallId.startsWith('mcp_approval_') ? 'mcp' : 'catty';
+}
+
+function emitApprovalTraceEvent(event: AgentEvent): void {
+  for (const listener of traceListeners) {
+    try { listener(event); } catch { /* ignore listener errors */ }
+  }
+}
+
+function emitApprovalRequested(request: ApprovalRequest, timeoutMs?: number): void {
+  if (!request.chatSessionId) return;
+  emitApprovalTraceEvent(createAgentEvent({
+    type: 'approval_requested',
+    sessionId: request.chatSessionId,
+    source: approvalSource(request.toolCallId),
+    approvalId: request.toolCallId,
+    toolCallId: request.toolCallId,
+    toolName: request.toolName,
+    args: request.args,
+    timeoutMs,
+  }));
+}
+
+function emitApprovalResolved(
+  request: ApprovalRequest,
+  approved: boolean,
+  resolution: Extract<AgentEvent, { type: 'approval_resolved' }>['resolution'],
+): void {
+  if (!request.chatSessionId) return;
+  emitApprovalTraceEvent(createAgentEvent({
+    type: 'approval_resolved',
+    sessionId: request.chatSessionId,
+    source: approvalSource(request.toolCallId),
+    approvalId: request.toolCallId,
+    toolCallId: request.toolCallId,
+    approved,
+    resolution,
+  }));
+}
 
 /**
  * Called from a tool's `execute` function when it needs user approval.
@@ -74,6 +120,7 @@ export function requestApproval(
       if (pendingApprovals.has(toolCallId)) {
         pendingApprovals.delete(toolCallId);
         wrappedResolve(false);
+        emitApprovalResolved(request, false, 'timeout');
         // Notify UI to remove the stale card
         for (const cl of clearedListeners) {
           try { cl([toolCallId]); } catch { /* ignore */ }
@@ -82,6 +129,7 @@ export function requestApproval(
     }, timeoutMs);
 
     // Notify all UI listeners
+    emitApprovalRequested(request, timeoutMs);
     for (const listener of listeners) {
       try { listener(request); } catch { /* ignore listener errors */ }
     }
@@ -98,6 +146,7 @@ export function resolveApproval(toolCallId: string, approved: boolean): void {
     pendingApprovals.delete(toolCallId);
     // SDK tool calls have a real resolve; MCP tool calls have a no-op resolve
     entry.resolve(approved);
+    emitApprovalResolved(entry.request, approved, approved ? 'approved' : 'denied');
   }
 
   // MCP tool call: also forward response to main process via IPC
@@ -123,6 +172,11 @@ export function onApprovalRequest(listener: ApprovalRequestListener): () => void
 export function onApprovalCleared(listener: ApprovalClearedListener): () => void {
   clearedListeners.add(listener);
   return () => { clearedListeners.delete(listener); };
+}
+
+export function onApprovalTraceEvent(listener: ApprovalTraceListener): () => void {
+  traceListeners.add(listener);
+  return () => { traceListeners.delete(listener); };
 }
 
 /**
@@ -162,6 +216,7 @@ export function clearAllPendingApprovals(chatSessionId?: string): void {
     // Clear everything (legacy / global stop)
     for (const [id, entry] of pendingApprovals) {
       entry.resolve(false);
+      emitApprovalResolved(entry.request, false, 'cleared');
       clearedIds.push(id);
     }
     pendingApprovals.clear();
@@ -171,6 +226,7 @@ export function clearAllPendingApprovals(chatSessionId?: string): void {
       if (entry.request.chatSessionId === chatSessionId) {
         pendingApprovals.delete(id);
         entry.resolve(false);
+        emitApprovalResolved(entry.request, false, 'cleared');
         clearedIds.push(id);
       }
     }
@@ -231,6 +287,7 @@ export function setupMcpApprovalBridge(): () => void {
     }
 
     // Notify all UI listeners
+    emitApprovalRequested(request);
     for (const listener of listeners) {
       try { listener(request); } catch { /* ignore listener errors */ }
     }
@@ -242,7 +299,11 @@ export function setupMcpApprovalBridge(): () => void {
     const clearedIds: string[] = [];
     for (const id of payload.approvalIds) {
       if (pendingApprovals.has(id)) {
+        const entry = pendingApprovals.get(id);
         pendingApprovals.delete(id);
+        if (entry) {
+          emitApprovalResolved(entry.request, false, 'cleared');
+        }
         clearedIds.push(id);
       }
     }

--- a/infrastructure/ai/traceStore.test.ts
+++ b/infrastructure/ai/traceStore.test.ts
@@ -1,0 +1,169 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAgentEvent } from './agentEvent';
+import {
+  appendAgentEvent,
+  projectAgentEventsToMessages,
+  trimAgentTrace,
+} from './traceStore';
+import type { AgentEvent } from './agentEvent';
+
+function event<T extends AgentEvent['type']>(
+  input: Omit<Extract<AgentEvent, { type: T }>, 'id' | 'timestamp'> & {
+    id: string;
+    timestamp: number;
+  },
+): Extract<AgentEvent, { type: T }> {
+  return createAgentEvent(input);
+}
+
+test('projectAgentEventsToMessages rebuilds a turn from unified events', () => {
+  const events: AgentEvent[] = [
+    event({
+      id: 'e1',
+      timestamp: 1,
+      type: 'turn_start',
+      sessionId: 's1',
+      source: 'catty',
+      agentId: 'catty',
+      prompt: 'check disk',
+    }),
+    event({
+      id: 'e2',
+      timestamp: 2,
+      type: 'reasoning_delta',
+      sessionId: 's1',
+      source: 'catty',
+      delta: 'Need df.',
+      phase: 'delta',
+    }),
+    event({
+      id: 'e3',
+      timestamp: 3,
+      type: 'model_delta',
+      sessionId: 's1',
+      source: 'catty',
+      delta: 'Running df...',
+    }),
+    event({
+      id: 'e4',
+      timestamp: 4,
+      type: 'tool_call',
+      sessionId: 's1',
+      source: 'catty',
+      toolCallId: 'tc1',
+      toolName: 'terminal_execute',
+      args: { command: 'df -h' },
+    }),
+    event({
+      id: 'e5',
+      timestamp: 5,
+      type: 'approval_requested',
+      sessionId: 's1',
+      source: 'catty',
+      approvalId: 'tc1',
+      toolCallId: 'tc1',
+      toolName: 'terminal_execute',
+      args: { command: 'df -h' },
+    }),
+    event({
+      id: 'e6',
+      timestamp: 6,
+      type: 'approval_resolved',
+      sessionId: 's1',
+      source: 'catty',
+      approvalId: 'tc1',
+      toolCallId: 'tc1',
+      approved: true,
+      resolution: 'approved',
+    }),
+    event({
+      id: 'e7',
+      timestamp: 7,
+      type: 'tool_result',
+      sessionId: 's1',
+      source: 'catty',
+      toolCallId: 'tc1',
+      toolName: 'terminal_execute',
+      output: '/dev/sda1 50%',
+    }),
+    event({
+      id: 'e8',
+      timestamp: 8,
+      type: 'model_delta',
+      sessionId: 's1',
+      source: 'catty',
+      delta: 'Disk usage is fine.',
+    }),
+    event({
+      id: 'e9',
+      timestamp: 9,
+      type: 'usage',
+      sessionId: 's1',
+      source: 'catty',
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    }),
+    event({
+      id: 'e10',
+      timestamp: 10,
+      type: 'turn_end',
+      sessionId: 's1',
+      source: 'catty',
+      status: 'completed',
+    }),
+  ];
+
+  const messages = projectAgentEventsToMessages(events);
+
+  assert.equal(messages.length, 4);
+  assert.equal(messages[0].role, 'user');
+  assert.equal(messages[0].content, 'check disk');
+  assert.equal(messages[1].role, 'assistant');
+  assert.equal(messages[1].thinking, 'Need df.');
+  assert.equal(messages[1].content, 'Running df...');
+  assert.deepEqual(messages[1].toolCalls, [{
+    id: 'tc1',
+    name: 'terminal_execute',
+    arguments: { command: 'df -h' },
+  }]);
+  assert.equal(messages[1].pendingApproval?.status, 'approved');
+  assert.equal(messages[2].role, 'tool');
+  assert.equal(messages[2].toolResults?.[0].content, '/dev/sda1 50%');
+  assert.equal(messages[3].role, 'assistant');
+  assert.equal(messages[3].content, 'Disk usage is fine.');
+});
+
+test('appendAgentEvent and trimAgentTrace enforce a bounded append-only trace', () => {
+  const first = event({
+    id: 'e1',
+    timestamp: 1,
+    type: 'model_delta',
+    sessionId: 's1',
+    source: 'external_sdk',
+    delta: 'a',
+  });
+  const second = event({
+    id: 'e2',
+    timestamp: 2,
+    type: 'model_delta',
+    sessionId: 's1',
+    source: 'external_sdk',
+    delta: 'b',
+  });
+  const third = event({
+    id: 'e3',
+    timestamp: 3,
+    type: 'model_delta',
+    sessionId: 's1',
+    source: 'external_sdk',
+    delta: 'c',
+  });
+
+  const trace = appendAgentEvent(appendAgentEvent([first], second, 2), third, 2);
+
+  assert.deepEqual(trace.map(item => item.id), ['e2', 'e3']);
+  assert.deepEqual(trimAgentTrace(trace, 1).map(item => item.id), ['e3']);
+});

--- a/infrastructure/ai/traceStore.ts
+++ b/infrastructure/ai/traceStore.ts
@@ -1,0 +1,217 @@
+import type { AgentEvent } from './agentEvent';
+import type { ChatMessage, ToolCall } from './types';
+
+export const DEFAULT_MAX_AGENT_TRACE_EVENTS = 2_000;
+
+export interface TraceStore {
+  events: AgentEvent[];
+}
+
+export function createTraceStore(events: AgentEvent[] = []): TraceStore {
+  return { events: [...events] };
+}
+
+export function trimAgentTrace(
+  events: AgentEvent[] | undefined,
+  maxEvents = DEFAULT_MAX_AGENT_TRACE_EVENTS,
+): AgentEvent[] {
+  if (!events?.length) return [];
+  return events.length > maxEvents ? events.slice(-maxEvents) : events;
+}
+
+export function appendAgentEvent(
+  events: AgentEvent[] | undefined,
+  event: AgentEvent,
+  maxEvents = DEFAULT_MAX_AGENT_TRACE_EVENTS,
+): AgentEvent[] {
+  return trimAgentTrace([...(events ?? []), event], maxEvents);
+}
+
+export function appendAgentEvents(
+  events: AgentEvent[] | undefined,
+  nextEvents: AgentEvent[],
+  maxEvents = DEFAULT_MAX_AGENT_TRACE_EVENTS,
+): AgentEvent[] {
+  if (nextEvents.length === 0) return trimAgentTrace(events, maxEvents);
+  return trimAgentTrace([...(events ?? []), ...nextEvents], maxEvents);
+}
+
+function createAssistantMessage(event: AgentEvent): ChatMessage {
+  return {
+    id: `trace-assistant-${event.id}`,
+    role: 'assistant',
+    content: '',
+    timestamp: event.timestamp,
+    model: event.model,
+    providerId: event.providerId as ChatMessage['providerId'],
+  };
+}
+
+function updateLastAssistant(
+  messages: ChatMessage[],
+  event: AgentEvent,
+  updater: (message: ChatMessage) => ChatMessage,
+): void {
+  let last = messages[messages.length - 1];
+  if (!last || last.role === 'tool' || last.role === 'user' || last.role === 'system') {
+    last = createAssistantMessage(event);
+    messages.push(last);
+  }
+  messages[messages.length - 1] = updater(last);
+}
+
+function ensureToolCallId(event: Extract<AgentEvent, { type: 'tool_call' }>): string {
+  return event.toolCallId || `trace-tool-${event.id}`;
+}
+
+function patchToolCallName(
+  toolCalls: ToolCall[] | undefined,
+  toolCallId: string,
+  toolName?: string,
+): ToolCall[] | undefined {
+  if (!toolCalls?.length || !toolName) return toolCalls;
+  return toolCalls.map(toolCall => (
+    toolCall.id === toolCallId && (!toolCall.name || toolCall.name === 'unknown')
+      ? { ...toolCall, name: toolName }
+      : toolCall
+  ));
+}
+
+export function projectAgentEventsToMessages(events: AgentEvent[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'turn_start': {
+        messages.push({
+          id: `trace-user-${event.id}`,
+          role: 'user',
+          content: event.prompt,
+          timestamp: event.timestamp,
+        });
+        break;
+      }
+      case 'model_delta': {
+        if (!event.delta) break;
+        updateLastAssistant(messages, event, message => ({
+          ...message,
+          content: message.content + event.delta,
+          statusText: undefined,
+        }));
+        break;
+      }
+      case 'reasoning_delta': {
+        if (event.phase === 'end') {
+          updateLastAssistant(messages, event, message => ({
+            ...message,
+            thinkingDurationMs: message.thinkingDurationMs || (event.timestamp - message.timestamp),
+          }));
+          break;
+        }
+        if (!event.delta) break;
+        updateLastAssistant(messages, event, message => ({
+          ...message,
+          thinking: (message.thinking || '') + event.delta,
+        }));
+        break;
+      }
+      case 'tool_call': {
+        const toolCallId = ensureToolCallId(event);
+        updateLastAssistant(messages, event, message => ({
+          ...message,
+          toolCalls: [
+            ...(message.toolCalls || []),
+            {
+              id: toolCallId,
+              name: event.toolName,
+              arguments: event.args,
+            },
+          ],
+          executionStatus: 'running',
+          statusText: undefined,
+        }));
+        break;
+      }
+      case 'tool_result': {
+        const previous = messages[messages.length - 1];
+        if (previous?.role === 'assistant') {
+          messages[messages.length - 1] = {
+            ...previous,
+            toolCalls: patchToolCallName(previous.toolCalls, event.toolCallId, event.toolName),
+            executionStatus: 'completed',
+            statusText: undefined,
+          };
+        }
+        messages.push({
+          id: `trace-tool-${event.id}`,
+          role: 'tool',
+          content: '',
+          toolResults: [{
+            toolCallId: event.toolCallId,
+            content: event.output,
+            isError: event.isError,
+          }],
+          timestamp: event.timestamp,
+          executionStatus: 'completed',
+        });
+        break;
+      }
+      case 'approval_requested': {
+        updateLastAssistant(messages, event, message => ({
+          ...message,
+          pendingApproval: {
+            approvalId: event.approvalId,
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            toolArgs: event.args,
+            status: 'pending',
+          },
+          executionStatus: 'pending',
+        }));
+        break;
+      }
+      case 'approval_resolved': {
+        const status = event.approved ? 'approved' : 'denied';
+        updateLastAssistant(messages, event, message => (
+          message.pendingApproval?.approvalId === event.approvalId
+            ? {
+                ...message,
+                pendingApproval: { ...message.pendingApproval, status },
+                executionStatus: event.approved ? 'approved' : 'rejected',
+              }
+            : message
+        ));
+        break;
+      }
+      case 'error': {
+        updateLastAssistant(messages, event, message => ({
+          ...message,
+          statusText: '',
+          executionStatus: message.executionStatus === 'running' ? 'failed' : message.executionStatus,
+        }));
+        messages.push({
+          id: `trace-error-${event.id}`,
+          role: 'assistant',
+          content: '',
+          errorInfo: {
+            type: 'agent',
+            message: event.error,
+            retryable: !!event.retryable,
+          },
+          timestamp: event.timestamp,
+        });
+        break;
+      }
+      case 'compaction':
+      case 'usage':
+      case 'turn_end':
+        break;
+      default: {
+        const neverEvent: never = event;
+        void neverEvent;
+      }
+    }
+  }
+
+  return messages;
+}

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -1,5 +1,6 @@
 // AI Provider types
 import defaultCommandBlocklist from '../../lib/commandBlocklist.json';
+import type { AgentEvent } from './agentEvent';
 import type { ProviderContinuation } from './providerContinuation';
 
 export type AIProviderId =
@@ -186,6 +187,8 @@ export interface AISession {
   agentId: string;
   scope: AISessionScope;
   messages: ChatMessage[];
+  /** Append-only runtime trace. `messages` remains the UI projection/cache. */
+  trace?: AgentEvent[];
   externalSessionId?: string;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a unified `AgentEvent` schema and bounded TraceStore projection helpers.
- Persist optional per-session traces alongside existing AI chat messages.
- Emit trace events from Catty streaming, external SDK streams, approval flow, compaction, usage, errors, and turn boundaries.
- Add focused tests for trace projection, approval trace events, and SDK event normalization.

## Validation
- `node --test --import tsx infrastructure/ai/traceStore.test.ts infrastructure/ai/approvalGateTrace.test.ts infrastructure/ai/sdkAgentAdapter.test.ts`
- `npm run lint`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fb0bc33-f27c-4bc6-8da5-3fc582728a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fb0bc33-f27c-4bc6-8da5-3fc582728a20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

