### PR TITLE
[codex] Fix host hostname whitespace handling

### DIFF
--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -108,6 +108,18 @@ test("HostDetailsPanel keeps explicitly cleared telnet credentials empty", () =>
   assert.doesNotMatch(markup, /placeholder="Telnet Password"[^>]*value="ssh-password"/);
 });
 
+test("HostDetailsPanel disables save when hostname is whitespace only", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    hostname: "   ",
+    proxyProfileId: undefined,
+  });
+
+  assert.match(markup, /<button[^>]*disabled=""[^>]*aria-label="Save"/);
+  assert.match(markup, />Save<\/button>/);
+  assert.match(markup, /<button[^>]*disabled=""[^>]*>Save<\/button>/);
+});
+
 test("HostDetailsPanel gives the telnet port field the same roomy layout as SSH", () => {
   const markup = renderHostDetails({
     ...hostWithMissingProxyProfile,

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -359,9 +359,11 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       return { ...prev, environmentVariables: filtered.length > 0 ? filtered : undefined };
     });
   };
+  const hasHostname = form.hostname.trim().length > 0;
 
   const handleSubmit = () => {
-    if (!form.hostname) return;
+    const hostname = form.hostname.trim();
+    if (!hostname) return;
     const normalizedProxyConfig = normalizeManualProxyConfig(form.proxyConfig);
     if (normalizedProxyConfig && !isCompleteProxyConfig(normalizedProxyConfig)) {
       toast.error(
@@ -375,7 +377,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       setActiveSubPanel("proxy");
       return;
     }
-    let finalLabel = form.label?.trim() || form.hostname;
+    let finalLabel = form.label?.trim() || hostname;
     const finalGroup = groupInputValue.trim() || form.group || "";
 
     const targetManagedSource = managedSources
@@ -407,6 +409,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
     let cleaned: Host = {
       ...formWithoutProxyDraft,
       ...(normalizedProxyConfig && { proxyConfig: normalizedProxyConfig }),
+      hostname,
       label: finalLabel,
       group: finalGroup,
       tags: form.tags || [],
@@ -711,7 +714,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
           size="icon"
           className="h-8 w-8"
           onClick={handleSubmit}
-          disabled={!form.hostname}
+          disabled={!hasHostname}
           aria-label={t("hostDetails.saveAria")}
         >
           <Check size={16} />
@@ -985,7 +988,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         <Button
           className="w-full h-10"
           onClick={handleSubmit}
-          disabled={!form.hostname}
+          disabled={!hasHostname}
         >
           {t("common.save")}
         </Button>

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -173,6 +173,14 @@ test("sanitizeHost removes invalid custom host icon fields", () => {
   assert.equal(sanitized.iconColor, undefined);
 });
 
+test("sanitizeHost trims leading whitespace before extracting the hostname", () => {
+  const sanitized = sanitizeHost(makeHost({
+    hostname: " 127.0.0.1",
+  }));
+
+  assert.equal(sanitized.hostname, "127.0.0.1");
+});
+
 test("preserves a concurrent terminal timestamp toggle when host details did not edit it", () => {
   const openedHost = makeHost({ showLineTimestamps: false });
   const latestHost = makeHost({ showLineTimestamps: true });

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -333,7 +333,7 @@ export const resolveHostKeepalive = (
 };
 
 export const sanitizeHost = (host: Host): Host => {
-  const cleanHostname = (host.hostname || '').split(/\s+/)[0];
+  const cleanHostname = (host.hostname || '').trim().split(/\s+/)[0];
   const cleanDistro = normalizeDistroId(host.distro);
   const cleanManualDistro = normalizeDistroId(host.manualDistro);
   const cleanDistroMode =


### PR DESCRIPTION
## Summary
- Trim hostnames before saving and before shared host cleanup extracts the address token
- Disable host save actions when the hostname contains only whitespace
- Add regression coverage for leading-whitespace hostnames and whitespace-only saves

## Root cause
The host cleanup path split the hostname on whitespace before trimming it. For an input like ` 127.0.0.1`, the first split segment was empty, so the saved host ended up with a blank address.

Fixes #1668

## Validation
- `node --test --import tsx domain/host.test.ts`
- `node --test --import tsx components/HostDetailsPanel.proxyProfile.test.tsx`
- `npm run lint`
- `npm run build`
- `npm test`