### PR TITLE
Add latency to terminal network stats

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -88,6 +88,7 @@ export const enTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Disk Usage (Root)',
   'terminal.serverStats.diskDetails': 'Mounted Disks',
   'terminal.serverStats.network': 'Network Speed',
+  'terminal.serverStats.latency': 'Latency',
   'terminal.serverStats.networkDetails': 'Network Interfaces',
   'terminal.serverStats.noData': 'No data available',
   'terminal.dragDrop.localTitle': 'Drop to Insert Paths',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -367,6 +367,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁盘使用（根分区）',
   'terminal.serverStats.diskDetails': '已挂载磁盘',
   'terminal.serverStats.network': '网络速度',
+  'terminal.serverStats.latency': '延迟',
   'terminal.serverStats.networkDetails': '网络接口',
   'terminal.serverStats.noData': '暂无数据',
   'terminal.dragDrop.localTitle': '拖放以插入路径',

--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowDownToLine, ArrowUpFromLine, Cpu, HardDrive, MemoryStick } from 'lucide-react';
+import { Activity, ArrowDownToLine, ArrowUpFromLine, Cpu, HardDrive, MemoryStick } from 'lucide-react';
 
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { cn } from '../../lib/utils';
@@ -16,6 +16,10 @@ interface TerminalServerStatsProps {
   isSupportedOs: boolean;
   isConnected: boolean;
 }
+
+const formatLatency = (latencyMs: number | null): string => (
+  typeof latencyMs === 'number' && Number.isFinite(latencyMs) ? `${latencyMs}ms` : '--ms'
+);
 
 /**
  * Self-contained server-stats (CPU / Memory / Disk / Network) indicator.
@@ -323,6 +327,8 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                         <span className="truncate">{formatNetSpeed(serverStats.netRxSpeed)}</span>
                         <ArrowUpFromLine size={9} className="flex-shrink-0 text-sky-400" />
                         <span className="truncate">{formatNetSpeed(serverStats.netTxSpeed)}</span>
+                        <Activity size={9} className="flex-shrink-0 text-violet-400" />
+                        <span className="truncate">{formatLatency(serverStats.latencyMs)}</span>
                       </button>
                     </HoverCardTrigger>
                     <HoverCardContent
@@ -333,6 +339,15 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                     >
                       <div className="text-xs space-y-2">
                         <div className="font-medium text-sm mb-2">{t("terminal.serverStats.networkDetails")}</div>
+                        <div className="flex items-center justify-between gap-4 min-w-[200px]">
+                          <span className="text-[10px] text-muted-foreground">
+                            {t("terminal.serverStats.latency")}
+                          </span>
+                          <span className="flex items-center gap-0.5 text-violet-400">
+                            <Activity size={9} />
+                            {formatLatency(serverStats.latencyMs)}
+                          </span>
+                        </div>
                         <div className="space-y-2 max-h-[200px] overflow-y-auto">
                           {serverStats.netInterfaces.map((iface, index) => (
                             <div key={index} className="flex items-center justify-between gap-4 min-w-[200px]">

--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -40,6 +40,7 @@ export interface ServerStats {
   disks: DiskInfo[];            // All mounted disks
   netRxSpeed: number;           // Total network receive speed (bytes/sec)
   netTxSpeed: number;           // Total network transmit speed (bytes/sec)
+  latencyMs: number | null;     // Approximate SSH stats round-trip latency
   netInterfaces: NetInterfaceInfo[];  // Per-interface network stats
   lastUpdated: number | null;   // Timestamp of last successful update
 }
@@ -79,6 +80,7 @@ export function useServerStats({
     disks: [],
     netRxSpeed: 0,
     netTxSpeed: 0,
+    latencyMs: null,
     netInterfaces: [],
     lastUpdated: null,
   });
@@ -167,6 +169,7 @@ export function useServerStats({
           disks: result.stats.disks || [],
           netRxSpeed: result.stats.netRxSpeed || 0,
           netTxSpeed: result.stats.netTxSpeed || 0,
+          latencyMs: Number.isFinite(result.stats.latencyMs) ? result.stats.latencyMs : null,
           netInterfaces: result.stats.netInterfaces || [],
           lastUpdated: Date.now(),
         });
@@ -236,6 +239,7 @@ export function useServerStats({
         disks: [],
         netRxSpeed: 0,
         netTxSpeed: 0,
+        latencyMs: null,
         netInterfaces: [],
         lastUpdated: null,
       });

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -784,11 +784,13 @@ function createSessionOpsApi(ctx) {
       ].join('; ');
     
       // Auto-detect OS via uname — only Linux and macOS are supported
-      const statsCommand = `ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
+      const latencyMarker = "NC_LATENCY_MARK";
+      const statsCommand = `printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
       return new Promise((resolve) => {
         const timeout = setTimeout(() => {
           resolve({ success: false, error: 'Timeout getting server stats' });
         }, 5000);
+        const latencyStartedAt = Date.now();
     
         conn.exec(statsCommand, (err, stream) => {
           if (err) {
@@ -799,8 +801,12 @@ function createSessionOpsApi(ctx) {
     
           let stdout = '';
           let stderr = '';
+          let latencyMs = null;
     
           stream.on('data', (data) => {
+            if (latencyMs === null) {
+              latencyMs = Math.max(0, Date.now() - latencyStartedAt);
+            }
             stdout += data.toString();
           });
     
@@ -812,7 +818,7 @@ function createSessionOpsApi(ctx) {
             clearTimeout(timeout);
     
             // Parse the output
-            const output = stdout.trim();
+            const output = stdout.trim().replace(new RegExp(`^${latencyMarker}\\|?`), '');
     
             // Unsupported OS — stop polling this session
             if (output.startsWith('UNSUPPORTED_OS:')) {
@@ -1086,6 +1092,7 @@ function createSessionOpsApi(ctx) {
                 disks,         // Array of all mounted disks
                 netRxSpeed,    // Total network receive speed (bytes/sec)
                 netTxSpeed,    // Total network transmit speed (bytes/sec)
+                latencyMs,      // Approximate SSH stats round-trip latency (ms)
                 netInterfaces, // Per-interface network stats
               },
             });

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -75,6 +75,7 @@ test("getServerStats opens a Mosh stats companion connection when session.conn i
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.cpuCores, 4);
+  assert.equal(typeof result.stats.latencyMs, "number");
 });
 
 test("getServerStats fails gracefully when the companion connection cannot be established", async () => {

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -216,6 +216,7 @@ declare global {
         }>;
         netRxSpeed: number;           // Total network receive speed (bytes/sec)
         netTxSpeed: number;           // Total network transmit speed (bytes/sec)
+        latencyMs: number | null;     // Approximate SSH stats round-trip latency
         netInterfaces: Array<{        // Per-interface network stats
           name: string;               // Interface name (e.g., eth0, ens33)
           rxBytes: number;            // Total received bytes


### PR DESCRIPTION
## Summary
- measure SSH server stats round-trip latency alongside network speed
- display latency in the terminal status bar and network details popover
- add localized latency labels and cover the stats response in tests

## Tests
- node --test electron/bridges/sshBridge/sessionOps.serverStats.test.cjs electron/bridges/sshBridge.sessionOps.et.test.cjs