### PR TITLE
[codex] fix focus sidebar dynamic title refresh

### DIFF
--- a/components/terminalLayer/TerminalFocusSidebar.test.ts
+++ b/components/terminalLayer/TerminalFocusSidebar.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('./TerminalFocusSidebar.tsx', import.meta.url), 'utf8');
+
+test('focus sidebar row memo refreshes when dynamic title mode changes', () => {
+  assert.match(source, /prev\.dynamicTabTitleMode === next\.dynamicTabTitleMode/);
+});

--- a/components/terminalLayer/TerminalFocusSidebar.tsx
+++ b/components/terminalLayer/TerminalFocusSidebar.tsx
@@ -230,6 +230,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
   && prev.onDragOver === next.onDragOver
   && prev.onDrop === next.onDrop
   && prev.onDragEnd === next.onDragEnd
+  && prev.dynamicTabTitleMode === next.dynamicTabTitleMode
   && prev.t === next.t
 ));
 WorkspaceFocusSessionRow.displayName = 'WorkspaceFocusSessionRow';


### PR DESCRIPTION
Summary
- Follow up on Codex review feedback from #1658.
- Refresh focus sidebar rows when Dynamic tab title mode changes.
- Add a regression check for the row memo comparison.

Validation
- node --test --import tsx components/terminalLayer/TerminalFocusSidebar.test.ts components/terminalLayer/terminalLayerViewMemo.test.ts components/terminalLayer/TerminalLayerTabBridge.test.ts domain/sessionTabTitle.test.ts
- npm run lint
- npm run build
- npm test