### PR TITLE
Skip pinned Vault and SFTP tabs when cycling with Ctrl+Tab

### DIFF
--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -5,7 +5,7 @@ import type { PassphraseRequest } from '../../components/PassphraseModal';
 import { getEffectiveHostDistro } from '../../domain/host';
 import { sanitizeHostIconFields } from '../../domain/hostIcon';
 import { getTerminalPassthroughActions } from '../state/useGlobalHotkeys';
-import { buildCycleTabTargets, buildNumberShortcutTabTargets } from './tabShortcutTargets';
+import { buildNumberShortcutTabTargets } from './tabShortcutTargets';
 
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
@@ -465,10 +465,6 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
       orderedTabs,
       editorTabIds: editorTabs.map((t) => toEditorTabId(t.id)),
     });
-    const cycleTabs = buildCycleTabTargets({
-      orderedTabs,
-      editorTabIds: editorTabs.map((t) => toEditorTabId(t.id)),
-    });
     switch (action) {
       case 'switchToTab': {
         // Get the number key pressed (1-9)
@@ -482,23 +478,23 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
       }
       case 'nextTab': {
         const currentId = activeTabStore.getActiveTabId();
-        const currentIdx = cycleTabs.indexOf(currentId);
-        if (currentIdx !== -1 && cycleTabs.length > 0) {
-          const nextIdx = (currentIdx + 1) % cycleTabs.length;
-          setActiveTabId(cycleTabs[nextIdx]);
-        } else if (cycleTabs.length > 0) {
-          setActiveTabId(cycleTabs[0]);
+        const currentIdx = allTabs.indexOf(currentId);
+        if (currentIdx !== -1 && allTabs.length > 0) {
+          const nextIdx = (currentIdx + 1) % allTabs.length;
+          setActiveTabId(allTabs[nextIdx]);
+        } else if (allTabs.length > 0) {
+          setActiveTabId(allTabs[0]);
         }
         break;
       }
       case 'prevTab': {
         const currentId = activeTabStore.getActiveTabId();
-        const currentIdx = cycleTabs.indexOf(currentId);
-        if (currentIdx !== -1 && cycleTabs.length > 0) {
-          const prevIdx = (currentIdx - 1 + cycleTabs.length) % cycleTabs.length;
-          setActiveTabId(cycleTabs[prevIdx]);
-        } else if (cycleTabs.length > 0) {
-          setActiveTabId(cycleTabs[cycleTabs.length - 1]);
+        const currentIdx = allTabs.indexOf(currentId);
+        if (currentIdx !== -1 && allTabs.length > 0) {
+          const prevIdx = (currentIdx - 1 + allTabs.length) % allTabs.length;
+          setActiveTabId(allTabs[prevIdx]);
+        } else if (allTabs.length > 0) {
+          setActiveTabId(allTabs[allTabs.length - 1]);
         }
         break;
       }

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -5,7 +5,7 @@ import type { PassphraseRequest } from '../../components/PassphraseModal';
 import { getEffectiveHostDistro } from '../../domain/host';
 import { sanitizeHostIconFields } from '../../domain/hostIcon';
 import { getTerminalPassthroughActions } from '../state/useGlobalHotkeys';
-import { buildNumberShortcutTabTargets } from './tabShortcutTargets';
+import { buildCycleTabTargets, buildNumberShortcutTabTargets } from './tabShortcutTargets';
 
 type AppContextGetter = () => Record<string, any>;
 const TERMINAL_PASSTHROUGH_ACTIONS = getTerminalPassthroughActions();
@@ -465,6 +465,10 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
       orderedTabs,
       editorTabIds: editorTabs.map((t) => toEditorTabId(t.id)),
     });
+    const cycleTabs = buildCycleTabTargets({
+      orderedTabs,
+      editorTabIds: editorTabs.map((t) => toEditorTabId(t.id)),
+    });
     switch (action) {
       case 'switchToTab': {
         // Get the number key pressed (1-9)
@@ -478,23 +482,23 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
       }
       case 'nextTab': {
         const currentId = activeTabStore.getActiveTabId();
-        const currentIdx = allTabs.indexOf(currentId);
-        if (currentIdx !== -1 && allTabs.length > 0) {
-          const nextIdx = (currentIdx + 1) % allTabs.length;
-          setActiveTabId(allTabs[nextIdx]);
-        } else if (allTabs.length > 0) {
-          setActiveTabId(allTabs[0]);
+        const currentIdx = cycleTabs.indexOf(currentId);
+        if (currentIdx !== -1 && cycleTabs.length > 0) {
+          const nextIdx = (currentIdx + 1) % cycleTabs.length;
+          setActiveTabId(cycleTabs[nextIdx]);
+        } else if (cycleTabs.length > 0) {
+          setActiveTabId(cycleTabs[0]);
         }
         break;
       }
       case 'prevTab': {
         const currentId = activeTabStore.getActiveTabId();
-        const currentIdx = allTabs.indexOf(currentId);
-        if (currentIdx !== -1 && allTabs.length > 0) {
-          const prevIdx = (currentIdx - 1 + allTabs.length) % allTabs.length;
-          setActiveTabId(allTabs[prevIdx]);
-        } else if (allTabs.length > 0) {
-          setActiveTabId(allTabs[allTabs.length - 1]);
+        const currentIdx = cycleTabs.indexOf(currentId);
+        if (currentIdx !== -1 && cycleTabs.length > 0) {
+          const prevIdx = (currentIdx - 1 + cycleTabs.length) % cycleTabs.length;
+          setActiveTabId(cycleTabs[prevIdx]);
+        } else if (cycleTabs.length > 0) {
+          setActiveTabId(cycleTabs[cycleTabs.length - 1]);
         }
         break;
       }

--- a/application/app/tabShortcutTargets.test.ts
+++ b/application/app/tabShortcutTargets.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildNumberShortcutTabTargets } from './tabShortcutTargets.ts';
+import { buildCycleTabTargets, buildNumberShortcutTabTargets } from './tabShortcutTargets.ts';
 
 test('number shortcut tabs include vault and sftp by default', () => {
   assert.deepEqual(
@@ -36,5 +36,15 @@ test('hidden sftp tab is omitted from default number shortcut targets', () => {
       editorTabIds: [],
     }),
     ['vault', 'session-1'],
+  );
+});
+
+test('cycle tab targets skip vault and sftp', () => {
+  assert.deepEqual(
+    buildCycleTabTargets({
+      orderedTabs: ['session-1', 'workspace-1'],
+      editorTabIds: ['editor:file-1'],
+    }),
+    ['session-1', 'workspace-1', 'editor:file-1'],
   );
 });

--- a/application/app/tabShortcutTargets.test.ts
+++ b/application/app/tabShortcutTargets.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { buildCycleTabTargets, buildNumberShortcutTabTargets } from './tabShortcutTargets.ts';
+import { buildNumberShortcutTabTargets } from './tabShortcutTargets.ts';
 
 test('number shortcut tabs include vault and sftp by default', () => {
   assert.deepEqual(
@@ -36,15 +36,5 @@ test('hidden sftp tab is omitted from default number shortcut targets', () => {
       editorTabIds: [],
     }),
     ['vault', 'session-1'],
-  );
-});
-
-test('cycle tab targets skip vault and sftp', () => {
-  assert.deepEqual(
-    buildCycleTabTargets({
-      orderedTabs: ['session-1', 'workspace-1'],
-      editorTabIds: ['editor:file-1'],
-    }),
-    ['session-1', 'workspace-1', 'editor:file-1'],
   );
 });

--- a/application/app/tabShortcutTargets.ts
+++ b/application/app/tabShortcutTargets.ts
@@ -12,11 +12,3 @@ export function buildNumberShortcutTabTargets(params: {
   const pinnedTabs = params.showSftpTab ? ['vault', 'sftp'] : ['vault'];
   return [...pinnedTabs, ...workTabs];
 }
-
-/** Tab ids targeted by next/previous tab shortcuts. */
-export function buildCycleTabTargets(params: {
-  orderedTabs: readonly string[];
-  editorTabIds: readonly string[];
-}): string[] {
-  return [...params.orderedTabs, ...params.editorTabIds];
-}

--- a/application/app/tabShortcutTargets.ts
+++ b/application/app/tabShortcutTargets.ts
@@ -12,3 +12,11 @@ export function buildNumberShortcutTabTargets(params: {
   const pinnedTabs = params.showSftpTab ? ['vault', 'sftp'] : ['vault'];
   return [...pinnedTabs, ...workTabs];
 }
+
+/** Tab ids targeted by next/previous tab shortcuts. */
+export function buildCycleTabTargets(params: {
+  orderedTabs: readonly string[];
+  editorTabIds: readonly string[];
+}): string[] {
+  return [...params.orderedTabs, ...params.editorTabIds];
+}


### PR DESCRIPTION
Summary
- Skip pinned Vault and SFTP tabs when cycling with Ctrl+Tab.

Tests
- Not run in this step.