### PR TITLE
Follow up host key setting memo refresh

### DIFF
--- a/components/SftpView.memo.test.tsx
+++ b/components/SftpView.memo.test.tsx
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("SftpView re-renders when host-key verification setting changes", async () => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    },
+  });
+  const { sftpViewAreEqual } = await import("./SftpView.tsx");
+
+  const baseProps = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    knownHosts: [],
+    groupConfigs: [],
+    proxyProfiles: [],
+    updateHosts: () => {},
+    onAddKnownHost: () => {},
+    sftpDefaultViewMode: "list",
+    sftpDoubleClickBehavior: "open",
+    sftpAutoSync: false,
+    sftpShowHiddenFiles: false,
+    sftpUseCompressedUpload: false,
+    hotkeyScheme: {},
+    keyBindings: [],
+    editorWordWrap: false,
+    setEditorWordWrap: () => {},
+    terminalSettings: {
+      verifyHostKeys: true,
+      keepaliveInterval: 30,
+      keepaliveCountMax: 10,
+    },
+  };
+
+  assert.equal(
+    sftpViewAreEqual(
+      baseProps as never,
+      {
+        ...baseProps,
+        terminalSettings: {
+          ...baseProps.terminalSettings,
+          verifyHostKeys: false,
+        },
+      } as never,
+    ),
+    false,
+  );
+});

--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -68,7 +68,7 @@ interface SftpViewProps {
   keyBindings: KeyBinding[];
   editorWordWrap: boolean;
   setEditorWordWrap: (enabled: boolean) => void;
-  terminalSettings?: { keepaliveInterval: number; keepaliveCountMax: number };
+  terminalSettings?: { verifyHostKeys: boolean; keepaliveInterval: number; keepaliveCountMax: number };
 }
 
 const SftpViewInner: React.FC<SftpViewProps> = ({
@@ -614,7 +614,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
   );
 };
 
-const sftpViewAreEqual = (prev: SftpViewProps, next: SftpViewProps): boolean =>
+export const sftpViewAreEqual = (prev: SftpViewProps, next: SftpViewProps): boolean =>
   prev.hosts === next.hosts &&
   prev.keys === next.keys &&
   prev.identities === next.identities &&
@@ -631,9 +631,10 @@ const sftpViewAreEqual = (prev: SftpViewProps, next: SftpViewProps): boolean =>
   prev.keyBindings === next.keyBindings &&
   prev.editorWordWrap === next.editorWordWrap &&
   prev.setEditorWordWrap === next.setEditorWordWrap &&
-  // Only the keepalive fields of terminalSettings affect SFTP connection
+  // Only these terminal connection settings affect SFTP connection
   // resolution today; compare them directly rather than the whole object
   // so unrelated terminal-setting changes don't tear the panel down.
+  prev.terminalSettings?.verifyHostKeys === next.terminalSettings?.verifyHostKeys &&
   prev.terminalSettings?.keepaliveInterval === next.terminalSettings?.keepaliveInterval &&
   prev.terminalSettings?.keepaliveCountMax === next.terminalSettings?.keepaliveCountMax;
 

--- a/components/VaultView.memo.test.tsx
+++ b/components/VaultView.memo.test.tsx
@@ -74,3 +74,45 @@ test("VaultView re-renders when proxy profiles change", () => {
     false,
   );
 });
+
+test("VaultView re-renders when host-key verification setting changes", () => {
+  const baseProps = {
+    hosts: [],
+    keys: [],
+    identities: [],
+    proxyProfiles: [],
+    snippets: [],
+    snippetPackages: [],
+    notes: [],
+    noteGroups: [],
+    customGroups: [],
+    knownHosts: [],
+    shellHistory: [],
+    connectionLogs: [],
+    sessions: [],
+    managedSources: [],
+    groupConfigs: {},
+    terminalThemeId: "default",
+    terminalFontSize: 14,
+    navigateToSection: null,
+    terminalSettings: {
+      verifyHostKeys: true,
+      keepaliveInterval: 30,
+      keepaliveCountMax: 10,
+    },
+  };
+
+  assert.equal(
+    vaultViewAreEqual(
+      baseProps as never,
+      {
+        ...baseProps,
+        terminalSettings: {
+          ...baseProps.terminalSettings,
+          verifyHostKeys: false,
+        },
+      } as never,
+    ),
+    false,
+  );
+});

--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -225,7 +225,7 @@ interface VaultViewProps {
   onNavigateToSectionHandled?: () => void;
   deepLinkHostDraft?: Host | null;
   onDeepLinkHostDraftHandled?: () => void;
-  terminalSettings?: { keepaliveInterval: number; keepaliveCountMax: number };
+  terminalSettings?: { verifyHostKeys: boolean; keepaliveInterval: number; keepaliveCountMax: number };
 }
 
 const VaultViewInner: React.FC<VaultViewProps> = ({
@@ -1188,10 +1188,11 @@ export const vaultViewAreEqual = (
     prev.terminalFontSize === next.terminalFontSize &&
     prev.navigateToSection === next.navigateToSection &&
     prev.deepLinkHostDraft === next.deepLinkHostDraft &&
-    // Only the keepalive fields of terminalSettings are forwarded to
+    // Only these terminal connection settings are forwarded to
     // PortForwarding inside the vault, so compare them directly. Other
     // terminal settings (fonts, themes, etc.) don't affect this subtree
     // and we don't want to re-render for them.
+    prev.terminalSettings?.verifyHostKeys === next.terminalSettings?.verifyHostKeys &&
     prev.terminalSettings?.keepaliveInterval === next.terminalSettings?.keepaliveInterval &&
     prev.terminalSettings?.keepaliveCountMax === next.terminalSettings?.keepaliveCountMax;
 


### PR DESCRIPTION
## Summary
- include verifyHostKeys in Vault/port-forwarding memo comparison
- include verifyHostKeys in SFTP memo comparison
- add memo tests so toggling host-key verification refreshes both views

## Verification
- node --test --import tsx components/VaultView.memo.test.tsx components/SftpView.memo.test.tsx
- node --test --import tsx application/state/sftp/useSftpHostCredentials.test.ts components/port-forwarding/hostKeyVerification.test.ts components/port-forwarding/PortForwardHostKeyDialog.test.ts
- npm run lint
- npm run build