### PR TITLE
[codex] Respect scrollback clear setting for terminal clears

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1190,6 +1190,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const scrollOnPasteRef = useRef(terminalSettings?.scrollOnPaste ?? true);
   scrollOnPasteRef.current = terminalSettings?.scrollOnPaste ?? true;
+  const clearWipesScrollbackRef = useRef(terminalSettings?.clearWipesScrollback ?? true);
+  clearWipesScrollbackRef.current = terminalSettings?.clearWipesScrollback ?? true;
 
   const scrollToBottomAfterProgrammaticInput = useCallback((data: string) => {
     if (termRef.current && shouldScrollOnTerminalInput(terminalSettingsRef.current, data)) {
@@ -1270,6 +1272,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sessionRef,
     onHasSelectionChange: setHasSelection,
     scrollOnPasteRef,
+    clearWipesScrollbackRef,
     isBroadcastEnabledRef,
     onBroadcastInputRef,
     isLocalConnection,

--- a/components/terminal/clearTerminalViewport.test.ts
+++ b/components/terminal/clearTerminalViewport.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { shouldPreserveViewportBeforeFullErase } from "./clearTerminalViewport.ts";
+import {
+  clearTerminalViewport,
+  shouldPreserveViewportBeforeFullErase,
+  shouldWipeScrollbackAfterFullErase,
+} from "./clearTerminalViewport.ts";
 
 const createMockTerm = (bufferType: "normal" | "alternate"): { buffer: { active: { type: "normal" | "alternate" } } } => ({
   buffer: {
@@ -24,4 +28,47 @@ test("skips viewport preservation inside DEC 2026 sync blocks", () => {
 test("skips viewport preservation on the alternate screen", () => {
   const term = createMockTerm("alternate");
   assert.equal(shouldPreserveViewportBeforeFullErase(term as never, false), false);
+});
+
+test("skips viewport preservation when full erase should wipe scrollback", () => {
+  const term = createMockTerm("normal");
+  assert.equal(shouldPreserveViewportBeforeFullErase(term as never, false, true), false);
+});
+
+test("wipes scrollback after full erase only on the normal screen outside sync blocks", () => {
+  assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("normal") as never, false, true), true);
+  assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("normal") as never, true, true), false);
+  assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("alternate") as never, false, true), false);
+  assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("normal") as never, false, false), false);
+});
+
+test("local clear writes erase-scrollback when requested", () => {
+  const writes: string[] = [];
+  const term = {
+    rows: 5,
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 0,
+        cursorY: 2,
+        cursorX: 4,
+      },
+    },
+    _core: {
+      scroll: () => {},
+      _inputHandler: {
+        _eraseAttrData: () => ({}),
+      },
+    },
+    write: (payload: string, callback?: () => void) => {
+      writes.push(payload);
+      callback?.();
+    },
+    scrollToBottom: () => {},
+  };
+
+  clearTerminalViewport(term as never, { wipeScrollback: true });
+
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].includes("\x1b[3J"), true);
 });

--- a/components/terminal/clearTerminalViewport.test.ts
+++ b/components/terminal/clearTerminalViewport.test.ts
@@ -72,3 +72,34 @@ test("local clear writes erase-scrollback when requested", () => {
   assert.equal(writes.length, 1);
   assert.equal(writes[0].includes("\x1b[3J"), true);
 });
+
+test("local clear preserves scrollback when erase-scrollback is not requested", () => {
+  const writes: string[] = [];
+  const term = {
+    rows: 5,
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 0,
+        cursorY: 2,
+        cursorX: 4,
+      },
+    },
+    _core: {
+      scroll: () => {},
+      _inputHandler: {
+        _eraseAttrData: () => ({}),
+      },
+    },
+    write: (payload: string, callback?: () => void) => {
+      writes.push(payload);
+      callback?.();
+    },
+    scrollToBottom: () => {},
+  };
+
+  clearTerminalViewport(term as never, { wipeScrollback: false });
+
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].includes("\x1b[3J"), false);
+});

--- a/components/terminal/clearTerminalViewport.ts
+++ b/components/terminal/clearTerminalViewport.ts
@@ -14,6 +14,11 @@ type ClearTerminalViewportOptions = {
   wipeScrollback?: boolean;
 };
 
+type AppendEraseScrollbackOptions = {
+  wipeScrollback: boolean;
+  normalScreen: boolean;
+};
+
 const getVisibleContentRowCount = (term: XTerm): number => {
   const buffer = term.buffer.active;
   if (buffer.type !== "normal") {
@@ -120,4 +125,72 @@ export const shouldWipeScrollbackAfterFullErase = (
     return false;
   }
   return term.buffer.active.type === "normal";
+};
+
+export const appendEraseScrollbackAfterFullErases = (
+  data: string,
+  { wipeScrollback, normalScreen }: AppendEraseScrollbackOptions,
+): string => {
+  if (!wipeScrollback || !normalScreen || data.length === 0) {
+    return data;
+  }
+
+  let result = "";
+  let index = 0;
+  let inDec2026SyncBlock = false;
+  let inAlternateScreen = false;
+
+  while (index < data.length) {
+    if (data.startsWith("\x1b[?2026h", index)) {
+      inDec2026SyncBlock = true;
+      result += "\x1b[?2026h";
+      index += "\x1b[?2026h".length;
+      continue;
+    }
+
+    if (data.startsWith("\x1b[?2026l", index)) {
+      inDec2026SyncBlock = false;
+      result += "\x1b[?2026l";
+      index += "\x1b[?2026l".length;
+      continue;
+    }
+
+    const altEnter = ["\x1b[?47h", "\x1b[?1047h", "\x1b[?1049h"].find((sequence) =>
+      data.startsWith(sequence, index)
+    );
+    if (altEnter) {
+      inAlternateScreen = true;
+      result += altEnter;
+      index += altEnter.length;
+      continue;
+    }
+
+    const altLeave = ["\x1b[?47l", "\x1b[?1047l", "\x1b[?1049l"].find((sequence) =>
+      data.startsWith(sequence, index)
+    );
+    if (altLeave) {
+      inAlternateScreen = false;
+      result += altLeave;
+      index += altLeave.length;
+      continue;
+    }
+
+    if (data.startsWith("\x1b[2J", index)) {
+      result += "\x1b[2J";
+      index += "\x1b[2J".length;
+      if (
+        !inDec2026SyncBlock
+        && !inAlternateScreen
+        && !data.startsWith("\x1b[3J", index)
+      ) {
+        result += "\x1b[3J";
+      }
+      continue;
+    }
+
+    result += data[index];
+    index += 1;
+  }
+
+  return result;
 };

--- a/components/terminal/clearTerminalViewport.ts
+++ b/components/terminal/clearTerminalViewport.ts
@@ -10,6 +10,10 @@ type InternalTerminal = XTerm & {
   };
 };
 
+type ClearTerminalViewportOptions = {
+  wipeScrollback?: boolean;
+};
+
 const getVisibleContentRowCount = (term: XTerm): number => {
   const buffer = term.buffer.active;
   if (buffer.type !== "normal") {
@@ -49,7 +53,10 @@ export const preserveTerminalViewportInScrollback = (term: XTerm): void => {
   }
 };
 
-export const clearTerminalViewport = (term: XTerm): void => {
+export const clearTerminalViewport = (
+  term: XTerm,
+  options: ClearTerminalViewportOptions = {},
+): void => {
   const buffer = term.buffer.active;
   if (buffer.type !== "normal") return;
 
@@ -73,7 +80,8 @@ export const clearTerminalViewport = (term: XTerm): void => {
   // Clear everything below the prompt and reposition the cursor on it.
   // CSI coordinates are 1-indexed.
   const col = cursorX + 1;
-  term.write(`\x1b[2;1H\x1b[J\x1b[1;${col}H`, () => {
+  const eraseScrollback = options.wipeScrollback ? "\x1b[3J" : "";
+  term.write(`\x1b[2;1H\x1b[J${eraseScrollback}\x1b[1;${col}H`, () => {
     term.scrollToBottom();
   });
 };
@@ -92,8 +100,23 @@ export const isEraseViewportSequence = (params: CsiParam[]): boolean =>
 export const shouldPreserveViewportBeforeFullErase = (
   term: XTerm,
   inDec2026SyncBlock: boolean,
+  clearWipesScrollback = false,
 ): boolean => {
   if (inDec2026SyncBlock) {
+    return false;
+  }
+  if (clearWipesScrollback) {
+    return false;
+  }
+  return term.buffer.active.type === "normal";
+};
+
+export const shouldWipeScrollbackAfterFullErase = (
+  term: XTerm,
+  inDec2026SyncBlock: boolean,
+  clearWipesScrollback: boolean,
+): boolean => {
+  if (!clearWipesScrollback || inDec2026SyncBlock) {
     return false;
   }
   return term.buffer.active.type === "normal";

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -39,6 +39,7 @@ export const useTerminalContextActions = ({
   onBroadcastInputRef,
   isLocalConnection,
   supportsRemoteImagePaste,
+  clearWipesScrollbackRef,
   terminalBackend,
   getRemoteCwd,
   scrollToBottomAfterProgrammaticInput,
@@ -53,6 +54,7 @@ export const useTerminalContextActions = ({
   onBroadcastInputRef?: RefObject<((data: string, sourceSessionId: string) => void) | undefined>;
   isLocalConnection: boolean;
   supportsRemoteImagePaste: boolean;
+  clearWipesScrollbackRef?: RefObject<boolean | undefined>;
   terminalBackend: {
     writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   };
@@ -154,8 +156,8 @@ export const useTerminalContextActions = ({
   const onClear = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    clearTerminalViewport(term);
-  }, [termRef]);
+    clearTerminalViewport(term, { wipeScrollback: clearWipesScrollbackRef?.current ?? true });
+  }, [clearWipesScrollbackRef, termRef]);
 
   const onSelectWord = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -40,6 +40,7 @@ import {
   isEraseViewportSequence,
   preserveTerminalViewportInScrollback,
   shouldPreserveViewportBeforeFullErase,
+  shouldWipeScrollbackAfterFullErase,
 } from "../clearTerminalViewport";
 import {
   createKittyKeyboardModeState,
@@ -873,7 +874,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "clearBuffer": {
-              clearTerminalViewport(term);
+              clearTerminalViewport(term, {
+                wipeScrollback: ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true,
+              });
               break;
             }
             case "searchTerminal": {
@@ -1111,9 +1114,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   );
 
   const eraseScrollbackDisposable = term.parser.registerCsiHandler({ final: "J" }, (params) => {
+    const wipeAllowed = ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true;
     if (isEraseViewportSequence(params)) {
-      if (shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock)) {
+      if (shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock, wipeAllowed)) {
         preserveTerminalViewportInScrollback(term);
+      }
+      if (shouldWipeScrollbackAfterFullErase(term, inDec2026SyncBlock, wipeAllowed)) {
+        queueMicrotask(() => term.write("\x1b[3J"));
       }
       return false;
     }
@@ -1122,7 +1129,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
     // CSI 3 J — POSIX/ncurses default `clear` emits this to wipe scrollback.
     // Honor it unless the user opts into the legacy "preserve history" behavior.
-    const wipeAllowed = ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true;
     return !wipeAllowed;
   });
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -40,7 +40,6 @@ import {
   isEraseViewportSequence,
   preserveTerminalViewportInScrollback,
   shouldPreserveViewportBeforeFullErase,
-  shouldWipeScrollbackAfterFullErase,
 } from "../clearTerminalViewport";
 import {
   createKittyKeyboardModeState,
@@ -1118,9 +1117,6 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     if (isEraseViewportSequence(params)) {
       if (shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock, wipeAllowed)) {
         preserveTerminalViewportInScrollback(term);
-      }
-      if (shouldWipeScrollbackAfterFullErase(term, inDec2026SyncBlock, wipeAllowed)) {
-        queueMicrotask(() => term.write("\x1b[3J"));
       }
       return false;
     }

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -113,6 +113,38 @@ test("writeSessionData resumes timestamps after leaving alternate screen in the 
   assert.deepEqual(markerLines, [0]);
 });
 
+test("writeSessionData inserts erase-scrollback immediately after normal full clear", () => {
+  const { term, writes } = createFakeTerm();
+  writeSessionData(createContext(false) as never, term, "\x1b[H\x1b[2Jfresh output");
+
+  assert.equal(writes.join(""), "\x1b[H\x1b[2J\x1b[3Jfresh output");
+});
+
+test("writeSessionData preserves scrollback after normal full clear when disabled", () => {
+  const { term, writes } = createFakeTerm();
+  const ctx = createContext(false);
+  ctx.terminalSettingsRef.current.clearWipesScrollback = false;
+  ctx.terminalSettings.clearWipesScrollback = false;
+
+  writeSessionData(ctx as never, term, "\x1b[H\x1b[2Jfresh output");
+
+  assert.equal(writes.join(""), "\x1b[H\x1b[2Jfresh output");
+});
+
+test("writeSessionData does not duplicate existing erase-scrollback after full clear", () => {
+  const { term, writes } = createFakeTerm();
+  writeSessionData(createContext(false) as never, term, "\x1b[H\x1b[2J\x1b[3Jfresh output");
+
+  assert.equal(writes.join(""), "\x1b[H\x1b[2J\x1b[3Jfresh output");
+});
+
+test("writeSessionData does not add erase-scrollback inside synchronized output", () => {
+  const { term, writes } = createFakeTerm();
+  writeSessionData(createContext(false) as never, term, "\x1b[?2026h\x1b[H\x1b[2Jframe\x1b[?2026l");
+
+  assert.equal(writes.join(""), "\x1b[?2026h\x1b[H\x1b[2Jframe\x1b[?2026l");
+});
+
 test("writeSessionData preserves timestamps across host gutter visibility changes", () => {
   const { term, writes, markerLines, disposedMarkerLines } = createFakeTerm();
   const ctx = createContext(false, { showLineTimestamps: false });

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -22,6 +22,7 @@ import {
   filterTerminalSessionData,
   resetTerminalSyncBlockFilter,
 } from "./terminalSyncBlockFilter";
+import { appendEraseScrollbackAfterFullErases } from "../clearTerminalViewport";
 import {
   enqueueCoalescedTerminalWrite,
   flushTerminalWriteCoalescer,
@@ -163,8 +164,12 @@ const writeSessionDataImmediate = (
   const flow = getFlowController(ctx, term);
   flow.received(data.length);
   enqueueTerminalWrite(term, (done) => {
-    const displayData = filterTerminalSessionData(term, data);
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
+    const filteredData = filterTerminalSessionData(term, data);
+    const displayData = appendEraseScrollbackAfterFullErases(filteredData, {
+      wipeScrollback: settings?.clearWipesScrollback ?? true,
+      normalScreen: term.buffer?.active?.type !== "alternate",
+    });
     const forcePromptNewLine = settings?.forcePromptNewLine ?? false;
     if (!forcePromptNewLine && ctx.promptLineBreakStateRef?.current) {
       ctx.promptLineBreakStateRef.current.pendingCommand = false;
@@ -197,7 +202,7 @@ const writeSessionDataImmediate = (
       }
       done();
       // Acknowledge the chunk so back-pressure can ease once xterm catches up.
-      flow.written(displayData.length);
+      flow.written(filteredData.length);
     };
 
     writeTerminalDataWithLineTimestamps(term, preparedDisplayData, afterWrite);


### PR DESCRIPTION
## Summary
- Make terminal clear shortcuts and context-menu clears honor the existing clear-wipes-scrollback setting.
- Apply the same setting when normal-screen full clear sequences are received, covering shell Ctrl+L behavior.
- Add regression tests for preserving vs wiping scrollback around full clears.

Fixes #1673

## Validation
- node --test --import tsx components/terminal/clearTerminalViewport.test.ts
- node --test --import tsx components/terminal/*.test.ts components/terminal/runtime/*.test.ts
- npm run lint
- npm run build