### PR TITLE
Fit large AI tool outputs before model replay

### DIFF
--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveSessionQueueKeyForTests } from './capabilityTools';
+import { createCattyToolsFromCatalog, resolveSessionQueueKeyForTests } from './capabilityTools';
+import { ToolOutputStore } from './toolOutputStore';
 
 describe('capabilityTools session queue keys', () => {
   it('does not queue read-only harness tools behind terminal session writes', () => {
@@ -27,5 +28,41 @@ describe('capabilityTools session queue keys', () => {
       'chat-1',
     );
     assert.equal(key, 'chat-1:session-a');
+  });
+});
+
+describe('capabilityTools result fitting', () => {
+  it('truncates large vault note content and stores the full note body behind a handle', async () => {
+    const store = new ToolOutputStore();
+    const body = `${'note line\n'.repeat(1000)}important ending`;
+    const tools = createCattyToolsFromCatalog(
+      {
+        aiCapability: async () => ({
+          ok: true,
+          note: {
+            id: 'note-1',
+            title: 'Long note',
+            content: body,
+          },
+        }),
+      },
+      { sessions: [] },
+      [],
+      'auto',
+      undefined,
+      'chat-1',
+      store,
+    );
+
+    const result = await tools.vault_notes_get.execute(
+      { noteId: 'note-1' },
+      { toolCallId: 'call-1', messages: [] },
+    ) as { note: { content: string } };
+
+    assert.notEqual(result.note.content, body);
+    assert.match(result.note.content, /tool output handle/);
+    const handleId = result.note.content.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
+    assert.ok(handleId);
+    assert.equal(store.read({ handleId, mode: 'full', maxChars: body.length + 100 }, 'chat-1'), body);
   });
 });

--- a/infrastructure/ai/harness/capabilityTools.test.ts
+++ b/infrastructure/ai/harness/capabilityTools.test.ts
@@ -65,4 +65,30 @@ describe('capabilityTools result fitting', () => {
     assert.ok(handleId);
     assert.equal(store.read({ handleId, mode: 'full', maxChars: body.length + 100 }, 'chat-1'), body);
   });
+
+  it('does not refit explicit tool output read-back content', async () => {
+    const store = new ToolOutputStore();
+    const body = `${'full note line\n'.repeat(1000)}important ending`;
+    const handle = store.store({
+      chatSessionId: 'chat-1',
+      capabilityId: 'vault.notes.get',
+      content: body,
+    });
+    const tools = createCattyToolsFromCatalog(
+      {},
+      { sessions: [] },
+      [],
+      'auto',
+      undefined,
+      'chat-1',
+      store,
+    );
+
+    const result = await tools.tool_output_read.execute(
+      { handleId: handle.id, mode: 'full', maxChars: body.length + 100 },
+      { toolCallId: 'call-1', messages: [] },
+    ) as { content: string };
+
+    assert.equal(result.content, body);
+  });
 });

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -119,6 +119,10 @@ function fitCapabilityResultForModel(
   chatSessionId?: string,
   toolOutputStore?: ToolOutputStore,
 ): unknown {
+  if (spec.capabilityId === 'harness.tool_output.read') {
+    return result;
+  }
+
   return fitLargeToolResultForModel({
     result,
     capabilityId: spec.capabilityId,

--- a/infrastructure/ai/harness/capabilityTools.ts
+++ b/infrastructure/ai/harness/capabilityTools.ts
@@ -16,6 +16,7 @@ import {
 import { requestApproval } from '../shared/approvalGate';
 import { reserveSessionSlot } from '../shared/sessionExecutionQueue';
 import { fitTerminalExecuteResultForModel } from './terminalCompression';
+import { fitLargeToolResultForModel } from './toolResultFitting';
 import type { ToolOutputStore } from './toolOutputStore';
 import {
   hashScopeKey,
@@ -110,6 +111,20 @@ function applyToolDedup(
   }
   dedup.remember(toolName, fingerprint, previewToolResult(result));
   return result;
+}
+
+function fitCapabilityResultForModel(
+  result: unknown,
+  spec: CattyToolSpec,
+  chatSessionId?: string,
+  toolOutputStore?: ToolOutputStore,
+): unknown {
+  return fitLargeToolResultForModel({
+    result,
+    capabilityId: spec.capabilityId,
+    chatSessionId,
+    toolOutputStore,
+  });
 }
 
 interface LocalExecutionContext {
@@ -304,7 +319,7 @@ function createCatalogTool(
         }
 
         if (spec.localExecution || spec.capabilityId.startsWith('harness.')) {
-          return executeLocalCattyCapability({
+          const result = await executeLocalCattyCapability({
             deps,
             spec,
             args: args as Record<string, unknown>,
@@ -312,6 +327,7 @@ function createCatalogTool(
             toolResultDedup,
             chatSessionId: deps.chatSessionId,
           });
+          return fitCapabilityResultForModel(result, spec, deps.chatSessionId, toolOutputStore);
         }
 
         if (!spec.rpcMethod) {
@@ -332,7 +348,12 @@ function createCatalogTool(
             hashScopeKey([deps.chatSessionId, ctx.workspaceId, String(ctx.sessions?.length ?? 0)]),
           );
           if (fingerprint) {
-            return applyToolDedup(spec.toolName, fingerprint, raw, toolResultDedup);
+            return fitCapabilityResultForModel(
+              applyToolDedup(spec.toolName, fingerprint, raw, toolResultDedup),
+              spec,
+              deps.chatSessionId,
+              toolOutputStore,
+            );
           }
         }
 
@@ -343,7 +364,12 @@ function createCatalogTool(
             hashScopeKey([sid, path]),
           );
           if (fingerprint) {
-            return applyToolDedup(spec.toolName, fingerprint, raw, toolResultDedup);
+            return fitCapabilityResultForModel(
+              applyToolDedup(spec.toolName, fingerprint, raw, toolResultDedup),
+              spec,
+              deps.chatSessionId,
+              toolOutputStore,
+            );
           }
 
           if (
@@ -374,7 +400,7 @@ function createCatalogTool(
           }
         }
 
-        return raw;
+        return fitCapabilityResultForModel(raw, spec, deps.chatSessionId, toolOutputStore);
       } finally {
         slot?.release();
       }

--- a/infrastructure/ai/harness/toolResultFitting.test.ts
+++ b/infrastructure/ai/harness/toolResultFitting.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fitLargeToolResultForModel } from './toolResultFitting';
+import { ToolOutputStore } from './toolOutputStore';
+
+describe('fitLargeToolResultForModel', () => {
+  it('truncates large nested string fields and stores the full content behind a handle', () => {
+    const store = new ToolOutputStore();
+    const body = `${'alpha\n'.repeat(1000)}important-tail`;
+
+    const fitted = fitLargeToolResultForModel({
+      result: {
+        ok: true,
+        note: {
+          id: 'note-1',
+          title: 'Runbook',
+          content: body,
+        },
+      },
+      capabilityId: 'vault.note.get',
+      chatSessionId: 'chat-1',
+      toolOutputStore: store,
+      maxStringChars: 500,
+    }) as {
+      note: { content: string };
+    };
+
+    assert.notEqual(fitted.note.content, body);
+    assert.match(fitted.note.content, /tool output handle/);
+    assert.match(fitted.note.content, /capability=vault\.note\.get/);
+    assert.match(fitted.note.content, /field=note\.content/);
+    assert.match(fitted.note.content, /handleId=tool-output-/);
+
+    const handleId = fitted.note.content.match(/handleId=(tool-output-[^\]\s]+)/)?.[1];
+    assert.ok(handleId);
+    assert.equal(store.read({ handleId, mode: 'full', maxChars: body.length + 100 }, 'chat-1'), body);
+  });
+
+  it('leaves small results unchanged', () => {
+    const result = {
+      ok: true,
+      note: {
+        id: 'note-1',
+        content: 'short note',
+      },
+    };
+
+    const fitted = fitLargeToolResultForModel({
+      result,
+      capabilityId: 'vault.note.get',
+      chatSessionId: 'chat-1',
+      toolOutputStore: new ToolOutputStore(),
+      maxStringChars: 500,
+    });
+
+    assert.equal(fitted, result);
+  });
+});

--- a/infrastructure/ai/harness/toolResultFitting.ts
+++ b/infrastructure/ai/harness/toolResultFitting.ts
@@ -1,0 +1,121 @@
+import { compressVerboseText, truncateTextWithHeadAndTail } from '../requestPayloadCompression';
+import type { ToolOutputStore } from './toolOutputStore';
+
+export const MAX_LIVE_TOOL_STRING_CHARS = 8_000;
+
+export interface FitLargeToolResultForModelInput {
+  result: unknown;
+  capabilityId: string;
+  chatSessionId?: string;
+  toolOutputStore?: ToolOutputStore;
+  maxStringChars?: number;
+}
+
+export function fitLargeToolResultForModel({
+  result,
+  capabilityId,
+  chatSessionId,
+  toolOutputStore,
+  maxStringChars = MAX_LIVE_TOOL_STRING_CHARS,
+}: FitLargeToolResultForModelInput): unknown {
+  return fitValue(result, {
+    capabilityId,
+    chatSessionId,
+    toolOutputStore,
+    maxStringChars,
+    path: [],
+  });
+}
+
+interface FitValueContext {
+  capabilityId: string;
+  chatSessionId?: string;
+  toolOutputStore?: ToolOutputStore;
+  maxStringChars: number;
+  path: string[];
+}
+
+function fitValue(value: unknown, ctx: FitValueContext): unknown {
+  if (typeof value === 'string') {
+    return fitString(value, ctx);
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((entry, index) => {
+      const fitted = fitValue(entry, {
+        ...ctx,
+        path: [...ctx.path, `[${index}]`],
+      });
+      if (fitted !== entry) changed = true;
+      return fitted;
+    });
+    return changed ? next : value;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const fitted = fitValue(entry, {
+      ...ctx,
+      path: [...ctx.path, key],
+    });
+    if (fitted !== entry) changed = true;
+    next[key] = fitted;
+  }
+
+  return changed ? next : value;
+}
+
+function fitString(value: string, ctx: FitValueContext): string {
+  if (value.length <= ctx.maxStringChars) return value;
+
+  const fitted = truncateTextWithHeadAndTail(
+    compressVerboseText(value),
+    ctx.maxStringChars,
+  );
+  if (fitted === value) return value;
+
+  let handleId: string | undefined;
+  if (ctx.toolOutputStore && ctx.chatSessionId) {
+    handleId = ctx.toolOutputStore.store({
+      chatSessionId: ctx.chatSessionId,
+      capabilityId: ctx.capabilityId,
+      content: value,
+    }).id;
+  }
+
+  return appendToolOutputHandleNotice(fitted, {
+    capabilityId: ctx.capabilityId,
+    fieldPath: formatFieldPath(ctx.path),
+    totalChars: value.length,
+    handleId,
+  });
+}
+
+function formatFieldPath(path: string[]): string {
+  if (path.length === 0) return '$';
+  return path
+    .map((part, index) => {
+      if (part.startsWith('[')) return part;
+      return index === 0 ? part : `.${part}`;
+    })
+    .join('');
+}
+
+function appendToolOutputHandleNotice(
+  fitted: string,
+  details: {
+    capabilityId: string;
+    fieldPath: string;
+    totalChars: number;
+    handleId?: string;
+  },
+): string {
+  const handleSuffix = details.handleId ? ` handleId=${details.handleId}` : '';
+  return `${fitted}\n\n[tool output handle: capability=${details.capabilityId} field=${details.fieldPath} chars=${details.totalChars} truncated for model context${handleSuffix}]`;
+}


### PR DESCRIPTION
## Summary
- add generic fitting for large AI tool result strings before they are sent back to the model
- apply it across catalog tools so large Vault note bodies are shortened in-context while the full text stays available by handle
- cover Vault note fitting with targeted tests

## Verification
- node --test --import tsx infrastructure/ai/harness/toolResultFitting.test.ts infrastructure/ai/harness/capabilityTools.test.ts
- node --test --import tsx infrastructure/ai/harness/*.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
- npm run build
- npm test (still has 12 pre-existing unrelated failures around Cursor SDK discovery, SSH compatibility, and capability catalog integrity)