### PR TITLE
[codex] Handle empty DeepSeek tool call fields

### DIFF
--- a/electron/capabilities/catalog/integrity.test.cjs
+++ b/electron/capabilities/catalog/integrity.test.cjs
@@ -54,9 +54,10 @@ test("implemented capabilities expose at least one surface binding", () => {
     assert.ok(surfaces.length > 0, `${capability.id} has no surfaces`);
     const hasRpc = surfaces.some((surface) => capability.surfaces[surface]?.rpcMethod);
     const hasCli = surfaces.some((surface) => capability.surfaces[surface]?.command);
+    const hasCatty = Boolean(capability.surfaces[CAPABILITY_SURFACES.CATTY]?.toolName);
     assert.ok(
-      hasRpc || hasCli || capability.surfaces[CAPABILITY_SURFACES.BUILTIN]?.mcpTool,
-      `${capability.id} has no rpc/cli/mcp binding`,
+      hasRpc || hasCli || hasCatty || capability.surfaces[CAPABILITY_SURFACES.BUILTIN]?.mcpTool,
+      `${capability.id} has no rpc/cli/catty/mcp binding`,
     );
   }
 });

--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -597,6 +597,231 @@ test('continues OpenAI-compatible streams when provider chunks omit the top-leve
   assert.equal(toolMessage.tool_call_id, assistantMessage.tool_calls?.[0]?.id);
 });
 
+test('continues DeepSeek-compatible tool streams when empty id, type, and name precede the real tool name', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      id: 'chatcmpl-one-api-test',
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'deepseek-chat',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                id: '',
+                type: '',
+                function: { name: '', arguments: '' },
+              }],
+            });
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                function: { name: 'terminal_exec', arguments: '{"command":"pwd"}' },
+              }],
+            });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { content: 'tool completed' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const executedCommands: string[] = [];
+  const model = createModelFromConfig({
+    id: 'deepseek-one-api',
+    providerId: 'custom',
+    name: 'DeepSeek One API',
+    apiKey: 'test-key',
+    baseURL: 'https://one-api.example/v1',
+    defaultModel: 'deepseek-chat',
+    enabled: true,
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect cwd' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          executedCommands.push(command);
+          return { ok: true };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  let text = '';
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    }
+  }
+
+  assert.deepEqual(executedCommands, ['pwd']);
+  assert.equal(text, 'tool completed');
+  const followUpMessages = sentBodies[1].messages as Array<Record<string, unknown>>;
+  const assistantMessage = followUpMessages[1] as {
+    tool_calls?: Array<{ id?: string; type?: string; function?: { name?: string; arguments?: string } }>;
+  };
+  const toolMessage = followUpMessages[2] as { tool_call_id?: string };
+  assert.ok(assistantMessage.tool_calls?.[0]?.id?.startsWith('call_netcatty_'));
+  assert.equal(assistantMessage.tool_calls?.[0]?.type, 'function');
+  assert.equal(assistantMessage.tool_calls?.[0]?.function?.name, 'terminal_exec');
+  assert.equal(toolMessage.tool_call_id, assistantMessage.tool_calls?.[0]?.id);
+});
+
+test('continues DeepSeek-compatible tool streams when later argument chunks keep empty id and type', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+  const sentBodies: Array<Record<string, unknown>> = [];
+  const emitChatChunk = (emit: (data: string) => void, delta: Record<string, unknown>, finishReason?: string) => {
+    emit(JSON.stringify({
+      id: 'chatcmpl-one-api-later-empty-test',
+      object: 'chat.completion.chunk',
+      created: 1777600000,
+      model: 'deepseek-chat',
+      choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+    }));
+  };
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (
+        requestId: string,
+        _url: string,
+        _headers: Record<string, string>,
+        body: string,
+      ) => {
+        sentBodies.push(JSON.parse(body));
+        const requestNumber = sentBodies.length;
+        setTimeout(() => {
+          const emit = dataHandlers.get(requestId);
+          assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+          if (requestNumber === 1) {
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                id: '',
+                type: '',
+                function: { name: 'terminal_exec', arguments: '{"command":' },
+              }],
+            });
+            emitChatChunk(emit, {
+              tool_calls: [{
+                index: 0,
+                id: '',
+                type: '',
+                function: { name: '', arguments: '"pwd"}' },
+              }],
+            });
+            emitChatChunk(emit, {}, 'tool_calls');
+          } else {
+            emitChatChunk(emit, { content: 'tool completed' });
+            emitChatChunk(emit, {}, 'stop');
+          }
+          endHandlers.get(requestId)?.();
+        }, 0);
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const executedCommands: string[] = [];
+  const model = createModelFromConfig({
+    id: 'deepseek-one-api',
+    providerId: 'custom',
+    name: 'DeepSeek One API',
+    apiKey: 'test-key',
+    baseURL: 'https://one-api.example/v1',
+    defaultModel: 'deepseek-chat',
+    enabled: true,
+  });
+
+  const result = streamText({
+    model,
+    messages: [{ role: 'user', content: 'inspect cwd' }],
+    tools: {
+      terminal_exec: tool({
+        inputSchema: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          executedCommands.push(command);
+          return { ok: true };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(2),
+  });
+
+  let text = '';
+  for await (const chunk of result.fullStream) {
+    if (chunk.type === 'text-delta') {
+      text += chunk.text;
+    }
+  }
+
+  assert.deepEqual(executedCommands, ['pwd']);
+  assert.equal(text, 'tool completed');
+});
+
 test('continues OpenAI-compatible tool streams when arguments arrive before the tool id and name', async (t) => {
   const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
   t.after(() => {

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -164,7 +164,18 @@ function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) =
           : toolCallRecord;
 
         if (existingId) {
-          normalizedToolCalls.push(toolCall);
+          const normalizedToolCall = normalizeOpenAIChatToolCall(toolCallRecord, existingId);
+          if (
+            normalizedToolCall.id === toolCallRecord.id &&
+            normalizedToolCall.type === toolCallRecord.type &&
+            normalizedToolCall.function === toolCallRecord.function
+          ) {
+            normalizedToolCalls.push(toolCall);
+          } else {
+            changed = true;
+            deltaChanged = true;
+            normalizedToolCalls.push(normalizedToolCall);
+          }
           continue;
         }
 
@@ -180,15 +191,20 @@ function createOpenAIChatToolCallNormalizer(requestId: string): (data: string) =
           : `call_netcatty_${requestIdToken}_${choiceIndex}_${toolCallIndex}`;
         toolCallIdsByChoiceAndIndex.set(key, toolCallId);
         pendingToolCallsByChoiceAndIndex.delete(key);
+        const normalizedToolCall = normalizeOpenAIChatToolCall(candidateToolCall, toolCallId);
 
-        if (candidateToolCall === toolCallRecord && toolCallId === toolCallRecord.id) {
+        if (
+          candidateToolCall === toolCallRecord &&
+          toolCallId === toolCallRecord.id &&
+          normalizedToolCall.type === toolCallRecord.type
+        ) {
           normalizedToolCalls.push(toolCall);
           continue;
         }
 
         changed = true;
         deltaChanged = true;
-        normalizedToolCalls.push({ ...candidateToolCall, id: toolCallId });
+        normalizedToolCalls.push(normalizedToolCall);
       }
 
       if (!deltaChanged) return choice;
@@ -221,10 +237,17 @@ function mergeOpenAIChatToolCallDeltas(
   const incomingFunction = incomingFn && typeof incomingFn === 'object'
     ? incomingFn as Record<string, unknown>
     : undefined;
-  const mergedFunction = {
+  const mergedFunction: Record<string, unknown> = {
     ...(currentFunction ?? {}),
     ...(incomingFunction ?? {}),
   };
+  if (
+    typeof currentFunction?.name === 'string' &&
+    currentFunction.name &&
+    incomingFunction?.name === ''
+  ) {
+    mergedFunction.name = currentFunction.name;
+  }
   const currentArgs = currentFunction?.arguments;
   const incomingArgs = incomingFunction?.arguments;
   if (typeof currentArgs === 'string' && typeof incomingArgs === 'string') {
@@ -236,6 +259,23 @@ function mergeOpenAIChatToolCallDeltas(
     ...incoming,
     function: mergedFunction,
   };
+}
+
+function normalizeOpenAIChatToolCall(
+  toolCall: Record<string, unknown>,
+  toolCallId: string,
+): Record<string, unknown> {
+  const normalized = { ...toolCall, id: toolCallId };
+  if (normalized.type === '') {
+    normalized.type = 'function';
+  }
+  const fn = normalized.function;
+  if (fn && typeof fn === 'object' && (fn as Record<string, unknown>).name === '') {
+    const normalizedFunction = { ...(fn as Record<string, unknown>) };
+    delete normalizedFunction.name;
+    normalized.function = normalizedFunction;
+  }
+  return normalized;
 }
 
 function hasFunctionName(toolCall: Record<string, unknown>): boolean {

--- a/package-lock.json
+++ b/package-lock.json
@@ -326,6 +326,29 @@
         "win32"
       ]
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.106.0.tgz",
+      "integrity": "sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -1255,7 +1278,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1535,6 +1557,14 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@buttercup/fetch": {
       "version": "0.2.1",
@@ -1854,7 +1884,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1944,7 +1973,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1954,12 +1982,21 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
       "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
@@ -2409,6 +2446,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2430,6 +2468,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3839,7 +3878,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -4122,7 +4160,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -7545,7 +7582,8 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -8155,7 +8193,6 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -8185,7 +8222,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8539,7 +8575,6 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.220.tgz",
       "integrity": "sha512-rwEKE75wfwfNWeGnjl0iQRA1W50HigKoGcGMeF3o5CqDSdI9IjmwzpV9xHXqLH6CYj6s9N1g6bbKFVDou9dJ/A==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "addons/*"
       ]
@@ -8604,7 +8639,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9306,7 +9340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10132,7 +10165,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10429,7 +10463,6 @@
       "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.2",
         "builder-util": "26.15.0",
@@ -10711,6 +10744,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10731,6 +10765,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10746,6 +10781,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10756,6 +10792,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -10980,7 +11017,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11434,7 +11470,8 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -12371,7 +12408,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12828,6 +12864,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12949,6 +12986,7 @@
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -13106,6 +13144,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14051,7 +14090,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -15172,6 +15210,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -15191,7 +15230,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -15942,6 +15980,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -15959,6 +15998,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -16263,7 +16303,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16273,7 +16312,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17611,6 +17649,7 @@
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -17916,6 +17955,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17942,6 +17982,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18016,7 +18057,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18111,7 +18151,8 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -18138,7 +18179,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -18250,7 +18290,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18291,7 +18330,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -18667,7 +18705,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18761,7 +18798,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19049,7 +19085,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Fixes #1683.

- Keeps OpenAI-compatible tool-call streams usable when DeepSeek / One API sends empty `id`, `type`, or `function.name` in early chunks.
- Fills an empty tool-call `type` with `function` once the tool call is ready to forward.
- Preserves a previously seen non-empty tool name when later chunks carry an empty name.
- Adds a regression test that exercises the full SDK tool loop and confirms the tool executes.

## Validation

- `node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts`
- `node --test --import tsx infrastructure/ai/providerContinuation.test.ts infrastructure/ai/providersBridgeFetch.test.ts infrastructure/ai/sdkProviders.test.ts infrastructure/ai/sdk/tools.test.ts`
- `npm run lint` (0 errors; existing warnings remain)

I also ran `npm test`; it still has unrelated environment/pre-existing failures around Electron/Cursor SDK detection and capability catalog integrity, while the AI provider tests above pass.