### PR TITLE
fix(terminal): 撰写栏多行输入只发送第一行

### DIFF
--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -708,6 +708,23 @@ function clearPendingAutomatedWrites(session) {
   session.pendingAutomatedWriteTimers = [];
 }
 
+// Terminal-originated automatic replies (cursor position reports, device
+// attributes, focus in/out, etc.) travel through the same write path as user
+// keystrokes but must NOT be treated as "the user started typing". A terminal
+// routinely emits such a reply right after the first line runs; counting it as
+// manual input would clear the pending automated line-by-line writes and only
+// the first line would ever be sent (multi-line compose-bar input bug).
+function isTerminalReportSequence(data) {
+  if (typeof data !== "string" || data.length === 0) return false;
+  // Focus in/out reports: ESC [ I  /  ESC [ O
+  if (data === "\x1b[I" || data === "\x1b[O") return true;
+  // CPR / DECXCPR / DA1 / DA2 / DSR: ESC [ (?|>)? digits/semicolons (R|c|n)
+  if (/^\x1b\[[?>]?[0-9;]*[Rcn]$/.test(data)) return true;
+  // DCS replies (XTGETTCAP / DECRQSS, etc.): ESC P ... ESC \
+  if (/^\x1bP[\s\S]*\x1b\\$/.test(data)) return true;
+  return false;
+}
+
 function splitTerminalInputIntoLineWrites(data) {
   if (typeof data !== "string") return [data];
   const chunks = [];
@@ -810,7 +827,9 @@ function writeToSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   if (!session) return;
 
-  if (!payload.automated) clearPendingAutomatedWrites(session);
+  if (!payload.automated && !isTerminalReportSequence(payload.data)) {
+    clearPendingAutomatedWrites(session);
+  }
   if (shouldBlockSessionInput(session, payload.data)) {
     return;
   }

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -720,6 +720,8 @@ function isTerminalReportSequence(data) {
   if (data === "\x1b[I" || data === "\x1b[O") return true;
   // CPR / DECXCPR / DA1 / DA2 / DSR: ESC [ (?|>)? digits/semicolons (R|c|n)
   if (/^\x1b\[[?>]?[0-9;]*[Rcn]$/.test(data)) return true;
+  // Kitty keyboard mode query reply: ESC [ ? digits u
+  if (/^\x1b\[\?[0-9]+u$/.test(data)) return true;
   // DCS replies (XTGETTCAP / DECRQSS, etc.): ESC P ... ESC \
   if (/^\x1bP[\s\S]*\x1b\\$/.test(data)) return true;
   return false;

--- a/electron/bridges/terminalBridge.composeMultiline.test.cjs
+++ b/electron/bridges/terminalBridge.composeMultiline.test.cjs
@@ -1,0 +1,87 @@
+/**
+ * 复现：撰写栏（Compose Bar）发送多行内容时只发出第一行。
+ *
+ * 链路：撰写栏 textarea → executeSnippetCommand(text, false) → 多行+autoRun
+ * 触发 lineDelayMs=250 → 后端 writeToSession 走"逐行延迟发送"：第一行立即发，
+ * 行2+ 用 setTimeout 排进 session.pendingAutomatedWriteTimers。
+ *
+ * 根因：writeToSession 开头
+ *   if (!payload.automated) clearPendingAutomatedWrites(session);
+ * 会被【任何】非自动写入触发——包括 xterm 对第一行命令输出的自动回写
+ * （光标位置查询 DSR 响应、焦点上报、bracketed-paste 响应等），它们同样走
+ * netcatty:write 且不带 automated 标志 → 清空行2+ 的待发队列 → 只发第一行。
+ * 与中文无关：shouldDelayAutoRunSnippetInput 只检测 \n，多行英文同样中招。
+ */
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const terminalBridge = require("./terminalBridge.cjs");
+
+function initBridge(sessions) {
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: { fromId: () => ({ send() {} }) },
+    },
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// 断言【期望的正确行为】：无害的终端自动回写不应取消后续行。
+// 因此在修复前，这个测试会失败（实际只发出 "echo one\r" + 那次自动回写）。
+test("[REPRO] terminal auto-reply between automated lines must NOT cancel pending lines", async () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: { signal() {}, write(data) { calls.push(data); } },
+  });
+  initBridge(sessions);
+
+  // 撰写栏多行（autoRun → 逐行延迟发送）
+  terminalBridge.writeToSession(
+    { sender: {} },
+    {
+      sessionId: "ssh-1",
+      data: "echo one\necho two\necho three\r",
+      automated: true,
+      lineDelayMs: 20,
+    },
+  );
+  assert.deepEqual(calls, ["echo one\r"], "第一行应立即发出");
+
+  // 模拟 xterm 对第一行命令输出的自动回写（光标位置查询 DSR 响应），非 automated
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x1b[2;1R" });
+
+  await delay(80);
+
+  assert.deepEqual(
+    calls,
+    ["echo one\r", "\x1b[2;1R", "echo two\r", "echo three\r"],
+    "终端自动回写不应清空逐行队列；行2/行3 应照常发出",
+  );
+});
+
+// 对照（护栏）：真正的用户中断（Ctrl+C）应当取消剩余自动逐行发送。
+// 这是既有的有意行为，修复 REPRO 时不能破坏。当前应通过。
+test("[GUARD] Ctrl+C between automated lines SHOULD cancel pending lines", async () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: { signal() {}, write(data) { calls.push(data); } },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession(
+    { sender: {} },
+    { sessionId: "ssh-1", data: "echo one\necho two\r", automated: true, lineDelayMs: 20 },
+  );
+  assert.deepEqual(calls, ["echo one\r"]);
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x03" }); // Ctrl+C
+  await delay(60);
+
+  assert.deepEqual(calls, ["echo one\r", "\x03"], "Ctrl+C 应取消行2（既有设计，修复后须保留）");
+});

--- a/electron/bridges/terminalBridge.composeMultiline.test.cjs
+++ b/electron/bridges/terminalBridge.composeMultiline.test.cjs
@@ -1,16 +1,14 @@
 /**
- * 复现：撰写栏（Compose Bar）发送多行内容时只发出第一行。
+ * Repro: multi-line compose bar input only sent the first line.
  *
- * 链路：撰写栏 textarea → executeSnippetCommand(text, false) → 多行+autoRun
- * 触发 lineDelayMs=250 → 后端 writeToSession 走"逐行延迟发送"：第一行立即发，
- * 行2+ 用 setTimeout 排进 session.pendingAutomatedWriteTimers。
+ * Path: compose bar textarea -> executeSnippetCommand(text, false) ->
+ * multi-line autoRun -> lineDelayMs=250 -> backend writeToSession sends the
+ * first line immediately and queues the remaining lines in
+ * session.pendingAutomatedWriteTimers.
  *
- * 根因：writeToSession 开头
- *   if (!payload.automated) clearPendingAutomatedWrites(session);
- * 会被【任何】非自动写入触发——包括 xterm 对第一行命令输出的自动回写
- * （光标位置查询 DSR 响应、焦点上报、bracketed-paste 响应等），它们同样走
- * netcatty:write 且不带 automated 标志 → 清空行2+ 的待发队列 → 只发第一行。
- * 与中文无关：shouldDelayAutoRunSnippetInput 只检测 \n，多行英文同样中招。
+ * Root cause: terminal-originated automatic replies used the same netcatty:write
+ * path without the automated flag. Treating those replies as user input cleared
+ * queued lines, so only the first line was sent.
  */
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -30,8 +28,7 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// 断言【期望的正确行为】：无害的终端自动回写不应取消后续行。
-// 因此在修复前，这个测试会失败（实际只发出 "echo one\r" + 那次自动回写）。
+// Expected behavior: harmless terminal auto-replies must not cancel queued lines.
 test("[REPRO] terminal auto-reply between automated lines must NOT cancel pending lines", async () => {
   const calls = [];
   const sessions = new Map();
@@ -40,7 +37,6 @@ test("[REPRO] terminal auto-reply between automated lines must NOT cancel pendin
   });
   initBridge(sessions);
 
-  // 撰写栏多行（autoRun → 逐行延迟发送）
   terminalBridge.writeToSession(
     { sender: {} },
     {
@@ -50,9 +46,8 @@ test("[REPRO] terminal auto-reply between automated lines must NOT cancel pendin
       lineDelayMs: 20,
     },
   );
-  assert.deepEqual(calls, ["echo one\r"], "第一行应立即发出");
+  assert.deepEqual(calls, ["echo one\r"], "the first line is sent immediately");
 
-  // 模拟 xterm 对第一行命令输出的自动回写（光标位置查询 DSR 响应），非 automated
   terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x1b[2;1R" });
 
   await delay(80);
@@ -60,12 +55,41 @@ test("[REPRO] terminal auto-reply between automated lines must NOT cancel pendin
   assert.deepEqual(
     calls,
     ["echo one\r", "\x1b[2;1R", "echo two\r", "echo three\r"],
-    "终端自动回写不应清空逐行队列；行2/行3 应照常发出",
+    "terminal auto-replies should not clear queued line writes",
   );
 });
 
-// 对照（护栏）：真正的用户中断（Ctrl+C）应当取消剩余自动逐行发送。
-// 这是既有的有意行为，修复 REPRO 时不能破坏。当前应通过。
+test("[REPRO] Kitty keyboard query reply must NOT cancel pending lines", async () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    stream: { signal() {}, write(data) { calls.push(data); } },
+  });
+  initBridge(sessions);
+
+  terminalBridge.writeToSession(
+    { sender: {} },
+    {
+      sessionId: "ssh-1",
+      data: "echo one\necho two\necho three\r",
+      automated: true,
+      lineDelayMs: 20,
+    },
+  );
+  assert.deepEqual(calls, ["echo one\r"], "the first line is sent immediately");
+
+  terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x1b[?0u" });
+
+  await delay(80);
+
+  assert.deepEqual(
+    calls,
+    ["echo one\r", "\x1b[?0u", "echo two\r", "echo three\r"],
+    "Kitty query replies should not clear queued line writes",
+  );
+});
+
+// Guardrail: real user interruption must still cancel queued automated writes.
 test("[GUARD] Ctrl+C between automated lines SHOULD cancel pending lines", async () => {
   const calls = [];
   const sessions = new Map();
@@ -83,5 +107,5 @@ test("[GUARD] Ctrl+C between automated lines SHOULD cancel pending lines", async
   terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "\x03" }); // Ctrl+C
   await delay(60);
 
-  assert.deepEqual(calls, ["echo one\r", "\x03"], "Ctrl+C 应取消行2（既有设计，修复后须保留）");
+  assert.deepEqual(calls, ["echo one\r", "\x03"], "Ctrl+C should cancel queued line writes");
 });


### PR DESCRIPTION
Fixes #1693

## 问题

从终端**撰写栏**（或任何自动执行的多行 snippet）发送多行内容时，只有**第一行**被发送，第一个换行之后的内容全部丢失。最初是在中文输入下发现的，但**与编码无关**。

## 根因

自动执行的多行输入采用"逐行延迟发送"（`lineDelayMs`）：第一行立即写入，其余行通过 `setTimeout` 排入 `session.pendingAutomatedWriteTimers`。`writeToSession` 在收到**任何**非自动写入时清空该队列：

```js
if (!payload.automated) clearPendingAutomatedWrites(session);
```

本意是"用户开始输入 / 按下 Ctrl+C → 中断整批发送"。但终端的**自动回写**——光标位置报告 `ESC[…R`、设备属性、焦点进出 `ESC[I`/`ESC[O`——走同一条 `netcatty:write` 路径且**不带** `automated` 标志，并且常在第一行执行后立即触发：队列被清空 → 第 2 行及之后再不发送 →「只发出第一行」。

`shouldDelayAutoRunSnippetInput` 仅检测 `\n`，因此任意多行输入都会触发，与语言无关（中文只是表象）。

## 修复

新增 `isTerminalReportSequence()`，将已识别的终端自动回写序列（光标位置报告 / 设备属性 / 焦点进出 / DCS 回复）从「取消整批发送」的判定中排除。这样：真正的用户输入仍能中断整批发送，无害的终端自动回写则不会。

## 测试

新增 `electron/bridges/terminalBridge.composeMultiline.test.cjs`：

- **[REPRO]** 行间的终端自动回写**不应**取消待发行 —— 修复前失败、修复后通过。
- **[GUARD]** 行间的 **Ctrl+C** 仍**应**取消待发行 —— 保留既有行为。

回归：`electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs` 仍 **8/8** 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)