### PR TITLE
[codex] Clean up lint warnings

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -10,7 +10,6 @@ import type {
   AgentModelPreset,
   AISessionScope,
   DiscoveredAgent,
-  ExternalAgentConfig,
 } from '../infrastructure/ai/types';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
 import { getAgentModelPresets } from '../infrastructure/ai/types';

--- a/components/settings/tabs/ai/managedAgentState.ts
+++ b/components/settings/tabs/ai/managedAgentState.ts
@@ -1,7 +1,6 @@
 import type { ExternalAgentConfig } from "../../../../infrastructure/ai/types";
 import {
   type ManagedAgentKey,
-  getExternalAgentSdkBackend,
   isPathLikeCommand,
 } from "../../../../infrastructure/ai/managedAgents";
 import type { AgentPathInfo } from "./types";

--- a/infrastructure/ai/harness/turnDrivers/types.ts
+++ b/infrastructure/ai/harness/turnDrivers/types.ts
@@ -6,7 +6,6 @@ import type {
   ChatMessage,
   ChatMessageAttachment,
   ExternalAgentConfig,
-  ProviderAdvancedParams,
   ProviderConfig,
   WebSearchConfig,
 } from '../../types';

--- a/infrastructure/ai/shared/approvalGate.ts
+++ b/infrastructure/ai/shared/approvalGate.ts
@@ -47,19 +47,12 @@ export type GrantPersister = (rule: PermissionGrantRule) => void;
 
 let grantPersister: GrantPersister | null = null;
 const grantPersisterStack: GrantPersister[] = [];
-let grantsHydrated = false;
 
 function refreshPermissionGrantsFromStorage(): void {
   if (typeof window === 'undefined') return;
   setActivePermissionGrants(
     sanitizePermissionGrants(localStorageAdapter.read<unknown>(STORAGE_KEY_AI_PERMISSION_GRANTS)),
   );
-  grantsHydrated = true;
-}
-
-function ensureGrantsHydrated(): void {
-  if (grantsHydrated) return;
-  refreshPermissionGrantsFromStorage();
 }
 
 export function setGrantPersister(persister: GrantPersister | null): void {
@@ -112,7 +105,6 @@ function emitApprovalEvent(
   extra?: { outcome?: 'approved' | 'denied' | 'timeout'; persistedGrantId?: string },
 ): void {
   const sessionId = request.chatSessionId ?? 'global';
-  const capabilityId = request.capabilityId ?? resolveCapabilityId(request.toolName);
   const base = {
     sessionId,
     chatSessionId: request.chatSessionId,


### PR DESCRIPTION
## What changed
- Removed unused type/import references that were triggering lint warnings.
- Removed stale approval grant hydration bookkeeping that was no longer read.

## Validation
- npm run lint
