### PR TITLE
[codex] Simplify confirm rules copy

### DIFF
--- a/application/i18n/locales/en/ai.ts
+++ b/application/i18n/locales/en/ai.ts
@@ -328,7 +328,7 @@ export const enAiMessages: Messages = {
   'ai.safety.blocklist.add': 'Add pattern',
   'ai.safety.grants.title': 'Permission memory',
   'ai.safety.grants.heading': 'Confirm-mode allow rules',
-  'ai.safety.grants.description': 'Rules apply globally in confirm mode (all terminal sessions/nodes). Terminal commands follow OpenCode: always-allow writes command prefix patterns (e.g. lscpu *, git checkout *).',
+  'ai.safety.grants.description': 'Confirm mode asks before running an operation. Saved rules automatically allow matching operations across all terminal sessions/nodes, and can be edited manually.',
   'ai.safety.grants.empty': 'No saved rules yet. Approve a tool with “Always allow”, or add one manually.',
   'ai.safety.grants.capability': 'Capability',
   'ai.safety.grants.sessionPattern': 'Session pattern',

--- a/application/i18n/locales/ru/ai.ts
+++ b/application/i18n/locales/ru/ai.ts
@@ -316,7 +316,7 @@ export const ruAiMessages: Messages = {
   'ai.safety.blocklist.add': 'Добавить шаблон',
   'ai.safety.grants.title': 'Память разрешений',
   'ai.safety.grants.heading': 'Правила для режима confirm',
-  'ai.safety.grants.description': 'Правила действуют глобально в режиме confirm (все терминальные сессии). Для команд используются префиксы OpenCode (например lscpu *).',
+  'ai.safety.grants.description': 'В режиме confirm действие сначала требует подтверждения. Сохранённые правила автоматически разрешают похожие действия во всех терминальных сессиях, их можно редактировать вручную.',
   'ai.safety.grants.empty': 'Правил пока нет. Выберите «Всегда разрешать» при одобрении или добавьте вручную.',
   'ai.safety.grants.capability': 'Capability ID',
   'ai.safety.grants.sessionPattern': 'Шаблон сессии',

--- a/application/i18n/locales/zh-CN/ai.ts
+++ b/application/i18n/locales/zh-CN/ai.ts
@@ -328,7 +328,7 @@ export const zhCNAiMessages: Messages = {
   'ai.safety.blocklist.add': '添加规则',
   'ai.safety.grants.title': '许可记忆表',
   'ai.safety.grants.heading': 'Confirm 模式放行规则',
-  'ai.safety.grants.description': '规则在 confirm 模式下全局生效（所有终端节点/会话）。终端命令遵循 OpenCode：「一律许可」会写入「命令前缀 + *」（如 lscpu *、git checkout *），也可手动编辑。',
+  'ai.safety.grants.description': 'Confirm 模式会先询问再执行；保存为规则后，匹配的同类操作会自动放行。规则对所有终端节点/会话生效，也可手动编辑。',
   'ai.safety.grants.empty': '尚无规则。可在审批时选择「一律许可」，或手动添加。',
   'ai.safety.grants.capability': '能力',
   'ai.safety.grants.sessionPattern': '节点/会话模式',


### PR DESCRIPTION
## What changed
- Simplified the confirm-mode permission memory description.
- Removed the OpenCode-specific explanation from this general settings copy.

## Validation
- npm run lint
- npm run build
