### PR TITLE
[codex] Fix node-pty spawn helper permissions

### DIFF
--- a/electron/bridges/nodePtySpawnHelperPermissions.cjs
+++ b/electron/bridges/nodePtySpawnHelperPermissions.cjs
@@ -1,0 +1,51 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function chmodExecutableIfNeeded(filePath) {
+  let stat;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile()) return false;
+  if ((stat.mode & 0o111) !== 0) return false;
+
+  fs.chmodSync(filePath, stat.mode | 0o111);
+  return true;
+}
+
+function listNodePtySpawnHelperCandidates(packageRoot, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  return [
+    path.join(packageRoot, "build", "Release", "spawn-helper"),
+    path.join(packageRoot, "build", "Debug", "spawn-helper"),
+    path.join(packageRoot, "prebuilds", `${platform}-${arch}`, "spawn-helper"),
+  ];
+}
+
+function ensureNodePtySpawnHelperExecutable(options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") return [];
+
+  const packageRoot = options.packageRoot ?? path.dirname(require.resolve("node-pty/package.json"));
+  const changed = [];
+
+  for (const helperPath of listNodePtySpawnHelperCandidates(packageRoot, options)) {
+    try {
+      if (chmodExecutableIfNeeded(helperPath)) {
+        changed.push(helperPath);
+      }
+    } catch {
+      // Best effort: a permission fix must not prevent the app from starting.
+    }
+  }
+
+  return changed;
+}
+
+module.exports = {
+  ensureNodePtySpawnHelperExecutable,
+  listNodePtySpawnHelperCandidates,
+};

--- a/electron/bridges/nodePtySpawnHelperPermissions.test.cjs
+++ b/electron/bridges/nodePtySpawnHelperPermissions.test.cjs
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { ensureNodePtySpawnHelperExecutable } = require("./nodePtySpawnHelperPermissions.cjs");
+
+function makeTempPackageRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-node-pty-perms-"));
+}
+
+function writeHelper(root, relativePath, mode = 0o644) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "#!/bin/sh\nexit 0\n");
+  fs.chmodSync(filePath, mode);
+  return filePath;
+}
+
+test("ensureNodePtySpawnHelperExecutable marks packaged helpers executable", () => {
+  const root = makeTempPackageRoot();
+  const prebuildHelper = writeHelper(root, "prebuilds/darwin-arm64/spawn-helper");
+  const releaseHelper = writeHelper(root, "build/Release/spawn-helper");
+
+  const changed = ensureNodePtySpawnHelperExecutable({
+    packageRoot: root,
+    platform: "darwin",
+    arch: "arm64",
+  });
+
+  assert.deepEqual(
+    changed.sort(),
+    [prebuildHelper, releaseHelper].sort(),
+  );
+  assert.notEqual(fs.statSync(prebuildHelper).mode & 0o111, 0);
+  assert.notEqual(fs.statSync(releaseHelper).mode & 0o111, 0);
+});
+
+test("ensureNodePtySpawnHelperExecutable ignores missing helpers", () => {
+  const root = makeTempPackageRoot();
+
+  assert.deepEqual(ensureNodePtySpawnHelperExecutable({
+    packageRoot: root,
+    platform: "darwin",
+    arch: "arm64",
+  }), []);
+});

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -11,6 +11,10 @@ const { execFile, execFileSync } = require("node:child_process");
 const path = require("node:path");
 const { promisify } = require("node:util");
 const { StringDecoder } = require("node:string_decoder");
+const { ensureNodePtySpawnHelperExecutable } = require("./nodePtySpawnHelperPermissions.cjs");
+
+ensureNodePtySpawnHelperExecutable();
+
 const pty = require("node-pty");
 const { SerialPort } = require("serialport");
 const { emitTerminalSessionData } = require("./emitTerminalSessionData.cjs");


### PR DESCRIPTION
## What changed
- Added a startup guard that restores execute permission on node-pty spawn-helper files before local terminals use node-pty.
- Added coverage for the permission guard.

## Validation
- npm run lint
- node --test electron/bridges/nodePtySpawnHelperPermissions.test.cjs electron/bridges/terminalBridge.bareMoshClient.test.cjs
- node-pty smoke check with /bin/echo
- npm run build

Note: a full local npm test run was attempted and currently reports unrelated Cursor SDK / SSH compatibility failures in this checkout.
