### PR TITLE
Fix restored terminal cwd tracking

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -654,9 +654,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     return cwd ?? undefined;
   }, [terminalBackend, terminalCwdTracker]);
 
-  const clearTerminalCwd = useCallback(() => {
+  const clearTerminalCwd = useCallback((options?: { persistRestoreMetadata?: boolean }) => {
     terminalCwdTracker.clearRendererCwd();
     knownCwdRef.current = undefined;
+    if (options?.persistRestoreMetadata === false) return;
     onTerminalCwdChange?.(sessionId, null);
   }, [onTerminalCwdChange, sessionId, terminalCwdTracker]);
 
@@ -1145,7 +1146,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     setChainProgress,
     t,
     onSessionAttached: (id: string) => {
-      clearTerminalCwd();
+      clearTerminalCwd({ persistRestoreMetadata: false });
       // SSH: always sync. Its backend starts in utf-8 regardless of
       // host.charset, so the push is what keeps the UI state aligned
       // across reconnects — including localhost SSH targets, hence
@@ -1169,6 +1170,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       if ((isTelnet || isSerial) && userPickedEncodingRef.current) {
         setSessionEncoding(id, terminalEncodingRef.current);
       }
+    },
+    onRestoreCwdIntentConsumed: (cwd: string) => {
+      knownCwdRef.current = cwd;
     },
     onSessionExit: (closedSessionId, evt) => {
       clearTerminalCwd();

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -63,9 +63,9 @@ import { resolveAiNoteArtifactPanelIntent } from './terminalLayer/aiNoteArtifact
 import {
   canUseDirectSessionWriteFallback,
 } from './terminalLayer/terminalLayerSessionRouting';
+import { shouldProbeCommandCwd } from './terminalLayer/commandCwdProbe';
 import { resolvePreferredTerminalCwd, scheduleBackendCwdProbeAfterCommand } from './terminal/sftpCwd';
 import { classifyDistroId, shouldProbeSessionCwd } from '../domain/host';
-import { resolveHostFollowTerminalCwd, resolveSftpFollowTerminalCwdTargetHost } from './sftp/sftpFollowTerminalCwd';
 
 import {
   AIChatPanelsHost,
@@ -712,14 +712,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     applySessionCodingCliProviderFromCommand(sessionId, command);
 
     const tabId = activeTabIdRef.current;
-    if (!tabId || sidePanelOpenTabsRef.current.get(tabId) !== 'sftp') return;
-
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     if (!session || !canReuseTerminalConnection(session)) return;
     const sessionHost = sessionHostsMapRef.current.get(sessionId);
-    const visibleSftpHost = sftpHostForTabRef.current.get(tabId) ?? null;
-    const followHost = resolveSftpFollowTerminalCwdTargetHost(visibleSftpHost, sessionHost);
-    if (!resolveHostFollowTerminalCwd(followHost?.sftpFollowTerminalCwd, sftpFollowTerminalCwdRef.current)) return;
+    const visibleSftpHost = tabId && sidePanelOpenTabsRef.current.get(tabId) === 'sftp'
+      ? sftpHostForTabRef.current.get(tabId) ?? null
+      : null;
+    if (!shouldProbeCommandCwd({
+      restoreTerminalCwd,
+      visibleSftpHost,
+      sessionHost,
+      globalSftpFollowTerminalCwd: sftpFollowTerminalCwdRef.current,
+    })) return;
 
     const osc7SignalAtCommand = terminalOsc7SignalBySessionRef.current.get(sessionId) ?? 0;
     const probeGeneration = (cwdProbeGenerationRef.current.get(sessionId) ?? 0) + 1;
@@ -751,7 +755,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       },
     });
     cwdProbeCancelersRef.current.set(sessionId, cancelProbe);
-  }, [applySessionCodingCliProviderFromCommand, handleTerminalCwdChange, terminalBackend]);
+  }, [applySessionCodingCliProviderFromCommand, handleTerminalCwdChange, restoreTerminalCwd, terminalBackend]);
 
   const handleCommandExecuted = useCallback((command: string, hostId: string, hostLabel: string, sessionId: string) => {
     onCommandExecuted?.(command, hostId, hostLabel, sessionId);

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -82,3 +82,49 @@ test("manual reconnect captures restore cwd intent before clearing restored stat
     "manual retry must reactivate the boot guard before opening a backend session",
   );
 });
+
+test("startup and attach cwd cache clears preserve restore cwd metadata", () => {
+  const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const effectsSource = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+
+  const clearDefinitionIndex = terminalSource.indexOf("const clearTerminalCwd = useCallback");
+  const clearNotifyIndex = terminalSource.indexOf("onTerminalCwdChange?.(sessionId, null)", clearDefinitionIndex);
+  const persistGuardIndex = terminalSource.indexOf("persistRestoreMetadata", clearDefinitionIndex);
+  const attachIndex = terminalSource.indexOf("onSessionAttached: (id: string) =>");
+  const attachClearIndex = terminalSource.indexOf("clearTerminalCwd({ persistRestoreMetadata: false })", attachIndex);
+  const startupClearIndex = effectsSource.indexOf("clearTerminalCwd({ persistRestoreMetadata: false })");
+
+  assert.notEqual(clearDefinitionIndex, -1);
+  assert.notEqual(clearNotifyIndex, -1);
+  assert.notEqual(persistGuardIndex, -1);
+  assert.notEqual(attachIndex, -1);
+  assert.notEqual(attachClearIndex, -1);
+  assert.notEqual(startupClearIndex, -1);
+  assert.ok(
+    persistGuardIndex < clearNotifyIndex,
+    "clearTerminalCwd must gate persisted restore metadata updates",
+  );
+});
+
+test("restored cwd intent marks known cwd before initial backend pwd probe can persist home", () => {
+  const terminalSource = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const effectsSource = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+
+  const callbackIndex = terminalSource.indexOf("onRestoreCwdIntentConsumed:");
+  const knownAssignIndex = terminalSource.indexOf("knownCwdRef.current = cwd", callbackIndex);
+  const backendProbeGuardIndex = effectsSource.indexOf("knownCwdRef.current");
+  const backendPwdWriteIndex = effectsSource.indexOf("onTerminalCwdChange?.(sessionId, cwd ?? null)", backendProbeGuardIndex);
+
+  assert.notEqual(callbackIndex, -1);
+  assert.notEqual(knownAssignIndex, -1);
+  assert.notEqual(backendProbeGuardIndex, -1);
+  assert.notEqual(backendPwdWriteIndex, -1);
+  assert.ok(
+    knownAssignIndex > callbackIndex,
+    "Terminal must preserve the restore target as a known cwd when the restore command is sent",
+  );
+  assert.ok(
+    backendProbeGuardIndex < backendPwdWriteIndex,
+    "initial backend pwd probe must remain guarded by knownCwdRef before it writes restore metadata",
+  );
+});

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -871,6 +871,7 @@ test("ssh session restores cwd before startup command after attaching", async ()
   const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
   const executedCommands: string[] = [];
   const progressLogs: string[] = [];
+  const restoredCwds: string[] = [];
 
   const terminalBackend = {
     backendAvailable: () => true,
@@ -906,6 +907,9 @@ test("ssh session restores cwd before startup command after attaching", async ()
     setProgressLogs: (updater: (prev: string[]) => string[]) => {
       progressLogs.splice(0, progressLogs.length, ...updater(progressLogs));
     },
+    onRestoreCwdIntentConsumed: (cwd: string) => {
+      restoredCwds.push(cwd);
+    },
     onCommandExecuted: (command: string) => {
       executedCommands.push(command);
     },
@@ -915,6 +919,7 @@ test("ssh session restores cwd before startup command after attaching", async ()
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(restoreCwdIntentRef.current, null);
+  assert.deepEqual(restoredCwds, ["/srv/app dir"]);
   assert.deepEqual(sessionWrites, [
     { id: "ssh-session", data: "cd -- '/srv/app dir'\r", automated: true },
     { id: "ssh-session", data: "pwd\r", automated: true },

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -73,6 +73,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     ctx.setProgressLogs((prev) => [...prev, tr("terminal.restore.cwdLog", `Restoring working directory: ${intent.cwd}`)
       .replace("{cwd}", intent.cwd)]);
     ctx.terminalBackend.writeToSession(id, `${intent.command}\r`, { automated: true });
+    ctx.onRestoreCwdIntentConsumed?.(intent.cwd);
     markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, intent.command);
   };
 

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -150,6 +150,7 @@ export type TerminalSessionStartersContext = {
   t?: (key: string) => string;
 
   onSessionAttached?: (sessionId: string) => void;
+  onRestoreCwdIntentConsumed?: (cwd: string) => void;
   onSessionExit?: (sessionId: string, evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void;
   onTerminalDataCapture?: (sessionId: string, data: string) => void;
   onTerminalLogData?: (data: string) => void;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -125,8 +125,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
 
   useEffect(() => {
-    clearTerminalCwd();
-    return clearTerminalCwd;
+    clearTerminalCwd({ persistRestoreMetadata: false });
+    return () => clearTerminalCwd({ persistRestoreMetadata: false });
   }, [clearTerminalCwd, host.id]);
 
 

--- a/components/terminalLayer/commandCwdProbe.test.ts
+++ b/components/terminalLayer/commandCwdProbe.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldProbeCommandCwd } from "./commandCwdProbe";
+
+test("probes command cwd for session restore even when the SFTP panel is not visible", () => {
+  assert.equal(
+    shouldProbeCommandCwd({
+      restoreTerminalCwd: true,
+      visibleSftpHost: null,
+      sessionHost: { sftpFollowTerminalCwd: false },
+      globalSftpFollowTerminalCwd: false,
+    }),
+    true,
+  );
+});
+
+test("does not probe command cwd when neither session restore nor SFTP follow cwd needs it", () => {
+  assert.equal(
+    shouldProbeCommandCwd({
+      restoreTerminalCwd: false,
+      visibleSftpHost: null,
+      sessionHost: { sftpFollowTerminalCwd: true },
+      globalSftpFollowTerminalCwd: true,
+    }),
+    false,
+  );
+});
+
+test("probes command cwd for visible SFTP follow cwd using host override", () => {
+  assert.equal(
+    shouldProbeCommandCwd({
+      restoreTerminalCwd: false,
+      visibleSftpHost: { sftpFollowTerminalCwd: true },
+      sessionHost: { sftpFollowTerminalCwd: false },
+      globalSftpFollowTerminalCwd: false,
+    }),
+    true,
+  );
+});
+
+test("visible SFTP host override can disable command cwd probing", () => {
+  assert.equal(
+    shouldProbeCommandCwd({
+      restoreTerminalCwd: false,
+      visibleSftpHost: { sftpFollowTerminalCwd: false },
+      sessionHost: { sftpFollowTerminalCwd: true },
+      globalSftpFollowTerminalCwd: true,
+    }),
+    false,
+  );
+});

--- a/components/terminalLayer/commandCwdProbe.ts
+++ b/components/terminalLayer/commandCwdProbe.ts
@@ -1,0 +1,28 @@
+import { resolveHostFollowTerminalCwd, resolveSftpFollowTerminalCwdTargetHost } from "../sftp/sftpFollowTerminalCwd";
+
+type FollowTerminalCwdHost = {
+  sftpFollowTerminalCwd?: boolean;
+};
+
+type ShouldProbeCommandCwdOptions = {
+  restoreTerminalCwd: boolean;
+  visibleSftpHost?: FollowTerminalCwdHost | null;
+  sessionHost?: FollowTerminalCwdHost | null;
+  globalSftpFollowTerminalCwd: boolean;
+};
+
+export const shouldProbeCommandCwd = ({
+  restoreTerminalCwd,
+  visibleSftpHost,
+  sessionHost,
+  globalSftpFollowTerminalCwd,
+}: ShouldProbeCommandCwdOptions): boolean => {
+  if (restoreTerminalCwd) return true;
+
+  if (!visibleSftpHost) return false;
+  const followHost = resolveSftpFollowTerminalCwdTargetHost(visibleSftpHost, sessionHost);
+  return resolveHostFollowTerminalCwd(
+    followHost?.sftpFollowTerminalCwd,
+    globalSftpFollowTerminalCwd,
+  );
+};


### PR DESCRIPTION
## Summary
- Preserve restored terminal cwd metadata during startup and attach cache clears
- Probe command cwd for session restore even when the SFTP panel is not open
- Guard restored cwd from being overwritten by the initial backend pwd probe

Fixes #1625

## Test Plan
- node --test --import tsx components/terminalLayer/commandCwdProbe.test.ts components/terminal/restoredSessionGate.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts application/state/sessionRestoreState.test.ts domain/sessionRestore.test.ts components/terminal/sftpCwd.test.ts components/sftp/sftpFollowTerminalCwd.test.ts
- npm run build