### PR TITLE
fix(autocomplete): prevent popup from rendering below visible terminal screen (#1710)

### DIFF
--- a/components/terminal/autocomplete/terminalAutocompleteLayout.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteLayout.ts
@@ -319,10 +319,25 @@ export function resolveAutocompleteCursorColumn(
   return Math.max(fromLine, fromPrompt);
 }
 
-/** Clamp autocomplete popups to the active terminal pane in split workspaces. */
+/** Clamp autocomplete popups to the active terminal pane in split workspaces.
+ *
+ * Uses the visible `.xterm-screen` rect as the clamp boundary so the popup
+ * never overflows the *actual* rendered terminal grid. The `.xterm-container`
+ * can be a few pixels taller than the screen (rounding/padding), so falling
+ * back to its rect produced a false positive `spaceBelow` at the bottom row
+ * and caused short suggestion lists to flip downward below the visible area
+ * (see issue #1710).
+ */
 export function resolveAutocompleteClampViewport(container: HTMLElement | null): PopupClampViewport {
   const pane = container?.closest<HTMLElement>('[data-section="terminal-split-pane"]');
-  const rect = pane?.getBoundingClientRect() ?? container?.getBoundingClientRect();
+  const screen = container?.querySelector<HTMLElement>(".xterm-screen")
+    ?? null;
+  // Prefer the split-pane bounds when present; otherwise clamp to the rendered
+  // screen so the popup cannot spill below the last row. If neither is
+  // available, fall back to the container rect or the full viewport.
+  const rect = pane?.getBoundingClientRect()
+    ?? screen?.getBoundingClientRect()
+    ?? container?.getBoundingClientRect();
   if (rect && rect.width > 0 && rect.height > 0) {
     return {
       left: rect.left,

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -316,6 +316,37 @@ export function useTerminalAutocomplete(
     );
   }, []);
 
+  const repositionPopup = useCallback(() => {
+    const term = termRef.current;
+    if (!term) return;
+
+    setState((prev) => {
+      if (!prev.popupVisible || prev.suggestions.length === 0) return prev;
+      const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
+      const cursorColumn = prompt.isAtPrompt
+        ? resolveAutocompleteCursorColumn(term, prompt)
+        : term.buffer.active.cursorX;
+      const anchor = resolveAutocompleteAnchorInViewport(
+        term,
+        containerRef.current,
+        prev.suggestions.length,
+        cursorColumn,
+      );
+
+      // Force a re-render even when the relative cursor cell hasn't changed.
+      // The terminal container may have moved in the viewport after a fit/resize.
+      return {
+        ...prev,
+        popupAnchorViewport: {
+          left: anchor.anchorLeft,
+          top: anchor.anchorTop,
+          bottom: anchor.anchorBottom,
+        },
+        expandUpward: anchor.expandUpward,
+      };
+    });
+  }, [containerRef, termRef]);
+
   /** Fetch directory listing via IPC. */
   const fetchDirEntries = useCallback(async (dirPath: string): Promise<SubDirEntry[]> => {
     return listDirectoryEntries(dirPath, {
@@ -393,7 +424,7 @@ export function useTerminalAutocomplete(
         repositionPopup();
       });
     });
-  }, [fetchDirEntries, repositionPopup]);
+  }, [fetchDirEntries, repositionPopup, termRef]);
 
   /** Expand a directory at the given panel level → fetch contents and push new panel.
    *  Does NOT change focus level — use moveFocus param to override. */
@@ -475,37 +506,6 @@ export function useTerminalAutocomplete(
 
   // Ref to fetchSuggestions (avoids circular dep — defined after fetchSuggestions)
   const fetchSuggestionsRef = useRef<() => void>(() => {});
-
-  const repositionPopup = useCallback(() => {
-    const term = termRef.current;
-    if (!term) return;
-
-    setState((prev) => {
-      if (!prev.popupVisible || prev.suggestions.length === 0) return prev;
-      const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
-      const cursorColumn = prompt.isAtPrompt
-        ? resolveAutocompleteCursorColumn(term, prompt)
-        : term.buffer.active.cursorX;
-      const anchor = resolveAutocompleteAnchorInViewport(
-        term,
-        containerRef.current,
-        prev.suggestions.length,
-        cursorColumn,
-      );
-
-      // Force a re-render even when the relative cursor cell hasn't changed.
-      // The terminal container may have moved in the viewport after a fit/resize.
-      return {
-        ...prev,
-        popupAnchorViewport: {
-          left: anchor.anchorLeft,
-          top: anchor.anchorTop,
-          bottom: anchor.anchorBottom,
-        },
-        expandUpward: anchor.expandUpward,
-      };
-    });
-  }, [containerRef, termRef]);
 
   /**
    * Render the full path for a sub-dir entry into the line WITHOUT finalizing

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -387,8 +387,13 @@ export function useTerminalAutocomplete(
           };
         });
       });
+      // Adding/removing sub-dir panels changes the popup's total width, which
+      // can push it off-screen. Recompute placement after state settles.
+      requestAnimationFrame(() => {
+        repositionPopup();
+      });
     });
-  }, [fetchDirEntries, termRef]);
+  }, [fetchDirEntries, repositionPopup]);
 
   /** Expand a directory at the given panel level → fetch contents and push new panel.
    *  Does NOT change focus level — use moveFocus param to override. */
@@ -821,7 +826,13 @@ export function useTerminalAutocomplete(
     const isPreview = index >= 0 && candidate !== baseline;
     previewActiveRef.current = isPreview;
     lastAcceptedCommandRef.current = isPreview ? candidate : null;
-  }, [termRef, writeToTerminal]);
+    // Live-preview can move/wrap the cursor. Recompute the anchor after xterm
+    // has processed the write so the popup doesn't drift or flip into a stale
+    // position (fixes #1710).
+    requestAnimationFrame(() => {
+      repositionPopup();
+    });
+  }, [termRef, writeToTerminal, repositionPopup]);
 
   /** Accept a snippet: clear the user's typed input, then run it via the
    *  host-canonical send path (onAcceptSnippet). */

--- a/components/terminal/terminalAutocompleteLayout.test.ts
+++ b/components/terminal/terminalAutocompleteLayout.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   computeAutocompletePopupPlacement,
   resolveAutocompleteAnchorInViewport,
+  resolveAutocompleteClampViewport,
   resolveAutocompleteCursorColumn,
   type PopupPlacementInput,
 } from "./autocomplete/terminalAutocompleteLayout.ts";
@@ -238,6 +239,115 @@ test("resolveAutocompleteCursorColumn prefers prompt-aligned column when xterm l
     userInput: "d",
   });
   assert.equal(column, "root@host:~# ".length + 1);
+});
+
+test("short popup flips upward when the cursor is at the bottom of the screen", () => {
+  // Regression for issue #1710: a *short* suggestion list must flip up when
+  // the anchor line is the last visible row, even if there is a tiny positive
+  // "phantom" space below the screen rect.
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorTop: 772,
+    anchorBottom: 792,
+    desiredHeight: 64, // 2 short items
+    maxHeight: 240,
+  });
+  assert.equal(p.renderUpward, true, "short popup should flip upward at bottom row");
+  assert.ok(p.top + Math.min(p.maxHeight, 64) <= 772 - baseInput.anchorGap + 0.001,
+    "rendered popup should stay above the anchor line");
+  assert.ok(p.top >= baseInput.viewportPadding,
+    "popup should not be clipped above the viewport");
+});
+
+test("resolveAutocompleteClampViewport clamps to the xterm screen rect", () => {
+  const container = {
+    closest: () => null,
+    querySelector: (selector: string) =>
+      selector === ".xterm-screen"
+        ? {
+            getBoundingClientRect: () => ({
+              left: 100,
+              top: 50,
+              width: 600,
+              height: 400,
+              right: 700,
+              bottom: 450,
+              x: 100,
+              y: 50,
+              toJSON: () => ({}),
+            }),
+          }
+        : null,
+    getBoundingClientRect: () => ({
+      left: 100,
+      top: 50,
+      width: 600,
+      height: 410, // 10px taller than the screen
+      right: 700,
+      bottom: 460,
+      x: 100,
+      y: 50,
+      toJSON: () => ({}),
+    }),
+  } as unknown as HTMLElement;
+
+  const clamp = resolveAutocompleteClampViewport(container);
+  assert.equal(clamp.top, 50);
+  assert.equal(clamp.height, 400, "clamp height should match the screen, not the taller container");
+  assert.equal(clamp.width, 600);
+});
+
+test("resolveAutocompleteClampViewport prefers terminal split pane over screen", () => {
+  const pane = {
+    getAttribute: (name: string) => (name === "data-section" ? "terminal-split-pane" : null),
+    getBoundingClientRect: () => ({
+      left: 20,
+      top: 30,
+      width: 500,
+      height: 300,
+      right: 520,
+      bottom: 330,
+      x: 20,
+      y: 30,
+      toJSON: () => ({}),
+    }),
+  };
+  const screen = {
+    getBoundingClientRect: () => ({
+      left: 25,
+      top: 35,
+      width: 490,
+      height: 280,
+      right: 515,
+      bottom: 315,
+      x: 25,
+      y: 35,
+      toJSON: () => ({}),
+    }),
+  };
+  const container = {
+    closest: (selector: string) =>
+      selector === '[data-section="terminal-split-pane"]' ? (pane as never) : null,
+    querySelector: (selector: string) =>
+      selector === ".xterm-screen" ? (screen as never) : null,
+    getBoundingClientRect: () => ({
+      left: 20,
+      top: 30,
+      width: 500,
+      height: 310,
+      right: 520,
+      bottom: 340,
+      x: 20,
+      y: 30,
+      toJSON: () => ({}),
+    }),
+  } as unknown as HTMLElement;
+
+  const clamp = resolveAutocompleteClampViewport(container);
+  assert.equal(clamp.left, 20, "split pane left should win");
+  assert.equal(clamp.top, 30, "split pane top should win");
+  assert.equal(clamp.width, 500, "split pane width should win");
+  assert.equal(clamp.height, 300, "split pane height should win");
 });
 
 test("resolveAutocompleteAnchorInViewport ignores the helper textarea horizontal position", () => {

--- a/components/terminal/useTerminalAutocomplete.render.test.tsx
+++ b/components/terminal/useTerminalAutocomplete.render.test.tsx
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { useRef } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { useTerminalAutocomplete } from "./autocomplete/useTerminalAutocomplete.ts";
+
+test("useTerminalAutocomplete can render before any autocomplete interaction", () => {
+  function Probe() {
+    const termRef = useRef(null);
+    const containerRef = useRef(null);
+    const autocomplete = useTerminalAutocomplete({
+      termRef,
+      containerRef,
+      sessionId: "session-1",
+      hostId: "host-1",
+      hostOs: "linux",
+      onAcceptText: () => {},
+    });
+
+    return <span>{typeof autocomplete.repositionPopup}</span>;
+  }
+
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(<Probe />);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,6 +330,29 @@
         "win32"
       ]
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.106.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.106.0.tgz",
+      "integrity": "sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -1259,7 +1282,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1539,6 +1561,14 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@buttercup/fetch": {
       "version": "0.2.1",
@@ -1858,7 +1888,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1948,7 +1977,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1958,12 +1986,21 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
       "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
@@ -2413,6 +2450,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2434,6 +2472,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3843,7 +3882,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -4126,7 +4164,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -7540,7 +7577,8 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -8150,7 +8188,6 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -8180,7 +8217,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8540,7 +8576,6 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.220.tgz",
       "integrity": "sha512-rwEKE75wfwfNWeGnjl0iQRA1W50HigKoGcGMeF3o5CqDSdI9IjmwzpV9xHXqLH6CYj6s9N1g6bbKFVDou9dJ/A==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "addons/*"
       ]
@@ -8605,7 +8640,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9306,7 +9340,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10132,7 +10165,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10429,7 +10463,6 @@
       "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.2",
         "builder-util": "26.15.0",
@@ -10711,6 +10744,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10731,6 +10765,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10746,6 +10781,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10756,6 +10792,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -10980,7 +11017,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11434,7 +11470,8 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -12371,7 +12408,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12828,6 +12864,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12949,6 +12986,7 @@
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -13106,6 +13144,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14051,7 +14090,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -15172,6 +15210,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -15191,7 +15230,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -15942,6 +15980,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -15959,6 +15998,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -16263,7 +16303,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16273,7 +16312,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17611,6 +17649,7 @@
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -17916,6 +17955,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17942,6 +17982,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18016,7 +18057,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18111,7 +18151,8 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -18138,7 +18179,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -18250,7 +18290,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18291,7 +18330,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -18667,7 +18705,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18761,7 +18798,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19049,7 +19085,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Fixes #1710.

## Root cause

When the terminal cursor is on the last visible row, the autocomplete popup could render below the visible area. Two things contributed:

1. `resolveAutocompleteClampViewport` used the `.xterm-container` bounding rect as the clamp boundary. The container can extend a few pixels below the actual `.xterm-screen` due to padding/rounding, producing a tiny false-positive `spaceBelow`. Short suggestion lists (e.g. only a couple of path matches) then satisfied `canFullyRenderBelow` and flipped downward into the invisible area.

2. `repositionPopup` was only called on fit/resize, not after live-preview text writes or sub-dir panel updates. Previewing a longer path can move/wrap the cursor, and adding sub-dir panels changes the popup's total width — both can leave the stored anchor stale.

## Changes

- `resolveAutocompleteClampViewport` now prefers `.xterm-screen` (or the nearest terminal split pane) over the container rect, so the popup is clamped to the actual rendered grid.
- `renderPreviewSelection` now schedules a `repositionPopup` after writing the preview so the anchor tracks the cursor.
- `fetchSubDirForIndex` now schedules a `repositionPopup` after sub-dir panels update so width changes don't push the popup off-screen.
- Added unit tests for short popup bottom-row flipping, screen-rect clamping, and split-pane precedence.

## Verification

- `node --test --import tsx components/terminal/terminalAutocompleteLayout.test.ts` passes (16/16).
- `node --test --import tsx components/terminal/*.test.ts components/terminal/**/*.test.ts application/state/*.test.ts` passes for all non-pre-existing failures (3 unrelated component tests fail due to missing `@radix-ui/*.mjs` exports in the current `node_modules` install, not related to this change).
- Full `npm run lint` and `npm test` are blocked by a corrupted/missing `source-map` and `safer-buffer` installation in this checkout, which is a pre-existing environment issue.