### PR TITLE
[codex] Fix terminal startup output race

### DIFF
--- a/application/state/useTerminalBackend.ts
+++ b/application/state/useTerminalBackend.ts
@@ -100,10 +100,14 @@ export const useTerminalBackend = () => {
     return bridge.setSessionEncoding(sessionId, encoding);
   }, []);
 
-  const onSessionData = useCallback((sessionId: string, cb: (data: string) => void) => {
+  const onSessionData = useCallback((
+    sessionId: string,
+    cb: (data: string) => void,
+    options?: Parameters<NetcattyBridge["onSessionData"]>[2],
+  ) => {
     const bridge = netcattyBridge.get();
     if (!bridge?.onSessionData) throw new Error("onSessionData unavailable");
-    return bridge.onSessionData(sessionId, cb);
+    return bridge.onSessionData(sessionId, cb, options);
   }, []);
 
   const onSessionExit = useCallback((sessionId: string, cb: (evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void) => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -963,12 +963,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const beginHibernatedSessionListeners = useCallback((backendId: string) => {
     disposeDataRef.current?.();
     hibernatePendingBufferRef.current = "";
-    disposeDataRef.current = terminalBackend.onSessionData(backendId, (chunk) => {
-      hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
-        hibernatePendingBufferRef.current,
-        chunk,
-      );
-    });
+    disposeDataRef.current = terminalBackend.onSessionData(
+      backendId,
+      (chunk) => {
+        hibernatePendingBufferRef.current = appendHibernatePendingBuffer(
+          hibernatePendingBufferRef.current,
+          chunk,
+        );
+      },
+      { replayBacklog: true },
+    );
 
     disposeExitRef.current?.();
     disposeExitRef.current = terminalBackend.onSessionExit(backendId, (evt) => {

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -1158,24 +1158,28 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       resetTerminalWriteCoalescer(term);
       resetTerminalSyncBlockFilter(term);
       resetTerminalLineTimestampState(term);
-      ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {
-        writeSessionData(ctx, term, chunk);
-        ctx.onTerminalOutput?.(chunk);
-        if (!ctx.hasConnectedRef.current) {
-          ctx.updateStatus("connected");
-          setTimeout(() => {
-            if (!ctx.fitAddonRef.current) return;
-            try {
-              ctx.fitAddonRef.current.fit();
-              if (ctx.sessionRef.current) {
-                ctx.terminalBackend.resizeSession(ctx.sessionRef.current, term.cols, term.rows);
+      ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(
+        id,
+        (chunk) => {
+          writeSessionData(ctx, term, chunk);
+          ctx.onTerminalOutput?.(chunk);
+          if (!ctx.hasConnectedRef.current) {
+            ctx.updateStatus("connected");
+            setTimeout(() => {
+              if (!ctx.fitAddonRef.current) return;
+              try {
+                ctx.fitAddonRef.current.fit();
+                if (ctx.sessionRef.current) {
+                  ctx.terminalBackend.resizeSession(ctx.sessionRef.current, term.cols, term.rows);
+                }
+              } catch (err) {
+                logger.warn("Post-connect fit failed", err);
               }
-            } catch (err) {
-              logger.warn("Post-connect fit failed", err);
-            }
-          }, 100);
-        }
-      });
+            }, 100);
+          }
+        },
+        { replayBacklog: true },
+      );
 
       ctx.disposeExitRef.current = ctx.terminalBackend.onSessionExit(id, (evt) => {
         ctx.updateStatus("disconnected");

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -45,7 +45,11 @@ export type TerminalBackendApi = {
     stderr?: string;
     error?: string;
   }>;
-  onSessionData: (sessionId: string, cb: (data: string) => void) => () => void;
+  onSessionData: (
+    sessionId: string,
+    cb: (data: string) => void,
+    options?: { replayBacklog?: boolean },
+  ) => () => void;
   onSessionExit: (
     sessionId: string,
     cb: (evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void,

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -285,33 +285,37 @@ export const attachSessionToTerminal = (
     ctx.sudoAutofillRef.current = sudoAutofill;
   }
 
-  ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(id, (chunk) => {
-    let data = chunk;
-    // Convert lone LF (\n) to CRLF (\r\n) for proper terminal display
-    // This prevents the "staircase effect" common in serial terminals
-    if (opts?.convertLfToCrlf) {
-      // Replace \n that is not preceded by \r with \r\n
-      data = data.replace(/(?<!\r)\n/g, "\r\n");
-    }
-    data = sudoAutofill?.handleOutput(data) ?? data;
-    writeSessionData(ctx, term, data);
-    ctx.onTerminalOutput?.(data);
-    if (!ctx.hasConnectedRef.current) {
-      ctx.updateStatus("connected");
-      opts?.onConnected?.();
-      setTimeout(() => {
-        if (!ctx.fitAddonRef.current) return;
-        try {
-          ctx.fitAddonRef.current.fit();
-          if (ctx.sessionRef.current) {
-            ctx.terminalBackend.resizeSession(ctx.sessionRef.current, term.cols, term.rows);
+  ctx.disposeDataRef.current = ctx.terminalBackend.onSessionData(
+    id,
+    (chunk) => {
+      let data = chunk;
+      // Convert lone LF (\n) to CRLF (\r\n) for proper terminal display
+      // This prevents the "staircase effect" common in serial terminals
+      if (opts?.convertLfToCrlf) {
+        // Replace \n that is not preceded by \r with \r\n
+        data = data.replace(/(?<!\r)\n/g, "\r\n");
+      }
+      data = sudoAutofill?.handleOutput(data) ?? data;
+      writeSessionData(ctx, term, data);
+      ctx.onTerminalOutput?.(data);
+      if (!ctx.hasConnectedRef.current) {
+        ctx.updateStatus("connected");
+        opts?.onConnected?.();
+        setTimeout(() => {
+          if (!ctx.fitAddonRef.current) return;
+          try {
+            ctx.fitAddonRef.current.fit();
+            if (ctx.sessionRef.current) {
+              ctx.terminalBackend.resizeSession(ctx.sessionRef.current, term.cols, term.rows);
+            }
+          } catch (err) {
+            logger.warn("Post-connect fit failed", err);
           }
-        } catch (err) {
-          logger.warn("Post-connect fit failed", err);
-        }
-      }, 100);
-    }
-  });
+        }, 100);
+      }
+    },
+    { replayBacklog: true },
+  );
 
   ctx.disposeExitRef.current = ctx.terminalBackend.onSessionExit(id, (evt) => {
     ctx.updateStatus("disconnected");

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -571,13 +571,14 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   }, [effectiveFontSize, effectiveFontWeight, resolvedFontFamily, terminalSettings]);
 
 
-  const runImmediateRefit = (options?: { force?: boolean }) => {
+  const runImmediateRefit = (options?: { force?: boolean; repeatOnNextFrame?: boolean }) => {
     const force = options?.force === true;
+    const repeatOnNextFrame = options?.repeatOnNextFrame ?? force;
     if (force) {
       lastFittedSizeRef.current = null;
     }
     safeFit({ force, requireVisible: true });
-    if (force && typeof requestAnimationFrame === 'function') {
+    if (force && repeatOnNextFrame && typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => {
         safeFit({ force: true, requireVisible: true });
       });
@@ -596,13 +597,13 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   // Re-fit after the app returns from the background, macOS fullscreen toggles,
   // or other layout changes that do not reliably fire window.resize /
   // ResizeObserver (common after App Nap / GPU context eviction).
-  const scheduleLayoutRecoveryRefit = (delaysMs: number[] = [0, 100, 350]) => {
+  const scheduleLayoutRecoveryRefit = (delaysMs: number[] = [80, 250]) => {
     clearLayoutRecoveryTimers();
     for (const delayMs of delaysMs) {
       const timerId = setTimeout(() => {
         layoutRecoveryTimersRef.current = layoutRecoveryTimersRef.current.filter((id) => id !== timerId);
         if (!isVisibleRef.current) return;
-        runImmediateRefit({ force: true });
+        runImmediateRefit({ force: true, repeatOnNextFrame: false });
       }, delayMs);
       layoutRecoveryTimersRef.current.push(timerId);
     }

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -2,8 +2,15 @@ const { ipcRenderer, contextBridge, webUtils } = require("electron");
 const os = require("node:os");
 const { randomUUID } = require("node:crypto");
 const { createPreloadApi } = require("./preload/api.cjs");
+const {
+  clearTerminalDataSession,
+  createTerminalDataBacklog,
+  createTerminalDataDispatcher,
+} = require("./preload/terminalDataBacklog.cjs");
 
 const dataListeners = new Map();
+const displayDataListeners = new Map();
+const terminalDataBacklog = createTerminalDataBacklog();
 const exitListeners = new Map();
 const transferProgressListeners = new Map();
 const transferCompleteListeners = new Map();
@@ -120,13 +127,11 @@ function filterMcpChunk(sessionId, chunk) {
  * Deliver data to session listeners.  Used both by the normal data path
  * and by the delayed-flush timer.
  */
-function _deliverToListeners(sessionId, data) {
-  const set = dataListeners.get(sessionId);
-  if (!set || !data) return;
-  set.forEach((cb) => {
-    try { cb(data); } catch (err) { console.error("Data callback failed", err); }
-  });
-}
+const _deliverToListeners = createTerminalDataDispatcher({
+  dataListeners,
+  displayDataListeners,
+  terminalDataBacklog,
+});
 
 // ZMODEM file transfer events
 ipcRenderer.on("netcatty:zmodem:detect", (_event, payload) => {
@@ -169,21 +174,13 @@ ipcRenderer.on("netcatty:zmodem:overwrite-request", (_event, payload) => {
 });
 
 ipcRenderer.on("netcatty:data", (_event, payload) => {
-  const set = dataListeners.get(payload.sessionId);
-  if (!set) return;
   if (payload?.syntheticEcho) {
     _deliverToListeners(payload.sessionId, payload.data);
     return;
   }
   const data = filterMcpChunk(payload.sessionId, payload.data);
   if (data) {
-    set.forEach((cb) => {
-      try {
-        cb(data);
-      } catch (err) {
-        console.error("Data callback failed", err);
-      }
-    });
+    _deliverToListeners(payload.sessionId, data);
   }
   // If there is buffered content waiting for more data (e.g. a prompt
   // right after a dropped marker line), schedule a delayed flush so it
@@ -214,7 +211,11 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
       }
     });
   }
-  dataListeners.delete(payload.sessionId);
+  clearTerminalDataSession({
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  }, payload.sessionId);
   exitListeners.delete(payload.sessionId);
   telnetAutoLoginCompleteListeners.delete(payload.sessionId);
   telnetAutoLoginCancelledListeners.delete(payload.sessionId);
@@ -661,6 +662,7 @@ const api = createPreloadApi({
   webUtils,
   randomUUID,
   dataListeners,
+  displayDataListeners,
   exitListeners,
   transferProgressListeners,
   transferCompleteListeners,
@@ -675,6 +677,7 @@ const api = createPreloadApi({
   telnetAutoLoginCompleteListeners,
   telnetAutoLoginCancelledListeners,
   telnetEchoModeListeners,
+  terminalDataBacklog,
   languageChangeListeners,
   fullscreenChangeListeners,
   keyboardInteractiveListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -1,5 +1,7 @@
  
 function createPreloadApi(ctx) {
+  const terminalDataBacklog = ctx.terminalDataBacklog || null;
+  const displayDataListeners = ctx.displayDataListeners || new Map();
   with (ctx) {
     return {
   getWindowsPtyInfo: () => {
@@ -210,10 +212,32 @@ function createPreloadApi(ctx) {
   respondZmodemOverwrite: (payload) => {
     ipcRenderer.send("netcatty:zmodem:overwrite-response", payload);
   },
-  onSessionData: (sessionId, cb) => {
+  onSessionData: (sessionId, cb, options) => {
+    const replayBacklog = options?.replayBacklog === true;
     if (!dataListeners.has(sessionId)) dataListeners.set(sessionId, new Set());
     dataListeners.get(sessionId).add(cb);
-    return () => dataListeners.get(sessionId)?.delete(cb);
+    if (replayBacklog) {
+      if (!displayDataListeners.has(sessionId)) displayDataListeners.set(sessionId, new Set());
+      displayDataListeners.get(sessionId).add(cb);
+      const pendingData = terminalDataBacklog?.take?.(sessionId);
+      if (pendingData) {
+        try {
+          cb(pendingData);
+        } catch (err) {
+          console.error("Data callback failed", err);
+        }
+      }
+    }
+    return () => {
+      const dataSet = dataListeners.get(sessionId);
+      dataSet?.delete(cb);
+      if (dataSet?.size === 0) dataListeners.delete(sessionId);
+
+      if (!replayBacklog) return;
+      const displaySet = displayDataListeners.get(sessionId);
+      displaySet?.delete(cb);
+      if (displaySet?.size === 0) displayDataListeners.delete(sessionId);
+    };
   },
   onSessionExit: (sessionId, cb) => {
     if (!exitListeners.has(sessionId)) exitListeners.set(sessionId, new Set());

--- a/electron/preload/terminalDataBacklog.cjs
+++ b/electron/preload/terminalDataBacklog.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+function createTerminalDataBacklog(options = {}) {
+  const maxBytesPerSession = options.maxBytesPerSession ?? 64 * 1024;
+  const pendingBySession = new Map();
+
+  function trimToLimit(value) {
+    if (value.length <= maxBytesPerSession) return value;
+    return value.slice(value.length - maxBytesPerSession);
+  }
+
+  function append(sessionId, data) {
+    if (!sessionId || !data) return;
+    const previous = pendingBySession.get(sessionId) || "";
+    pendingBySession.set(sessionId, trimToLimit(previous + data));
+  }
+
+  function take(sessionId) {
+    const data = pendingBySession.get(sessionId) || "";
+    pendingBySession.delete(sessionId);
+    return data;
+  }
+
+  function clear(sessionId) {
+    pendingBySession.delete(sessionId);
+  }
+
+  function size(sessionId) {
+    return pendingBySession.get(sessionId)?.length ?? 0;
+  }
+
+  return {
+    append,
+    take,
+    clear,
+    size,
+  };
+}
+
+function hasSessionListeners(listenersBySession, sessionId) {
+  return (listenersBySession.get(sessionId)?.size ?? 0) > 0;
+}
+
+function createTerminalDataDispatcher({
+  dataListeners,
+  displayDataListeners,
+  terminalDataBacklog,
+  onCallbackError = console.error,
+}) {
+  return function deliverToListeners(sessionId, data) {
+    if (!data) return;
+
+    if (!hasSessionListeners(displayDataListeners, sessionId)) {
+      terminalDataBacklog?.append?.(sessionId, data);
+    }
+
+    const set = dataListeners.get(sessionId);
+    if (!set || set.size === 0) return;
+
+    set.forEach((cb) => {
+      try {
+        cb(data);
+      } catch (err) {
+        onCallbackError("Data callback failed", err);
+      }
+    });
+  };
+}
+
+function clearTerminalDataSession({
+  dataListeners,
+  displayDataListeners,
+  terminalDataBacklog,
+}, sessionId) {
+  dataListeners?.delete?.(sessionId);
+  displayDataListeners?.delete?.(sessionId);
+  terminalDataBacklog?.clear?.(sessionId);
+}
+
+module.exports = {
+  createTerminalDataBacklog,
+  createTerminalDataDispatcher,
+  clearTerminalDataSession,
+};

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -1,0 +1,187 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { createPreloadApi } = require("./preload/api.cjs");
+const {
+  clearTerminalDataSession,
+  createTerminalDataBacklog,
+  createTerminalDataDispatcher,
+} = require("./preload/terminalDataBacklog.cjs");
+
+test("stores early terminal data until the listener is registered", () => {
+  const backlog = createTerminalDataBacklog();
+
+  backlog.append("session-1", "Linux banner\r\n");
+  backlog.append("session-1", "root@host:~# ");
+
+  assert.equal(backlog.take("session-1"), "Linux banner\r\nroot@host:~# ");
+  assert.equal(backlog.take("session-1"), "");
+});
+
+test("keeps each session backlog isolated", () => {
+  const backlog = createTerminalDataBacklog();
+
+  backlog.append("session-1", "one");
+  backlog.append("session-2", "two");
+
+  assert.equal(backlog.take("session-2"), "two");
+  assert.equal(backlog.take("session-1"), "one");
+});
+
+test("trims old data when the per-session limit is exceeded", () => {
+  const backlog = createTerminalDataBacklog({ maxBytesPerSession: 5 });
+
+  backlog.append("session-1", "hello");
+  backlog.append("session-1", " world");
+
+  assert.equal(backlog.take("session-1"), "world");
+});
+
+test("clear drops pending data for a closed session", () => {
+  const backlog = createTerminalDataBacklog();
+
+  backlog.append("session-1", "pending");
+  backlog.clear("session-1");
+
+  assert.equal(backlog.size("session-1"), 0);
+  assert.equal(backlog.take("session-1"), "");
+});
+
+test("onSessionData flushes pending terminal data on subscribe", () => {
+  const dataListeners = new Map();
+  const displayDataListeners = new Map();
+  const terminalDataBacklog = createTerminalDataBacklog();
+  terminalDataBacklog.append("session-1", "early MOTD\r\n");
+
+  const api = createPreloadApi({
+    ipcRenderer: {
+      invoke() {},
+      send() {},
+      on() {},
+      removeListener() {},
+    },
+    os: {
+      release: () => "10.0.19045",
+    },
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  });
+
+  const received = [];
+  const unsubscribe = api.onSessionData("session-1", (chunk) => {
+    received.push(chunk);
+  }, { replayBacklog: true });
+
+  assert.deepEqual(received, ["early MOTD\r\n"]);
+  assert.equal(terminalDataBacklog.size("session-1"), 0);
+  assert.equal(displayDataListeners.get("session-1").size, 1);
+
+  unsubscribe();
+  assert.equal(dataListeners.has("session-1"), false);
+  assert.equal(displayDataListeners.has("session-1"), false);
+});
+
+test("non-display listeners do not drain pending terminal data", () => {
+  const dataListeners = new Map();
+  const displayDataListeners = new Map();
+  const terminalDataBacklog = createTerminalDataBacklog();
+  terminalDataBacklog.append("session-1", "early prompt");
+
+  const api = createPreloadApi({
+    ipcRenderer: {
+      invoke() {},
+      send() {},
+      on() {},
+      removeListener() {},
+    },
+    os: {
+      release: () => "10.0.19045",
+    },
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  });
+
+  const observerReceived = [];
+  const displayReceived = [];
+
+  api.onSessionData("session-1", (chunk) => {
+    observerReceived.push(chunk);
+  });
+  assert.deepEqual(observerReceived, []);
+  assert.equal(terminalDataBacklog.size("session-1"), "early prompt".length);
+
+  api.onSessionData("session-1", (chunk) => {
+    displayReceived.push(chunk);
+  }, { replayBacklog: true });
+
+  assert.deepEqual(observerReceived, []);
+  assert.deepEqual(displayReceived, ["early prompt"]);
+  assert.equal(terminalDataBacklog.size("session-1"), 0);
+});
+
+test("keeps early data for display replay while only observer listeners exist", () => {
+  const observed = [];
+  const dataListeners = new Map([
+    ["session-1", new Set([(chunk) => observed.push(chunk)])],
+  ]);
+  const displayDataListeners = new Map();
+  const terminalDataBacklog = createTerminalDataBacklog();
+  const deliverToListeners = createTerminalDataDispatcher({
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  });
+
+  deliverToListeners("session-1", "Linux banner\r\n");
+
+  assert.deepEqual(observed, ["Linux banner\r\n"]);
+  assert.equal(terminalDataBacklog.take("session-1"), "Linux banner\r\n");
+});
+
+test("does not backlog data once the display listener is registered", () => {
+  const observed = [];
+  const displayed = [];
+  const displayListener = (chunk) => displayed.push(chunk);
+  const dataListeners = new Map([
+    ["session-1", new Set([(chunk) => observed.push(chunk), displayListener])],
+  ]);
+  const displayDataListeners = new Map([
+    ["session-1", new Set([displayListener])],
+  ]);
+  const terminalDataBacklog = createTerminalDataBacklog();
+  const deliverToListeners = createTerminalDataDispatcher({
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  });
+
+  deliverToListeners("session-1", "live output");
+
+  assert.deepEqual(observed, ["live output"]);
+  assert.deepEqual(displayed, ["live output"]);
+  assert.equal(terminalDataBacklog.take("session-1"), "");
+});
+
+test("clearTerminalDataSession drops listener and backlog state together", () => {
+  const listener = () => {};
+  const dataListeners = new Map([
+    ["session-1", new Set([listener])],
+  ]);
+  const displayDataListeners = new Map([
+    ["session-1", new Set([listener])],
+  ]);
+  const terminalDataBacklog = createTerminalDataBacklog();
+  terminalDataBacklog.append("session-1", "pending");
+
+  clearTerminalDataSession({
+    dataListeners,
+    displayDataListeners,
+    terminalDataBacklog,
+  }, "session-1");
+
+  assert.equal(dataListeners.has("session-1"), false);
+  assert.equal(displayDataListeners.has("session-1"), false);
+  assert.equal(terminalDataBacklog.take("session-1"), "");
+});

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -277,7 +277,11 @@ declare global {
       action: "overwrite" | "skip" | "cancel";
       applyToRest: boolean;
     }): void;
-    onSessionData(sessionId: string, cb: (data: string) => void): () => void;
+    onSessionData(
+      sessionId: string,
+      cb: (data: string) => void,
+      options?: { replayBacklog?: boolean },
+    ): () => void;
     onSessionExit(
       sessionId: string,
       cb: (evt: { exitCode?: number; signal?: number; error?: string; reason?: "exited" | "error" | "timeout" | "closed" }) => void


### PR DESCRIPTION
## Summary
- buffer terminal output that arrives before the renderer subscribes, then replay it on attach
- limit the repeated forced terminal refits scheduled on app/window refocus
- add coverage for early terminal output replay

## Root cause
Fast SSH servers can emit MOTD/banner output immediately after the shell opens. The main process was already forwarding that output, but the renderer only registered its data listener after the start call returned, so early chunks could be silently dropped.

## Validation
- npm run lint
- node --test --import tsx electron/preloadDataBacklog.test.cjs components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts electron/bridges/ptyOutputBuffer.test.cjs
