### PR TITLE
[codex] Lazy load OpenCode model catalogs

### DIFF
--- a/application/state/useAgentDiscovery.ts
+++ b/application/state/useAgentDiscovery.ts
@@ -148,7 +148,7 @@ export function useAgentDiscovery(
         );
         if (!match) return ea;
 
-        // Check if args, SDK backend, or Claude's resolved system path differ
+        // Check if args, SDK backend, or managed SDK path env differ.
         const currentArgs = JSON.stringify(ea.args || []);
         const newArgs = JSON.stringify(match.args);
         const backend = match.sdkBackend ?? match.command;
@@ -158,9 +158,12 @@ export function useAgentDiscovery(
         const matchPath = match.binPath || match.path;
         const env = match.command === 'claude'
           ? { ...(ea.env ?? {}), CLAUDE_CODE_EXECUTABLE: matchPath }
-          : ea.env;
-        const envChanged = match.command === 'claude'
-          && ea.env?.CLAUDE_CODE_EXECUTABLE !== matchPath;
+          : match.command === 'opencode'
+            ? { ...(ea.env ?? {}), OPENCODE_BIN: matchPath }
+            : ea.env;
+        const envChanged =
+          (match.command === 'claude' && ea.env?.CLAUDE_CODE_EXECUTABLE !== matchPath)
+          || (match.command === 'opencode' && ea.env?.OPENCODE_BIN !== matchPath);
         if (currentArgs !== newArgs || backendChanged || envChanged) {
           changed = true;
           const { acpCommand: _legacyCommand, acpArgs: _legacyArgs, ...rest } = ea;
@@ -193,6 +196,8 @@ export function useAgentDiscovery(
         sdkBackend: backend,
         ...(agent.command === 'claude'
           ? { env: { CLAUDE_CODE_EXECUTABLE: agent.binPath || agent.path || '' } }
+          : agent.command === 'opencode'
+            ? { env: { OPENCODE_BIN: agent.binPath || agent.path || '' } }
           : {}),
       };
     },

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -10,6 +10,7 @@ import type {
   AgentModelPreset,
   AISessionScope,
   DiscoveredAgent,
+  ExternalAgentConfig,
 } from '../infrastructure/ai/types';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
 import { getAgentModelPresets } from '../infrastructure/ai/types';
@@ -54,11 +55,14 @@ import { useAIPermissionGrantsState } from '../application/state/useAIPermission
 import { useConversationExport } from './ai/hooks/useConversationExport';
 import type { AIChatSidePanelProps } from './AIChatSidePanel.types';
 import {
+  buildSdkRuntimeModelCacheKey,
+  sdkRuntimeModelCache,
   generateId,
   normalizeSdkRuntimeModelPresets,
   shouldAdoptSdkCurrentModel,
   shouldLoadSdkRuntimeModels,
   shouldUseStoredAgentModel,
+  type SdkRuntimeModelCatalog,
 } from './AIChatSidePanelHelpers';
 import { AIChatPanelContent } from './AIChatPanelContent';
 import {
@@ -74,6 +78,13 @@ type UserSkillsStatusResult = { ok: boolean; skills?: Array<{
   status: 'ready' | 'warning';
 }> } | null;
 type UserSkillsStatusLoadResult = UserSkillsStatusResult | undefined;
+type SdkRuntimeModelTarget = {
+  agentId: string;
+  cacheKey: string;
+  sdkBackend: string;
+  agentEnv?: Record<string, string>;
+  agentCommand?: string;
+};
 
 const USER_SKILLS_STATUS_CACHE_TTL_MS = 60_000;
 let userSkillsStatusCache: {
@@ -654,55 +665,178 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   const agentModelMapRef = useRef(agentModelMap);
   agentModelMapRef.current = agentModelMap;
 
-  useEffect(() => {
-    if (!isVisible) return;
-    const sdkBackend = getExternalAgentSdkBackend(currentAgentConfig);
-    if (!sdkBackend) return;
-    if (!shouldLoadSdkRuntimeModels(currentAgentConfig) && !isCodexManagedAgent) return;
-
-    const bridge = getNetcattyBridge();
-    if (!bridge?.aiSdkAgentListModels) return;
-
-    let cancelled = false;
-    void bridge.aiSdkAgentListModels(
+  const buildExternalAgentRuntimeModelTarget = useCallback((agent: ExternalAgentConfig | undefined): SdkRuntimeModelTarget | null => {
+    if (!agent) return null;
+    const sdkBackend = getExternalAgentSdkBackend(agent);
+    if (!sdkBackend) return null;
+    return {
+      agentId: agent.id,
+      cacheKey: buildSdkRuntimeModelCacheKey(agent),
       sdkBackend,
-      undefined,
-      undefined,
-      `models_${currentAgentId}`,
-      currentAgentConfig.env,
-      getManualAgentCommand(currentAgentConfig),
-    ).then((result) => {
-      if (cancelled || !result?.ok || !Array.isArray(result.models)) return;
-      const runtimePresets = normalizeSdkRuntimeModelPresets(result.models, result.currentModelId);
-      const storedModelId = agentModelMapRef.current[currentAgentId];
-      if (runtimePresets.length === 0) {
-        setRuntimeAgentModelPresets((prev) => {
-          if (!(currentAgentId in prev)) return prev;
-          const { [currentAgentId]: _removed, ...rest } = prev;
-          return rest;
-        });
-        if (shouldAdoptSdkCurrentModel(result.currentModelId, storedModelId, runtimePresets)) {
-          setAgentModel(currentAgentId, result.currentModelId!);
-        }
-        return;
-      }
+      agentEnv: agent.env,
+      agentCommand: getManualAgentCommand(agent),
+    };
+  }, []);
+
+  const buildDiscoveredAgentRuntimeModelTarget = useCallback((agent: DiscoveredAgent): SdkRuntimeModelTarget | null => {
+    const sdkBackend = agent.sdkBackend ?? agent.command;
+    if (sdkBackend !== 'opencode') return null;
+    const command = agent.binPath || agent.path || agent.command;
+    const agentId = `discovered_${agent.command}`;
+    return {
+      agentId,
+      cacheKey: buildSdkRuntimeModelCacheKey({
+        id: agentId,
+        command,
+        sdkBackend,
+        env: command ? { OPENCODE_BIN: command } : undefined,
+      }),
+      sdkBackend,
+      agentCommand: command,
+    };
+  }, []);
+
+  const applySdkRuntimeModelCatalog = useCallback((
+    agentId: string,
+    catalog: SdkRuntimeModelCatalog,
+    options: { adoptCurrentModel?: boolean } = {},
+  ) => {
+    const runtimePresets = normalizeSdkRuntimeModelPresets(catalog.models, catalog.currentModelId);
+    const storedModelId = agentModelMapRef.current[agentId];
+    if (runtimePresets.length === 0) {
+      setRuntimeAgentModelPresets((prev) => {
+        if (!(agentId in prev)) return prev;
+        const { [agentId]: _removed, ...rest } = prev;
+        return rest;
+      });
+    } else {
       setRuntimeAgentModelPresets((prev) => ({
         ...prev,
-        [currentAgentId]: runtimePresets,
+        [agentId]: runtimePresets,
       }));
-      if (shouldAdoptSdkCurrentModel(result.currentModelId, storedModelId, runtimePresets)) {
-        setAgentModel(currentAgentId, result.currentModelId);
-      }
-    }).catch((err) => {
-      if (!cancelled) {
+    }
+
+    if (
+      options.adoptCurrentModel
+      && catalog.currentModelId
+      && shouldAdoptSdkCurrentModel(catalog.currentModelId, storedModelId, runtimePresets)
+    ) {
+      setAgentModel(agentId, catalog.currentModelId);
+    }
+  }, [setAgentModel]);
+
+  const loadSdkRuntimeModelCatalog = useCallback((
+    target: SdkRuntimeModelTarget,
+    options: { force?: boolean; logErrors?: boolean } = {},
+  ): Promise<SdkRuntimeModelCatalog | null> => {
+    const bridge = getNetcattyBridge();
+    if (!bridge?.aiSdkAgentListModels) return Promise.resolve(null);
+
+    return sdkRuntimeModelCache.refresh(
+      target.cacheKey,
+      async () => {
+        const result = await bridge.aiSdkAgentListModels!(
+          target.sdkBackend,
+          undefined,
+          undefined,
+          `models_${target.agentId}`,
+          target.agentEnv,
+          target.agentCommand,
+        );
+        if (!result?.ok || !Array.isArray(result.models)) {
+          throw new Error(result?.error || 'Failed to load SDK agent models');
+        }
+        return {
+          currentModelId: result.currentModelId ?? null,
+          models: result.models,
+        };
+      },
+      { force: options.force },
+    ).catch((err) => {
+      if (options.logErrors !== false) {
         console.warn('[AIChatSidePanel] Failed to load SDK agent models:', err);
       }
+      return null;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    if (!currentAgentConfig) return;
+    if (!shouldLoadSdkRuntimeModels(currentAgentConfig) && !isCodexManagedAgent) return;
+
+    const target = buildExternalAgentRuntimeModelTarget(currentAgentConfig);
+    if (!target) return;
+
+    const cached = sdkRuntimeModelCache.read(target.cacheKey);
+    if (cached) {
+      applySdkRuntimeModelCatalog(target.agentId, cached);
+    }
+
+    let cancelled = false;
+    void loadSdkRuntimeModelCatalog(target, {
+      force: target.sdkBackend === 'opencode',
+    }).then((catalog) => {
+      if (cancelled || !catalog) return;
+      applySdkRuntimeModelCatalog(target.agentId, catalog, { adoptCurrentModel: true });
     });
 
     return () => {
       cancelled = true;
     };
-  }, [isVisible, currentAgentConfig, currentAgentId, isCodexManagedAgent, setAgentModel]);
+  }, [
+    isVisible,
+    currentAgentConfig,
+    isCodexManagedAgent,
+    buildExternalAgentRuntimeModelTarget,
+    loadSdkRuntimeModelCatalog,
+    applySdkRuntimeModelCatalog,
+  ]);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const targets = new Map<string, SdkRuntimeModelTarget>();
+    const configuredTargetCacheKeys = new Set<string>();
+
+    for (const agent of externalAgents) {
+      if (!agent.enabled || getExternalAgentSdkBackend(agent) !== 'opencode') continue;
+      const target = buildExternalAgentRuntimeModelTarget(agent);
+      if (target) {
+        targets.set(target.cacheKey, target);
+        configuredTargetCacheKeys.add(target.cacheKey);
+      }
+    }
+
+    for (const agent of discoveredAgents) {
+      const target = buildDiscoveredAgentRuntimeModelTarget(agent);
+      if (target) targets.set(target.cacheKey, target);
+    }
+
+    if (targets.size === 0) return;
+
+    let cancelled = false;
+    for (const target of targets.values()) {
+      void loadSdkRuntimeModelCatalog(target, { logErrors: false })
+        .then((catalog) => {
+          if (cancelled || !catalog) return;
+          if (configuredTargetCacheKeys.has(target.cacheKey)) {
+            applySdkRuntimeModelCatalog(target.agentId, catalog);
+          }
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isVisible,
+    externalAgents,
+    discoveredAgents,
+    buildExternalAgentRuntimeModelTarget,
+    buildDiscoveredAgentRuntimeModelTarget,
+    loadSdkRuntimeModelCatalog,
+    applySdkRuntimeModelCatalog,
+  ]);
 
   const hasCodexCustomConfig = codexCustomConfigResolved && isCodexManagedAgent;
 

--- a/components/AIChatSidePanelHelpers.test.tsx
+++ b/components/AIChatSidePanelHelpers.test.tsx
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  createSdkRuntimeModelCache,
   modelPresetsContainId,
   normalizeSdkRuntimeModelPresets,
   shouldAdoptSdkCurrentModel,
@@ -84,4 +85,117 @@ test('shouldUseStoredAgentModel trusts SDK defaults when no runtime list is retu
     ], opencodeAgent),
     false,
   );
+});
+
+test('SDK runtime model cache coalesces concurrent refreshes', async () => {
+  const cache = createSdkRuntimeModelCache();
+  let calls = 0;
+  let resolveLoad!: (value: { currentModelId: string | null; models: AgentModelPreset[] }) => void;
+  const load = () => {
+    calls += 1;
+    return new Promise<{ currentModelId: string | null; models: AgentModelPreset[] }>((resolve) => {
+      resolveLoad = resolve;
+    });
+  };
+
+  const first = cache.refresh('opencode:/opt/bin/opencode', load);
+  const second = cache.refresh('opencode:/opt/bin/opencode', load);
+
+  assert.equal(first, second);
+  assert.equal(calls, 1);
+
+  resolveLoad({
+    currentModelId: 'openai/gpt-5.1',
+    models: [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  });
+  assert.deepEqual(await first, {
+    currentModelId: 'openai/gpt-5.1',
+    models: [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  });
+});
+
+test('SDK runtime model cache serves cached models while background refresh updates them', async () => {
+  let now = 1_000;
+  const cache = createSdkRuntimeModelCache({ now: () => now });
+
+  await cache.refresh('opencode:/opt/bin/opencode', async () => ({
+    currentModelId: 'openai/gpt-5.1',
+    models: [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  }));
+
+  assert.deepEqual(cache.read('opencode:/opt/bin/opencode')?.models, [
+    { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+  ]);
+
+  now = 2_000;
+  const refresh = cache.refresh(
+    'opencode:/opt/bin/opencode',
+    async () => ({
+      currentModelId: 'anthropic/claude-sonnet-4-6',
+      models: [{ id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6' }],
+    }),
+    { force: true },
+  );
+
+  assert.deepEqual(cache.read('opencode:/opt/bin/opencode')?.models, [
+    { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+  ]);
+
+  await refresh;
+  assert.deepEqual(cache.read('opencode:/opt/bin/opencode')?.models, [
+    { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6' },
+  ]);
+});
+
+test('SDK runtime model cache keeps the previous catalog when a refresh fails', async () => {
+  const cache = createSdkRuntimeModelCache();
+
+  await cache.refresh('opencode:/opt/bin/opencode', async () => ({
+    currentModelId: 'openai/gpt-5.1',
+    models: [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  }));
+
+  await assert.rejects(
+    cache.refresh(
+      'opencode:/opt/bin/opencode',
+      async () => {
+        throw new Error('OpenCode unavailable');
+      },
+      { force: true },
+    ),
+    /OpenCode unavailable/,
+  );
+
+  assert.deepEqual(cache.read('opencode:/opt/bin/opencode')?.models, [
+    { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+  ]);
+});
+
+test('SDK runtime model cache ignores degraded empty catalogs', async () => {
+  const cache = createSdkRuntimeModelCache();
+
+  await cache.refresh('opencode:/opt/bin/opencode', async () => ({
+    currentModelId: 'openai/gpt-5.1',
+    models: [{ id: 'openai/gpt-5.1', name: 'GPT-5.1' }],
+  }));
+
+  const refreshed = await cache.refresh(
+    'opencode:/opt/bin/opencode',
+    async () => ({ currentModelId: null, models: [] }),
+    { force: true },
+  );
+
+  assert.deepEqual(refreshed.models, [
+    { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+  ]);
+  assert.deepEqual(cache.read('opencode:/opt/bin/opencode')?.models, [
+    { id: 'openai/gpt-5.1', name: 'GPT-5.1' },
+  ]);
+
+  const emptyCache = createSdkRuntimeModelCache();
+  await emptyCache.refresh('opencode:/usr/bin/opencode', async () => ({
+    currentModelId: null,
+    models: [],
+  }));
+  assert.equal(emptyCache.read('opencode:/usr/bin/opencode'), null);
 });

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -1,6 +1,102 @@
 import type { AgentModelPreset, ExternalAgentConfig } from '../infrastructure/ai/types';
 import { getExternalAgentSdkBackend } from '../infrastructure/ai/managedAgents';
 
+export type SdkRuntimeModelCatalog = {
+  currentModelId: string | null;
+  models: AgentModelPreset[];
+};
+
+export type SdkRuntimeModelCacheEntry = SdkRuntimeModelCatalog & {
+  updatedAt: number;
+};
+
+type SdkRuntimeModelCacheOptions = {
+  ttlMs?: number;
+  now?: () => number;
+};
+
+type SdkRuntimeModelRefreshOptions = {
+  force?: boolean;
+};
+
+const SDK_RUNTIME_MODEL_CACHE_TTL_MS = 5 * 60 * 1000;
+const MODEL_CACHE_ENV_HINTS = ['CLAUDE_CODE_EXECUTABLE', 'CODEBUDDY_CODE_PATH', 'OPENCODE_BIN'] as const;
+
+function cloneCatalog(catalog: SdkRuntimeModelCatalog): SdkRuntimeModelCatalog {
+  return {
+    currentModelId: catalog.currentModelId ?? null,
+    models: [...catalog.models],
+  };
+}
+
+function normalizeSdkRuntimeModelCatalog(catalog: SdkRuntimeModelCatalog): SdkRuntimeModelCatalog {
+  return {
+    currentModelId: catalog.currentModelId ?? null,
+    models: Array.isArray(catalog.models)
+      ? catalog.models.filter((model): model is AgentModelPreset => Boolean(model?.id))
+      : [],
+  };
+}
+
+export function buildSdkRuntimeModelCacheKey(agent: {
+  id: string;
+  command?: string;
+  sdkBackend?: string;
+  acpCommand?: string;
+  env?: Record<string, string>;
+}): string {
+  const sdkBackend = agent.sdkBackend || agent.acpCommand || '';
+  const envHints = MODEL_CACHE_ENV_HINTS.map((key) => `${key}=${agent.env?.[key] ?? ''}`);
+  return [agent.id, sdkBackend, agent.command ?? '', ...envHints].join('\u0000');
+}
+
+export function createSdkRuntimeModelCache(options: SdkRuntimeModelCacheOptions = {}) {
+  const ttlMs = options.ttlMs ?? SDK_RUNTIME_MODEL_CACHE_TTL_MS;
+  const now = options.now ?? (() => Date.now());
+  const entries = new Map<string, SdkRuntimeModelCacheEntry>();
+  const inFlight = new Map<string, Promise<SdkRuntimeModelCatalog>>();
+
+  return {
+    read(key: string): SdkRuntimeModelCacheEntry | null {
+      const entry = entries.get(key);
+      return entry ? { ...cloneCatalog(entry), updatedAt: entry.updatedAt } : null;
+    },
+    refresh(
+      key: string,
+      load: () => Promise<SdkRuntimeModelCatalog>,
+      refreshOptions: SdkRuntimeModelRefreshOptions = {},
+    ): Promise<SdkRuntimeModelCatalog> {
+      const cached = entries.get(key);
+      if (!refreshOptions.force && cached && now() - cached.updatedAt < ttlMs) {
+        return Promise.resolve(cloneCatalog(cached));
+      }
+
+      const existing = inFlight.get(key);
+      if (existing) return existing;
+
+      const promise = Promise.resolve(load())
+        .then((catalog) => {
+          const normalized = normalizeSdkRuntimeModelCatalog(catalog);
+          if (normalized.models.length === 0 && !normalized.currentModelId) {
+            return cached ? cloneCatalog(cached) : cloneCatalog(normalized);
+          }
+          entries.set(key, { ...cloneCatalog(normalized), updatedAt: now() });
+          return cloneCatalog(normalized);
+        })
+        .finally(() => {
+          if (inFlight.get(key) === promise) {
+            inFlight.delete(key);
+          }
+        });
+
+      inFlight.set(key, promise);
+      return promise;
+    },
+  };
+}
+
+export const sdkRuntimeModelCache = createSdkRuntimeModelCache();
+
 export function modelPresetMatchesId(preset: AgentModelPreset, modelId: string): boolean {
   if (preset.thinkingLevels?.length) {
     return preset.thinkingLevels.some((level) => `${preset.id}/${level}` === modelId);

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -308,7 +308,6 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   const mountedRef = useRef(true);
   const agentPathRequestIdRef = useRef<Partial<Record<ManagedAgentKey, number>>>({});
   const codexRequestIdRef = useRef(0);
-
   useEffect(() => () => {
     mountedRef.current = false;
     codexRequestIdRef.current += 1;

--- a/components/settings/tabs/ai/types.ts
+++ b/components/settings/tabs/ai/types.ts
@@ -112,6 +112,7 @@ export interface NetcattyAiBridge {
   aiCodexCancelLogin?: (sessionId: string) => Promise<{ ok: boolean; found?: boolean; session?: CodexLoginSession; error?: string }>;
   aiCodexLogout?: (options?: { codexPath?: string }) => Promise<{ ok: boolean; state?: CodexIntegrationState; isConnected?: boolean; rawOutput?: string; logoutOutput?: string; error?: string }>;
   aiResolveCli?: (params: { command: string; customPath?: string; refreshShellEnv?: boolean; apiKeyPresent?: boolean }) => Promise<AgentPathInfo>;
+  aiSdkAgentListModels?: (sdkBackend: string, cwd?: string, providerId?: string, chatSessionId?: string, agentEnv?: Record<string, string>, agentCommand?: string) => Promise<{ ok: boolean; models?: Array<{ id: string; name: string; description?: string; thinkingLevels?: string[] }>; currentModelId?: string | null; error?: string }>;
   aiUserSkillsGetStatus?: () => Promise<UserSkillsStatusResult>;
   aiUserSkillsOpenFolder?: () => Promise<UserSkillsStatusResult>;
   openExternal?: (url: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- Cache SDK model catalogs in the chat sidebar so OpenCode can show cached choices immediately.
- Refresh OpenCode model catalogs in the background when the tab is opened or selected.
- Keep stale-but-useful cached models when refreshes fail or return degraded empty data.
- Store the discovered OpenCode binary path for matching cache and runtime behavior.

Closes #1704

## Validation
- codex review --uncommitted: clean
- node --test --import tsx components/AIChatSidePanelHelpers.test.tsx components/AIChatSidePanel.mountRetention.test.ts components/ai/managedAgentState.test.ts components/settings/tabs/ai/managedAgentState.test.ts
- npx eslint application/state/useAgentDiscovery.ts components/AIChatSidePanel.tsx components/AIChatSidePanelHelpers.test.tsx components/AIChatSidePanelHelpers.ts components/settings/tabs/SettingsAITab.tsx components/settings/tabs/ai/types.ts
- npm run build