### PR TITLE
Fix serial autocomplete preview

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -88,6 +88,7 @@ import { useTerminalAuthState } from "./terminal/hooks/useTerminalAuthState";
 import { useTerminalDragDrop } from "./terminal/hooks/useTerminalDragDrop";
 import { useTerminalFilePaste } from "./terminal/hooks/useTerminalFilePaste";
 import { TerminalAutocomplete } from "./terminal/TerminalAutocomplete";
+import { resolveTerminalAutocompleteSettings } from "./terminal/autocomplete/terminalAutocompleteSettings";
 import { buildOsc7SetupExecCommand, runOsc7SetupAction, shouldOfferOsc7SetupAction } from "./terminal/osc7Setup";
 import {
   getRemoteClipboardImageUploadErrorMessageKey,
@@ -635,14 +636,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const autocompleteHostOs: "linux" | "windows" | "macos" = host.protocol === "local"
     ? detectLocalOs(navigator.userAgent || navigator.platform)
     : (host.os || "linux");
-  const autocompleteSettings = terminalSettings ? {
-    enabled: terminalSettings.autocompleteEnabled ?? true,
-    showGhostText: terminalSettings.autocompleteGhostText ?? true,
-    showPopupMenu: terminalSettings.autocompletePopupMenu ?? true,
-    debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
-    minChars: terminalSettings.autocompleteMinChars ?? 1,
-    maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
-  } : undefined;
+  const autocompleteSettings = resolveTerminalAutocompleteSettings({
+    protocol: host.protocol,
+    terminalSettings,
+  });
 
   const resolveSftpInitialPath = useCallback(async (options?: { preferFreshBackend?: boolean }): Promise<string | undefined> => {
     const cwd = await resolvePreferredTerminalCwd({

--- a/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteKeyEvent.ts
@@ -19,7 +19,8 @@ interface TerminalAutocompleteKeyEventContext {
   handleSubDirSelect: (level: number, entry: SubDirEntry) => void;
   fetchSubDirForIndex: (index: number) => void;
   renderPreviewSelection: (index: number) => void;
-  acceptSnippet: (snippet: Snippet) => void;
+  acceptPreviewlessSelection: (index: number) => boolean;
+  acceptSnippet: (snippet: Snippet) => boolean;
 }
 
 export function handleTerminalAutocompleteKeyEvent(
@@ -42,6 +43,7 @@ export function handleTerminalAutocompleteKeyEvent(
     handleSubDirSelect,
     fetchSubDirForIndex,
     renderPreviewSelection,
+    acceptPreviewlessSelection,
     acceptSnippet,
   } = context;
   if (!settingsRef.current.enabled || e.type !== "keydown") return true;
@@ -203,7 +205,7 @@ export function handleTerminalAutocompleteKeyEvent(
         });
         // Live-render the highlighted entry's full path into the line (#1005).
         const newEntry = focusedPanel.entries[newIdx];
-        if (newEntry) renderSubDirPath(focusLevel, newEntry);
+        if (newEntry && settingsRef.current.livePreview) renderSubDirPath(focusLevel, newEntry);
         // Auto-expand next level if the newly selected item is a directory
         if (newEntry?.type === "directory") {
           expandSubDir(focusLevel, newEntry);
@@ -276,7 +278,7 @@ export function handleTerminalAutocompleteKeyEvent(
         selectedIndex: next,
         subDirPanels: [], subDirFocusLevel: -1,
       }));
-      renderPreviewSelection(next);
+      if (settingsRef.current.livePreview) renderPreviewSelection(next);
       if (next >= 0) fetchSubDirForIndex(next);
       return false;
     }
@@ -290,10 +292,24 @@ export function handleTerminalAutocompleteKeyEvent(
     if (e.key === "Enter") {
       const selected = s.selectedIndex >= 0 ? s.suggestions[s.selectedIndex] : null;
       if (selected?.source === "snippet" && selected.snippet) {
+        if (!acceptSnippet(selected.snippet)) {
+          clearState();
+          previewActiveRef.current = false;
+          return true;
+        }
         e.preventDefault();
         previewActiveRef.current = false;
-        acceptSnippet(selected.snippet);
         return false; // consume — run the snippet, not the typed text
+      }
+      if (!settingsRef.current.livePreview && selected) {
+        if (acceptPreviewlessSelection(s.selectedIndex)) {
+          e.preventDefault();
+          previewActiveRef.current = false;
+          return false;
+        }
+        clearState();
+        previewActiveRef.current = false;
+        return true;
       }
       clearState();
       previewActiveRef.current = false;

--- a/components/terminal/autocomplete/terminalAutocompleteSettings.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteSettings.ts
@@ -1,0 +1,43 @@
+import type { AutocompleteSettings } from "./useTerminalAutocomplete";
+
+type TerminalAutocompleteSettingFields = {
+  autocompleteEnabled?: boolean;
+  autocompleteGhostText?: boolean;
+  autocompletePopupMenu?: boolean;
+  autocompleteDebounceMs?: number;
+  autocompleteMinChars?: number;
+  autocompleteMaxSuggestions?: number;
+};
+
+export function resolveTerminalAutocompleteSettings(input: {
+  protocol?: string;
+  terminalSettings?: TerminalAutocompleteSettingFields;
+}): Partial<AutocompleteSettings> | undefined {
+  const { protocol, terminalSettings } = input;
+
+  if (protocol === "serial") {
+    return {
+      enabled: terminalSettings?.autocompleteEnabled ?? true,
+      showGhostText: terminalSettings?.autocompleteGhostText ?? true,
+      showPopupMenu: terminalSettings?.autocompletePopupMenu ?? true,
+      livePreview: false,
+      allowLineReplacement: false,
+      debounceMs: terminalSettings?.autocompleteDebounceMs ?? 100,
+      minChars: terminalSettings?.autocompleteMinChars ?? 1,
+      maxSuggestions: terminalSettings?.autocompleteMaxSuggestions ?? 8,
+    };
+  }
+
+  if (!terminalSettings) return undefined;
+
+  return {
+    enabled: terminalSettings.autocompleteEnabled ?? true,
+    showGhostText: terminalSettings.autocompleteGhostText ?? true,
+    showPopupMenu: terminalSettings.autocompletePopupMenu ?? true,
+    livePreview: true,
+    allowLineReplacement: true,
+    debounceMs: terminalSettings.autocompleteDebounceMs ?? 100,
+    minChars: terminalSettings.autocompleteMinChars ?? 1,
+    maxSuggestions: terminalSettings.autocompleteMaxSuggestions ?? 8,
+  };
+}

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -41,6 +41,10 @@ export interface AutocompleteSettings {
   enabled: boolean;
   showGhostText: boolean;
   showPopupMenu: boolean;
+  /** Whether popup navigation should render the highlighted candidate into the terminal input line. */
+  livePreview: boolean;
+  /** Whether accepting a candidate may clear/replace the current input line. */
+  allowLineReplacement: boolean;
   debounceMs: number;
   minChars: number;
   maxSuggestions: number;
@@ -52,6 +56,8 @@ export const DEFAULT_AUTOCOMPLETE_SETTINGS: AutocompleteSettings = {
   enabled: true,
   showGhostText: true,
   showPopupMenu: true,
+  livePreview: true,
+  allowLineReplacement: true,
   debounceMs: 100,
   minChars: 1,
   maxSuggestions: 8,
@@ -646,7 +652,7 @@ export function useTerminalAutocomplete(
     );
 
     // Single query for both ghost text and popup
-    const completions = await getCompletions(input, {
+    let completions = await getCompletions(input, {
       hostId: hostIdRef.current,
       os: hostOsRef.current,
       maxResults: settingsRef.current.maxSuggestions,
@@ -656,6 +662,11 @@ export function useTerminalAutocomplete(
       cwdSource: cwdResolution.source,
       snippets: snippetsRef.current,
     });
+    if (!settingsRef.current.allowLineReplacement) {
+      completions = completions.filter((completion) =>
+        completion.source !== "snippet" && completion.text.startsWith(input),
+      );
+    }
 
     if (disposedRef.current || version !== fetchVersionRef.current) return;
 
@@ -789,6 +800,7 @@ export function useTerminalAutocomplete(
       handleSubDirSelect,
       fetchSubDirForIndex,
       renderPreviewSelection,
+      acceptPreviewlessSelection,
       acceptSnippet,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- handler uses refs and callbacks initialized below.
@@ -800,6 +812,7 @@ export function useTerminalAutocomplete(
    * live-preview, #1005). `index < 0` restores the user's typed baseline.
    */
   const renderPreviewSelection = useCallback((index: number) => {
+    if (!settingsRef.current.livePreview) return;
     const s = stateRef.current;
     const term = termRef.current;
     if (!term) return;
@@ -836,11 +849,12 @@ export function useTerminalAutocomplete(
 
   /** Accept a snippet: clear the user's typed input, then run it via the
    *  host-canonical send path (onAcceptSnippet). */
-  const acceptSnippet = useCallback((snippet: Snippet) => {
+  const acceptSnippet = useCallback((snippet: Snippet): boolean => {
     const term = termRef.current;
     if (term) {
       const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
       if (prompt.isAtPrompt && prompt.userInput.length > 0) {
+        if (!settingsRef.current.allowLineReplacement) return false;
         const clearSequence = hostOsRef.current === "windows"
           ? "\b".repeat(prompt.userInput.length)
           : "\x15"; // Ctrl+U (readline kill-line)
@@ -851,6 +865,7 @@ export function useTerminalAutocomplete(
     typedBufferReliableRef.current = true;
     onAcceptSnippetRef.current?.(snippet);
     clearState();
+    return true;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- clearState is stable
   }, [termRef, writeToTerminal]);
 
@@ -861,12 +876,12 @@ export function useTerminalAutocomplete(
   const insertSuggestion = useCallback(
     (suggestion: CompletionSuggestion, execute: boolean) => {
       const term = termRef.current;
-      if (!term) return;
+      if (!term) return false;
 
       // Always use real-time prompt detection — lastPromptRef may be stale
       // if the user typed more characters after suggestions were fetched.
       const { prompt } = getAlignedPrompt(term, typedInputBufferRef.current, typedBufferReliableRef.current);
-      if (!prompt.isAtPrompt) return;
+      if (!prompt.isAtPrompt) return false;
 
       // If suggestion starts with the current input, insert only the remaining part.
       // Otherwise (fuzzy match), clear the line first and write the full suggestion.
@@ -875,6 +890,7 @@ export function useTerminalAutocomplete(
         const textToInsert = suggestion.text.substring(prompt.userInput.length);
         payload = execute ? textToInsert + "\r" : textToInsert;
       } else {
+        if (!settingsRef.current.allowLineReplacement) return false;
         // Fuzzy match: clear current input, then write full command.
         // Ctrl+U works on POSIX shells (bash/zsh/fish).
         // On Windows (cmd.exe/PowerShell), use backspaces to erase instead.
@@ -916,10 +932,20 @@ export function useTerminalAutocomplete(
       }
 
       clearState();
+      return true;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- clearState is stable
     [termRef, writeToTerminal],
   );
+
+  const acceptPreviewlessSelection = useCallback((index: number): boolean => {
+    const suggestion = stateRef.current.suggestions[index];
+    if (!suggestion) return false;
+    if (suggestion.source === "snippet" && suggestion.snippet) {
+      return acceptSnippet(suggestion.snippet);
+    }
+    return insertSuggestion(suggestion, true);
+  }, [acceptSnippet, insertSuggestion]);
 
   /**
    * Select a suggestion from the popup (Tab / mouse click — insert only, no execute).

--- a/components/terminal/terminalAutocompleteKeyEvent.test.ts
+++ b/components/terminal/terminalAutocompleteKeyEvent.test.ts
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { handleTerminalAutocompleteKeyEvent } from "./autocomplete/terminalAutocompleteKeyEvent.ts";
+
+const suggestion = (text: string) => ({
+  text,
+  displayText: text,
+  source: "history" as const,
+  score: 1,
+});
+
+function keyEvent(key: string) {
+  return {
+    type: "keydown",
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+  } as KeyboardEvent & { defaultPrevented: boolean };
+}
+
+function createContext(overrides: Record<string, unknown> = {}) {
+  let state = {
+    suggestions: [suggestion("show version")],
+    selectedIndex: -1,
+    popupVisible: true,
+    popupAnchorViewport: { left: 0, top: 0, bottom: 0 },
+    expandUpward: false,
+    subDirPanels: [],
+    subDirFocusLevel: -1,
+  };
+  const writes: string[] = [];
+  const previews: number[] = [];
+  const accepted: number[] = [];
+  const clears: number[] = [];
+  const stateRef = { current: state };
+
+  return {
+    writes,
+    previews,
+    accepted,
+    clears,
+    context: {
+      settingsRef: {
+        current: {
+          enabled: true,
+          showGhostText: false,
+          showPopupMenu: true,
+          debounceMs: 100,
+          minChars: 1,
+          maxSuggestions: 8,
+          livePreview: false,
+          allowLineReplacement: false,
+        },
+      },
+      stateRef,
+      ghostAddonRef: { current: null },
+      typedInputBufferRef: { current: "sh" },
+      typedBufferReliableRef: { current: true },
+      previewActiveRef: { current: false },
+      lastAcceptedCommandRef: { current: null },
+      setState(update: typeof state | ((prev: typeof state) => typeof state)) {
+        state = typeof update === "function" ? update(state) : update;
+        stateRef.current = state;
+      },
+      expandSubDir() {},
+      writeToTerminal(text: string) { writes.push(text); },
+      clearState() { clears.push(1); },
+      renderSubDirPath() {},
+      handleSubDirSelect() {},
+      fetchSubDirForIndex() {},
+      renderPreviewSelection(index: number) { previews.push(index); },
+      acceptSnippet() { return true; },
+      acceptPreviewlessSelection(index: number) { accepted.push(index); return true; },
+      ...overrides,
+    },
+  };
+}
+
+test("serial-style popup navigation does not render candidates into the input line", () => {
+  const { context, previews } = createContext();
+  const event = keyEvent("ArrowDown");
+
+  const result = handleTerminalAutocompleteKeyEvent(event, context);
+
+  assert.equal(result, false);
+  assert.equal(event.defaultPrevented, true);
+  assert.deepEqual(previews, []);
+});
+
+test("serial-style popup Enter confirms the selected candidate instead of passing Enter through", () => {
+  const { context, accepted, clears } = createContext({
+    stateRef: {
+      current: {
+        suggestions: [suggestion("show version")],
+        selectedIndex: 0,
+        popupVisible: true,
+        popupAnchorViewport: { left: 0, top: 0, bottom: 0 },
+        expandUpward: false,
+        subDirPanels: [],
+        subDirFocusLevel: -1,
+      },
+    },
+  });
+  const event = keyEvent("Enter");
+
+  const result = handleTerminalAutocompleteKeyEvent(event, context);
+
+  assert.equal(result, false);
+  assert.equal(event.defaultPrevented, true);
+  assert.deepEqual(accepted, [0]);
+  assert.deepEqual(clears, []);
+});
+
+test("serial-style popup Enter passes through when the selected candidate is stale", () => {
+  const { context, accepted, clears } = createContext({
+    stateRef: {
+      current: {
+        suggestions: [suggestion("show version")],
+        selectedIndex: 0,
+        popupVisible: true,
+        popupAnchorViewport: { left: 0, top: 0, bottom: 0 },
+        expandUpward: false,
+        subDirPanels: [],
+        subDirFocusLevel: -1,
+      },
+    },
+    acceptPreviewlessSelection(index: number) {
+      accepted.push(index);
+      return false;
+    },
+  });
+  const event = keyEvent("Enter");
+
+  const result = handleTerminalAutocompleteKeyEvent(event, context);
+
+  assert.equal(result, true);
+  assert.equal(event.defaultPrevented, false);
+  assert.deepEqual(accepted, [0]);
+  assert.deepEqual(clears, [1]);
+});

--- a/components/terminal/terminalAutocompleteSettings.test.ts
+++ b/components/terminal/terminalAutocompleteSettings.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveTerminalAutocompleteSettings } from "./autocomplete/terminalAutocompleteSettings.ts";
+
+test("keeps autocomplete enabled for shell-like terminal protocols", () => {
+  assert.deepEqual(
+    resolveTerminalAutocompleteSettings({
+      protocol: "ssh",
+      terminalSettings: {
+        autocompleteEnabled: true,
+        autocompleteGhostText: false,
+        autocompletePopupMenu: true,
+        autocompleteDebounceMs: 120,
+        autocompleteMinChars: 2,
+        autocompleteMaxSuggestions: 6,
+      },
+    }),
+    {
+      enabled: true,
+      showGhostText: false,
+      showPopupMenu: true,
+      livePreview: true,
+      allowLineReplacement: true,
+      debounceMs: 120,
+      minChars: 2,
+      maxSuggestions: 6,
+    },
+  );
+});
+
+test("keeps serial autocomplete available but disables input-line preview and replacement", () => {
+  assert.deepEqual(
+    resolveTerminalAutocompleteSettings({
+      protocol: "serial",
+      terminalSettings: {
+        autocompleteEnabled: true,
+        autocompleteGhostText: false,
+        autocompletePopupMenu: true,
+        autocompleteDebounceMs: 100,
+        autocompleteMinChars: 1,
+        autocompleteMaxSuggestions: 8,
+      },
+    }),
+    {
+      enabled: true,
+      showGhostText: false,
+      showPopupMenu: true,
+      debounceMs: 100,
+      minChars: 1,
+      maxSuggestions: 8,
+      livePreview: false,
+      allowLineReplacement: false,
+    },
+  );
+});


### PR DESCRIPTION
Fixes #1717.

Summary:
- Keep serial autocomplete available, but stop arrow-key navigation from writing previews into the serial input line.
- Prevent serial autocomplete from using clear-and-replace completions.
- Let Enter pass through if a selected serial suggestion is stale instead of swallowing the command.

Verification:
- node --test --import tsx components/terminal/terminalAutocompleteKeyEvent.test.ts components/terminal/terminalAutocompleteSettings.test.ts components/terminal/completionGate.test.ts components/terminal/livePreviewSequence.test.ts components/terminal/completionEngine.test.ts components/terminal/completionEngineSnippets.test.ts components/terminal/snippetCompleter.test.ts
- npm run lint
- npm run build
- codex review --uncommitted clean

Note: full npm test is still blocked locally by existing unrelated environment/dependency failures.