### PR TITLE
fix(autocomplete): clamp popup within terminal viewport

### DIFF
--- a/components/terminal/autocomplete/terminalAutocompleteLayout.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteLayout.ts
@@ -246,14 +246,21 @@ export function computeAutocompletePopupPlacement(
         : spaceAbove > spaceBelow;
 
   const availableVerticalSpace = renderUpward ? spaceAbove : spaceBelow;
-  const effectiveMaxHeight = Math.max(0, Math.min(maxHeight, availableVerticalSpace));
+  const availableViewportHeight = Math.max(0, bounds.height - viewportPadding * 2);
+  const effectiveMaxHeight = Math.max(
+    0,
+    Math.min(maxHeight, availableVerticalSpace, availableViewportHeight),
+  );
   const contentHeightForPlacement = Math.min(effectiveMaxHeight, cappedDesiredHeight);
-  const top = renderUpward
+  const unclampedTop = renderUpward
     ? Math.max(bounds.top + viewportPadding, anchorTop - anchorGap - contentHeightForPlacement)
     : Math.min(
         anchorBottom + anchorGap,
         boundsBottom - viewportPadding - contentHeightForPlacement,
       );
+  const minTop = bounds.top + viewportPadding;
+  const maxTop = Math.max(minTop, boundsBottom - viewportPadding - contentHeightForPlacement);
+  const top = Math.max(minTop, Math.min(unclampedTop, maxTop));
 
   // Right edge that keeps the clamped assembly inside the bounds. When the
   // assembly is wider than the available room this goes below the left padding,
@@ -319,7 +326,7 @@ export function resolveAutocompleteCursorColumn(
   return Math.max(fromLine, fromPrompt);
 }
 
-/** Clamp autocomplete popups to the active terminal pane in split workspaces.
+/** Clamp autocomplete popups to the active terminal screen in split workspaces.
  *
  * Uses the visible `.xterm-screen` rect as the clamp boundary so the popup
  * never overflows the *actual* rendered terminal grid. The `.xterm-container`
@@ -332,11 +339,11 @@ export function resolveAutocompleteClampViewport(container: HTMLElement | null):
   const pane = container?.closest<HTMLElement>('[data-section="terminal-split-pane"]');
   const screen = container?.querySelector<HTMLElement>(".xterm-screen")
     ?? null;
-  // Prefer the split-pane bounds when present; otherwise clamp to the rendered
-  // screen so the popup cannot spill below the last row. If neither is
-  // available, fall back to the container rect or the full viewport.
-  const rect = pane?.getBoundingClientRect()
-    ?? screen?.getBoundingClientRect()
+  // Clamp to the rendered screen so the popup cannot spill past the visible
+  // terminal rows. If the screen is not mounted yet, fall back to the split
+  // pane/container rect or the full viewport.
+  const rect = screen?.getBoundingClientRect()
+    ?? pane?.getBoundingClientRect()
     ?? container?.getBoundingClientRect();
   if (rect && rect.width > 0 && rect.height > 0) {
     return {

--- a/components/terminal/terminalAutocompleteLayout.test.ts
+++ b/components/terminal/terminalAutocompleteLayout.test.ts
@@ -259,6 +259,50 @@ test("short popup flips upward when the cursor is at the bottom of the screen", 
     "popup should not be clipped above the viewport");
 });
 
+test("clamps a downward popup back inside the terminal when the anchor is above the viewport", () => {
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorTop: -60,
+    anchorBottom: -40,
+    desiredHeight: 96,
+    maxHeight: 240,
+    expandUpwardHint: false,
+  });
+  const contentHeight = Math.min(p.maxHeight, 96);
+
+  assert.equal(p.renderUpward, false);
+  assert.ok(
+    p.top >= baseInput.viewportPadding,
+    `popup top ${p.top} should stay inside the terminal viewport`,
+  );
+  assert.ok(
+    p.top + contentHeight <= baseInput.viewportHeight - baseInput.viewportPadding + 0.001,
+    `popup bottom ${p.top + contentHeight} should stay inside the terminal viewport`,
+  );
+});
+
+test("clamps an upward popup back inside the terminal when the anchor is below the viewport", () => {
+  const p = computeAutocompletePopupPlacement({
+    ...baseInput,
+    anchorTop: 860,
+    anchorBottom: 880,
+    desiredHeight: 96,
+    maxHeight: 240,
+    expandUpwardHint: true,
+  });
+  const contentHeight = Math.min(p.maxHeight, 96);
+
+  assert.equal(p.renderUpward, true);
+  assert.ok(
+    p.top >= baseInput.viewportPadding,
+    `popup top ${p.top} should stay inside the terminal viewport`,
+  );
+  assert.ok(
+    p.top + contentHeight <= baseInput.viewportHeight - baseInput.viewportPadding + 0.001,
+    `popup bottom ${p.top + contentHeight} should stay inside the terminal viewport`,
+  );
+});
+
 test("resolveAutocompleteClampViewport clamps to the xterm screen rect", () => {
   const container = {
     closest: () => null,
@@ -297,7 +341,7 @@ test("resolveAutocompleteClampViewport clamps to the xterm screen rect", () => {
   assert.equal(clamp.width, 600);
 });
 
-test("resolveAutocompleteClampViewport prefers terminal split pane over screen", () => {
+test("resolveAutocompleteClampViewport prefers the visible terminal screen over the split pane", () => {
   const pane = {
     getAttribute: (name: string) => (name === "data-section" ? "terminal-split-pane" : null),
     getBoundingClientRect: () => ({
@@ -344,10 +388,10 @@ test("resolveAutocompleteClampViewport prefers terminal split pane over screen",
   } as unknown as HTMLElement;
 
   const clamp = resolveAutocompleteClampViewport(container);
-  assert.equal(clamp.left, 20, "split pane left should win");
-  assert.equal(clamp.top, 30, "split pane top should win");
-  assert.equal(clamp.width, 500, "split pane width should win");
-  assert.equal(clamp.height, 300, "split pane height should win");
+  assert.equal(clamp.left, 25, "screen left should win");
+  assert.equal(clamp.top, 35, "screen top should win");
+  assert.equal(clamp.width, 490, "screen width should win");
+  assert.equal(clamp.height, 280, "screen height should win");
 });
 
 test("resolveAutocompleteAnchorInViewport ignores the helper textarea horizontal position", () => {


### PR DESCRIPTION
## Summary
- Clamp autocomplete popups to the visible terminal screen so they cannot escape above or below the terminal viewport.
- Prefer the real terminal screen bounds over the larger split-pane/container fallback.
- Add boundary regressions for anchors outside the viewport.

## Test Plan
- node --test --import tsx components/terminal/terminalAutocompleteLayout.test.ts components/terminal/useTerminalAutocomplete.render.test.tsx components/terminal/completionEngine.test.ts components/terminal/terminalAutocompleteKeyEvent.test.ts components/terminal/terminalAutocompleteInput.test.ts
- npm run lint
- npm test
- npm run build
- codex review --base origin/main