### PR TITLE
fix(windows): restore main-window input focus on show/hide hotkey (#1722)

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { Suspense, lazy, useMemo } from 'react';
+import React, { Suspense, lazy, useCallback, useMemo } from 'react';
 import { AlertTriangle, Download, Trash2 } from 'lucide-react';
 import { activeTabStore, toEditorTabId, useIsEditorTabActive } from '../state/activeTabStore';
 import { editorTabStore } from '../state/editorTabStore';
@@ -22,6 +22,7 @@ import { toast } from '../../components/ui/toast';
 import { AppHostTreeLayer } from './AppHostTreeLayer';
 import { getUiThemeById } from '../../infrastructure/config/uiThemes';
 import { buildAppThemeCssVars } from '../state/settingsStateDefaults';
+import { useMainWindowInputFocusRecovery } from '../state/useMainWindowInputFocusRecovery';
 
 const LazyProtocolSelectDialog = lazy(() => import('../../components/ProtocolSelectDialog'));
 const LazyQuickSwitcher = lazy(() =>
@@ -54,6 +55,36 @@ type AppViewContext = Record<string, any>;
 
 export function AppView({ ctx }: { ctx: AppViewContext }) {
   const {
+    resetSessionRename,
+    resetWorkspaceRename,
+    setAddToWorkspaceDialog,
+    setIsCreateWorkspaceOpen,
+    setIsQuickSwitcherOpen,
+    setProtocolSelectHost,
+    setQuickSearch,
+  } = ctx;
+
+  const dismissTransientOverlays = useCallback(() => {
+    setIsQuickSwitcherOpen(false);
+    setQuickSearch('');
+    setIsCreateWorkspaceOpen(false);
+    setProtocolSelectHost(null);
+    setAddToWorkspaceDialog(null);
+    resetSessionRename();
+    resetWorkspaceRename();
+  }, [
+    resetSessionRename,
+    resetWorkspaceRename,
+    setAddToWorkspaceDialog,
+    setIsCreateWorkspaceOpen,
+    setIsQuickSwitcherOpen,
+    setProtocolSelectHost,
+    setQuickSearch,
+  ]);
+
+  useMainWindowInputFocusRecovery({ onPageHidden: dismissTransientOverlays });
+
+  const {
     accentMode, addShellHistoryEntry, addSessionToWorkspace, addToWorkspaceDialog, appendHostToWorkspace, appendLocalTerminalToWorkspace,
     clearAndRemoveSource, clearAndRemoveSources, clearUnsavedConnectionLogs, closeLogView, closeSession, closeTabsBatch, closeWorkspace, copySessionToNewWindowWithCurrentShell, copySessionWithCurrentShell,
     connectionLogs, convertKnownHostToHost, createWorkspaceFromSessions, createWorkspaceFromTargets, createWorkspaceWithHosts, customAccent,
@@ -64,10 +95,10 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     handleRequestCloseEditorTabRef, handleSessionStatusChange, handleSyncNowManual, handleTerminalDataCapture, handleToggleTheme, handleUpdateHostFromTerminal,
     hostById, hosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen,
     keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, noteGroups, notes, openLogView, openNoteRequest, orderedTabsWithEditors, orphanSessions,
-    passphraseQueue, protocolSelectHost, proxyProfiles, portForwardingRules, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions, resetSessionRename,
-    resetWorkspaceRename, resolveEmptyVaultConflict, resolvedTheme, runSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sshDebugLogsEnabled,
-    sessionRenameValue, sessions, setActiveTabId, setAddToWorkspaceDialog, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap, setIsCreateWorkspaceOpen, setIsQuickSwitcherOpen,
-    setNavigateToSection, setProtocolSelectHost, setQuickSearch, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, setVaultFocusRequest, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, clearSessionFontSizeOverride,
+    passphraseQueue, protocolSelectHost, proxyProfiles, portForwardingRules, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions,
+    resolveEmptyVaultConflict, resolvedTheme, runSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sshDebugLogsEnabled,
+    sessionRenameValue, sessions, setActiveTabId, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap,
+    setNavigateToSection, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setTerminalThemeId, setVaultFocusRequest, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, clearSessionFontSizeOverride,
     setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior,
     sftpShowHiddenFiles, sftpUseCompressedUpload, shellHistory, snippetPackages, snippets, splitSessionWithCurrentShell, startSessionRename,
     startWorkspaceRename, submitSessionRename, submitWorkspaceRename, t, terminalFontFamilyId, terminalFontSize, terminalSettings, terminalThemeId, themeById,

--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -25,6 +25,15 @@ test("useMainWindowInputFocusRecovery dismisses transient UI when the page hides
   assert.match(source, /onPageHidden\?\.\(\)/);
   assert.match(source, /onWindowShown/);
   assert.match(source, /onWindowWillHide/);
+  assert.match(source, /cancelPendingFocusRecovery/);
+});
+
+test("scheduleWindowInputFocus skips deferred focus when the page is hidden", () => {
+  const source = readProjectFile("application/state/windowInputFocus.ts");
+
+  assert.match(source, /document\.visibilityState !== "visible"/);
+  assert.match(source, /cancelAnimationFrame/);
+  assert.match(source, /clearTimeout/);
 });
 
 test("AppView mounts main-window input focus recovery with overlay dismiss", () => {

--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = new URL("../..", import.meta.url);
+
+function readProjectFile(path: string): string {
+  return readFileSync(join(root.pathname, path), "utf8");
+}
+
+test("useMainWindowInputFocusRecovery listens for visibility and window focus", () => {
+  const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
+
+  assert.match(source, /document\.visibilityState !== "visible"/);
+  assert.match(source, /scheduleWindowInputFocus\(\)/);
+  assert.match(source, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/);
+  assert.match(source, /window\.addEventListener\("focus", recoverFocus\)/);
+});
+
+test("useMainWindowInputFocusRecovery dismisses transient UI when the page hides", () => {
+  const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
+
+  assert.match(source, /document\.visibilityState === "hidden"/);
+  assert.match(source, /onPageHidden\?\.\(\)/);
+  assert.match(source, /onWindowShown/);
+  assert.match(source, /onWindowWillHide/);
+});
+
+test("AppView mounts main-window input focus recovery with overlay dismiss", () => {
+  const source = readProjectFile("application/app/AppView.tsx");
+
+  assert.match(source, /useMainWindowInputFocusRecovery\(\{ onPageHidden: dismissTransientOverlays \}\)/);
+  assert.match(source, /setIsQuickSwitcherOpen\(false\)/);
+  assert.match(source, /setProtocolSelectHost\(null\)/);
+});
+
+test("dropdown closes when the document becomes hidden", () => {
+  const source = readProjectFile("components/ui/dropdown.tsx");
+
+  assert.match(source, /document\.visibilityState === "hidden"/);
+  assert.match(source, /setOpen\(false\)/);
+});

--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-const root = new URL("../..", import.meta.url);
+const root = fileURLToPath(new URL("../..", import.meta.url));
 
 function readProjectFile(path: string): string {
-  return readFileSync(join(root.pathname, path), "utf8");
+  return readFileSync(join(root, path), "utf8");
 }
 
 test("useMainWindowInputFocusRecovery listens for visibility and window focus", () => {

--- a/application/state/useMainWindowInputFocusRecovery.ts
+++ b/application/state/useMainWindowInputFocusRecovery.ts
@@ -1,7 +1,10 @@
 import { useEffect } from "react";
 
 import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
-import { scheduleWindowInputFocus } from "./windowInputFocus";
+import {
+  scheduleWindowInputFocus,
+  type ScheduledWindowInputFocus,
+} from "./windowInputFocus";
 
 export type MainWindowInputFocusRecoveryOptions = {
   /** Close transient overlays before the window hides (#1722). */
@@ -18,12 +21,21 @@ export function useMainWindowInputFocusRecovery(
   const { onPageHidden } = options;
 
   useEffect(() => {
+    let pendingFocusRecovery: ScheduledWindowInputFocus | null = null;
+
+    const cancelPendingFocusRecovery = () => {
+      pendingFocusRecovery?.cancel();
+      pendingFocusRecovery = null;
+    };
+
     const recoverFocus = () => {
       if (document.visibilityState !== "visible") return;
-      scheduleWindowInputFocus();
+      cancelPendingFocusRecovery();
+      pendingFocusRecovery = scheduleWindowInputFocus();
     };
 
     const dismissTransientUi = () => {
+      cancelPendingFocusRecovery();
       onPageHidden?.();
     };
 
@@ -47,6 +59,7 @@ export function useMainWindowInputFocusRecovery(
     });
 
     return () => {
+      cancelPendingFocusRecovery();
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("focus", recoverFocus);
       unsubscribeShown?.();

--- a/application/state/useMainWindowInputFocusRecovery.ts
+++ b/application/state/useMainWindowInputFocusRecovery.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+
+import { netcattyBridge } from "../../infrastructure/services/netcattyBridge";
+import { scheduleWindowInputFocus } from "./windowInputFocus";
+
+export type MainWindowInputFocusRecoveryOptions = {
+  /** Close transient overlays before the window hides (#1722). */
+  onPageHidden?: () => void;
+};
+
+/**
+ * Recover OS/renderer input focus when the main window returns from hide,
+ * another app, or a virtual desktop (#760, #1714, #1722).
+ */
+export function useMainWindowInputFocusRecovery(
+  options: MainWindowInputFocusRecoveryOptions = {},
+): void {
+  const { onPageHidden } = options;
+
+  useEffect(() => {
+    const recoverFocus = () => {
+      if (document.visibilityState !== "visible") return;
+      scheduleWindowInputFocus();
+    };
+
+    const dismissTransientUi = () => {
+      onPageHidden?.();
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        dismissTransientUi();
+        return;
+      }
+      recoverFocus();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", recoverFocus);
+
+    const bridge = netcattyBridge.get();
+    const unsubscribeShown = bridge?.onWindowShown?.(() => {
+      recoverFocus();
+    });
+    const unsubscribeWillHide = bridge?.onWindowWillHide?.(() => {
+      dismissTransientUi();
+    });
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", recoverFocus);
+      unsubscribeShown?.();
+      unsubscribeWillHide?.();
+    };
+  }, [onPageHidden]);
+}

--- a/application/state/windowInputFocus.ts
+++ b/application/state/windowInputFocus.ts
@@ -9,17 +9,49 @@ export const requestWindowInputFocus = (): void => {
   }
 };
 
-export const scheduleWindowInputFocus = (): void => {
-  const scheduleFrame: (callback: () => void) => unknown =
+export type ScheduledWindowInputFocus = {
+  cancel: () => void;
+};
+
+export const scheduleWindowInputFocus = (): ScheduledWindowInputFocus => {
+  let cancelled = false;
+  let frameId: number | undefined;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const cancel = () => {
+    cancelled = true;
+    if (frameId !== undefined && typeof cancelAnimationFrame === "function") {
+      cancelAnimationFrame(frameId);
+      frameId = undefined;
+    }
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+
+  const runIfVisible = () => {
+    if (cancelled || document.visibilityState !== "visible") return;
+    requestWindowInputFocus();
+  };
+
+  const scheduleFrame: (callback: FrameRequestCallback) => number =
     typeof requestAnimationFrame === "function"
       ? requestAnimationFrame
       : (callback) => {
-        callback();
-        return undefined;
+        callback(0);
+        return 0;
       };
 
-  scheduleFrame(() => {
-    requestWindowInputFocus();
-    setTimeout(requestWindowInputFocus, 50);
+  frameId = scheduleFrame(() => {
+    frameId = undefined;
+    runIfVisible();
+    if (cancelled) return;
+    timeoutId = setTimeout(() => {
+      timeoutId = undefined;
+      runIfVisible();
+    }, 50);
   });
+
+  return { cancel };
 };

--- a/components/ui/dropdown.tsx
+++ b/components/ui/dropdown.tsx
@@ -50,6 +50,16 @@ const Dropdown: React.FC<DropdownProps> = ({
     [controlledOpen, onOpenChange],
   );
 
+  useEffect(() => {
+    const closeOnPageHidden = () => {
+      if (document.visibilityState === "hidden") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("visibilitychange", closeOnPageHidden);
+    return () => document.removeEventListener("visibilitychange", closeOnPageHidden);
+  }, [setOpen]);
+
   return (
     <DropdownContext.Provider value={{ open, setOpen, triggerRef }}>
       {children}

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -161,19 +161,21 @@ function startPendingFullscreenHideWatchdog(win) {
   }, FULLSCREEN_LEAVE_WATCHDOG_MS);
 }
 
-function openMainWindow() {
-  const { app } = electronModule;
-  const win = getMainWindow();
-  if (!win) return;
+function bringMainWindowToForeground(win) {
+  if (!win || win.isDestroyed?.()) return false;
   clearPendingFullscreenHide(win);
-  if (win.isMinimized()) win.restore();
-  win.show();
-  win.focus();
+  const windowManager = require("./windowManager.cjs");
+  const focused = windowManager.showAndFocusMainWindow?.(win) ?? false;
   try {
-    app.focus({ steal: true });
+    electronModule?.app?.focus?.({ steal: true });
   } catch {
     // ignore
   }
+  return focused;
+}
+
+function openMainWindow() {
+  bringMainWindowToForeground(getMainWindow());
 }
 
 function getTrayPanelUrl() {
@@ -477,42 +479,18 @@ function toggleWindowVisibility() {
   try {
     // Check if window is minimized first - minimized windows may still report isVisible() = true
     if (win.isMinimized()) {
-      clearPendingFullscreenHide(win);
-      win.restore();
-      win.show();
-      win.focus();
-      const { app } = electronModule;
-      try {
-        app.focus({ steal: true });
-      } catch {
-        // ignore
-      }
+      bringMainWindowToForeground(win);
     } else if (win.isVisible()) {
       if (win.isFocused()) {
         // Window is visible and focused - hide it
         hideWindowRespectingMacFullscreen(win);
       } else {
         // Window is visible but not focused - focus it
-        clearPendingFullscreenHide(win);
-        win.focus();
-        const { app } = electronModule;
-        try {
-          app.focus({ steal: true });
-        } catch {
-          // ignore
-        }
+        bringMainWindowToForeground(win);
       }
     } else {
       // Window is hidden - show and focus it
-      clearPendingFullscreenHide(win);
-      win.show();
-      win.focus();
-      const { app } = electronModule;
-      try {
-        app.focus({ steal: true });
-      } catch {
-        // ignore
-      }
+      bringMainWindowToForeground(win);
     }
   } catch (err) {
     console.warn("[GlobalShortcut] Error toggling window visibility:", err);
@@ -687,10 +665,7 @@ function buildTrayMenuTemplate() {
         click: () => {
           // Focus window and switch to this session
           const win = getMainWindow();
-          if (win) {
-            if (win.isMinimized()) win.restore();
-            win.show();
-            win.focus();
+          if (win && bringMainWindowToForeground(win)) {
             // Notify renderer to focus this session
             win.webContents?.send("netcatty:tray:focusSession", session.id);
           }

--- a/electron/bridges/globalShortcutBridge.cjs
+++ b/electron/bridges/globalShortcutBridge.cjs
@@ -87,6 +87,8 @@ function performPendingFullscreenHide(win) {
   clearPendingFullscreenHide(win);
 
   try {
+    const windowManager = require("./windowManager.cjs");
+    windowManager.notifyWindowWillHide?.(win);
     win.hide();
     return "hidden";
   } catch (err) {
@@ -406,6 +408,8 @@ function hideWindowRespectingMacFullscreen(win) {
   }
 
   try {
+    const windowManager = require("./windowManager.cjs");
+    windowManager.notifyWindowWillHide?.(win);
     win.hide();
     return true;
   } catch (err) {

--- a/electron/bridges/globalShortcutBridge.test.cjs
+++ b/electron/bridges/globalShortcutBridge.test.cjs
@@ -554,3 +554,125 @@ test("tray icon event registration is platform-dependent", async () => {
     bridge.cleanup();
   });
 });
+
+test("toggleWindowVisibility show path delegates to showAndFocusMainWindow on win32", async () => {
+  await withPlatform("win32", async () => {
+    const windowManagerPath = require.resolve("./windowManager.cjs");
+    const actualWindowManager = require(windowManagerPath);
+    const showCalls = [];
+    let appFocusCalls = 0;
+
+    require.cache[windowManagerPath].exports = {
+      ...actualWindowManager,
+      showAndFocusMainWindow(win) {
+        showCalls.push(win);
+        return true;
+      },
+    };
+
+    try {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      electronModule.app.focus = () => {
+        appFocusCalls += 1;
+      };
+      const win = new FakeWindow();
+      win.visible = false;
+      win.focused = false;
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      let toggleWindow = null;
+      electronModule.globalShortcut.register = (_accelerator, handler) => {
+        toggleWindow = handler;
+        return true;
+      };
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+      await ipcMain.handlers.get("netcatty:globalHotkey:register")(null, { hotkey: "Ctrl + `" });
+
+      assert.ok(toggleWindow, "expected global hotkey handler to register");
+      toggleWindow();
+
+      assert.equal(showCalls.length, 1);
+      assert.equal(showCalls[0], win);
+      assert.equal(appFocusCalls, 1);
+      assert.equal(win.showCalls, 0, "should not call bare win.show()");
+      assert.equal(win.focusCalls, 0, "should not call bare win.focus()");
+    } finally {
+      require.cache[windowManagerPath].exports = actualWindowManager;
+    }
+  });
+});
+
+test("openMainWindow delegates to showAndFocusMainWindow on win32", async () => {
+  await withPlatform("win32", async () => {
+    const windowManagerPath = require.resolve("./windowManager.cjs");
+    const actualWindowManager = require(windowManagerPath);
+    const showCalls = [];
+
+    require.cache[windowManagerPath].exports = {
+      ...actualWindowManager,
+      showAndFocusMainWindow(win) {
+        showCalls.push(win);
+        return true;
+      },
+    };
+
+    try {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      electronModule.app.focus = () => {};
+      const win = new FakeWindow();
+      win.visible = false;
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+
+      await ipcMain.handlers.get("netcatty:trayPanel:openMainWindow")();
+
+      assert.equal(showCalls.length, 1);
+      assert.equal(showCalls[0], win);
+      assert.equal(win.showCalls, 0);
+      assert.equal(win.focusCalls, 0);
+    } finally {
+      require.cache[windowManagerPath].exports = actualWindowManager;
+    }
+  });
+});
+
+test("toggleWindowVisibility focuses visible-but-unfocused windows via showAndFocusMainWindow", async () => {
+  await withPlatform("win32", async () => {
+    const windowManagerPath = require.resolve("./windowManager.cjs");
+    const actualWindowManager = require(windowManagerPath);
+    const showCalls = [];
+
+    require.cache[windowManagerPath].exports = {
+      ...actualWindowManager,
+      showAndFocusMainWindow(win) {
+        showCalls.push(win);
+        return true;
+      },
+    };
+
+    try {
+      const bridge = loadBridge();
+      const electronModule = createElectronStub();
+      electronModule.app.focus = () => {};
+      const win = new FakeWindow();
+      win.visible = true;
+      win.focused = false;
+      electronModule.BrowserWindow.getAllWindows = () => [win];
+      let toggleWindow = null;
+      electronModule.globalShortcut.register = (_accelerator, handler) => {
+        toggleWindow = handler;
+        return true;
+      };
+      const { ipcMain } = await enableCloseToTray(bridge, electronModule);
+      await ipcMain.handlers.get("netcatty:globalHotkey:register")(null, { hotkey: "Ctrl + `" });
+
+      toggleWindow();
+
+      assert.equal(showCalls.length, 1);
+      assert.equal(win.hideCalls, 0);
+    } finally {
+      require.cache[windowManagerPath].exports = actualWindowManager;
+    }
+  });
+});

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -6,6 +6,8 @@
 const path = require("node:path");
 const fs = require("node:fs");
 
+const { safeSend } = require("./ipcUtils.cjs");
+
 const V8_CACHE_OPTIONS = "bypassHeatCheck";
 
 function getGlobalShortcutBridge() {
@@ -1242,6 +1244,15 @@ function showAndFocusMainWindow(win) {
   return restoreWindowInputFocus(win, { show: true });
 }
 
+/**
+ * Tell the renderer to dismiss transient overlays before the native hide (#1722).
+ * Must run before BrowserWindow.hide(), not from Electron's post-hide event.
+ */
+function notifyWindowWillHide(win) {
+  if (!win || win.isDestroyed?.()) return;
+  safeSend(win.webContents, "netcatty:window:will-hide");
+}
+
 module.exports = {
   createWindow,
   openSettingsWindow,
@@ -1264,6 +1275,7 @@ module.exports = {
   registerWindowHandlers,
   restoreWindowInputFocus,
   showAndFocusMainWindow,
+  notifyWindowWillHide,
   requestWindowCommandClose,
   shouldCloseWindowFromInput,
   WINDOW_COMMAND_CLOSE_CHANNEL,

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1225,6 +1225,23 @@ function getSettingsWindow() {
   return settingsWindow;
 }
 
+/**
+ * Show the main window and restore reliable keyboard/caret routing (#760, #1722).
+ * Global hotkeys and tray entry points invoke this from non-foreground contexts
+ * where bare BrowserWindow.focus() is silently rejected on Windows.
+ */
+function showAndFocusMainWindow(win) {
+  if (!win || win.isDestroyed?.()) return false;
+  if (win.isMinimized?.()) {
+    try {
+      win.restore();
+    } catch {
+      // ignore
+    }
+  }
+  return restoreWindowInputFocus(win, { show: true });
+}
+
 module.exports = {
   createWindow,
   openSettingsWindow,
@@ -1246,6 +1263,7 @@ module.exports = {
   isWindowUsable,
   registerWindowHandlers,
   restoreWindowInputFocus,
+  showAndFocusMainWindow,
   requestWindowCommandClose,
   shouldCloseWindowFromInput,
   WINDOW_COMMAND_CLOSE_CHANNEL,

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -342,10 +342,6 @@ function createMainWindowApi(ctx) {
       win.on("show", () => {
         safeSend("netcatty:window:shown");
       });
-
-      win.on("hide", () => {
-        safeSend("netcatty:window:will-hide");
-      });
     
       // Ensure native background matches frontend background, even before first paint.
       try {

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -338,6 +338,14 @@ function createMainWindowApi(ctx) {
         updateNormalBounds();
         scheduleSaveState();
       });
+
+      win.on("show", () => {
+        safeSend("netcatty:window:shown");
+      });
+
+      win.on("hide", () => {
+        safeSend("netcatty:window:will-hide");
+      });
     
       // Ensure native background matches frontend background, even before first paint.
       try {

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -10,6 +10,7 @@ const {
   registerWindowHandlers,
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
+  showAndFocusMainWindow,
   requestWindowCommandClose,
   sendWhenRendererReady,
   shouldCloseWindowFromInput,
@@ -214,6 +215,40 @@ test("restoreWindowInputFocus can show the window when requested", () => {
 
   assert.equal(restored, true);
   assert.deepEqual(calls, ["show", "focus", "webContents.focus"]);
+});
+
+test("showAndFocusMainWindow restores minimized windows before focusing", () => {
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    isMinimized() {
+      return true;
+    },
+    restore() {
+      calls.push("restore");
+    },
+    show() {
+      calls.push("show");
+    },
+    focus() {
+      calls.push("focus");
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      focus() {
+        calls.push("webContents.focus");
+      },
+    },
+  };
+
+  const restored = showAndFocusMainWindow(win);
+
+  assert.equal(restored, true);
+  assert.deepEqual(calls, ["restore", "show", "focus", "webContents.focus"]);
 });
 
 test("buildAppMenu closes a non-app window directly when Cmd+W is invoked", () => {

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -11,6 +11,7 @@ const {
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
   showAndFocusMainWindow,
+  notifyWindowWillHide,
   requestWindowCommandClose,
   sendWhenRendererReady,
   shouldCloseWindowFromInput,
@@ -249,6 +250,27 @@ test("showAndFocusMainWindow restores minimized windows before focusing", () => 
 
   assert.equal(restored, true);
   assert.deepEqual(calls, ["restore", "show", "focus", "webContents.focus"]);
+});
+
+test("notifyWindowWillHide sends will-hide IPC before native hide", () => {
+  const sent = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      send(channel) {
+        sent.push(channel);
+      },
+    },
+  };
+
+  notifyWindowWillHide(win);
+
+  assert.deepEqual(sent, ["netcatty:window:will-hide"]);
 });
 
 test("buildAppMenu closes a non-app window directly when Cmd+W is invoked", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -354,15 +354,7 @@ function focusMainWindow() {
       getGlobalShortcutBridge().clearPendingFullscreenHide?.(win);
     } catch {}
 
-    try {
-      if (win.isMinimized && win.isMinimized()) win.restore();
-    } catch {}
-    try {
-      win.show();
-    } catch {}
-    try {
-      win.focus();
-    } catch {}
+    getWindowManager().showAndFocusMainWindow?.(win);
     try {
       app.focus({ steal: true });
     } catch {}
@@ -827,9 +819,7 @@ if (!gotLock) {
           try {
             getGlobalShortcutBridge().clearPendingFullscreenHide?.(mainWin);
           } catch {}
-          if (mainWin.isMinimized?.()) mainWin.restore();
-          mainWin.show?.();
-          mainWin.focus?.();
+          getWindowManager().showAndFocusMainWindow?.(mainWin);
           try {
             app.focus({ steal: true });
           } catch {}

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -27,6 +27,8 @@ const telnetAutoLoginCancelledListeners = new Map();
 const telnetEchoModeListeners = new Map();
 const languageChangeListeners = new Set();
 const fullscreenChangeListeners = new Set();
+const windowShownListeners = new Set();
+const windowWillHideListeners = new Set();
 const keyboardInteractiveListeners = new Set();
 const hostKeyVerificationListeners = new Set();
 const passphraseListeners = new Set();
@@ -281,6 +283,26 @@ ipcRenderer.on("netcatty:window:fullscreen-changed", (_event, isFullscreen) => {
       cb(isFullscreen);
     } catch (err) {
       console.error("Fullscreen changed callback failed", err);
+    }
+  });
+});
+
+ipcRenderer.on("netcatty:window:shown", () => {
+  windowShownListeners.forEach((cb) => {
+    try {
+      cb();
+    } catch (err) {
+      console.error("Window shown callback failed", err);
+    }
+  });
+});
+
+ipcRenderer.on("netcatty:window:will-hide", () => {
+  windowWillHideListeners.forEach((cb) => {
+    try {
+      cb();
+    } catch (err) {
+      console.error("Window will-hide callback failed", err);
     }
   });
 });
@@ -680,6 +702,8 @@ const api = createPreloadApi({
   terminalDataBacklog,
   languageChangeListeners,
   fullscreenChangeListeners,
+  windowShownListeners,
+  windowWillHideListeners,
   keyboardInteractiveListeners,
   hostKeyVerificationListeners,
   passphraseListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -508,6 +508,14 @@ function createPreloadApi(ctx) {
     fullscreenChangeListeners.add(cb);
     return () => fullscreenChangeListeners.delete(cb);
   },
+  onWindowShown: (cb) => {
+    windowShownListeners.add(cb);
+    return () => windowShownListeners.delete(cb);
+  },
+  onWindowWillHide: (cb) => {
+    windowWillHideListeners.add(cb);
+    return () => windowWillHideListeners.delete(cb);
+  },
   
   // Settings window
   openSettingsWindow: () => ipcRenderer.invoke("netcatty:settings:open"),

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -26,6 +26,8 @@ declare global {
     }) => void): () => void;
     onWindowCommandCloseRequested?(cb: () => void): () => void;
     onWindowFullScreenChanged?(cb: (isFullscreen: boolean) => void): () => void;
+    onWindowShown?(cb: () => void): () => void;
+    onWindowWillHide?(cb: () => void): () => void;
 
     // Settings window
     openSettingsWindow?(): Promise<boolean>;


### PR DESCRIPTION
## Summary

- Route global hotkey, tray, and app activate show paths through `showAndFocusMainWindow()` so Windows uses the same `restoreWindowInputFocus` always-on-top trick as settings (#760).
- Add renderer-side `useMainWindowInputFocusRecovery` to call `scheduleWindowInputFocus()` on visibility/show/focus, with main-process `netcatty:window:shown` / `netcatty:window:will-hide` IPC for edge cases.
- Dismiss transient overlays (QuickSwitcher, create-workspace/protocol dialogs, rename dialogs, custom dropdowns) when the main window hides so Radix/Dropdown layers cannot block clicks after Ctrl+` toggle.

Closes #1722

## Test plan

- [ ] Windows 11: open Netcatty on a virtual desktop, connect SSH, press `Ctrl+\`` to hide, switch desktop and back, press `Ctrl+\`` again — UI accepts keyboard/mouse and `document.hasFocus()` is true
- [ ] Repeat with QuickSwitcher or a dropdown open before hide — overlays close on hide and do not block input after show
- [ ] Alt+Tab away and back while visible — terminal input still works
- [ ] macOS/Linux smoke: hotkey show/hide and dock/taskbar activate still behave normally
- [x] `node --test application/state/useMainWindowInputFocusRecovery.test.ts electron/bridges/globalShortcutBridge.test.cjs electron/bridges/windowManagerReadiness.test.cjs`


Made with [Cursor](https://cursor.com)