### PR TITLE
[codex] fix AI command permission splitting

### DIFF
--- a/electron/capabilities/policy.test.cjs
+++ b/electron/capabilities/policy.test.cjs
@@ -195,3 +195,282 @@ test("evaluatePermissionWithGrants skips approval when a grant matches", () => {
   assert.equal(decision.allowed, true);
   assert.equal(decision.requiresApproval, false);
 });
+
+test("evaluatePermissionWithGrants does not let a comment grant approve a multiline command", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "# 1a) clear the kernel_options_post profile field",
+        "cobbler profile edit --name=openEuler-22.03-aarch64 --kernel-options-post=\"\"",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-comment",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "# *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let a here-doc body grant approve the command", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat <<'EOF'",
+        "rm -rf /tmp/demo",
+        "EOF",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-rm",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "rm *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let a piped here-doc body grant approve the command", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat <<EOF | grep needle",
+        "rm -rf /tmp/demo",
+        "EOF",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-rm",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "rm *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let an fd-prefixed here-doc body grant approve the command", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat 0<<EOF",
+        "rm -rf /tmp/demo",
+        "EOF",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-rm",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "rm *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let a background command grant approve the next command", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: "cd /tmp; sleep 1 & rm -rf demo",
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-sleep",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "sleep *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let cwd substitutions hide before a later grant", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: "cd \"$(pwd)\"; ls -la",
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-ls",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "ls *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let quoted here-doc operator text hide later commands", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cd /tmp; echo '<<EOF'",
+        "rm -rf demo",
+        "EOF",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-echo",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "echo *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants keeps commands after mixed-quoted here-doc delimiters grantable", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat <<E\"OF\"",
+        "body text",
+        "EOF",
+        "ls -la",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-cat",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "cat *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants does not let arithmetic shifts hide following commands", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "ls $((1 << 2))",
+        "rm -rf demo",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-ls",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "ls *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants keeps commands after ANSI-C quoted here-doc delimiters grantable", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat <<$'E\\x4fF'",
+        "body text",
+        "EOF",
+        "rm -rf demo",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-cat",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "cat *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});
+
+test("evaluatePermissionWithGrants keeps commands after dollar-quoted here-doc delimiters grantable", () => {
+  const decision = evaluatePermissionWithGrants({
+    rpcMethod: "netcatty/exec",
+    permissionMode: PERMISSION_MODES.CONFIRM,
+    params: {
+      chatSessionId: "chat-1",
+      sessionId: "session-a",
+      command: [
+        "cat <<$'EOF'",
+        "body text",
+        "EOF",
+        "rm -rf demo",
+      ].join("\n"),
+    },
+    context: { chatSessionCancelled: false },
+  }, [{
+    id: "grant-cat",
+    capabilityId: "terminal.execute",
+    sessionPattern: "session-a",
+    commandPattern: "cat *",
+    createdAt: Date.now(),
+  }]);
+
+  assert.equal(decision.allowed, true);
+  assert.equal(decision.requiresApproval, true);
+});

--- a/electron/shared/permissionGrants.cjs
+++ b/electron/shared/permissionGrants.cjs
@@ -57,20 +57,496 @@ function argsPatternMatches(argsPattern, args) {
   return true;
 }
 
+const CWD_COMMANDS = new Set([
+  "cd",
+  "chdir",
+  "popd",
+  "pushd",
+  "push-location",
+  "set-location",
+]);
+
+function unquoteShellToken(token) {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token[token.length - 1];
+    if ((first === "\"" || first === "'") && first === last) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+}
+
+function tokenizeShellCommand(command) {
+  const matches = command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
+  return matches.map(unquoteShellToken);
+}
+
+function lastNonWhitespaceChar(value) {
+  return value.match(/\S(?=\s*$)/)?.[0];
+}
+
+function readArithmeticExpansionEnd(segment, startIndex) {
+  if (segment[startIndex] !== "$" || segment[startIndex + 1] !== "(" || segment[startIndex + 2] !== "(") {
+    return null;
+  }
+
+  let depth = 1;
+  let quote = null;
+
+  for (let index = startIndex + 3; index < segment.length; index += 1) {
+    const char = segment[index];
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === "\\" && quote !== "'" && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "\\" && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      if (depth === 1 && next === ")") return index + 2;
+      if (depth > 1) depth -= 1;
+    }
+  }
+
+  return segment.length;
+}
+
+function hasExecutableShellExpansion(segment) {
+  let quote = null;
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index];
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === "\\" && quote === "\"" && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+      if (quote === "\"" && char === "$" && next === "(") return true;
+      if (quote === "\"" && char === "`") return true;
+      continue;
+    }
+
+    if (char === "\\" && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "\"") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "`") return true;
+    if (char === "$" && next === "(") return true;
+    if ((char === "<" || char === ">") && next === "(") return true;
+  }
+
+  return false;
+}
+
+function readEscapeDigits(value, startIndex, maxLength, pattern) {
+  let endIndex = startIndex;
+  while (
+    endIndex < value.length
+    && endIndex < startIndex + maxLength
+    && pattern.test(value[endIndex])
+  ) {
+    endIndex += 1;
+  }
+
+  if (endIndex === startIndex) return null;
+  return { digits: value.slice(startIndex, endIndex), endIndex: endIndex - 1 };
+}
+
+function codePointToString(codePoint) {
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return "";
+  }
+}
+
+function readAnsiCEscape(value, backslashIndex) {
+  const escapeIndex = backslashIndex + 1;
+  const char = value[escapeIndex];
+  if (!char) return { text: "\\", endIndex: backslashIndex };
+
+  const simpleEscapes = {
+    a: "\x07",
+    b: "\b",
+    e: "\x1B",
+    E: "\x1B",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\v",
+    "\\": "\\",
+    "'": "'",
+    "\"": "\"",
+    "?": "?",
+  };
+
+  const simple = simpleEscapes[char];
+  if (simple !== undefined) return { text: simple, endIndex: escapeIndex };
+
+  if (char === "x") {
+    const digits = readEscapeDigits(value, escapeIndex + 1, 2, /[0-9a-fA-F]/);
+    if (!digits) return { text: "\\x", endIndex: escapeIndex };
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 16)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  if (char === "u" || char === "U") {
+    const digits = readEscapeDigits(value, escapeIndex + 1, char === "u" ? 4 : 8, /[0-9a-fA-F]/);
+    if (!digits) return { text: `\\${char}`, endIndex: escapeIndex };
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 16)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  if (/[0-7]/.test(char)) {
+    const digits = readEscapeDigits(value, escapeIndex, 3, /[0-7]/);
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 8)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  return { text: `\\${char}`, endIndex: escapeIndex };
+}
+
+function readHereDocDelimiterWord(segment, startIndex) {
+  let index = startIndex;
+  while (index < segment.length && /\s/.test(segment[index])) index += 1;
+
+  let text = "";
+  let quote = null;
+  let ansiQuote = false;
+
+  for (; index < segment.length; index += 1) {
+    const char = segment[index];
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (ansiQuote && char === "\\") {
+        const escape = readAnsiCEscape(segment, index);
+        text += escape.text;
+        index = escape.endIndex;
+        continue;
+      }
+      if (char === "\\" && quote !== "'" && next) {
+        text += next;
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        ansiQuote = false;
+        continue;
+      }
+      text += char;
+      continue;
+    }
+
+    if (/\s/.test(char) || char === ";" || char === "|" || char === "&") break;
+
+    if (char === "\\" && next) {
+      text += next;
+      index += 1;
+      continue;
+    }
+
+    if (char === "$" && (next === "'" || next === "\"")) {
+      quote = next;
+      ansiQuote = next === "'";
+      index += 1;
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      ansiQuote = false;
+      continue;
+    }
+
+    text += char;
+  }
+
+  return text ? { text, endIndex: index } : null;
+}
+
+function extractHereDocTerminators(segment) {
+  const terminators = [];
+  let quote = null;
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index];
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === "\\" && quote !== "'" && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    const arithmeticEnd = readArithmeticExpansionEnd(segment, index);
+    if (arithmeticEnd !== null) {
+      index = arithmeticEnd - 1;
+      continue;
+    }
+
+    if (char === "\\" && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char !== "<" || next !== "<") continue;
+    if (segment[index + 2] === "<") {
+      index += 2;
+      continue;
+    }
+
+    const stripLeadingTabs = segment[index + 2] === "-";
+    const delimiterStart = index + (stripLeadingTabs ? 3 : 2);
+    const delimiter = readHereDocDelimiterWord(segment, delimiterStart);
+    if (!delimiter) continue;
+    terminators.push({ text: delimiter.text, stripLeadingTabs });
+    index = delimiter.endIndex - 1;
+  }
+
+  return terminators;
+}
+
+function skipHereDocBodies(command, startIndex, terminators) {
+  let cursor = startIndex;
+
+  for (const terminator of terminators) {
+    while (cursor < command.length) {
+      const lineEnd = command.indexOf("\n", cursor);
+      const end = lineEnd === -1 ? command.length : lineEnd;
+      const rawLine = command.slice(cursor, end);
+      const line = terminator.stripLeadingTabs ? rawLine.replace(/^\t+/, "") : rawLine;
+      cursor = lineEnd === -1 ? command.length : lineEnd + 1;
+
+      if (line === terminator.text) break;
+    }
+  }
+
+  return cursor;
+}
+
+function splitShellCommandSegments(command) {
+  const segments = [];
+  let current = "";
+  let quote = null;
+  let inComment = false;
+  let lineHereDocTerminators = [];
+
+  const flush = () => {
+    const segment = current.trim();
+    if (segment) segments.push(segment);
+    current = "";
+  };
+
+  const flushCommandSegment = () => {
+    lineHereDocTerminators.push(...extractHereDocTerminators(current));
+    flush();
+  };
+
+  const finishLine = (bodyStartIndex) => {
+    flushCommandSegment();
+    const hereDocTerminators = lineHereDocTerminators;
+    lineHereDocTerminators = [];
+    if (hereDocTerminators.length === 0) return bodyStartIndex;
+    return skipHereDocBodies(command, bodyStartIndex, hereDocTerminators);
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index];
+    const next = command[index + 1];
+
+    if (inComment) {
+      if (char === "\n") {
+        inComment = false;
+        index = finishLine(index + 1) - 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === "\\" && quote !== "'" && next) {
+        current += next;
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "\\" && next === "\n") {
+      index += 1;
+      continue;
+    }
+
+    if (char === "\\" && next) {
+      current += char + next;
+      index += 1;
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    const arithmeticEnd = readArithmeticExpansionEnd(command, index);
+    if (arithmeticEnd !== null) {
+      current += command.slice(index, arithmeticEnd);
+      index = arithmeticEnd - 1;
+      continue;
+    }
+
+    if (char === "#") {
+      const previous = current[current.length - 1];
+      if (!previous || /\s/.test(previous)) {
+        inComment = true;
+        continue;
+      }
+    }
+
+    if (char === "\n") {
+      index = finishLine(index + 1) - 1;
+      continue;
+    }
+
+    if (char === ";") {
+      flushCommandSegment();
+      continue;
+    }
+
+    if (char === "&" && next === "&") {
+      flushCommandSegment();
+      index += 1;
+      continue;
+    }
+
+    if (char === "|" && next === "|") {
+      flushCommandSegment();
+      index += 1;
+      continue;
+    }
+
+    if (char === "&") {
+      const previous = lastNonWhitespaceChar(current);
+      if (next === ">" || previous === ">" || previous === "<") {
+        current += char;
+        continue;
+      }
+      flushCommandSegment();
+      continue;
+    }
+
+    if (char === "|") {
+      flushCommandSegment();
+      if (next === "&") index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  flush();
+  return segments;
+}
+
+function extractGrantableShellCommandSegments(command) {
+  return splitShellCommandSegments(command).filter((segment) => {
+    const tokens = tokenizeShellCommand(segment);
+    const cmd = tokens[0] && tokens[0].toLowerCase();
+    return tokens.length > 0 && !(cmd && CWD_COMMANDS.has(cmd) && !hasExecutableShellExpansion(segment));
+  });
+}
+
+function matchCommandPatternGrants(rules, ctx, command, args) {
+  const commandSegments = extractGrantableShellCommandSegments(command);
+  if (commandSegments.length === 0) return null;
+
+  const eligibleRules = rules.filter((rule) => (
+    rule
+    && rule.capabilityId === ctx?.capabilityId
+    && rule.commandPattern
+    && argsPatternMatches(rule.argsPattern, args)
+  ));
+  if (eligibleRules.length === 0) return null;
+
+  let firstMatch = null;
+  for (const segment of commandSegments) {
+    const matched = eligibleRules.find((rule) => patternMatches(rule.commandPattern, segment));
+    if (!matched) return null;
+    if (!firstMatch) firstMatch = matched;
+  }
+
+  return firstMatch;
+}
+
 function matchPermissionGrant(rules, ctx) {
   if (!Array.isArray(rules) || rules.length === 0) return null;
 
   const args = ctx?.args && typeof ctx.args === "object" ? ctx.args : {};
+  const command = typeof args.command === "string" ? args.command : "";
+  const commandGrantMatch = command ? matchCommandPatternGrants(rules, ctx, command, args) : null;
+  if (commandGrantMatch) return commandGrantMatch;
 
   for (const rule of rules) {
     if (!rule || typeof rule.capabilityId !== "string") continue;
 
     if (rule.capabilityId !== ctx?.capabilityId) continue;
-
-    if (rule.commandPattern) {
-      const command = typeof args.command === "string" ? args.command : "";
-      if (!patternMatches(rule.commandPattern, command)) continue;
-    }
+    if (rule.commandPattern) continue;
 
     if (!argsPatternMatches(rule.argsPattern, args)) continue;
 

--- a/infrastructure/ai/harness/permissionGrants.test.ts
+++ b/infrastructure/ai/harness/permissionGrants.test.ts
@@ -66,6 +66,327 @@ describe('permissionGrants', () => {
     assert.equal(grants[0]?.commandPattern, 'lscpu *');
   });
 
+  it('does not let a comment grant approve a multiline command', () => {
+    const rules = [baseRule({ sessionPattern: '*', commandPattern: '# *' })];
+    const matched = matchPermissionGrant(rules, {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: {
+        command: [
+          '# 1a) clear the kernel_options_post profile field',
+          'cobbler profile edit --name=openEuler-22.03-aarch64 --kernel-options-post=""',
+        ].join('\n'),
+      },
+    });
+
+    assert.equal(matched, null);
+  });
+
+  it('requires every grantable command segment to be covered', () => {
+    const rules = [
+      baseRule({ id: 'grant-lscpu', sessionPattern: '*', commandPattern: 'lscpu *' }),
+      baseRule({ id: 'grant-grep', sessionPattern: '*', commandPattern: 'grep *' }),
+    ];
+    const matched = matchPermissionGrant(rules, {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command: 'cd /tmp && lscpu | grep CPU' },
+    });
+
+    assert.ok(matched);
+
+    const missingPipeSegment = matchPermissionGrant([rules[0]!], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command: 'cd /tmp && lscpu | grep CPU' },
+    });
+
+    assert.equal(missingPipeSegment, null);
+  });
+
+  it('requires every background command segment to be covered', () => {
+    const command = 'cd /tmp; sleep 1 & rm -rf demo';
+
+    const matchedBySleepOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-sleep', sessionPattern: '*', commandPattern: 'sleep *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedBySleepOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-sleep', sessionPattern: '*', commandPattern: 'sleep *' }),
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
+  it('requires cwd segments with shell substitutions to be covered', () => {
+    const command = 'cd "$(pwd)"; ls -la';
+
+    const matchedByLsOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-ls', sessionPattern: '*', commandPattern: 'ls *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByLsOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-cd', sessionPattern: '*', commandPattern: 'cd *' }),
+      baseRule({ id: 'grant-ls', sessionPattern: '*', commandPattern: 'ls *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
+  it('does not let a here-doc body grant approve the wrapping command', () => {
+    const command = [
+      "cat <<'EOF'",
+      'rm -rf /tmp/demo',
+      'EOF',
+    ].join('\n');
+
+    const matchedByBody = matchPermissionGrant([
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByBody, null);
+
+    const matchedByWrapper = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByWrapper);
+  });
+
+  it('does not let a piped here-doc body grant approve the command', () => {
+    const command = [
+      'cat <<EOF | grep needle',
+      'rm -rf /tmp/demo',
+      'EOF',
+    ].join('\n');
+
+    const matchedByBody = matchPermissionGrant([
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByBody, null);
+
+    const matchedByPipeline = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+      baseRule({ id: 'grant-grep', sessionPattern: '*', commandPattern: 'grep *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByPipeline);
+  });
+
+  it('does not let an fd-prefixed here-doc body grant approve the command', () => {
+    const command = [
+      'cat 0<<EOF',
+      'rm -rf /tmp/demo',
+      'EOF',
+    ].join('\n');
+
+    const matchedByBody = matchPermissionGrant([
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByBody, null);
+
+    const matchedByWrapper = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByWrapper);
+  });
+
+  it('does not let quoted here-doc operator text hide later commands', () => {
+    const command = [
+      "cd /tmp; echo '<<EOF'",
+      'rm -rf demo',
+      'EOF',
+    ].join('\n');
+
+    const matchedByEchoOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-echo', sessionPattern: '*', commandPattern: 'echo *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByEchoOnly, null);
+
+    const matchedByAll = matchPermissionGrant([
+      baseRule({ id: 'grant-echo', sessionPattern: '*', commandPattern: 'echo *' }),
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+      baseRule({ id: 'grant-eof', sessionPattern: '*', commandPattern: 'EOF *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByAll);
+  });
+
+  it('keeps commands after mixed-quoted here-doc delimiters grantable', () => {
+    const command = [
+      'cat <<E"OF"',
+      'body text',
+      'EOF',
+      'ls -la',
+    ].join('\n');
+
+    const matchedByCatOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByCatOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+      baseRule({ id: 'grant-ls', sessionPattern: '*', commandPattern: 'ls *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
+  it('keeps commands after dollar-quoted here-doc delimiters grantable', () => {
+    const command = [
+      "cat <<$'EOF'",
+      'body text',
+      'EOF',
+      'rm -rf demo',
+    ].join('\n');
+
+    const matchedByCatOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByCatOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
+  it('keeps commands after ANSI-C quoted here-doc delimiters grantable', () => {
+    const command = [
+      "cat <<$'E\\x4fF'",
+      'body text',
+      'EOF',
+      'rm -rf demo',
+    ].join('\n');
+
+    const matchedByCatOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByCatOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-cat', sessionPattern: '*', commandPattern: 'cat *' }),
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
+  it('does not let arithmetic shifts hide following commands', () => {
+    const command = [
+      'ls $((1 << 2))',
+      'rm -rf demo',
+    ].join('\n');
+
+    const matchedByLsOnly = matchPermissionGrant([
+      baseRule({ id: 'grant-ls', sessionPattern: '*', commandPattern: 'ls *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.equal(matchedByLsOnly, null);
+
+    const matchedByBoth = matchPermissionGrant([
+      baseRule({ id: 'grant-ls', sessionPattern: '*', commandPattern: 'ls *' }),
+      baseRule({ id: 'grant-rm', sessionPattern: '*', commandPattern: 'rm *' }),
+    ], {
+      capabilityId: 'terminal.execute',
+      sessionId: 'session-a',
+      args: { command },
+    });
+
+    assert.ok(matchedByBoth);
+  });
+
   it('OpenCode wildcard allows optional args after prefix', () => {
     assert.equal(patternMatches('lscpu *', 'lscpu'), true);
     assert.equal(patternMatches('lscpu *', 'lscpu -e'), true);

--- a/infrastructure/ai/harness/permissionGrants.ts
+++ b/infrastructure/ai/harness/permissionGrants.ts
@@ -1,5 +1,8 @@
 import cattyToolSpecs from './generated/cattyToolSpecs.json';
-import { buildAlwaysAllowCommandPatterns } from '../shared/shellCommandGrant';
+import {
+  buildAlwaysAllowCommandPatterns,
+  extractGrantableShellCommandSegments,
+} from '../shared/shellCommandGrant';
 
 export interface PermissionGrantRule {
   id: string;
@@ -106,14 +109,13 @@ export function matchPermissionGrant(
   if (rules.length === 0) return null;
 
   const args = ctx.args ?? {};
+  const command = typeof args.command === 'string' ? args.command : '';
+  const commandGrantMatch = command ? matchCommandPatternGrants(rules, ctx, command, args) : null;
+  if (commandGrantMatch) return commandGrantMatch;
 
   for (const rule of rules) {
     if (rule.capabilityId !== ctx.capabilityId) continue;
-
-    if (rule.commandPattern) {
-      const command = typeof args.command === 'string' ? args.command : '';
-      if (!patternMatches(rule.commandPattern, command)) continue;
-    }
+    if (rule.commandPattern) continue;
 
     if (!argsPatternMatches(rule.argsPattern, args)) continue;
 
@@ -121,6 +123,32 @@ export function matchPermissionGrant(
   }
 
   return null;
+}
+
+function matchCommandPatternGrants(
+  rules: readonly PermissionGrantRule[],
+  ctx: PermissionGrantMatchContext,
+  command: string,
+  args: Record<string, unknown>,
+): PermissionGrantRule | null {
+  const commandSegments = extractGrantableShellCommandSegments(command);
+  if (commandSegments.length === 0) return null;
+
+  const eligibleRules = rules.filter((rule) => (
+    rule.capabilityId === ctx.capabilityId
+    && Boolean(rule.commandPattern)
+    && argsPatternMatches(rule.argsPattern, args)
+  ));
+  if (eligibleRules.length === 0) return null;
+
+  let firstMatch: PermissionGrantRule | null = null;
+  for (const segment of commandSegments) {
+    const matched = eligibleRules.find((rule) => patternMatches(rule.commandPattern!, segment));
+    if (!matched) return null;
+    firstMatch ??= matched;
+  }
+
+  return firstMatch;
 }
 
 export function sanitizePermissionGrants(raw: unknown): PermissionGrantRule[] {
@@ -215,7 +243,7 @@ export function buildGrantsFromApproval(
   const commandPatterns = resolveCommandGrantPatterns(capabilityId, args);
   const createdAt = Date.now();
 
-  if (!commandPatterns || commandPatterns.length === 0) {
+  if (!commandPatterns) {
     return [{
       id: createPermissionGrantId(),
       capabilityId,
@@ -223,6 +251,8 @@ export function buildGrantsFromApproval(
       createdAt,
     }];
   }
+
+  if (commandPatterns.length === 0) return [];
 
   return commandPatterns.map((commandPattern) => ({
     id: createPermissionGrantId(),

--- a/infrastructure/ai/shared/shellCommandGrant.test.ts
+++ b/infrastructure/ai/shared/shellCommandGrant.test.ts
@@ -20,4 +20,127 @@ describe('shellCommandGrant (OpenCode always patterns)', () => {
       ['ls *'],
     );
   });
+
+  it('keeps cwd segments that execute shell substitutions grantable', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns('cd "$(pwd)"; ls -la'),
+      ['cd *', 'ls *'],
+    );
+  });
+
+  it('splits single ampersand background commands', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns('cd /tmp; sleep 1 & rm -rf demo'),
+      ['sleep *', 'rm *'],
+    );
+  });
+
+  it('ignores comments when building grants for multiline commands', () => {
+    const command = [
+      '# 1a) clear the kernel_options_post profile field',
+      'cobbler profile edit --name=openEuler-22.03-aarch64 --kernel-options-post=""',
+      '',
+      '# verify',
+      "cobbler profile report --name=openEuler-22.03-aarch64 | grep -i 'kernel.options'",
+    ].join('\n');
+
+    assert.deepEqual(buildAlwaysAllowCommandPatterns(command), ['cobbler *', 'grep *']);
+  });
+
+  it('does not build grants from here-doc body lines', () => {
+    const command = [
+      "cat <<'EOF'",
+      'rm -rf /tmp/demo',
+      'EOF',
+    ].join('\n');
+
+    assert.deepEqual(buildAlwaysAllowCommandPatterns(command), ['cat *']);
+  });
+
+  it('does not build grants from piped here-doc body lines', () => {
+    const command = [
+      'cat <<EOF | grep needle',
+      'rm -rf /tmp/demo',
+      'EOF',
+    ].join('\n');
+
+    assert.deepEqual(buildAlwaysAllowCommandPatterns(command), ['cat *', 'grep *']);
+  });
+
+  it('does not build grants from fd-prefixed here-doc body lines', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        'cat 0<<EOF',
+        'rm -rf /tmp/demo',
+        'EOF',
+      ].join('\n')),
+      ['cat *'],
+    );
+
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        'cat 3<<-EOF | grep needle',
+        '\trm -rf /tmp/demo',
+        '\tEOF',
+      ].join('\n')),
+      ['cat *', 'grep *'],
+    );
+  });
+
+  it('does not treat quoted here-doc operator text as a here-doc', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        "cd /tmp; echo '<<EOF'",
+        'rm -rf demo',
+        'EOF',
+      ].join('\n')),
+      ['echo *', 'rm *', 'EOF *'],
+    );
+  });
+
+  it('resumes parsing after mixed-quoted here-doc delimiters', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        'cat <<E"OF"',
+        'body text',
+        'EOF',
+        'ls -la',
+      ].join('\n')),
+      ['cat *', 'ls *'],
+    );
+  });
+
+  it('resumes parsing after dollar-quoted here-doc delimiters', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        "cat <<$'EOF'",
+        'body text',
+        'EOF',
+        'rm -rf demo',
+      ].join('\n')),
+      ['cat *', 'rm *'],
+    );
+  });
+
+  it('resumes parsing after ANSI-C quoted here-doc delimiters', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        "cat <<$'E\\x4fF'",
+        'body text',
+        'EOF',
+        'rm -rf demo',
+      ].join('\n')),
+      ['cat *', 'rm *'],
+    );
+  });
+
+  it('does not treat arithmetic shifts as here-doc delimiters', () => {
+    assert.deepEqual(
+      buildAlwaysAllowCommandPatterns([
+        'ls $((1 << 2))',
+        'rm -rf demo',
+      ].join('\n')),
+      ['ls *', 'rm *'],
+    );
+  });
 });

--- a/infrastructure/ai/shared/shellCommandGrant.ts
+++ b/infrastructure/ai/shared/shellCommandGrant.ts
@@ -26,11 +26,451 @@ export function tokenizeShellCommand(command: string): string[] {
   return matches.map(unquoteShellToken);
 }
 
+type HereDocTerminator = {
+  text: string;
+  stripLeadingTabs: boolean;
+};
+
+function lastNonWhitespaceChar(value: string): string | undefined {
+  return value.match(/\S(?=\s*$)/)?.[0];
+}
+
+function readArithmeticExpansionEnd(segment: string, startIndex: number): number | null {
+  if (segment[startIndex] !== '$' || segment[startIndex + 1] !== '(' || segment[startIndex + 2] !== '(') {
+    return null;
+  }
+
+  let depth = 1;
+  let quote: '"' | "'" | '`' | null = null;
+
+  for (let index = startIndex + 3; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === '\\' && quote !== "'" && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '\\' && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      if (depth === 1 && next === ')') return index + 2;
+      if (depth > 1) depth -= 1;
+    }
+  }
+
+  return segment.length;
+}
+
+function hasExecutableShellExpansion(segment: string): boolean {
+  let quote: '"' | "'" | null = null;
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === '\\' && quote === '"' && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+      if (quote === '"' && char === '$' && next === '(') return true;
+      if (quote === '"' && char === '`') return true;
+      continue;
+    }
+
+    if (char === '\\' && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '`') return true;
+    if (char === '$' && next === '(') return true;
+    if ((char === '<' || char === '>') && next === '(') return true;
+  }
+
+  return false;
+}
+
+function readEscapeDigits(
+  value: string,
+  startIndex: number,
+  maxLength: number,
+  pattern: RegExp,
+): { digits: string; endIndex: number } | null {
+  let endIndex = startIndex;
+  while (
+    endIndex < value.length
+    && endIndex < startIndex + maxLength
+    && pattern.test(value[endIndex]!)
+  ) {
+    endIndex += 1;
+  }
+
+  if (endIndex === startIndex) return null;
+  return { digits: value.slice(startIndex, endIndex), endIndex: endIndex - 1 };
+}
+
+function codePointToString(codePoint: number): string {
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    return '';
+  }
+}
+
+function readAnsiCEscape(value: string, backslashIndex: number): { text: string; endIndex: number } {
+  const escapeIndex = backslashIndex + 1;
+  const char = value[escapeIndex];
+  if (!char) return { text: '\\', endIndex: backslashIndex };
+
+  const simpleEscapes: Record<string, string> = {
+    a: '\x07',
+    b: '\b',
+    e: '\x1B',
+    E: '\x1B',
+    f: '\f',
+    n: '\n',
+    r: '\r',
+    t: '\t',
+    v: '\v',
+    '\\': '\\',
+    "'": "'",
+    '"': '"',
+    '?': '?',
+  };
+
+  const simple = simpleEscapes[char];
+  if (simple !== undefined) return { text: simple, endIndex: escapeIndex };
+
+  if (char === 'x') {
+    const digits = readEscapeDigits(value, escapeIndex + 1, 2, /[0-9a-fA-F]/);
+    if (!digits) return { text: '\\x', endIndex: escapeIndex };
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 16)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  if (char === 'u' || char === 'U') {
+    const digits = readEscapeDigits(value, escapeIndex + 1, char === 'u' ? 4 : 8, /[0-9a-fA-F]/);
+    if (!digits) return { text: `\\${char}`, endIndex: escapeIndex };
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 16)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  if (/[0-7]/.test(char)) {
+    const digits = readEscapeDigits(value, escapeIndex, 3, /[0-7]/)!;
+    return {
+      text: codePointToString(Number.parseInt(digits.digits, 8)),
+      endIndex: digits.endIndex,
+    };
+  }
+
+  return { text: `\\${char}`, endIndex: escapeIndex };
+}
+
+function readHereDocDelimiterWord(
+  segment: string,
+  startIndex: number,
+): { text: string; endIndex: number } | null {
+  let index = startIndex;
+  while (index < segment.length && /\s/.test(segment[index]!)) index += 1;
+
+  let text = '';
+  let quote: '"' | "'" | '`' | null = null;
+  let ansiQuote = false;
+
+  for (; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (ansiQuote && char === '\\') {
+        const escape = readAnsiCEscape(segment, index);
+        text += escape.text;
+        index = escape.endIndex;
+        continue;
+      }
+      if (char === '\\' && quote !== "'" && next) {
+        text += next;
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+        ansiQuote = false;
+        continue;
+      }
+      text += char;
+      continue;
+    }
+
+    if (/\s/.test(char) || char === ';' || char === '|' || char === '&') break;
+
+    if (char === '\\' && next) {
+      text += next;
+      index += 1;
+      continue;
+    }
+
+    if (char === '$' && (next === "'" || next === '"')) {
+      quote = next;
+      ansiQuote = next === "'";
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      ansiQuote = false;
+      continue;
+    }
+
+    text += char;
+  }
+
+  return text ? { text, endIndex: index } : null;
+}
+
+function extractHereDocTerminators(segment: string): HereDocTerminator[] {
+  const terminators: HereDocTerminator[] = [];
+  let quote: '"' | "'" | '`' | null = null;
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    const next = segment[index + 1];
+
+    if (quote) {
+      if (char === '\\' && quote !== "'" && next) {
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    const arithmeticEnd = readArithmeticExpansionEnd(segment, index);
+    if (arithmeticEnd !== null) {
+      index = arithmeticEnd - 1;
+      continue;
+    }
+
+    if (char === '\\' && next) {
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char !== '<' || next !== '<') continue;
+    if (segment[index + 2] === '<') {
+      index += 2;
+      continue;
+    }
+
+    const stripLeadingTabs = segment[index + 2] === '-';
+    const delimiterStart = index + (stripLeadingTabs ? 3 : 2);
+    const delimiter = readHereDocDelimiterWord(segment, delimiterStart);
+    if (!delimiter) continue;
+    terminators.push({ text: delimiter.text, stripLeadingTabs });
+    index = delimiter.endIndex - 1;
+  }
+
+  return terminators;
+}
+
+function skipHereDocBodies(
+  command: string,
+  startIndex: number,
+  terminators: HereDocTerminator[],
+): number {
+  let cursor = startIndex;
+
+  for (const terminator of terminators) {
+    while (cursor < command.length) {
+      const lineEnd = command.indexOf('\n', cursor);
+      const end = lineEnd === -1 ? command.length : lineEnd;
+      const rawLine = command.slice(cursor, end);
+      const line = terminator.stripLeadingTabs ? rawLine.replace(/^\t+/, '') : rawLine;
+      cursor = lineEnd === -1 ? command.length : lineEnd + 1;
+
+      if (line === terminator.text) break;
+    }
+  }
+
+  return cursor;
+}
+
 export function splitShellCommandSegments(command: string): string[] {
-  return command
-    .split(/\s*(?:&&|\|\||;)\s*/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+  const segments: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | '`' | null = null;
+  let inComment = false;
+  let lineHereDocTerminators: HereDocTerminator[] = [];
+
+  const flush = () => {
+    const segment = current.trim();
+    if (segment) segments.push(segment);
+    current = '';
+  };
+
+  const flushCommandSegment = () => {
+    lineHereDocTerminators.push(...extractHereDocTerminators(current));
+    flush();
+  };
+
+  const finishLine = (bodyStartIndex: number): number => {
+    flushCommandSegment();
+    const hereDocTerminators = lineHereDocTerminators;
+    lineHereDocTerminators = [];
+    if (hereDocTerminators.length === 0) return bodyStartIndex;
+    return skipHereDocBodies(command, bodyStartIndex, hereDocTerminators);
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+    const next = command[index + 1];
+
+    if (inComment) {
+      if (char === '\n') {
+        inComment = false;
+        index = finishLine(index + 1) - 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === '\\' && quote !== "'" && next) {
+        current += next;
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '\\' && next === '\n') {
+      index += 1;
+      continue;
+    }
+
+    if (char === '\\' && next) {
+      current += char + next;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    const arithmeticEnd = readArithmeticExpansionEnd(command, index);
+    if (arithmeticEnd !== null) {
+      current += command.slice(index, arithmeticEnd);
+      index = arithmeticEnd - 1;
+      continue;
+    }
+
+    if (char === '#') {
+      const previous = current[current.length - 1];
+      if (!previous || /\s/.test(previous)) {
+        inComment = true;
+        continue;
+      }
+    }
+
+    if (char === '\n') {
+      index = finishLine(index + 1) - 1;
+      continue;
+    }
+
+    if (char === ';') {
+      flushCommandSegment();
+      continue;
+    }
+
+    if (char === '&' && next === '&') {
+      flushCommandSegment();
+      index += 1;
+      continue;
+    }
+
+    if (char === '|' && next === '|') {
+      flushCommandSegment();
+      index += 1;
+      continue;
+    }
+
+    if (char === '&') {
+      const previous = lastNonWhitespaceChar(current);
+      if (next === '>' || previous === '>' || previous === '<') {
+        current += char;
+        continue;
+      }
+      flushCommandSegment();
+      continue;
+    }
+
+    if (char === '|') {
+      flushCommandSegment();
+      if (next === '&') index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  flush();
+  return segments;
+}
+
+export function extractGrantableShellCommandSegments(command: string): string[] {
+  return splitShellCommandSegments(command).filter((segment) => {
+    const tokens = tokenizeShellCommand(segment);
+    const cmd = tokens[0]?.toLowerCase();
+    return tokens.length > 0 && !(cmd && CWD_COMMANDS.has(cmd) && !hasExecutableShellExpansion(segment));
+  });
 }
 
 /**
@@ -42,23 +482,13 @@ export function buildAlwaysAllowCommandPatterns(command: string): string[] {
   if (!trimmed) return [];
 
   const patterns = new Set<string>();
-  const segments = splitShellCommandSegments(trimmed);
+  const segments = extractGrantableShellCommandSegments(trimmed);
 
   for (const segment of segments) {
     const tokens = tokenizeShellCommand(segment);
-    if (tokens.length === 0) continue;
-    const cmd = tokens[0]?.toLowerCase();
-    if (cmd && CWD_COMMANDS.has(cmd)) continue;
     const prefix = bashArityPrefix(tokens);
     if (prefix.length === 0) continue;
     patterns.add(`${prefix.join(' ')} *`);
-  }
-
-  if (patterns.size === 0) {
-    const tokens = tokenizeShellCommand(trimmed);
-    if (tokens.length > 0) {
-      patterns.add(`${bashArityPrefix(tokens).join(' ')} *`);
-    }
   }
 
   return [...patterns];


### PR DESCRIPTION
## Summary
- Fix AI command permission matching for multiline shell commands with comments.
- Split grant checks across grantable command segments so one saved comment rule cannot approve later commands.
- Add regression coverage for Catty and external-agent permission paths.

## Root cause
Saved command grants were matched against the full multiline shell input. A wildcard comment grant such as `# *` could match across newlines and approve the real command that followed.

## Validation
- `node --test --import tsx infrastructure/ai/shared/shellCommandGrant.test.ts infrastructure/ai/harness/permissionGrants.test.ts`
- `node --test electron/capabilities/policy.test.cjs`
- `npm run lint`

Fixes #1727