### PR TITLE
Fix remote macOS SSH server stats display

### DIFF
--- a/components/HostDetailsPanel.helpers.ts
+++ b/components/HostDetailsPanel.helpers.ts
@@ -1,6 +1,10 @@
 import type { GroupConfig } from "../domain/models";
 import type { Host } from "../types";
-import { LINUX_DISTRO_OPTIONS, NETWORK_DEVICE_OPTIONS } from "../domain/host";
+import {
+  LINUX_DISTRO_OPTIONS,
+  NETWORK_DEVICE_OPTIONS,
+  POSIX_PLATFORM_OPTIONS,
+} from "../domain/host";
 
 export const parseOptionalPortInput = (value: string): number | undefined =>
   value ? Number(value) : undefined;
@@ -76,5 +80,6 @@ export const resolveDetailsTelnetPassword = (
 
 export const LINUX_DISTRO_OPTION_IDS = [
   ...LINUX_DISTRO_OPTIONS,
+  ...POSIX_PLATFORM_OPTIONS,
   ...NETWORK_DEVICE_OPTIONS,
 ];

--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -47,6 +47,8 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
     isConnected,
     isVisible,
   });
+  const hasNetworkDetails = serverStats.netInterfaces.length > 0;
+  const hasLatency = serverStats.latencyMs !== null;
 
   if (!enabled || !isConnected || !serverStats.lastUpdated) return null;
 
@@ -316,7 +318,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                   </HoverCardContent>
                 </HoverCard>
                 {/* Network - with HoverCard for per-interface details */}
-                {serverStats.netInterfaces.length > 0 && (
+                {(hasNetworkDetails || hasLatency) && (
                   <HoverCard openDelay={200} closeDelay={100}>
                     <HoverCardTrigger asChild>
                       <button
@@ -348,25 +350,29 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                             {formatLatency(serverStats.latencyMs)}
                           </span>
                         </div>
-                        <div className="space-y-2 max-h-[200px] overflow-y-auto">
-                          {serverStats.netInterfaces.map((iface, index) => (
-                            <div key={index} className="flex items-center justify-between gap-4 min-w-[200px]">
-                              <span className="text-[10px] text-muted-foreground font-mono">
-                                {iface.name}
-                              </span>
-                              <div className="flex items-center gap-2">
-                                <span className="flex items-center gap-0.5 text-emerald-400">
-                                  <ArrowDownToLine size={9} />
-                                  {formatNetSpeed(iface.rxSpeed)}
+                        {hasNetworkDetails ? (
+                          <div className="space-y-2 max-h-[200px] overflow-y-auto">
+                            {serverStats.netInterfaces.map((iface, index) => (
+                              <div key={index} className="flex items-center justify-between gap-4 min-w-[200px]">
+                                <span className="text-[10px] text-muted-foreground font-mono">
+                                  {iface.name}
                                 </span>
-                                <span className="flex items-center gap-0.5 text-sky-400">
-                                  <ArrowUpFromLine size={9} />
-                                  {formatNetSpeed(iface.txSpeed)}
-                                </span>
+                                <div className="flex items-center gap-2">
+                                  <span className="flex items-center gap-0.5 text-emerald-400">
+                                    <ArrowDownToLine size={9} />
+                                    {formatNetSpeed(iface.rxSpeed)}
+                                  </span>
+                                  <span className="flex items-center gap-0.5 text-sky-400">
+                                    <ArrowUpFromLine size={9} />
+                                    {formatNetSpeed(iface.txSpeed)}
+                                  </span>
+                                </div>
                               </div>
-                            </div>
-                          ))}
-                        </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="text-muted-foreground">{t("terminal.serverStats.noData")}</div>
+                        )}
                       </div>
                     </HoverCardContent>
                   </HoverCard>

--- a/components/terminal/runtime/terminalDistroDetection.test.ts
+++ b/components/terminal/runtime/terminalDistroDetection.test.ts
@@ -39,3 +39,40 @@ test("runDistroDetection uses SSH banner but skips POSIX probes for manually mar
   assert.equal(distroProbeCalls, 0);
   assert.deepEqual(detected, ["hpe"]);
 });
+
+test("runDistroDetection normalizes Darwin probe output to macos", async () => {
+  let remoteInfoCalls = 0;
+  let distroProbeCalls = 0;
+  const detected: string[] = [];
+  const token = registerConnectionToken("macos-session");
+
+  await runDistroDetection({
+    host: {
+      id: "macos-host",
+      label: "Mac mini",
+      hostname: "mac-mini.local",
+      username: "dev",
+    },
+    terminalBackend: {
+      getSessionRemoteInfo: async () => {
+        remoteInfoCalls += 1;
+        return { success: true, remoteSshVersion: "SSH-2.0-OpenSSH_9.9" };
+      },
+      getSessionDistroInfo: async () => {
+        distroProbeCalls += 1;
+        return {
+          success: true,
+          stdout: "Darwin mac-mini.local 24.5.0 Darwin Kernel Version 24.5.0\n",
+          stderr: "",
+        };
+      },
+    },
+    onOsDetected: (_hostId: string, distro: string) => {
+      detected.push(distro);
+    },
+  } as never, "macos-session", token);
+
+  assert.equal(remoteInfoCalls, 1);
+  assert.equal(distroProbeCalls, 1);
+  assert.deepEqual(detected, ["macos"]);
+});

--- a/components/terminal/runtime/terminalDistroDetection.ts
+++ b/components/terminal/runtime/terminalDistroDetection.ts
@@ -1,4 +1,8 @@
-import { classifyDistroId, detectVendorFromSshVersion } from "../../../domain/host";
+import {
+  classifyDistroId,
+  detectVendorFromSshVersion,
+  normalizeDistroId,
+} from "../../../domain/host";
 import { logger } from "../../../lib/logger";
 import type { TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
 
@@ -87,9 +91,10 @@ export const runDistroDetection = async (
       if (!res?.success) return;
       const data = `${res.stdout || ""}\n${res.stderr || ""}`;
       const idMatch = data.match(/^ID="?([\w-]+)"?$/im);
-      const distro = idMatch
+      const rawDistro = idMatch
         ? idMatch[1]
         : (data.split(/\s+/)[0] || "").toLowerCase();
+      const distro = normalizeDistroId(rawDistro) || rawDistro;
       if (distro) ctx.onOsDetected?.(ctx.host.id, distro);
     }
   } catch (err) {

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import type { Host } from "./models.ts";
 import {
+  classifyDistroId,
   detectVendorFromSshVersion,
   migrateHostsFromLegacyLineTimestamps,
   normalizeDistroId,
@@ -324,6 +325,18 @@ test("normalizeDistroId maps openEuler before the generic Linux fallback", () =>
   assert.equal(normalizeDistroId("openeuler"), "openeuler");
   assert.equal(normalizeDistroId("openEuler"), "openeuler");
   assert.notEqual(normalizeDistroId("openeuler"), "linux");
+});
+
+test("normalizeDistroId maps Darwin and macOS labels to macos", () => {
+  assert.equal(normalizeDistroId("Darwin"), "macos");
+  assert.equal(normalizeDistroId("Darwin Kernel Version 24.5.0"), "macos");
+  assert.equal(normalizeDistroId("macOS"), "macos");
+  assert.equal(normalizeDistroId("Mac OS X"), "macos");
+});
+
+test("classifyDistroId treats macos as a POSIX stats target", () => {
+  assert.equal(classifyDistroId("macos"), "linux-like");
+  assert.equal(classifyDistroId("Darwin"), "linux-like");
 });
 
 test("shouldProbeSessionCwd allows the probe on a plain Linux host", () => {

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -51,6 +51,10 @@ export const LINUX_DISTRO_OPTIONS = [
   'openeuler',
 ] as const;
 
+export const POSIX_PLATFORM_OPTIONS = [
+  'macos',
+] as const;
+
 /**
  * Known network-device vendor IDs that Netcatty can detect from the SSH
  * server identification string. When a host is classified as one of these,
@@ -76,6 +80,17 @@ export type NetworkDeviceVendor = typeof NETWORK_DEVICE_OPTIONS[number];
 export const normalizeDistroId = (value?: string) => {
   const v = (value || '').toLowerCase().trim();
   if (!v) return '';
+  if (
+    v === 'darwin' ||
+    v === 'macos' ||
+    v === 'mac os' ||
+    v === 'mac os x' ||
+    v.includes('darwin kernel') ||
+    v.includes('macos') ||
+    v.includes('mac os')
+  ) {
+    return 'macos';
+  }
   if (v.includes('ubuntu')) return 'ubuntu';
   if (v.includes('debian')) return 'debian';
   if (v.includes('centos')) return 'centos';
@@ -177,10 +192,11 @@ export const detectVendorFromSshVersion = (softwareVersion?: string): '' | Netwo
 export type DeviceClass = 'linux-like' | 'network-device' | 'other';
 
 export const classifyDistroId = (distroId?: string): DeviceClass => {
-  const v = (distroId || '').toLowerCase().trim();
+  const v = normalizeDistroId(distroId) || (distroId || '').toLowerCase().trim();
   if (!v) return 'other';
   if ((NETWORK_DEVICE_OPTIONS as readonly string[]).includes(v)) return 'network-device';
   if ((LINUX_DISTRO_OPTIONS as readonly string[]).includes(v)) return 'linux-like';
+  if ((POSIX_PLATFORM_OPTIONS as readonly string[]).includes(v)) return 'linux-like';
   return 'other';
 };
 

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -667,7 +667,7 @@ function createSessionOpsApi(ctx) {
       function createEtStatsExecConn(etSession) {
         return {
           exec(command, cb) {
-            execOnEtSession(etSession, command, 4500, {
+            execOnEtSession(etSession, command, 10000, {
               requireTrustedHost: true,
               knownHosts: etSession.etStatsAuth?.knownHosts,
             })
@@ -725,16 +725,16 @@ function createSessionOpsApi(ctx) {
         return { success: false, error: 'Session not found or not connected' };
       }
     
-      // macOS stats command: uses sysctl, vm_stat, top, ps, df, netstat
-      // CPU reported as direct percentage (top computes delta internally)
+      // macOS stats command: uses sysctl, vm_stat, ps, df, netstat
+      // CPU is a fast best-effort sum of process %CPU, clamped by the parser.
       // cpuPerCore not available on macOS without sudo
       const macosStatsCommand = [
         `cores=$(sysctl -n hw.logicalcpu 2>/dev/null || echo "1")`,
         `pagesize=$(sysctl -n hw.pagesize 2>/dev/null || echo "4096")`,
         `memsize=$(sysctl -n hw.memsize 2>/dev/null || echo "0")`,
-        // CPU usage: top -l 1 gives one logging sample, parse idle%
-        `cpuline=$(top -l 1 -s 0 -n 0 2>/dev/null | grep "CPU usage:" | head -1)`,
-        `cpupct=$(echo "$cpuline" | awk '{for(i=1;i<=NF;i++){if($(i+1)~/^idle/){v=$i;gsub(/%/,"",v);idle=v+0;found=1}};if(found)printf "%.0f",100-idle}')`,
+        // CPU usage: avoid top here; on some remote macOS shells top can block long enough
+        // to trip the stats timeout. ps is fast and present on supported macOS versions.
+        `cpupct=$(ps -A -o %cpu= 2>/dev/null | awk '{s+=$1} END{if(s<0)s=0;if(s>100)s=100;printf "%.0f",s}')`,
         // Memory: single vm_stat pipe → awk extracts all page counts (strip trailing dots with gsub)
         // Outputs: "memfree memcached" in MB
         `vmmem=$(vm_stat 2>/dev/null | awk -v ps="$pagesize" '/^Pages free:/{gsub(/[^0-9]/,"",$NF);free=$NF+0} /^Pages speculative:/{gsub(/[^0-9]/,"",$NF);spec=$NF+0} /^Pages inactive:/{gsub(/[^0-9]/,"",$NF);inact=$NF+0} /^Pages purgeable:/{gsub(/[^0-9]/,"",$NF);purg=$NF+0} END{mfree=int((free+spec)*ps/1024/1024);mcached=int((inact+purg)*ps/1024/1024);printf "%d %d",mfree,mcached}')`,
@@ -748,10 +748,10 @@ function createSessionOpsApi(ctx) {
         `swapfree=$(echo "$swaptotal $swapused" | awk '{printf "%.0f",$1-$2}')`,
         // Top processes by memory%
         `procs=$(ps -A -o pid=,%mem=,comm= 2>/dev/null | sort -k2 -rn | head -10 | awk '{gsub(/;/,"_",$3);printf "%s;%.1f;%s,",$1,$2,$3}' | sed 's/,$//')`,
-        // Disk: only show root "/" and external volumes "/Volumes/*", skip system APFS snapshots
-        `disks=$(df -k 2>/dev/null | awk 'NR>1&&index($1,"/dev/")==1&&NF>=9&&($NF=="/"||index($NF,"/Volumes/")==1){u=$3/1048576;t=$2/1048576;p=$5;gsub(/%/,"",p);printf "%s:%.0f:%.0f:%s,",$NF,u,t,p}' | sed 's/,$//')`,
+        // Disk: -P keeps a stable six-column POSIX layout on macOS.
+        `disks=$(df -kP 2>/dev/null | awk 'NR>1&&index($1,"/dev/")==1{m=$6;if(m=="/"||index(m,"/Volumes/")==1){u=$3/1048576;t=$2/1048576;p=$5;gsub(/%/,"",p);printf "%s:%.0f:%.0f:%s,",m,u,t,p}}' | sed 's/,$//')`,
         // Network: Link# lines only, exclude loopback, detect column shift (no MAC addr → cols shift left)
-        `net=$(netstat -ib 2>/dev/null | awk '/^[a-z]/&&$3~/Link/&&$1!~/^lo/{if($4~/:/){rx=$7;tx=$10}else{rx=$6;tx=$9};if((rx+0)>0){gsub(/[*]/,"",$1);printf "%s:%s:%s,",$1,rx,tx}}' | sed 's/,$//')`,
+        `net=$(netstat -ibn 2>/dev/null | awk 'NR==1{for(i=1;i<=NF;i++){if($i=="Ibytes")ib=i;if($i=="Obytes")ob=i}next} ib&&ob&&$1~/^[[:alpha:]]/&&$1!~/^lo/&&$0~/<Link#/{name=$1;gsub(/[*]/,"",name);rx=$(ib)+0;tx=$(ob)+0;if(rx>0||tx>0){seen[name]=rx ":" tx}} END{for(name in seen)printf "%s:%s,",name,seen[name]}' | sed 's/,$//')`,
         `echo "CPU:$cpupct|CORES:$cores|MEMINFO:$memtotal $memfree 0 $memcached $swaptotal $swapfree|PROCS:$procs|DISKS:$disks|NET:$net"`,
       ].join('; ');
     
@@ -789,7 +789,7 @@ function createSessionOpsApi(ctx) {
       return new Promise((resolve) => {
         const timeout = setTimeout(() => {
           resolve({ success: false, error: 'Timeout getting server stats' });
-        }, 5000);
+        }, 10000);
         const latencyStartedAt = Date.now();
     
         conn.exec(statsCommand, (err, stream) => {

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -726,7 +726,7 @@ function createSessionOpsApi(ctx) {
       }
     
       // macOS stats command: uses sysctl, vm_stat, ps, df, netstat
-      // CPU is a fast best-effort sum of process %CPU, clamped by the parser.
+      // CPU is a fast best-effort sum of process %CPU normalized by logical cores.
       // cpuPerCore not available on macOS without sudo
       const macosStatsCommand = [
         `cores=$(sysctl -n hw.logicalcpu 2>/dev/null || echo "1")`,
@@ -734,7 +734,7 @@ function createSessionOpsApi(ctx) {
         `memsize=$(sysctl -n hw.memsize 2>/dev/null || echo "0")`,
         // CPU usage: avoid top here; on some remote macOS shells top can block long enough
         // to trip the stats timeout. ps is fast and present on supported macOS versions.
-        `cpupct=$(ps -A -o %cpu= 2>/dev/null | awk '{s+=$1} END{if(s<0)s=0;if(s>100)s=100;printf "%.0f",s}')`,
+        `cpupct=$(ps -A -o %cpu= 2>/dev/null | awk -v c="$cores" '{s+=$1} END{if(c<=0)c=1;s=s/c;if(s<0)s=0;if(s>100)s=100;printf "%.0f",s}')`,
         // Memory: single vm_stat pipe → awk extracts all page counts (strip trailing dots with gsub)
         // Outputs: "memfree memcached" in MB
         `vmmem=$(vm_stat 2>/dev/null | awk -v ps="$pagesize" '/^Pages free:/{gsub(/[^0-9]/,"",$NF);free=$NF+0} /^Pages speculative:/{gsub(/[^0-9]/,"",$NF);spec=$NF+0} /^Pages inactive:/{gsub(/[^0-9]/,"",$NF);inact=$NF+0} /^Pages purgeable:/{gsub(/[^0-9]/,"",$NF);purg=$NF+0} END{mfree=int((free+spec)*ps/1024/1024);mcached=int((inact+purg)*ps/1024/1024);printf "%d %d",mfree,mcached}')`,
@@ -846,7 +846,7 @@ function createSessionOpsApi(ctx) {
     
             for (const part of parts) {
               if (part.startsWith('CPU:')) {
-                // macOS: top reports CPU% directly (no delta needed)
+                // macOS: command reports normalized CPU% directly (no delta needed)
                 const val = parseFloat(part.substring(4).trim());
                 if (!isNaN(val)) cpuDirect = Math.min(100, Math.max(0, Math.round(val)));
               } else if (part.startsWith('CPURAW:')) {

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -30,6 +30,8 @@ function fakeConn(stdout) {
 // success gate only requires cpu OR memTotal OR cpuCores to be non-null.
 const LINUX_STATS =
   "CPURAW:1000 900|CORES:4|PERCORERAW:|MEMINFO:8000 4000 100 900 0 0|PROCS:|DISKS:|NET:";
+const MACOS_STATS =
+  "NC_LATENCY_MARK|CPU:27|CORES:10|MEMINFO:32768 4096 0 8192 2048 1536|PROCS:123;1.2;Finder|DISKS:/:120:460:26|NET:en0:1000:3000";
 
 function makeSessionOps(sessions) {
   return createSessionOpsApi({
@@ -122,6 +124,39 @@ test("getServerStats does not touch the companion path for a normal SSH session"
 
   assert.equal(ensureCalls, 0);
   assert.equal(result.success, true);
+});
+
+test("getServerStats parses macOS stats and avoids blocking top command", async () => {
+  const sessions = new Map();
+  let command = "";
+  const session = {
+    type: "ssh",
+    conn: {
+      exec(cmd, cb) {
+        command = cmd;
+        cb(null, fakeStream(MACOS_STATS));
+      },
+    },
+  };
+  sessions.set("sid", session);
+
+  const api = makeSessionOps(sessions);
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, true);
+  assert.match(command, /Darwin/);
+  assert.match(command, /ps -A -o %cpu=/);
+  assert.doesNotMatch(command, /top -l/);
+  assert.equal(result.stats.cpu, 27);
+  assert.equal(result.stats.cpuCores, 10);
+  assert.equal(result.stats.memTotal, 32768);
+  assert.equal(result.stats.memUsed, 20480);
+  assert.equal(result.stats.diskPercent, 26);
+  assert.equal(result.stats.netInterfaces.length, 1);
+  assert.equal(result.stats.netInterfaces[0].name, "en0");
+  assert.equal(result.stats.netInterfaces[0].rxBytes, 1000);
+  assert.equal(result.stats.netInterfaces[0].txBytes, 3000);
+  assert.equal(typeof result.stats.latencyMs, "number");
 });
 
 test("getServerStats reports pending (not a hard failure) for a Mosh session before the handshake swap", async () => {

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -146,6 +146,8 @@ test("getServerStats parses macOS stats and avoids blocking top command", async 
   assert.equal(result.success, true);
   assert.match(command, /Darwin/);
   assert.match(command, /ps -A -o %cpu=/);
+  assert.match(command, /awk -v c="\$cores"/);
+  assert.match(command, /s=s\/c/);
   assert.doesNotMatch(command, /top -l/);
   assert.equal(result.stats.cpu, 27);
   assert.equal(result.stats.cpuCores, 10);


### PR DESCRIPTION
## Summary
- detect Darwin/macOS probe output as `macos` so remote macOS SSH sessions are treated as POSIX stats targets
- make remote macOS server stats collection faster and more robust by avoiding `top`, using stable `df -kP`, and parsing `netstat` byte counters by header name
- show latency even when macOS network interface counters cannot be parsed yet

## Testing
- `node --test electron\bridges\sshBridge\sessionOps.serverStats.test.cjs electron\bridges\sshBridge.sessionOps.et.test.cjs`
- manually verified the Windows test build against a remote macOS SSH session: CPU/memory/disk/network/latency stats now display