### PR TITLE
Fix empty command approval grants

### DIFF
--- a/infrastructure/ai/harness/permissionGrants.test.ts
+++ b/infrastructure/ai/harness/permissionGrants.test.ts
@@ -53,8 +53,18 @@ describe('permissionGrants', () => {
       sessionId: 'ssh-1',
       command: 'systemctl status nginx',
     }, 'chat-1');
+    assert.ok(grant);
     assert.equal(grant.sessionPattern, '*');
     assert.equal(grant.commandPattern, 'systemctl status *');
+  });
+
+  it('buildGrantFromApproval returns null when no command grant is produced', () => {
+    const grant = buildGrantFromApproval('terminal.execute', {
+      sessionId: 'ssh-1',
+      command: 'cd /tmp',
+    }, 'chat-1');
+
+    assert.equal(grant, null);
   });
 
   it('buildGrantsFromApproval emits one rule per chained command segment', () => {

--- a/infrastructure/ai/harness/permissionGrants.ts
+++ b/infrastructure/ai/harness/permissionGrants.ts
@@ -267,8 +267,8 @@ export function buildGrantFromApproval(
   capabilityId: string,
   args: Record<string, unknown>,
   chatSessionId?: string,
-): PermissionGrantRule {
-  return buildGrantsFromApproval(capabilityId, args, chatSessionId)[0];
+): PermissionGrantRule | null {
+  return buildGrantsFromApproval(capabilityId, args, chatSessionId)[0] ?? null;
 }
 
 let activeRules: PermissionGrantRule[] = [];


### PR DESCRIPTION
## Summary
- Return null from the single-rule approval helper when an approval creates no command grant
- Add coverage for CWD-only commands such as cd /tmp

## Test Plan
- node --test --import tsx infrastructure/ai/harness/permissionGrants.test.ts
- node --test --import tsx infrastructure/ai/shared/shellCommandGrant.test.ts infrastructure/ai/harness/permissionGrants.test.ts
- npm run lint

Addresses Codex feedback from #1729.