### PR TITLE
fix(logs): preserve connection log terminal replay data (#1733)

### DIFF
--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -577,9 +577,10 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
         break;
       }
       case 'newTab':
-      case 'openLocal':
-        // Add connection log for local terminal
+      case 'openLocal': {
+        const sessionId = createLocalTerminalWithCurrentShell();
         addConnectionLogRef.current({
+          sessionId,
           hostId: '',
           hostLabel: 'Local Terminal',
           hostname: 'localhost',
@@ -590,8 +591,8 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
           localHostname: systemInfoRef.current.hostname,
           saved: false,
         });
-        createLocalTerminalWithCurrentShell();
         break;
+      }
       case 'openHosts':
         setActiveTabId('vault');
         break;

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -159,16 +159,22 @@ const readLegacyLineTimestampsEnabled = (): boolean => {
 const readConnectionLogTerminalDataMap = (): ConnectionLogTerminalDataMap =>
   localStorageAdapter.read<ConnectionLogTerminalDataMap>(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA) ?? {};
 
+const readPersistedConnectionLogIds = (): Set<string> => {
+  const stored = localStorageAdapter.read<ConnectionLog[]>(STORAGE_KEY_CONNECTION_LOGS) ?? [];
+  return new Set(stored.map((log) => log.id));
+};
+
 const writeConnectionLogTerminalDataMap = (
   logs: ConnectionLog[],
-  map: ConnectionLogTerminalDataMap,
+  localMaps: ConnectionLogTerminalDataMap[],
 ): boolean => {
+  const existing = readConnectionLogTerminalDataMap();
   const pruned = mergeTerminalDataMapsForStorage(
     logs,
-    readConnectionLogTerminalDataMap(),
-    map,
+    existing,
+    localMaps,
+    readPersistedConnectionLogIds(),
   );
-  const existing = readConnectionLogTerminalDataMap();
   if (JSON.stringify(existing) === JSON.stringify(pruned)) return true;
   return localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA, pruned);
 };
@@ -211,13 +217,18 @@ export const useVaultState = () => {
   const connectionLogTerminalDataRef = useRef<ConnectionLogTerminalDataMap>({});
 
   const syncConnectionLogTerminalDataMap = useCallback((logs: ConnectionLog[]) => {
-    const merged = mergeTerminalDataMapsForStorage(
-      logs,
-      readConnectionLogTerminalDataMap(),
+    const localMaps = [
       connectionLogTerminalDataRef.current,
       buildTerminalDataMapFromLogs(logs),
+    ];
+    const existing = readConnectionLogTerminalDataMap();
+    const merged = mergeTerminalDataMapsForStorage(
+      logs,
+      existing,
+      localMaps,
+      readPersistedConnectionLogIds(),
     );
-    const persisted = writeConnectionLogTerminalDataMap(logs, merged);
+    const persisted = writeConnectionLogTerminalDataMap(logs, localMaps);
     if (persisted) {
       connectionLogTerminalDataRef.current = merged;
     } else {
@@ -233,19 +244,32 @@ export const useVaultState = () => {
     logs: ConnectionLog[],
     options?: { pruneMainBlob?: boolean },
   ) => {
-    const { persisted } = syncConnectionLogTerminalDataMap(logs);
     const unsavedTerminalDataPending = logs.some(
       (log) => !log.saved && log.terminalData !== undefined,
     );
-    const shouldPruneMainBlob = options?.pruneMainBlob
-      && (persisted || !unsavedTerminalDataPending);
-    const mainPayload = shouldPruneMainBlob
-      ? pruneConnectionLogsForStorage(logs)
-      : logs;
-    const mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, mainPayload);
+
+    let mainPersisted = true;
+    if (options?.pruneMainBlob) {
+      const prunedMain = pruneConnectionLogsForStorage(logs);
+      mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, prunedMain);
+      if (!mainPersisted && unsavedTerminalDataPending) {
+        mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);
+      }
+    }
+
+    const { persisted: sidePersisted } = syncConnectionLogTerminalDataMap(logs);
+
+    if (!options?.pruneMainBlob) {
+      mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);
+    }
+
     if (!mainPersisted && unsavedTerminalDataPending) {
       console.warn(
         "[useVaultState] Failed to persist connection log terminal replay data to localStorage.",
+      );
+    } else if (!sidePersisted && unsavedTerminalDataPending && options?.pruneMainBlob && mainPersisted) {
+      console.warn(
+        "[useVaultState] Failed to persist connection log terminal replay data side store.",
       );
     }
   }, [syncConnectionLogTerminalDataMap]);

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -164,16 +164,30 @@ const readPersistedConnectionLogIds = (): Set<string> => {
   return new Set(stored.map((log) => log.id));
 };
 
+const buildPersistedLogIds = (
+  logs: ConnectionLog[],
+  usePersistedLogIdsFromDisk: boolean,
+): Set<string> => {
+  const ids = new Set(logs.map((log) => log.id));
+  if (usePersistedLogIdsFromDisk) {
+    for (const id of readPersistedConnectionLogIds()) {
+      ids.add(id);
+    }
+  }
+  return ids;
+};
+
 const writeConnectionLogTerminalDataMap = (
   logs: ConnectionLog[],
   localMaps: ConnectionLogTerminalDataMap[],
+  usePersistedLogIdsFromDisk: boolean,
 ): boolean => {
   const existing = readConnectionLogTerminalDataMap();
   const pruned = mergeTerminalDataMapsForStorage(
     logs,
     existing,
     localMaps,
-    readPersistedConnectionLogIds(),
+    buildPersistedLogIds(logs, usePersistedLogIdsFromDisk),
   );
   if (JSON.stringify(existing) === JSON.stringify(pruned)) return true;
   return localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA, pruned);
@@ -216,7 +230,11 @@ export const useVaultState = () => {
   const groupConfigsReadSeq = useRef(0);
   const connectionLogTerminalDataRef = useRef<ConnectionLogTerminalDataMap>({});
 
-  const syncConnectionLogTerminalDataMap = useCallback((logs: ConnectionLog[]) => {
+  const syncConnectionLogTerminalDataMap = useCallback((
+    logs: ConnectionLog[],
+    options?: { usePersistedLogIdsFromDisk?: boolean },
+  ) => {
+    const usePersistedLogIdsFromDisk = options?.usePersistedLogIdsFromDisk ?? false;
     const localMaps = [
       connectionLogTerminalDataRef.current,
       buildTerminalDataMapFromLogs(logs),
@@ -226,9 +244,13 @@ export const useVaultState = () => {
       logs,
       existing,
       localMaps,
-      readPersistedConnectionLogIds(),
+      buildPersistedLogIds(logs, usePersistedLogIdsFromDisk),
     );
-    const persisted = writeConnectionLogTerminalDataMap(logs, localMaps);
+    const persisted = writeConnectionLogTerminalDataMap(
+      logs,
+      localMaps,
+      usePersistedLogIdsFromDisk,
+    );
     if (persisted) {
       connectionLogTerminalDataRef.current = merged;
     } else {
@@ -257,7 +279,12 @@ export const useVaultState = () => {
       }
     }
 
-    const { persisted: sidePersisted } = syncConnectionLogTerminalDataMap(logs);
+    let sidePersisted = true;
+    if (mainPersisted || !options?.pruneMainBlob) {
+      ({ persisted: sidePersisted } = syncConnectionLogTerminalDataMap(logs, {
+        usePersistedLogIdsFromDisk: Boolean(options?.pruneMainBlob && mainPersisted),
+      }));
+    }
 
     if (!options?.pruneMainBlob) {
       mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -47,7 +47,6 @@ import {
   mergeConnectionLogsFromStorage,
   mergeTerminalDataIntoLogs,
   mergeTerminalDataMapsForStorage,
-  pruneTerminalDataMapForStorage,
   type ConnectionLogTerminalDataMap,
 } from "../../domain/connectionLogTerminalData";
 import { getNextVaultOrder, normalizeVaultOrder } from "../../domain/vaultOrder";
@@ -240,10 +239,14 @@ export const useVaultState = () => {
     );
     const shouldPruneMainBlob = options?.pruneMainBlob
       && (persisted || !unsavedTerminalDataPending);
-    if (shouldPruneMainBlob) {
-      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(logs));
-    } else {
-      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);
+    const mainPayload = shouldPruneMainBlob
+      ? pruneConnectionLogsForStorage(logs)
+      : logs;
+    const mainPersisted = localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, mainPayload);
+    if (!mainPersisted && unsavedTerminalDataPending) {
+      console.warn(
+        "[useVaultState] Failed to persist connection log terminal replay data to localStorage.",
+      );
     }
   }, [syncConnectionLogTerminalDataMap]);
 

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -23,6 +23,7 @@ import {
 } from "../../infrastructure/config/defaultData";
 import {
   STORAGE_KEY_CONNECTION_LOGS,
+  STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA,
   STORAGE_KEY_GROUP_CONFIGS,
   STORAGE_KEY_GROUPS,
   STORAGE_KEY_HOSTS,
@@ -39,8 +40,15 @@ import {
   STORAGE_KEY_SNIPPETS,
   STORAGE_KEY_TERM_SETTINGS,
 } from "../../infrastructure/config/storageKeys";
-import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
+import { localStorageAdapter, LOCAL_STORAGE_ADAPTER_CHANGED_EVENT } from "../../infrastructure/persistence/localStorageAdapter";
 import { mergeGlobalHistoryOnAppend, sanitizeGlobalHistoryEntries } from "../../domain/globalHistory";
+import {
+  buildTerminalDataMapFromLogs,
+  mergeConnectionLogsFromStorage,
+  mergeTerminalDataIntoLogs,
+  pruneTerminalDataMapForStorage,
+  type ConnectionLogTerminalDataMap,
+} from "../../domain/connectionLogTerminalData";
 import { getNextVaultOrder, normalizeVaultOrder } from "../../domain/vaultOrder";
 import { loadSanitizedShellHistory } from "./shellHistoryPersistence";
 import {
@@ -148,6 +156,19 @@ const readLegacyLineTimestampsEnabled = (): boolean => {
   return stored?.showLineTimestamps === true;
 };
 
+const readConnectionLogTerminalDataMap = (): ConnectionLogTerminalDataMap =>
+  localStorageAdapter.read<ConnectionLogTerminalDataMap>(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA) ?? {};
+
+const writeConnectionLogTerminalDataMap = (
+  logs: ConnectionLog[],
+  map: ConnectionLogTerminalDataMap,
+): void => {
+  const pruned = pruneTerminalDataMapForStorage(logs, map);
+  const existing = readConnectionLogTerminalDataMap();
+  if (JSON.stringify(existing) === JSON.stringify(pruned)) return;
+  localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA, pruned);
+};
+
 export const useVaultState = () => {
   const [isInitialized, setIsInitialized] = useState(false);
   const [hosts, setHosts] = useState<Host[]>([]);
@@ -183,6 +204,41 @@ export const useVaultState = () => {
   const identitiesReadSeq = useRef(0);
   const proxyProfilesReadSeq = useRef(0);
   const groupConfigsReadSeq = useRef(0);
+  const connectionLogTerminalDataRef = useRef<ConnectionLogTerminalDataMap>({});
+
+  const syncConnectionLogTerminalDataMap = useCallback((logs: ConnectionLog[]) => {
+    const merged = pruneTerminalDataMapForStorage(
+      logs,
+      {
+        ...connectionLogTerminalDataRef.current,
+        ...buildTerminalDataMapFromLogs(logs),
+      },
+    );
+    connectionLogTerminalDataRef.current = merged;
+    writeConnectionLogTerminalDataMap(logs, merged);
+    return merged;
+  }, []);
+
+  const persistConnectionLogState = useCallback((
+    logs: ConnectionLog[],
+    options?: { pruneMainBlob?: boolean },
+  ) => {
+    syncConnectionLogTerminalDataMap(logs);
+    if (options?.pruneMainBlob) {
+      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(logs));
+    } else {
+      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);
+    }
+  }, [syncConnectionLogTerminalDataMap]);
+
+  const applyConnectionLogsFromStorage = useCallback((
+    prev: ConnectionLog[],
+    storedLogs: ConnectionLog[],
+    terminalDataMap: ConnectionLogTerminalDataMap,
+  ) => {
+    connectionLogTerminalDataRef.current = terminalDataMap;
+    return mergeConnectionLogsFromStorage(prev, storedLogs, terminalDataMap);
+  }, []);
 
   const updateHosts = useCallback((data: Host[]) => {
     const cleaned = normalizeVaultOrder(data.map(sanitizeHost));
@@ -403,12 +459,12 @@ export const useVaultState = () => {
         const final = [...updated, ...savedLogs].sort(
           (a, b) => b.startTime - a.startTime
         );
-        localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(final));
+        persistConnectionLogState(final, { pruneMainBlob: true });
         return final;
       });
       return newLog.id;
     },
-    []
+    [persistConnectionLogState],
   );
 
   const updateConnectionLog = useCallback(
@@ -417,11 +473,11 @@ export const useVaultState = () => {
         const updated = prev.map((log) =>
           log.id === id ? { ...log, ...updates } : log
         );
-        localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(updated));
+        persistConnectionLogState(updated, { pruneMainBlob: true });
         return updated;
       });
     },
-    []
+    [persistConnectionLogState],
   );
 
   const toggleConnectionLogSaved = useCallback((id: string) => {
@@ -429,26 +485,29 @@ export const useVaultState = () => {
       const updated = prev.map((log) =>
         log.id === id ? { ...log, saved: !log.saved } : log
       );
-      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, updated);
+      persistConnectionLogState(updated, { pruneMainBlob: false });
       return updated;
     });
-  }, []);
+  }, [persistConnectionLogState]);
 
   const deleteConnectionLog = useCallback((id: string) => {
     setConnectionLogs((prev) => {
       const updated = prev.filter((log) => log.id !== id);
-      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, updated);
+      const map = { ...connectionLogTerminalDataRef.current };
+      delete map[id];
+      connectionLogTerminalDataRef.current = map;
+      persistConnectionLogState(updated, { pruneMainBlob: true });
       return updated;
     });
-  }, []);
+  }, [persistConnectionLogState]);
 
   const clearUnsavedConnectionLogs = useCallback(() => {
     setConnectionLogs((prev) => {
       const saved = prev.filter((log) => log.saved);
-      localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(saved));
+      persistConnectionLogState(saved, { pruneMainBlob: true });
       return saved;
     });
-  }, []);
+  }, [persistConnectionLogState]);
 
   // Convert a known host to a managed host
   const convertKnownHostToHost = useCallback((knownHost: KnownHost): Host => {
@@ -644,7 +703,11 @@ export const useVaultState = () => {
         const savedConnectionLogs = localStorageAdapter.read<ConnectionLog[]>(
           STORAGE_KEY_CONNECTION_LOGS,
         );
-        if (savedConnectionLogs) setConnectionLogs(savedConnectionLogs);
+        const terminalDataMap = readConnectionLogTerminalDataMap();
+        connectionLogTerminalDataRef.current = terminalDataMap;
+        if (savedConnectionLogs) {
+          setConnectionLogs(mergeTerminalDataIntoLogs(savedConnectionLogs, terminalDataMap));
+        }
 
         // Load managed sources
         const savedManagedSources = localStorageAdapter.read<ManagedSource[]>(
@@ -787,7 +850,16 @@ export const useVaultState = () => {
 
       if (key === STORAGE_KEY_CONNECTION_LOGS) {
         const next = safeParse<ConnectionLog[]>(event.newValue) ?? [];
-        setConnectionLogs(next);
+        setConnectionLogs((prev) =>
+          applyConnectionLogsFromStorage(prev, next, connectionLogTerminalDataRef.current),
+        );
+        return;
+      }
+
+      if (key === STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA) {
+        const next = safeParse<ConnectionLogTerminalDataMap>(event.newValue) ?? {};
+        connectionLogTerminalDataRef.current = next;
+        setConnectionLogs((prev) => mergeConnectionLogsFromStorage(prev, prev, next));
         return;
       }
 
@@ -810,9 +882,29 @@ export const useVaultState = () => {
       }
     };
 
+    const handleLocalStorageAdapterChanged = (event: Event) => {
+      const key = (event as CustomEvent<{ key?: string }>).detail?.key;
+      if (key === STORAGE_KEY_CONNECTION_LOGS) {
+        const next = localStorageAdapter.read<ConnectionLog[]>(STORAGE_KEY_CONNECTION_LOGS) ?? [];
+        setConnectionLogs((prev) =>
+          applyConnectionLogsFromStorage(prev, next, connectionLogTerminalDataRef.current),
+        );
+        return;
+      }
+      if (key === STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA) {
+        const next = readConnectionLogTerminalDataMap();
+        connectionLogTerminalDataRef.current = next;
+        setConnectionLogs((prev) => mergeConnectionLogsFromStorage(prev, prev, next));
+      }
+    };
+
     window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
-  }, []);
+    window.addEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleLocalStorageAdapterChanged);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, handleLocalStorageAdapterChanged);
+    };
+  }, [applyConnectionLogsFromStorage]);
 
   const updateHostLastConnected = useCallback((hostId: string) => {
     setHosts((prev) => {

--- a/application/state/useVaultState.ts
+++ b/application/state/useVaultState.ts
@@ -46,6 +46,7 @@ import {
   buildTerminalDataMapFromLogs,
   mergeConnectionLogsFromStorage,
   mergeTerminalDataIntoLogs,
+  mergeTerminalDataMapsForStorage,
   pruneTerminalDataMapForStorage,
   type ConnectionLogTerminalDataMap,
 } from "../../domain/connectionLogTerminalData";
@@ -162,11 +163,15 @@ const readConnectionLogTerminalDataMap = (): ConnectionLogTerminalDataMap =>
 const writeConnectionLogTerminalDataMap = (
   logs: ConnectionLog[],
   map: ConnectionLogTerminalDataMap,
-): void => {
-  const pruned = pruneTerminalDataMapForStorage(logs, map);
+): boolean => {
+  const pruned = mergeTerminalDataMapsForStorage(
+    logs,
+    readConnectionLogTerminalDataMap(),
+    map,
+  );
   const existing = readConnectionLogTerminalDataMap();
-  if (JSON.stringify(existing) === JSON.stringify(pruned)) return;
-  localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA, pruned);
+  if (JSON.stringify(existing) === JSON.stringify(pruned)) return true;
+  return localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA, pruned);
 };
 
 export const useVaultState = () => {
@@ -207,24 +212,35 @@ export const useVaultState = () => {
   const connectionLogTerminalDataRef = useRef<ConnectionLogTerminalDataMap>({});
 
   const syncConnectionLogTerminalDataMap = useCallback((logs: ConnectionLog[]) => {
-    const merged = pruneTerminalDataMapForStorage(
+    const merged = mergeTerminalDataMapsForStorage(
       logs,
-      {
+      readConnectionLogTerminalDataMap(),
+      connectionLogTerminalDataRef.current,
+      buildTerminalDataMapFromLogs(logs),
+    );
+    const persisted = writeConnectionLogTerminalDataMap(logs, merged);
+    if (persisted) {
+      connectionLogTerminalDataRef.current = merged;
+    } else {
+      connectionLogTerminalDataRef.current = {
         ...connectionLogTerminalDataRef.current,
         ...buildTerminalDataMapFromLogs(logs),
-      },
-    );
-    connectionLogTerminalDataRef.current = merged;
-    writeConnectionLogTerminalDataMap(logs, merged);
-    return merged;
+      };
+    }
+    return { map: connectionLogTerminalDataRef.current, persisted };
   }, []);
 
   const persistConnectionLogState = useCallback((
     logs: ConnectionLog[],
     options?: { pruneMainBlob?: boolean },
   ) => {
-    syncConnectionLogTerminalDataMap(logs);
-    if (options?.pruneMainBlob) {
+    const { persisted } = syncConnectionLogTerminalDataMap(logs);
+    const unsavedTerminalDataPending = logs.some(
+      (log) => !log.saved && log.terminalData !== undefined,
+    );
+    const shouldPruneMainBlob = options?.pruneMainBlob
+      && (persisted || !unsavedTerminalDataPending);
+    if (shouldPruneMainBlob) {
       localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, pruneConnectionLogsForStorage(logs));
     } else {
       localStorageAdapter.write(STORAGE_KEY_CONNECTION_LOGS, logs);

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -167,6 +167,19 @@ test("mergeTerminalDataMapsForStorage keeps replay data from other windows", () 
   assert.equal(merged.other, "other-window only");
 });
 
+test("mergeTerminalDataMapsForStorage prefers fresher local replay data for orphans", () => {
+  const logs: ConnectionLog[] = [{ ...baseLog, id: "local", startTime: 2000 }];
+
+  const merged = mergeTerminalDataMapsForStorage(
+    logs,
+    { other: "stale snapshot" },
+    [{ other: "fresh local" }],
+    new Set(["local", "other"]),
+  );
+
+  assert.equal(merged.other, "fresh local");
+});
+
 test("mergeTerminalDataMapsForStorage drops deleted log replay buffers", () => {
   const logs: ConnectionLog[] = [{ ...baseLog, id: "local", startTime: 2000 }];
 

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -157,10 +157,11 @@ test("mergeTerminalDataMapsForStorage keeps replay data from other windows", () 
 
   const merged = mergeTerminalDataMapsForStorage(
     logs,
-    { remote: "remote-window output" },
+    { remote: "remote-window output", other: "other-window only" },
     { local: "local-window output" },
   );
 
   assert.equal(merged.remote, "remote-window output");
   assert.equal(merged.local, "local-window output");
+  assert.equal(merged.other, "other-window only");
 });

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 
 import type { ConnectionLog } from "./models.ts";
 import { selectConnectionLogForTerminalDataCapture } from "./connectionLog.ts";
+import {
+  MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES,
+  mergeConnectionLogsFromStorage,
+  mergeTerminalDataIntoLogs,
+  pruneTerminalDataMapForStorage,
+} from "./connectionLogTerminalData.ts";
 
 const baseLog: ConnectionLog = {
   id: "log-base",
@@ -65,4 +71,79 @@ test("selectConnectionLogForTerminalDataCapture reuses the latest log for repeat
     )?.id,
     "first-capture",
   );
+});
+
+test("selectConnectionLogForTerminalDataCapture does not cross-match localhost logs without sessionId", () => {
+  const openLocalWithoutSession = {
+    ...baseLog,
+    id: "open-local",
+    sessionId: undefined,
+    hostname: "localhost",
+    protocol: "local",
+    startTime: 3000,
+  };
+  const targetLocal = {
+    ...baseLog,
+    id: "target-local",
+    sessionId: "session-local-a",
+    hostname: "localhost",
+    protocol: "local",
+    startTime: 2000,
+  };
+
+  assert.equal(
+    selectConnectionLogForTerminalDataCapture(
+      [openLocalWithoutSession, targetLocal],
+      { sessionId: "session-local-b", hostname: "localhost" },
+    ),
+    undefined,
+  );
+});
+
+test("mergeConnectionLogsFromStorage keeps in-memory terminal replay data", () => {
+  const memoryLog = {
+    ...baseLog,
+    id: "memory",
+    terminalData: "captured output",
+  };
+  const storedLog = {
+    ...baseLog,
+    id: "memory",
+    endTime: 2000,
+  };
+
+  const merged = mergeConnectionLogsFromStorage(
+    [memoryLog],
+    [storedLog],
+    {},
+  );
+
+  assert.equal(merged[0]?.terminalData, "captured output");
+});
+
+test("mergeTerminalDataIntoLogs hydrates unsaved logs from side storage", () => {
+  const storedLog = { ...baseLog, id: "hydrate" };
+  const hydrated = mergeTerminalDataIntoLogs([storedLog], {
+    hydrate: "side-store output",
+  });
+
+  assert.equal(hydrated[0]?.terminalData, "side-store output");
+});
+
+test("pruneTerminalDataMapForStorage caps unsaved replay buffers", () => {
+  const logs: ConnectionLog[] = Array.from({ length: 60 }, (_, index) => ({
+    ...baseLog,
+    id: `log-${index}`,
+    startTime: index,
+    saved: false,
+  }));
+
+  const map = Object.fromEntries(
+    logs.map((log) => [log.id, `data-${log.id}`]),
+  );
+
+  const pruned = pruneTerminalDataMapForStorage(logs, map);
+  assert.equal(Object.keys(pruned).length, MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES);
+  assert.equal(pruned["log-59"], "data-log-59");
+  assert.equal(pruned["log-0"], undefined);
 });

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -158,10 +158,25 @@ test("mergeTerminalDataMapsForStorage keeps replay data from other windows", () 
   const merged = mergeTerminalDataMapsForStorage(
     logs,
     { remote: "remote-window output", other: "other-window only" },
-    { local: "local-window output" },
+    [{ local: "local-window output" }],
+    new Set(["local", "remote", "other"]),
   );
 
   assert.equal(merged.remote, "remote-window output");
   assert.equal(merged.local, "local-window output");
   assert.equal(merged.other, "other-window only");
+});
+
+test("mergeTerminalDataMapsForStorage drops deleted log replay buffers", () => {
+  const logs: ConnectionLog[] = [{ ...baseLog, id: "local", startTime: 2000 }];
+
+  const merged = mergeTerminalDataMapsForStorage(
+    logs,
+    { local: "keep", deleted: "drop me" },
+    [],
+    new Set(["local"]),
+  );
+
+  assert.equal(merged.local, "keep");
+  assert.equal(merged.deleted, undefined);
 });

--- a/domain/connectionLog.test.ts
+++ b/domain/connectionLog.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES,
   mergeConnectionLogsFromStorage,
   mergeTerminalDataIntoLogs,
+  mergeTerminalDataMapsForStorage,
   pruneTerminalDataMapForStorage,
 } from "./connectionLogTerminalData.ts";
 
@@ -146,4 +147,20 @@ test("pruneTerminalDataMapForStorage caps unsaved replay buffers", () => {
   assert.equal(Object.keys(pruned).length, MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES);
   assert.equal(pruned["log-59"], "data-log-59");
   assert.equal(pruned["log-0"], undefined);
+});
+
+test("mergeTerminalDataMapsForStorage keeps replay data from other windows", () => {
+  const logs: ConnectionLog[] = [
+    { ...baseLog, id: "local", startTime: 2000 },
+    { ...baseLog, id: "remote", startTime: 1000 },
+  ];
+
+  const merged = mergeTerminalDataMapsForStorage(
+    logs,
+    { remote: "remote-window output" },
+    { local: "local-window output" },
+  );
+
+  assert.equal(merged.remote, "remote-window output");
+  assert.equal(merged.local, "local-window output");
 });

--- a/domain/connectionLog.ts
+++ b/domain/connectionLog.ts
@@ -9,17 +9,22 @@ export const selectConnectionLogForTerminalDataCapture = (
   connectionLogs: ConnectionLog[],
   target: TerminalDataCaptureTarget,
 ): ConnectionLog | undefined => {
-  const matchingOpenLog = connectionLogs
+  if (target.sessionId) {
+    const sessionMatches = connectionLogs
+      .filter((log) => log.sessionId === target.sessionId)
+      .sort((a, b) => b.startTime - a.startTime);
+
+    const openLog = sessionMatches.find((log) => !log.endTime && !log.terminalData);
+    if (openLog) return openLog;
+
+    return sessionMatches[0];
+  }
+
+  // Legacy logs created without sessionId (e.g. old hotkey local terminals).
+  return connectionLogs
     .filter((log) => {
-      if (log.endTime || log.terminalData) return false;
-      if (log.sessionId) return log.sessionId === target.sessionId;
+      if (log.endTime || log.terminalData || log.sessionId) return false;
       return !!target.hostname && log.hostname === target.hostname;
     })
-    .sort((a, b) => b.startTime - a.startTime)[0];
-
-  if (matchingOpenLog) return matchingOpenLog;
-
-  return connectionLogs
-    .filter((log) => log.sessionId === target.sessionId)
     .sort((a, b) => b.startTime - a.startTime)[0];
 };

--- a/domain/connectionLogTerminalData.ts
+++ b/domain/connectionLogTerminalData.ts
@@ -88,11 +88,16 @@ export const pruneTerminalDataMapForStorage = (
   return next;
 };
 
-export const upsertTerminalDataInMap = (
-  map: ConnectionLogTerminalDataMap,
-  logId: string,
-  terminalData: string,
-): ConnectionLogTerminalDataMap => ({
-  ...map,
-  [logId]: terminalData,
-});
+/** Fold side-store maps together, then cap to the allowed unsaved/saved set. */
+export const mergeTerminalDataMapsForStorage = (
+  logs: ConnectionLog[],
+  ...maps: ConnectionLogTerminalDataMap[]
+): ConnectionLogTerminalDataMap => {
+  const combined: ConnectionLogTerminalDataMap = {};
+  for (const map of maps) {
+    for (const [id, data] of Object.entries(map)) {
+      if (data) combined[id] = data;
+    }
+  }
+  return pruneTerminalDataMapForStorage(logs, combined);
+};

--- a/domain/connectionLogTerminalData.ts
+++ b/domain/connectionLogTerminalData.ts
@@ -91,21 +91,22 @@ export const pruneTerminalDataMapForStorage = (
 /** Fold side-store maps together, then cap to the allowed unsaved/saved set. */
 export const mergeTerminalDataMapsForStorage = (
   logs: ConnectionLog[],
-  ...maps: ConnectionLogTerminalDataMap[]
+  persistedSnapshot: ConnectionLogTerminalDataMap,
+  localMaps: ConnectionLogTerminalDataMap[],
+  persistedLogIds: ReadonlySet<string>,
 ): ConnectionLogTerminalDataMap => {
-  const combined: ConnectionLogTerminalDataMap = {};
-  for (const map of maps) {
+  const combined: ConnectionLogTerminalDataMap = { ...persistedSnapshot };
+  for (const map of localMaps) {
     for (const [id, data] of Object.entries(map)) {
       if (data) combined[id] = data;
     }
   }
   const pruned = pruneTerminalDataMapForStorage(logs, combined);
 
-  // Retain replay buffers for log ids this window has not loaded yet (another
-  // window may have created the log before our connectionLogs state catches up).
-  const persistedSnapshot = maps[0] ?? {};
+  // Retain replay buffers only for log ids still present in the persisted
+  // connection-log blob but not yet loaded into this window's React state.
   for (const [id, data] of Object.entries(persistedSnapshot)) {
-    if (data && !logs.some((log) => log.id === id)) {
+    if (data && !logs.some((log) => log.id === id) && persistedLogIds.has(id)) {
       pruned[id] = data;
     }
   }

--- a/domain/connectionLogTerminalData.ts
+++ b/domain/connectionLogTerminalData.ts
@@ -99,5 +99,16 @@ export const mergeTerminalDataMapsForStorage = (
       if (data) combined[id] = data;
     }
   }
-  return pruneTerminalDataMapForStorage(logs, combined);
+  const pruned = pruneTerminalDataMapForStorage(logs, combined);
+
+  // Retain replay buffers for log ids this window has not loaded yet (another
+  // window may have created the log before our connectionLogs state catches up).
+  const persistedSnapshot = maps[0] ?? {};
+  for (const [id, data] of Object.entries(persistedSnapshot)) {
+    if (data && !logs.some((log) => log.id === id)) {
+      pruned[id] = data;
+    }
+  }
+
+  return pruned;
 };

--- a/domain/connectionLogTerminalData.ts
+++ b/domain/connectionLogTerminalData.ts
@@ -105,9 +105,9 @@ export const mergeTerminalDataMapsForStorage = (
 
   // Retain replay buffers only for log ids still present in the persisted
   // connection-log blob but not yet loaded into this window's React state.
-  for (const [id, data] of Object.entries(persistedSnapshot)) {
-    if (data && !logs.some((log) => log.id === id) && persistedLogIds.has(id)) {
-      pruned[id] = data;
+  for (const id of persistedLogIds) {
+    if (!logs.some((log) => log.id === id) && combined[id]) {
+      pruned[id] = combined[id];
     }
   }
 

--- a/domain/connectionLogTerminalData.ts
+++ b/domain/connectionLogTerminalData.ts
@@ -1,0 +1,98 @@
+import type { ConnectionLog } from "./models.ts";
+
+/** Max unsaved connection logs whose terminal replay data we persist separately. */
+export const MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES = 50;
+
+export type ConnectionLogTerminalDataMap = Record<string, string>;
+
+export const readTerminalDataFromLog = (log: ConnectionLog): string | undefined =>
+  log.terminalData;
+
+export const mergeTerminalDataIntoLogs = (
+  logs: ConnectionLog[],
+  terminalDataMap: ConnectionLogTerminalDataMap,
+): ConnectionLog[] => {
+  if (logs.length === 0) return logs;
+
+  let changed = false;
+  const next = logs.map((log) => {
+    if (log.terminalData) return log;
+    const sideData = terminalDataMap[log.id];
+    if (!sideData) return log;
+    changed = true;
+    return { ...log, terminalData: sideData };
+  });
+  return changed ? next : logs;
+};
+
+/**
+ * When another window or a pruned localStorage write reloads connection logs,
+ * keep in-memory / side-store terminal replay data instead of wiping it.
+ */
+export const mergeConnectionLogsFromStorage = (
+  prev: ConnectionLog[],
+  next: ConnectionLog[],
+  terminalDataMap: ConnectionLogTerminalDataMap,
+): ConnectionLog[] => {
+  if (next.length === 0) return next;
+
+  const prevById = new Map(prev.map((log) => [log.id, log]));
+  let changed = false;
+  const merged = next.map((log) => {
+    const memoryData = readTerminalDataFromLog(prevById.get(log.id) ?? log);
+    const sideData = terminalDataMap[log.id];
+    const terminalData = memoryData ?? readTerminalDataFromLog(log) ?? sideData;
+    if (!terminalData || log.terminalData === terminalData) return log;
+    changed = true;
+    return { ...log, terminalData };
+  });
+  return changed ? merged : next;
+};
+
+export const buildTerminalDataMapFromLogs = (
+  logs: ConnectionLog[],
+): ConnectionLogTerminalDataMap => {
+  const map: ConnectionLogTerminalDataMap = {};
+  for (const log of logs) {
+    const data = readTerminalDataFromLog(log);
+    if (data) map[log.id] = data;
+  }
+  return map;
+};
+
+/**
+ * Keep only unsaved logs' terminal data, capped to the most recent entries.
+ * Saved logs keep terminalData in the main connection log blob when bookmarked.
+ */
+export const pruneTerminalDataMapForStorage = (
+  logs: ConnectionLog[],
+  map: ConnectionLogTerminalDataMap,
+): ConnectionLogTerminalDataMap => {
+  const unsavedIds = logs
+    .filter((log) => !log.saved)
+    .sort((a, b) => b.startTime - a.startTime)
+    .slice(0, MAX_PERSISTED_UNSAVED_TERMINAL_DATA_ENTRIES)
+    .map((log) => log.id);
+
+  const allowed = new Set(unsavedIds);
+  for (const log of logs) {
+    if (log.saved && map[log.id]) {
+      allowed.add(log.id);
+    }
+  }
+
+  const next: ConnectionLogTerminalDataMap = {};
+  for (const id of allowed) {
+    if (map[id]) next[id] = map[id];
+  }
+  return next;
+};
+
+export const upsertTerminalDataInMap = (
+  map: ConnectionLogTerminalDataMap,
+  logId: string,
+  terminalData: string,
+): ConnectionLogTerminalDataMap => ({
+  ...map,
+  [logId]: terminalData,
+});

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -33,6 +33,8 @@ export const STORAGE_KEY_PF_VIEW_MODE = 'netcatty_pf_view_mode_v1';
 export const STORAGE_KEY_KNOWN_HOSTS = 'netcatty_known_hosts_v1';
 export const STORAGE_KEY_SHELL_HISTORY = 'netcatty_shell_history_v1';
 export const STORAGE_KEY_CONNECTION_LOGS = 'netcatty_connection_logs_v1';
+/** Side store for unsaved connection-log terminal replay buffers (main blob omits them for perf). */
+export const STORAGE_KEY_CONNECTION_LOG_TERMINAL_DATA = 'netcatty_connection_log_terminal_data_v1';
 export const STORAGE_KEY_SESSION_RESTORE = 'netcatty_session_restore_v1';
 export const STORAGE_KEY_RESTORE_PREVIOUS_SESSION = 'netcatty_restore_previous_session_v1';
 export const STORAGE_KEY_RESTORE_TERMINAL_CWD = 'netcatty_restore_terminal_cwd_v1';


### PR DESCRIPTION
## Summary
- Persist unsaved connection log `terminalData` in a side localStorage key so the main connection-log blob can stay small without losing replay content on reload or sync.
- Merge in-memory and side-store replay data when connection logs reload from storage events (including same-window adapter notifications).
- Bind hotkey-created local terminals to `sessionId` and match terminal captures strictly by session to avoid localhost log cross-assignment.

## Test plan
- [x] `node --test --import tsx domain/connectionLog.test.ts`
- [ ] Connect multiple local consoles via hotkey, close each, and verify each log replay shows its own output
- [ ] Connect many SSH hosts, reopen logs after app restart, and verify unsaved replays still load
- [ ] With two Netcatty windows open, capture logs in one window and confirm the other does not wipe replay data


Made with [Cursor](https://cursor.com)