### PR TITLE
fix(terminal): 修复长上下文终端从后台切回时卡顿/空白/CPU 飙升 (#1735)

### DIFF
--- a/components/terminal/runtime/writeCoalescer.test.ts
+++ b/components/terminal/runtime/writeCoalescer.test.ts
@@ -6,19 +6,32 @@ import {
   MAX_PENDING_WRITE_COALESCE_BYTES,
 } from "./writeCoalescer.ts";
 
-type FrameCallback = (time: number) => void;
+type ScheduledCallback = () => void;
 
-let frameCallbacks: Map<number, FrameCallback>;
-let nextFrameId: number;
+let frameCallbacks: Map<number, ScheduledCallback>;
+let timerCallbacks: Map<number, ScheduledCallback>;
+let nextId: number;
 
-const createTestCoalescer = (write: (data: string) => void) =>
+const createTestCoalescer = (
+  write: (data: string) => void,
+  options: { maxFlushBytes?: number } = {},
+) =>
   createWriteCoalescer(write, {
+    maxFlushBytes: options.maxFlushBytes,
     scheduleFrame(callback) {
-      const id = nextFrameId;
-      nextFrameId += 1;
+      const id = nextId;
+      nextId += 1;
       frameCallbacks.set(id, callback);
       return () => {
         frameCallbacks.delete(id);
+      };
+    },
+    scheduleTimer(callback) {
+      const id = nextId;
+      nextId += 1;
+      timerCallbacks.set(id, callback);
+      return () => {
+        timerCallbacks.delete(id);
       };
     },
   });
@@ -27,13 +40,22 @@ const fireFrame = (): void => {
   const callbacks = [...frameCallbacks.values()];
   frameCallbacks.clear();
   for (const callback of callbacks) {
-    callback(performance.now());
+    callback();
+  }
+};
+
+const fireTimer = (): void => {
+  const callbacks = [...timerCallbacks.values()];
+  timerCallbacks.clear();
+  for (const callback of callbacks) {
+    callback();
   }
 };
 
 beforeEach(() => {
   frameCallbacks = new Map();
-  nextFrameId = 1;
+  timerCallbacks = new Map();
+  nextId = 1;
 });
 
 test("coalesces chunks in the same frame into one write", () => {
@@ -70,6 +92,7 @@ test("flushSync writes pending bytes immediately and cancels the scheduled frame
   assert.deepEqual(writes, ["pending"]);
 
   fireFrame();
+  fireTimer();
   assert.deepEqual(writes, ["pending"]);
 });
 
@@ -80,8 +103,12 @@ test("flushes synchronously when pending bytes exceed the cap", () => {
 
   coalescer.push(chunk);
   coalescer.push("y");
-  assert.equal(writes.length, 1);
-  assert.equal(writes[0]?.length, MAX_PENDING_WRITE_COALESCE_BYTES + 1);
+  // Over the hard ceiling it flushes synchronously (no frame needed) and, since
+  // the backlog far exceeds the per-write slice, drains the oversized chunk and
+  // the tail as separate writes rather than one giant batch.
+  assert.equal(writes.length, 2);
+  assert.equal(writes[0]?.length, MAX_PENDING_WRITE_COALESCE_BYTES);
+  assert.equal(writes[1], "y");
 });
 
 test("dispose flushes remaining bytes and stops accepting new chunks", () => {
@@ -95,4 +122,60 @@ test("dispose flushes remaining bytes and stops accepting new chunks", () => {
   coalescer.push("ignored");
   fireFrame();
   assert.deepEqual(writes, ["tail"]);
+});
+
+test("drains a backlog in bounded slices, never splitting a chunk", () => {
+  const writes: string[] = [];
+  const coalescer = createTestCoalescer((data) => writes.push(data), {
+    maxFlushBytes: 10,
+  });
+
+  coalescer.push("aaaa");
+  coalescer.push("bbbb");
+  coalescer.push("cccc");
+  coalescer.push("dddd");
+  fireFrame();
+
+  // Batched on chunk boundaries without exceeding the 10-byte slice cap.
+  assert.deepEqual(writes, ["aaaabbbb", "ccccdddd"]);
+  assert.equal(writes.join(""), "aaaabbbbccccdddd");
+});
+
+test("emits an oversized single chunk whole rather than splitting it", () => {
+  const writes: string[] = [];
+  const coalescer = createTestCoalescer((data) => writes.push(data), {
+    maxFlushBytes: 10,
+  });
+
+  const big = "x".repeat(25);
+  coalescer.push(big);
+  coalescer.push("y");
+  fireFrame();
+
+  assert.deepEqual(writes, [big, "y"]);
+});
+
+test("timer flushes the backlog when the frame never fires (hidden window)", () => {
+  const writes: string[] = [];
+  const coalescer = createTestCoalescer((data) => writes.push(data));
+
+  coalescer.push("background");
+  // rAF stays throttled (no fireFrame) — the timer fallback must still drain.
+  fireTimer();
+  assert.deepEqual(writes, ["background"]);
+
+  // The frame that lost the race was cancelled, so it cannot double-write.
+  fireFrame();
+  assert.deepEqual(writes, ["background"]);
+});
+
+test("a winning frame cancels the pending fallback timer", () => {
+  const writes: string[] = [];
+  const coalescer = createTestCoalescer((data) => writes.push(data));
+
+  coalescer.push("once");
+  fireFrame();
+  fireTimer();
+
+  assert.deepEqual(writes, ["once"]);
 });

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -8,10 +8,39 @@
  *
  * Ported from superset-sh/superset (issues #2241 / #2244):
  * apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
+ *
+ * Background-resume behaviour: while the window is hidden Chromium throttles (or
+ * fully pauses) requestAnimationFrame, so the rAF-only flush stalls and a busy
+ * source piles up to the hard ceiling. Returning to the foreground then dumps
+ * that whole batch into a single write(), whose synchronous filtering + parse
+ * kickoff janks for seconds. Two mechanisms keep the resume responsive without
+ * pausing the remote source: a timer races the frame so flushing continues when
+ * rAF is throttled, and a flush drains in bounded slices so the catch-up work
+ * is paced through the downstream write queue instead of blocking in one go.
  */
 
 /** Pending-byte ceiling when rAF is throttled (hidden window). */
 export const MAX_PENDING_WRITE_COALESCE_BYTES = 1024 * 1024;
+
+/**
+ * Upper bound on the bytes handed to a single downstream write(). A backlog
+ * accumulated while the window was hidden is drained in slices of this size so
+ * the per-write synchronous work (session-data filtering + xterm parse kickoff)
+ * stays small and the serialized write queue interleaves with the event loop —
+ * the foreground catch-up stays responsive instead of freezing for seconds.
+ * Chunk boundaries are never split, so a single chunk larger than this is still
+ * emitted whole (PTY chunks are ~16KB, comfortably under it) and normal
+ * per-frame batches (a few KB) keep emitting as one atomic write.
+ */
+export const MAX_WRITE_COALESCE_FLUSH_BYTES = 64 * 1024;
+
+/**
+ * Fallback flush delay used when requestAnimationFrame is throttled or paused
+ * (hidden window). rAF wins the race while the window is visible; this timer
+ * takes over when it does not, so the backlog keeps draining and resume no
+ * longer faces one giant accumulated batch.
+ */
+export const HIDDEN_WRITE_COALESCE_FLUSH_MS = 200;
 
 export type WriteCoalescer = {
   push(chunk: string): void;
@@ -21,6 +50,7 @@ export type WriteCoalescer = {
 };
 
 type ScheduleWriteFrame = (callback: () => void) => (() => void) | null;
+type ScheduleWriteTimer = (callback: () => void, delayMs: number) => () => void;
 
 const scheduleWriteFrame = (callback: () => void): (() => void) | null => {
   if (typeof globalThis.requestAnimationFrame === "function") {
@@ -35,28 +65,90 @@ const scheduleWriteFrame = (callback: () => void): (() => void) | null => {
   return null;
 };
 
+const scheduleWriteTimer: ScheduleWriteTimer = (callback, delayMs) => {
+  const timerId = setTimeout(callback, delayMs);
+  return () => clearTimeout(timerId);
+};
+
 export const createWriteCoalescer = (
   write: (data: string) => void,
-  options: { scheduleFrame?: ScheduleWriteFrame } = {},
+  options: {
+    scheduleFrame?: ScheduleWriteFrame;
+    scheduleTimer?: ScheduleWriteTimer;
+    maxFlushBytes?: number;
+    hiddenFlushMs?: number;
+  } = {},
 ): WriteCoalescer => {
   let pending: string[] = [];
   let pendingBytes = 0;
-  let cancelPendingFrame: (() => void) | null = null;
+  let cancelScheduled: (() => void) | null = null;
   let disposed = false;
   const scheduleFrame = options.scheduleFrame ?? scheduleWriteFrame;
+  const scheduleTimer = options.scheduleTimer ?? scheduleWriteTimer;
+  const maxFlushBytes = options.maxFlushBytes ?? MAX_WRITE_COALESCE_FLUSH_BYTES;
+  const hiddenFlushMs = options.hiddenFlushMs ?? HIDDEN_WRITE_COALESCE_FLUSH_MS;
+
+  const cancelSchedule = (): void => {
+    if (cancelScheduled !== null) {
+      cancelScheduled();
+      cancelScheduled = null;
+    }
+  };
+
+  // Drain `pending` into write() in batches no larger than maxFlushBytes,
+  // never splitting an individual chunk (keeps multi-byte sequences and normal
+  // TUI frame boundaries intact). The common case (a few KB per frame) emits
+  // exactly one batch; only a hidden-window backlog is sliced. Reset state
+  // before writing so a re-entrant push lands in a fresh batch.
+  const drainPending = (): void => {
+    const chunks = pending;
+    pending = [];
+    pendingBytes = 0;
+
+    let batch = "";
+    for (const chunk of chunks) {
+      if (batch.length > 0 && batch.length + chunk.length > maxFlushBytes) {
+        write(batch);
+        batch = "";
+      }
+      batch += chunk;
+    }
+    if (batch.length > 0) {
+      write(batch);
+    }
+  };
 
   const flushSync = (): void => {
-    if (cancelPendingFrame !== null) {
-      cancelPendingFrame();
-      cancelPendingFrame = null;
-    }
+    cancelSchedule();
     if (pendingBytes === 0) {
       return;
     }
-    const batch = pending.length === 1 ? pending[0]! : pending.join("");
-    pending = [];
-    pendingBytes = 0;
-    write(batch);
+    drainPending();
+  };
+
+  // Race a frame against a timer: rAF gives smooth per-frame batching while the
+  // window is visible; the timer is the fallback for when rAF is throttled or
+  // paused in the background, so the backlog keeps draining instead of growing
+  // to the hard ceiling and bursting on resume. Whichever fires first cancels
+  // the other.
+  const scheduleFlush = (): void => {
+    if (cancelScheduled !== null) {
+      return;
+    }
+    let cancelFrame: (() => void) | null = null;
+    let cancelTimer: (() => void) | null = null;
+    const cancelBoth = (): void => {
+      cancelFrame?.();
+      cancelTimer?.();
+    };
+    const run = (): void => {
+      cancelScheduled = null;
+      cancelBoth();
+      flushSync();
+    };
+    cancelFrame = scheduleFrame(run);
+    cancelTimer = scheduleTimer(run, hiddenFlushMs);
+    cancelScheduled = cancelBoth;
   };
 
   const push = (chunk: string): void => {
@@ -69,17 +161,7 @@ export const createWriteCoalescer = (
       flushSync();
       return;
     }
-    if (cancelPendingFrame === null) {
-      const cancelFrame = scheduleFrame(() => {
-        cancelPendingFrame = null;
-        flushSync();
-      });
-      if (cancelFrame === null) {
-        flushSync();
-        return;
-      }
-      cancelPendingFrame = cancelFrame;
-    }
+    scheduleFlush();
   };
 
   return {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1184,14 +1184,29 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       !inWorkspace || isFocusMode || isFocused
     );
 
+    // A whole-window return from the background does not change pane `isVisible`,
+    // so the pane-visibility WebGL recovery effect above never runs for this
+    // case. But Chromium can evict the GPU/WebGL context while the window is
+    // backgrounded (App Nap / occlusion), and xterm's onContextLoss then
+    // disposes the WebGL addon and silently falls back to the far slower DOM
+    // renderer — which janks on heavy / long-context output and can leave the
+    // terminal degraded until the next tab switch. Recreate the renderer on
+    // resume; ensureWebglRenderer is idempotent (a no-op unless a context loss
+    // disposed it, or WebGL is disabled for this device).
+    const recoverWebglRendererOnAppResume = () => {
+      xtermRuntimeRef.current?.ensureWebglRenderer();
+    };
+
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       if (!shouldRecoverOnAppResume()) return;
+      recoverWebglRendererOnAppResume();
       scheduleLayoutRecoveryRefit();
     };
 
     const handleWindowFocus = () => {
       if (!shouldRecoverOnAppResume()) return;
+      recoverWebglRendererOnAppResume();
       scheduleLayoutRecoveryRefit();
     };
 


### PR DESCRIPTION
Fixes #1735

## 问题
SSH 跑 Claude Code 等高输出 TUI、App 在后台停留一段时间后切回,出现 5–10s
卡顿 + CPU 飙升 + 终端短暂空白(Windows / Always 复现)。

## 根因
1. 主窗口未设 `backgroundThrottling:false` → 后台 Chromium 节流 rAF;
2. `writeCoalescer` 靠 rAF 泄洪、积压超 1MB 才强制 flush → 后台堆到 1MB;
3. `flow.received()` 记账在合并器 flush 回调内 → 后台 256KB 背压失明、SSH
   源不暂停。切回首帧巨批同步解析 + 迭代追帧 + force refit 占满主线程;GPU
   上下文被驱逐后整窗 resume 不重建 WebGL → 回退 DOM 渲染器 → 空白。

## 改动
- `writeCoalescer.ts`:分块泄洪(≤64KB、不裂 chunk)+ rAF/timer 竞速调度
- `useTerminalEffects.ts`:整窗 resume(visibilitychange/focus)恢复 WebGL(幂等)
- `writeCoalescer.test.ts`:+4 用例

## 取舍
采用“不暂停远程源”方案(避免后台运行的命令被挂起),只让切回追帧保持响应:
总 CPU 不减,但 UI 不再冻结/空白。整缓冲 reflow、多次 atlas 清除在该路径不触发
(尺寸不变),故未改动。

## 验证
- `npm run lint` 通过;`npm test`(writeCoalescer)9/9 通过。
- 真机端到端复现验证待桌面环境确认(建议:后台放 30s/2min + 远端持续输出后切回,
  用 DevTools performance trace 对比首帧 `term.write` 单批字节数与主线程长任务时长)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
