### PR TITLE
[codex] fix packaged tool cli runtime

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -144,8 +144,9 @@ module.exports = {
         'node_modules/fast-uri/**/*',
         'node_modules/json-schema-traverse/**/*',
         'electron/cli/**/*',
-        'electron/mcp/**/*'
-        ,
+        'electron/capabilities/**/*',
+        'electron/shared/**/*',
+        'electron/mcp/**/*',
         'skills/**/*'
     ],
     mac: {

--- a/electron/cli/netcatty-tool-cli.capabilities.test.cjs
+++ b/electron/cli/netcatty-tool-cli.capabilities.test.cjs
@@ -2,6 +2,8 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
 const { spawnSync } = require("node:child_process");
 const path = require("node:path");
 
@@ -16,4 +18,34 @@ test("netcatty-tool-cli capabilities lists implemented commands without app conn
   assert.ok(payload.capabilities.some((entry) => entry.id === "terminal.execute"));
   assert.ok(payload.capabilities.some((entry) => entry.id === "vault.host.get"));
   assert.ok(payload.capabilities.some((entry) => entry.id === "portforward.rules.list"));
+});
+
+test("netcatty-tool-cli capabilities runs from unpacked CLI runtime without app services", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-cli-runtime-"));
+  try {
+    const electronDir = path.join(tmpDir, "electron");
+    const cliDir = path.join(electronDir, "cli");
+    const capabilitiesDir = path.join(electronDir, "capabilities");
+
+    fs.mkdirSync(electronDir, { recursive: true });
+    fs.cpSync(path.join(__dirname), cliDir, { recursive: true });
+    fs.cpSync(path.join(__dirname, "..", "capabilities"), capabilitiesDir, { recursive: true });
+    fs.rmSync(path.join(capabilitiesDir, "index.cjs"));
+    fs.rmSync(path.join(capabilitiesDir, "services"), { recursive: true });
+
+    const result = spawnSync(process.execPath, [
+      path.join(cliDir, "netcatty-tool-cli.cjs"),
+      "capabilities",
+      "--json",
+    ], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.ok(payload.capabilities.some((entry) => entry.id === "terminal.execute"));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });

--- a/electron/cli/netcattyRpcClient.cjs
+++ b/electron/cli/netcattyRpcClient.cjs
@@ -4,10 +4,8 @@ const fs = require("node:fs");
 const net = require("node:net");
 
 const { getCliDiscoveryFilePath } = require("./discoveryPath.cjs");
-const {
-  CAPABILITY_SURFACES,
-  createNdjsonRpcClient,
-} = require("../capabilities/index.cjs");
+const { CAPABILITY_SURFACES } = require("../capabilities/constants.cjs");
+const { createNdjsonRpcClient } = require("../capabilities/rpcTransport.cjs");
 
 function createError(code, message) {
   const err = new Error(message);

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -18,6 +18,21 @@ test("unpacked MCP server includes its shared CommonJS dependencies", () => {
   );
 });
 
+test("unpacked Tool CLI includes capability runtime dependencies", () => {
+  assert.ok(
+    config.asarUnpack.includes("electron/cli/**/*"),
+    "Tool CLI launcher and scripts must stay unpacked so agents can launch them as child processes",
+  );
+  assert.ok(
+    config.asarUnpack.includes("electron/capabilities/**/*"),
+    "Tool CLI requires capability catalog, registry, policy, timeout, and RPC transport modules from the unpacked runtime path",
+  );
+  assert.ok(
+    config.asarUnpack.includes("electron/shared/**/*"),
+    "Capability policy may load shared permission grant helpers from the unpacked runtime path",
+  );
+});
+
 test("build.files excludes per-platform agent binaries", () => {
   const files = config.files;
   const expectExclusions = [


### PR DESCRIPTION
Fixes #1737

## Summary
- Keep the packaged Tool CLI from loading the full capabilities aggregate and app services at startup.
- Unpack the capability and shared runtime modules that the packaged CLI needs.
- Add regression coverage for the unpacked CLI runtime and packaging config.

## Validation
- `npm test`
- `npm run lint`