### PR TITLE
fix(pack): ship terminal flow constants in app.asar

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -46,6 +46,10 @@ module.exports = {
     files: [
         'dist/**/*',
         'electron/**/*',
+        // Main-process terminal flow control reads shared thresholds from here
+        // (terminalFlowAck.cjs). Must ship beside electron/ in app.asar.
+        'infrastructure/config/terminalFlowConstants.cjs',
+        'infrastructure/config/terminalFlowConstants.json',
         'lib/**/*.cjs',
         'lib/**/*.json',
         '!electron/.dev-config.json',

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -18,6 +18,17 @@ test("unpacked MCP server includes its shared CommonJS dependencies", () => {
   );
 });
 
+test("build.files includes shared terminal flow constants for main process", () => {
+  assert.ok(
+    config.files.includes("infrastructure/config/terminalFlowConstants.cjs"),
+    "terminalFlowAck.cjs requires infrastructure/config/terminalFlowConstants.cjs at packaged startup",
+  );
+  assert.ok(
+    config.files.includes("infrastructure/config/terminalFlowConstants.json"),
+    "terminalFlowConstants.cjs requires sibling terminalFlowConstants.json at packaged startup",
+  );
+});
+
 test("unpacked Tool CLI includes capability runtime dependencies", () => {
   assert.ok(
     config.asarUnpack.includes("electron/cli/**/*"),


### PR DESCRIPTION
## Summary
- Include `infrastructure/config/terminalFlowConstants.cjs` and `.json` in electron-builder `files` so packaged apps can start.
- Add a regression test in `scripts/electron-builder-config.test.cjs`.

## Context
v1.1.46 crashes on launch because `terminalFlowAck.cjs` requires shared flow constants that were not shipped in `app.asar`.

## Test plan
- [x] `node --test scripts/electron-builder-config.test.cjs`
- [ ] Repackage v1.1.46 and verify app launches


Made with [Cursor](https://cursor.com)