### PR TITLE
Remember terminal compose and search visibility

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -36,6 +36,7 @@ import { classifyDistroId, shouldProbeSessionCwd } from "../domain/host";
 import { supportsZmodemTerminalDragDrop } from "../lib/zmodemDragDrop";
 import { resolveHostAuth } from "../domain/sshAuth";
 import { useTerminalBackend } from "../application/state/useTerminalBackend";
+import { useStoredBoolean } from "../application/state/useStoredBoolean";
 import { useSessionLogBackend } from "../application/state/useSessionLogBackend";
 import { useTerminalLayoutSuppressActive } from "../application/state/terminalLayoutSuppressStore";
 // SFTPModal removed - SFTP is now handled by SftpSidePanel in TerminalLayer
@@ -47,6 +48,7 @@ import { useAvailableFonts } from "../application/state/fontStore";
 import { composeFontFamilyStack, type SupportedPlatform } from "../infrastructure/config/cjkFonts";
 import { resolveTerminalFontFamilyId } from "../infrastructure/config/fonts";
 import { getBuiltinTerminalThemeById } from "../infrastructure/config/terminalThemes";
+import { STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN } from "../infrastructure/config/storageKeys";
 import { useCustomThemes } from "../application/state/customThemeStore";
 
 import { TerminalConnectionDialog } from "./terminal/TerminalConnectionDialog";
@@ -504,7 +506,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   } | null>(null);
 
   // pendingUploadEntries removed - drag-drop uploads now handled by SftpSidePanel
-  const [isComposeBarOpen, setIsComposeBarOpen] = useState(false);
+  const [isComposeBarOpen, setIsComposeBarOpen] = useStoredBoolean(
+    STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN,
+    false,
+  );
   const [terminalEncoding, setTerminalEncoding] = useState<'utf-8' | 'gb18030'>(() => {
     return resolveInitialTerminalEncoding(host?.charset);
   });
@@ -1867,6 +1872,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onOpenHistory,
     onOpenTheme,
     onToggleComposeBar,
+    setIsComposeBarOpen,
     handleUpdateHostFromTerminal,
     sessionId,
     snippetPackages,

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -22,8 +22,10 @@ import { cn, normalizeLineEndings } from '../lib/utils';
 import { detectLocalOs } from '../lib/localShell';
 import { useStoredString } from '../application/state/useStoredString';
 import { useStoredNumber } from '../application/state/useStoredNumber';
+import { useStoredBoolean } from '../application/state/useStoredBoolean';
 import {
   STORAGE_KEY_SIDE_PANEL_WIDTH,
+  STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN,
 } from '../infrastructure/config/storageKeys';
 import { buildCacheKey } from '../application/state/sftp/sharedRemoteHostCache';
 import type { DropEntry } from '../lib/sftpFileUtils';
@@ -463,7 +465,10 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   );
 
   // Workspace-level compose bar state
-  const [isComposeBarOpen, setIsComposeBarOpen] = useState(false);
+  const [isComposeBarOpen, setIsComposeBarOpen] = useStoredBoolean(
+    STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN,
+    false,
+  );
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
   const workspacesRef = useRef(workspaces);
@@ -517,7 +522,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
   const handleToggleWorkspaceComposeBar = useCallback(() => {
     setIsComposeBarOpen(prev => !prev);
-  }, []);
+  }, [setIsComposeBarOpen]);
 
   const handleOpenSftp = useCallback((host: Host, initialPath?: string, pendingUploadEntries?: DropEntry[], sourceSessionId?: string) => {
     const tabId = activeTabIdRef.current;

--- a/components/terminal/hooks/useTerminalSearch.ts
+++ b/components/terminal/hooks/useTerminalSearch.ts
@@ -2,6 +2,8 @@ import type { SearchAddon } from "@xterm/addon-search";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef, useState } from "react";
 import type { RefObject } from "react";
+import { useStoredBoolean } from "../../../application/state/useStoredBoolean";
+import { STORAGE_KEY_TERMINAL_SEARCH_OPEN } from "../../../infrastructure/config/storageKeys";
 
 type SearchMatchCount = { current: number; total: number } | null;
 
@@ -28,7 +30,10 @@ export const useTerminalSearch = ({
   searchAddonRef: RefObject<SearchAddon | null>;
   termRef: RefObject<XTerm | null>;
 }) => {
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isSearchOpen, setIsSearchOpen] = useStoredBoolean(
+    STORAGE_KEY_TERMINAL_SEARCH_OPEN,
+    false,
+  );
   const [searchMatchCount, setSearchMatchCount] = useState<SearchMatchCount>(null);
   const searchTermRef = useRef<string>("");
 
@@ -37,12 +42,13 @@ export const useTerminalSearch = ({
   }, [searchAddonRef]);
 
   const handleToggleSearch = useCallback(() => {
-    setIsSearchOpen((prev) => !prev);
-    if (isSearchOpen) {
+    const next = !isSearchOpen;
+    setIsSearchOpen(next);
+    if (!next) {
       setSearchMatchCount(null);
       clearSearchDecorations();
     }
-  }, [clearSearchDecorations, isSearchOpen]);
+  }, [clearSearchDecorations, isSearchOpen, setIsSearchOpen]);
 
   const handleSearch = useCallback(
     (term: string): boolean => {
@@ -87,7 +93,7 @@ export const useTerminalSearch = ({
     setSearchMatchCount(null);
     clearSearchDecorations();
     termRef.current?.focus();
-  }, [clearSearchDecorations, termRef]);
+  }, [clearSearchDecorations, setIsSearchOpen, termRef]);
 
   return {
     isSearchOpen,

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -192,6 +192,8 @@ export const STORAGE_KEY_TERMINAL_SIDE_PANEL_TAB_ORDER = 'netcatty_terminal_side
 export const STORAGE_KEY_WORKSPACE_FOCUS_SIDEBAR_WIDTH = 'netcatty_workspace_focus_sidebar_width';
 export const STORAGE_KEY_TERMINAL_HOST_TREE_WIDTH = 'netcatty_terminal_host_tree_width_v1';
 export const STORAGE_KEY_TERMINAL_HOST_TREE_COLLAPSED = 'netcatty_terminal_host_tree_collapsed_v1';
+export const STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN = 'netcatty_terminal_compose_bar_open_v1';
+export const STORAGE_KEY_TERMINAL_SEARCH_OPEN = 'netcatty_terminal_search_open_v1';
 
 // Port Forwarding (transient cross-window broadcast key)
 export const STORAGE_KEY_PF_RECONNECT_CANCEL = '__netcatty_pf_cancel_reconnect';


### PR DESCRIPTION
## Summary
- remember terminal compose bar visibility after users open or close it
- remember terminal search bar visibility after users open or close it
- reuse a small localStorage-backed boolean helper for both states

Fixes #1743.

## Tests
- node --test --import tsx application/state/useRememberedBoolean.test.ts