### PR TITLE
[codex] scale Catty timeout for multi-step turns

### DIFF
--- a/infrastructure/ai/harness/streamTimeouts.test.ts
+++ b/infrastructure/ai/harness/streamTimeouts.test.ts
@@ -29,4 +29,32 @@ describe('buildCattyStreamTimeouts', () => {
     assert.ok(timeouts.stepMs >= expectedMinimum);
     assert.ok(timeouts.totalMs >= expectedMinimum);
   });
+
+  it('scales the total stream budget for multi-step long command turns', () => {
+    const commandTimeoutMs = 10 * 60 * 1000;
+    const singleStepBudgetMs = commandTimeoutMs + CATTY_APPROVAL_TIMEOUT_MS + (90 * 1000);
+    const timeouts = buildCattyStreamTimeouts({
+      permissionMode: 'confirm',
+      commandTimeoutMs,
+      maxIterations: 2,
+    });
+
+    assert.ok(timeouts.chunkMs >= singleStepBudgetMs);
+    assert.ok(timeouts.toolMs >= singleStepBudgetMs);
+    assert.ok(timeouts.stepMs >= singleStepBudgetMs);
+    assert.ok(timeouts.totalMs != null);
+    assert.ok(timeouts.totalMs >= singleStepBudgetMs * 2);
+  });
+
+  it('omits total timeout when the multi-step budget exceeds timer limits', () => {
+    const timeouts = buildCattyStreamTimeouts({
+      commandTimeoutMs: 86_400 * 1000,
+      maxIterations: 100,
+    });
+
+    assert.equal(timeouts.totalMs, undefined);
+    assert.ok(timeouts.chunkMs > 86_400 * 1000);
+    assert.ok(timeouts.toolMs > 86_400 * 1000);
+    assert.ok(timeouts.stepMs > 86_400 * 1000);
+  });
 });

--- a/infrastructure/ai/harness/streamTimeouts.ts
+++ b/infrastructure/ai/harness/streamTimeouts.ts
@@ -6,10 +6,12 @@ const TEN_MINUTES_MS = 10 * 60 * 1000;
 const TWO_MINUTES_MS = 2 * 60 * 1000;
 const NINETY_SECONDS_MS = 90 * 1000;
 const COMPACTION_TIMEOUT_MS = 90 * 1000;
+const MAX_ABORT_TIMEOUT_MS = 2_147_483_647;
 
 export interface BuildCattyStreamTimeoutsInput {
   permissionMode?: AIPermissionMode;
   commandTimeoutMs?: number;
+  maxIterations?: number;
 }
 
 /** v7 streamText timeout profile for Catty multi-step agent turns. */
@@ -17,12 +19,18 @@ export function buildCattyStreamTimeouts(
   input: BuildCattyStreamTimeoutsInput = {},
 ) {
   const approvalBudgetMs = input.permissionMode === 'confirm' ? CATTY_APPROVAL_TIMEOUT_MS : 0;
+  const stepCount =
+    Number.isFinite(input.maxIterations) && input.maxIterations != null && input.maxIterations > 0
+      ? Math.max(1, Math.floor(input.maxIterations))
+      : 1;
   const commandTimeoutBudgetMs =
     Number.isFinite(input.commandTimeoutMs) && input.commandTimeoutMs > 0
       ? input.commandTimeoutMs + approvalBudgetMs + NINETY_SECONDS_MS
       : 0;
+  const totalBudgetMs = Math.max(THIRTY_MINUTES_MS, commandTimeoutBudgetMs * stepCount);
+  const totalMs = totalBudgetMs <= MAX_ABORT_TIMEOUT_MS ? totalBudgetMs : undefined;
   return {
-    totalMs: Math.max(THIRTY_MINUTES_MS, commandTimeoutBudgetMs),
+    totalMs,
     stepMs: Math.max(TEN_MINUTES_MS, commandTimeoutBudgetMs),
     chunkMs: Math.max(TWO_MINUTES_MS, commandTimeoutBudgetMs),
     toolMs: Math.max(CATTY_APPROVAL_TIMEOUT_MS + NINETY_SECONDS_MS, commandTimeoutBudgetMs),

--- a/infrastructure/ai/harness/turnDrivers/cattyStreamProcessor.ts
+++ b/infrastructure/ai/harness/turnDrivers/cattyStreamProcessor.ts
@@ -126,7 +126,11 @@ export async function processCattyStream(input: ProcessCattyStreamInput): Promis
     stopWhen: isStepCount(maxIterations),
     abortSignal: signal,
     include: { rawChunks: true },
-    timeout: buildCattyStreamTimeouts({ permissionMode: runtimeContext.permissionMode, commandTimeoutMs }),
+    timeout: buildCattyStreamTimeouts({
+      permissionMode: runtimeContext.permissionMode,
+      commandTimeoutMs,
+      maxIterations,
+    }),
     telemetry: {
       functionId: `catty-${runtimeContext.agentKind}`,
       metadata: {


### PR DESCRIPTION
Follow-up for the Codex review comment on #1748.\n\nThis adjusts Catty stream timeout sizing so the total turn budget accounts for multiple long-running steps instead of only one command-sized step. It keeps the per-step/tool/chunk budgets unchanged, and omits the global total timeout when the computed multi-step budget exceeds the safe timer range.\n\nValidation:\n- node --test --import tsx infrastructure/ai/harness/streamTimeouts.test.ts infrastructure/ai/harness/cattyStreamProcessor.test.ts infrastructure/ai/harness/cattyTurnDriver.attachments.test.ts\n- npm test\n- npm run lint\n- npm run build\n\nNote: repo-wide npx tsc --noEmit still reports existing Catty SDK typing issues unrelated to this change.