### PR TITLE
[codex] Recover terminal renderer on app resume

### DIFF
--- a/components/terminal/appResumeWebglRecovery.test.ts
+++ b/components/terminal/appResumeWebglRecovery.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const assertHandlerRecoversWebglBeforeRefit = (
+  source: string,
+  handlerName: string,
+): void => {
+  const handlerIndex = source.indexOf(`const ${handlerName} = () => {`);
+  assert.notEqual(handlerIndex, -1, `${handlerName} must exist`);
+
+  const nextHandlerIndex = source.indexOf("const ", handlerIndex + 1);
+  const handlerSource = source.slice(
+    handlerIndex,
+    nextHandlerIndex === -1 ? undefined : nextHandlerIndex,
+  );
+  const recoveryIndex = handlerSource.indexOf("recoverWebglRendererOnAppResume()");
+  const refitIndex = handlerSource.indexOf("scheduleLayoutRecoveryRefit()");
+
+  assert.notEqual(recoveryIndex, -1, `${handlerName} must recover WebGL on app resume`);
+  assert.notEqual(refitIndex, -1, `${handlerName} must schedule layout recovery`);
+  assert.ok(
+    recoveryIndex < refitIndex,
+    `${handlerName} must recover WebGL before layout recovery`,
+  );
+};
+
+test("app resume handlers recover the terminal renderer before refit", () => {
+  const source = readFileSync(new URL("./useTerminalEffects.ts", import.meta.url), "utf8");
+
+  assertHandlerRecoversWebglBeforeRefit(source, "handleVisibilityChange");
+  assertHandlerRecoversWebglBeforeRefit(source, "handleWindowFocus");
+});

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1242,14 +1242,20 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       !inWorkspace || isFocusMode || isFocused
     );
 
+    const recoverWebglRendererOnAppResume = () => {
+      xtermRuntimeRef.current?.ensureWebglRenderer();
+    };
+
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       if (!shouldRecoverOnAppResume()) return;
+      recoverWebglRendererOnAppResume();
       scheduleLayoutRecoveryRefit();
     };
 
     const handleWindowFocus = () => {
       if (!shouldRecoverOnAppResume()) return;
+      recoverWebglRendererOnAppResume();
       scheduleLayoutRecoveryRefit();
     };
 


### PR DESCRIPTION
## Summary

This extracts the low-risk app-resume renderer recovery piece from #1736 onto current `main`.

When Netcatty returns from the background or regains focus, the active terminal pane now asks the xterm runtime to restore the WebGL renderer before running the existing layout recovery. This covers the case where the whole app resumes without a tab or pane visibility change.

This PR intentionally does not include the write coalescer changes from #1736, because current `main` already has newer terminal flow-control work that addresses the output backlog side of #1735.

## Validation

- `node --test --import tsx components/terminal/appResumeWebglRecovery.test.ts components/terminal/TerminalView.test.tsx components/terminal/restoredSessionGate.test.ts components/terminal/selectionOverlayPosition.test.ts`
- `npm run lint` (passes with two pre-existing warnings in `components/Terminal.tsx`)