### PR TITLE
fix(sftp): 同一终端重开 SFTP 恢复上次浏览目录

### DIFF
--- a/application/state/sftp/sftpReopenLocation.test.ts
+++ b/application/state/sftp/sftpReopenLocation.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveSftpOpenLocation } from "./sftpReopenLocation.ts";
+
+test("first open of a terminal lands on the terminal CWD", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    terminalCwd: "/home/deploy",
+    remembered: null,
+  });
+
+  assert.equal(location, "/home/deploy");
+});
+
+test("re-opening the same terminal restores the last browsed path, not the terminal CWD", () => {
+  // Repro: SFTP first opened at /home/deploy (terminal CWD), user navigated
+  // into /home/deploy/projects/app, closed, then re-opened. The terminal shell
+  // never moved, so terminalCwd is still /home/deploy — but the panel must
+  // return to the folder the user was browsing.
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    terminalCwd: "/home/deploy",
+    remembered: { hostId: "host-1", path: "/home/deploy/projects/app" },
+  });
+
+  assert.equal(location, "/home/deploy/projects/app");
+});
+
+test("remembered path for a different host is ignored in favour of the terminal CWD", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-2",
+    terminalCwd: "/srv",
+    remembered: { hostId: "host-1", path: "/home/deploy/projects/app" },
+  });
+
+  assert.equal(location, "/srv");
+});
+
+test("an empty remembered path falls back to the terminal CWD", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    terminalCwd: "/srv",
+    remembered: { hostId: "host-1", path: "" },
+  });
+
+  assert.equal(location, "/srv");
+});
+
+test("no remembered path and no terminal CWD yields undefined", () => {
+  assert.equal(
+    resolveSftpOpenLocation({ hostId: "host-1", remembered: null }),
+    undefined,
+  );
+  assert.equal(
+    resolveSftpOpenLocation({ hostId: "host-1", terminalCwd: "", remembered: null }),
+    undefined,
+  );
+});

--- a/application/state/sftp/sftpReopenLocation.ts
+++ b/application/state/sftp/sftpReopenLocation.ts
@@ -1,0 +1,30 @@
+export interface SftpRememberedLocation {
+  hostId: string;
+  path: string;
+}
+
+/**
+ * Decides which directory a terminal-opened SFTP panel should land on.
+ *
+ * The first time SFTP is opened for a terminal there is no remembered location,
+ * so it lands on the terminal's current working directory. Re-opening the same
+ * terminal restores the last directory the user browsed to in that terminal's
+ * SFTP panel — otherwise it would snap back to the terminal CWD, which never
+ * moves while the user only navigates inside SFTP.
+ *
+ * The remembered location only applies when it belongs to the host being opened;
+ * switching to a different host falls back to the terminal CWD.
+ */
+export function resolveSftpOpenLocation(params: {
+  hostId: string;
+  terminalCwd?: string;
+  remembered?: SftpRememberedLocation | null;
+}): string | undefined {
+  const { hostId, terminalCwd, remembered } = params;
+
+  if (remembered && remembered.hostId === hostId && remembered.path) {
+    return remembered.path;
+  }
+
+  return terminalCwd && terminalCwd.length > 0 ? terminalCwd : undefined;
+}

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -68,6 +68,7 @@ interface SftpSidePanelProps {
   activeSessionId?: string | null;
   initialLocation?: { hostId: string; path: string } | null;
   onInitialLocationApplied?: (location: { hostId: string; path: string }) => void;
+  onCurrentPathChange?: (location: { hostId: string; path: string }) => void;
   showWorkspaceHostHeader?: boolean;
   isVisible?: boolean;
   renderOverlays?: boolean;
@@ -108,6 +109,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   activeSessionId,
   initialLocation,
   onInitialLocationApplied,
+  onCurrentPathChange,
   showWorkspaceHostHeader = false,
   isVisible = true,
   renderOverlays = true,
@@ -386,6 +388,21 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     onInitialLocationApplied,
     sftp.leftPane,
   ]);
+
+  // Report the directory currently browsed so the terminal layer can restore it
+  // when this terminal's SFTP panel is closed and re-opened.
+  const onCurrentPathChangeRef = useRef(onCurrentPathChange);
+  onCurrentPathChangeRef.current = onCurrentPathChange;
+  useEffect(() => {
+    const connection = sftp.leftPane.connection;
+    if (!connection || connection.isLocal) return;
+    if (connection.status !== "connected") return;
+    if (!connection.currentPath) return;
+    onCurrentPathChangeRef.current?.({
+      hostId: connection.hostId,
+      path: connection.currentPath,
+    });
+  }, [sftp.leftPane.connection]);
 
   useEffect(() => {
     if (!pendingUpload || !activeHost) return;

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -28,6 +28,7 @@ import {
   STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN,
 } from '../infrastructure/config/storageKeys';
 import { buildCacheKey } from '../application/state/sftp/sharedRemoteHostCache';
+import { resolveSftpOpenLocation, type SftpRememberedLocation } from '../application/state/sftp/sftpReopenLocation';
 import type { DropEntry } from '../lib/sftpFileUtils';
 import { Host, KnownHost, TerminalSession, Workspace } from '../types';
 import { applySessionFontSizeToHost } from '../domain/terminalAppearance';
@@ -531,6 +532,9 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const notesOpenRequestIdRef = useRef(0);
   const sftpHostForTabRef = useRef(sftpHostForTab);
   sftpHostForTabRef.current = sftpHostForTab;
+  // Last directory browsed in each terminal tab's SFTP panel, kept across the
+  // panel being closed/unmounted so re-opening the same terminal restores it.
+  const sftpLastPathForTabRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
 
   const handleToggleWorkspaceComposeBar = useCallback(() => {
     setIsComposeBarOpen(prev => !prev);
@@ -589,10 +593,20 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return next;
     });
 
+    // First open of a terminal lands on the terminal CWD; re-opening restores
+    // the last directory browsed in this terminal's SFTP panel. Drag-and-drop
+    // uploads keep their explicit target path.
+    const effectiveInitialPath = pendingUploadEntries?.length
+      ? initialPath
+      : resolveSftpOpenLocation({
+          hostId: host.id,
+          terminalCwd: initialPath,
+          remembered: sftpLastPathForTabRef.current.get(tabId),
+        });
     setSftpInitialLocationForTab(prev => {
       const next = new Map(prev);
-      if (initialPath) {
-        next.set(tabId, { hostId: host.id, path: initialPath });
+      if (effectiveInitialPath) {
+        next.set(tabId, { hostId: host.id, path: effectiveInitialPath });
       } else {
         next.delete(tabId);
       }
@@ -639,6 +653,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.delete(tabId);
       return next;
     });
+  }, []);
+
+  const handleSftpCurrentPathChange = useCallback((tabId: string, location: SftpRememberedLocation) => {
+    if (!location.path) return;
+    sftpLastPathForTabRef.current.set(tabId, location);
   }, []);
 
   // Pre-compute host lookup map for O(1) access
@@ -1377,6 +1396,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     handlePendingTerminalSelectionConsumed,
     handlePendingUploadHandled,
     handleSessionExit,
+    handleSftpCurrentPathChange,
     handleSftpInitialLocationApplied,
     persistSidePanelWidth,
     handleSnippetClickForFocusedSession,

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -122,6 +122,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
     activeTerminalSessionForSystem,
     activeSystemSessionHost,
     handlePendingTerminalSelectionConsumed,
+    handleSftpCurrentPathChange,
     handleSftpInitialLocationApplied,
     handleSnippetFromPanel,
     handleThemeChangeForFocusedSession,
@@ -534,6 +535,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                       : null
                   }
                   onInitialLocationApplied={(location) => handleSftpInitialLocationApplied(tabId, location)}
+                  onCurrentPathChange={(location) => handleSftpCurrentPathChange(tabId, location)}
                   showWorkspaceHostHeader={isVisibleSftpPanel && !!activeWorkspace}
                   isVisible={isVisibleSftpPanel}
                   renderOverlays={isVisibleSftpPanel}


### PR DESCRIPTION
## 概述

Fixes #1753.

从终端打开 SFTP、进入子目录、关闭后在**同一个终端**重开时,面板会跳回第一次打开的目录(终端 CWD),而不是用户上次浏览的目录。

## 根因

`handleOpenSftp`(`components/TerminalLayer.tsx`)每次打开都把 `initialLocation` 设为终端实时 CWD。由于用户只在 SFTP 内导航时终端 shell 不移动,重开时捕获到的 CWD 不变;面板连接后,`components/SftpSidePanel.tsx` 的二次导航 effect 导航到该 CWD,覆盖了 host 级内存缓存(`sharedRemoteHostCache`)刚恢复的上次路径。

## 改动

- **新增纯函数** `resolveSftpOpenLocation`(`application/state/sftp/sftpReopenLocation.ts`):该终端记住的同 host 路径存在则用它,否则回退终端 CWD;附单元测试。
- **`SftpSidePanel`**:新增 `onCurrentPathChange`,连接后上报当前浏览目录。
- **`TerminalLayer`**:按终端标签页(tabId)用 ref 记住最后浏览路径(跨面板关闭/卸载存活),重开时经上述纯函数优先采用。

## 行为

- 首次打开终端 → 终端 CWD(不变)。
- 导航后重开 → 上次浏览目录(已修复)。
- 拖拽上传仍使用显式目标路径;"跳到终端 cwd"按钮与 follow-terminal-cwd 开关不受影响。

## 测试

- `node --test`:`resolveSftpOpenLocation` 新增 5 个用例全过。
- 既有 SFTP 状态层 / 组件 / `terminalLayer` 套件:155/155 通过。
- 改动文件 `eslint` 干净;`tsc` 在改动文件无新增错误。
- 尚未在桌面运行版验证(无 GUI 环境);改动属逻辑层,已由单测 + 数据流分析覆盖。

## 备注

记忆为会话内内存(与当前 SFTP 路径的保存方式一致),不跨 app 重启。后续可在终端标签页彻底关闭时清理该 tab 记住的条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
