### PR TITLE
Fix restored session sidebar chrome for host tree and side panel

### DIFF
--- a/application/app/AppHostTreeLayer.test.ts
+++ b/application/app/AppHostTreeLayer.test.ts
@@ -42,3 +42,9 @@ test('host tree layer hides immediately when leaving work tab surfaces', () => {
   assert.match(hostTreeLayerSource, /getAppHostTreeLayerStyle\(surfaceVisible\)/);
   assert.doesNotMatch(hostTreeLayerSource, /layerVisible/);
 });
+
+test('shared host tree theme follows active chrome resolution and manual chrome injection', () => {
+  assert.match(hostTreeLayerSource, /resolveActiveChromeTheme/);
+  assert.match(hostTreeLayerSource, /useManualTerminalChromeSurfaceInjection/);
+  assert.match(hostTreeLayerSource, /resolveSessionAppearance/);
+});

--- a/application/app/AppHostTreeLayer.tsx
+++ b/application/app/AppHostTreeLayer.tsx
@@ -3,12 +3,17 @@ import React, { useMemo } from 'react';
 import { useActiveTabId } from '../state/activeTabStore';
 import type { EditorTab } from '../state/editorTabStore';
 import type { LogView } from '../state/logViewState';
+import { useManualTerminalChromeSurfaceInjection } from '../state/useManualTerminalChromeSurfaceInjection';
 import { TerminalHostTreeSidebar } from '../../components/terminalLayer/TerminalHostTreeSidebar';
+import type {
+  ResolvedAppearance,
+  TerminalAppearanceHostScope,
+} from '../../domain/terminalAppearanceRuntime';
 import type { GroupConfig, Host, TerminalSession, TerminalTheme, Workspace } from '../../types';
+import { resolveActiveChromeTheme } from './activeChromeTheme';
 import {
   isHostTreeWorkTabSurface,
   resolveWorkTabActiveHostId,
-  resolveWorkTabHostTreeTheme,
 } from './workTabSurface';
 
 interface AppHostTreeLayerProps {
@@ -27,6 +32,7 @@ interface AppHostTreeLayerProps {
   followAppTerminalTheme: boolean;
   hostById: ReadonlyMap<string, Host>;
   themeById: ReadonlyMap<string, TerminalTheme>;
+  resolveSessionAppearance?: (hostScope: TerminalAppearanceHostScope) => ResolvedAppearance;
   onConnect: (host: Host) => void;
   onCreateLocalTerminal?: () => void;
 }
@@ -55,6 +61,7 @@ export const AppHostTreeLayer: React.FC<AppHostTreeLayerProps> = ({
   followAppTerminalTheme,
   hostById,
   themeById,
+  resolveSessionAppearance,
   onConnect,
   onCreateLocalTerminal,
 }) => {
@@ -62,6 +69,14 @@ export const AppHostTreeLayer: React.FC<AppHostTreeLayerProps> = ({
   const sessionIds = useMemo(() => new Set(sessions.map((session) => session.id)), [sessions]);
   const workspaceIds = useMemo(() => new Set(workspaces.map((workspace) => workspace.id)), [workspaces]);
   const logViewIds = useMemo(() => new Set(logViews.map((logView) => logView.id)), [logViews]);
+  const sessionById = useMemo(
+    () => new Map(sessions.map((session) => [session.id, session])),
+    [sessions],
+  );
+  const workspaceById = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+    [workspaces],
+  );
   const surfaceVisible = isHostTreeWorkTabSurface({
     enabled,
     activeTabId,
@@ -78,23 +93,40 @@ export const AppHostTreeLayer: React.FC<AppHostTreeLayerProps> = ({
     workspaces,
   }), [activeTabId, editorTabs, sessions, workspaces]);
 
-  const hostTreeTheme = useMemo(() => resolveWorkTabHostTreeTheme({
-    activeHostId,
+  const hostTreeTheme = useMemo(() => (
+    resolveActiveChromeTheme({
+      accentMode,
+      activeTabId,
+      currentTerminalTheme,
+      customAccent,
+      editorTabs,
+      followAppTerminalTheme,
+      hostById,
+      logViews,
+      resolveSessionAppearance,
+      sessionById,
+      themeById,
+      workspaceById,
+    }) ?? currentTerminalTheme
+  ), [
     accentMode,
+    activeTabId,
     currentTerminalTheme,
     customAccent,
+    editorTabs,
     followAppTerminalTheme,
     hostById,
+    logViews,
+    resolveSessionAppearance,
+    sessionById,
     themeById,
-  }), [
-    activeHostId,
-    accentMode,
-    currentTerminalTheme,
-    customAccent,
-    followAppTerminalTheme,
-    hostById,
-    themeById,
+    workspaceById,
   ]);
+
+  useManualTerminalChromeSurfaceInjection(
+    hostTreeTheme,
+    !followAppTerminalTheme && surfaceVisible,
+  );
 
   return (
     <div

--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -97,7 +97,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
     hostById, hosts, hotkeyScheme, identities, importOrReuseKey, isBroadcastEnabled, isCreateWorkspaceOpen, isMacClient, isQuickSwitcherOpen,
     keyBindings, keyboardInteractiveQueue, keys, logViews, managedSources, navigateToSection, noteGroups, notes, openLogView, openNoteRequest, orderedTabsWithEditors, orphanSessions,
     passphraseQueue, protocolSelectHost, proxyProfiles, portForwardingRules, quickResults, quickSearch, removeSessionFromWorkspace, reorderWorkTabs, reorderWorkspaceSessions,
-    resolveEmptyVaultConflict, resolvedTheme, runSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sshDebugLogsEnabled,
+    resolveEmptyVaultConflict, resolvedTheme, resolveSessionAppearance, runSnippet, sessionLogsDir, sessionLogsEnabled, sessionLogsFormat, sessionLogsTimestampsEnabled, sessionRenameTarget, sshDebugLogsEnabled,
     sessionRenameValue, sessions, setActiveTabId, setDeepLinkHostDraft, setDraggingSessionId, setEditorWordWrap,
     setNavigateToSection, setSessionRenameValue, setTerminalFontFamilyId, setTerminalFontSize, setVaultFocusRequest, updateSessionFontSize, updateSessionRestoreCwd, updateSessionDynamicTitle, updateSessionCodingCliProvider, clearSessionFontSizeOverride,
     setWorkspaceFocusedSession, setWorkspaceRenameValue, settings, sftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpAutoSync, sftpDefaultViewMode, sftpDoubleClickBehavior,
@@ -225,6 +225,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
           followAppTerminalTheme={followAppTerminalTheme}
           hostById={hostById}
           themeById={themeById}
+          resolveSessionAppearance={resolveSessionAppearance}
           onConnect={handleConnectToHost}
           onCreateLocalTerminal={handleCreateLocalTerminal}
         />

--- a/application/app/activeChromeTheme.test.ts
+++ b/application/app/activeChromeTheme.test.ts
@@ -182,6 +182,43 @@ test("manual workspace split view uses the focused session theme when panes diff
   assert.equal(resolved?.id, focusedTheme.id);
 });
 
+test("manual split workspace falls back to the first tree session theme when focus is stale", () => {
+  const workspace: Workspace = {
+    id: "ws-1",
+    name: "Workspace",
+    viewMode: "split",
+    focusedSessionId: "missing-session",
+    root: {
+      type: "split",
+      direction: "horizontal",
+      sizes: [50, 50],
+      children: [
+        { type: "pane", sessionId: "session-1" },
+        { type: "pane", sessionId: "session-2" },
+      ],
+    },
+  } as unknown as Workspace;
+
+  const hostA = { id: "host-a", theme: hostTheme.id, themeOverride: true } as unknown as Host;
+  const hostB = { id: "host-b", theme: logTheme.id, themeOverride: true } as unknown as Host;
+
+  const resolved = resolveActiveChromeTheme({
+    ...baseInput,
+    activeTabId: "ws-1",
+    hostById: new Map([
+      ["host-a", hostA],
+      ["host-b", hostB],
+    ]),
+    sessionById: new Map([
+      ["session-1", { id: "session-1", hostId: "host-a" } as TerminalSession],
+      ["session-2", { id: "session-2", hostId: "host-b" } as TerminalSession],
+    ]),
+    workspaceById: new Map([["ws-1", workspace]]),
+  });
+
+  assert.equal(resolved?.id, hostTheme.id);
+});
+
 test("manual mode prefers runtime session appearance over stale host theme ids", () => {
   const intentTheme = theme("intent-theme");
   const resolved = resolveActiveChromeTheme({

--- a/application/app/activeChromeTheme.ts
+++ b/application/app/activeChromeTheme.ts
@@ -9,6 +9,7 @@ import { collectSessionIds } from "../../domain/workspace";
 import type { EditorTab } from "../state/editorTabStore";
 import type { LogView } from "../state/logViewState";
 import type { Host, TerminalSession, TerminalTheme, Workspace } from "../../types";
+import { resolveWorkspaceTargetSessionFromMap } from "./workTabSurface";
 
 export type ResolveActiveChromeThemeInput = {
   accentMode: "theme" | "custom";
@@ -97,11 +98,7 @@ export function resolveActiveChromeTheme({
     if (followAppTerminalTheme) return currentTerminalTheme;
 
     if (workspace.viewMode === "focus") {
-      const workspaceSessionIds = collectSessionIds(workspace.root);
-      const focusedSession = (workspace.focusedSessionId
-        ? sessionById.get(workspace.focusedSessionId)
-        : null)
-        ?? workspaceSessionIds.map((id) => sessionById.get(id)).find(Boolean);
+      const focusedSession = resolveWorkspaceTargetSessionFromMap(workspace, sessionById);
       return focusedSession ? resolveSessionTheme(focusedSession) : null;
     }
 
@@ -114,9 +111,7 @@ export function resolveActiveChromeTheme({
     const allSame = workspaceSessions.every((session) => resolveSessionTheme(session).id === firstTheme.id);
     if (allSame) return firstTheme;
 
-    const focusedSession = workspace.focusedSessionId
-      ? sessionById.get(workspace.focusedSessionId)
-      : null;
+    const focusedSession = resolveWorkspaceTargetSessionFromMap(workspace, sessionById);
     return focusedSession ? resolveSessionTheme(focusedSession) : null;
   }
 

--- a/application/app/workTabSurface.test.ts
+++ b/application/app/workTabSurface.test.ts
@@ -164,6 +164,34 @@ test('shared host tree falls back to the first workspace session when focused se
   }), 'host-1');
 });
 
+test('shared host tree fallback prefers workspace tree order over sessions array order', () => {
+  const sessions = [
+    { id: 'session-2', hostId: 'host-2', workspaceId: 'workspace-1' },
+    { id: 'session-1', hostId: 'host-1', workspaceId: 'workspace-1' },
+  ] as TerminalSession[];
+  const workspaces = [{
+    id: 'workspace-1',
+    focusedSessionId: 'missing-session',
+    root: {
+      id: 'split-1',
+      type: 'split',
+      direction: 'horizontal',
+      children: [
+        { id: 'pane-1', type: 'pane', sessionId: 'session-1' },
+        { id: 'pane-2', type: 'pane', sessionId: 'session-2' },
+      ],
+      sizes: [0.5, 0.5],
+    },
+  }] as Workspace[];
+
+  assert.equal(resolveWorkTabActiveHostId({
+    activeTabId: 'workspace-1',
+    sessions,
+    workspaces,
+    editorTabs: [],
+  }), 'host-1');
+});
+
 test('shared host tree uses the active host theme when follow-app terminal theme is off', () => {
   const currentTheme = makeTheme('app-dark', 'dark', '#111111');
   const hostTheme = makeTheme('host-light', 'light', '#fafafa');

--- a/application/app/workTabSurface.test.ts
+++ b/application/app/workTabSurface.test.ts
@@ -119,11 +119,13 @@ test('terminal content surface is limited to sessions and workspaces', () => {
 test('shared host tree resolves active host ids across work tab types', () => {
   const sessions = [
     { id: 'session-1', hostId: 'host-1' },
-    { id: 'session-2', hostId: 'host-2' },
+    { id: 'session-2', hostId: 'host-2', workspaceId: 'workspace-1' },
   ] as TerminalSession[];
-  const workspaces = [
-    { id: 'workspace-1', focusedSessionId: 'session-2' },
-  ] as Workspace[];
+  const workspaces = [{
+    id: 'workspace-1',
+    focusedSessionId: 'session-2',
+    root: { id: 'pane-2', type: 'pane', sessionId: 'session-2' },
+  }] as Workspace[];
   const editorTabs = [
     { id: 'file-1', hostId: 'host-3' },
   ] as EditorTab[];
@@ -132,6 +134,34 @@ test('shared host tree resolves active host ids across work tab types', () => {
   assert.equal(resolveWorkTabActiveHostId({ activeTabId: 'workspace-1', sessions, workspaces, editorTabs }), 'host-2');
   assert.equal(resolveWorkTabActiveHostId({ activeTabId: 'editor:file-1', sessions, workspaces, editorTabs }), 'host-3');
   assert.equal(resolveWorkTabActiveHostId({ activeTabId: 'log-1', sessions, workspaces, editorTabs }), null);
+});
+
+test('shared host tree falls back to the first workspace session when focused session is missing', () => {
+  const sessions = [
+    { id: 'session-1', hostId: 'host-1', workspaceId: 'workspace-1' },
+    { id: 'session-2', hostId: 'host-2', workspaceId: 'workspace-1' },
+  ] as TerminalSession[];
+  const workspaces = [{
+    id: 'workspace-1',
+    focusedSessionId: 'missing-session',
+    root: {
+      id: 'split-1',
+      type: 'split',
+      direction: 'horizontal',
+      children: [
+        { id: 'pane-1', type: 'pane', sessionId: 'session-1' },
+        { id: 'pane-2', type: 'pane', sessionId: 'session-2' },
+      ],
+      sizes: [0.5, 0.5],
+    },
+  }] as Workspace[];
+
+  assert.equal(resolveWorkTabActiveHostId({
+    activeTabId: 'workspace-1',
+    sessions,
+    workspaces,
+    editorTabs: [],
+  }), 'host-1');
 });
 
 test('shared host tree uses the active host theme when follow-app terminal theme is off', () => {

--- a/application/app/workTabSurface.ts
+++ b/application/app/workTabSurface.ts
@@ -98,6 +98,34 @@ export function isTerminalContentTabSurface({
   return sessionIds.has(activeTabId) || workspaceIds.has(activeTabId);
 }
 
+export function resolveWorkspaceTargetSession(
+  workspace: Workspace,
+  sessions: readonly TerminalSession[],
+): TerminalSession | undefined {
+  const sessionById = new Map(sessions.map((session) => [session.id, session]));
+  return resolveWorkspaceTargetSessionFromMap(workspace, sessionById);
+}
+
+export function resolveWorkspaceTargetSessionFromMap(
+  workspace: Workspace,
+  sessionById: ReadonlyMap<string, TerminalSession>,
+): TerminalSession | undefined {
+  const orderedSessionIds = collectSessionIds(workspace.root);
+  const workspaceSessionIdSet = new Set(orderedSessionIds);
+  const focusedSession = workspace.focusedSessionId
+    ? sessionById.get(workspace.focusedSessionId)
+    : undefined;
+  const validFocusedSession = focusedSession && workspaceSessionIdSet.has(focusedSession.id)
+    ? focusedSession
+    : undefined;
+  if (validFocusedSession) return validFocusedSession;
+  for (const sessionId of orderedSessionIds) {
+    const session = sessionById.get(sessionId);
+    if (session) return session;
+  }
+  return undefined;
+}
+
 export function resolveWorkTabActiveHostId({
   activeTabId,
   editorTabs,
@@ -120,17 +148,7 @@ export function resolveWorkTabActiveHostId({
   const activeWorkspace = workspaces.find((workspace) => workspace.id === activeTabId);
   if (!activeWorkspace) return null;
 
-  const workspaceSessionIds = new Set(collectSessionIds(activeWorkspace.root));
-  const focusedSessionId = activeWorkspace.focusedSessionId;
-  const focusedSession = focusedSessionId
-    ? sessions.find((session) => session.id === focusedSessionId)
-    : undefined;
-  const validFocusedSession = focusedSession && workspaceSessionIds.has(focusedSession.id)
-    ? focusedSession
-    : undefined;
-  const targetSession = validFocusedSession
-    ?? sessions.find((session) => workspaceSessionIds.has(session.id));
-
+  const targetSession = resolveWorkspaceTargetSession(activeWorkspace, sessions);
   return targetSession?.hostId ?? null;
 }
 

--- a/application/app/workTabSurface.ts
+++ b/application/app/workTabSurface.ts
@@ -3,6 +3,7 @@ import {
   isEditorTabId,
 } from '../state/activeTabStore';
 import { applyCustomAccentToTerminalTheme, resolveHostTerminalThemeId } from '../../domain/terminalAppearance';
+import { collectSessionIds } from '../../domain/workspace';
 import type { EditorTab } from '../state/editorTabStore';
 import type { Host, TerminalSession, TerminalTheme, Workspace } from '../../types';
 
@@ -119,12 +120,18 @@ export function resolveWorkTabActiveHostId({
   const activeWorkspace = workspaces.find((workspace) => workspace.id === activeTabId);
   if (!activeWorkspace) return null;
 
+  const workspaceSessionIds = new Set(collectSessionIds(activeWorkspace.root));
   const focusedSessionId = activeWorkspace.focusedSessionId;
-  if (focusedSessionId) {
-    return sessions.find((session) => session.id === focusedSessionId)?.hostId ?? null;
-  }
+  const focusedSession = focusedSessionId
+    ? sessions.find((session) => session.id === focusedSessionId)
+    : undefined;
+  const validFocusedSession = focusedSession && workspaceSessionIds.has(focusedSession.id)
+    ? focusedSession
+    : undefined;
+  const targetSession = validFocusedSession
+    ?? sessions.find((session) => workspaceSessionIds.has(session.id));
 
-  return null;
+  return targetSession?.hostId ?? null;
 }
 
 export function resolveWorkTabHostTreeTheme({

--- a/application/state/useManualTerminalChromeSurfaceInjection.test.ts
+++ b/application/state/useManualTerminalChromeSurfaceInjection.test.ts
@@ -11,6 +11,7 @@ test('manual mode injects chrome surfaces from focused session theme', () => {
   assert.match(appSource, /includeChromeSurfaces: followAppTerminalTheme/);
   assert.match(bridgeSource, /useManualTerminalChromeSurfaceInjection/);
   assert.match(bridgeSource, /!s\.followAppTerminalTheme && isTerminalLayerVisible/);
+  assert.match(readFileSync(new URL('../app/AppHostTreeLayer.tsx', import.meta.url), 'utf8'), /useManualTerminalChromeSurfaceInjection/);
   assert.match(appSource, /resolveSessionAppearance=\{themeRuntime\.resolveFocusedAppearance\}/);
   assert.match(hookSource, /applyTopTabsChromeThemeVars\(theme\)/);
   assert.match(hookSource, /injectTerminalLayerChromeSurfaceVars\(theme\)/);

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -419,7 +419,12 @@ const HostTreeFlatRowItem = memo<HostTreeFlatRowProps>(({
             style={{ color: theme.termFg }}
           />
         ) : (
-          <span className="flex h-5 min-w-0 flex-1 translate-y-px items-center truncate leading-none">{row.host.label}</span>
+          <span
+            className="flex h-5 min-w-0 flex-1 translate-y-px items-center truncate leading-none"
+            style={{ color: theme.termFg }}
+          >
+            {row.host.label}
+          </span>
         )}
         {row.host.protocol && row.host.protocol !== 'ssh' && (
           <span className="flex h-5 shrink-0 translate-y-px items-center text-[10px] leading-none uppercase opacity-70" style={{ color: theme.mutedFg }}>

--- a/components/terminalLayer/TerminalHostTreeToolbar.test.ts
+++ b/components/terminalLayer/TerminalHostTreeToolbar.test.ts
@@ -8,6 +8,8 @@ test('host tree toolbar keeps the close button outside the clipped action row', 
   assert.match(source, /data-section="terminal-host-tree-toolbar-actions"/);
   assert.match(source, /data-section="terminal-host-tree-toolbar-close"/);
   assert.match(source, /data-section="terminal-host-tree-toolbar-actions-fade"/);
+  assert.match(source, /data-section="terminal-host-tree-toolbar"/);
+  assert.match(source, /backgroundColor: theme\.termBg/);
   assert.match(source, /linear-gradient\(to right, transparent, \$\{theme\.termBg\}\)/);
   assert.doesNotMatch(source, /compactActions/);
   assert.doesNotMatch(source, /flex-1 min-w-0" \/>/);

--- a/components/terminalLayer/TerminalHostTreeToolbar.tsx
+++ b/components/terminalLayer/TerminalHostTreeToolbar.tsx
@@ -86,7 +86,10 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
     <div className="flex-shrink-0">
       <div
         className="flex h-9 shrink-0 min-w-0 items-center gap-0.5 px-1.5 py-1"
-        style={{ borderBottom: `1px solid ${theme.separator}` }}
+        style={{
+          backgroundColor: theme.termBg,
+          borderBottom: `1px solid ${theme.separator}`,
+        }}
         data-section="terminal-host-tree-toolbar"
       >
         <div
@@ -225,9 +228,12 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
           'overflow-hidden transition-[max-height,opacity] duration-200 ease-out',
           expandedPanel === 'search' ? 'max-h-9 opacity-100' : 'max-h-0 opacity-0',
         )}
-        style={{ borderBottom: expandedPanel === 'search' ? `1px solid ${theme.separator}` : undefined }}
+        style={{
+          backgroundColor: theme.termBg,
+          borderBottom: expandedPanel === 'search' ? `1px solid ${theme.separator}` : undefined,
+        }}
       >
-        <div className="h-9 flex items-center gap-0.5 px-1.5">
+        <div className="h-9 flex items-center gap-0.5 px-1.5" style={{ backgroundColor: theme.termBg }}>
           <div className="relative flex-1 min-w-0">
             <Search
               size={12}
@@ -271,10 +277,14 @@ export const TerminalHostTreeToolbar: React.FC<TerminalHostTreeToolbarProps> = (
           'overflow-hidden transition-[max-height,opacity] duration-200 ease-out',
           expandedPanel === 'tags' ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0',
         )}
-        style={{ borderBottom: expandedPanel === 'tags' ? `1px solid ${theme.separator}` : undefined }}
+        style={{
+          backgroundColor: theme.termBg,
+          borderBottom: expandedPanel === 'tags' ? `1px solid ${theme.separator}` : undefined,
+        }}
       >
         <div
           className="max-h-40 overflow-y-auto overflow-x-hidden py-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+          style={{ backgroundColor: theme.termBg }}
         >
           {allTags.length === 0 ? (
             <div className="px-3 py-3 text-center text-xs" style={{ color: theme.mutedFg }}>

--- a/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
@@ -91,3 +91,14 @@ test('notes side panel forwards repeated open-note requests', () => {
   assert.match(layerSource, /next\.set\(tabId, \{ noteId, requestId \}\)/);
   assert.match(sectionSource, /openNoteRequestId=\{openNoteRequest\?\.requestId \?\? null\}/);
 });
+
+test('side panel tab bar and borders use inline resolved terminal theme colors', () => {
+  const sectionSource = readFileSync(new URL('./TerminalLayerSidePanelSection.tsx', import.meta.url), 'utf8');
+
+  assert.match(sectionSource, /buildSidePanelChromeThemeFromTerminalTheme/);
+  assert.match(sectionSource, /backgroundColor: sidePanelTheme\.termBg/);
+  assert.match(sectionSource, /borderBottom: `1px solid \$\{sidePanelTheme\.separator\}`/);
+  assert.match(sectionSource, /borderLeft: `1px solid \$\{sidePanelTheme\.separator\}`/);
+  assert.doesNotMatch(sectionSource, /terminalAppearanceSidePanelStyle/);
+  assert.doesNotMatch(sectionSource, /var\(--terminal-sidepanel-border\)/);
+});

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Activity, FolderTree, History, MessageSquare, NotebookText, Palette, PanelLeft, PanelRight, X, Zap } from 'lucide-react';
 import { SystemManagerSidePanel } from '../systemManager/SystemManagerSidePanel';
-import { terminalAppearanceSidePanelStyle } from '../../infrastructure/theme/terminalAppearanceTokens';
-import React, { memo, useCallback, useRef, useState } from 'react';
+import { buildSidePanelChromeThemeFromTerminalTheme } from '../../infrastructure/theme/terminalAppearanceTokens';
+import { injectTerminalLayerChromeSurfaceVars } from '../../infrastructure/theme/terminalAppearanceVars';
+import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useActiveTabId } from '../../application/state/activeTabStore';
 import {
@@ -154,6 +155,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
     previewedOrVisibleThemeId,
     refocusActiveTerminalSession,
     remoteHistory,
+    resolvedPreviewTheme,
     shellHistory,
     resolveAIExecutorContext,
     ScriptsSidePanel,
@@ -193,6 +195,21 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
 
   const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
   const { sidePanelTabOrder, setSidePanelTabOrder } = useTerminalSidePanelTabOrder();
+  const sidePanelTheme = useMemo(
+    () => buildSidePanelChromeThemeFromTerminalTheme(resolvedPreviewTheme ?? terminalTheme),
+    [resolvedPreviewTheme, terminalTheme],
+  );
+
+  useLayoutEffect(() => {
+    if (followAppTerminalTheme || !isSidePanelOpenForCurrentTab) return;
+    injectTerminalLayerChromeSurfaceVars(resolvedPreviewTheme ?? terminalTheme);
+  }, [
+    followAppTerminalTheme,
+    isSidePanelOpenForCurrentTab,
+    resolvedPreviewTheme,
+    terminalTheme,
+  ]);
+
   const [dragOverSidePanelTab, setDragOverSidePanelTab] = useState<{
     tab: TerminalSidePanelTabId;
     placement: 'before' | 'after';
@@ -371,21 +388,29 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
         <div
           className={cn(
             'h-full flex flex-col overflow-hidden',
-            isSidePanelOpenForCurrentTab && sidePanelPosition === 'left' && 'border-r',
-            isSidePanelOpenForCurrentTab && sidePanelPosition === 'right' && 'border-l',
             !isSidePanelOpenForCurrentTab && 'pointer-events-none',
           )}
           data-section={isSidePanelOpenForCurrentTab ? 'terminal-side-panel' : undefined}
           data-open={isSidePanelOpenForCurrentTab ? 'true' : 'false'}
           data-side-panel-tab={isSidePanelOpenForCurrentTab ? (activeSidePanelTab ?? undefined) : undefined}
-          style={terminalAppearanceSidePanelStyle}
+          style={{
+            backgroundColor: sidePanelTheme.termBg,
+            color: sidePanelTheme.termFg,
+            ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'left'
+              ? { borderRight: `1px solid ${sidePanelTheme.separator}` }
+              : {}),
+            ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'right'
+              ? { borderLeft: `1px solid ${sidePanelTheme.separator}` }
+              : {}),
+          }}
         >
           {isSidePanelOpenForCurrentTab && !isAiShellForceHidden && (
             <div
               className="flex h-9 items-center px-1.5 py-1 flex-shrink-0 gap-1"
               data-section="terminal-side-panel-tabs"
               style={{
-                borderBottom: '1px solid var(--terminal-sidepanel-border)',
+                backgroundColor: sidePanelTheme.termBg,
+                borderBottom: `1px solid ${sidePanelTheme.separator}`,
               }}
             >
               {sidePanelTabOrder.map((tabId) => {
@@ -408,11 +433,11 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                         className="netcatty-tab relative h-7 w-7 rounded-md p-0 hover:bg-transparent"
                         style={{
                           backgroundColor: isActive
-                            ? 'color-mix(in srgb, var(--terminal-sidepanel-accent) 24%, transparent)'
+                            ? `color-mix(in srgb, ${sidePanelTheme.accent} 24%, transparent)`
                             : 'transparent',
                           color: isActive
-                            ? 'var(--terminal-sidepanel-fg)'
-                            : 'var(--terminal-sidepanel-muted)',
+                            ? sidePanelTheme.termFg
+                            : sidePanelTheme.mutedFg,
                         }}
                         onClick={item.onClick}
                         onDragStart={(event: React.DragEvent) => handleSidePanelTabDragStart(event, item.id)}
@@ -431,7 +456,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                               'pointer-events-none absolute top-1 bottom-1 w-0.5 rounded-none',
                               dragOverSidePanelTab?.placement === 'after' ? 'right-0' : 'left-0',
                             )}
-                            style={{ backgroundColor: 'var(--terminal-sidepanel-accent)' }}
+                            style={{ backgroundColor: sidePanelTheme.accent }}
                           />
                         )}
                         {item.icon}
@@ -449,7 +474,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                     size="icon"
                     className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
                     style={{
-                      color: 'var(--terminal-sidepanel-muted)',
+                      color: sidePanelTheme.mutedFg,
                     }}
                     onClick={() => setSidePanelPosition((p: 'left' | 'right') => (p === 'left' ? 'right' : 'left'))}
                   >
@@ -467,7 +492,7 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
                     size="icon"
                     className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
                     style={{
-                      color: 'var(--terminal-sidepanel-muted)',
+                      color: sidePanelTheme.mutedFg,
                     }}
                     onClick={handleCloseSidePanel}
                   >

--- a/infrastructure/theme/terminalAppearanceTokens.test.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildTerminalAppearanceCssVars } from './terminalAppearanceTokens';
+import { buildSidePanelChromeThemeFromTerminalTheme, buildTerminalAppearanceCssVars } from './terminalAppearanceTokens';
 
 test('buildTerminalAppearanceCssVars maps core terminal colors', () => {
   const vars = buildTerminalAppearanceCssVars({
@@ -36,4 +36,39 @@ test('buildTerminalAppearanceCssVars maps core terminal colors', () => {
   assert.equal(vars['--nc-term-fg'], '#100f0f');
   assert.equal(vars['--nc-term-panel-bg'], '#f7f7f7');
   assert.equal(vars['--nc-term-host-tree-bg'], '#f7f7f7');
+});
+
+test('buildSidePanelChromeThemeFromTerminalTheme uses resolved terminal colors', () => {
+  const theme = buildSidePanelChromeThemeFromTerminalTheme({
+    id: 'test',
+    name: 'Test',
+    type: 'light',
+    colors: {
+      background: '#f7f7f7',
+      foreground: '#100f0f',
+      cursor: '#24837b',
+      selection: '#24837b44',
+      black: '#000',
+      red: '#000',
+      green: '#000',
+      yellow: '#000',
+      blue: '#000',
+      magenta: '#000',
+      cyan: '#000',
+      white: '#fff',
+      brightBlack: '#000',
+      brightRed: '#000',
+      brightGreen: '#000',
+      brightYellow: '#000',
+      brightBlue: '#000',
+      brightMagenta: '#000',
+      brightCyan: '#000',
+      brightWhite: '#fff',
+    },
+  });
+
+  assert.equal(theme.termBg, '#f7f7f7');
+  assert.equal(theme.termFg, '#100f0f');
+  assert.equal(theme.accent, '#24837b');
+  assert.match(theme.separator, /^color-mix\(/);
 });

--- a/infrastructure/theme/terminalAppearanceTokens.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.ts
@@ -105,6 +105,26 @@ export type HostTreeThemeColors = {
   folderFg: string;
 };
 
+export type SidePanelChromeTheme = {
+  termBg: string;
+  termFg: string;
+  mutedFg: string;
+  separator: string;
+  accent: string;
+};
+
+export function buildSidePanelChromeThemeFromTerminalTheme(theme: TerminalTheme): SidePanelChromeTheme {
+  const bg = theme.colors.background;
+  const fg = theme.colors.foreground;
+  return {
+    termBg: bg,
+    termFg: fg,
+    mutedFg: mix(fg, bg, 58),
+    separator: mix(fg, bg, 12),
+    accent: theme.colors.cursor,
+  };
+}
+
 export function buildHostTreeThemeFromTerminalTheme(theme: TerminalTheme): HostTreeThemeColors {
   const bg = theme.colors.background;
   const fg = theme.colors.foreground;


### PR DESCRIPTION
## Summary
- Align AppHostTreeLayer theme resolution with `resolveActiveChromeTheme` and manual chrome injection so restored workspace sessions pick up the focused terminal theme.
- Replace side panel tab bar and border CSS-variable fallbacks with inline colors derived from `resolvedPreviewTheme`, fixing dark app-theme bleed on restore.
- Fall back workspace `activeHostId` to the first valid pane session when `focusedSessionId` is stale after restore.

## Test plan
- [x] `npm run lint`
- [x] Targeted unit tests for work tab surface, host tree layer, side panel section, and theme tokens
- [ ] Manual: enable session restore, restart app, open restored workspace with side panel (Catty) and verify tab bar + borders match terminal theme in manual mode


Made with [Cursor](https://cursor.com)