### PR TITLE
Fix terminal theme mode switching and workspace tab switch perf

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { activeTabStore, toEditorTabId, fromEditorTabId, isEditorTabId } from './application/state/activeTabStore';
 import { useAutoSync } from './application/state/useAutoSync';
 import { useManagedSourceSync } from './application/state/useManagedSourceSync';
@@ -316,6 +316,13 @@ function App({ settings }: { settings: SettingsState }) {
   useTerminalAppearanceInjection(themeRuntime.globalAppearance, {
     includeChromeSurfaces: followAppTerminalTheme,
   });
+  const prevFollowAppTerminalThemeRef = useRef(followAppTerminalTheme);
+  const clearThemeIntent = themeRuntime.clearIntent;
+  useLayoutEffect(() => {
+    if (prevFollowAppTerminalThemeRef.current === followAppTerminalTheme) return;
+    prevFollowAppTerminalThemeRef.current = followAppTerminalTheme;
+    clearThemeIntent();
+  }, [followAppTerminalTheme, clearThemeIntent]);
   const currentTerminalTheme = themeRuntime.currentTerminalTheme;
   const editorTabs = useEditorTabs();
 

--- a/application/app/AppFollowTerminalTheme.test.ts
+++ b/application/app/AppFollowTerminalTheme.test.ts
@@ -17,6 +17,8 @@ test("follow-app terminal theme selection updates the matching UI theme via Them
   assert.match(appSource, /themeRuntime\.pickTheme\(themeId\)/);
   assert.match(appSource, /useTerminalAppearanceInjection/);
   assert.match(appSource, /includeChromeSurfaces: followAppTerminalTheme/);
+  assert.match(appSource, /clearThemeIntent\(\)/);
+  assert.match(runtimeSource, /injectTerminalAppearanceVars\(appearance\.theme, \{ includeChromeSurfaces \}\)/);
   assert.doesNotMatch(settingsSource, /pendingFollowAppTerminalThemeId/);
   assert.doesNotMatch(settingsSource, /applyFollowAppTerminalThemePick/);
   assert.match(settingsSource, /appearanceTransitionModeRef\.current = 'instant'/);

--- a/application/app/topTabsChromeTheme.ts
+++ b/application/app/topTabsChromeTheme.ts
@@ -70,13 +70,17 @@ const TOP_TABS_THEME_PROPERTIES = [
   '--muted-foreground',
 ] as const;
 
+let topTabsChromeThemeVarsApplied = false;
+
 export function clearTopTabsChromeThemeVars(): void {
   if (typeof document === 'undefined') return;
+  if (!topTabsChromeThemeVarsApplied) return;
   const tabsRoot = document.querySelector<HTMLElement>('[data-top-tabs-root]');
   if (!tabsRoot) return;
   for (const property of TOP_TABS_THEME_PROPERTIES) {
     removeStylePropertyIfSet(tabsRoot, property);
   }
+  topTabsChromeThemeVarsApplied = false;
 }
 
 export function applyTopTabsChromeThemeVars(theme: TerminalTheme): void {
@@ -107,6 +111,7 @@ export function applyTopTabsChromeThemeVars(theme: TerminalTheme): void {
   setStylePropertyIfChanged(tabsRoot, '--top-tabs-muted', 'hsl(var(--muted-foreground))');
   setStylePropertyIfChanged(tabsRoot, '--top-tabs-active-bg', 'hsl(var(--background))');
   setStylePropertyIfChanged(tabsRoot, '--top-tabs-accent', 'hsl(var(--accent))');
+  topTabsChromeThemeVarsApplied = true;
 }
 
 export function hasActiveChromeThemeDataset(): boolean {

--- a/application/state/sidePanelLiveStore.test.ts
+++ b/application/state/sidePanelLiveStore.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getSidePanelLiveSnapshot,
+  sidePanelLiveStore,
+  SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT,
+} from './sidePanelLiveStore.ts';
+
+test('sidePanelLiveStore skips notify when snapshot is unchanged', () => {
+  let notifications = 0;
+  const unsubscribe = sidePanelLiveStore.subscribe(() => {
+    notifications += 1;
+  });
+
+  const snapshot = {
+    ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT,
+    activeTerminalCwd: '/tmp',
+  };
+  sidePanelLiveStore.update(snapshot);
+  sidePanelLiveStore.update({ ...snapshot });
+  unsubscribe();
+
+  assert.equal(notifications, 1);
+});
+
+test('getSidePanelLiveSnapshot returns inactive snapshot when disabled', () => {
+  sidePanelLiveStore.update({
+    ...SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT,
+    activeTerminalCwd: '/var/log',
+  });
+
+  assert.equal(getSidePanelLiveSnapshot(false), SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT);
+  assert.equal(getSidePanelLiveSnapshot(true).activeTerminalCwd, '/var/log');
+});

--- a/application/state/sidePanelLiveStore.ts
+++ b/application/state/sidePanelLiveStore.ts
@@ -1,0 +1,98 @@
+import type { Host, TerminalSession, TerminalTheme, Workspace } from '../../types';
+
+export type SidePanelLiveSnapshot = {
+  sftpActiveHost: Host | null;
+  activeTerminalSessionIdForSftp: string | null;
+  activeTerminalCwd: string | null;
+  activeWorkspace: Workspace | undefined;
+  activeTerminalSessionForSystem: TerminalSession | null;
+  activeSystemSessionHost: Host | null;
+  focusedHost: Host | null;
+  historySessionId: string | null;
+  resolvedPreviewTheme: TerminalTheme | null;
+  previewedOrVisibleThemeId: string | undefined;
+  focusedFontFamilyId: string | undefined;
+  focusedFontFamilyOverridden: boolean;
+  focusedFontSize: number | undefined;
+  focusedFontSizeOverridden: boolean;
+  focusedFontWeight: number | undefined;
+  focusedFontWeightOverridden: boolean;
+  focusedThemeOverridden: boolean;
+};
+
+const EMPTY_SNAPSHOT: SidePanelLiveSnapshot = {
+  sftpActiveHost: null,
+  activeTerminalSessionIdForSftp: null,
+  activeTerminalCwd: null,
+  activeWorkspace: undefined,
+  activeTerminalSessionForSystem: null,
+  activeSystemSessionHost: null,
+  focusedHost: null,
+  historySessionId: null,
+  resolvedPreviewTheme: null,
+  previewedOrVisibleThemeId: undefined,
+  focusedFontFamilyId: undefined,
+  focusedFontFamilyOverridden: false,
+  focusedFontSize: undefined,
+  focusedFontSizeOverridden: false,
+  focusedFontWeight: undefined,
+  focusedFontWeightOverridden: false,
+  focusedThemeOverridden: false,
+};
+
+export const SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT = EMPTY_SNAPSHOT;
+
+type Listener = () => void;
+
+function liveSnapshotEqual(a: SidePanelLiveSnapshot, b: SidePanelLiveSnapshot): boolean {
+  return a.sftpActiveHost === b.sftpActiveHost
+    && a.activeTerminalSessionIdForSftp === b.activeTerminalSessionIdForSftp
+    && a.activeTerminalCwd === b.activeTerminalCwd
+    && a.activeWorkspace === b.activeWorkspace
+    && a.activeTerminalSessionForSystem === b.activeTerminalSessionForSystem
+    && a.activeSystemSessionHost === b.activeSystemSessionHost
+    && a.focusedHost === b.focusedHost
+    && a.historySessionId === b.historySessionId
+    && a.resolvedPreviewTheme === b.resolvedPreviewTheme
+    && a.previewedOrVisibleThemeId === b.previewedOrVisibleThemeId
+    && a.focusedFontFamilyId === b.focusedFontFamilyId
+    && a.focusedFontFamilyOverridden === b.focusedFontFamilyOverridden
+    && a.focusedFontSize === b.focusedFontSize
+    && a.focusedFontSizeOverridden === b.focusedFontSizeOverridden
+    && a.focusedFontWeight === b.focusedFontWeight
+    && a.focusedFontWeightOverridden === b.focusedFontWeightOverridden
+    && a.focusedThemeOverridden === b.focusedThemeOverridden;
+}
+
+class SidePanelLiveStore {
+  private snapshot: SidePanelLiveSnapshot = EMPTY_SNAPSHOT;
+  private listeners = new Set<Listener>();
+
+  getSnapshot = (): SidePanelLiveSnapshot => this.snapshot;
+
+  subscribe = (listener: Listener): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  update(next: SidePanelLiveSnapshot): void {
+    if (liveSnapshotEqual(this.snapshot, next)) return;
+    this.snapshot = next;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const sidePanelLiveStore = new SidePanelLiveStore();
+
+const noopSubscribe = () => () => {};
+
+export function subscribeSidePanelLiveSnapshot(enabled: boolean, listener: Listener): () => void {
+  if (!enabled) return noopSubscribe();
+  return sidePanelLiveStore.subscribe(listener);
+}
+
+export function getSidePanelLiveSnapshot(enabled: boolean): SidePanelLiveSnapshot {
+  return enabled ? sidePanelLiveStore.getSnapshot() : SIDE_PANEL_INACTIVE_LIVE_SNAPSHOT;
+}

--- a/application/state/useActiveChromeTheme.test.ts
+++ b/application/state/useActiveChromeTheme.test.ts
@@ -61,7 +61,7 @@ test("chrome layout animations wait until theme settle frames complete", () => {
   cancel();
 });
 
-test("syncActiveChromeTheme refreshes top tabs when the active theme fingerprint is unchanged", () => {
+test("syncActiveChromeTheme skips surface refresh when the active theme fingerprint is unchanged", () => {
   const globalWithDocument = globalThis as typeof globalThis & { document?: Document };
   const originalDocument = globalWithDocument.document;
   const theme = TERMINAL_THEMES[0];
@@ -83,9 +83,9 @@ test("syncActiveChromeTheme refreshes top tabs when the active theme fingerprint
       throw new Error("app theme should not be restored for an unchanged active chrome theme");
     });
 
-    assert.notEqual(topTabsRoot.style.getPropertyValue("--top-tabs-bg"), "");
-    assert.notEqual(topTabsRoot.style.getPropertyValue("--top-tabs-active-bg"), "");
-    assert.notEqual(topTabsRoot.style.getPropertyValue("--top-tabs-accent"), "");
+    assert.equal(topTabsRoot.style.getPropertyValue("--top-tabs-bg"), "");
+    assert.equal(topTabsRoot.style.getPropertyValue("--top-tabs-active-bg"), "");
+    assert.equal(topTabsRoot.style.getPropertyValue("--top-tabs-accent"), "");
   } finally {
     if (originalDocument) {
       globalWithDocument.document = originalDocument;

--- a/application/state/useActiveChromeTheme.ts
+++ b/application/state/useActiveChromeTheme.ts
@@ -228,11 +228,6 @@ export function syncActiveChromeTheme(
   const nextFingerprint = activeTheme ? themeFingerprint(activeTheme) : null;
   const appliedFingerprint = getAppliedChromeFingerprint();
   if (nextFingerprint === appliedFingerprint) {
-    if (activeTheme) {
-      refreshActiveChromeThemeSurfaces(activeTheme);
-    } else {
-      clearTopTabsChromeThemeVars();
-    }
     return;
   }
 

--- a/application/state/useManualTerminalChromeSurfaceInjection.test.ts
+++ b/application/state/useManualTerminalChromeSurfaceInjection.test.ts
@@ -15,5 +15,8 @@ test('manual mode injects chrome surfaces from focused session theme', () => {
   assert.match(appSource, /resolveSessionAppearance=\{themeRuntime\.resolveFocusedAppearance\}/);
   assert.match(hookSource, /applyTopTabsChromeThemeVars\(theme\)/);
   assert.match(hookSource, /injectTerminalLayerChromeSurfaceVars\(theme\)/);
+  assert.match(hookSource, /if \(wasEnabled\) \{[\s\S]*clearTerminalLayerChromeSurfaceVars\(\)/);
+  assert.doesNotMatch(hookSource, /clearTopTabsChromeThemeVars\(\)/);
   assert.match(varsSource, /injectTerminalLayerChromeSurfaceVars/);
+  assert.match(varsSource, /clearTerminalLayerChromeSurfaceVars/);
 });

--- a/application/state/useManualTerminalChromeSurfaceInjection.ts
+++ b/application/state/useManualTerminalChromeSurfaceInjection.ts
@@ -1,17 +1,28 @@
-import { useLayoutEffect } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import type { TerminalTheme } from '../../domain/models';
 import { applyTopTabsChromeThemeVars } from '../app/topTabsChromeTheme';
-import { injectTerminalLayerChromeSurfaceVars } from '../../infrastructure/theme/terminalAppearanceVars';
+import {
+  clearTerminalLayerChromeSurfaceVars,
+  injectTerminalLayerChromeSurfaceVars,
+} from '../../infrastructure/theme/terminalAppearanceVars';
 
 /** Manual mode: side panel + host tree follow the focused session theme, not the global default. */
 export function useManualTerminalChromeSurfaceInjection(
   theme: TerminalTheme,
   enabled: boolean,
 ): void {
+  const prevEnabledRef = useRef(enabled);
   useLayoutEffect(() => {
-    if (!enabled) return;
-    injectTerminalLayerChromeSurfaceVars(theme);
-    applyTopTabsChromeThemeVars(theme);
+    const wasEnabled = prevEnabledRef.current;
+    prevEnabledRef.current = enabled;
+    if (enabled) {
+      injectTerminalLayerChromeSurfaceVars(theme);
+      applyTopTabsChromeThemeVars(theme);
+      return;
+    }
+    if (wasEnabled) {
+      clearTerminalLayerChromeSurfaceVars();
+    }
   }, [enabled, theme.id, theme]);
 }

--- a/application/state/useThemeRuntime.ts
+++ b/application/state/useThemeRuntime.ts
@@ -12,7 +12,9 @@ import {
   type ThemeUserIntent,
 } from '../../domain/terminalAppearanceRuntime';
 import { getFollowAppTerminalThemeSelectionUpdate } from '../../domain/terminalAppearance';
-import { injectTerminalAppearanceVars } from '../../infrastructure/theme/terminalAppearanceVars';
+import {
+  injectTerminalAppearanceVars,
+} from '../../infrastructure/theme/terminalAppearanceVars';
 
 export type ThemeRuntimeSettings = TerminalAppearanceSettings & {
   customThemes: TerminalTheme[];

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1892,14 +1892,17 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       : status === "connecting"
         ? "bg-amber-400"
         : "bg-rose-500";
-  const terminalPreviewVars = useMemo(() => ({
-    ['--terminal-ui-bg' as never]: `var(--terminal-preview-bg, ${effectiveTheme.colors.background})`,
-    ['--terminal-ui-fg' as never]: `var(--terminal-preview-fg, ${effectiveTheme.colors.foreground})`,
-    ['--terminal-ui-border' as never]: `var(--terminal-preview-border, color-mix(in srgb, ${effectiveTheme.colors.foreground} 8%, ${effectiveTheme.colors.background} 92%))`,
-    ['--terminal-ui-toolbar-btn' as never]: `var(--terminal-preview-toolbar-btn, color-mix(in srgb, ${effectiveTheme.colors.background} 88%, ${effectiveTheme.colors.foreground} 12%))`,
-    ['--terminal-ui-toolbar-btn-hover' as never]: `var(--terminal-preview-toolbar-btn-hover, color-mix(in srgb, ${effectiveTheme.colors.background} 78%, ${effectiveTheme.colors.foreground} 22%))`,
-    ['--terminal-ui-toolbar-btn-active' as never]: `var(--terminal-preview-toolbar-btn-active, color-mix(in srgb, ${effectiveTheme.colors.cursor} 78%, ${effectiveTheme.colors.background} 22%))`,
-  }), [effectiveTheme.colors.background, effectiveTheme.colors.cursor, effectiveTheme.colors.foreground]);
+  const terminalPreviewVars = useMemo(() => {
+    const { background, foreground, cursor } = effectiveTheme.colors;
+    return {
+      ['--terminal-ui-bg' as never]: background,
+      ['--terminal-ui-fg' as never]: foreground,
+      ['--terminal-ui-border' as never]: `color-mix(in srgb, ${foreground} 8%, ${background} 92%)`,
+      ['--terminal-ui-toolbar-btn' as never]: `color-mix(in srgb, ${background} 88%, ${foreground} 12%)`,
+      ['--terminal-ui-toolbar-btn-hover' as never]: `color-mix(in srgb, ${background} 78%, ${foreground} 22%)`,
+      ['--terminal-ui-toolbar-btn-active' as never]: `color-mix(in srgb, ${cursor} 78%, ${background} 22%)`,
+    };
+  }, [effectiveTheme.colors]);
 
   const effectiveComposeBarOpen = inWorkspace ? !!isWorkspaceComposeBarOpen : isComposeBarOpen;
 

--- a/components/terminal/TerminalConnectionDialog.tsx
+++ b/components/terminal/TerminalConnectionDialog.tsx
@@ -144,10 +144,14 @@ export const TerminalConnectionDialog: React.FC<TerminalConnectionDialogProps> =
     const secondSegmentWidth = shouldCompleteProgress || secondSegmentUnlocked ? targetSecondSegmentWidth : 0;
 
     return (
-        <div className={cn(
-            "absolute inset-0 z-20 flex items-center justify-center",
-            needsAuth ? "bg-black" : "bg-black/30"
-        )}>
+        <div
+            className="absolute inset-0 z-20 flex items-center justify-center"
+            style={{
+                backgroundColor: needsAuth
+                    ? 'var(--terminal-ui-bg, var(--background))'
+                    : 'color-mix(in srgb, var(--terminal-ui-bg, var(--background)) 35%, transparent)',
+            }}
+        >
             <div
                 className="w-[540px] max-w-[88vw] rounded-xl shadow-xl p-4 space-y-3 transition-all duration-200"
                 style={{

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -150,10 +150,13 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
     >
       <div
         className={cn(
-          "relative h-full w-full flex min-h-0 overflow-hidden bg-gradient-to-br from-[#050910] via-[#06101a] to-[#0b1220]",
+          "relative h-full w-full flex min-h-0 overflow-hidden",
           isComposeBarOpen && !inWorkspace && "flex-col"
         )}
-        style={terminalPreviewVars}
+        style={{
+          ...terminalPreviewVars,
+          backgroundColor: 'var(--terminal-ui-bg)',
+        }}
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Activity, FolderTree, History, MessageSquare, NotebookText, Palette, PanelLeft, PanelRight, X, Zap } from 'lucide-react';
-import { SystemManagerSidePanel } from '../systemManager/SystemManagerSidePanel';
 import { buildSidePanelChromeThemeFromTerminalTheme } from '../../infrastructure/theme/terminalAppearanceTokens';
 import { injectTerminalLayerChromeSurfaceVars } from '../../infrastructure/theme/terminalAppearanceVars';
 import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -17,14 +16,17 @@ import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import type { SidePanelTab } from './TerminalLayerSupport';
-import { terminalLayerSidePanelCtxEqual } from './terminalLayerViewMemo';
-import { resolveSftpFollowTerminalCwdTargetHost } from '../sftp/sftpFollowTerminalCwd';
-import { resolveTerminalFontFamilyId } from '../../infrastructure/config/fonts';
-import type { Host } from '../../types';
+import { terminalLayerSidePanelStableCtxEqual } from './terminalLayerViewMemo';
+import { SidePanelMountedContent } from './terminalLayerSidePanelSlots';
+
+const MemoizedSidePanelMountedContent = memo(
+  SidePanelMountedContent,
+  (prev, next) => terminalLayerSidePanelStableCtxEqual(prev.ctx, next.ctx),
+);
+MemoizedSidePanelMountedContent.displayName = 'MemoizedSidePanelMountedContent';
 
 type SidePanelContext = Record<string, any>;
 const SIDE_PANEL_TAB_DRAG_MIME = 'application/x-netcatty-sidepanel-tab';
-const navigatorPlatform = typeof navigator !== 'undefined' ? navigator.platform : '';
 
 export function getTerminalSidePanelShellWidth({
   activeSidePanelTab,
@@ -45,7 +47,7 @@ export function getTerminalSidePanelShellWidth({
     : 0;
 }
 
-function TerminalLayerSidePanelShell({ ctx }: { ctx: SidePanelContext }) {
+function hasMountedSidePanelContent(ctx: SidePanelContext): boolean {
   const {
     mountedAiTabIds,
     mountedSftpTabIds,
@@ -61,7 +63,7 @@ function TerminalLayerSidePanelShell({ ctx }: { ctx: SidePanelContext }) {
   const anyNotesOpen = sidePanelOpenTabs instanceof Map
     && Array.from((sidePanelOpenTabs as Map<string, SidePanelTab>).values()).includes('notes');
 
-  if (
+  return !(
     mountedSftpTabIds.length === 0
     && mountedAiTabIds.length === 0
     && notesMountedTabIds.length === 0
@@ -70,139 +72,58 @@ function TerminalLayerSidePanelShell({ ctx }: { ctx: SidePanelContext }) {
     && themeMountedTabIds.length === 0
     && !anyHistoryOpen
     && !anyNotesOpen
-  ) {
-    return null;
-  }
-
-  return <TerminalLayerSidePanelTabBody ctx={ctx} />;
+  );
 }
 
-function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
+export function TerminalLayerSidePanelSection({ ctx }: { ctx: SidePanelContext }) {
+  if (!hasMountedSidePanelContent(ctx)) return null;
+  return <TerminalLayerSidePanelInner ctx={ctx} />;
+}
+TerminalLayerSidePanelSection.displayName = 'TerminalLayerSidePanelSection';
+
+function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
   const activeTabId = useActiveTabId();
   const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
   const isSidePanelOpenForCurrentTab = activeTabId ? sidePanelOpenTabs.has(activeTabId) : false;
   const activeSidePanelTab = activeTabId ? sidePanelOpenTabs.get(activeTabId) ?? null : null;
 
   const {
-    activeTerminalCwd,
-    activeTerminalSessionIdForSftp,
-    activeWorkspace,
-    AIChatPanelsHost,
-    AISidePanelStateRoot,
-    aiContextsByTabId,
     Button: Btn,
     cn,
-    editorWordWrap,
-    effectiveHosts,
-    focusedFontFamilyId,
-    focusedFontFamilyOverridden,
-    focusedFontSize,
-    focusedFontSizeOverridden,
-    focusedFontWeight,
-    focusedFontWeightOverridden,
-    focusedHost,
-    focusedThemeOverridden,
     followAppTerminalTheme,
-    getTerminalCwd,
     handleCloseSidePanel,
-    handleHistoryPaste,
-    handleHistoryRun,
-    handleAddKnownHost,
-    handleOpenHistory,
-    handleFontFamilyChangeForFocusedSession,
-    handleFontFamilyResetForFocusedSession,
-    handleFontSizeChangeForFocusedSession,
-    handleFontSizeResetForFocusedSession,
-    handleFontWeightChangeForFocusedSession,
-    handleFontWeightResetForFocusedSession,
     handleOpenAI,
+    handleOpenHistory,
     handleOpenNotes,
-    handleOpenHostFromNotes,
     handleOpenScripts,
     handleOpenSystem,
     handleOpenTheme,
-    activeTerminalSessionForSystem,
-    activeSystemSessionHost,
-    handlePendingTerminalSelectionConsumed,
-    handleSftpInitialLocationApplied,
-    handleSnippetFromPanel,
-    handleThemeChangeForFocusedSession,
-    handleThemeResetForFocusedSession,
     handleToggleSftpFromBar,
-    handlePendingUploadHandled,
-    historySessionId,
-    HistorySidePanel,
-    hosts,
-    hotkeyScheme,
-    identities,
-    keyBindings,
-    keys,
-    knownHosts,
-    mountedAiTabIds,
-    mountedSftpTabIds,
-    notesMountedTabIds,
-    notesOpenNoteByTab,
-    NotesManager,
-    noteGroups,
-    notes,
-    onOpenVaultHostFromChat,
-    onOpenVaultNoteFromChat,
-    onOpenVaultSectionFromChat,
-    scriptsMountedTabIds,
-    systemMountedTabIds,
-    themeMountedTabIds,
-    pendingTerminalSelectionForAI,
-    previewedOrVisibleThemeId,
-    refocusActiveTerminalSession,
-    remoteHistory,
     resolvedPreviewTheme,
-    shellHistory,
-    resolveAIExecutorContext,
-    ScriptsSidePanel,
-    setEditorWordWrap,
     setSidePanelPosition,
     setSidePanelWidth,
-    setSftpFollowTerminalCwd,
     persistSidePanelWidth,
-    sftpActiveHost,
-    sftpHostForTab,
-    sftpAutoSync,
-    sftpDefaultViewMode,
-    sftpDoubleClickBehavior,
-    sftpFollowTerminalCwd,
-    sftpInitialLocationForTab,
-    sftpPendingUploadsForTab,
-    sftpShowHiddenFiles,
-    SftpSidePanel,
-    sftpUseCompressedUpload,
     sidePanelPosition,
     sidePanelWidth,
-    snippetPackages,
-    snippets,
     t,
-    terminalFontFamilyId,
-    terminalSettings,
     terminalTheme,
-    terminalThemeId,
-    ThemeSidePanel,
-    updateHosts,
-    updateNoteGroups,
-    updateNotes,
-    updateSnippetPackages,
-    updateSnippets,
-    validAIScopeTargetIds,
   } = ctx;
 
   const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
   const { sidePanelTabOrder, setSidePanelTabOrder } = useTerminalSidePanelTabOrder();
-  const sidePanelTheme = useMemo(
-    () => buildSidePanelChromeThemeFromTerminalTheme(resolvedPreviewTheme ?? terminalTheme),
-    [resolvedPreviewTheme, terminalTheme],
-  );
+  const sidePanelTheme = useMemo(() => {
+    const chromeTheme = followAppTerminalTheme
+      ? terminalTheme
+      : (resolvedPreviewTheme ?? terminalTheme);
+    return buildSidePanelChromeThemeFromTerminalTheme(chromeTheme);
+  }, [followAppTerminalTheme, resolvedPreviewTheme, terminalTheme]);
 
   useLayoutEffect(() => {
-    if (followAppTerminalTheme || !isSidePanelOpenForCurrentTab) return;
-    injectTerminalLayerChromeSurfaceVars(resolvedPreviewTheme ?? terminalTheme);
+    if (!isSidePanelOpenForCurrentTab) return;
+    const chromeTheme = followAppTerminalTheme
+      ? terminalTheme
+      : (resolvedPreviewTheme ?? terminalTheme);
+    injectTerminalLayerChromeSurfaceVars(chromeTheme);
   }, [
     followAppTerminalTheme,
     isSidePanelOpenForCurrentTab,
@@ -216,7 +137,6 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
   } | null>(null);
   const draggedSidePanelTabRef = useRef<TerminalSidePanelTabId | null>(null);
   const isAiShellForceHidden = AI_PANEL_FORCE_HIDE_SHELL && activeSidePanelTab === 'ai';
-  const shouldRenderAiPanels = mountedAiTabIds.length > 0 && !isAiShellForceHidden;
   const shellWidth = getTerminalSidePanelShellWidth({
     activeSidePanelTab,
     forceHideAiShell: AI_PANEL_FORCE_HIDE_SHELL,
@@ -312,407 +232,168 @@ function TerminalLayerSidePanelTabBody({ ctx }: { ctx: SidePanelContext }) {
     setDragOverSidePanelTab(null);
   }, [dragOverSidePanelTab]);
 
-  const sidePanelTabItems: Array<{
-    id: TerminalSidePanelTabId;
-    label: string;
-    icon: React.ReactNode;
-    onClick: () => void;
-  }> = [
-    {
-      id: 'sftp',
-      label: t('terminal.layer.sftp'),
-      icon: <FolderTree size={15} />,
-      onClick: handleToggleSftpFromBar,
-    },
-    {
-      id: 'scripts',
-      label: t('terminal.layer.scripts'),
-      icon: <Zap size={15} />,
-      onClick: handleOpenScripts,
-    },
-    {
-      id: 'history',
-      label: t('terminal.layer.history'),
-      icon: <History size={15} />,
-      onClick: handleOpenHistory,
-    },
-    {
-      id: 'theme',
-      label: t('terminal.layer.theme'),
-      icon: <Palette size={15} />,
-      onClick: handleOpenTheme,
-    },
-    {
-      id: 'system',
-      label: t('terminal.layer.system'),
-      icon: <Activity size={15} />,
-      onClick: handleOpenSystem,
-    },
-    {
-      id: 'notes',
-      label: t('terminal.layer.notes'),
-      icon: <NotebookText size={15} />,
-      onClick: handleOpenNotes,
-    },
-    {
-      id: 'ai',
-      label: t('terminal.layer.aiChat'),
-      icon: <MessageSquare size={15} />,
-      onClick: handleOpenAI,
-    },
-  ];
-  const sidePanelTabItemById = new Map(sidePanelTabItems.map((item) => [item.id, item]));
+  const sidePanelTabItems = useMemo(() => [
+    { id: 'sftp' as const, label: t('terminal.layer.sftp'), icon: <FolderTree size={15} />, onClick: handleToggleSftpFromBar },
+    { id: 'scripts' as const, label: t('terminal.layer.scripts'), icon: <Zap size={15} />, onClick: handleOpenScripts },
+    { id: 'history' as const, label: t('terminal.layer.history'), icon: <History size={15} />, onClick: handleOpenHistory },
+    { id: 'theme' as const, label: t('terminal.layer.theme'), icon: <Palette size={15} />, onClick: handleOpenTheme },
+    { id: 'system' as const, label: t('terminal.layer.system'), icon: <Activity size={15} />, onClick: handleOpenSystem },
+    { id: 'notes' as const, label: t('terminal.layer.notes'), icon: <NotebookText size={15} />, onClick: handleOpenNotes },
+    { id: 'ai' as const, label: t('terminal.layer.aiChat'), icon: <MessageSquare size={15} />, onClick: handleOpenAI },
+  ], [
+    handleOpenAI,
+    handleOpenHistory,
+    handleOpenNotes,
+    handleOpenScripts,
+    handleOpenSystem,
+    handleOpenTheme,
+    handleToggleSftpFromBar,
+    t,
+  ]);
+  const sidePanelTabItemById = useMemo(
+    () => new Map(sidePanelTabItems.map((item) => [item.id, item])),
+    [sidePanelTabItems],
+  );
 
   return (
-    <>
+    <div
+      style={{ width: shellWidth, contain: 'layout paint style' }}
+      className={cn(
+        'flex-shrink-0 h-full relative z-20',
+        shellWidth === 0 && 'overflow-hidden',
+        sidePanelPosition === 'right' && 'order-last',
+      )}
+      data-section="terminal-side-panel-shell"
+      data-side-panel-position={sidePanelPosition}
+    >
+      {isSidePanelOpenForCurrentTab && !isAiShellForceHidden && (
+        <div
+          className={cn(
+            'absolute top-0 h-full w-2 cursor-ew-resize z-30',
+            sidePanelPosition === 'left' ? 'right-[-3px]' : 'left-[-3px]',
+          )}
+          data-section="terminal-side-panel-resizer"
+          onMouseDown={handleSidePanelResizeStart}
+        />
+      )}
       <div
-        style={{ width: shellWidth, contain: 'layout paint style' }}
         className={cn(
-          'flex-shrink-0 h-full relative z-20',
-          shellWidth === 0 && 'overflow-hidden',
-          sidePanelPosition === 'right' && 'order-last',
+          'h-full flex flex-col overflow-hidden',
+          !isSidePanelOpenForCurrentTab && 'pointer-events-none',
         )}
-        data-section="terminal-side-panel-shell"
-        data-side-panel-position={sidePanelPosition}
+        data-section={isSidePanelOpenForCurrentTab ? 'terminal-side-panel' : undefined}
+        data-open={isSidePanelOpenForCurrentTab ? 'true' : 'false'}
+        data-side-panel-tab={isSidePanelOpenForCurrentTab ? (activeSidePanelTab ?? undefined) : undefined}
+        style={{
+          backgroundColor: sidePanelTheme.termBg,
+          color: sidePanelTheme.termFg,
+          ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'left'
+            ? { borderRight: `1px solid ${sidePanelTheme.separator}` }
+            : {}),
+          ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'right'
+            ? { borderLeft: `1px solid ${sidePanelTheme.separator}` }
+            : {}),
+        }}
       >
         {isSidePanelOpenForCurrentTab && !isAiShellForceHidden && (
           <div
-            className={cn(
-              'absolute top-0 h-full w-2 cursor-ew-resize z-30',
-              sidePanelPosition === 'left' ? 'right-[-3px]' : 'left-[-3px]',
-            )}
-            data-section="terminal-side-panel-resizer"
-            onMouseDown={handleSidePanelResizeStart}
-          />
-        )}
-        <div
-          className={cn(
-            'h-full flex flex-col overflow-hidden',
-            !isSidePanelOpenForCurrentTab && 'pointer-events-none',
-          )}
-          data-section={isSidePanelOpenForCurrentTab ? 'terminal-side-panel' : undefined}
-          data-open={isSidePanelOpenForCurrentTab ? 'true' : 'false'}
-          data-side-panel-tab={isSidePanelOpenForCurrentTab ? (activeSidePanelTab ?? undefined) : undefined}
-          style={{
-            backgroundColor: sidePanelTheme.termBg,
-            color: sidePanelTheme.termFg,
-            ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'left'
-              ? { borderRight: `1px solid ${sidePanelTheme.separator}` }
-              : {}),
-            ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'right'
-              ? { borderLeft: `1px solid ${sidePanelTheme.separator}` }
-              : {}),
-          }}
-        >
-          {isSidePanelOpenForCurrentTab && !isAiShellForceHidden && (
-            <div
-              className="flex h-9 items-center px-1.5 py-1 flex-shrink-0 gap-1"
-              data-section="terminal-side-panel-tabs"
-              style={{
-                backgroundColor: sidePanelTheme.termBg,
-                borderBottom: `1px solid ${sidePanelTheme.separator}`,
-              }}
-            >
-              {sidePanelTabOrder.map((tabId) => {
-                const item = sidePanelTabItemById.get(tabId);
-                if (!item) return null;
-                const isActive = activeSidePanelTab === item.id;
-                const showDropIndicator = dragOverSidePanelTab?.tab === item.id
-                  && draggedSidePanelTabRef.current !== null
-                  && draggedSidePanelTabRef.current !== item.id;
-                return (
-                  <Tooltip key={item.id}>
-                    <TooltipTrigger asChild>
-                      <Btn
-                        variant="ghost"
-                        size="icon"
-                        draggable
-                        data-tab-id={item.id}
-                        data-tab-type="sidepanel"
-                        data-state={isActive ? 'active' : 'inactive'}
-                        className="netcatty-tab relative h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                        style={{
-                          backgroundColor: isActive
-                            ? `color-mix(in srgb, ${sidePanelTheme.accent} 24%, transparent)`
-                            : 'transparent',
-                          color: isActive
-                            ? sidePanelTheme.termFg
-                            : sidePanelTheme.mutedFg,
-                        }}
-                        onClick={item.onClick}
-                        onDragStart={(event: React.DragEvent) => handleSidePanelTabDragStart(event, item.id)}
-                        onDragOver={(event: React.DragEvent) => handleSidePanelTabDragOver(event, item.id)}
-                        onDragLeave={(event: React.DragEvent) => handleSidePanelTabDragLeave(event, item.id)}
-                        onDrop={(event: React.DragEvent) => handleSidePanelTabDrop(event, item.id)}
-                        onDragEnd={() => {
-                          draggedSidePanelTabRef.current = null;
-                          setDragOverSidePanelTab(null);
-                        }}
-                      >
-                        {showDropIndicator && (
-                          <span
-                            aria-hidden="true"
-                            className={cn(
-                              'pointer-events-none absolute top-1 bottom-1 w-0.5 rounded-none',
-                              dragOverSidePanelTab?.placement === 'after' ? 'right-0' : 'left-0',
-                            )}
-                            style={{ backgroundColor: sidePanelTheme.accent }}
-                          />
-                        )}
-                        {item.icon}
-                      </Btn>
-                    </TooltipTrigger>
-                    <TooltipContent>{item.label}</TooltipContent>
-                  </Tooltip>
-                );
-              })}
-              <div className="flex-1" />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      color: sidePanelTheme.mutedFg,
-                    }}
-                    onClick={() => setSidePanelPosition((p: 'left' | 'right') => (p === 'left' ? 'right' : 'left'))}
-                  >
-                    {sidePanelPosition === 'left' ? <PanelRight size={15} /> : <PanelLeft size={15} />}
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {sidePanelPosition === 'left' ? t('terminal.layer.movePanelRight') : t('terminal.layer.movePanelLeft')}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Btn
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
-                    style={{
-                      color: sidePanelTheme.mutedFg,
-                    }}
-                    onClick={handleCloseSidePanel}
-                  >
-                    <X size={15} />
-                  </Btn>
-                </TooltipTrigger>
-                <TooltipContent>{t('terminal.layer.closePanel')}</TooltipContent>
-              </Tooltip>
-            </div>
-          )}
-          <div className="flex-1 min-h-0 relative" data-section="terminal-side-panel-content">
-            {mountedSftpTabIds.map((tabId: string) => {
-              const isVisibleSftpPanel = activeTabId === tabId && activeSidePanelTab === 'sftp';
-              const storedSftpHost = sftpHostForTab.get(tabId) ?? null;
-              const panelActiveHost = isVisibleSftpPanel
-                ? (sftpActiveHost ?? storedSftpHost)
-                : storedSftpHost;
-              const handlePanelFollowTerminalCwdChange = (enabled: boolean, visibleHost?: Host | null) => {
-                const targetHost = resolveSftpFollowTerminalCwdTargetHost(visibleHost, panelActiveHost);
-                if (!targetHost?.id) {
-                  setSftpFollowTerminalCwd(enabled);
-                  return;
-                }
-                let updated = false;
-                const nextHosts = (hosts as Host[]).map((host) => {
-                  if (host.id !== targetHost.id) return host;
-                  updated = true;
-                  return { ...host, sftpFollowTerminalCwd: enabled };
-                });
-                if (updated) {
-                  updateHosts(nextHosts);
-                } else {
-                  setSftpFollowTerminalCwd(enabled);
-                }
-              };
+            className="flex h-9 items-center px-1.5 py-1 flex-shrink-0 gap-1"
+            data-section="terminal-side-panel-tabs"
+            style={{
+              backgroundColor: sidePanelTheme.termBg,
+              borderBottom: `1px solid ${sidePanelTheme.separator}`,
+            }}
+          >
+            {sidePanelTabOrder.map((tabId) => {
+              const item = sidePanelTabItemById.get(tabId);
+              if (!item) return null;
+              const isActive = activeSidePanelTab === item.id;
+              const showDropIndicator = dragOverSidePanelTab?.tab === item.id
+                && draggedSidePanelTabRef.current !== null
+                && draggedSidePanelTabRef.current !== item.id;
               return (
-                <div
-                  key={tabId}
-                  className={cn('absolute inset-0 z-10', !isVisibleSftpPanel && 'hidden')}
-                >
-                <SftpSidePanel
-                  hosts={effectiveHosts}
-                  writableHosts={hosts}
-                  keys={keys}
-                  identities={identities}
-                  knownHosts={knownHosts}
-                  updateHosts={updateHosts}
-                  onAddKnownHost={handleAddKnownHost}
-                  sftpDefaultViewMode={sftpDefaultViewMode}
-                  activeHost={panelActiveHost}
-                  activeSessionId={isVisibleSftpPanel ? activeTerminalSessionIdForSftp : null}
-                  initialLocation={
-                    isVisibleSftpPanel
-                      ? (sftpInitialLocationForTab.get(tabId) ?? null)
-                      : null
-                  }
-                  onInitialLocationApplied={(location) => handleSftpInitialLocationApplied(tabId, location)}
-                  showWorkspaceHostHeader={isVisibleSftpPanel && !!activeWorkspace}
-                  isVisible={isVisibleSftpPanel}
-                  renderOverlays={isVisibleSftpPanel}
-                  pendingUpload={sftpPendingUploadsForTab.get(tabId) ?? null}
-                  onPendingUploadHandled={(requestId) => handlePendingUploadHandled(tabId, requestId)}
-                  sftpDoubleClickBehavior={sftpDoubleClickBehavior}
-                  sftpAutoSync={isVisibleSftpPanel ? sftpAutoSync : false}
-                  sftpShowHiddenFiles={sftpShowHiddenFiles}
-                  sftpUseCompressedUpload={sftpUseCompressedUpload}
-                  hotkeyScheme={hotkeyScheme}
-                  keyBindings={keyBindings}
-                  editorWordWrap={editorWordWrap}
-                  setEditorWordWrap={setEditorWordWrap}
-                  onGetTerminalCwd={getTerminalCwd}
-                  activeTerminalCwd={isVisibleSftpPanel ? activeTerminalCwd : null}
-                  sftpFollowTerminalCwd={sftpFollowTerminalCwd}
-                  onSftpFollowTerminalCwdChange={handlePanelFollowTerminalCwdChange}
-                  onRequestTerminalFocus={refocusActiveTerminalSession}
-                  terminalSettings={terminalSettings}
-                />
-                </div>
+                <Tooltip key={item.id}>
+                  <TooltipTrigger asChild>
+                    <Btn
+                      variant="ghost"
+                      size="icon"
+                      draggable
+                      data-tab-id={item.id}
+                      data-tab-type="sidepanel"
+                      data-state={isActive ? 'active' : 'inactive'}
+                      className="netcatty-tab relative h-7 w-7 rounded-md p-0 hover:bg-transparent"
+                      style={{
+                        backgroundColor: isActive
+                          ? `color-mix(in srgb, ${sidePanelTheme.accent} 24%, transparent)`
+                          : 'transparent',
+                        color: isActive
+                          ? sidePanelTheme.termFg
+                          : sidePanelTheme.mutedFg,
+                      }}
+                      onClick={item.onClick}
+                      onDragStart={(event: React.DragEvent) => handleSidePanelTabDragStart(event, item.id)}
+                      onDragOver={(event: React.DragEvent) => handleSidePanelTabDragOver(event, item.id)}
+                      onDragLeave={(event: React.DragEvent) => handleSidePanelTabDragLeave(event, item.id)}
+                      onDrop={(event: React.DragEvent) => handleSidePanelTabDrop(event, item.id)}
+                      onDragEnd={() => {
+                        draggedSidePanelTabRef.current = null;
+                        setDragOverSidePanelTab(null);
+                      }}
+                    >
+                      {showDropIndicator && (
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            'pointer-events-none absolute top-1 bottom-1 w-0.5 rounded-none',
+                            dragOverSidePanelTab?.placement === 'after' ? 'right-0' : 'left-0',
+                          )}
+                          style={{ backgroundColor: sidePanelTheme.accent }}
+                        />
+                      )}
+                      {item.icon}
+                    </Btn>
+                  </TooltipTrigger>
+                  <TooltipContent>{item.label}</TooltipContent>
+                </Tooltip>
               );
             })}
-
-            {systemMountedTabIds.map((tabId: string) => {
-              const isVisibleSystemPanel = activeTabId === tabId && activeSidePanelTab === 'system';
-              return (
-                <div
-                  key={`system-${tabId}`}
-                  className={cn('absolute inset-0 z-10', !isVisibleSystemPanel && 'hidden')}
+            <div className="flex-1" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Btn
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
+                  style={{ color: sidePanelTheme.mutedFg }}
+                  onClick={() => setSidePanelPosition((p: 'left' | 'right') => (p === 'left' ? 'right' : 'left'))}
                 >
-                  <SystemManagerSidePanel
-                    key={activeTerminalSessionForSystem?.id ?? 'system-none'}
-                    session={activeTerminalSessionForSystem ?? null}
-                    sessionHost={activeSystemSessionHost ?? null}
-                    showWorkspaceHostHeader={isVisibleSystemPanel && !!activeWorkspace}
-                    isVisible={isVisibleSystemPanel}
-                    terminalSettings={terminalSettings}
-                    snippets={snippets}
-                    onRequestTerminalFocus={refocusActiveTerminalSession}
-                  />
-                </div>
-              );
-            })}
-
-            {scriptsMountedTabIds.map((tabId: string) => {
-              const isVisibleScriptsPanel = activeTabId === tabId && activeSidePanelTab === 'scripts';
-              return (
-                <div
-                  key={`scripts-${tabId}`}
-                  className={cn('absolute inset-0 z-10', !isVisibleScriptsPanel && 'hidden')}
+                  {sidePanelPosition === 'left' ? <PanelRight size={15} /> : <PanelLeft size={15} />}
+                </Btn>
+              </TooltipTrigger>
+              <TooltipContent>
+                {sidePanelPosition === 'left' ? t('terminal.layer.movePanelRight') : t('terminal.layer.movePanelLeft')}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Btn
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 rounded-md p-0 hover:bg-transparent"
+                  style={{ color: sidePanelTheme.mutedFg }}
+                  onClick={handleCloseSidePanel}
                 >
-                  <ScriptsSidePanel
-                    snippets={snippets}
-                    packages={snippetPackages}
-                    onSnippetsChange={updateSnippets}
-                    onPackagesChange={updateSnippetPackages}
-                    onSnippetClick={handleSnippetFromPanel}
-                    isVisible={isVisibleScriptsPanel}
-                  />
-                </div>
-              );
-            })}
-
-            {activeSidePanelTab === 'history' && (
-              <div className="absolute inset-0 z-10">
-                <HistorySidePanel
-                  focusedHost={focusedHost}
-                  focusedSessionId={historySessionId}
-                  state={remoteHistory.getState(focusedHost?.id, historySessionId)}
-                  globalEntries={shellHistory}
-                  onFetch={remoteHistory.fetch}
-                  onPasteToTerminal={handleHistoryPaste}
-                  onRunInTerminal={handleHistoryRun}
-                  isVisible
-                />
-              </div>
-            )}
-
-            {themeMountedTabIds.map((tabId: string) => {
-              const isVisibleThemePanel = activeTabId === tabId && activeSidePanelTab === 'theme';
-              return (
-                <div
-                  key={`theme-${tabId}`}
-                  className={cn('absolute inset-0 z-10', !isVisibleThemePanel && 'hidden')}
-                >
-                  <ThemeSidePanel
-                    followAppTerminalTheme={followAppTerminalTheme}
-                    currentThemeId={previewedOrVisibleThemeId}
-                    globalThemeId={terminalThemeId ?? terminalTheme.id}
-                    currentFontFamilyId={resolveTerminalFontFamilyId(focusedFontFamilyId, navigatorPlatform)}
-                    globalFontFamilyId={resolveTerminalFontFamilyId(terminalFontFamilyId, navigatorPlatform)}
-                    currentFontSize={focusedFontSize}
-                    currentFontWeight={focusedFontWeight}
-                    canResetTheme={followAppTerminalTheme ? false : focusedThemeOverridden}
-                    canResetFontFamily={focusedFontFamilyOverridden}
-                    canResetFontSize={focusedFontSizeOverridden}
-                    canResetFontWeight={focusedFontWeightOverridden}
-                    onThemeChange={handleThemeChangeForFocusedSession}
-                    onThemeReset={handleThemeResetForFocusedSession}
-                    onFontFamilyChange={handleFontFamilyChangeForFocusedSession}
-                    onFontFamilyReset={handleFontFamilyResetForFocusedSession}
-                    onFontSizeChange={handleFontSizeChangeForFocusedSession}
-                    onFontSizeReset={handleFontSizeResetForFocusedSession}
-                    onFontWeightChange={handleFontWeightChangeForFocusedSession}
-                    onFontWeightReset={handleFontWeightResetForFocusedSession}
-                    isVisible={isVisibleThemePanel}
-                  />
-                </div>
-              );
-            })}
-
-            {notesMountedTabIds.map((tabId: string) => {
-              const isVisibleNotesPanel = activeTabId === tabId && activeSidePanelTab === 'notes';
-              const openNoteRequest = notesOpenNoteByTab.get(tabId) ?? null;
-              return (
-                <div
-                  key={`notes-${tabId}`}
-                  className={cn('absolute inset-0 z-20 bg-background text-foreground', !isVisibleNotesPanel && 'hidden')}
-                  data-section={isVisibleNotesPanel ? 'terminal-notes-panel' : undefined}
-                >
-                  <NotesManager
-                    notes={notes}
-                    noteGroups={noteGroups}
-                    hosts={hosts}
-                    onUpdateNotes={updateNotes}
-                    onUpdateNoteGroups={updateNoteGroups}
-                    onOpenHost={handleOpenHostFromNotes}
-                    displayMode="sidebar"
-                    openNoteId={openNoteRequest?.noteId ?? null}
-                    openNoteRequestId={openNoteRequest?.requestId ?? null}
-                  />
-                </div>
-              );
-            })}
-
-            {shouldRenderAiPanels && (
-              <AISidePanelStateRoot validAIScopeTargetIds={validAIScopeTargetIds}>
-                <AIChatPanelsHost
-                  mountedTabIds={mountedAiTabIds}
-                  activeTabId={activeTabId}
-                  activeSidePanelTab={activeSidePanelTab}
-                  contextsByTabId={aiContextsByTabId}
-                  resolveExecutorContext={resolveAIExecutorContext}
-                  pendingTerminalSelection={pendingTerminalSelectionForAI}
-                  onPendingTerminalSelectionConsumed={handlePendingTerminalSelectionConsumed}
-                  notes={notes}
-                  hosts={hosts}
-                  onOpenVaultNoteFromChat={onOpenVaultNoteFromChat}
-                  onOpenVaultHostFromChat={onOpenVaultHostFromChat}
-                  onOpenVaultSectionFromChat={onOpenVaultSectionFromChat}
-                />
-              </AISidePanelStateRoot>
-            )}
+                  <X size={15} />
+                </Btn>
+              </TooltipTrigger>
+              <TooltipContent>{t('terminal.layer.closePanel')}</TooltipContent>
+            </Tooltip>
           </div>
+        )}
+        <div className="flex-1 min-h-0 relative" data-section="terminal-side-panel-content">
+          <MemoizedSidePanelMountedContent ctx={ctx} />
         </div>
       </div>
-    </>
+    </div>
   );
 }
-
-export const TerminalLayerSidePanelSection = memo(
-  TerminalLayerSidePanelShell,
-  (prev, next) => terminalLayerSidePanelCtxEqual(prev.ctx, next.ctx),
-);
-TerminalLayerSidePanelSection.displayName = 'TerminalLayerSidePanelSection';

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -15,6 +15,7 @@ import { useTerminalAiContexts } from './useTerminalAiContexts';
 import { useTerminalLayerEffects } from './useTerminalLayerEffects';
 import { useTerminalThemePanelState } from './useTerminalThemePanelState';
 import { useManualTerminalChromeSurfaceInjection } from '../../application/state/useManualTerminalChromeSurfaceInjection';
+import { sidePanelLiveStore } from '../../application/state/sidePanelLiveStore';
 import { useTerminalWorkspaceLayout } from './useTerminalWorkspaceLayout';
 import type { SidePanelTab } from './TerminalLayerSupport';
 
@@ -206,6 +207,26 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     themeState.resolvedPreviewTheme,
     !s.followAppTerminalTheme && isTerminalLayerVisible,
   );
+
+  sidePanelLiveStore.update({
+    sftpActiveHost,
+    activeTerminalSessionIdForSftp,
+    activeTerminalCwd,
+    activeWorkspace,
+    activeTerminalSessionForSystem: activeTerminalSessionForSystem ?? null,
+    activeSystemSessionHost,
+    focusedHost,
+    historySessionId,
+    resolvedPreviewTheme: themeState.resolvedPreviewTheme,
+    previewedOrVisibleThemeId: themeState.previewedOrVisibleThemeId,
+    focusedFontFamilyId: themeState.focusedFontFamilyId,
+    focusedFontFamilyOverridden: themeState.focusedFontFamilyOverridden,
+    focusedFontSize: themeState.focusedFontSize,
+    focusedFontSizeOverridden: themeState.focusedFontSizeOverridden,
+    focusedFontWeight: themeState.focusedFontWeight,
+    focusedFontWeightOverridden: themeState.focusedFontWeightOverridden,
+    focusedThemeOverridden: themeState.focusedThemeOverridden,
+  });
 
   const { aiContextsByTabId, resolveAIExecutorContext } = useTerminalAiContexts({
     hosts: s.hosts,

--- a/components/terminalLayer/terminalLayerSidePanelHiddenWrapper.ts
+++ b/components/terminalLayer/terminalLayerSidePanelHiddenWrapper.ts
@@ -1,0 +1,15 @@
+import { cn } from '../../lib/utils';
+
+export function sidePanelHiddenPanelClassName(hidden: boolean): string {
+  return cn(
+    'absolute inset-0 z-10',
+    hidden && 'hidden [content-visibility:hidden] [contain:strict]',
+  );
+}
+
+export function sidePanelHiddenNotesPanelClassName(hidden: boolean): string {
+  return cn(
+    'absolute inset-0 z-20 bg-background text-foreground',
+    hidden && 'hidden [content-visibility:hidden] [contain:strict]',
+  );
+}

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -1,0 +1,466 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { memo, useCallback, useSyncExternalStore } from 'react';
+
+import { activeTabStore, useIsTabActive } from '../../application/state/activeTabStore';
+import {
+  getSidePanelLiveSnapshot,
+  subscribeSidePanelLiveSnapshot,
+} from '../../application/state/sidePanelLiveStore';
+import { resolveTerminalFontFamilyId } from '../../infrastructure/config/fonts';
+import type { Host } from '../../types';
+import { SystemManagerSidePanel } from '../systemManager/SystemManagerSidePanel';
+import { resolveSftpFollowTerminalCwdTargetHost } from '../sftp/sftpFollowTerminalCwd';
+import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
+import type { SidePanelTab } from './TerminalLayerSupport';
+import { sidePanelHiddenNotesPanelClassName, sidePanelHiddenPanelClassName } from './terminalLayerSidePanelHiddenWrapper';
+
+type SidePanelStableContext = Record<string, any>;
+const navigatorPlatform = typeof navigator !== 'undefined' ? navigator.platform : '';
+
+function useSidePanelTabType(tabId: string, sidePanelOpenTabs: Map<string, SidePanelTab>): SidePanelTab | null {
+  return sidePanelOpenTabs.get(tabId) ?? null;
+}
+
+function useSidePanelLiveSnapshotForTab(tabId: string, subscribe: boolean) {
+  const getSnapshot = useCallback(
+    () => getSidePanelLiveSnapshot(subscribe),
+    [subscribe],
+  );
+  return useSyncExternalStore(
+    (listener) => subscribeSidePanelLiveSnapshot(subscribe, listener),
+    getSnapshot,
+    getSnapshot,
+  );
+}
+
+function SidePanelSftpSlotInner({
+  tabId,
+  ctx,
+}: {
+  tabId: string;
+  ctx: SidePanelStableContext;
+}) {
+  const isTabActive = useIsTabActive(tabId);
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
+  const isVisible = isTabActive && sidePanelTab === 'sftp';
+  const live = useSidePanelLiveSnapshotForTab(tabId, isVisible);
+
+  const {
+    SftpSidePanel,
+    effectiveHosts,
+    hosts,
+    keys,
+    identities,
+    knownHosts,
+    updateHosts,
+    handleAddKnownHost,
+    sftpDefaultViewMode,
+    sftpHostForTab,
+    sftpInitialLocationForTab,
+    sftpPendingUploadsForTab,
+    handleSftpInitialLocationApplied,
+    handlePendingUploadHandled,
+    sftpDoubleClickBehavior,
+    sftpAutoSync,
+    sftpShowHiddenFiles,
+    sftpUseCompressedUpload,
+    hotkeyScheme,
+    keyBindings,
+    editorWordWrap,
+    setEditorWordWrap,
+    getTerminalCwd,
+    sftpFollowTerminalCwd,
+    setSftpFollowTerminalCwd,
+    refocusActiveTerminalSession,
+    terminalSettings,
+  } = ctx;
+
+  const storedSftpHost = sftpHostForTab.get(tabId) ?? null;
+  const panelActiveHost = isVisible
+    ? (live.sftpActiveHost ?? storedSftpHost)
+    : storedSftpHost;
+
+  const handleFollowTerminalCwdChange = useCallback((enabled: boolean, visibleHost?: Host | null) => {
+    const isActive = activeTabStore.getActiveTabId() === tabId;
+    const stored = (sftpHostForTab as Map<string, Host>).get(tabId) ?? null;
+    const snapshot = getSidePanelLiveSnapshot(isActive);
+    const activeHost = isActive ? (snapshot.sftpActiveHost ?? stored) : stored;
+    const targetHost = resolveSftpFollowTerminalCwdTargetHost(visibleHost, activeHost);
+    if (!targetHost?.id) {
+      setSftpFollowTerminalCwd(enabled);
+      return;
+    }
+    let updated = false;
+    const nextHosts = (hosts as Host[]).map((host) => {
+      if (host.id !== targetHost.id) return host;
+      updated = true;
+      return { ...host, sftpFollowTerminalCwd: enabled };
+    });
+    if (updated) {
+      updateHosts(nextHosts);
+    } else {
+      setSftpFollowTerminalCwd(enabled);
+    }
+  }, [hosts, sftpHostForTab, setSftpFollowTerminalCwd, tabId, updateHosts]);
+
+  const handleInitialLocationApplied = useCallback(
+    (location: { hostId: string; path: string }) => {
+      handleSftpInitialLocationApplied(tabId, location);
+    },
+    [handleSftpInitialLocationApplied, tabId],
+  );
+
+  const handlePendingUploadHandledForTab = useCallback(
+    (requestId: string) => {
+      handlePendingUploadHandled(tabId, requestId);
+    },
+    [handlePendingUploadHandled, tabId],
+  );
+
+  return (
+    <div className={sidePanelHiddenPanelClassName(!isVisible)}>
+      <SftpSidePanel
+        hosts={effectiveHosts}
+        writableHosts={hosts}
+        keys={keys}
+        identities={identities}
+        knownHosts={knownHosts}
+        updateHosts={updateHosts}
+        onAddKnownHost={handleAddKnownHost}
+        sftpDefaultViewMode={sftpDefaultViewMode}
+        activeHost={panelActiveHost}
+        activeSessionId={isVisible ? live.activeTerminalSessionIdForSftp : null}
+        initialLocation={isVisible ? (sftpInitialLocationForTab.get(tabId) ?? null) : null}
+        onInitialLocationApplied={handleInitialLocationApplied}
+        showWorkspaceHostHeader={isVisible && !!live.activeWorkspace}
+        isVisible={isVisible}
+        renderOverlays={isVisible}
+        pendingUpload={sftpPendingUploadsForTab.get(tabId) ?? null}
+        onPendingUploadHandled={handlePendingUploadHandledForTab}
+        sftpDoubleClickBehavior={sftpDoubleClickBehavior}
+        sftpAutoSync={isVisible ? sftpAutoSync : false}
+        sftpShowHiddenFiles={sftpShowHiddenFiles}
+        sftpUseCompressedUpload={sftpUseCompressedUpload}
+        hotkeyScheme={hotkeyScheme}
+        keyBindings={keyBindings}
+        editorWordWrap={editorWordWrap}
+        setEditorWordWrap={setEditorWordWrap}
+        onGetTerminalCwd={getTerminalCwd}
+        activeTerminalCwd={isVisible ? live.activeTerminalCwd : null}
+        sftpFollowTerminalCwd={sftpFollowTerminalCwd}
+        onSftpFollowTerminalCwdChange={handleFollowTerminalCwdChange}
+        onRequestTerminalFocus={refocusActiveTerminalSession}
+        terminalSettings={terminalSettings}
+      />
+    </div>
+  );
+}
+
+export const SidePanelSftpSlot = memo(SidePanelSftpSlotInner);
+SidePanelSftpSlot.displayName = 'SidePanelSftpSlot';
+
+function SidePanelSystemSlotInner({
+  tabId,
+  ctx,
+}: {
+  tabId: string;
+  ctx: SidePanelStableContext;
+}) {
+  const isTabActive = useIsTabActive(tabId);
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
+  const isVisible = isTabActive && sidePanelTab === 'system';
+  const live = useSidePanelLiveSnapshotForTab(tabId, isTabActive);
+
+  const {
+    refocusActiveTerminalSession,
+    snippets,
+    terminalSettings,
+  } = ctx;
+
+  return (
+    <div className={sidePanelHiddenPanelClassName(!isVisible)}>
+      <SystemManagerSidePanel
+        key={live.activeTerminalSessionForSystem?.id ?? 'system-none'}
+        session={live.activeTerminalSessionForSystem ?? null}
+        sessionHost={live.activeSystemSessionHost ?? null}
+        showWorkspaceHostHeader={isVisible && !!live.activeWorkspace}
+        isVisible={isVisible}
+        terminalSettings={terminalSettings}
+        snippets={snippets}
+        onRequestTerminalFocus={refocusActiveTerminalSession}
+      />
+    </div>
+  );
+}
+
+export const SidePanelSystemSlot = memo(SidePanelSystemSlotInner);
+SidePanelSystemSlot.displayName = 'SidePanelSystemSlot';
+
+function SidePanelScriptsSlotInner({
+  tabId,
+  ctx,
+}: {
+  tabId: string;
+  ctx: SidePanelStableContext;
+}) {
+  const isTabActive = useIsTabActive(tabId);
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
+  const isVisible = isTabActive && sidePanelTab === 'scripts';
+
+  const {
+    ScriptsSidePanel,
+    snippets,
+    snippetPackages,
+    updateSnippets,
+    updateSnippetPackages,
+    handleSnippetFromPanel,
+  } = ctx;
+
+  return (
+    <div className={sidePanelHiddenPanelClassName(!isVisible)}>
+      <ScriptsSidePanel
+        snippets={snippets}
+        packages={snippetPackages}
+        onSnippetsChange={updateSnippets}
+        onPackagesChange={updateSnippetPackages}
+        onSnippetClick={handleSnippetFromPanel}
+        isVisible={isVisible}
+      />
+    </div>
+  );
+}
+
+export const SidePanelScriptsSlot = memo(SidePanelScriptsSlotInner);
+SidePanelScriptsSlot.displayName = 'SidePanelScriptsSlot';
+
+function SidePanelThemeSlotInner({
+  tabId,
+  ctx,
+}: {
+  tabId: string;
+  ctx: SidePanelStableContext;
+}) {
+  const isTabActive = useIsTabActive(tabId);
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
+  const isVisible = isTabActive && sidePanelTab === 'theme';
+  const live = useSidePanelLiveSnapshotForTab(tabId, isTabActive);
+
+  const {
+    ThemeSidePanel,
+    followAppTerminalTheme,
+    terminalTheme,
+    terminalThemeId,
+    terminalFontFamilyId,
+    handleThemeChangeForFocusedSession,
+    handleThemeResetForFocusedSession,
+    handleFontFamilyChangeForFocusedSession,
+    handleFontFamilyResetForFocusedSession,
+    handleFontSizeChangeForFocusedSession,
+    handleFontSizeResetForFocusedSession,
+    handleFontWeightChangeForFocusedSession,
+    handleFontWeightResetForFocusedSession,
+  } = ctx;
+
+  return (
+    <div className={sidePanelHiddenPanelClassName(!isVisible)}>
+      <ThemeSidePanel
+        followAppTerminalTheme={followAppTerminalTheme}
+        currentThemeId={live.previewedOrVisibleThemeId}
+        globalThemeId={terminalThemeId ?? terminalTheme.id}
+        currentFontFamilyId={resolveTerminalFontFamilyId(live.focusedFontFamilyId, navigatorPlatform)}
+        globalFontFamilyId={resolveTerminalFontFamilyId(terminalFontFamilyId, navigatorPlatform)}
+        currentFontSize={live.focusedFontSize}
+        currentFontWeight={live.focusedFontWeight}
+        canResetTheme={followAppTerminalTheme ? false : live.focusedThemeOverridden}
+        canResetFontFamily={live.focusedFontFamilyOverridden}
+        canResetFontSize={live.focusedFontSizeOverridden}
+        canResetFontWeight={live.focusedFontWeightOverridden}
+        onThemeChange={handleThemeChangeForFocusedSession}
+        onThemeReset={handleThemeResetForFocusedSession}
+        onFontFamilyChange={handleFontFamilyChangeForFocusedSession}
+        onFontFamilyReset={handleFontFamilyResetForFocusedSession}
+        onFontSizeChange={handleFontSizeChangeForFocusedSession}
+        onFontSizeReset={handleFontSizeResetForFocusedSession}
+        onFontWeightChange={handleFontWeightChangeForFocusedSession}
+        onFontWeightReset={handleFontWeightResetForFocusedSession}
+        isVisible={isVisible}
+      />
+    </div>
+  );
+}
+
+export const SidePanelThemeSlot = memo(SidePanelThemeSlotInner);
+SidePanelThemeSlot.displayName = 'SidePanelThemeSlot';
+
+function SidePanelNotesSlotInner({
+  tabId,
+  ctx,
+}: {
+  tabId: string;
+  ctx: SidePanelStableContext;
+}) {
+  const isTabActive = useIsTabActive(tabId);
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = useSidePanelTabType(tabId, sidePanelOpenTabs);
+  const isVisible = isTabActive && sidePanelTab === 'notes';
+  const openNoteRequest = (ctx.notesOpenNoteByTab as Map<string, { noteId: string; requestId: number }>).get(tabId) ?? null;
+
+  const {
+    NotesManager,
+    notes,
+    noteGroups,
+    hosts,
+    updateNotes,
+    updateNoteGroups,
+    handleOpenHostFromNotes,
+  } = ctx;
+
+  return (
+    <div
+      className={sidePanelHiddenNotesPanelClassName(!isVisible)}
+      data-section={isVisible ? 'terminal-notes-panel' : undefined}
+    >
+      <NotesManager
+        notes={notes}
+        noteGroups={noteGroups}
+        hosts={hosts}
+        onUpdateNotes={updateNotes}
+        onUpdateNoteGroups={updateNoteGroups}
+        onOpenHost={handleOpenHostFromNotes}
+        displayMode="sidebar"
+        openNoteId={openNoteRequest?.noteId ?? null}
+        openNoteRequestId={openNoteRequest?.requestId ?? null}
+      />
+    </div>
+  );
+}
+
+export const SidePanelNotesSlot = memo(SidePanelNotesSlotInner);
+SidePanelNotesSlot.displayName = 'SidePanelNotesSlot';
+
+function SidePanelHistorySlotInner({ ctx }: { ctx: SidePanelStableContext }) {
+  const activeTabId = useSyncExternalStore(
+    activeTabStore.subscribe,
+    activeTabStore.getActiveTabId,
+    activeTabStore.getActiveTabId,
+  );
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const sidePanelTab = activeTabId ? sidePanelOpenTabs.get(activeTabId) ?? null : null;
+  const isVisible = sidePanelTab === 'history';
+  const live = useSidePanelLiveSnapshotForTab(activeTabId ?? '', isVisible);
+
+  const {
+    HistorySidePanel,
+    remoteHistory,
+    shellHistory,
+    handleHistoryPaste,
+    handleHistoryRun,
+  } = ctx;
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="absolute inset-0 z-10">
+      <HistorySidePanel
+        focusedHost={live.focusedHost}
+        focusedSessionId={live.historySessionId}
+        state={remoteHistory.getState(live.focusedHost?.id, live.historySessionId)}
+        globalEntries={shellHistory}
+        onFetch={remoteHistory.fetch}
+        onPasteToTerminal={handleHistoryPaste}
+        onRunInTerminal={handleHistoryRun}
+        isVisible
+      />
+    </div>
+  );
+}
+
+export const SidePanelHistorySlot = memo(SidePanelHistorySlotInner);
+SidePanelHistorySlot.displayName = 'SidePanelHistorySlot';
+
+function SidePanelAiSlotInner({ ctx }: { ctx: SidePanelStableContext }) {
+  const activeTabId = useSyncExternalStore(
+    activeTabStore.subscribe,
+    activeTabStore.getActiveTabId,
+    activeTabStore.getActiveTabId,
+  );
+  const sidePanelOpenTabs = ctx.sidePanelOpenTabs as Map<string, SidePanelTab>;
+  const activeSidePanelTab = activeTabId ? sidePanelOpenTabs.get(activeTabId) ?? null : null;
+
+  const {
+    AIChatPanelsHost,
+    AISidePanelStateRoot,
+    mountedAiTabIds,
+    aiContextsByTabId,
+    resolveAIExecutorContext,
+    pendingTerminalSelectionForAI,
+    handlePendingTerminalSelectionConsumed,
+    notes,
+    hosts,
+    onOpenVaultNoteFromChat,
+    onOpenVaultHostFromChat,
+    onOpenVaultSectionFromChat,
+    validAIScopeTargetIds,
+  } = ctx;
+
+  if (mountedAiTabIds.length === 0) return null;
+  if (AI_PANEL_FORCE_HIDE_SHELL && activeSidePanelTab === 'ai') return null;
+
+  return (
+    <AISidePanelStateRoot validAIScopeTargetIds={validAIScopeTargetIds}>
+      <AIChatPanelsHost
+        mountedTabIds={mountedAiTabIds}
+        activeTabId={activeTabId}
+        activeSidePanelTab={activeSidePanelTab}
+        contextsByTabId={aiContextsByTabId}
+        resolveExecutorContext={resolveAIExecutorContext}
+        pendingTerminalSelection={pendingTerminalSelectionForAI}
+        onPendingTerminalSelectionConsumed={handlePendingTerminalSelectionConsumed}
+        notes={notes}
+        hosts={hosts}
+        onOpenVaultNoteFromChat={onOpenVaultNoteFromChat}
+        onOpenVaultHostFromChat={onOpenVaultHostFromChat}
+        onOpenVaultSectionFromChat={onOpenVaultSectionFromChat}
+      />
+    </AISidePanelStateRoot>
+  );
+}
+
+export const SidePanelAiSlot = memo(SidePanelAiSlotInner);
+SidePanelAiSlot.displayName = 'SidePanelAiSlot';
+
+export function SidePanelMountedContent({ ctx }: { ctx: SidePanelStableContext }) {
+  const {
+    mountedSftpTabIds,
+    systemMountedTabIds,
+    scriptsMountedTabIds,
+    themeMountedTabIds,
+    notesMountedTabIds,
+  } = ctx;
+
+  return (
+    <>
+      {mountedSftpTabIds.map((tabId: string) => (
+        <SidePanelSftpSlot key={tabId} tabId={tabId} ctx={ctx} />
+      ))}
+      {systemMountedTabIds.map((tabId: string) => (
+        <SidePanelSystemSlot key={`system-${tabId}`} tabId={tabId} ctx={ctx} />
+      ))}
+      {scriptsMountedTabIds.map((tabId: string) => (
+        <SidePanelScriptsSlot key={`scripts-${tabId}`} tabId={tabId} ctx={ctx} />
+      ))}
+      <SidePanelHistorySlot ctx={ctx} />
+      {themeMountedTabIds.map((tabId: string) => (
+        <SidePanelThemeSlot key={`theme-${tabId}`} tabId={tabId} ctx={ctx} />
+      ))}
+      {notesMountedTabIds.map((tabId: string) => (
+        <SidePanelNotesSlot key={`notes-${tabId}`} tabId={tabId} ctx={ctx} />
+      ))}
+      <SidePanelAiSlot ctx={ctx} />
+    </>
+  );
+}

--- a/components/terminalLayer/terminalLayerViewMemo.test.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.test.ts
@@ -5,6 +5,7 @@ import type { Workspace } from "../../types";
 import {
   terminalLayerFocusSidebarPropsEqual,
   terminalLayerSidePanelCtxEqual,
+  terminalLayerSidePanelStableCtxEqual,
   terminalLayerViewCtxEqual,
   terminalLayerWorkspaceCtxEqual,
 } from "./terminalLayerViewMemo.ts";
@@ -93,6 +94,30 @@ test("terminal layer memo re-renders when active workspace root changes", () => 
     terminalLayerViewCtxEqual(
       { activeWorkspace: prevWorkspace },
       { activeWorkspace: nextWorkspace },
+    ),
+    false,
+  );
+});
+
+test("terminal layer side panel stable ctx ignores linked terminal cwd changes", () => {
+  const baseCtx = {
+    mountedSftpTabIds: ["workspace-1"],
+    sidePanelOpenTabs: new Map([["workspace-1", "sftp"]]),
+    activeTerminalCwd: "/home/user",
+    sftpFollowTerminalCwd: true,
+  };
+
+  assert.equal(
+    terminalLayerSidePanelStableCtxEqual(
+      baseCtx,
+      { ...baseCtx, activeTerminalCwd: "/home/user/project" },
+    ),
+    true,
+  );
+  assert.equal(
+    terminalLayerSidePanelCtxEqual(
+      baseCtx,
+      { ...baseCtx, activeTerminalCwd: "/home/user/project" },
     ),
     false,
   );

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -135,7 +135,27 @@ function sidePanelCtxKeyEqual(prev: Ctx, next: Ctx, key: string): boolean {
   return prev[key] === next[key];
 }
 
-const SIDE_PANEL_CTX_KEYS = [
+const SIDE_PANEL_LIVE_CTX_KEYS = [
+  'activeTerminalSessionForSystem',
+  'activeSystemSessionHost',
+  'focusedHost',
+  'historySessionId',
+  'resolvedPreviewTheme',
+  'previewedOrVisibleThemeId',
+  'sftpActiveHost',
+  'activeTerminalSessionIdForSftp',
+  'activeTerminalCwd',
+  'activeWorkspace',
+  'focusedFontFamilyId',
+  'focusedFontFamilyOverridden',
+  'focusedFontSize',
+  'focusedFontSizeOverridden',
+  'focusedFontWeight',
+  'focusedFontWeightOverridden',
+  'focusedThemeOverridden',
+] as const;
+
+const SIDE_PANEL_STABLE_CTX_KEYS = [
   'mountedSftpTabIds',
   'mountedAiTabIds',
   'notesMountedTabIds',
@@ -143,10 +163,6 @@ const SIDE_PANEL_CTX_KEYS = [
   'scriptsMountedTabIds',
   'systemMountedTabIds',
   'themeMountedTabIds',
-  'activeTerminalSessionForSystem',
-  'activeSystemSessionHost',
-  'focusedHost',
-  'historySessionId',
   'remoteHistory',
   'shellHistory',
   'handleHistoryPaste',
@@ -157,12 +173,7 @@ const SIDE_PANEL_CTX_KEYS = [
   'sidePanelWidth',
   'sidePanelPosition',
   'sidePanelOpenTabs',
-  'resolvedPreviewTheme',
-  'sftpActiveHost',
   'sftpHostForTab',
-  'activeTerminalSessionIdForSftp',
-  'activeTerminalCwd',
-  'activeWorkspace',
   'effectiveHosts',
   'hosts',
   'keys',
@@ -190,16 +201,9 @@ const SIDE_PANEL_CTX_KEYS = [
   'snippetPackages',
   'handleSnippetFromPanel',
   'followAppTerminalTheme',
-  'previewedOrVisibleThemeId',
   'terminalTheme',
+  'terminalThemeId',
   'terminalFontFamilyId',
-  'focusedFontFamilyId',
-  'focusedFontFamilyOverridden',
-  'focusedFontSize',
-  'focusedFontSizeOverridden',
-  'focusedFontWeight',
-  'focusedFontWeightOverridden',
-  'focusedThemeOverridden',
   'handleThemeChangeForFocusedSession',
   'handleThemeResetForFocusedSession',
   'handleFontFamilyChangeForFocusedSession',
@@ -330,8 +334,16 @@ const WORKSPACE_CTX_KEYS = [
   'onEndSessionDrag',
 ] as const;
 
+export function terminalLayerSidePanelStableCtxEqual(prev: Ctx, next: Ctx): boolean {
+  for (const key of SIDE_PANEL_STABLE_CTX_KEYS as unknown as string[]) {
+    if (!sidePanelCtxKeyEqual(prev, next, key)) return false;
+  }
+  return true;
+}
+
 export function terminalLayerSidePanelCtxEqual(prev: Ctx, next: Ctx): boolean {
-  for (const key of SIDE_PANEL_CTX_KEYS as unknown as string[]) {
+  if (!terminalLayerSidePanelStableCtxEqual(prev, next)) return false;
+  for (const key of SIDE_PANEL_LIVE_CTX_KEYS as unknown as string[]) {
     if (!sidePanelCtxKeyEqual(prev, next, key)) return false;
   }
   return true;

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -24,6 +24,16 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
 
   const activityEscapeFiltersRef = useRef<any>(new Map());
 
+  const remeasureScheduledRef = useRef(false);
+  const layoutEffectSnapshotRef = useRef({
+    workspaceId: undefined as string | undefined,
+    viewMode: undefined as string | undefined,
+    composeBarOpen: false,
+    shellWidth: 0,
+    width: 0,
+    height: 0,
+  });
+
   const remeasureWorkspaceArea = useCallback(() => {
     const el = workspaceInnerRef.current;
     if (!el) return;
@@ -38,10 +48,15 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   }, [setWorkspaceArea, workspaceInnerRef]);
 
   const scheduleWorkspaceAreaRemeasure = useCallback(() => {
+    if (remeasureScheduledRef.current) return;
+    remeasureScheduledRef.current = true;
     remeasureWorkspaceArea();
     requestAnimationFrame(() => {
       remeasureWorkspaceArea();
-      requestAnimationFrame(remeasureWorkspaceArea);
+      requestAnimationFrame(() => {
+        remeasureWorkspaceArea();
+        remeasureScheduledRef.current = false;
+      });
     });
   }, [remeasureWorkspaceArea, requestAnimationFrame]);
 
@@ -158,6 +173,31 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   // because it updates continuously during drag.
   useEffect(() => {
       if (!isTerminalLayerVisible) return;
+      const el = workspaceInnerRef.current;
+      const width = el?.clientWidth ?? 0;
+      const height = el?.clientHeight ?? 0;
+      const prev = layoutEffectSnapshotRef.current;
+      const dimensionsUnchanged = width > 0
+        && height > 0
+        && prev.width === width
+        && prev.height === height
+        && prev.shellWidth === sidePanelShellWidth;
+      if (
+        dimensionsUnchanged
+        && prev.workspaceId === activeWorkspaceId
+        && prev.viewMode === activeWorkspaceViewMode
+        && prev.composeBarOpen === isComposeBarOpen
+      ) {
+        return;
+      }
+      layoutEffectSnapshotRef.current = {
+        workspaceId: activeWorkspaceId,
+        viewMode: activeWorkspaceViewMode,
+        composeBarOpen: isComposeBarOpen,
+        shellWidth: sidePanelShellWidth,
+        width,
+        height,
+      };
       scheduleWorkspaceAreaRemeasure();
     }, [
       activeWorkspaceId,

--- a/infrastructure/theme/terminalAppearanceVars.ts
+++ b/infrastructure/theme/terminalAppearanceVars.ts
@@ -63,6 +63,25 @@ export function injectTerminalLayerChromeSurfaceVars(theme: TerminalTheme): void
   applyTerminalAppearanceVarsToTargets(collectTerminalLayerChromeSurfaceElements(), theme);
 }
 
+function clearTerminalAppearanceVarsOnTargets(targets: HTMLElement[]): void {
+  for (const target of targets) {
+    for (const key of TERMINAL_APPEARANCE_VAR_KEYS) {
+      removeStylePropertyIfSet(target, key);
+    }
+    delete target.dataset.terminalAppearanceId;
+  }
+}
+
+export function clearTerminalChromeSurfaceVars(): void {
+  if (typeof document === 'undefined') return;
+  clearTerminalAppearanceVarsOnTargets(collectTerminalChromeSurfaceElements());
+}
+
+export function clearTerminalLayerChromeSurfaceVars(): void {
+  if (typeof document === 'undefined') return;
+  clearTerminalAppearanceVarsOnTargets(collectTerminalLayerChromeSurfaceElements());
+}
+
 export type InjectTerminalAppearanceVarsOptions = {
   root?: HTMLElement | null;
   includeChromeSurfaces?: boolean;
@@ -102,12 +121,7 @@ export function clearTerminalAppearanceVars(root?: HTMLElement | null): void {
   )) {
     if (!targets.includes(hostTreeRoot)) targets.push(hostTreeRoot);
   }
-  for (const target of targets) {
-    for (const key of TERMINAL_APPEARANCE_VAR_KEYS) {
-      removeStylePropertyIfSet(target, key);
-    }
-    delete target.dataset.terminalAppearanceId;
-  }
+  clearTerminalAppearanceVarsOnTargets(targets);
 }
 
 export function injectTerminalPaneAppearanceVars(sessionId: string, theme: TerminalTheme): void {


### PR DESCRIPTION
## Summary
- Fix manual ↔ follow-app terminal theme inconsistencies, including SSH connection dialog overlay and chrome surface variable injection order.
- Isolate side-panel live state per active tab and split mounted side-panel slots so workspace tab switches no longer re-render every hidden panel.
- Address Bugbot findings: avoid parent layout effect clearing child chrome injections, preserve system panel session when switching side-panel tabs, and stop wiping shared top-tab vars when manual chrome hooks disable.

## Test plan
- [x] `npm run lint`
- [x] Theme/side-panel unit tests (AppFollowTerminalTheme, useManualTerminalChromeSurfaceInjection, useActiveChromeTheme, sidePanelLiveStore, terminalLayerViewMemo)
- [x] Bugbot review clean
- [ ] Manual: toggle follow-app ↔ manual theme and verify connection dialog, toolbar, host tree, and side panel match
- [ ] Manual: switch between workspace tabs with SFTP/system/theme side panels open and confirm no stale session or theme flash


Made with [Cursor](https://cursor.com)