### PR TITLE
[codex] Fix Ctrl+C full-screen terminal cleanup

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -810,15 +810,15 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         const rendererKeyAt = Date.now();
         e.preventDefault();
         e.stopPropagation();
-        const priorityOptions = shouldArmTerminalInterruptDisplayGateForProtocol(ctx.host.protocol)
-          ? { reason: "interrupt" as const }
-          : undefined;
         const priority = prioritizeTerminalInput(
           term,
           id,
           getFlowControllerForTerm(term),
           ctx.terminalBackend,
-          priorityOptions,
+          {
+            reason: "interrupt",
+            drainStaleOutput: shouldArmTerminalInterruptDisplayGateForProtocol(ctx.host.protocol),
+          },
         );
         const interruptTrace = createTerminalInterruptTrace({
           sessionId: id,

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -8,7 +8,6 @@ import {
   filterTerminalInterruptDisplayOutput,
   prioritizeTerminalInput,
   releaseTerminalFlowOutputForTerm,
-  shouldArmTerminalInterruptDisplayGateForProtocol,
   teardownTerminalOutputPipeline,
 } from "./terminalOutputPipeline.ts";
 import { FLOW_LOW_WATER_MARK } from "./terminalFlowConstants.ts";
@@ -239,43 +238,307 @@ test("prioritizeTerminalInput defers source resume until after input is forwarde
   clearTerminalSessionFlowAck("sess-1");
 });
 
-test("interrupt display gate is only enabled for ssh-like protocols", () => {
-  assert.equal(shouldArmTerminalInterruptDisplayGateForProtocol(undefined), true);
-  assert.equal(shouldArmTerminalInterruptDisplayGateForProtocol("ssh"), true);
-  assert.equal(shouldArmTerminalInterruptDisplayGateForProtocol("local"), false);
-  assert.equal(shouldArmTerminalInterruptDisplayGateForProtocol("telnet"), false);
-  assert.equal(shouldArmTerminalInterruptDisplayGateForProtocol("serial"), false);
+test("interrupt priority drains queued display output for ssh-like interrupts", () => {
+  const term = createFakeTerm();
+  const events: string[] = [];
+  const backend = {
+    ackSessionFlow: (_sessionId: string, bytes: number) => {
+      events.push(`ack:${bytes}`);
+    },
+    setSessionFlowPaused: (_sessionId: string, paused: boolean) => {
+      events.push(paused ? "ipc-pause" : "ipc-resume");
+    },
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => events.push("pause"),
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1024);
+  enqueueTerminalWrite(term, 20, () => {});
+  enqueueTerminalWrite(term, 30, () => {});
+
+  const priority = prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => {
+      events.push("input-forwarded");
+      callback();
+    },
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 4000,
+      quietMs: 100,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  assert.equal(priority.skippedReason, undefined);
+  assert.equal(priority.scheduledBackendResume, true);
+  assert.equal(priority.ackAfterInputBytes, 30);
+  assert.equal(priority.writeQueueDepth, 1);
+  assert.equal(flow.pendingBytes(), 0);
+  assert.deepEqual(events, ["pause", "input-forwarded", "ack:30", "ipc-resume"]);
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "old output", { now: 4001 }),
+    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "more old^C\r\n$ ", { now: 4002 }),
+    { accepted: true, data: "^C\r\n$ ", droppedBytes: 8, reason: "interrupt-echo" },
+  );
 });
 
-test("interrupt display gate is not armed when there is no renderer backlog", () => {
+test("interrupt display drain preserves alternate-screen exit controls", () => {
   const term = createFakeTerm();
   const backend = {
     ackSessionFlow: () => {},
     setSessionFlowPaused: () => {},
   };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
 
-  const priority = prioritizeTerminalInput(
+  prioritizeTerminalInput(
     term,
     "sess-1",
-    undefined,
+    flow,
     backend,
     (callback: () => void) => callback(),
-    { reason: "interrupt", now: 900, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 6100,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
   );
 
-  assert.equal(priority.skippedReason, "below-threshold");
   assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "KeyboardInterrupt\r\n$ ", { now: 901 }),
+    filterTerminalInterruptDisplayOutput(term, "stale frame\x1b[?1049l", { now: 6101 }),
     {
       accepted: true,
-      data: "KeyboardInterrupt\r\n$ ",
-      droppedBytes: 0,
-      reason: "inactive",
+      data: "\x1b[?1049l",
+      droppedBytes: "stale frame".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "stale frame\x1b[?1049l\r\n$ ", { now: 6200 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l$ ",
+      droppedBytes: "stale frame\r\n".length,
+      reason: "prompt-gap",
     },
   );
 });
 
-test("interrupt display gate is not armed for deferred ack-only output", () => {
+test("interrupt display drain preserves split alternate-screen exit controls", () => {
+  clearTerminalSessionFlowAck("sess-1");
+  const term = createFakeTerm();
+  const backend = {
+    ackSessionFlow: () => {},
+    setSessionFlowPaused: () => {},
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
+
+  prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => callback(),
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7100,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "stale frame\x1b[?104", { now: 7101 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "stale frame".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "9l^C\r\n$ ", { now: 7102 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l^C\r\n$ ",
+      droppedBytes: 0,
+      reason: "interrupt-echo",
+    },
+  );
+});
+
+test("interrupt display drain does not preserve unsafe combined private modes", () => {
+  clearTerminalSessionFlowAck("sess-1");
+  const term = createFakeTerm();
+  const backend = {
+    ackSessionFlow: () => {},
+    setSessionFlowPaused: () => {},
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
+
+  prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => callback(),
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7200,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  const unsafeSequence = "\x1b[?1049;25h";
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `stale frame${unsafeSequence}^C\r\n$ `, {
+      now: 7201,
+    }),
+    {
+      accepted: true,
+      data: "^C\r\n$ ",
+      droppedBytes: "stale frame".length + unsafeSequence.length,
+      reason: "interrupt-echo",
+    },
+  );
+});
+
+test("interrupt display drain accepts prompt candidates with OSC title and spaces", () => {
+  clearTerminalSessionFlowAck("sess-1");
+  const term = createFakeTerm();
+  const backend = {
+    ackSessionFlow: () => {},
+    setSessionFlowPaused: () => {},
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
+
+  prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => callback(),
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7300,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "old output", { now: 7301 }).accepted,
+    false,
+  );
+  const prompt = "\x1b]0;~/My Project\x07~/My Project$ ";
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, prompt, { now: 7400 }),
+    {
+      accepted: true,
+      data: prompt,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("interrupt display drain accepts split OSC prompt candidates", () => {
+  clearTerminalSessionFlowAck("sess-1");
+  const term = createFakeTerm();
+  const backend = {
+    ackSessionFlow: () => {},
+    setSessionFlowPaused: () => {},
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
+
+  prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => callback(),
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7500,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "old output\x1b]0;~/My ", { now: 7501 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "old output".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Project\x07~/My Project$ ", { now: 7600 }),
+    {
+      accepted: true,
+      data: "\x1b]0;~/My Project\x07~/My Project$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("interrupt priority leaves display output alone when stale drain is disabled", () => {
   clearTerminalSessionFlowAck("sess-deferred");
   const term = createFakeTerm();
   const acked: number[] = [];
@@ -294,13 +557,23 @@ test("interrupt display gate is not armed for deferred ack-only output", () => {
     undefined,
     backend,
     (callback: () => void) => deferred.push(callback),
-    { reason: "interrupt", now: 950, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
+    {
+      reason: "interrupt",
+      drainStaleOutput: false,
+      now: 5000,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 100,
+    },
   );
 
+  assert.equal(priority.skippedReason, "interrupt-priority-disabled");
   assert.equal(priority.deferredAckBytes, 42);
-  assert.equal(priority.scheduledBackendResume, true);
+  assert.equal(priority.scheduledBackendResume, false);
+  assert.deepEqual(deferred, []);
+  assert.deepEqual(acked, []);
   assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "KeyboardInterrupt\r\n$ ", { now: 951 }),
+    filterTerminalInterruptDisplayOutput(term, "KeyboardInterrupt\r\n$ ", { now: 5001 }),
     {
       accepted: true,
       data: "KeyboardInterrupt\r\n$ ",
@@ -308,233 +581,50 @@ test("interrupt display gate is not armed for deferred ack-only output", () => {
       reason: "inactive",
     },
   );
-
-  deferred[0]!();
-  assert.deepEqual(acked, [42]);
   clearTerminalSessionFlowAck("sess-deferred");
 });
 
-test("interrupt display gate drops stale output until the interrupt echo", () => {
+test("interrupt priority leaves display output alone below pressure threshold", () => {
+  clearTerminalSessionFlowAck("sess-low-pressure");
   const term = createFakeTerm();
-  const backend = {
-    ackSessionFlow: () => {},
-    setSessionFlowPaused: () => {},
-  };
   const flow = createOutputFlowController({
     highWaterMark: 100,
     lowWaterMark: 20,
     onPause: () => {},
     onResume: () => {},
   });
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 1000, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 1001 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "more old^C\r\n$ ", { now: 1002 }),
-    { accepted: true, data: "^C\r\n$ ", droppedBytes: 8, reason: "interrupt-echo" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "next output", { now: 1003 }),
-    { accepted: true, data: "next output", droppedBytes: 0, reason: "inactive" },
-  );
-});
-
-test("interrupt display gate resumes when interrupt echo is split across chunks", () => {
-  const term = createFakeTerm();
   const backend = {
     ackSessionFlow: () => {},
     setSessionFlowPaused: () => {},
   };
-  const flow = createOutputFlowController({
-    highWaterMark: 100,
-    lowWaterMark: 20,
-    onPause: () => {},
-    onResume: () => {},
-  });
-  flow.received(FLOW_LOW_WATER_MARK + 1);
 
-  prioritizeTerminalInput(
+  flow.received(119);
+  const priority = prioritizeTerminalInput(
     term,
-    "sess-1",
+    "sess-low-pressure",
     flow,
     backend,
     (callback: () => void) => callback(),
-    { reason: "interrupt", now: 1200, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 1201 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "^", { now: 1202 }),
-    { accepted: false, data: "", droppedBytes: 1, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "C\r\n$ ", { now: 1203 }),
     {
-      accepted: true,
-      data: "^C\r\n$ ",
-      droppedBytes: 0,
-      acceptedBytes: 5,
-      reason: "interrupt-echo",
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7800,
     },
   );
+
+  assert.equal(priority.skippedReason, "below-threshold");
   assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "next output", { now: 1204 }),
-    { accepted: true, data: "next output", droppedBytes: 0, reason: "inactive" },
+    filterTerminalInterruptDisplayOutput(
+      term,
+      "Type  :qa  and press <Enter> to exit Vim",
+      { now: 7801 },
+    ),
+    {
+      accepted: true,
+      data: "Type  :qa  and press <Enter> to exit Vim",
+      droppedBytes: 0,
+      reason: "inactive",
+    },
   );
-});
-
-test("interrupt display gate accepts a prompt after a quiet gap and ordinary input disarms it", () => {
-  const term = createFakeTerm();
-  const backend = {
-    ackSessionFlow: () => {},
-    setSessionFlowPaused: () => {},
-  };
-  const flow = createOutputFlowController({
-    highWaterMark: 100,
-    lowWaterMark: 20,
-    onPause: () => {},
-    onResume: () => {},
-  });
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 2000, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 2001 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 2100 }),
-    { accepted: true, data: "$ ", droppedBytes: 0, reason: "prompt-gap" },
-  );
-
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 3000, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 3001 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    undefined,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "input", now: 3002 },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "fresh output", { now: 3003 }),
-    { accepted: true, data: "fresh output", droppedBytes: 0, reason: "inactive" },
-  );
-});
-
-test("prompt candidate keeps only the prompt suffix and drops stale prefix", () => {
-  const term = createFakeTerm();
-  const backend = {
-    ackSessionFlow: () => {},
-    setSessionFlowPaused: () => {},
-  };
-  const flow = createOutputFlowController({
-    highWaterMark: 100,
-    lowWaterMark: 20,
-    onPause: () => {},
-    onResume: () => {},
-  });
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 6000, quietMs: 500, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "stale flood\r\n$ ", { now: 6001 }),
-    { accepted: true, data: "$ ", droppedBytes: 13, reason: "prompt-candidate" },
-  );
-});
-
-test("interrupt display gate falls back after quiet and max-drain limits", () => {
-  const term = createFakeTerm();
-  const backend = {
-    ackSessionFlow: () => {},
-    setSessionFlowPaused: () => {},
-  };
-  const flow = createOutputFlowController({
-    highWaterMark: 100,
-    lowWaterMark: 20,
-    onPause: () => {},
-    onResume: () => {},
-  });
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 4000, quietMs: 100, promptQuietMs: 80, maxDrainMs: 1000 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 4001 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "fresh output", { now: 4120 }),
-    { accepted: true, data: "fresh output", droppedBytes: 0, reason: "quiet-gap" },
-  );
-
-  flow.received(FLOW_LOW_WATER_MARK + 1);
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => callback(),
-    { reason: "interrupt", now: 5000, quietMs: 500, promptQuietMs: 80, maxDrainMs: 100 },
-  );
-
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "old output", { now: 5001 }),
-    { accepted: false, data: "", droppedBytes: 10, reason: "draining" },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "latest output", { now: 5100 }),
-    { accepted: true, data: "latest output", droppedBytes: 0, reason: "max-drain" },
-  );
+  clearTerminalSessionFlowAck("sess-low-pressure");
 });

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -395,6 +395,67 @@ test("interrupt display drain preserves split alternate-screen exit controls", (
   );
 });
 
+test("interrupt display drain preserves restore controls on split caret echo", () => {
+  clearTerminalSessionFlowAck("sess-1");
+  const term = createFakeTerm();
+  const backend = {
+    ackSessionFlow: () => {},
+    setSessionFlowPaused: () => {},
+  };
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  flow.received(FLOW_LOW_WATER_MARK + 1);
+
+  prioritizeTerminalInput(
+    term,
+    "sess-1",
+    flow,
+    backend,
+    (callback: () => void) => callback(),
+    {
+      reason: "interrupt",
+      drainStaleOutput: true,
+      now: 7150,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 1000,
+    },
+  );
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "stale frame\x1b[?104", { now: 7151 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "stale frame".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "9l^", { now: 7152 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: 1,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "C\r\n$ ", { now: 7153 }),
+    {
+      accepted: true,
+      data: "^C\r\n$ ",
+      droppedBytes: 0,
+      acceptedBytes: 5,
+      reason: "interrupt-echo",
+    },
+  );
+});
+
 test("interrupt display drain does not preserve unsafe combined private modes", () => {
   clearTerminalSessionFlowAck("sess-1");
   const term = createFakeTerm();
@@ -538,7 +599,7 @@ test("interrupt display drain accepts split OSC prompt candidates", () => {
   );
 });
 
-test("interrupt priority leaves display output alone when stale drain is disabled", () => {
+test("interrupt priority skips stale display drain but still flushes deferred acks", () => {
   clearTerminalSessionFlowAck("sess-deferred");
   const term = createFakeTerm();
   const acked: number[] = [];
@@ -567,11 +628,13 @@ test("interrupt priority leaves display output alone when stale drain is disable
     },
   );
 
-  assert.equal(priority.skippedReason, "interrupt-priority-disabled");
+  assert.equal(priority.skippedReason, undefined);
   assert.equal(priority.deferredAckBytes, 42);
-  assert.equal(priority.scheduledBackendResume, false);
-  assert.deepEqual(deferred, []);
-  assert.deepEqual(acked, []);
+  assert.equal(priority.scheduledBackendResume, true);
+  assert.equal(priority.ackAfterInputBytes, 42);
+  assert.equal(deferred.length, 1);
+  deferred[0]!();
+  assert.deepEqual(acked, [42]);
   assert.deepEqual(
     filterTerminalInterruptDisplayOutput(term, "KeyboardInterrupt\r\n$ ", { now: 5001 }),
     {

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -32,6 +32,7 @@ type TerminalInputPriorityReason = "interrupt" | "input";
 
 export type TerminalInputPriorityOptions = {
   reason?: TerminalInputPriorityReason;
+  drainStaleOutput?: boolean;
   now?: number;
   quietMs?: number;
   promptQuietMs?: number;
@@ -63,7 +64,7 @@ export type TerminalInputPrioritySnapshot = {
   deferredAckBytes: number;
   ackAfterInputBytes: number;
   scheduledBackendResume: boolean;
-  skippedReason?: "missing-session" | "below-threshold";
+  skippedReason?: "missing-session" | "below-threshold" | "interrupt-priority-disabled";
 };
 
 const scheduleAfterCurrentInput: ResumeScheduler = (callback) => {
@@ -86,6 +87,7 @@ type TerminalInterruptDisplayGate = {
   droppedBytes: number;
   droppedChunks: number;
   pendingInterruptCaret: boolean;
+  pendingDisplayControl: string;
 };
 
 const TERMINAL_INTERRUPT_DISPLAY_GATE_KEY = Symbol.for("netcatty.terminalInterruptDisplayGate");
@@ -135,9 +137,139 @@ const charLength = (value: string): number => value.length;
 
 const ANSI_ESCAPE = String.fromCharCode(27);
 const ANSI_SEQUENCE_PATTERN = new RegExp(`${ANSI_ESCAPE}\\[[0-?]*[ -/]*[@-~]`, "g");
+const OSC_SEQUENCE_PATTERN = new RegExp(
+  `${ANSI_ESCAPE}\\][\\s\\S]*?(?:\\x07|${ANSI_ESCAPE}\\\\)`,
+  "g",
+);
 
 const stripAnsi = (value: string): string =>
-  value.replace(ANSI_SEQUENCE_PATTERN, "");
+  value
+    .replace(OSC_SEQUENCE_PATTERN, "")
+    .replace(ANSI_SEQUENCE_PATTERN, "");
+
+const TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN = new RegExp(
+  `${ANSI_ESCAPE}\\[[0-?]*[ -/]*[@-~]|${ANSI_ESCAPE}[=>]`,
+  "g",
+);
+const RESTORE_PRIVATE_MODE_PARAMS = new Set([
+  1,
+  47,
+  1000,
+  1002,
+  1003,
+  1004,
+  1005,
+  1006,
+  1015,
+  1047,
+  1048,
+  1049,
+  2004,
+]);
+const SHOW_CURSOR_PRIVATE_MODE_PARAM = 25;
+const PRIVATE_MODE_PATTERN = new RegExp(`^${ANSI_ESCAPE}\\[\\?([0-9;:]*)([hl])$`);
+const TRAILING_RESTORE_CONTROL_PREFIX_PATTERN = new RegExp(
+  `^${ANSI_ESCAPE}\\[\\?[0-9;:]*$`,
+);
+
+const getPrivateModeParams = (raw: string): { params: number[]; final: "h" | "l" } | null => {
+  const match = PRIVATE_MODE_PATTERN.exec(raw);
+  if (!match) return null;
+  const params = match[1]!
+    .split(/[;:]/)
+    .map((param) => Number(param))
+    .filter((param) => Number.isFinite(param));
+  if (params.length === 0) return null;
+  return { params, final: match[2] as "h" | "l" };
+};
+
+const shouldPreserveTerminalStateRestore = (raw: string): boolean => {
+  if (raw === "\x1b>") return true;
+  const privateModes = getPrivateModeParams(raw);
+  if (!privateModes) return false;
+  if (privateModes.final === "h") {
+    return privateModes.params.every((param) => param === SHOW_CURSOR_PRIVATE_MODE_PARAM);
+  }
+  return privateModes.params.every((param) => RESTORE_PRIVATE_MODE_PARAMS.has(param));
+};
+
+const getTrailingRestoreControlPrefix = (text: string): string => {
+  const escapeIndex = text.lastIndexOf(ANSI_ESCAPE);
+  if (escapeIndex < 0) return "";
+  const suffix = text.slice(escapeIndex);
+  if (suffix === ANSI_ESCAPE) return suffix;
+  if (suffix === `${ANSI_ESCAPE}[`) return suffix;
+  if (
+    suffix.startsWith(`${ANSI_ESCAPE}[?`)
+    && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(suffix)
+  ) {
+    return suffix;
+  }
+  return "";
+};
+
+const getTrailingOscControlPrefix = (text: string): string => {
+  const oscIndex = text.lastIndexOf(`${ANSI_ESCAPE}]`);
+  if (oscIndex < 0) return "";
+  const suffix = text.slice(oscIndex);
+  if (suffix.includes("\x07") || suffix.includes(`${ANSI_ESCAPE}\\`)) return "";
+  return suffix;
+};
+
+const getTrailingDisplayControlPrefix = (text: string): string =>
+  getTrailingRestoreControlPrefix(text) || getTrailingOscControlPrefix(text);
+
+const extractTerminalStateRestoreControls = (
+  text: string,
+  options: { holdTrailingPartial?: boolean } = {},
+): { preserved: string; pending: string; droppedBytes: number } => {
+  const pending = options.holdTrailingPartial ? getTrailingDisplayControlPrefix(text) : "";
+  const searchableText = pending ? text.slice(0, -pending.length) : text;
+  let preserved = "";
+  for (const match of searchableText.matchAll(TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN)) {
+    const raw = match[0];
+    if (shouldPreserveTerminalStateRestore(raw)) {
+      preserved += raw;
+    }
+  }
+  return {
+    preserved,
+    pending,
+    droppedBytes: Math.max(0, charLength(text) - charLength(preserved) - charLength(pending)),
+  };
+};
+
+const takePendingDisplayControl = (gate: TerminalInterruptDisplayGate): string => {
+  const pending = gate.pendingDisplayControl;
+  gate.pendingDisplayControl = "";
+  return pending;
+};
+
+const finalizeAcceptedTextAfterPendingDisplayControl = (
+  pending: string,
+  text: string,
+): { data: string; droppedBytes: number } => {
+  if (!pending) return { data: text, droppedBytes: 0 };
+  const combined = `${pending}${text}`;
+  TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+  const restoreMatch = TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.exec(combined);
+  TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+  if (restoreMatch?.index === 0 && restoreMatch[0].length > pending.length) {
+    const raw = restoreMatch[0];
+    const remainder = combined.slice(raw.length);
+    if (shouldPreserveTerminalStateRestore(raw)) {
+      return { data: `${raw}${remainder}`, droppedBytes: 0 };
+    }
+    return { data: remainder, droppedBytes: charLength(raw) };
+  }
+  OSC_SEQUENCE_PATTERN.lastIndex = 0;
+  const oscMatch = OSC_SEQUENCE_PATTERN.exec(combined);
+  OSC_SEQUENCE_PATTERN.lastIndex = 0;
+  if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
+    return { data: combined, droppedBytes: 0 };
+  }
+  return { data: text, droppedBytes: charLength(pending) };
+};
 
 export const shouldArmTerminalInterruptDisplayGateForProtocol = (
   protocol: string | null | undefined,
@@ -156,6 +288,7 @@ const getPromptCandidateSuffix = (text: string): string | null => {
   const looksLikePrompt = (
     /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
+    || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
     || /^<[^>\r\n]{1,80}>\s*$/.test(candidate)
     || /^\[[^\]\r\n]{1,120}\]\s*[#$>%]\s*$/.test(candidate)
   );
@@ -188,6 +321,7 @@ export const armTerminalInterruptDisplayGate = (
     droppedBytes: 0,
     droppedChunks: 0,
     pendingInterruptCaret: false,
+    pendingDisplayControl: "",
   });
 };
 
@@ -207,7 +341,9 @@ export const filterTerminalInterruptDisplayOutput = (
   }
 
   const now = nowFromPriorityOptions(options);
-  const bytes = charLength(text);
+  const pendingDisplayControl = takePendingDisplayControl(gate);
+  const combinedText = `${pendingDisplayControl}${text}`;
+  const bytes = charLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;
 
   if (gate.pendingInterruptCaret) {
@@ -224,64 +360,94 @@ export const filterTerminalInterruptDisplayOutput = (
     }
   }
 
-  const interruptEchoIndex = text.indexOf("^C");
+  const interruptEchoIndex = combinedText.indexOf("^C");
   if (interruptEchoIndex >= 0) {
-    const droppedBytes = charLength(text.slice(0, interruptEchoIndex));
+    const droppedPrefix = combinedText.slice(0, interruptEchoIndex);
+    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+    const droppedBytes = restoreControls.droppedBytes;
     gate.droppedBytes += droppedBytes;
     gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptDisplayGate(term);
     return {
       accepted: true,
-      data: text.slice(interruptEchoIndex),
+      data: `${restoreControls.preserved}${combinedText.slice(interruptEchoIndex)}`,
       droppedBytes,
       reason: "interrupt-echo",
     };
   }
 
   const promptCandidate = bytes <= gate.promptCandidateBytes
-    ? getPromptCandidateSuffix(text)
+    ? getPromptCandidateSuffix(combinedText)
     : null;
   if (promptCandidate && gate.droppedBytes === 0) {
-    const droppedBytes = charLength(text.slice(0, text.length - promptCandidate.length));
+    const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+    const droppedBytes = restoreControls.droppedBytes;
     gate.droppedBytes += droppedBytes;
     gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptDisplayGate(term);
     return {
       accepted: true,
-      data: promptCandidate,
+      data: `${restoreControls.preserved}${promptCandidate}`,
       droppedBytes,
       reason: "prompt-candidate",
     };
   }
 
   if (promptCandidate && quietGapMs >= gate.promptQuietMs) {
-    const droppedBytes = charLength(text.slice(0, text.length - promptCandidate.length));
+    const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+    const droppedBytes = restoreControls.droppedBytes;
     gate.droppedBytes += droppedBytes;
     gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptDisplayGate(term);
     return {
       accepted: true,
-      data: promptCandidate,
+      data: `${restoreControls.preserved}${promptCandidate}`,
       droppedBytes,
       reason: "prompt-gap",
     };
   }
 
   if (quietGapMs >= gate.quietMs) {
+    const accepted = finalizeAcceptedTextAfterPendingDisplayControl(pendingDisplayControl, text);
+    gate.droppedBytes += accepted.droppedBytes;
+    gate.droppedChunks += accepted.droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptDisplayGate(term);
-    return { accepted: true, data: text, droppedBytes: 0, reason: "quiet-gap" };
+    return {
+      accepted: true,
+      data: accepted.data,
+      droppedBytes: accepted.droppedBytes,
+      reason: "quiet-gap",
+    };
   }
 
   if (now - gate.startedAt >= gate.maxDrainMs) {
+    const accepted = finalizeAcceptedTextAfterPendingDisplayControl(pendingDisplayControl, text);
+    gate.droppedBytes += accepted.droppedBytes;
+    gate.droppedChunks += accepted.droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptDisplayGate(term);
-    return { accepted: true, data: text, droppedBytes: 0, reason: "max-drain" };
+    return {
+      accepted: true,
+      data: accepted.data,
+      droppedBytes: accepted.droppedBytes,
+      reason: "max-drain",
+    };
   }
 
+  const restoreControls = extractTerminalStateRestoreControls(combinedText, {
+    holdTrailingPartial: true,
+  });
+  const droppedBytes = restoreControls.droppedBytes;
+  gate.pendingDisplayControl = restoreControls.pending;
   gate.pendingInterruptCaret = text.endsWith("^");
   gate.lastDroppedAt = now;
-  gate.droppedBytes += bytes;
-  gate.droppedChunks += 1;
-  return { accepted: false, data: "", droppedBytes: bytes, reason: "draining" };
+  gate.droppedBytes += droppedBytes;
+  gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+  if (restoreControls.preserved) {
+    return { accepted: true, data: restoreControls.preserved, droppedBytes, reason: "draining" };
+  }
+  return { accepted: false, data: "", droppedBytes, reason: "draining" };
 };
 
 const resolvePrioritizeTerminalInputArgs = (
@@ -367,9 +533,7 @@ export const prioritizeTerminalInput = (
     maybeOptions,
   );
   const isInterrupt = options.reason === "interrupt";
-  if (!isInterrupt) {
-    disarmTerminalInterruptDisplayGate(term);
-  }
+  disarmTerminalInterruptDisplayGate(term);
 
   if (!sessionId) {
     disarmTerminalInterruptDisplayGate(term);
@@ -387,7 +551,18 @@ export const prioritizeTerminalInput = (
   const backlog = flow?.pendingBytes() ?? 0;
   const queueDepth = getTerminalWriteQueueDepth(term);
   const deferredAck = getDeferredTerminalWriteAckBytes(term);
-  const hasVisibleBacklog = backlog > FLOW_LOW_WATER_MARK || queueDepth > 0;
+  if (isInterrupt && !options.drainStaleOutput) {
+    return {
+      sessionId,
+      backlogBytes: backlog,
+      writeQueueDepth: queueDepth,
+      deferredAckBytes: deferredAck,
+      ackAfterInputBytes: 0,
+      scheduledBackendResume: false,
+      skippedReason: "interrupt-priority-disabled",
+    };
+  }
+
   if (backlog <= FLOW_LOW_WATER_MARK && queueDepth === 0 && deferredAck === 0) {
     disarmTerminalInterruptDisplayGate(term);
     return {
@@ -401,10 +576,9 @@ export const prioritizeTerminalInput = (
     };
   }
 
+  const hasVisibleBacklog = backlog > FLOW_LOW_WATER_MARK || queueDepth > 0;
   if (isInterrupt && hasVisibleBacklog) {
     armTerminalInterruptDisplayGate(term, options);
-  } else if (isInterrupt) {
-    disarmTerminalInterruptDisplayGate(term);
   }
 
   let ackAfterInput = 0;

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -64,7 +64,7 @@ export type TerminalInputPrioritySnapshot = {
   deferredAckBytes: number;
   ackAfterInputBytes: number;
   scheduledBackendResume: boolean;
-  skippedReason?: "missing-session" | "below-threshold" | "interrupt-priority-disabled";
+  skippedReason?: "missing-session" | "below-threshold";
 };
 
 const scheduleAfterCurrentInput: ResumeScheduler = (callback) => {
@@ -349,11 +349,15 @@ export const filterTerminalInterruptDisplayOutput = (
   if (gate.pendingInterruptCaret) {
     gate.pendingInterruptCaret = false;
     if (text.startsWith("C")) {
+      const restoreControls = extractTerminalStateRestoreControls(pendingDisplayControl);
+      const droppedBytes = restoreControls.droppedBytes;
+      gate.droppedBytes += droppedBytes;
+      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
       disarmTerminalInterruptDisplayGate(term);
       return {
         accepted: true,
-        data: `^${text}`,
-        droppedBytes: 0,
+        data: `${restoreControls.preserved}^${text}`,
+        droppedBytes,
         acceptedBytes: bytes,
         reason: "interrupt-echo",
       };
@@ -551,17 +555,6 @@ export const prioritizeTerminalInput = (
   const backlog = flow?.pendingBytes() ?? 0;
   const queueDepth = getTerminalWriteQueueDepth(term);
   const deferredAck = getDeferredTerminalWriteAckBytes(term);
-  if (isInterrupt && !options.drainStaleOutput) {
-    return {
-      sessionId,
-      backlogBytes: backlog,
-      writeQueueDepth: queueDepth,
-      deferredAckBytes: deferredAck,
-      ackAfterInputBytes: 0,
-      scheduledBackendResume: false,
-      skippedReason: "interrupt-priority-disabled",
-    };
-  }
 
   if (backlog <= FLOW_LOW_WATER_MARK && queueDepth === 0 && deferredAck === 0) {
     disarmTerminalInterruptDisplayGate(term);
@@ -577,7 +570,7 @@ export const prioritizeTerminalInput = (
   }
 
   const hasVisibleBacklog = backlog > FLOW_LOW_WATER_MARK || queueDepth > 0;
-  if (isInterrupt && hasVisibleBacklog) {
+  if (isInterrupt && hasVisibleBacklog && options.drainStaleOutput !== false) {
     armTerminalInterruptDisplayGate(term, options);
   }
 

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -314,7 +314,7 @@ test("attachSessionToTerminal resets timestamp state for a reused terminal", () 
   assert.equal(writes[1], "fresh");
 });
 
-test("attachSessionToTerminal drops interrupt-stale output before terminal, AI, and log side effects", () => {
+test("attachSessionToTerminal keeps interrupt-time output visible", () => {
   clearTerminalSessionFlowAck("session-1");
   const { term, writes } = createFakeTerm();
   const acked: number[] = [];
@@ -365,28 +365,28 @@ test("attachSessionToTerminal drops interrupt-stale output before terminal, AI, 
   onData?.("old output");
   flushTerminalWriteCoalescer(term);
 
-  assert.deepEqual(writes, []);
-  assert.deepEqual(output, []);
-  assert.deepEqual(logs, []);
-  assert.deepEqual(acked, [10]);
+  assert.equal(writes.join(""), "old output");
+  assert.equal(output.join(""), "old output");
+  assert.equal(logs.join(""), "old output");
+  assert.deepEqual(acked, []);
 
   onData?.("^");
   flushTerminalWriteCoalescer(term);
 
-  assert.deepEqual(writes, []);
-  assert.deepEqual(output, []);
-  assert.deepEqual(logs, []);
-  assert.deepEqual(acked, [10, 1]);
+  assert.equal(writes.join(""), "old output^");
+  assert.equal(output.join(""), "old output^");
+  assert.equal(logs.join(""), "old output^");
+  assert.deepEqual(acked, []);
 
   onData?.("C\r\n$ ");
   flushTerminalWriteCoalescer(term);
   flushTerminalSessionFlowAck("session-1");
 
-  assert.equal(writes.join(""), "^C\r\n$ ");
-  assert.equal(output.join(""), "^C\r\n$ ");
-  assert.equal(logs.join(""), "^C\r\n$ ");
-  assert.deepEqual(acked, [10, 1]);
-  assert.equal(getDeferredTerminalWriteAckBytes(term), 5);
+  assert.equal(writes.join(""), "old output^C\r\n$ ");
+  assert.equal(output.join(""), "old output^C\r\n$ ");
+  assert.equal(logs.join(""), "old output^C\r\n$ ");
+  assert.deepEqual(acked, []);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 16);
   clearDeferredTerminalWriteAck(term);
   clearTerminalSessionFlowAck("session-1");
 });

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1377,15 +1377,15 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     const prioritizeBroadcastInterrupt = () => {
       const term = termRef.current;
       if (!term) return;
-      const priorityOptions = shouldArmTerminalInterruptDisplayGateForProtocol(host.protocol)
-        ? { reason: "interrupt" as const }
-        : undefined;
       prioritizeTerminalInput(
         term,
         sessionId,
         getFlowControllerForTerm(term),
         terminalBackend,
-        priorityOptions,
+        {
+          reason: "interrupt",
+          drainStaleOutput: shouldArmTerminalInterruptDisplayGateForProtocol(host.protocol),
+        },
       );
     };
     onBroadcastInterruptPriorityChange?.(sessionId, prioritizeBroadcastInterrupt);

--- a/electron/bridges/ptyOutputBuffer.cjs
+++ b/electron/bridges/ptyOutputBuffer.cjs
@@ -24,7 +24,7 @@
  *   floodFlushDelayMs?: number,
  *   maxFloodBufferSize?: number,
  * }} [options]
- * @returns {{ bufferData: (data: string) => void, flush: () => void, discard: () => void }}
+ * @returns {{ bufferData: (data: string) => void, flush: () => void, takePending: () => string, discard: () => number }}
  */
 function createPtyOutputBuffer(sendFn, options = {}) {
   const maxBufferSize = options.maxBufferSize ?? 16384; // 16KB
@@ -91,14 +91,19 @@ function createPtyOutputBuffer(sendFn, options = {}) {
     flushNow();
   };
 
-  const discard = () => {
+  const takePending = () => {
     cancelScheduled();
-    const discardedBytes = dataBuffer.length;
+    const pending = dataBuffer;
     dataBuffer = "";
-    return discardedBytes;
+    return pending;
   };
 
-  return { bufferData, flush, discard };
+  const discard = () => {
+    const pending = takePending();
+    return pending.length;
+  };
+
+  return { bufferData, flush, takePending, discard };
 }
 
 module.exports = { createPtyOutputBuffer };

--- a/electron/bridges/ptyOutputBuffer.test.cjs
+++ b/electron/bridges/ptyOutputBuffer.test.cjs
@@ -110,6 +110,18 @@ test("discard() drops pending data and cancels the pending turn", async () => {
   assert.deepEqual(sends, []);
 });
 
+test("takePending() returns pending data without sending it", async () => {
+  const sends = [];
+  const buffer = createPtyOutputBuffer((data) => sends.push(data));
+
+  buffer.bufferData("tail");
+
+  assert.equal(buffer.takePending(), "tail");
+  assert.deepEqual(sends, []);
+  await tick();
+  assert.deepEqual(sends, []);
+});
+
 test("drops incoming data when shouldAcceptOutput returns false", async () => {
   const sends = [];
   let accept = true;

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -110,6 +110,7 @@ function createStartSessionApi(ctx) {
       const {
         bufferData,
         flush: flushBuffer,
+        takePending: takePendingBuffer,
         discard: discardBuffer,
       } = createPtyOutputBuffer((data) => {
         const contents = event.sender;
@@ -122,6 +123,7 @@ function createStartSessionApi(ctx) {
         shouldAcceptOutput: () => shouldAcceptSessionOutput(sessions.get(sessionId)),
       });
       session.flushPendingData = flushBuffer;
+      session.takePendingData = takePendingBuffer;
       session.discardPendingData = discardBuffer;
 
       const sshZmodemSentry = createZmodemSentry({

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -41,6 +41,7 @@ const {
 const {
   armTerminalInterruptOutputGate,
   disarmTerminalInterruptOutputGate,
+  filterTerminalInterruptOutput,
   shouldArmTerminalInterruptOutputGate,
 } = require("./terminalInterruptOutputGate.cjs");
 const iconv = require("iconv-lite");
@@ -450,6 +451,7 @@ function startLocalSession(event, payload) {
   const {
     bufferData: bufferLocalData,
     flush: flushLocal,
+    takePending: takePendingLocal,
     discard: discardLocal,
   } = createPtyOutputBuffer((data) => {
     const contents = electronModule.webContents.fromId(session.webContentsId);
@@ -461,6 +463,7 @@ function startLocalSession(event, payload) {
     shouldAcceptOutput: () => shouldAcceptSessionOutput(session),
   });
   session.flushPendingData = flushLocal;
+  session.takePendingData = takePendingLocal;
   session.discardPendingData = discardLocal;
 
   // On Windows, node-pty ignores encoding: null and still emits UTF-8
@@ -981,6 +984,27 @@ function writeToSession(event, payload) {
   writeToSessionNow(payload, payload.data);
 }
 
+function drainPendingOutputForInterrupt(sessionId, session, trace) {
+  if (typeof session?.takePendingData !== "function") return;
+  const pending = session.takePendingData();
+  if (!pending) return;
+  const output = filterTerminalInterruptOutput(session, pending);
+  if (!output.accepted || output.droppedBytes > 0) {
+    logTerminalInterruptDebug("interrupt-pending-output-filtered", {
+      session: getSessionSnapshot(session),
+      droppedBytes: output.droppedBytes,
+      reason: output.reason,
+      accepted: output.accepted,
+    }, trace);
+  }
+  if (!output.accepted || !output.data) return;
+  const contents = electronModule.webContents.fromId(session.webContentsId);
+  emitTerminalSessionData(contents, sessionId, output.data, {
+    cols: session.cols,
+    rows: session.rows,
+  });
+}
+
 function interruptSession(event, payload) {
   const session = sessions.get(payload.sessionId);
   const trace = normalizeTrace(payload);
@@ -1001,18 +1025,16 @@ function interruptSession(event, payload) {
   }, trace);
 
   clearPendingAutomatedWrites(session);
-  const pausedForInterrupt = pauseSshOutputForInterrupt(session, trace);
-  const discardedBytes = session.discardPendingData?.() || 0;
-  logTerminalInterruptDebug("interrupt-discard-pending-output", {
-    discardedBytes,
-    session: getSessionSnapshot(session),
-  }, trace);
-  const shouldDrainOldOutput = Boolean(session.stream) || shouldArmTerminalInterruptOutputGate(session);
+  const shouldDrainOldOutput = shouldArmTerminalInterruptOutputGate(session);
+  const pausedForInterrupt = shouldDrainOldOutput
+    ? pauseSshOutputForInterrupt(session, trace)
+    : false;
   if (shouldDrainOldOutput) {
     armTerminalInterruptOutputGate(session);
     logTerminalInterruptDebug("interrupt-output-drain-armed", {
       session: getSessionSnapshot(session),
     }, trace);
+    drainPendingOutputForInterrupt(payload.sessionId, session, trace);
   }
   logTerminalInterruptDebug("interrupt-clear-flow-start", {
     session: getSessionSnapshot(session),

--- a/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
+++ b/electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs
@@ -3,12 +3,16 @@ const assert = require("node:assert/strict");
 
 const terminalBridge = require("./terminalBridge.cjs");
 
-function initBridge(sessions) {
+function initBridge(sessions, sent = []) {
   terminalBridge.init({
     sessions,
     electronModule: {
       webContents: {
-        fromId: () => ({ send() {} }),
+        fromId: () => ({
+          send(channel, payload) {
+            sent.push([channel, payload]);
+          },
+        }),
       },
     },
   });
@@ -40,7 +44,7 @@ test("SSH Ctrl+C writes the original byte without sending a channel signal", () 
   ]);
 });
 
-test("interruptSession discards pending output before sending SSH Ctrl+C", () => {
+test("interruptSession sends SSH Ctrl+C without discarding pending output", () => {
   const calls = [];
   const sessions = new Map();
   sessions.set("ssh-1", {
@@ -61,7 +65,6 @@ test("interruptSession discards pending output before sending SSH Ctrl+C", () =>
   terminalBridge.interruptSession({ sender: {} }, { sessionId: "ssh-1" });
 
   assert.deepEqual(calls, [
-    ["discard"],
     ["write", "\x03"],
   ]);
 });
@@ -95,25 +98,32 @@ test("interruptSession sends SSH Ctrl+C before resuming a paused output flood", 
 
   assert.deepEqual(calls, [
     ["pause"],
-    ["discard"],
     ["write", "\x03"],
   ]);
 
   await delay(0);
   assert.deepEqual(calls, [
     ["pause"],
-    ["discard"],
     ["write", "\x03"],
     ["resume"],
   ]);
 });
 
-test("interruptSession pauses SSH output before sending Ctrl+C even without existing backpressure", async () => {
+test("interruptSession sends SSH Ctrl+C without fastpath under low output pressure", async () => {
   const calls = [];
   const sessions = new Map();
   sessions.set("ssh-1", {
+    takePendingData() {
+      calls.push(["take-pending"]);
+      return "Type  :qa  and press <Enter> to exit Vim";
+    },
     discardPendingData() {
       calls.push(["discard"]);
+    },
+    flowState: {
+      rendererPaused: false,
+      unackedBytes: 119,
+      appliedPause: false,
     },
     stream: {
       pause() {
@@ -135,21 +145,64 @@ test("interruptSession pauses SSH output before sending Ctrl+C even without exis
   terminalBridge.interruptSession({ sender: {} }, { sessionId: "ssh-1" });
 
   assert.deepEqual(calls, [
-    ["pause"],
-    ["discard"],
     ["write", "\x03"],
   ]);
 
   await delay(0);
   assert.deepEqual(calls, [
-    ["pause"],
-    ["discard"],
     ["write", "\x03"],
-    ["resume"],
   ]);
 });
 
-test("interruptSession arms SSH output drain even for tiny in-flight echo", () => {
+test("interruptSession filters pending SSH output under high output pressure", () => {
+  const calls = [];
+  const sent = [];
+  const sessions = new Map();
+  sessions.set("ssh-1", {
+    cols: 80,
+    rows: 24,
+    webContentsId: 1,
+    takePendingData() {
+      calls.push(["take-pending"]);
+      return "stale frame\x1b[?1049l";
+    },
+    discardPendingData() {
+      calls.push(["discard"]);
+    },
+    flowState: {
+      rendererPaused: false,
+      unackedBytes: 34068,
+      appliedPause: false,
+    },
+    stream: {
+      pause() {
+        calls.push(["pause"]);
+      },
+      resume() {},
+      signal(signalName) {
+        calls.push(["signal", signalName]);
+      },
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions, sent);
+
+  terminalBridge.interruptSession({ sender: {} }, { sessionId: "ssh-1" });
+
+  assert.deepEqual(calls, [
+    ["pause"],
+    ["take-pending"],
+    ["pause"],
+    ["write", "\x03"],
+  ]);
+  assert.deepEqual(sent, [
+    ["netcatty:data", { sessionId: "ssh-1", data: "\x1b[?1049l" }],
+  ]);
+});
+
+test("interruptSession does not arm SSH output drain for tiny in-flight echo", () => {
   const sessions = new Map();
   const session = {
     discardPendingData() {},
@@ -170,7 +223,7 @@ test("interruptSession arms SSH output drain even for tiny in-flight echo", () =
 
   terminalBridge.interruptSession({ sender: {} }, { sessionId: "ssh-1" });
 
-  assert.equal(session._interruptOutputGate?.active, true);
+  assert.notEqual(session._interruptOutputGate?.active, true);
 });
 
 test("interruptSession arms SSH output drain when interrupting a paused output flood", () => {
@@ -196,7 +249,7 @@ test("interruptSession arms SSH output drain when interrupting a paused output f
   assert.equal(session._interruptOutputGate?.active, true);
 });
 
-test("ordinary SSH input disarms a pending interrupt output drain", () => {
+test("ordinary SSH input still disarms a pending interrupt output drain", () => {
   const sessions = new Map();
   const session = {
     discardPendingData() {},
@@ -214,7 +267,7 @@ test("ordinary SSH input disarms a pending interrupt output drain", () => {
   sessions.set("ssh-1", session);
   initBridge(sessions);
 
-  terminalBridge.interruptSession({ sender: {} }, { sessionId: "ssh-1" });
+  session._interruptOutputGate = { active: true };
   assert.equal(session._interruptOutputGate?.active, true);
 
   terminalBridge.writeToSession({ sender: {} }, { sessionId: "ssh-1", data: "l" });
@@ -283,6 +336,28 @@ test("local Ctrl+C behavior is unchanged", () => {
   assert.deepEqual(calls, [["write", "\x03"]]);
 });
 
+test("local interruptSession writes Ctrl+C without fastpath", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("local-1", {
+    type: "local",
+    takePendingData() {
+      calls.push(["take-pending"]);
+      return "pending";
+    },
+    proc: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.interruptSession({ sender: {} }, { sessionId: "local-1" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});
+
 test("telnet Ctrl+C behavior is unchanged", () => {
   const calls = [];
   const sessions = new Map();
@@ -301,6 +376,28 @@ test("telnet Ctrl+C behavior is unchanged", () => {
   assert.deepEqual(calls, [["write", "\x03"]]);
 });
 
+test("telnet interruptSession writes Ctrl+C without fastpath", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("telnet-1", {
+    type: "telnet-native",
+    takePendingData() {
+      calls.push(["take-pending"]);
+      return "pending";
+    },
+    socket: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.interruptSession({ sender: {} }, { sessionId: "telnet-1" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});
+
 test("serial Ctrl+C behavior is unchanged", () => {
   const calls = [];
   const sessions = new Map();
@@ -315,6 +412,28 @@ test("serial Ctrl+C behavior is unchanged", () => {
   initBridge(sessions);
 
   terminalBridge.writeToSession({ sender: {} }, { sessionId: "serial-1", data: "\x03" });
+
+  assert.deepEqual(calls, [["write", "\x03"]]);
+});
+
+test("serial interruptSession writes Ctrl+C without fastpath", () => {
+  const calls = [];
+  const sessions = new Map();
+  sessions.set("serial-1", {
+    type: "serial",
+    takePendingData() {
+      calls.push(["take-pending"]);
+      return "pending";
+    },
+    serialPort: {
+      write(data) {
+        calls.push(["write", data]);
+      },
+    },
+  });
+  initBridge(sessions);
+
+  terminalBridge.interruptSession({ sender: {} }, { sessionId: "serial-1" });
 
   assert.deepEqual(calls, [["write", "\x03"]]);
 });

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -5,6 +5,29 @@ const DEFAULT_PROMPT_QUIET_MS = 80;
 const DEFAULT_MAX_DRAIN_MS = 2500;
 const DEFAULT_PROMPT_CANDIDATE_BYTES = 512;
 const OUTPUT_GATE_UNACKED_THRESHOLD = 8192;
+const ESC = String.fromCharCode(27);
+const TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN = new RegExp(
+  `${ESC}\\[[0-?]*[ -/]*[@-~]|${ESC}[=>]`,
+  "g",
+);
+const PRIVATE_MODE_PATTERN = new RegExp(`^${ESC}\\[\\?([0-9;:]*)([hl])$`);
+const TRAILING_RESTORE_CONTROL_PREFIX_PATTERN = new RegExp(`^${ESC}\\[\\?[0-9;:]*$`);
+const RESTORE_PRIVATE_MODE_PARAMS = new Set([
+  1,
+  47,
+  1000,
+  1002,
+  1003,
+  1004,
+  1005,
+  1006,
+  1015,
+  1047,
+  1048,
+  1049,
+  2004,
+]);
+const SHOW_CURSOR_PRIVATE_MODE_PARAM = 25;
 
 function nowFromOptions(options = {}) {
   return Number.isFinite(options.now) ? options.now : Date.now();
@@ -24,7 +47,104 @@ function getStreamPaused(stream) {
 }
 
 function stripAnsi(value) {
-  return String(value || "").replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+  const raw = String(value || "");
+  return raw
+    .replace(new RegExp(`${ESC}\\][\\s\\S]*?(?:\\x07|${ESC}\\\\)`, "g"), "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function getPrivateModeParams(raw) {
+  const match = PRIVATE_MODE_PATTERN.exec(raw);
+  if (!match) return null;
+  const params = match[1]
+    .split(/[;:]/)
+    .map((param) => Number(param))
+    .filter((param) => Number.isFinite(param));
+  if (params.length === 0) return null;
+  return { params, final: match[2] };
+}
+
+function shouldPreserveTerminalStateRestore(raw) {
+  if (raw === `${ESC}>`) return true;
+  const privateModes = getPrivateModeParams(raw);
+  if (!privateModes) return false;
+  if (privateModes.final === "h") {
+    return privateModes.params.every((param) => param === SHOW_CURSOR_PRIVATE_MODE_PARAM);
+  }
+  return privateModes.params.every((param) => RESTORE_PRIVATE_MODE_PARAMS.has(param));
+}
+
+function getTrailingRestoreControlPrefix(text) {
+  const raw = String(text || "");
+  const escapeIndex = raw.lastIndexOf(ESC);
+  if (escapeIndex < 0) return "";
+  const suffix = raw.slice(escapeIndex);
+  if (suffix === ESC) return suffix;
+  if (suffix === `${ESC}[`) return suffix;
+  if (suffix.startsWith(`${ESC}[?`) && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(suffix)) {
+    return suffix;
+  }
+  return "";
+}
+
+function getTrailingOscControlPrefix(text) {
+  const raw = String(text || "");
+  const oscIndex = raw.lastIndexOf(`${ESC}]`);
+  if (oscIndex < 0) return "";
+  const suffix = raw.slice(oscIndex);
+  if (suffix.includes("\x07") || suffix.includes(`${ESC}\\`)) return "";
+  return suffix;
+}
+
+function getTrailingDisplayControlPrefix(text) {
+  return getTrailingRestoreControlPrefix(text) || getTrailingOscControlPrefix(text);
+}
+
+function extractTerminalStateRestoreControls(text, options = {}) {
+  const rawText = String(text || "");
+  const pending = options.holdTrailingPartial ? getTrailingDisplayControlPrefix(rawText) : "";
+  const searchableText = pending ? rawText.slice(0, -pending.length) : rawText;
+  let preserved = "";
+  for (const match of searchableText.matchAll(TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN)) {
+    const raw = match[0];
+    if (shouldPreserveTerminalStateRestore(raw)) {
+      preserved += raw;
+    }
+  }
+  return {
+    preserved,
+    pending,
+    droppedBytes: Math.max(0, byteLength(rawText) - byteLength(preserved) - byteLength(pending)),
+  };
+}
+
+function takePendingDisplayControl(gate) {
+  const pending = gate.pendingDisplayControl || "";
+  gate.pendingDisplayControl = "";
+  return pending;
+}
+
+function finalizeAcceptedTextAfterPendingDisplayControl(pending, text) {
+  const rawText = String(text || "");
+  if (!pending) return { data: rawText, droppedBytes: 0 };
+  const combined = `${pending}${rawText}`;
+  TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+  const restoreMatch = TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.exec(combined);
+  TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+  if (restoreMatch?.index === 0 && restoreMatch[0].length > pending.length) {
+    const raw = restoreMatch[0];
+    const remainder = combined.slice(raw.length);
+    if (shouldPreserveTerminalStateRestore(raw)) {
+      return { data: `${raw}${remainder}`, droppedBytes: 0 };
+    }
+    return { data: remainder, droppedBytes: byteLength(raw) };
+  }
+  const oscPattern = new RegExp(`${ESC}\\][\\s\\S]*?(?:\\x07|${ESC}\\\\)`, "g");
+  const oscMatch = oscPattern.exec(combined);
+  if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
+    return { data: combined, droppedBytes: 0 };
+  }
+  return { data: rawText, droppedBytes: byteLength(pending) };
 }
 
 function getPromptCandidateSuffix(text) {
@@ -38,6 +158,7 @@ function getPromptCandidateSuffix(text) {
   const looksLikePrompt = (
     /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
+    || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
     || /^<[^>\r\n]{1,80}>\s*$/.test(candidate)
     || /^\[[^\]\r\n]{1,120}\]\s*[#$>%]\s*$/.test(candidate)
   );
@@ -73,6 +194,7 @@ function armTerminalInterruptOutputGate(session, options = {}) {
     droppedBytes: 0,
     droppedChunks: 0,
     pendingInterruptCaret: false,
+    pendingDisplayControl: "",
   };
   return true;
 }
@@ -91,7 +213,9 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
   }
 
   const now = nowFromOptions(options);
-  const bytes = byteLength(data);
+  const pendingDisplayControl = takePendingDisplayControl(gate);
+  const combinedText = `${pendingDisplayControl}${text}`;
+  const bytes = byteLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;
 
   if (gate.pendingInterruptCaret) {
@@ -107,45 +231,51 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     }
   }
 
-  const interruptEchoIndex = text.indexOf("^C");
+  const interruptEchoIndex = combinedText.indexOf("^C");
   if (interruptEchoIndex >= 0) {
-    const droppedBytes = byteLength(text.slice(0, interruptEchoIndex));
+    const droppedPrefix = combinedText.slice(0, interruptEchoIndex);
+    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+    const droppedBytes = restoreControls.droppedBytes;
     gate.droppedBytes += droppedBytes;
     gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptOutputGate(session);
     return {
       accepted: true,
-      data: text.slice(interruptEchoIndex),
+      data: `${restoreControls.preserved}${combinedText.slice(interruptEchoIndex)}`,
       droppedBytes,
       reason: "interrupt-echo",
     };
   }
 
   if (gate.droppedBytes === 0 && bytes <= gate.promptCandidateBytes) {
-    const promptCandidate = getPromptCandidateSuffix(text);
+    const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate) {
-      const droppedBytes = byteLength(text.slice(0, text.length - promptCandidate.length));
+      const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+      const droppedBytes = restoreControls.droppedBytes;
       gate.droppedBytes += droppedBytes;
       gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
       disarmTerminalInterruptOutputGate(session);
       return {
         accepted: true,
-        data: promptCandidate,
+        data: `${restoreControls.preserved}${promptCandidate}`,
         droppedBytes,
         reason: "prompt-candidate",
       };
     }
   }
   if (quietGapMs >= gate.promptQuietMs && bytes <= gate.promptCandidateBytes) {
-    const promptCandidate = getPromptCandidateSuffix(text);
+    const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate) {
-      const droppedBytes = byteLength(text.slice(0, text.length - promptCandidate.length));
+      const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+      const droppedBytes = restoreControls.droppedBytes;
       gate.droppedBytes += droppedBytes;
       gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
       disarmTerminalInterruptOutputGate(session);
       return {
         accepted: true,
-        data: promptCandidate,
+        data: `${restoreControls.preserved}${promptCandidate}`,
         droppedBytes,
         reason: "prompt-gap",
       };
@@ -153,20 +283,44 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
   }
 
   if (quietGapMs >= gate.quietMs) {
+    const accepted = finalizeAcceptedTextAfterPendingDisplayControl(pendingDisplayControl, text);
+    gate.droppedBytes += accepted.droppedBytes;
+    gate.droppedChunks += accepted.droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptOutputGate(session);
-    return { accepted: true, data: text, droppedBytes: 0, reason: "quiet-gap" };
+    return {
+      accepted: true,
+      data: accepted.data,
+      droppedBytes: accepted.droppedBytes,
+      reason: "quiet-gap",
+    };
   }
 
   if (now - gate.startedAt >= gate.maxDrainMs) {
+    const accepted = finalizeAcceptedTextAfterPendingDisplayControl(pendingDisplayControl, text);
+    gate.droppedBytes += accepted.droppedBytes;
+    gate.droppedChunks += accepted.droppedBytes > 0 ? 1 : 0;
     disarmTerminalInterruptOutputGate(session);
-    return { accepted: true, data: text, droppedBytes: 0, reason: "max-drain" };
+    return {
+      accepted: true,
+      data: accepted.data,
+      droppedBytes: accepted.droppedBytes,
+      reason: "max-drain",
+    };
   }
 
+  const restoreControls = extractTerminalStateRestoreControls(combinedText, {
+    holdTrailingPartial: true,
+  });
+  const droppedBytes = restoreControls.droppedBytes;
+  gate.pendingDisplayControl = restoreControls.pending;
   gate.pendingInterruptCaret = text.endsWith("^");
   gate.lastDroppedAt = now;
-  gate.droppedBytes += bytes;
-  gate.droppedChunks += 1;
-  return { accepted: false, data: "", droppedBytes: bytes, reason: "draining" };
+  gate.droppedBytes += droppedBytes;
+  gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+  if (restoreControls.preserved) {
+    return { accepted: true, data: restoreControls.preserved, droppedBytes, reason: "draining" };
+  }
+  return { accepted: false, data: "", droppedBytes, reason: "draining" };
 }
 
 module.exports = {

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -221,11 +221,15 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
   if (gate.pendingInterruptCaret) {
     gate.pendingInterruptCaret = false;
     if (text.startsWith("C")) {
+      const restoreControls = extractTerminalStateRestoreControls(pendingDisplayControl);
+      const droppedBytes = restoreControls.droppedBytes;
+      gate.droppedBytes += droppedBytes;
+      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
       disarmTerminalInterruptOutputGate(session);
       return {
         accepted: true,
-        data: `^${text}`,
-        droppedBytes: 0,
+        data: `${restoreControls.preserved}^${text}`,
+        droppedBytes,
         reason: "interrupt-echo",
       };
     }

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -107,6 +107,143 @@ test("prompt gap keeps only the prompt suffix and drops stale prefix", () => {
   );
 });
 
+test("preserves alternate-screen exit controls while draining stale output", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 3800,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 1000,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "stale frame\x1b[?1049l", { now: 3801 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: "stale frame".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "more stale\x1b[?25h\r\n$ ", { now: 3900 }),
+    {
+      accepted: true,
+      data: "\x1b[?25h$ ",
+      droppedBytes: "more stale\r\n".length,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("preserves split alternate-screen exit controls while draining stale output", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 4800,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 1000,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "stale frame\x1b[?104", { now: 4801 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "stale frame".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "9l^C\r\n$ ", { now: 4802 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l^C\r\n$ ",
+      droppedBytes: 0,
+      reason: "interrupt-echo",
+    },
+  );
+});
+
+test("does not preserve unsafe combined private modes while draining stale output", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 4900,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 1000,
+  });
+
+  const unsafeSequence = "\x1b[?1049;25h";
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `stale frame${unsafeSequence}^C\r\n$ `, {
+      now: 4901,
+    }),
+    {
+      accepted: true,
+      data: "^C\r\n$ ",
+      droppedBytes: "stale frame".length + unsafeSequence.length,
+      reason: "interrupt-echo",
+    },
+  );
+});
+
+test("accepts prompt candidates with OSC title and spaces after stale output", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 5000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 1000,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "old output", { now: 5001 }).accepted, false);
+  const prompt = "\x1b]0;~/My Project\x07~/My Project$ ";
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, prompt, { now: 5100 }),
+    {
+      accepted: true,
+      data: prompt,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("accepts split OSC prompt candidates after stale output", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 5200,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 1000,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "old output\x1b]0;~/My ", { now: 5201 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "old output".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Project\x07~/My Project$ ", { now: 5300 }),
+    {
+      accepted: true,
+      data: "\x1b]0;~/My Project\x07~/My Project$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("keeps draining large chunks after a short quiet gap", () => {
   const session = {};
 


### PR DESCRIPTION
## Summary
- Restores fast Ctrl+C handling only when there is real output pressure, instead of using the fastpath for every SSH Ctrl+C.
- Keeps normal low-pressure full-screen app messages visible, including Vim's Ctrl+C exit hint.
- Keeps terminal screen restoration controls, including split alternate-screen exit sequences, so full-screen apps such as htop can exit cleanly when the fastpath is needed.
- Filters already-buffered SSH output through the same Ctrl+C drain gate under high pressure instead of sending stale buffered frames or wholesale-discarding everything.
- Adds regression coverage for split restore controls, split OSC/title prompt controls, unsafe combined private modes, pending buffered output, unchanged local/telnet/serial real interrupt paths, and low-pressure SSH Ctrl+C bypassing the fastpath.

## Validation
- `node --test --import tsx electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs electron/bridges/terminalInterruptOutputGate.test.cjs electron/bridges/ptyOutputBuffer.test.cjs`
- `node --test --import tsx components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/createXTermRuntime.test.ts`
- `npx eslint electron/bridges/terminalBridge.cjs electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs electron/bridges/terminalInterruptOutputGate.cjs electron/bridges/terminalInterruptOutputGate.test.cjs electron/bridges/ptyOutputBuffer.cjs electron/bridges/ptyOutputBuffer.test.cjs electron/bridges/sshBridge/startSession.cjs components/terminal/runtime/terminalOutputPipeline.ts components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/createXTermRuntime.ts components/terminal/useTerminalEffects.ts`
- `git diff --check`

## Notes
A full `npm test` run was also attempted and still shows existing failures outside this Ctrl+C path, including active chrome theme / side-panel snapshot expectations and Cursor SDK discovery expectations.