### PR TITLE
fix(terminal): keep tmux updating when window loses focus (#1761)

### DIFF
--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -56,7 +56,10 @@ import {
   releaseTerminalFlowOutputForTerm,
   teardownTerminalOutputPipeline,
 } from "./terminalOutputPipeline";
-import { scheduleTerminalRepaintWhenUnfocused } from "./terminalUnfocusedRepaint";
+import {
+  maybeFlushTerminalWriteCoalescerWhenUnfocused,
+  scheduleTerminalRepaintWhenUnfocused,
+} from "./terminalUnfocusedRepaint";
 
 export { FLOW_HIGH_WATER_MARK, FLOW_LOW_WATER_MARK };
 
@@ -174,6 +177,10 @@ export const writeSessionData = (
   enqueueCoalescedTerminalWrite(term, data, (batch, batchIngress) => {
     writeSessionDataImmediate(ctx, term, batch, batchIngress);
   }, ingressBytes);
+  maybeFlushTerminalWriteCoalescerWhenUnfocused(
+    term,
+    ctx.isVisibleRef?.current !== false,
+  );
 };
 
 const writeSessionDataImmediate = (

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -56,6 +56,7 @@ import {
   releaseTerminalFlowOutputForTerm,
   teardownTerminalOutputPipeline,
 } from "./terminalOutputPipeline";
+import { scheduleTerminalRepaintWhenUnfocused } from "./terminalUnfocusedRepaint";
 
 export { FLOW_HIGH_WATER_MARK, FLOW_LOW_WATER_MARK };
 
@@ -219,6 +220,7 @@ const writeSessionDataImmediate = (
       if (shouldScrollOnTerminalOutput(settings)) {
         handleTerminalOutputAutoScroll(ctx, term);
       }
+      scheduleTerminalRepaintWhenUnfocused(term);
       done();
     };
     const commitIpcAck = (ackedBytes: number) => {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -220,7 +220,9 @@ const writeSessionDataImmediate = (
       if (shouldScrollOnTerminalOutput(settings)) {
         handleTerminalOutputAutoScroll(ctx, term);
       }
-      scheduleTerminalRepaintWhenUnfocused(term);
+      if (ctx.isVisibleRef?.current !== false) {
+        scheduleTerminalRepaintWhenUnfocused(term);
+      }
       done();
     };
     const commitIpcAck = (ackedBytes: number) => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -38,6 +38,14 @@ test("forceTerminalRepaintBypassingAnimationFrame refreshes alternate-screen vie
   assert.equal(renderRowsCalled, true);
 });
 
+test("maybeFlushTerminalWriteCoalescerWhenUnfocused bypasses RAF-bound coalescer", () => {
+  const source = readFileSync(
+    new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /flushTerminalWriteCoalescer\(term\)/);
+});
+
 test("scheduleTerminalRepaintWhenUnfocused debounces repaint scheduling", () => {
   const source = readFileSync(
     new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
@@ -45,6 +53,17 @@ test("scheduleTerminalRepaintWhenUnfocused debounces repaint scheduling", () => 
   );
   assert.match(source, /if \(unfocusedRepaintTimers\.has\(term\)\) return;/);
   assert.match(source, /UNFOCUSED_REPAINT_DEBOUNCE_MS/);
+});
+
+test("writeSessionData flushes the coalescer before RAF when unfocused", () => {
+  const source = readFileSync(
+    new URL("./terminalSessionAttachment.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /maybeFlushTerminalWriteCoalescerWhenUnfocused\(\s*term,\s*ctx\.isVisibleRef\?\.current !== false,\s*\)/,
+  );
 });
 
 test("writeSessionDataImmediate schedules unfocused repaint only for visible panes", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+import {
+  forceTerminalRepaintBypassingAnimationFrame,
+} from "./terminalUnfocusedRepaint.ts";
+
+test("isTerminalWindowUnfocusedButVisible checks visible page without focus", () => {
+  const source = readFileSync(
+    new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /document\.visibilityState === "visible"/);
+  assert.match(source, /!document\.hasFocus\(\)/);
+});
+
+test("forceTerminalRepaintBypassingAnimationFrame refreshes alternate-screen viewports", () => {
+  let refreshed: [number, number] | null = null;
+  let renderRowsCalled = false;
+  const term = {
+    rows: 24,
+    buffer: { active: { type: "alternate" } },
+    refresh: (start: number, end: number) => {
+      refreshed = [start, end];
+    },
+    _core: {
+      _renderService: {
+        _renderRows: () => {
+          renderRowsCalled = true;
+        },
+      },
+    },
+  };
+
+  forceTerminalRepaintBypassingAnimationFrame(term as never);
+  assert.deepEqual(refreshed, [0, 23]);
+  assert.equal(renderRowsCalled, true);
+});
+
+test("scheduleTerminalRepaintWhenUnfocused debounces repaint scheduling", () => {
+  const source = readFileSync(
+    new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /if \(unfocusedRepaintTimers\.has\(term\)\) return;/);
+  assert.match(source, /UNFOCUSED_REPAINT_DEBOUNCE_MS/);
+});
+
+test("writeSessionDataImmediate schedules unfocused repaint after output", () => {
+  const source = readFileSync(
+    new URL("./terminalSessionAttachment.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /scheduleTerminalRepaintWhenUnfocused\(term\)/);
+});
+
+test("window focus cancels pending unfocused repaint before layout recovery", () => {
+  const source = readFileSync(
+    new URL("../useTerminalEffects.ts", import.meta.url),
+    "utf8",
+  );
+  const handlerIndex = source.indexOf("const handleWindowFocus = () => {");
+  assert.notEqual(handlerIndex, -1);
+  const handlerEnd = source.indexOf("document.addEventListener('visibilitychange'", handlerIndex);
+  assert.notEqual(handlerEnd, -1);
+  const handlerSource = source.slice(handlerIndex, handlerEnd);
+  const cancelIndex = handlerSource.indexOf("cancelScheduledUnfocusedRepaint(term)");
+  const recoveryIndex = handlerSource.indexOf("recoverWebglRendererOnAppResume()");
+  assert.notEqual(cancelIndex, -1);
+  assert.ok(cancelIndex < recoveryIndex);
+});

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -47,12 +47,12 @@ test("scheduleTerminalRepaintWhenUnfocused debounces repaint scheduling", () => 
   assert.match(source, /UNFOCUSED_REPAINT_DEBOUNCE_MS/);
 });
 
-test("writeSessionDataImmediate schedules unfocused repaint after output", () => {
+test("writeSessionDataImmediate schedules unfocused repaint only for visible panes", () => {
   const source = readFileSync(
     new URL("./terminalSessionAttachment.ts", import.meta.url),
     "utf8",
   );
-  assert.match(source, /scheduleTerminalRepaintWhenUnfocused\(term\)/);
+  assert.match(source, /if \(ctx\.isVisibleRef\?\.current !== false\) \{\s*scheduleTerminalRepaintWhenUnfocused\(term\)/);
 });
 
 test("window focus cancels pending unfocused repaint before layout recovery", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -1,0 +1,42 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+import { forceSyncRenderAfterResize } from "../terminalHelpers";
+import {
+  isTerminalAlternateScreenActive,
+  refreshTerminalViewport,
+} from "../terminalHibernateRuntime";
+
+const UNFOCUSED_REPAINT_DEBOUNCE_MS = 16;
+const unfocusedRepaintTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
+
+export function isTerminalWindowUnfocusedButVisible(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.visibilityState === "visible" && !document.hasFocus();
+}
+
+export function forceTerminalRepaintBypassingAnimationFrame(term: XTerm): void {
+  if (isTerminalAlternateScreenActive(term)) {
+    refreshTerminalViewport(term);
+  }
+  forceSyncRenderAfterResize(term);
+}
+
+export function scheduleTerminalRepaintWhenUnfocused(term: XTerm): void {
+  if (!isTerminalWindowUnfocusedButVisible()) return;
+
+  if (unfocusedRepaintTimers.has(term)) return;
+
+  const timer = setTimeout(() => {
+    unfocusedRepaintTimers.delete(term);
+    if (!isTerminalWindowUnfocusedButVisible()) return;
+    forceTerminalRepaintBypassingAnimationFrame(term);
+  }, UNFOCUSED_REPAINT_DEBOUNCE_MS);
+  unfocusedRepaintTimers.set(term, timer);
+}
+
+export function cancelScheduledUnfocusedRepaint(term: XTerm): void {
+  const timer = unfocusedRepaintTimers.get(term);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  unfocusedRepaintTimers.delete(term);
+}

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -5,6 +5,7 @@ import {
   isTerminalAlternateScreenActive,
   refreshTerminalViewport,
 } from "../terminalHibernateRuntime";
+import { flushTerminalWriteCoalescer } from "./terminalWriteCoalescer";
 
 const UNFOCUSED_REPAINT_DEBOUNCE_MS = 16;
 const unfocusedRepaintTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
@@ -39,4 +40,12 @@ export function cancelScheduledUnfocusedRepaint(term: XTerm): void {
   if (timer === undefined) return;
   clearTimeout(timer);
   unfocusedRepaintTimers.delete(term);
+}
+
+export function maybeFlushTerminalWriteCoalescerWhenUnfocused(
+  term: XTerm,
+  isPaneVisible: boolean,
+): void {
+  if (!isPaneVisible || !isTerminalWindowUnfocusedButVisible()) return;
+  flushTerminalWriteCoalescer(term);
 }

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -23,6 +23,10 @@ import {
   nudgeAlternateScreenRedraw,
 } from './terminalHibernateRuntime';
 import {
+  cancelScheduledUnfocusedRepaint,
+  forceTerminalRepaintBypassingAnimationFrame,
+} from './runtime/terminalUnfocusedRepaint';
+import {
   isTerminalCloseGenerationCurrent,
   resolveConnectionLogCapturePayload,
   scheduleTerminalCloseTeardown,
@@ -1336,6 +1340,11 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
     const handleWindowFocus = () => {
       if (!shouldRecoverOnAppResume()) return;
+      const term = termRef.current;
+      if (term) {
+        cancelScheduledUnfocusedRepaint(term);
+        forceTerminalRepaintBypassingAnimationFrame(term);
+      }
       recoverWebglRendererOnAppResume();
       scheduleLayoutRecoveryRefit();
     };


### PR DESCRIPTION
## Summary
- Fixes #1761: on Windows, clicking outside Netcatty while running tmux stopped the terminal from refreshing until refocus.
- Root cause: when the window is visible but unfocused, Chromium throttles `requestAnimationFrame`, so xterm write callbacks and WebGL repaints stall. Output flow control then pauses the PTY backlog, which makes tmux appear frozen and slow to catch up after refocus.
- Adds debounced synchronous repaints for visible-but-unfocused windows, with alternate-screen refresh for tmux/full-screen TUIs, and immediate recovery on window focus.

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/terminalUnfocusedRepaint.test.ts`
- [ ] Windows: connect to a host, run `tmux`, click another app so Netcatty loses focus but stays visible; confirm tmux status/output keeps updating
- [ ] Refocus Netcatty and confirm the session responds immediately without a long catch-up delay
- [ ] macOS/Linux smoke check: unfocus/refocus a tmux session and confirm no regression


Made with [Cursor](https://cursor.com)