### PR TITLE
Fix autocomplete popup boundary clamp

### DIFF
--- a/components/terminal/autocomplete/AutocompletePopup.tsx
+++ b/components/terminal/autocomplete/AutocompletePopup.tsx
@@ -5,10 +5,11 @@
  * Colors are derived from the active terminal theme for visual consistency.
  */
 
-import React, { useEffect, useRef, useState, memo } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState, memo } from "react";
 import { Folder, File, Link } from "lucide-react";
 import type { CompletionSuggestion, SuggestionSource } from "./completionEngine";
 import {
+  clampAutocompletePopupGeometry,
   computeAutocompletePopupPlacement,
   resolveAutocompleteClampViewport,
 } from "./terminalAutocompleteLayout";
@@ -139,6 +140,7 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const listRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLDivElement>(null);
   const [hoveredIndex, setHoveredIndex] = useState(-1);
+  const [measuredSize, setMeasuredSize] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {
     if (selectedRef.current && listRef.current) {
@@ -177,6 +179,56 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
       window.removeEventListener("resize", requestReposition);
     };
   }, [containerRef, onRequestReposition, visible]);
+
+  useEffect(() => {
+    if (!visible || !onRequestReposition || suggestions.length === 0) return;
+
+    let firstFrame = 0;
+    let secondFrame = 0;
+    firstFrame = requestAnimationFrame(() => {
+      onRequestReposition();
+      secondFrame = requestAnimationFrame(onRequestReposition);
+    });
+
+    return () => {
+      if (firstFrame) cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [onRequestReposition, subDirPanels.length, suggestions, visible]);
+
+  useLayoutEffect(() => {
+    if (!visible || suggestions.length === 0) {
+      setMeasuredSize((current) => (current === null ? current : null));
+      return;
+    }
+
+    let frameId = 0;
+    const measure = () => {
+      const rect = wrapperRef.current?.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) return;
+      setMeasuredSize((current) => {
+        if (
+          current &&
+          Math.abs(current.width - rect.width) < 0.5 &&
+          Math.abs(current.height - rect.height) < 0.5
+        ) {
+          return current;
+        }
+        return { width: rect.width, height: rect.height };
+      });
+    };
+
+    measure();
+    const wrapper = wrapperRef.current;
+    const observer = wrapper ? new ResizeObserver(measure) : null;
+    observer?.observe(wrapper);
+    frameId = requestAnimationFrame(measure);
+
+    return () => {
+      if (frameId) cancelAnimationFrame(frameId);
+      observer?.disconnect();
+    };
+  }, [hoveredIndex, selectedIndex, subDirPanels, suggestions, visible]);
 
   // Dismiss popup when clicking outside
   useEffect(() => {
@@ -270,6 +322,16 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
   const effectiveMaxHeight = placement.maxHeight;
   const anchoredTop = placement.top;
   const clampedLeft = placement.left;
+  const finalGeometry = measuredSize
+    ? clampAutocompletePopupGeometry({
+        left: clampedLeft,
+        top: anchoredTop,
+        width: measuredSize.width,
+        height: measuredSize.height,
+        clampViewport,
+        viewportPadding,
+      })
+    : { left: clampedLeft, top: anchoredTop };
 
   const sharedBoxStyle = {
     // border-box so each panel's maxWidth is its true outer width (padding +
@@ -292,8 +354,8 @@ const AutocompletePopup: React.FC<AutocompletePopupProps> = ({
       ref={wrapperRef}
       style={{
         position: "fixed",
-        left: `${clampedLeft}px`,
-        top: `${anchoredTop}px`,
+        left: `${finalGeometry.left}px`,
+        top: `${finalGeometry.top}px`,
         zIndex: 10000,
         display: "flex",
         alignItems: renderUpward ? "flex-end" : "flex-start",

--- a/components/terminal/autocomplete/terminalAutocompleteLayout.ts
+++ b/components/terminal/autocomplete/terminalAutocompleteLayout.ts
@@ -187,6 +187,48 @@ export interface PopupPlacement {
   maxHeight: number;
 }
 
+export interface PopupGeometryClampInput {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  clampViewport: PopupClampViewport;
+  viewportPadding: number;
+}
+
+export interface PopupGeometry {
+  top: number;
+  left: number;
+}
+
+function clampCoordinate(value: number, min: number, max: number): number {
+  if (max <= min) return min;
+  return Math.max(min, Math.min(value, max));
+}
+
+/**
+ * Final guardrail using the rendered popup's actual DOM size. The placement
+ * pass uses estimated list/detail/panel sizes so it can decide before render;
+ * this pass prevents any estimate mismatch or delayed xterm cursor refresh
+ * from letting the fixed-position portal escape the terminal/app bounds.
+ */
+export function clampAutocompletePopupGeometry(
+  input: PopupGeometryClampInput,
+): PopupGeometry {
+  const { left, top, width, height, clampViewport, viewportPadding } = input;
+  const safeWidth = Number.isFinite(width) ? Math.max(0, width) : 0;
+  const safeHeight = Number.isFinite(height) ? Math.max(0, height) : 0;
+  const minLeft = clampViewport.left + viewportPadding;
+  const minTop = clampViewport.top + viewportPadding;
+  const maxLeft = clampViewport.left + clampViewport.width - viewportPadding - safeWidth;
+  const maxTop = clampViewport.top + clampViewport.height - viewportPadding - safeHeight;
+
+  return {
+    left: clampCoordinate(left, minLeft, Math.max(minLeft, maxLeft)),
+    top: clampCoordinate(top, minTop, Math.max(minTop, maxTop)),
+  };
+}
+
 /**
  * Decide where to place the autocomplete popup so it never spills past the
  * viewport edges. Pure and deterministic so the boundary math is unit-tested

--- a/components/terminal/terminalAutocompleteLayout.test.ts
+++ b/components/terminal/terminalAutocompleteLayout.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  clampAutocompletePopupGeometry,
   computeAutocompletePopupPlacement,
   resolveAutocompleteAnchorInViewport,
   resolveAutocompleteClampViewport,
@@ -164,6 +165,38 @@ test("clamps within a split terminal pane instead of the full window", () => {
   });
   assert.ok(p.left >= pane.left + baseInput.viewportPadding);
   assert.ok(p.left + 400 <= pane.left + pane.width - baseInput.viewportPadding + 0.001);
+});
+
+test("final popup geometry clamps the actual rendered width", () => {
+  const pane = { left: 700, top: 80, width: 680, height: 520 };
+  const geometry = clampAutocompletePopupGeometry({
+    left: 970,
+    top: 180,
+    width: 520,
+    height: 220,
+    clampViewport: pane,
+    viewportPadding: 8,
+  });
+
+  assert.equal(geometry.left, 852);
+  assert.ok(geometry.left >= pane.left + 8);
+  assert.ok(geometry.left + 520 <= pane.left + pane.width - 8);
+});
+
+test("final popup geometry clamps the actual rendered height", () => {
+  const pane = { left: 700, top: 80, width: 680, height: 520 };
+  const geometry = clampAutocompletePopupGeometry({
+    left: 760,
+    top: 470,
+    width: 360,
+    height: 180,
+    clampViewport: pane,
+    viewportPadding: 8,
+  });
+
+  assert.equal(geometry.top, 412);
+  assert.ok(geometry.top >= pane.top + 8);
+  assert.ok(geometry.top + 180 <= pane.top + pane.height - 8);
 });
 
 test("resolveAutocompleteAnchorInViewport uses the xterm screen rect in split panes", () => {


### PR DESCRIPTION
## Summary
- Add a final DOM-size clamp for terminal autocomplete popups so rendered popup assemblies cannot escape the terminal/app bounds even when estimates are stale.
- Reposition autocomplete after candidate set changes across animation frames to cover xterm cursor refresh delays after accepting a completion.
- Add regression coverage for final rendered-width and rendered-height clamping.

## Test plan
- `node --test --import tsx components/terminal/terminalAutocompleteLayout.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (fails in this local worktree on pre-existing text-matching tests and Electron binary install errors, unrelated to the autocomplete changes)

Fixes #1766

Made with [Cursor](https://cursor.com)