### PR TITLE
fix(sync): show sync dates and pending-only green dot (#1765)

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -575,6 +575,7 @@ export const enCoreMessages: Messages = {
   'sync.cloudSync': 'Cloud Sync',
   'sync.settings': 'Sync Settings',
   'sync.active': 'Cloud Sync Active',
+  'sync.pending': 'Changes pending sync',
   'sync.syncing': 'Syncing...',
   'sync.error': 'Sync Error',
   'sync.notConfigured': 'Not Configured',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -592,6 +592,7 @@ export const ruCoreMessages: Messages = {
   'sync.cloudSync': 'Облачная синхронизация',
   'sync.settings': 'Настройки синхронизации',
   'sync.active': 'Облачная синхронизация активна',
+  'sync.pending': 'Есть несинхронизированные изменения',
   'sync.syncing': 'Синхронизация...',
   'sync.error': 'Ошибка синхронизации',
   'sync.notConfigured': 'Не настроено',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -304,6 +304,7 @@ export const zhCNCoreMessages: Messages = {
   'sync.cloudSync': '云同步',
   'sync.settings': '同步设置',
   'sync.active': '云同步已启用',
+  'sync.pending': '有待同步的更改',
   'sync.syncing': '正在同步…',
   'sync.error': '同步错误',
   'sync.notConfigured': '未配置',

--- a/application/state/useAutoSync.ts
+++ b/application/state/useAutoSync.ts
@@ -385,6 +385,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
       }
 
       lastSyncedDataRef.current = dataHash;
+      manager.setPendingLocalSync(false);
 
       // Successful sync implies a successful per-provider
       // `checkProviderConflict` (which inspects remote) — equivalent
@@ -458,6 +459,28 @@ export const useAutoSync = (config: AutoSyncConfig) => {
   useEffect(() => {
     getDataHashRef.current = getDataHash;
   }, [getDataHash]);
+
+  const refreshPendingLocalSync = useCallback(async () => {
+    if (!enabled || !sync.hasAnyConnectedProvider || !sync.isUnlocked) {
+      manager.setPendingLocalSync(false);
+      return;
+    }
+    if (!remoteCheckDoneRef.current) {
+      return;
+    }
+    const currentHash = await getDataHashRef.current();
+    const hashDecision = resolveAutoSyncHashDecision({
+      currentHash,
+      lastSyncedHash: lastSyncedDataRef.current,
+      appliedSkipHash: skipNextSyncHashRef.current,
+    });
+    manager.setPendingLocalSync(hashDecision === 'sync');
+  }, [enabled, sync.hasAnyConnectedProvider, sync.isUnlocked]);
+
+  const refreshPendingLocalSyncRef = useRef(refreshPendingLocalSync);
+  useEffect(() => {
+    refreshPendingLocalSyncRef.current = refreshPendingLocalSync;
+  }, [refreshPendingLocalSync]);
 
   // Serialize `checkRemoteVersion` invocations. Overlapping runs would
   // race on `commitRemoteInspection` + `onApplyPayload`: two merges
@@ -713,6 +736,7 @@ export const useAutoSync = (config: AutoSyncConfig) => {
         // unlock/startupReady transition, and a manual sync from
         // Settings remains available as an escape hatch.
         remoteCheckDoneRef.current = true;
+        await refreshPendingLocalSyncRef.current();
       }
       checkRemoteInFlightRef.current = false;
     }
@@ -838,6 +862,21 @@ export const useAutoSync = (config: AutoSyncConfig) => {
     sync.isSyncing,
     getDataHash,
     syncNow,
+    config.settingsVersion,
+    enabled,
+    bookmarksVersion,
+    syncableSettingsStorageVersion,
+  ]);
+
+  // Reflect unsynced local edits in the top-bar cloud indicator.
+  useEffect(() => {
+    void refreshPendingLocalSync();
+  }, [
+    refreshPendingLocalSync,
+    getDataHash,
+    sync.hasAnyConnectedProvider,
+    sync.isUnlocked,
+    sync.isSyncing,
     config.settingsVersion,
     enabled,
     bookmarksVersion,

--- a/application/state/useCloudSync.ts
+++ b/application/state/useCloudSync.ts
@@ -58,6 +58,7 @@ export interface CloudSyncHook {
   remoteVersion: number;
   remoteUpdatedAt: number;
   syncHistory: SyncHistoryEntry[];
+  pendingLocalSync: boolean;
   pendingBrowserAuthProvider: 'google' | 'onedrive' | null;
   
   // Computed
@@ -731,6 +732,7 @@ export const useCloudSync = (): CloudSyncHook => {
     remoteVersion: state.remoteVersion,
     remoteUpdatedAt: state.remoteUpdatedAt,
     syncHistory: state.syncHistory,
+    pendingLocalSync: state.pendingLocalSync,
     pendingBrowserAuthProvider: pendingBrowserAuth?.provider ?? null,
     
     // Computed

--- a/components/SyncStatusButton.tsx
+++ b/components/SyncStatusButton.tsx
@@ -2,7 +2,7 @@
  * SyncStatusButton - Cloud Sync Status Indicator for Top Bar
  *
  * Shows current sync state with cloud icon and colored indicators:
- * - Green dot: All synced
+ * - Green dot: Local changes pending upload
  * - Blue dot + spin: Syncing in progress
  * - Red dot: Error
  * - Gray dot: No providers connected
@@ -25,7 +25,7 @@ import {
     Server,
 } from 'lucide-react';
 import { useCloudSync } from '../application/state/useCloudSync';
-import { isProviderReadyForSync, type CloudProvider } from '../domain/sync';
+import { isProviderReadyForSync, type CloudProvider, formatSyncDateTime } from '../domain/sync';
 import { useI18n } from '../application/i18n/I18nProvider';
 import { cn } from '../lib/utils';
 import { Button } from './ui/button';
@@ -136,6 +136,11 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
     const connectedProvider = getConnectedProvider();
     const providerConnection = connectedProvider ? sync.providers[connectedProvider] : null;
 
+    const hasVersionMismatch = sync.hasAnyConnectedProvider
+        && sync.localVersion !== sync.remoteVersion;
+
+    const hasPendingSync = sync.pendingLocalSync || hasVersionMismatch;
+
     // Determine overall status for the button indicator
     const getOverallStatus = (): StatusIndicatorProps['status'] => {
         if (sync.overallSyncStatus === 'syncing') return 'syncing';
@@ -146,7 +151,7 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
         ) {
             return 'error';
         }
-        if (sync.overallSyncStatus === 'synced') return 'synced';
+        if (hasPendingSync) return 'synced';
         return 'none';
     };
 
@@ -164,7 +169,7 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
         const diff = Date.now() - timestamp;
         if (diff < 60000) return t('time.justNow');
         if (diff < 3600000) return t('time.minutesAgo', { minutes: Math.floor(diff / 60000) });
-        return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        return formatSyncDateTime(timestamp);
     };
 
     // Create a unique key based on sync state to force re-render
@@ -186,12 +191,13 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
                         >
                             {getButtonIcon()}
 
-                            {/* Status indicator dot */}
-                            <StatusIndicator
-                                status={overallStatus}
-                                size="sm"
-                                className="absolute top-0.5 right-0.5 ring-2 ring-background"
-                            />
+                            {overallStatus !== 'none' && (
+                                <StatusIndicator
+                                    status={overallStatus}
+                                    size="sm"
+                                    className="absolute top-0.5 right-0.5 ring-2 ring-background"
+                                />
+                            )}
                         </Button>
                     </PopoverTrigger>
                 </TooltipTrigger>
@@ -208,7 +214,7 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
                 <div className="px-3 py-2.5 border-b border-border/60">
                     <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
-                            {overallStatus === 'synced' && (
+                            {overallStatus === 'synced' && hasPendingSync && (
                                 <Cloud size={16} className="text-green-500" />
                             )}
                             {overallStatus === 'syncing' && (
@@ -217,15 +223,19 @@ export const SyncStatusButton: React.FC<SyncStatusButtonProps> = ({
                             {overallStatus === 'error' && (
                                 <Cloud size={16} className="text-red-500" />
                             )}
-                            {overallStatus === 'none' && (
+                            {overallStatus === 'none' && sync.hasAnyConnectedProvider && (
+                                <Cloud size={16} className="text-muted-foreground" />
+                            )}
+                            {overallStatus === 'none' && !sync.hasAnyConnectedProvider && (
                                 <CloudOff size={16} className="text-muted-foreground" />
                             )}
 
                             <span className="text-sm font-medium">
-                                {overallStatus === 'synced' && t('sync.active')}
+                                {overallStatus === 'synced' && hasPendingSync && t('sync.pending')}
                                 {overallStatus === 'syncing' && t('sync.syncing')}
                                 {overallStatus === 'error' && t('sync.error')}
-                                {overallStatus === 'none' && t('sync.notConfigured')}
+                                {overallStatus === 'none' && sync.hasAnyConnectedProvider && t('sync.active')}
+                                {overallStatus === 'none' && !sync.hasAnyConnectedProvider && t('sync.notConfigured')}
                             </span>
                         </div>
 

--- a/components/cloud-sync/CloudSyncControls.tsx
+++ b/components/cloud-sync/CloudSyncControls.tsx
@@ -32,7 +32,7 @@ import { useI18n } from '../../application/i18n/I18nProvider';
 import { useCloudSync } from '../../application/state/useCloudSync';
 
 
-import { type CloudProvider, type ConflictInfo, type SyncChangeEntityKey, type SyncEntityChangeCounts } from '../../domain/sync';
+import { type CloudProvider, type ConflictInfo, type SyncChangeEntityKey, type SyncEntityChangeCounts, formatLastSync } from '../../domain/sync';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -302,16 +302,15 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
     extraActions,
 }) => {
     const { t } = useI18n();
-    const formatLastSync = (timestamp?: number): string => {
+    const formatLastSyncLabel = (timestamp?: number): string => {
         if (!timestamp) return t('cloudSync.lastSync.never');
-        const date = new Date(timestamp);
-        const now = new Date();
-        const diff = now.getTime() - date.getTime();
+        const now = Date.now();
+        const diff = now - timestamp;
 
         if (diff < 60000) return t('cloudSync.lastSync.justNow');
         if (diff < 3600000) return t('cloudSync.lastSync.minutesAgo', { minutes: Math.floor(diff / 60000) });
 
-        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        return formatLastSync(timestamp);
     };
 
     const status = error
@@ -358,7 +357,7 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
                             {account.name || account.email}
                         </span>
                         <span className="text-xs text-muted-foreground">
-                            · {formatLastSync(lastSync)}
+                            · {formatLastSyncLabel(lastSync)}
                         </span>
                     </div>
                 ) : error ? (

--- a/domain/sync.format.test.ts
+++ b/domain/sync.format.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { formatLastSync, formatSyncDateTime } from './sync';
+
+test('formatSyncDateTime renders yyyymmdd hhmm', () => {
+  const timestamp = new Date(2025, 5, 28, 14, 30, 0).getTime();
+  assert.equal(formatSyncDateTime(timestamp), '20250628 1430');
+});
+
+test('formatLastSync uses compact datetime for older timestamps', () => {
+  const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+  const formatted = formatLastSync(twoHoursAgo);
+  assert.match(formatted, /^\d{8} \d{4}$/);
+});

--- a/domain/sync.ts
+++ b/domain/sync.ts
@@ -634,23 +634,31 @@ export const getDefaultDeviceName = (): string => {
 };
 
 /**
+ * Format a sync timestamp as `yyyymmdd hhmm` (e.g. `20250628 1430`).
+ */
+export const formatSyncDateTime = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}${month}${day} ${hours}${minutes}`;
+};
+
+/**
  * Format last sync time for display
  */
 export const formatLastSync = (timestamp?: number): string => {
   if (!timestamp) return 'Never synced';
-  
+
   const now = Date.now();
   const diff = now - timestamp;
-  
+
   if (diff < 60000) return 'Just now';
   if (diff < 3600000) return `${Math.floor(diff / 60000)} min ago`;
-  if (diff < 86400000) {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  }
-  
-  const date = new Date(timestamp);
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+
+  return formatSyncDateTime(timestamp);
 };
 
 /**

--- a/infrastructure/services/CloudSyncManager.ts
+++ b/infrastructure/services/CloudSyncManager.ts
@@ -137,6 +137,8 @@ export interface SyncManagerState {
   autoSyncInterval: number;
   syncStrategy: CloudSyncStrategy;
   syncHistory: SyncHistoryEntry[];
+  /** True when local vault data differs from the last successful sync snapshot. */
+  pendingLocalSync: boolean;
   /** Last shrink finding that put us into BLOCKED state, retained until
    * a sync actually succeeds (SYNC_COMPLETED with result.success) or
    * `clearShrinkBlockedState()` is called. Renderer hydrates the banner
@@ -774,6 +776,14 @@ export class CloudSyncManager {
   setSyncStrategy(strategy: CloudSyncStrategy): void {
     this.state.syncStrategy = strategy;
     this.saveSyncConfig();
+    this.notifyStateChange();
+  }
+
+  setPendingLocalSync(pending: boolean): void {
+    if (this.state.pendingLocalSync === pending) {
+      return;
+    }
+    this.state.pendingLocalSync = pending;
     this.notifyStateChange();
   }
 

--- a/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
+++ b/infrastructure/services/cloudSync/stateAndSecurityMethods.ts
@@ -89,6 +89,7 @@ export function loadInitialStateImpl(this: any): SyncManagerState {
       autoSyncInterval: syncConfig?.interval || SYNC_CONSTANTS.DEFAULT_AUTO_SYNC_INTERVAL,
       syncStrategy: normalizeCloudSyncStrategy(syncConfig?.syncStrategy ?? DEFAULT_CLOUD_SYNC_STRATEGY),
       syncHistory,
+      pendingLocalSync: false,
     };
   }
 


### PR DESCRIPTION
## Summary
- 云同步记录时间超过 1 小时后显示 `yyyymmdd hhmm` 格式（如 `20250628 1430`），避免只显示时间让人误以为都是当天
- 顶部云图标绿点仅在本地有待同步更改或本地/云端版本不一致时出现；已全部同步时不再显示绿点

## Test plan
- [ ] 打开顶部云同步弹窗，确认历史记录中较早的条目显示日期+时间
- [ ] 全部同步完成后，云图标上不应有绿点
- [ ] 修改主机/密钥等触发本地变更后，绿点应出现；同步成功后绿点消失
- [ ] `node --test --import tsx domain/sync.format.test.ts`

Closes #1765


Made with [Cursor](https://cursor.com)