### PR TITLE
Polish vault UI: resizable host panels, snippet tooltips, known hosts actions

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -483,6 +483,7 @@ export const enVaultMessages: Messages = {
   // Host Details
   'hostDetails.title.details': 'Host Details',
   'hostDetails.title.new': 'New Host',
+  'vault.panel.resizeWidth': 'Resize panel width',
   'hostDetails.saveAria': 'Save',
   'hostDetails.section.address': 'Address',
   'hostDetails.hostname.placeholder': 'IP or Hostname',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -518,6 +518,7 @@ export const ruVaultMessages: Messages = {
   // Host Details
   'hostDetails.title.details': 'Сведения о хосте',
   'hostDetails.title.new': 'Новый хост',
+  'vault.panel.resizeWidth': 'Изменить ширину панели',
   'hostDetails.saveAria': 'Сохранить',
   'hostDetails.section.address': 'Адрес',
   'hostDetails.hostname.placeholder': 'IP или имя хоста',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -57,6 +57,7 @@ export const zhCNVaultMessages: Messages = {
   // Host Details
   'hostDetails.title.details': '主机详情',
   'hostDetails.title.new': '新建主机',
+  'vault.panel.resizeWidth': '调整面板宽度',
   'hostDetails.saveAria': '保存',
   'hostDetails.section.address': '地址',
   'hostDetails.hostname.placeholder': 'IP 或 主机名',

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -36,12 +36,14 @@ import {
   EnvVarsPanel,
   HostDetailsSection,
   HostDetailsSettingRow,
+  HostDetailsOverrideReset,
   ProxyPanel,
 } from "./host-details";
 import {
   AsidePanel,
   AsidePanelContent,
   type AsidePanelLayout,
+  type AsidePanelResizeProps,
 } from "./ui/aside-panel";
 import { Button } from "./ui/button";
 import { Combobox } from "./ui/combobox";
@@ -79,7 +81,9 @@ interface GroupDetailsPanelProps {
   layout?: AsidePanelLayout;
 }
 
-const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
+type GroupDetailsPanelPropsWithResize = GroupDetailsPanelProps & AsidePanelResizeProps;
+
+const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
   groupPath,
   config,
   availableKeys,
@@ -93,8 +97,16 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
   onSave,
   onCancel,
   layout = "overlay",
+  resizable,
+  persistWidthStorageKey,
+  resizeAriaLabel,
 }) => {
   const { t } = useI18n();
+  const asideResizeProps = {
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
+  };
   const availableFonts = useAvailableFonts();
 
   const originalName = groupPath.includes("/")
@@ -463,6 +475,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -481,6 +494,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -509,6 +523,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -530,6 +545,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         showBackButton={true}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -548,6 +564,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
       dataSection="group-details-panel"
       title={t("vault.groups.details")}
       layout={layout}
+      {...asideResizeProps}
       actions={
         <Button
           variant="ghost"
@@ -725,79 +742,76 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelProps> = ({
           title={t("vault.groups.details.appearance")}
         >
 
-          <button
-            type="button"
-            className="w-full flex items-center gap-3 p-2 rounded-lg bg-secondary/50 hover:bg-secondary transition-colors text-left"
-            onClick={() => setActiveSubPanel("theme-select")}
-          >
-            <div
-              className="w-12 h-8 rounded-md border border-border/60 flex items-center justify-center text-[6px] font-mono overflow-hidden"
-              style={{
-                backgroundColor:
-                  customThemeStore.getThemeById(effectiveThemeId)?.colors.background || "#100F0F",
-                color:
-                  customThemeStore.getThemeById(effectiveThemeId)?.colors.foreground || "#CECDC3",
-              }}
+          <div className="flex w-full items-center gap-1 rounded-lg bg-secondary/50 p-2 transition-colors hover:bg-secondary">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-3 text-left"
+              onClick={() => setActiveSubPanel("theme-select")}
             >
-              <div className="p-0.5">
-                <div
-                  style={{
-                    color: customThemeStore.getThemeById(effectiveThemeId)?.colors.green,
-                  }}
-                >
-                  $
+              <div
+                className="w-12 h-8 rounded-md border border-border/60 flex items-center justify-center text-[6px] font-mono overflow-hidden shrink-0"
+                style={{
+                  backgroundColor:
+                    customThemeStore.getThemeById(effectiveThemeId)?.colors.background || "#100F0F",
+                  color:
+                    customThemeStore.getThemeById(effectiveThemeId)?.colors.foreground || "#CECDC3",
+                }}
+              >
+                <div className="p-0.5">
+                  <div
+                    style={{
+                      color: customThemeStore.getThemeById(effectiveThemeId)?.colors.green,
+                    }}
+                  >
+                    $
+                  </div>
                 </div>
               </div>
-            </div>
-            <span className="text-sm flex-1">
-              {customThemeStore.getThemeById(effectiveThemeId)?.name || "Flexoki Dark"}
-            </span>
-          </button>
-          {hasActiveThemeOverride && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start text-primary"
-              onClick={() =>
-                setForm((prev) => ({
-                  ...prev,
-                  theme: undefined,
-                  themeOverride: false,
-                }))
-              }
-            >
-              {t("common.useGlobal")}
-            </Button>
-          )}
+              <span className="text-sm flex-1 truncate">
+                {customThemeStore.getThemeById(effectiveThemeId)?.name || "Flexoki Dark"}
+              </span>
+            </button>
+            {hasActiveThemeOverride && (
+              <HostDetailsOverrideReset
+                label={t("common.useGlobal")}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setForm((prev) => ({
+                    ...prev,
+                    theme: undefined,
+                    themeOverride: false,
+                  }));
+                }}
+              />
+            )}
+          </div>
 
-          <TerminalFontSelect
-            value={form.fontFamily || availableFonts[0]?.id || ""}
-            fonts={availableFonts}
-            onChange={(id) => {
-              setForm((prev) => ({
-                ...prev,
-                fontFamily: id,
-                fontFamilyOverride: true,
-              }));
-            }}
-            className="w-full"
-          />
-          {form.fontFamilyOverride && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start text-primary"
-              onClick={() =>
+          <div className="flex items-center gap-2">
+            <TerminalFontSelect
+              value={form.fontFamily || availableFonts[0]?.id || ""}
+              fonts={availableFonts}
+              onChange={(id) => {
                 setForm((prev) => ({
                   ...prev,
-                  fontFamily: undefined,
-                  fontFamilyOverride: false,
-                }))
-              }
-            >
-              {t("common.useGlobal")}
-            </Button>
-          )}
+                  fontFamily: id,
+                  fontFamilyOverride: true,
+                }));
+              }}
+              className="min-w-0 flex-1"
+            />
+            {form.fontFamilyOverride && (
+              <HostDetailsOverrideReset
+                label={t("common.useGlobal")}
+                onClick={() =>
+                  setForm((prev) => ({
+                    ...prev,
+                    fontFamily: undefined,
+                    fontFamilyOverride: false,
+                  }))
+                }
+              />
+            )}
+          </div>
 
           {/* Font Size */}
           <HostDetailsSettingRow label="Font Size">

--- a/components/HostDetailsAdvancedSections.tsx
+++ b/components/HostDetailsAdvancedSections.tsx
@@ -6,7 +6,7 @@ import { MAX_FONT_SIZE, MIN_FONT_SIZE } from "../infrastructure/config/fonts";
 import { AlgorithmOverridesPanel } from "./host-details/AlgorithmOverridesPanel";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
-import { HostDetailsSection, HostDetailsSettingRow } from "./host-details";
+import { HostDetailsSection, HostDetailsSettingRow, HostDetailsOverrideReset } from "./host-details";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
 import { Input } from "./ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
@@ -58,110 +58,110 @@ export const HostDetailsAdvancedSections: React.FC<HostDetailsAdvancedSectionsPr
         >
 
           {/* SSH Theme Selection */}
-          <button
-            type="button"
-            className="w-full flex items-center gap-3 p-2 rounded-lg bg-secondary/50 hover:bg-secondary transition-colors text-left"
-            onClick={() => setActiveSubPanel("theme-select")}
-          >
-            <div
-              className="w-12 h-8 rounded-md border border-border/60 flex items-center justify-center text-[6px] font-mono overflow-hidden"
-              style={{
-                backgroundColor:
-                  customThemeStore.getThemeById(effectiveThemeId)?.colors.background || "#100F0F",
-                color:
-                  customThemeStore.getThemeById(effectiveThemeId)?.colors.foreground || "#CECDC3",
-              }}
+          <div className="flex w-full items-center gap-1 rounded-lg bg-secondary/50 p-2 transition-colors hover:bg-secondary">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-3 text-left"
+              onClick={() => setActiveSubPanel("theme-select")}
             >
-              <div className="p-0.5">
-                <div
-                  style={{
-                    color: customThemeStore.getThemeById(effectiveThemeId)?.colors.green,
-                  }}
-                >
-                  $
+              <div
+                className="w-12 h-8 rounded-md border border-border/60 flex items-center justify-center text-[6px] font-mono overflow-hidden shrink-0"
+                style={{
+                  backgroundColor:
+                    customThemeStore.getThemeById(effectiveThemeId)?.colors.background || "#100F0F",
+                  color:
+                    customThemeStore.getThemeById(effectiveThemeId)?.colors.foreground || "#CECDC3",
+                }}
+              >
+                <div className="p-0.5">
+                  <div
+                    style={{
+                      color: customThemeStore.getThemeById(effectiveThemeId)?.colors.green,
+                    }}
+                  >
+                    $
+                  </div>
                 </div>
               </div>
-            </div>
-            <span className="text-sm flex-1">
-              {customThemeStore.getThemeById(effectiveThemeId)?.name || "Flexoki Dark"}
-            </span>
-          </button>
-          {hasEffectiveThemeOverride && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-full justify-start text-primary"
-              onClick={() => setForm((prev) => clearHostThemeOverride(prev))}
-            >
-              {t("common.useGlobal")}
-            </Button>
-          )}
+              <span className="text-sm flex-1 truncate">
+                {customThemeStore.getThemeById(effectiveThemeId)?.name || "Flexoki Dark"}
+              </span>
+            </button>
+            {hasEffectiveThemeOverride && (
+              <HostDetailsOverrideReset
+                label={t("common.useGlobal")}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setForm((prev) => clearHostThemeOverride(prev));
+                }}
+              />
+            )}
+          </div>
 
           {/* Font Size */}
           <HostDetailsSettingRow label="Font Size">
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  if (effectiveFontSize > MIN_FONT_SIZE) {
-                    setForm((prev) => ({
-                      ...prev,
-                      fontSize: effectiveFontSize - 1,
-                      fontSizeOverride: true,
-                    }));
-                  }
-                }}
-                disabled={effectiveFontSize <= MIN_FONT_SIZE}
-                className="h-8 w-8 px-0"
-              >
-                -
-              </Button>
-              <Input
-                type="number"
-                min={MIN_FONT_SIZE}
-                max={MAX_FONT_SIZE}
-                value={effectiveFontSize}
-                onChange={(e) => {
-                  const val = parseInt(e.target.value);
-                  if (val >= MIN_FONT_SIZE && val <= MAX_FONT_SIZE) {
-                    setForm((prev) => ({
-                      ...prev,
-                      fontSize: val,
-                      fontSizeOverride: true,
-                    }));
-                  }
-                }}
-                className="h-8 w-16 text-center"
-              />
-              <span className="text-sm text-muted-foreground">pt</span>
-              {hasEffectiveFontSizeOverride && (
+              <div className="flex items-center gap-1.5">
                 <Button
-                  variant="ghost"
+                  variant="outline"
                   size="sm"
-                  className="h-8 text-primary"
-                  onClick={() => setForm((prev) => clearHostFontSizeOverride(prev))}
+                  onClick={() => {
+                    if (effectiveFontSize > MIN_FONT_SIZE) {
+                      setForm((prev) => ({
+                        ...prev,
+                        fontSize: effectiveFontSize - 1,
+                        fontSizeOverride: true,
+                      }));
+                    }
+                  }}
+                  disabled={effectiveFontSize <= MIN_FONT_SIZE}
+                  className="h-8 w-8 px-0"
                 >
-                  {t("common.useGlobal")}
+                  -
                 </Button>
+                <Input
+                  type="number"
+                  min={MIN_FONT_SIZE}
+                  max={MAX_FONT_SIZE}
+                  value={effectiveFontSize}
+                  onChange={(e) => {
+                    const val = parseInt(e.target.value);
+                    if (val >= MIN_FONT_SIZE && val <= MAX_FONT_SIZE) {
+                      setForm((prev) => ({
+                        ...prev,
+                        fontSize: val,
+                        fontSizeOverride: true,
+                      }));
+                    }
+                  }}
+                  className="h-8 w-16 text-center"
+                />
+                <span className="text-sm text-muted-foreground">pt</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (effectiveFontSize < MAX_FONT_SIZE) {
+                      setForm((prev) => ({
+                        ...prev,
+                        fontSize: effectiveFontSize + 1,
+                        fontSizeOverride: true,
+                      }));
+                    }
+                  }}
+                  disabled={effectiveFontSize >= MAX_FONT_SIZE}
+                  className="h-8 w-8 px-0"
+                >
+                  +
+                </Button>
+              </div>
+              {hasEffectiveFontSizeOverride && (
+                <HostDetailsOverrideReset
+                  size="sm"
+                  label={t("common.useGlobal")}
+                  onClick={() => setForm((prev) => clearHostFontSizeOverride(prev))}
+                />
               )}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  if (effectiveFontSize < MAX_FONT_SIZE) {
-                    setForm((prev) => ({
-                      ...prev,
-                      fontSize: effectiveFontSize + 1,
-                      fontSizeOverride: true,
-                    }));
-                  }
-                }}
-                disabled={effectiveFontSize >= MAX_FONT_SIZE}
-                className="h-8 w-8 px-0"
-              >
-                +
-              </Button>
             </div>
           </HostDetailsSettingRow>
         </HostDetailsSection>

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -38,6 +38,7 @@ import {
   AsidePanelContent,
   AsidePanelFooter,
   type AsidePanelLayout,
+  type AsidePanelResizeProps,
 } from "./ui/aside-panel";
 import { HostDetailsAdvancedSections } from "./HostDetailsAdvancedSections";
 import { HostDetailsConnectionSections } from "./HostDetailsConnectionSections";
@@ -104,7 +105,9 @@ interface HostDetailsPanelProps {
   onSnippetsChange?: (snippets: Snippet[]) => void;
 }
 
-const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
+type HostDetailsPanelPropsWithResize = HostDetailsPanelProps & AsidePanelResizeProps;
+
+const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   initialData,
   availableKeys,
   identities,
@@ -126,8 +129,16 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
   onImportKey,
   snippets = [],
   onSnippetsChange,
+  resizable,
+  persistWidthStorageKey,
+  resizeAriaLabel,
 }) => {
   const { t } = useI18n();
+  const asideResizeProps = {
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
+  };
   const { checkSshAgent } = useApplicationBackend();
   const [form, setForm] = useState<Host>(
     () =>
@@ -638,6 +649,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -654,6 +666,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -672,6 +685,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -700,6 +714,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         onCancel={onCancel}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -721,6 +736,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         showBackButton={true}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -757,6 +773,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
         onBack={() => setActiveSubPanel("none")}
         showBackButton={true}
         layout={layout}
+        {...asideResizeProps}
       />
     );
   }
@@ -768,6 +785,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelProps> = ({
       width="w-[420px]"
       layout={layout}
       dataSection="host-details-panel"
+      {...asideResizeProps}
       title={
         initialData ? t("hostDetails.title.details") : t("hostDetails.title.new")
       }

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -123,6 +123,57 @@ interface HostItemProps {
   onConvertToHost: (knownHost: KnownHost) => void;
 }
 
+const knownHostActionButtonClass =
+  "h-8 w-8 shrink-0 opacity-0 transition-opacity group-hover:opacity-100";
+
+const KnownHostItemActions: React.FC<{
+  knownHost: KnownHost;
+  converted: boolean;
+  onDelete: (id: string) => void;
+  onConvertToHost: (knownHost: KnownHost) => void;
+}> = ({ knownHost, converted, onDelete, onConvertToHost }) => {
+  const { t } = useI18n();
+
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {!converted && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={knownHostActionButtonClass}
+              onClick={(e) => {
+                e.stopPropagation();
+                onConvertToHost(knownHost);
+              }}
+            >
+              <ArrowRight size={14} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t("action.convertToHost")}</TooltipContent>
+        </Tooltip>
+      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(knownHostActionButtonClass, "text-destructive hover:text-destructive hover:bg-destructive/10")}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(knownHost.id);
+            }}
+          >
+            <Trash2 size={14} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t("action.remove")}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
 const HostItem = React.memo<HostItemProps>(
   ({ knownHost, converted, viewMode, reorderProps, onDelete, onConvertToHost }) => {
     const { t } = useI18n();
@@ -141,39 +192,6 @@ const HostItem = React.memo<HostItemProps>(
                 reorderProps?.className,
               )}
             >
-              {/* Quick action buttons on hover */}
-              <div className="absolute top-1 right-1 flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                {!converted && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        className="p-1 rounded hover:bg-primary/20 text-primary"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onConvertToHost(knownHost);
-                        }}
-                      >
-                        <ArrowRight size={12} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>{t("action.convertToHost")}</TooltipContent>
-                  </Tooltip>
-                )}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      className="p-1 rounded hover:bg-destructive/20 text-destructive"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete(knownHost.id);
-                      }}
-                    >
-                      <Trash2 size={12} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t("action.remove")}</TooltipContent>
-                </Tooltip>
-              </div>
               <div className="flex items-center gap-3 h-full">
                 <VaultEntityIcon
                   className={vaultPrimaryIconClass}
@@ -184,6 +202,12 @@ const HostItem = React.memo<HostItemProps>(
                     {knownHost.hostname}
                   </span>
                 </div>
+                <KnownHostItemActions
+                  knownHost={knownHost}
+                  converted={converted}
+                  onDelete={onDelete}
+                  onConvertToHost={onConvertToHost}
+                />
               </div>
             </div>
           </ContextMenuTrigger>
@@ -226,26 +250,12 @@ const HostItem = React.memo<HostItemProps>(
                 {knownHost.hostname}
               </span>
             </div>
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              {!converted && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onConvertToHost(knownHost);
-                      }}
-                    >
-                      <ArrowRight size={14} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t("action.convertToHost")}</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            <KnownHostItemActions
+              knownHost={knownHost}
+              converted={converted}
+              onDelete={onDelete}
+              onConvertToHost={onConvertToHost}
+            />
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -26,6 +26,7 @@ import {
 } from './ui/context-menu';
 import { FixedSizeVirtualList } from './ui/FixedSizeVirtualList';
 import { Input } from './ui/input';
+import { SnippetCommandTooltipContent } from './snippets/SnippetCommandTooltipContent';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 
 const SCRIPT_ROW_HEIGHT = 34;
@@ -917,11 +918,8 @@ const SnippetRow = memo<SnippetRowProps>(({
               )}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="right" align="start" className="max-w-[480px]">
-            <div className="font-medium text-xs mb-1 break-all">{snippet.label}</div>
-            <pre className="font-mono text-[11px] whitespace-pre-wrap break-all leading-snug opacity-90">
-              {snippet.command}
-            </pre>
+          <TooltipContent side="right" align="start">
+            <SnippetCommandTooltipContent label={snippet.label} command={snippet.command} />
           </TooltipContent>
         </Tooltip>
       </div>

--- a/components/SerialHostDetailsPanel.tsx
+++ b/components/SerialHostDetailsPanel.tsx
@@ -19,6 +19,7 @@ import {
   AsidePanelContent,
   AsidePanelFooter,
   type AsidePanelLayout,
+  type AsidePanelResizeProps,
 } from './ui/aside-panel';
 import { HostNotesEditor } from './host/HostNotesEditor';
 
@@ -41,19 +42,24 @@ interface SerialHostDetailsPanelProps {
   layout?: AsidePanelLayout;
 }
 
+type SerialHostDetailsPanelPropsWithResize = SerialHostDetailsPanelProps & AsidePanelResizeProps;
+
 const BAUD_RATES = [300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600];
 const DATA_BITS: Array<5 | 6 | 7 | 8> = [5, 6, 7, 8];
 const STOP_BITS: Array<1 | 1.5 | 2> = [1, 1.5, 2];
 const PARITY_OPTIONS: SerialParity[] = ['none', 'even', 'odd', 'mark', 'space'];
 const FLOW_CONTROL_OPTIONS: SerialFlowControl[] = ['none', 'xon/xoff', 'rts/cts'];
 
-export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
+export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelPropsWithResize> = ({
   initialData,
   allTags = [],
   groups = [],
   onSave,
   onCancel,
   layout = 'overlay',
+  resizable,
+  persistWidthStorageKey,
+  resizeAriaLabel,
 }) => {
   const { t } = useI18n();
   const terminalBackend = useTerminalBackend();
@@ -173,6 +179,9 @@ export const SerialHostDetailsPanel: React.FC<SerialHostDetailsPanelProps> = ({
       className="z-40"
       layout={layout}
       dataSection="serial-host-details-panel"
+      resizable={resizable}
+      persistWidthStorageKey={persistWidthStorageKey}
+      resizeAriaLabel={resizeAriaLabel}
     >
       <AsidePanelContent>
         {/* Label */}

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -16,6 +16,7 @@ import {
 } from '../domain/snippetTransfer';
 import { getRunnableHostsForSnippet, snippetHasRunTargets } from '../domain/snippetTargets.ts';
 import { removeHostConnectScript, syncHostsForSnippetTargetChange } from '../domain/hostConnectScripts.ts';
+import { flattenSnippetCommandPreview } from '../domain/snippetPreview.ts';
 import { DEFAULT_SCRIPT_TEMPLATE, isScriptSnippet } from '../domain/snippetScript.ts';
 import { reorderVaultItems, reorderVaultStrings, sortByVaultOrder } from '../domain/vaultOrder';
 import { Button } from './ui/button';
@@ -26,6 +27,7 @@ import { Dropdown, DropdownContent, DropdownTrigger } from './ui/dropdown';
 import { SortDropdown, SortMode } from './ui/sort-dropdown';
 import { toast } from './ui/toast';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+import { SnippetCommandTooltipContent } from './snippets/SnippetCommandTooltipContent';
 import { SnippetsRightPanel } from './SnippetsRightPanel';
 import { SnippetsPackageDialogs } from './SnippetsPackageDialogs';
 import {
@@ -499,6 +501,44 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   const [isSnippetImportDialogOpen, setIsSnippetImportDialogOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingSnippetImport | null>(null);
   const prepareGridLayoutAnimation = useVaultGridLayoutAnimation(listRef);
+  const hasSnippetsSidePanel = rightPanelMode !== 'none';
+  const splitGridColsRef = useRef(2);
+  const splitViewGridStyle = hasSnippetsSidePanel && viewMode === 'grid'
+    ? { gridTemplateColumns: 'var(--snippets-grid-cols, repeat(2, minmax(0, 1fr)))' }
+    : undefined;
+
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const GAP = 12;
+    const MIN_CARD = 220;
+    const PADDING_X = 32;
+
+    const recompute = () => {
+      const usable = el.clientWidth - PADDING_X;
+      if (usable <= 0) return;
+      const next = Math.max(1, Math.floor((usable + GAP) / (MIN_CARD + GAP)));
+      if (next === splitGridColsRef.current) return;
+      splitGridColsRef.current = next;
+      el.style.setProperty('--snippets-grid-cols', `repeat(${next}, minmax(0, 1fr))`);
+    };
+
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasSnippetsSidePanel, viewMode]);
+
+  const snippetsHeaderSectionCollapseClass = (
+    collapsed: boolean,
+    expandedMaxWidth: string,
+  ) => cn(
+    'flex items-center gap-2 overflow-hidden transition-[max-width,opacity,margin] duration-200 ease-in-out shrink-0',
+    collapsed
+      ? 'max-w-0 opacity-0 -ml-2 pointer-events-none'
+      : `${expandedMaxWidth} opacity-100`,
+  );
 
   const [historyVisibleCount, setHistoryVisibleCount] = useState(HISTORY_PAGE_SIZE);
   const historyScrollRef = useRef<HTMLDivElement>(null);
@@ -1572,19 +1612,20 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
 
   return (
     <TooltipProvider delayDuration={300}>
-    <div className="h-full min-h-0 flex relative">
-      <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-        <VaultPageHeader>
+    <div className="flex flex-1 min-h-0 min-w-0 relative">
+      <div className="flex flex-1 flex-col min-h-0 min-w-0 overflow-hidden">
+        <VaultPageHeader contentClassName="min-w-0 overflow-hidden">
             <VaultHeaderSearch
               placeholder={t('snippets.searchPlaceholder')}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-64"
+              className={cn(hasSnippetsSidePanel ? 'flex-1 min-w-[120px]' : 'w-64 shrink-0')}
             />
-            <Button onClick={() => handleEdit()} size="sm" className="h-10 px-3">
+            <div className={snippetsHeaderSectionCollapseClass(hasSnippetsSidePanel, 'max-w-[520px]')}>
+            <Button onClick={() => handleEdit()} size="sm" className="h-10 px-3 shrink-0">
               <Plus size={14} className="mr-2" /> {t('snippets.action.newSnippet')}
             </Button>
-            <Button onClick={() => handleEdit(undefined, true)} size="sm" variant="secondary" className={vaultHeaderSecondaryButtonClass}>
+            <Button onClick={() => handleEdit(undefined, true)} size="sm" variant="secondary" className={cn(vaultHeaderSecondaryButtonClass, 'shrink-0')}>
               <Play size={14} className="mr-2" /> {t('snippets.action.newScript')}
             </Button>
             <Button
@@ -1594,14 +1635,14 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               }}
               size="sm"
               variant="secondary"
-              className={vaultHeaderSecondaryButtonClass}
+              className={cn(vaultHeaderSecondaryButtonClass, 'shrink-0')}
             >
               <FolderPlus size={14} className="mr-1" /> {t('snippets.action.newPackage')}
             </Button>
             <Button
               variant="secondary"
               size="sm"
-              className={vaultHeaderSecondaryButtonClass}
+              className={cn(vaultHeaderSecondaryButtonClass, 'shrink-0')}
               onClick={() => {
                 setPendingImport(null);
                 setIsSnippetImportDialogOpen(true);
@@ -1614,13 +1655,15 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               size="sm"
               className={cn(
                 vaultHeaderSecondaryButtonClass,
+                'shrink-0',
                 rightPanelMode === 'history' && "bg-foreground/10 hover:bg-foreground/15",
               )}
               onClick={() => setRightPanelMode(rightPanelMode === 'history' ? 'none' : 'history')}
             >
               <Clock size={14} /> {t('snippets.history.title')}
             </Button>
-            <div className="flex items-center gap-1 ml-auto">
+            </div>
+            <div className="flex items-center gap-1 ml-auto shrink-0">
               <Dropdown>
                 <DropdownTrigger asChild>
                   <Button variant="ghost" size="icon" className={vaultHeaderIconButtonClass}>
@@ -1751,9 +1794,16 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               </div>
               <div className={cn(
                 viewMode === 'grid'
-                  ? "grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
+                  ? cn(
+                    "grid gap-3",
+                    hasSnippetsSidePanel
+                      ? "grid-cols-1"
+                      : "grid-cols-1 md:grid-cols-2 xl:grid-cols-3",
+                  )
                   : "flex flex-col gap-0"
-              )}>
+              )}
+              style={splitViewGridStyle}
+              >
                 {displayedPackages.map((pkg) => (
                   <ContextMenu key={pkg.path}>
                     <ContextMenuTrigger>
@@ -1825,9 +1875,16 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
               <h3 className={vaultSectionTitleClass}>{t('snippets.section.snippets')}</h3>
               <div className={cn(
                 viewMode === 'grid'
-                  ? "grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
+                  ? cn(
+                    "grid gap-3",
+                    hasSnippetsSidePanel
+                      ? "grid-cols-1"
+                      : "grid-cols-1 md:grid-cols-2 xl:grid-cols-3",
+                  )
                   : "flex flex-col gap-0"
-              )}>
+              )}
+              style={splitViewGridStyle}
+              >
                 {displayedSnippets.map((snippet) => {
                   const isSelected = selectedSnippetIds.has(snippet.id);
                   return (
@@ -1890,11 +1947,14 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <div className="text-[11px] text-muted-foreground font-mono leading-4 truncate">
-                                  {snippet.command.replace(/\s+/g, ' ') || t('snippets.commandFallback')}
+                                  {flattenSnippetCommandPreview(snippet.command) || t('snippets.commandFallback')}
                                 </div>
                               </TooltipTrigger>
-                              <TooltipContent side="bottom" className="max-w-sm break-all font-mono text-xs">
-                                {snippet.command}
+                              <TooltipContent side="bottom">
+                                <SnippetCommandTooltipContent
+                                  command={snippet.command}
+                                  fallback={t('snippets.commandFallback')}
+                                />
                               </TooltipContent>
                             </Tooltip>
                           </div>

--- a/components/ThemeSelectPanel.tsx
+++ b/components/ThemeSelectPanel.tsx
@@ -3,6 +3,7 @@ import {
     AsidePanel,
     AsidePanelContent,
     type AsidePanelLayout,
+    type AsidePanelResizeProps,
 } from './ui/aside-panel';
 import { ScrollArea } from './ui/scroll-area';
 import { ThemeList } from './ThemeList';
@@ -17,7 +18,9 @@ interface ThemeSelectPanelProps {
     layout?: AsidePanelLayout;
 }
 
-const ThemeSelectPanel: React.FC<ThemeSelectPanelProps> = ({
+type ThemeSelectPanelPropsWithResize = ThemeSelectPanelProps & AsidePanelResizeProps;
+
+const ThemeSelectPanel: React.FC<ThemeSelectPanelPropsWithResize> = ({
     open,
     selectedThemeId,
     onSelect,
@@ -25,6 +28,9 @@ const ThemeSelectPanel: React.FC<ThemeSelectPanelProps> = ({
     onBack,
     showBackButton = true,
     layout = 'overlay',
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     return (
         <AsidePanel
@@ -34,6 +40,9 @@ const ThemeSelectPanel: React.FC<ThemeSelectPanelProps> = ({
             showBackButton={showBackButton}
             onBack={onBack}
             layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
         >
             <AsidePanelContent className="p-0">
                 <ScrollArea className="h-full">

--- a/components/host-details/ChainPanel.tsx
+++ b/components/host-details/ChainPanel.tsx
@@ -7,7 +7,7 @@ import React, { useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { Host } from '../../types';
 import { DistroAvatar } from '../DistroAvatar';
-import { AsidePanel, type AsidePanelLayout } from '../ui/aside-panel';
+import { AsidePanel, type AsidePanelLayout, type AsidePanelResizeProps } from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -27,7 +27,9 @@ export interface ChainPanelProps {
     layout?: AsidePanelLayout;
 }
 
-export const ChainPanel: React.FC<ChainPanelProps> = ({
+export type ChainPanelPropsWithResize = ChainPanelProps & AsidePanelResizeProps;
+
+export const ChainPanel: React.FC<ChainPanelPropsWithResize> = ({
     formLabel,
     formHostname,
     form,
@@ -39,6 +41,9 @@ export const ChainPanel: React.FC<ChainPanelProps> = ({
     onBack,
     onCancel,
     layout = 'overlay',
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     const [searchQuery, setSearchQuery] = useState('');
@@ -57,6 +62,9 @@ export const ChainPanel: React.FC<ChainPanelProps> = ({
             showBackButton={true}
             onBack={onBack}
             layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
             actions={
                 <Button size="sm" onClick={onBack}>
                     {t('common.save')}

--- a/components/host-details/CreateGroupPanel.tsx
+++ b/components/host-details/CreateGroupPanel.tsx
@@ -5,7 +5,7 @@
 import { FolderPlus,HelpCircle,Plus } from 'lucide-react';
 import React from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
-import { AsidePanel,AsidePanelContent,type AsidePanelLayout } from '../ui/aside-panel';
+import { AsidePanel,AsidePanelContent,type AsidePanelLayout,type AsidePanelResizeProps } from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -45,7 +45,9 @@ export interface CreateGroupPanelProps {
     layout?: AsidePanelLayout;
 }
 
-export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
+export type CreateGroupPanelPropsWithResize = CreateGroupPanelProps & AsidePanelResizeProps;
+
+export const CreateGroupPanel: React.FC<CreateGroupPanelPropsWithResize> = ({
     newGroupName,
     setNewGroupName,
     newGroupParent,
@@ -55,6 +57,9 @@ export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
     onBack,
     onCancel,
     layout = 'overlay',
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     return (
@@ -65,6 +70,9 @@ export const CreateGroupPanel: React.FC<CreateGroupPanelProps> = ({
             showBackButton={true}
             onBack={onBack}
             layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
             actions={
                 <Button size="sm" onClick={onSave} disabled={!newGroupName.trim()}>
                     {t('common.save')}

--- a/components/host-details/EnvVarsPanel.tsx
+++ b/components/host-details/EnvVarsPanel.tsx
@@ -6,7 +6,7 @@ import { Plus,X } from 'lucide-react';
 import React from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { EnvVar } from '../../types';
-import { AsidePanel,AsidePanelContent,type AsidePanelLayout } from '../ui/aside-panel';
+import { AsidePanel,AsidePanelContent,type AsidePanelLayout,type AsidePanelResizeProps } from '../ui/aside-panel';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -28,7 +28,9 @@ export interface EnvVarsPanelProps {
     layout?: AsidePanelLayout;
 }
 
-export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
+export type EnvVarsPanelPropsWithResize = EnvVarsPanelProps & AsidePanelResizeProps;
+
+export const EnvVarsPanel: React.FC<EnvVarsPanelPropsWithResize> = ({
     hostLabel,
     hostHostname,
     environmentVariables,
@@ -43,6 +45,9 @@ export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
     onBack,
     onCancel,
     layout = 'overlay',
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     return (
@@ -53,6 +58,9 @@ export const EnvVarsPanel: React.FC<EnvVarsPanelProps> = ({
             showBackButton={true}
             onBack={onBack}
             layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
             actions={
                 <Button size="sm" onClick={onSave}>
                     {t('common.save')}

--- a/components/host-details/HostDetailsOverrideReset.tsx
+++ b/components/host-details/HostDetailsOverrideReset.tsx
@@ -1,0 +1,39 @@
+import { RotateCcw } from "lucide-react";
+import React from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+export function HostDetailsOverrideReset({
+  label,
+  onClick,
+  className,
+  size = "md",
+}: {
+  label: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+  size?: "md" | "sm";
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "shrink-0 border-0 bg-transparent text-primary shadow-none hover:bg-transparent hover:text-primary/80",
+            size === "md" ? "h-8 w-8" : "h-7 w-7",
+            className,
+          )}
+          onClick={onClick}
+          aria-label={label}
+        >
+          <RotateCcw size={size === "md" ? 14 : 13} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="left">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/host-details/ProxyPanel.tsx
+++ b/components/host-details/ProxyPanel.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { formatProxyConfigEndpoint, formatProxyConfigType, isProxyCommandConfig, isValidProxyPort } from '../../domain/proxyProfiles';
 import { ProxyConfig, ProxyProfile } from '../../types';
-import { AsidePanel, AsidePanelContent, type AsidePanelLayout } from '../ui/aside-panel';
+import { AsidePanel, AsidePanelContent, type AsidePanelLayout, type AsidePanelResizeProps } from '../ui/aside-panel';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
@@ -26,7 +26,9 @@ export interface ProxyPanelProps {
     layout?: AsidePanelLayout;
 }
 
-export const ProxyPanel: React.FC<ProxyPanelProps> = ({
+export type ProxyPanelPropsWithResize = ProxyPanelProps & AsidePanelResizeProps;
+
+export const ProxyPanel: React.FC<ProxyPanelPropsWithResize> = ({
     proxyConfig,
     proxyProfiles = [],
     selectedProxyProfileId,
@@ -36,6 +38,9 @@ export const ProxyPanel: React.FC<ProxyPanelProps> = ({
     onBack,
     onCancel,
     layout = 'overlay',
+    resizable,
+    persistWidthStorageKey,
+    resizeAriaLabel,
 }) => {
     const { t } = useI18n();
     const customValue = '__custom__';
@@ -65,6 +70,9 @@ export const ProxyPanel: React.FC<ProxyPanelProps> = ({
             showBackButton={true}
             onBack={handleBack}
             layout={layout}
+            resizable={resizable}
+            persistWidthStorageKey={persistWidthStorageKey}
+            resizeAriaLabel={resizeAriaLabel}
             actions={
                 <Button size="sm" onClick={handleBack} disabled={!canSave}>
                     {t('common.save')}

--- a/components/host-details/index.ts
+++ b/components/host-details/index.ts
@@ -20,3 +20,5 @@ export {
   HostDetailsSection,
   HostDetailsSettingRow,
 } from './HostDetailsSection';
+
+export { HostDetailsOverrideReset } from './HostDetailsOverrideReset';

--- a/components/snippets/SnippetCommandPicker.tsx
+++ b/components/snippets/SnippetCommandPicker.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../lib/utils';
 import type { Snippet } from '../../types';
 import { FixedSizeVirtualList } from '../ui/FixedSizeVirtualList';
 import { Input } from '../ui/input';
+import { SnippetCommandTooltipContent } from './SnippetCommandTooltipContent';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 
 const ROW_HEIGHT = 34;
@@ -112,11 +113,8 @@ export const SnippetCommandPicker = memo(function SnippetCommandPicker({
                         ) : null}
                       </button>
                     </TooltipTrigger>
-                    <TooltipContent side="right" align="start" className="max-w-[480px]">
-                      <div className="mb-1 break-all text-xs font-medium">{snippet.label}</div>
-                      <pre className="whitespace-pre-wrap break-all font-mono text-[11px] leading-snug opacity-90">
-                        {snippet.command}
-                      </pre>
+                    <TooltipContent side="right" align="start">
+                      <SnippetCommandTooltipContent label={snippet.label} command={snippet.command} />
                     </TooltipContent>
                   </Tooltip>
                 );

--- a/components/snippets/SnippetCommandTooltipContent.tsx
+++ b/components/snippets/SnippetCommandTooltipContent.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { formatSnippetCommandTooltip } from "@/domain/snippetPreview";
+import { cn } from "@/lib/utils";
+
+export function SnippetCommandTooltipContent({
+  label,
+  command,
+  className,
+  fallback,
+}: {
+  label?: string;
+  command: string;
+  className?: string;
+  fallback?: string;
+}) {
+  const preview = formatSnippetCommandTooltip(command);
+
+  return (
+    <div className={cn("max-w-sm", className)}>
+      {label ? (
+        <div className="mb-1 break-all text-xs font-medium">{label}</div>
+      ) : null}
+      <pre className="max-h-36 overflow-hidden font-mono text-[11px] leading-snug whitespace-pre-wrap break-all">
+        {preview || fallback || "—"}
+      </pre>
+    </div>
+  );
+}

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -13,6 +13,12 @@ export function clampAsideInlineWidth(width: number): number {
     return Math.max(MIN_ASIDE_INLINE_WIDTH_PX, Math.min(MAX_ASIDE_INLINE_WIDTH_PX, width));
 }
 
+export interface AsidePanelResizeProps {
+    resizable?: boolean;
+    persistWidthStorageKey?: string;
+    resizeAriaLabel?: string;
+}
+
 function parseInlineWidthPx(width: string): number {
     const arbitraryWidthMatch = width.match(/w-\[(.+)\]/);
     if (arbitraryWidthMatch) {
@@ -66,7 +72,7 @@ export const useAsidePanel = () => {
 };
 
 // Props
-interface AsidePanelProps {
+interface AsidePanelProps extends AsidePanelResizeProps {
     open: boolean;
     onClose: () => void;
     title?: string;
@@ -78,9 +84,6 @@ interface AsidePanelProps {
     className?: string;
     width?: string;
     layout?: AsidePanelLayout;
-    resizable?: boolean;
-    persistWidthStorageKey?: string;
-    resizeAriaLabel?: string;
     /**
      * Optional stable identifier emitted as `data-section` on the panel
      * root. Used as a targeting hook for Custom CSS (Settings → Appearance).
@@ -294,7 +297,7 @@ export const AsidePanelStack: React.FC<AsidePanelStackProps> = ({
         <AsidePanelContext.Provider value={{ push, pop, replace, clear, canGoBack, currentItem }}>
             <div className={cn(
                 layout === 'inline'
-                    ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
+                    ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
                     : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
                 layout === 'overlay' && width,
                 className
@@ -389,7 +392,7 @@ export const AsidePanel: React.FC<AsidePanelProps> = ({
     return (
         <div className={cn(
             layout === 'inline'
-                ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
+                ? "relative split-panel-enter shrink-0 h-full min-h-0 max-w-full border-l border-border/60 bg-background flex flex-col app-no-drag overflow-hidden shadow-[-16px_0_32px_hsl(var(--foreground)/0.08)]"
                 : "absolute right-0 top-0 bottom-0 max-w-full border-l border-border/60 bg-background z-30 flex flex-col app-no-drag overflow-hidden",
             layout === 'overlay' && width,
             isResizing && layout === 'inline' && 'transition-none',

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
 import { preserveConcurrentHostLineTimestampUpdate } from "../../domain/host";
+import { STORAGE_KEY_VAULT_HOST_PANEL_WIDTH } from "@/infrastructure/config/storageKeys.ts";
 import { VaultHostListSection } from "./VaultHostListSection";
 import {
   VaultHeaderSearch,
@@ -19,6 +20,11 @@ const VaultSectionLoading = () => (
 export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
   const { Activity, allGroupPaths, allTags, AppLogo, Array, Badge, BookMarked, Boolean, Button, cancelInlineGroupEdit, CheckSquare, ChevronDown, clearHostSelection, ClipboardCopy, Clock, cn, commitInlineGroupRename, connectionLogs, connectSelectedHosts, ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Copy, currentSection, customGroups, deleteGroupPath, deleteGroupWithHosts, deleteSelectedHosts, deleteTargetPath, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, displayedGroups, displayedHosts, DistroAvatar, Download, Dropdown, DropdownContent, DropdownTrigger, Edit2, editingGroupPath, editingHost, editingHostGroupDefaults, FileCode, FileSymlink, FolderPlus, FolderTree, getDropTargetClasses, getEffectiveHostDistro, Globe, groupConfigs, GroupDetailsPanel, groupedDisplayHosts, handleConnectClick, handleCopyCredentials, handleDeleteTag, handleDuplicateHost, handleEditGroupConfig, handleEditHost, handleEditTag, handleExportHosts, handleHostConnect, handleImportFileSelected, handleNewHost, handleProtocolSelect, handleQuickConnect, handleQuickConnectSaveHost, handleSaveGroupConfig, handleSearchKeyDown, handleUnmanageGroup, handleSidebarWidthCommit, hasHostsSidePanel, HostDetailsPanel, hostListScrollRef, hosts, HostTreeView, hotkeyScheme, identities, ImportVaultDialog, Input, isDeleteGroupOpen, isGroupPanelOpen, isHostPanelOpen, isHostsSectionActive, isImportOpen, isMultiSelectMode, isNewFolderOpen, isQuickConnectOpen, isRenameGroupOpen, isSearchQuickConnect, isSerialModalOpen, Key, keyBindings, KeychainManager, keys, knownHostsManagerElement, Label, lastPinnedId, LayoutGrid, LazyConnectionLogsManager, LazyProtocolSelectDialog, List, managedGroupPaths, managedSources, moveGroup, moveHostToGroup, Network, newFolderName, newHostGroupPath, onClearUnsavedConnectionLogs, onConnectSerial, onCreateLocalTerminal, onDeleteConnectionLog, onDeleteHost, onImportOrReuseKey, onOpenLogView, onOpenSettings, onRunSnippet, onToggleConnectionLogSaved, onUpdateCustomGroups, onUpdateGroupConfigs, onUpdateHosts, onUpdateIdentities, onUpdateKeys, onUpdateProxyProfiles, onUpdateSnippetPackages, onUpdateSnippets, Pin, pinnedHosts, pinnedRecentIds, Plug, Plus, PortForwarding, protocolSelectHost, proxyProfiles, ProxyProfilesManager, quickConnectTarget, quickConnectWarnings, QuickConnectWizard, recentHosts, renameGroupError, renameGroupName, renameTargetPath, reorderGroup, reorderHost, RippleButton, rootRef, sanitizeHost, search, selectedGroupPath, selectedHostIds, selectedTags, SerialConnectModal, SerialHostDetailsPanel, sessionCount, Set, setCurrentSection, setDeleteGroupWithHosts, setDeleteTargetPath, setDragOverDropTarget, setEditingGroupPath, setEditingHost, setGroupDragOverDropTarget, setIsDeleteGroupOpen, setIsGroupPanelOpen, setIsHostPanelOpen, setIsImportOpen, setIsMultiSelectMode, setIsNewFolderOpen, setIsQuickConnectOpen, setIsRenameGroupOpen, setIsSerialModalOpen, setLastPinnedId, setNewFolderName, setNewHostGroupPath, setProtocolSelectHost, setQuickConnectTarget, setQuickConnectWarnings, setRenameGroupError, setRenameGroupName, setRenameTargetPath, setSearch, setSelectedGroupPath, setSelectedHostIds, setSelectedTags, setSidebarCollapsed, setSidebarWidth, setSortMode, setTargetParentPath, Settings, setViewMode, shellHistory, shouldHideEmptyRootHostsSection, showRecentHosts, sidebarCollapsed, sidebarWidth, snippetPackages, snippets, SnippetsManager, SortDropdown, sortMode, splitViewGridStyle, Square, Star, startInlineDeleteGroup, startInlineNewGroup, startInlineRenameGroup, submitNewFolder, submitRenameGroup, Suspense, t, TagFilterDropdown, targetParentPath, terminalFontSize, terminalSettings, TerminalSquare, terminalThemeId, toggleHostPinned, toggleHostSelection, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Trash2, treeExpandedState, treeViewGroupTree, treeViewHosts, Upload, upsertHostById, Usb, viewMode, visibleDisplayedHosts, X, Zap } = ctx;
   const { knownHosts, noteGroups, NotebookText, notes, NotesManager, onOpenHostFromNote, onOpenNoteIdHandled, onOpenSnippetIdHandled, onUpdateNoteGroups, onUpdateNotes, openNoteId, openSnippetId } = ctx;
+  const vaultHostPanelResizeProps = {
+    resizable: true as const,
+    persistWidthStorageKey: STORAGE_KEY_VAULT_HOST_PANEL_WIDTH,
+    resizeAriaLabel: t("vault.panel.resizeWidth"),
+  };
   const [isSidebarResizing, setIsSidebarResizing] = React.useState(false);
   const newHostActionsRef = React.useRef<HTMLDivElement>(null);
   const sessionActionsRef = React.useRef<HTMLDivElement>(null);
@@ -579,6 +585,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
         {currentSection === "snippets" && (
           <LazyLoadBoundary name="Snippets" resetKey="snippets">
             <Suspense fallback={<VaultSectionLoading />}>
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
               <SnippetsManager
                 snippets={snippets}
                 packages={snippetPackages}
@@ -613,6 +620,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
                 openSnippetId={openSnippetId ?? null}
                 onOpenSnippetIdHandled={onOpenSnippetIdHandled}
               />
+              </div>
             </Suspense>
           </LazyLoadBoundary>
         )}
@@ -769,6 +777,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             setEditingGroupPath(null);
           }}
           layout="inline"
+          {...vaultHostPanelResizeProps}
         />
       )}
 
@@ -814,6 +823,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             );
           }}
           layout="inline"
+          {...vaultHostPanelResizeProps}
         />
       )}
 
@@ -835,6 +845,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
             setNewHostGroupPath(null);
           }}
           layout="inline"
+          {...vaultHostPanelResizeProps}
         />
       )}
         </div>

--- a/domain/snippetPreview.test.ts
+++ b/domain/snippetPreview.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  flattenSnippetCommandPreview,
+  formatSnippetCommandTooltip,
+} from "./snippetPreview.ts";
+
+test("formatSnippetCommandTooltip truncates long single-line commands with ellipsis", () => {
+  const command = "a".repeat(400);
+  const preview = formatSnippetCommandTooltip(command, { maxChars: 120, maxLines: 4 });
+  assert.equal(preview.endsWith("…"), true);
+  assert.ok(preview.length <= 121);
+});
+
+test("formatSnippetCommandTooltip truncates multi-line commands", () => {
+  const command = Array.from({ length: 12 }, (_, index) => `line-${index}`).join("\n");
+  const preview = formatSnippetCommandTooltip(command, { maxChars: 280, maxLines: 4 });
+  assert.match(preview, /^line-0\nline-1\nline-2\nline-3…$/);
+});
+
+test("flattenSnippetCommandPreview collapses whitespace", () => {
+  assert.equal(flattenSnippetCommandPreview("whoami\n  id -u"), "whoami id -u");
+});

--- a/domain/snippetPreview.ts
+++ b/domain/snippetPreview.ts
@@ -1,0 +1,33 @@
+const DEFAULT_TOOLTIP_MAX_CHARS = 280;
+const DEFAULT_TOOLTIP_MAX_LINES = 8;
+
+export function flattenSnippetCommandPreview(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
+/** Truncate multi-line snippet/script commands for compact tooltip previews. */
+export function formatSnippetCommandTooltip(
+  command: string,
+  options?: { maxChars?: number; maxLines?: number },
+): string {
+  if (!command.trim()) return "";
+
+  const maxChars = options?.maxChars ?? DEFAULT_TOOLTIP_MAX_CHARS;
+  const maxLines = options?.maxLines ?? DEFAULT_TOOLTIP_MAX_LINES;
+  const normalized = command.replace(/\r\n/g, "\n").trimEnd();
+  const lines = normalized.split("\n");
+
+  let preview = lines.slice(0, maxLines).join("\n");
+  const truncatedByLines = lines.length > maxLines;
+
+  if (preview.length > maxChars) {
+    preview = preview.slice(0, maxChars).replace(/\s+$/, "");
+  }
+
+  const truncated = truncatedByLines || normalized.length > preview.length;
+  if (truncated && !preview.endsWith("…")) {
+    preview += "…";
+  }
+
+  return preview;
+}

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -54,6 +54,8 @@ export const STORAGE_KEY_VAULT_NOTES_SELECTED_GROUP = 'netcatty_vault_notes_sele
 export const STORAGE_KEY_VAULT_NOTES_TREE_WIDTH = 'netcatty_vault_notes_tree_width_v1';
 /** Inline snippet/script edit panel width (px). */
 export const STORAGE_KEY_SNIPPETS_PANEL_WIDTH = 'netcatty_snippets_panel_width_v1';
+/** Inline vault host/group details panel width (px). */
+export const STORAGE_KEY_VAULT_HOST_PANEL_WIDTH = 'netcatty_vault_host_panel_width_v1';
 /** Inline snippet script editor height (px) in vault edit panel. */
 export const STORAGE_KEY_SNIPPET_SCRIPT_EDITOR_HEIGHT = 'netcatty_snippet_script_editor_height_v1';
 /** Automation script Monaco editor height (px) in vault sidebar. */


### PR DESCRIPTION
## Summary
- Truncate long snippet command tooltips with ellipsis instead of overflowing the screen
- Enable drag-resize on inline vault host/group/serial detail panels (width persisted)
- Compact host appearance override reset controls in host details
- Align known hosts grid/list hover actions with vault host list button styling

## Test plan
- [x] Hover long script cards in Snippets — tooltip stays compact with ellipsis
- [x] Open host details panel — drag left edge to resize; width persists after reopen
- [x] Known hosts grid — hover shows trailing ghost icon buttons (convert/delete)

Made with [Cursor](https://cursor.com)