### PR TITLE
Fix waitForScriptRun TDZ crash and remove connect script auto-retry

### DIFF
--- a/application/state/scriptAutomationCoordinator.test.ts
+++ b/application/state/scriptAutomationCoordinator.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  setScriptRuns,
+  waitForScriptRun,
+} from './scriptAutomationCoordinator.ts';
+
+test('waitForScriptRun resolves when run is already completed on subscribe', async () => {
+  const runId = 'run-already-done';
+  setScriptRuns([{
+    runId,
+    scriptId: 's1',
+    sessionId: 'sess1',
+    status: 'completed',
+    startedAt: Date.now() - 1000,
+    endedAt: Date.now(),
+    logs: [],
+  }]);
+
+  const run = await waitForScriptRun(runId, { timeoutMs: 5000 });
+  assert.equal(run.runId, runId);
+  assert.equal(run.status, 'completed');
+});
+
+test('waitForScriptRun rejects when run already failed on subscribe', async () => {
+  const runId = 'run-already-failed';
+  setScriptRuns([{
+    runId,
+    sessionId: 'sess1',
+    status: 'failed',
+    startedAt: Date.now() - 1000,
+    endedAt: Date.now(),
+    error: 'boom',
+    logs: [],
+  }]);
+
+  await assert.rejects(
+    () => waitForScriptRun(runId, { timeoutMs: 5000 }),
+    /boom/,
+  );
+});

--- a/application/state/scriptAutomationCoordinator.ts
+++ b/application/state/scriptAutomationCoordinator.ts
@@ -77,6 +77,7 @@ export function waitForScriptRun(
   return new Promise((resolve, reject) => {
     let settled = false;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribe: () => void = () => {};
 
     const finish = (handler: () => void) => {
       if (settled) return;
@@ -102,7 +103,7 @@ export function waitForScriptRun(
       finish(() => reject(new Error(run.error || 'Script failed')));
     };
 
-    const unsubscribe = subscribeScriptRuns((currentRuns) => {
+    unsubscribe = subscribeScriptRuns((currentRuns) => {
       settleRun(currentRuns.find((entry) => entry.runId === runId));
     });
 

--- a/application/state/scriptAutomationCoordinator.ts
+++ b/application/state/scriptAutomationCoordinator.ts
@@ -19,7 +19,11 @@ function readPermissionMode(): AIPermissionMode {
 
 export function subscribeScriptRuns(listener: RunsListener): () => void {
   runsListeners.add(listener);
-  listener(runs);
+  queueMicrotask(() => {
+    if (runsListeners.has(listener)) {
+      listener(runs);
+    }
+  });
   return () => runsListeners.delete(listener);
 }
 
@@ -72,6 +76,14 @@ export function waitForScriptRun(
   runId: string,
   options: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<ScriptRun> {
+  const existing = runs.find((entry) => entry.runId === runId);
+  if (existing && TERMINAL_SCRIPT_STATUSES.has(existing.status)) {
+    if (existing.status === 'completed') {
+      return Promise.resolve(existing);
+    }
+    return Promise.reject(new Error(existing.error || 'Script failed'));
+  }
+
   const timeoutMs = options.timeoutMs ?? 3_600_000;
 
   return new Promise((resolve, reject) => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1477,12 +1477,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
             connectScriptsConsumedRef.current = true;
           }
         })
-        .catch((err) => {
+        .catch(async (err) => {
           const message = err instanceof Error ? err.message : String(err);
           toast.error(message.includes('Observer mode') ? t('scripts.observer.blocked') : message);
-          for (const id of connectIdsInBatch) {
-            connectScriptsCompletedIdsRef.current.add(id);
-          }
           connectScriptsConsumedRef.current = true;
 
           const pendingStillNeeded = pendingScriptToMark && (
@@ -1492,25 +1489,27 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           );
           if (!pendingStillNeeded) return;
 
-          void runConnectScriptsSequential({
-            scripts: [pendingScriptToMark],
-            sessionId,
-            sessionMeta: {
-              connected: true,
-              hostname: host.hostname,
-              username: host.username,
-            },
-            onScriptComplete: (snippet) => {
-              if (snippet.id) {
-                pendingScriptRunIdRef.current = snippet.id;
-              } else {
-                pendingScriptHandledRef.current = snippet;
-              }
-            },
-          }).catch((pendingErr) => {
+          try {
+            await runConnectScriptsSequential({
+              scripts: [pendingScriptToMark],
+              sessionId,
+              sessionMeta: {
+                connected: true,
+                hostname: host.hostname,
+                username: host.username,
+              },
+              onScriptComplete: (snippet) => {
+                if (snippet.id) {
+                  pendingScriptRunIdRef.current = snippet.id;
+                } else {
+                  pendingScriptHandledRef.current = snippet;
+                }
+              },
+            });
+          } catch (pendingErr) {
             const pendingMessage = pendingErr instanceof Error ? pendingErr.message : String(pendingErr);
             toast.error(pendingMessage.includes('Observer mode') ? t('scripts.observer.blocked') : pendingMessage);
-          });
+          }
         })
         .finally(() => {
           connectScriptsInFlightRef.current = false;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1480,7 +1480,37 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         .catch((err) => {
           const message = err instanceof Error ? err.message : String(err);
           toast.error(message.includes('Observer mode') ? t('scripts.observer.blocked') : message);
+          for (const id of connectIdsInBatch) {
+            connectScriptsCompletedIdsRef.current.add(id);
+          }
           connectScriptsConsumedRef.current = true;
+
+          const pendingStillNeeded = pendingScriptToMark && (
+            pendingScriptToMark.id
+              ? pendingScriptRunIdRef.current !== pendingScriptToMark.id
+              : pendingScriptHandledRef.current !== pendingScriptToMark
+          );
+          if (!pendingStillNeeded) return;
+
+          void runConnectScriptsSequential({
+            scripts: [pendingScriptToMark],
+            sessionId,
+            sessionMeta: {
+              connected: true,
+              hostname: host.hostname,
+              username: host.username,
+            },
+            onScriptComplete: (snippet) => {
+              if (snippet.id) {
+                pendingScriptRunIdRef.current = snippet.id;
+              } else {
+                pendingScriptHandledRef.current = snippet;
+              }
+            },
+          }).catch((pendingErr) => {
+            const pendingMessage = pendingErr instanceof Error ? pendingErr.message : String(pendingErr);
+            toast.error(pendingMessage.includes('Observer mode') ? t('scripts.observer.blocked') : pendingMessage);
+          });
         })
         .finally(() => {
           connectScriptsInFlightRef.current = false;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -272,7 +272,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const connectScriptsInFlightRef = useRef(false);
   const pendingScriptRunIdRef = useRef<string | null>(null);
   const pendingScriptHandledRef = useRef<Snippet | null>(null);
-  const [connectScriptRetryTick, setConnectScriptRetryTick] = useState(0);
   const [saveRecordingOpen, setSaveRecordingOpen] = useState(false);
   const [recordedCode, setRecordedCode] = useState('');
   const recorder = useScriptRecorder(sessionId);
@@ -1481,7 +1480,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         .catch((err) => {
           const message = err instanceof Error ? err.message : String(err);
           toast.error(message.includes('Observer mode') ? t('scripts.observer.blocked') : message);
-          setConnectScriptRetryTick((tick) => tick + 1);
+          connectScriptsConsumedRef.current = true;
         })
         .finally(() => {
           connectScriptsInFlightRef.current = false;
@@ -1489,7 +1488,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }, 400);
 
     return () => window.clearTimeout(timer);
-  }, [host, isPendingScriptAlreadyHandled, pendingScript, pendingScriptId, sessionId, snippets, status, t, connectScriptRetryTick]);
+  }, [host, isPendingScriptAlreadyHandled, pendingScript, pendingScriptId, sessionId, snippets, status, t]);
 
   useEffect(() => {
     return registerScreenSnapshotProvider(sessionId, () => {

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -379,7 +379,6 @@ async function runScriptOnSession({
 
   try {
     await syncOutputBufferFromSnapshot(sessionId);
-    getOrCreateBuffer(sessionId).markScanBaseline();
     await runtime.execute(content);
     if (run.aborted) {
       run.status = "failed";

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -379,6 +379,7 @@ async function runScriptOnSession({
 
   try {
     await syncOutputBufferFromSnapshot(sessionId);
+    getOrCreateBuffer(sessionId).markScanBaseline();
     await runtime.execute(content);
     if (run.aborted) {
       run.status = "failed";

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -1,6 +1,12 @@
 "use strict";
 
 const DEFAULT_BUFFER_SIZE = 1024 * 1024;
+/** Matches within this many bytes of buffer end count as live terminal output. */
+const FRESH_MATCH_TAIL_SLACK = 512;
+
+function isFreshTailMatch(textLength, matchEndAbsolute) {
+  return matchEndAbsolute >= textLength - FRESH_MATCH_TAIL_SLACK;
+}
 
 function isRegExpLike(pattern) {
   return Boolean(
@@ -76,14 +82,37 @@ class SessionOutputBuffer {
     return tryMatchWithEnd(this.getPendingText(), pattern);
   }
 
+  consumeFreshPendingMatch(pattern) {
+    while (true) {
+      const matched = this.tryMatchPending(pattern);
+      if (matched === null) return null;
+      const absoluteEnd = this.scanOffset + matched.endOffset;
+      if (isFreshTailMatch(this.getText().length, absoluteEnd)) {
+        return matched;
+      }
+      this.advanceScanOffset(matched.endOffset);
+    }
+  }
+
+  consumeFreshPendingMatchAny(patterns) {
+    for (let index = 0; index < patterns.length; index += 1) {
+      const pattern = patterns[index];
+      while (true) {
+        const matched = this.tryMatchPending(pattern);
+        if (matched === null) break;
+        const absoluteEnd = this.scanOffset + matched.endOffset;
+        if (isFreshTailMatch(this.getText().length, absoluteEnd)) {
+          return { index, matched };
+        }
+        this.advanceScanOffset(matched.endOffset);
+      }
+    }
+    return null;
+  }
+
   advanceScanOffset(endOffset) {
     const absoluteEnd = this.scanOffset + endOffset;
     this.scanOffset = Math.min(absoluteEnd, this.getText().length);
-  }
-
-  /** Ignore scrollback already on screen when a script run starts. */
-  markScanBaseline() {
-    this.scanOffset = this.getText().length;
   }
 
   clear() {
@@ -102,7 +131,7 @@ class SessionOutputBuffer {
         }
         continue;
       }
-      const matched = this.tryMatchPending(waiter.pattern);
+      const matched = this.consumeFreshPendingMatch(waiter.pattern);
       if (matched !== null) {
         this.advanceScanOffset(matched.endOffset);
         clearTimeout(waiter.timer);
@@ -116,7 +145,7 @@ class SessionOutputBuffer {
   }
 
   waitFor(pattern, timeoutMs = 30000, shouldAbort) {
-    const immediate = this.tryMatchPending(pattern);
+    const immediate = this.consumeFreshPendingMatch(pattern);
     if (immediate !== null) {
       this.advanceScanOffset(immediate.endOffset);
       return Promise.resolve(immediate.value);
@@ -160,12 +189,10 @@ class SessionOutputBuffer {
     if (!Array.isArray(patterns) || patterns.length === 0) {
       throw new TypeError("waitForAny requires a non-empty patterns array");
     }
-    for (let index = 0; index < patterns.length; index += 1) {
-      const matched = this.tryMatchPending(patterns[index]);
-      if (matched !== null) {
-        this.advanceScanOffset(matched.endOffset);
-        return index;
-      }
+    const fresh = this.consumeFreshPendingMatchAny(patterns);
+    if (fresh !== null) {
+      this.advanceScanOffset(fresh.matched.endOffset);
+      return fresh.index;
     }
 
     return new Promise((resolve, reject) => {
@@ -177,17 +204,15 @@ class SessionOutputBuffer {
         timer: null,
         interval: null,
         check: () => {
-          for (let index = 0; index < patterns.length; index += 1) {
-            const matched = this.tryMatchPending(patterns[index]);
-            if (matched !== null) {
-              this.advanceScanOffset(matched.endOffset);
-              clearTimeout(waiter.timer);
-              if (waiter.interval) clearInterval(waiter.interval);
-              if (waiter.abortInterval) clearInterval(waiter.abortInterval);
-              this.waiters = this.waiters.filter((entry) => entry.custom !== waiter);
-              resolve(index);
-              return true;
-            }
+          const fresh = this.consumeFreshPendingMatchAny(patterns);
+          if (fresh !== null) {
+            this.advanceScanOffset(fresh.matched.endOffset);
+            clearTimeout(waiter.timer);
+            if (waiter.interval) clearInterval(waiter.interval);
+            if (waiter.abortInterval) clearInterval(waiter.abortInterval);
+            this.waiters = this.waiters.filter((entry) => entry.custom !== waiter);
+            resolve(fresh.index);
+            return true;
           }
           return false;
         },

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -81,6 +81,11 @@ class SessionOutputBuffer {
     this.scanOffset = Math.min(absoluteEnd, this.getText().length);
   }
 
+  /** Ignore scrollback already on screen when a script run starts. */
+  markScanBaseline() {
+    this.scanOffset = this.getText().length;
+  }
+
   clear() {
     this.chunks = [];
     this.totalLength = 0;

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -49,10 +49,9 @@ test("SessionOutputBuffer waitForAny matches shell prompt patterns", async () =>
   assert.equal(await pending, 0);
 });
 
-test("SessionOutputBuffer markScanBaseline ignores prior scrollback for waitFor", async () => {
+test("SessionOutputBuffer waitFor ignores stale scrollback not near buffer tail", async () => {
   const buffer = new SessionOutputBuffer("s1");
-  buffer.append("Do you want to reset password? ");
-  buffer.markScanBaseline();
+  buffer.append(`${"x".repeat(600)}Do you want to reset password? ${"x".repeat(600)}`);
 
   const pending = buffer.waitFor(/Do you want to reset password/, 200);
   let resolvedEarly = false;
@@ -64,6 +63,12 @@ test("SessionOutputBuffer markScanBaseline ignores prior scrollback for waitFor"
 
   buffer.append("Do you want to reset password? ");
   assert.equal(await pending, "Do you want to reset password");
+});
+
+test("SessionOutputBuffer waitFor resolves prompt already at buffer tail", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("root@host:~# ");
+  assert.equal(await buffer.waitFor("# ", 1000), "# ");
 });
 
 test("SessionOutputBuffer waitFor ignores stale prompt before cursor", async () => {

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -49,6 +49,23 @@ test("SessionOutputBuffer waitForAny matches shell prompt patterns", async () =>
   assert.equal(await pending, 0);
 });
 
+test("SessionOutputBuffer markScanBaseline ignores prior scrollback for waitFor", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("Do you want to reset password? ");
+  buffer.markScanBaseline();
+
+  const pending = buffer.waitFor(/Do you want to reset password/, 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("Do you want to reset password? ");
+  assert.equal(await pending, "Do you want to reset password");
+});
+
 test("SessionOutputBuffer waitFor ignores stale prompt before cursor", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.append("user@host:~$ ");


### PR DESCRIPTION
## Summary
- Fix `waitForScriptRun` TDZ crash when `subscribeScriptRuns` synchronously delivers an already-completed run (`Cannot access 'unsubscribe' before initialization`, minified as `x` in packaged builds).
- Remove `connectScriptRetryTick` auto-retry loop that re-queued onConnect scripts after errors, causing infinite script reruns.
- Fix `waitFor` / `waitForAny` matching stale scrollback at script start — interactive prompts like password-reset confirmations no longer trigger `sendLine('y')` immediately ([#1776](https://github.com/binaricat/Netcatty/discussions/1776)).

## Root causes
1. **TDZ:** `finish()` called `unsubscribe()` before `const unsubscribe = subscribeScriptRuns(...)` when the run was already terminal on subscribe.
2. **Infinite loop:** connect-script failure incremented `connectScriptRetryTick`, re-running the same onConnect scripts forever.
3. **Stale waitFor:** `SessionOutputBuffer.scanOffset` started at 0, so `waitFor(/Do you want to reset password/)` matched old terminal history immediately.

## Test plan
- [x] `node --test electron/scripts/sessionOutputBuffer.test.cjs`
- [x] `node --test --import tsx application/state/scriptAutomationCoordinator.test.ts`
- [x] `npm run lint`
- [ ] Manual: onConnect script completes once, no toast loop
- [ ] Manual: waitFor on password-reset prompt waits for new output before sendLine