### PR TITLE
Fix dev 504 Outdated Optimize Dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "npm run fetch:mosh:dev && npm run fetch:et:dev && npm run lint && concurrently -k \"vite --strictPort\" \"npm:dev:electron\"",
     "dev:electron": "wait-on http-get://localhost:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 node electron/launch.cjs",
-    "clean:vite": "rm -rf node_modules/.vite",
+    "clean:vite": "node scripts/clean-vite-cache.cjs",
     "dev:clean": "npm run clean:vite && npm run dev",
     "prebuild": "node scripts/copy-monaco.cjs",
     "fetch:mosh": "node scripts/fetch-mosh-binaries.cjs",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "scripts": {
     "dev": "npm run fetch:mosh:dev && npm run fetch:et:dev && npm run lint && concurrently -k \"vite --strictPort\" \"npm:dev:electron\"",
     "dev:electron": "wait-on http-get://localhost:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 node electron/launch.cjs",
+    "clean:vite": "rm -rf node_modules/.vite",
+    "dev:clean": "npm run clean:vite && npm run dev",
     "prebuild": "node scripts/copy-monaco.cjs",
     "fetch:mosh": "node scripts/fetch-mosh-binaries.cjs",
     "fetch:mosh:dev": "node scripts/fetch-mosh-binaries.cjs --host --resolve-release",

--- a/scripts/clean-vite-cache.cjs
+++ b/scripts/clean-vite-cache.cjs
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const cacheDir = path.join(__dirname, '..', 'node_modules', '.vite');
+
+if (!fs.existsSync(cacheDir)) {
+  console.log('[clean-vite] No Vite cache to remove');
+  process.exit(0);
+}
+
+fs.rmSync(cacheDir, { recursive: true, force: true });
+console.log('[clean-vite] Removed', cacheDir);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 
 // Custom plugin to suppress monaco-editor source map warnings
 const suppressMonacoSourcemapWarning = () => ({
@@ -15,6 +15,25 @@ const suppressMonacoSourcemapWarning = () => ({
       if (msg.includes('loader.js.map')) return;
       originalWarn(msg, options);
     };
+  },
+});
+
+/** After git pull / npm install, stale pre-bundles return 504; force a full reload. */
+const reloadOnOutdatedOptimizeDep = (): Plugin => ({
+  name: 'reload-on-outdated-optimize-dep',
+  apply: 'serve',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      res.on('finish', () => {
+        if (
+          res.statusCode === 504
+          && req.url?.includes('/node_modules/.vite/deps/')
+        ) {
+          server.ws.send({ type: 'full-reload', path: '*' });
+        }
+      });
+      next();
+    });
   },
 });
 
@@ -72,7 +91,7 @@ export default defineConfig(() => {
           },
         },
       },
-      plugins: [suppressMonacoSourcemapWarning(), tailwindcss(), react()],
+      plugins: [suppressMonacoSourcemapWarning(), reloadOnOutdatedOptimizeDep(), tailwindcss(), react()],
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- Add `npm run clean:vite` and `npm run dev:clean` to clear stale Vite pre-bundle cache after `git pull` / `npm install`
- Add a dev-server plugin that triggers a full reload when Vite returns `504 Outdated Optimize Dep` for `/node_modules/.vite/deps/` requests

## Context
Electron dev sometimes keeps a stale module graph after dependency pre-bundling changes, surfacing as:

```
Failed to load resource: the server responded with a status of 504 (Outdated Optimize Dep)
```

Manual fix was deleting `node_modules/.vite` and restarting dev.

## Test plan
- [ ] `npm run clean:vite` removes `node_modules/.vite`
- [ ] `npm run dev:clean` starts dev successfully after a stale cache
- [ ] After simulating outdated deps, renderer auto full-reloads instead of staying broken


Made with [Cursor](https://cursor.com)