### PR TITLE
Fix remote autocomplete probe on blank path arguments

### DIFF
--- a/components/terminal/autocomplete/completionEngine.ts
+++ b/components/terminal/autocomplete/completionEngine.ts
@@ -29,6 +29,7 @@ import {
   shouldDoPathCompletion,
   getPathSuggestions,
   resolvePathComponents,
+  hasRemotePathLookupToken,
 } from "./remotePathCompleter";
 import { getSnippetSuggestions } from "./snippetCompleter";
 import type { Snippet } from "../../../domain/models";
@@ -240,7 +241,8 @@ export async function getCompletions(
     }
   }
 
-  const canQueryPaths = options.protocol === "local" || options.sessionId !== undefined;
+  const canQueryPaths = options.protocol === "local" ||
+    (options.sessionId !== undefined && hasRemotePathLookupToken(ctx.currentWord));
 
   const pathEntries = canQueryPaths && pathCheck.shouldComplete
     ? await getPathSuggestions(ctx, {

--- a/components/terminal/autocomplete/remotePathCompleter.ts
+++ b/components/terminal/autocomplete/remotePathCompleter.ts
@@ -129,6 +129,10 @@ export function shouldDoPathCompletion(
   return { shouldComplete: false, foldersOnly: false };
 }
 
+export function hasRemotePathLookupToken(currentWord: string): boolean {
+  return stripWrappingQuotes(currentWord).length > 0;
+}
+
 /**
  * Parse the current word into directory-to-list and filter prefix.
  */

--- a/components/terminal/completionEngine.test.ts
+++ b/components/terminal/completionEngine.test.ts
@@ -216,6 +216,20 @@ test("getCompletions keeps remote shell cwd when absolute cwd is only a fallback
   assert.equal(completions.some((entry) => entry.text === "cat old-user-file.txt"), false);
 });
 
+test("getCompletions does not query remote directories after a blank path command argument", async () => {
+  bridgeState.remoteEntriesByPath.set(".", [{ name: "worktree.txt", type: "file" }]);
+
+  const completions = await getCompletions("cat ", {
+    hostId: "host-1",
+    os: "linux",
+    protocol: "ssh",
+    sessionId: "session-1",
+  });
+
+  assert.deepEqual(bridgeState.remoteCalls, []);
+  assert.equal(completions.some((entry) => entry.source === "path"), false);
+});
+
 test("getCompletions does not reuse cached remote relative listings after cwd changes", async () => {
   bridgeState.remoteEntriesByPath.set(".", [{ name: "home-only.txt", type: "file" }]);
 
@@ -235,6 +249,6 @@ test("getCompletions does not reuse cached remote relative listings after cwd ch
     sessionId: "session-1",
   });
 
-  assert.equal(bridgeState.remoteCalls.length, 2);
+  assert.equal(bridgeState.remoteCalls.length, 1);
   assert.equal(completions[0]?.text, "cat worktree.txt");
 });


### PR DESCRIPTION
## Root cause

Terminal autocomplete treated blank path arguments such as `cd ` and `cat ` as path-completion requests. On SSH sessions, that called `netcatty:ssh:listdir`, which opened an extra SSH `exec` channel and ran a remote `find` command on the existing connection. Strict bastion/audit gateways and network CLIs can close the connection when that hidden exec channel appears, so typing a space after path commands looked like the terminal input itself disconnected the session.

## Fix

Remote path completion no longer queries remote directories when the current path token is blank. Local terminals keep the previous behavior, and non-empty relative remote path prefixes such as `cat wo` still complete as before.

## Verification

- `node --test --import tsx components/terminal/completionEngine.test.ts`
- `npm run lint`
- `npm run build`

Fixes #1193