### PR TITLE
test: harden terminal WebGL recovery guard

### DIFF
--- a/components/terminal/appResumeWebglRecovery.test.ts
+++ b/components/terminal/appResumeWebglRecovery.test.ts
@@ -9,11 +9,25 @@ const assertHandlerRecoversWebglBeforeRefit = (
   const handlerIndex = source.indexOf(`const ${handlerName} = () => {`);
   assert.notEqual(handlerIndex, -1, `${handlerName} must exist`);
 
-  const nextHandlerIndex = source.indexOf("const ", handlerIndex + 1);
-  const handlerSource = source.slice(
-    handlerIndex,
-    nextHandlerIndex === -1 ? undefined : nextHandlerIndex,
-  );
+  const bodyStart = source.indexOf("{", handlerIndex);
+  assert.notEqual(bodyStart, -1, `${handlerName} must have a body`);
+
+  let depth = 0;
+  let bodyEnd = -1;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        bodyEnd = index + 1;
+        break;
+      }
+    }
+  }
+  assert.notEqual(bodyEnd, -1, `${handlerName} body must close`);
+
+  const handlerSource = source.slice(handlerIndex, bodyEnd);
   const recoveryIndex = handlerSource.indexOf("recoverWebglRendererOnAppResume()");
   const refitIndex = handlerSource.indexOf("scheduleLayoutRecoveryRefit()");
 


### PR DESCRIPTION
## Root cause
Netcatty 1.1.40 loaded xterm's WebGL renderer by default in components/terminal/runtime/createXTermRuntime.ts via loadWebglRenderer, using @xterm/xterm 6.0.0 and @xterm/addon-webgl 0.19.0. In that path the WebGL glyph/cell rendering layer can leave stale cells or repaint cells incorrectly, so the SSH command bytes and the remote echo can be correct while the canvas displays missing/extra characters. That explains both issue symptoms: `uname -r` executed correctly while the screen looked like `unamer`, and `--prefix=/usr/local` appeared as `---prefix=/usr/lolocal` without requiring any keyboard, paste, IME, or backend send-path mutation.

The current codebase already contains the post-1.1.40 WebGL recovery/atlas protections. While validating this issue I found the guard test was brittle and could miss the recovery call because it stopped reading a handler at an inner `const` declaration.

## Fix
- Harden the app-resume WebGL recovery guard test by extracting handler bodies with brace matching.
- Keep the check focused on the existing requirement: recover the renderer before scheduling the layout refit.

## Validation
- `node --test --import tsx components/terminal/appResumeWebglRecovery.test.ts`
- `node --test --import tsx components/terminal/appResumeWebglRecovery.test.ts scripts/patch-xterm-webgl-atlas.test.cjs components/terminal/runtime/terminalUserPaste.test.ts electron/bridges/terminalBridge.inputEncoding.test.cjs`
- `npx eslint components/terminal/appResumeWebglRecovery.test.ts scripts/patch-xterm-webgl-atlas.test.cjs components/terminal/runtime/terminalUserPaste.test.ts electron/bridges/terminalBridge.inputEncoding.test.cjs`
- `npm run lint`

I also ran `npm test`; it currently exits 1 on existing unrelated failures outside this change area.

Fixes #1497