### PR TITLE
fix(sftp): restore last path when reopening panel

### DIFF
--- a/application/state/sftp/sftpReopenLocation.test.ts
+++ b/application/state/sftp/sftpReopenLocation.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getSftpCurrentPathMemoryKey,
+  getSftpReopenMemoryKey,
+  resolveSftpOpenLocation,
+} from "./sftpReopenLocation.ts";
+
+test("first open of a terminal lands on the terminal cwd", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    connectionKey: "host-1:server-a:22:ssh::deploy",
+    terminalCwd: "/home/deploy",
+    remembered: null,
+  });
+
+  assert.equal(location, "/home/deploy");
+});
+
+test("reopening the same terminal restores the last browsed path", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    connectionKey: "host-1:server-a:22:ssh::deploy",
+    terminalCwd: "/home/deploy",
+    remembered: {
+      hostId: "host-1",
+      connectionKey: "host-1:server-a:22:ssh::deploy",
+      path: "/home/deploy/projects/app",
+    },
+  });
+
+  assert.equal(location, "/home/deploy/projects/app");
+});
+
+test("remembered path for a different host falls back to terminal cwd", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-2",
+    connectionKey: "host-2:server-b:22:ssh::root",
+    terminalCwd: "/srv",
+    remembered: {
+      hostId: "host-1",
+      connectionKey: "host-1:server-a:22:ssh::deploy",
+      path: "/home/deploy/projects/app",
+    },
+  });
+
+  assert.equal(location, "/srv");
+});
+
+test("explicit upload target wins over remembered path", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    connectionKey: "host-1:server-a:22:ssh::deploy",
+    terminalCwd: "/home/deploy",
+    explicitTargetPath: "/tmp/upload-here",
+    hasPendingUpload: true,
+    remembered: {
+      hostId: "host-1",
+      connectionKey: "host-1:server-a:22:ssh::deploy",
+      path: "/home/deploy/projects/app",
+    },
+  });
+
+  assert.equal(location, "/tmp/upload-here");
+});
+
+test("untargeted upload does not inherit a remembered reopen path", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    connectionKey: "host-1:server-a:22:ssh::deploy",
+    terminalCwd: undefined,
+    hasPendingUpload: true,
+    remembered: {
+      hostId: "host-1",
+      connectionKey: "host-1:server-a:22:ssh::deploy",
+      path: "/home/deploy/projects/app",
+    },
+  });
+
+  assert.equal(location, undefined);
+});
+
+test("remembered path for the same saved host but different endpoint falls back to terminal cwd", () => {
+  const location = resolveSftpOpenLocation({
+    hostId: "host-1",
+    connectionKey: "host-1:server-a:2200:ssh::root",
+    terminalCwd: "/srv/root",
+    remembered: {
+      hostId: "host-1",
+      connectionKey: "host-1:server-a:22:ssh::deploy",
+      path: "/home/deploy/projects/app",
+    },
+  });
+
+  assert.equal(location, "/srv/root");
+});
+
+test("workspace sftp memory is keyed by source session rather than workspace tab", () => {
+  const workspaceTabId = "workspace-1";
+
+  assert.equal(
+    getSftpReopenMemoryKey({ tabId: workspaceTabId, sourceSessionId: "session-a" }),
+    "session-a",
+  );
+  assert.equal(
+    getSftpReopenMemoryKey({ tabId: workspaceTabId, sourceSessionId: "session-b" }),
+    "session-b",
+  );
+  assert.equal(getSftpReopenMemoryKey({ tabId: "terminal-tab-1" }), "terminal-tab-1");
+});
+
+test("path changes for non-reusable sessions still use the focused terminal session", () => {
+  assert.equal(
+    getSftpCurrentPathMemoryKey({
+      tabId: "workspace-1",
+      activeTerminalSessionIdForSftp: null,
+      focusedSessionId: "mosh-session-1",
+    }),
+    "mosh-session-1",
+  );
+});

--- a/application/state/sftp/sftpReopenLocation.ts
+++ b/application/state/sftp/sftpReopenLocation.ts
@@ -1,0 +1,50 @@
+export interface SftpRememberedLocation {
+  hostId: string;
+  connectionKey: string;
+  path: string;
+}
+
+export function getSftpReopenMemoryKey(params: {
+  tabId: string;
+  sourceSessionId?: string | null;
+}): string {
+  return params.sourceSessionId || params.tabId;
+}
+
+export function getSftpCurrentPathMemoryKey(params: {
+  tabId: string;
+  activeTerminalSessionIdForSftp?: string | null;
+  focusedSessionId?: string | null;
+}): string {
+  return params.activeTerminalSessionIdForSftp || params.focusedSessionId || params.tabId;
+}
+
+export function resolveSftpOpenLocation(params: {
+  hostId: string;
+  connectionKey: string;
+  terminalCwd?: string;
+  explicitTargetPath?: string;
+  hasPendingUpload?: boolean;
+  remembered?: SftpRememberedLocation | null;
+}): string | undefined {
+  const { hostId, connectionKey, terminalCwd, explicitTargetPath, hasPendingUpload, remembered } = params;
+
+  if (explicitTargetPath) {
+    return explicitTargetPath;
+  }
+
+  if (hasPendingUpload) {
+    return terminalCwd && terminalCwd.length > 0 ? terminalCwd : undefined;
+  }
+
+  if (
+    remembered &&
+    remembered.hostId === hostId &&
+    remembered.connectionKey === connectionKey &&
+    remembered.path
+  ) {
+    return remembered.path;
+  }
+
+  return terminalCwd && terminalCwd.length > 0 ? terminalCwd : undefined;
+}

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -68,6 +68,7 @@ interface SftpSidePanelProps {
   activeSessionId?: string | null;
   initialLocation?: { hostId: string; path: string } | null;
   onInitialLocationApplied?: (location: { hostId: string; path: string }) => void;
+  onCurrentPathChange?: (location: { hostId: string; connectionKey: string; path: string }) => void;
   showWorkspaceHostHeader?: boolean;
   isVisible?: boolean;
   renderOverlays?: boolean;
@@ -108,6 +109,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   activeSessionId,
   initialLocation,
   onInitialLocationApplied,
+  onCurrentPathChange,
   showWorkspaceHostHeader = false,
   isVisible = true,
   renderOverlays = true,
@@ -385,6 +387,28 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     initialLocation,
     onInitialLocationApplied,
     sftp.leftPane,
+  ]);
+
+  const onCurrentPathChangeRef = useRef(onCurrentPathChange);
+  onCurrentPathChangeRef.current = onCurrentPathChange;
+  useEffect(() => {
+    const connection = sftp.leftPane.connection;
+    if (!connection || connection.isLocal) return;
+    if (connection.status !== "connected") return;
+    if (!connection.currentPath) return;
+    const connectionKey = tabConnectionKeyMapRef.current.get(sftp.leftPane.id);
+    if (!connectionKey) return;
+    onCurrentPathChangeRef.current?.({
+      hostId: connection.hostId,
+      connectionKey,
+      path: connection.currentPath,
+    });
+  }, [
+    sftp.leftPane.connection,
+    sftp.leftPane.connection?.currentPath,
+    sftp.leftPane.connection?.hostId,
+    sftp.leftPane.connection?.status,
+    sftp.leftPane.id,
   ]);
 
   useEffect(() => {
@@ -1144,6 +1168,7 @@ const sidePanelAreEqual = (prev: SftpSidePanelProps, next: SftpSidePanelProps): 
   prev.sftpFollowTerminalCwd === next.sftpFollowTerminalCwd &&
   prev.onSftpFollowTerminalCwdChange === next.onSftpFollowTerminalCwdChange &&
   prev.onRequestTerminalFocus === next.onRequestTerminalFocus &&
+  prev.onCurrentPathChange === next.onCurrentPathChange &&
   prev.initialLocation?.hostId === next.initialLocation?.hostId &&
   prev.initialLocation?.path === next.initialLocation?.path &&
   // Only the keepalive fields of terminalSettings affect SFTP connection

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -29,6 +29,11 @@ import {
   STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN,
 } from '../infrastructure/config/storageKeys';
 import { buildCacheKey } from '../application/state/sftp/sharedRemoteHostCache';
+import {
+  getSftpReopenMemoryKey,
+  resolveSftpOpenLocation,
+  type SftpRememberedLocation,
+} from '../application/state/sftp/sftpReopenLocation';
 import type { DropEntry } from '../lib/sftpFileUtils';
 import { Host, KnownHost, TerminalSession, Workspace } from '../types';
 import { applySessionFontSizeToHost } from '../domain/terminalAppearance';
@@ -562,6 +567,29 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const notesOpenRequestIdRef = useRef(0);
   const sftpHostForTabRef = useRef(sftpHostForTab);
   sftpHostForTabRef.current = sftpHostForTab;
+  const sftpLastPathForSourceRef = useRef<Map<string, SftpRememberedLocation>>(new Map());
+
+  const resolveSftpOpenTarget = useCallback((params: {
+    tabId: string;
+    host: Host;
+    initialPath?: string;
+    pendingUploadEntries?: DropEntry[];
+    sourceSessionId?: string | null;
+  }) => {
+    const { tabId, host, initialPath, pendingUploadEntries, sourceSessionId } = params;
+    const connectionKey = buildCacheKey(host.id, host.hostname, host.port, host.protocol, host.sftpSudo, host.username);
+    const memoryKey = getSftpReopenMemoryKey({ tabId, sourceSessionId });
+    const effectiveInitialPath = resolveSftpOpenLocation({
+      hostId: host.id,
+      connectionKey,
+      terminalCwd: initialPath,
+      explicitTargetPath: pendingUploadEntries?.length ? initialPath : undefined,
+      hasPendingUpload: !!pendingUploadEntries?.length,
+      remembered: sftpLastPathForSourceRef.current.get(memoryKey),
+    });
+
+    return { connectionKey, effectiveInitialPath };
+  }, []);
 
   const handleToggleWorkspaceComposeBar = useCallback(() => {
     setIsComposeBarOpen(prev => !prev);
@@ -620,10 +648,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       return next;
     });
 
+    const { connectionKey, effectiveInitialPath } = resolveSftpOpenTarget({
+      tabId,
+      host,
+      initialPath,
+      pendingUploadEntries,
+      sourceSessionId,
+    });
+
     setSftpInitialLocationForTab(prev => {
       const next = new Map(prev);
-      if (initialPath) {
-        next.set(tabId, { hostId: host.id, path: initialPath });
+      if (effectiveInitialPath) {
+        next.set(tabId, { hostId: host.id, path: effectiveInitialPath });
       } else {
         next.delete(tabId);
       }
@@ -639,14 +675,14 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         next.set(tabId, {
           requestId: crypto.randomUUID(),
           hostId: host.id,
-          connectionKey: buildCacheKey(host.id, host.hostname, host.port, host.protocol, host.sftpSudo, host.username),
+          connectionKey,
           targetPath: initialPath,
           entries: pendingUploadEntries,
         });
       }
       return next;
     });
-  }, []);
+  }, [resolveSftpOpenTarget]);
 
   const handlePendingUploadHandled = useCallback((tabId: string, requestId: string) => {
     setSftpPendingUploadsForTab(prev => {
@@ -670,6 +706,11 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       next.delete(tabId);
       return next;
     });
+  }, []);
+
+  const handleSftpCurrentPathChange = useCallback((memoryKey: string, location: SftpRememberedLocation) => {
+    if (!memoryKey || !location.path) return;
+    sftpLastPathForSourceRef.current.set(memoryKey, location);
   }, []);
 
   // Pre-compute host lookup map for O(1) access
@@ -1032,6 +1073,21 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         next.set(tabId, host);
         return next;
       });
+      const sourceSessionId = getActiveTerminalSessionId();
+      const { effectiveInitialPath } = resolveSftpOpenTarget({
+        tabId,
+        host,
+        sourceSessionId,
+      });
+      setSftpInitialLocationForTab(prev => {
+        const next = new Map(prev);
+        if (effectiveInitialPath) {
+          next.set(tabId, { hostId: host.id, path: effectiveInitialPath });
+        } else {
+          next.delete(tabId);
+        }
+        return next;
+      });
     }
 
     // Note: When switching away from SFTP, we keep the SFTP host state
@@ -1046,7 +1102,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
         return next;
       });
     });
-  }, [markSidePanelSubTabOpened, resolveSftpHostForTab]);
+  }, [getActiveTerminalSessionId, markSidePanelSubTabOpened, resolveSftpHostForTab, resolveSftpOpenTarget]);
 
   // Toggle SFTP from activity bar header
   const handleToggleSftpFromBar = useCallback(() => {
@@ -1530,6 +1586,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     handlePendingTerminalSelectionConsumed,
     handlePendingUploadHandled,
     handleSessionExit,
+    handleSftpCurrentPathChange,
     handleSftpInitialLocationApplied,
     persistSidePanelWidth,
     handleSnippetClickForFocusedSession,

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -403,6 +403,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     handlePendingTerminalSelectionConsumed: s.handlePendingTerminalSelectionConsumed,
     handlePendingUploadHandled: s.handlePendingUploadHandled,
     handleSessionExit: s.handleSessionExit,
+    handleSftpCurrentPathChange: s.handleSftpCurrentPathChange,
     handleSftpInitialLocationApplied: s.handleSftpInitialLocationApplied,
     persistSidePanelWidth: s.persistSidePanelWidth,
     setSidePanelWidth: s.setSidePanelWidth,

--- a/components/terminalLayer/terminalLayerSidePanelSlots.tsx
+++ b/components/terminalLayer/terminalLayerSidePanelSlots.tsx
@@ -2,6 +2,7 @@
 import React, { memo, useCallback, useSyncExternalStore } from 'react';
 
 import { activeTabStore, useIsTabActive } from '../../application/state/activeTabStore';
+import { getSftpCurrentPathMemoryKey } from '../../application/state/sftp/sftpReopenLocation';
 import {
   getSidePanelLiveSnapshot,
   subscribeSidePanelLiveSnapshot,
@@ -60,6 +61,7 @@ function SidePanelSftpSlotInner({
     sftpInitialLocationForTab,
     sftpPendingUploadsForTab,
     handleSftpInitialLocationApplied,
+    handleSftpCurrentPathChange,
     handlePendingUploadHandled,
     sftpDoubleClickBehavior,
     sftpAutoSync,
@@ -118,6 +120,20 @@ function SidePanelSftpSlotInner({
     [handlePendingUploadHandled, tabId],
   );
 
+  const handleCurrentPathChange = useCallback(
+    (location: { hostId: string; connectionKey: string; path: string }) => {
+      handleSftpCurrentPathChange(
+        getSftpCurrentPathMemoryKey({
+          tabId,
+          activeTerminalSessionIdForSftp: live.activeTerminalSessionIdForSftp,
+          focusedSessionId: live.focusedSessionId,
+        }),
+        location,
+      );
+    },
+    [handleSftpCurrentPathChange, live.activeTerminalSessionIdForSftp, live.focusedSessionId, tabId],
+  );
+
   return (
     <div className={sidePanelHiddenPanelClassName(!isVisible)}>
       <SftpSidePanel
@@ -133,6 +149,7 @@ function SidePanelSftpSlotInner({
         activeSessionId={isVisible ? live.activeTerminalSessionIdForSftp : null}
         initialLocation={isVisible ? (sftpInitialLocationForTab.get(tabId) ?? null) : null}
         onInitialLocationApplied={handleInitialLocationApplied}
+        onCurrentPathChange={handleCurrentPathChange}
         showWorkspaceHostHeader={isVisible && !!live.activeWorkspace}
         isVisible={isVisible}
         renderOverlays={isVisible}

--- a/components/terminalLayer/terminalLayerStableSnapshot.ts
+++ b/components/terminalLayer/terminalLayerStableSnapshot.ts
@@ -107,6 +107,7 @@ export type TerminalLayerStableSnapshot = {
   handleOpenSftp: (host: Host, initialPath?: string, pendingUploadEntries?: DropEntry[], sourceSessionId?: string) => void;
   handlePendingUploadHandled: (tabId: string, requestId: string) => void;
   handleSftpInitialLocationApplied: (tabId: string, location: { hostId: string; path: string }) => void;
+  handleSftpCurrentPathChange: (memoryKey: string, location: { hostId: string; path: string }) => void;
   handleSidePanelResizeStart: (e: React.MouseEvent) => void;
   handleToggleWorkspaceComposeBar: () => void;
   handleSwitchSidePanelTab: (tab: SidePanelTab) => void;

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -212,6 +212,7 @@ const SIDE_PANEL_STABLE_CTX_KEYS = [
   'sftpDefaultViewMode',
   'sftpInitialLocationForTab',
   'sftpPendingUploadsForTab',
+  'handleSftpCurrentPathChange',
   'sftpDoubleClickBehavior',
   'sftpAutoSync',
   'sftpShowHiddenFiles',


### PR DESCRIPTION
## Root cause

Fixes #1753.

`handleOpenSftp` in `components/TerminalLayer.tsx` always stored the terminal's current working directory as the SFTP initial location. When a user only navigated inside SFTP, the terminal cwd stayed at the first opened directory. On reopen, `components/SftpSidePanel.tsx` applied that initial location after connecting, so it overrode the SFTP panel's restored last browsed path and sent the user back to the original terminal cwd.

## Fix

- Remember the last browsed SFTP directory by the source terminal session.
- Reopen SFTP with that remembered directory when it belongs to the same host.
- Keep first-open behavior on the terminal cwd.
- Keep explicit upload targets ahead of remembered paths.
- Key workspace SFTP memory by the source session instead of the workspace tab, so split terminals do not share paths accidentally.

## Validation

- `node --test --import tsx application/state/sftp/sftpReopenLocation.test.ts`
- `node --test --import tsx application/state/sftp/sftpReopenLocation.test.ts application/state/sftp/sftpConnectStartPath.test.ts components/sftp/*.test.ts components/terminalLayer/terminalLayerBridge.test.ts components/terminalLayer/terminalLayerSidePanel.test.ts`
- `npx eslint application/state/sftp/sftpReopenLocation.ts application/state/sftp/sftpReopenLocation.test.ts components/SftpSidePanel.tsx components/TerminalLayer.tsx components/terminalLayer/terminalLayerSidePanelSlots.tsx components/terminalLayer/TerminalLayerTabBridge.tsx components/terminalLayer/terminalLayerStableSnapshot.ts components/terminalLayer/terminalLayerViewMemo.ts`
- `npm run lint`
- `npm run build`

Notes: I also ran a broader terminal/SFTP test sweep; the new SFTP coverage passed, while several pre-existing unrelated terminal/snippet tests failed. `npx tsc --noEmit` also reports pre-existing repository-wide type errors unrelated to these changed files.
