### PR TITLE
[codex] Fix host keyword highlight enablement

### DIFF
--- a/components/terminal/HostKeywordHighlightPopover.test.ts
+++ b/components/terminal/HostKeywordHighlightPopover.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host, KeywordHighlightRule } from "../../types.ts";
+import { addHostKeywordHighlightRule } from "./HostKeywordHighlightPopover.tsx";
+
+const baseHost: Host = {
+  id: "host-1",
+  label: "Production",
+  hostname: "prod.example.com",
+  username: "root",
+  tags: [],
+  os: "linux",
+  keywordHighlightEnabled: false,
+  keywordHighlightRules: [
+    {
+      id: "old-rule",
+      label: "Old rule",
+      patterns: ["OLD"],
+      color: "#FBBF24",
+      enabled: true,
+    },
+  ],
+};
+
+const newRule: KeywordHighlightRule = {
+  id: "new-rule",
+  label: "Deploy",
+  patterns: ["DEPLOY"],
+  color: "#F87171",
+  enabled: true,
+};
+
+test("adding a host keyword highlight rule enables host highlighting", () => {
+  const updated = addHostKeywordHighlightRule(baseHost, newRule);
+
+  assert.equal(updated.keywordHighlightEnabled, true);
+  assert.deepEqual(updated.keywordHighlightRules, [
+    ...(baseHost.keywordHighlightRules ?? []),
+    newRule,
+  ]);
+});

--- a/components/terminal/HostKeywordHighlightPopover.tsx
+++ b/components/terminal/HostKeywordHighlightPopover.tsx
@@ -23,6 +23,14 @@ export interface HostKeywordHighlightPopoverProps {
 
 const DEFAULT_NEW_RULE_COLOR = '#F87171';
 
+export function addHostKeywordHighlightRule(host: Host, rule: KeywordHighlightRule): Host {
+  return {
+    ...host,
+    keywordHighlightRules: [...(host.keywordHighlightRules ?? []), rule],
+    keywordHighlightEnabled: true,
+  };
+}
+
 export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverProps> = ({
   host,
   onUpdateHost,
@@ -76,19 +84,16 @@ export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverPr
       enabled: true,
     };
 
-    updateRules([...rules, newRule]);
+    if (host && onUpdateHost) {
+      onUpdateHost(addHostKeywordHighlightRule(host, newRule));
+    }
 
     // Reset form
     setNewRuleLabel('');
     setNewRulePattern('');
     setNewRuleColor(DEFAULT_NEW_RULE_COLOR);
     setPatternError(null);
-
-    // Auto-enable if adding the first rule and not enabled
-    if (rules.length === 0 && !enabled && host && onUpdateHost) {
-      onUpdateHost({ ...host, keywordHighlightRules: [newRule], keywordHighlightEnabled: true });
-    }
-  }, [newRuleLabel, newRulePattern, newRuleColor, rules, updateRules, enabled, host, onUpdateHost, t]);
+  }, [newRuleLabel, newRulePattern, newRuleColor, host, onUpdateHost, t]);
 
   const handleDeleteRule = useCallback((ruleId: string) => {
     updateRules(rules.filter((r) => r.id !== ruleId));

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { KeywordHighlighter } from "./keywordHighlight.ts";
+import type { KeywordHighlightRule } from "../../types.ts";
+
+type RafCallback = (time: number) => void;
+
+function installAnimationFrameQueue() {
+  const callbacks: RafCallback[] = [];
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const previousCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  globalThis.requestAnimationFrame = ((callback: RafCallback) => {
+    callbacks.push(callback);
+    return callbacks.length;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+  return {
+    flush() {
+      while (callbacks.length > 0) {
+        callbacks.shift()?.(performance.now());
+      }
+    },
+    restore() {
+      globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = previousCancelAnimationFrame;
+    },
+  };
+}
+
+function createFakeLine(text: string) {
+  return {
+    isWrapped: false,
+    length: text.length,
+    translateToString() {
+      return text;
+    },
+    getCell(index: number) {
+      if (index < 0 || index >= text.length) return undefined;
+      return {
+        getChars: () => text[index],
+        getWidth: () => 1,
+      };
+    },
+  };
+}
+
+function createFakeTerminal(lineText: string) {
+  const line = createFakeLine(lineText);
+  const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
+  const noopDisposable = { dispose() {} };
+  const term = {
+    rows: 3,
+    cols: 80,
+    buffer: {
+      active: {
+        type: "normal",
+        viewportY: 0,
+        baseY: 0,
+        cursorY: 0,
+        length: 1,
+        getLine: (lineY: number) => (lineY === 0 ? line : undefined),
+      },
+    },
+    onScroll: () => noopDisposable,
+    onWriteParsed: () => noopDisposable,
+    onResize: () => noopDisposable,
+    onRender: () => noopDisposable,
+    registerMarker(offset: number) {
+      return {
+        line: offset,
+        isDisposed: false,
+        dispose() {
+          this.isDisposed = true;
+        },
+      };
+    },
+    registerDecoration(options: { x: number; width: number; foregroundColor: string }) {
+      decorations.push(options);
+      return {
+        isDisposed: false,
+        dispose() {
+          this.isDisposed = true;
+        },
+      };
+    },
+    refresh() {},
+  };
+
+  return { term, decorations };
+}
+
+test("setRules immediately highlights a newly added rule against visible terminal text", () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, decorations } = createFakeTerminal("hello DEPLOY world");
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    highlighter.dispose();
+
+    assert.deepEqual(decorations.map(({ x, width, foregroundColor }) => ({ x, width, foregroundColor })), [
+      { x: 6, width: 6, foregroundColor: "#F87171" },
+    ]);
+  } finally {
+    raf.restore();
+  }
+});


### PR DESCRIPTION
## Root cause

In `components/terminal/HostKeywordHighlightPopover.tsx`, `handleAddRule` appended the new host-level rule but only turned on `keywordHighlightEnabled` when the host previously had zero rules. If a host already had saved rules while the host highlight switch was off, a newly added rule was saved and shown in the panel but never included by the terminal's rule merge in `useTerminalEffects`, because host rules are passed to the highlighter only when `host.keywordHighlightEnabled` is true. That explains the visible saved rule, the open rule row, and no terminal highlight for newly added current-connection rules.

The global path was checked separately: current `KeywordHighlighter.setRules` does highlight a newly added rule against visible terminal text, and this PR adds a regression test for that behavior too.

## Fix

- Add a single helper for adding host keyword highlight rules that always enables host-level highlighting.
- Use that helper from the current-connection highlight popover so the rule list and switch cannot diverge.
- Add regression tests for current-connection enablement and renderer-level matching of a newly added rule.

## Verification

- `node --test --import tsx components/terminal/HostKeywordHighlightPopover.test.ts components/terminal/keywordHighlight.test.ts components/terminal/keywordHighlightRegex.test.ts domain/keywordHighlight.test.ts`
- `npx eslint components/terminal/HostKeywordHighlightPopover.tsx components/terminal/HostKeywordHighlightPopover.test.ts components/terminal/keywordHighlight.test.ts components/terminal/keywordHighlight.ts components/terminal/keywordHighlightRegex.ts`
- `npm run build`
- `npm test` was attempted; it fails on unrelated existing/environment issues, including Electron binary installation errors and unrelated UI/memo tests, while all keyword-highlight targeted tests pass.

Fixes #1502
