### PR TITLE
Fix script output trigger modal layout

### DIFF
--- a/components/ScriptMetaFields.test.tsx
+++ b/components/ScriptMetaFields.test.tsx
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { I18nProvider } from "../application/i18n/I18nProvider.tsx";
+import type { Snippet } from "../domain/models.ts";
+import { ScriptMetaFields } from "./scripts/ScriptMetaFields.tsx";
+
+const snippet: Snippet = {
+  id: "script",
+  label: "Deploy",
+  command: "echo ok",
+  trigger: "onOutput",
+  triggerPattern: "ready",
+};
+
+test("toolbar script metadata keeps output trigger fields on a full row", () => {
+  const markup = renderToStaticMarkup(
+    <I18nProvider locale="en">
+      <ScriptMetaFields snippet={snippet} onChange={() => {}} layout="toolbar" />
+    </I18nProvider>,
+  );
+
+  assert.match(
+    markup,
+    /sm:grid-cols-\[minmax\(0,1fr\)_148px\]/,
+  );
+  assert.match(markup, /col-span-full space-y-1/);
+});

--- a/components/scripts/ScriptMetaFields.tsx
+++ b/components/scripts/ScriptMetaFields.tsx
@@ -27,8 +27,8 @@ export const ScriptMetaFields: React.FC<ScriptMetaFieldsProps> = ({
   if (layout === 'toolbar') {
     return (
       <div className="flex flex-col gap-2 shrink-0">
-        <div className="flex flex-wrap items-end gap-2">
-          <div className="flex-1 min-w-[160px] space-y-1">
+        <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_148px] gap-2 items-end">
+          <div className="min-w-0 space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">{t('scripts.meta.name')}</label>
             <Input
               value={snippet.label}
@@ -36,7 +36,7 @@ export const ScriptMetaFields: React.FC<ScriptMetaFieldsProps> = ({
               className="h-8"
             />
           </div>
-          <div className="w-[148px] space-y-1">
+          <div className="space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">{t('scripts.meta.trigger')}</label>
             <Select
               value={snippet.trigger || 'manual'}
@@ -54,7 +54,7 @@ export const ScriptMetaFields: React.FC<ScriptMetaFieldsProps> = ({
             </Select>
           </div>
           {snippet.trigger === 'onOutput' ? (
-            <div className="flex-1 min-w-[180px] space-y-1">
+            <div className="col-span-full space-y-1">
               <label className="text-[11px] font-medium text-muted-foreground">{t('scripts.meta.triggerPattern')}</label>
               <Input
                 value={snippet.triggerPattern || ''}


### PR DESCRIPTION
## Root cause

`components/scripts/ScriptMetaFields.tsx` used the modal `layout="toolbar"` as one wrapping flex row for Name, Trigger, and Output pattern when the trigger is `onOutput`. The Output pattern block also renders the long explanatory text, so in a maximized dialog it became taller while sitting beside Name, matching the broken layout shown in #1779.

## Fix

- Changed the modal metadata toolbar to a responsive grid.
- Kept Name and Trigger on the first row for wide dialogs.
- Moved Output pattern and its hint to a full-width row.
- Added a regression test for the toolbar output-trigger layout.

Fixes #1779

## Verification

- `node --test --import tsx components/ScriptMetaFields.test.tsx`
- `node --test --import tsx components/ScriptMetaFields.test.tsx components/ScriptsSidePanel.test.ts components/TextEditorModal.test.tsx`
- `npx eslint components/scripts/ScriptMetaFields.tsx components/ScriptMetaFields.test.tsx`
- `git diff --check`
- `npm run lint`
- `npm run build`
- Browser QA on `http://127.0.0.1:5173/`: Scripts -> New automation script -> Open editor -> Run on output match. Checked default viewport and a 2046x606 viewport matching the issue screenshot; Output pattern stays on its own row and console warnings/errors were empty.

## Notes

After repairing the local Electron binary with `npx install-electron --no`, `npm test` ran through but the existing full suite still reports unrelated failures in terminal/theme/completion/capability tests, outside the files touched by this PR. The targeted regression and affected UI flow passed.