### PR TITLE
[codex] Fix terminal flow ack idle flush

### DIFF
--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
+  FLOW_HIGH_WATER_MARK,
   FLOW_CHAR_COUNT_ACK_SIZE,
   FLOW_LOW_WATER_MARK,
   XTERM_WRITE_CALLBACK_BATCH_BYTES,
@@ -100,6 +101,53 @@ test("writeSessionData clears renderer backlog while deferring IPC ack", () => {
   const flow = getFlowController(ctx as never, term);
   assert.equal(flow.pendingBytes(), 0);
   assert.ok(getDeferredTerminalWriteAckBytes(term) > 0);
+  clearDeferredTerminalWriteAck(term);
+});
+
+test("writeSessionData flushes deferred IPC acks before small output can leave the source paused", async () => {
+  clearTerminalSessionFlowAck("session-1");
+  const term = {
+    buffer: { active: { type: "normal" } },
+    write(_data: string, callback?: () => void) {
+      callback?.();
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  let mainUnackedBytes = 0;
+  let mainPaused = false;
+  const ctx = {
+    ...createContext(false),
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      ackSessionFlow: (_sessionId: string, bytes: number) => {
+        mainUnackedBytes = Math.max(0, mainUnackedBytes - bytes);
+        if (mainPaused && mainUnackedBytes <= FLOW_LOW_WATER_MARK) {
+          mainPaused = false;
+        }
+      },
+    },
+  };
+  const chunk = "x".repeat(512);
+
+  for (let index = 0; index < 120; index += 1) {
+    mainUnackedBytes += chunk.length;
+    if (mainUnackedBytes >= FLOW_HIGH_WATER_MARK) {
+      mainPaused = true;
+    }
+    writeSessionData(ctx as never, term, chunk);
+  }
+  flushTerminalWriteCoalescer(term);
+
+  assert.equal(mainPaused, false);
+  assert.equal(mainUnackedBytes, 28672);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 28672);
+
+  await new Promise((resolve) => { setTimeout(resolve, 25); });
+
+  assert.equal(mainPaused, false);
+  assert.equal(mainUnackedBytes, 0);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
+  clearTerminalSessionFlowAck("session-1");
 });
 
 test("writeSessionData acks ingress bytes to match main-process trackEmitted", () => {
@@ -352,7 +400,7 @@ test("attachSessionToTerminal keeps interrupt-time output visible", () => {
 
   attachSessionToTerminal(ctx as never, term, "session-1");
   const flow = getFlowController(ctx as never, term);
-  flow.received(FLOW_LOW_WATER_MARK + 1);
+  flow.received(FLOW_LOW_WATER_MARK);
   prioritizeTerminalInput(
     term,
     "session-1",

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -34,6 +34,7 @@ import {
   clearDeferredTerminalWriteAck,
   getDeferredTerminalWriteAckBytes,
   resetDeferredTerminalWriteAck,
+  scheduleDeferredTerminalWriteAckFlush,
   shouldDeferTerminalWriteCallback,
 } from "./terminalWriteAckDeferral";
 import {
@@ -236,6 +237,13 @@ const writeSessionDataImmediate = (
       if (ackedBytes <= 0) return;
       ackTerminalSessionFlow(ctx.terminalBackend, ctx.sessionRef.current, ackedBytes);
     };
+    const flushIpcAck = (ackedBytes: number) => {
+      commitIpcAck(ackedBytes);
+      flushTerminalSessionFlowAck(ctx.sessionRef.current);
+    };
+    const flushDeferredIpcAck = () => {
+      flushIpcAck(clearDeferredTerminalWriteAck(term));
+    };
     const deferredBeforeWrite = getDeferredTerminalWriteAckBytes(term);
     const deferFlowAck = !forcePromptNewLine
       && shouldDeferTerminalWriteCallback(
@@ -252,7 +260,9 @@ const writeSessionDataImmediate = (
         flow.written(ingressBytes);
         const deferredTotal = accumulateDeferredTerminalWriteAck(term, ingressBytes);
         if (deferredTotal >= XTERM_WRITE_CALLBACK_BATCH_BYTES) {
-          commitIpcAck(clearDeferredTerminalWriteAck(term));
+          flushDeferredIpcAck();
+        } else {
+          scheduleDeferredTerminalWriteAckFlush(term, flushIpcAck);
         }
       });
       return;
@@ -263,7 +273,11 @@ const writeSessionDataImmediate = (
     writeTerminalDataWithLineTimestamps(term, preparedDisplayData, () => {
       finishQueueItem();
       flow.written(ingressBytes);
-      commitIpcAck(ackOnCallback);
+      if (deferredBeforeCallback > 0) {
+        flushIpcAck(ackOnCallback);
+      } else {
+        commitIpcAck(ackOnCallback);
+      }
     });
   });
 };

--- a/components/terminal/runtime/terminalWriteAckDeferral.ts
+++ b/components/terminal/runtime/terminalWriteAckDeferral.ts
@@ -2,8 +2,18 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 import { XTERM_WRITE_CALLBACK_BATCH_BYTES } from "./terminalFlowConstants";
 
+const DEFERRED_TERMINAL_WRITE_ACK_IDLE_FLUSH_MS = 16;
+
 /** Ingress bytes written to xterm but not yet reported to main-process IPC ACK. */
 const deferredIpcAckBytesByTerm = new WeakMap<XTerm, number>();
+const deferredIpcAckFlushTimersByTerm = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
+
+const cancelDeferredTerminalWriteAckFlush = (term: XTerm): void => {
+  const timer = deferredIpcAckFlushTimersByTerm.get(term);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  deferredIpcAckFlushTimersByTerm.delete(term);
+};
 
 export const getDeferredTerminalWriteAckBytes = (term: XTerm): number =>
   deferredIpcAckBytesByTerm.get(term) ?? 0;
@@ -19,9 +29,28 @@ export const accumulateDeferredTerminalWriteAck = (
 };
 
 export const clearDeferredTerminalWriteAck = (term: XTerm): number => {
+  cancelDeferredTerminalWriteAckFlush(term);
   const bytes = deferredIpcAckBytesByTerm.get(term) ?? 0;
   deferredIpcAckBytesByTerm.delete(term);
   return bytes;
+};
+
+export const scheduleDeferredTerminalWriteAckFlush = (
+  term: XTerm,
+  onFlush: (bytes: number) => void,
+  delayMs: number = DEFERRED_TERMINAL_WRITE_ACK_IDLE_FLUSH_MS,
+): void => {
+  if (getDeferredTerminalWriteAckBytes(term) <= 0) return;
+  if (deferredIpcAckFlushTimersByTerm.has(term)) return;
+
+  const timer = setTimeout(() => {
+    deferredIpcAckFlushTimersByTerm.delete(term);
+    const bytes = clearDeferredTerminalWriteAck(term);
+    if (bytes > 0) {
+      onFlush(bytes);
+    }
+  }, Math.max(0, delayMs));
+  deferredIpcAckFlushTimersByTerm.set(term, timer);
 };
 
 export const shouldDeferTerminalWriteCallback = (
@@ -35,5 +64,6 @@ export const shouldDeferTerminalWriteCallback = (
   && deferredIngressBytes + ingressBytes < batchBytes;
 
 export const resetDeferredTerminalWriteAck = (term: XTerm): void => {
+  cancelDeferredTerminalWriteAckFlush(term);
   deferredIpcAckBytesByTerm.delete(term);
 };


### PR DESCRIPTION
## Root cause

`tail -f`-style output often arrives as many small chunks. In 1.1.47, `writeSessionDataImmediate` could defer renderer-to-main flow ACKs until `XTERM_WRITE_CALLBACK_BATCH_BYTES`, while the main process pauses terminal output at the same high-water range. When a deferred ACK crossed the batch boundary, the nested flow ACK buffer could still keep a remainder unsent; when output then stopped just under the next batch, the renderer had already drained xterm but the main process still believed enough bytes were unacked to keep the SSH/PTY stream paused. Clicking UI does not flush terminal ACKs, so the session stayed stuck until reconnect/close reset the flow state.

## Fix

- Flush the flow ACK remainder whenever deferred write ACK bytes are released at the batch boundary.
- Add a short idle flush for deferred ACK leftovers so a small-output burst cannot leave the backend paused waiting for another chunk.
- Cancel pending idle flush timers when deferred ACK state is cleared or reset.
- Add a regression test that reproduces repeated 512-byte log chunks reaching the pause threshold and verifies the main-process accounting drains back to zero.

Fixes #1790

## Validation

- `node --test --import tsx components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/terminalWriteAckDeferral.test.ts components/terminal/runtime/terminalFlowAckBuffer.test.ts electron/bridges/terminalFlowAck.test.cjs electron/bridges/terminalBridge.outputFlood.test.cjs` ✅ 37 passed
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` was run; the new terminal flow tests passed in the full run, but the full suite still has unrelated existing failures in theme/source snapshot, snippet completion, terminal memo, and capability codegen tests.
