### PR TITLE
Fix terminal history edit echo desync

### DIFF
--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -11,6 +11,12 @@ import {
   teardownTerminalOutputPipeline,
 } from "./terminalOutputPipeline.ts";
 import { FLOW_LOW_WATER_MARK } from "./terminalFlowConstants.ts";
+import {
+  enqueueCoalescedTerminalWrite,
+  flushTerminalWriteCoalescer,
+  getTerminalWriteCoalescerPendingBytes,
+  resetTerminalWriteCoalescer,
+} from "./terminalWriteCoalescer.ts";
 import { enqueueTerminalWrite } from "./terminalWriteQueue.ts";
 import { accumulateDeferredTerminalWriteAck } from "./terminalWriteAckDeferral.ts";
 import { clearTerminalSessionFlowAck } from "./terminalFlowAckBuffer.ts";
@@ -236,6 +242,76 @@ test("prioritizeTerminalInput defers source resume until after input is forwarde
 
   assert.deepEqual(events, ["pause", "input-forwarded", "ipc-resume"]);
   clearTerminalSessionFlowAck("sess-1");
+});
+
+test("ordinary input priority preserves pending line-edit echo when flushing deferred acks", () => {
+  clearTerminalSessionFlowAck("sess-edit");
+  const scheduler = globalThis as typeof globalThis & {
+    requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+    cancelAnimationFrame?: (handle: number) => void;
+  };
+  const originalRequestAnimationFrame = scheduler.requestAnimationFrame;
+  const originalCancelAnimationFrame = scheduler.cancelAnimationFrame;
+  scheduler.requestAnimationFrame = () => 1;
+  scheduler.cancelAnimationFrame = () => {};
+
+  const term = createFakeTerm();
+  const echoedHistoryCommand = "systemctl dddd";
+  const written: string[] = [];
+  const acked: number[] = [];
+  const deferred: Array<() => void> = [];
+  const flow = createOutputFlowController({
+    highWaterMark: 100,
+    lowWaterMark: 20,
+    onPause: () => {},
+    onResume: () => {},
+  });
+  const backend = {
+    ackSessionFlow: (_sessionId: string, bytes: number) => {
+      acked.push(bytes);
+    },
+    setSessionFlowPaused: () => {},
+  };
+
+  try {
+    accumulateDeferredTerminalWriteAck(term, 2);
+    flow.received(echoedHistoryCommand.length);
+    enqueueCoalescedTerminalWrite(
+      term,
+      echoedHistoryCommand,
+      (data, ingressBytes) => {
+        written.push(data);
+        flow.written(ingressBytes);
+      },
+      echoedHistoryCommand.length,
+    );
+    assert.equal(getTerminalWriteCoalescerPendingBytes(term), echoedHistoryCommand.length);
+
+    const priority = prioritizeTerminalInput(
+      term,
+      "sess-edit",
+      flow,
+      backend,
+      (callback: () => void) => deferred.push(callback),
+      { reason: "input" },
+    );
+
+    assert.equal(priority.ackAfterInputBytes, 2);
+    assert.equal(flow.pendingBytes(), echoedHistoryCommand.length);
+    assert.equal(getTerminalWriteCoalescerPendingBytes(term), echoedHistoryCommand.length);
+
+    deferred[0]!();
+    assert.deepEqual(acked, [2]);
+
+    flushTerminalWriteCoalescer(term);
+    assert.deepEqual(written, [echoedHistoryCommand]);
+    assert.equal(flow.pendingBytes(), 0);
+  } finally {
+    resetTerminalWriteCoalescer(term);
+    scheduler.requestAnimationFrame = originalRequestAnimationFrame;
+    scheduler.cancelAnimationFrame = originalCancelAnimationFrame;
+    clearTerminalSessionFlowAck("sess-edit");
+  }
 });
 
 test("interrupt priority drains queued display output for ssh-like interrupts", () => {

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -570,7 +570,27 @@ export const prioritizeTerminalInput = (
   }
 
   const hasVisibleBacklog = backlog > FLOW_LOW_WATER_MARK || queueDepth > 0;
-  if (isInterrupt && hasVisibleBacklog && options.drainStaleOutput !== false) {
+  if (!hasVisibleBacklog && deferredAck > 0) {
+    const ackAfterInput = clearDeferredTerminalWriteAck(term);
+    scheduleResume(() => {
+      if (ackAfterInput > 0) {
+        ackTerminalSessionFlow(backend, sessionId, ackAfterInput);
+      }
+      flushTerminalSessionFlowAck(sessionId);
+      backend.setSessionFlowPaused?.(sessionId, false);
+    });
+
+    return {
+      sessionId,
+      backlogBytes: backlog,
+      writeQueueDepth: queueDepth,
+      deferredAckBytes: deferredAck,
+      ackAfterInputBytes: ackAfterInput,
+      scheduledBackendResume: true,
+    };
+  }
+
+  if (isInterrupt && hasVisibleBacklog && options.drainStaleOutput === true) {
     armTerminalInterruptDisplayGate(term, options);
   }
 


### PR DESCRIPTION
## Root cause
`components/terminal/runtime/terminalOutputPipeline.ts` `prioritizeTerminalInput()` treated deferred IPC ACK bytes as a reason to run the full stale-output drain. `createXTermRuntime.ts` calls that function before ordinary `term.onData` input, including Up-arrow history recall edits and Backspace. When a small readline/history echo such as `systemctl dddd` was still coalesced for the next render frame, any older deferred ACK made the function abort the pending display write and reset flow state. The remote shell still had the full line, but xterm missed part of the echo, so deleting/editing made the prefix appear undeletable and later echoes looked like duplicated or added characters.

## Fix
- When there is no visible output backlog and only deferred ACK bytes exist, flush the deferred ACK after the input is forwarded without aborting the pending display coalescer/write queue.
- Make interrupt stale-output draining opt-in via `drainStaleOutput === true`, preserving ordinary/direct-call display output unless the caller explicitly requested interrupt cleanup.
- Added a regression test that simulates a deferred ACK plus a pending `systemctl dddd` line-edit echo before ordinary input.

Fixes #1768

## Verification
- `node --test --import tsx components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/terminalWriteAckDeferral.test.ts components/terminal/runtime/terminalWriteQueue.test.ts components/terminal/runtime/createXTermRuntime.test.ts`
- `node --test electron/bridges/terminalBridge.ctrlCInterrupt.test.cjs electron/bridges/terminalFlowAck.test.cjs`
- `npm run lint`
- `git diff --check`

I also ran full `npm test`. After running `npm run postinstall` to apply dependency patches, the remaining failures were outside this change area (theme/app-resume/snippet completer/terminal memo/capability codegen tests), while the terminal input/output and Ctrl+C flow tests above pass.