### PR TITLE
[codex] Collapse host notes editor

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -501,6 +501,8 @@ export const enVaultMessages: Messages = {
   'hostDetails.notes.tab.edit': 'Edit',
   'hostDetails.notes.tab.preview': 'Preview',
   'hostDetails.notes.preview.empty': 'Nothing to preview yet.',
+  'hostDetails.notes.toggle.show': 'Show notes editor',
+  'hostDetails.notes.toggle.hide': 'Hide notes editor',
   'hostDetails.group.placeholder': 'Parent Group',
   'hostDetails.section.credentials': 'Credentials',
   'hostDetails.section.portCredentials': 'Port & Credentials',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -536,6 +536,8 @@ export const ruVaultMessages: Messages = {
   'hostDetails.notes.tab.edit': 'Редактировать',
   'hostDetails.notes.tab.preview': 'Просмотр',
   'hostDetails.notes.preview.empty': 'Пока нечего просматривать.',
+  'hostDetails.notes.toggle.show': 'Показать редактор заметок',
+  'hostDetails.notes.toggle.hide': 'Скрыть редактор заметок',
   'hostDetails.group.placeholder': 'Родительская группа',
   'hostDetails.section.credentials': 'Учётные данные',
   'hostDetails.section.portCredentials': 'Порт и учётные данные',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -75,6 +75,8 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.notes.tab.edit': '编辑',
   'hostDetails.notes.tab.preview': '预览',
   'hostDetails.notes.preview.empty': '暂无内容可预览。',
+  'hostDetails.notes.toggle.show': '显示备注编辑框',
+  'hostDetails.notes.toggle.hide': '隐藏备注编辑框',
   'hostDetails.group.placeholder': '父级 Group',
   'hostDetails.section.credentials': '凭据',
   'hostDetails.section.portCredentials': '端口与凭据',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -74,6 +74,8 @@ export const zhTWVaultMessages: Messages = {
   'hostDetails.notes.tab.edit': '編輯',
   'hostDetails.notes.tab.preview': '預覽',
   'hostDetails.notes.preview.empty': '暫無內容可預覽。',
+  'hostDetails.notes.toggle.show': '顯示備註編輯框',
+  'hostDetails.notes.toggle.hide': '隱藏備註編輯框',
   'hostDetails.group.placeholder': '父級 Group',
   'hostDetails.section.credentials': '憑證',
   'hostDetails.section.portCredentials': '埠與憑證',

--- a/components/HostDetailsPanel.proxyProfile.test.tsx
+++ b/components/HostDetailsPanel.proxyProfile.test.tsx
@@ -326,3 +326,34 @@ test("HostDetailsPanel shows color and icon controls in the connection settings"
   assert.match(markup, /Blue/);
   assert.match(markup, /IP or Hostname/);
 });
+
+test("HostDetailsPanel keeps empty notes collapsed below connection settings", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    proxyProfileId: undefined,
+    notes: "",
+  });
+
+  assert.match(markup, /aria-label="Show notes editor"/);
+  assert.doesNotMatch(markup, /placeholder="Hardware, project, customer, region, role\.\.\."/);
+  assert.ok(
+    markup.indexOf("IP or Hostname") < markup.indexOf("Notes"),
+    "expected notes to render after connection settings",
+  );
+});
+
+test("HostDetailsPanel expands notes when the host already has notes", () => {
+  const markup = renderHostDetails({
+    ...hostWithMissingProxyProfile,
+    proxyProfileId: undefined,
+    notes: "Runs nightly backups",
+  });
+
+  assert.match(markup, /aria-label="Hide notes editor"/);
+  assert.match(markup, /Runs nightly backups/);
+  assert.match(markup, /placeholder="Hardware, project, customer, region, role\.\.\."/);
+  assert.ok(
+    markup.indexOf("IP or Hostname") < markup.indexOf("Notes"),
+    "expected notes to render after connection settings",
+  );
+});

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -171,6 +171,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
   const [showPassword, setShowPassword] = useState(false);
   const [showTelnetPassword, setShowTelnetPassword] = useState(false);
   const [showAlgorithmOverrides, setShowAlgorithmOverrides] = useState(false);
+  const [showNotesEditor, setShowNotesEditor] = useState(() => Boolean(initialData?.notes?.trim()));
 
   const [newKeyFilePath, setNewKeyFilePath] = useState("");
   const [pendingReferenceKeyPath, setPendingReferenceKeyPath] = useState<string | null>(null);
@@ -208,6 +209,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
     setPendingReferenceKeyPath(null);
     setShowPassword(false);
     setShowTelnetPassword(false);
+    setShowNotesEditor(Boolean(normalized.notes?.trim()));
     // Reset only when opening a different host — not when snippets list updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialHostId]);
@@ -865,19 +867,6 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
           </div>
         </HostDetailsSection>
 
-        <HostDetailsSection
-          icon={<FileText size={14} className="text-muted-foreground shrink-0" />}
-          title={t("hostDetails.notes.label")}
-          hint={t("hostDetails.notes.help")}
-        >
-          <HostNotesEditor
-            panelKey={form.id}
-            value={form.notes ?? ""}
-            onChange={(notes) => update("notes", notes)}
-            showHeader={false}
-          />
-        </HostDetailsSection>
-
         <HostDetailsConnectionSections
           t={t}
           form={form}
@@ -917,6 +906,33 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
             t={t}
           />
         ) : null}
+
+        <HostDetailsSection
+          icon={<FileText size={14} className="text-muted-foreground shrink-0" />}
+          title={t("hostDetails.notes.label")}
+          hint={t("hostDetails.notes.help")}
+          action={
+            <Switch
+              checked={showNotesEditor}
+              onCheckedChange={setShowNotesEditor}
+              aria-label={
+                showNotesEditor
+                  ? t("hostDetails.notes.toggle.hide")
+                  : t("hostDetails.notes.toggle.show")
+              }
+            />
+          }
+        >
+          {showNotesEditor ? (
+            <HostNotesEditor
+              panelKey={form.id}
+              value={form.notes ?? ""}
+              onChange={(notes) => update("notes", notes)}
+              showHeader={false}
+              defaultTab="edit"
+            />
+          ) : null}
+        </HostDetailsSection>
 
         <HostDetailsAdvancedSections
           t={t}

--- a/components/host/HostNotesEditor.tsx
+++ b/components/host/HostNotesEditor.tsx
@@ -10,7 +10,8 @@ import { cn } from "../../lib/utils";
 const PREVIEW_PROSE_CLASS =
   "text-sm text-foreground/90 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0";
 
-function defaultNotesTab(notes: string): "edit" | "preview" {
+function defaultNotesTab(notes: string, preferredTab?: "edit" | "preview"): "edit" | "preview" {
+  if (preferredTab) return preferredTab;
   return notes.trim() ? "preview" : "edit";
 }
 
@@ -21,6 +22,7 @@ export interface HostNotesEditorProps {
   panelKey?: string;
   className?: string;
   showHeader?: boolean;
+  defaultTab?: "edit" | "preview";
 }
 
 export const HostNotesEditor: React.FC<HostNotesEditorProps> = ({
@@ -29,16 +31,17 @@ export const HostNotesEditor: React.FC<HostNotesEditorProps> = ({
   panelKey,
   className,
   showHeader = true,
+  defaultTab,
 }) => {
   const { t } = useI18n();
-  const [tab, setTab] = useState<"edit" | "preview">(() => defaultNotesTab(value));
+  const [tab, setTab] = useState<"edit" | "preview">(() => defaultNotesTab(value, defaultTab));
 
   useEffect(() => {
     if (panelKey === undefined) return;
-    setTab(defaultNotesTab(value));
+    setTab(defaultNotesTab(value, defaultTab));
     // Only reset tab when opening another host, not while editing notes.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- value read on panelKey change
-  }, [panelKey]);
+  }, [panelKey, defaultTab]);
 
   const trimmed = value.trim();
 


### PR DESCRIPTION
## Summary
- Move host notes below the primary connection fields.
- Keep empty notes collapsed behind a switch to save space.
- Keep existing notes easy to edit by expanding them automatically.

## Validation
- `node --test --import tsx components/HostDetailsPanel.proxyProfile.test.tsx`
- `npm run lint`
- `npm run build`