### PR TITLE
[codex] Fix terminal input echo drift

### DIFF
--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -17,7 +17,10 @@ import {
   getTerminalWriteCoalescerPendingBytes,
   resetTerminalWriteCoalescer,
 } from "./terminalWriteCoalescer.ts";
-import { enqueueTerminalWrite } from "./terminalWriteQueue.ts";
+import {
+  enqueueTerminalWrite,
+  getTerminalWriteQueueDepth,
+} from "./terminalWriteQueue.ts";
 import { accumulateDeferredTerminalWriteAck } from "./terminalWriteAckDeferral.ts";
 import { clearTerminalSessionFlowAck } from "./terminalFlowAckBuffer.ts";
 
@@ -66,10 +69,11 @@ test("releaseTerminalFlowOutputForTerm resumes renderer pause without a flow con
   assert.deepEqual(events, ["ipc-resume"]);
 });
 
-test("prioritizeTerminalInput flushes batched ack remainders after dropping bytes", () => {
+test("ordinary input priority preserves queued display output", () => {
   const term = createFakeTerm();
   const acked: number[] = [];
   const deferred: Array<() => void> = [];
+  let completed = 0;
   const flow = createOutputFlowController({
     highWaterMark: 100,
     lowWaterMark: 20,
@@ -85,8 +89,11 @@ test("prioritizeTerminalInput flushes batched ack remainders after dropping byte
 
   flow.received(FLOW_LOW_WATER_MARK + 80);
   enqueueTerminalWrite(term, 50, () => {});
-  enqueueTerminalWrite(term, 30, () => {});
-  prioritizeTerminalInput(
+  enqueueTerminalWrite(term, 30, (done) => {
+    completed += 1;
+    done();
+  });
+  const priority = prioritizeTerminalInput(
     term,
     "sess-1",
     flow,
@@ -94,9 +101,12 @@ test("prioritizeTerminalInput flushes batched ack remainders after dropping byte
     (callback: () => void) => deferred.push(callback),
   );
 
+  assert.equal(priority.scheduledBackendResume, false);
+  assert.equal(priority.ackAfterInputBytes, 0);
+  assert.equal(getTerminalWriteQueueDepth(term), 1);
   assert.deepEqual(acked, []);
-  deferred[0]!();
-  assert.deepEqual(acked, [30]);
+  assert.deepEqual(deferred, []);
+  assert.equal(completed, 0);
 });
 
 test("prioritizeTerminalInput flushes deferred xterm write ack bytes", () => {
@@ -133,7 +143,7 @@ test("prioritizeTerminalInput flushes deferred xterm write ack bytes", () => {
   clearTerminalSessionFlowAck("sess-1");
 });
 
-test("prioritizeTerminalInput drains backlog before user input is forwarded", () => {
+test("ordinary input priority leaves queued backlog intact", () => {
   const term = createFakeTerm();
   const events: string[] = [];
   const deferred: Array<() => void> = [];
@@ -155,23 +165,25 @@ test("prioritizeTerminalInput drains backlog before user input is forwarded", ()
   enqueueTerminalWrite(term, 30, (done) => {
     release = done;
   });
-  prioritizeTerminalInput(
+  const priority = prioritizeTerminalInput(
     term,
     "sess-1",
     flow,
     backend,
     (callback: () => void) => deferred.push(callback),
   );
-  release?.();
 
+  assert.equal(priority.scheduledBackendResume, false);
+  assert.equal(priority.writeQueueDepth, 0);
+  assert.equal(getTerminalWriteQueueDepth(term), 0);
   assert.equal(events.includes("ipc-resume"), false);
+  assert.deepEqual(deferred, []);
   events.push("input-forwarded");
-  deferred[0]!();
-  assert.ok(events.includes("ipc-resume"));
-  assert.deepEqual(events.slice(-2), ["input-forwarded", "ipc-resume"]);
+  release?.();
+  assert.deepEqual(events, ["pause", "input-forwarded"]);
 });
 
-test("prioritizeTerminalInput does not resume while collecting dropped bytes", () => {
+test("ordinary input priority does not drop queued bytes or resume paused output", () => {
   const term = createFakeTerm();
   const events: string[] = [];
   const deferred: Array<() => void> = [];
@@ -191,7 +203,7 @@ test("prioritizeTerminalInput does not resume while collecting dropped bytes", (
   flow.received(110);
   enqueueTerminalWrite(term, 10, () => {});
   enqueueTerminalWrite(term, 100, () => {});
-  prioritizeTerminalInput(
+  const priority = prioritizeTerminalInput(
     term,
     "sess-1",
     flow,
@@ -199,16 +211,30 @@ test("prioritizeTerminalInput does not resume while collecting dropped bytes", (
     (callback: () => void) => deferred.push(callback),
   );
 
+  assert.equal(priority.scheduledBackendResume, false);
+  assert.equal(priority.ackAfterInputBytes, 0);
   assert.deepEqual(events, ["pause"]);
+  assert.equal(getTerminalWriteQueueDepth(term), 1);
   events.push("input-forwarded");
-  deferred[0]!();
+  assert.deepEqual(deferred, []);
 
-  assert.deepEqual(events, ["pause", "input-forwarded", "ipc-resume"]);
+  assert.deepEqual(events, ["pause", "input-forwarded"]);
 });
 
-test("prioritizeTerminalInput defers source resume until after input is forwarded", () => {
+test("ordinary input priority preserves a pending coalesced backlog above the pressure threshold", () => {
   clearTerminalSessionFlowAck("sess-1");
+  const scheduler = globalThis as typeof globalThis & {
+    requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+    cancelAnimationFrame?: (handle: number) => void;
+  };
+  const originalRequestAnimationFrame = scheduler.requestAnimationFrame;
+  const originalCancelAnimationFrame = scheduler.cancelAnimationFrame;
+  scheduler.requestAnimationFrame = () => 1;
+  scheduler.cancelAnimationFrame = () => {};
+
   const term = createFakeTerm();
+  const payload = "x".repeat(FLOW_LOW_WATER_MARK + 1024);
+  const written: string[] = [];
   const events: string[] = [];
   const deferred: Array<() => void> = [];
   const flow = createOutputFlowController({
@@ -224,24 +250,42 @@ test("prioritizeTerminalInput defers source resume until after input is forwarde
     ackSessionFlow: () => {},
   };
 
-  flow.received(FLOW_LOW_WATER_MARK + 1024);
-  prioritizeTerminalInput(
-    term,
-    "sess-1",
-    flow,
-    backend,
-    (callback: () => void) => deferred.push(callback),
-  );
+  try {
+    flow.received(payload.length);
+    enqueueCoalescedTerminalWrite(
+      term,
+      payload,
+      (data, ingressBytes) => {
+        written.push(data);
+        flow.written(ingressBytes);
+      },
+      payload.length,
+    );
+    const priority = prioritizeTerminalInput(
+      term,
+      "sess-1",
+      flow,
+      backend,
+      (callback: () => void) => deferred.push(callback),
+    );
 
-  assert.equal(flow.isPaused(), false);
-  assert.deepEqual(events, ["pause"]);
-  assert.equal(deferred.length, 1);
+    assert.equal(priority.scheduledBackendResume, false);
+    assert.equal(flow.isPaused(), true);
+    assert.deepEqual(events, ["pause"]);
+    assert.deepEqual(deferred, []);
+    assert.equal(getTerminalWriteCoalescerPendingBytes(term), payload.length);
 
-  events.push("input-forwarded");
-  deferred[0]!();
+    events.push("input-forwarded");
+    flushTerminalWriteCoalescer(term);
 
-  assert.deepEqual(events, ["pause", "input-forwarded", "ipc-resume"]);
-  clearTerminalSessionFlowAck("sess-1");
+    assert.deepEqual(written, [payload]);
+    assert.equal(flow.pendingBytes(), 0);
+  } finally {
+    resetTerminalWriteCoalescer(term);
+    scheduler.requestAnimationFrame = originalRequestAnimationFrame;
+    scheduler.cancelAnimationFrame = originalCancelAnimationFrame;
+    clearTerminalSessionFlowAck("sess-1");
+  }
 });
 
 test("ordinary input priority preserves pending line-edit echo when flushing deferred acks", () => {

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -590,6 +590,28 @@ export const prioritizeTerminalInput = (
     };
   }
 
+  if (hasVisibleBacklog && (!isInterrupt || options.drainStaleOutput !== true)) {
+    let ackAfterInput = 0;
+    if (deferredAck > 0) {
+      ackAfterInput = clearDeferredTerminalWriteAck(term);
+      scheduleResume(() => {
+        if (ackAfterInput > 0) {
+          ackTerminalSessionFlow(backend, sessionId, ackAfterInput);
+        }
+        flushTerminalSessionFlowAck(sessionId);
+      });
+    }
+
+    return {
+      sessionId,
+      backlogBytes: backlog,
+      writeQueueDepth: queueDepth,
+      deferredAckBytes: deferredAck,
+      ackAfterInputBytes: ackAfterInput,
+      scheduledBackendResume: ackAfterInput > 0,
+    };
+  }
+
   if (isInterrupt && hasVisibleBacklog && options.drainStaleOutput === true) {
     armTerminalInterruptDisplayGate(term, options);
   }

--- a/components/terminal/runtime/terminalWriteQueue.test.ts
+++ b/components/terminal/runtime/terminalWriteQueue.test.ts
@@ -8,6 +8,7 @@ import {
   abortTerminalWriteQueue,
   enqueueTerminalWrite,
   getTerminalWriteQueueDepth,
+  isTerminalWriteQueueInFloodMode,
   setTerminalWriteQueueDropHandler,
 } from "./terminalWriteQueue.ts";
 
@@ -29,10 +30,11 @@ test("enqueueTerminalWrite serializes writes in order", () => {
   assert.deepEqual(order, [1, 2]);
 });
 
-test("collapses queued writes when item cap is exceeded", () => {
+test("marks flood mode without dropping queued writes when item cap is exceeded", () => {
   const term = createFakeTerm();
   const dropped: number[] = [];
   let releaseFirst: (() => void) | null = null;
+  let completed = 0;
 
   enqueueTerminalWrite(term, 10, (done) => {
     releaseFirst = done;
@@ -42,17 +44,22 @@ test("collapses queued writes when item cap is exceeded", () => {
     enqueueTerminalWrite(
       term,
       10,
-      (done) => done(),
+      (done) => {
+        completed += 1;
+        done();
+      },
       { onDropped: (bytes) => dropped.push(bytes) },
     );
   }
 
-  assert.ok(dropped.length > 0);
-  assert.ok(getTerminalWriteQueueDepth(term) <= 1);
+  assert.deepEqual(dropped, []);
+  assert.equal(isTerminalWriteQueueInFloodMode(term), true);
+  assert.equal(getTerminalWriteQueueDepth(term), MAX_WRITE_QUEUE_ITEMS + 1);
   releaseFirst?.();
+  assert.equal(completed, MAX_WRITE_QUEUE_ITEMS + 1);
 });
 
-test("setTerminalWriteQueueDropHandler applies to queues created after registration", () => {
+test("setTerminalWriteQueueDropHandler only reports explicit queue aborts", () => {
   const term = createFakeTerm();
   const dropped: number[] = [];
   let releaseFirst: (() => void) | null = null;
@@ -66,7 +73,10 @@ test("setTerminalWriteQueueDropHandler applies to queues created after registrat
     enqueueTerminalWrite(term, 10, (done) => done());
   }
 
-  assert.ok(dropped.length > 0);
+  assert.deepEqual(dropped, []);
+  assert.equal(isTerminalWriteQueueInFloodMode(term), true);
+  abortTerminalWriteQueue(term);
+  assert.deepEqual(dropped, [MAX_WRITE_QUEUE_ITEMS * 10 + 10]);
   releaseFirst?.();
 });
 

--- a/components/terminal/runtime/terminalWriteQueue.ts
+++ b/components/terminal/runtime/terminalWriteQueue.ts
@@ -49,20 +49,16 @@ const scheduleNextTerminalWrite = (term: XTerm, queue: TerminalWriteQueue) => {
   next.run();
 };
 
-const collapseFloodQueue = (queue: TerminalWriteQueue) => {
-  if (queue.pending.length <= 1) {
-    return;
-  }
-  let droppedBytes = 0;
-  const latest = queue.pending[queue.pending.length - 1]!;
-  for (let index = 0; index < queue.pending.length - 1; index += 1) {
-    droppedBytes += queue.pending[index]!.bytes;
-  }
-  queue.pending = [latest];
-  queue.pendingBytes = latest.bytes;
-  queue.floodMode = true;
-  if (droppedBytes > 0) {
-    queue.onDropped?.(droppedBytes);
+const updateFloodMode = (
+  queue: TerminalWriteQueue,
+  nextBytes: number,
+): void => {
+  if (
+    queue.floodMode
+    || queue.pending.length >= MAX_WRITE_QUEUE_ITEMS
+    || queue.pendingBytes + nextBytes > MAX_WRITE_QUEUE_BYTES
+  ) {
+    queue.floodMode = true;
   }
 };
 
@@ -100,9 +96,7 @@ export const enqueueTerminalWrite = (
     queue.onDropped = terminalWriteQueueDropHandlers.get(term);
   }
 
-  const shouldCollapse = queue.floodMode
-    || queue.pending.length >= MAX_WRITE_QUEUE_ITEMS
-    || queue.pendingBytes + bytes > MAX_WRITE_QUEUE_BYTES;
+  updateFloodMode(queue, bytes);
 
   queue.pending.push({
     bytes,
@@ -111,10 +105,6 @@ export const enqueueTerminalWrite = (
     },
   });
   queue.pendingBytes += bytes;
-
-  if (shouldCollapse) {
-    collapseFloodQueue(queue);
-  }
 
   if (!queue.writing) {
     scheduleNextTerminalWrite(term, queue);
@@ -142,6 +132,6 @@ export const abortTerminalWriteQueue = (
   terminalWriteQueues.delete(term);
 
   if (droppedBytes > 0) {
-    onDropped?.(droppedBytes);
+    (onDropped ?? queue.onDropped)?.(droppedBytes);
   }
 };


### PR DESCRIPTION
## Summary

Fixes #1807.

This fixes a terminal display drift where holding Backspace or arrow keys could leave the visible command line different from the command actually sent to the shell.

## Root cause

Ordinary terminal input was allowed to clear pending display output when the renderer had backlog, and the write queue could also collapse pending display chunks under pressure. During repeated key input, that could drop intermediate shell echo updates, so the backend command state stayed correct while the visible terminal line skipped edits.

## Changes

- Preserve pending terminal display output for ordinary user input.
- Keep stale-output draining limited to explicit interrupt handling.
- Mark terminal write flood pressure without dropping queued display chunks.
- Update regression tests to cover queued and coalesced display backlog preservation.

## Validation

- `node --test --import tsx components/terminal/runtime/terminalWriteQueue.test.ts components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts`
- `npx eslint components/terminal/runtime/terminalOutputPipeline.ts components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalWriteQueue.ts components/terminal/runtime/terminalWriteQueue.test.ts`
- `npm run build`