### PR TITLE
fix: Windows UI font fallback order

### DIFF
--- a/index.css
+++ b/index.css
@@ -140,10 +140,10 @@
 
 }
 
-/* Windows: bundled flag font + Segoe UI Emoji ahead of Mona Sans so host
+/* Windows: bundled flag font ahead of Mona Sans so host
    labels render flag icons instead of ISO country codes (#1589, #1604). */
 html.platform-win32 {
-  --font-sans: "Noto Color Emoji Flags", "Segoe UI Emoji", "Segoe UI Symbol", "Mona Sans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", system-ui, sans-serif;
+  --font-sans: "Noto Color Emoji Flags", "Mona Sans", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", system-ui, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 @keyframes top-tab-enter {

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
     }
 
     html.platform-win32 body {
-      font-family: 'Noto Color Emoji Flags', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Space Grotesk', system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      font-family: 'Noto Color Emoji Flags', 'Space Grotesk', system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol';
     }
 
     /* Global Modern Scrollbar */

--- a/infrastructure/config/uiFonts.ts
+++ b/infrastructure/config/uiFonts.ts
@@ -23,7 +23,7 @@ export const WINDOWS_FLAG_EMOJI_FONT = '"Noto Color Emoji Flags"';
  * render as separate letters instead of composed flag emoji unless a color
  * emoji font is consulted first — see #1589.
  */
-export const WINDOWS_UI_EMOJI_FONTS = `${WINDOWS_FLAG_EMOJI_FONT}, "Segoe UI Emoji", "Segoe UI Symbol"`;
+export const WINDOWS_UI_EMOJI_FONTS = WINDOWS_FLAG_EMOJI_FONT;
 
 /**
  * Fallback fonts for CJK (Chinese, Japanese, Korean) support
@@ -66,7 +66,7 @@ export function withWindowsEmojiFallback(
   if (trimmed.includes('Noto Color Emoji Flags') || trimmed.includes('Segoe UI Emoji')) {
     return trimmed;
   }
-  return `${WINDOWS_UI_EMOJI_FONTS}, ${trimmed}`;
+  return `${WINDOWS_UI_EMOJI_FONTS}, ${trimmed}, "Segoe UI Emoji", "Segoe UI Symbol"`;
 }
 
 const BASE_UI_FONTS: UIFont[] = [


### PR DESCRIPTION
## Summary
- Keep only the bundled flag emoji subset before the selected UI font on Windows
- Move broad Segoe emoji/symbol fallbacks after the selected UI font
- Align the initial CSS font stack with the runtime UI font stack

## Why
`Segoe UI Emoji` / `Segoe UI Symbol` were placed before the selected UI font on Windows. One of those fonts can cover Latin glyphs, so English UI text ignored the selected interface font and rendered heavier/blurrier, while Cyrillic text continued to fall through to the selected/fallback text font.

`Noto Color Emoji Flags` is safe to keep first because it is unicode-range limited to regional indicator glyphs.

Before:
<img width="515" height="308" alt="Netcatty_Zk1SGENBVy" src="https://github.com/user-attachments/assets/7b3aa882-06d7-443f-85bd-d61f2241e5b7" />

After:
<img width="500" height="270" alt="Netcatty_32us2loQZo" src="https://github.com/user-attachments/assets/d7d3559f-58d3-4bee-a662-31bbfea97335" />


## Testing
- node --test --import tsx infrastructure/config/uiFonts.test.ts
- npm run lint -- infrastructure/config/uiFonts.ts index.css