### PR TITLE
[codex] Add Windows zip release artifact

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -199,6 +199,10 @@ module.exports = {
             {
                 target: 'portable',
                 arch: ['x64', 'arm64']
+            },
+            {
+                target: 'zip',
+                arch: ['x64', 'arm64']
             }
         ],
         extraResources: [...moshExtraResources('win32'), ...etExtraResources('win32')]

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -201,8 +201,7 @@ module.exports = {
                 arch: ['x64', 'arm64']
             },
             {
-                target: 'zip',
-                arch: ['x64', 'arm64']
+                target: 'zip'
             }
         ],
         extraResources: [...moshExtraResources('win32'), ...etExtraResources('win32')]

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -162,6 +162,14 @@ test("linux packaging includes an Arch Linux pacman package target", () => {
   );
 });
 
+test("windows packaging includes a zip archive target", () => {
+  const winTargets = config.win.target.map((entry) => entry.target);
+  assert.ok(
+    winTargets.includes("zip"),
+    "windows package builds must publish a zip archive for no-install environments",
+  );
+});
+
 test("linux FPM packages refresh the hicolor icon cache after install and remove", () => {
   const fs = require("node:fs");
   const path = require("node:path");

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -170,6 +170,31 @@ test("windows packaging includes a zip archive target", () => {
   );
 });
 
+test("windows zip follows the requested build architecture", () => {
+  const { Arch } = require("builder-util");
+  const { Platform } = require("app-builder-lib");
+  const { computeArchToTargetNamesMap } = require("app-builder-lib/out/targets/targetFactory");
+
+  const rawCliTargets = new Map([[Arch.x64, []]]);
+  const targetsByArch = computeArchToTargetNamesMap(
+    rawCliTargets,
+    {
+      platformSpecificBuildOptions: config.win,
+      defaultTarget: ["nsis"],
+    },
+    Platform.WINDOWS,
+  );
+
+  assert.ok(
+    targetsByArch.get(Arch.x64)?.includes("zip"),
+    "pack:win-x64 must publish an x64 zip archive",
+  );
+  assert.ok(
+    !targetsByArch.get(Arch.arm64)?.includes("zip"),
+    "pack:win-x64 must not publish an arm64 zip archive without arm64 bundled binaries",
+  );
+});
+
 test("linux FPM packages refresh the hicolor icon cache after install and remove", () => {
   const fs = require("node:fs");
   const path = require("node:path");


### PR DESCRIPTION
## Summary
- Add a Windows zip archive to the release outputs alongside the installer and portable app.
- Add a packaging config check so the zip target does not regress.

## Why
Windows users in locked-down environments may be unable to run installers. A zip archive gives them a no-install download option.

Fixes #1764

## Validation
- `node --test scripts/electron-builder-config.test.cjs`
- `node --test scripts/github-workflow-build.test.cjs`