### PR TITLE
[codex] Fix ZMODEM download picker in terminal worker

### DIFF
--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -388,6 +388,7 @@ let sessions = null;
 let electronModule = null;
 let terminalOutputChannel = null;
 let selectZmodemUploadFiles = null;
+let selectZmodemDownloadDirectory = null;
 
 // Authentication method cache - remembers successful auth methods per host
 // Key format: "username@hostname:port"
@@ -479,6 +480,7 @@ function init(deps) {
   electronModule = deps.electronModule;
   terminalOutputChannel = deps.terminalOutputChannel || null;
   selectZmodemUploadFiles = deps.selectZmodemUploadFiles || null;
+  selectZmodemDownloadDirectory = deps.selectZmodemDownloadDirectory || null;
   configureTerminalSessionDataEmitter({
     getSession: (sessionId) => sessions?.get(sessionId),
     outputChannel: terminalOutputChannel,
@@ -874,6 +876,7 @@ const startSessionApi = createStartSessionApi({
   buildAlgorithms, randomUUID, findDefaultPrivateKey, findAllDefaultPrivateKeys,
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
+  get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
   preparePrivateKeyForAuth, loadFirstIdentityFileForAuth, hasUserConfiguredKey, createKeyboardInteractiveHandler,
   createConnectionRef, acquireConnectionRef, releaseConnectionRef, findReusableSession,
   get probeReceiveConflicts() { return probeReceiveConflicts; },

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -196,6 +196,9 @@ function createStartSessionApi(ctx) {
         selectUploadFiles: selectZmodemUploadFiles
           ? () => selectZmodemUploadFiles(event.sender.id)
           : undefined,
+        selectDownloadDirectory: selectZmodemDownloadDirectory
+          ? () => selectZmodemDownloadDirectory(event.sender.id)
+          : undefined,
         label: "SSH",
       });
       session.zmodemSentry = sshZmodemSentry;

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -69,6 +69,7 @@ let sessions = null;
 let electronModule = null;
 let terminalOutputChannel = null;
 let selectZmodemUploadFiles = null;
+let selectZmodemDownloadDirectory = null;
 
 const DEFAULT_UTF8_LOCALE = "en_US.UTF-8";
 const LOGIN_SHELLS = new Set(["bash", "zsh", "fish", "ksh"]);
@@ -104,6 +105,7 @@ function init(deps) {
   electronModule = deps.electronModule;
   terminalOutputChannel = deps.terminalOutputChannel || null;
   selectZmodemUploadFiles = deps.selectZmodemUploadFiles || null;
+  selectZmodemDownloadDirectory = deps.selectZmodemDownloadDirectory || null;
   configureTerminalSessionDataEmitter({
     getSession: (sessionId) => sessions?.get(sessionId),
     outputChannel: terminalOutputChannel,
@@ -491,6 +493,9 @@ function startLocalSession(event, payload) {
       selectUploadFiles: selectZmodemUploadFiles
         ? () => selectZmodemUploadFiles(session.webContentsId)
         : undefined,
+      selectDownloadDirectory: selectZmodemDownloadDirectory
+        ? () => selectZmodemDownloadDirectory(session.webContentsId)
+        : undefined,
       label: "Local",
     });
     session.zmodemSentry = zmodemSentry;
@@ -537,6 +542,7 @@ const telnetSessionApi = createTelnetSessionApi({
   enableTcpNoDelay, trackSessionIdlePrompt, stripAnsi, clearPendingAutomatedWrites,
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
+  get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
 });
 const { startTelnetSession } = telnetSessionApi;
 
@@ -557,6 +563,7 @@ const moshSessionApi = createMoshSessionApi({
   resolvePosixExecutable, findExecutable, isExecutableFile,
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
+  get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
   bundledMoshClient: (...args) => bundledMoshClient(...args),
 });
 const {
@@ -589,6 +596,7 @@ const etSessionApi = createEtSessionApi({
   findExecutable,
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
+  get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
   bundledEtClient: (...args) => bundledEtClient(...args),
 });
 const {
@@ -713,6 +721,9 @@ async function startSerialSession(event, options) {
           },
           selectUploadFiles: selectZmodemUploadFiles
             ? () => selectZmodemUploadFiles(session.webContentsId)
+            : undefined,
+          selectDownloadDirectory: selectZmodemDownloadDirectory
+            ? () => selectZmodemDownloadDirectory(session.webContentsId)
             : undefined,
           label: "Serial",
         });

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -859,6 +859,9 @@ main();
             selectUploadFiles: selectZmodemUploadFiles
               ? () => selectZmodemUploadFiles(session.webContentsId)
               : undefined,
+            selectDownloadDirectory: selectZmodemDownloadDirectory
+              ? () => selectZmodemDownloadDirectory(session.webContentsId)
+              : undefined,
             label: "ET",
           });
           session.zmodemSentry = etZmodemSentry;

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -623,6 +623,9 @@ function createMoshSessionApi(ctx) {
           selectUploadFiles: selectZmodemUploadFiles
             ? () => selectZmodemUploadFiles(session.webContentsId)
             : undefined,
+          selectDownloadDirectory: selectZmodemDownloadDirectory
+            ? () => selectZmodemDownloadDirectory(session.webContentsId)
+            : undefined,
           protocolLabel: "Mosh",
         });
         session.zmodemSentry = sentry;

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -288,6 +288,9 @@ function createTelnetSessionApi(ctx) {
           selectUploadFiles: selectZmodemUploadFiles
             ? () => selectZmodemUploadFiles(telnetWebContentsId)
             : undefined,
+          selectDownloadDirectory: selectZmodemDownloadDirectory
+            ? () => selectZmodemDownloadDirectory(telnetWebContentsId)
+            : undefined,
           label: "Telnet",
         });
         // Attach sentry to session once created (connect callback runs after this)

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -246,6 +246,10 @@ function createTerminalWorkerManager(options = {}) {
     }
     if (message.kind === "zmodem-upload-dialog") {
       void handleZmodemUploadDialogRequest(message);
+      return;
+    }
+    if (message.kind === "zmodem-download-dialog") {
+      void handleZmodemDownloadDialogRequest(message);
     }
   }
 
@@ -267,6 +271,30 @@ function createTerminalWorkerManager(options = {}) {
     } catch (err) {
       child?.postMessage?.({
         kind: "zmodem-upload-dialog-result",
+        requestId: message.requestId,
+        error: err?.message || String(err),
+      });
+    }
+  }
+
+  async function handleZmodemDownloadDialogRequest(message) {
+    try {
+      const contents = electronModule?.webContents?.fromId?.(message.webContentsId);
+      const win = contents && electronModule?.BrowserWindow?.fromWebContents
+        ? electronModule.BrowserWindow.fromWebContents(contents)
+        : null;
+      const result = await electronModule?.dialog?.showOpenDialog?.(win || undefined, {
+        properties: ["openDirectory", "createDirectory"],
+        title: "Select download directory (ZMODEM)",
+      });
+      child?.postMessage?.({
+        kind: "zmodem-download-dialog-result",
+        requestId: message.requestId,
+        result: result || { canceled: true, filePaths: [] },
+      });
+    } catch (err) {
+      child?.postMessage?.({
+        kind: "zmodem-download-dialog-result",
         requestId: message.requestId,
         error: err?.message || String(err),
       });

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -178,6 +178,63 @@ test("worker ZMODEM upload dialog request opens picker from the owning webConten
   });
 });
 
+test("worker ZMODEM download dialog request opens directory picker from the owning webContents", async () => {
+  const child = new FakeChild();
+  const shown = [];
+  const contents = { id: 7 };
+  const window = { id: "main-window" };
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        return child;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          assert.equal(id, 7);
+          return contents;
+        },
+      },
+      BrowserWindow: {
+        fromWebContents(value) {
+          assert.equal(value, contents);
+          return window;
+        },
+      },
+      dialog: {
+        async showOpenDialog(owner, options) {
+          shown.push({ owner, options });
+          return { canceled: false, filePaths: ["/tmp/downloads"] };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  manager.ensureStarted();
+  child.emit("message", {
+    kind: "zmodem-download-dialog",
+    requestId: "download-dialog-1",
+    webContentsId: 7,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(shown, [{
+    owner: window,
+    options: {
+      properties: ["openDirectory", "createDirectory"],
+      title: "Select download directory (ZMODEM)",
+    },
+  }]);
+  assert.deepEqual(child.messages.at(-1), {
+    kind: "zmodem-download-dialog-result",
+    requestId: "download-dialog-1",
+    result: { canceled: false, filePaths: ["/tmp/downloads"] },
+  });
+});
+
 test("request transfers the output port to the worker when available", async () => {
   const child = new FakeChild();
   const outputPort = { label: "worker-output-port" };

--- a/electron/bridges/zmodemHelper.cjs
+++ b/electron/bridges/zmodemHelper.cjs
@@ -934,7 +934,6 @@ async function handleDownload(zsession, opts) {
   const contents = getWebContents();
   const { BrowserWindow, dialog } = getElectron();
 
-  const win = contents ? BrowserWindow.fromWebContents(contents) : null;
   let fileIndex = 0;
   const pendingStreams = [];
   const pendingOffers = [];
@@ -1073,10 +1072,15 @@ async function handleDownload(zsession, opts) {
   // time out waiting for ZRINIT while the user browses for a folder.
   zsession.start();
 
-  const result = await dialog.showOpenDialog(win || undefined, {
-    properties: ["openDirectory", "createDirectory"],
-    title: "Select download directory (ZMODEM)",
-  });
+  const result = opts.selectDownloadDirectory
+    ? await opts.selectDownloadDirectory({ sessionId, contents })
+    : await (async () => {
+      const win = contents ? BrowserWindow.fromWebContents(contents) : null;
+      return dialog.showOpenDialog(win || undefined, {
+        properties: ["openDirectory", "createDirectory"],
+        title: "Select download directory (ZMODEM)",
+      });
+    })();
 
   if (result.canceled || !result.filePaths.length) {
     try { zsession.abort(); } catch { /* ignore */ }
@@ -1107,4 +1111,4 @@ function safeSend(contents, channel, data) {
   }
 }
 
-module.exports = { createZmodemSentry, buildUploadPlan, buildModeRestores, handleUpload };
+module.exports = { createZmodemSentry, buildUploadPlan, buildModeRestores, handleUpload, handleDownload };

--- a/electron/bridges/zmodemHelper.test.cjs
+++ b/electron/bridges/zmodemHelper.test.cjs
@@ -3,7 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { createZmodemSentry, buildUploadPlan, buildModeRestores, handleUpload } = require("./zmodemHelper.cjs");
+const { createZmodemSentry, buildUploadPlan, buildModeRestores, handleUpload, handleDownload } = require("./zmodemHelper.cjs");
 
 const never = () => { throw new Error("resolver should not be called"); };
 
@@ -302,6 +302,39 @@ test("handleUpload uses injected file picker when no drag-drop upload is queued"
 
   assert.equal(pickerCalled, true);
   assert.equal(endCalled, true);
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("handleDownload uses injected directory picker before accepting remote files", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-zmodem-download-"));
+  let pickerCalled = false;
+  const handlers = new Map();
+  let startCalled = false;
+
+  const zsession = {
+    on(event, handler) {
+      handlers.set(event, handler);
+    },
+    start() {
+      startCalled = true;
+      setImmediate(() => handlers.get("session_end")?.());
+    },
+  };
+
+  await handleDownload(zsession, {
+    sessionId: "session-1",
+    getWebContents: () => ({
+      isDestroyed: () => false,
+      send() {},
+    }),
+    selectDownloadDirectory: async () => {
+      pickerCalled = true;
+      return { canceled: false, filePaths: [tempDir] };
+    },
+  });
+
+  assert.equal(startCalled, true);
+  assert.equal(pickerCalled, true);
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 

--- a/electron/terminalWorker/process.cjs
+++ b/electron/terminalWorker/process.cjs
@@ -69,6 +69,37 @@ function createZmodemUploadFileSelector(parentPort, options = {}) {
   };
 }
 
+function createZmodemDownloadDirectorySelector(parentPort, options = {}) {
+  const randomUUIDFn = options.randomUUID || randomUUID;
+  const pendingRequests = new Map();
+
+  parentPort.on("message", (eventOrMessage) => {
+    const message = normalizeParentPortMessage(eventOrMessage);
+    if (message?.kind !== "zmodem-download-dialog-result") return;
+    const pending = pendingRequests.get(message.requestId);
+    if (!pending) return;
+    pendingRequests.delete(message.requestId);
+    if (message.error) {
+      pending.reject(new Error(message.error));
+    } else {
+      pending.resolve(message.result || { canceled: true, filePaths: [] });
+    }
+  });
+
+  return function selectZmodemDownloadDirectory(webContentsId) {
+    const requestId = randomUUIDFn();
+    const promise = new Promise((resolve, reject) => {
+      pendingRequests.set(requestId, { resolve, reject });
+    });
+    parentPort.postMessage({
+      kind: "zmodem-download-dialog",
+      requestId,
+      webContentsId,
+    });
+    return promise;
+  };
+}
+
 function main() {
   const parentPort = process.parentPort;
   if (!parentPort) {
@@ -89,6 +120,7 @@ function main() {
     },
   };
   const selectZmodemUploadFiles = createZmodemUploadFileSelector(parentPort);
+  const selectZmodemDownloadDirectory = createZmodemDownloadDirectorySelector(parentPort);
 
   const terminalBridge = require("../bridges/terminalBridge.cjs");
   const sshBridge = require("../bridges/sshBridge.cjs");
@@ -102,6 +134,7 @@ function main() {
     sftpClients,
     electronModule,
     selectZmodemUploadFiles,
+    selectZmodemDownloadDirectory,
   };
 
   runtime = createTerminalWorkerRuntime({
@@ -198,6 +231,7 @@ if (require.main === module) {
 
 module.exports = {
   createWorkerSender,
+  createZmodemDownloadDirectorySelector,
   createZmodemUploadFileSelector,
   normalizeParentPortMessage,
   main,

--- a/electron/terminalWorker/process.test.cjs
+++ b/electron/terminalWorker/process.test.cjs
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const {
+  createZmodemDownloadDirectorySelector,
   createZmodemUploadFileSelector,
   normalizeParentPortMessage,
 } = require("./process.cjs");
@@ -58,5 +59,32 @@ test("ZMODEM upload selector resolves dialog results delivered as MessageEvent d
   assert.deepEqual(await promise, {
     canceled: false,
     filePaths: ["/tmp/upload.txt"],
+  });
+});
+
+test("ZMODEM download selector resolves directory dialog results delivered as MessageEvent data", async () => {
+  const parentPort = createParentPort();
+  const selectDownloadDirectory = createZmodemDownloadDirectorySelector(parentPort, {
+    randomUUID: () => "download-dialog-1",
+  });
+
+  const promise = selectDownloadDirectory(7);
+  assert.deepEqual(parentPort.messages, [{
+    kind: "zmodem-download-dialog",
+    requestId: "download-dialog-1",
+    webContentsId: 7,
+  }]);
+
+  parentPort.emitMessage({
+    data: {
+      kind: "zmodem-download-dialog-result",
+      requestId: "download-dialog-1",
+      result: { canceled: false, filePaths: ["/tmp/downloads"] },
+    },
+  });
+
+  assert.deepEqual(await promise, {
+    canceled: false,
+    filePaths: ["/tmp/downloads"],
   });
 });


### PR DESCRIPTION
## Summary
- Route ZMODEM download directory selection through the terminal worker bridge, matching the upload picker path.
- Wire the download picker dependency into SSH, local, serial, Telnet, ET, and Mosh ZMODEM sessions.
- Add regression coverage for worker download picker messages and the download handler injection path.

## Root cause
`rz` uploads already used a worker-safe file picker bridge, but `sz` downloads still tried to open the download directory picker directly from ZMODEM transfer code. In terminal-worker mode that path could not safely resolve the owning BrowserWindow, causing the `fromWebContents` error reported in #1817.

Fixes #1817

## Validation
- `node --test electron/terminalWorker/process.test.cjs electron/bridges/terminalWorkerManager.test.cjs electron/bridges/zmodemHelper.test.cjs`
- `npm run lint`
- `npm run build`
- `npm test`
