### PR TITLE
Fix Windows focus recovery trigger

### DIFF
--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -4,29 +4,130 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
+import { startMainWindowInputFocusRecovery } from "./useMainWindowInputFocusRecovery.ts";
+
 const root = fileURLToPath(new URL("../..", import.meta.url));
 
 function readProjectFile(path: string): string {
   return readFileSync(join(root, path), "utf8");
 }
 
-test("useMainWindowInputFocusRecovery listens for visibility and window focus", () => {
-  const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
+type Listener = () => void;
 
-  assert.match(source, /document\.visibilityState !== "visible"/);
-  assert.match(source, /scheduleWindowInputFocus\(\)/);
-  assert.match(source, /document\.addEventListener\("visibilitychange", onVisibilityChange\)/);
-  assert.match(source, /window\.addEventListener\("focus", recoverFocus\)/);
+function createEventTargetStub() {
+  const listeners = new Map<string, Set<Listener>>();
+
+  return {
+    addEventListener(eventName: string, listener: Listener) {
+      const eventListeners = listeners.get(eventName) ?? new Set<Listener>();
+      eventListeners.add(listener);
+      listeners.set(eventName, eventListeners);
+    },
+    removeEventListener(eventName: string, listener: Listener) {
+      listeners.get(eventName)?.delete(listener);
+    },
+    dispatch(eventName: string) {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener();
+      }
+    },
+    listenerCount(eventName: string) {
+      return listeners.get(eventName)?.size ?? 0;
+    },
+  };
+}
+
+test("main-window input focus recovery ignores generic focus and visible visibility changes", () => {
+  let visibilityState: DocumentVisibilityState = "visible";
+  let scheduleFocusCalls = 0;
+  let cancelFocusCalls = 0;
+  let hiddenCalls = 0;
+  let shownHandler: Listener | null = null;
+  let willHideHandler: Listener | null = null;
+
+  const documentTarget = createEventTargetStub();
+  const windowTarget = createEventTargetStub();
+
+  const cleanup = startMainWindowInputFocusRecovery(
+    { onPageHidden: () => { hiddenCalls += 1; } },
+    {
+      documentRef: {
+        ...documentTarget,
+        get visibilityState() {
+          return visibilityState;
+        },
+      },
+      windowRef: windowTarget,
+      bridge: {
+        onWindowShown(cb: Listener) {
+          shownHandler = cb;
+          return () => { shownHandler = null; };
+        },
+        onWindowWillHide(cb: Listener) {
+          willHideHandler = cb;
+          return () => { willHideHandler = null; };
+        },
+      },
+      scheduleFocus: () => {
+        scheduleFocusCalls += 1;
+        return { cancel: () => { cancelFocusCalls += 1; } };
+      },
+    },
+  );
+
+  assert.equal(windowTarget.listenerCount("focus"), 0);
+
+  windowTarget.dispatch("focus");
+  documentTarget.dispatch("visibilitychange");
+
+  assert.equal(scheduleFocusCalls, 0);
+  assert.equal(hiddenCalls, 0);
+
+  shownHandler?.();
+
+  assert.equal(scheduleFocusCalls, 1);
+
+  willHideHandler?.();
+
+  assert.equal(hiddenCalls, 1);
+  assert.equal(cancelFocusCalls, 1);
+
+  shownHandler?.();
+
+  assert.equal(scheduleFocusCalls, 2);
+
+  visibilityState = "hidden";
+  documentTarget.dispatch("visibilitychange");
+
+  assert.equal(hiddenCalls, 2);
+  assert.equal(cancelFocusCalls, 2);
+
+  cleanup();
 });
 
-test("useMainWindowInputFocusRecovery dismisses transient UI when the page hides", () => {
+test("useMainWindowInputFocusRecovery restores input focus only after explicit window-shown IPC", () => {
   const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
 
-  assert.match(source, /document\.visibilityState === "hidden"/);
+  assert.match(source, /visibilityState !== "visible"/);
+  assert.match(source, /scheduleFocus\(\)/);
+  assert.match(source, /onWindowShown\?\.\(\(\) => \{\s*recoverFocus\(\);\s*\}\)/);
+  assert.doesNotMatch(source, /window\.addEventListener\("focus"/);
+  assert.doesNotMatch(source, /window\.removeEventListener\("focus"/);
+});
+
+test("useMainWindowInputFocusRecovery uses visibility changes only to dismiss transient UI", () => {
+  const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
+  const handlerStart = source.indexOf("const onVisibilityChange");
+  const handlerEnd = source.indexOf('addEventListener("visibilitychange"', handlerStart);
+  const visibilityHandler = source.slice(handlerStart, handlerEnd);
+
+  assert.match(source, /visibilityState === "hidden"/);
+  assert.match(source, /addEventListener\("visibilitychange", onVisibilityChange\)/);
   assert.match(source, /onPageHidden\?\.\(\)/);
-  assert.match(source, /onWindowShown/);
   assert.match(source, /onWindowWillHide/);
   assert.match(source, /cancelPendingFocusRecovery/);
+  assert.match(visibilityHandler, /dismissTransientUi\(\)/);
+  assert.doesNotMatch(visibilityHandler, /recoverFocus\(\)/);
 });
 
 test("scheduleWindowInputFocus skips deferred focus when the page is hidden", () => {

--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -105,12 +105,59 @@ test("main-window input focus recovery ignores generic focus and visible visibil
   cleanup();
 });
 
+test("main-window input focus recovery retries an explicit show when visibility catches up", () => {
+  let visibilityState: DocumentVisibilityState = "hidden";
+  let scheduleFocusCalls = 0;
+  let hiddenCalls = 0;
+  let shownHandler: Listener | null = null;
+
+  const documentTarget = createEventTargetStub();
+
+  const cleanup = startMainWindowInputFocusRecovery(
+    { onPageHidden: () => { hiddenCalls += 1; } },
+    {
+      documentRef: {
+        ...documentTarget,
+        get visibilityState() {
+          return visibilityState;
+        },
+      },
+      bridge: {
+        onWindowShown(cb: Listener) {
+          shownHandler = cb;
+          return () => { shownHandler = null; };
+        },
+      },
+      scheduleFocus: () => {
+        scheduleFocusCalls += 1;
+        return { cancel: () => undefined };
+      },
+    },
+  );
+
+  shownHandler?.();
+
+  assert.equal(scheduleFocusCalls, 0);
+
+  visibilityState = "visible";
+  documentTarget.dispatch("visibilitychange");
+
+  assert.equal(scheduleFocusCalls, 1);
+  assert.equal(hiddenCalls, 0);
+
+  documentTarget.dispatch("visibilitychange");
+
+  assert.equal(scheduleFocusCalls, 1);
+
+  cleanup();
+});
+
 test("useMainWindowInputFocusRecovery restores input focus only after explicit window-shown IPC", () => {
   const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
 
   assert.match(source, /visibilityState !== "visible"/);
   assert.match(source, /scheduleFocus\(\)/);
-  assert.match(source, /onWindowShown\?\.\(\(\) => \{\s*recoverFocus\(\);\s*\}\)/);
+  assert.match(source, /onWindowShown\?\.\(\(\) => \{\s*pendingExplicitShowRecovery = true;\s*recoverFocus\(\);\s*\}\)/);
   assert.doesNotMatch(source, /window\.addEventListener\("focus"/);
   assert.doesNotMatch(source, /window\.removeEventListener\("focus"/);
 });
@@ -127,7 +174,8 @@ test("useMainWindowInputFocusRecovery uses visibility changes only to dismiss tr
   assert.match(source, /onWindowWillHide/);
   assert.match(source, /cancelPendingFocusRecovery/);
   assert.match(visibilityHandler, /dismissTransientUi\(\)/);
-  assert.doesNotMatch(visibilityHandler, /recoverFocus\(\)/);
+  assert.doesNotMatch(visibilityHandler, /else\s*\{\s*recoverFocus\(\);\s*\}/);
+  assert.doesNotMatch(visibilityHandler, /visibilityState !== "hidden"[\s\S]*recoverFocus\(\)/);
 });
 
 test("scheduleWindowInputFocus skips deferred focus when the page is hidden", () => {

--- a/application/state/useMainWindowInputFocusRecovery.ts
+++ b/application/state/useMainWindowInputFocusRecovery.ts
@@ -11,9 +11,91 @@ export type MainWindowInputFocusRecoveryOptions = {
   onPageHidden?: () => void;
 };
 
+type Listener = () => void;
+
+type MainWindowInputFocusRecoveryDocument = {
+  visibilityState: DocumentVisibilityState;
+  addEventListener: (eventName: "visibilitychange", listener: Listener) => void;
+  removeEventListener: (eventName: "visibilitychange", listener: Listener) => void;
+};
+
+type MainWindowInputFocusRecoveryWindow = {
+  addEventListener: (eventName: "focus", listener: Listener) => void;
+  removeEventListener: (eventName: "focus", listener: Listener) => void;
+};
+
+type MainWindowInputFocusRecoveryBridge = {
+  onWindowShown?: (callback: Listener) => Listener;
+  onWindowWillHide?: (callback: Listener) => Listener;
+};
+
+export type MainWindowInputFocusRecoveryDependencies = {
+  documentRef: MainWindowInputFocusRecoveryDocument;
+  windowRef?: MainWindowInputFocusRecoveryWindow;
+  bridge?: MainWindowInputFocusRecoveryBridge;
+  scheduleFocus?: () => ScheduledWindowInputFocus;
+};
+
+export function startMainWindowInputFocusRecovery(
+  options: MainWindowInputFocusRecoveryOptions = {},
+  dependencies: MainWindowInputFocusRecoveryDependencies = {
+    documentRef: document,
+    windowRef: window,
+    bridge: netcattyBridge.get(),
+    scheduleFocus: scheduleWindowInputFocus,
+  },
+): () => void {
+  const { onPageHidden } = options;
+  const {
+    documentRef,
+    bridge,
+    scheduleFocus = scheduleWindowInputFocus,
+  } = dependencies;
+
+  let pendingFocusRecovery: ScheduledWindowInputFocus | null = null;
+
+  const cancelPendingFocusRecovery = () => {
+    pendingFocusRecovery?.cancel();
+    pendingFocusRecovery = null;
+  };
+
+  const recoverFocus = () => {
+    if (documentRef.visibilityState !== "visible") return;
+    cancelPendingFocusRecovery();
+    pendingFocusRecovery = scheduleFocus();
+  };
+
+  const dismissTransientUi = () => {
+    cancelPendingFocusRecovery();
+    onPageHidden?.();
+  };
+
+  const onVisibilityChange = () => {
+    if (documentRef.visibilityState === "hidden") {
+      dismissTransientUi();
+    }
+  };
+
+  documentRef.addEventListener("visibilitychange", onVisibilityChange);
+
+  const unsubscribeShown = bridge?.onWindowShown?.(() => {
+    recoverFocus();
+  });
+  const unsubscribeWillHide = bridge?.onWindowWillHide?.(() => {
+    dismissTransientUi();
+  });
+
+  return () => {
+    cancelPendingFocusRecovery();
+    documentRef.removeEventListener("visibilitychange", onVisibilityChange);
+    unsubscribeShown?.();
+    unsubscribeWillHide?.();
+  };
+}
+
 /**
- * Recover OS/renderer input focus when the main window returns from hide,
- * another app, or a virtual desktop (#760, #1714, #1722).
+ * Recover OS/renderer input focus when the main process explicitly shows the
+ * main window (#760, #1714, #1722).
  */
 export function useMainWindowInputFocusRecovery(
   options: MainWindowInputFocusRecoveryOptions = {},
@@ -21,49 +103,6 @@ export function useMainWindowInputFocusRecovery(
   const { onPageHidden } = options;
 
   useEffect(() => {
-    let pendingFocusRecovery: ScheduledWindowInputFocus | null = null;
-
-    const cancelPendingFocusRecovery = () => {
-      pendingFocusRecovery?.cancel();
-      pendingFocusRecovery = null;
-    };
-
-    const recoverFocus = () => {
-      if (document.visibilityState !== "visible") return;
-      cancelPendingFocusRecovery();
-      pendingFocusRecovery = scheduleWindowInputFocus();
-    };
-
-    const dismissTransientUi = () => {
-      cancelPendingFocusRecovery();
-      onPageHidden?.();
-    };
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        dismissTransientUi();
-        return;
-      }
-      recoverFocus();
-    };
-
-    document.addEventListener("visibilitychange", onVisibilityChange);
-    window.addEventListener("focus", recoverFocus);
-
-    const bridge = netcattyBridge.get();
-    const unsubscribeShown = bridge?.onWindowShown?.(() => {
-      recoverFocus();
-    });
-    const unsubscribeWillHide = bridge?.onWindowWillHide?.(() => {
-      dismissTransientUi();
-    });
-
-    return () => {
-      cancelPendingFocusRecovery();
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.removeEventListener("focus", recoverFocus);
-      unsubscribeShown?.();
-      unsubscribeWillHide?.();
-    };
+    return startMainWindowInputFocusRecovery({ onPageHidden });
   }, [onPageHidden]);
 }

--- a/application/state/useMainWindowInputFocusRecovery.ts
+++ b/application/state/useMainWindowInputFocusRecovery.ts
@@ -53,19 +53,23 @@ export function startMainWindowInputFocusRecovery(
   } = dependencies;
 
   let pendingFocusRecovery: ScheduledWindowInputFocus | null = null;
+  let pendingExplicitShowRecovery = false;
 
   const cancelPendingFocusRecovery = () => {
     pendingFocusRecovery?.cancel();
     pendingFocusRecovery = null;
   };
 
-  const recoverFocus = () => {
-    if (documentRef.visibilityState !== "visible") return;
+  const recoverFocus = (): boolean => {
+    if (documentRef.visibilityState !== "visible") return false;
+    pendingExplicitShowRecovery = false;
     cancelPendingFocusRecovery();
     pendingFocusRecovery = scheduleFocus();
+    return true;
   };
 
   const dismissTransientUi = () => {
+    pendingExplicitShowRecovery = false;
     cancelPendingFocusRecovery();
     onPageHidden?.();
   };
@@ -73,12 +77,17 @@ export function startMainWindowInputFocusRecovery(
   const onVisibilityChange = () => {
     if (documentRef.visibilityState === "hidden") {
       dismissTransientUi();
+      return;
+    }
+    if (pendingExplicitShowRecovery) {
+      recoverFocus();
     }
   };
 
   documentRef.addEventListener("visibilitychange", onVisibilityChange);
 
   const unsubscribeShown = bridge?.onWindowShown?.(() => {
+    pendingExplicitShowRecovery = true;
     recoverFocus();
   });
   const unsubscribeWillHide = bridge?.onWindowWillHide?.(() => {
@@ -86,6 +95,7 @@ export function startMainWindowInputFocusRecovery(
   });
 
   return () => {
+    pendingExplicitShowRecovery = false;
     cancelPendingFocusRecovery();
     documentRef.removeEventListener("visibilitychange", onVisibilityChange);
     unsubscribeShown?.();


### PR DESCRIPTION
Fixes #1820.

## Root cause

The focus recovery added for #1722 ran from generic renderer events as well as Netcatty's own show event. On Windows, ordinary `window.focus` or visibility changes could therefore call the native focus bridge and bring Netcatty back above another app.

## Fix

- Keep input focus recovery for the explicit main-process `netcatty:window:shown` path used by tray/global-hotkey/show flows.
- Stop generic `window.focus` and visibility-visible events from scheduling native focus recovery.
- Keep hide/will-hide behavior so pending focus recovery is cancelled and transient UI is dismissed before the window hides.
- Add behavior-level regression coverage for generic focus, visible visibility changes, explicit shown, and hide cancellation.

## Validation

- `node --test --import tsx application/state/useMainWindowInputFocusRecovery.test.ts`
- `node --test --import tsx application/state/useMainWindowInputFocusRecovery.test.ts electron/bridges/globalShortcutBridge.test.cjs electron/bridges/windowManagerReadiness.test.cjs`
- `npm run lint`
- `npm test` (3790 passed, 0 failed, 3 skipped)
- Local multi-agent review: clean after second review.
