### PR TITLE
Fix script waits matching stale terminal output

### DIFF
--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -9,6 +9,7 @@ const {
   getOrCreateBuffer,
   removeSessionBuffer,
 } = require("../scripts/sessionOutputBuffer.cjs");
+const { shellPromptPatterns } = require("../scripts/shellPromptPatterns.cjs");
 const { addTerminalDataTap } = require("../bridges/emitTerminalSessionData.cjs");
 const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
 
@@ -260,11 +261,12 @@ function showWaitForTimeoutDialog(pattern, timeoutMs) {
   );
 }
 
-function syncOutputBufferFromSnapshot(sessionId) {
-  return requestScreenSnapshot(sessionId).then((snapshot) => {
+async function syncOutputBufferFromSnapshot(sessionId) {
+  const buffer = getOrCreateBuffer(sessionId);
+  try {
+    const snapshot = await requestScreenSnapshot(sessionId);
     const screenText = (snapshot.lines || []).join("\n");
     if (!screenText) return;
-    const buffer = getOrCreateBuffer(sessionId);
     const existing = buffer.getText();
     if (!existing) {
       buffer.append(screenText.endsWith("\n") ? screenText : `${screenText}\n`);
@@ -281,7 +283,11 @@ function syncOutputBufferFromSnapshot(sessionId) {
     if (!existing.includes(tail.trim())) {
       buffer.append(tail.startsWith("\n") ? tail : `\n${tail}`);
     }
-  }).catch(() => {});
+  } catch {
+    // Keep startup synchronization best-effort; the current buffer is still baselined below.
+  } finally {
+    buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+  }
 }
 
 async function runScriptOnSession({

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -263,13 +263,17 @@ function showWaitForTimeoutDialog(pattern, timeoutMs) {
 
 async function syncOutputBufferFromSnapshot(sessionId) {
   const buffer = getOrCreateBuffer(sessionId);
+  const syncStartText = buffer.getText();
+  let consumedLength = syncStartText.length;
   try {
     const snapshot = await requestScreenSnapshot(sessionId);
     const screenText = (snapshot.lines || []).join("\n");
     if (!screenText) return;
+    if (buffer.getText() !== syncStartText) return;
     const existing = buffer.getText();
     if (!existing) {
       buffer.append(screenText.endsWith("\n") ? screenText : `${screenText}\n`);
+      consumedLength = buffer.getText().length;
       return;
     }
     const tail = screenText.slice(-8192);
@@ -278,15 +282,17 @@ async function syncOutputBufferFromSnapshot(sessionId) {
     if (tail === existingTail || existing.endsWith(tail)) return;
     if (existingTail && tail.includes(existingTail)) {
       buffer.append(tail.slice(tail.indexOf(existingTail) + existingTail.length));
+      consumedLength = buffer.getText().length;
       return;
     }
     if (!existing.includes(tail.trim())) {
       buffer.append(tail.startsWith("\n") ? tail : `\n${tail}`);
+      consumedLength = buffer.getText().length;
     }
   } catch {
     // Keep startup synchronization best-effort; the current buffer is still baselined below.
   } finally {
-    buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+    buffer.markOutputConsumedThrough(consumedLength, { preserveTailPatterns: shellPromptPatterns() });
   }
 }
 

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -3,6 +3,10 @@ const test = require("node:test");
 
 const scriptBridge = require("./scriptBridge.cjs");
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 test("script run writes through terminal worker manager when enabled", async () => {
   const handlers = new Map();
   const workerSends = [];
@@ -260,4 +264,154 @@ test("script run uses renderer sessionMeta when main-process session map is empt
   const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "renderer-meta");
   assert.equal(finalRun.status, "completed");
   assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /10\.0\.0\.1@root/);
+});
+
+test("script waitFor ignores keywords from the startup screen snapshot until new output arrives", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-stale-startup-output";
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:screen-snapshot-response")({}, {
+                requestId: payload.requestId,
+                snapshot: {
+                  rows: 24,
+                  cols: 80,
+                  currentRow: 1,
+                  lines: [
+                    "old deployment READY marker",
+                    "user@host:~$ ",
+                  ],
+                },
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "stale-output",
+    scriptLabel: "Stale output",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitFor('READY', 1000);
+      nct.log('matched ' + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(50);
+  const earlyRun = sentRunUpdates.at(-1)?.find((run) => run.scriptId === "stale-output");
+  assert.notEqual(earlyRun?.status, "completed");
+  assert.doesNotMatch(
+    (earlyRun?.logs || []).map((entry) => entry.message).join("\n"),
+    /matched READY/,
+  );
+
+  scriptBridge.appendSessionOutput(sessionId, "fresh READY\n");
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "stale-output");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
+test("script waitForPrompt can still use the current startup prompt", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-startup-prompt";
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:screen-snapshot-response")({}, {
+                requestId: payload.requestId,
+                snapshot: {
+                  rows: 24,
+                  cols: 80,
+                  currentRow: 0,
+                  lines: ["root@host:~# "],
+                },
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  await handlers.get("netcatty:script:run")({}, {
+    scriptId: "startup-prompt",
+    scriptLabel: "Startup prompt",
+    sessionId,
+    content: `
+      const index = await nct.screen.waitForPrompt(1000);
+      nct.log('prompt index ' + index);
+    `,
+    permissionMode: "auto",
+  });
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "startup-prompt");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /prompt index/);
+  scriptBridge.removeSessionBuffer(sessionId);
 });

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -348,6 +348,88 @@ test("script waitFor ignores keywords from the startup screen snapshot until new
   scriptBridge.removeSessionBuffer(sessionId);
 });
 
+test("script waitFor sees output that arrives while startup snapshot sync is pending", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-output-during-startup-sync";
+  let snapshotRequestId;
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            snapshotRequestId = payload.requestId;
+          }
+          if (channel === "netcatty:script:dialog-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:dialog-response")({}, {
+                requestId: payload.requestId,
+                value: "abort",
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "output-during-sync",
+    scriptLabel: "Output during sync",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitFor('READY', 1000);
+      nct.log('matched ' + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(20);
+  assert.ok(snapshotRequestId);
+  scriptBridge.appendSessionOutput(sessionId, "fresh READY\n");
+  handlers.get("netcatty:script:screen-snapshot-response")({}, {
+    requestId: snapshotRequestId,
+    snapshot: {
+      rows: 24,
+      cols: 80,
+      currentRow: 0,
+      lines: ["user@host:~$ "],
+    },
+  });
+
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "output-during-sync");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
 test("script waitForPrompt can still use the current startup prompt", async () => {
   const handlers = new Map();
   const sentRunUpdates = [];

--- a/electron/scripts/scriptRuntime.cjs
+++ b/electron/scripts/scriptRuntime.cjs
@@ -117,6 +117,7 @@ function createScriptRuntime(deps) {
           shellPromptPatterns(),
           timeoutMs,
           () => Boolean(deps.isAborted?.()),
+          { allowPreservedTailMatch: true },
         );
       } catch (err) {
         if (!String(err?.message || err).includes("timed out")) {

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -39,12 +39,59 @@ function tryMatch(text, pattern) {
 
 function tryMatchWithEnd(text, pattern) {
   const regex = compilePattern(pattern);
+  if (typeof regex.lastIndex === "number") regex.lastIndex = 0;
   const match = regex.exec(text);
   if (!match || match.index === undefined) return null;
   return {
     value: match[0],
     endOffset: match.index + match[0].length,
   };
+}
+
+function findFreshTailMatchAny(text, patterns) {
+  for (let index = 0; index < patterns.length; index += 1) {
+    const pattern = patterns[index];
+    let offset = 0;
+    while (offset <= text.length) {
+      const matched = tryMatchWithEnd(text.slice(offset), pattern);
+      if (matched === null) break;
+      const absoluteEnd = offset + matched.endOffset;
+      if (isFreshTailMatch(text.length, absoluteEnd)) {
+        return {
+          index,
+          matched: {
+            value: matched.value,
+            endOffset: absoluteEnd,
+          },
+        };
+      }
+      offset = Math.max(absoluteEnd, offset + 1);
+    }
+  }
+  return null;
+}
+
+function findMatchingPreservedTailMatch(text, patterns, preserved) {
+  for (let index = 0; index < patterns.length; index += 1) {
+    const pattern = patterns[index];
+    let offset = 0;
+    while (offset <= text.length) {
+      const matched = tryMatchWithEnd(text.slice(offset), pattern);
+      if (matched === null) break;
+      const absoluteEnd = offset + matched.endOffset;
+      if (absoluteEnd === preserved.endOffset && matched.value === preserved.value) {
+        return {
+          index,
+          matched: {
+            value: matched.value,
+            endOffset: absoluteEnd,
+          },
+        };
+      }
+      offset = Math.max(absoluteEnd, offset + 1);
+    }
+  }
+  return null;
 }
 
 class SessionOutputBuffer {
@@ -55,10 +102,12 @@ class SessionOutputBuffer {
     this.totalLength = 0;
     this.scanOffset = 0;
     this.waiters = [];
+    this.preservedTailMatch = null;
   }
 
   append(data) {
     if (!data) return;
+    this.preservedTailMatch = null;
     this.chunks.push(String(data));
     this.totalLength += this.chunks[this.chunks.length - 1].length;
     while (this.totalLength > this.maxSize && this.chunks.length > 1) {
@@ -115,10 +164,46 @@ class SessionOutputBuffer {
     this.scanOffset = Math.min(absoluteEnd, this.getText().length);
   }
 
+  markCurrentOutputConsumed(options = {}) {
+    const text = this.getText();
+    this.scanOffset = text.length;
+    this.preservedTailMatch = null;
+
+    const preserveTailPatterns = Array.isArray(options.preserveTailPatterns)
+      ? options.preserveTailPatterns
+      : [];
+    if (preserveTailPatterns.length === 0 || text.length === 0) return;
+
+    const fresh = findFreshTailMatchAny(text, preserveTailPatterns);
+    if (fresh === null) return;
+    this.preservedTailMatch = {
+      textLength: text.length,
+      value: fresh.matched.value,
+      endOffset: fresh.matched.endOffset,
+    };
+  }
+
+  consumePreservedTailMatchAny(patterns) {
+    const preserved = this.preservedTailMatch;
+    if (!preserved) return null;
+    const text = this.getText();
+    if (text.length !== preserved.textLength) {
+      this.preservedTailMatch = null;
+      return null;
+    }
+
+    const fresh = findMatchingPreservedTailMatch(text, patterns, preserved);
+    if (fresh === null) return null;
+
+    this.preservedTailMatch = null;
+    return fresh;
+  }
+
   clear() {
     this.chunks = [];
     this.totalLength = 0;
     this.scanOffset = 0;
+    this.preservedTailMatch = null;
   }
 
   flushWaiters() {
@@ -185,9 +270,15 @@ class SessionOutputBuffer {
     this.waiters = [];
   }
 
-  async waitForAny(patterns, timeoutMs = 30000, shouldAbort) {
+  async waitForAny(patterns, timeoutMs = 30000, shouldAbort, options = {}) {
     if (!Array.isArray(patterns) || patterns.length === 0) {
       throw new TypeError("waitForAny requires a non-empty patterns array");
+    }
+    if (options.allowPreservedTailMatch === true) {
+      const preserved = this.consumePreservedTailMatchAny(patterns);
+      if (preserved !== null) {
+        return preserved.index;
+      }
     }
     const fresh = this.consumeFreshPendingMatchAny(patterns);
     if (fresh !== null) {
@@ -204,6 +295,17 @@ class SessionOutputBuffer {
         timer: null,
         interval: null,
         check: () => {
+          if (options.allowPreservedTailMatch === true) {
+            const preserved = this.consumePreservedTailMatchAny(patterns);
+            if (preserved !== null) {
+              clearTimeout(waiter.timer);
+              if (waiter.interval) clearInterval(waiter.interval);
+              if (waiter.abortInterval) clearInterval(waiter.abortInterval);
+              this.waiters = this.waiters.filter((entry) => entry.custom !== waiter);
+              resolve(preserved.index);
+              return true;
+            }
+          }
           const fresh = this.consumeFreshPendingMatchAny(patterns);
           if (fresh !== null) {
             this.advanceScanOffset(fresh.matched.endOffset);
@@ -255,6 +357,7 @@ class SessionOutputBuffer {
     this.chunks = [];
     this.totalLength = 0;
     this.scanOffset = 0;
+    this.preservedTailMatch = null;
   }
 }
 

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -165,19 +165,25 @@ class SessionOutputBuffer {
   }
 
   markCurrentOutputConsumed(options = {}) {
+    this.markOutputConsumedThrough(this.getText().length, options);
+  }
+
+  markOutputConsumedThrough(length, options = {}) {
     const text = this.getText();
-    this.scanOffset = text.length;
+    const consumedLength = Math.max(0, Math.min(Number(length) || 0, text.length));
+    const consumedText = text.slice(0, consumedLength);
+    this.scanOffset = consumedLength;
     this.preservedTailMatch = null;
 
     const preserveTailPatterns = Array.isArray(options.preserveTailPatterns)
       ? options.preserveTailPatterns
       : [];
-    if (preserveTailPatterns.length === 0 || text.length === 0) return;
+    if (preserveTailPatterns.length === 0 || consumedText.length === 0) return;
 
-    const fresh = findFreshTailMatchAny(text, preserveTailPatterns);
+    const fresh = findFreshTailMatchAny(consumedText, preserveTailPatterns);
     if (fresh === null) return;
     this.preservedTailMatch = {
-      textLength: text.length,
+      textLength: consumedText.length,
       value: fresh.matched.value,
       endOffset: fresh.matched.endOffset,
     };

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -3,7 +3,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { SessionOutputBuffer, tryMatch } = require("./sessionOutputBuffer.cjs");
-const { SHELL_PROMPT_END_REGEX } = require("./shellPromptPatterns.cjs");
+const { SHELL_PROMPT_END_REGEX, shellPromptPatterns } = require("./shellPromptPatterns.cjs");
 const { stepsToJavaScript } = require("./scriptCodegen.cjs");
 
 test("tryMatch finds substring patterns", () => {
@@ -87,6 +87,83 @@ test("SessionOutputBuffer waitFor ignores stale prompt before cursor", async () 
 
   buffer.append("ls output\nuser@host:~$ ");
   assert.equal(await second, "$ ");
+});
+
+test("SessionOutputBuffer markCurrentOutputConsumed prevents startup text from matching", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("previous deploy READY\nuser@host:~$ ");
+  buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+
+  const pending = buffer.waitFor("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("fresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
+test("SessionOutputBuffer markCurrentOutputConsumed preserves the startup prompt once", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("root@host:~# ");
+  buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    0,
+  );
+
+  const second = buffer.waitForAny(shellPromptPatterns(), 200);
+  let resolvedEarly = false;
+  void second.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("root@host:~# ");
+  assert.equal(await second, 0);
+});
+
+test("SessionOutputBuffer normal waitForAny does not consume preserved startup prompts", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("previous deploy READY\nuser@host:~$ ");
+  buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+
+  const pending = buffer.waitForAny(["READY", ...shellPromptPatterns()], 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("READY\n");
+  assert.equal(await pending, 0);
+});
+
+test("SessionOutputBuffer preserved prompt can be consumed explicitly for waitForPrompt", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append("previous deploy READY\nuser@host:~$ ");
+  buffer.markCurrentOutputConsumed({ preserveTailPatterns: shellPromptPatterns() });
+
+  assert.equal(
+    await buffer.waitForAny(
+      ["READY", ...shellPromptPatterns()],
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    2,
+  );
 });
 
 test("stepsToJavaScript sends sensitive prompt result", () => {


### PR DESCRIPTION
Fixes #1821

## Root cause
Script startup synchronization copied the currently visible terminal screen into the session output buffer, but normal `waitFor` / `waitForAny` treated that copied snapshot as fresh tail output. If a keyword was still visible from a previous run, the next run could match it immediately without any new terminal output.

## Fix
- Mark the current output buffer as consumed after startup screen synchronization.
- Preserve only the current shell prompt for the explicit `waitForPrompt` startup use case.
- Keep normal `waitFor` / `waitForAny` scoped to output produced after the script starts or after new terminal data arrives.
- Add regression coverage for stale keyword matching, prompt preservation, and normal `waitForAny` not consuming preserved startup prompts.

## Verification
- `node --test --import tsx electron/scripts/sessionOutputBuffer.test.cjs`
- `node --test --import tsx electron/bridges/scriptBridge.test.cjs`
- `node --test --import tsx electron/scripts/scriptRuntime.test.cjs`
- `npm run lint`
- `npm test` (3794 tests: 3791 passed, 3 skipped, 0 failed)

## Local review
Two local review agents were run. The first found an important edge case where generic `waitForAny` could still consume a preserved startup prompt; that was fixed. The second review was clean with no blocker or important findings.
