### PR TITLE
Fix ZMODEM transfer progress notifications

### DIFF
--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -598,6 +598,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                 fileIndex={zmodem.fileIndex}
                 fileCount={zmodem.fileCount}
                 finalizing={zmodem.finalizing}
+                bytesPerSecond={zmodem.bytesPerSecond}
                 onCancel={zmodem.cancel}
               />
             </div>

--- a/components/terminal/ZmodemProgressIndicator.tsx
+++ b/components/terminal/ZmodemProgressIndicator.tsx
@@ -11,6 +11,7 @@ interface ZmodemProgressIndicatorProps {
   fileIndex: number;
   fileCount: number;
   finalizing: boolean;
+  bytesPerSecond: number | null;
   onCancel: () => void;
 }
 
@@ -22,6 +23,11 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
 }
 
+function formatSpeed(bytesPerSecond: number | null): string | null {
+  if (!bytesPerSecond || bytesPerSecond <= 0) return null;
+  return `${formatBytes(bytesPerSecond)}/s`;
+}
+
 export const ZmodemProgressIndicator: React.FC<ZmodemProgressIndicatorProps> = ({
   transferType,
   filename,
@@ -30,6 +36,7 @@ export const ZmodemProgressIndicator: React.FC<ZmodemProgressIndicatorProps> = (
   fileIndex,
   fileCount,
   finalizing,
+  bytesPerSecond,
   onCancel,
 }) => {
   const { t } = useI18n();
@@ -41,6 +48,7 @@ export const ZmodemProgressIndicator: React.FC<ZmodemProgressIndicatorProps> = (
       ? t('zmodem.uploading')
       : t('zmodem.downloading');
   const fileInfo = fileCount > 0 ? ` (${fileIndex + 1}/${fileCount})` : '';
+  const speed = formatSpeed(bytesPerSecond);
 
   return (
     <div
@@ -71,7 +79,9 @@ export const ZmodemProgressIndicator: React.FC<ZmodemProgressIndicatorProps> = (
           />
         </div>
         <div className="text-[10px] opacity-50 mt-0.5">
-          {finalizing ? label : `${formatBytes(transferred)} / ${formatBytes(total)}`}
+          {finalizing
+            ? label
+            : `${formatBytes(transferred)} / ${formatBytes(total)}${speed ? ` · ${speed}` : ''}`}
         </div>
       </div>
       <Tooltip>

--- a/components/terminal/hooks/useZmodemTransfer.ts
+++ b/components/terminal/hooks/useZmodemTransfer.ts
@@ -1,6 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { netcattyBridge } from '../../../infrastructure/services/netcattyBridge';
 
+export interface ZmodemTransferEvent {
+  type: 'detect' | 'progress' | 'complete' | 'error';
+  sessionId: string;
+  transferType?: 'upload' | 'download';
+  filename?: string;
+  transferred?: number;
+  total?: number;
+  fileIndex?: number;
+  fileCount?: number;
+  finalizing?: boolean;
+  error?: string;
+}
+
 export interface ZmodemTransferState {
   active: boolean;
   transferType: 'upload' | 'download' | null;
@@ -10,6 +23,10 @@ export interface ZmodemTransferState {
   fileIndex: number;
   fileCount: number;
   finalizing: boolean;
+  completed: boolean;
+  startedAt: number | null;
+  updatedAt: number | null;
+  bytesPerSecond: number | null;
   error: string | null;
 }
 
@@ -22,8 +39,81 @@ const initialState: ZmodemTransferState = {
   fileIndex: 0,
   fileCount: 0,
   finalizing: false,
+  completed: false,
+  startedAt: null,
+  updatedAt: null,
+  bytesPerSecond: null,
   error: null,
 };
+
+export function reduceZmodemTransferState(
+  prev: ZmodemTransferState,
+  event: ZmodemTransferEvent,
+  now: number = Date.now(),
+): ZmodemTransferState {
+  switch (event.type) {
+    case 'detect':
+      return {
+        ...initialState,
+        active: true,
+        transferType: event.transferType ?? null,
+        startedAt: now,
+        updatedAt: now,
+      };
+    case 'progress': {
+      const transferred = event.transferred ?? prev.transferred;
+      const fileChanged = (
+        prev.filename !== null
+        && (
+          (typeof event.fileIndex === 'number' && event.fileIndex !== prev.fileIndex)
+          || (typeof event.filename === 'string' && event.filename !== prev.filename)
+        )
+      );
+      const previousUpdatedAt = fileChanged ? now : (prev.updatedAt ?? now);
+      const elapsedSeconds = Math.max((now - previousUpdatedAt) / 1000, 0);
+      const deltaBytes = Math.max(transferred - prev.transferred, 0);
+      const bytesPerSecond = elapsedSeconds > 0 && deltaBytes > 0
+        ? deltaBytes / elapsedSeconds
+        : fileChanged
+          ? null
+          : prev.bytesPerSecond;
+
+      return {
+        ...prev,
+        active: true,
+        transferType: event.transferType ?? prev.transferType,
+        filename: event.filename ?? prev.filename,
+        transferred,
+        total: event.total ?? prev.total,
+        fileIndex: event.fileIndex ?? prev.fileIndex,
+        fileCount: event.fileCount ?? prev.fileCount,
+        finalizing: !!event.finalizing,
+        completed: false,
+        startedAt: prev.startedAt ?? now,
+        updatedAt: now,
+        bytesPerSecond,
+        error: null,
+      };
+    }
+    case 'complete':
+      return {
+        ...prev,
+        active: false,
+        finalizing: false,
+        completed: true,
+        updatedAt: now,
+      };
+    case 'error':
+      return {
+        ...prev,
+        active: false,
+        finalizing: false,
+        completed: false,
+        updatedAt: now,
+        error: event.error ?? 'Unknown error',
+      };
+  }
+}
 
 export function useZmodemTransfer(sessionId: string | null) {
   const [state, setState] = useState<ZmodemTransferState>(initialState);
@@ -39,43 +129,7 @@ export function useZmodemTransfer(sessionId: string | null) {
     if (!bridge?.onZmodemEvent) return;
 
     disposeRef.current = bridge.onZmodemEvent(sessionId, (event) => {
-      switch (event.type) {
-        case 'detect':
-          setState({
-            active: true,
-            transferType: event.transferType ?? null,
-            filename: null,
-            transferred: 0,
-            total: 0,
-            fileIndex: 0,
-            fileCount: 0,
-            error: null,
-          });
-          break;
-        case 'progress':
-          setState((prev) => ({
-            ...prev,
-            active: true,
-            transferType: event.transferType ?? prev.transferType,
-            filename: event.filename ?? prev.filename,
-            transferred: event.transferred ?? prev.transferred,
-            total: event.total ?? prev.total,
-            fileIndex: event.fileIndex ?? prev.fileIndex,
-            fileCount: event.fileCount ?? prev.fileCount,
-            finalizing: !!((event as Record<string, unknown>).finalizing),
-          }));
-          break;
-        case 'complete':
-          setState((prev) => ({ ...prev, active: false }));
-          break;
-        case 'error':
-          setState((prev) => ({
-            ...prev,
-            active: false,
-            error: event.error ?? 'Unknown error',
-          }));
-          break;
-      }
+      setState((prev) => reduceZmodemTransferState(prev, event));
     });
 
     const disposeOverwrite = bridge.onZmodemOverwriteRequest?.(sessionId, (payload) => {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -41,6 +41,33 @@ type SelectionOverlayPosition = {
   top: number;
 } | null;
 
+type ZmodemToast =
+  | { kind: 'error'; message: string; title: string }
+  | { kind: 'success'; message: string; title: string }
+  | null;
+
+export function resolveZmodemTransferToast(zmodem: {
+  active?: boolean;
+  completed?: boolean;
+  error?: string | null;
+  filename?: string | null;
+  transferType?: 'upload' | 'download' | null;
+}): ZmodemToast {
+  if (zmodem.active) return null;
+  if (zmodem.error) {
+    return { kind: 'error', message: zmodem.error, title: 'ZMODEM' };
+  }
+  if (!zmodem.completed) return null;
+
+  const action = zmodem.transferType === 'upload'
+    ? 'Uploaded'
+    : zmodem.transferType === 'download'
+      ? 'Downloaded'
+      : 'Transfer completed';
+  const message = zmodem.filename ? `${action}: ${zmodem.filename}` : action;
+  return { kind: 'success', message, title: 'ZMODEM' };
+}
+
 const areSelectionOverlayPositionsEqual = (
   a: SelectionOverlayPosition,
   b: SelectionOverlayPosition,
@@ -206,17 +233,15 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       return;
     }
     if (zmodemToastedRef.current) return;
-    if (zmodem.error) {
-      zmodemToastedRef.current = true;
-      toast.error(zmodem.error, 'ZMODEM');
-    } else if (zmodem.filename) {
-      zmodemToastedRef.current = true;
-      toast.success(
-        `${zmodem.transferType === 'upload' ? 'Uploaded' : 'Downloaded'}: ${zmodem.filename}`,
-        'ZMODEM',
-      );
+    const zmodemToast = resolveZmodemTransferToast(zmodem);
+    if (!zmodemToast) return;
+    zmodemToastedRef.current = true;
+    if (zmodemToast.kind === 'error') {
+      toast.error(zmodemToast.message, zmodemToast.title);
+    } else {
+      toast.success(zmodemToast.message, zmodemToast.title);
     }
-  }, [zmodem.active, zmodem.error, zmodem.filename, zmodem.transferType]);
+  }, [zmodem.active, zmodem.completed, zmodem.error, zmodem.filename, zmodem.transferType]);
 
 
   useEffect(() => {

--- a/components/terminal/useZmodemTransfer.test.ts
+++ b/components/terminal/useZmodemTransfer.test.ts
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  reduceZmodemTransferState,
+  type ZmodemTransferState,
+} from "./hooks/useZmodemTransfer.ts";
+import { resolveZmodemTransferToast } from "./useTerminalEffects.ts";
+
+const initialState: ZmodemTransferState = {
+  active: false,
+  transferType: null,
+  filename: null,
+  transferred: 0,
+  total: 0,
+  fileIndex: 0,
+  fileCount: 0,
+  finalizing: false,
+  completed: false,
+  startedAt: null,
+  updatedAt: null,
+  bytesPerSecond: null,
+  error: null,
+};
+
+test("ZMODEM state drives success toast after completion", () => {
+  const detected = reduceZmodemTransferState(initialState, {
+    type: "detect",
+    sessionId: "session-1",
+    transferType: "download",
+  }, 1_000);
+
+  assert.equal(detected.active, true);
+  assert.equal(detected.transferType, "download");
+  assert.equal(detected.startedAt, 1_000);
+
+  const progressed = reduceZmodemTransferState(detected, {
+    type: "progress",
+    sessionId: "session-1",
+    transferType: "download",
+    filename: "large.bin",
+    transferred: 1024 * 1024,
+    total: 2 * 1024 * 1024,
+    fileIndex: 0,
+    fileCount: -1,
+  }, 2_000);
+
+  assert.equal(progressed.active, true);
+  assert.equal(progressed.filename, "large.bin");
+  assert.equal(progressed.bytesPerSecond, 1024 * 1024);
+
+  const completed = reduceZmodemTransferState(progressed, {
+    type: "complete",
+    sessionId: "session-1",
+  }, 3_000);
+
+  assert.equal(completed.active, false);
+  assert.equal(completed.completed, true);
+  assert.equal(completed.filename, "large.bin");
+  assert.equal(completed.transferType, "download");
+  assert.equal(completed.finalizing, false);
+  assert.deepEqual(resolveZmodemTransferToast(completed), {
+    kind: "success",
+    message: "Downloaded: large.bin",
+    title: "ZMODEM",
+  });
+});
+
+test("ZMODEM completion without a filename still produces a success toast", () => {
+  const detected = reduceZmodemTransferState(initialState, {
+    type: "detect",
+    sessionId: "session-1",
+    transferType: "upload",
+  }, 1_000);
+
+  const completed = reduceZmodemTransferState(detected, {
+    type: "complete",
+    sessionId: "session-1",
+  }, 1_500);
+
+  assert.deepEqual(resolveZmodemTransferToast(completed), {
+    kind: "success",
+    message: "Uploaded",
+    title: "ZMODEM",
+  });
+});
+
+test("ZMODEM state drives error toast after a transfer fails", () => {
+  const detected = reduceZmodemTransferState(initialState, {
+    type: "detect",
+    sessionId: "session-1",
+    transferType: "upload",
+  }, 1_000);
+
+  const failed = reduceZmodemTransferState(detected, {
+    type: "error",
+    sessionId: "session-1",
+    error: "Transfer cancelled",
+  }, 1_500);
+
+  assert.equal(failed.active, false);
+  assert.equal(failed.transferType, "upload");
+  assert.equal(failed.error, "Transfer cancelled");
+  assert.equal(failed.finalizing, false);
+  assert.deepEqual(resolveZmodemTransferToast(failed), {
+    kind: "error",
+    message: "Transfer cancelled",
+    title: "ZMODEM",
+  });
+});
+
+test("ZMODEM progress clears old speed when the next file starts", () => {
+  const firstFile = reduceZmodemTransferState(initialState, {
+    type: "progress",
+    sessionId: "session-1",
+    transferType: "upload",
+    filename: "first.bin",
+    fileIndex: 0,
+    fileCount: 2,
+    transferred: 1024 * 1024,
+    total: 2 * 1024 * 1024,
+  }, 1_000);
+  const firstFileProgressed = reduceZmodemTransferState(firstFile, {
+    type: "progress",
+    sessionId: "session-1",
+    filename: "first.bin",
+    fileIndex: 0,
+    transferred: 2 * 1024 * 1024,
+    total: 2 * 1024 * 1024,
+  }, 2_000);
+
+  assert.equal(firstFileProgressed.bytesPerSecond, 1024 * 1024);
+
+  const secondFileStarted = reduceZmodemTransferState(firstFileProgressed, {
+    type: "progress",
+    sessionId: "session-1",
+    filename: "second.bin",
+    fileIndex: 1,
+    fileCount: 2,
+    transferred: 0,
+    total: 1024,
+  }, 3_000);
+
+  assert.equal(secondFileStarted.filename, "second.bin");
+  assert.equal(secondFileStarted.bytesPerSecond, null);
+});


### PR DESCRIPTION
## Summary
- Restore reliable ZMODEM completion/error toast handling, including transfers that finish without a filename in the completion event.
- Show transfer speed in the floating ZMODEM progress card and clear stale speed when moving to the next file.
- Add focused tests for success/error notifications and multi-file speed reset behavior.

Fixes #1824

## Test Plan
- node --test --import tsx components/terminal/useZmodemTransfer.test.ts
- node --test --import tsx electron/bridges/zmodemHelper.test.cjs electron/terminalWorker/process.test.cjs electron/bridges/terminalWorkerManager.test.cjs
- npm run lint
- npm run build
- npm test

## Review
- Two local review agents re-reviewed the final diff and reported clean.