### PR TITLE
[codex] Preserve terminal output on reconnect

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -241,9 +241,10 @@ ipcRenderer.on("netcatty:data", (_event, payload) => {
 
 ipcRenderer.on("netcatty:exit", (_event, payload) => {
   const sessionId = payload?.sessionId;
-  if (!sessionId || closedTerminalDataSessions.has(sessionId)) return;
+  if (!sessionId) return;
+  const wasClosed = closedTerminalDataSessions.has(sessionId);
   closedTerminalDataSessions.add(sessionId);
-  const set = exitListeners.get(sessionId);
+  const set = wasClosed ? null : exitListeners.get(sessionId);
   if (set) {
     set.forEach((cb) => {
       try {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -3,6 +3,7 @@ const os = require("node:os");
 const { randomUUID } = require("node:crypto");
 const { createPreloadApi } = require("./preload/api.cjs");
 const {
+  clearTerminalDataBacklog,
   clearTerminalDataSession,
   createTerminalDataBacklog,
   createTerminalDataDispatcher,
@@ -250,11 +251,7 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
       }
     });
   }
-  clearTerminalDataSession({
-    dataListeners,
-    displayDataListeners,
-    terminalDataBacklog,
-  }, payload.sessionId);
+  clearTerminalDataBacklog({ terminalDataBacklog }, payload.sessionId);
   terminalOutputPorts.closeSession(payload.sessionId);
   exitListeners.delete(payload.sessionId);
   telnetAutoLoginCompleteListeners.delete(payload.sessionId);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -240,8 +240,10 @@ ipcRenderer.on("netcatty:data", (_event, payload) => {
 });
 
 ipcRenderer.on("netcatty:exit", (_event, payload) => {
-  closedTerminalDataSessions.add(payload.sessionId);
-  const set = exitListeners.get(payload.sessionId);
+  const sessionId = payload?.sessionId;
+  if (!sessionId || closedTerminalDataSessions.has(sessionId)) return;
+  closedTerminalDataSessions.add(sessionId);
+  const set = exitListeners.get(sessionId);
   if (set) {
     set.forEach((cb) => {
       try {
@@ -251,20 +253,20 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
       }
     });
   }
-  clearTerminalDataBacklog({ terminalDataBacklog }, payload.sessionId);
-  terminalOutputPorts.closeSession(payload.sessionId);
-  telnetAutoLoginCompleteListeners.delete(payload.sessionId);
-  telnetAutoLoginCancelledListeners.delete(payload.sessionId);
-  telnetEchoModeListeners.delete(payload.sessionId);
-  zmodemListeners.delete(payload.sessionId);
-  zmodemOverwriteListeners.delete(payload.sessionId);
-  const pendingTimer = _mcpFlushTimers.get(payload.sessionId);
+  clearTerminalDataBacklog({ terminalDataBacklog }, sessionId);
+  terminalOutputPorts.closeSession(sessionId);
+  telnetAutoLoginCompleteListeners.delete(sessionId);
+  telnetAutoLoginCancelledListeners.delete(sessionId);
+  telnetEchoModeListeners.delete(sessionId);
+  zmodemListeners.delete(sessionId);
+  zmodemOverwriteListeners.delete(sessionId);
+  const pendingTimer = _mcpFlushTimers.get(sessionId);
   if (pendingTimer) {
     clearTimeout(pendingTimer);
-    _mcpFlushTimers.delete(payload.sessionId);
+    _mcpFlushTimers.delete(sessionId);
   }
-  _mcpLineBufs.delete(payload.sessionId); // clean up any held fragment
-  _mcpDroppingWrappedLine.delete(payload.sessionId);
+  _mcpLineBufs.delete(sessionId); // clean up any held fragment
+  _mcpDroppingWrappedLine.delete(sessionId);
 });
 
 // Chain progress events (for jump host connections)

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -253,7 +253,6 @@ ipcRenderer.on("netcatty:exit", (_event, payload) => {
   }
   clearTerminalDataBacklog({ terminalDataBacklog }, payload.sessionId);
   terminalOutputPorts.closeSession(payload.sessionId);
-  exitListeners.delete(payload.sessionId);
   telnetAutoLoginCompleteListeners.delete(payload.sessionId);
   telnetAutoLoginCancelledListeners.delete(payload.sessionId);
   telnetEchoModeListeners.delete(payload.sessionId);

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -313,7 +313,11 @@ function createPreloadApi(ctx) {
   onSessionExit: (sessionId, cb) => {
     if (!exitListeners.has(sessionId)) exitListeners.set(sessionId, new Set());
     exitListeners.get(sessionId).add(cb);
-    return () => exitListeners.get(sessionId)?.delete(cb);
+    return () => {
+      const set = exitListeners.get(sessionId);
+      set?.delete(cb);
+      if (set?.size === 0) exitListeners.delete(sessionId);
+    };
   },
   onTelnetAutoLoginComplete: (sessionId, cb) => {
     if (!telnetAutoLoginCompleteListeners.has(sessionId)) {

--- a/electron/preload/terminalDataBacklog.cjs
+++ b/electron/preload/terminalDataBacklog.cjs
@@ -79,7 +79,14 @@ function clearTerminalDataSession({
   terminalDataBacklog?.clear?.(sessionId);
 }
 
+function clearTerminalDataBacklog({
+  terminalDataBacklog,
+}, sessionId) {
+  terminalDataBacklog?.clear?.(sessionId);
+}
+
 module.exports = {
+  clearTerminalDataBacklog,
   createTerminalDataBacklog,
   createTerminalDataDispatcher,
   clearTerminalDataSession,

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -3,10 +3,77 @@ const test = require("node:test");
 
 const { createPreloadApi } = require("./preload/api.cjs");
 const {
+  clearTerminalDataBacklog,
   clearTerminalDataSession,
   createTerminalDataBacklog,
   createTerminalDataDispatcher,
 } = require("./preload/terminalDataBacklog.cjs");
+
+function loadPreloadWithFakeElectron() {
+  const handlers = new Map();
+  let exposedApi = null;
+  const fakeElectron = {
+    ipcRenderer: {
+      on(channel, handler) {
+        handlers.set(channel, handler);
+      },
+      send() {},
+      async invoke(channel, payload) {
+        if (channel === "netcatty:local:start") {
+          return { sessionId: payload?.sessionId };
+        }
+        return null;
+      },
+    },
+    contextBridge: {
+      exposeInMainWorld(_name, value) {
+        exposedApi = value;
+      },
+    },
+    webUtils: {
+      getPathForFile(file) {
+        return file?.path ?? "";
+      },
+    },
+  };
+
+  const electronPath = require.resolve("electron");
+  const preloadPath = require.resolve("./preload.cjs");
+  const previousElectron = require.cache[electronPath];
+  const previousWindow = global.window;
+
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: fakeElectron,
+  };
+  delete require.cache[preloadPath];
+  global.window = {
+    location: { origin: "app://netcatty" },
+    netcatty: undefined,
+  };
+
+  require(preloadPath);
+
+  return {
+    api: exposedApi,
+    handlers,
+    cleanup() {
+      delete require.cache[preloadPath];
+      if (previousElectron) {
+        require.cache[electronPath] = previousElectron;
+      } else {
+        delete require.cache[electronPath];
+      }
+      if (previousWindow === undefined) {
+        delete global.window;
+      } else {
+        global.window = previousWindow;
+      }
+    },
+  };
+}
 
 test("stores early terminal data until the listener is registered", () => {
   const backlog = createTerminalDataBacklog();
@@ -205,6 +272,56 @@ test("clearTerminalDataSession drops listener and backlog state together", () =>
   assert.equal(dataListeners.has("session-1"), false);
   assert.equal(displayDataListeners.has("session-1"), false);
   assert.equal(terminalDataBacklog.take("session-1"), "");
+});
+
+test("clearTerminalDataBacklog preserves live display listeners for reconnect", () => {
+  const listener = () => {};
+  const dataListeners = new Map([
+    ["session-1", new Set([listener])],
+  ]);
+  const displayDataListeners = new Map([
+    ["session-1", new Set([listener])],
+  ]);
+  const terminalDataBacklog = createTerminalDataBacklog();
+  terminalDataBacklog.append("session-1", "pending");
+
+  clearTerminalDataBacklog({ terminalDataBacklog }, "session-1");
+
+  assert.equal(dataListeners.get("session-1")?.has(listener), true);
+  assert.equal(displayDataListeners.get("session-1")?.has(listener), true);
+  assert.equal(terminalDataBacklog.take("session-1"), "");
+});
+
+test("backend exit preserves live display listener for same-id reconnect", async () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const received = [];
+    preload.api.onSessionData("session-1", (chunk) => {
+      received.push(chunk);
+    }, { replayBacklog: true });
+
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "before exit",
+    });
+    preload.handlers.get("netcatty:exit")?.({}, {
+      sessionId: "session-1",
+      reason: "closed",
+    });
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "dropped while closed",
+    });
+    await preload.api.startLocalSession({ sessionId: "session-1" });
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "after reconnect",
+    });
+
+    assert.deepEqual(received, ["before exit", "after reconnect"]);
+  } finally {
+    preload.cleanup();
+  }
 });
 
 test("closeSession clears terminal data state and marks the session closed", () => {

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -337,6 +337,37 @@ test("backend exit preserves live listeners for same-id reconnect", async () => 
   }
 });
 
+test("backend exit after explicit close still cleans per-session listeners", () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const zmodemEvents = [];
+    const overwriteRequests = [];
+    preload.api.onZmodemEvent("session-1", (evt) => {
+      zmodemEvents.push(evt.type);
+    });
+    preload.api.onZmodemOverwriteRequest("session-1", (payload) => {
+      overwriteRequests.push(payload.sessionId);
+    });
+
+    preload.api.closeSession("session-1");
+    preload.handlers.get("netcatty:exit")?.({}, {
+      sessionId: "session-1",
+      reason: "closed",
+    });
+    preload.handlers.get("netcatty:zmodem:detect")?.({}, {
+      sessionId: "session-1",
+    });
+    preload.handlers.get("netcatty:zmodem:overwrite-request")?.({}, {
+      sessionId: "session-1",
+    });
+
+    assert.deepEqual(zmodemEvents, []);
+    assert.deepEqual(overwriteRequests, []);
+  } finally {
+    preload.cleanup();
+  }
+});
+
 test("onSessionExit unsubscribe removes empty listener set", () => {
   const exitListeners = new Map();
   const api = createPreloadApi({

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -312,6 +312,10 @@ test("backend exit preserves live listeners for same-id reconnect", async () => 
       sessionId: "session-1",
       reason: "closed",
     });
+    preload.handlers.get("netcatty:exit")?.({}, {
+      sessionId: "session-1",
+      reason: "duplicate-closed",
+    });
     preload.handlers.get("netcatty:data")?.({}, {
       sessionId: "session-1",
       data: "dropped while closed",

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -292,13 +292,17 @@ test("clearTerminalDataBacklog preserves live display listeners for reconnect", 
   assert.equal(terminalDataBacklog.take("session-1"), "");
 });
 
-test("backend exit preserves live display listener for same-id reconnect", async () => {
+test("backend exit preserves live listeners for same-id reconnect", async () => {
   const preload = loadPreloadWithFakeElectron();
   try {
     const received = [];
+    const exits = [];
     preload.api.onSessionData("session-1", (chunk) => {
       received.push(chunk);
     }, { replayBacklog: true });
+    preload.api.onSessionExit("session-1", (evt) => {
+      exits.push(evt.reason);
+    });
 
     preload.handlers.get("netcatty:data")?.({}, {
       sessionId: "session-1",
@@ -317,11 +321,42 @@ test("backend exit preserves live display listener for same-id reconnect", async
       sessionId: "session-1",
       data: "after reconnect",
     });
+    preload.handlers.get("netcatty:exit")?.({}, {
+      sessionId: "session-1",
+      reason: "closed-again",
+    });
 
     assert.deepEqual(received, ["before exit", "after reconnect"]);
+    assert.deepEqual(exits, ["closed", "closed-again"]);
   } finally {
     preload.cleanup();
   }
+});
+
+test("onSessionExit unsubscribe removes empty listener set", () => {
+  const exitListeners = new Map();
+  const api = createPreloadApi({
+    ipcRenderer: {
+      invoke() {},
+      send() {},
+      on() {},
+      removeListener() {},
+    },
+    os: {
+      release: () => "10.0.19045",
+    },
+    dataListeners: new Map(),
+    displayDataListeners: new Map(),
+    terminalDataBacklog: createTerminalDataBacklog(),
+    exitListeners,
+  });
+
+  const off = api.onSessionExit("session-1", () => {});
+  assert.equal(exitListeners.has("session-1"), true);
+
+  off();
+
+  assert.equal(exitListeners.has("session-1"), false);
 });
 
 test("closeSession clears terminal data state and marks the session closed", () => {


### PR DESCRIPTION
Fixes #1201

## What changed
- Preserve the live terminal display listener when a backend session exits, so reconnecting the same terminal can keep using the existing output history.
- Keep dropping late output while the session is closed, then resume delivery after reconnect starts.
- Preserve full cleanup for explicit terminal close.

## Validation
- `node --test electron/preloadDataBacklog.test.cjs electron/preloadTerminalOutputPorts.test.cjs`
- `node --test --import tsx components/terminal/restoredSessionGate.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/createTerminalSessionStarters.test.ts`
- `npm run lint -- --quiet`
- `npm run build`
- `npm test`
- Two local multi-agent review rounds ended clean.