### PR TITLE
Fix ZMODEM transfer progress events

### DIFF
--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -595,10 +595,10 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                 filename={zmodem.filename}
                 transferred={zmodem.transferred}
                 total={zmodem.total}
+                bytesPerSecond={zmodem.bytesPerSecond}
                 fileIndex={zmodem.fileIndex}
                 fileCount={zmodem.fileCount}
                 finalizing={zmodem.finalizing}
-                bytesPerSecond={zmodem.bytesPerSecond}
                 onCancel={zmodem.cancel}
               />
             </div>

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -41,18 +41,25 @@ type SelectionOverlayPosition = {
   top: number;
 } | null;
 
-type ZmodemToast =
-  | { kind: 'error'; message: string; title: string }
-  | { kind: 'success'; message: string; title: string }
-  | null;
-
-export function resolveZmodemTransferToast(zmodem: {
+type ZmodemToastInput = {
   active?: boolean;
   completed?: boolean;
   error?: string | null;
   filename?: string | null;
   transferType?: 'upload' | 'download' | null;
-}): ZmodemToast {
+};
+
+type ZmodemToast =
+  | { kind: 'error'; message: string; title: string }
+  | { kind: 'success'; message: string; title: string }
+  | null;
+
+type ZmodemToastApi = {
+  success: (message: string, title?: string) => void;
+  error: (message: string, title?: string) => void;
+};
+
+export function resolveZmodemTransferToast(zmodem: ZmodemToastInput): ZmodemToast {
   if (zmodem.active) return null;
   if (zmodem.error) {
     return { kind: 'error', message: zmodem.error, title: 'ZMODEM' };
@@ -66,6 +73,26 @@ export function resolveZmodemTransferToast(zmodem: {
       : 'Transfer completed';
   const message = zmodem.filename ? `${action}: ${zmodem.filename}` : action;
   return { kind: 'success', message, title: 'ZMODEM' };
+}
+
+export function applyZmodemTransferToast(
+  zmodem: ZmodemToastInput,
+  toastedRef: { current: boolean },
+  toast: ZmodemToastApi,
+): void {
+  if (zmodem.active) {
+    toastedRef.current = false;
+    return;
+  }
+  if (toastedRef.current) return;
+  const zmodemToast = resolveZmodemTransferToast(zmodem);
+  if (!zmodemToast) return;
+  toastedRef.current = true;
+  if (zmodemToast.kind === 'error') {
+    toast.error(zmodemToast.message, zmodemToast.title);
+  } else {
+    toast.success(zmodemToast.message, zmodemToast.title);
+  }
 }
 
 const areSelectionOverlayPositionsEqual = (
@@ -228,19 +255,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   }, [isVisible]);
 
   useEffect(() => {
-    if (zmodem.active) {
-      zmodemToastedRef.current = false;
-      return;
-    }
-    if (zmodemToastedRef.current) return;
-    const zmodemToast = resolveZmodemTransferToast(zmodem);
-    if (!zmodemToast) return;
-    zmodemToastedRef.current = true;
-    if (zmodemToast.kind === 'error') {
-      toast.error(zmodemToast.message, zmodemToast.title);
-    } else {
-      toast.success(zmodemToast.message, zmodemToast.title);
-    }
+    applyZmodemTransferToast(zmodem, zmodemToastedRef, toast);
   }, [zmodem.active, zmodem.completed, zmodem.error, zmodem.filename, zmodem.transferType]);
 
 

--- a/components/terminal/useZmodemTransfer.test.ts
+++ b/components/terminal/useZmodemTransfer.test.ts
@@ -5,7 +5,7 @@ import {
   reduceZmodemTransferState,
   type ZmodemTransferState,
 } from "./hooks/useZmodemTransfer.ts";
-import { resolveZmodemTransferToast } from "./useTerminalEffects.ts";
+import { applyZmodemTransferToast, resolveZmodemTransferToast } from "./useTerminalEffects.ts";
 
 const initialState: ZmodemTransferState = {
   active: false,
@@ -143,4 +143,58 @@ test("ZMODEM progress clears old speed when the next file starts", () => {
 
   assert.equal(secondFileStarted.filename, "second.bin");
   assert.equal(secondFileStarted.bytesPerSecond, null);
+});
+
+test("ZMODEM toast application calls success and error once per transfer", () => {
+  const successCalls: Array<[string, string | undefined]> = [];
+  const errorCalls: Array<[string, string | undefined]> = [];
+  const toast = {
+    success: (message: string, title?: string) => successCalls.push([message, title]),
+    error: (message: string, title?: string) => errorCalls.push([message, title]),
+  };
+  const toastedRef = { current: false };
+
+  applyZmodemTransferToast({
+    active: false,
+    completed: true,
+    transferType: "upload",
+    filename: "large.bin",
+    error: null,
+  }, toastedRef, toast);
+
+  assert.deepEqual(successCalls, [["Uploaded: large.bin", "ZMODEM"]]);
+  assert.deepEqual(errorCalls, []);
+  assert.equal(toastedRef.current, true);
+
+  applyZmodemTransferToast({
+    active: false,
+    completed: true,
+    transferType: "upload",
+    filename: "large.bin",
+    error: null,
+  }, toastedRef, toast);
+
+  assert.deepEqual(successCalls, [["Uploaded: large.bin", "ZMODEM"]]);
+  assert.deepEqual(errorCalls, []);
+
+  applyZmodemTransferToast({
+    active: true,
+    completed: false,
+    transferType: "download",
+    filename: null,
+    error: null,
+  }, toastedRef, toast);
+  assert.equal(toastedRef.current, false);
+
+  applyZmodemTransferToast({
+    active: false,
+    completed: false,
+    transferType: "download",
+    filename: "large.bin",
+    error: "Remote closed the transfer",
+  }, toastedRef, toast);
+
+  assert.deepEqual(successCalls, [["Uploaded: large.bin", "ZMODEM"]]);
+  assert.deepEqual(errorCalls, [["Remote closed the transfer", "ZMODEM"]]);
+  assert.equal(toastedRef.current, true);
 });

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -187,7 +187,20 @@ function createTerminalWorkerManager(options = {}) {
     }
   }
 
-  function handleMessage(message) {
+  function unwrapMessageEvent(eventOrMessage) {
+    if (
+      eventOrMessage &&
+      typeof eventOrMessage === "object" &&
+      !("kind" in eventOrMessage) &&
+      "data" in eventOrMessage
+    ) {
+      return eventOrMessage.data;
+    }
+    return eventOrMessage;
+  }
+
+  function handleMessage(eventOrMessage) {
+    const message = unwrapMessageEvent(eventOrMessage);
     if (!message || typeof message !== "object") return;
     if (message.kind === "response") {
       const entry = pending.get(message.requestId);

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -746,6 +746,60 @@ test("worker renderer events are forwarded to their original webContents", () =>
   ]);
 });
 
+test("worker renderer events wrapped in MessageEvent data are forwarded", () => {
+  const child = new FakeChild();
+  const forwarded = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        return child;
+      },
+    },
+    electronModule: {
+      webContents: {
+        fromId(id) {
+          return {
+            send(channel, payload) {
+              forwarded.push({ id, channel, payload });
+            },
+          };
+        },
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  manager.ensureStarted();
+  child.emit("message", {
+    data: {
+      kind: "renderer-event",
+      webContentsId: 7,
+      channel: "netcatty:zmodem:progress",
+      payload: {
+        sessionId: "session-1",
+        filename: "large.bin",
+        transferred: 1024,
+        total: 2048,
+        transferType: "download",
+      },
+    },
+  });
+
+  assert.deepEqual(forwarded, [
+    {
+      id: 7,
+      channel: "netcatty:zmodem:progress",
+      payload: {
+        sessionId: "session-1",
+        filename: "large.bin",
+        transferred: 1024,
+        total: 2048,
+        transferType: "download",
+      },
+    },
+  ]);
+});
+
 test("worker exit events close the session output route", () => {
   const child = new FakeChild();
   const closed = [];


### PR DESCRIPTION
Fixes #1824.

## Summary
- Restores ZMODEM progress, completion, and failure updates when terminal events come through the worker.
- Keeps transfer speed and completion/failure notifications visible in the terminal UI.
- Adds regression coverage for worker event forwarding and ZMODEM progress/toast behavior.

## Validation
- `node --test --import tsx electron/bridges/terminalWorkerManager.test.cjs components/terminal/useZmodemTransfer.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`

## Review
- Ran local multi-agent review, fixed the test coverage finding, and re-reviewed until clean.
- Resolved conflicts with latest `main` before merge.