### PR TITLE
Fix Telnet identity credential resolution

### DIFF
--- a/components/VaultView.tsx
+++ b/components/VaultView.tsx
@@ -631,11 +631,11 @@ const VaultViewInner: React.FC<VaultViewProps> = ({
       : undefined;
 
     const username = isTelnet
-      ? resolveTelnetUsername(effective)
+      ? resolveTelnetUsername(effective, identity)
       : (identity?.username?.trim() || effective.username?.trim());
 
     const rawPassword = isTelnet
-      ? resolveTelnetPassword(effective)
+      ? resolveTelnetPassword(effective, identity)
       : (identity?.password || effective.password);
     const password = sanitizeCredentialValue(rawPassword);
 

--- a/components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts
@@ -237,6 +237,91 @@ test("startTelnet preserves an explicitly cleared telnet password", async () => 
   assert.equal(capturedOptions.password, "");
 });
 
+test("startTelnet uses a referenced identity when telnet credentials are unset", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "telnet-session";
+    },
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = {
+    host: {
+      id: "host-1",
+      label: "Example",
+      hostname: "example.test",
+      username: "ssh-user",
+      password: "ssh-password",
+      identityId: "identity-1",
+      telnetUsername: undefined,
+      telnetPassword: undefined,
+      telnetPort: 2323,
+    },
+    identities: [{
+      id: "identity-1",
+      label: "Telnet Identity",
+      username: "identity-user",
+      authMethod: "password",
+      password: "identity-password",
+      created: 1,
+    }],
+    keys: [],
+    resolvedChainHosts: [],
+    sessionId: "session-1",
+    terminalSettings: {},
+    terminalBackend,
+    sessionRef: { current: null },
+    hasConnectedRef: { current: false },
+    hasRunStartupCommandRef: { current: false },
+    disposeDataRef: { current: null },
+    disposeExitRef: { current: null },
+    fitAddonRef: { current: null },
+    serializeAddonRef: { current: null },
+    pendingAuthRef: { current: null },
+    updateStatus: noop,
+    setStatus: noop,
+    setError: noop,
+    setNeedsAuth: noop,
+    setAuthRetryMessage: noop,
+    setAuthPassword: noop,
+    setProgressLogs: noop,
+    setProgressValue: noop,
+    setChainProgress: noop,
+  };
+
+  const term = {
+    cols: 120,
+    rows: 32,
+    write: noop,
+    writeln: noop,
+    scrollToBottom: noop,
+  };
+
+  await createTerminalSessionStarters(ctx as never).startTelnet(term as never);
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions.username, "identity-user");
+  assert.equal(capturedOptions.password, "identity-password");
+});
+
 test("startTelnet marks the session connected before the server sends output", async () => {
   let status = "connecting";
   let progressValue = 0;

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -654,9 +654,12 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       clearTelnetEchoMode();
     };
     try {
+      const resolvedTelnetIdentity = ctx.host.identityId
+        ? resolveHostAuth({ host: ctx.host, keys: ctx.keys, identities: ctx.identities }).identity
+        : undefined;
       const telnetEnv = buildTermEnv(ctx.host, ctx.terminalSettings);
-      const telnetUsername = resolveTelnetUsername(ctx.host);
-      const rawTelnetPassword = resolveTelnetPassword(ctx.host);
+      const telnetUsername = resolveTelnetUsername(ctx.host, resolvedTelnetIdentity);
+      const rawTelnetPassword = resolveTelnetPassword(ctx.host, resolvedTelnetIdentity);
       const telnetPassword = sanitizeCredentialValue(rawTelnetPassword);
       const hasTelnetPasswordForAutoLogin = rawTelnetPassword !== undefined;
       if (isEncryptedCredentialPlaceholder(rawTelnetPassword)) {

--- a/domain/host.test.ts
+++ b/domain/host.test.ts
@@ -78,7 +78,7 @@ test("telnet credential helpers preserve explicitly cleared values", () => {
   assert.equal(resolveTelnetPassword(host), "");
 });
 
-test("telnet credential helpers fall back only when telnet fields are unset", () => {
+test("telnet credential helpers do not fall back to SSH credentials when telnet fields are unset", () => {
   const host = makeHost({
     username: " ssh-user ",
     password: "ssh-password",
@@ -86,8 +86,24 @@ test("telnet credential helpers fall back only when telnet fields are unset", ()
     telnetPassword: undefined,
   });
 
-  assert.equal(resolveTelnetUsername(host), "ssh-user");
-  assert.equal(resolveTelnetPassword(host), "ssh-password");
+  assert.equal(resolveTelnetUsername(host), undefined);
+  assert.equal(resolveTelnetPassword(host), undefined);
+});
+
+test("telnet credential helpers can resolve a referenced identity", () => {
+  const host = makeHost({
+    username: " ssh-user ",
+    password: "ssh-password",
+    telnetUsername: undefined,
+    telnetPassword: undefined,
+  });
+  const identity = {
+    username: " telnet-identity ",
+    password: "identity-password",
+  };
+
+  assert.equal(resolveTelnetUsername(host, identity), "telnet-identity");
+  assert.equal(resolveTelnetPassword(host, identity), "identity-password");
 });
 
 test("normalizePrimaryTelnetState enables primary telnet without materializing a port", () => {

--- a/domain/host.ts
+++ b/domain/host.ts
@@ -1,4 +1,4 @@
-import { Host, Snippet, TerminalSettings } from './models';
+import { Host, Identity, Snippet, TerminalSettings } from './models';
 import { sanitizeHostIconFields } from './hostIcon';
 import { migrateHostConnectScriptIds } from './hostConnectScripts.ts';
 import { migrateDeprecatedFontOverride } from '../infrastructure/config/fonts';
@@ -239,18 +239,20 @@ export const formatHostPort = (hostname: string, port?: number | null): string =
 };
 
 export const resolveTelnetUsername = (
-  host: Pick<Host, 'telnetUsername' | 'username'>,
+  host: Pick<Host, 'telnetUsername'>,
+  identity?: Pick<Identity, 'username'>,
 ): string | undefined =>
   host.telnetUsername !== undefined
     ? host.telnetUsername.trim()
-    : host.username?.trim();
+    : identity?.username?.trim();
 
 export const resolveTelnetPassword = (
-  host: Pick<Host, 'telnetPassword' | 'password'>,
+  host: Pick<Host, 'telnetPassword'>,
+  identity?: Pick<Identity, 'password'>,
 ): string | undefined =>
   host.telnetPassword !== undefined
     ? host.telnetPassword
-    : host.password;
+    : identity?.password;
 
 export const resolveTelnetPort = (
   host: Pick<Host, 'protocol' | 'telnetPort' | 'port'>,


### PR DESCRIPTION
## Summary
- Stop Telnet from falling back to SSH username/password when Telnet credentials are unset
- Let Telnet use the selected Keychain identity username/password
- Update Telnet startup and credential-copy tests

## Verification
- node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.test.ts components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts domain/host.test.ts application/AppHandlers.connect.test.ts
- npx eslint domain/host.ts domain/host.test.ts components/terminal/runtime/createTerminalSessionStarters.ts components/terminal/runtime/createTerminalSessionStarters.telnet.test.ts components/VaultView.tsx
- npm run build