### PR TITLE
fix(snippets): preserve multi-line shell commands when auto-running

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1752,7 +1752,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     if (!term || !id) return;
 
     let data = normalizeLineEndings(command);
-    const lineDelayMs = shouldDelayAutoRunSnippetInput(data, { noAutoRun })
+    const lineDelayMs = shouldDelayAutoRunSnippetInput(data, { noAutoRun, protocol: host.protocol })
       ? AUTO_RUN_SNIPPET_LINE_DELAY_MS
       : undefined;
     const isMultiLine = data.includes('\n');

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -1353,10 +1353,14 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
 
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     if (!session || !canUseDirectSessionWriteFallback(session)) return;
+    const sessionHost = sessionHostsMapRef.current.get(sessionId);
 
     let data = normalizeLineEndings(command);
     if (!noAutoRun) data = `${data}\r`;
-    const lineDelayMs = shouldDelayAutoRunSnippetInput(data, { noAutoRun })
+    const lineDelayMs = shouldDelayAutoRunSnippetInput(data, {
+      noAutoRun,
+      protocol: sessionHost?.protocol ?? session.protocol,
+    })
       ? AUTO_RUN_SNIPPET_LINE_DELAY_MS
       : undefined;
     terminalBackend.writeToSession(sessionId, data, {

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -6,7 +6,7 @@ import {
   getMissingChainHostIds,
 } from "./createTerminalSessionStarters";
 import { createPromptLineBreakState } from "./promptLineBreak";
-import { resolveStartupCommand } from "./terminalStartupCommands";
+import { resolveStartupCommand, scheduleStartupCommand } from "./terminalStartupCommands";
 import { pasteTextIntoTerminal } from "./terminalUserPaste";
 
 const noop = () => undefined;
@@ -2588,4 +2588,78 @@ test("startSSH sends local identity file paths with saved passwords for key auth
   assert.ok(capturedOptions);
   assert.equal(capturedOptions.password, "saved-password");
   assert.deepEqual(capturedOptions.identityFilePaths, ["/Users/alice/.ssh/id_ed25519"]);
+});
+
+test("scheduleStartupCommand sends shell multi-line snippets in one write", async () => {
+  const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
+  const executedCommands: string[] = [];
+  const terminalBackend = {
+    writeToSession: (id: string, data: string, options?: { automated?: boolean }) => {
+      sessionWrites.push({ id, data, automated: options?.automated });
+    },
+  };
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "Target",
+      hostname: "target.example.test",
+      username: "alice",
+      protocol: "ssh",
+    },
+    terminalSettings: { startupCommandDelayMs: 0 },
+    terminalBackend,
+    startupCommand: 'sudo apt install gconf2-common -y\necho "123456"',
+    sessionRef: { current: "ssh-session" },
+    promptLineBreakStateRef: undefined,
+    onCommandExecuted: (command: string) => {
+      executedCommands.push(command);
+    },
+  });
+
+  const cancel = scheduleStartupCommand(ctx as never, createTermStub() as never, "ssh-session");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(typeof cancel, "function");
+  assert.deepEqual(sessionWrites, [{
+    id: "ssh-session",
+    data: 'sudo apt install gconf2-common -y\necho "123456"\r',
+    automated: true,
+  }]);
+  assert.deepEqual(executedCommands, [
+    "sudo apt install gconf2-common -y",
+    'echo "123456"',
+  ]);
+});
+
+test("scheduleStartupCommand still sequences telnet multi-line startup commands", async () => {
+  const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
+  const terminalBackend = {
+    writeToSession: (id: string, data: string, options?: { automated?: boolean }) => {
+      sessionWrites.push({ id, data, automated: options?.automated });
+    },
+  };
+  const ctx = createStarterContext({
+    host: {
+      id: "host-1",
+      label: "Target",
+      hostname: "target.example.test",
+      username: "alice",
+      protocol: "telnet",
+    },
+    terminalSettings: { startupCommandDelayMs: 0 },
+    terminalBackend,
+    startupCommand: "first cmd\nsecond cmd",
+    sessionRef: { current: "telnet-session" },
+    promptLineBreakStateRef: undefined,
+  });
+
+  scheduleStartupCommand(ctx as never, createTermStub() as never, "telnet-session");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(sessionWrites, [{ id: "telnet-session", data: "first cmd\r", automated: true }]);
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(sessionWrites, [
+    { id: "telnet-session", data: "first cmd\r", automated: true },
+    { id: "telnet-session", data: "second cmd\r", automated: true },
+  ]);
 });

--- a/components/terminal/runtime/terminalStartupCommands.ts
+++ b/components/terminal/runtime/terminalStartupCommands.ts
@@ -1,4 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { normalizeLineEndings } from "../../../lib/utils";
 import { markPromptLineBreakCommandPending } from "./promptLineBreak";
 import type { TerminalSessionStartersContext } from "./createTerminalSessionStarters.types";
 
@@ -73,15 +74,39 @@ export const scheduleStartupCommand = (
     };
   }
 
-  // Auto-run: send each non-empty line in sequence, waiting delayMs before the
-  // first and between each, so a line runs inside any sub-shell opened by a
-  // previous line (e.g. `sudo -i` then `alias ...`).
   const lines = splitStartupCommandLines(commandToRun);
   if (lines.length === 0) {
     onSettled?.();
     return undefined;
   }
 
+  const isTelnetStartup = ctx.host.protocol === "telnet";
+
+  // Shell sessions: send all lines in one write so the shell can queue commands
+  // while a long-running foreground job is active (issue #1836).
+  if (!isTelnetStartup) {
+    timeoutId = setTimeout(() => {
+      if (cancelled) return;
+      if (!sessionIsCurrent()) {
+        onSettled?.();
+        return;
+      }
+      const data = `${normalizeLineEndings(commandToRun)}\r`;
+      ctx.terminalBackend.writeToSession(ctx.sessionRef.current, data, { automated: true });
+      for (const line of lines) {
+        markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, line);
+        ctx.onCommandExecuted?.(line, ctx.host.id, ctx.host.label, ctx.sessionId);
+      }
+      onSettled?.();
+    }, delayMs);
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }
+
+  // Telnet: send each non-empty line in sequence, waiting delayMs before the
+  // first and between each, so prompts can respond between steps.
   let index = 0;
   const runNext = () => {
     if (cancelled) return;

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -262,9 +262,13 @@ export function shouldShowTerminalConnectionDialog({
 
 export function shouldDelayAutoRunSnippetInput(
   data: string,
-  opts: { noAutoRun?: boolean },
+  opts: { noAutoRun?: boolean; protocol?: Host["protocol"] },
 ): boolean {
   if (opts.noAutoRun) return false;
+  // Telnet login sequences need a pause between lines so prompts can respond.
+  // Shell sessions should paste all lines at once so bash can queue commands
+  // (e.g. a long-running apt install followed by echo).
+  if (opts.protocol !== "telnet") return false;
   const normalized = normalizeLineEndings(String(data ?? "")).replace(/\r/g, "\n");
   const withoutSubmitEnter = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
   return withoutSubmitEnter.includes("\n");

--- a/components/terminalHelpers.test.ts
+++ b/components/terminalHelpers.test.ts
@@ -129,10 +129,20 @@ test("connection reuse hides connecting dialog only while reuse is still possibl
   );
 });
 
-test("auto-run snippets delay multi-line input but paste-only snippets do not", () => {
+test("auto-run snippets delay multi-line telnet input but paste-only snippets do not", () => {
   assert.equal(AUTO_RUN_SNIPPET_LINE_DELAY_MS > 0, true);
-  assert.equal(shouldDelayAutoRunSnippetInput("tthdf 0 2323\nadmin\ntest123", { noAutoRun: false }), true);
-  assert.equal(shouldDelayAutoRunSnippetInput("tthdf 0 2323\nadmin\ntest123", { noAutoRun: true }), false);
-  assert.equal(shouldDelayAutoRunSnippetInput("show version", { noAutoRun: false }), false);
-  assert.equal(shouldDelayAutoRunSnippetInput("show version\r", { noAutoRun: false }), false);
+  assert.equal(
+    shouldDelayAutoRunSnippetInput("tthdf 0 2323\nadmin\ntest123", { noAutoRun: false, protocol: "telnet" }),
+    true,
+  );
+  assert.equal(
+    shouldDelayAutoRunSnippetInput("sudo apt install -y\necho done", { noAutoRun: false, protocol: "ssh" }),
+    false,
+  );
+  assert.equal(
+    shouldDelayAutoRunSnippetInput("tthdf 0 2323\nadmin\ntest123", { noAutoRun: true, protocol: "telnet" }),
+    false,
+  );
+  assert.equal(shouldDelayAutoRunSnippetInput("show version", { noAutoRun: false, protocol: "telnet" }), false);
+  assert.equal(shouldDelayAutoRunSnippetInput("show version\r", { noAutoRun: false, protocol: "telnet" }), false);
 });


### PR DESCRIPTION
## Summary

Fixes #1836

Multi-line snippet auto-run used a fixed inter-line delay for every connection type. When the first command was still running (e.g. `sudo apt install ...`), later lines were injected into the foreground process instead of being queued by the shell, so trailing commands like `echo "123456"` were lost.

- **Shell sessions (SSH/local/etc.)**: send multi-line startup snippets in one write so the shell can queue commands, matching manual paste behavior.
- **Connected terminals**: only use inter-line delays for telnet prompt sequences; SSH sessions use bracketed-paste batching again.
- **Telnet**: keep the existing line-by-line delay for login prompt sequences.

## Test plan

- [x] `node --test --import tsx components/terminalHelpers.test.ts`
- [x] `node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.test.ts` (new regression tests for shell batch send + telnet sequencing)
- [ ] Manually run a two-line snippet (`sudo apt install ...` + `echo "123456"`) and confirm the second line executes after the first finishes