### PR TITLE
Show target address on SSH and telnet tabs

### DIFF
--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -127,6 +127,24 @@ test("session top tab label appends the target address for ssh sessions", () => 
   );
 });
 
+test("session top tab label treats missing protocol as ssh", () => {
+  assert.equal(
+    formatSessionTopTabLabel({
+      hostLabel: "prod-web",
+      hostname: "10.1.2.34",
+    }),
+    "prod-web · 10.1.2.34",
+  );
+  assert.equal(
+    formatSessionTopTabTooltip({
+      username: "root",
+      hostname: "10.1.2.34",
+      port: 22,
+    }),
+    "root@10.1.2.34:22",
+  );
+});
+
 test("session top tab label avoids duplicating the target address", () => {
   assert.equal(
     formatSessionTopTabLabel({

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -30,7 +30,11 @@ const {
   hasWorkspaceSessionDrag,
   isPointInsideRect,
 } = await import("../application/state/terminalDragData.ts");
-const { activateLogViewTab } = await import("./top-tabs/TopTabItems.tsx");
+const {
+  activateLogViewTab,
+  formatSessionTopTabLabel,
+  formatSessionTopTabTooltip,
+} = await import("./top-tabs/TopTabItems.tsx");
 const { activeTabStore } = await import("../application/state/activeTabStore.ts");
 const indexCss = readFileSync(new URL("../index.css", import.meta.url), "utf8");
 const topTabsSource = readFileSync(new URL("./TopTabs.tsx", import.meta.url), "utf8");
@@ -109,6 +113,61 @@ test("SessionTabIcon checks custom host icon appearance before distro logos", ()
   assert.ok(
     source.indexOf("resolveHostIconAppearance(host)") < source.indexOf("getEffectiveHostDistro(host)"),
     "custom host icon should be checked before distro fallback",
+  );
+});
+
+test("session top tab label appends the target address for ssh sessions", () => {
+  assert.equal(
+    formatSessionTopTabLabel({
+      hostLabel: "prod-web",
+      hostname: "10.1.2.34",
+      protocol: "ssh",
+    }),
+    "prod-web · 10.1.2.34",
+  );
+});
+
+test("session top tab label avoids duplicating the target address", () => {
+  assert.equal(
+    formatSessionTopTabLabel({
+      hostLabel: "10.1.2.34",
+      hostname: "10.1.2.34",
+      protocol: "ssh",
+    }),
+    "10.1.2.34",
+  );
+});
+
+test("session top tab tooltip includes username and port when present", () => {
+  assert.equal(
+    formatSessionTopTabTooltip({
+      username: "root",
+      hostname: "db.internal",
+      port: 2222,
+      protocol: "ssh",
+    }),
+    "root@db.internal:2222",
+  );
+});
+
+test("session top tab helpers ignore local and mosh sessions", () => {
+  assert.equal(
+    formatSessionTopTabLabel({
+      hostLabel: "Local shell",
+      hostname: "127.0.0.1",
+      protocol: "local",
+    }),
+    "Local shell",
+  );
+  assert.equal(
+    formatSessionTopTabTooltip({
+      username: "root",
+      hostname: "10.1.2.34",
+      port: 22,
+      protocol: "ssh",
+      moshEnabled: true,
+    }),
+    null,
   );
 });
 

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -168,10 +168,11 @@ export const sessionStatusDot = (status: TerminalSession['status'], hasActivity:
 const getSessionTopTabAddress = (
   session: Pick<TerminalSession, 'protocol' | 'hostname' | 'moshEnabled' | 'etEnabled'>,
 ): string | null => {
+  const protocol = session.protocol ?? 'ssh';
   if (
     session.moshEnabled
     || session.etEnabled
-    || (session.protocol !== 'ssh' && session.protocol !== 'telnet')
+    || (protocol !== 'ssh' && protocol !== 'telnet')
     || !session.hostname
   ) {
     return null;
@@ -646,19 +647,21 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
   );
 
   const tabTrigger = (
-    <ContextMenuTrigger asChild>
-      {addressTooltip ? (
-        <Tooltip>
-          <TooltipTrigger asChild>{tabBody}</TooltipTrigger>
-          <TooltipContent
-            sideOffset={6}
-            className="rounded-md border border-border/60 bg-popover/95 px-2.5 py-1.5 font-mono text-[11px] font-medium leading-none text-foreground shadow-lg supports-[backdrop-filter]:backdrop-blur-sm"
-          >
-            {addressTooltip}
-          </TooltipContent>
-        </Tooltip>
-      ) : tabBody}
-    </ContextMenuTrigger>
+    addressTooltip ? (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ContextMenuTrigger asChild>{tabBody}</ContextMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent
+          sideOffset={6}
+          className="rounded-md border border-border/60 bg-popover/95 px-2.5 py-1.5 font-mono text-[11px] font-medium leading-none text-foreground shadow-lg supports-[backdrop-filter]:backdrop-blur-sm"
+        >
+          {addressTooltip}
+        </TooltipContent>
+      </Tooltip>
+    ) : (
+      <ContextMenuTrigger asChild>{tabBody}</ContextMenuTrigger>
+    )
   );
 
   return (

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -165,6 +165,43 @@ export const sessionStatusDot = (status: TerminalSession['status'], hasActivity:
   );
 };
 
+const getSessionTopTabAddress = (
+  session: Pick<TerminalSession, 'protocol' | 'hostname' | 'moshEnabled' | 'etEnabled'>,
+): string | null => {
+  if (
+    session.moshEnabled
+    || session.etEnabled
+    || (session.protocol !== 'ssh' && session.protocol !== 'telnet')
+    || !session.hostname
+  ) {
+    return null;
+  }
+  return session.hostname;
+};
+
+export const formatSessionTopTabTooltip = (
+  session: Pick<TerminalSession, 'protocol' | 'hostname' | 'moshEnabled' | 'etEnabled' | 'username' | 'port'>,
+): string | null => {
+  const address = getSessionTopTabAddress(session);
+  if (!address) return null;
+  return `${session.username ? `${session.username}@` : ''}${address}${session.port ? `:${session.port}` : ''}`;
+};
+
+export const formatSessionTopTabLabel = (
+  session: Pick<
+    TerminalSession,
+    'customName' | 'hostLabel' | 'dynamicTitle' | 'codingCliProviderId' | 'protocol' | 'hostname' | 'moshEnabled' | 'etEnabled'
+  >,
+  dynamicTabTitleMode?: DynamicTabTitleMode,
+): string => {
+  const baseTitle = resolveSessionTabTitle(session, dynamicTabTitleMode);
+  const address = getSessionTopTabAddress(session);
+  if (!address) return baseTitle;
+  if (!baseTitle) return address;
+  if (baseTitle.trim() === address) return baseTitle;
+  return `${baseTitle} · ${address}`;
+};
+
 // Custom window controls for Windows/Linux (frameless window)
 export const WindowControls: React.FC = memo(() => {
   const { minimize, maximize, close, isMaximized: fetchIsMaximized } = useWindowControls();
@@ -536,88 +573,97 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
   const handleClick = useCallback(() => {
     activeTabStore.setActiveTabId(session.id);
   }, [session.id]);
-
-  // mosh/ET wrap SSH but use their own transports; we still want the tooltip
-  // off for them because the displayed address can differ from what's dialed.
-  const showAddressTooltip =
-    !session.moshEnabled
-    && !session.etEnabled
-    && (session.protocol === 'ssh' || session.protocol === 'telnet')
-    && Boolean(session.hostname);
-  const addressTooltip = showAddressTooltip
-    ? `${session.username ? `${session.username}@` : ''}${session.hostname}${session.port ? `:${session.port}` : ''}`
-    : null;
+  const addressTooltip = formatSessionTopTabTooltip(session);
+  const tabTitle = formatSessionTopTabLabel(session, dynamicTabTitleMode);
 
   const tabBody = (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
+    <div
+      data-tab-id={session.id}
+      data-tab-type="session"
+      data-state={isActive ? 'active' : 'inactive'}
+      onClick={handleClick}
+      onMouseDown={handleTabMiddleMouseDown}
+      onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseSession(session.id))}
+      draggable
+      onDragStart={(e) => onTabDragStart(e, session.id)}
+      onDragEnd={onTabDragEnd}
+      onDragOver={(e) => onTabDragOver(e, session.id)}
+      onDragLeave={onTabDragLeave}
+      onDrop={(e) => onTabDrop(e, session.id)}
+      className={cn(
+        "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
+        "transition-transform duration-150",
+        isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : "",
+        tabAnimationClass,
+      )}
+      style={{
+        ...shiftStyle,
+        backgroundColor: isActive
+          ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
+          : 'transparent',
+        color: isActive
+          ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
+          : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
+      }}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
+          e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.backgroundColor = 'transparent';
+          e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
+        }
+      }}
+    >
+      {showDropIndicatorBefore && isDraggingForReorder && (
         <div
-          data-tab-id={session.id}
-          data-tab-type="session"
-          data-state={isActive ? 'active' : 'inactive'}
-          onClick={handleClick}
-          onMouseDown={handleTabMiddleMouseDown}
-          onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseSession(session.id))}
-          draggable
-          onDragStart={(e) => onTabDragStart(e, session.id)}
-          onDragEnd={onTabDragEnd}
-          onDragOver={(e) => onTabDragOver(e, session.id)}
-          onDragLeave={onTabDragLeave}
-          onDrop={(e) => onTabDrop(e, session.id)}
-          className={cn(
-            "netcatty-tab relative h-7 pl-3 pr-2 min-w-[140px] max-w-[240px] rounded-t-md overflow-hidden text-xs font-semibold cursor-pointer flex items-center justify-between gap-2 app-no-drag flex-shrink-0",
-            "transition-transform duration-150",
-            isBeingDragged && isDraggingForReorder ? "opacity-40 scale-95" : "",
-            tabAnimationClass,
-          )}
-          style={{
-            ...shiftStyle,
-            backgroundColor: isActive
-              ? 'var(--top-tabs-active-bg, hsl(var(--background)))'
-              : 'transparent',
-            color: isActive
-              ? 'var(--top-tabs-fg, hsl(var(--foreground)))'
-              : 'var(--top-tabs-muted, hsl(var(--muted-foreground)))',
-          }}
-          onMouseEnter={(e) => {
-            if (!isActive) {
-              e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--top-tabs-active-bg, hsl(var(--background))) 40%, transparent)';
-              e.currentTarget.style.color = 'var(--top-tabs-fg, hsl(var(--foreground)))';
-            }
-          }}
-          onMouseLeave={(e) => {
-            if (!isActive) {
-              e.currentTarget.style.backgroundColor = 'transparent';
-              e.currentTarget.style.color = 'var(--top-tabs-muted, hsl(var(--muted-foreground)))';
-            }
-          }}
-        >
-          {showDropIndicatorBefore && isDraggingForReorder && (
-            <div
-              className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-            />
-          )}
-          {showDropIndicatorAfter && isDraggingForReorder && (
-            <div
-              className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
-              style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
-            />
-          )}
-          <div className="flex items-center gap-2 min-w-0 flex-1">
-            <SessionTabIcon host={host} session={session} isActive={isActive} protocol={session.protocol} shellIcon={session.localShellIcon} />
-            <span className="truncate">{resolveSessionTabTitle(session, dynamicTabTitleMode)}</span>
-            <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
-          </div>
-          <button
-            onClick={(e) => onCloseSession(session.id, e)}
-            className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
-            aria-label={t('tabs.closeSessionAria')}
+          className="absolute -left-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+          style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+        />
+      )}
+      {showDropIndicatorAfter && isDraggingForReorder && (
+        <div
+          className="absolute -right-0.5 top-1 bottom-1 w-0.5 rounded-full animate-pulse"
+          style={{ backgroundColor: 'var(--top-tabs-accent, hsl(var(--accent)))', boxShadow: '0 0 8px 2px color-mix(in srgb, var(--top-tabs-accent, hsl(var(--accent))) 50%, transparent)' }}
+        />
+      )}
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <SessionTabIcon host={host} session={session} isActive={isActive} protocol={session.protocol} shellIcon={session.localShellIcon} />
+        <span className="truncate">{tabTitle}</span>
+        <div className="flex-shrink-0">{sessionStatusDot(session.status, hasActivity)}</div>
+      </div>
+      <button
+        onClick={(e) => onCloseSession(session.id, e)}
+        className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
+        aria-label={t('tabs.closeSessionAria')}
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+
+  const tabTrigger = (
+    <ContextMenuTrigger asChild>
+      {addressTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{tabBody}</TooltipTrigger>
+          <TooltipContent
+            sideOffset={6}
+            className="rounded-md border border-border/60 bg-popover/95 px-2.5 py-1.5 font-mono text-[11px] font-medium leading-none text-foreground shadow-lg supports-[backdrop-filter]:backdrop-blur-sm"
           >
-            <X size={12} />
-          </button>
-        </div>
-      </ContextMenuTrigger>
+            {addressTooltip}
+          </TooltipContent>
+        </Tooltip>
+      ) : tabBody}
+    </ContextMenuTrigger>
+  );
+
+  return (
+    <ContextMenu>
+      {tabTrigger}
       <SessionTabContextMenuContent
         sessionId={session.id}
         onCloseSession={onCloseSession}
@@ -628,15 +674,6 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
         t={t}
       />
     </ContextMenu>
-  );
-
-  if (!addressTooltip) return tabBody;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{tabBody}</TooltipTrigger>
-      <TooltipContent>{addressTooltip}</TooltipContent>
-    </Tooltip>
   );
 });
 SessionTopTab.displayName = 'SessionTopTab';

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -537,7 +537,18 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
     activeTabStore.setActiveTabId(session.id);
   }, [session.id]);
 
-  return (
+  // mosh/ET wrap SSH but use their own transports; we still want the tooltip
+  // off for them because the displayed address can differ from what's dialed.
+  const showAddressTooltip =
+    !session.moshEnabled
+    && !session.etEnabled
+    && (session.protocol === 'ssh' || session.protocol === 'telnet')
+    && Boolean(session.hostname);
+  const addressTooltip = showAddressTooltip
+    ? `${session.username ? `${session.username}@` : ''}${session.hostname}${session.port ? `:${session.port}` : ''}`
+    : null;
+
+  const tabBody = (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
@@ -617,6 +628,15 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
         t={t}
       />
     </ContextMenu>
+  );
+
+  if (!addressTooltip) return tabBody;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{tabBody}</TooltipTrigger>
+      <TooltipContent>{addressTooltip}</TooltipContent>
+    </Tooltip>
   );
 });
 SessionTopTab.displayName = 'SessionTopTab';


### PR DESCRIPTION
## Summary

- Show the target hostname/IP directly in SSH and telnet session tab labels.
- Keep the full `user@host:port` connection string available in the tab hover tooltip.
- Restyle the session address tooltip so it appears as a lightweight connection info popover.

## Testing

- `node --test --import tsx components/TopTabs.test.ts domain/sessionTabTitle.test.ts`
- `npx eslint components/top-tabs/TopTabItems.tsx components/TopTabs.test.ts`

Closes #1677