### PR TITLE
[codex] Fix worker legacy SSH key exchange

### DIFF
--- a/electron/terminalWorker/process.cjs
+++ b/electron/terminalWorker/process.cjs
@@ -6,6 +6,10 @@ const { randomUUID } = require("node:crypto");
 const { createTerminalWorkerRuntime } = require("./runtime.cjs");
 const tempDirBridge = require("../bridges/tempDirBridge.cjs");
 
+// The worker owns SSH sessions in the default runtime path. Install the same
+// DH compatibility shim as the main process before loading ssh2-backed bridges.
+require("../bridges/boringSslDhCompat.cjs").installBoringSslDhCompat();
+
 function createWorkerSender(parentPort, webContentsId) {
   return {
     id: webContentsId,

--- a/electron/terminalWorker/process.test.cjs
+++ b/electron/terminalWorker/process.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const test = require("node:test");
 
 const {
@@ -33,6 +34,10 @@ test("normalizeParentPortMessage unwraps Electron utility process MessageEvent d
     normalizeParentPortMessage({ kind: "request" }),
     { kind: "request" },
   );
+});
+
+test("terminal worker installs DH compatibility before SSH bridges load", () => {
+  assert.equal(crypto.createDiffieHellmanGroup.__boringSslDhCompat, true);
 });
 
 test("ZMODEM upload selector resolves dialog results delivered as MessageEvent data", async () => {


### PR DESCRIPTION
## What changed

- Install the BoringSSL DH compatibility shim inside the terminal worker before any ssh2-backed bridge is loaded.
- Add a regression test that proves the worker entrypoint installs the shim.

## Root cause

Issue #1841 happens on the default terminal-worker path: the main process installed the compatibility shim that restores legacy DH groups such as `diffie-hellman-group1-sha1`, but the worker process loaded the SSH bridge without installing that shim first. A legacy Cisco SSH server can then fail key exchange even when "Allow Legacy Algorithms" is enabled.

## Validation

- `node --test electron/terminalWorker/process.test.cjs electron/bridges/sshAlgorithms.test.cjs`
- `node --test electron/bridges/terminalWorkerProxyRegistration.test.cjs`
- `npx eslint electron/terminalWorker/process.cjs electron/terminalWorker/process.test.cjs`
- `npm run build`
- Manual probe confirmed the worker loads with the shim installed and legacy KEX includes `diffie-hellman-group1-sha1`, `diffie-hellman-group14-sha1`, and `diffie-hellman-group-exchange-sha1`.

Fixes #1841
