### PR TITLE
[codex] Harden SSH compat entrypoints

### DIFF
--- a/electron/bridges/portForwardingBridge.cjs
+++ b/electron/bridges/portForwardingBridge.cjs
@@ -4,6 +4,7 @@
  */
 
 const net = require("node:net");
+require("./boringSslDhCompat.cjs").installBoringSslDhCompat();
 const { Client: SSHClient } = require("ssh2");
 const { NetcattyAgent } = require("./netcattyAgent.cjs");
 const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");

--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -9,6 +9,7 @@ const net = require("node:net");
 const { randomUUID } = require("node:crypto");
 const { pipeline } = require("node:stream/promises");
 const { TextDecoder } = require("node:util");
+require("./boringSslDhCompat.cjs").installBoringSslDhCompat();
 const SftpClient = require("ssh2-sftp-client");
 const { Client: SSHClient } = require("ssh2");
 const iconv = require("iconv-lite");

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -10,6 +10,7 @@ const { randomUUID } = require("node:crypto");
 const os = require("node:os");
 const crypto = require("node:crypto");
 const { exec } = require("node:child_process");
+require("./boringSslDhCompat.cjs").installBoringSslDhCompat();
 const { Client: SSHClient, utils: sshUtils } = require("ssh2");
 const { NetcattyAgent } = require("./netcattyAgent.cjs");
 const keyboardInteractiveHandler = require("./keyboardInteractiveHandler.cjs");

--- a/electron/bridges/sshCompatEntrypoints.test.cjs
+++ b/electron/bridges/sshCompatEntrypoints.test.cjs
@@ -1,0 +1,41 @@
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const path = require("node:path");
+const test = require("node:test");
+
+function assertSsh2LoadsAfterCompat(modulePath) {
+  const script = `
+    const assert = require("node:assert/strict");
+    const crypto = require("node:crypto");
+    const Module = require("node:module");
+    const originalLoad = Module._load;
+    const hits = [];
+    Module._load = function(request, parent, isMain) {
+      if (request === "ssh2" || request.startsWith("ssh2/") || request === "ssh2-sftp-client") {
+        hits.push({
+          request,
+          installed: crypto.createDiffieHellmanGroup.__boringSslDhCompat === true,
+        });
+      }
+      return originalLoad.apply(this, arguments);
+    };
+    require(${JSON.stringify(modulePath)});
+    Module._load = originalLoad;
+    assert.ok(hits.length > 0, "expected the entrypoint to load ssh2");
+    assert.deepEqual(hits.filter((hit) => !hit.installed), []);
+  `;
+  execFileSync(process.execPath, ["-e", script], {
+    cwd: path.resolve(__dirname, "..", ".."),
+    stdio: "pipe",
+  });
+}
+
+for (const [label, modulePath] of [
+  ["SSH bridge", "./electron/bridges/sshBridge.cjs"],
+  ["SFTP bridge", "./electron/bridges/sftpBridge.cjs"],
+  ["Port forwarding bridge", "./electron/bridges/portForwardingBridge.cjs"],
+]) {
+  test(`${label} installs DH compatibility before loading ssh2`, () => {
+    assertSsh2LoadsAfterCompat(modulePath);
+  });
+}


### PR DESCRIPTION
## What changed

- Make the SSH, SFTP, and port-forwarding bridges install the BoringSSL DH compatibility shim before loading ssh2.
- Add a regression test that directly imports each bridge in a fresh process and verifies ssh2 is first loaded only after the shim is installed.

## Why

After fixing #1841, I audited the other ways SSH-backed code can be loaded. The current app paths are covered by main/worker initialization, but the direct bridge entrypoints still depended on their caller remembering to install the shim first. This hardens those entrypoints so future refactors or new process boundaries are less likely to repeat the same class of miss.

## Validation

- `node --test electron/bridges/sshCompatEntrypoints.test.cjs electron/terminalWorker/process.test.cjs electron/bridges/sshAlgorithms.test.cjs electron/bridges/terminalWorkerProxyRegistration.test.cjs electron/bridges/mcpServerBridge.workerTerminal.test.cjs`
- `npx eslint electron/bridges/sshBridge.cjs electron/bridges/sftpBridge.cjs electron/bridges/portForwardingBridge.cjs electron/bridges/sshCompatEntrypoints.test.cjs`
- `npm run build`
- Manual require trace against `mcpServerBridge.cjs` confirmed all ssh2 loads happen after the shim is installed.
