### PR TITLE
[codex] Add Nix AppImage package

### DIFF
--- a/.github/scripts/update-nix-release.js
+++ b/.github/scripts/update-nix-release.js
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function usage() {
+  console.error('Usage: node .github/scripts/update-nix-release.js --artifacts <dir> --version <semver>');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--artifacts' || arg === '--version') {
+      args[arg.slice(2)] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    usage();
+    process.exit(2);
+  }
+  if (!args.artifacts || !args.version) {
+    usage();
+    process.exit(2);
+  }
+  return args;
+}
+
+function sriSha256(filePath) {
+  const digest = crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('base64');
+  return `sha256-${digest}`;
+}
+
+function findArtifact(artifactsDir, fileName) {
+  const filePath = path.join(artifactsDir, fileName);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing release artifact: ${filePath}`);
+  }
+  return filePath;
+}
+
+function renderReleaseNix({ version, x64Hash, arm64Hash }) {
+  return `{
+  version = "${version}";
+
+  sources = {
+    x86_64-linux = {
+      appImageArch = "x86_64";
+      hash = "${x64Hash}";
+    };
+    aarch64-linux = {
+      appImageArch = "arm64";
+      hash = "${arm64Hash}";
+    };
+  };
+}
+`;
+}
+
+const args = parseArgs(process.argv);
+const version = args.version.replace(/^v/, '');
+
+if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-.+)?$/.test(version)) {
+  throw new Error(`Expected semver version, got: ${args.version}`);
+}
+
+const x64AppImage = findArtifact(args.artifacts, `Netcatty-${version}-linux-x86_64.AppImage`);
+const arm64AppImage = findArtifact(args.artifacts, `Netcatty-${version}-linux-arm64.AppImage`);
+
+const releaseNix = renderReleaseNix({
+  version,
+  x64Hash: sriSha256(x64AppImage),
+  arm64Hash: sriSha256(arm64AppImage),
+});
+
+fs.writeFileSync('nix/release.nix', releaseNix);
+console.log(`Updated nix/release.nix for Netcatty ${version}`);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,6 +693,7 @@ jobs:
     needs: release
     if: |
       startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref_name, '-')
       && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_release))
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,6 +687,45 @@ jobs:
           fail_on_unmatched_files: false
           token: ${{ secrets.RELEASE_TOKEN }}
 
+  update-nix-release:
+    name: update Nix release metadata
+    runs-on: ubuntu-latest
+    needs: release
+    if: |
+      startsWith(github.ref, 'refs/tags/v')
+      && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_release))
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Update Nix release metadata
+        run: node .github/scripts/update-nix-release.js --artifacts artifacts --version "${GITHUB_REF_NAME#v}"
+
+      - name: Commit Nix release metadata
+        shell: bash
+        run: |
+          if git diff --quiet -- nix/release.nix; then
+            echo "Nix release metadata is already current."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add nix/release.nix
+          git commit -m "Update Nix release metadata for ${GITHUB_REF_NAME}"
+          git push origin HEAD:${{ github.event.repository.default_branch }}
+
   homebrew-tap:
     name: bump homebrew tap
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -294,6 +294,16 @@ Or browse all releases at [GitHub Releases](https://github.com/binaricat/Netcatt
 
 > **macOS Users:** Current releases are expected to be code-signed and notarized. If Gatekeeper still warns, make sure you downloaded the latest official build from GitHub Releases.
 
+### Nix / NixOS
+
+Netcatty provides a flake that wraps the official Linux AppImage release for Nix and NixOS users:
+
+```bash
+nix run github:binaricat/Netcatty
+```
+
+For declarative installs, add the Netcatty flake as an input and use `inputs.netcatty.packages.${pkgs.system}.default` in your NixOS or Home Manager package list.
+
 ### Prerequisites
 - Node.js 18+ and npm
 - macOS, Windows 10+, or Linux

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Netcatty packages";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        rec {
+          netcatty = pkgs.callPackage ./nix/package.nix { };
+          default = netcatty;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        netcatty = {
+          type = "app";
+          program = "${nixpkgs.lib.getExe self.packages.${system}.netcatty}";
+        };
+        default = self.apps.${system}.netcatty;
+      });
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,63 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  stdenv,
+}:
+
+let
+  pname = "netcatty";
+  version = "1.1.51";
+
+  sources = {
+    x86_64-linux = {
+      appImageArch = "x86_64";
+      hash = "sha256-xMTXP3gjBuAzDXIYuhbQsCkwcf9lDMnRvqkL01PbGTA=";
+    };
+    aarch64-linux = {
+      appImageArch = "arm64";
+      hash = "sha256-UyWRFuc1yN2CkUl0/jyJ3+lJkrpvGHZB0u5itJ0CkG4=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Netcatty AppImage packages are available for x86_64-linux and aarch64-linux only.");
+
+  src = fetchurl {
+    url = "https://github.com/binaricat/Netcatty/releases/download/v${version}/Netcatty-${version}-linux-${source.appImageArch}.AppImage";
+    inherit (source) hash;
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    desktopSource="$(find ${appimageContents} -maxdepth 3 -name '*.desktop' -print -quit)"
+    if [ -n "$desktopSource" ]; then
+      desktopFile="$out/share/applications/netcatty.desktop"
+      install -Dm444 "$desktopSource" "$desktopFile"
+      substituteInPlace "$desktopFile" \
+        --replace "Exec=AppRun" "Exec=netcatty" \
+        --replace "Exec=Netcatty" "Exec=netcatty"
+    fi
+
+    if [ -d "${appimageContents}/usr/share/icons" ]; then
+      mkdir -p "$out/share"
+      cp -r "${appimageContents}/usr/share/icons" "$out/share/"
+    fi
+  '';
+
+  meta = {
+    description = "Modern SSH client and terminal manager";
+    homepage = "https://github.com/binaricat/Netcatty";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "netcatty";
+    platforms = builtins.attrNames sources;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,23 +2,13 @@
   appimageTools,
   fetchurl,
   lib,
+  release ? import ./release.nix,
   stdenv,
 }:
 
 let
   pname = "netcatty";
-  version = "1.1.51";
-
-  sources = {
-    x86_64-linux = {
-      appImageArch = "x86_64";
-      hash = "sha256-xMTXP3gjBuAzDXIYuhbQsCkwcf9lDMnRvqkL01PbGTA=";
-    };
-    aarch64-linux = {
-      appImageArch = "arm64";
-      hash = "sha256-UyWRFuc1yN2CkUl0/jyJ3+lJkrpvGHZB0u5itJ0CkG4=";
-    };
-  };
+  inherit (release) sources version;
 
   source =
     sources.${stdenv.hostPlatform.system}

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,0 +1,14 @@
+{
+  version = "1.1.51";
+
+  sources = {
+    x86_64-linux = {
+      appImageArch = "x86_64";
+      hash = "sha256-xMTXP3gjBuAzDXIYuhbQsCkwcf9lDMnRvqkL01PbGTA=";
+    };
+    aarch64-linux = {
+      appImageArch = "arm64";
+      hash = "sha256-UyWRFuc1yN2CkUl0/jyJ3+lJkrpvGHZB0u5itJ0CkG4=";
+    };
+  };
+}

--- a/scripts/update-nix-release.test.cjs
+++ b/scripts/update-nix-release.test.cjs
@@ -1,0 +1,34 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const { execFileSync } = require('node:child_process');
+
+test('update-nix-release writes version and AppImage hashes', () => {
+  const root = path.join(__dirname, '..');
+  const script = path.join(root, '.github', 'scripts', 'update-nix-release.js');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'netcatty-nix-release-'));
+  const artifacts = path.join(tmp, 'artifacts');
+  fs.mkdirSync(path.join(tmp, 'nix'));
+  fs.mkdirSync(artifacts);
+
+  const x64 = Buffer.from('x64 appimage');
+  const arm64 = Buffer.from('arm64 appimage');
+  fs.writeFileSync(path.join(artifacts, 'Netcatty-1.2.3-linux-x86_64.AppImage'), x64);
+  fs.writeFileSync(path.join(artifacts, 'Netcatty-1.2.3-linux-arm64.AppImage'), arm64);
+
+  execFileSync(process.execPath, [script, '--artifacts', artifacts, '--version', 'v1.2.3'], {
+    cwd: tmp,
+    stdio: 'pipe',
+  });
+
+  const releaseNix = fs.readFileSync(path.join(tmp, 'nix', 'release.nix'), 'utf8');
+  const x64Hash = `sha256-${crypto.createHash('sha256').update(x64).digest('base64')}`;
+  const arm64Hash = `sha256-${crypto.createHash('sha256').update(arm64).digest('base64')}`;
+
+  assert.match(releaseNix, /version = "1\.2\.3";/);
+  assert.match(releaseNix, new RegExp(`hash = "${x64Hash.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}";`));
+  assert.match(releaseNix, new RegExp(`hash = "${arm64Hash.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}";`));
+});


### PR DESCRIPTION
## Summary

Adds first-party Nix/NixOS installation support by wrapping the official Linux AppImage release with a repository flake.

This includes:
- `packages.x86_64-linux.default`
- `packages.aarch64-linux.default`
- `apps.*.default` for `nix run`
- a committed `flake.lock` so remote `nix run github:binaricat/Netcatty` works without writing a lock file
- release metadata in `nix/release.nix` instead of hardcoding the version inside the package expression
- release automation that updates the Nix version and AppImage hashes from the real Linux artifacts after tag builds
- README guidance for Nix and NixOS users

Addresses #1833.

## Validation

- `git diff --check`
- confirmed both AppImage release URLs resolve
- confirmed release asset digests for x86_64 and arm64 match the package hashes
- `node --test scripts/update-nix-release.test.cjs`
- `npm run lint`
- `npm run build`
- Docker/Nix: `nix flake show --all-systems`
- Docker/Nix: `nix build .#packages.aarch64-linux.default --no-link`

Note: local Docker currently runs `aarch64-linux`, so the full Nix build was run for arm64. The x86_64 output was evaluated by `nix flake show --all-systems`. 