### PR TITLE
[codex] Fix host tree font clipping

### DIFF
--- a/components/terminalLayer/TerminalHostTreeSidebar.test.ts
+++ b/components/terminalLayer/TerminalHostTreeSidebar.test.ts
@@ -183,8 +183,8 @@ test('host tree hover card renders markdown notes and keeps host details out of 
   assert.match(source, /<LazyMessageResponse/);
   assert.match(source, /size="sm"/);
   assert.match(source, /items-center gap-2/);
-  assert.match(source, /flex h-5 min-w-0 items-center/);
-  assert.match(source, /translate-y-px truncate text-\[15px\] font-semibold leading-none/);
+  assert.match(source, /flex min-h-6 min-w-0 items-center/);
+  assert.match(source, /truncate text-\[15px\] font-semibold leading-5/);
   assert.match(source, /details\.host/);
   assert.doesNotMatch(source, /text-muted-foreground">\{host\.hostname\}/);
   assert.match(source, /host-tree-notes-scroll/);
@@ -196,9 +196,9 @@ test('host tree row icons, labels, and protocol badges share centered line boxes
   const source = readFileSync(new URL('./TerminalHostTreeSidebar.tsx', import.meta.url), 'utf8');
 
   assert.match(source, /flex h-5 shrink-0 items-center justify-center">\s*<DistroAvatar/);
-  assert.match(source, /flex min-w-0 flex-1 items-center truncate leading-none/);
-  assert.match(source, /flex shrink-0 items-center text-\[10px\] leading-none uppercase/);
+  assert.match(source, /flex min-w-0 flex-1 items-center truncate leading-5/);
+  assert.match(source, /flex shrink-0 items-center text-\[10px\] leading-4 uppercase/);
   assert.match(source, /flex h-5 w-4 shrink-0 items-center/);
   assert.match(source, /flex h-5 shrink-0 items-center">\s*\{isExpanded/);
-  assert.match(source, /flex min-w-0 flex-1 items-center truncate leading-none">\{node\.name\}/);
+  assert.match(source, /flex min-w-0 flex-1 items-center truncate leading-5">\{node\.name\}/);
 });

--- a/components/terminalLayer/TerminalHostTreeSidebar.tsx
+++ b/components/terminalLayer/TerminalHostTreeSidebar.tsx
@@ -273,8 +273,8 @@ const TerminalHostTreeHostHoverCard: React.FC<{ host: Host }> = ({ host }) => {
           size="sm"
           fallback={host.label.slice(0, 1).toUpperCase()}
         />
-        <div className="flex h-5 min-w-0 items-center">
-          <div className="translate-y-px truncate text-[15px] font-semibold leading-none">{host.label}</div>
+        <div className="flex min-h-6 min-w-0 items-center">
+          <div className="truncate text-[15px] font-semibold leading-5">{host.label}</div>
         </div>
       </div>
       <div className="mt-3 space-y-1.5">
@@ -419,14 +419,14 @@ const HostTreeFlatRowItem = memo<HostTreeFlatRowProps>(({
           />
         ) : (
           <span
-            className="flex min-w-0 flex-1 items-center truncate leading-none"
+            className="flex min-w-0 flex-1 items-center truncate leading-5"
             style={{ color: theme.termFg }}
           >
             {row.host.label}
           </span>
         )}
         {row.host.protocol && row.host.protocol !== 'ssh' && (
-          <span className="flex shrink-0 items-center text-[10px] leading-none uppercase opacity-70" style={{ color: theme.mutedFg }}>
+          <span className="flex shrink-0 items-center text-[10px] leading-4 uppercase opacity-70" style={{ color: theme.mutedFg }}>
             {row.host.protocol}
           </span>
         )}
@@ -554,7 +554,7 @@ const HostTreeFlatRowItem = memo<HostTreeFlatRowProps>(({
           style={{ color: theme.termFg }}
         />
       ) : (
-        <span className="flex min-w-0 flex-1 items-center truncate leading-none">{node.name}</span>
+        <span className="flex min-w-0 flex-1 items-center truncate leading-5">{node.name}</span>
       )}
     </div>
   );


### PR DESCRIPTION
## What changed
- Adjusted the host tree row text spacing so labels have enough vertical room.
- Adjusted the host hover card title spacing so the title no longer sits against a clipped line box.
- Updated the matching host tree style tests.

## Why
The host tree labels and hover card title used very tight line boxes, which made some fonts look like their lower edge was cut off.

## Validation
- `node --test --import tsx components/terminalLayer/TerminalHostTreeSidebar.test.ts`
- `npx eslint components/terminalLayer/TerminalHostTreeSidebar.tsx components/terminalLayer/TerminalHostTreeSidebar.test.ts`

Note: I briefly opened the local page and confirmed the host tree rendered; the terminal body could not load in plain browser mode because the desktop backend is not present there.