### PR TITLE
[codex] Isolate agent shell commands

### DIFF
--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
-const { mkdtempSync, rmSync } = require("node:fs");
+const { mkdtempSync, rmSync, symlinkSync, writeFileSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const { join } = require("node:path");
 
@@ -12,6 +12,20 @@ const {
 const {
   buildWrappedCommand,
 } = require("./ptyExecHelpers.cjs");
+
+function commandAvailable(command) {
+  const result = spawnSync(command, ["--version"], { encoding: "utf8" });
+  return !result.error && result.status === 0;
+}
+
+function shellAvailable(command) {
+  const result = spawnSync(command, ["-c", ":"], { encoding: "utf8" });
+  return !result.error && result.status === 0;
+}
+
+const HAS_BASH = process.platform !== "win32" && commandAvailable("bash");
+const HAS_ZSH = process.platform !== "win32" && commandAvailable("zsh");
+const HAS_DASH = process.platform !== "win32" && shellAvailable("dash");
 
 test("uses PowerShell wrapping when a session with no confirmed shell sees a PowerShell prompt", () => {
   // SSH sessions don't set shellKind (sshBridge never assigns one), which
@@ -161,6 +175,72 @@ test("posix wrapper keeps non-exiting state changes in the parent shell", () => 
   }
 });
 
+test("posix wrapper keeps safe state changes inside control structures", () => {
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-control-state-"));
+  try {
+    for (const [name, command, expectedPattern] of [
+      ["if_cd", `if true; then cd '${dir.replace(/'/g, "'\\''")}'; fi`, new RegExp(`PWD=${dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)],
+      ["case_export", "case x in x) export NETCATTY_CASE_EXPORT=ok;; esac", /VALUE=ok/],
+      ["loop_export", "for x in y; do export NETCATTY_LOOP_EXPORT=ok; done", /VALUE=ok/],
+    ]) {
+      const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+      const wrapped = buildWrappedCommand(command, "posix", marker);
+      const result = spawnSync("sh", ["-c", `${wrapped}printf 'PWD=%s VALUE=%s%s\\n' "$PWD" "$NETCATTY_CASE_EXPORT" "$NETCATTY_LOOP_EXPORT"`], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SHELL: "/bin/sh",
+        },
+      });
+
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+      assert.match(result.stdout, expectedPattern);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper emits markers in dash-backed POSIX shells", { skip: !HAS_DASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf DASH_OK", "posix", marker);
+  const result = spawnSync("dash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /DASH_OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper emits markers in dash when parent errexit is active", { skip: !HAS_DASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf DASH_ERREXIT_OK", "posix", marker);
+  const result = spawnSync("dash", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /DASH_ERREXIT_OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
 test("posix wrapper survives a failing command when parent errexit is already active", () => {
   const marker = "__NCMCP_TEST__";
   const wrapped = buildWrappedCommand("false", "posix", marker);
@@ -179,7 +259,69 @@ test("posix wrapper survives a failing command when parent errexit is already ac
   assert.match(result.stdout, /PARENT_STILL_ALIVE/);
 });
 
-test("posix wrapper isolates inside the current shell instead of SHELL env", { skip: process.platform === "win32" }, () => {
+test("posix wrapper isolates nounset exits from the parent shell", () => {
+  for (const [name, setup, command] of [
+    ["command_sets_nounset", "", "set -u; echo $NETCATTY_MISSING_NOUNSET; echo SHOULD_NOT_PRINT"],
+    ["parent_has_nounset", "set -u; ", "echo $NETCATTY_MISSING_NOUNSET; echo SHOULD_NOT_PRINT"],
+    ["parent_has_nounset_positional", "set -u; ", "export NETCATTY_FROM_POSITIONAL=$1; echo SHOULD_NOT_PRINT"],
+    ["parent_has_nounset_braced_positional", "set -u; ", "export NETCATTY_FROM_BRACED=${1}; echo SHOULD_NOT_PRINT"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${setup}${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_S`));
+    assert.match(result.stdout, new RegExp(`${marker}_E:2|${marker}_E:1`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+  }
+});
+
+test("posix wrapper emits markers in dash when parent nounset is active", { skip: !HAS_DASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf DASH_NOUNSET_OK", "posix", marker);
+  const result = spawnSync("dash", ["-c", `set -u; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /DASH_NOUNSET_OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper emits markers in zsh when parent nounset is active", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf ZSH_NOUNSET_OK", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `set -u; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /ZSH_NOUNSET_OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates inside the current shell instead of SHELL env", { skip: !HAS_BASH }, () => {
   const marker = "__NCMCP_TEST__";
   const wrapped = buildWrappedCommand("set -e\n[[ 1 == 1 ]] && echo BASH_OK", "posix", marker);
   const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
@@ -210,6 +352,1722 @@ test("posix wrapper emits the end marker on a fresh line after exec without trai
 
   assert.equal(result.error, undefined);
   assert.match(result.stdout, new RegExp(`OK\\n${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates exit inside shell control structures", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("if true; then exit 7; fi", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:7`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates exit behind leading fd redirections", () => {
+  for (const [name, command, code] of [
+    ["stderr_to_stdout", "2>&1 exit 7", 7],
+    ["fd_to_stdout", "3>&1 exit 8", 8],
+    ["stdin_dup", "2<&0 exit 9", 9],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:${code}`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper isolates exit inside loop and case structures", () => {
+  for (const [name, command, code] of [
+    ["while", "while true; do exit 8; done", 8],
+    ["case", "case x in x) exit 9;; esac", 9],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:${code}`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper isolates exec invoked through command", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("command exec printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`OK\\n${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates exec invoked through builtin", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("builtin exec printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`OK\\n${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper ignores quoted risky-looking text when preserving state", () => {
+  const marker = "__NCMCP_TEST__";
+  const cwd = mkdtempSync(join(tmpdir(), "netcatty-pty-quoted-"));
+  try {
+    const wrapped = buildWrappedCommand(`cd '${cwd.replace(/'/g, "'\\''")}' && echo '; exit'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}pwd`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.match(result.stdout, /; exit/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, new RegExp(`${cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks self-kill commands instead of running them", () => {
+  for (const [name, command] of [
+    ["pid", "kill -TERM $$"],
+    ["group", "kill 0"],
+    ["group_00", "kill 00"],
+    ["group_plus_0", "kill +0"],
+    ["group_minus_00", "kill -TERM -00"],
+    ["group_negative", "kill -- -1"],
+    ["group_negative_with_signal", "kill -TERM -1234"],
+    ["path", "/bin/kill -TERM $$"],
+    ["env", "env kill -TERM $$"],
+    ["env_path", "/usr/bin/env kill -TERM 0"],
+    ["env_unset", "env -u FOO kill -TERM 0"],
+    ["env_chdir", "env -C /tmp kill -TERM 0"],
+    ["env_dash", "env - kill -TERM 0"],
+    ["env_path", "env -P /bin kill -TERM 0"],
+    ["env_i_split", "env -iS 'kill -TERM 0'"],
+    ["env_split", "env -S 'kill -TERM 0'"],
+    ["shell_c", "sh -c 'kill -TERM $$'"],
+    ["shell_ec", "sh -ec 'kill -TERM 0'"],
+    ["shell_lc", "bash -lc 'kill -TERM 0'"],
+    ["shell_option_arg", "bash -O extglob -c 'kill -TERM 0'"],
+    ["time_option", "time -p kill -TERM 0"],
+    ["command_option", "command -p kill -TERM 0"],
+    ["nice", "nice kill -TERM 0"],
+    ["nohup", "nohup kill -TERM 0"],
+    ["timeout", "timeout 2 kill -TERM $$"],
+    ["stdbuf", "stdbuf -oL kill -TERM 0"],
+    ["stdbuf_long_output", "stdbuf --output L kill -TERM 0"],
+    ["setsid", "setsid kill -TERM 0"],
+    ["flock", "flock /tmp/netcatty-pty-test.lock kill -TERM 0"],
+    ["flock_long_timeout", "flock --timeout 1 /tmp/netcatty-pty-test.lock kill -TERM 0"],
+    ["flock_command", "flock -c 'kill -TERM 0' /tmp/netcatty-pty-test.lock"],
+    ["coproc", "coproc kill -TERM 0"],
+    ["python_parent_pid", "python3 -c \"import os,signal; os.kill($$, signal.SIGTERM)\""],
+    ["python_getppid", "python3 -c 'import os,signal; os.kill(os.getppid(), signal.SIGTERM)'"],
+    ["python_group_kill", "python3 -c 'import os,signal; os.kill(0, signal.SIGTERM)'"],
+    ["python_getpgrp", "python3 -c 'import os,signal; os.kill(os.getpgrp(), signal.SIGTERM)'"],
+    ["node_group_kill", "node -e 'process.kill(0, \"SIGTERM\")'"],
+    ["node_parent_kill", "node -e 'process.kill(process.ppid, \"SIGTERM\")'"],
+    ["perl_group_kill", "perl -e 'kill TERM, 0'"],
+    ["perl_parent_kill", "perl -e 'kill TERM, getppid'"],
+    ["perl_getpgrp", "perl -e 'kill TERM, getpgrp'"],
+    ["ruby_group_kill", "ruby -e 'Process.kill(\"TERM\", 0)'"],
+    ["ruby_parent_kill", "ruby -e 'Process.kill(\"TERM\", Process.ppid)'"],
+    ["ruby_getpgrp", "ruby -e 'Process.kill(\"TERM\", Process.getpgrp)'"],
+    ["xargs_kill_pid", "printf '%s\\n' $$ | xargs kill -TERM"],
+    ["xargs_kill_group", "printf '%s\\n' 0 | xargs kill -TERM"],
+    ["xargs_shell_group", "printf x | xargs sh -c 'kill -TERM 0'"],
+    ["find_exec_kill_group", "find . -maxdepth 0 -exec kill -TERM 0 \\;"],
+    ["find_exec_shell_group", "find . -maxdepth 0 -exec sh -c 'kill -TERM 0' \\;"],
+    ["function_call", "bye(){ kill -TERM $$; }; bye"],
+    ["backtick", "echo `kill -TERM $$`"],
+    ["dollar_paren", "echo $(kill -TERM $$)"],
+    ["nested_dollar_paren", "echo $(echo $(kill -TERM $$))"],
+    ["backtick_command", "`printf kill` -TERM $$"],
+    ["backtick_target", "kill -TERM `printf 0`"],
+    ["eval", "eval 'kill -TERM $$'"],
+    ["eval_dynamic", "x='kill -TERM $$'; eval \"$x\""],
+    ["source", ". /tmp/netcatty-unsafe-source"],
+    ["redirect", ">/dev/null kill -TERM $$"],
+    ["multiline", "echo FIRST\nkill -TERM $$"],
+    ["dynamic", "x=kill; $x -TERM $$"],
+    ["dynamic_pid", "p=$$; kill -TERM $p"],
+    ["dynamic_group", "p=0; kill -TERM $p"],
+    ["dynamic_exit", "x=exit; $x 11"],
+    ["dynamic_exec", "x=exec; $x printf OK"],
+    ["risky_alias", "alias bye='exit 7'; bye"],
+    ["trap_debug_exit", "trap 'exit 17' DEBUG"],
+    ["trap_debug_kill", "trap 'kill -TERM $$' DEBUG; echo OK"],
+    ["trap_debug_int_exit", "trap 'exit 17' DEBUG INT"],
+    ["trap_debug_int_kill", "trap 'kill -TERM $$' DEBUG INT"],
+    ["trap_int_exit", "trap 'exit 17' INT; echo OK"],
+    ["trap_exit_exit", "trap 'exit 17' EXIT; echo OK"],
+    ["trap_zero_kill", "trap 'kill -TERM $$' 0; echo OK"],
+    ["trap_term_exit", "trap 'exit 17' TERM; echo OK"],
+    ["trap_int_reset_then_sleep", "trap INT; sleep 1"],
+    ["trap_sigint_reset_then_sleep", "trap -- SIGINT; sleep 1"],
+    ["trap_numeric_int_reset_then_sleep", "trap 2; sleep 1"],
+    ["trap_debug_lower", "trap 'kill -TERM $$' debug"],
+    ["trap_err_lower", "trap 'kill -TERM $$' err; false"],
+    ["trap_zerr", "trap 'kill -TERM 0' ZERR; false"],
+    ["trap_debug_dynamic", "trap 'x=exit; $x 17' DEBUG"],
+    ["trap_debug_variable_handler", "x='kill -TERM $$'; trap \"$x\" DEBUG"],
+    ["trap_debug_eval_handler", "x='kill -TERM $$'; trap 'eval \"$x\"' DEBUG"],
+    ["trap_debug_substitution", "trap '$(kill -TERM $$)' DEBUG"],
+    ["prefix_function_timeout", "timeout(){ kill -TERM 0; }; timeout 1 printf OK"],
+    ["prefix_function_command", "command(){ kill -TERM 0; }; command printf OK"],
+    ["readonly_internal", "readonly __NCMCP_rc=0"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper allows harmless nested shell command strings", { skip: !HAS_BASH }, () => {
+  for (const [name, command] of [
+    ["sh_c", "sh -c 'printf SAFE'"],
+    ["bash_lc", "bash -lc 'printf SAFE'"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, /SAFE/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper recognizes versioned script interpreter names", () => {
+  const pythonPath = spawnSync("sh", ["-c", "command -v python3"], {
+    encoding: "utf8",
+  }).stdout.trim();
+  if (!pythonPath) return;
+
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-python-"));
+  const versionedPythonPath = join(dir, "python3.11");
+  try {
+    symlinkSync(pythonPath, versionedPythonPath);
+    const command = `'${versionedPythonPath.replace(/'/g, "'\\''")}' -c 'import os,signal; os.kill(0, signal.SIGTERM)'`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper allows reading the current shell pid", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("echo $$", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper preserves state through command prefix options", { skip: !HAS_BASH }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-command-prefix-"));
+  try {
+    for (const [name, command, expected] of [
+      ["command_p_cd", `command -p cd '${dir.replace(/'/g, "'\\''")}'`, dir],
+      ["command_dashdash_cd", `command -- cd '${dir.replace(/'/g, "'\\''")}'`, dir],
+      ["command_export", "command export NETCATTY_COMMAND_PREFIX=ok", "ok"],
+    ]) {
+      const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+      const wrapped = buildWrappedCommand(command, "posix", marker);
+      const result = spawnSync("bash", ["-c", `${wrapped}printf 'PWD=%s VALUE=%s\\n' "$PWD" "$NETCATTY_COMMAND_PREFIX"`], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SHELL: "/bin/false",
+        },
+      });
+
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 0);
+      assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+      assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+      assert.match(result.stdout, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper keeps safe source state but blocks unsafe source files", () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-safe-source-"));
+  const scriptPath = join(dir, "env file.sh");
+  try {
+    writeFileSync(scriptPath, "export NETCATTY_SAFE_SOURCE=ok\nexport NETCATTY_SOURCE_PATH=.:$PATH:/netcatty\nexport NETCATTY_DOT=.\n");
+    const wrapped = buildWrappedCommand(`. '${scriptPath.replace(/'/g, "'\\''")}'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'SOURCE=%s\\nPATH=%s\\n' "$NETCATTY_SAFE_SOURCE" "$NETCATTY_SOURCE_PATH"`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /SOURCE=ok/);
+    assert.match(result.stdout, /netcatty/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper keeps multiple safe source files in zsh", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-zsh-source-"));
+  const firstPath = join(dir, "first.sh");
+  const secondPath = join(dir, "second.sh");
+  try {
+    writeFileSync(firstPath, "export NETCATTY_ZSH_SOURCE_ONE=one\n");
+    writeFileSync(secondPath, "export NETCATTY_ZSH_SOURCE_TWO=two\n");
+    const command = `. '${firstPath.replace(/'/g, "'\\''")}'; . '${secondPath.replace(/'/g, "'\\''")}'`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'ONE=%s TWO=%s\\n' "$NETCATTY_ZSH_SOURCE_ONE" "$NETCATTY_ZSH_SOURCE_TWO"`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /ONE=one TWO=two/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks source files before they can exit the parent", () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-source-"));
+  const scriptPath = join(dir, "exit.sh");
+  try {
+    writeFileSync(scriptPath, "exit 7\n");
+    const wrapped = buildWrappedCommand(`. '${scriptPath.replace(/'/g, "'\\''")}'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks source files with dynamic shell-terminating commands", () => {
+  for (const [name, content] of [
+    ["dynamic_exit", "x=exit; $x 7\n"],
+    ["dynamic_set", "opt=-e; set $opt; false\n"],
+    ["trap_debug", "trap 'exit 9' DEBUG\n"],
+    ["eval", "eval 'exit 8'\n"],
+    ["setopt_errexit", "setopt err_exit\n"],
+    ["setopt_upper_errexit", "setopt ERR_EXIT\n"],
+    ["dangerous_alias", "alias bye='exit 7'\n"],
+    ["dangerous_alias_path_kill", "alias bye='/bin/kill -TERM 0'\n"],
+    ["dangerous_alias_path_signal_kill", "alias bye='/bin/kill -s TERM 0'\n"],
+    ["dangerous_alias_path_signal_number_kill", "alias bye='/bin/kill -n 15 0'\n"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-source-risk-"));
+    const scriptPath = join(dir, "risk.sh");
+    try {
+      writeFileSync(scriptPath, content);
+      const wrapped = buildWrappedCommand(`. '${scriptPath.replace(/'/g, "'\\''")}'`, "posix", marker);
+      const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SHELL: "/bin/sh",
+        },
+      });
+
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+      assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+      assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("posix wrapper blocks source files with assignment-prefixed path kill", () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-source-path-kill-"));
+  const scriptPath = join(dir, "risk.sh");
+  try {
+    writeFileSync(scriptPath, "FOO=bar /bin/kill -TERM 0\n");
+    const wrapped = buildWrappedCommand(`. '${scriptPath.replace(/'/g, "'\\''")}'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      detached: true,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper isolates eval and shell command prefixes that can exit", () => {
+  for (const [name, command, code] of [
+    ["function_call", "bye(){ exit 5; }; bye", 5],
+    ["multiline_exit", "echo FIRST\nexit 6", 6],
+    ["bang_exit", "! exit 8", 8],
+    ["time_exit", "time exit 9", 9],
+    ["redirect_exit", ">/dev/null exit 10", 10],
+    ["command_set", "command set -e; false; echo SHOULD_NOT_PRINT", 1],
+    ["dynamic_set", "opt=-e; set $opt; false; echo SHOULD_NOT_PRINT", 1],
+    ["dynamic_errexit", "opt=errexit; set -o $opt; false; echo SHOULD_NOT_PRINT", 1],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:${code}`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+  }
+});
+
+test("posix wrapper keeps export state when command substitution exits", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("export X=$(printf ok; exit 7)", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'X=%s\\n' \"$X\"`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /X=ok/);
+});
+
+test("posix wrapper blocks existing shell functions before they can exit the parent", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("bye", "posix", marker);
+  const result = spawnSync("sh", ["-c", `bye(){ exit 7; }; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper blocks dangerous existing aliases", { skip: !HAS_BASH }, () => {
+  for (const [name, aliasDefinition] of [
+    ["bare_kill_group", "kill 0"],
+    ["path_kill_signal_option", "/bin/kill -s TERM 0"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand("bye", "posix", marker);
+    const result = spawnSync("bash", ["-c", `shopt -s expand_aliases; alias bye='${aliasDefinition}'; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      detached: true,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper blocks existing shell functions with indirect self-kill", () => {
+  for (const [name, functionBody] of [
+    ["signal_option_group", "/bin/kill -s TERM 0"],
+    ["long_signal_option_group", "/bin/kill --signal TERM 0"],
+    ["equals_signal_option_group", "/bin/kill --signal=TERM 0"],
+    ["signal_number_option_group", "/bin/kill -n 15 0"],
+    ["variable_group", "p=0; kill -TERM \"$p\""],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand("bye", "posix", marker);
+    const result = spawnSync("sh", ["-c", `bye(){ ${functionBody}; }; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      detached: true,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper allows harmless existing functions and aliases", { skip: !HAS_BASH }, () => {
+  for (const [name, setup, command, expected] of [
+    ["function", "hello(){ printf FUNCTION_OK; };", "hello", "FUNCTION_OK"],
+    ["alias", "shopt -s expand_aliases; alias ll='printf ALIAS_OK';", "ll", "ALIAS_OK"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("bash", ["-c", `${setup} ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, new RegExp(expected));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper keeps safe custom function state changes", { skip: !HAS_BASH }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-safe-function-state-"));
+  try {
+    for (const [name, setup, command, probe, expected] of [
+      ["export", "activate(){ export NETCATTY_FUNCTION_STATE=ok; }", "activate", "printf 'VALUE=%s\\n' \"$NETCATTY_FUNCTION_STATE\"", /VALUE=ok/],
+      ["cd", `jump(){ cd '${dir.replace(/'/g, "'\\''")}'; }`, "jump", "pwd", new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))],
+    ]) {
+      const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+      const wrapped = buildWrappedCommand(command, "posix", marker);
+      const result = spawnSync("bash", ["-c", `${setup}; ${wrapped}${probe}`], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SHELL: "/bin/false",
+        },
+      });
+
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 0);
+      assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+      assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+      assert.match(result.stdout, expected);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks redefined safe builtins before they can exit the parent", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp", "posix", marker);
+  const result = spawnSync("sh", ["-c", `cd(){ exit 7; }; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates bash-only command prefixes that can exit", { skip: !HAS_BASH }, () => {
+  for (const [name, command, code] of [
+    ["builtin_set", "builtin set -e; false; echo SHOULD_NOT_PRINT", 1],
+    ["ansi_exit", "$'exit' 7", 7],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:${code}`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+  }
+});
+
+test("posix wrapper isolates zsh setopt errexit", { skip: !HAS_ZSH }, () => {
+  for (const [name, command] of [
+    ["errexit", "setopt errexit; false; echo SHOULD_NOT_PRINT"],
+    ["err_exit", "setopt err_exit; false; echo SHOULD_NOT_PRINT"],
+    ["upper", "setopt ERR_EXIT; false; echo SHOULD_NOT_PRINT"],
+    ["set_o", "set -o err_exit; false; echo SHOULD_NOT_PRINT"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+  }
+});
+
+test("posix wrapper isolates zsh emulate errexit", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp; emulate sh -o errexit; false; echo SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper handles zsh return and repeat without losing the marker", { skip: !HAS_ZSH }, () => {
+  for (const [name, command, code] of [
+    ["return", "cd /tmp; return 7", 7],
+    ["repeat_exit", "cd /tmp; repeat 1 exit 12", 12],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:${code}`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper blocks zsh repeat self-kill", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp; repeat 1 kill -TERM $$", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper keeps safe zsh setopt state", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("setopt noclobber", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `${wrapped}setopt | grep -q '^noclobber$' && printf 'NOCLOBBER_ON\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /NOCLOBBER_ON/);
+});
+
+test("posix wrapper keeps safe zsh unsetopt state", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("unsetopt noclobber", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `setopt noclobber; ${wrapped}setopt | grep -q '^noclobber$' || printf 'NOCLOBBER_OFF\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /NOCLOBBER_OFF/);
+});
+
+test("posix wrapper keeps safe bash shopt state", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("shopt -s extglob", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}shopt -q extglob && printf 'EXTGLOB_ON\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /EXTGLOB_ON/);
+});
+
+test("posix wrapper keeps safe shell state builtins", { skip: !HAS_BASH }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-state-builtins-"));
+  try {
+    for (const [name, command, probe, expected] of [
+      ["umask", "umask 077", "umask", /077/],
+      ["pushd", `pushd '${dir.replace(/'/g, "'\\''")}' >/dev/null`, "pwd", new RegExp(dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))],
+      ["popd", `pushd '${dir.replace(/'/g, "'\\''")}' >/dev/null; popd >/dev/null`, "pwd", /^\/tmp$/m],
+    ]) {
+      const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+      const wrapped = buildWrappedCommand(command, "posix", marker);
+      const result = spawnSync("bash", ["-c", `cd /tmp; ${wrapped}${probe}`], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SHELL: "/bin/false",
+        },
+      });
+
+      assert.equal(result.error, undefined);
+      assert.equal(result.status, 0);
+      assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+      assert.match(result.stdout, expected);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks dangerous zsh debug trap functions", { skip: !HAS_ZSH }, () => {
+  for (const [name, command] of [
+    ["exit", "TRAPDEBUG(){ exit 17; }"],
+    ["kill", "TRAPDEBUG(){ kill -TERM $$; }"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper clears its temporary INT trap in zsh", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.doesNotMatch(result.stdout, /__NCMCP_int_seen/);
+});
+
+test("posix wrapper isolates exit behind zsh precommand modifiers", { skip: !HAS_ZSH }, () => {
+  for (const [name, command] of [
+    ["noglob", "cd /tmp; noglob exit 7"],
+    ["nocorrect", "cd /tmp; nocorrect exit 7"],
+    ["dash", "cd /tmp; - exit 7"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:7`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper blocks zsh autoload functions with unknown bodies", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-autoload-"));
+  try {
+    writeFileSync(join(dir, "bye"), "bye(){ kill -TERM $$; }\n");
+    const wrapped = buildWrappedCommand("cd /tmp; bye", "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `fpath=('${dir.replace(/'/g, "'\\''")}' $fpath); autoload bye; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper keeps function definitions with exit in the parent shell", () => {
+  for (const [name, command] of [
+    ["brace", "bye(){ exit 7; }"],
+    ["subshell", "bye() ( exit 7 )"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}type bye >/dev/null && printf 'FUNCTION_DEFINED\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /FUNCTION_DEFINED/);
+  }
+});
+
+test("posix wrapper allows safe existing functions with return and child cleanup", { skip: !HAS_BASH }, () => {
+  for (const [name, setup, command] of [
+    ["return", "helper(){ return 0; }", "helper"],
+    ["child_kill", "helper(){ sleep 1 & child_pid=$!; kill \"$child_pid\"; wait \"$child_pid\" 2>/dev/null; return 0; }", "helper"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("bash", ["-c", `${setup}; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper restores existing INT trap when the command leaves it alone", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("sh", ["-c", `trap 'echo USER_INT' INT; ${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /USER_INT/);
+});
+
+test("posix wrapper allows clearing DEBUG and ERR traps", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("trap - DEBUG; trap - ERR", "posix", marker);
+  const result = spawnSync("bash", ["-c", `trap 'echo DEBUG_TRAP' DEBUG; trap 'echo ERR_TRAP' ERR; ${wrapped}trap -p DEBUG ERR`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.doesNotMatch(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.doesNotMatch(result.stdout, /trap -- 'echo DEBUG_TRAP' DEBUG/);
+  assert.doesNotMatch(result.stdout, /trap -- 'echo ERR_TRAP' ERR/);
+});
+
+test("posix wrapper isolates dash-unsupported trap query options", { skip: !HAS_DASH }, () => {
+  for (const [name, command] of [
+    ["trap_p_int", "trap -p INT"],
+    ["trap_l", "trap -l"],
+    ["trap_p_int_then_sleep", "trap -p INT; sleep 0"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("dash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_S`));
+    assert.match(result.stdout, new RegExp(`${marker}_E:2`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper does not expose its temporary INT trap to trap queries", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("trap", "posix", marker);
+  const result = spawnSync("sh", ["-c", wrapped], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.doesNotMatch(result.stdout, /__NCMCP_int_seen/);
+});
+
+test("posix wrapper keeps a user command's new INT trap", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("trap 'echo NEW_INT' INT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /NEW_INT/);
+});
+
+test("posix wrapper keeps a user command's new INT trap in a compound command", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp; trap 'echo NEW_INT' INT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /NEW_INT/);
+});
+
+test("posix wrapper keeps an allowed function's new INT trap", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp; setint", "posix", marker);
+  const result = spawnSync("sh", ["-c", `setint(){ trap 'echo FUNCTION_INT' INT; }; ${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /FUNCTION_INT/);
+});
+
+test("posix wrapper keeps a same-command function's new INT trap", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("setint(){ trap 'echo FUNCTION_INT' INT; }; setint", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /FUNCTION_INT/);
+});
+
+test("posix wrapper detects dangerous functions when PATH cannot find grep", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp", "posix", marker);
+  const result = spawnSync("bash", ["-c", `cd(){ exit 7; }; PATH=/tmp; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper detects dangerous functions when shell inspection names are redefined", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("bye", "posix", marker);
+  const result = spawnSync("bash", ["-c", `type(){ :; }; alias(){ :; }; typeset(){ :; }; functions(){ :; }; printf(){ :; }; bye(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper avoids user-defined type while inspecting dangerous functions", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp", "posix", marker);
+  const result = spawnSync("bash", ["-c", `type(){ kill -TERM 0; }; cd(){ exit 7; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper avoids user-defined trap for commands that do not need INT protection", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `trap(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper avoids user-defined trap for path commands", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("/bin/sleep 0", "posix", marker);
+  const result = spawnSync("bash", ["-c", `trap(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper avoids user-defined eval for path commands", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("/bin/echo OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `eval(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper avoids user-defined cleanup helpers", { skip: !HAS_BASH }, () => {
+  for (const [name, helper] of [
+    ["unset", "unset"],
+    ["exit", "exit"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+    const result = spawnSync("bash", ["-c", `${helper}(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /OK/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper avoids user-defined zsh eval and unset helpers", { skip: !HAS_ZSH }, () => {
+  for (const [name, helper] of [
+    ["eval", "eval"],
+    ["unset", "unset"],
+  ]) {
+    const marker = `__NCMCP_TEST_ZSH_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand("/bin/echo OK", "posix", marker);
+    const result = spawnSync("zsh", ["-fc", `${helper}(){ kill -TERM 0; }; ${wrapped}print -r PARENT_STILL_ALIVE`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /OK/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper emits markers when builtin is redefined", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `builtin(){ kill -TERM 0; }; ${wrapped}command printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper emits markers when command is redefined", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("/bin/echo OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `command(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper blocks when command and builtin are both redefined", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("/bin/echo SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("bash", ["-c", `command(){ kill -TERM 0; }; builtin(){ kill -TERM 0; }; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper avoids user-defined bracket and true helpers", { skip: !HAS_BASH }, () => {
+  for (const [name, helper] of [
+    ["bracket", "["],
+    ["true", "true"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand("/bin/echo OK", "posix", marker);
+    const result = spawnSync("bash", ["-c", `${helper}(){ kill -TERM 0; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /OK/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  }
+});
+
+test("posix wrapper isolates commands that redefine cleanup helpers", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("command(){ printf USER_COMMAND; }; true", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}if declare -F __NCMCP_p >/dev/null || set | grep -q '^__NCMCP'; then printf 'LEAKED\\n'; else printf 'CLEAN\\n'; fi; builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /CLEAN/);
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /USER_COMMAND/);
+  assert.doesNotMatch(result.stdout, /LEAKED/);
+});
+
+test("posix wrapper blocks user-defined zsh builtin before it can exit the parent", { skip: !HAS_ZSH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("/bin/echo SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("zsh", ["-fc", `builtin(){ kill -TERM 0; }; ${wrapped}print -r PARENT_STILL_ALIVE`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper blocks user-defined printf before it can exit the parent", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `printf(){ exit 7; }; ${wrapped}builtin printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper cleans up internal helper names", { skip: !HAS_BASH }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}if declare -F __NCMCP_p >/dev/null || set | grep -q '^__NCMCP'; then printf 'LEAKED\\n'; else printf 'CLEAN\\n'; fi`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /CLEAN/);
+  assert.doesNotMatch(result.stdout, /LEAKED/);
+});
+
+test("posix wrapper clears its temporary INT trap after PATH changes", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("export PATH=/tmp", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.doesNotMatch(result.stdout, /__NCMCP_int_seen/);
+});
+
+test("posix wrapper keeps a user command's no-op INT trap", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("trap ':' INT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}trap`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /trap -- ':' INT/);
+});
+
+test("posix wrapper preserves errexit semantics inside isolated parent-errexit commands", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("false; echo SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper preserves parent-errexit semantics for state-prefixed compound commands", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("cd /tmp; false; echo SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper preserves parent-errexit semantics for common failing commands", () => {
+  for (const [name, command] of [
+    ["grep", "cd /tmp; grep NETCATTY_NO_MATCH /dev/null; echo SHOULD_NOT_PRINT"],
+    ["test", "cd /tmp; test -f /tmp/netcatty-definitely-missing; echo SHOULD_NOT_PRINT"],
+    ["pipeline", "cd /tmp; printf x | grep y; echo SHOULD_NOT_PRINT"],
+    ["node", "cd /tmp; node -e 'process.exit(1)'; echo SHOULD_NOT_PRINT"],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+    assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+  }
+});
+
+test("posix wrapper keeps successful compound state changes with parent errexit", () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-errexit-state-"));
+  try {
+    const wrapped = buildWrappedCommand(`cd '${dir.replace(/'/g, "'\\''")}'; export NETCATTY_ERREXIT_STATE=ok`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PWD=%s VALUE=%s\\n' "$PWD" "$NETCATTY_ERREXIT_STATE"`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, new RegExp(`PWD=${dir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+    assert.match(result.stdout, /VALUE=ok/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper does not treat set option words as arguments", () => {
+  const errexitMarker = "__NCMCP_TEST_ERREXIT_ARG__";
+  const errexitWrapped = buildWrappedCommand("echo set +e", "posix", errexitMarker);
+  const errexitResult = spawnSync("sh", ["-c", `set -e; ${errexitWrapped}false; printf 'SHOULD_NOT_PRINT\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(errexitResult.error, undefined);
+  assert.notEqual(errexitResult.status, 0);
+  assert.match(errexitResult.stdout, new RegExp(`${errexitMarker}_E:0`));
+  assert.doesNotMatch(errexitResult.stdout, /SHOULD_NOT_PRINT/);
+
+  const nounsetMarker = "__NCMCP_TEST_NOUNSET_ARG__";
+  const nounsetWrapped = buildWrappedCommand("printf 'set +u\\n'", "posix", nounsetMarker);
+  const nounsetResult = spawnSync("sh", ["-c", `set -u; ${nounsetWrapped}printf '%s\\n' "$NETCATTY_STILL_MISSING"; printf 'SHOULD_NOT_PRINT\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(nounsetResult.error, undefined);
+  assert.notEqual(nounsetResult.status, 0);
+  assert.match(nounsetResult.stdout, new RegExp(`${nounsetMarker}_E:0`));
+  assert.doesNotMatch(nounsetResult.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper keeps safe nounset parent state changes", () => {
+  const homePattern = new RegExp(`PWD=${String(process.env.HOME || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} HOME=${String(process.env.HOME || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`);
+  for (const [name, command, probe, expected] of [
+    ["substitution", "export NETCATTY_NOUNSET_SAFE=$(printf ok)", "printf 'VALUE=%s\\n' \"$NETCATTY_NOUNSET_SAFE\"", /VALUE=ok/],
+    ["literal", "export NETCATTY_NOUNSET_LITERAL='$MISSING'", "printf 'VALUE=%s\\n' \"$NETCATTY_NOUNSET_LITERAL\"", /VALUE=\$MISSING/],
+    ["safe_cd_expansion", "cd \"$HOME\"", "printf 'PWD=%s HOME=%s\\n' \"$PWD\" \"$HOME\"", homePattern],
+    ["safe_export_expansion", "export NETCATTY_NOUNSET_HOME=\"$HOME\"", "printf 'VALUE=%s HOME=%s\\n' \"$NETCATTY_NOUNSET_HOME\" \"$HOME\"", /VALUE=.+ HOME=.+/],
+    ["default_export_expansion", "export NETCATTY_DEFAULTED=${NETCATTY_MISSING:-ok}", "printf 'VALUE=%s\\n' \"$NETCATTY_DEFAULTED\"", /VALUE=ok/],
+    ["default_cd_expansion", "cd ${NETCATTY_MISSING_DIR:-/tmp}", "printf 'PWD=%s\\n' \"$PWD\"", /PWD=\/tmp/],
+    ["assign_default_expansion", "export NETCATTY_MEQ_VALUE=${NETCATTY_MEQ:=ok}", "printf 'VALUE=%s ASSIGNED=%s\\n' \"$NETCATTY_MEQ_VALUE\" \"$NETCATTY_MEQ\"", /VALUE=ok ASSIGNED=ok/],
+    ["alternate_expansion_unset", "export NETCATTY_ALT_VALUE=${NETCATTY_ALT:+nope}", "printf 'VALUE=%s\\n' \"$NETCATTY_ALT_VALUE\"", /VALUE=/],
+    ["alternate_expansion_set", "NETCATTY_ALT=yes; export NETCATTY_ALT_VALUE=${NETCATTY_ALT:+ok}", "printf 'VALUE=%s\\n' \"$NETCATTY_ALT_VALUE\"", /VALUE=ok/],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `set -u; ${wrapped}${probe}`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, expected);
+  }
+});
+
+test("posix wrapper keeps user-disabled errexit and nounset disabled", () => {
+  for (const [name, setup, command, probe, expected] of [
+    ["errexit", "set -e; ", "set +e", "false; printf 'ERREXIT_OFF\\n'", /ERREXIT_OFF/],
+    ["nounset", "set -u; ", "set +u", "printf 'NOUNSET_OFF=%s\\n' \"$NETCATTY_STILL_MISSING\"", /NOUNSET_OFF=/],
+  ]) {
+    const marker = `__NCMCP_TEST_${name.toUpperCase()}__`;
+    const wrapped = buildWrappedCommand(command, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${setup}${wrapped}${probe}`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, expected);
+  }
+});
+
+test("posix wrapper restores parent options when commands re-enable them", () => {
+  const errexitMarker = "__NCMCP_TEST_ERREXIT_REENABLE__";
+  const errexitWrapped = buildWrappedCommand("set +e; set -e", "posix", errexitMarker);
+  const errexitResult = spawnSync("sh", ["-c", `set -e; ${errexitWrapped}false; printf 'SHOULD_NOT_PRINT\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(errexitResult.error, undefined);
+  assert.notEqual(errexitResult.status, 0);
+  assert.match(errexitResult.stdout, new RegExp(`${errexitMarker}_E:0`));
+  assert.doesNotMatch(errexitResult.stdout, /SHOULD_NOT_PRINT/);
+
+  const nounsetMarker = "__NCMCP_TEST_NOUNSET_REENABLE__";
+  const nounsetWrapped = buildWrappedCommand("set +u; set -u", "posix", nounsetMarker);
+  const nounsetResult = spawnSync("sh", ["-c", `set -u; ${nounsetWrapped}printf '%s\\n' "$NETCATTY_STILL_MISSING"; printf 'SHOULD_NOT_PRINT\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(nounsetResult.error, undefined);
+  assert.notEqual(nounsetResult.status, 0);
+  assert.match(nounsetResult.stdout, new RegExp(`${nounsetMarker}_E:0`));
+  assert.doesNotMatch(nounsetResult.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper allows ordinary arguments containing its marker prefix", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("printf '%s\\n' __NCMCP_demo", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /__NCMCP_demo/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper blocks relative source after changing directory", () => {
+  const marker = "__NCMCP_TEST__";
+  const dir = mkdtempSync(join(tmpdir(), "netcatty-pty-relative-source-"));
+  try {
+    writeFileSync(join(dir, "profile"), "kill -TERM 0\n");
+    const wrapped = buildWrappedCommand(`cd '${dir.replace(/'/g, "'\\''")}'; . profile`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/sh",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:126`));
+    assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper blocks existing shell functions used later in a compound command", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("echo hi; bye", "posix", marker);
+  const result = spawnSync("sh", ["-c", `bye(){ kill -TERM 0; }; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Blocked unsafe shell-terminating command/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:126`));
   assert.match(result.stdout, /PARENT_STILL_ALIVE/);
 });
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1,5 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
 
 const {
   resolveEffectiveShellKind,
@@ -116,6 +120,97 @@ test("cmd wrapper uses interactive cmd variable expansion", () => {
   const wrapped = buildWrappedCommand("ipconfig /all", "cmd", "__NCMCP_TEST__");
   assert.match(wrapped, /"%__NCMCP_TEST___CMD%"/);
   assert.doesNotMatch(wrapped, /"%%__NCMCP_TEST___CMD%%"/);
+});
+
+test("posix wrapper isolates set -e failures from the parent login shell", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("  set -e\nfalse\necho SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper keeps non-exiting state changes in the parent shell", () => {
+  const marker = "__NCMCP_TEST__";
+  const cwd = mkdtempSync(join(tmpdir(), "netcatty-pty-cd-"));
+  try {
+    const wrapped = buildWrappedCommand(`cd '${cwd.replace(/'/g, "'\\''")}'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}pwd`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SHELL: "/bin/false",
+      },
+    });
+
+    assert.equal(result.error, undefined);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, new RegExp(`${cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("posix wrapper survives a failing command when parent errexit is already active", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("false", "posix", marker);
+  const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper isolates inside the current shell instead of SHELL env", { skip: process.platform === "win32" }, () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("set -e\n[[ 1 == 1 ]] && echo BASH_OK", "posix", marker);
+  const result = spawnSync("bash", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/false",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /BASH_OK/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper emits the end marker on a fresh line after exec without trailing newline", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("exec printf OK", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      SHELL: "/bin/sh",
+    },
+  });
+
+  assert.equal(result.error, undefined);
+  assert.match(result.stdout, new RegExp(`OK\\n${marker}_E:0`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
 });
 
 test("execViaChannel registers a pending-cancel marker before the SSH channel opens", () => {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -76,6 +76,11 @@ function escapeCmdForNestedShell(text) {
   return String(text || "").replace(/"/g, '""').replace(/%/g, "%%");
 }
 
+function shouldIsolatePosixCommand(command) {
+  const text = String(command || "");
+  return /(^|[\n\r;|&({])\s*(?:set\s+(?:-[^\n\r;|&)]*e[^\n\r;|&)]*|-o\s+errexit)\b|exit\b|logout\b|exec\b|kill\s+(?:-[A-Za-z0-9]+\s+)?(?:\$\$|0)\b)/.test(text);
+}
+
 // Matches PowerShell's default prompt only (e.g. `PS C:\Users\alice>`,
 // `PS>`). Custom prompt functions (oh-my-posh, starship, PSReadLine themes
 // that emit `❯`/`λ`/etc.) intentionally fall through — we'd rather miss
@@ -158,7 +163,7 @@ function buildWrappedCommand(command, shellKind, marker) {
     default: {
       // Single-line compound command with early marker.
       //
-      // Layout: __NCMCP_xxx=0; { ... MARKER_S; eval command; MARKER_E; }
+      // Layout: __NCMCP_xxx=0; { ... MARKER_S; command; MARKER_E; }
       //
       // Key design decisions:
       //
@@ -169,9 +174,10 @@ function buildWrappedCommand(command, shellKind, marker) {
       //    long echo line might not contain the marker and would leak
       //    through to the terminal as garbage.
       //
-      // 2) The user command is executed via eval on a quoted string. This
-      //    keeps shell syntax errors inside the eval call so the wrapper
-      //    can still emit the end marker and return a non-zero exit code.
+      // 2) Normal commands still run in the active shell so state changes like
+      //    `cd` and `export` keep affecting the visible terminal. Commands
+      //    that can exit the shell (`set -e`, `exit`, `exec`, ...) run in a
+      //    subshell of the current shell so the wrapper can emit the end marker.
       //
       // 3) Single-line { ... } is parsed fully before execution, so SIGINT
       //    cannot cause bash to flush the end marker from the input buffer.
@@ -179,6 +185,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       //    preventing the shell from aborting the compound command.
       const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
       const escaped = escapePosixSingleQuoted(command);
+      const isolate = shouldIsolatePosixCommand(command) ? "1" : "0";
       // Leading single space: lets bash/zsh skip recording this command
       // in history when the user already has HISTCONTROL=ignorespace
       // (bash) or HIST_IGNORE_SPACE (zsh) configured — Debian/Ubuntu and
@@ -187,7 +194,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       // Without that config the prefix is harmless; it just doesn't
       // suppress history recording.
       return (
-        ` ${marker}=0; ${marker}_cmd='${escaped}'; { printf '%s\\n' '${marker}_S'; trap ':' INT; ${noPager}eval "$${marker}_cmd"; __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }\n`
+        ` ${marker}=0; ${marker}_cmd='${escaped}'; ${marker}_isolate=${isolate}; ${marker}_flags=$-; { printf '%s\\n' '${marker}_S'; trap ':' INT; case "$${marker}_flags" in *e*) set +e; ${marker}_isolate=1 ;; esac; if [ "$${marker}_isolate" = 1 ]; then ( ${noPager}eval "$${marker}_cmd" ); else ${noPager}eval "$${marker}_cmd"; fi; __NCMCP_rc=$?; printf '\\n%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; trap - INT; case "$${marker}_flags" in *e*) set -e; true ;; *) (exit $__NCMCP_rc) ;; esac; }\n`
       );
     }
   }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -76,9 +76,1698 @@ function escapeCmdForNestedShell(text) {
   return String(text || "").replace(/"/g, '""').replace(/%/g, "%%");
 }
 
-function shouldIsolatePosixCommand(command) {
+const POSIX_WRAPPER_HELPER_NAMES = new Set([
+  "[",
+  "alias",
+  "builtin",
+  "command",
+  "eval",
+  "exit",
+  "functions",
+  "printf",
+  "test",
+  "trap",
+  "true",
+  "type",
+  "typeset",
+  "unset",
+]);
+
+const POSIX_NOUNSET_SAFE_VARIABLES = new Set([
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "OLDPWD",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "SHLVL",
+  "TERM",
+  "TMPDIR",
+  "USER",
+]);
+
+function tokenizePosixCommand(command) {
+  const tokens = [];
   const text = String(command || "");
-  return /(^|[\n\r;|&({])\s*(?:set\s+(?:-[^\n\r;|&)]*e[^\n\r;|&)]*|-o\s+errexit)\b|exit\b|logout\b|exec\b|kill\s+(?:-[A-Za-z0-9]+\s+)?(?:\$\$|0)\b)/.test(text);
+  let word = "";
+  let quote = null;
+
+  const pushWord = () => {
+    if (!word) return;
+    tokens.push({ type: "word", value: word });
+    word = "";
+  };
+  const pushOp = (value) => {
+    pushWord();
+    tokens.push({ type: "op", value });
+  };
+  const readDollarParen = (startIndex) => {
+    let value = "$(";
+    let depth = 1;
+    let nestedQuote = null;
+    for (let i = startIndex + 2; i < text.length; i += 1) {
+      const ch = text[i];
+      value += ch;
+      if (nestedQuote === "'") {
+        if (ch === "'") nestedQuote = null;
+        continue;
+      }
+      if (nestedQuote === "\"" || nestedQuote === "`") {
+        if (ch === "\\") {
+          if (i + 1 < text.length) value += text[++i];
+          continue;
+        }
+        if (ch === nestedQuote) nestedQuote = null;
+        continue;
+      }
+      if (ch === "'" || ch === "\"" || ch === "`") {
+        nestedQuote = ch;
+        continue;
+      }
+      if (ch === "\\") {
+        if (i + 1 < text.length) value += text[++i];
+        continue;
+      }
+      if (ch === "(") depth += 1;
+      if (ch === ")") {
+        depth -= 1;
+        if (depth === 0) return { value, endIndex: i };
+      }
+    }
+    return null;
+  };
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      else word += ch;
+      continue;
+    }
+    if (quote === "ansi-single") {
+      if (ch === "\\") {
+        if (i + 1 < text.length) word += text[++i];
+        continue;
+      }
+      if (ch === "'") quote = null;
+      else word += ch;
+      continue;
+    }
+    if (quote === "\"") {
+      if (ch === "\\") {
+        if (i + 1 < text.length) word += text[++i];
+        continue;
+      }
+      if (ch === "\"") quote = null;
+      else word += ch;
+      continue;
+    }
+    if (quote === "`") {
+      if (ch === "\\") {
+        if (i + 1 < text.length) word += text[++i];
+        continue;
+      }
+      if (ch === "`") {
+        word += ch;
+        quote = null;
+      }
+      else word += ch;
+      continue;
+    }
+
+    if (ch === "$" && text[i + 1] === "(" && text[i + 2] !== "(") {
+      const result = readDollarParen(i);
+      if (result) {
+        word += result.value;
+        i = result.endIndex;
+        continue;
+      }
+    }
+    if (ch === "$" && text[i + 1] === "'") {
+      quote = "ansi-single";
+      i += 1;
+      continue;
+    }
+    if (ch === "`") {
+      word += ch;
+      quote = ch;
+      continue;
+    }
+    if (ch === "'" || ch === "\"") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "\\") {
+      if (i + 1 < text.length) word += text[++i];
+      continue;
+    }
+    if (ch === "\n" || ch === "\r") {
+      pushOp(";");
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      pushWord();
+      continue;
+    }
+    if (ch === "&" && /[<>]$/.test(word) && /[0-9-]/.test(text[i + 1] || "")) {
+      word += ch;
+      continue;
+    }
+    if (";|&(){}".includes(ch)) {
+      const next = text[i + 1];
+      if ((ch === "&" && next === "&") || (ch === "|" && next === "|") || (ch === ";" && next === ";")) {
+        pushOp(ch + next);
+        i += 1;
+      } else {
+        pushOp(ch);
+      }
+      continue;
+    }
+    word += ch;
+  }
+  pushWord();
+  return tokens;
+}
+
+function isAssignmentWord(word) {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(word);
+}
+
+function isRedirectionWord(word) {
+  return /^\d*(?:<>|>>|>\||<&|>&|[<>])/.test(word);
+}
+
+function redirectionConsumesNextWord(word) {
+  return /^\d*(?:<>|>>|>\||<&|>&|[<>])$/.test(word);
+}
+
+function commandBasename(word) {
+  return String(word || "").split("/").pop();
+}
+
+function isCommandPrefixWord(word) {
+  const base = commandBasename(word);
+  return word === "!" || base === "time" || base === "command" || base === "builtin" || base === "nice" || base === "nohup" || base === "coproc" || base === "repeat" || base === "noglob" || base === "nocorrect" || base === "-" || base === "timeout" || base === "sudo" || base === "doas" || base === "stdbuf" || base === "setsid" || base === "flock";
+}
+
+function isUnsafeKillTarget(word) {
+  if (word === "$$" || word.includes("$") || word.includes("`") || word.includes("$(")) return true;
+  return /^[+-]?0+$/.test(word);
+}
+
+function hasUnsafeKillTarget(words) {
+  let signalOptionConsumed = false;
+  let afterDoubleDash = false;
+
+  for (const word of words) {
+    if (!afterDoubleDash && word === "--") {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (
+      !afterDoubleDash
+      && !signalOptionConsumed
+      && (/^-[A-Za-z][A-Za-z0-9_-]*$/.test(word) || /^-\d+$/.test(word))
+    ) {
+      signalOptionConsumed = true;
+      continue;
+    }
+    if (isUnsafeKillTarget(word) || /^-\d+$/.test(word)) return true;
+  }
+
+  return false;
+}
+
+function isShellCommand(word) {
+  return new Set(["sh", "bash", "zsh", "dash", "ksh", "mksh"]).has(commandBasename(word));
+}
+
+function isScriptInterpreterCommand(word) {
+  return /^(?:python(?:[0-9]+(?:\.[0-9]+)*)?|perl(?:[0-9]+(?:\.[0-9]+)*)?|ruby(?:[0-9]+(?:\.[0-9]+)*)?|node(?:js|[0-9]+(?:\.[0-9]+)*)?|php(?:[0-9]+(?:\.[0-9]+)*)?|awk|gawk|mawk|nawk)$/.test(commandBasename(word));
+}
+
+function extractShellCommandString(words) {
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    if (word === "--") return null;
+    if (!word.startsWith("-") || word === "-") return null;
+    if (word.slice(1).includes("c")) return words[i + 1] || "";
+    if (word === "-O" || word === "-o" || word === "--option") {
+      i += 1;
+    }
+  }
+  return null;
+}
+
+function hasExpandableDoubleDollarWord(words) {
+  return words.some((word) => String(word || "").includes("$$"));
+}
+
+function hasDangerousScriptKill(words) {
+  return words.some((word) => {
+    const text = String(word || "");
+    return (
+      /(?:^|[^A-Za-z0-9_])(?:os\.)?kill\s*\(\s*[+-]?0(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])(?:os\.)?kill\s*\(\s*(?:os\.)?getppid\s*\(/.test(text)
+      || /(?:^|[^A-Za-z0-9_])(?:os\.)?kill\s*\(\s*(?:os\.)?getpgrp\s*\(/.test(text)
+      || /(?:^|[^A-Za-z0-9_])killpg\s*\(/.test(text)
+      || /(?:^|[^A-Za-z0-9_])process\.kill\s*\(\s*[+-]?0(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])process\.kill\s*\(\s*process\.ppid(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])Process\.kill\s*\(\s*[^,]+,\s*[+-]?0(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])Process\.kill\s*\(\s*[^,]+,\s*(?:Process\.)?ppid(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])Process\.kill\s*\(\s*[^,]+,\s*(?:Process\.)?getpgrp(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])kill\s+[^;&|]*[, ]\s*[+-]?0(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])kill\s+[^;&|]*[, ]\s*(?:getppid|ppid)(?:\D|$)/.test(text)
+      || /(?:^|[^A-Za-z0-9_])kill\s+[^;&|]*[, ]\s*(?:getpgrp|pgrp)(?:\D|$)/.test(text)
+    );
+  });
+}
+
+function hasDangerousRunnerKill(tokens, depth = 0) {
+  const words = tokens.filter((token) => token.type === "word").map((token) => token.value);
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = commandBasename(words[i]);
+    if (word !== "xargs" && word !== "parallel" && word !== "find") continue;
+
+    for (let j = i + 1; j < words.length; j += 1) {
+      if (commandBasename(words[j]) !== "kill") continue;
+      const killArgs = words.slice(j + 1);
+      if (word === "xargs" || word === "parallel") return true;
+      if (hasUnsafeKillTarget(killArgs)) return true;
+    }
+
+    if (depth >= 24) continue;
+    for (let j = i + 1; j < words.length; j += 1) {
+      const candidate = words[j];
+      if (!isShellCommand(candidate)) continue;
+      const shellCommandString = extractShellCommandString(words.slice(j + 1));
+      if (shellCommandString === null) continue;
+      const nested = analyzePosixCommand(shellCommandString, depth + 1);
+      if (nested.blockUnsafe) return true;
+    }
+  }
+
+  return false;
+}
+
+function isFunctionName(word) {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(word) && ![
+    "if",
+    "then",
+    "else",
+    "elif",
+    "fi",
+    "for",
+    "while",
+    "until",
+    "do",
+    "done",
+    "case",
+    "esac",
+    "function",
+  ].includes(word);
+}
+
+function functionBodyStartIndex(tokens, index) {
+  const token = tokens[index];
+  if (!token || token.type !== "word") return -1;
+
+  const isFunctionBodyStart = (candidate) => (
+    candidate?.type === "op" && (candidate.value === "{" || candidate.value === "(")
+  );
+
+  if (
+    token.value === "function"
+    && tokens[index + 1]?.type === "word"
+    && isFunctionName(tokens[index + 1].value)
+  ) {
+    let cursor = index + 2;
+    if (tokens[cursor]?.type === "op" && tokens[cursor].value === "(" && tokens[cursor + 1]?.type === "op" && tokens[cursor + 1].value === ")") {
+      cursor += 2;
+    }
+    return isFunctionBodyStart(tokens[cursor]) ? cursor : -1;
+  }
+
+  if (
+    isFunctionName(token.value)
+    && tokens[index + 1]?.type === "op"
+    && tokens[index + 1].value === "("
+    && tokens[index + 2]?.type === "op"
+    && tokens[index + 2].value === ")"
+    && isFunctionBodyStart(tokens[index + 3])
+  ) {
+    return index + 3;
+  }
+
+  return -1;
+}
+
+function functionDefinitionAt(tokens, index) {
+  const token = tokens[index];
+  const bodyStart = functionBodyStartIndex(tokens, index);
+  if (bodyStart === -1) return null;
+  return {
+    name: token.value === "function" ? tokens[index + 1]?.value : token.value,
+    bodyStart,
+  };
+}
+
+function skipFunctionBody(tokens, bodyStartIndex) {
+  const opener = tokens[bodyStartIndex]?.value;
+  const closer = opener === "{" ? "}" : ")";
+  let depth = 0;
+  for (let i = bodyStartIndex; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type !== "op") continue;
+    if (token.value === opener) depth += 1;
+    if (token.value === closer) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return bodyStartIndex;
+}
+
+function tokensToCommand(tokens) {
+  return tokens.map((token) => token.value).join(" ");
+}
+
+function commandWordsBeforeOperator(tokens, startIndex) {
+  const words = [];
+  for (let i = startIndex; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type === "op") break;
+    if (token.type === "word") words.push(token.value);
+  }
+  return words;
+}
+
+function isCommandPositionResetWord(word) {
+  return ["if", "while", "until", "then", "do", "else", "elif"].includes(word);
+}
+
+function isShellReservedWord(word) {
+  return [
+    "if",
+    "then",
+    "else",
+    "elif",
+    "fi",
+    "for",
+    "while",
+    "until",
+    "do",
+    "done",
+    "case",
+    "esac",
+    "in",
+    "function",
+  ].includes(word);
+}
+
+function skipPrefixOptionWords(tokens, index, prefixWord) {
+  let cursor = index;
+  let lookupOnly = false;
+
+  const nextWord = () => tokens[cursor + 1]?.type === "word" ? tokens[cursor + 1].value : null;
+  const consumeNext = () => {
+    cursor += 1;
+  };
+
+  const prefixBase = commandBasename(prefixWord);
+
+  if (prefixBase === "time") {
+    while (nextWord() && /^-[A-Za-z]+$/.test(nextWord())) consumeNext();
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "command") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      if (word.includes("v") || word.includes("V")) lookupOnly = true;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "builtin") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "nice") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (word === "-n") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (/^-n.+/.test(word) || /^-[+-]?\d+$/.test(word)) {
+        consumeNext();
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "nohup") {
+    if (nextWord() === "--") consumeNext();
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "coproc") {
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "repeat") {
+    if (nextWord() && /^\d+$/.test(nextWord())) consumeNext();
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "timeout") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (word === "-s" || word === "--signal" || word === "-k" || word === "--kill-after") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (
+        word.startsWith("--signal=")
+        || word.startsWith("--kill-after=")
+        || word === "-v"
+        || word === "--verbose"
+        || word === "--foreground"
+        || word === "--preserve-status"
+      ) {
+        consumeNext();
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    if (nextWord()) consumeNext();
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "sudo") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (["-A", "-b", "-E", "-e", "-H", "-h", "-K", "-k", "-n", "-S", "-s", "-V", "-v"].includes(word)) {
+        consumeNext();
+        continue;
+      }
+      if (["-C", "-c", "-D", "-g", "-p", "-R", "-r", "-t", "-U", "-u"].includes(word)) {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (/^-[A-Za-z].+/.test(word) || word.startsWith("--")) {
+        consumeNext();
+        continue;
+      }
+      break;
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "doas") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (word === "-n" || word === "-s") {
+        consumeNext();
+        continue;
+      }
+      if (word === "-u" || word === "-C") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "stdbuf") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (word === "-i" || word === "-o" || word === "-e") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (/^-(?:i|o|e).+/.test(word) || word.startsWith("--input=") || word.startsWith("--output=") || word.startsWith("--error=")) {
+        consumeNext();
+        continue;
+      }
+      if (word === "--input" || word === "--output" || word === "--error") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "setsid") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    return { index: cursor, lookupOnly };
+  }
+
+  if (prefixBase === "flock") {
+    while (nextWord()) {
+      const word = nextWord();
+      if (word === "--") {
+        consumeNext();
+        break;
+      }
+      if (["-c", "-E", "-F", "-o", "-s", "-x", "-n", "-u", "-w"].includes(word)) {
+        consumeNext();
+        if (word === "-c" || word === "-E" || word === "-w") {
+          if (nextWord()) consumeNext();
+        }
+        continue;
+      }
+      if (word.startsWith("--command=") || word.startsWith("--conflict-exit-code=") || word.startsWith("--timeout=")) {
+        consumeNext();
+        continue;
+      }
+      if (word === "--command" || word === "--conflict-exit-code" || word === "--timeout") {
+        consumeNext();
+        if (nextWord()) consumeNext();
+        continue;
+      }
+      if (!word.startsWith("-") || word === "-") break;
+      consumeNext();
+    }
+    if (nextWord()) consumeNext();
+    return { index: cursor, lookupOnly };
+  }
+
+  return { index: cursor, lookupOnly };
+}
+
+function parseEnvInvocation(words) {
+  let commandIndex = -1;
+  let blockUnsafe = false;
+
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    if (word === "-") {
+      continue;
+    }
+    if (word === "--") {
+      commandIndex = i + 1 < words.length ? i + 1 : -1;
+      break;
+    }
+    if (word === "-S" || word.startsWith("-S") || /^-[A-Za-z]*S/.test(word) || word === "--split-string" || word.startsWith("--split-string=")) {
+      blockUnsafe = true;
+      continue;
+    }
+    if (word === "-u" || word === "-C" || word === "-P" || word === "--unset" || word === "--chdir") {
+      i += 1;
+      continue;
+    }
+    if (word.startsWith("--unset=") || word.startsWith("--chdir=") || /^-[uCP].+/.test(word)) {
+      continue;
+    }
+    if (word.startsWith("-") && word !== "-") {
+      continue;
+    }
+    if (isAssignmentWord(word)) {
+      continue;
+    }
+    commandIndex = i;
+    break;
+  }
+
+  return {
+    blockUnsafe,
+    command: commandIndex === -1 ? "" : words[commandIndex],
+    args: commandIndex === -1 ? [] : words.slice(commandIndex + 1),
+  };
+}
+
+function extractFlockCommandString(words) {
+  for (let i = 0; i < words.length; i += 1) {
+    const word = words[i];
+    if (word === "--") continue;
+    if (word === "-c" || word === "--command") return words[i + 1] || "";
+    if (word.startsWith("--command=")) return word.slice("--command=".length);
+    if (word === "-E" || word === "-w" || word === "--conflict-exit-code" || word === "--timeout") {
+      i += 1;
+      continue;
+    }
+    if (word.startsWith("--conflict-exit-code=") || word.startsWith("--timeout=")) continue;
+    if (word.startsWith("-") && word !== "-") continue;
+    break;
+  }
+  return null;
+}
+
+function topLevelCommandHasSeparator(tokens) {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      i = skipFunctionBody(tokens, bodyStart);
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op" && [";", ";;", "&&", "||", "|"].includes(token.value)) return true;
+  }
+  return false;
+}
+
+function normalizeTrapSignal(signal) {
+  const normalized = String(signal || "").toUpperCase().replace(/^SIG/, "");
+  if (normalized === "2") return "INT";
+  return normalized;
+}
+
+function looksLikeTrapSignal(word) {
+  const normalized = normalizeTrapSignal(word);
+  return new Set([
+    "0",
+    "EXIT",
+    "HUP",
+    "INT",
+    "QUIT",
+    "ILL",
+    "ABRT",
+    "FPE",
+    "KILL",
+    "SEGV",
+    "PIPE",
+    "ALRM",
+    "TERM",
+    "USR1",
+    "USR2",
+    "CHLD",
+    "CONT",
+    "STOP",
+    "TSTP",
+    "TTIN",
+    "TTOU",
+    "DEBUG",
+    "ERR",
+    "ZERR",
+  ]).has(normalized) || /^\d+$/.test(String(word || ""));
+}
+
+function parseTrapInvocation(words) {
+  const args = [];
+  let queryOnly = false;
+
+  for (const word of words) {
+    if (word === "--") continue;
+    if (args.length === 0 && (word === "-p" || word === "-l" || word === "--print")) {
+      queryOnly = true;
+      continue;
+    }
+    args.push(word);
+  }
+
+  if (queryOnly) {
+  return {
+      queryOnly: true,
+      handler: "",
+      signals: args.filter(looksLikeTrapSignal).map(normalizeTrapSignal),
+    };
+  }
+
+  if (args.length > 0 && args.every(looksLikeTrapSignal)) {
+    return {
+      queryOnly: false,
+      handler: "-",
+      signals: args.map(normalizeTrapSignal),
+    };
+  }
+
+  return {
+    queryOnly: false,
+    handler: args[0] || "",
+    signals: args.slice(1).map(normalizeTrapSignal),
+  };
+}
+
+function isUnsafeTrapHandler(handler, depth) {
+  const text = String(handler || "");
+  const handlerRisk = analyzePosixCommand(text, depth + 1);
+  return (
+    handlerRisk.blockUnsafe
+    || /(^|[^A-Za-z0-9_./-])(exit|logout|exec|return|eval)($|[^A-Za-z0-9_./-])/.test(text)
+    || /(^|[^A-Za-z0-9_./-])kill([^;&|]*)(\$\$|[+]?0+|-[0-9]+)($|[^A-Za-z0-9_./-])/.test(text)
+    || /(^|[^A-Za-z0-9_./-])set[ \t].*(-[A-Za-z]*[eu]|-o[ \t]+(?:err_?exit|errexit|nounset|unset))($|[^A-Za-z0-9_./-])/i.test(text)
+    || /(^|[^A-Za-z0-9_./-])setopt[ \t].*(err_?exit|errexit|nounset|unset)($|[^A-Za-z0-9_./-])/i.test(text)
+  );
+}
+
+function posixCommandNeedsIntTrapBypass(tokens) {
+  let startOfCommand = true;
+  const hasSeparator = topLevelCommandHasSeparator(tokens);
+  const intTrapFunctions = new Set();
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      const definition = functionDefinitionAt(tokens, i);
+      if (definition) {
+        const bodyEnd = skipFunctionBody(tokens, definition.bodyStart);
+        const bodyTokens = tokens.slice(definition.bodyStart + 1, bodyEnd);
+        if (posixCommandNeedsIntTrapBypass(bodyTokens)) {
+          intTrapFunctions.add(definition.name);
+        }
+        i = bodyEnd;
+        startOfCommand = false;
+        continue;
+      }
+      i = skipFunctionBody(tokens, bodyStart);
+      startOfCommand = false;
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op") {
+      startOfCommand = true;
+      continue;
+    }
+    if (token.type !== "word") continue;
+    if (isCommandPositionResetWord(token.value)) {
+      startOfCommand = true;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      continue;
+    }
+    if (intTrapFunctions.has(token.value)) return true;
+    if (token.value !== "trap") {
+      startOfCommand = false;
+      continue;
+    }
+
+    const trap = parseTrapInvocation(commandWordsBeforeOperator(tokens, i + 1));
+    if (!trap.queryOnly && trap.signals.some((signal) => signal === "INT")) return true;
+    if (trap.queryOnly && !hasSeparator && (trap.signals.length === 0 || trap.signals.some((signal) => signal === "INT"))) return true;
+    if (!trap.queryOnly && !hasSeparator && !trap.handler && trap.signals.length === 0) return true;
+    startOfCommand = false;
+  }
+
+  return false;
+}
+
+function posixCommandHasTrapQuery(tokens) {
+  let startOfCommand = true;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      i = skipFunctionBody(tokens, bodyStart);
+      startOfCommand = false;
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op") {
+      startOfCommand = true;
+      continue;
+    }
+    if (token.type !== "word") continue;
+    if (isCommandPositionResetWord(token.value)) {
+      startOfCommand = true;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      continue;
+    }
+    if (token.value !== "trap") {
+      startOfCommand = false;
+      continue;
+    }
+
+    const trap = parseTrapInvocation(commandWordsBeforeOperator(tokens, i + 1));
+    if (trap.queryOnly) return true;
+    startOfCommand = false;
+  }
+
+  return false;
+}
+
+function firstCommandWord(tokens) {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type === "op") continue;
+    if (token.type !== "word") continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      continue;
+    }
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    return token.value;
+  }
+  return "";
+}
+
+function firstCommandIndex(tokens) {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type === "op") continue;
+    if (token.type !== "word") continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      continue;
+    }
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function isStatePreservingCommandWord(word) {
+  return new Set([
+    "cd",
+    "pushd",
+    "popd",
+    "dirs",
+    "export",
+    "alias",
+    "unalias",
+    "unset",
+    "readonly",
+    "set",
+    "setopt",
+    "unsetopt",
+    "shopt",
+    "trap",
+    ".",
+    "source",
+    "umask",
+    "ulimit",
+    "read",
+    "typeset",
+    "declare",
+  ]).has(commandBasename(word));
+}
+
+function escapePosixSingleQuotedWord(word) {
+  return escapePosixSingleQuoted(word || "");
+}
+
+function isStatePreservingPosixCommand(tokens) {
+  let startOfCommand = true;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      if (startOfCommand && functionDefinitionAt(tokens, i)) return true;
+      i = skipFunctionBody(tokens, bodyStart);
+      startOfCommand = false;
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op") {
+      startOfCommand = true;
+      continue;
+    }
+    if (token.type !== "word") continue;
+    if (isCommandPositionResetWord(token.value)) {
+      startOfCommand = true;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      continue;
+    }
+    if (isStatePreservingCommandWord(token.value)) return true;
+    startOfCommand = false;
+  }
+
+  return false;
+}
+
+function extractCommandSubstitutions(command) {
+  const text = String(command || "");
+  const substitutions = [];
+  let quote = null;
+
+  const readBacktick = (startIndex) => {
+    let value = "";
+    for (let i = startIndex + 1; i < text.length; i += 1) {
+      const ch = text[i];
+      if (ch === "\\") {
+        if (i + 1 < text.length) value += text[++i];
+        continue;
+      }
+      if (ch === "`") return { value, endIndex: i };
+      value += ch;
+    }
+    return null;
+  };
+
+  const readDollarParen = (startIndex) => {
+    let value = "";
+    let depth = 1;
+    let nestedQuote = null;
+    for (let i = startIndex + 2; i < text.length; i += 1) {
+      const ch = text[i];
+      if (nestedQuote === "'") {
+        if (ch === "'") nestedQuote = null;
+        value += ch;
+        continue;
+      }
+      if (nestedQuote === "\"" || nestedQuote === "`") {
+        if (ch === "\\") {
+          value += ch;
+          if (i + 1 < text.length) value += text[++i];
+          continue;
+        }
+        if (ch === nestedQuote) nestedQuote = null;
+        value += ch;
+        continue;
+      }
+      if (ch === "'" || ch === "\"" || ch === "`") {
+        nestedQuote = ch;
+        value += ch;
+        continue;
+      }
+      if (ch === "\\") {
+        value += ch;
+        if (i + 1 < text.length) value += text[++i];
+        continue;
+      }
+      if (ch === "(") depth += 1;
+      if (ch === ")") {
+        depth -= 1;
+        if (depth === 0) return { value, endIndex: i };
+      }
+      value += ch;
+    }
+    return null;
+  };
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === "ansi-single") {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === "\"") {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
+      if (ch === "\"") {
+        quote = null;
+        continue;
+      }
+    }
+
+    if (!quote && ch === "$" && text[i + 1] === "'") {
+      quote = "ansi-single";
+      i += 1;
+      continue;
+    }
+    if (!quote && ch === "'") {
+      quote = "'";
+      continue;
+    }
+    if (ch === "\"") {
+      quote = quote === "\"" ? null : "\"";
+      continue;
+    }
+    if (ch === "\\") {
+      i += 1;
+      continue;
+    }
+    if (ch === "`") {
+      const result = readBacktick(i);
+      if (result) {
+        substitutions.push(result.value);
+        i = result.endIndex;
+      }
+      continue;
+    }
+    if (ch === "$" && text[i + 1] === "(" && text[i + 2] !== "(") {
+      const result = readDollarParen(i);
+      if (result) {
+        substitutions.push(result.value);
+        i = result.endIndex;
+      }
+    }
+  }
+
+  return substitutions;
+}
+
+function normalizeShellOptionName(word) {
+  return String(word || "").toLowerCase().replace(/[-_]/g, "");
+}
+
+function isErrexitOptionName(word) {
+  return normalizeShellOptionName(word) === "errexit";
+}
+
+function isNounsetOptionName(word) {
+  const normalized = normalizeShellOptionName(word);
+  return normalized === "nounset" || normalized === "unset";
+}
+
+function hasShortShellOption(word, option) {
+  return new RegExp(`^-[^-]*${option}`).test(String(word || ""));
+}
+
+function readShellVariableName(text, startIndex) {
+  const match = String(text || "").slice(startIndex).match(/^[A-Za-z_][A-Za-z0-9_]*/);
+  return match ? match[0] : "";
+}
+
+function isNounsetSafeShellVariable(name) {
+  return POSIX_NOUNSET_SAFE_VARIABLES.has(name) || /^LC_[A-Za-z0-9_]+$/.test(name);
+}
+
+function hasPotentialNounsetExpansion(command) {
+  const text = String(command || "");
+  let quote = null;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === "ansi-single") {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === "\"") {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
+      if (ch === "\"") {
+        quote = null;
+        continue;
+      }
+    }
+    if (quote === "`") {
+      if (ch === "\\") {
+        i += 1;
+        continue;
+      }
+      if (ch === "`") quote = null;
+      continue;
+    }
+
+    if (!quote && ch === "$" && text[i + 1] === "'") {
+      quote = "ansi-single";
+      i += 1;
+      continue;
+    }
+    if (!quote && ch === "'") {
+      quote = "'";
+      continue;
+    }
+    if (ch === "\"") {
+      quote = quote === "\"" ? null : "\"";
+      continue;
+    }
+    if (ch === "\\") {
+      i += 1;
+      continue;
+    }
+    if (ch === "`") {
+      quote = "`";
+      continue;
+    }
+    if (ch !== "$") continue;
+    if (text[i + 1] === "(") continue;
+    if (/[0-9]/.test(text[i + 1] || "")) return true;
+    if (/[A-Za-z_]/.test(text[i + 1] || "")) {
+      const name = readShellVariableName(text, i + 1);
+      if (!isNounsetSafeShellVariable(name)) return true;
+      i += name.length;
+      continue;
+    }
+    if (text[i + 1] === "{" && /[0-9]/.test(text[i + 2] || "")) return true;
+    if (text[i + 1] === "{" && /[A-Za-z_]/.test(text[i + 2] || "")) {
+      const name = readShellVariableName(text, i + 2);
+      const suffix = text[i + 2 + name.length];
+      const next = text[i + 3 + name.length];
+      if (
+        (suffix === ":" && ["-", "=", "+"].includes(next))
+        || ["-", "=", "+"].includes(suffix)
+      ) {
+        i += name.length + 2;
+        continue;
+      }
+      if (!isNounsetSafeShellVariable(name)) return true;
+      i += name.length + 2;
+    }
+  }
+
+  return false;
+}
+
+function isRelativeSourcePath(path) {
+  const text = String(path || "");
+  return !!text && !text.startsWith("/") && !text.startsWith("~/");
+}
+
+function isDisableShellOptionWord(word, option) {
+  return new RegExp(`^[+][^+]*${option}`).test(String(word || ""));
+}
+
+function isEnableShellOptionWord(word, option) {
+  return new RegExp(`^-[^-]*${option}`).test(String(word || ""));
+}
+
+function commandFinalShellOptionState(tokens, option, longNames) {
+  let startOfCommand = true;
+  let state = null;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      i = skipFunctionBody(tokens, bodyStart);
+      startOfCommand = false;
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op") {
+      startOfCommand = true;
+      continue;
+    }
+    if (token.type !== "word") continue;
+    if (isCommandPositionResetWord(token.value)) {
+      startOfCommand = true;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      continue;
+    }
+    if (token.value !== "set") {
+      startOfCommand = false;
+      continue;
+    }
+    const words = commandWordsBeforeOperator(tokens, i + 1);
+    for (let index = 0; index < words.length; index += 1) {
+      const word = words[index];
+      if (isDisableShellOptionWord(word, option)) {
+        state = "disabled";
+      } else if (isEnableShellOptionWord(word, option)) {
+        state = "enabled";
+      } else if (word === "+o" && longNames.some((name) => normalizeShellOptionName(words[index + 1]) === name)) {
+        state = "disabled";
+        index += 1;
+      } else if (word === "-o" && longNames.some((name) => normalizeShellOptionName(words[index + 1]) === name)) {
+        state = "enabled";
+        index += 1;
+      }
+    }
+    startOfCommand = false;
+  }
+  return state;
+}
+
+function commandHasErrexitSensitiveWord(tokens) {
+  let startOfCommand = true;
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const bodyStart = functionBodyStartIndex(tokens, i);
+    if (bodyStart !== -1) {
+      i = skipFunctionBody(tokens, bodyStart);
+      startOfCommand = false;
+      continue;
+    }
+    const token = tokens[i];
+    if (token.type === "op") {
+      if (token.value === "|") return true;
+      startOfCommand = true;
+      continue;
+    }
+    if (token.type !== "word") continue;
+    if (isCommandPositionResetWord(token.value)) {
+      startOfCommand = true;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(token.value)) continue;
+    if (isRedirectionWord(token.value)) {
+      if (redirectionConsumesNextWord(token.value)) i += 1;
+      continue;
+    }
+    if (isCommandPrefixWord(token.value)) {
+      const prefix = skipPrefixOptionWords(tokens, i, token.value);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      continue;
+    }
+    if (!isShellReservedWord(token.value) && !isStatePreservingCommandWord(token.value)) return true;
+    if (["false", "grep", "test", "[", "[["].includes(commandBasename(token.value))) return true;
+    if (token.value.includes("/") || token.value.startsWith("$") || token.value.includes("`") || token.value.includes("$(")) return true;
+    startOfCommand = false;
+  }
+
+  return false;
+}
+
+function commandNeedsTemporaryIntTrap(command, tokens) {
+  if (posixCommandNeedsIntTrapBypass(tokens)) return false;
+  return /\bsleep\b/.test(String(command || ""));
+}
+
+function analyzePosixCommand(command, depth = 0) {
+  const tokens = tokenizePosixCommand(command);
+  const commandWord = firstCommandWord(tokens);
+  const skipTemporaryIntTrap = posixCommandNeedsIntTrapBypass(tokens);
+  let startOfCommand = true;
+  let risky = false;
+  let blockUnsafe = false;
+  let bypassRuntimeCheck = false;
+  let cwdMayHaveChanged = false;
+  const sourceCheckPaths = new Set();
+  const functionCheckWords = new Set();
+  const riskyFunctions = new Map();
+  const riskyAliases = new Map();
+
+  if (hasDangerousRunnerKill(tokens, depth)) {
+    blockUnsafe = true;
+  }
+  if (tokens.some((token) => token.type === "word" && isAssignmentWord(token.value) && token.value.includes("__NCMCP"))) {
+    blockUnsafe = true;
+  }
+
+  if (depth < 24) {
+    for (const substitution of extractCommandSubstitutions(command)) {
+      const nested = analyzePosixCommand(substitution, depth + 1);
+      if (nested.blockUnsafe) blockUnsafe = true;
+    }
+  }
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.type === "op") {
+      startOfCommand = true;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (token.type !== "word") continue;
+
+    const word = token.value;
+    if (isCommandPositionResetWord(word)) {
+      startOfCommand = true;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (!startOfCommand) continue;
+    if (isAssignmentWord(word)) continue;
+    if (isRedirectionWord(word)) {
+      if (redirectionConsumesNextWord(word)) i += 1;
+      startOfCommand = true;
+      continue;
+    }
+    if (word === "!") {
+      startOfCommand = true;
+      continue;
+    }
+
+    const functionDefinition = functionDefinitionAt(tokens, i);
+    if (functionDefinition) {
+      const bodyEnd = skipFunctionBody(tokens, functionDefinition.bodyStart);
+      const bodyTokens = tokens.slice(functionDefinition.bodyStart + 1, bodyEnd);
+      const body = analyzePosixCommand(tokensToCommand(bodyTokens), depth + 1);
+      if (POSIX_WRAPPER_HELPER_NAMES.has(functionDefinition.name)) {
+        risky = true;
+      }
+      if (/^TRAP(?:DEBUG|ZERR)$/.test(functionDefinition.name) && (body.blockUnsafe || body.isolate)) {
+        blockUnsafe = true;
+      }
+      if (body.blockUnsafe || body.isolate) {
+        riskyFunctions.set(functionDefinition.name, body);
+      }
+      i = bodyEnd;
+      startOfCommand = false;
+      continue;
+    }
+
+    if (
+      isCommandPrefixWord(word)
+      && !word.includes("/")
+      && !word.startsWith("$")
+      && word !== "!"
+      && word !== "-"
+    ) {
+      functionCheckWords.add(commandBasename(word));
+    }
+    if (riskyFunctions.has(word)) {
+      const functionRisk = riskyFunctions.get(word);
+      if (functionRisk.blockUnsafe) blockUnsafe = true;
+      if (functionRisk.isolate) risky = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (riskyAliases.has(word)) {
+      const aliasRisk = riskyAliases.get(word);
+      if (aliasRisk.blockUnsafe || aliasRisk.isolate) blockUnsafe = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (commandBasename(word) === "flock") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      const flockCommandString = extractFlockCommandString(words);
+      if (flockCommandString !== null) {
+        const nested = analyzePosixCommand(flockCommandString, depth + 1);
+        if (nested.blockUnsafe) blockUnsafe = true;
+      }
+    }
+    if (isCommandPrefixWord(word)) {
+      const prefix = skipPrefixOptionWords(tokens, i, word);
+      i = prefix.index;
+      startOfCommand = !prefix.lookupOnly;
+      bypassRuntimeCheck = (word === "command" || word === "builtin") && !prefix.lookupOnly;
+      continue;
+    }
+
+    if (word.startsWith("__NCMCP") || word.includes("/__NCMCP")) {
+      blockUnsafe = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word.startsWith("$") || word.includes("`") || word.includes("$(")) {
+      blockUnsafe = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (!bypassRuntimeCheck && !isShellReservedWord(word) && !word.includes("/") && !word.startsWith("$")) {
+      functionCheckWords.add(word);
+    }
+    if (word === "eval") {
+      blockUnsafe = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "alias") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      for (const entry of words) {
+        const match = entry.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+        if (!match) continue;
+        const aliasRisk = analyzePosixCommand(match[2], depth + 1);
+        if (aliasRisk.blockUnsafe || aliasRisk.isolate) {
+          riskyAliases.set(match[1], aliasRisk);
+        }
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "." || word === "source") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      const sourcePath = words[0] || "";
+      if (
+        sourcePath
+        && !sourcePath.includes("$")
+        && !sourcePath.includes("`")
+        && !sourcePath.includes("$(")
+        && !(cwdMayHaveChanged && isRelativeSourcePath(sourcePath))
+      ) {
+        sourceCheckPaths.add(sourcePath);
+      } else {
+        blockUnsafe = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (commandBasename(word) === "env") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      const env = parseEnvInvocation(words);
+      const envCommand = env.command;
+      const envArgs = env.args;
+      if (env.blockUnsafe) {
+        blockUnsafe = true;
+      }
+      if (
+        commandBasename(envCommand) === "kill"
+        && hasUnsafeKillTarget(envArgs)
+      ) {
+        blockUnsafe = true;
+      }
+      if (isShellCommand(envCommand)) {
+        const shellCommandString = extractShellCommandString(envArgs);
+        if (shellCommandString !== null) {
+          const nested = analyzePosixCommand(shellCommandString, depth + 1);
+          if (nested.blockUnsafe) blockUnsafe = true;
+        }
+      }
+      if (isScriptInterpreterCommand(envCommand) && hasExpandableDoubleDollarWord(envArgs)) {
+        blockUnsafe = true;
+      }
+      if (isScriptInterpreterCommand(envCommand) && hasDangerousScriptKill(envArgs)) {
+        blockUnsafe = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "cd" || word === "pushd" || word === "popd") {
+      cwdMayHaveChanged = true;
+    }
+    if (isShellCommand(word)) {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      const shellCommandString = extractShellCommandString(words);
+      if (shellCommandString !== null) {
+        const nested = analyzePosixCommand(shellCommandString, depth + 1);
+        if (nested.blockUnsafe) blockUnsafe = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (isScriptInterpreterCommand(word)) {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      if (hasExpandableDoubleDollarWord(words)) {
+        blockUnsafe = true;
+      }
+      if (hasDangerousScriptKill(words)) {
+        blockUnsafe = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "setopt") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      if (words.some((entry) => entry.includes("$") || isErrexitOptionName(entry) || isNounsetOptionName(entry))) {
+        risky = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "emulate") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      if (words.some((entry, index) => (
+        entry.includes("$")
+        || isErrexitOptionName(entry)
+        || isNounsetOptionName(entry)
+        || ((entry === "-o" || entry === "--option") && (isErrexitOptionName(words[index + 1]) || isNounsetOptionName(words[index + 1])))
+      ))) {
+        risky = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "trap") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      const trap = parseTrapInvocation(words);
+      if (!trap.queryOnly && trap.signals.length > 0) {
+        const handler = trap.handler || "";
+        if (handler === "-" && trap.signals.some((signal) => signal === "INT") && topLevelCommandHasSeparator(tokens)) {
+          blockUnsafe = true;
+        } else if (handler !== "-" && handler !== ":" && handler !== "true" && handler !== "") {
+          if (isUnsafeTrapHandler(handler, depth)) {
+            blockUnsafe = true;
+          }
+        }
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "set") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      if (words.some((entry, index) => (
+        entry.includes("$")
+        || hasShortShellOption(entry, "e")
+        || hasShortShellOption(entry, "u")
+        || (entry === "-o" && (isErrexitOptionName(words[index + 1]) || isNounsetOptionName(words[index + 1])))
+      ))) {
+        risky = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (word === "exit" || word === "logout" || word === "exec" || word === "return") {
+      risky = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (commandBasename(word) === "kill") {
+      const words = commandWordsBeforeOperator(tokens, i + 1);
+      if (hasUnsafeKillTarget(words)) {
+        blockUnsafe = true;
+      }
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (riskyFunctions.has(word)) {
+      const functionRisk = riskyFunctions.get(word);
+      if (functionRisk.blockUnsafe) blockUnsafe = true;
+      if (functionRisk.isolate) risky = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    if (riskyAliases.has(word)) {
+      const aliasRisk = riskyAliases.get(word);
+      if (aliasRisk.blockUnsafe || aliasRisk.isolate) blockUnsafe = true;
+      startOfCommand = false;
+      bypassRuntimeCheck = false;
+      continue;
+    }
+    startOfCommand = false;
+    bypassRuntimeCheck = false;
+  }
+
+  const errexitState = commandFinalShellOptionState(tokens, "e", ["errexit"]);
+  const nounsetState = commandFinalShellOptionState(tokens, "u", ["nounset", "unset"]);
+  const disablesErrexit = errexitState === "disabled";
+  const disablesNounset = nounsetState === "disabled";
+
+  return {
+    blockUnsafe,
+    isolate: risky || posixCommandHasTrapQuery(tokens),
+    isolateOnErrexit: !disablesErrexit && topLevelCommandHasSeparator(tokens) && commandHasErrexitSensitiveWord(tokens),
+    isolateOnNounset: hasPotentialNounsetExpansion(command),
+    disablesErrexit,
+    disablesNounset,
+    skipTemporaryIntTrap,
+    installTemporaryIntTrap: commandNeedsTemporaryIntTrap(command, tokens),
+    functionCheckWords: [...functionCheckWords],
+    sourceCheckPaths: [...sourceCheckPaths],
+  };
 }
 
 // Matches PowerShell's default prompt only (e.g. `PS C:\Users\alice>`,
@@ -181,11 +1870,61 @@ function buildWrappedCommand(command, shellKind, marker) {
       //
       // 3) Single-line { ... } is parsed fully before execution, so SIGINT
       //    cannot cause bash to flush the end marker from the input buffer.
-      //    trap ':' INT lets child processes receive SIGINT normally while
-      //    preventing the shell from aborting the compound command.
+      //    When no user INT trap exists, a temporary trap prevents the shell
+      //    from aborting the compound command. Existing or newly-set traps are
+      //    left alone.
       const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
+      const temporaryIntTrap = "__NCMCP_int_seen=1";
+      const restoreIntTrap = `if "$__NCMCP_t" "$__NCMCP_set_int_trap" = 1; then if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then command builtin trap - INT; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin trap - INT; else \\trap - INT; fi; fi`;
       const escaped = escapePosixSingleQuoted(command);
-      const isolate = shouldIsolatePosixCommand(command) ? "1" : "0";
+      const analysis = analyzePosixCommand(command);
+      const blockUnsafe = analysis.blockUnsafe ? "1" : "0";
+      const isolate = analysis.isolate ? "1" : "0";
+      const isolateOnErrexit = analysis.isolateOnErrexit ? "1" : "0";
+      const isolateOnNounset = analysis.isolateOnNounset ? "1" : "0";
+      const disablesErrexit = analysis.disablesErrexit ? "1" : "0";
+      const disablesNounset = analysis.disablesNounset ? "1" : "0";
+      const skipTemporaryIntTrap = analysis.skipTemporaryIntTrap || !analysis.installTemporaryIntTrap ? "1" : "0";
+      const functionCheckWords = escapePosixSingleQuotedWord(analysis.functionCheckWords.join("\n"));
+      const sourceCheckPaths = escapePosixSingleQuotedWord(analysis.sourceCheckPaths.join("\n"));
+      const needsRuntimeInspection = true;
+      const runtimeInspection = needsRuntimeInspection ? "1" : "0";
+      const safeSourceBareAtom = "[^[:space:];&|`$()'\"]+";
+      const safeSourceVarAtom = "[$][A-Za-z_][A-Za-z0-9_]*|[$][{][A-Za-z_][A-Za-z0-9_]*[}]";
+      const safeSourceSingleQuotedAtom = "'[^`$;&|()]*'";
+      const safeSourceDoubleQuotedAtom = `"([^"\`;&|()]|${safeSourceVarAtom})*"`;
+      const safeSourceValue = `(${safeSourceBareAtom}|${safeSourceVarAtom}|${safeSourceSingleQuotedAtom}|${safeSourceDoubleQuotedAtom})*`;
+      const safeSourcePattern = [
+        "^[[:space:]]*(#.*)?$",
+        `^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=${safeSourceValue}[[:space:]]*$`,
+        `^[[:space:]]*export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=${safeSourceValue}[[:space:]]*$`,
+        "^[[:space:]]*(unset|unalias)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*( [A-Za-z_][A-Za-z0-9_]*)*[[:space:]]*$",
+        "^[[:space:]]*alias[[:space:]]+[A-Za-z_][A-Za-z0-9_]*='[^`$;&|()]*'[[:space:]]*$",
+        `^[[:space:]]*readonly[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=${safeSourceValue}[[:space:]]*$`,
+        "^[[:space:]]*(setopt|unsetopt)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*( [A-Za-z_][A-Za-z0-9_]*)*[[:space:]]*$",
+      ].join("|");
+      const safeSourcePatternWord = escapePosixSingleQuotedWord(safeSourcePattern);
+      const dangerousSourcePattern = "(^|[^A-Za-z0-9_./-])(exit|logout|exec|return|kill|eval|source|set[[:space:]].*(-[A-Za-z]*[eu]|-o[[:space:]]+(err_?exit|errexit|nounset|unset))|setopt[[:space:]].*(err_?exit|errexit|nounset|unset))($|[^A-Za-z0-9_./-])|\\$\\$|`|\\$[(]";
+      const dangerousDefinitionPattern = "(^|[^A-Za-z0-9_./-])(exit|logout|exec|eval|source|set[[:space:]].*(-[A-Za-z]*[eu]|-o[[:space:]]+(err_?exit|errexit|nounset|unset))|setopt[[:space:]].*(err_?exit|errexit|nounset|unset))($|[^A-Za-z0-9_./-])|`|\\$[(]";
+      const dangerousDefinitionKillOption = "(-s|--signal|-n)[[:space:]]+[^[:space:]]+|--signal=[^[:space:]]+|-[A-Za-z][A-Za-z0-9_-]*|-[0-9]+|--";
+      const dangerousDefinitionKillTarget = "\\$\\$|[+]?0+|-[0-9]+";
+      const dangerousDefinitionKillVariableTarget = "[\"']?[$][{]?[A-Za-z_][A-Za-z0-9_]*[}]?[\"']?";
+      const dangerousDefinitionKillPattern = `(^|[^A-Za-z0-9_.-])([./A-Za-z0-9_-]*/)*kill([[:space:]]+(${dangerousDefinitionKillOption}))*[[:space:]]+(${dangerousDefinitionKillTarget})($|[^A-Za-z0-9_./-])`;
+      const dangerousDefinitionKillVariablePattern = `(^|[^A-Za-z0-9_.-])([./A-Za-z0-9_-]*/)*kill([[:space:]]+(${dangerousDefinitionKillOption}))*[[:space:]]+(${dangerousDefinitionKillVariableTarget})($|[^A-Za-z0-9_./-])`;
+      const dangerousDefinitionKillAssignmentPattern = "(^|[^A-Za-z0-9_])[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*(\\$\\$|[+]?0+|-[0-9]+)($|[^A-Za-z0-9_])";
+      const intTrapDefinitionPattern = "(^|[^A-Za-z0-9_./-])trap([^;&|]*[[:space:]])(INT|SIGINT|2)($|[^A-Za-z0-9_./-])";
+      const dangerousSourcePatternWord = escapePosixSingleQuotedWord(dangerousSourcePattern);
+      const dangerousDefinitionPatternWord = escapePosixSingleQuotedWord(dangerousDefinitionPattern);
+      const dangerousDefinitionKillPatternWord = escapePosixSingleQuotedWord(dangerousDefinitionKillPattern);
+      const dangerousDefinitionKillVariablePatternWord = escapePosixSingleQuotedWord(dangerousDefinitionKillVariablePattern);
+      const dangerousDefinitionKillAssignmentPatternWord = escapePosixSingleQuotedWord(dangerousDefinitionKillAssignmentPattern);
+      const intTrapDefinitionPatternWord = escapePosixSingleQuotedWord(intTrapDefinitionPattern);
+      const runtimeHelpers = `__NCMCP_use_builtin=0; __NCMCP_bash_builtin_direct=0; __NCMCP_zsh_builtin_safe=0; __NCMCP_bash_plain_cleanup=0; __NCMCP_shell_functions=; __NCMCP_command_is_function=0; __NCMCP_builtin_is_function=0; __NCMCP_t=/bin/test; __NCMCP_printf=; if "$__NCMCP_t" -x /usr/bin/printf; then __NCMCP_printf=/usr/bin/printf; elif "$__NCMCP_t" -x /bin/printf; then __NCMCP_printf=/bin/printf; fi; __NCMCP_p(){ if "$__NCMCP_t" -n "$__NCMCP_printf"; then "$__NCMCP_printf" "$@"; else \\printf "$@"; fi; }; __NCMCP_unset(){ if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then if "$__NCMCP_t" "$__NCMCP_bash_plain_cleanup" = 1; then unset "$@"; elif "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then builtin unset "$@"; else command builtin unset "$@"; fi; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin unset "$@"; else unset "$@"; fi; }; __NCMCP_unset_f(){ if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then if "$__NCMCP_t" "$__NCMCP_bash_plain_cleanup" = 1; then unset -f "$@"; elif "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then builtin unset -f "$@"; else command builtin unset -f "$@"; fi; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin unset -f "$@"; else unset -f "$@"; fi; }; if "$__NCMCP_t" -x /usr/bin/grep; then __NCMCP_grep=/usr/bin/grep; elif "$__NCMCP_t" -x /bin/grep; then __NCMCP_grep=/bin/grep; else __NCMCP_grep=; fi; if "$__NCMCP_t" -n "\${ZSH_VERSION-}"; then __NCMCP_builtin_probe=$(\\type builtin 2>/dev/null || :); if "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n' "$__NCMCP_builtin_probe" | "$__NCMCP_grep" -Eiq 'builtin' && ! __NCMCP_p '%s\\n' "$__NCMCP_builtin_probe" | "$__NCMCP_grep" -Eiq 'function|not found'; then __NCMCP_zsh_builtin_safe=1; else ${marker}_blocked=1; fi; fi; if "$__NCMCP_t" "$${marker}_runtime_inspection" = 1; then if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then __NCMCP_shell_functions=$(set 2>/dev/null || :); if "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n' "$__NCMCP_shell_functions" | "$__NCMCP_grep" -Eq '^command[[:space:]]*[(][)]'; then __NCMCP_command_is_function=1; fi; if "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n' "$__NCMCP_shell_functions" | "$__NCMCP_grep" -Eq '^builtin[[:space:]]*[(][)]'; then __NCMCP_builtin_is_function=1; fi; if "$__NCMCP_t" "$__NCMCP_command_is_function" = 1 && "$__NCMCP_t" "$__NCMCP_builtin_is_function" = 1; then __NCMCP_bash_plain_cleanup=1; ${marker}_blocked=1; elif "$__NCMCP_t" "$__NCMCP_command_is_function" = 1; then __NCMCP_bash_builtin_direct=1; elif "$__NCMCP_t" "$__NCMCP_builtin_is_function" = 1; then __NCMCP_use_builtin=1; else __NCMCP_builtin_probe=$(command builtin type builtin 2>/dev/null || :); if "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n' "$__NCMCP_builtin_probe" | "$__NCMCP_grep" -Eiq 'builtin' && ! __NCMCP_p '%s\\n' "$__NCMCP_builtin_probe" | "$__NCMCP_grep" -Eiq 'function|not found'; then __NCMCP_use_builtin=1; fi; fi; fi; if "$__NCMCP_t" "$__NCMCP_use_builtin" != 1; then if "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then __NCMCP_type_probe=$(builtin type type 2>/dev/null || :); __NCMCP_command_probe=$(builtin type command 2>/dev/null || :); elif "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then __NCMCP_type_probe=$(builtin type type 2>/dev/null || :); __NCMCP_command_probe="command is a shell builtin"; else __NCMCP_type_probe=$(\\type type 2>/dev/null || :); __NCMCP_command_probe=$(\\type command 2>/dev/null || :); fi; if "$__NCMCP_t" -z "$__NCMCP_type_probe" || "$__NCMCP_t" -z "$__NCMCP_command_probe" || { "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n%s\\n' "$__NCMCP_type_probe" "$__NCMCP_command_probe" | "$__NCMCP_grep" -Eiq 'function'; }; then ${marker}_blocked=1; fi; fi; if "$__NCMCP_t" "$${marker}_skip_int_trap" != 1 && "$__NCMCP_t" "$__NCMCP_use_builtin" != 1; then if "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1 || "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then __NCMCP_trap_probe=$(builtin type trap 2>/dev/null || :); else __NCMCP_trap_probe=$(\\type trap 2>/dev/null || :); fi; if "$__NCMCP_t" -z "$__NCMCP_trap_probe" || { "$__NCMCP_t" -n "$__NCMCP_grep" && __NCMCP_p '%s\\n' "$__NCMCP_trap_probe" | "$__NCMCP_grep" -Eiq 'function|not found'; }; then ${marker}_skip_int_trap=1; fi; fi; fi`;
+      const sourceCheck = `__NCMCP_safe_source_pattern='${safeSourcePatternWord}'; __NCMCP_dangerous_source_pattern='${dangerousSourcePatternWord}'; __NCMCP_dangerous_kill_pattern='${dangerousDefinitionKillPatternWord}'; __NCMCP_dangerous_kill_variable_pattern='${dangerousDefinitionKillVariablePatternWord}'; __NCMCP_dangerous_kill_assignment_pattern='${dangerousDefinitionKillAssignmentPatternWord}'; __NCMCP_source_blocked=$(__NCMCP_p '%s\\n' "$${marker}_source_paths" | while IFS= read -r __NCMCP_source; do if "$__NCMCP_t" -z "$__NCMCP_source"; then continue; fi; if "$__NCMCP_t" "\${__NCMCP_source#~/}" != "$__NCMCP_source"; then __NCMCP_source="$HOME/\${__NCMCP_source#~/}"; fi; if "$__NCMCP_t" -z "$__NCMCP_grep" || ! "$__NCMCP_t" -r "$__NCMCP_source" || "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_source_pattern" "$__NCMCP_source" || "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_pattern" "$__NCMCP_source" || { "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_assignment_pattern" "$__NCMCP_source" && "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_variable_pattern" "$__NCMCP_source"; } || "$__NCMCP_grep" -Evq "$__NCMCP_safe_source_pattern" "$__NCMCP_source"; then __NCMCP_p '1\\n'; fi; done); if "$__NCMCP_t" "\${__NCMCP_source_blocked#*1}" != "$__NCMCP_source_blocked"; then ${marker}_blocked=1; fi`;
+      const functionCheck = `__NCMCP_dangerous_def_pattern='${dangerousDefinitionPatternWord}'; __NCMCP_dangerous_kill_pattern='${dangerousDefinitionKillPatternWord}'; __NCMCP_dangerous_kill_variable_pattern='${dangerousDefinitionKillVariablePatternWord}'; __NCMCP_dangerous_kill_assignment_pattern='${dangerousDefinitionKillAssignmentPatternWord}'; __NCMCP_int_trap_def_pattern='${intTrapDefinitionPatternWord}'; __NCMCP_function_blocked=$(__NCMCP_p '%s\\n' "$${marker}_check_words" | while IFS= read -r __NCMCP_word; do if "$__NCMCP_t" -z "$__NCMCP_word"; then continue; fi; if "$__NCMCP_t" -z "$__NCMCP_grep"; then __NCMCP_p '1\\n'; continue; fi; if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then __NCMCP_type=$(command builtin type "$__NCMCP_word" 2>/dev/null); elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1 || "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then __NCMCP_type=$(builtin type "$__NCMCP_word" 2>/dev/null); else __NCMCP_type=$(\\type "$__NCMCP_word" 2>/dev/null); fi; if __NCMCP_p '%s\\n' "$__NCMCP_type" | "$__NCMCP_grep" -Eiq 'autoload|undefined shell function'; then __NCMCP_p '1\\n'; elif __NCMCP_p '%s\\n' "$__NCMCP_type" | "$__NCMCP_grep" -Eiq ' alias|aliased '; then if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then __NCMCP_def=$(command builtin alias "$__NCMCP_word" 2>/dev/null); elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1 || "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then __NCMCP_def=$(builtin alias "$__NCMCP_word" 2>/dev/null); else __NCMCP_def=$(\\alias "$__NCMCP_word" 2>/dev/null); fi; if __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_def_pattern" || __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_pattern" || { __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_assignment_pattern" && __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_variable_pattern"; }; then __NCMCP_p '1\\n'; fi; if __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_int_trap_def_pattern"; then __NCMCP_p 'T\\n'; fi; elif __NCMCP_p '%s\\n' "$__NCMCP_type" | "$__NCMCP_grep" -Eiq ' function|shell function'; then if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then __NCMCP_def=$( { command builtin type "$__NCMCP_word"; command builtin typeset -f "$__NCMCP_word"; command builtin functions "$__NCMCP_word"; } 2>/dev/null ); elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1 || "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then __NCMCP_def=$( { builtin type "$__NCMCP_word"; builtin typeset -f "$__NCMCP_word"; builtin functions "$__NCMCP_word"; } 2>/dev/null ); else __NCMCP_def=$( { \\type "$__NCMCP_word"; \\typeset -f "$__NCMCP_word"; \\functions "$__NCMCP_word"; } 2>/dev/null ); fi; if __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_def_pattern" || __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_pattern" || { __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_assignment_pattern" && __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_dangerous_kill_variable_pattern"; }; then __NCMCP_p '1\\n'; fi; if __NCMCP_p '%s\\n' "$__NCMCP_def" | "$__NCMCP_grep" -Eiq "$__NCMCP_int_trap_def_pattern"; then __NCMCP_p 'T\\n'; fi; fi; done); if "$__NCMCP_t" "\${__NCMCP_function_blocked#*1}" != "$__NCMCP_function_blocked"; then ${marker}_blocked=1; fi; if "$__NCMCP_t" "\${__NCMCP_function_blocked#*T}" != "$__NCMCP_function_blocked" && "$__NCMCP_t" "$__NCMCP_set_int_trap" = 1; then if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then command builtin trap - INT; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin trap - INT; else \\trap - INT; fi; __NCMCP_set_int_trap=0; fi`;
+      const cleanupVariables = `__NCMCP_use_builtin __NCMCP_shell_functions __NCMCP_command_is_function __NCMCP_builtin_is_function __NCMCP_printf __NCMCP_grep __NCMCP_builtin_probe __NCMCP_type_probe __NCMCP_command_probe __NCMCP_trap_probe __NCMCP_safe_source_pattern __NCMCP_dangerous_source_pattern __NCMCP_source_blocked __NCMCP_source __NCMCP_dangerous_def_pattern __NCMCP_dangerous_kill_pattern __NCMCP_dangerous_kill_variable_pattern __NCMCP_dangerous_kill_assignment_pattern __NCMCP_int_trap_def_pattern __NCMCP_function_blocked __NCMCP_word __NCMCP_type __NCMCP_def __NCMCP_set_int_trap __NCMCP_int_seen __NCMCP_rc __NCMCP_status ${marker} ${marker}_cmd ${marker}_blocked ${marker}_isolate ${marker}_isolate_on_errexit ${marker}_isolate_on_nounset ${marker}_disables_errexit ${marker}_disables_nounset ${marker}_errexit ${marker}_nounset ${marker}_skip_int_trap ${marker}_runtime_inspection ${marker}_check_words ${marker}_source_paths ${marker}_flags ${marker}_traps`;
+      const cleanupCoreVariables = "__NCMCP_bash_builtin_direct __NCMCP_zsh_builtin_safe __NCMCP_bash_plain_cleanup __NCMCP_t";
+      const cleanupRuntime = `__NCMCP_unset ${cleanupVariables} 2>/dev/null; __NCMCP_unset_f __NCMCP_p __NCMCP_unset __NCMCP_unset_f 2>/dev/null; if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then if "$__NCMCP_t" "$__NCMCP_bash_plain_cleanup" = 1; then unset ${cleanupCoreVariables} 2>/dev/null; elif "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then builtin unset ${cleanupCoreVariables} 2>/dev/null; else command builtin unset ${cleanupCoreVariables} 2>/dev/null; fi; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin unset ${cleanupCoreVariables} 2>/dev/null; else unset ${cleanupCoreVariables} 2>/dev/null; fi`;
       // Leading single space: lets bash/zsh skip recording this command
       // in history when the user already has HISTCONTROL=ignorespace
       // (bash) or HIST_IGNORE_SPACE (zsh) configured — Debian/Ubuntu and
@@ -194,7 +1933,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       // Without that config the prefix is harmless; it just doesn't
       // suppress history recording.
       return (
-        ` ${marker}=0; ${marker}_cmd='${escaped}'; ${marker}_isolate=${isolate}; ${marker}_flags=$-; { printf '%s\\n' '${marker}_S'; trap ':' INT; case "$${marker}_flags" in *e*) set +e; ${marker}_isolate=1 ;; esac; if [ "$${marker}_isolate" = 1 ]; then ( ${noPager}eval "$${marker}_cmd" ); else ${noPager}eval "$${marker}_cmd"; fi; __NCMCP_rc=$?; printf '\\n%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; trap - INT; case "$${marker}_flags" in *e*) set -e; true ;; *) (exit $__NCMCP_rc) ;; esac; }\n`
+        ` ${marker}=0; ${marker}_cmd='${escaped}'; ${marker}_blocked=${blockUnsafe}; ${marker}_isolate=${isolate}; ${marker}_isolate_on_errexit=${isolateOnErrexit}; ${marker}_isolate_on_nounset=${isolateOnNounset}; ${marker}_disables_errexit=${disablesErrexit}; ${marker}_disables_nounset=${disablesNounset}; ${marker}_errexit=0; ${marker}_nounset=0; ${marker}_skip_int_trap=${skipTemporaryIntTrap}; ${marker}_runtime_inspection=${runtimeInspection}; ${marker}_check_words='${functionCheckWords}'; ${marker}_source_paths='${sourceCheckPaths}'; ${marker}_flags=$-; ${runtimeHelpers}; if "$__NCMCP_t" "$${marker}_skip_int_trap" = 1; then ${marker}_traps=; elif "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then ${marker}_traps=$(command builtin trap); elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then ${marker}_traps=$(builtin trap); else ${marker}_traps=$(\\trap); fi; { __NCMCP_p '%s\\n' '${marker}_S'; __NCMCP_set_int_trap=0; case "$${marker}_skip_int_trap:$${marker}_traps" in 1:*|*:*" INT"*|*:*" SIGINT"*) ;; *) __NCMCP_set_int_trap=1; if "$__NCMCP_t" "$__NCMCP_use_builtin" = 1; then command builtin trap '${temporaryIntTrap}' INT; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then builtin trap '${temporaryIntTrap}' INT; else \\trap '${temporaryIntTrap}' INT; fi ;; esac; case "$${marker}_flags" in *e*) set +e; if "$__NCMCP_t" "$${marker}_isolate_on_errexit" = 1; then ${marker}_isolate=1; ${marker}_errexit=1; fi ;; esac; case "$${marker}_flags" in *u*) set +u; if "$__NCMCP_t" "$${marker}_isolate_on_nounset" = 1; then ${marker}_isolate=1; ${marker}_nounset=1; fi ;; esac; ${sourceCheck}; ${functionCheck}; if "$__NCMCP_t" "$${marker}_blocked" = 1; then __NCMCP_p '%s\\n' 'Blocked unsafe shell-terminating command'; __NCMCP_rc=126; elif "$__NCMCP_t" "$${marker}_isolate" = 1; then ( if "$__NCMCP_t" "$${marker}_errexit" = 1; then set -e; fi; if "$__NCMCP_t" "$${marker}_nounset" = 1; then set -u; fi; if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then if "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then ${noPager}builtin eval "$${marker}_cmd"; else ${noPager}command builtin eval "$${marker}_cmd"; fi; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then ${noPager}builtin eval "$${marker}_cmd"; else ${noPager}eval "$${marker}_cmd"; fi ); __NCMCP_rc=$?; else if "$__NCMCP_t" -n "\${BASH_VERSION-}"; then if "$__NCMCP_t" "$__NCMCP_bash_builtin_direct" = 1; then ${noPager}builtin eval "$${marker}_cmd"; else ${noPager}command builtin eval "$${marker}_cmd"; fi; elif "$__NCMCP_t" "$__NCMCP_zsh_builtin_safe" = 1; then ${noPager}builtin eval "$${marker}_cmd"; else ${noPager}eval "$${marker}_cmd"; fi; __NCMCP_rc=$?; fi; __NCMCP_status=$__NCMCP_rc; __NCMCP_p '\\n%s\\n' '${marker}_E:'\"$__NCMCP_status\"; ${restoreIntTrap}; case "$${marker}_flags:$${marker}_disables_nounset" in *u*:0) set -u ;; esac; case "$${marker}_flags:$${marker}_disables_errexit" in *e*:0) set -e; ${cleanupRuntime} ;; *) ${cleanupRuntime} ;; esac; }\n`
       );
     }
   }


### PR DESCRIPTION
## Summary
- Prevent AI shell commands from killing or exiting the active terminal before Netcatty can emit the completion marker.
- Preserve ordinary state changes such as cd/export/source when they are safe.
- Block or isolate risky shell paths including sourced files, helper redefinitions, shell options, traps, aliases/functions, redirections, path-prefixed kill commands, and signal-option kill variants.

## Verification
- node --test --test-name-pattern "dynamic shell-terminating|dangerous existing aliases|indirect self-kill|assignment-prefixed path kill" electron/bridges/ai/ptyExec.test.cjs
- node --test electron/bridges/ai/ptyExec.test.cjs
- node --test electron/terminalWorker/aiExec.test.cjs electron/bridges/aiBridge/cattyExecHandlers.worker.test.cjs electron/bridges/aiBridge.test.cjs
- npm run lint
- git diff --check
- npm test (3983 pass, 0 fail, 3 skip)

## Review note
- Independent review found source/function/alias kill bypasses; this branch now includes regression tests for assignment-prefixed path kill plus `-s`, `--signal`, `--signal=`, `-n`, and variable-target kill forms, and the full local suite passes.