### PR TITLE
[codex] Clarify Telnet manual identity label

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -724,7 +724,7 @@ export const enVaultMessages: Messages = {
   'hostDetails.telnetOn': 'Telnet on',
   'hostDetails.port': 'port',
   'hostDetails.telnet.credentials': 'Credentials',
-  'hostDetails.telnet.identity.placeholder': 'Select Telnet Identity',
+  'hostDetails.telnet.identity.placeholder': 'Manual identity',
   'hostDetails.telnet.username': 'Telnet Username',
   'hostDetails.telnet.password': 'Telnet Password',
   'hostDetails.charset.placeholder': 'Charset (e.g. UTF-8)',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -755,7 +755,7 @@ export const ruVaultMessages: Messages = {
   'hostDetails.telnetOn': 'Telnet на',
   'hostDetails.port': 'порт',
   'hostDetails.telnet.credentials': 'Учётные данные',
-  'hostDetails.telnet.identity.placeholder': 'Выберите идентификатор Telnet',
+  'hostDetails.telnet.identity.placeholder': 'Ручной идентификатор',
   'hostDetails.telnet.username': 'Имя пользователя Telnet',
   'hostDetails.telnet.password': 'Пароль Telnet',
   'hostDetails.charset.placeholder': 'Кодировка (например, UTF-8)',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -256,7 +256,7 @@ export const zhCNVaultMessages: Messages = {
   'hostDetails.telnetOn': 'Telnet on',
   'hostDetails.port': '端口',
   'hostDetails.telnet.credentials': '凭据',
-  'hostDetails.telnet.identity.placeholder': '选择 Telnet 身份',
+  'hostDetails.telnet.identity.placeholder': '手动身份',
   'hostDetails.telnet.username': 'Telnet 用户名',
   'hostDetails.telnet.password': 'Telnet 密码',
   'hostDetails.charset.placeholder': '字符集（例如 UTF-8）',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -256,7 +256,7 @@ export const zhTWVaultMessages: Messages = {
   'hostDetails.telnetOn': 'Telnet on',
   'hostDetails.port': '埠',
   'hostDetails.telnet.credentials': '憑證',
-  'hostDetails.telnet.identity.placeholder': '選擇 Telnet 身份',
+  'hostDetails.telnet.identity.placeholder': '手動身份',
   'hostDetails.telnet.username': 'Telnet 使用者名稱',
   'hostDetails.telnet.password': 'Telnet 密碼',
   'hostDetails.charset.placeholder': '字元集（例如 UTF-8）',


### PR DESCRIPTION
## Summary
- Update Telnet identity placeholder copy to say manual identity in English, Russian, Simplified Chinese, and Traditional Chinese.

## Validation
- node --test --import tsx application/i18n/locales/*.test.ts
- npm run build