### PR TITLE
[codex] Fix CPU core stats scrolling

### DIFF
--- a/components/terminal/TerminalServerStats.test.ts
+++ b/components/terminal/TerminalServerStats.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+test("CPU per-core stats list can scroll when many cores are reported", () => {
+  const source = readFileSync(new URL("./TerminalServerStats.tsx", import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /className="grid gap-1\.5 max-h-\[\d+px\] overflow-y-auto/,
+  );
+});

--- a/components/terminal/TerminalServerStats.tsx
+++ b/components/terminal/TerminalServerStats.tsx
@@ -77,7 +77,7 @@ export const TerminalServerStats: React.FC<TerminalServerStatsProps> = ({
                     <div className="text-xs space-y-2">
                       <div className="font-medium text-sm mb-2">{t("terminal.serverStats.cpuCores")}</div>
                       {serverStats.cpuPerCore.length > 0 ? (
-                        <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${Math.min(4, serverStats.cpuPerCore.length)}, 1fr)` }}>
+                        <div className="grid gap-1.5 max-h-[260px] overflow-y-auto pr-1 overscroll-contain" style={{ gridTemplateColumns: `repeat(${Math.min(4, serverStats.cpuPerCore.length)}, 1fr)` }}>
                           {serverStats.cpuPerCore.map((usage, index) => (
                             <div key={index} className="flex flex-col items-center gap-1 min-w-[48px]">
                               <div className="text-[10px] text-muted-foreground">Core {index}</div>


### PR DESCRIPTION
## Summary
- Add scrolling to the CPU per-core stats popover so hosts with many CPU cores can show every core.
- Add regression coverage to keep the per-core list scrollable.

Fixes #1860

## Validation
- `node --test --import tsx components/terminal/TerminalServerStats.test.ts`
- `node --test --import tsx components/terminal/*.test.ts components/terminal/*.test.tsx`
- `npm run lint`
- `npm run build`