### PR TITLE
Improve terminal scroll and input smoothness

### DIFF
--- a/components/terminal/TerminalTimestampGutter.test.ts
+++ b/components/terminal/TerminalTimestampGutter.test.ts
@@ -6,6 +6,7 @@ import {
   TERMINAL_TIMESTAMP_GUTTER_HORIZONTAL_PADDING,
   TERMINAL_TIMESTAMP_GUTTER_MIN_WIDTH,
   getTerminalTimestampTypography,
+  resolveTerminalTimestampGutterRenderSignature,
   resolveTerminalTimestampGutterColor,
   resolveTerminalTimestampGutterWidth,
 } from "./TerminalTimestampGutter.tsx";
@@ -70,4 +71,50 @@ test("timestamp gutter uses the terminal background", () => {
   assert.doesNotMatch(source, /bg-black\/10/);
   assert.match(source, /boxShadow: "inset -0\.5px 0 0 color-mix\(in srgb, var\(--terminal-ui-fg\) 8%, transparent\)"/);
   assert.doesNotMatch(source, /border-r/);
+});
+
+test("timestamp gutter render signature is stable and changes only for visible inputs", () => {
+  const base = resolveTerminalTimestampGutterRenderSignature({
+    screenTop: 8,
+    cellHeight: 17,
+    color: "#66e8ff",
+    fontFamily: "JetBrains Mono",
+    fontSize: 14,
+    fontWeight: 500,
+    rows: [
+      { row: 0, label: "10:00:00" },
+      { row: 2, label: "10:00:02" },
+    ],
+  });
+
+  assert.equal(
+    resolveTerminalTimestampGutterRenderSignature({
+      screenTop: 8,
+      cellHeight: 17,
+      color: "#66e8ff",
+      fontFamily: "JetBrains Mono",
+      fontSize: 14,
+      fontWeight: 500,
+      rows: [
+        { row: 0, label: "10:00:00" },
+        { row: 2, label: "10:00:02" },
+      ],
+    }),
+    base,
+  );
+  assert.notEqual(
+    resolveTerminalTimestampGutterRenderSignature({
+      screenTop: 8,
+      cellHeight: 17,
+      color: "#66e8ff",
+      fontFamily: "JetBrains Mono",
+      fontSize: 14,
+      fontWeight: 500,
+      rows: [
+        { row: 0, label: "10:00:00" },
+        { row: 3, label: "10:00:02" },
+      ],
+    }),
+    base,
+  );
 });

--- a/components/terminal/TerminalTimestampGutter.tsx
+++ b/components/terminal/TerminalTimestampGutter.tsx
@@ -6,6 +6,7 @@ import {
   getVisibleTerminalLineTimestampRows,
   onTerminalLineTimestampsChange,
 } from "./runtime/terminalLineTimestamps";
+import type { TerminalTimestampGutterRow } from "./runtime/terminalLineTimestamps";
 
 export const TERMINAL_TIMESTAMP_GUTTER_MIN_WIDTH = 56;
 export const TERMINAL_TIMESTAMP_GUTTER_HORIZONTAL_PADDING = 16;
@@ -95,6 +96,30 @@ export const resolveTerminalTimestampGutterWidth = ({
     TERMINAL_TIMESTAMP_GUTTER_MIN_WIDTH,
     textWidth + TERMINAL_TIMESTAMP_GUTTER_HORIZONTAL_PADDING,
   ));
+};
+
+export const resolveTerminalTimestampGutterRenderSignature = ({
+  screenTop,
+  cellHeight,
+  color,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  rows,
+}: {
+  screenTop: number;
+  cellHeight: number;
+  color: string;
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string | number;
+  rows: readonly TerminalTimestampGutterRow[];
+}): string => {
+  let signature = `${screenTop}|${cellHeight}|${color}|${fontFamily}|${fontSize}|${fontWeight}`;
+  for (const { row, label } of rows) {
+    signature += `|${row}:${label}`;
+  }
+  return signature;
 };
 
 export function TerminalTimestampGutter({
@@ -189,7 +214,7 @@ export function TerminalTimestampGutter({
       const gutterRect = gutter.getBoundingClientRect();
       const screenTop = screenRect.top - gutterRect.top;
       const visibleRows = getVisibleTerminalLineTimestampRows(term);
-      const signature = JSON.stringify({
+      const signature = resolveTerminalTimestampGutterRenderSignature({
         screenTop,
         cellHeight,
         color,

--- a/components/terminal/keywordHighlight.test.ts
+++ b/components/terminal/keywordHighlight.test.ts
@@ -81,6 +81,7 @@ function createFakeTerminalFromLines(lines: Array<{ text: string; isWrapped: boo
       },
     },
     onScroll: () => noopDisposable,
+    onData: () => noopDisposable,
     onWriteParsed: () => noopDisposable,
     onResize: () => noopDisposable,
     onRender: () => noopDisposable,
@@ -121,6 +122,13 @@ function createFakeTerminalFromLargeWrappedBlock({
   let getLineCount = 0;
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
   const noopDisposable = { dispose() {} };
+  const handlers: {
+    scroll?: () => void;
+    data?: (data: string) => void;
+    writeParsed?: () => void;
+    resize?: () => void;
+    render?: () => void;
+  } = {};
   const term = {
     rows,
     cols: lineText.length,
@@ -138,10 +146,26 @@ function createFakeTerminalFromLargeWrappedBlock({
         },
       },
     },
-    onScroll: () => noopDisposable,
-    onWriteParsed: () => noopDisposable,
-    onResize: () => noopDisposable,
-    onRender: () => noopDisposable,
+    onScroll(handler: () => void) {
+      handlers.scroll = handler;
+      return noopDisposable;
+    },
+    onData(handler: (data: string) => void) {
+      handlers.data = handler;
+      return noopDisposable;
+    },
+    onWriteParsed(handler: () => void) {
+      handlers.writeParsed = handler;
+      return noopDisposable;
+    },
+    onResize(handler: () => void) {
+      handlers.resize = handler;
+      return noopDisposable;
+    },
+    onRender(handler: () => void) {
+      handlers.render = handler;
+      return noopDisposable;
+    },
     registerMarker(offset: number) {
       return {
         line: offset,
@@ -162,21 +186,32 @@ function createFakeTerminalFromLargeWrappedBlock({
     },
     refresh() {},
   };
-  return { term, decorations, getLineCount: () => getLineCount };
+  return {
+    term,
+    decorations,
+    handlers,
+    getLineCount: () => getLineCount,
+    resetGetLineCount: () => {
+      getLineCount = 0;
+    },
+  };
 }
 
 function createFakeTerminal(lineText: string, options: { lineCount?: number } = {}) {
   const lineCount = options.lineCount ?? 1;
   let translateCount = 0;
+  const translatedLineIndexes: number[] = [];
   const lines = Array.from({ length: lineCount }, (_, index) =>
     createFakeLine(`${lineText} ${index}`, () => {
       translateCount += 1;
+      translatedLineIndexes.push(index);
     })
   );
   const decorations: Array<{ x: number; width: number; foregroundColor: string }> = [];
   const noopDisposable = { dispose() {} };
   const handlers: {
     scroll?: () => void;
+    data?: (data: string) => void;
     writeParsed?: () => void;
     resize?: () => void;
     render?: () => void;
@@ -196,6 +231,10 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     },
     onScroll: (handler: () => void) => {
       handlers.scroll = handler;
+      return noopDisposable;
+    },
+    onData: (handler: (data: string) => void) => {
+      handlers.data = handler;
       return noopDisposable;
     },
     onWriteParsed: (handler: () => void) => {
@@ -236,8 +275,10 @@ function createFakeTerminal(lineText: string, options: { lineCount?: number } = 
     decorations,
     handlers,
     getTranslateCount: () => translateCount,
+    getTranslatedLineIndexes: () => [...translatedLineIndexes],
     resetTranslateCount: () => {
       translateCount = 0;
+      translatedLineIndexes.length = 0;
     },
   };
 }
@@ -300,6 +341,168 @@ test("output-driven viewport changes defer keyword highlight scans", async () =>
     assert.equal(getTranslateCount(), 0);
 
     await new Promise((resolve) => { setTimeout(resolve, 220); });
+    assert.ok(getTranslateCount() > 0);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("user scroll defers keyword highlight scans and scans only visible rows", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers, getTranslateCount, resetTranslateCount } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 80,
+    });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    term.buffer.active.viewportY = 10;
+    handlers.scroll?.();
+    handlers.render?.();
+
+    assert.equal(getTranslateCount(), 0);
+
+    await new Promise((resolve) => { setTimeout(resolve, 130); });
+    assert.equal(getTranslateCount(), term.rows);
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("continuous user scroll cancels stale keyword highlight continuation work", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const {
+      term,
+      handlers,
+      getTranslatedLineIndexes,
+      resetTranslateCount,
+    } = createFakeTerminal("hello DEPLOY world", { lineCount: 120 });
+    term.rows = 30;
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    term.buffer.active.viewportY = 10;
+    handlers.scroll?.();
+    await new Promise((resolve) => { setTimeout(resolve, 60); });
+
+    term.buffer.active.viewportY = 60;
+    handlers.scroll?.();
+    await new Promise((resolve) => { setTimeout(resolve, 130); });
+    raf.flush();
+
+    assert.deepEqual(
+      getTranslatedLineIndexes().filter((lineY) => lineY > 17 && lineY < 60),
+      [],
+      "stale continuation from the first scroll should not keep scanning old viewport rows",
+    );
+    assert.ok(
+      getTranslatedLineIndexes().some((lineY) => lineY >= 60 && lineY < 90),
+      "latest viewport should be highlighted after scroll settles",
+    );
+    highlighter.dispose();
+  } finally {
+    raf.restore();
+  }
+});
+
+test("large output delays keyword highlight scans until output quiets", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers, getTranslateCount, resetTranslateCount } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    noteTerminalOutputPressureData(
+      term as never,
+      "x\n".repeat(Math.ceil(TERMINAL_LONG_LINE_PRESSURE_BYTES / 2)),
+    );
+    handlers.writeParsed?.();
+    raf.flush();
+
+    assert.equal(getTranslateCount(), 0);
+
+    await new Promise((resolve) => { setTimeout(resolve, 220); });
+    assert.ok(getTranslateCount() > 0);
+    highlighter.dispose();
+    resetTerminalOutputPressure(term as never);
+  } finally {
+    raf.restore();
+  }
+});
+
+test("recent user input delays keyword highlight scans until typing is quiet", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const { term, handlers, getTranslateCount, resetTranslateCount } = createFakeTerminal("hello DEPLOY world", {
+      lineCount: 40,
+    });
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "deploy",
+        label: "Deploy",
+        patterns: ["DEPLOY"],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetTranslateCount();
+
+    handlers.data?.("a");
+    handlers.writeParsed?.();
+    raf.flush();
+
+    assert.equal(getTranslateCount(), 0);
+
+    await new Promise((resolve) => { setTimeout(resolve, 120); });
+    assert.equal(getTranslateCount(), 0);
+
+    await new Promise((resolve) => { setTimeout(resolve, 100); });
     assert.ok(getTranslateCount() > 0);
     highlighter.dispose();
   } finally {
@@ -400,6 +603,51 @@ test("wrapped highlight scanning stops before walking an oversized soft-wrapped 
       getLineCount() < 3_000,
       `expected capped wrapped scan, got ${getLineCount()} getLine calls`,
     );
+  } finally {
+    raf.restore();
+  }
+});
+
+test("scroll refresh reuses wrapped scan misses across visible rows", async () => {
+  const raf = installAnimationFrameQueue();
+  try {
+    const lineText = "a".repeat(80);
+    const {
+      term,
+      handlers,
+      getLineCount,
+      resetGetLineCount,
+    } = createFakeTerminalFromLargeWrappedBlock({
+      lineCount: 30_000,
+      lineText,
+      viewportY: 29_000,
+      rows: 30,
+    });
+    const highlighter = new KeywordHighlighter(term as never);
+    const rules: KeywordHighlightRule[] = [
+      {
+        id: "wrapped",
+        label: "Wrapped",
+        patterns: [`${lineText}${lineText}`],
+        color: "#F87171",
+        enabled: true,
+      },
+    ];
+
+    highlighter.setRules(rules, true);
+    raf.flush();
+    resetGetLineCount();
+
+    term.buffer.active.viewportY = 29_500;
+    handlers.scroll?.();
+    await new Promise((resolve) => { setTimeout(resolve, 130); });
+
+    assert.ok(
+      getLineCount() < 1_000,
+      `expected scroll chunk to share wrapped scan cache, got ${getLineCount()} getLine calls`,
+    );
+    highlighter.dispose();
+    resetTerminalOutputPressure(term as never);
   } finally {
     raf.restore();
   }

--- a/components/terminal/keywordHighlight.ts
+++ b/components/terminal/keywordHighlight.ts
@@ -60,6 +60,15 @@ interface WrappedBlockScanCache {
   cappedMiss: DirtyLineSegment | null;
 }
 
+interface ScrollRefreshJob {
+  generation: number;
+  start: number;
+  end: number;
+  nextLine: number;
+  cursorAbsoluteY: number;
+  wrappedBlockCache: WrappedBlockScanCache;
+}
+
 /** Shared empty array for non-matching lines to avoid per-call allocations. */
 const EMPTY_RANGES: readonly CachedDecorationRange[] = Object.freeze([]);
 
@@ -95,8 +104,12 @@ export class KeywordHighlighter implements IDisposable {
   private recentWriteBurst = 0;
   private lastWriteAt = 0;
   private lastBurstDecayAt = 0;
-  private forceViewportReconcileOnNextScroll = false;
+  private lastUserInputAt = 0;
+  private scrollRefreshJob: ScrollRefreshJob | null = null;
+  private scrollRefreshGeneration = 0;
   private static readonly DIRTY_SCAN_PADDING = XTERM_PERFORMANCE_CONFIG.highlighting.dirtyScanPadding;
+  private static readonly SCROLL_SETTLE_DEBOUNCE_MS = XTERM_PERFORMANCE_CONFIG.highlighting.scrollSettleDebounceMs;
+  private static readonly INPUT_QUIET_MS = XTERM_PERFORMANCE_CONFIG.highlighting.inputQuietMs;
   private static readonly WRITE_BURST_INTERVAL_MS = 28;
   private static readonly WRITE_BURST_DECAY_MS = 80;
   private static readonly WRITE_BURST_THRESHOLD = 6;
@@ -116,13 +129,29 @@ export class KeywordHighlighter implements IDisposable {
       this.term.onScroll(() => {
         this.triggerViewportChangeRefresh();
       }),
+      // User input should keep terminal echo responsive; highlight can catch up
+      // once typing pauses.
+      this.term.onData(() => {
+        this.lastUserInputAt = performance.now();
+      }),
       // When new data is written, refresh on the next frame so highlights land
       // with the freshly rendered content instead of trailing behind it.
       this.term.onWriteParsed(() => {
-        this.markDirtyFromWrite();
         const pressure = getTerminalOutputPressure(this.term);
+        if (
+          pressure.longLine
+          || pressure.largeOutput
+          || pressure.background
+          || this.isInputProtectionActive(performance.now())
+        ) {
+          this.updateWriteBurst();
+          this.markVisibleRangeDirty();
+          this.triggerRefresh("debounced", "write");
+          return;
+        }
+        this.markDirtyFromWrite();
         this.triggerRefresh(
-          pressure.longLine || pressure.background ? "debounced" : "immediate",
+          "immediate",
           "write",
         );
       }),
@@ -177,6 +206,7 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   public dispose() {
+    this.cancelScrollRefresh();
     this.clearDecorations();
     this.disposables.forEach(d => d.dispose());
     this.disposables = [];
@@ -200,6 +230,7 @@ export class KeywordHighlighter implements IDisposable {
     // Re-check state: may have changed since the refresh was scheduled
     if (!this.enabled || this.compiledRules.length === 0) return;
     if (this.term.buffer.active.type === 'alternate') {
+      this.cancelScrollRefresh();
       if (this.lineDecorations.size > 0) this.clearDecorations();
       return;
     }
@@ -207,10 +238,11 @@ export class KeywordHighlighter implements IDisposable {
     const reason = this.pendingRefreshReason;
     this.pendingRefreshReason = "write";
     this.refreshViewport(reason);
-    this.lastBufferSnapshot = this.readBufferSnapshot();
+    this.lastBufferSnapshot = this.readBufferSnapshot({ includeViewportProbe: reason !== "scroll" });
   }
 
   private clearDecorations() {
+    this.cancelScrollRefresh();
     const hadDecorations = this.lineDecorations.size > 0;
     for (const [lineY, state] of this.lineDecorations) {
       this.disposeLineDecorations(lineY, state);
@@ -347,6 +379,9 @@ export class KeywordHighlighter implements IDisposable {
 
   private triggerRefresh(mode: "immediate" | "debounced" | "continuation", reason: RefreshReason = "full") {
     if (!this.enabled || this.compiledRules.length === 0) return;
+    if (reason !== "scroll") {
+      this.cancelScrollRefresh();
+    }
     this.pendingRefreshReason = this.mergeRefreshReason(this.pendingRefreshReason, reason);
 
     // Optimization: Disable highlighting in Alternate Buffer (e.g. Vim, Htop)
@@ -375,22 +410,6 @@ export class KeywordHighlighter implements IDisposable {
         this.debounceTimer = null;
         this.executeRefresh();
       }, delay);
-      return;
-    }
-
-    // Prefer true "what you see is what gets highlighted" behavior on scroll:
-    // process the current viewport immediately instead of waiting for next rAF.
-    if (mode === "immediate" && reason === "scroll") {
-      if (this.animationFrameId !== null) {
-        cancelAnimationFrame(this.animationFrameId);
-        this.animationFrameId = null;
-      }
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = null;
-      }
-      this.forceViewportReconcileOnNextScroll = true;
-      this.executeRefresh();
       return;
     }
 
@@ -424,7 +443,6 @@ export class KeywordHighlighter implements IDisposable {
         if (reason === "scroll") {
           cancelAnimationFrame(this.animationFrameId);
           this.animationFrameId = null;
-          this.forceViewportReconcileOnNextScroll = true;
           if (this.debounceTimer) {
             clearTimeout(this.debounceTimer);
             this.debounceTimer = null;
@@ -476,7 +494,12 @@ export class KeywordHighlighter implements IDisposable {
       clearTimeout(this.debounceTimer);
     }
 
-    const delay = this.getAdaptiveHighlightingProfile().debounceMs;
+    const inputQuietDelay = reason === "write"
+      ? this.getInputProtectionRemainingMs(performance.now())
+      : 0;
+    const delay = reason === "scroll"
+      ? KeywordHighlighter.SCROLL_SETTLE_DEBOUNCE_MS
+      : Math.max(this.getAdaptiveHighlightingProfile().debounceMs, inputQuietDelay);
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
       this.executeRefresh();
@@ -484,6 +507,7 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private triggerViewportChangeRefresh() {
+    this.cancelScrollRefresh();
     const now = performance.now();
     const isOutputDrivenViewportChange =
       this.lastWriteAt > 0 &&
@@ -494,7 +518,7 @@ export class KeywordHighlighter implements IDisposable {
       return;
     }
 
-    this.triggerRefresh("immediate", "scroll");
+    this.triggerRefresh("debounced", "scroll");
   }
 
   private refreshViewport(reason: RefreshReason) {
@@ -520,13 +544,8 @@ export class KeywordHighlighter implements IDisposable {
       if (reason === "write") {
         this.processDirtyLinesInRange(rangeStart, rangeEnd, cursorAbsoluteY, "write");
       } else if (reason === "scroll") {
-        // Hard scroll mode: rebuild the whole render window synchronously
-        // (viewport + overscan), avoiding dirty-range races under fast wheel drags.
-        this.clearLineDecorationsInRange(rangeStart, rangeEnd);
-        this.processLineRange(rangeStart, rangeEnd, cursorAbsoluteY);
-        this.removeDirtyRange(rangeStart, rangeEnd);
-        this.dirtyAllInRenderRange = false;
-        this.forceViewportReconcileOnNextScroll = false;
+        this.startScrollRefresh(viewportStart, viewportEnd, cursorAbsoluteY);
+        return;
       } else if (previousRange !== null && this.lineDecorations.size > 0) {
         if (rangeStart < previousRange.start) {
           this.processLineRange(rangeStart, Math.min(rangeEnd, previousRange.start - 1), cursorAbsoluteY);
@@ -552,26 +571,11 @@ export class KeywordHighlighter implements IDisposable {
         this.lastRenderRange = null;
       } else {
         this.lastViewportRange = { start: viewportStart, end: viewportEnd };
-        const scrollRangeFullyProcessed =
-          reason !== "scroll" || !this.hasDirtyRangeInWindow(rangeStart, rangeEnd);
-        this.lastRenderRange = scrollRangeFullyProcessed
-          ? { start: rangeStart, end: rangeEnd }
-          : { start: viewportStart, end: viewportEnd };
+        this.lastRenderRange = { start: rangeStart, end: rangeEnd };
       }
     } finally {
       this.flushTerminalRefresh();
     }
-  }
-
-  private hasDirtyRangeInWindow(start: number, end: number): boolean {
-    if (end < start) return false;
-    if (this.dirtyAllInRenderRange) return true;
-    for (const segment of this.dirtySegments) {
-      if (segment.end < start) continue;
-      if (segment.start > end) return false;
-      return true;
-    }
-    return false;
   }
 
   private beginTerminalRefreshTracking(viewportStart: number, viewportEnd: number) {
@@ -645,10 +649,9 @@ export class KeywordHighlighter implements IDisposable {
     continuationReason: RefreshReason
   ) {
     if (this.dirtyAllInRenderRange) {
-      this.processLineRange(rangeStart, rangeEnd, cursorAbsoluteY);
+      this.dirtySegments = [{ start: rangeStart, end: rangeEnd }];
+      this.rebuildDirtyLineCount();
       this.dirtyAllInRenderRange = false;
-      this.clearDirtySegments();
-      return;
     }
 
     if (this.dirtySegments.length === 0) {
@@ -701,7 +704,7 @@ export class KeywordHighlighter implements IDisposable {
     return weight[next] > weight[current] ? next : current;
   }
 
-  private readBufferSnapshot(): BufferSnapshot | null {
+  private readBufferSnapshot({ includeViewportProbe = true }: { includeViewportProbe?: boolean } = {}): BufferSnapshot | null {
     const buffer = this.term?.buffer?.active;
     if (!buffer) return null;
     return {
@@ -709,7 +712,7 @@ export class KeywordHighlighter implements IDisposable {
       baseY: buffer.baseY,
       viewportY: buffer.viewportY,
       cursorAbsoluteY: buffer.baseY + buffer.cursorY,
-      viewportProbe: this.buildViewportProbe(buffer, this.term.rows),
+      viewportProbe: includeViewportProbe ? this.buildViewportProbe(buffer, this.term.rows) : [],
     };
   }
 
@@ -968,6 +971,15 @@ export class KeywordHighlighter implements IDisposable {
     return now - this.lastWriteAt <= KeywordHighlighter.WRITE_BURST_DECAY_MS * 2;
   }
 
+  private getInputProtectionRemainingMs(now: number): number {
+    if (this.lastUserInputAt <= 0) return 0;
+    return Math.max(0, KeywordHighlighter.INPUT_QUIET_MS - (now - this.lastUserInputAt));
+  }
+
+  private isInputProtectionActive(now: number): boolean {
+    return this.getInputProtectionRemainingMs(now) > 0;
+  }
+
   private getAdaptiveHighlightingProfile(now = performance.now()) {
     const config = XTERM_PERFORMANCE_CONFIG.highlighting;
     const overscanLines = this.getBaseOverscanLines();
@@ -1004,6 +1016,9 @@ export class KeywordHighlighter implements IDisposable {
   }
 
   private getOverscanLines(reason: RefreshReason): number {
+    if (reason === "scroll") {
+      return 0;
+    }
     if (reason === "write") {
       return this.getAdaptiveHighlightingProfile().overscanLines;
     }
@@ -1027,13 +1042,21 @@ export class KeywordHighlighter implements IDisposable {
     return Math.max(16, quietWindow - elapsedSinceWrite);
   }
 
-  private processLineRange(start: number, end: number, cursorAbsoluteY: number) {
-    if (end < start) return;
-    const buffer = this.term.buffer.active;
-    const wrappedBlockCache: WrappedBlockScanCache = {
+  private createWrappedBlockScanCache(): WrappedBlockScanCache {
+    return {
       contexts: new Map<number, WrappedBlockCacheEntry>(),
       cappedMiss: null,
     };
+  }
+
+  private processLineRange(
+    start: number,
+    end: number,
+    cursorAbsoluteY: number,
+    wrappedBlockCache = this.createWrappedBlockScanCache(),
+  ) {
+    if (end < start) return;
+    const buffer = this.term.buffer.active;
     const pressure = getTerminalOutputPressure(this.term);
     for (let lineY = start; lineY <= end; lineY++) {
       const line = buffer.getLine(lineY);
@@ -1075,11 +1098,65 @@ export class KeywordHighlighter implements IDisposable {
     }
   }
 
-  private clearLineDecorationsInRange(start: number, end: number) {
-    if (end < start || this.lineDecorations.size === 0) return;
+  private startScrollRefresh(start: number, end: number, cursorAbsoluteY: number) {
+    this.cancelScrollRefresh();
+    const generation = this.scrollRefreshGeneration;
+    this.scrollRefreshJob = {
+      generation,
+      start,
+      end,
+      nextLine: start,
+      cursorAbsoluteY,
+      wrappedBlockCache: this.createWrappedBlockScanCache(),
+    };
+    this.runScrollRefreshChunk(generation);
+  }
+
+  private runScrollRefreshChunk(generation: number) {
+    const job = this.scrollRefreshJob;
+    if (!job || job.generation !== generation) return;
+    if (!this.enabled || this.compiledRules.length === 0 || this.term.buffer.active.type === "alternate") {
+      this.cancelScrollRefresh();
+      return;
+    }
+
+    this.beginTerminalRefreshTracking(job.start, job.end);
+    try {
+      this.reindexLineDecorationsFromMarkers();
+      this.processLineRange(
+        job.nextLine,
+        job.end,
+        job.cursorAbsoluteY,
+        job.wrappedBlockCache,
+      );
+      this.removeDirtyRange(job.nextLine, job.end);
+      job.nextLine = job.end + 1;
+    } finally {
+      this.flushTerminalRefresh();
+    }
+
+    this.finishScrollRefresh(job);
+  }
+
+  private finishScrollRefresh(job: ScrollRefreshJob) {
+    if (this.scrollRefreshJob !== job) return;
+    this.scrollRefreshJob = null;
+    this.dirtyAllInRenderRange = false;
+    this.clearLineDecorationsOutsideRange(job.start, job.end);
+    this.lastViewportRange = { start: job.start, end: job.end };
+    this.lastRenderRange = { start: job.start, end: job.end };
+  }
+
+  private cancelScrollRefresh() {
+    this.scrollRefreshJob = null;
+    this.scrollRefreshGeneration += 1;
+  }
+
+  private clearLineDecorationsOutsideRange(start: number, end: number) {
+    if (this.lineDecorations.size === 0) return;
     const entries = Array.from(this.lineDecorations.entries());
     for (const [lineY, state] of entries) {
-      if (lineY < start || lineY > end) continue;
+      if (lineY >= start && lineY <= end) continue;
       this.disposeLineDecorations(lineY, state);
     }
   }

--- a/components/terminal/runtime/terminalOutputPressure.test.ts
+++ b/components/terminal/runtime/terminalOutputPressure.test.ts
@@ -10,6 +10,7 @@ import {
   setTerminalOutputPressureVisibility,
 } from "./terminalOutputPressure.ts";
 import { TERMINAL_LONG_LINE_PRESSURE_BYTES } from "./terminalFlowConstants.ts";
+import { XTERM_PERFORMANCE_CONFIG } from "../../../infrastructure/config/xtermPerformance.ts";
 
 const createFakeTerm = () => ({}) as XTerm;
 
@@ -40,7 +41,8 @@ test("reports newline-terminated long terminal lines as long-line pressure", () 
 
   noteTerminalOutputPressureData(term, "short\n");
   assert.equal(getTerminalOutputPressure(term).longLine, false);
-  assert.equal(getTerminalOutputPressure(term).mode, "normal");
+  assert.equal(getTerminalOutputPressure(term).largeOutput, true);
+  assert.equal(getTerminalOutputPressure(term).mode, "large-output");
 
   resetTerminalOutputPressure(term);
 });
@@ -57,4 +59,36 @@ test("reports background pressure separately from output volume", () => {
   assert.equal(getTerminalOutputPressure(term).mode, "normal");
 
   resetTerminalOutputPressure(term);
+});
+
+test("keeps large-output pressure through small input echoes until output is quiet", () => {
+  const term = createFakeTerm();
+  const originalNow = performance.now.bind(performance);
+  let now = 1_000;
+
+  Object.defineProperty(performance, "now", {
+    configurable: true,
+    value: () => now,
+  });
+
+  try {
+    noteTerminalOutputPressureData(term, "x\n".repeat(Math.ceil(TERMINAL_LONG_LINE_PRESSURE_BYTES / 2)));
+    assert.equal(getTerminalOutputPressure(term).largeOutput, true);
+    assert.equal(getTerminalOutputPressure(term).mode, "large-output");
+
+    now += 16;
+    noteTerminalOutputPressureData(term, "a");
+    assert.equal(getTerminalOutputPressure(term).largeOutput, true);
+    assert.equal(getTerminalOutputPressure(term).mode, "large-output");
+
+    now += XTERM_PERFORMANCE_CONFIG.highlighting.largeOutputQuietMs + 1;
+    assert.equal(getTerminalOutputPressure(term).largeOutput, false);
+    assert.equal(getTerminalOutputPressure(term).mode, "normal");
+  } finally {
+    Object.defineProperty(performance, "now", {
+      configurable: true,
+      value: originalNow,
+    });
+    resetTerminalOutputPressure(term);
+  }
 });

--- a/components/terminal/runtime/terminalOutputPressure.ts
+++ b/components/terminal/runtime/terminalOutputPressure.ts
@@ -1,5 +1,6 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
+import { XTERM_PERFORMANCE_CONFIG } from "../../../infrastructure/config/xtermPerformance";
 import { TERMINAL_LONG_LINE_PRESSURE_BYTES } from "./terminalFlowConstants";
 
 export type TerminalOutputPressureMode =
@@ -19,6 +20,7 @@ export type TerminalOutputPressureSnapshot = {
 type TerminalOutputPressureState = {
   background: boolean;
   largeOutput: boolean;
+  largeOutputUntil: number;
   longLine: boolean;
   consecutiveUnbrokenBytes: number;
 };
@@ -31,6 +33,7 @@ const getOrCreateState = (term: XTerm): TerminalOutputPressureState => {
     state = {
       background: false,
       largeOutput: false,
+      largeOutputUntil: 0,
       longLine: false,
       consecutiveUnbrokenBytes: 0,
     };
@@ -65,7 +68,13 @@ export const noteTerminalOutputPressureData = (
 ): void => {
   if (!data) return;
   const state = getOrCreateState(term);
-  state.largeOutput = data.length >= TERMINAL_LONG_LINE_PRESSURE_BYTES;
+  const now = performance.now();
+  if (data.length >= TERMINAL_LONG_LINE_PRESSURE_BYTES) {
+    state.largeOutputUntil = now + XTERM_PERFORMANCE_CONFIG.highlighting.largeOutputQuietMs;
+    state.largeOutput = true;
+  } else if (now >= state.largeOutputUntil) {
+    state.largeOutput = false;
+  }
   const { maxRunBytes, trailingRunBytes } = measureUnbrokenRuns(
     data,
     state.consecutiveUnbrokenBytes,
@@ -85,25 +94,30 @@ export const setTerminalOutputPressureLargeOutput = (
   term: XTerm,
   largeOutput: boolean,
 ): void => {
-  getOrCreateState(term).largeOutput = largeOutput;
+  const state = getOrCreateState(term);
+  state.largeOutput = largeOutput;
+  state.largeOutputUntil = largeOutput
+    ? performance.now() + XTERM_PERFORMANCE_CONFIG.highlighting.largeOutputQuietMs
+    : 0;
 };
 
 export const getTerminalOutputPressure = (
   term: XTerm,
 ): TerminalOutputPressureSnapshot => {
   const state = getOrCreateState(term);
+  const largeOutput = state.largeOutput && performance.now() < state.largeOutputUntil;
   const mode: TerminalOutputPressureMode = state.background
     ? "background"
     : state.longLine
       ? "long-line"
-      : state.largeOutput
+      : largeOutput
         ? "large-output"
         : "normal";
 
   return {
     mode,
     background: state.background,
-    largeOutput: state.largeOutput,
+    largeOutput,
     longLine: state.longLine,
     consecutiveUnbrokenBytes: state.consecutiveUnbrokenBytes,
   };

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1222,6 +1222,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     };
 
     const scheduleSelectionOverlayPosition = () => {
+      if (lastHasSelection === false) return;
       if (overlayRafId !== null) return;
       overlayRafId = requestFrame(publishSelectionOverlayPosition);
     };
@@ -1233,12 +1234,18 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         lastHasSelection = hasText;
         setHasSelection(hasText);
       }
-      scheduleSelectionOverlayPosition();
-
       if (copyTimer) {
         clearTimeout(copyTimer);
         copyTimer = null;
       }
+      if (!hasText) {
+        if (lastOverlayPosition !== null) {
+          lastOverlayPosition = null;
+          setSelectionOverlayPosition?.(null);
+        }
+        return;
+      }
+      scheduleSelectionOverlayPosition();
 
       if (hasText && terminalSettings?.copyOnSelect && !isRestoringSelectionRef.current) {
         copyTimer = setTimeout(() => {

--- a/infrastructure/config/xtermPerformance.ts
+++ b/infrastructure/config/xtermPerformance.ts
@@ -124,6 +124,12 @@ export const XTERM_PERFORMANCE_CONFIG = {
     writeRefreshBudgetMs: 4,
     // Process dirty contiguous lines in chunks so budget checks can preempt.
     dirtySegmentChunkSize: 48,
+    // User-scroll catch-up should be almost invisible to the renderer.
+    scrollSettleDebounceMs: 120,
+    // Keep highlighting deprioritized briefly after a large output burst.
+    largeOutputQuietMs: 320,
+    // Give interactive typing priority over keyword highlight catch-up.
+    inputQuietMs: 180,
   },
 };
 


### PR DESCRIPTION
## Summary
- defer keyword highlighting while users scroll or type so terminal rendering stays responsive
- only refresh visible terminal rows after scroll settles and deprioritize highlighting during large output bursts
- reduce redundant timestamp gutter work and skip selection overlay repositioning when there is no selection

## Verification
- node --test --import tsx components/terminal/keywordHighlight.test.ts components/terminal/runtime/terminalOutputPressure.test.ts
- npx eslint components/terminal/keywordHighlight.ts components/terminal/keywordHighlight.test.ts components/terminal/runtime/terminalOutputPressure.ts components/terminal/runtime/terminalOutputPressure.test.ts infrastructure/config/xtermPerformance.ts
- git diff --check
- node --test --import tsx components/terminal/*.test.ts components/terminal/*.test.tsx components/terminal/runtime/*.test.ts
- npm run build
- npm test
