### PR TITLE
fix terminal address title

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2296,12 +2296,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     recorder,
   ]);
 
-  const statusDotTone =
-    status === "connected"
-      ? "bg-emerald-400"
-      : status === "connecting"
-        ? "bg-amber-400"
-        : "bg-rose-500";
   const terminalPreviewVars = useMemo(() => {
     const { background, foreground, cursor } = effectiveTheme.colors;
     return {
@@ -2501,7 +2495,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           onStop={() => { void stopScriptRun(activeScriptRun.runId); }}
           onDismiss={dismissScriptOverlay}
         />
-      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, statusDotTone, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
+      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
       <ScriptSaveRecordingDialog
         open={saveRecordingOpen}
         code={recordedCode}

--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -116,14 +116,14 @@ test("SessionTabIcon checks custom host icon appearance before distro logos", ()
   );
 });
 
-test("session top tab label appends the target address for ssh sessions", () => {
+test("session top tab label only shows the host label for ssh sessions", () => {
   assert.equal(
     formatSessionTopTabLabel({
       hostLabel: "prod-web",
       hostname: "10.1.2.34",
       protocol: "ssh",
     }),
-    "prod-web · 10.1.2.34",
+    "prod-web",
   );
 });
 
@@ -133,7 +133,7 @@ test("session top tab label treats missing protocol as ssh", () => {
       hostLabel: "prod-web",
       hostname: "10.1.2.34",
     }),
-    "prod-web · 10.1.2.34",
+    "prod-web",
   );
   assert.equal(
     formatSessionTopTabTooltip({

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 import {
+  formatTerminalTitleConnectionAddress,
   getLineTimestampToggleHostUpdate,
   shouldShowSelectionAIOverlay,
   shouldShowLineTimestampToolbarToggle,
@@ -63,6 +64,41 @@ test("selection AI overlay honors the visibility preference", () => {
     }),
     false,
   );
+});
+
+test("terminal title formats the connection address for remote sessions", () => {
+  assert.equal(
+    formatTerminalTitleConnectionAddress({
+      protocol: "ssh",
+      username: "root",
+      hostname: "10.1.2.34",
+      port: 2222,
+    }),
+    "root@10.1.2.34:2222",
+  );
+  assert.equal(formatTerminalTitleConnectionAddress({ protocol: "local", hostname: "localhost" }), null);
+});
+
+test("terminal title row does not render a status dot beside the address", () => {
+  const source = readFileSync(new URL("./TerminalView.tsx", import.meta.url), "utf8");
+  const titleStart = source.indexOf("data-terminal-detach-drag-handle");
+  const titleEnd = source.indexOf("shouldShowLineTimestampToolbarToggle", titleStart);
+  assert.notEqual(titleStart, -1);
+  assert.notEqual(titleEnd, -1);
+
+  assert.doesNotMatch(source.slice(titleStart, titleEnd), /statusDotTone/);
+});
+
+test("terminal title keeps the copy host action beside the address", () => {
+  const source = readFileSync(new URL("./TerminalView.tsx", import.meta.url), "utf8");
+  const titleStart = source.indexOf("data-terminal-detach-drag-handle");
+  const copyAction = source.indexOf('aria-label={t("terminal.statusbar.copyHostname.label")}', titleStart);
+  const timestampToggle = source.indexOf("shouldShowLineTimestampToolbarToggle", titleStart);
+
+  assert.notEqual(titleStart, -1);
+  assert.notEqual(copyAction, -1);
+  assert.notEqual(timestampToggle, -1);
+  assert.ok(copyAction < timestampToggle);
 });
 
 test("popup terminals disable line timestamp controls", () => {

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -72,6 +72,24 @@ export function shouldShowSelectionAIOverlay({
   );
 }
 
+type TerminalTitleAddressHost = {
+  id?: string;
+  protocol?: string;
+  username?: string;
+  hostname?: string;
+  port?: number;
+};
+
+export function formatTerminalTitleConnectionAddress(host?: TerminalTitleAddressHost): string | null {
+  if (!host || host.protocol === 'local' || host.id?.startsWith('local-') || !host.hostname || host.hostname === 'localhost') {
+    return null;
+  }
+  const isSerial = host.protocol === 'serial' || host.id?.startsWith('serial-');
+  const username = !isSerial && host.username ? `${host.username}@` : '';
+  const port = !isSerial && host.port ? `:${host.port}` : '';
+  return `${username}${host.hostname}${port}`;
+}
+
 /**
  * Shallow-compare every ctx value. <Terminal> rebuilds the ctx object on every
  * render, but many re-renders (layout/fit/visibility-of-other-panes, suppress
@@ -97,7 +115,7 @@ function terminalViewCtxEqual(
 }
 
 function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
-  const { Activity, Button, Clock3, Copy, Maximize2, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isConnectionAwaitingUserInput, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onCloseSession, onDetach, onDetachPointerDown, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onToggleBroadcast, onUpdateHost, osc52ReadPromptVisible, osc7SetupOpen, osc7SetupRunning, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scriptExecutionOverlay, searchMatchCount, searchFocusToken, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, statusDotTone, sudoHintRef, sudoHintText, t, termRef, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem } = ctx;
+  const { Activity, Button, Clock3, Copy, Maximize2, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isConnectionAwaitingUserInput, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onCloseSession, onDetach, onDetachPointerDown, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onToggleBroadcast, onUpdateHost, osc52ReadPromptVisible, osc7SetupOpen, osc7SetupRunning, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scriptExecutionOverlay, searchMatchCount, searchFocusToken, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText, t, termRef, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem } = ctx;
   const ymodemActionEnabled = shouldEnableYmodemAction({
     isSerialConnection,
     status,
@@ -123,6 +141,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
   const lineTimestampToggleLabel = showLineTimestampGutter
     ? t("terminal.toolbar.timestampsDisable")
     : t("terminal.toolbar.timestampsEnable");
+  const titleConnectionAddress = formatTerminalTitleConnectionAddress(host);
   return (
     <TerminalContextMenu
       hasSelection={hasSelection}
@@ -213,13 +232,31 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                 data-terminal-detach-drag-handle={inWorkspace && onDetachPointerDown ? "true" : undefined}
                 onPointerDown={onDetachPointerDown}
               >
-                <span className="whitespace-nowrap truncate min-w-0 max-w-[12rem]">{sessionDisplayName || host.label}</span>
-                <span
-                  className={cn(
-                    "inline-block h-2 w-2 rounded-full flex-shrink-0",
-                    statusDotTone,
-                  )}
-                />
+                <span className="whitespace-nowrap truncate min-w-0 max-w-[18rem]" title={titleConnectionAddress || sessionDisplayName || host.label}>
+                  {titleConnectionAddress || sessionDisplayName || host.label}
+                </span>
+                {host.protocol !== "local" && host.hostname && host.hostname !== "localhost" && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={() => {
+                          void navigator.clipboard.writeText(host.hostname).then(() => {
+                            toast.success(t("terminal.statusbar.copyHostname.toast", { hostname: host.hostname }));
+                          }).catch(() => {
+                            toast.error(t("terminal.statusbar.copyHostname.error"));
+                          });
+                        }}
+                        aria-label={t("terminal.statusbar.copyHostname.label")}
+                      >
+                        <Copy size={10} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
+                  </Tooltip>
+                )}
               </div>
               {shouldShowLineTimestampToolbarToggle(lineTimestampsAvailable, onUpdateHost) && (
                 <Tooltip>
@@ -247,27 +284,6 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">{lineTimestampToggleLabel}</TooltipContent>
-                </Tooltip>
-              )}
-              {host.protocol !== "local" && host.hostname && host.hostname !== "localhost" && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
-                      onClick={() => {
-                        void navigator.clipboard.writeText(host.hostname).then(() => {
-                          toast.success(t("terminal.statusbar.copyHostname.toast", { hostname: host.hostname }));
-                        }).catch(() => {
-                          toast.error(t("terminal.statusbar.copyHostname.error"));
-                        });
-                      }}
-                      aria-label={t("terminal.statusbar.copyHostname.label")}
-                    >
-                      <Copy size={10} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
                 </Tooltip>
               )}
               {isSystemSidebarEligible && (

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -195,12 +195,7 @@ export const formatSessionTopTabLabel = (
   >,
   dynamicTabTitleMode?: DynamicTabTitleMode,
 ): string => {
-  const baseTitle = resolveSessionTabTitle(session, dynamicTabTitleMode);
-  const address = getSessionTopTabAddress(session);
-  if (!address) return baseTitle;
-  if (!baseTitle) return address;
-  if (baseTitle.trim() === address) return baseTitle;
-  return `${baseTitle} · ${address}`;
+  return resolveSessionTabTitle(session, dynamicTabTitleMode);
 };
 
 // Custom window controls for Windows/Linux (frameless window)


### PR DESCRIPTION
## Summary

- Show the connection address in the terminal title area while keeping top tabs on the host label.
- Keep the copy-host action immediately beside the connection address.
- Remove the extra status dot from the terminal title row.

## Validation
- node --test --import tsx components/terminal/TerminalView.test.tsx components/TopTabs.test.ts
- npm run lint
- npm run build
- npm test









