### PR TITLE
update nix release metadata for v1.1.53

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.51";
+  version = "1.1.53";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-xMTXP3gjBuAzDXIYuhbQsCkwcf9lDMnRvqkL01PbGTA=";
+      hash = "sha256-4H77H+CoXCoU1IdL9A6BAnCkctjkiN+F/FL5NIvtDBE=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-UyWRFuc1yN2CkUl0/jyJ3+lJkrpvGHZB0u5itJ0CkG4=";
+      hash = "sha256-5d1a7KVlPwyQOiPFnOi2B5nLaVZFSNMBhrcvqgKP0Gg=";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Update Nix release metadata to v1.1.53.
- Use the v1.1.53 Linux AppImage hashes from the published release assets.

## Validation
- node --test scripts/update-nix-release.test.cjs
