### PR TITLE
[codex] Fix terminal tab switch recovery

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1623,10 +1623,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     });
   }, [reuseConnectionFromSessionId, sessionId, terminalBackend]);
 
-  const safeFit = (options?: { force?: boolean; requireVisible?: boolean }) => {
+  const safeFit = (options?: { force?: boolean; requireVisible?: boolean; immediate?: boolean; allowHidden?: boolean }) => {
     const fitAddon = fitAddonRef.current;
     if (!fitAddon) return;
-    if (options?.requireVisible && !isVisibleRef.current) return;
+    if (!isVisibleRef.current && !options?.allowHidden) {
+      lastFittedSizeRef.current = null;
+      return;
+    }
 
     const container = containerRef.current;
     if (!container) return;
@@ -1696,7 +1699,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     if (
       XTERM_PERFORMANCE_CONFIG.resize.useRAF &&
-      typeof requestAnimationFrame === "function"
+      typeof requestAnimationFrame === "function" &&
+      !options?.immediate
     ) {
       requestAnimationFrame(runFit);
     } else {
@@ -2483,7 +2487,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onWake: wakeFromHibernateRuntime,
   });
 
-  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
+  useTerminalEffects({ CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen: effectiveComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing: deferTerminalResize, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef: noteOutputTriggerUserInputRef, onSnippetShortkeyRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef: recorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, snippetsRef, splitResizeActive: isResizing, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState });
 
   return (
     <>

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -1303,6 +1303,12 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
           if (!ctx.hasConnectedRef.current) {
             ctx.updateStatus("connected");
             setTimeout(() => {
+              if (ctx.isVisibleRef?.current === false) {
+                if (ctx.pendingOutputScrollRef) {
+                  ctx.pendingOutputScrollRef.current = true;
+                }
+                return;
+              }
               if (!ctx.fitAddonRef.current) return;
               try {
                 ctx.fitAddonRef.current.fit();

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -15,6 +15,7 @@ import {
   closeOrphanBackendSession,
   getFlowController,
   isTerminalBootActive,
+  notePendingOutputScrollIfEnabled,
   resetTerminalLineTimestampState,
   tryAttachSessionToTerminal,
   writeSessionData,
@@ -1304,9 +1305,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
             ctx.updateStatus("connected");
             setTimeout(() => {
               if (ctx.isVisibleRef?.current === false) {
-                if (ctx.pendingOutputScrollRef) {
-                  ctx.pendingOutputScrollRef.current = true;
-                }
+                notePendingOutputScrollIfEnabled(ctx);
                 return;
               }
               if (!ctx.fitAddonRef.current) return;

--- a/components/terminal/runtime/terminalPostConnectVisibility.test.ts
+++ b/components/terminal/runtime/terminalPostConnectVisibility.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const attachmentSource = readFileSync(new URL('./terminalSessionAttachment.ts', import.meta.url), 'utf8');
+const startersSource = readFileSync(new URL('./createTerminalSessionStarters.ts', import.meta.url), 'utf8');
+
+const hiddenPostConnectFitGuard =
+  /setTimeout\(\(\) => \{\s*if \(ctx\.isVisibleRef\?\.current === false\) \{\s*if \(ctx\.pendingOutputScrollRef\) \{\s*ctx\.pendingOutputScrollRef\.current = true;\s*\}\s*return;\s*\}\s*if \(!ctx\.fitAddonRef\.current\) return;[\s\S]*ctx\.fitAddonRef\.current\.fit\(\)/;
+
+test('reattached sessions do not fit hidden terminal panes after first output', () => {
+  assert.match(attachmentSource, hiddenPostConnectFitGuard);
+});
+
+test('local sessions do not fit hidden terminal panes after first output', () => {
+  assert.match(startersSource, hiddenPostConnectFitGuard);
+});

--- a/components/terminal/runtime/terminalPostConnectVisibility.test.ts
+++ b/components/terminal/runtime/terminalPostConnectVisibility.test.ts
@@ -6,7 +6,7 @@ const attachmentSource = readFileSync(new URL('./terminalSessionAttachment.ts', 
 const startersSource = readFileSync(new URL('./createTerminalSessionStarters.ts', import.meta.url), 'utf8');
 
 const hiddenPostConnectFitGuard =
-  /setTimeout\(\(\) => \{\s*if \(ctx\.isVisibleRef\?\.current === false\) \{\s*if \(ctx\.pendingOutputScrollRef\) \{\s*ctx\.pendingOutputScrollRef\.current = true;\s*\}\s*return;\s*\}\s*if \(!ctx\.fitAddonRef\.current\) return;[\s\S]*ctx\.fitAddonRef\.current\.fit\(\)/;
+  /setTimeout\(\(\) => \{\s*if \(ctx\.isVisibleRef\?\.current === false\) \{\s*notePendingOutputScrollIfEnabled\(ctx\);\s*return;\s*\}\s*if \(!ctx\.fitAddonRef\.current\) return;[\s\S]*ctx\.fitAddonRef\.current\.fit\(\)/;
 
 test('reattached sessions do not fit hidden terminal panes after first output', () => {
   assert.match(attachmentSource, hiddenPostConnectFitGuard);
@@ -14,4 +14,11 @@ test('reattached sessions do not fit hidden terminal panes after first output', 
 
 test('local sessions do not fit hidden terminal panes after first output', () => {
   assert.match(startersSource, hiddenPostConnectFitGuard);
+});
+
+test('hidden post-connect scroll recovery respects the scroll-on-output setting', () => {
+  assert.match(
+    attachmentSource,
+    /export const notePendingOutputScrollIfEnabled[\s\S]*shouldScrollOnTerminalOutput\(settings\)[\s\S]*ctx\.pendingOutputScrollRef\.current = true/,
+  );
 });

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   attachSessionToTerminal,
   getFlowController,
+  notePendingOutputScrollIfEnabled,
   tryAttachSessionToTerminal,
   writeSessionData,
 } from "./terminalSessionAttachment.ts";
@@ -79,6 +80,28 @@ const createContext = (showLineTimestamps: boolean, host: Record<string, unknown
   terminalBackend: {},
   sessionRef: { current: "session-1" },
   promptLineBreakStateRef: { current: undefined },
+});
+
+test("notePendingOutputScrollIfEnabled leaves hidden output unmarked when scroll-on-output is disabled", () => {
+  const pendingOutputScrollRef = { current: false };
+
+  notePendingOutputScrollIfEnabled({
+    terminalSettingsRef: { current: { scrollOnOutput: false } },
+    pendingOutputScrollRef,
+  } as never);
+
+  assert.equal(pendingOutputScrollRef.current, false);
+});
+
+test("notePendingOutputScrollIfEnabled marks hidden output when scroll-on-output is enabled", () => {
+  const pendingOutputScrollRef = { current: false };
+
+  notePendingOutputScrollIfEnabled({
+    terminalSettingsRef: { current: { scrollOnOutput: true } },
+    pendingOutputScrollRef,
+  } as never);
+
+  assert.equal(pendingOutputScrollRef.current, true);
 });
 
 test("writeSessionData clears renderer backlog while deferring IPC ack", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -409,6 +409,12 @@ export const attachSessionToTerminal = (
         ctx.updateStatus("connected");
         opts?.onConnected?.();
         setTimeout(() => {
+          if (ctx.isVisibleRef?.current === false) {
+            if (ctx.pendingOutputScrollRef) {
+              ctx.pendingOutputScrollRef.current = true;
+            }
+            return;
+          }
           if (!ctx.fitAddonRef.current) return;
           try {
             ctx.fitAddonRef.current.fit();

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -94,13 +94,21 @@ const handleTerminalOutputAutoScroll = (
   }
 
   if (ctx.isVisibleRef?.current === false) {
-    if (ctx.pendingOutputScrollRef) {
-      ctx.pendingOutputScrollRef.current = true;
-    }
+    notePendingOutputScrollIfEnabled(ctx);
     return;
   }
 
   term.scrollToBottom();
+};
+
+export const notePendingOutputScrollIfEnabled = (
+  ctx: TerminalSessionStartersContext,
+): void => {
+  const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
+  if (!shouldScrollOnTerminalOutput(settings)) return;
+  if (ctx.pendingOutputScrollRef) {
+    ctx.pendingOutputScrollRef.current = true;
+  }
 };
 
 const terminalFlowControllers = new WeakMap<XTerm, OutputFlowController>();
@@ -410,9 +418,7 @@ export const attachSessionToTerminal = (
         opts?.onConnected?.();
         setTimeout(() => {
           if (ctx.isVisibleRef?.current === false) {
-            if (ctx.pendingOutputScrollRef) {
-              ctx.pendingOutputScrollRef.current = true;
-            }
+            notePendingOutputScrollIfEnabled(ctx);
             return;
           }
           if (!ctx.fitAddonRef.current) return;

--- a/components/terminal/terminalSafeFitVisibility.test.ts
+++ b/components/terminal/terminalSafeFitVisibility.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('../Terminal.tsx', import.meta.url), 'utf8');
+
+test('safeFit skips hidden terminal panes unless explicitly allowed', () => {
+  assert.match(
+    source,
+    /if \(!isVisibleRef\.current && !options\?\.allowHidden\) \{\s*lastFittedSizeRef\.current = null;\s*return;\s*\}/,
+  );
+});
+
+test('safeFit can run synchronously for first-frame tab recovery', () => {
+  assert.match(source, /immediate\?: boolean/);
+  assert.match(
+    source,
+    /XTERM_PERFORMANCE_CONFIG\.resize\.useRAF &&\s*typeof requestAnimationFrame === "function" &&\s*!options\?\.immediate/,
+  );
+});

--- a/components/terminal/terminalTabVisibilityRecovery.test.ts
+++ b/components/terminal/terminalTabVisibilityRecovery.test.ts
@@ -20,3 +20,25 @@ test('layout recovery refit also syncs PTY size for full-screen TUIs', () => {
   assert.match(source, /runImmediateRefit\(\{ force: true, repeatOnNextFrame: false \}\);\s*finishLayoutRecoveryAfterFit\(\)/);
   assert.match(source, /finishLayoutRecoveryAfterFit/);
 });
+
+test('tab-switch suppression does not consume the visible recovery pass', () => {
+  assert.match(source, /const becameVisible = isVisible && !wasVisibleRef\.current/);
+  assert.match(
+    source,
+    /if \(!isVisible\) \{\s*wasVisibleRef\.current = false;\s*return;\s*\}[\s\S]*if \(splitResizeActive\) return;[\s\S]*wasVisibleRef\.current = true;[\s\S]*recoverTerminalAfterBecomeVisible\(\)/,
+  );
+  assert.doesNotMatch(source, /wasVisibleRef\.current = isVisible;\s*if \(!isVisible \|\| isResizing\) return/);
+});
+
+test('immediate visibility recovery does not wait for the next animation frame', () => {
+  assert.match(source, /safeFit\(\{ force, requireVisible: true, immediate: true \}\)/);
+  assert.match(source, /safeFit\(\{ force: true, requireVisible: true, immediate: true \}\)/);
+});
+
+test('visible tab recovery reuses a cached fit when the container size is unchanged', () => {
+  assert.match(source, /const currentContainerSizeAlreadyFit = \(\) => \{/);
+  assert.match(
+    source,
+    /if \(currentContainerSizeAlreadyFit\(\)\) \{\s*finishLayoutRecovery\(\);\s*commitVisibleLayout\(\);\s*return;\s*\}/,
+  );
+});

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -143,7 +143,7 @@ export function resolveSelectionOverlayPosition(term: any, container: HTMLElemen
 }
 
 export function useTerminalEffects(ctx: TerminalEffectsContext) {
-  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
+  const { CONNECTION_TIMEOUT, Error, XTERM_PERFORMANCE_CONFIG, applyUserCursorPreference, auth, autocompleteCloseRef, autocompleteInputRef, autocompleteKeyEventRef, captureTerminalLogData, clearTerminalCwd, commandBufferRef, connectionLogBufferRef, containerRef, createPromptLineBreakState, createReplaySafeTerminalLogSanitizer, createXTermRuntime, deferTerminalResizeRef, disableTerminalFontZoomRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippetCommand, finalizeTerminalLogData, fitAddonRef, fontFamilyId, fontSize, fontWeightFixupDoneRef, forceCloseHibernatedSession, forceSyncRenderAfterResize, handleOsc52ReadRequest, handleTerminalDataCaptureOnce, hasConnectedRef, hasRuntimeRef, host, hotkeySchemeRef, hibernatedRef, identities, inWorkspace, isBootActiveRef, isBroadcastEnabledRef, isComposeBarOpen, isConnectionAwaitingUserInput, isConnectionPastTcpDial, isFocusMode, isFocused, isLocalConnection, isNetworkDevice, isResizing, isRestoringSelectionRef, isSearchOpen, isSerialConnection, isVisible, isVisibleRef, keyBindingsRef, keys, knownCwdRef, lastFittedSizeRef, lastToastedErrorRef, logger, mouseTrackingRef, needsHostKeyVerification, onBroadcastInputRef, onBroadcastInterruptPriorityChange, onCommandExecuted, onCommandSubmitted, onHotkeyActionRef, onOutputTriggerUserInputRef, onSnippetExecutorChange, onTerminalCwdChange, onTerminalTitleChange, onTerminalBell, onTerminalFontSizeChange, paneLayoutKey, passwordPromptActiveRef, pendingAuthRef, pendingOutputScrollRef, prepareRestoredReconnect, prevIsResizingRef, promptLineBreakStateRef, resizeSession, resolveHostAuth, resolvedFontFamily, safeFit, scriptRecorderRef, searchAddonRef, serialConfig, serialLineBufferRef, serializeAddonRef, sessionId, sessionRef, sessionStarters, setError, setHasMouseTracking, setHasSelection, setIsCancelling, setIsDisconnectedDialogDismissed, requestSearchFocus, setNeedsHostKeyVerification, setPendingHostKeyInfo, setPendingHostKeyRequestId, setProgressLogs, setProgressValue, setSelectionOverlayPosition, setShowLogs, setStatus, setTimeLeft, shouldEnableNativeUserInputAutoScroll, shouldProbeSessionCwd, shouldStartTerminalBackend, onSnippetShortkeyRef, snippetsRef, splitResizeActive, status, statusRef, sudoAutofillRef, t, teardown, telnetLocalEchoRef, termRef, terminalAltKeyOptions, terminalBackend, terminalContextActionsRef, terminalCwdTracker, terminalDataCapturedRef, terminalLogSanitizerRef, terminalSettings, terminalSettingsRef, toHostKeyInfo, toast, updateStatus, useEffect, useLayoutEffect, xtermRuntimeRef, zmodem, zmodemToastedRef, restoreState } = ctx;
 
   // Remember the last layout we successfully refit while visible so revisiting
   // the same workspace tab does not replay expensive force-fit/WebGL recovery.
@@ -712,10 +712,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     if (force) {
       lastFittedSizeRef.current = null;
     }
-    safeFit({ force, requireVisible: true });
+    safeFit({ force, requireVisible: true, immediate: true });
     if (force && repeatOnNextFrame && typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => {
-        safeFit({ force: true, requireVisible: true });
+        safeFit({ force: true, requireVisible: true, immediate: true });
       });
     }
   };
@@ -811,11 +811,27 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     lastCommittedVisibleLayoutKeyRef.current = paneLayoutKey;
   };
 
+  const currentContainerSizeAlreadyFit = () => {
+    const container = containerRef.current;
+    const lastSize = lastFittedSizeRef.current;
+    if (!container || !lastSize) return false;
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    return width > 0 && height > 0 && lastSize.width === width && lastSize.height === height;
+  };
+
   const recoverTerminalAfterBecomeVisible = () => {
     lastCommittedVisibleLayoutKeyRef.current = null;
-    lastFittedSizeRef.current = null;
     xtermRuntimeRef.current?.ensureWebglRenderer();
     xtermRuntimeRef.current?.clearTextureAtlas();
+
+    if (currentContainerSizeAlreadyFit()) {
+      finishLayoutRecovery();
+      commitVisibleLayout();
+      return;
+    }
+
+    lastFittedSizeRef.current = null;
     runImmediateRefit({ force: true, repeatOnNextFrame: false });
     finishLayoutRecoveryAfterFit();
     commitVisibleLayout();
@@ -825,14 +841,20 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   // Refit synchronously when a split pane becomes visible or its bounds change.
   // Tab switches move hidden panes off-screen without resizing xterm; becoming
   // visible again does not always fire ResizeObserver, leaving a gap below content.
-  // Skip during split-divider drag — refit runs once when isResizing becomes false.
+  // Skip during split-divider drag — refit runs once when split resizing ends.
   // In multi-split workspaces only the focused pane refits on tab switch; other
   // visible panes defer so N terminals don't block the main thread together.
   useLayoutEffect(() => {
     const becameVisible = isVisible && !wasVisibleRef.current;
-    wasVisibleRef.current = isVisible;
 
-    if (!isVisible || isResizing) return;
+    if (!isVisible) {
+      wasVisibleRef.current = false;
+      return;
+    }
+
+    if (splitResizeActive) return;
+
+    wasVisibleRef.current = true;
 
     if (becameVisible) {
       if (shouldRefitImmediatelyOnShow()) {
@@ -854,7 +876,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     commitVisibleLayout();
     runImmediateRefit({ force: true, repeatOnNextFrame: false });
     finishLayoutRecoveryAfterFit();
-  }, [isVisible, paneLayoutKey, isResizing, inWorkspace, isFocusMode, isFocused]);
+  }, [isVisible, paneLayoutKey, splitResizeActive, inWorkspace, isFocusMode, isFocused]);
 
   // Defer refit for non-focused split panes that became visible on a tab switch.
   useEffect(() => {
@@ -955,6 +977,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         renderer?: { remeasureFont?: () => void };
       } | null;
       if (cancelled || !term) return;
+      if (!isVisibleRef.current) {
+        lastFittedSizeRef.current = null;
+        return;
+      }
       const fitAddon = fitAddonRef.current;
       try {
         term.renderer?.remeasureFont?.();
@@ -1093,15 +1119,15 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   }, [isVisible, isResizing]);
 
   useLayoutEffect(() => {
-    if (isResizing) {
+    if (splitResizeActive) {
       prevIsResizingRef.current = true;
       return;
     }
     if (!prevIsResizingRef.current || !isVisible) {
-      prevIsResizingRef.current = isResizing;
+      prevIsResizingRef.current = splitResizeActive;
       return;
     }
-    prevIsResizingRef.current = isResizing;
+    prevIsResizingRef.current = splitResizeActive;
     lastFittedSizeRef.current = null;
     safeFit({ force: true, requireVisible: true });
     finishLayoutRecoveryAfterFit();
@@ -1115,7 +1141,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
         }
       });
     }
-  }, [isResizing, isVisible]);
+  }, [splitResizeActive, isVisible]);
 
 
   useEffect(() => {

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import React, { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import { activeTabStore } from '../../application/state/activeTabStore';
 import { useTerminalLayoutSuppressActive } from '../../application/state/terminalLayoutSuppressStore';
@@ -23,6 +23,8 @@ import type { TerminalContextReader } from '../../domain/terminalContextRead';
 import {
   getTerminalPaneRenderSnapshot,
   parseTerminalPaneRenderSnapshot,
+  resolveHiddenTerminalPaneStyle,
+  type TerminalPaneHiddenSize,
 } from '../terminalPaneVisibility';
 import type { ResolvedAppearance, TerminalAppearanceHostScope } from '../../domain/terminalAppearanceRuntime';
 import type { TerminalSidePanelAutoOpenTab } from '../../domain/terminalSidePanelAutoOpen';
@@ -1000,6 +1002,8 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   const { paneState, isFocusedPane } = parseTerminalPaneRenderSnapshot(renderSnapshot);
   const activeWorkspaceId = paneState.workspaceId;
   const isVisible = paneState.isVisible;
+  const paneElementRef = useRef<HTMLDivElement | null>(null);
+  const lastVisiblePaneSizeRef = useRef<TerminalPaneHiddenSize | null>(null);
 
   // Publish visibility to the per-session store so TerminalServerStats /
   // TerminalAutocomplete can self-subscribe — keeping isVisible out of the
@@ -1062,12 +1066,24 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   const paneLayoutKey = paneLayoutKeyRef.current;
   const style: React.CSSProperties = { ...layoutStyle };
 
+  useLayoutEffect(() => {
+    if (!isVisible) return;
+    const element = paneElementRef.current;
+    if (!element) return;
+    const width = element.clientWidth;
+    const height = element.clientHeight;
+    if (width > 0 && height > 0) {
+      lastVisiblePaneSizeRef.current = { width, height };
+    }
+  }, [
+    isVisible,
+    layoutStyle.height,
+    layoutStyle.width,
+    activeWorkspaceId,
+  ]);
+
   if (!isVisible) {
-    style.visibility = 'hidden';
-    style.pointerEvents = 'none';
-    // Preserve xterm state while keeping hidden terminals out of layout.
-    style.left = '-9999px';
-    style.top = '-9999px';
+    Object.assign(style, resolveHiddenTerminalPaneStyle(style, lastVisiblePaneSizeRef.current));
   }
 
   const workspaceFocusHandler = activeWorkspaceId
@@ -1287,6 +1303,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
 
   return (
     <div
+      ref={paneElementRef}
       data-session-id={session.id}
       data-section="terminal-split-pane"
       data-focused={isFocusedPane ? 'true' : undefined}

--- a/components/terminalPaneVisibility.test.tsx
+++ b/components/terminalPaneVisibility.test.tsx
@@ -6,6 +6,7 @@ import {
   getTerminalPaneSnapshot,
   HIDDEN_TERMINAL_PANE_SNAPSHOT,
   parseTerminalPaneRenderSnapshot,
+  resolveHiddenTerminalPaneStyle,
 } from "./terminalPaneVisibility";
 import type { Workspace } from "../types";
 
@@ -136,4 +137,18 @@ test("terminal pane render snapshot combines visibility and focus in one token",
   assert.equal(parsed.paneState.isVisible, true);
   assert.equal(parsed.paneState.mode, "split");
   assert.equal(parsed.isFocusedPane, true);
+});
+
+test("hidden terminal pane keeps its last visible size instead of inheriting the active tab width", () => {
+  const hiddenStyle = resolveHiddenTerminalPaneStyle(
+    { left: 0, top: 0, width: "100%", height: "100%" },
+    { width: 1180, height: 720 },
+  );
+
+  assert.equal(hiddenStyle.left, "-9999px");
+  assert.equal(hiddenStyle.top, "-9999px");
+  assert.equal(hiddenStyle.visibility, "hidden");
+  assert.equal(hiddenStyle.pointerEvents, "none");
+  assert.equal(hiddenStyle.width, "1180px");
+  assert.equal(hiddenStyle.height, "720px");
 });

--- a/components/terminalPaneVisibility.ts
+++ b/components/terminalPaneVisibility.ts
@@ -11,6 +11,39 @@ export type TerminalPaneSnapshot =
 
 export type TerminalPaneFocusSnapshot = "na" | "focused" | "unfocused";
 
+export type TerminalPaneHiddenSize = {
+  width: number;
+  height: number;
+};
+
+export type TerminalPaneStyle = {
+  left?: string | number;
+  top?: string | number;
+  width?: string | number;
+  height?: string | number;
+  visibility?: string;
+  pointerEvents?: string;
+};
+
+export function resolveHiddenTerminalPaneStyle<T extends TerminalPaneStyle>(
+  layoutStyle: T,
+  lastVisibleSize: TerminalPaneHiddenSize | null,
+): T {
+  return {
+    ...layoutStyle,
+    visibility: "hidden",
+    pointerEvents: "none",
+    left: "-9999px",
+    top: "-9999px",
+    ...(lastVisibleSize
+      ? {
+        width: `${lastVisibleSize.width}px`,
+        height: `${lastVisibleSize.height}px`,
+      }
+      : {}),
+  };
+}
+
 interface GetTerminalPaneSnapshotOptions {
   activeTabId: string | null;
   sessionId: string;


### PR DESCRIPTION
## Summary

Fix terminal tab switching so background terminal panes keep their own sizing context and do not briefly inherit the active tab's AI-panel width. The recovery path now restores newly visible terminals immediately, while hidden terminals skip background refits from output, connection completion, and font loading.

## Why

A hidden tab could be affected by another tab's side panel width, especially while heavy terminal output was streaming. When switching back, the terminal could paint with stale geometry before the follow-up fit corrected it, leaving a visible blank area for a moment.

## Validation

- `node --test --import tsx components/terminal/terminalTabVisibilityRecovery.test.ts components/terminal/terminalSafeFitVisibility.test.ts components/terminal/runtime/terminalPostConnectVisibility.test.ts components/terminalPaneVisibility.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`
- `git diff --check`