### PR TITLE
[codex] Improve terminal tab switching stability

### DIFF
--- a/application/state/activeTabStore.test.ts
+++ b/application/state/activeTabStore.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { fromEditorTabId, isEditorTabId, toEditorTabId } from './activeTabStore';
+import { activeTabStore, fromEditorTabId, isEditorTabId, toEditorTabId } from './activeTabStore';
+import { terminalLayoutSuppressStore } from './terminalLayoutSuppressStore';
 
 test('editor tab helpers round trip ids', () => {
   assert.equal(toEditorTabId('file-1'), 'editor:file-1');
@@ -11,4 +12,43 @@ test('editor tab helpers round trip ids', () => {
 test('editor tab helper detects editor top-tab ids', () => {
   assert.equal(isEditorTabId('editor:file-1'), true);
   assert.equal(isEditorTabId('session-1'), false);
+});
+
+test('active tab changes do not start terminal layout suppression', async () => {
+  const previousWindow = (globalThis as { window?: unknown }).window;
+  (globalThis as { window?: unknown }).window ??= globalThis;
+
+  while (terminalLayoutSuppressStore.getActive()) {
+    terminalLayoutSuppressStore.end();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let activeNotifyCount = 0;
+  let suppressNotifyCount = 0;
+  const unsubscribeActiveTab = activeTabStore.subscribe(() => {
+    activeNotifyCount += 1;
+  });
+  const unsubscribeSuppress = terminalLayoutSuppressStore.subscribe(() => {
+    suppressNotifyCount += 1;
+  });
+
+  try {
+    activeTabStore.setActiveTabId(`no-suppress-test-${Date.now()}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(activeNotifyCount, 1);
+    assert.equal(suppressNotifyCount, 0);
+    assert.equal(terminalLayoutSuppressStore.getActive(), false);
+  } finally {
+    unsubscribeActiveTab();
+    unsubscribeSuppress();
+    if (previousWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = previousWindow;
+    }
+    while (terminalLayoutSuppressStore.getActive()) {
+      terminalLayoutSuppressStore.end();
+    }
+  }
 });

--- a/application/state/activeTabStore.ts
+++ b/application/state/activeTabStore.ts
@@ -1,7 +1,5 @@
 import { useCallback, useSyncExternalStore } from 'react';
 
-import { terminalLayoutSuppressStore } from './terminalLayoutSuppressStore';
-
 // Simple store for active tab that allows fine-grained subscriptions
 type Listener = () => void;
 type SyncListener = (activeTabId: string) => void;
@@ -39,20 +37,11 @@ class ActiveTabStore {
 
   setActiveTabId = (id: string) => {
     if (this.activeTabId !== id) {
-      terminalLayoutSuppressStore.begin();
       this.activeTabId = id;
       this.syncListeners.forEach((listener) => listener(id));
       // Coalesce rapid tab switches into one notification per frame and avoid
       // "setState during render" if called from a render phase.
       this.scheduleNotify();
-      const schedule = typeof requestAnimationFrame === 'function'
-        ? requestAnimationFrame
-        : (cb: () => void) => window.setTimeout(cb, 0) as unknown as number;
-      schedule(() => {
-        schedule(() => {
-          terminalLayoutSuppressStore.end();
-        });
-      });
     }
   };
 

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -46,6 +46,79 @@ import { resolveRestorePreviousSessionSetting } from './sessionRestoreSettings';
 import type { CodingCliProviderId } from '../../domain/codingCliProviders';
 import { normalizeCodingCliDynamicTitleForStorage } from '../../domain/codingCliTitleParse';
 
+export function addWorkspaceIfMissing(
+  workspaces: Workspace[],
+  workspace: Workspace,
+): Workspace[] {
+  return workspaces.some(ws => ws.id === workspace.id) ? workspaces : [...workspaces, workspace];
+}
+
+export function addTerminalSessionIfMissing(
+  sessions: TerminalSession[],
+  session: TerminalSession,
+): TerminalSession[] {
+  return sessions.some(candidate => candidate.id === session.id) ? sessions : [...sessions, session];
+}
+
+export function insertWorkspacePaneIfMissing(
+  workspaces: Workspace[],
+  workspaceId: string,
+  sessionId: string,
+  hint: SplitHint,
+): Workspace[] {
+  return workspaces.map(ws => {
+    if (ws.id !== workspaceId) return ws;
+    if (collectSessionIds(ws.root).includes(sessionId)) return ws;
+    return { ...ws, root: insertPaneIntoWorkspace(ws.root, sessionId, hint) };
+  });
+}
+
+export function appendWorkspaceRootPaneIfMissing(
+  workspaces: Workspace[],
+  workspaceId: string,
+  sessionId: string,
+  direction: SplitDirection = 'vertical',
+): Workspace[] {
+  return workspaces.map(ws => {
+    if (ws.id !== workspaceId) return ws;
+    if (collectSessionIds(ws.root).includes(sessionId)) {
+      return ws.focusedSessionId === sessionId ? ws : { ...ws, focusedSessionId: sessionId };
+    }
+    return {
+      ...ws,
+      root: appendPaneToWorkspaceRoot(ws.root, sessionId, direction),
+      focusedSessionId: sessionId,
+    };
+  });
+}
+
+export function insertCopiedTabOrderIdOnce(
+  prevTabOrder: string[],
+  sourceTabId: string,
+  copiedTabId: string,
+  allTabIds: string[],
+): string[] {
+  if (prevTabOrder.includes(copiedTabId)) return prevTabOrder;
+
+  const directIdx = prevTabOrder.indexOf(sourceTabId);
+  if (directIdx !== -1) {
+    const next = [...prevTabOrder];
+    next.splice(directIdx + 1, 0, copiedTabId);
+    return next;
+  }
+
+  const allTabIdSet = new Set(allTabIds);
+  const orderedIds = prevTabOrder.filter(id => allTabIdSet.has(id));
+  const orderedIdSet = new Set(orderedIds);
+  const newIds = allTabIds.filter(id => !orderedIdSet.has(id));
+  const currentOrder = [...orderedIds, ...newIds];
+  const sourceIdx = currentOrder.indexOf(sourceTabId);
+  if (sourceIdx === -1) return [...prevTabOrder, copiedTabId];
+  const next = [...currentOrder];
+  next.splice(sourceIdx + 1, 0, copiedTabId);
+  return next;
+}
+
 
 export const useSessionState = ({
   persistSessionRestore = true,
@@ -641,7 +714,7 @@ export const useSessionState = ({
       const joining = prevSessions.find(s => s.id === joiningSessionId);
       if (!base || !joining || base.workspaceId || joining.workspaceId) return prevSessions;
 
-      setWorkspaces(prev => prev.some(ws => ws.id === newWorkspace.id) ? prev : [...prev, newWorkspace]);
+      setWorkspaces(prev => addWorkspaceIfMissing(prev, newWorkspace));
       setActiveTabId(newWorkspace.id);
       
       return prevSessions.map(s => {
@@ -668,11 +741,7 @@ export const useSessionState = ({
         const targetWorkspace = prevWorkspaces.find(w => w.id === workspaceId);
         if (!targetWorkspace) return prevWorkspaces;
         
-        return prevWorkspaces.map(ws => {
-          if (ws.id !== workspaceId) return ws;
-          if (collectSessionIds(ws.root).includes(sessionId)) return ws;
-          return { ...ws, root: insertPaneIntoWorkspace(ws.root, sessionId, hint) };
-        });
+        return insertWorkspacePaneIfMissing(prevWorkspaces, workspaceId, sessionId, hint);
       });
       
       setActiveTabId(workspaceId);
@@ -727,19 +796,9 @@ export const useSessionState = ({
     setWorkspaces(prev => {
       const target = prev.find(w => w.id === workspaceId);
       if (!target) return prev;
-      setSessions(s => s.some(x => x.id === newSessionId) ? s : [...s, newSession]);
+      setSessions(s => addTerminalSessionIfMissing(s, newSession));
       setActiveTabId(workspaceId);
-      return prev.map(ws => {
-        if (ws.id !== workspaceId) return ws;
-        if (collectSessionIds(ws.root).includes(newSessionId)) {
-          return { ...ws, focusedSessionId: newSessionId };
-        }
-        return {
-          ...ws,
-          root: appendPaneToWorkspaceRoot(ws.root, newSessionId, direction),
-          focusedSessionId: newSessionId,
-        };
-      });
+      return appendWorkspaceRootPaneIfMissing(prev, workspaceId, newSessionId, direction);
     });
     return newSessionId;
   }, [setActiveTabId]);
@@ -782,19 +841,9 @@ export const useSessionState = ({
     setWorkspaces(prev => {
       const target = prev.find(w => w.id === workspaceId);
       if (!target) return prev;
-      setSessions(s => s.some(x => x.id === newSessionId) ? s : [...s, newSession]);
+      setSessions(s => addTerminalSessionIfMissing(s, newSession));
       setActiveTabId(workspaceId);
-      return prev.map(ws => {
-        if (ws.id !== workspaceId) return ws;
-        if (collectSessionIds(ws.root).includes(newSessionId)) {
-          return { ...ws, focusedSessionId: newSessionId };
-        }
-        return {
-          ...ws,
-          root: appendPaneToWorkspaceRoot(ws.root, newSessionId, direction),
-          focusedSessionId: newSessionId,
-        };
-      });
+      return appendWorkspaceRootPaneIfMissing(prev, workspaceId, newSessionId, direction);
     });
     return newSessionId;
   }, [setActiveTabId]);
@@ -843,16 +892,10 @@ export const useSessionState = ({
         };
         
         setWorkspaces(prevWorkspaces => {
-          return prevWorkspaces.map(ws => {
-            if (ws.id !== session.workspaceId) return ws;
-            if (collectSessionIds(ws.root).includes(newSession.id)) return ws;
-            return { ...ws, root: insertPaneIntoWorkspace(ws.root, newSession.id, hint) };
-          });
+          return insertWorkspacePaneIfMissing(prevWorkspaces, session.workspaceId, newSession.id, hint);
         });
         
-        return prevSessions.some(s => s.id === newSession.id)
-          ? prevSessions
-          : [...prevSessions, newSession];
+        return addTerminalSessionIfMissing(prevSessions, newSession);
       }
       
       // Session is standalone - create a new workspace
@@ -861,7 +904,7 @@ export const useSessionState = ({
         localShellType: options?.localShellType,
       });
 
-      setWorkspaces(prev => prev.some(ws => ws.id === standaloneWorkspace.id) ? prev : [...prev, standaloneWorkspace]);
+      setWorkspaces(prev => addWorkspaceIfMissing(prev, standaloneWorkspace));
       setActiveTabId(standaloneWorkspace.id);
       
       return prevSessions.map(s => {
@@ -1035,31 +1078,12 @@ export const useSessionState = ({
       // StrictMode's double-invocation is harmless.
       setActiveTabId(newSessionId);
       setTabOrder(prevTabOrder => {
-        if (prevTabOrder.includes(newSessionId)) return prevTabOrder;
-        // Fast path: source is already tracked in tabOrder — splice directly.
-        const directIdx = prevTabOrder.indexOf(sessionId);
-        if (directIdx !== -1) {
-          const next = [...prevTabOrder];
-          next.splice(directIdx + 1, 0, newSessionId);
-          return next;
-        }
-        // Fallback: source is only in the derived tab collections. Rebuild the
-        // effective order (same pattern as reorderTabs) to locate its position.
         const allTabIds = [
           ...orphanSessions.map(s => s.id),
           ...workspaces.map(w => w.id),
           ...logViews.map(lv => lv.id),
         ];
-        const allTabIdSet = new Set(allTabIds);
-        const orderedIds = prevTabOrder.filter(id => allTabIdSet.has(id));
-        const orderedIdSet = new Set(orderedIds);
-        const newIds = allTabIds.filter(id => !orderedIdSet.has(id));
-        const currentOrder = [...orderedIds, ...newIds];
-        const sourceIdx = currentOrder.indexOf(sessionId);
-        if (sourceIdx === -1) return [...prevTabOrder, newSessionId];
-        const next = [...currentOrder];
-        next.splice(sourceIdx + 1, 0, newSessionId);
-        return next;
+        return insertCopiedTabOrderIdOnce(prevTabOrder, sessionId, newSessionId, allTabIds);
       });
 
       return [...prevSessions, newSession];

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -634,14 +634,14 @@ export const useSessionState = ({
     hint: SplitHint
   ) => {
     if (!hint || baseSessionId === joiningSessionId) return;
+    const newWorkspace = createWorkspaceEntity(baseSessionId, joiningSessionId, hint);
     
 	    setSessions(prevSessions => {
       const base = prevSessions.find(s => s.id === baseSessionId);
       const joining = prevSessions.find(s => s.id === joiningSessionId);
       if (!base || !joining || base.workspaceId || joining.workspaceId) return prevSessions;
 
-      const newWorkspace = createWorkspaceEntity(baseSessionId, joiningSessionId, hint);
-      setWorkspaces(prev => [...prev, newWorkspace]);
+      setWorkspaces(prev => prev.some(ws => ws.id === newWorkspace.id) ? prev : [...prev, newWorkspace]);
       setActiveTabId(newWorkspace.id);
       
       return prevSessions.map(s => {
@@ -670,6 +670,7 @@ export const useSessionState = ({
         
         return prevWorkspaces.map(ws => {
           if (ws.id !== workspaceId) return ws;
+          if (collectSessionIds(ws.root).includes(sessionId)) return ws;
           return { ...ws, root: insertPaneIntoWorkspace(ws.root, sessionId, hint) };
         });
       });
@@ -730,6 +731,9 @@ export const useSessionState = ({
       setActiveTabId(workspaceId);
       return prev.map(ws => {
         if (ws.id !== workspaceId) return ws;
+        if (collectSessionIds(ws.root).includes(newSessionId)) {
+          return { ...ws, focusedSessionId: newSessionId };
+        }
         return {
           ...ws,
           root: appendPaneToWorkspaceRoot(ws.root, newSessionId, direction),
@@ -782,6 +786,9 @@ export const useSessionState = ({
       setActiveTabId(workspaceId);
       return prev.map(ws => {
         if (ws.id !== workspaceId) return ws;
+        if (collectSessionIds(ws.root).includes(newSessionId)) {
+          return { ...ws, focusedSessionId: newSessionId };
+        }
         return {
           ...ws,
           root: appendPaneToWorkspaceRoot(ws.root, newSessionId, direction),
@@ -808,6 +815,13 @@ export const useSessionState = ({
       localShellType?: TerminalSession['shellType'];
     },
   ) => {
+    const newSessionId = crypto.randomUUID();
+    const standaloneHint: SplitHint = {
+      direction,
+      position: direction === 'horizontal' ? 'bottom' : 'right',
+    };
+    const standaloneWorkspace = createWorkspaceEntity(sessionId, newSessionId, standaloneHint);
+
 	    setSessions(prevSessions => {
       const session = prevSessions.find(s => s.id === sessionId);
       if (!session) return prevSessions;
@@ -816,7 +830,7 @@ export const useSessionState = ({
       if (session.workspaceId) {
         // Create a new session with the same host
         const newSession = createSplitTerminalSessionClone(session, {
-          id: crypto.randomUUID(),
+          id: newSessionId,
           localShellType: options?.localShellType,
           workspaceId: session.workspaceId,
         });
@@ -831,34 +845,31 @@ export const useSessionState = ({
         setWorkspaces(prevWorkspaces => {
           return prevWorkspaces.map(ws => {
             if (ws.id !== session.workspaceId) return ws;
+            if (collectSessionIds(ws.root).includes(newSession.id)) return ws;
             return { ...ws, root: insertPaneIntoWorkspace(ws.root, newSession.id, hint) };
           });
         });
         
-        return [...prevSessions, newSession];
+        return prevSessions.some(s => s.id === newSession.id)
+          ? prevSessions
+          : [...prevSessions, newSession];
       }
       
       // Session is standalone - create a new workspace
       const newSession = createSplitTerminalSessionClone(session, {
-        id: crypto.randomUUID(),
+        id: newSessionId,
         localShellType: options?.localShellType,
       });
 
-      const hint: SplitHint = {
-        direction,
-        position: direction === 'horizontal' ? 'bottom' : 'right',
-      };
-
-      const newWorkspace = createWorkspaceEntity(sessionId, newSession.id, hint);
-      setWorkspaces(prev => [...prev, newWorkspace]);
-      setActiveTabId(newWorkspace.id);
+      setWorkspaces(prev => prev.some(ws => ws.id === standaloneWorkspace.id) ? prev : [...prev, standaloneWorkspace]);
+      setActiveTabId(standaloneWorkspace.id);
       
       return prevSessions.map(s => {
         if (s.id === sessionId) {
-          return { ...s, workspaceId: newWorkspace.id };
+          return { ...s, workspaceId: standaloneWorkspace.id };
         }
         return s;
-      }).concat({ ...newSession, workspaceId: newWorkspace.id });
+      }).concat({ ...newSession, workspaceId: standaloneWorkspace.id });
 	    });
 	  }, [setActiveTabId]);
 
@@ -1024,6 +1035,7 @@ export const useSessionState = ({
       // StrictMode's double-invocation is harmless.
       setActiveTabId(newSessionId);
       setTabOrder(prevTabOrder => {
+        if (prevTabOrder.includes(newSessionId)) return prevTabOrder;
         // Fast path: source is already tracked in tabOrder — splice directly.
         const directIdx = prevTabOrder.indexOf(sessionId);
         if (directIdx !== -1) {

--- a/application/state/useSessionStateWorkspaceStrictMode.test.ts
+++ b/application/state/useSessionStateWorkspaceStrictMode.test.ts
@@ -1,71 +1,83 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const source = readFileSync(new URL('./useSessionState.ts', import.meta.url), 'utf8');
+import type { TerminalSession, Workspace } from '../../domain/models';
+import { collectSessionIds, type SplitHint } from '../../domain/workspace';
+import {
+  addTerminalSessionIfMissing,
+  addWorkspaceIfMissing,
+  appendWorkspaceRootPaneIfMissing,
+  insertCopiedTabOrderIdOnce,
+  insertWorkspacePaneIfMissing,
+} from './useSessionState';
 
-test('workspace creation preallocates workspace ids outside session updaters', () => {
-  const createStart = source.indexOf('const createWorkspaceFromSessions = useCallback');
-  const createSetSessions = source.indexOf('setSessions(prevSessions => {', createStart);
-  const createWorkspace = source.indexOf('const newWorkspace = createWorkspaceEntity(baseSessionId, joiningSessionId, hint);', createStart);
-
-  assert.notEqual(createStart, -1);
-  assert.notEqual(createSetSessions, -1);
-  assert.ok(createWorkspace > createStart && createWorkspace < createSetSessions);
-
-  const createBlock = source.slice(createStart, source.indexOf('const addSessionToWorkspace = useCallback', createStart));
-  assert.match(
-    createBlock,
-    /setWorkspaces\(prev => prev\.some\(ws => ws\.id === newWorkspace\.id\) \? prev : \[\.\.\.prev, newWorkspace\]\)/,
-  );
+const session = (id: string, workspaceId?: string): TerminalSession => ({
+  id,
+  hostId: `host-${id}`,
+  hostLabel: `Host ${id}`,
+  hostname: `${id}.example.test`,
+  username: 'user',
+  status: 'connecting',
+  workspaceId,
 });
 
-test('split session workspace creation is idempotent under repeated updater execution', () => {
-  const splitStart = source.indexOf('const splitSession = useCallback');
-  const splitSetSessions = source.indexOf('setSessions(prevSessions => {', splitStart);
-  const newSessionId = source.indexOf('const newSessionId = crypto.randomUUID();', splitStart);
-  const standaloneWorkspace = source.indexOf('const standaloneWorkspace = createWorkspaceEntity(sessionId, newSessionId, standaloneHint);', splitStart);
-
-  assert.notEqual(splitStart, -1);
-  assert.notEqual(splitSetSessions, -1);
-  assert.ok(newSessionId > splitStart && newSessionId < splitSetSessions);
-  assert.ok(standaloneWorkspace > splitStart && standaloneWorkspace < splitSetSessions);
-
-  const splitBlock = source.slice(splitStart, source.indexOf('// Toggle workspace view mode', splitStart));
-  assert.match(splitBlock, /collectSessionIds\(ws\.root\)\.includes\(newSession\.id\)/);
-  assert.match(
-    splitBlock,
-    /setWorkspaces\(prev => prev\.some\(ws => ws\.id === standaloneWorkspace\.id\) \? prev : \[\.\.\.prev, standaloneWorkspace\]\)/,
-  );
+const workspace = (id = 'ws-1'): Workspace => ({
+  id,
+  title: 'Workspace',
+  focusedSessionId: 's1',
+  root: { id: 'pane-1', type: 'pane', sessionId: 's1' },
 });
 
-test('workspace pane insertion paths skip panes that are already present', () => {
-  const addStart = source.indexOf('const addSessionToWorkspace = useCallback');
-  const appendHostStart = source.indexOf('const appendHostToWorkspace = useCallback');
-  const appendLocalStart = source.indexOf('const appendLocalTerminalToWorkspace = useCallback');
-  const splitStart = source.indexOf('const splitSession = useCallback');
+const paneCount = (ws: Workspace, sessionId: string) => (
+  collectSessionIds(ws.root).filter(id => id === sessionId).length
+);
 
-  assert.notEqual(addStart, -1);
-  assert.notEqual(appendHostStart, -1);
-  assert.notEqual(appendLocalStart, -1);
-  assert.notEqual(splitStart, -1);
+test('workspace creation remains idempotent when the same update runs twice', () => {
+  const ws = workspace();
 
-  const addBlock = source.slice(addStart, appendHostStart);
-  const appendHostBlock = source.slice(appendHostStart, appendLocalStart);
-  const appendLocalBlock = source.slice(appendLocalStart, splitStart);
+  const once = addWorkspaceIfMissing([], ws);
+  const twice = addWorkspaceIfMissing(once, ws);
 
-  assert.match(addBlock, /collectSessionIds\(ws\.root\)\.includes\(sessionId\)/);
-  assert.match(appendHostBlock, /collectSessionIds\(ws\.root\)\.includes\(newSessionId\)/);
-  assert.match(appendLocalBlock, /collectSessionIds\(ws\.root\)\.includes\(newSessionId\)/);
+  assert.equal(twice.length, 1);
+  assert.equal(twice[0], ws);
 });
 
-test('copy session does not add the same copied tab to tab order twice', () => {
-  const copyStart = source.indexOf('const copySession = useCallback');
-  const createCloneStart = source.indexOf('const createSessionFromCloneSource = useCallback');
+test('terminal session insertion remains idempotent when the same update runs twice', () => {
+  const newSession = session('s2', 'ws-1');
 
-  assert.notEqual(copyStart, -1);
-  assert.notEqual(createCloneStart, -1);
+  const once = addTerminalSessionIfMissing([session('s1', 'ws-1')], newSession);
+  const twice = addTerminalSessionIfMissing(once, newSession);
 
-  const copyBlock = source.slice(copyStart, createCloneStart);
-  assert.match(copyBlock, /if \(prevTabOrder\.includes\(newSessionId\)\) return prevTabOrder;/);
+  assert.equal(twice.filter(candidate => candidate.id === 's2').length, 1);
+});
+
+test('workspace pane insertion remains idempotent when the same update runs twice', () => {
+  const hint: SplitHint = {
+    direction: 'vertical',
+    position: 'right',
+    targetSessionId: 's1',
+  };
+
+  const once = insertWorkspacePaneIfMissing([workspace()], 'ws-1', 's2', hint);
+  const twice = insertWorkspacePaneIfMissing(once, 'ws-1', 's2', hint);
+
+  assert.deepEqual(collectSessionIds(twice[0].root), ['s1', 's2']);
+  assert.equal(paneCount(twice[0], 's2'), 1);
+});
+
+test('workspace root append remains idempotent when the same update runs twice', () => {
+  const once = appendWorkspaceRootPaneIfMissing([workspace()], 'ws-1', 's2', 'vertical');
+  const twice = appendWorkspaceRootPaneIfMissing(once, 'ws-1', 's2', 'vertical');
+
+  assert.deepEqual(collectSessionIds(twice[0].root), ['s1', 's2']);
+  assert.equal(paneCount(twice[0], 's2'), 1);
+  assert.equal(twice[0].focusedSessionId, 's2');
+});
+
+test('copied tab order insertion remains idempotent when the same update runs twice', () => {
+  const once = insertCopiedTabOrderIdOnce(['s1', 'ws-1'], 's1', 's2', ['s1', 'ws-1']);
+  const twice = insertCopiedTabOrderIdOnce(once, 's1', 's2', ['s1', 'ws-1']);
+
+  assert.deepEqual(twice, ['s1', 's2', 'ws-1']);
+  assert.equal(twice.filter(id => id === 's2').length, 1);
 });

--- a/application/state/useSessionStateWorkspaceStrictMode.test.ts
+++ b/application/state/useSessionStateWorkspaceStrictMode.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('./useSessionState.ts', import.meta.url), 'utf8');
+
+test('workspace creation preallocates workspace ids outside session updaters', () => {
+  const createStart = source.indexOf('const createWorkspaceFromSessions = useCallback');
+  const createSetSessions = source.indexOf('setSessions(prevSessions => {', createStart);
+  const createWorkspace = source.indexOf('const newWorkspace = createWorkspaceEntity(baseSessionId, joiningSessionId, hint);', createStart);
+
+  assert.notEqual(createStart, -1);
+  assert.notEqual(createSetSessions, -1);
+  assert.ok(createWorkspace > createStart && createWorkspace < createSetSessions);
+
+  const createBlock = source.slice(createStart, source.indexOf('const addSessionToWorkspace = useCallback', createStart));
+  assert.match(
+    createBlock,
+    /setWorkspaces\(prev => prev\.some\(ws => ws\.id === newWorkspace\.id\) \? prev : \[\.\.\.prev, newWorkspace\]\)/,
+  );
+});
+
+test('split session workspace creation is idempotent under repeated updater execution', () => {
+  const splitStart = source.indexOf('const splitSession = useCallback');
+  const splitSetSessions = source.indexOf('setSessions(prevSessions => {', splitStart);
+  const newSessionId = source.indexOf('const newSessionId = crypto.randomUUID();', splitStart);
+  const standaloneWorkspace = source.indexOf('const standaloneWorkspace = createWorkspaceEntity(sessionId, newSessionId, standaloneHint);', splitStart);
+
+  assert.notEqual(splitStart, -1);
+  assert.notEqual(splitSetSessions, -1);
+  assert.ok(newSessionId > splitStart && newSessionId < splitSetSessions);
+  assert.ok(standaloneWorkspace > splitStart && standaloneWorkspace < splitSetSessions);
+
+  const splitBlock = source.slice(splitStart, source.indexOf('// Toggle workspace view mode', splitStart));
+  assert.match(splitBlock, /collectSessionIds\(ws\.root\)\.includes\(newSession\.id\)/);
+  assert.match(
+    splitBlock,
+    /setWorkspaces\(prev => prev\.some\(ws => ws\.id === standaloneWorkspace\.id\) \? prev : \[\.\.\.prev, standaloneWorkspace\]\)/,
+  );
+});
+
+test('workspace pane insertion paths skip panes that are already present', () => {
+  const addStart = source.indexOf('const addSessionToWorkspace = useCallback');
+  const appendHostStart = source.indexOf('const appendHostToWorkspace = useCallback');
+  const appendLocalStart = source.indexOf('const appendLocalTerminalToWorkspace = useCallback');
+  const splitStart = source.indexOf('const splitSession = useCallback');
+
+  assert.notEqual(addStart, -1);
+  assert.notEqual(appendHostStart, -1);
+  assert.notEqual(appendLocalStart, -1);
+  assert.notEqual(splitStart, -1);
+
+  const addBlock = source.slice(addStart, appendHostStart);
+  const appendHostBlock = source.slice(appendHostStart, appendLocalStart);
+  const appendLocalBlock = source.slice(appendLocalStart, splitStart);
+
+  assert.match(addBlock, /collectSessionIds\(ws\.root\)\.includes\(sessionId\)/);
+  assert.match(appendHostBlock, /collectSessionIds\(ws\.root\)\.includes\(newSessionId\)/);
+  assert.match(appendLocalBlock, /collectSessionIds\(ws\.root\)\.includes\(newSessionId\)/);
+});
+
+test('copy session does not add the same copied tab to tab order twice', () => {
+  const copyStart = source.indexOf('const copySession = useCallback');
+  const createCloneStart = source.indexOf('const createSessionFromCloneSource = useCallback');
+
+  assert.notEqual(copyStart, -1);
+  assert.notEqual(createCloneStart, -1);
+
+  const copyBlock = source.slice(copyStart, createCloneStart);
+  assert.match(copyBlock, /if \(prevTabOrder\.includes\(newSessionId\)\) return prevTabOrder;/);
+});

--- a/components/terminal/terminalTabVisibilityRecovery.test.ts
+++ b/components/terminal/terminalTabVisibilityRecovery.test.ts
@@ -39,7 +39,7 @@ test('visible tab recovery reuses a cached fit when the container size is unchan
   assert.match(source, /const currentContainerSizeAlreadyFit = \(\) => \{/);
   assert.match(
     source,
-    /if \(currentContainerSizeAlreadyFit\(\)\) \{\s*finishLayoutRecovery\(\);\s*commitVisibleLayout\(\);\s*return;\s*\}/,
+    /if \(currentContainerSizeAlreadyFit\(\)\) \{\s*finishLayoutRecovery\(\);\s*flushPendingOutputScroll\(\);\s*commitVisibleLayout\(\);\s*return;\s*\}/,
   );
 });
 
@@ -54,6 +54,27 @@ test('short unchanged tab reveals skip the recovery work entirely', () => {
   assert.match(
     source.slice(fastPathIndex, webglRecoveryIndex),
     /currentContainerSizeAlreadyFit\(\)[\s\S]*lastWebglRecoveryLayoutKeyRef\.current = paneLayoutKey;[\s\S]*commitVisibleLayout\(\);[\s\S]*return;/,
+  );
+});
+
+test('short unchanged tab reveals still flush pending hidden-output scroll', () => {
+  const recoverIndex = source.indexOf('const recoverTerminalAfterBecomeVisible = () => {');
+  const fastPathIndex = source.indexOf('getHiddenDurationMs() < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS', recoverIndex);
+  const webglRecoveryIndex = source.indexOf('xtermRuntimeRef.current?.ensureWebglRenderer();', recoverIndex);
+  const delayedSkipIndex = source.indexOf('lastWebglRecoveryLayoutKeyRef.current === paneLayoutKey', webglRecoveryIndex);
+  const delayedTimerIndex = source.indexOf('const timer = setTimeout', delayedSkipIndex);
+
+  assert.match(
+    source,
+    /const flushPendingOutputScroll = \(\) => \{[\s\S]*pendingOutputScrollRef\.current[\s\S]*scrollToBottom\(\)[\s\S]*pendingOutputScrollRef\.current = false;/,
+  );
+  assert.match(
+    source.slice(fastPathIndex, webglRecoveryIndex),
+    /flushPendingOutputScroll\(\);[\s\S]*commitVisibleLayout\(\);[\s\S]*return;/,
+  );
+  assert.match(
+    source.slice(delayedSkipIndex, delayedTimerIndex),
+    /flushPendingOutputScroll\(\);\s*return;/,
   );
 });
 

--- a/components/terminal/terminalTabVisibilityRecovery.test.ts
+++ b/components/terminal/terminalTabVisibilityRecovery.test.ts
@@ -42,3 +42,28 @@ test('visible tab recovery reuses a cached fit when the container size is unchan
     /if \(currentContainerSizeAlreadyFit\(\)\) \{\s*finishLayoutRecovery\(\);\s*commitVisibleLayout\(\);\s*return;\s*\}/,
   );
 });
+
+test('short unchanged tab reveals skip the recovery work entirely', () => {
+  const recoverIndex = source.indexOf('const recoverTerminalAfterBecomeVisible = () => {');
+  const fastPathIndex = source.indexOf('getHiddenDurationMs() < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS', recoverIndex);
+  const webglRecoveryIndex = source.indexOf('xtermRuntimeRef.current?.ensureWebglRenderer();', recoverIndex);
+
+  assert.ok(recoverIndex >= 0);
+  assert.ok(fastPathIndex > recoverIndex);
+  assert.ok(webglRecoveryIndex > fastPathIndex);
+  assert.match(
+    source.slice(fastPathIndex, webglRecoveryIndex),
+    /currentContainerSizeAlreadyFit\(\)[\s\S]*lastWebglRecoveryLayoutKeyRef\.current = paneLayoutKey;[\s\S]*commitVisibleLayout\(\);[\s\S]*return;/,
+  );
+});
+
+test('immediate tab recovery marks webgl recovery to skip the delayed duplicate pass', () => {
+  assert.match(
+    source,
+    /const recoverTerminalAfterBecomeVisible = \(\) => \{[\s\S]*xtermRuntimeRef\.current\?\.clearTextureAtlas\(\);\s*lastWebglRecoveryLayoutKeyRef\.current = paneLayoutKey;/,
+  );
+  assert.match(
+    source,
+    /lastWebglRecoveryLayoutKeyRef\.current === paneLayoutKey\s*&& hiddenMs < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS/,
+  );
+});

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -59,6 +59,8 @@ type ZmodemToastApi = {
   error: (message: string, title?: string) => void;
 };
 
+const CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS = 3000;
+
 export function resolveZmodemTransferToast(zmodem: ZmodemToastInput): ZmodemToast {
   if (zmodem.active) return null;
   if (zmodem.error) {
@@ -820,10 +822,27 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     return width > 0 && height > 0 && lastSize.width === width && lastSize.height === height;
   };
 
+  const getHiddenDurationMs = () => (
+    hiddenAtRef.current !== null
+      ? Date.now() - hiddenAtRef.current
+      : Number.POSITIVE_INFINITY
+  );
+
   const recoverTerminalAfterBecomeVisible = () => {
     lastCommittedVisibleLayoutKeyRef.current = null;
+
+    if (
+      getHiddenDurationMs() < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS
+      && currentContainerSizeAlreadyFit()
+    ) {
+      lastWebglRecoveryLayoutKeyRef.current = paneLayoutKey;
+      commitVisibleLayout();
+      return;
+    }
+
     xtermRuntimeRef.current?.ensureWebglRenderer();
     xtermRuntimeRef.current?.clearTextureAtlas();
+    lastWebglRecoveryLayoutKeyRef.current = paneLayoutKey;
 
     if (currentContainerSizeAlreadyFit()) {
       finishLayoutRecovery();
@@ -839,8 +858,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
   };
 
   // Refit synchronously when a split pane becomes visible or its bounds change.
-  // Tab switches move hidden panes off-screen without resizing xterm; becoming
-  // visible again does not always fire ResizeObserver, leaving a gap below content.
+  // Tab switches hide inactive panes without resizing xterm; becoming visible
+  // again does not always fire ResizeObserver, leaving a gap below content.
   // Skip during split-divider drag — refit runs once when split resizing ends.
   // In multi-split workspaces only the focused pane refits on tab switch; other
   // visible panes defer so N terminals don't block the main thread together.
@@ -926,7 +945,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
     if (
       lastWebglRecoveryLayoutKeyRef.current === paneLayoutKey
-      && hiddenMs < 3000
+      && hiddenMs < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS
     ) {
       return;
     }

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -828,6 +828,17 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       : Number.POSITIVE_INFINITY
   );
 
+  const flushPendingOutputScroll = () => {
+    if (!pendingOutputScrollRef.current) return;
+    termRef.current?.scrollToBottom();
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => {
+        termRef.current?.scrollToBottom();
+      });
+    }
+    pendingOutputScrollRef.current = false;
+  };
+
   const recoverTerminalAfterBecomeVisible = () => {
     lastCommittedVisibleLayoutKeyRef.current = null;
 
@@ -836,6 +847,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       && currentContainerSizeAlreadyFit()
     ) {
       lastWebglRecoveryLayoutKeyRef.current = paneLayoutKey;
+      flushPendingOutputScroll();
       commitVisibleLayout();
       return;
     }
@@ -846,6 +858,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
     if (currentContainerSizeAlreadyFit()) {
       finishLayoutRecovery();
+      flushPendingOutputScroll();
       commitVisibleLayout();
       return;
     }
@@ -853,6 +866,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     lastFittedSizeRef.current = null;
     runImmediateRefit({ force: true, repeatOnNextFrame: false });
     finishLayoutRecoveryAfterFit();
+    flushPendingOutputScroll();
     commitVisibleLayout();
     scheduleLayoutRecoveryRefit([100, 350]);
   };
@@ -947,6 +961,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       lastWebglRecoveryLayoutKeyRef.current === paneLayoutKey
       && hiddenMs < CSS_ONLY_TAB_REVEAL_MAX_HIDDEN_MS
     ) {
+      flushPendingOutputScroll();
       return;
     }
 
@@ -967,15 +982,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       xtermRuntimeRef.current?.clearTextureAtlas();
       runImmediateRefit({ force: true });
       finishLayoutRecoveryAfterFit();
-      if (pendingOutputScrollRef.current) {
-        termRef.current?.scrollToBottom();
-        if (typeof requestAnimationFrame === "function") {
-          requestAnimationFrame(() => {
-            termRef.current?.scrollToBottom();
-          });
-        }
-        pendingOutputScrollRef.current = false;
-      }
+      flushPendingOutputScroll();
     }, 50);
     return () => clearTimeout(timer);
   }, [isVisible, paneLayoutKey, inWorkspace, isFocusMode, isFocused]);

--- a/components/terminalLayer/TerminalLayerTabBridge.test.ts
+++ b/components/terminalLayer/TerminalLayerTabBridge.test.ts
@@ -31,3 +31,12 @@ test('terminal layer bridge passes vault open callbacks into the side panel cont
   assert.match(source, /onOpenVaultHostFromChat: s\.onOpenVaultHostFromChat/);
   assert.match(source, /onOpenVaultSectionFromChat: s\.onOpenVaultSectionFromChat/);
 });
+
+test('terminal layer bridge updates side panel live state after render', () => {
+  assert.match(source, /const sidePanelLiveSnapshot = useMemo<SidePanelLiveSnapshot>/);
+  assert.match(
+    source,
+    /useLayoutEffect\(\(\) => \{\s*sidePanelLiveStore\.update\(sidePanelLiveSnapshot\);\s*\}, \[sidePanelLiveSnapshot\]\);/,
+  );
+  assert.doesNotMatch(source, /sidePanelLiveStore\.update\(\{\s*sftpActiveHost/);
+});

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 
 import { useActiveTabId } from '../../application/state/activeTabStore';
 import { sessionCapabilitiesStore } from '../../application/state/sessionCapabilitiesStore';
@@ -15,7 +15,7 @@ import { useTerminalAiContexts } from './useTerminalAiContexts';
 import { useTerminalLayerEffects } from './useTerminalLayerEffects';
 import { useTerminalThemePanelState } from './useTerminalThemePanelState';
 import { useManualTerminalChromeSurfaceInjection } from '../../application/state/useManualTerminalChromeSurfaceInjection';
-import { sidePanelLiveStore } from '../../application/state/sidePanelLiveStore';
+import { sidePanelLiveStore, type SidePanelLiveSnapshot } from '../../application/state/sidePanelLiveStore';
 import { useTerminalWorkspaceLayout } from './useTerminalWorkspaceLayout';
 import type { SidePanelTab } from './TerminalLayerSupport';
 
@@ -215,7 +215,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     !s.followAppTerminalTheme && isTerminalLayerVisible,
   );
 
-  sidePanelLiveStore.update({
+  const sidePanelLiveSnapshot = useMemo<SidePanelLiveSnapshot>(() => ({
     sftpActiveHost,
     activeTerminalSessionIdForSftp,
     activeTerminalCwd,
@@ -234,7 +234,30 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     focusedFontWeight: themeState.focusedFontWeight,
     focusedFontWeightOverridden: themeState.focusedFontWeightOverridden,
     focusedThemeOverridden: themeState.focusedThemeOverridden,
-  });
+  }), [
+    activeSystemSessionHost,
+    activeTerminalCwd,
+    activeTerminalSessionForSystem,
+    activeTerminalSessionIdForSftp,
+    activeWorkspace,
+    effectiveFocusedSessionId,
+    focusedHost,
+    historySessionId,
+    sftpActiveHost,
+    themeState.focusedFontFamilyId,
+    themeState.focusedFontFamilyOverridden,
+    themeState.focusedFontSize,
+    themeState.focusedFontSizeOverridden,
+    themeState.focusedFontWeight,
+    themeState.focusedFontWeightOverridden,
+    themeState.focusedThemeOverridden,
+    themeState.previewedOrVisibleThemeId,
+    themeState.resolvedPreviewTheme,
+  ]);
+
+  useLayoutEffect(() => {
+    sidePanelLiveStore.update(sidePanelLiveSnapshot);
+  }, [sidePanelLiveSnapshot]);
 
   const { aiContextsByTabId, resolveAIExecutorContext } = useTerminalAiContexts({
     hosts: s.hosts,

--- a/components/terminalLayer/useTerminalLayerEffects.test.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.test.ts
@@ -25,3 +25,16 @@ test("terminal activity filter stays in sync before notification guards", () => 
   assert.ok(filterIndex < visibleGuardIndex);
   assert.ok(filterIndex < alreadyActiveGuardIndex);
 });
+
+test("side panel layout changes remeasure workspace before paint", () => {
+  assert.match(source, /import \{ useCallback, useEffect, useLayoutEffect, useRef \} from 'react';/);
+
+  const commentIndex = source.indexOf("Discrete layout changes (side panel toggle");
+  const layoutEffectIndex = source.indexOf("useLayoutEffect(() => {", commentIndex);
+  const shellWidthDependencyIndex = source.indexOf("sidePanelShellWidth,", layoutEffectIndex);
+
+  assert.notEqual(commentIndex, -1);
+  assert.notEqual(layoutEffectIndex, -1);
+  assert.notEqual(shellWidthDependencyIndex, -1);
+  assert.ok(commentIndex < layoutEffectIndex);
+});

--- a/components/terminalLayer/useTerminalLayerEffects.ts
+++ b/components/terminalLayer/useTerminalLayerEffects.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/exhaustive-deps */
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
 import { terminalLayoutSuppressStore } from '../../application/state/terminalLayoutSuppressStore';
 import { AI_PANEL_FORCE_HIDE_SHELL } from '../ai/aiPanelDiagnostics';
@@ -179,43 +179,43 @@ export function useTerminalLayerEffects(ctx: TerminalLayerEffectsContext) {
   // Discrete layout changes (side panel toggle, compose bar, workspace tab/view mode)
   // can miss a ResizeObserver tick; host-tree width is handled by the observer
   // because it updates continuously during drag.
-  useEffect(() => {
-      if (!isTerminalLayerVisible) return;
-      const el = workspaceInnerRef.current;
-      const width = el?.clientWidth ?? 0;
-      const height = el?.clientHeight ?? 0;
-      const prev = layoutEffectSnapshotRef.current;
-      const dimensionsUnchanged = width > 0
-        && height > 0
-        && prev.width === width
-        && prev.height === height
-        && prev.shellWidth === sidePanelShellWidth;
-      if (
-        dimensionsUnchanged
-        && prev.workspaceId === activeWorkspaceId
-        && prev.viewMode === activeWorkspaceViewMode
-        && prev.composeBarOpen === isComposeBarOpen
-      ) {
-        return;
-      }
-      layoutEffectSnapshotRef.current = {
-        workspaceId: activeWorkspaceId,
-        viewMode: activeWorkspaceViewMode,
-        composeBarOpen: isComposeBarOpen,
-        shellWidth: sidePanelShellWidth,
-        width,
-        height,
-      };
-      scheduleWorkspaceAreaRemeasure();
-    }, [
-      activeWorkspaceId,
-      activeWorkspaceViewMode,
-      isComposeBarOpen,
-      isTerminalLayerVisible,
-      scheduleWorkspaceAreaRemeasure,
-      sidePanelPosition,
-      sidePanelShellWidth,
-    ]);
+  useLayoutEffect(() => {
+    if (!isTerminalLayerVisible) return;
+    const el = workspaceInnerRef.current;
+    const width = el?.clientWidth ?? 0;
+    const height = el?.clientHeight ?? 0;
+    const prev = layoutEffectSnapshotRef.current;
+    const dimensionsUnchanged = width > 0
+      && height > 0
+      && prev.width === width
+      && prev.height === height
+      && prev.shellWidth === sidePanelShellWidth;
+    if (
+      dimensionsUnchanged
+      && prev.workspaceId === activeWorkspaceId
+      && prev.viewMode === activeWorkspaceViewMode
+      && prev.composeBarOpen === isComposeBarOpen
+    ) {
+      return;
+    }
+    layoutEffectSnapshotRef.current = {
+      workspaceId: activeWorkspaceId,
+      viewMode: activeWorkspaceViewMode,
+      composeBarOpen: isComposeBarOpen,
+      shellWidth: sidePanelShellWidth,
+      width,
+      height,
+    };
+    scheduleWorkspaceAreaRemeasure();
+  }, [
+    activeWorkspaceId,
+    activeWorkspaceViewMode,
+    isComposeBarOpen,
+    isTerminalLayerVisible,
+    scheduleWorkspaceAreaRemeasure,
+    sidePanelPosition,
+    sidePanelShellWidth,
+  ]);
   
   // Keep sftpHostForTab in sync with focus changes in workspace mode
     // so that the toggle check uses the currently displayed host.

--- a/components/terminalPaneVisibility.test.tsx
+++ b/components/terminalPaneVisibility.test.tsx
@@ -139,14 +139,14 @@ test("terminal pane render snapshot combines visibility and focus in one token",
   assert.equal(parsed.isFocusedPane, true);
 });
 
-test("hidden terminal pane keeps its last visible size instead of inheriting the active tab width", () => {
+test("hidden terminal pane keeps its last visible size without moving offscreen", () => {
   const hiddenStyle = resolveHiddenTerminalPaneStyle(
     { left: 0, top: 0, width: "100%", height: "100%" },
     { width: 1180, height: 720 },
   );
 
-  assert.equal(hiddenStyle.left, "-9999px");
-  assert.equal(hiddenStyle.top, "-9999px");
+  assert.equal(hiddenStyle.left, 0);
+  assert.equal(hiddenStyle.top, 0);
   assert.equal(hiddenStyle.visibility, "hidden");
   assert.equal(hiddenStyle.pointerEvents, "none");
   assert.equal(hiddenStyle.width, "1180px");

--- a/components/terminalPaneVisibility.ts
+++ b/components/terminalPaneVisibility.ts
@@ -33,8 +33,6 @@ export function resolveHiddenTerminalPaneStyle<T extends TerminalPaneStyle>(
     ...layoutStyle,
     visibility: "hidden",
     pointerEvents: "none",
-    left: "-9999px",
-    top: "-9999px",
     ...(lastVisibleSize
       ? {
         width: `${lastVisibleSize.width}px`,

--- a/domain/workspace.test.ts
+++ b/domain/workspace.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import type { WorkspaceNode } from "./models.ts";
 import {
+  appendPaneToWorkspaceRoot,
+  insertPaneIntoWorkspace,
   reorderWorkspaceFocusSessionOrder,
   resolveWorkspaceFocusSessionOrder,
 } from "./workspace.ts";
@@ -40,5 +42,20 @@ test("reorderWorkspaceFocusSessionOrder moves a session after a target", () => {
   assert.deepEqual(
     reorderWorkspaceFocusSessionOrder(root, ["s1", "s2", "s3"], "s1", "s3", "after"),
     ["s2", "s3", "s1"],
+  );
+});
+
+test("appendPaneToWorkspaceRoot ignores an existing session pane", () => {
+  assert.equal(appendPaneToWorkspaceRoot(root, "s2"), root);
+});
+
+test("insertPaneIntoWorkspace ignores an existing session pane", () => {
+  assert.equal(
+    insertPaneIntoWorkspace(root, "s2", {
+      direction: "vertical",
+      position: "right",
+      targetSessionId: "s1",
+    }),
+    root,
   );
 });

--- a/domain/workspace.ts
+++ b/domain/workspace.ts
@@ -64,6 +64,8 @@ export const appendPaneToWorkspaceRoot = (
   sessionId: string,
   direction: SplitDirection = 'vertical',
 ): WorkspaceNode => {
+  if (collectSessionIds(root).includes(sessionId)) return root;
+
   const newPane: WorkspaceNode = { id: crypto.randomUUID(), type: 'pane', sessionId };
 
   if (root.type === 'split' && root.direction === direction) {
@@ -105,6 +107,8 @@ export const insertPaneIntoWorkspace = (
   sessionId: string,
   hint: SplitHint
 ): WorkspaceNode => {
+  if (collectSessionIds(root).includes(sessionId)) return root;
+
   const pane: WorkspaceNode = { id: crypto.randomUUID(), type: 'pane', sessionId };
 
   if (!hint.targetSessionId) {


### PR DESCRIPTION
## Summary

- Stop active tab changes from triggering global terminal layout suppression.
- Keep hidden terminal panes in their last visible footprint and skip expensive recovery work for short unchanged tab reveals.
- Make workspace pane insertion and copied tab ordering idempotent so dev-time repeated updater execution cannot duplicate panes, tabs, or empty workspaces.
- Move side panel live state updates out of render and into a layout effect.

## Root Cause

Switching tabs was coupled to a global terminal layout suppression store. With terminals kept resident, every tab switch notified all mounted terminal panes twice even when only the old and new tab mattered. In development this was amplified by React/dev tooling overhead and by several workspace update paths that were not fully idempotent under repeated updater execution.

## Impact

Tab switches with high-volume terminal scrollback should feel lighter and should no longer briefly inherit another tab's side-panel width. Development mode should also be less prone to phantom workspace/pane state caused by repeated updater execution.

## Validation

- `node --test --import tsx application/state/activeTabStore.test.ts application/state/terminalLayoutSuppressStore.test.ts application/state/useSessionStateWorkspaceStrictMode.test.ts domain/workspace.test.ts components/terminalLayer/TerminalLayerTabBridge.test.ts components/terminal/terminalTabVisibilityRecovery.test.ts components/terminalPaneVisibility.test.tsx components/terminalLayer/useTerminalLayerEffects.test.ts components/terminalLayer/TerminalHostTreeSidebar.test.ts`
- `git diff --check`
- `npm run lint`
- `npm test`