### PR TITLE
Adjust All Hosts header spacing

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -141,7 +141,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
           }}
         >
                 {viewMode !== "tree" && (
-                  <section className="space-y-2">
+                  <section className="space-y-2 pt-2">
                     <div className="flex items-center gap-2 text-sm font-semibold">
                       <button
                         className={cn(


### PR DESCRIPTION
## Summary
- Move the Vaults All Hosts header slightly lower so it sits more naturally below the search bar.

## Checks
- npm run lint
- git diff --check