### PR TITLE
Update Nix release metadata for v1.1.54

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.53";
+  version = "1.1.54";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-4H77H+CoXCoU1IdL9A6BAnCkctjkiN+F/FL5NIvtDBE=";
+      hash = "sha256-QohX1ntkB3t36NH9nu0FIOuks1fzFm1CGGZim3M8Kfc=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-5d1a7KVlPwyQOiPFnOi2B5nLaVZFSNMBhrcvqgKP0Gg=";
+      hash = "sha256-Jvp0MGs7C+Vx+/zE+oWPC2JOIznzx7qWguQ05CuL32s=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- Update Nix AppImage release metadata for v1.1.54.
- This mirrors the release workflow's generated metadata, which could not push directly because main requires PRs.

## Checks
- node --test --import tsx scripts/update-nix-release.test.cjs
- git diff --check