### PR TITLE
修复 SSH 加密默认密钥重试导致会话提前关闭

### DIFF
--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -1,0 +1,325 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const Module = require("node:module");
+
+function makeSender(events = null) {
+  return {
+    id: 1,
+    isDestroyed: () => false,
+    sent: [],
+    send(channel, payload) {
+      events?.push(`send:${channel}`);
+      this.sent.push({ channel, payload });
+    },
+  };
+}
+
+function makeIpcMain() {
+  return {
+    handlers: new Map(),
+    handle(channel, handler) {
+      this.handlers.set(channel, handler);
+    },
+    on() {},
+  };
+}
+
+function createShellStream() {
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  stream.write = () => true;
+  stream.end = () => {};
+  stream.destroy = () => {};
+  stream.setWindow = () => {};
+  return stream;
+}
+
+function nextTick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function loadBridgeWithAuthRetryMocks(t, options = {}) {
+  const bridgePath = require.resolve("./sshBridge.cjs");
+  const startSessionPath = require.resolve("./sshBridge/startSession.cjs");
+  const authHelperPath = require.resolve("./sshAuthHelper.cjs");
+  const originalLoad = Module._load;
+  const originalAuthHelper = require(authHelperPath);
+  const connectEvents = options.connectEvents || ["auth-error", "ready"];
+
+  class MockSSHClient extends EventEmitter {
+    constructor() {
+      super();
+      MockSSHClient.instances.push(this);
+      this._remoteVer = "OpenSSH_test";
+      this._sock = {
+        setTimeout() {},
+        setNoDelay() {},
+      };
+    }
+
+    connect(opts) {
+      this.connectOpts = opts;
+      const eventName = connectEvents[MockSSHClient.instances.length - 1] || "auth-error";
+      setImmediate(() => {
+        if (eventName === "auth-error") {
+          const err = new Error("All configured authentication methods failed");
+          err.level = "client-authentication";
+          this.emit("error", err);
+          return;
+        }
+        if (eventName === "ready") {
+          this.emit("connect");
+          this.emit("handshake");
+          this.emit("ready");
+        }
+      });
+    }
+
+    shell(_pty, _opts, cb) {
+      setImmediate(() => cb(null, createShellStream()));
+    }
+
+    end() {
+      this.ended = true;
+    }
+
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+  MockSSHClient.instances = [];
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "ssh2") {
+      return {
+        Client: MockSSHClient,
+        utils: { parseKey: () => new Error("no key parse needed") },
+      };
+    }
+    if (request === "./sshAuthHelper.cjs" || request.endsWith("/sshAuthHelper.cjs")) {
+      return {
+        ...originalAuthHelper,
+        findAllDefaultPrivateKeys: async (args = {}) => {
+          if (args.includeEncrypted) {
+            return options.encryptedKeys || [];
+          }
+          return [];
+        },
+        requestPassphrasesForEncryptedKeys: async () => (
+          options.onPassphraseRequest?.(),
+          options.passphraseResult || { cancelled: false, keys: [] }
+        ),
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[bridgePath];
+  delete require.cache[startSessionPath];
+  const bridge = require("./sshBridge.cjs");
+
+  t.after(() => {
+    delete require.cache[bridgePath];
+    delete require.cache[startSessionPath];
+    Module._load = originalLoad;
+  });
+
+  return { bridge, MockSSHClient };
+}
+
+test("retryable encrypted-key auth failure does not emit exit before retry success", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  const result = await start(
+    { sender },
+    {
+      sessionId: "retry-session",
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "retry-session" });
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "retry-session"
+    )),
+    false,
+  );
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:auth:failed"
+      && message.payload.sessionId === "retry-session"
+    )),
+    true,
+  );
+});
+
+test("stale close from failed first attempt does not close successful retry session", async (t) => {
+  const sessions = new Map();
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions, electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await start(
+    { sender },
+    {
+      sessionId: "stale-close-session",
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.equal(sessions.has("stale-close-session"), true);
+
+  MockSSHClient.instances[0].emit("close");
+  await nextTick();
+
+  assert.equal(sessions.has("stale-close-session"), true);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "stale-close-session"
+    )),
+    false,
+  );
+});
+
+test("non-retryable auth failure still emits one exit", async (t) => {
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error"],
+    encryptedKeys: [],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await assert.rejects(
+    () => start(
+      { sender },
+      {
+        sessionId: "failed-session",
+        hostname: "example.test",
+        username: "alice",
+        port: 22,
+        knownHosts: [],
+      },
+    ),
+    /All configured authentication methods failed/,
+  );
+
+  const exits = sender.sent.filter((message) => (
+    message.channel === "netcatty:exit"
+    && message.payload.sessionId === "failed-session"
+  ));
+  assert.equal(exits.length, 1);
+  assert.equal(exits[0].payload.reason, "error");
+});
+
+test("cancelled encrypted-key retry emits one final exit", async (t) => {
+  const events = [];
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: true,
+      keys: [],
+    },
+    onPassphraseRequest: () => events.push("passphrase-request"),
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender(events);
+
+  await assert.rejects(
+    () => start(
+      { sender },
+      {
+        sessionId: "cancelled-session",
+        hostname: "example.test",
+        username: "alice",
+        port: 22,
+        knownHosts: [],
+      },
+    ),
+    /All configured authentication methods failed/,
+  );
+
+  const exits = sender.sent.filter((message) => (
+    message.channel === "netcatty:exit"
+    && message.payload.sessionId === "cancelled-session"
+  ));
+  assert.equal(exits.length, 1);
+  assert.equal(exits[0].payload.reason, "error");
+  assert.equal(events.includes("passphrase-request"), true);
+  assert.equal(
+    events.indexOf("send:netcatty:exit") > events.indexOf("passphrase-request"),
+    true,
+  );
+});

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -43,6 +43,31 @@ function nextTick() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+function makeReusableSourceSession(endpoint) {
+  const conn = new EventEmitter();
+  conn._sock = { destroyed: false };
+  conn._remoteVer = "OpenSSH_test";
+  conn.shell = () => { throw new Error("Not connected"); };
+  conn.end = () => {};
+  conn.destroy = () => {};
+  const stream = createShellStream();
+  return {
+    conn,
+    stream,
+    chainConnections: [],
+    connRef: { count: 1, conn, chainConnections: [] },
+    webContentsId: 1,
+    zmodemSentry: { cancel() {} },
+    hostname: endpoint.hostname,
+    username: endpoint.username,
+    _reuseEndpoint: {
+      hostname: endpoint.hostname,
+      port: endpoint.port || 22,
+      username: endpoint.username,
+    },
+  };
+}
+
 function loadBridgeWithAuthRetryMocks(t, options = {}) {
   const bridgePath = require.resolve("./sshBridge.cjs");
   const startSessionPath = require.resolve("./sshBridge/startSession.cjs");
@@ -250,6 +275,57 @@ test("stale close from failed first attempt does not close successful retry sess
   );
 });
 
+test("stale error from failed first attempt does not mark successful retry session failed", async (t) => {
+  const sessions = new Map();
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions, electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await start(
+    { sender },
+    {
+      sessionId: "stale-error-session",
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.equal(sessions.has("stale-error-session"), true);
+
+  const err = new Error("late error from failed first attempt");
+  err.level = "client-socket";
+  MockSSHClient.instances[0].emit("error", err);
+  await nextTick();
+
+  assert.equal(sessions.get("stale-error-session")._transportError, undefined);
+});
+
 test("jump-host auth failure does not emit exit before encrypted-key retry success", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
     connectEvents: ["auth-error", "ready", "ready"],
@@ -299,6 +375,128 @@ test("jump-host auth failure does not emit exit before encrypted-key retry succe
     )),
     false,
   );
+});
+
+test("fresh fallback after reuse failure still retries encrypted default key", async (t) => {
+  const events = [];
+  const sessions = new Map([
+    [
+      "source",
+      makeReusableSourceSession({
+        hostname: "example.test",
+        username: "alice",
+        port: 22,
+      }),
+    ],
+  ]);
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+    onPassphraseRequest: () => events.push("passphrase-request"),
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions, electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender(events);
+
+  const result = await start(
+    { sender },
+    {
+      sessionId: "reuse-fallback-retry-session",
+      sourceSessionId: "source",
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "reuse-fallback-retry-session" });
+  assert.equal(MockSSHClient.instances.length, 2);
+  assert.equal(events.includes("passphrase-request"), true);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:connection-reuse:fallback"
+      && message.payload.sessionId === "reuse-fallback-retry-session"
+    )),
+    true,
+  );
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "reuse-fallback-retry-session"
+    )),
+    false,
+  );
+});
+
+test("fresh fallback after reuse failure without encrypted keys emits one final exit", async (t) => {
+  const sessions = new Map([
+    [
+      "source",
+      makeReusableSourceSession({
+        hostname: "example.test",
+        username: "alice",
+        port: 22,
+      }),
+    ],
+  ]);
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error"],
+    encryptedKeys: [],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions, electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await assert.rejects(
+    () => start(
+      { sender },
+      {
+        sessionId: "reuse-fallback-failed-session",
+        sourceSessionId: "source",
+        hostname: "example.test",
+        username: "alice",
+        port: 22,
+        knownHosts: [],
+      },
+    ),
+    /All configured authentication methods failed/,
+  );
+
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:connection-reuse:fallback"
+      && message.payload.sessionId === "reuse-fallback-failed-session"
+    )),
+    true,
+  );
+  const exits = sender.sent.filter((message) => (
+    message.channel === "netcatty:exit"
+    && message.payload.sessionId === "reuse-fallback-failed-session"
+  ));
+  assert.equal(exits.length, 1);
+  assert.equal(exits[0].payload.reason, "error");
 });
 
 test("stale close from failed encrypted-key retry does not stop successful retry log stream", async (t) => {

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -1,7 +1,11 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
 const Module = require("node:module");
+const os = require("node:os");
+const path = require("node:path");
+const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
 
 function makeSender(events = null) {
   return {
@@ -60,7 +64,7 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
 
     connect(opts) {
       this.connectOpts = opts;
-      const eventName = connectEvents[MockSSHClient.instances.length - 1] || "auth-error";
+      const eventName = connectEvents[MockSSHClient.connectCount++] || "auth-error";
       setImmediate(() => {
         if (eventName === "auth-error") {
           const err = new Error("All configured authentication methods failed");
@@ -76,6 +80,10 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
       });
     }
 
+    forwardOut(_srcHost, _srcPort, _dstHost, _dstPort, cb) {
+      setImmediate(() => cb(null, new EventEmitter()));
+    }
+
     shell(_pty, _opts, cb) {
       setImmediate(() => cb(null, createShellStream()));
     }
@@ -89,6 +97,7 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
     }
   }
   MockSSHClient.instances = [];
+  MockSSHClient.connectCount = 0;
 
   Module._load = function patchedLoad(request, parent, isMain) {
     if (request === "ssh2") {
@@ -239,6 +248,117 @@ test("stale close from failed first attempt does not close successful retry sess
     )),
     false,
   );
+});
+
+test("jump-host auth failure does not emit exit before encrypted-key retry success", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  const result = await start(
+    { sender },
+    {
+      sessionId: "jump-retry-session",
+      hostname: "target.example",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+      jumpHosts: [{ hostname: "jump.example", username: "alice", port: 22 }],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "jump-retry-session" });
+  assert.equal(MockSSHClient.connectCount, 3);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "jump-retry-session"
+    )),
+    false,
+  );
+});
+
+test("stale close from failed encrypted-key retry does not stop successful retry log stream", async (t) => {
+  const sessionId = "retry-session-log";
+  const logDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-auth-retry-log-"));
+  t.after(async () => {
+    await sessionLogStreamManager.stopStream(sessionId);
+    fs.rmSync(logDirectory, { recursive: true, force: true });
+  });
+
+  const sessions = new Map();
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "ready"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions, electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await start(
+    { sender },
+    {
+      sessionId,
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      knownHosts: [],
+      sessionLog: {
+        enabled: true,
+        directory: logDirectory,
+        format: "raw",
+      },
+    },
+  );
+
+  assert.equal(sessionLogStreamManager.hasStream(sessionId), true);
+
+  MockSSHClient.instances[0].emit("close");
+  await nextTick();
+
+  assert.equal(sessionLogStreamManager.hasStream(sessionId), true);
 });
 
 test("non-retryable auth failure still emits one exit", async (t) => {

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -946,22 +946,57 @@ async function generateKeyPair(event, options) {
  * Wrapper for SSH session handler to suppress noisy auth error stack traces
  * Auth failures are expected when fallback to password is available
  */
+function isStartAuthError(err) {
+  return err?.message?.toLowerCase().includes('authentication') ||
+    err?.message?.toLowerCase().includes('auth') ||
+    err?.message?.toLowerCase().includes('password') ||
+    err?.level === 'client-authentication';
+}
+
+function canRetryWithEncryptedDefaultKeys(options) {
+  const hasJumpHosts = options.jumpHosts && options.jumpHosts.length > 0;
+  const isPasswordOnly = !hasJumpHosts &&
+    !options.agentForwarding &&
+    !!options.password &&
+    !options.privateKey &&
+    !options.certificate;
+  return !isPasswordOnly &&
+    (!options._unlockedEncryptedKeys || options._unlockedEncryptedKeys.length === 0);
+}
+
+function sendFinalStartFailureExit(event, options, err) {
+  const sessionId = options.sessionId;
+  if (!sessionId || event.sender?.isDestroyed?.()) return;
+  safeSend(event.sender, "netcatty:exit", {
+    sessionId,
+    exitCode: 1,
+    error: err?.message || String(err),
+    reason: "error",
+  });
+}
+
 async function startSSHSessionWrapper(event, options) {
+  let retryableEncryptedKeys = [];
+  let shouldSuppressInitialAuthExit = false;
+  if (canRetryWithEncryptedDefaultKeys(options)) {
+    const allKeysWithEncrypted = await findAllDefaultPrivateKeysFromHelper({ includeEncrypted: true });
+    retryableEncryptedKeys = allKeysWithEncrypted.filter(k => k.isEncrypted);
+    shouldSuppressInitialAuthExit = retryableEncryptedKeys.length > 0;
+  }
+
   try {
-    return await startSSHSession(event, options);
+    return await startSSHSession(event, {
+      ...options,
+      _suppressPreShellAuthExit: shouldSuppressInitialAuthExit,
+    });
   } catch (err) {
-    const isAuthError = err.message?.toLowerCase().includes('authentication') ||
-      err.message?.toLowerCase().includes('auth') ||
-      err.level === 'client-authentication';
+    const isAuthError = isStartAuthError(err);
 
     if (isAuthError) {
       // Check if there are encrypted default keys we haven't tried yet
       // Only offer retry if no unlocked keys were provided in this attempt
-      const hasJumpHosts = options.jumpHosts && options.jumpHosts.length > 0;
-      const isPasswordOnly = !hasJumpHosts && !options.agentForwarding && !!options.password && !options.privateKey && !options.certificate;
-      if (!isPasswordOnly && (!options._unlockedEncryptedKeys || options._unlockedEncryptedKeys.length === 0)) {
-        const allKeysWithEncrypted = await findAllDefaultPrivateKeysFromHelper({ includeEncrypted: true });
-        const encryptedKeys = allKeysWithEncrypted.filter(k => k.isEncrypted);
+      if (canRetryWithEncryptedDefaultKeys(options)) {
+        const encryptedKeys = retryableEncryptedKeys;
 
         if (encryptedKeys.length > 0) {
           console.log('[SSH] Auth failed, found encrypted default keys. Requesting passphrases for retry...');
@@ -1003,9 +1038,7 @@ async function startSSHSessionWrapper(event, options) {
               }
 
               // Re-wrap retry errors the same way as initial errors
-              const isRetryAuthError = retryErr.message?.toLowerCase().includes('authentication') ||
-                retryErr.message?.toLowerCase().includes('auth') ||
-                retryErr.level === 'client-authentication';
+              const isRetryAuthError = isStartAuthError(retryErr);
 
               if (isRetryAuthError) {
                 const authError = new Error(retryErr.message);
@@ -1023,6 +1056,10 @@ async function startSSHSessionWrapper(event, options) {
             console.log('[SSH] User did not unlock any keys, not retrying');
           }
         }
+      }
+
+      if (shouldSuppressInitialAuthExit) {
+        sendFinalStartFailureExit(event, options, err);
       }
 
       // Re-throw with a clean error to avoid Electron printing full stack trace

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -964,6 +964,15 @@ function canRetryWithEncryptedDefaultKeys(options) {
     (!options._unlockedEncryptedKeys || options._unlockedEncryptedKeys.length === 0);
 }
 
+function canReuseExistingSession(options) {
+  if (!options.sourceSessionId || options.x11Forwarding) return false;
+  return Boolean(findReusableSession(sessions, options.sourceSessionId, {
+    hostname: options.hostname,
+    port: options.port || 22,
+    username: options.username || "root",
+  }));
+}
+
 function sendFinalStartFailureExit(event, options, err) {
   const sessionId = options.sessionId;
   if (!sessionId || event.sender?.isDestroyed?.()) return;
@@ -977,11 +986,25 @@ function sendFinalStartFailureExit(event, options, err) {
 
 async function startSSHSessionWrapper(event, options) {
   let retryableEncryptedKeys = [];
+  let loadedRetryableEncryptedKeys = false;
   let shouldSuppressInitialAuthExit = false;
-  if (canRetryWithEncryptedDefaultKeys(options)) {
+  const canRetryEncryptedDefaults = canRetryWithEncryptedDefaultKeys(options);
+  const mayReuseExistingSession = canRetryEncryptedDefaults && canReuseExistingSession(options);
+  const loadRetryableEncryptedKeys = async () => {
     const allKeysWithEncrypted = await findAllDefaultPrivateKeysFromHelper({ includeEncrypted: true });
     retryableEncryptedKeys = allKeysWithEncrypted.filter(k => k.isEncrypted);
+    loadedRetryableEncryptedKeys = true;
+    return retryableEncryptedKeys;
+  };
+
+  if (canRetryEncryptedDefaults && !mayReuseExistingSession) {
+    await loadRetryableEncryptedKeys();
     shouldSuppressInitialAuthExit = retryableEncryptedKeys.length > 0;
+  } else if (mayReuseExistingSession) {
+    // Let Copy Tab reuse an authenticated transport without waiting on key
+    // discovery. If reuse falls back to a fresh connection and auth fails, the
+    // catch path below lazily loads encrypted keys before deciding final failure.
+    shouldSuppressInitialAuthExit = true;
   }
 
   try {
@@ -995,8 +1018,10 @@ async function startSSHSessionWrapper(event, options) {
     if (isAuthError) {
       // Check if there are encrypted default keys we haven't tried yet
       // Only offer retry if no unlocked keys were provided in this attempt
-      if (canRetryWithEncryptedDefaultKeys(options)) {
-        const encryptedKeys = retryableEncryptedKeys;
+      if (canRetryEncryptedDefaults) {
+        const encryptedKeys = loadedRetryableEncryptedKeys
+          ? retryableEncryptedKeys
+          : await loadRetryableEncryptedKeys();
 
         if (encryptedKeys.length > 0) {
           console.log('[SSH] Auth failed, found encrypted default keys. Requesting passphrases for retry...');

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1256,13 +1256,14 @@ function createStartSessionApi(ctx) {
               // ssh2 closes every channel when the transport errors, so each
               // affected session (the owner and any reused siblings) gets the
               // flag and reports the error via its own stream close handler.
-              if (sessions.has(sessionId)) {
-                const session = sessions.get(sessionId);
-                if (session) session._transportError = err.message;
+              const currentSession = sessions.get(sessionId);
+              const ownsCurrentSession = Boolean(connRef && currentSession?.connRef === connRef);
+              if (ownsCurrentSession) {
+                currentSession._transportError = err.message;
               }
               if (connRef) {
                 for (const sibling of sessions.values()) {
-                  if (sibling !== sessions.get(sessionId) && sibling.connRef === connRef) {
+                  if (sibling !== currentSession && sibling.connRef === connRef) {
                     sibling._transportError = err.message;
                   }
                 }

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1305,7 +1305,15 @@ function createStartSessionApi(ctx) {
             }
 
             sendProgress(totalHops, totalHops, options.hostname, 'error', err.message);
-            safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
+            const suppressPreShellAuthExit = Boolean(options._suppressPreShellAuthExit && isAuthError);
+            if (suppressPreShellAuthExit) {
+              log("suppressing pre-shell auth exit for wrapper-managed retry", {
+                sessionId,
+                hostname: options.hostname,
+              });
+            } else {
+              safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message, reason: "error" });
+            }
             sessionLogStreamManager.stopStream(sessionId, ownerLogStreamToken);
             if (detachX11Forwarding) {
               detachX11Forwarding();
@@ -1345,11 +1353,14 @@ function createStartSessionApi(ctx) {
 
           conn.once("close", () => {
             const contents = event.sender;
+            const currentSession = sessions.get(sessionId);
+            const ownsCurrentSession = Boolean(connRef && currentSession?.connRef === connRef);
             log("connection closed", {
               sessionId,
               hostname: options.hostname,
               settled,
-              transportError: sessions.get(sessionId)?._transportError,
+              staleForCurrentSession: Boolean(currentSession && !ownsCurrentSession),
+              transportError: ownsCurrentSession ? currentSession?._transportError : undefined,
             });
             if (!settled) {
               sendProgress(totalHops, totalHops, options.hostname, 'error', `Connection to ${options.hostname} closed unexpectedly`);
@@ -1360,8 +1371,8 @@ function createStartSessionApi(ctx) {
             // close then no-ops because the session is already gone. Reused
             // sibling channels each clean themselves up via their own stream
             // "close" (ssh2 closes every channel when the transport drops).
-            if (sessions.has(sessionId)) {
-              const session = sessions.get(sessionId);
+            if (ownsCurrentSession) {
+              const session = currentSession;
               const transportError = session?._transportError;
               if (transportError) {
                 // A transport error was recorded — report it as an error exit

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -1398,7 +1398,9 @@ function createStartSessionApi(ctx) {
               // Owner already cleaned up (e.g. its stream closed first). Ensure
               // this connection's log stream is stopped defensively, scoped by
               // the captured token so a reconnect's fresh stream is left alone.
-              sessionLogStreamManager.stopStream(sessionId, ownerLogStreamToken);
+              if (ownerLogStreamToken) {
+                sessionLogStreamManager.stopStream(sessionId, ownerLogStreamToken);
+              }
             }
             if (!settled) {
               settled = true;
@@ -1457,8 +1459,15 @@ function createStartSessionApi(ctx) {
         });
       } catch (err) {
         console.error("[Chain] SSH chain connection error:", err.message);
-        const contents = event.sender;
-        safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message });
+        const isAuthError = err.message?.toLowerCase().includes('authentication') ||
+          err.message?.toLowerCase().includes('auth') ||
+          err.message?.toLowerCase().includes('password') ||
+          err.level === 'client-authentication';
+        const suppressPreShellAuthExit = Boolean(options._suppressPreShellAuthExit && isAuthError);
+        if (!suppressPreShellAuthExit) {
+          const contents = event.sender;
+          safeSend(contents, "netcatty:exit", { sessionId, exitCode: 1, error: err.message });
+        }
         throw err;
       }
     }


### PR DESCRIPTION
## 背景

在使用加密的默认 SSH key（例如 ~/.ssh/id_ed25519）时，第一次认证失败会触发 passphrase 请求并用同一个 sessionId 重试。新版本中第一次可恢复认证失败会先发出 netcatty:exit，preload 会把同一个 sessionId 标记为 closed，导致后续重试实际成功后 renderer 仍可能丢弃数据或表现为超时。

Fixes #1876

## 修复

- 在 wrapper 预扫描 encrypted default keys，只对可由 passphrase 重试恢复的第一次 pre-shell auth failure 抑制 netcatty:exit。
- 保留 netcatty:auth:failed、进度日志、清理和 reject 行为。
- 如果用户取消 passphrase 或没有解锁任何 key，由 wrapper 补发一次最终 netcatty:exit，避免失败路径挂住。
- retry 成功后，旧失败连接的延迟 close 需要匹配当前 session 的 connRef 才能清理，避免误删同 sessionId 的新成功会话。

## 测试

- node --test electron/bridges/sshBridge.authRetryExit.test.cjs electron/bridges/sshBridge.connectionTimeout.test.cjs electron/bridges/sshBridge.defaultKeyEquivalence.test.cjs electron/bridges/sshBridge.execCommandPassphrase.test.cjs electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs electron/preloadDataBacklog.test.cjs electron/preloadTerminalOutputPorts.test.cjs
- 本地 dev 验证：重试成功时 wasClosedBeforeOpen 为 false，renderer 正常收到 session data。