### PR TITLE
[codex] Fix terminal catch-up after backgrounding

### DIFF
--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -82,6 +82,26 @@ const createContext = (showLineTimestamps: boolean, host: Record<string, unknown
   promptLineBreakStateRef: { current: undefined },
 });
 
+const withDocumentVisibility = (visibilityState: "visible" | "hidden", run: () => void) => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "document");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState,
+      hasFocus: () => visibilityState === "visible",
+    },
+  });
+  try {
+    run();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, "document", original);
+    } else {
+      Reflect.deleteProperty(globalThis, "document");
+    }
+  }
+};
+
 test("notePendingOutputScrollIfEnabled leaves hidden output unmarked when scroll-on-output is disabled", () => {
   const pendingOutputScrollRef = { current: false };
 
@@ -125,6 +145,52 @@ test("writeSessionData clears renderer backlog while deferring IPC ack", () => {
   assert.equal(flow.pendingBytes(), 0);
   assert.ok(getDeferredTerminalWriteAckBytes(term) > 0);
   clearDeferredTerminalWriteAck(term);
+});
+
+test("writeSessionData flushes xterm writes while the page is hidden", () => {
+  clearTerminalSessionFlowAck("session-1");
+  const payload = "x".repeat(FLOW_CHAR_COUNT_ACK_SIZE + 1);
+  const writes: string[] = [];
+  const pendingCallbacks: Array<() => void> = [];
+  const writeBuffer = {
+    flushSync() {
+      while (pendingCallbacks.length > 0) {
+        pendingCallbacks.shift()?.();
+      }
+    },
+  };
+  const term = {
+    buffer: { active: { type: "normal" } },
+    _core: { _writeBuffer: writeBuffer },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      if (callback) pendingCallbacks.push(callback);
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const acked: number[] = [];
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      ackSessionFlow: (_sessionId: string, bytes: number) => {
+        acked.push(bytes);
+      },
+    },
+  };
+
+  withDocumentVisibility("hidden", () => {
+    writeSessionData(ctx as never, term, payload);
+  });
+  flushTerminalSessionFlowAck("session-1");
+
+  assert.deepEqual(writes, [payload]);
+  assert.equal(pendingCallbacks.length, 0);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
+  assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
+  clearTerminalSessionFlowAck("session-1");
 });
 
 test("writeSessionData flushes deferred IPC acks before small output can leave the source paused", async () => {

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -6,6 +6,7 @@ import {
   FLOW_HIGH_WATER_MARK,
   FLOW_CHAR_COUNT_ACK_SIZE,
   FLOW_LOW_WATER_MARK,
+  MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES,
   XTERM_WRITE_CALLBACK_BATCH_BYTES,
 } from "./terminalFlowConstants.ts";
 import {
@@ -102,6 +103,37 @@ const withDocumentVisibility = (visibilityState: "visible" | "hidden", run: () =
   }
 };
 
+const withAnimationFrameQueue = (run: (frames: Array<FrameRequestCallback>) => void) => {
+  const originalRequest = Object.getOwnPropertyDescriptor(globalThis, "requestAnimationFrame");
+  const originalCancel = Object.getOwnPropertyDescriptor(globalThis, "cancelAnimationFrame");
+  const frames: Array<FrameRequestCallback> = [];
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: () => {},
+  });
+  try {
+    run(frames);
+  } finally {
+    if (originalRequest) {
+      Object.defineProperty(globalThis, "requestAnimationFrame", originalRequest);
+    } else {
+      Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+    }
+    if (originalCancel) {
+      Object.defineProperty(globalThis, "cancelAnimationFrame", originalCancel);
+    } else {
+      Reflect.deleteProperty(globalThis, "cancelAnimationFrame");
+    }
+  }
+};
+
 test("notePendingOutputScrollIfEnabled leaves hidden output unmarked when scroll-on-output is disabled", () => {
   const pendingOutputScrollRef = { current: false };
 
@@ -185,11 +217,79 @@ test("writeSessionData flushes xterm writes while the page is hidden", () => {
   });
   flushTerminalSessionFlowAck("session-1");
 
-  assert.deepEqual(writes, [payload]);
+  assert.equal(writes.join(""), payload);
+  assert.deepEqual(writes.map((write) => write.length), [FLOW_CHAR_COUNT_ACK_SIZE, 1]);
   assert.equal(pendingCallbacks.length, 0);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
   assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
   assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
+  clearTerminalSessionFlowAck("session-1");
+});
+
+test("writeSessionData flushes pending coalesced output with the hidden-page fast path", () => {
+  clearTerminalSessionFlowAck("session-1");
+  const pendingPayload = `${Array.from({ length: 20 }, () => "x".repeat(1000)).join("\n")}\n`;
+  assert.ok(pendingPayload.length > MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES);
+  const currentPayload = "current\n";
+  const writes: string[] = [];
+  const pendingCallbacks: Array<() => void> = [];
+  const writeBuffer = {
+    flushSync() {
+      while (pendingCallbacks.length > 0) {
+        pendingCallbacks.shift()?.();
+      }
+    },
+  };
+  const term = {
+    buffer: { active: { type: "normal" } },
+    _core: { _writeBuffer: writeBuffer },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      if (callback) pendingCallbacks.push(callback);
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const acked: number[] = [];
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      ackSessionFlow: (_sessionId: string, bytes: number) => {
+        acked.push(bytes);
+      },
+    },
+  };
+
+  withAnimationFrameQueue((frames) => {
+    withDocumentVisibility("visible", () => {
+      writeSessionData(ctx as never, term, pendingPayload);
+    });
+    assert.equal(frames.length, 1);
+    assert.deepEqual(writes, []);
+
+    withDocumentVisibility("hidden", () => {
+      writeSessionData(ctx as never, term, currentPayload);
+    });
+  });
+  flushTerminalSessionFlowAck("session-1");
+
+  assert.equal(writes.join(""), `${pendingPayload}${currentPayload}`);
+  assert.deepEqual(
+    writes.map((write) => write.length),
+    [
+      MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES,
+      pendingPayload.length - MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES,
+      currentPayload.length,
+    ],
+  );
+  assert.equal(pendingCallbacks.length, 0);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
+  assert.equal(
+    acked.reduce((total, bytes) => total + bytes, 0),
+    pendingPayload.length + currentPayload.length,
+  );
   clearTerminalSessionFlowAck("session-1");
 });
 

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -64,8 +64,10 @@ import {
   teardownTerminalOutputPipeline,
 } from "./terminalOutputPipeline";
 import {
+  flushTerminalWriteBufferBypassingTimers,
   maybeFlushTerminalWriteCoalescerWhenUnfocused,
   scheduleTerminalRepaintWhenUnfocused,
+  shouldFlushTerminalWritesForHiddenPage,
 } from "./terminalUnfocusedRepaint";
 
 export { FLOW_HIGH_WATER_MARK, FLOW_LOW_WATER_MARK };
@@ -112,6 +114,10 @@ export const notePendingOutputScrollIfEnabled = (
 };
 
 const terminalFlowControllers = new WeakMap<XTerm, OutputFlowController>();
+
+type TerminalSessionWriteOptions = CoalescedTerminalWriteOptions & {
+  flushXtermWriteBuffer?: boolean;
+};
 
 export const getFlowControllerForTerm = (term: XTerm): OutputFlowController | undefined =>
   terminalFlowControllers.get(term);
@@ -188,15 +194,24 @@ export const writeSessionData = (
   ingressBytes: number = data.length,
 ) => {
   const flow = getFlowController(ctx, term);
+  const isPaneVisible = ctx.isVisibleRef?.current !== false;
   flow.received(ingressBytes);
-  setTerminalOutputPressureVisibility(term, ctx.isVisibleRef?.current !== false);
+  setTerminalOutputPressureVisibility(term, isPaneVisible);
   noteTerminalOutputPressureData(term, data);
+  if (shouldFlushTerminalWritesForHiddenPage(isPaneVisible)) {
+    flushTerminalWriteCoalescer(term);
+    flushTerminalWriteBufferBypassingTimers(term);
+    writeSessionDataImmediate(ctx, term, data, ingressBytes, {
+      flushXtermWriteBuffer: true,
+    });
+    return;
+  }
   enqueueCoalescedTerminalWrite(term, data, (batch, batchIngress, writeOptions) => {
     writeSessionDataImmediate(ctx, term, batch, batchIngress, writeOptions);
   }, ingressBytes);
   maybeFlushTerminalWriteCoalescerWhenUnfocused(
     term,
-    ctx.isVisibleRef?.current !== false,
+    isPaneVisible,
   );
 };
 
@@ -205,7 +220,7 @@ const writeSessionDataImmediate = (
   term: XTerm,
   data: string,
   ingressBytes: number = data.length,
-  writeOptions: CoalescedTerminalWriteOptions = {},
+  writeOptions: TerminalSessionWriteOptions = {},
 ) => {
   const flow = getFlowController(ctx, term);
   enqueueTerminalWrite(term, ingressBytes, (done) => {
@@ -262,7 +277,8 @@ const writeSessionDataImmediate = (
       flushIpcAck(clearDeferredTerminalWriteAck(term));
     };
     const deferredBeforeWrite = getDeferredTerminalWriteAckBytes(term);
-    const deferFlowAck = !forcePromptNewLine
+    const deferFlowAck = !writeOptions.flushXtermWriteBuffer
+      && !forcePromptNewLine
       && shouldDeferTerminalWriteCallback(
         preparedDisplayData.length,
         deferredBeforeWrite,
@@ -271,8 +287,15 @@ const writeSessionDataImmediate = (
         XTERM_WRITE_CALLBACK_BATCH_BYTES,
       );
 
+    const writePreparedDisplayData = (callback: () => void): void => {
+      writeTerminalDataWithLineTimestamps(term, preparedDisplayData, callback);
+      if (writeOptions.flushXtermWriteBuffer) {
+        flushTerminalWriteBufferBypassingTimers(term);
+      }
+    };
+
     if (deferFlowAck) {
-      writeTerminalDataWithLineTimestamps(term, preparedDisplayData, () => {
+      writePreparedDisplayData(() => {
         finishQueueItem();
         flow.written(ingressBytes);
         const deferredTotal = accumulateDeferredTerminalWriteAck(term, ingressBytes);
@@ -287,7 +310,7 @@ const writeSessionDataImmediate = (
 
     const deferredBeforeCallback = clearDeferredTerminalWriteAck(term);
     const ackOnCallback = deferredBeforeCallback + ingressBytes;
-    writeTerminalDataWithLineTimestamps(term, preparedDisplayData, () => {
+    writePreparedDisplayData(() => {
       finishQueueItem();
       flow.written(ingressBytes);
       if (deferredBeforeCallback > 0) {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -55,6 +55,7 @@ import {
 } from "./terminalFlowAckBuffer";
 import {
   enqueueTerminalWrite,
+  flushTerminalWriteQueueBypassingTimers,
   isTerminalWriteQueueInFloodMode,
   setTerminalWriteQueueDropHandler,
 } from "./terminalWriteQueue";
@@ -117,6 +118,18 @@ const terminalFlowControllers = new WeakMap<XTerm, OutputFlowController>();
 
 type TerminalSessionWriteOptions = CoalescedTerminalWriteOptions & {
   flushXtermWriteBuffer?: boolean;
+};
+
+const HIDDEN_PAGE_FLUSH_MAX_PASSES = 64;
+
+const flushTerminalWritesForHiddenPage = (term: XTerm): void => {
+  flushTerminalWriteBufferBypassingTimers(term);
+  for (let pass = 0; pass < HIDDEN_PAGE_FLUSH_MAX_PASSES; pass += 1) {
+    if (!flushTerminalWriteQueueBypassingTimers(term)) {
+      return;
+    }
+    flushTerminalWriteBufferBypassingTimers(term);
+  }
 };
 
 export const getFlowControllerForTerm = (term: XTerm): OutputFlowController | undefined =>
@@ -199,11 +212,20 @@ export const writeSessionData = (
   setTerminalOutputPressureVisibility(term, isPaneVisible);
   noteTerminalOutputPressureData(term, data);
   if (shouldFlushTerminalWritesForHiddenPage(isPaneVisible)) {
-    flushTerminalWriteCoalescer(term);
-    flushTerminalWriteBufferBypassingTimers(term);
-    writeSessionDataImmediate(ctx, term, data, ingressBytes, {
-      flushXtermWriteBuffer: true,
-    });
+    const writeHiddenPageData = (
+      batch: string,
+      batchIngress: number,
+    ): void => {
+      writeSessionDataImmediate(ctx, term, batch, batchIngress, {
+        flushXtermWriteBuffer: true,
+      });
+      flushTerminalWritesForHiddenPage(term);
+    };
+    flushTerminalWriteCoalescer(term, writeHiddenPageData);
+    flushTerminalWritesForHiddenPage(term);
+    enqueueCoalescedTerminalWrite(term, data, writeHiddenPageData, ingressBytes);
+    flushTerminalWriteCoalescer(term, writeHiddenPageData);
+    flushTerminalWritesForHiddenPage(term);
     return;
   }
   enqueueCoalescedTerminalWrite(term, data, (batch, batchIngress, writeOptions) => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -88,6 +88,41 @@ test("flushTerminalWriteBufferBypassingTimers drains xterm's internal write buff
   assert.equal(flushed, true);
 });
 
+test("flushTerminalWriteBufferBypassingTimers skips already parsed xterm chunks", () => {
+  const processed: string[] = [];
+  let oldCallbackCalled = false;
+  let pendingCallbackCalled = false;
+  const writeBuffer = {
+    _bufferOffset: 1,
+    _callbacks: [
+      () => { oldCallbackCalled = true; },
+      () => { pendingCallbackCalled = true; },
+    ] as Array<() => void>,
+    _pendingData: "pending".length,
+    _writeBuffer: ["already-parsed", "pending"],
+    flushSync() {
+      while (this._writeBuffer.length > 0) {
+        processed.push(this._writeBuffer.shift()!);
+        this._callbacks.shift()?.();
+      }
+      this._pendingData = 0;
+      this._bufferOffset = 0;
+    },
+  };
+  const term = {
+    _core: {
+      _writeBuffer: writeBuffer,
+    },
+  };
+
+  flushTerminalWriteBufferBypassingTimers(term as never);
+
+  assert.deepEqual(processed, ["pending"]);
+  assert.equal(oldCallbackCalled, false);
+  assert.equal(pendingCallbackCalled, true);
+  assert.equal(writeBuffer._pendingData, 0);
+});
+
 test("maybeFlushTerminalWriteCoalescerWhenUnfocused throttles coalescer flushes", () => {
   const source = readFileSync(
     new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
@@ -123,7 +158,9 @@ test("writeSessionData bypasses animation-frame coalescing on hidden pages", () 
     "utf8",
   );
   assert.match(source, /shouldFlushTerminalWritesForHiddenPage\(isPaneVisible\)/);
-  assert.match(source, /flushTerminalWriteCoalescer\(term\);[\s\S]*flushTerminalWriteBufferBypassingTimers\(term\);[\s\S]*writeSessionDataImmediate\(ctx, term, data, ingressBytes, \{\s*flushXtermWriteBuffer: true,/);
+  assert.match(source, /flushTerminalWriteCoalescer\(term, writeHiddenPageData\)/);
+  assert.match(source, /enqueueCoalescedTerminalWrite\(term, data, writeHiddenPageData, ingressBytes\)/);
+  assert.match(source, /flushTerminalWriteQueueBypassingTimers\(term\)/);
   assert.match(source, /const deferFlowAck = !writeOptions\.flushXtermWriteBuffer/);
 });
 

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -3,8 +3,30 @@ import test from "node:test";
 import { readFileSync } from "node:fs";
 
 import {
+  flushTerminalWriteBufferBypassingTimers,
   forceTerminalRepaintBypassingAnimationFrame,
+  shouldFlushTerminalWritesForHiddenPage,
 } from "./terminalUnfocusedRepaint.ts";
+
+const withDocumentVisibility = (visibilityState: "visible" | "hidden", run: () => void) => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "document");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState,
+      hasFocus: () => visibilityState === "visible",
+    },
+  });
+  try {
+    run();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, "document", original);
+    } else {
+      Reflect.deleteProperty(globalThis, "document");
+    }
+  }
+};
 
 test("isTerminalWindowUnfocusedButVisible checks visible page without focus", () => {
   const source = readFileSync(
@@ -38,6 +60,34 @@ test("forceTerminalRepaintBypassingAnimationFrame refreshes alternate-screen vie
   assert.equal(renderRowsCalled, true);
 });
 
+test("shouldFlushTerminalWritesForHiddenPage only flushes visible panes on hidden pages", () => {
+  withDocumentVisibility("hidden", () => {
+    assert.equal(shouldFlushTerminalWritesForHiddenPage(true), true);
+    assert.equal(shouldFlushTerminalWritesForHiddenPage(false), false);
+  });
+  withDocumentVisibility("visible", () => {
+    assert.equal(shouldFlushTerminalWritesForHiddenPage(true), false);
+  });
+});
+
+test("flushTerminalWriteBufferBypassingTimers drains xterm's internal write buffer", () => {
+  let flushed = false;
+  const writeBuffer = {
+    flushSync() {
+      flushed = this === writeBuffer;
+    },
+  };
+  const term = {
+    _core: {
+      _writeBuffer: writeBuffer,
+    },
+  };
+
+  flushTerminalWriteBufferBypassingTimers(term as never);
+
+  assert.equal(flushed, true);
+});
+
 test("maybeFlushTerminalWriteCoalescerWhenUnfocused throttles coalescer flushes", () => {
   const source = readFileSync(
     new URL("./terminalUnfocusedRepaint.ts", import.meta.url),
@@ -63,8 +113,18 @@ test("writeSessionData schedules a throttled coalescer flush when unfocused", ()
   );
   assert.match(
     source,
-    /maybeFlushTerminalWriteCoalescerWhenUnfocused\(\s*term,\s*ctx\.isVisibleRef\?\.current !== false,\s*\)/,
+    /maybeFlushTerminalWriteCoalescerWhenUnfocused\(\s*term,\s*isPaneVisible,\s*\)/,
   );
+});
+
+test("writeSessionData bypasses animation-frame coalescing on hidden pages", () => {
+  const source = readFileSync(
+    new URL("./terminalSessionAttachment.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /shouldFlushTerminalWritesForHiddenPage\(isPaneVisible\)/);
+  assert.match(source, /flushTerminalWriteCoalescer\(term\);[\s\S]*flushTerminalWriteBufferBypassingTimers\(term\);[\s\S]*writeSessionDataImmediate\(ctx, term, data, ingressBytes, \{\s*flushXtermWriteBuffer: true,/);
+  assert.match(source, /const deferFlowAck = !writeOptions\.flushXtermWriteBuffer/);
 });
 
 test("writeSessionDataImmediate schedules unfocused repaint only for visible panes", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -16,9 +16,17 @@ type XTermWithPrivateWriteBuffer = XTerm & {
   _core?: {
     _writeBuffer?: {
       flushSync?: () => void;
+      _bufferOffset?: number;
+      _callbacks?: Array<(() => void) | undefined>;
+      _pendingData?: number;
+      _writeBuffer?: Array<string | Uint8Array>;
     };
   };
 };
+
+type XTermPrivateWriteBuffer = NonNullable<
+  NonNullable<XTermWithPrivateWriteBuffer["_core"]>["_writeBuffer"]
+>;
 
 export function isTerminalWindowUnfocusedButVisible(): boolean {
   if (typeof document === "undefined") return false;
@@ -34,10 +42,31 @@ export function shouldFlushTerminalWritesForHiddenPage(isPaneVisible: boolean): 
   return isPaneVisible && isTerminalPageHidden();
 }
 
+function normalizeXtermWriteBufferOffset(writeBuffer: XTermPrivateWriteBuffer): void {
+  const buffer = writeBuffer._writeBuffer;
+  const callbacks = writeBuffer._callbacks;
+  const offset = writeBuffer._bufferOffset;
+  if (!Array.isArray(buffer) || !Array.isArray(callbacks) || typeof offset !== "number") {
+    return;
+  }
+  if (offset <= 0) return;
+  if (offset >= buffer.length) {
+    buffer.length = 0;
+    callbacks.length = 0;
+    writeBuffer._pendingData = 0;
+    writeBuffer._bufferOffset = 0;
+    return;
+  }
+  writeBuffer._writeBuffer = buffer.slice(offset);
+  writeBuffer._callbacks = callbacks.slice(offset);
+  writeBuffer._bufferOffset = 0;
+}
+
 export function flushTerminalWriteBufferBypassingTimers(term: XTerm): void {
   const writeBuffer = (term as XTermWithPrivateWriteBuffer)._core?._writeBuffer;
   if (typeof writeBuffer?.flushSync !== "function") return;
   try {
+    normalizeXtermWriteBufferOffset(writeBuffer);
     writeBuffer.flushSync();
   } catch {
     // Best-effort private xterm recovery; normal async writes will continue.

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -12,9 +12,36 @@ const UNFOCUSED_FLUSH_DEBOUNCE_MS = 67;
 const unfocusedRepaintTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const unfocusedFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 
+type XTermWithPrivateWriteBuffer = XTerm & {
+  _core?: {
+    _writeBuffer?: {
+      flushSync?: () => void;
+    };
+  };
+};
+
 export function isTerminalWindowUnfocusedButVisible(): boolean {
   if (typeof document === "undefined") return false;
   return document.visibilityState === "visible" && !document.hasFocus();
+}
+
+export function isTerminalPageHidden(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.visibilityState !== "visible";
+}
+
+export function shouldFlushTerminalWritesForHiddenPage(isPaneVisible: boolean): boolean {
+  return isPaneVisible && isTerminalPageHidden();
+}
+
+export function flushTerminalWriteBufferBypassingTimers(term: XTerm): void {
+  const writeBuffer = (term as XTermWithPrivateWriteBuffer)._core?._writeBuffer;
+  if (typeof writeBuffer?.flushSync !== "function") return;
+  try {
+    writeBuffer.flushSync();
+  } catch {
+    // Best-effort private xterm recovery; normal async writes will continue.
+  }
 }
 
 export function forceTerminalRepaintBypassingAnimationFrame(term: XTerm): void {

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -16,6 +16,32 @@ import {
 } from "./terminalFlowConstants.ts";
 
 const createFakeTerm = () => ({}) as XTerm;
+const withAnimationFrameQueue = (run: () => void) => {
+  const originalRequest = Object.getOwnPropertyDescriptor(globalThis, "requestAnimationFrame");
+  const originalCancel = Object.getOwnPropertyDescriptor(globalThis, "cancelAnimationFrame");
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: () => 1,
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: () => {},
+  });
+  try {
+    run();
+  } finally {
+    if (originalRequest) {
+      Object.defineProperty(globalThis, "requestAnimationFrame", originalRequest);
+    } else {
+      Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+    }
+    if (originalCancel) {
+      Object.defineProperty(globalThis, "cancelAnimationFrame", originalCancel);
+    } else {
+      Reflect.deleteProperty(globalThis, "cancelAnimationFrame");
+    }
+  }
+};
 
 test("splits a single flood-sized terminal batch before it reaches xterm", () => {
   const term = createFakeTerm();
@@ -171,6 +197,38 @@ test("keeps control-sequence terminal batches intact up to the coalescing cap", 
 
   assert.deepEqual(writes.map((write) => write.data.length), [payload.length]);
   assert.deepEqual(writes.map((write) => write.options), [undefined]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("uses the latest coalesced writer when pending output is flushed", () => {
+  const term = createFakeTerm();
+  const firstWriter: string[] = [];
+  const secondWriter: string[] = [];
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 100);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "pending",
+      (data) => {
+        firstWriter.push(data);
+      },
+      "pending".length,
+    );
+    enqueueCoalescedTerminalWrite(
+      term,
+      " output",
+      (data) => {
+        secondWriter.push(data);
+      },
+      " output".length,
+    );
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(firstWriter, []);
+  assert.deepEqual(secondWriter, ["pending output"]);
 
   resetTerminalWriteCoalescer(term);
 });

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -13,10 +13,16 @@ export type CoalescedTerminalWriteOptions = {
   deferStart?: boolean;
   yieldAfter?: boolean;
 };
+type CoalescedTerminalWriteNow = (
+  data: string,
+  ingressBytes: number,
+  options?: CoalescedTerminalWriteOptions,
+) => void;
 
 const terminalWriteCoalescers = new WeakMap<XTerm, WriteCoalescer>();
 const terminalWriteCoalescerIngress = new WeakMap<XTerm, number>();
 const terminalWriteCoalescerByteCapResolvers = new WeakMap<XTerm, CoalescerByteCapResolver>();
+const terminalWriteCoalescerWriters = new WeakMap<XTerm, CoalescedTerminalWriteNow>();
 
 const defaultCoalescerByteCap = (): number => MAX_PENDING_WRITE_COALESCE_BYTES;
 
@@ -129,13 +135,10 @@ const writeLargeTerminalBatch = (
 export const enqueueCoalescedTerminalWrite = (
   term: XTerm,
   data: string,
-  writeNow: (
-    data: string,
-    ingressBytes: number,
-    options?: CoalescedTerminalWriteOptions,
-  ) => void,
+  writeNow: CoalescedTerminalWriteNow,
   ingressBytes: number = data.length,
 ): void => {
+  terminalWriteCoalescerWriters.set(term, writeNow);
   const maxPendingBytes = resolveCoalescerByteCap(term);
   if (getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {
     flushTerminalWriteCoalescer(term);
@@ -159,11 +162,12 @@ export const enqueueCoalescedTerminalWrite = (
   if (!coalescer) {
     coalescer = createWriteCoalescer((batch) => {
       const batchIngress = takePendingIngressBytes(term, batch.length);
+      const activeWriteNow = terminalWriteCoalescerWriters.get(term) ?? writeNow;
       writeLargeTerminalBatch(
         batch,
         batchIngress,
         resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
-        writeNow,
+        activeWriteNow,
       );
     }, {
       getMaxPendingBytes: () => resolveCoalescerByteCap(term),
@@ -173,8 +177,25 @@ export const enqueueCoalescedTerminalWrite = (
   coalescer.push(data);
 };
 
-export const flushTerminalWriteCoalescer = (term: XTerm): void => {
-  terminalWriteCoalescers.get(term)?.flushSync();
+export const flushTerminalWriteCoalescer = (
+  term: XTerm,
+  writeNow?: CoalescedTerminalWriteNow,
+): void => {
+  const coalescer = terminalWriteCoalescers.get(term);
+  if (!coalescer) return;
+  if (!writeNow) {
+    coalescer.flushSync();
+    return;
+  }
+  coalescer.flushSync((batch) => {
+    const batchIngress = takePendingIngressBytes(term, batch.length);
+    writeLargeTerminalBatch(
+      batch,
+      batchIngress,
+      resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
+      writeNow,
+    );
+  });
 };
 
 export const resetTerminalWriteCoalescer = (term: XTerm): void => {
@@ -182,6 +203,7 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   terminalWriteCoalescers.delete(term);
   terminalWriteCoalescerIngress.delete(term);
   terminalWriteCoalescerByteCapResolvers.delete(term);
+  terminalWriteCoalescerWriters.delete(term);
 };
 
 export const getTerminalWriteCoalescerPendingBytes = (term: XTerm): number =>

--- a/components/terminal/runtime/terminalWriteQueue.test.ts
+++ b/components/terminal/runtime/terminalWriteQueue.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_WRITE_QUEUE_ITEMS,
   abortTerminalWriteQueue,
   enqueueTerminalWrite,
+  flushTerminalWriteQueueBypassingTimers,
   getTerminalWriteQueueDepth,
   isTerminalWriteQueueInFloodMode,
   setTerminalWriteQueueDropHandler,
@@ -69,6 +70,25 @@ test("yieldAfter lets the event loop run between queued write chunks", async () 
   assert.deepEqual(order, [1]);
   await waitForQueuedWriteYield();
   assert.deepEqual(order, [1, 2]);
+});
+
+test("flushTerminalWriteQueueBypassingTimers drains deferred queue steps immediately", () => {
+  const term = createFakeTerm();
+  const order: number[] = [];
+
+  enqueueTerminalWrite(term, 1, (done) => {
+    order.push(1);
+    done();
+  }, { deferStart: true, yieldAfter: true });
+  enqueueTerminalWrite(term, 1, (done) => {
+    order.push(2);
+    done();
+  });
+
+  assert.deepEqual(order, []);
+  assert.equal(flushTerminalWriteQueueBypassingTimers(term), true);
+  assert.deepEqual(order, [1, 2]);
+  assert.equal(flushTerminalWriteQueueBypassingTimers(term), false);
 });
 
 test("marks flood mode and coalesces queued writes when item cap is exceeded", async () => {
@@ -243,6 +263,27 @@ test("merged flood backlog still yields between synchronous write steps", async 
   assert.deepEqual(order, [0]);
   await waitForQueuedWriteYield();
   assert.deepEqual(order, [0, 1]);
+});
+
+test("flushTerminalWriteQueueBypassingTimers drains merged flood backlog without timer yields", () => {
+  const term = createFakeTerm();
+  const order: number[] = [];
+
+  for (let index = 0; index < MAX_WRITE_QUEUE_ITEMS + 1; index += 1) {
+    enqueueTerminalWrite(
+      term,
+      10,
+      (done) => {
+        order.push(index);
+        done();
+      },
+      { deferStart: true, yieldAfter: true },
+    );
+  }
+
+  assert.equal(getTerminalWriteQueueDepth(term), 1);
+  assert.equal(flushTerminalWriteQueueBypassingTimers(term), true);
+  assert.deepEqual(order, Array.from({ length: MAX_WRITE_QUEUE_ITEMS + 1 }, (_, index) => index));
 });
 
 test("write queue yields when a drain reaches its byte budget", async () => {

--- a/components/terminal/runtime/terminalWriteQueue.ts
+++ b/components/terminal/runtime/terminalWriteQueue.ts
@@ -36,6 +36,8 @@ type TerminalWriteQueue = {
   floodMode: boolean;
   onDropped?: (bytes: number) => void;
   drainTimer?: ReturnType<typeof setTimeout>;
+  stepTimer?: ReturnType<typeof setTimeout>;
+  stepContinuation?: () => void;
 };
 
 const terminalWriteQueues = new WeakMap<XTerm, TerminalWriteQueue>();
@@ -110,6 +112,17 @@ const scheduleNextTerminalWrite = (term: XTerm, queue: TerminalWriteQueue) => {
       queue.drainBytes = 0;
     }
     scheduleQueueDrain(term, queue, next.yieldAfter);
+  }, (continuation) => {
+    const timer = setTimeout(() => {
+      if (terminalWriteQueues.get(term) !== queue || queue.stepTimer !== timer) {
+        return;
+      }
+      queue.stepTimer = undefined;
+      queue.stepContinuation = undefined;
+      continuation();
+    }, 0);
+    queue.stepTimer = timer;
+    queue.stepContinuation = continuation;
   });
 };
 
@@ -119,7 +132,11 @@ const resolveMaxDrainBytes = (value?: number): number => (
     : MAX_TERMINAL_WRITE_QUEUE_DRAIN_BYTES
 );
 
-const runQueuedWrite = (item: QueuedWrite, done: () => void): void => {
+const runQueuedWrite = (
+  item: QueuedWrite,
+  done: () => void,
+  deferStep: (continuation: () => void) => void,
+): void => {
   let index = 0;
   let completed = false;
   let currentDrainBytes = 0;
@@ -144,7 +161,7 @@ const runQueuedWrite = (item: QueuedWrite, done: () => void): void => {
       && currentDrainBytes + step.bytes > item.maxDrainBytes
     ) {
       currentDrainBytes = 0;
-      setTimeout(runNext, 0);
+      deferStep(runNext);
       return;
     }
     index += 1;
@@ -156,7 +173,7 @@ const runQueuedWrite = (item: QueuedWrite, done: () => void): void => {
       currentDrainBytes += step.bytes;
       if ((step.yieldAfter || item.yieldAfter) && index < item.steps.length) {
         currentDrainBytes = 0;
-        setTimeout(runNext, 0);
+        deferStep(runNext);
         return;
       }
       runNext();
@@ -175,6 +192,29 @@ const runQueuedWrite = (item: QueuedWrite, done: () => void): void => {
   };
 
   runNext();
+};
+
+const runDeferredQueueStepNow = (queue: TerminalWriteQueue): boolean => {
+  const continuation = queue.stepContinuation;
+  if (!continuation) return false;
+  if (queue.stepTimer !== undefined) {
+    clearTimeout(queue.stepTimer);
+  }
+  queue.stepTimer = undefined;
+  queue.stepContinuation = undefined;
+  continuation();
+  return true;
+};
+
+const runDeferredQueueDrainNow = (
+  term: XTerm,
+  queue: TerminalWriteQueue,
+): boolean => {
+  if (queue.drainTimer === undefined) return false;
+  clearTimeout(queue.drainTimer);
+  queue.drainTimer = undefined;
+  scheduleNextTerminalWrite(term, queue);
+  return true;
 };
 
 const mergePendingWrites = (queue: TerminalWriteQueue): void => {
@@ -231,6 +271,29 @@ export const getTerminalWriteQueueDepth = (term: XTerm): number =>
 
 export const isTerminalWriteQueueInFloodMode = (term: XTerm): boolean =>
   terminalWriteQueues.get(term)?.floodMode ?? false;
+
+export const flushTerminalWriteQueueBypassingTimers = (term: XTerm): boolean => {
+  let flushed = false;
+  for (let guard = 0; guard < 4096; guard += 1) {
+    const queue = terminalWriteQueues.get(term);
+    if (!queue) return flushed;
+    if (runDeferredQueueStepNow(queue)) {
+      flushed = true;
+      continue;
+    }
+    if (runDeferredQueueDrainNow(term, queue)) {
+      flushed = true;
+      continue;
+    }
+    if (!queue.writing && queue.pending.length > 0) {
+      scheduleNextTerminalWrite(term, queue);
+      flushed = true;
+      continue;
+    }
+    return flushed;
+  }
+  return flushed;
+};
 
 export const enqueueTerminalWrite = (
   term: XTerm,
@@ -294,6 +357,11 @@ export const abortTerminalWriteQueue = (
     clearTimeout(queue.drainTimer);
     queue.drainTimer = undefined;
   }
+  if (queue.stepTimer !== undefined) {
+    clearTimeout(queue.stepTimer);
+    queue.stepTimer = undefined;
+  }
+  queue.stepContinuation = undefined;
   terminalWriteQueues.delete(term);
 
   if (droppedBytes > 0) {

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -23,7 +23,7 @@ export {
 export type WriteCoalescer = {
   push(chunk: string): void;
   /** Flush pending bytes synchronously before ordered writes (exit notices). */
-  flushSync(): void;
+  flushSync(writeOverride?: (data: string) => void): void;
   /** Drop pending bytes without writing (flood recovery / teardown). */
   abort(onDropped?: (bytes: number) => void): void;
   pendingBytes(): number;
@@ -69,7 +69,7 @@ export const createWriteCoalescer = (
     }
   };
 
-  const flushSync = (): void => {
+  const flushSync = (writeOverride?: (data: string) => void): void => {
     cancelScheduledFrame();
     if (pendingBytes === 0) {
       return;
@@ -77,7 +77,7 @@ export const createWriteCoalescer = (
     const batch = pending.length === 1 ? pending[0]! : pending.join("");
     pending = [];
     pendingBytes = 0;
-    write(batch);
+    (writeOverride ?? write)(batch);
   };
 
   const abort = (onDropped?: (bytes: number) => void): void => {


### PR DESCRIPTION
## Summary

Fixes #1880.

This changes terminal output handling so visible panes keep draining incoming output while the app page is hidden or backgrounded. That prevents the terminal from replaying old log output slowly when the window returns to the foreground.

The follow-up review pass also hardened the fix so already pending output, internal queue delays, and partially processed terminal buffers are handled safely instead of waiting for the app to become visible again.

## Root Cause

Terminal writes were coalesced through animation-frame driven rendering. When the renderer page was hidden, those frame callbacks could stop, leaving terminal write callbacks and flow acknowledgements stuck until the app became visible again. The backend stream then resumed with old buffered output and replayed it in order.

## Validation

- `node --test --import tsx components/terminal/runtime/terminalUnfocusedRepaint.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts components/terminal/runtime/terminalWriteQueue.test.ts components/terminal/runtime/terminalWriteCoalescer.test.ts`
- `node --test --import tsx components/terminal/runtime/terminalWriteAckDeferral.test.ts components/terminal/runtime/terminalOutputPipeline.test.ts components/terminal/runtime/terminalFlowAckBuffer.test.ts`
- `npm run lint`
- `git diff --check`
- `npm test`
- `npm run build`
- Final local review round: 2 independent reviewers returned CLEAN