### PR TITLE
[codex] Keep agent set -e failures from closing shells

### DIFF
--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -1,5 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, rmSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join } = require("node:path");
 
 const {
   resolveEffectiveShellKind,
@@ -116,6 +120,53 @@ test("cmd wrapper uses interactive cmd variable expansion", () => {
   const wrapped = buildWrappedCommand("ipconfig /all", "cmd", "__NCMCP_TEST__");
   assert.match(wrapped, /"%__NCMCP_TEST___CMD%"/);
   assert.doesNotMatch(wrapped, /"%%__NCMCP_TEST___CMD%%"/);
+});
+
+test("posix wrapper isolates set -e failures from the active shell", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("set -e\nfalse\necho SHOULD_NOT_PRINT", "posix", marker);
+  const result = spawnSync("sh", ["-c", `${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+  assert.doesNotMatch(result.stdout, /SHOULD_NOT_PRINT/);
+});
+
+test("posix wrapper survives failures when the active shell already has errexit", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("false", "posix", marker);
+  const result = spawnSync("sh", ["-c", `set -e; ${wrapped}printf 'PARENT_STILL_ALIVE\\n'`], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, new RegExp(`${marker}_S`));
+  assert.match(result.stdout, new RegExp(`${marker}_E:1`));
+  assert.match(result.stdout, /PARENT_STILL_ALIVE/);
+});
+
+test("posix wrapper still keeps safe state changes in the active shell", () => {
+  const marker = "__NCMCP_TEST__";
+  const cwd = mkdtempSync(join(tmpdir(), "netcatty-pty-cd-"));
+  try {
+    const wrapped = buildWrappedCommand(`cd '${cwd.replace(/'/g, "'\\''")}'`, "posix", marker);
+    const result = spawnSync("sh", ["-c", `${wrapped}pwd`], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+    assert.match(result.stdout, new RegExp(`${cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("execViaChannel registers a pending-cancel marker before the SSH channel opens", () => {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -76,6 +76,11 @@ function escapeCmdForNestedShell(text) {
   return String(text || "").replace(/"/g, '""').replace(/%/g, "%%");
 }
 
+function commandEnablesPosixErrexit(command) {
+  const text = String(command || "");
+  return /(^|[\n\r;|&({])\s*set\s+(?:-[^\n\r;|&)]*e[^\n\r;|&)]*|-o\s+errexit)\b/.test(text);
+}
+
 // Matches PowerShell's default prompt only (e.g. `PS C:\Users\alice>`,
 // `PS>`). Custom prompt functions (oh-my-posh, starship, PSReadLine themes
 // that emit `❯`/`λ`/etc.) intentionally fall through — we'd rather miss
@@ -172,6 +177,8 @@ function buildWrappedCommand(command, shellKind, marker) {
       // 2) The user command is executed via eval on a quoted string. This
       //    keeps shell syntax errors inside the eval call so the wrapper
       //    can still emit the end marker and return a non-zero exit code.
+      //    Commands that enable errexit run in a subshell so a failing
+      //    generated script cannot terminate the active login shell.
       //
       // 3) Single-line { ... } is parsed fully before execution, so SIGINT
       //    cannot cause bash to flush the end marker from the input buffer.
@@ -179,6 +186,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       //    preventing the shell from aborting the compound command.
       const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
       const escaped = escapePosixSingleQuoted(command);
+      const isolate = commandEnablesPosixErrexit(command) ? "1" : "0";
       // Leading single space: lets bash/zsh skip recording this command
       // in history when the user already has HISTCONTROL=ignorespace
       // (bash) or HIST_IGNORE_SPACE (zsh) configured — Debian/Ubuntu and
@@ -187,7 +195,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       // Without that config the prefix is harmless; it just doesn't
       // suppress history recording.
       return (
-        ` ${marker}=0; ${marker}_cmd='${escaped}'; { printf '%s\\n' '${marker}_S'; trap ':' INT; ${noPager}eval "$${marker}_cmd"; __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }\n`
+        ` ${marker}=0; ${marker}_cmd='${escaped}'; ${marker}_isolate=${isolate}; ${marker}_flags=$-; { printf '%s\\n' '${marker}_S'; trap ':' INT; case "$${marker}_flags" in *e*) set +e; ${marker}_isolate=1 ;; esac; if [ "$${marker}_isolate" = 1 ]; then ( ${noPager}eval "$${marker}_cmd" ); else ${noPager}eval "$${marker}_cmd"; fi; __NCMCP_rc=$?; trap - INT; printf '\\n%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; case "$${marker}_flags" in *e*) set -e; true ;; *) (exit $__NCMCP_rc) ;; esac; }\n`
       );
     }
   }


### PR DESCRIPTION
## Summary

- Apply the smallest shell-wrapper change for issue #1850.
- When an Agent command enables `set -e` / `set -o errexit`, run that command in a subshell so a command failure does not close the active SSH/login shell.
- If the active shell already has errexit enabled, temporarily relax it around the wrapper and restore it afterward.
- Keep normal stateful commands, such as `cd`, running in the active shell as before.

## Intentional scope

This PR is deliberately not a broad shell-isolation rewrite. The previous attempt grew into detecting many shell-terminating patterns and regressed normal AI behavior. This version only targets the simplest high-value path behind #1850: `set -e` failures taking down the active session.

It does not try to solve every possible way a command could exit or kill a shell.

Fixes #1850

## Validation

- `node --test electron/bridges/ai/ptyExec.test.cjs electron/terminalWorker/aiExec.test.cjs electron/bridges/aiBridge/cattyExecHandlers.worker.test.cjs`
- `npx eslint electron/bridges/ai/ptyExecHelpers.cjs electron/bridges/ai/ptyExec.test.cjs`
- `git diff --check`
