### PR TITLE
Update Nix release metadata for v1.1.55

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.54";
+  version = "1.1.55";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-QohX1ntkB3t36NH9nu0FIOuks1fzFm1CGGZim3M8Kfc=";
+      hash = "sha256-90ii0mMasW3yeMGy54OzRewEayUftktEBg6FPSjDtcE=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-Jvp0MGs7C+Vx+/zE+oWPC2JOIznzx7qWguQ05CuL32s=";
+      hash = "sha256-HJ/BtJs7AVLSktTvcsN0DgKyBDVIJ/0K6a0go/IUdRc=";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Update Nix release metadata to v1.1.55
- Refresh AppImage hashes from the published v1.1.55 release assets

## Validation

- node --test scripts/update-nix-release.test.cjs