### PR TITLE
[codex] fix ssh-agent certificate auth

### DIFF
--- a/electron/bridges/ssh2CertificateAgentPatch.test.cjs
+++ b/electron/bridges/ssh2CertificateAgentPatch.test.cjs
@@ -1,0 +1,79 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { AgentProtocol } = require("ssh2/lib/agent.js");
+const { parseKey } = require("ssh2/lib/protocol/keyParser.js");
+
+const ECDSA_CERT_LINE = "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgSkptPjkhM3ZnXER1QSNpaSg0JzJ9Z3dLTU0oKkpCYGIAAAAIbmlzdHAyNTYAAABBBAMxijjYHek6JS1XtFt1YPJuDs7Zkpg+UMz/b5jzTB+Srl0hT9V4kexCpwyMDnx8gd3k4daGWZXxsesQaQGC4rX0cwh4uddx3gAAAAEAAAAQbWVAaW1sb25naGFvLmNvbQAAAAgAAAAEcm9vdAAAAABqRmpZAAAAAGpGlNQAAAAAAAAAggAAABVwZXJtaXQtWDExLWZvcndhcmRpbmcAAAAAAAAAF3Blcm1pdC1hZ2VudC1mb3J3YXJkaW5nAAAAAAAAABZwZXJtaXQtcG9ydC1mb3J3YXJkaW5nAAAAAAAAAApwZXJtaXQtcHR5AAAAAAAAAA5wZXJtaXQtdXNlci1yYwAAAAAAAAAAAAAAaAAAABNlY2RzYS1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQQkWxbD3AqBZgxF3n5W1Tm6EaRShuvZjkvILa6IcVrnsLnPG1IFBaYDw3nWze+3ih3RA55xnnPEPWHKOS6VLunmAAAAZQAAABNlY2RzYS1zaGEyLW5pc3RwMjU2AAAASgAAACEA4JLPuC1ZEh6viYhY8lK0SeevuNpSTiIIushCe78Jmj0AAAAhAOFEBe05MOCxfaVo4gptJKz2BjR3hFJrMb0CEukNgcFo root";
+
+function keyBlobFromLine(line) {
+  return Buffer.from(line.split(/\s+/)[1], "base64");
+}
+
+function writeString(value) {
+  const data = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const buf = Buffer.alloc(4 + data.length);
+  buf.writeUInt32BE(data.length, 0);
+  data.copy(buf, 4);
+  return buf;
+}
+
+function readString(buf, offset) {
+  const len = buf.readUInt32BE(offset);
+  const start = offset + 4;
+  return { value: buf.subarray(start, start + len), next: start + len };
+}
+
+function signRequestFor(key, options = {}) {
+  const protocol = new AgentProtocol(true);
+  protocol.sign(key, Buffer.from("payload"), options, () => {});
+  const request = protocol.read();
+  assert.ok(request, "expected agent sign request");
+  assert.equal(request[4], 13);
+  return request;
+}
+
+test("ssh2 parses OpenSSH certificate identities from ssh-agent without dropping the certificate blob", () => {
+  const certBlob = keyBlobFromLine(ECDSA_CERT_LINE);
+
+  for (const input of [ECDSA_CERT_LINE, certBlob]) {
+    const key = parseKey(input);
+    assert.equal(key instanceof Error, false, key.message);
+    assert.equal(key.type, "ecdsa-sha2-nistp256-cert-v01@openssh.com");
+    assert.deepEqual(key.getPublicSSH(), certBlob);
+  }
+});
+
+test("ssh2 agent signing requests use the full certificate blob as the key identity", () => {
+  const certBlob = keyBlobFromLine(ECDSA_CERT_LINE);
+
+  const request = signRequestFor(certBlob);
+  let parsed = readString(request, 5);
+  assert.deepEqual(parsed.value, certBlob);
+  parsed = readString(request, parsed.next);
+  assert.equal(parsed.value.toString(), "payload");
+  assert.equal(request.readUInt32BE(parsed.next), 0);
+});
+
+test("ssh2 agent signing requests pass RSA SHA2 flags for RSA certificate identities", () => {
+  const rsaCertBlob = Buffer.concat([
+    writeString("ssh-rsa-cert-v01@openssh.com"),
+    writeString(Buffer.from("nonce")),
+    writeString(Buffer.from([0x01, 0x00, 0x01])),
+    writeString(Buffer.concat([Buffer.from([0x00]), Buffer.alloc(32, 0xaa)])),
+  ]);
+
+  const key = parseKey(rsaCertBlob);
+  assert.equal(key instanceof Error, false, key.message);
+  assert.equal(key.type, "ssh-rsa-cert-v01@openssh.com");
+  assert.deepEqual(key.getPublicSSH(), rsaCertBlob);
+
+  const request = signRequestFor(rsaCertBlob, { hash: "sha512" });
+  let parsed = readString(request, 5);
+  assert.deepEqual(parsed.value, rsaCertBlob);
+  parsed = readString(request, parsed.next);
+  assert.equal(parsed.value.toString(), "payload");
+  assert.equal(request.readUInt32BE(parsed.next), 1 << 2);
+});

--- a/patches/ssh2+1.17.0.patch
+++ b/patches/ssh2+1.17.0.patch
@@ -1,3 +1,32 @@
+diff --git a/node_modules/ssh2/lib/agent.js b/node_modules/ssh2/lib/agent.js
+index bb495d1..c0d5def 100644
+--- a/node_modules/ssh2/lib/agent.js
++++ b/node_modules/ssh2/lib/agent.js
+@@ -711,7 +711,10 @@ const AgentProtocol = (() => {
+                 hash: undefined,
+               };
+               let ctx;
+-              if (pubKey.type === 'ssh-rsa') {
++              if (pubKey.type === 'ssh-rsa'
++                  || pubKey.type === 'ssh-rsa-cert-v01@openssh.com'
++                  || pubKey.type === 'rsa-sha2-256-cert-v01@openssh.com'
++                  || pubKey.type === 'rsa-sha2-512-cert-v01@openssh.com') {
+                 if (flagsVal & SSH_AGENT_RSA_SHA2_256) {
+                   ctx = 'rsa-sha2-256';
+                   flags.hash = 'sha256';
+@@ -781,7 +784,11 @@ const AgentProtocol = (() => {
+       if (pubKey instanceof Error)
+         throw new Error('Invalid public key argument');
+ 
+-      if (pubKey.type === 'ssh-rsa' && options) {
++      if ((pubKey.type === 'ssh-rsa'
++           || pubKey.type === 'ssh-rsa-cert-v01@openssh.com'
++           || pubKey.type === 'rsa-sha2-256-cert-v01@openssh.com'
++           || pubKey.type === 'rsa-sha2-512-cert-v01@openssh.com')
++          && options) {
+         switch (options.hash) {
+           case 'sha256':
+             flags = SSH_AGENT_RSA_SHA2_256;
 diff --git a/node_modules/ssh2/lib/client.js b/node_modules/ssh2/lib/client.js
 index 7291c2c..8943c9a 100644
 --- a/node_modules/ssh2/lib/client.js
@@ -742,12 +771,14 @@ diff --git a/node_modules/ssh2/lib/protocol/constants.js b/node_modules/ssh2/lib
 index ad77592..4b3f71a 100644
 --- a/node_modules/ssh2/lib/protocol/constants.js
 +++ b/node_modules/ssh2/lib/protocol/constants.js
-@@ -160,4 +160,5 @@ const COMPAT = {
+@@ -160,6 +160,7 @@ const COMPAT = {
    DYN_RPORT_BUG: 1 << 2,
    BUG_DHGEX_LARGE: 1 << 3,
    IMPLY_RSA_SHA2_SIGALGS: 1 << 4,
 +  COMWARE_DHGEX_1024: 1 << 5,
  };
+ 
+ module.exports = {
 @@ -330,6 +331,7 @@ module.exports = {
    COMPAT_CHECKS: [
      [ 'Cisco-1.25', COMPAT.BAD_DHGEX ],
@@ -775,3 +806,99 @@ index 811e631..4b5f792 100644
        this._maxBits = GEX_MAX_BITS;
      }
      start() {
+diff --git a/node_modules/ssh2/lib/protocol/keyParser.js b/node_modules/ssh2/lib/protocol/keyParser.js
+index a276c1a..df123fd 100644
+--- a/node_modules/ssh2/lib/protocol/keyParser.js
++++ b/node_modules/ssh2/lib/protocol/keyParser.js
+@@ -1186,6 +1186,26 @@ function OpenSSH_Public(type, comment, pubPEM, pubSSH, algo) {
+   this[SYM_DECRYPTED] = false;
+ }
+ OpenSSH_Public.prototype = BaseKey;
++
++function isOpenSSHCertType(type) {
++  return (typeof type === 'string'
++          && /-cert-v0[01]@openssh\.com$/.test(type));
++}
++
++function getOpenSSHCertBaseType(type) {
++  if (!isOpenSSHCertType(type))
++    return type;
++
++  const baseType = type.replace(/-cert-v0[01]@openssh\.com$/, '');
++  switch (baseType) {
++    case 'rsa-sha2-256':
++    case 'rsa-sha2-512':
++      return 'ssh-rsa';
++    default:
++      return baseType;
++  }
++}
++
+ {
+   let regexp;
+   if (eddsaSupported)
+@@ -1210,7 +1230,13 @@ OpenSSH_Public.prototype = BaseKey;
+     if (type === undefined || type.indexOf(baseType) !== 0)
+       return new Error('Malformed OpenSSH public key');
+ 
+-    return parseDER(data, baseType, comment, fullType);
++    return parseDER(
++      data,
++      baseType,
++      comment,
++      fullType,
++      isOpenSSHCertType(fullType) ? data : undefined
++    );
+   };
+ }
+ 
+@@ -1309,7 +1335,7 @@ RFC4716_Public.prototype = BaseKey;
+ }
+ 
+ 
+-function parseDER(data, baseType, comment, fullType) {
++function parseDER(data, baseType, comment, fullType, originalPubSSH) {
+   if (!isSupportedKeyType(baseType))
+     return new Error(`Unsupported OpenSSH public key type: ${baseType}`);
+ 
+@@ -1317,6 +1343,10 @@ function parseDER(data, baseType, comment, fullType) {
+   let oid;
+   let pubPEM = null;
+   let pubSSH = null;
++  const isCertificate = isOpenSSHCertType(fullType);
++
++  if (isCertificate && !skipFields(data, 1))
++    return new Error('Malformed OpenSSH public key');
+ 
+   switch (baseType) {
+     case 'ssh-rsa': {
+@@ -1387,7 +1417,13 @@ function parseDER(data, baseType, comment, fullType) {
+       return new Error(`Unsupported OpenSSH public key type: ${baseType}`);
+   }
+ 
+-  return new OpenSSH_Public(fullType, comment, pubPEM, pubSSH, algo);
++  return new OpenSSH_Public(
++    fullType,
++    comment,
++    pubPEM,
++    isCertificate ? Buffer.from(originalPubSSH || data) : pubSSH,
++    algo
++  );
+ }
+ 
+ function isSupportedKeyType(type) {
+@@ -1460,7 +1496,13 @@ function parseKey(data, passphrase) {
+     if (type !== undefined) {
+       data = binaryKeyParser.readRaw();
+       if (data !== undefined) {
+-        ret = parseDER(data, type, '', type);
++        ret = parseDER(
++          data,
++          getOpenSSHCertBaseType(type),
++          '',
++          type,
++          isOpenSSHCertType(type) ? origBuffer : undefined
++        );
+         // Ignore potentially useless errors in case the data was not actually
+         // in the binary format
+         if (ret instanceof Error)


### PR DESCRIPTION
## What changed

- Patch `ssh2` so OpenSSH certificate identities returned by `ssh-agent` are parsed from both text and binary agent blobs without dropping the original certificate blob.
- Preserve the full certificate blob in agent signing requests so the server receives the certificate identity, not a plain public key fragment.
- Pass RSA SHA2 signing flags for RSA certificate identities.
- Add regression tests covering the reported ECDSA certificate shape and RSA certificate signing flags.

## Root cause

`ssh2` parsed certificate identities from `ssh-agent` as certificate types, but binary certificate blobs from the agent were rejected, and text certificate identities lost the original certificate blob when `getPublicSSH()` was called. Netcatty then had no usable agent certificate identity to send to the SSH server.

Fixes #1888

## Validation

- `node --test electron/bridges/ssh2CertificateAgentPatch.test.cjs electron/bridges/sshCompatEntrypoints.test.cjs electron/bridges/sshAlgorithms.test.cjs`
- `npm run lint`
- `npm test`
- `npm run build`
- Clean temp `patch-package --error-on-fail` applies `patches/ssh2+1.17.0.patch` to `ssh2@1.17.0`
