### PR TITLE
[codex] Update Nix release metadata for v1.1.56

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.55";
+  version = "1.1.56";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-90ii0mMasW3yeMGy54OzRewEayUftktEBg6FPSjDtcE=";
+      hash = "sha256-MRgvd9kKeKXIp0GRAGtBpOxHYInZtHwbHaZKA9yexbY=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-HJ/BtJs7AVLSktTvcsN0DgKyBDVIJ/0K6a0go/IUdRc=";
+      hash = "sha256-0RFcN4LtsceI3ukD9OFwaEuwyTbSTYqr5oUss6ax6VA=";
     };
   };
 }


### PR DESCRIPTION
## Summary

- Update `nix/release.nix` to Netcatty 1.1.56.
- Refresh the Linux AppImage hashes from the published v1.1.56 release assets.

## Validation

- Regenerated the file with `.github/scripts/update-nix-release.js` using the v1.1.56 release AppImages.
- Ran `git diff --check`.