### PR TITLE
[codex] Fix vault host drag reset

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -7,6 +7,7 @@ import {
   getVaultDropIntent,
   getVaultDropPosition,
   hasVaultDragType,
+  handleVaultRootDrop,
   markVaultDropIndicator,
   useVaultGridLayoutAnimation,
 } from "./vaultReorderDrag";
@@ -163,12 +164,14 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                           );
                         }}
                         onDrop={(e) => {
-                          e.preventDefault();
-                          setDragOverDropTarget(null);
-                          const groupPath = e.dataTransfer.getData("group-path");
-                          const hostId = e.dataTransfer.getData("host-id");
-                          if (groupPath) moveGroup(groupPath, null);
-                          if (hostId) moveHostToGroup(hostId, null);
+                          handleVaultRootDrop({
+                            dataTransfer: e.dataTransfer,
+                            preventDefault: () => e.preventDefault(),
+                            setDragOverDropTarget,
+                            moveGroup,
+                            moveHostToGroup,
+                            resetHostDragState,
+                          });
                         }}
                       >
                         {t("vault.hosts.allHosts")}

--- a/components/vault/vaultReorderDrag.test.ts
+++ b/components/vault/vaultReorderDrag.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getVaultDropIntent,
   getVaultDropPosition,
+  handleVaultRootDrop,
 } from "./vaultReorderDrag.ts";
 
 const makeElement = (rect: Partial<DOMRect>): HTMLElement => ({
@@ -39,4 +40,55 @@ test("vault drop intent uses edges for sorting and middle for nesting", () => {
   assert.equal(getVaultDropIntent(element, 150, 45, false), "before");
   assert.equal(getVaultDropIntent(element, 150, 95, false), "after");
   assert.equal(getVaultDropIntent(element, 150, 70, false), "inside");
+});
+
+test("root host drop resets host drag state after moving the host to all hosts", () => {
+  const calls: string[] = [];
+
+  handleVaultRootDrop({
+    dataTransfer: {
+      getData: (type: string) => (type === "host-id" ? "host-1" : ""),
+    },
+    preventDefault: () => calls.push("preventDefault"),
+    setDragOverDropTarget: (target) => calls.push(`drop:${String(target)}`),
+    moveGroup: (groupPath, targetPath) => {
+      calls.push(`group:${groupPath}:${String(targetPath)}`);
+    },
+    moveHostToGroup: (hostId, targetPath) => {
+      calls.push(`host:${hostId}:${String(targetPath)}`);
+    },
+    resetHostDragState: () => calls.push("resetHostDragState"),
+  });
+
+  assert.deepEqual(calls, [
+    "preventDefault",
+    "drop:null",
+    "host:host-1:null",
+    "resetHostDragState",
+  ]);
+});
+
+test("root group drop moves the group to all hosts without resetting host drag state", () => {
+  const calls: string[] = [];
+
+  handleVaultRootDrop({
+    dataTransfer: {
+      getData: (type: string) => (type === "group-path" ? "team/prod" : ""),
+    },
+    preventDefault: () => calls.push("preventDefault"),
+    setDragOverDropTarget: (target) => calls.push(`drop:${String(target)}`),
+    moveGroup: (groupPath, targetPath) => {
+      calls.push(`group:${groupPath}:${String(targetPath)}`);
+    },
+    moveHostToGroup: (hostId, targetPath) => {
+      calls.push(`host:${hostId}:${String(targetPath)}`);
+    },
+    resetHostDragState: () => calls.push("resetHostDragState"),
+  });
+
+  assert.deepEqual(calls, [
+    "preventDefault",
+    "drop:null",
+    "group:team/prod:null",
+  ]);
 });

--- a/components/vault/vaultReorderDrag.ts
+++ b/components/vault/vaultReorderDrag.ts
@@ -41,6 +41,32 @@ export const getVaultDropIntent = (
 export const hasVaultDragType = (dataTransfer: DataTransfer, type: string) =>
   Array.from(dataTransfer.types).includes(type);
 
+export const handleVaultRootDrop = ({
+  dataTransfer,
+  preventDefault,
+  setDragOverDropTarget,
+  moveGroup,
+  moveHostToGroup,
+  resetHostDragState,
+}: {
+  dataTransfer: Pick<DataTransfer, "getData">;
+  preventDefault: () => void;
+  setDragOverDropTarget: (target: null) => void;
+  moveGroup: (groupPath: string, targetParentPath: string | null) => void;
+  moveHostToGroup: (hostId: string, targetPath: string | null) => void;
+  resetHostDragState: () => void;
+}) => {
+  preventDefault();
+  setDragOverDropTarget(null);
+  const groupPath = dataTransfer.getData("group-path");
+  const hostId = dataTransfer.getData("host-id");
+  if (groupPath) moveGroup(groupPath, null);
+  if (hostId) {
+    moveHostToGroup(hostId, null);
+    resetHostDragState();
+  }
+};
+
 let activeVaultDropIndicator: HTMLElement | null = null;
 
 export const clearVaultDropIndicator = () => {


### PR DESCRIPTION
## Summary
- Fixes the All Hosts drop path so a dragged host clears its drag state after being moved to the root.
- Adds regression coverage for host drops to All Hosts and preserves group drops to All Hosts.

Fixes #1913

## Verification
- node --test --import tsx components/vault/vaultReorderDrag.test.ts
- node --test --import tsx components/VaultHostListSection.test.ts components/vault/vaultReorderDrag.test.ts
- npm run lint
- npm test
- npm run build

## Review
- review-until-clean completed with two independent final reviewers returning CLEAN.