### PR TITLE
[codex] Add double-click copy for session tabs

### DIFF
--- a/components/TopTabs.test.ts
+++ b/components/TopTabs.test.ts
@@ -32,12 +32,15 @@ const {
 } = await import("../application/state/terminalDragData.ts");
 const {
   activateLogViewTab,
+  createSessionTopTabDoubleClickHandler,
   formatSessionTopTabLabel,
   formatSessionTopTabTooltip,
+  stopCloseButtonDoubleClickPropagation,
 } = await import("./top-tabs/TopTabItems.tsx");
 const { activeTabStore } = await import("../application/state/activeTabStore.ts");
 const indexCss = readFileSync(new URL("../index.css", import.meta.url), "utf8");
 const topTabsSource = readFileSync(new URL("./TopTabs.tsx", import.meta.url), "utf8");
+const topTabItemsSource = readFileSync(new URL("./top-tabs/TopTabItems.tsx", import.meta.url), "utf8");
 const terminalViewSource = readFileSync(new URL("./terminal/TerminalView.tsx", import.meta.url), "utf8");
 
 test("host tree tab gutter fills the remaining sidebar width", () => {
@@ -108,12 +111,37 @@ test("quick switcher plus button exposes a custom CSS hook", () => {
 });
 
 test("SessionTabIcon checks custom host icon appearance before distro logos", () => {
-  const source = readFileSync(new URL("./top-tabs/TopTabItems.tsx", import.meta.url), "utf8");
-  assert.match(source, /resolveHostIconAppearance\(host\)/);
+  assert.match(topTabItemsSource, /resolveHostIconAppearance\(host\)/);
   assert.ok(
-    source.indexOf("resolveHostIconAppearance(host)") < source.indexOf("getEffectiveHostDistro(host)"),
+    topTabItemsSource.indexOf("resolveHostIconAppearance(host)") < topTabItemsSource.indexOf("getEffectiveHostDistro(host)"),
     "custom host icon should be checked before distro fallback",
   );
+});
+
+test("session top tabs copy the session on double click through the existing copy handler", () => {
+  const copiedSessionIds: string[] = [];
+  const handleDoubleClick = createSessionTopTabDoubleClickHandler(
+    (sessionId) => copiedSessionIds.push(sessionId),
+    "session-1",
+  );
+
+  handleDoubleClick({} as Parameters<typeof handleDoubleClick>[0]);
+
+  assert.deepEqual(copiedSessionIds, ["session-1"]);
+  assert.match(topTabItemsSource, /onDoubleClick=\{handleDoubleClick\}/);
+});
+
+test("session close button double click stays on the close button", () => {
+  let stopPropagationCount = 0;
+
+  stopCloseButtonDoubleClickPropagation({
+    stopPropagation: () => {
+      stopPropagationCount += 1;
+    },
+  });
+
+  assert.equal(stopPropagationCount, 1);
+  assert.match(topTabItemsSource, /onDoubleClick=\{stopCloseButtonDoubleClickPropagation\}/);
 });
 
 test("session top tab label only shows the host label for ssh sessions", () => {

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -1,5 +1,5 @@
 import { Copy, FileCode, FileText, LayoutGrid, Minus, Server, Square, TerminalSquare, Usb, X } from 'lucide-react';
-import React, { memo, useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { activeTabStore, useActiveTabId, useIsTabActive } from '../../application/state/activeTabStore';
 import type { EditorTab } from '../../application/state/editorTabStore';
 import type { LogView } from '../../application/state/logViewState';
@@ -196,6 +196,17 @@ export const formatSessionTopTabLabel = (
   dynamicTabTitleMode?: DynamicTabTitleMode,
 ): string => {
   return resolveSessionTabTitle(session, dynamicTabTitleMode);
+};
+
+export const createSessionTopTabDoubleClickHandler = (
+  onCopySession: (sessionId: string) => void,
+  sessionId: string,
+): React.MouseEventHandler<HTMLDivElement> => () => onCopySession(sessionId);
+
+export const stopCloseButtonDoubleClickPropagation = (
+  event: Pick<React.MouseEvent, 'stopPropagation'>,
+): void => {
+  event.stopPropagation();
 };
 
 // Custom window controls for Windows/Linux (frameless window)
@@ -569,6 +580,10 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
   const handleClick = useCallback(() => {
     activeTabStore.setActiveTabId(session.id);
   }, [session.id]);
+  const handleDoubleClick = useMemo(
+    () => createSessionTopTabDoubleClickHandler(onCopySession, session.id),
+    [onCopySession, session.id],
+  );
   const addressTooltip = formatSessionTopTabTooltip(session);
   const tabTitle = formatSessionTopTabLabel(session, dynamicTabTitleMode);
 
@@ -578,6 +593,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
       data-tab-type="session"
       data-state={isActive ? 'active' : 'inactive'}
       onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onMouseDown={handleTabMiddleMouseDown}
       onAuxClick={(e) => handleTabMiddleClickClose(e, () => onCloseSession(session.id))}
       draggable
@@ -633,6 +649,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
       </div>
       <button
         onClick={(e) => onCloseSession(session.id, e)}
+        onDoubleClick={stopCloseButtonDoubleClickPropagation}
         className="p-1 rounded-full hover:bg-destructive/10 hover:text-destructive transition-colors"
         aria-label={t('tabs.closeSessionAria')}
       >


### PR DESCRIPTION
## Summary
- add double-click copy behavior to normal session top tabs by reusing the existing copy-tab handler
- keep close-button double-clicks from bubbling into tab copy
- add regression coverage for the double-click copy path and close-button propagation guard

Fixes #1908

## Verification
- `node --test --import tsx components/TopTabs.test.ts`
- `./node_modules/.bin/eslint components/top-tabs/TopTabItems.tsx components/TopTabs.test.ts`
- `git diff --check`
- `node --test electron/bridges/ssh2CertificateAgentPatch.test.cjs`
- `npm test`
- `npm run build`

## Review Until Clean
- Ran one final review round with two independent reviewers on the #1908 branch diff.
- Final result: CLEAN / CLEAN.
