### PR TITLE
Fix RPM build-id file conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,8 +411,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Install pacman packaging dependencies
-        run: sudo apt-get update && sudo apt-get install -y libarchive-tools
+      - name: Install Linux packaging dependencies
+        run: sudo apt-get update && sudo apt-get install -y libarchive-tools rpm
 
       - name: Set version
         shell: bash
@@ -452,6 +452,9 @@ jobs:
 
       - name: Verify packaged deb artifact
         run: bash scripts/verify-linux-deb-artifact.sh amd64
+
+      - name: Verify packaged rpm artifact
+        run: bash scripts/verify-linux-rpm-artifact.sh x86_64
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -565,6 +568,9 @@ jobs:
 
       - name: Verify packaged deb artifact
         run: bash scripts/verify-linux-deb-artifact.sh arm64
+
+      - name: Verify packaged rpm artifact
+        run: bash scripts/verify-linux-rpm-artifact.sh aarch64
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -234,6 +234,11 @@ module.exports = {
         // Deepin OS and other distros that have issues with lzma decompression
         compression: 'gz'
     },
+    rpm: {
+        // Avoid rpm's generated /usr/lib/.build-id symlinks. Those hashes are
+        // global on the host, so owning them can conflict with other RPMs.
+        fpm: ['--rpm-rpmbuild-define', '_build_id_links none']
+    },
     pacman: {
         // FPM-generated .pacman packages bypass Arch's alpm hooks that
         // normally refresh the hicolor icon cache. Without this, KDE cannot

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -162,6 +162,14 @@ test("linux packaging includes an Arch Linux pacman package target", () => {
   );
 });
 
+test("rpm packaging disables generated build-id symlinks", () => {
+  assert.deepEqual(
+    config.rpm?.fpm,
+    ["--rpm-rpmbuild-define", "_build_id_links none"],
+    "RPM packages must not own /usr/lib/.build-id links that can conflict with other RPMs",
+  );
+});
+
 test("windows packaging includes a zip archive target", () => {
   const winTargets = config.win.target.map((entry) => entry.target);
   assert.ok(

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -44,3 +44,14 @@ test("build workflow installs bsdtar for Arch pacman packaging", () => {
     "both Linux package jobs must install libarchive-tools for pacman metadata generation",
   );
 });
+
+test("build workflow verifies RPM artifacts for both Linux architectures", () => {
+  assert.ok(
+    buildWorkflow.includes("bash scripts/verify-linux-rpm-artifact.sh x86_64"),
+    "Linux x64 package job must verify the RPM artifact",
+  );
+  assert.ok(
+    buildWorkflow.includes("bash scripts/verify-linux-rpm-artifact.sh aarch64"),
+    "Linux arm64 package job must verify the RPM artifact",
+  );
+});

--- a/scripts/verify-linux-rpm-artifact.sh
+++ b/scripts/verify-linux-rpm-artifact.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <x86_64|aarch64> [rpm-file]" >&2
+  exit 1
+}
+
+checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$@"
+  else
+    shasum -a 256 "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "${cmd}" >/dev/null 2>&1 || {
+    echo "[rpm-verify] missing required command: ${cmd}" >&2
+    exit 1
+  }
+}
+
+assert_exists() {
+  local file="$1"
+  if [[ ! -e "${file}" ]]; then
+    echo "[rpm-verify] expected file does not exist: ${file}" >&2
+    exit 1
+  fi
+}
+
+log_file_info() {
+  local file="$1"
+  echo "[rpm-verify] file: ${file}"
+  ls -lh "${file}"
+  file "${file}"
+  checksum "${file}"
+}
+
+resolve_file_from_glob() {
+  local search_dir="$1"
+  local pattern="$2"
+  find "${search_dir}" -maxdepth 1 -type f -name "${pattern}" -print | sort | head -n 1
+}
+
+resolve_single_file() {
+  local search_dir="$1"
+  local pattern="$2"
+  local file
+
+  file="$(resolve_file_from_glob "${search_dir}" "${pattern}")"
+  if [[ -z "${file}" ]]; then
+    echo "[rpm-verify] no file matched ${pattern} under ${search_dir}" >&2
+    exit 1
+  fi
+
+  echo "${file}"
+}
+
+assert_file_arch() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(rpm -qp --qf '%{ARCH}' "${file}")"
+  echo "[rpm-verify] rpm metadata architecture: ${actual}"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "[rpm-verify] RPM metadata architecture mismatch for ${file}" >&2
+    echo "[rpm-verify] expected: ${expected}" >&2
+    echo "[rpm-verify] actual: ${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_manifest_has_no_matches() {
+  local manifest="$1"
+  local pattern="$2"
+  local description="$3"
+  local matches
+
+  matches="$(printf "%s\n" "${manifest}" | grep -E "${pattern}" || true)"
+  if [[ -n "${matches}" ]]; then
+    echo "[rpm-verify] unexpected ${description} in RPM file list:" >&2
+    printf "%s\n" "${matches}" | head -n 20 >&2
+    exit 1
+  fi
+}
+
+main() {
+  if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+  fi
+
+  local rpm_arch="$1"
+  local rpm_file
+  local rpm_pattern
+  local manifest
+
+  require_cmd bsdtar
+  require_cmd file
+  require_cmd rpm
+
+  case "${rpm_arch}" in
+    x86_64|aarch64)
+      rpm_pattern="*-linux-${rpm_arch}.rpm"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+
+  if [[ $# -eq 2 ]]; then
+    rpm_file="$2"
+    assert_exists "${rpm_file}"
+  else
+    rpm_file="$(resolve_single_file "release" "${rpm_pattern}")"
+  fi
+
+  echo "[rpm-verify] verifying rpm artifact: ${rpm_file}"
+  log_file_info "${rpm_file}"
+  assert_file_arch "${rpm_file}" "${rpm_arch}"
+
+  manifest="$(bsdtar -tf "${rpm_file}")"
+  if [[ -z "${manifest}" ]]; then
+    echo "[rpm-verify] RPM file list is empty or unreadable: ${rpm_file}" >&2
+    exit 1
+  fi
+
+  assert_manifest_has_no_matches \
+    "${manifest}" \
+    '^(\./)?usr/lib/\.build-id(/|$)' \
+    "/usr/lib/.build-id entries"
+
+  assert_manifest_has_no_matches \
+    "${manifest}" \
+    '(^|/)lib(ggml|ggml-base|transcribe)\.so([./0-9A-Za-z_-]*|$)' \
+    "libggml/libtranscribe entries"
+
+  echo "[rpm-verify] rpm artifact verification passed for ${rpm_file}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Disable RPM build-id symlink generation so Netcatty RPMs do not own `/usr/lib/.build-id` entries that can conflict with other RPM packages.
- Add an RPM artifact verifier that checks the package is readable, has the expected architecture, and does not include `/usr/lib/.build-id`, `libggml`, or `libtranscribe` entries.
- Run the RPM verifier in both Linux package CI jobs.

## Validation
- `npm ci`
- `node --test scripts/electron-builder-config.test.cjs scripts/github-workflow-build.test.cjs`
- `npm run build`
- Verified the new RPM script fails against the released `Netcatty-1.1.53-linux-x86_64.rpm` because it contains `/usr/lib/.build-id` entries.
- Built an ARM64 RPM in a Linux Docker container and verified it passes `scripts/verify-linux-rpm-artifact.sh aarch64`.

## Notes
Refs #1914. This fixes the confirmed `.build-id` ownership conflict. I did not change anything for the `libggml` / `libtranscribe` ldconfig messages because those files were not present in the checked Netcatty RPM file list; the new verifier also guards against accidentally shipping them.