### PR TITLE
[codex] Fix OpenCode Windows permission allowlist

### DIFF
--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
@@ -3,32 +3,68 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-function normalizeOpenCodePath(targetPath) {
-  return process.platform === "win32"
+function normalizeOpenCodePath(targetPath, platform = process.platform) {
+  return platform === "win32"
     ? targetPath.replace(/\\/g, "/")
     : targetPath;
 }
 
-function toOpenCodeDirectoryGlob(dirPath) {
+function appendOpenCodePathPattern(baseDir, suffix) {
+  const trimmedSuffix = suffix.replace(/^\//, "");
+  return baseDir.endsWith("/")
+    ? `${baseDir}${trimmedSuffix}`
+    : `${baseDir}/${trimmedSuffix}`;
+}
+
+function toOpenCodeDirectoryBase(dirPath, options = {}) {
   if (!dirPath || typeof dirPath !== "string") return null;
+  const pathModule = options.pathModule || path;
+  const platform = options.platform || process.platform;
   try {
-    const resolved = path.resolve(dirPath);
+    const resolved = pathModule.resolve(dirPath);
     let baseDir = resolved;
     if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
-      baseDir = path.dirname(resolved);
+      baseDir = pathModule.dirname(resolved);
     }
-    return `${normalizeOpenCodePath(baseDir)}/**`;
+    return normalizeOpenCodePath(baseDir, platform);
   } catch {
     return null;
   }
 }
 
-function toOpenCodeFileParentGlob(filePath) {
+function toOpenCodeDirectoryGlob(dirPath, options = {}) {
+  const baseDir = toOpenCodeDirectoryBase(dirPath, options);
+  return baseDir ? appendOpenCodePathPattern(baseDir, "**") : null;
+}
+
+function toOpenCodeDirectoryPermissionPatterns(dirPath, options = {}) {
+  const baseDir = toOpenCodeDirectoryBase(dirPath, options);
+  return baseDir
+    ? [
+        baseDir,
+        appendOpenCodePathPattern(baseDir, "*"),
+        appendOpenCodePathPattern(baseDir, "**"),
+      ]
+    : [];
+}
+
+function toOpenCodeFileParentGlob(filePath, options = {}) {
   if (!filePath || typeof filePath !== "string") return null;
+  const pathModule = options.pathModule || path;
   try {
-    return toOpenCodeDirectoryGlob(path.dirname(path.resolve(filePath)));
+    return toOpenCodeDirectoryGlob(pathModule.dirname(pathModule.resolve(filePath)), options);
   } catch {
     return null;
+  }
+}
+
+function toOpenCodeFileParentPermissionPatterns(filePath, options = {}) {
+  if (!filePath || typeof filePath !== "string") return [];
+  const pathModule = options.pathModule || path;
+  try {
+    return toOpenCodeDirectoryPermissionPatterns(pathModule.dirname(pathModule.resolve(filePath)), options);
+  } catch {
+    return [];
   }
 }
 
@@ -45,7 +81,7 @@ function buildNetcattySkillsOpenCodePathAllowlist({
   runtimeBinaryPath,
   tempDir,
   extraFilePaths,
-} = {}) {
+} = {}, options = {}) {
   const filePaths = [
     launcherPath,
     cliScriptPath,
@@ -55,9 +91,9 @@ function buildNetcattySkillsOpenCodePathAllowlist({
     ...(Array.isArray(extraFilePaths) ? extraFilePaths : []),
   ];
   return dedupePatterns([
-    ...filePaths.map((filePath) => filePath && toOpenCodeFileParentGlob(filePath)),
-    cliStateDir && toOpenCodeDirectoryGlob(cliStateDir),
-    tempDir && toOpenCodeDirectoryGlob(tempDir),
+    ...filePaths.flatMap((filePath) => toOpenCodeFileParentPermissionPatterns(filePath, options)),
+    ...(cliStateDir ? toOpenCodeDirectoryPermissionPatterns(cliStateDir, options) : []),
+    ...(tempDir ? toOpenCodeDirectoryPermissionPatterns(tempDir, options) : []),
   ]);
 }
 
@@ -83,6 +119,8 @@ function buildOpenCodeSkillsPermissionRules(pathAllowlist = []) {
 module.exports = {
   buildNetcattySkillsOpenCodePathAllowlist,
   buildOpenCodeSkillsPermissionRules,
+  toOpenCodeDirectoryPermissionPatterns,
   toOpenCodeDirectoryGlob,
+  toOpenCodeFileParentPermissionPatterns,
   toOpenCodeFileParentGlob,
 };

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
@@ -1,10 +1,13 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const path = require("node:path");
 
 const {
   buildNetcattySkillsOpenCodePathAllowlist,
   buildOpenCodeSkillsPermissionRules,
+  toOpenCodeDirectoryPermissionPatterns,
   toOpenCodeDirectoryGlob,
+  toOpenCodeFileParentPermissionPatterns,
   toOpenCodeFileParentGlob,
 } = require("./netcattySkillsOpenCodePermissions.cjs");
 
@@ -26,6 +29,31 @@ test("toOpenCodeDirectoryGlob keeps directory roots stable when missing on disk"
   );
 });
 
+test("toOpenCodeDirectoryPermissionPatterns includes exact and wildcard forms", () => {
+  assert.deepEqual(
+    toOpenCodeDirectoryPermissionPatterns("/Users/me/Library/Application Support/netcatty/netcatty-tool-cli"),
+    [
+      "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli",
+      "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/*",
+      "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+    ],
+  );
+});
+
+test("toOpenCodeFileParentPermissionPatterns normalizes Windows paths", () => {
+  assert.deepEqual(
+    toOpenCodeFileParentPermissionPatterns(
+      "C:\\Users\\me\\AppData\\Local\\Programs\\Netcatty\\resources\\app.asar.unpacked\\electron\\cli\\netcatty-tool-cli.cmd",
+      { platform: "win32", pathModule: path.win32 },
+    ),
+    [
+      "C:/Users/me/AppData/Local/Programs/Netcatty/resources/app.asar.unpacked/electron/cli",
+      "C:/Users/me/AppData/Local/Programs/Netcatty/resources/app.asar.unpacked/electron/cli/*",
+      "C:/Users/me/AppData/Local/Programs/Netcatty/resources/app.asar.unpacked/electron/cli/**",
+    ],
+  );
+});
+
 test("buildNetcattySkillsOpenCodePathAllowlist dedupes launcher and script roots", () => {
   const launcher = "/Applications/Netcatty.app/Contents/MacOS/netcatty-tool-cli";
   const script = "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli/netcatty-tool-cli.cjs";
@@ -39,9 +67,17 @@ test("buildNetcattySkillsOpenCodePathAllowlist dedupes launcher and script roots
   });
 
   assert.deepEqual(patterns, [
+    "/Applications/Netcatty.app/Contents/MacOS",
+    "/Applications/Netcatty.app/Contents/MacOS/*",
     "/Applications/Netcatty.app/Contents/MacOS/**",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli/*",
     "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/electron/cli/**",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/skills/netcatty-tool-cli",
+    "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/skills/netcatty-tool-cli/*",
     "/Applications/Netcatty.app/Contents/Resources/app.asar.unpacked/skills/netcatty-tool-cli/**",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/*",
     "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
   ]);
 });
@@ -54,9 +90,30 @@ test("buildNetcattySkillsOpenCodePathAllowlist includes temp dir and extra attac
   });
 
   assert.deepEqual(patterns, [
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli",
+    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/*",
     "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**",
+    "/var/folders/tmp/Netcatty",
+    "/var/folders/tmp/Netcatty/*",
     "/var/folders/tmp/Netcatty/**",
   ]);
+});
+
+test("buildNetcattySkillsOpenCodePathAllowlist includes OpenCode-compatible Windows directory resources", () => {
+  const patterns = buildNetcattySkillsOpenCodePathAllowlist({
+    launcherPath: "C:\\Users\\me\\AppData\\Local\\Programs\\Netcatty\\resources\\app.asar.unpacked\\electron\\cli\\netcatty-tool-cli.cmd",
+    cliScriptPath: "C:\\Users\\me\\AppData\\Local\\Programs\\Netcatty\\resources\\app.asar.unpacked\\electron\\cli\\netcatty-tool-cli.cjs",
+    skillPath: "C:\\Users\\me\\AppData\\Local\\Programs\\Netcatty\\resources\\app.asar.unpacked\\skills\\netcatty-tool-cli\\SKILL.md",
+    discoveryFilePath: "C:\\Users\\me\\AppData\\Roaming\\netcatty\\netcatty-tool-cli\\discovery.json",
+    runtimeBinaryPath: "C:\\Users\\me\\AppData\\Local\\Programs\\Netcatty\\Netcatty.exe",
+    tempDir: "C:\\Users\\me\\AppData\\Local\\Temp\\Netcatty",
+    extraFilePaths: ["C:\\Users\\me\\AppData\\Local\\Temp\\Netcatty\\attachment.png"],
+  }, { platform: "win32", pathModule: path.win32 });
+
+  assert.equal(patterns.includes("C:/Users/me/AppData/Local/Programs/Netcatty/resources/app.asar.unpacked/electron/cli/*"), true);
+  assert.equal(patterns.includes("C:/Users/me/AppData/Roaming/netcatty/netcatty-tool-cli/*"), true);
+  assert.equal(patterns.includes("C:/Users/me/AppData/Local/Temp/Netcatty/*"), true);
+  assert.equal(patterns.includes("C:/Users/me/AppData/Local/Programs/Netcatty/*"), true);
 });
 
 test("buildOpenCodeSkillsPermissionRules allowlists Netcatty CLI paths and denies other external access", () => {


### PR DESCRIPTION
## Summary
- Expand OpenCode skills-mode path allowlists to include exact directory, one-level wildcard, and recursive wildcard forms.
- Add a Windows path regression test for Netcatty's OpenCode permission allowlist.

## Root cause
OpenCode checks some `external_directory` resources as directory-style paths such as `.../*`, while Netcatty only emitted recursive `.../**` entries. On Windows this could leave the Netcatty launcher, discovery state, temp, or runtime directories unmatched and cause OpenCode to reject the tool call before the Netcatty CLI could run.

Fixes #1904.

## Validation
- `node --test electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs`
- `node --test electron/bridges/aiBridge/sdk/*.test.cjs`
- `git diff --check`