### PR TITLE
[codex] Fix SFTP follow cwd manual navigation

### DIFF
--- a/application/state/sftp/useSftpPaneActions.ts
+++ b/application/state/sftp/useSftpPaneActions.ts
@@ -43,10 +43,15 @@ interface UseSftpPaneActionsParams {
   dirCacheTtlMs: number;
 }
 
-export type SftpNavigateResult = "reached" | "failed" | "aborted";
+export type SftpNavigateResult = "reached" | "failed" | "aborted" | "superseded";
+export type SftpNavigateOptions = {
+  force?: boolean;
+  tabId?: string;
+  shouldApply?: () => boolean;
+};
 
 interface UseSftpPaneActionsResult {
-  navigateTo: (side: "left" | "right", path: string, options?: { force?: boolean; tabId?: string }) => Promise<SftpNavigateResult>;
+  navigateTo: (side: "left" | "right", path: string, options?: SftpNavigateOptions) => Promise<SftpNavigateResult>;
   refresh: (side: "left" | "right", options?: { tabId?: string }) => Promise<void>;
   navigateUp: (side: "left" | "right") => Promise<void>;
   openEntry: (side: "left" | "right", entry: SftpFileEntry) => Promise<void>;
@@ -161,7 +166,7 @@ export const useSftpPaneActions = ({
     async (
       side: "left" | "right",
       path: string,
-      options?: { force?: boolean; tabId?: string },
+      options?: SftpNavigateOptions,
     ): Promise<SftpNavigateResult> => {
       const sideTabs = side === "left" ? leftTabsRef.current : rightTabsRef.current;
       // When tabId is specified, target that specific tab instead of the active one.
@@ -173,6 +178,10 @@ export const useSftpPaneActions = ({
         : getActivePane(side);
 
       if (!pane?.connection || !targetTabId) {
+        return "aborted";
+      }
+
+      if (options?.shouldApply?.() === false) {
         return "aborted";
       }
 
@@ -244,6 +253,31 @@ export const useSftpPaneActions = ({
       const previousFiles = confirmed.files;
       const previousSelection = confirmed.selectedFiles;
       const previousFilter = confirmed.filter;
+      const previousError = pane.error;
+      const isTargetRequestCurrent = () => tabNavSeqRef.current.get(targetTabId) === requestId;
+      const getTargetPane = () => {
+        const currentSideTabs = side === "left" ? leftTabsRef.current : rightTabsRef.current;
+        return currentSideTabs.tabs.find((t) => t.id === targetTabId) ?? null;
+      };
+      const shouldApplyNavigationState = () => (
+        getTargetPane()?.connection?.id === connectionId
+        && (options?.shouldApply?.() ?? true)
+      );
+      const restoreConfirmedStateIfCurrent = () => {
+        if (!isTargetRequestCurrent()) return;
+        updateTab(side, targetTabId, (prev) => {
+          if (prev.connection?.id !== connectionId || !isTargetRequestCurrent()) return prev;
+          return {
+            ...prev,
+            connection: { ...prev.connection, currentPath: previousPath },
+            files: previousFiles,
+            selectedFiles: previousSelection,
+            filter: previousFilter,
+            error: previousError,
+            loading: false,
+          };
+        });
+      };
       tabNavSeqRef.current.set(targetTabId, requestId);
       // Keep existing files visible during loading — the loading overlay
       // (pointer-events-none) prevents interaction. This avoids blanking a tab
@@ -267,6 +301,13 @@ export const useSftpPaneActions = ({
         } else {
           const sftpId = sftpSessionsRef.current.get(pane.connection.id);
           if (!sftpId) {
+            if (!isTargetRequestCurrent()) {
+              return "superseded";
+            }
+            if (!shouldApplyNavigationState()) {
+              restoreConfirmedStateIfCurrent();
+              return "aborted";
+            }
             clearCacheForConnection(pane.connection.id);
             // For background tabs (explicit tabId), update that tab directly
             // instead of handleSessionError which targets the active tab.
@@ -286,6 +327,13 @@ export const useSftpPaneActions = ({
             files = await listRemoteFiles(sftpId, path, pane.filenameEncoding);
           } catch (err) {
             if (isSessionError(err)) {
+              if (!isTargetRequestCurrent()) {
+                return "superseded";
+              }
+              if (!shouldApplyNavigationState()) {
+                restoreConfirmedStateIfCurrent();
+                return "aborted";
+              }
               sftpSessionsRef.current.delete(pane.connection.id);
               clearCacheForConnection(pane.connection.id);
               if (options?.tabId) {
@@ -306,13 +354,17 @@ export const useSftpPaneActions = ({
         if (navSeqRef.current[side] !== requestId) {
           // Side-level sequence was bumped by another tab's navigation or
           // a connect/disconnect. Check if THIS tab's request is still current.
-          if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
+          if (!isTargetRequestCurrent()) {
             // This tab also has a newer navigation — drop completely.
-            return "aborted";
+            return "superseded";
           }
           // Side was superseded by another tab, but this tab's request is
           // still current. The fetched files are valid — fall through to
           // apply them instead of restoring previousPath.
+        }
+        if (!shouldApplyNavigationState()) {
+          restoreConfirmedStateIfCurrent();
+          return "aborted";
         }
 
         dirCacheRef.current.set(cacheKey, {
@@ -349,11 +401,15 @@ export const useSftpPaneActions = ({
         return "reached";
       } catch (err) {
         if (navSeqRef.current[side] !== requestId) {
-          if (tabNavSeqRef.current.get(targetTabId) !== requestId) {
-            return "aborted";
+          if (!isTargetRequestCurrent()) {
+            return "superseded";
           }
           // Side superseded by another tab, but this tab's request is
           // current — fall through to show the error on this tab.
+        }
+        if (!shouldApplyNavigationState()) {
+          restoreConfirmedStateIfCurrent();
+          return "aborted";
         }
         let navigationFailed = false;
         updateTab(side, targetTabId, (prev) => {

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -43,6 +43,7 @@ import { KeyBinding, HotkeyScheme } from "../domain/models";
 import {
   mergeLatestFollowTerminalCwdHostSetting,
   resolveHostFollowTerminalCwd,
+  shouldApplyFollowTerminalCwdSyncResult,
   shouldClearBlockedFollowOnReach,
   shouldFollowTerminalCwdNavigate,
   type SftpFollowTerminalCwdBlock,
@@ -778,25 +779,32 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     || (sftp.activeFileWatchCountRef?.current ?? 0) > 0;
 
   const blockedFollowRef = useRef<SftpFollowTerminalCwdBlock | null>(null);
+  const handledFollowRef = useRef<SftpFollowTerminalCwdBlock | null>(null);
   const followSyncGenerationRef = useRef(0);
   const effectiveFollowTerminalCwdRef = useRef(effectiveFollowTerminalCwd);
   const canFollowTerminalCwdRef = useRef(canFollowTerminalCwd);
+  const activeTerminalCwdRef = useRef(activeTerminalCwd);
+  const connectionId = sftp.leftPane.connection?.id ?? null;
+  const connectionIdRef = useRef(connectionId);
+  const connectionPath = sftp.leftPane.connection?.currentPath ?? null;
   effectiveFollowTerminalCwdRef.current = effectiveFollowTerminalCwd;
   canFollowTerminalCwdRef.current = canFollowTerminalCwd;
-  const connectionId = sftp.leftPane.connection?.id ?? null;
-  const connectionPath = sftp.leftPane.connection?.currentPath ?? null;
+  activeTerminalCwdRef.current = activeTerminalCwd;
+  connectionIdRef.current = connectionId;
 
   const invalidateInFlightFollowSync = useCallback(() => {
     followSyncGenerationRef.current += 1;
     blockedFollowRef.current = null;
+    handledFollowRef.current = null;
   }, []);
 
   useEffect(() => {
-    blockedFollowRef.current = null;
+    invalidateInFlightFollowSync();
   }, [
     activeTerminalCwd,
     followTerminalCwdHost?.id,
     connectionId,
+    invalidateInFlightFollowSync,
   ]);
 
   useEffect(() => {
@@ -805,15 +813,17 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
   }, [effectiveFollowTerminalCwd, invalidateInFlightFollowSync]);
 
   useEffect(() => {
+    const blockedFollow = blockedFollowRef.current;
     if (
       shouldClearBlockedFollowOnReach(
-        blockedFollowRef.current,
+        blockedFollow,
         connectionId,
         connectionPath,
         sftp.leftPane.loading,
       )
     ) {
       blockedFollowRef.current = null;
+      handledFollowRef.current = blockedFollow;
     }
   }, [connectionId, connectionPath, sftp.leftPane.loading]);
 
@@ -824,6 +834,10 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     const navigateResult = await sftpRef.current.navigateTo("left", cwd);
     if (navigateResult === "reached") {
       blockedFollowRef.current = null;
+      const connection = sftpRef.current.leftPane.connection;
+      if (connection?.id) {
+        handledFollowRef.current = { connectionId: connection.id, terminalCwd: cwd };
+      }
     }
   }, [onGetTerminalCwd, sftpRef]);
 
@@ -834,16 +848,18 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
 
     const syncGeneration = followSyncGenerationRef.current;
 
+    const usesLiveTerminalCwd = Boolean(activeTerminalCwd);
     let terminalCwd = activeTerminalCwd;
     if (!terminalCwd) {
       terminalCwd = await onGetTerminalCwd({ preferFreshBackend: true });
     }
     if (!terminalCwd) return;
-    if (
-      syncGeneration !== followSyncGenerationRef.current
-      || !effectiveFollowTerminalCwdRef.current
-      || !canFollowTerminalCwdRef.current
-    ) {
+    if (!shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration,
+      currentGeneration: followSyncGenerationRef.current,
+      followEnabled: effectiveFollowTerminalCwdRef.current,
+      canFollow: canFollowTerminalCwdRef.current,
+    })) {
       return;
     }
 
@@ -857,16 +873,43 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
       hasActiveWork,
       isConnected: Boolean(connection && !connection.isLocal && connection.status === "connected"),
       blockedFollow: blockedFollowRef.current,
+      handledFollow: handledFollowRef.current,
     })) {
+      if (
+        connection?.id
+        && !connection.isLocal
+        && connection.status === "connected"
+        && connection.currentPath === terminalCwd
+      ) {
+        handledFollowRef.current = { connectionId: connection.id, terminalCwd };
+      }
       return;
     }
 
-    const navigateResult = await sftpRef.current.navigateTo("left", terminalCwd);
-    if (
-      syncGeneration !== followSyncGenerationRef.current
-      || !effectiveFollowTerminalCwdRef.current
-      || !canFollowTerminalCwdRef.current
-    ) {
+    const expectedConnectionId = connection?.id ?? null;
+    const shouldApplyCurrentFollowSync = () => (
+      shouldApplyFollowTerminalCwdSyncResult({
+        syncGeneration,
+        currentGeneration: followSyncGenerationRef.current,
+        followEnabled: effectiveFollowTerminalCwdRef.current,
+        canFollow: canFollowTerminalCwdRef.current,
+        expectedConnectionId,
+        liveConnectionId: connectionIdRef.current,
+        paneConnectionId: sftpRef.current.leftPane.connection?.id ?? null,
+        expectedTerminalCwd: terminalCwd,
+        liveTerminalCwd: activeTerminalCwdRef.current,
+        requireLiveTerminalCwd: usesLiveTerminalCwd,
+      })
+    );
+    const navigateResult = await sftpRef.current.navigateTo("left", terminalCwd, {
+      shouldApply: shouldApplyCurrentFollowSync,
+    });
+    if (!shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration,
+      currentGeneration: followSyncGenerationRef.current,
+      followEnabled: effectiveFollowTerminalCwdRef.current,
+      canFollow: canFollowTerminalCwdRef.current,
+    })) {
       return;
     }
 
@@ -877,8 +920,11 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
 
     if (navigateResult === "failed" && currentConnection.id) {
       blockedFollowRef.current = { connectionId: currentConnection.id, terminalCwd };
+    } else if (navigateResult === "superseded" && currentConnection.id) {
+      handledFollowRef.current = { connectionId: currentConnection.id, terminalCwd };
     } else if (navigateResult === "reached") {
       blockedFollowRef.current = null;
+      handledFollowRef.current = { connectionId: currentConnection.id, terminalCwd };
     }
   }, [
     activeTerminalCwd,
@@ -892,9 +938,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
 
   const handleToggleFollowTerminalCwd = useCallback(() => {
     const nextEnabled = !effectiveFollowTerminalCwd;
-    if (!nextEnabled) {
-      invalidateInFlightFollowSync();
-    }
+    invalidateInFlightFollowSync();
     if (followTerminalCwdHost?.id) {
       setPendingFollowOverride({ hostId: followTerminalCwdHost.id, value: nextEnabled });
     }
@@ -910,7 +954,7 @@ const SftpSidePanelInteractiveBody: React.FC<SftpSidePanelInteractiveBodyProps> 
     effectiveFollowTerminalCwd,
     hasActiveWork,
     isVisible,
-    sftp.leftPane.connection?.currentPath,
+    connectionId,
     sftp.leftPane.connection?.status,
     sftp.leftPane.connection?.isLocal,
     syncFollowToTerminalCwd,

--- a/components/sftp/sftpFollowTerminalCwd.test.ts
+++ b/components/sftp/sftpFollowTerminalCwd.test.ts
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   mergeLatestFollowTerminalCwdHostSetting,
   resolveHostFollowTerminalCwd,
   resolveSftpFollowTerminalCwdTargetHost,
+  shouldApplyFollowTerminalCwdSyncResult,
   shouldClearBlockedFollowOnReach,
   shouldFollowTerminalCwdNavigate,
 } from "./sftpFollowTerminalCwd";
@@ -17,6 +19,10 @@ const base = {
   hasActiveWork: false,
   isConnected: true,
 };
+
+const readComponentSource = (relativePath: string) => (
+  readFileSync(new URL(relativePath, import.meta.url), "utf8")
+);
 
 test("shouldFollowTerminalCwdNavigate returns true when follow is on and paths differ", () => {
   assert.equal(shouldFollowTerminalCwdNavigate(base), true);
@@ -68,6 +74,29 @@ test("shouldFollowTerminalCwdNavigate ignores blocked cwd when terminal cwd chan
       ...base,
       terminalCwd: "/home/user/other",
       blockedFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
+    }),
+    true,
+  );
+});
+
+test("shouldFollowTerminalCwdNavigate does not recapture manual navigation after the cwd was handled", () => {
+  assert.equal(
+    shouldFollowTerminalCwdNavigate({
+      ...base,
+      currentPath: "/srv/bookmark",
+      handledFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
+    }),
+    false,
+  );
+});
+
+test("shouldFollowTerminalCwdNavigate resumes when the terminal cwd changes", () => {
+  assert.equal(
+    shouldFollowTerminalCwdNavigate({
+      ...base,
+      terminalCwd: "/home/user/other",
+      currentPath: "/srv/bookmark",
+      handledFollow: { connectionId: "conn-1", terminalCwd: "/home/user/project" },
     }),
     true,
   );
@@ -188,4 +217,151 @@ test("shouldClearBlockedFollowOnReach keeps block while navigation is still load
     ),
     false,
   );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult rejects stale follow results after cwd changes", () => {
+  let generation = 0;
+  const followA = generation;
+
+  generation += 1;
+  const followB = generation;
+
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: followB,
+      currentGeneration: generation,
+      followEnabled: true,
+      canFollow: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: followA,
+      currentGeneration: generation,
+      followEnabled: true,
+      canFollow: true,
+    }),
+    false,
+  );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult rejects results after follow is unavailable", () => {
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: false,
+      canFollow: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: true,
+      canFollow: false,
+    }),
+    false,
+  );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult rejects results for an old connection", () => {
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: true,
+      canFollow: true,
+      expectedConnectionId: "conn-1",
+      liveConnectionId: "conn-2",
+      paneConnectionId: "conn-2",
+    }),
+    false,
+  );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult rejects results for an old terminal cwd", () => {
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: true,
+      canFollow: true,
+      expectedConnectionId: "conn-1",
+      liveConnectionId: "conn-1",
+      paneConnectionId: "conn-1",
+      expectedTerminalCwd: "/srv/old",
+      liveTerminalCwd: "/srv/new",
+    }),
+    false,
+  );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult rejects missing live cwd when required", () => {
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: true,
+      canFollow: true,
+      expectedConnectionId: "conn-1",
+      liveConnectionId: "conn-1",
+      paneConnectionId: "conn-1",
+      expectedTerminalCwd: "/srv/project",
+      liveTerminalCwd: null,
+      requireLiveTerminalCwd: true,
+    }),
+    false,
+  );
+});
+
+test("shouldApplyFollowTerminalCwdSyncResult allows missing live cwd when target was fetched fresh", () => {
+  assert.equal(
+    shouldApplyFollowTerminalCwdSyncResult({
+      syncGeneration: 2,
+      currentGeneration: 2,
+      followEnabled: true,
+      canFollow: true,
+      expectedConnectionId: "conn-1",
+      liveConnectionId: "conn-1",
+      paneConnectionId: "conn-1",
+      expectedTerminalCwd: "/srv/project",
+      liveTerminalCwd: null,
+    }),
+    true,
+  );
+});
+
+test("SftpSidePanel follow effect is not keyed by SFTP path changes", () => {
+  const source = readComponentSource("../SftpSidePanel.tsx");
+  const followEffect = source.match(
+    /useEffect\(\(\) => \{\n\s+if \(!effectiveFollowTerminalCwd[\s\S]*?void syncFollowToTerminalCwd\(\);\n\s+\}, \[\n(?<deps>[\s\S]*?)\n\s+\]\);/,
+  );
+
+  assert.ok(followEffect?.groups?.deps);
+  assert.match(followEffect.groups.deps, /activeTerminalCwd/);
+  assert.match(followEffect.groups.deps, /connectionId/);
+  assert.doesNotMatch(followEffect.groups.deps, /currentPath|connectionPath/);
+});
+
+test("SftpSidePanel passes a stale-result guard into automatic follow navigation", () => {
+  const source = readComponentSource("../SftpSidePanel.tsx");
+
+  assert.match(
+    source,
+    /navigateTo\("left", terminalCwd, \{\n\s+shouldApply: shouldApplyCurrentFollowSync,\n\s+\}\)/,
+  );
+});
+
+test("SftpSidePanel invalidates follow state whenever the follow toggle changes", () => {
+  const source = readComponentSource("../SftpSidePanel.tsx");
+  const toggleHandler = source.match(
+    /const handleToggleFollowTerminalCwd = useCallback\(\(\) => \{[\s\S]*?\}, \[effectiveFollowTerminalCwd/,
+  );
+
+  assert.ok(toggleHandler);
+  assert.match(toggleHandler[0], /invalidateInFlightFollowSync\(\);/);
+  assert.doesNotMatch(toggleHandler[0], /if \(!nextEnabled\)/);
 });

--- a/components/sftp/sftpFollowTerminalCwd.ts
+++ b/components/sftp/sftpFollowTerminalCwd.ts
@@ -13,6 +13,21 @@ export type SftpFollowTerminalCwdContext = {
   isConnected: boolean;
   /** Skip auto-follow while this terminal cwd cannot be reached on SFTP. */
   blockedFollow?: SftpFollowTerminalCwdBlock | null;
+  /** Skip auto-follow after this terminal cwd was already handled for the connection. */
+  handledFollow?: SftpFollowTerminalCwdBlock | null;
+};
+
+export type SftpFollowTerminalCwdSyncResultContext = {
+  syncGeneration: number;
+  currentGeneration: number;
+  followEnabled: boolean;
+  canFollow: boolean;
+  expectedConnectionId?: string | null;
+  liveConnectionId?: string | null;
+  paneConnectionId?: string | null;
+  expectedTerminalCwd?: string | null;
+  liveTerminalCwd?: string | null;
+  requireLiveTerminalCwd?: boolean;
 };
 
 export const resolveHostFollowTerminalCwd = (
@@ -59,6 +74,34 @@ export const shouldClearBlockedFollowOnReach = (
   );
 };
 
+/** Whether an async follow result still belongs to the current terminal/connection state. */
+export const shouldApplyFollowTerminalCwdSyncResult = ({
+  syncGeneration,
+  currentGeneration,
+  followEnabled,
+  canFollow,
+  expectedConnectionId,
+  liveConnectionId,
+  paneConnectionId,
+  expectedTerminalCwd,
+  liveTerminalCwd,
+  requireLiveTerminalCwd = false,
+}: SftpFollowTerminalCwdSyncResultContext): boolean => {
+  if (syncGeneration !== currentGeneration || !followEnabled || !canFollow) {
+    return false;
+  }
+  if (expectedConnectionId !== undefined) {
+    if (!expectedConnectionId) return false;
+    if (liveConnectionId !== undefined && liveConnectionId !== expectedConnectionId) return false;
+    if (paneConnectionId !== undefined && paneConnectionId !== expectedConnectionId) return false;
+  }
+  if (expectedTerminalCwd !== undefined) {
+    if (requireLiveTerminalCwd && !liveTerminalCwd) return false;
+    if (liveTerminalCwd && liveTerminalCwd !== expectedTerminalCwd) return false;
+  }
+  return true;
+};
+
 /** Whether SFTP should auto-navigate to match the linked terminal cwd. */
 export const shouldFollowTerminalCwdNavigate = ({
   followEnabled,
@@ -69,10 +112,19 @@ export const shouldFollowTerminalCwdNavigate = ({
   hasActiveWork,
   isConnected,
   blockedFollow,
+  handledFollow,
 }: SftpFollowTerminalCwdContext): boolean => {
   if (!followEnabled || !isVisible || !isConnected) return false;
   if (hasActiveWork) return false;
   if (!terminalCwd || terminalCwd.trim().length === 0) return false;
+  if (
+    handledFollow
+    && connectionId
+    && handledFollow.connectionId === connectionId
+    && handledFollow.terminalCwd === terminalCwd
+  ) {
+    return false;
+  }
   if (
     blockedFollow
     && connectionId


### PR DESCRIPTION
## Summary
- Fixes SFTP follow-terminal-directory so it does not immediately pull the pane back after a user manually opens a bookmark, home, or another path.
- Tracks when the current terminal directory has already been handled for the active SFTP connection, then resumes following only after the terminal directory changes or follow state is reset.
- Adds regression coverage for manual navigation after a handled terminal cwd and resuming when the terminal cwd changes.

## Root cause
The follow effect was also triggered by SFTP current-path changes. After the user clicked a bookmark or home, that path change woke follow mode and navigated back to the unchanged terminal cwd.

## Validation
- `node --test --import tsx components/sftp/*.test.ts components/terminalLayer/commandCwdProbe.test.ts components/terminalLayer/terminalLayerViewMemo.test.ts`
- `npx eslint components/SftpSidePanel.tsx components/sftp/sftpFollowTerminalCwd.ts components/sftp/sftpFollowTerminalCwd.test.ts`
- `npm run build`
- `npm test`