### PR TITLE
[codex] Fix Ctrl-L scrollback preservation

### DIFF
--- a/components/terminal/clearTerminalViewport.test.ts
+++ b/components/terminal/clearTerminalViewport.test.ts
@@ -1,19 +1,152 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import xterm from "@xterm/xterm";
 
 import {
   clearTerminalViewport,
+  installEraseInDisplayHandlers,
+  isEraseBelowSequence,
+  preserveTerminalViewportInScrollback,
+  shouldPreserveViewportBeforeEraseBelow,
   shouldPreserveViewportBeforeFullErase,
+  shouldScrollOnEraseInDisplay,
   shouldWipeScrollbackAfterFullErase,
 } from "./clearTerminalViewport.ts";
 
-const createMockTerm = (bufferType: "normal" | "alternate"): { buffer: { active: { type: "normal" | "alternate" } } } => ({
+const { Terminal } = xterm;
+
+const createMockTerm = (
+  bufferType: "normal" | "alternate",
+  cursor: { cursorX?: number; cursorY?: number } = {},
+): { buffer: { active: { type: "normal" | "alternate"; cursorX: number; cursorY: number } } } => ({
   buffer: {
     active: {
       type: bufferType,
+      cursorX: cursor.cursorX ?? 0,
+      cursorY: cursor.cursorY ?? 0,
     },
   },
 });
+
+type RegisteredCsiHandler = {
+  id: { prefix?: string; final: string };
+  callback: (params: Array<number | number[]>) => boolean | Promise<boolean>;
+  disposed: boolean;
+};
+
+const createEraseHandlerHarness = (
+  options: {
+    bufferType?: "normal" | "alternate";
+    clearWipesScrollback?: boolean;
+    cursorX?: number;
+    cursorY?: number;
+    inDec2026SyncBlock?: boolean;
+    scrollTop?: number;
+    scrollBottom?: number;
+  } = {},
+) => {
+  const handlers: RegisteredCsiHandler[] = [];
+  const microtasks: Array<() => void> = [];
+  const trimStartCalls: number[] = [];
+  const onScrollPositions: number[] = [];
+  const scrollRegion = {
+    lines: {
+      length: options.clearWipesScrollback ? 9 : 5,
+      trimStart: (count: number) => {
+        trimStartCalls.push(count);
+        scrollRegion.lines.length -= count;
+      },
+    },
+    scrollTop: options.scrollTop ?? 0,
+    scrollBottom: options.scrollBottom ?? 4,
+    ybase: options.clearWipesScrollback ? 4 : 0,
+    ydisp: options.clearWipesScrollback ? 4 : 0,
+  };
+  const observedScrollRegions: Array<[number, number]> = [];
+  const term = {
+    rows: 5,
+    options: {
+      scrollOnEraseInDisplay: false,
+    },
+    parser: {
+      registerCsiHandler: (id: { prefix?: string; final: string }, callback: RegisteredCsiHandler["callback"]) => {
+        const handler = {
+          id,
+          callback,
+          disposed: false,
+        };
+        handlers.push(handler);
+        return {
+          dispose: () => {
+            handler.disposed = true;
+          },
+        };
+      },
+    },
+    buffer: {
+      active: {
+        type: options.bufferType ?? "normal",
+        baseY: 0,
+        cursorX: options.cursorX ?? 0,
+        cursorY: options.cursorY ?? 0,
+        getLine: (line: number) => {
+          if (line < 0 || line >= 5) {
+            return undefined;
+          }
+          return {
+            translateToString: () => `row-${line}`,
+          };
+        },
+      },
+    },
+    _core: {
+      buffer: scrollRegion,
+      scroll: () => {
+        observedScrollRegions.push([scrollRegion.scrollTop, scrollRegion.scrollBottom]);
+      },
+      _inputHandler: {
+        _onScroll: {
+          fire: (position: number) => {
+            onScrollPositions.push(position);
+          },
+        },
+        _eraseAttrData: () => ({}),
+      },
+    },
+  };
+  const disposable = installEraseInDisplayHandlers(term as never, {
+    getClearWipesScrollback: () => options.clearWipesScrollback ?? false,
+    isInDec2026SyncBlock: () => options.inDec2026SyncBlock ?? false,
+    scheduleMicrotask: (callback) => {
+      microtasks.push(callback);
+    },
+  });
+  const erase = handlers.find((handler) => handler.id.final === "J" && handler.id.prefix === undefined);
+  const selectiveErase = handlers.find((handler) => handler.id.final === "J" && handler.id.prefix === "?");
+  if (!erase || !selectiveErase) {
+    throw new Error("erase handlers were not registered");
+  }
+
+  return {
+    disposable,
+    erase: erase.callback,
+    flushMicrotasks: () => {
+      while (microtasks.length > 0) {
+        microtasks.shift()?.();
+      }
+    },
+    handlers,
+    observedScrollRegions,
+    onScrollPositions,
+    scrollRegion,
+    selectiveErase: selectiveErase.callback,
+    term,
+    trimStartCalls,
+  };
+};
+
+const writeTerminal = (term: InstanceType<typeof Terminal>, data: string): Promise<void> =>
+  new Promise((resolve) => term.write(data, resolve));
 
 test("preserves viewport before full erase on the normal screen outside sync blocks", () => {
   const term = createMockTerm("normal");
@@ -40,6 +173,192 @@ test("wipes scrollback after full erase only on the normal screen outside sync b
   assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("normal") as never, true, true), false);
   assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("alternate") as never, false, true), false);
   assert.equal(shouldWipeScrollbackAfterFullErase(createMockTerm("normal") as never, false, false), false);
+});
+
+test("native erase-in-display scrollback preservation follows the clear history setting", () => {
+  assert.equal(shouldScrollOnEraseInDisplay(createMockTerm("normal") as never, false, false), true);
+  assert.equal(shouldScrollOnEraseInDisplay(createMockTerm("normal") as never, false, true), false);
+  assert.equal(shouldScrollOnEraseInDisplay(createMockTerm("normal") as never, true, false), false);
+  assert.equal(shouldScrollOnEraseInDisplay(createMockTerm("alternate") as never, false, false), false);
+});
+
+test("native erase-in-display scrollback preservation is skipped with active scroll margins", () => {
+  const term = {
+    rows: 5,
+    buffer: {
+      active: {
+        type: "normal",
+        cursorX: 0,
+        cursorY: 0,
+      },
+    },
+    _core: {
+      buffer: {
+        scrollTop: 1,
+        scrollBottom: 3,
+      },
+    },
+  };
+
+  assert.equal(shouldScrollOnEraseInDisplay(term as never, false, false), false);
+  assert.equal(shouldPreserveViewportBeforeFullErase(term as never, false, false), true);
+  assert.equal(shouldPreserveViewportBeforeEraseBelow(term as never, false, false), true);
+});
+
+test("erase-below is treated as viewport clear only from the home position", () => {
+  assert.equal(isEraseBelowSequence([]), true);
+  assert.equal(isEraseBelowSequence([0]), true);
+  assert.equal(isEraseBelowSequence([2]), false);
+  assert.equal(shouldPreserveViewportBeforeEraseBelow(createMockTerm("normal") as never, false, false), true);
+  assert.equal(
+    shouldPreserveViewportBeforeEraseBelow(createMockTerm("normal", { cursorX: 1 }) as never, false, false),
+    false,
+  );
+  assert.equal(
+    shouldPreserveViewportBeforeEraseBelow(createMockTerm("normal", { cursorY: 1 }) as never, false, false),
+    false,
+  );
+  assert.equal(shouldPreserveViewportBeforeEraseBelow(createMockTerm("alternate") as never, false, false), false);
+});
+
+test("viewport preservation temporarily uses the full scroll region", () => {
+  const scrollRegion = {
+    scrollTop: 1,
+    scrollBottom: 3,
+  };
+  const observedScrollRegions: Array<[number, number]> = [];
+  const term = {
+    rows: 5,
+    buffer: {
+      active: {
+        type: "normal",
+        baseY: 0,
+        getLine: (line: number) => {
+          if (line < 0 || line >= 5) {
+            return undefined;
+          }
+          return {
+            translateToString: () => `row-${line}`,
+          };
+        },
+      },
+    },
+    _core: {
+      buffer: scrollRegion,
+      scroll: () => {
+        observedScrollRegions.push([scrollRegion.scrollTop, scrollRegion.scrollBottom]);
+      },
+      _inputHandler: {
+        _eraseAttrData: () => ({}),
+      },
+    },
+  };
+
+  preserveTerminalViewportInScrollback(term as never);
+
+  assert.equal(observedScrollRegions.length, 5);
+  assert.deepEqual(observedScrollRegions, [
+    [0, 4],
+    [0, 4],
+    [0, 4],
+    [0, 4],
+    [0, 4],
+  ]);
+  assert.deepEqual(scrollRegion, {
+    scrollTop: 1,
+    scrollBottom: 3,
+  });
+});
+
+test("installed erase handlers preserve scrollback by behavior", () => {
+  const fullClear = createEraseHandlerHarness();
+
+  assert.equal(fullClear.erase([2]), false);
+  assert.equal(fullClear.term.options.scrollOnEraseInDisplay, true);
+  assert.deepEqual(fullClear.observedScrollRegions, []);
+  fullClear.flushMicrotasks();
+  assert.equal(fullClear.term.options.scrollOnEraseInDisplay, false);
+
+  const marginFullClear = createEraseHandlerHarness({ scrollTop: 1, scrollBottom: 3 });
+  assert.equal(marginFullClear.erase([2]), false);
+  assert.equal(marginFullClear.term.options.scrollOnEraseInDisplay, false);
+  assert.deepEqual(marginFullClear.observedScrollRegions, [
+    [0, 4],
+    [0, 4],
+    [0, 4],
+    [0, 4],
+    [0, 4],
+  ]);
+  assert.equal(marginFullClear.scrollRegion.scrollTop, 1);
+  assert.equal(marginFullClear.scrollRegion.scrollBottom, 3);
+
+  const eraseBelow = createEraseHandlerHarness();
+  assert.equal(eraseBelow.erase([]), false);
+  assert.equal(eraseBelow.observedScrollRegions.length, 5);
+
+  const eraseBelowAwayFromHome = createEraseHandlerHarness({ cursorY: 1 });
+  assert.equal(eraseBelowAwayFromHome.erase([]), false);
+  assert.equal(eraseBelowAwayFromHome.observedScrollRegions.length, 0);
+
+  const wipeEraseBelow = createEraseHandlerHarness({ clearWipesScrollback: true });
+  assert.equal(wipeEraseBelow.erase([]), false);
+  assert.deepEqual(wipeEraseBelow.trimStartCalls, [4]);
+  assert.equal(wipeEraseBelow.scrollRegion.ybase, 0);
+  assert.equal(wipeEraseBelow.scrollRegion.ydisp, 0);
+  assert.deepEqual(wipeEraseBelow.onScrollPositions, [0]);
+
+  const wipeEraseBelowAwayFromHome = createEraseHandlerHarness({
+    clearWipesScrollback: true,
+    cursorY: 1,
+  });
+  assert.equal(wipeEraseBelowAwayFromHome.erase([]), false);
+  assert.deepEqual(wipeEraseBelowAwayFromHome.trimStartCalls, []);
+});
+
+test("erase-below wipe preserves later output from the same write batch", async () => {
+  const term = new Terminal({ cols: 20, rows: 5, scrollback: 100 });
+  const disposable = installEraseInDisplayHandlers(term as never, {
+    getClearWipesScrollback: () => true,
+    isInDec2026SyncBlock: () => false,
+  });
+
+  await writeTerminal(term, "old1\r\nold2\r\nold3\r\nold4\r\nold5\r\nold6\r\nold7\r\nold8");
+  await writeTerminal(term, "\x1b[H\x1b[Jnew1\r\nnew2\r\nnew3\r\nnew4\r\nnew5\r\nnew6\r\nnew7\r\nnew8");
+
+  const scrollback = Array.from({ length: term.buffer.active.baseY }, (_, row) =>
+    term.buffer.active.getLine(row)?.translateToString(true) ?? ""
+  );
+
+  assert.equal(scrollback.some((line) => line.startsWith("old")), false);
+  assert.equal(scrollback.some((line) => line.startsWith("new")), true);
+
+  disposable.dispose();
+  term.dispose();
+});
+
+test("installed erase handlers honor wipe, sync, alternate, and selective clears", () => {
+  const preserveHistory = createEraseHandlerHarness({ clearWipesScrollback: false });
+  assert.equal(preserveHistory.erase([3]), true);
+
+  const wipeHistory = createEraseHandlerHarness({ clearWipesScrollback: true });
+  assert.equal(wipeHistory.erase([3]), false);
+
+  const syncBlock = createEraseHandlerHarness({ inDec2026SyncBlock: true });
+  assert.equal(syncBlock.erase([2]), false);
+  assert.equal(syncBlock.term.options.scrollOnEraseInDisplay, false);
+  assert.deepEqual(syncBlock.observedScrollRegions, []);
+
+  const alternateScreen = createEraseHandlerHarness({ bufferType: "alternate" });
+  assert.equal(alternateScreen.erase([2]), false);
+  assert.equal(alternateScreen.term.options.scrollOnEraseInDisplay, false);
+  assert.deepEqual(alternateScreen.observedScrollRegions, []);
+
+  const selectiveClear = createEraseHandlerHarness();
+  selectiveClear.term.options.scrollOnEraseInDisplay = true;
+  assert.equal(selectiveClear.selectiveErase([2]), false);
+  assert.equal(selectiveClear.term.options.scrollOnEraseInDisplay, false);
+  selectiveClear.disposable.dispose();
+  assert.equal(selectiveClear.handlers.every((handler) => handler.disposed), true);
 });
 
 test("local clear writes erase-scrollback when requested", () => {

--- a/components/terminal/clearTerminalViewport.ts
+++ b/components/terminal/clearTerminalViewport.ts
@@ -1,10 +1,26 @@
-import type { Terminal as XTerm } from "@xterm/xterm";
+import type { IDisposable, IParser, Terminal as XTerm } from "@xterm/xterm";
 
 type CsiParam = number | number[];
+type EraseInDisplayTerminal = XTerm & {
+  parser: Pick<IParser, "registerCsiHandler">;
+};
 type InternalTerminal = XTerm & {
   _core?: {
+    buffer?: {
+      lines?: {
+        length: number;
+        trimStart?: (count: number) => void;
+      };
+      scrollTop: number;
+      scrollBottom: number;
+      ybase?: number;
+      ydisp?: number;
+    };
     scroll?: (eraseAttr: unknown, isWrapped?: boolean) => void;
     _inputHandler?: {
+      _onScroll?: {
+        fire?: (position: number) => void;
+      };
       _eraseAttrData?: () => unknown;
     };
   };
@@ -17,6 +33,12 @@ type ClearTerminalViewportOptions = {
 type AppendEraseScrollbackOptions = {
   wipeScrollback: boolean;
   normalScreen: boolean;
+};
+
+type EraseInDisplayHandlerOptions = {
+  getClearWipesScrollback: () => boolean;
+  isInDec2026SyncBlock: () => boolean;
+  scheduleMicrotask?: (callback: () => void) => void;
 };
 
 const getVisibleContentRowCount = (term: XTerm): number => {
@@ -39,6 +61,25 @@ const getVisibleContentRowCount = (term: XTerm): number => {
   return 0;
 };
 
+const getInternalScrollRegion = (term: XTerm): { scrollTop: number; scrollBottom: number } | undefined => {
+  const internalBuffer = (term as InternalTerminal)._core?.buffer;
+  if (
+    typeof internalBuffer?.scrollTop !== "number"
+    || typeof internalBuffer.scrollBottom !== "number"
+  ) {
+    return undefined;
+  }
+  return internalBuffer;
+};
+
+const hasDefaultScrollRegion = (term: XTerm): boolean => {
+  const scrollRegion = getInternalScrollRegion(term);
+  if (!scrollRegion) {
+    return true;
+  }
+  return scrollRegion.scrollTop === 0 && scrollRegion.scrollBottom === term.rows - 1;
+};
+
 export const preserveTerminalViewportInScrollback = (term: XTerm): void => {
   const rowsToPreserve = getVisibleContentRowCount(term);
   if (rowsToPreserve <= 0) {
@@ -53,8 +94,28 @@ export const preserveTerminalViewportInScrollback = (term: XTerm): void => {
     return;
   }
 
-  for (let row = 0; row < rowsToPreserve; row++) {
-    scroll.call(internal._core, eraseAttr, false);
+  const scrollRegion = getInternalScrollRegion(term);
+  const previousScrollTop = scrollRegion?.scrollTop;
+  const previousScrollBottom = scrollRegion?.scrollBottom;
+
+  try {
+    // xterm scrolls inside active DECSTBM margins; widen them while preserving.
+    if (scrollRegion) {
+      scrollRegion.scrollTop = 0;
+      scrollRegion.scrollBottom = term.rows - 1;
+    }
+    for (let row = 0; row < rowsToPreserve; row++) {
+      scroll.call(internal._core, eraseAttr, false);
+    }
+  } finally {
+    if (
+      scrollRegion
+      && previousScrollTop !== undefined
+      && previousScrollBottom !== undefined
+    ) {
+      scrollRegion.scrollTop = previousScrollTop;
+      scrollRegion.scrollBottom = previousScrollBottom;
+    }
   }
 };
 
@@ -97,6 +158,20 @@ export const isEraseScrollbackSequence = (params: CsiParam[]): boolean =>
 export const isEraseViewportSequence = (params: CsiParam[]): boolean =>
   params.length > 0 && params[0] === 2;
 
+export const isEraseBelowSequence = (params: CsiParam[]): boolean =>
+  params.length === 0 || params[0] === 0;
+
+export const shouldScrollOnEraseInDisplay = (
+  term: XTerm,
+  inDec2026SyncBlock: boolean,
+  clearWipesScrollback: boolean,
+): boolean => {
+  if (clearWipesScrollback || inDec2026SyncBlock) {
+    return false;
+  }
+  return term.buffer.active.type === "normal" && hasDefaultScrollRegion(term);
+};
+
 /**
  * Netcatty preserves visible rows in scrollback before CSI 2 J so shell `clear`
  * does not discard history. TUIs inside DEC 2026 sync blocks or the alternate
@@ -107,13 +182,49 @@ export const shouldPreserveViewportBeforeFullErase = (
   inDec2026SyncBlock: boolean,
   clearWipesScrollback = false,
 ): boolean => {
-  if (inDec2026SyncBlock) {
-    return false;
-  }
-  if (clearWipesScrollback) {
+  if (inDec2026SyncBlock || clearWipesScrollback) {
     return false;
   }
   return term.buffer.active.type === "normal";
+};
+
+export const shouldPreserveViewportBeforeEraseBelow = (
+  term: XTerm,
+  inDec2026SyncBlock: boolean,
+  clearWipesScrollback = false,
+): boolean => {
+  if (!shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock, clearWipesScrollback)) {
+    return false;
+  }
+  const buffer = term.buffer.active;
+  return buffer.cursorX === 0 && buffer.cursorY === 0;
+};
+
+export const shouldWipeScrollbackAfterEraseBelow = (
+  term: XTerm,
+  inDec2026SyncBlock: boolean,
+  clearWipesScrollback: boolean,
+): boolean => {
+  if (!shouldWipeScrollbackAfterFullErase(term, inDec2026SyncBlock, clearWipesScrollback)) {
+    return false;
+  }
+  const buffer = term.buffer.active;
+  return buffer.cursorX === 0 && buffer.cursorY === 0;
+};
+
+const wipeTerminalScrollback = (term: XTerm): void => {
+  const internal = term as InternalTerminal;
+  const buffer = internal._core?.buffer;
+  const lines = buffer?.lines;
+  const scrollBackSize = (lines?.length ?? 0) - term.rows;
+  if (!buffer || !lines || scrollBackSize <= 0 || typeof lines.trimStart !== "function") {
+    return;
+  }
+
+  lines.trimStart(scrollBackSize);
+  buffer.ybase = Math.max((buffer.ybase ?? 0) - scrollBackSize, 0);
+  buffer.ydisp = Math.max((buffer.ydisp ?? 0) - scrollBackSize, 0);
+  internal._core?._inputHandler?._onScroll?.fire?.(0);
 };
 
 export const shouldWipeScrollbackAfterFullErase = (
@@ -125,6 +236,71 @@ export const shouldWipeScrollbackAfterFullErase = (
     return false;
   }
   return term.buffer.active.type === "normal";
+};
+
+export const installEraseInDisplayHandlers = (
+  term: EraseInDisplayTerminal,
+  {
+    getClearWipesScrollback,
+    isInDec2026SyncBlock,
+    scheduleMicrotask = queueMicrotask,
+  }: EraseInDisplayHandlerOptions,
+): IDisposable => {
+  const setScrollOnEraseInDisplayOnce = (enabled: boolean): void => {
+    term.options.scrollOnEraseInDisplay = enabled;
+    if (enabled) {
+      scheduleMicrotask(() => {
+        term.options.scrollOnEraseInDisplay = false;
+      });
+    }
+  };
+
+  const eraseDisposable = term.parser.registerCsiHandler({ final: "J" }, (params) => {
+    const wipeAllowed = getClearWipesScrollback();
+    const inDec2026SyncBlock = isInDec2026SyncBlock();
+    // Scope xterm's native preservation to shell clears, not TUI redraws.
+    if (isEraseViewportSequence(params)) {
+      const useNativeScrollPreservation = shouldScrollOnEraseInDisplay(
+        term,
+        inDec2026SyncBlock,
+        wipeAllowed,
+      );
+      setScrollOnEraseInDisplayOnce(useNativeScrollPreservation);
+      if (
+        !useNativeScrollPreservation
+        && shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock, wipeAllowed)
+      ) {
+        preserveTerminalViewportInScrollback(term);
+      }
+      return false;
+    }
+    setScrollOnEraseInDisplayOnce(false);
+    if (isEraseBelowSequence(params)) {
+      if (shouldPreserveViewportBeforeEraseBelow(term, inDec2026SyncBlock, wipeAllowed)) {
+        preserveTerminalViewportInScrollback(term);
+      } else if (shouldWipeScrollbackAfterEraseBelow(term, inDec2026SyncBlock, wipeAllowed)) {
+        wipeTerminalScrollback(term);
+      }
+      return false;
+    }
+    if (!isEraseScrollbackSequence(params)) {
+      return false;
+    }
+    // CSI 3 J — POSIX/ncurses default `clear` emits this to wipe scrollback.
+    // Honor it unless the user opts into the legacy "preserve history" behavior.
+    return !wipeAllowed;
+  });
+  const selectiveEraseDisposable = term.parser.registerCsiHandler({ prefix: "?", final: "J" }, () => {
+    setScrollOnEraseInDisplayOnce(false);
+    return false;
+  });
+
+  return {
+    dispose: () => {
+      eraseDisposable.dispose();
+      selectiveEraseDisposable.dispose();
+    },
+  };
 };
 
 export const appendEraseScrollbackAfterFullErases = (

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -36,10 +36,7 @@ import { isMacPlatform } from "../../../lib/utils";
 import { netcattyBridge } from "../../../infrastructure/services/netcattyBridge";
 import {
   clearTerminalViewport,
-  isEraseScrollbackSequence,
-  isEraseViewportSequence,
-  preserveTerminalViewportInScrollback,
-  shouldPreserveViewportBeforeFullErase,
+  installEraseInDisplayHandlers,
 } from "../clearTerminalViewport";
 import {
   createKittyKeyboardModeState,
@@ -1206,20 +1203,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     },
   );
 
-  const eraseScrollbackDisposable = term.parser.registerCsiHandler({ final: "J" }, (params) => {
-    const wipeAllowed = ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true;
-    if (isEraseViewportSequence(params)) {
-      if (shouldPreserveViewportBeforeFullErase(term, inDec2026SyncBlock, wipeAllowed)) {
-        preserveTerminalViewportInScrollback(term);
-      }
-      return false;
-    }
-    if (!isEraseScrollbackSequence(params)) {
-      return false;
-    }
-    // CSI 3 J — POSIX/ncurses default `clear` emits this to wipe scrollback.
-    // Honor it unless the user opts into the legacy "preserve history" behavior.
-    return !wipeAllowed;
+  const eraseScrollbackDisposable = installEraseInDisplayHandlers(term, {
+    getClearWipesScrollback: () => ctx.terminalSettingsRef.current?.clearWipesScrollback ?? true,
+    isInDec2026SyncBlock: () => inDec2026SyncBlock,
   });
 
   const markCursorPositionReportRequest = (params: readonly (number | number[])[]): boolean => {


### PR DESCRIPTION
## Summary
- Treat shell-driven Ctrl-L clears the same as the `clear` command when scrollback wiping is disabled.
- Use xterm's native erase-in-display preservation for full-screen clears, scoped away from synchronized-output redraws and alternate-screen TUIs.
- Preserve viewport history for home-position erase-below clears as a fallback form used by some shells/programs.
- Reset erase-in-display preservation after the single clear that needs it, and force prefixed selective clears to stay in-place.

## Root cause
`clearWipesScrollback=false` filtered scrollback erase commands, but Ctrl-L relies on shell-emitted erase-in-display sequences. Netcatty was manually preserving history for full clears instead of enabling xterm's built-in preservation at the exact time the erase is processed, leaving Ctrl-L-style clears inconsistent with `clear` in some terminal flows.

Closes #1898.

## Validation
- `node --test --import tsx components/terminal/runtime/createXTermRuntime.test.ts`
- `node --test --import tsx components/terminal/clearTerminalViewport.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts`
- `npx eslint components/terminal/clearTerminalViewport.ts components/terminal/clearTerminalViewport.test.ts components/terminal/runtime/createXTermRuntime.ts components/terminal/runtime/createXTermRuntime.test.ts`
- `npm run build`