### PR TITLE
Show Enter reconnect hint

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -166,6 +166,7 @@ export const enTerminalMessages: Messages = {
   'terminal.progress.disconnected': 'Disconnected',
   'terminal.progress.cancelling': 'Cancelling...',
   'terminal.progress.startOver': 'Start over',
+  'terminal.progress.enterReconnectHint': 'Press Enter to reconnect',
   'terminal.connection.dismissDisconnectedDialog': 'Dismiss disconnected notice',
   'terminal.connection.chainOf': 'Chain {current} of {total}',
   'terminal.connection.showLogs': 'Show logs',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -186,6 +186,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.progress.disconnected': 'Отключено',
   'terminal.progress.cancelling': 'Отмена...',
   'terminal.progress.startOver': 'Начать заново',
+  'terminal.progress.enterReconnectHint': 'Нажмите Enter, чтобы подключиться снова',
   'terminal.connection.dismissDisconnectedDialog': 'Закрыть уведомление об отключении',
   'terminal.connection.chainOf': 'Цепочка {current} из {total}',
   'terminal.connection.showLogs': 'Показать журналы',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -20,6 +20,7 @@ export const zhCNTerminalMessages: Messages = {
   'terminal.osc7Setup.sent': '目录追踪配置已发送到终端',
   'terminal.toolbar.timestampsEnable': '显示时间戳',
   'terminal.toolbar.timestampsDisable': '隐藏时间戳',
+  'terminal.progress.enterReconnectHint': '按 Enter 重新连接',
   'terminal.connection.protocol.et': 'EternalTerminal',
   'terminal.et.proxyUnsupported': 'EternalTerminal 目前不支持 Netcatty 的代理设置。请改用 SSH，或移除该主机的代理。',
   'terminal.et.multiJumpUnsupported': 'EternalTerminal 目前在 Netcatty 中最多支持一个跳板机。',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -20,6 +20,7 @@ export const zhTWTerminalMessages: Messages = {
   'terminal.osc7Setup.sent': '目錄追蹤設定已傳送到終端',
   'terminal.toolbar.timestampsEnable': '顯示時間戳',
   'terminal.toolbar.timestampsDisable': '隱藏時間戳',
+  'terminal.progress.enterReconnectHint': '按 Enter 重新連線',
   'terminal.connection.protocol.et': 'EternalTerminal',
   'terminal.et.proxyUnsupported': 'EternalTerminal 目前不支援 Netcatty 的代理設定。請改用 SSH，或移除該主機的代理。',
   'terminal.et.multiJumpUnsupported': 'EternalTerminal 目前在 Netcatty 中最多支援一個跳板機。',

--- a/components/terminal/TerminalConnectionDialog.test.ts
+++ b/components/terminal/TerminalConnectionDialog.test.ts
@@ -108,6 +108,25 @@ test("does not show a countdown while waiting for user input", () => {
   assert.equal(markup.includes("Timeout in"), false);
 });
 
+test("shows enter reconnect hint when disconnected reconnect is available", () => {
+  const markup = renderDialog({
+    status: "disconnected",
+    error: null,
+    showEnterReconnectHint: true,
+  });
+
+  assert.match(markup, /Press Enter to reconnect/);
+});
+
+test("does not show enter reconnect hint until the caller marks enter reconnect available", () => {
+  const markup = renderDialog({
+    status: "disconnected",
+    error: null,
+  });
+
+  assert.equal(markup.includes("Press Enter to reconnect"), false);
+});
+
 test("renders changed host key warning in the same connection dialog", () => {
   const markup = renderDialog({
     hostKeyVerification: {

--- a/components/terminal/TerminalConnectionDialog.tsx
+++ b/components/terminal/TerminalConnectionDialog.tsx
@@ -35,6 +35,7 @@ export interface TerminalConnectionDialogProps {
     authProps: Omit<TerminalAuthDialogProps, 'keys'>;
     keys: SSHKey[];
     onDismissDisconnected?: () => void;
+    showEnterReconnectHint?: boolean;
     hostKeyVerification?: {
         hostKeyInfo: HostKeyInfo;
         onClose: () => void;
@@ -42,7 +43,7 @@ export interface TerminalConnectionDialogProps {
         onAddAndContinue: () => void;
     };
     // Progress props
-    progressProps: Omit<TerminalConnectionProgressProps, 'status' | 'error' | 'showLogs'>;
+    progressProps: Omit<TerminalConnectionProgressProps, 'status' | 'error' | 'showLogs' | 'showEnterReconnectHint'>;
 }
 
 // Helper to get protocol display info
@@ -89,6 +90,7 @@ export const TerminalConnectionDialog: React.FC<TerminalConnectionDialogProps> =
     authProps,
     keys,
     onDismissDisconnected,
+    showEnterReconnectHint,
     hostKeyVerification,
     progressProps,
 }) => {
@@ -324,6 +326,7 @@ export const TerminalConnectionDialog: React.FC<TerminalConnectionDialogProps> =
                             status={status}
                             error={error}
                             showLogs={showLogs}
+                            showEnterReconnectHint={showEnterReconnectHint}
                             reconnectLabel={isRestoredDisconnected ? t('terminal.restore.placeholder.reconnect') : undefined}
                             {...progressProps}
                         />

--- a/components/terminal/TerminalConnectionProgress.tsx
+++ b/components/terminal/TerminalConnectionProgress.tsx
@@ -13,6 +13,7 @@ export interface TerminalConnectionProgressProps {
     error: string | null;
     timeLeft: number;
     isAwaitingUserInput?: boolean;
+    showEnterReconnectHint?: boolean;
     isCancelling: boolean;
     showLogs: boolean;
     progressLogs: string[];
@@ -56,6 +57,7 @@ export const TerminalConnectionProgress: React.FC<TerminalConnectionProgressProp
     error,
     timeLeft,
     isAwaitingUserInput = false,
+    showEnterReconnectHint = false,
     isCancelling: _isCancelling,
     showLogs,
     progressLogs,
@@ -94,18 +96,23 @@ export const TerminalConnectionProgress: React.FC<TerminalConnectionProgressProp
                 <TerminalConnectionLogList progressLogs={progressLogs} error={error} />
             )}
 
-            <div className="flex justify-end gap-2">
-                {status !== 'connecting' && (
-                    <>
+            {status !== 'connecting' && (
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    {showEnterReconnectHint && (
+                        <div className="min-w-0 break-words text-[11px] leading-5 text-muted-foreground">
+                            {t('terminal.progress.enterReconnectHint')}
+                        </div>
+                    )}
+                    <div className="ml-auto flex shrink-0 justify-end gap-2">
                         <Button variant="ghost" size="sm" className="h-7 px-3 text-[11px]" onClick={onCloseSession}>
                             {t('terminal.toolbar.closeSession')}
                         </Button>
                         <Button size="sm" className="h-7 px-3 text-[11px]" onClick={onRetry}>
                             <Play className="h-3 w-3 mr-1.5" /> {reconnectLabel ?? t('terminal.progress.startOver')}
                         </Button>
-                    </>
-                )}
-            </div>
+                    </div>
+                </div>
+            )}
         </>
     );
 };

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -204,6 +204,17 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
     ? t("terminal.toolbar.timestampsDisable")
     : t("terminal.toolbar.timestampsEnable");
   const titleConnectionAddress = formatTerminalTitleConnectionAddress(host);
+  const hasBlockingReconnectOverlay = Boolean(osc52ReadPromptVisible || osc7SetupOpen || scriptExecutionOverlay || zmodem.active || zmodem.overwriteRequest);
+  const showEnterReconnectHint = shouldReconnectTerminalOnEnterKey({
+    key: "Enter",
+    status,
+    hasRetryHandler: Boolean(handleRetry),
+    isSearchOpen,
+    isComposeBarOpen,
+    needsAuth: Boolean(auth.needsAuth),
+    needsHostKeyVerification: Boolean(needsHostKeyVerification),
+    hasBlockingOverlay: hasBlockingReconnectOverlay,
+  });
   const handleTerminalKeyDownCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (!shouldReconnectTerminalOnEnterKey({
       key: event.key,
@@ -213,7 +224,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
       isComposeBarOpen,
       needsAuth: Boolean(auth.needsAuth),
       needsHostKeyVerification: Boolean(needsHostKeyVerification),
-      hasBlockingOverlay: Boolean(osc52ReadPromptVisible || osc7SetupOpen || scriptExecutionOverlay || zmodem.active || zmodem.overwriteRequest),
+      hasBlockingOverlay: hasBlockingReconnectOverlay,
       altKey: event.altKey,
       ctrlKey: event.ctrlKey,
       metaKey: event.metaKey,
@@ -231,15 +242,11 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
   }, [
     auth.needsAuth,
     handleRetry,
+    hasBlockingReconnectOverlay,
     isComposeBarOpen,
     isSearchOpen,
     needsHostKeyVerification,
-    osc52ReadPromptVisible,
-    osc7SetupOpen,
-    scriptExecutionOverlay,
     status,
-    zmodem.active,
-    zmodem.overwriteRequest,
   ]);
   return (
     <TerminalContextMenu
@@ -664,6 +671,7 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                 _setShowLogs={setShowLogs}
                 keys={keys}
                 onDismissDisconnected={handleDismissDisconnectedDialog}
+                showEnterReconnectHint={showEnterReconnectHint}
                 hostKeyVerification={needsHostKeyVerification && pendingHostKeyInfo ? {
                   hostKeyInfo: pendingHostKeyInfo,
                   onClose: handleHostKeyClose,


### PR DESCRIPTION
## Summary
- show a lightweight “Press Enter to reconnect” hint when a disconnected terminal can be reconnected with Enter
- hide the hint when search, compose, auth, host-key, or other blocking UI is active
- add localized text for English, Simplified Chinese, Traditional Chinese, and Russian

## Verification
- node --test --import tsx components/terminal/TerminalView.test.tsx components/terminal/TerminalConnectionDialog.test.ts components/terminal/TerminalContextMenu.test.ts components/terminal/restoredSessionGate.test.ts components/terminalHelpers.test.ts application/state/resolveTerminalSessionExitIntent.test.ts
- npx eslint components/terminal/TerminalConnectionDialog.tsx components/terminal/TerminalConnectionProgress.tsx components/terminal/TerminalView.tsx components/terminal/TerminalConnectionDialog.test.ts application/i18n/locales/en/terminal.ts application/i18n/locales/zh-CN/terminal.ts application/i18n/locales/zh-TW/terminal.ts application/i18n/locales/ru/terminal.ts
- git diff --check HEAD~1
- npm run build

Follow-up to #1924.