### PR TITLE
[codex] Fix terminal font remeasure after load

### DIFF
--- a/components/terminal/runtime/terminalFontRemeasure.test.ts
+++ b/components/terminal/runtime/terminalFontRemeasure.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { forceXTermFontRemeasure } from "./terminalFontRemeasure";
+
+test("forceXTermFontRemeasure uses xterm char size service when available", () => {
+  let measured = 0;
+  const term = {
+    _core: {
+      _charSizeService: {
+        measure() {
+          measured += 1;
+        },
+      },
+    },
+    options: {
+      fontSize: 14,
+    },
+  };
+
+  assert.equal(forceXTermFontRemeasure(term), true);
+  assert.equal(measured, 1);
+  assert.equal(term.options.fontSize, 14);
+});
+
+test("forceXTermFontRemeasure falls back to a restored font size nudge", () => {
+  let fontSize = 14;
+  const writes: number[] = [];
+  const term = {
+    options: {},
+  } as { options: { fontSize: number } };
+
+  Object.defineProperty(term.options, "fontSize", {
+    get: () => fontSize,
+    set: (next: number) => {
+      writes.push(next);
+      fontSize = next;
+    },
+  });
+
+  assert.equal(forceXTermFontRemeasure(term), true);
+  assert.equal(writes.length, 2);
+  assert.ok(writes[0] > 14);
+  assert.equal(writes[1], 14);
+  assert.equal(term.options.fontSize, 14);
+});
+
+test("forceXTermFontRemeasure reports unavailable when no measurement path exists", () => {
+  assert.equal(forceXTermFontRemeasure({}), false);
+  assert.equal(forceXTermFontRemeasure({ options: { fontSize: Number.NaN } }), false);
+});

--- a/components/terminal/runtime/terminalFontRemeasure.ts
+++ b/components/terminal/runtime/terminalFontRemeasure.ts
@@ -1,0 +1,28 @@
+export type XTermFontRemeasureTarget = {
+  _core?: {
+    _charSizeService?: {
+      measure?: () => void;
+    };
+  };
+  options?: {
+    fontSize?: number;
+  };
+};
+
+export function forceXTermFontRemeasure(term: XTermFontRemeasureTarget): boolean {
+  const charSizeService = term._core?._charSizeService;
+  if (typeof charSizeService?.measure === "function") {
+    charSizeService.measure();
+    return true;
+  }
+
+  const options = term.options;
+  const fontSize = options?.fontSize;
+  if (typeof fontSize !== "number" || !Number.isFinite(fontSize)) return false;
+
+  // xterm remeasures fonts when fontSize changes. Nudge and restore the value
+  // so the measurement path runs without changing the user's effective size.
+  options.fontSize = fontSize + 0.001;
+  options.fontSize = fontSize;
+  return true;
+}

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -27,6 +27,10 @@ import {
   forceTerminalRepaintBypassingAnimationFrame,
 } from './runtime/terminalUnfocusedRepaint';
 import {
+  forceXTermFontRemeasure,
+  type XTermFontRemeasureTarget,
+} from './runtime/terminalFontRemeasure';
+import {
   isTerminalCloseGenerationCurrent,
   resolveConnectionLogCapturePayload,
   scheduleTerminalCloseTeardown,
@@ -1000,8 +1004,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       const term = termRef.current as {
         cols: number;
         rows: number;
-        renderer?: { remeasureFont?: () => void };
-      } | null;
+      } & XTermFontRemeasureTarget | null;
       if (cancelled || !term) return;
       if (!isVisibleRef.current) {
         lastFittedSizeRef.current = null;
@@ -1009,12 +1012,14 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       }
       const fitAddon = fitAddonRef.current;
       try {
-        term.renderer?.remeasureFont?.();
+        if (!forceXTermFontRemeasure(term)) {
+          logger.warn("Font remeasure skipped: xterm measurement hook unavailable");
+        }
       } catch (err) {
         logger.warn("Font remeasure failed", err);
       }
 
-      // remeasureFont does not invalidate cells rasterized before fonts were ready.
+      // Font remeasurement does not invalidate cells rasterized before fonts were ready.
       xtermRuntimeRef.current?.clearTextureAtlas();
       const visibleTerm = termRef.current;
       if (visibleTerm) {
@@ -1118,7 +1123,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       if (remeasureTimer) clearTimeout(remeasureTimer);
       fontFaceSet?.removeEventListener?.("loadingdone", onLoadingDone);
     };
-  }, [effectiveFontSize, effectiveFontWeight, resizeSession, terminalSettings]);
+  }, [effectiveFontSize, effectiveFontWeight, resizeSession, resolvedFontFamily, terminalSettings]);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Fix terminal font recovery after delayed font loading by forcing xterm to remeasure actual font metrics before repaint/refit.
- Add a small helper with regression coverage for the xterm measurement path and fallback behavior.
- Include the resolved font family in the recovery effect dependencies so font-family changes re-arm the recovery path.

## Root Cause

For issue #1920, the terminal could open before the selected font stack was fully ready. The existing recovery path tried to call a stale/nonexistent renderer remeasure hook, so repaint/refit could still use the old cell metrics until the user changed font size manually.

## Validation

- `npx --yes tsx --test components/terminal/runtime/terminalFontRemeasure.test.ts lib/fontAvailability.test.ts infrastructure/config/cjkFonts.test.ts`
- `npx --yes esbuild components/terminal/useTerminalEffects.ts --bundle --packages=external --platform=browser --format=esm --outfile=/tmp/netcatty-useTerminalEffects-check.js --log-level=warning`

Fixes #1920