### PR TITLE
[codex] Remember serial YMODEM send directory

### DIFF
--- a/application/state/ymodemFileMemory.test.ts
+++ b/application/state/ymodemFileMemory.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import * as storageKeys from "../../infrastructure/config/storageKeys.ts";
+import { getRememberedYmodemSendDefaultPath, rememberYmodemSendFilePath } from "./ymodemFileMemory.ts";
+
+type TestStore = {
+  readString: (key: string) => string | null;
+  writeString: (key: string, value: string) => boolean;
+};
+
+const createStore = (initial: Record<string, string> = {}): {
+  store: TestStore;
+  values: Map<string, string>;
+} => {
+  const values = new Map(Object.entries(initial));
+  return {
+    store: {
+      readString: (key: string) => values.get(key) ?? null,
+      writeString: (key: string, value: string) => {
+        values.set(key, value);
+        return true;
+      },
+    },
+    values,
+  };
+};
+
+test("uses the remembered YMODEM send directory as the file picker default path", () => {
+  assert.equal(
+    storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR,
+    "netcatty_terminal_ymodem_send_dir_v1",
+  );
+
+  const { store } = createStore({
+    [storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR]: "/firmware/releases",
+  });
+
+  assert.equal(getRememberedYmodemSendDefaultPath(store), "/firmware/releases");
+});
+
+test("remembers the directory containing a selected YMODEM send file", () => {
+  const { store, values } = createStore();
+
+  assert.equal(rememberYmodemSendFilePath("/firmware/releases/device.bin", store), true);
+  assert.equal(
+    values.get(storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR),
+    "/firmware/releases",
+  );
+});
+
+test("remembers Windows-style YMODEM send directories", () => {
+  const { store, values } = createStore();
+
+  assert.equal(rememberYmodemSendFilePath("C:\\Users\\catty\\device.bin", store), true);
+  assert.equal(
+    values.get(storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR),
+    "C:\\Users\\catty",
+  );
+});
+
+test("ignores blank remembered paths and selected file names without a parent directory", () => {
+  const { store, values } = createStore({
+    [storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR]: "   ",
+  });
+
+  assert.equal(getRememberedYmodemSendDefaultPath(store), undefined);
+  assert.equal(rememberYmodemSendFilePath("device.bin", store), false);
+  assert.equal(values.get(storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR), "   ");
+});

--- a/application/state/ymodemFileMemory.test.ts
+++ b/application/state/ymodemFileMemory.test.ts
@@ -39,6 +39,14 @@ test("uses the remembered YMODEM send directory as the file picker default path"
   assert.equal(getRememberedYmodemSendDefaultPath(store), "/firmware/releases");
 });
 
+test("preserves valid remembered directory whitespace", () => {
+  const { store } = createStore({
+    [storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR]: "/firmware/releases ",
+  });
+
+  assert.equal(getRememberedYmodemSendDefaultPath(store), "/firmware/releases ");
+});
+
 test("remembers the directory containing a selected YMODEM send file", () => {
   const { store, values } = createStore();
 
@@ -46,6 +54,16 @@ test("remembers the directory containing a selected YMODEM send file", () => {
   assert.equal(
     values.get(storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR),
     "/firmware/releases",
+  );
+});
+
+test("keeps POSIX backslashes as part of the selected file name", () => {
+  const { store, values } = createStore();
+
+  assert.equal(rememberYmodemSendFilePath("/firmware/releases\\device.bin", store), true);
+  assert.equal(
+    values.get(storageKeys.STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR),
+    "/firmware",
   );
 });
 

--- a/application/state/ymodemFileMemory.ts
+++ b/application/state/ymodemFileMemory.ts
@@ -8,8 +8,10 @@ type YmodemFileMemoryStore = {
 
 const getParentDirectory = (filePath: string): string | null => {
   const lastForwardSlash = filePath.lastIndexOf("/");
-  const lastBackslash = filePath.lastIndexOf("\\");
-  const lastSeparator = Math.max(lastForwardSlash, lastBackslash);
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(filePath) || filePath.startsWith("\\\\");
+  const lastSeparator = isWindowsPath
+    ? Math.max(lastForwardSlash, filePath.lastIndexOf("\\"))
+    : lastForwardSlash;
 
   if (lastSeparator < 0) return null;
   if (lastSeparator === 0) return filePath.slice(0, 1);
@@ -21,8 +23,9 @@ const getParentDirectory = (filePath: string): string | null => {
 export const getRememberedYmodemSendDefaultPath = (
   store: YmodemFileMemoryStore = localStorageAdapter,
 ): string | undefined => {
-  const rememberedPath = store.readString(STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR)?.trim();
-  return rememberedPath || undefined;
+  const rememberedPath = store.readString(STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR);
+  if (!rememberedPath || rememberedPath.trim() === "") return undefined;
+  return rememberedPath;
 };
 
 export const rememberYmodemSendFilePath = (

--- a/application/state/ymodemFileMemory.ts
+++ b/application/state/ymodemFileMemory.ts
@@ -1,0 +1,35 @@
+import { STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR } from "../../infrastructure/config/storageKeys";
+import { localStorageAdapter } from "../../infrastructure/persistence/localStorageAdapter";
+
+type YmodemFileMemoryStore = {
+  readString: (key: string) => string | null;
+  writeString: (key: string, value: string) => boolean;
+};
+
+const getParentDirectory = (filePath: string): string | null => {
+  const lastForwardSlash = filePath.lastIndexOf("/");
+  const lastBackslash = filePath.lastIndexOf("\\");
+  const lastSeparator = Math.max(lastForwardSlash, lastBackslash);
+
+  if (lastSeparator < 0) return null;
+  if (lastSeparator === 0) return filePath.slice(0, 1);
+  if (lastSeparator === 2 && filePath[1] === ":") return filePath.slice(0, 3);
+
+  return filePath.slice(0, lastSeparator);
+};
+
+export const getRememberedYmodemSendDefaultPath = (
+  store: YmodemFileMemoryStore = localStorageAdapter,
+): string | undefined => {
+  const rememberedPath = store.readString(STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR)?.trim();
+  return rememberedPath || undefined;
+};
+
+export const rememberYmodemSendFilePath = (
+  filePath: string,
+  store: YmodemFileMemoryStore = localStorageAdapter,
+): boolean => {
+  const directory = getParentDirectory(filePath);
+  if (!directory) return false;
+  return store.writeString(STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR, directory);
+};

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -126,6 +126,7 @@ import { useTerminalContextActions } from "./terminal/hooks/useTerminalContextAc
 import { useTerminalAuthState } from "./terminal/hooks/useTerminalAuthState";
 import { useTerminalDragDrop } from "./terminal/hooks/useTerminalDragDrop";
 import { useTerminalFilePaste } from "./terminal/hooks/useTerminalFilePaste";
+import { getRememberedYmodemSendDefaultPath, rememberYmodemSendFilePath } from "../application/state/ymodemFileMemory";
 import { TerminalAutocomplete } from "./terminal/TerminalAutocomplete";
 import { resolveTerminalAutocompleteSettings } from "./terminal/autocomplete/terminalAutocompleteSettings";
 import { buildOsc7SetupExecCommand, runOsc7SetupAction, shouldOfferOsc7SetupAction } from "./terminal/osc7Setup";
@@ -1893,12 +1894,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     try {
+      const defaultPath = getRememberedYmodemSendDefaultPath();
       const filePath = await selectFile(
         t("terminal.ymodem.selectFile"),
-        undefined,
+        defaultPath,
         [{ name: t("terminal.ymodem.allFiles"), extensions: ["*"] }],
       );
       if (!filePath) return;
+      rememberYmodemSendFilePath(filePath);
 
       const fileName = filePath.split(/[\\/]/).pop() || filePath;
       toast.info(t("terminal.ymodem.started", { fileName }));

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -203,6 +203,7 @@ export const STORAGE_KEY_TERMINAL_HOST_TREE_COLLAPSED = 'netcatty_terminal_host_
 export const STORAGE_KEY_TERMINAL_COMPOSE_BAR_OPEN = 'netcatty_terminal_compose_bar_open_v1';
 export const STORAGE_KEY_TERMINAL_SEARCH_OPEN = 'netcatty_terminal_search_open_v1';
 export const STORAGE_KEY_TERMINAL_ENCODING_BY_HOST_PREFIX = 'netcatty_terminal_encoding_by_host_v1:';
+export const STORAGE_KEY_TERMINAL_YMODEM_SEND_DIR = 'netcatty_terminal_ymodem_send_dir_v1';
 
 // Port Forwarding (transient cross-window broadcast key)
 export const STORAGE_KEY_PF_RECONNECT_CANCEL = '__netcatty_pf_cancel_reconnect';


### PR DESCRIPTION
## Summary
- Remember the last folder used when sending a file over serial YMODEM.
- Reuse that folder as the default location the next time the YMODEM file picker opens.
- Add coverage for POSIX paths, Windows paths, blank saved values, and filename-only selections.

Fixes #1679

## Checks
- `node --test --import tsx application/state/ymodemFileMemory.test.ts`
- `npx eslint components/Terminal.tsx application/state/ymodemFileMemory.ts application/state/ymodemFileMemory.test.ts infrastructure/config/storageKeys.ts`
- `npm run build`
- `npm test`