### PR TITLE
[codex] Add Catty provider model picker

### DIFF
--- a/components/AIChatPanelContent.tsx
+++ b/components/AIChatPanelContent.tsx
@@ -4,6 +4,7 @@ import type { AIPermissionMode, AISession, ChatMessage, DiscoveredAgent, Externa
 import type { Host, VaultNote } from '../types';
 import type { UserSkillOption } from './ai/userSkillsState';
 import type { AIQuickMessage } from '../infrastructure/ai/quickMessages';
+import type { ProviderModelOption } from './ai/providerSwitcherModels';
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import AgentSelector from './ai/AgentSelector';
@@ -61,7 +62,7 @@ interface AIChatPanelContentProps {
   cattyConfiguredProviders: ProviderConfig[];
   effectiveActiveProvider?: ProviderConfig;
   effectiveActiveModelId?: string;
-  handleAgentProviderModelSelect: (providerId: string, modelId: string) => void;
+  handleAgentProviderModelSelect: (providerId: string, modelId: string, model?: ProviderModelOption) => void;
   files: UploadedFile[];
   addFiles: (inputFiles: File[]) => Promise<void>;
   removeFile: (fileId: string) => void;

--- a/components/AIChatSidePanel.mountRetention.test.ts
+++ b/components/AIChatSidePanel.mountRetention.test.ts
@@ -93,6 +93,7 @@ const baseProps = (overrides: Partial<AIChatSidePanelProps> = {}): AIChatSidePan
   providers: [],
   activeProviderId: '',
   activeModelId: '',
+  updateProvider: () => undefined,
   defaultAgentId: 'catty',
   toolIntegrationMode: 'mcp',
   externalAgents: [],

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -65,6 +65,7 @@ import {
   type SdkRuntimeModelCatalog,
 } from './AIChatSidePanelHelpers';
 import { AIChatPanelContent } from './AIChatPanelContent';
+import { mergeProviderModelContextWindow, type ProviderModelOption } from './ai/providerSwitcherModels';
 import {
   getAIPanelProfilerProps,
   profileAIPanelCalculation,
@@ -252,6 +253,7 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   providers,
   activeProviderId,
   activeModelId,
+  updateProvider,
   defaultAgentId,
   toolIntegrationMode,
   externalAgents,
@@ -618,11 +620,24 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
   );
 
   const handleAgentProviderModelSelect = useCallback(
-    (providerId: string, modelId: string) => {
+    (providerId: string, modelId: string, model?: ProviderModelOption) => {
       setAgentProvider(currentAgentId, providerId);
       setAgentModel(currentAgentId, modelId);
+      if (!model) return;
+
+      const provider = providers.find((p) => p.id === providerId);
+      if (!provider) return;
+      const nextModelContextWindows = mergeProviderModelContextWindow(provider.modelContextWindows, model);
+      if (
+        !nextModelContextWindows
+        || nextModelContextWindows === provider.modelContextWindows
+        || nextModelContextWindows[model.id] === provider.modelContextWindows?.[model.id]
+      ) {
+        return;
+      }
+      updateProvider(providerId, { modelContextWindows: nextModelContextWindows });
     },
-    [currentAgentId, setAgentProvider, setAgentModel],
+    [currentAgentId, providers, setAgentProvider, setAgentModel, updateProvider],
   );
 
   const providerDisplayName = effectiveActiveProvider?.name ?? '';
@@ -1316,6 +1331,7 @@ const AI_CHAT_SIDE_PANEL_AI_STATE_KEYS = [
   'providers',
   'activeProviderId',
   'activeModelId',
+  'updateProvider',
   'defaultAgentId',
   'toolIntegrationMode',
   'externalAgents',

--- a/components/AIChatSidePanel.types.ts
+++ b/components/AIChatSidePanel.types.ts
@@ -54,6 +54,7 @@ export interface AIChatSidePanelProps {
   providers: ProviderConfig[];
   activeProviderId: string;
   activeModelId: string;
+  updateProvider: (id: string, updates: Partial<ProviderConfig>) => void;
 
   // Agent info
   defaultAgentId: string;

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -29,7 +29,10 @@ import { getFetchBridge } from '../settings/tabs/ai/types';
 import { parseFetchedModels } from '../settings/tabs/ai/modelMetadata';
 import {
   buildProviderModelOptions,
+  buildProviderModelCatalogRequestKey,
   getProviderModelDiscoveryConfig,
+  shouldLoadProviderModelCatalog,
+  type ProviderModelCatalogState,
   type ProviderModelOption,
 } from './providerSwitcherModels';
 import { ScrollArea } from '../ui/scroll-area';
@@ -58,16 +61,9 @@ export interface ProviderSwitcherConfig {
   selectedProviderId?: string;
   /** Currently bound model id under the selected provider. */
   selectedModelId?: string;
-  /** Fires when the user picks a (providerId, modelId) pair. */
-  onSelect: (providerId: string, modelId: string) => void;
+  /** Fires when the user picks a provider/model pair. */
+  onSelect: (providerId: string, modelId: string, model?: ProviderModelOption) => void;
 }
-
-type ProviderModelCatalogState = {
-  status: 'idle' | 'loading' | 'loaded' | 'error';
-  models: ProviderModelOption[];
-  error?: string;
-  requestKey?: string;
-};
 
 interface ChatInputProps {
   value: string;
@@ -481,17 +477,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const discovery = getProviderModelDiscoveryConfig(provider);
     if (!discovery.canFetch || !discovery.endpoint) return;
 
-    const requestKey = JSON.stringify({
-      providerId: provider.id,
-      baseURL: discovery.baseURL,
-      endpoint: discovery.endpoint,
-      apiKeyPresent: Boolean(provider.apiKey),
-      style: discovery.style,
-      skipTLSVerify: provider.skipTLSVerify,
-    });
+    const requestKey = buildProviderModelCatalogRequestKey(provider, discovery);
 
     const current = providerModelCatalogsRef.current[provider.id];
-    if (!options.force && current?.requestKey === requestKey && (current.status === 'loading' || current.status === 'loaded')) return;
+    if (!shouldLoadProviderModelCatalog(current, requestKey, options.force)) return;
 
     const bridge = getFetchBridge();
     if (!bridge?.aiFetch) return;
@@ -1058,6 +1047,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
                             </Tooltip>
                           )}
                         </div>
+                        {activeProviderModelOptions.length > 0 && activeProviderModelCatalog?.status === 'error' && activeProviderModelCatalog.error && (
+                          <div className="border-b border-border/25 px-2.5 py-1 text-[10px] leading-snug text-destructive/75">
+                            {activeProviderModelCatalog.error}
+                          </div>
+                        )}
                         {activeProviderModelOptions.length > 0 ? (
                           <div className="p-1">
                             {activeProviderModelOptions.slice(0, 100).map((model) => {
@@ -1072,7 +1066,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
                                   aria-selected={isSelected}
                                   onClick={() => {
                                     if (!activeProviderMenuProvider) return;
-                                    providerSwitcher!.onSelect(activeProviderMenuProvider.id, model.id);
+                                    providerSwitcher!.onSelect(activeProviderMenuProvider.id, model.id, model);
                                     closeAllMenus();
                                   }}
                                   className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors hover:bg-muted/30 cursor-pointer"

--- a/components/ai/ChatInput.tsx
+++ b/components/ai/ChatInput.tsx
@@ -6,7 +6,7 @@
  * and a bottom toolbar with muted controls + subtle send button.
  */
 
-import { AtSign, Check, ChevronDown, ChevronRight, Cpu, Expand, Eye, FileText, ImageIcon, MessageSquare, Package, Plus, ShieldCheck, SquareTerminal, X, Zap } from 'lucide-react';
+import { AtSign, Check, ChevronDown, ChevronRight, Cpu, Expand, Eye, FileText, ImageIcon, MessageSquare, Package, Plus, RefreshCw, ShieldCheck, SquareTerminal, X, Zap } from 'lucide-react';
 import { filterQuickMessages, buildSlashCommandItems, filterUserSkillsForSlash, getSlashCommandItemKey, isSystemStopSlashCommand, type AIQuickMessage, type SlashCommandItem, type UserSkillSlashOption } from '../../infrastructure/ai/quickMessages';
 import { SlashCommandPicker } from './SlashCommandPicker';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -23,23 +23,31 @@ import {
 import type { PromptInputStatus } from '../ai-elements/prompt-input';
 import { formatThinkingLabel } from '../../infrastructure/ai/types';
 import type { AgentModelPreset, AIPermissionMode, ProviderConfig, UploadedFile } from '../../infrastructure/ai/types';
+import { buildModelDiscoveryHeaders } from '../../infrastructure/ai/modelDiscoveryHeaders';
 import { ProviderIconBadge } from '../settings/tabs/ai/ProviderIconBadge';
+import { getFetchBridge } from '../settings/tabs/ai/types';
+import { parseFetchedModels } from '../settings/tabs/ai/modelMetadata';
+import {
+  buildProviderModelOptions,
+  getProviderModelDiscoveryConfig,
+  type ProviderModelOption,
+} from './providerSwitcherModels';
 import { ScrollArea } from '../ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
 // Keep in sync with the popover's Tailwind max-width below.
 const MODEL_PICKER_MAX_WIDTH = 360;
-// Slightly wider for the provider picker so the per-row default-model
-// caption doesn't truncate.
-const PROVIDER_PICKER_MAX_WIDTH = 320;
+// Wide enough for the provider column plus the model column.
+const PROVIDER_PICKER_MAX_WIDTH = 520;
+// Must match the main-process AI bridge placeholder; the real key is injected
+// there so renderer UI never handles decrypted provider secrets.
+const API_KEY_PLACEHOLDER = '__IPC_SECURED__';
 
 /**
  * Provider picker payload used by Catty Agent. When set, the model chip
- * switches to a flat provider list (provider icon + name + the provider's
- * configured default model as caption) in place of the generic Cpu glyph
- * + model-preset dropdown. Each provider exposes a single model — its
- * `defaultModel` — so a two-level menu would be empty noise; picking a
- * provider implicitly picks its model.
+ * switches to a provider-aware picker in place of the generic Cpu glyph +
+ * model-preset dropdown. Users choose a provider first, then choose one of
+ * that provider's remembered, preset, or discovered models.
  */
 export interface ProviderSwitcherConfig {
   /** Every configured provider — Settings-level visibility, not the
@@ -53,6 +61,13 @@ export interface ProviderSwitcherConfig {
   /** Fires when the user picks a (providerId, modelId) pair. */
   onSelect: (providerId: string, modelId: string) => void;
 }
+
+type ProviderModelCatalogState = {
+  status: 'idle' | 'loading' | 'loaded' | 'error';
+  models: ProviderModelOption[];
+  error?: string;
+  requestKey?: string;
+};
 
 interface ChatInputProps {
   value: string;
@@ -138,6 +153,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const [menuPos, setMenuPos] = useState<{ left: number; bottom: number } | null>(null);
   const [inputPanelPos, setInputPanelPos] = useState<{ left: number; bottom: number; width: number } | null>(null);
   const [hoveredModelId, setHoveredModelId] = useState<string | null>(null);
+  const [activeProviderMenuId, setActiveProviderMenuId] = useState<string | null>(null);
+  const [providerModelCatalogs, setProviderModelCatalogs] = useState<Record<string, ProviderModelCatalogState>>({});
   const [slashQuery, setSlashQuery] = useState('');
   const [slashRange, setSlashRange] = useState<{ start: number; end: number } | null>(null);
   // Active highlight index for @ mention / slash skill keyboard navigation
@@ -155,6 +172,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
     setMenuPos(null);
     setInputPanelPos(null);
     setHoveredModelId(null);
+    setActiveProviderMenuId(null);
     setSlashQuery('');
     setSlashRange(null);
   }, []);
@@ -165,6 +183,11 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const attachBtnRef = useRef<HTMLButtonElement>(null);
   const slashPickerListRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const providerModelCatalogsRef = useRef(providerModelCatalogs);
+
+  useEffect(() => {
+    providerModelCatalogsRef.current = providerModelCatalogs;
+  }, [providerModelCatalogs]);
 
   const findSlashTrigger = useCallback((text: string, caretPosition: number) => {
     const beforeCaret = text.slice(0, caretPosition);
@@ -454,6 +477,80 @@ const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [onAddFiles]);
 
+  const loadProviderModels = useCallback(async (provider: ProviderConfig, options: { force?: boolean } = {}) => {
+    const discovery = getProviderModelDiscoveryConfig(provider);
+    if (!discovery.canFetch || !discovery.endpoint) return;
+
+    const requestKey = JSON.stringify({
+      providerId: provider.id,
+      baseURL: discovery.baseURL,
+      endpoint: discovery.endpoint,
+      apiKeyPresent: Boolean(provider.apiKey),
+      style: discovery.style,
+      skipTLSVerify: provider.skipTLSVerify,
+    });
+
+    const current = providerModelCatalogsRef.current[provider.id];
+    if (!options.force && current?.requestKey === requestKey && (current.status === 'loading' || current.status === 'loaded')) return;
+
+    const bridge = getFetchBridge();
+    if (!bridge?.aiFetch) return;
+
+    setProviderModelCatalogs((prev) => ({
+      ...prev,
+      [provider.id]: {
+        status: 'loading',
+        models: prev[provider.id]?.models ?? [],
+        requestKey,
+      },
+    }));
+
+    try {
+      if (bridge.aiAllowlistAddHost && discovery.baseURL) {
+        await bridge.aiAllowlistAddHost(discovery.baseURL);
+      }
+      const result = await bridge.aiFetch(
+        `${discovery.baseURL}${discovery.endpoint}`,
+        'GET',
+        buildModelDiscoveryHeaders(discovery.style, provider.apiKey ? API_KEY_PLACEHOLDER : undefined),
+        undefined,
+        provider.id,
+        undefined,
+        undefined,
+        provider.skipTLSVerify,
+      );
+      if (!result.ok) {
+        throw new Error(result.error || 'Failed to fetch models');
+      }
+      const models = parseFetchedModels(JSON.parse(result.data));
+      models.sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
+      setProviderModelCatalogs((prev) => {
+        if (prev[provider.id]?.requestKey !== requestKey) return prev;
+        return {
+          ...prev,
+          [provider.id]: {
+            status: 'loaded',
+            models,
+            requestKey,
+          },
+        };
+      });
+    } catch (err) {
+      setProviderModelCatalogs((prev) => {
+        if (prev[provider.id]?.requestKey !== requestKey) return prev;
+        return {
+          ...prev,
+          [provider.id]: {
+            status: 'error',
+            models: prev[provider.id]?.models ?? [],
+            error: err instanceof Error ? err.message : 'Failed to fetch models',
+            requestKey,
+          },
+        };
+      });
+    }
+  }, []);
+
   const defaultPlaceholder = agentName
     ? t('ai.chat.placeholder').replace('{agent}', agentName)
     : t('ai.chat.placeholderDefault');
@@ -505,6 +602,39 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const selectedSwitcherProvider = hasProviderSwitcher
     ? providerSwitcher!.providers.find((p) => p.id === providerSwitcher!.selectedProviderId)
     : undefined;
+  const activeProviderMenuProvider = hasProviderSwitcher
+    ? (
+        providerSwitcher!.providers.find((p) => p.id === activeProviderMenuId)
+        ?? selectedSwitcherProvider
+        ?? providerSwitcher!.providers[0]
+      )
+    : undefined;
+  const activeProviderModelCatalog = activeProviderMenuProvider
+    ? providerModelCatalogs[activeProviderMenuProvider.id]
+    : undefined;
+  const activeProviderModelOptions = useMemo(
+    () => activeProviderMenuProvider
+      ? buildProviderModelOptions(activeProviderMenuProvider, activeProviderModelCatalog?.models ?? [])
+      : [],
+    [activeProviderMenuProvider, activeProviderModelCatalog?.models],
+  );
+  const activeProviderDiscovery = activeProviderMenuProvider
+    ? getProviderModelDiscoveryConfig(activeProviderMenuProvider)
+    : undefined;
+
+  useEffect(() => {
+    if (!showModelPicker || !hasProviderSwitcher || !activeProviderMenuProvider) return;
+    if (activeProviderModelCatalog?.status === 'loading') return;
+    void loadProviderModels(activeProviderMenuProvider);
+  }, [
+    activeProviderMenuProvider,
+    activeProviderModelCatalog?.requestKey,
+    activeProviderModelCatalog?.status,
+    hasProviderSwitcher,
+    loadProviderModels,
+    showModelPicker,
+  ]);
+
   const providerSwitcherChipLabel = hasProviderSwitcher
     ? (selectedSwitcherProvider
         ? (providerSwitcher!.selectedModelId
@@ -830,6 +960,9 @@ const ChatInput: React.FC<ChatInputProps> = ({
                   if (selectedPreset?.thinkingLevels?.length) {
                     setHoveredModelId(selectedPreset.id);
                   }
+                  if (hasProviderSwitcher) {
+                    setActiveProviderMenuId(selectedSwitcherProvider?.id ?? providerSwitcher!.providers[0]?.id ?? null);
+                  }
                   setActiveMenu('model');
                 } else {
                   closeAllMenus();
@@ -859,50 +992,107 @@ const ChatInput: React.FC<ChatInputProps> = ({
                   onMouseLeave={() => setHoveredModelId(null)}
                 >
                   {hasProviderSwitcher ? (
-                    <div className="min-w-[260px] max-h-[320px] overflow-y-auto">
-                      {providerSwitcher!.providers.map((p) => {
-                        const isSelected = providerSwitcher!.selectedProviderId === p.id;
-                        const defaultModel = p.defaultModel?.trim() ?? '';
-                        const hasModel = defaultModel.length > 0;
-                        // Rows without a defaultModel are inert — picking
-                        // one would save a binding with an empty model id
-                        // and produce a confusing model error at send time.
-                        // User has to set a defaultModel in Settings first.
-                        const disabled = !hasModel;
-                        const modelCaption = hasModel
-                          ? defaultModel
-                          : t('ai.chat.noProviderModel');
-                        return (
-                          <button
-                            key={p.id}
-                            type="button"
-                            role="option"
-                            aria-selected={isSelected}
-                            aria-disabled={disabled}
-                            disabled={disabled}
-                            title={disabled ? t('ai.chat.noProviderModel') : undefined}
-                            onClick={() => {
-                              if (disabled) return;
-                              providerSwitcher!.onSelect(p.id, defaultModel);
-                              closeAllMenus();
-                            }}
-                            className={`w-full flex items-center gap-2.5 px-2.5 py-2 text-left transition-colors ${
-                              disabled
-                                ? 'opacity-55 cursor-not-allowed'
-                                : 'hover:bg-muted/30 cursor-pointer'
-                            }`}
-                          >
-                            <ProviderIconBadge provider={p} size="md" />
-                            <div className="flex-1 min-w-0">
-                              <div className="truncate text-[12px] text-foreground/85">{p.name}</div>
-                              <div className={`truncate text-[10.5px] ${hasModel ? 'text-muted-foreground/70 font-mono' : 'text-muted-foreground/55 italic'}`}>
-                                {modelCaption}
+                    <div className="grid min-w-[420px] grid-cols-[minmax(130px,0.85fr)_minmax(190px,1.15fr)]">
+                      <div className="max-h-[340px] overflow-y-auto border-r border-border/40 p-1">
+                        {providerSwitcher!.providers.map((p) => {
+                          const isMenuActive = activeProviderMenuProvider?.id === p.id;
+                          const isBound = providerSwitcher!.selectedProviderId === p.id;
+                          const catalog = providerModelCatalogs[p.id];
+                          const caption =
+                            (isBound ? providerSwitcher!.selectedModelId : undefined)
+                            || p.defaultModel
+                            || buildProviderModelOptions(p, catalog?.models ?? [])[0]?.id
+                            || t('ai.chat.noModel');
+                          return (
+                            <button
+                              key={p.id}
+                              type="button"
+                              role="option"
+                              aria-selected={isMenuActive}
+                              onClick={() => {
+                                setActiveProviderMenuId(p.id);
+                                void loadProviderModels(p);
+                              }}
+                              className={`w-full flex items-center gap-2 px-2 py-2 text-left transition-colors rounded-md cursor-pointer ${
+                                isMenuActive ? 'bg-muted/42' : 'hover:bg-muted/28'
+                              }`}
+                            >
+                              <ProviderIconBadge provider={p} size="sm" />
+                              <div className="min-w-0 flex-1">
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                  <span className="truncate text-[12px] text-foreground/86">{p.name}</span>
+                                  {isBound && <Check size={11} className="text-primary shrink-0" />}
+                                </div>
+                                <div className="truncate font-mono text-[10px] text-muted-foreground/62">
+                                  {caption}
+                                </div>
                               </div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <div className="max-h-[340px] min-w-0 overflow-y-auto">
+                        <div className="sticky top-0 z-[1] flex items-center justify-between gap-2 border-b border-border/35 bg-popover px-2.5 py-1.5">
+                          <div className="min-w-0">
+                            <div className="truncate text-[11px] font-medium text-foreground/78">
+                              {activeProviderMenuProvider?.name ?? t('ai.chat.selectProvider')}
                             </div>
-                            {isSelected && <Check size={12} className="text-primary shrink-0" />}
-                          </button>
-                        );
-                      })}
+                            {activeProviderModelCatalog?.status === 'loading' && (
+                              <div className="text-[10px] text-muted-foreground/55">{t('ai.providers.loadingModels')}</div>
+                            )}
+                          </div>
+                          {activeProviderMenuProvider && activeProviderDiscovery?.canFetch && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={() => void loadProviderModels(activeProviderMenuProvider, { force: true })}
+                                  disabled={activeProviderModelCatalog?.status === 'loading'}
+                                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/62 hover:bg-muted/35 hover:text-foreground disabled:opacity-50"
+                                  aria-label={t('ai.providers.refreshModels')}
+                                >
+                                  <RefreshCw size={12} className={activeProviderModelCatalog?.status === 'loading' ? 'animate-spin' : ''} />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>{t('ai.providers.refreshModels')}</TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
+                        {activeProviderModelOptions.length > 0 ? (
+                          <div className="p-1">
+                            {activeProviderModelOptions.slice(0, 100).map((model) => {
+                              const isSelected =
+                                providerSwitcher!.selectedProviderId === activeProviderMenuProvider?.id
+                                && providerSwitcher!.selectedModelId === model.id;
+                              return (
+                                <button
+                                  key={model.id}
+                                  type="button"
+                                  role="option"
+                                  aria-selected={isSelected}
+                                  onClick={() => {
+                                    if (!activeProviderMenuProvider) return;
+                                    providerSwitcher!.onSelect(activeProviderMenuProvider.id, model.id);
+                                    closeAllMenus();
+                                  }}
+                                  className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors hover:bg-muted/30 cursor-pointer"
+                                >
+                                  {isSelected ? <Check size={11} className="text-primary shrink-0" /> : <span className="w-[11px] shrink-0" />}
+                                  <span className="min-w-0 flex-1 truncate font-mono text-foreground/86">{model.id}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <div className="px-3 py-8 text-center text-[11px] text-muted-foreground/58">
+                            {activeProviderModelCatalog?.status === 'loading'
+                              ? t('ai.providers.loadingModels')
+                              : activeProviderModelCatalog?.status === 'error'
+                                ? activeProviderModelCatalog.error
+                                : t('ai.chat.noProviderModel')}
+                          </div>
+                        )}
+                      </div>
                     </div>
                   ) : (
                     <div className="min-w-[260px] max-h-[320px] overflow-y-auto">

--- a/components/ai/providerSwitcherModels.test.ts
+++ b/components/ai/providerSwitcherModels.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { ProviderConfig } from '../../infrastructure/ai/types';
+import { buildProviderModelOptions } from './providerSwitcherModels';
+
+function makeProvider(overrides: Partial<ProviderConfig>): ProviderConfig {
+  return {
+    id: 'provider-1',
+    providerId: 'custom',
+    name: 'Provider',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+test('provider model options include preset models when no default model is configured', () => {
+  const provider = makeProvider({
+    providerId: 'deepseek',
+    name: 'DeepSeek',
+  });
+
+  const options = buildProviderModelOptions(provider);
+
+  assert.equal(options[0]?.id, 'deepseek-v4-flash');
+  assert.ok(options.some((option) => option.id === 'deepseek-chat'));
+});
+
+test('provider model options merge fetched, remembered, default, and preset models without duplicates', () => {
+  const provider = makeProvider({
+    providerId: 'qwen',
+    name: 'Qwen',
+    defaultModel: 'qwen3.7-plus',
+    modelContextWindows: {
+      'qwen3-coder-plus': 131072,
+    },
+  });
+
+  const options = buildProviderModelOptions(provider, [
+    { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus' },
+    { id: 'qwen3.7-plus', name: 'Duplicate default' },
+  ]);
+
+  assert.deepEqual(
+    options.slice(0, 4).map((option) => option.id),
+    ['qwen3.7-plus', 'qwen3.6-plus', 'qwen3-coder-plus', 'qwen3.7-max'],
+  );
+  assert.equal(options.find((option) => option.id === 'qwen3.6-plus')?.name, 'Qwen 3.6 Plus');
+  assert.equal(options.filter((option) => option.id === 'qwen3.7-plus').length, 1);
+});

--- a/components/ai/providerSwitcherModels.test.ts
+++ b/components/ai/providerSwitcherModels.test.ts
@@ -2,7 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import type { ProviderConfig } from '../../infrastructure/ai/types';
-import { buildProviderModelOptions } from './providerSwitcherModels';
+import {
+  buildProviderModelCatalogRequestKey,
+  buildProviderModelOptions,
+  getProviderModelDiscoveryConfig,
+  mergeProviderModelContextWindow,
+  shouldLoadProviderModelCatalog,
+} from './providerSwitcherModels';
 
 function makeProvider(overrides: Partial<ProviderConfig>): ProviderConfig {
   return {
@@ -47,4 +53,60 @@ test('provider model options merge fetched, remembered, default, and preset mode
   );
   assert.equal(options.find((option) => option.id === 'qwen3.6-plus')?.name, 'Qwen 3.6 Plus');
   assert.equal(options.filter((option) => option.id === 'qwen3.7-plus').length, 1);
+});
+
+test('provider model options preserve remembered and fetched context windows', () => {
+  const provider = makeProvider({
+    providerId: 'custom',
+    defaultModel: 'known-model',
+    modelContextWindows: {
+      'known-model': 32768,
+    },
+  });
+
+  const options = buildProviderModelOptions(provider, [
+    { id: 'fetched-model', contextWindow: 65536 },
+  ]);
+
+  assert.equal(options.find((option) => option.id === 'known-model')?.contextWindow, 32768);
+  assert.equal(options.find((option) => option.id === 'fetched-model')?.contextWindow, 65536);
+});
+
+test('provider model catalog does not auto-retry a failed request until forced or config changes', () => {
+  const provider = makeProvider({
+    id: 'qwen-1',
+    providerId: 'qwen',
+    apiKey: 'enc:v1:first',
+  });
+  const discovery = getProviderModelDiscoveryConfig(provider);
+  const requestKey = buildProviderModelCatalogRequestKey(provider, discovery);
+
+  assert.equal(
+    shouldLoadProviderModelCatalog({ status: 'error', requestKey }, requestKey),
+    false,
+  );
+  assert.equal(
+    shouldLoadProviderModelCatalog({ status: 'error', requestKey }, requestKey, true),
+    true,
+  );
+
+  const changedKey = buildProviderModelCatalogRequestKey(
+    { ...provider, apiKey: 'enc:v1:second' },
+    discovery,
+  );
+  assert.equal(
+    shouldLoadProviderModelCatalog({ status: 'error', requestKey }, changedKey),
+    true,
+  );
+});
+
+test('provider model context windows merge only valid selected model metadata', () => {
+  assert.deepEqual(
+    mergeProviderModelContextWindow({ existing: 8192 }, { id: 'qwen3.6-plus', contextWindow: 131072 }),
+    { existing: 8192, 'qwen3.6-plus': 131072 },
+  );
+  assert.deepEqual(
+    mergeProviderModelContextWindow({ existing: 8192 }, { id: 'bad-model' }),
+    { existing: 8192 },
+  );
 });

--- a/components/ai/providerSwitcherModels.ts
+++ b/components/ai/providerSwitcherModels.ts
@@ -5,6 +5,7 @@ import {
   type ProviderStyle,
 } from '../../infrastructure/ai/types';
 import { resolveModelsDiscoveryEndpoint } from '../../infrastructure/ai/modelDiscoveryHeaders';
+import { sanitizeContextWindow } from '../../infrastructure/ai/contextCompaction';
 
 export interface ProviderModelOption {
   id: string;
@@ -17,6 +18,15 @@ export interface ProviderModelDiscoveryConfig {
   endpoint?: string;
   style: ProviderStyle;
   canFetch: boolean;
+}
+
+export type ProviderModelCatalogStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+export interface ProviderModelCatalogState {
+  status: ProviderModelCatalogStatus;
+  models: ProviderModelOption[];
+  error?: string;
+  requestKey?: string;
 }
 
 export function buildProviderModelOptions(
@@ -42,7 +52,9 @@ export function buildProviderModelOptions(
 
   addModel(provider.defaultModel);
   for (const model of fetchedModels) addModel(model);
-  for (const modelId of Object.keys(provider.modelContextWindows ?? {})) addModel(modelId);
+  for (const [modelId, contextWindow] of Object.entries(provider.modelContextWindows ?? {})) {
+    addModel({ id: modelId, contextWindow });
+  }
   for (const modelId of PROVIDER_PRESETS[provider.providerId]?.defaultModels ?? []) addModel(modelId);
 
   return Array.from(byId.values());
@@ -63,4 +75,37 @@ export function getProviderModelDiscoveryConfig(
     style,
     canFetch: Boolean(baseURL && endpoint && (!needsApiKey || provider.apiKey)),
   };
+}
+
+export function buildProviderModelCatalogRequestKey(
+  provider: Pick<ProviderConfig, 'id' | 'apiKey' | 'skipTLSVerify'>,
+  discovery: Pick<ProviderModelDiscoveryConfig, 'baseURL' | 'endpoint' | 'style'>,
+): string {
+  return JSON.stringify({
+    providerId: provider.id,
+    baseURL: discovery.baseURL,
+    endpoint: discovery.endpoint,
+    apiKeyFingerprint: provider.apiKey ?? '',
+    style: discovery.style,
+    skipTLSVerify: provider.skipTLSVerify,
+  });
+}
+
+export function shouldLoadProviderModelCatalog(
+  current: Pick<ProviderModelCatalogState, 'requestKey' | 'status'> | undefined,
+  requestKey: string,
+  force = false,
+): boolean {
+  if (force) return true;
+  if (current?.requestKey !== requestKey) return true;
+  return current.status === 'idle';
+}
+
+export function mergeProviderModelContextWindow(
+  current: Record<string, number> | undefined,
+  model: ProviderModelOption,
+): Record<string, number> | undefined {
+  const sanitized = sanitizeContextWindow(model.contextWindow);
+  if (!model.id || sanitized == null) return current;
+  return { ...(current ?? {}), [model.id]: sanitized };
 }

--- a/components/ai/providerSwitcherModels.ts
+++ b/components/ai/providerSwitcherModels.ts
@@ -1,0 +1,66 @@
+import {
+  PROVIDER_PRESETS,
+  resolveProviderStyle,
+  type ProviderConfig,
+  type ProviderStyle,
+} from '../../infrastructure/ai/types';
+import { resolveModelsDiscoveryEndpoint } from '../../infrastructure/ai/modelDiscoveryHeaders';
+
+export interface ProviderModelOption {
+  id: string;
+  name?: string;
+  contextWindow?: number;
+}
+
+export interface ProviderModelDiscoveryConfig {
+  baseURL: string;
+  endpoint?: string;
+  style: ProviderStyle;
+  canFetch: boolean;
+}
+
+export function buildProviderModelOptions(
+  provider: Pick<ProviderConfig, 'providerId' | 'defaultModel' | 'modelContextWindows'>,
+  fetchedModels: ProviderModelOption[] = [],
+): ProviderModelOption[] {
+  const byId = new Map<string, ProviderModelOption>();
+
+  const addModel = (model: ProviderModelOption | string | undefined) => {
+    const rawId = typeof model === 'string' ? model : model?.id;
+    const id = rawId?.trim();
+    if (!id) return;
+    const nextModel = typeof model === 'string' ? { id } : { ...model, id };
+    const existing = byId.get(id);
+    if (!existing) {
+      byId.set(id, nextModel);
+      return;
+    }
+    if ((!existing.name && nextModel.name) || (!existing.contextWindow && nextModel.contextWindow)) {
+      byId.set(id, { ...existing, ...nextModel });
+    }
+  };
+
+  addModel(provider.defaultModel);
+  for (const model of fetchedModels) addModel(model);
+  for (const modelId of Object.keys(provider.modelContextWindows ?? {})) addModel(modelId);
+  for (const modelId of PROVIDER_PRESETS[provider.providerId]?.defaultModels ?? []) addModel(modelId);
+
+  return Array.from(byId.values());
+}
+
+export function getProviderModelDiscoveryConfig(
+  provider: Pick<ProviderConfig, 'providerId' | 'style' | 'baseURL' | 'apiKey'>,
+): ProviderModelDiscoveryConfig {
+  const style = resolveProviderStyle(provider);
+  const preset = PROVIDER_PRESETS[provider.providerId];
+  const endpoint = resolveModelsDiscoveryEndpoint(style, preset?.modelsEndpoint);
+  const baseURL = (provider.baseURL || preset?.defaultBaseURL || '').trim().replace(/\/+$/, '');
+  const needsApiKey = provider.providerId !== 'ollama';
+
+  return {
+    baseURL,
+    endpoint,
+    style,
+    canFetch: Boolean(baseURL && endpoint && (!needsApiKey || provider.apiKey)),
+  };
+}

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -542,6 +542,7 @@ const AIChatPanelsHostInner: React.FC<AIChatPanelsHostProps> = ({
                     providers={aiState.providers}
                     activeProviderId={aiState.activeProviderId}
                     activeModelId={aiState.activeModelId}
+                    updateProvider={aiState.updateProvider}
                     defaultAgentId={aiState.defaultAgentId}
                     toolIntegrationMode={aiState.toolIntegrationMode}
                     externalAgents={aiState.externalAgents}


### PR DESCRIPTION
Fixes #1884.

## What changed
- Catty 输入框里的模型选择现在先选 provider，再选该 provider 下的模型。
- 不再需要为了切换 Catty provider/model 反复去设置页。
- 模型列表会结合已配置模型、已发现模型和常见默认模型，并支持在面板里刷新。

## Validation
- `node --test --import tsx components/ai/ChatInput.test.tsx components/ai/providerSwitcherModels.test.ts components/settings/tabs/ai/modelMetadata.test.ts components/settings/tabs/ai/dropdownLayout.test.ts infrastructure/ai/modelDiscoveryHeaders.test.ts infrastructure/ai/providerStyle.test.ts`
- Targeted `npx tsc --noEmit ... components/ai/ChatInput.tsx components/ai/providerSwitcherModels.ts components/ai/providerSwitcherModels.test.ts`
- `npm run lint -- components/ai/ChatInput.tsx components/ai/providerSwitcherModels.ts components/ai/providerSwitcherModels.test.ts`
- `npm run build`

Note: I also tried a full-repo `npx tsc --noEmit`; it still reports pre-existing unrelated type errors elsewhere in the repo.
