### PR TITLE
[codex] Fix terminal Shift mouse selection

### DIFF
--- a/components/terminal/TerminalContextMenu.test.ts
+++ b/components/terminal/TerminalContextMenu.test.ts
@@ -53,6 +53,15 @@ const shouldRenderTerminalContextMenuContent = (
     }) => boolean;
   }
 ).shouldRenderTerminalContextMenuContent;
+const shouldAllowSuppressedTerminalContextMenuContent = (
+  terminalContextMenu as {
+    shouldAllowSuppressedTerminalContextMenuContent?: (options: {
+      event: { shiftKey?: boolean; nativeEvent: MouseEvent };
+      isAlternateScreen?: boolean;
+      showReconnectAction?: boolean;
+    }) => boolean;
+  }
+).shouldAllowSuppressedTerminalContextMenuContent;
 
 test("shows reconnect only for reconnectable terminals with a handler", () => {
   assert.equal(typeof shouldShowReconnectAction, "function");
@@ -216,30 +225,40 @@ test("opens a middle-click menu even when right-click is configured to paste", (
 test("opens and renders middle-click menu while alternate-screen mouse tracking suppresses right-click menus", () => {
   assert.equal(typeof shouldOpenTerminalContextMenu, "function");
   assert.equal(typeof shouldRenderTerminalContextMenuContent, "function");
+  assert.equal(typeof shouldAllowSuppressedTerminalContextMenuContent, "function");
   if (
     typeof shouldOpenTerminalContextMenu !== "function" ||
-    typeof shouldRenderTerminalContextMenuContent !== "function"
+    typeof shouldRenderTerminalContextMenuContent !== "function" ||
+    typeof shouldAllowSuppressedTerminalContextMenuContent !== "function"
   ) {
     return;
   }
 
+  const middleClickEvent = {
+    shiftKey: false,
+    nativeEvent: markMiddleClickContextMenuEvent({} as MouseEvent),
+  };
+
   assert.equal(
     shouldOpenTerminalContextMenu({
-      event: {
-        shiftKey: false,
-        nativeEvent: markMiddleClickContextMenuEvent({} as MouseEvent),
-      },
+      event: middleClickEvent,
       rightClickBehavior: "paste",
       isAlternateScreen: true,
       showReconnectAction: false,
     }),
     true,
   );
+  const allowSuppressedMenuContent = shouldAllowSuppressedTerminalContextMenuContent({
+    event: middleClickEvent,
+    isAlternateScreen: true,
+    showReconnectAction: false,
+  });
+  assert.equal(allowSuppressedMenuContent, true);
   assert.equal(
     shouldRenderTerminalContextMenuContent({
       isAlternateScreen: true,
       showReconnectAction: false,
-      allowSuppressedMenuContent: true,
+      allowSuppressedMenuContent,
     }),
     true,
   );
@@ -257,10 +276,88 @@ test("opens and renders middle-click menu while alternate-screen mouse tracking 
     false,
   );
   assert.equal(
+    shouldAllowSuppressedTerminalContextMenuContent({
+      event: {
+        nativeEvent: {} as MouseEvent,
+      },
+      isAlternateScreen: true,
+      showReconnectAction: false,
+    }),
+    false,
+  );
+  assert.equal(
     shouldRenderTerminalContextMenuContent({
       isAlternateScreen: true,
       showReconnectAction: false,
       allowSuppressedMenuContent: false,
+    }),
+    false,
+  );
+});
+
+test("opens Shift right-click menu content for all right-click modes while mouse tracking suppresses unmodified menus", () => {
+  assert.equal(typeof shouldOpenTerminalContextMenu, "function");
+  assert.equal(typeof shouldRenderTerminalContextMenuContent, "function");
+  assert.equal(typeof shouldAllowSuppressedTerminalContextMenuContent, "function");
+  if (
+    typeof shouldOpenTerminalContextMenu !== "function" ||
+    typeof shouldRenderTerminalContextMenuContent !== "function" ||
+    typeof shouldAllowSuppressedTerminalContextMenuContent !== "function"
+  ) {
+    return;
+  }
+
+  const event = {
+    shiftKey: true,
+    nativeEvent: {} as MouseEvent,
+  };
+
+  for (const rightClickBehavior of ["context-menu", "paste", "select-word"] as const) {
+    assert.equal(
+      shouldOpenTerminalContextMenu({
+        event,
+        rightClickBehavior,
+        isAlternateScreen: true,
+        showReconnectAction: false,
+      }),
+      true,
+    );
+
+    const allowSuppressedMenuContent = shouldAllowSuppressedTerminalContextMenuContent({
+      event,
+      isAlternateScreen: true,
+      showReconnectAction: false,
+    });
+
+    assert.equal(allowSuppressedMenuContent, true);
+    assert.equal(
+      shouldRenderTerminalContextMenuContent({
+        isAlternateScreen: true,
+        showReconnectAction: false,
+        allowSuppressedMenuContent,
+      }),
+      true,
+    );
+  }
+
+  assert.equal(
+    shouldOpenTerminalContextMenu({
+      event: {
+        nativeEvent: {} as MouseEvent,
+      },
+      rightClickBehavior: "context-menu",
+      isAlternateScreen: true,
+      showReconnectAction: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldAllowSuppressedTerminalContextMenuContent({
+      event: {
+        nativeEvent: {} as MouseEvent,
+      },
+      isAlternateScreen: true,
+      showReconnectAction: false,
     }),
     false,
   );

--- a/components/terminal/TerminalContextMenu.tsx
+++ b/components/terminal/TerminalContextMenu.tsx
@@ -91,6 +91,18 @@ export const shouldRenderTerminalContextMenuContent = ({
   allowSuppressedMenuContent ||
   !shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction });
 
+export const shouldAllowSuppressedTerminalContextMenuContent = ({
+  event,
+  isAlternateScreen,
+  showReconnectAction,
+}: {
+  event: { shiftKey?: boolean; nativeEvent: MouseEvent };
+  isAlternateScreen?: boolean;
+  showReconnectAction?: boolean;
+}): boolean =>
+  isMiddleClickContextMenuEvent(event.nativeEvent)
+  || Boolean(event.shiftKey && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction }));
+
 export const shouldOpenTerminalContextMenu = ({
   event,
   rightClickBehavior = 'context-menu',
@@ -106,11 +118,15 @@ export const shouldOpenTerminalContextMenu = ({
     return true;
   }
 
+  if (event.shiftKey) {
+    return true;
+  }
+
   if (shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction })) {
     return false;
   }
 
-  return Boolean(event.shiftKey || rightClickBehavior === 'context-menu');
+  return rightClickBehavior === 'context-menu';
 };
 
 export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
@@ -187,7 +203,6 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
         isAlternateScreen,
         showReconnectAction,
       });
-      const isMiddleClickMenu = isMiddleClickContextMenuEvent(e.nativeEvent);
 
       if (!shouldOpenMenu && shouldSuppressMouseTrackingContextMenu({ isAlternateScreen, showReconnectAction })) {
         e.preventDefault();
@@ -202,7 +217,11 @@ export const TerminalContextMenu: React.FC<TerminalContextMenuProps> = ({
           pane.setAttribute('data-menu-open', '');
           markedPaneRef.current = pane;
         }
-        setAllowSuppressedMenuContent(isMiddleClickMenu);
+        setAllowSuppressedMenuContent(shouldAllowSuppressedTerminalContextMenuContent({
+          event: e,
+          isAlternateScreen,
+          showReconnectAction,
+        }));
         return;
       }
 

--- a/components/terminal/runtime/middleClickBehavior.test.ts
+++ b/components/terminal/runtime/middleClickBehavior.test.ts
@@ -3,10 +3,14 @@ import test from "node:test";
 
 import {
   isMiddleClickContextMenuEvent,
+  isShiftSelectionReplayMouseEvent,
   markMiddleClickContextMenuEvent,
+  markShiftSelectionReplayMouseEvent,
   captureMiddleClickTerminalMouseEvent,
   resolveMiddleClickBehavior,
   shouldInterceptMouseTrackingContextMenu,
+  shouldReplayShiftMouseSelectionAsMacOption,
+  shouldStopShiftRightClickMouseTrackingMouseDown,
 } from "./middleClickBehavior";
 
 test("resolveMiddleClickBehavior uses the explicit middle-click behavior", () => {
@@ -50,6 +54,187 @@ test("mouse-tracking context menu capture lets middle-click menu events pass thr
       status: "connected",
     }),
     true,
+  );
+});
+
+test("mouse-tracking context menu capture lets Shift-modified mouse events pass through", () => {
+  assert.equal(
+    shouldInterceptMouseTrackingContextMenu({
+      event: { shiftKey: true } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+    }),
+    false,
+  );
+});
+
+test("Shift selection replay events are identifiable", () => {
+  const event = {} as MouseEvent;
+
+  assert.equal(isShiftSelectionReplayMouseEvent(event), false);
+  assert.equal(isShiftSelectionReplayMouseEvent(markShiftSelectionReplayMouseEvent(event)), true);
+});
+
+test("macOS mouse tracking replays plain Shift left-click as xterm option selection", () => {
+  const event = {
+    button: 0,
+    shiftKey: true,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  } as MouseEvent;
+
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event,
+      mouseTracking: true,
+      status: "connected",
+      isMacPlatform: true,
+    }),
+    true,
+  );
+});
+
+test("Shift selection replay is limited to the macOS connected mouse-tracking case", () => {
+  const baseEvent = {
+    button: 0,
+    shiftKey: true,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  } as MouseEvent;
+
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event: baseEvent,
+      mouseTracking: true,
+      status: "connected",
+      isMacPlatform: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event: baseEvent,
+      mouseTracking: false,
+      status: "connected",
+      isMacPlatform: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event: baseEvent,
+      mouseTracking: true,
+      status: "disconnected",
+      isMacPlatform: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event: { ...baseEvent, button: 2 } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      isMacPlatform: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldReplayShiftMouseSelectionAsMacOption({
+      event: { ...baseEvent, shiftKey: false } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+      isMacPlatform: true,
+    }),
+    false,
+  );
+});
+
+test("Shift selection replay ignores modified and already replayed mouse events", () => {
+  const baseEvent = {
+    button: 0,
+    shiftKey: true,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  } as MouseEvent;
+
+  for (const event of [
+    { ...baseEvent, altKey: true },
+    { ...baseEvent, ctrlKey: true },
+    { ...baseEvent, metaKey: true },
+    markShiftSelectionReplayMouseEvent({ ...baseEvent } as MouseEvent),
+  ]) {
+    assert.equal(
+      shouldReplayShiftMouseSelectionAsMacOption({
+        event: event as MouseEvent,
+        mouseTracking: true,
+        status: "connected",
+        isMacPlatform: true,
+      }),
+      false,
+    );
+  }
+});
+
+test("Shift right-click mousedown is stopped while connected mouse tracking is active", () => {
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: {
+        button: 2,
+        shiftKey: true,
+      } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+    }),
+    true,
+  );
+});
+
+test("Shift right-click mousedown capture is limited to connected mouse tracking", () => {
+  const baseEvent = {
+    button: 2,
+    shiftKey: true,
+  } as MouseEvent;
+
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: baseEvent,
+      mouseTracking: false,
+      status: "connected",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: baseEvent,
+      mouseTracking: true,
+      status: "disconnected",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: {
+        button: 2,
+        shiftKey: false,
+      } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldStopShiftRightClickMouseTrackingMouseDown({
+      event: {
+        button: 0,
+        shiftKey: true,
+      } as MouseEvent,
+      mouseTracking: true,
+      status: "connected",
+    }),
+    false,
   );
 });
 

--- a/components/terminal/runtime/middleClickBehavior.ts
+++ b/components/terminal/runtime/middleClickBehavior.ts
@@ -7,7 +7,26 @@ type MiddleClickContextMenuEvent = MouseEvent & {
   [MIDDLE_CONTEXT_MENU_EVENT_KEY]?: boolean;
 };
 
+const SHIFT_SELECTION_REPLAY_EVENT_KEY = "__netcattyShiftSelectionReplay";
+
+type ShiftSelectionReplayMouseEvent = MouseEvent & {
+  [SHIFT_SELECTION_REPLAY_EVENT_KEY]?: boolean;
+};
+
 export interface MouseTrackingContextMenuCaptureState {
+  event: MouseEvent;
+  mouseTracking: boolean;
+  status?: string | null;
+}
+
+export interface ShiftMouseSelectionReplayState {
+  event: MouseEvent;
+  mouseTracking: boolean;
+  status?: string | null;
+  isMacPlatform: boolean;
+}
+
+export interface ShiftRightClickMouseDownCaptureState {
   event: MouseEvent;
   mouseTracking: boolean;
   status?: string | null;
@@ -39,12 +58,72 @@ export const markMiddleClickContextMenuEvent = (event: MouseEvent): MouseEvent =
 export const isMiddleClickContextMenuEvent = (event: MouseEvent): boolean =>
   (event as MiddleClickContextMenuEvent)[MIDDLE_CONTEXT_MENU_EVENT_KEY] === true;
 
+export const markShiftSelectionReplayMouseEvent = (event: MouseEvent): MouseEvent => {
+  Object.defineProperty(event, SHIFT_SELECTION_REPLAY_EVENT_KEY, {
+    value: true,
+    configurable: true,
+  });
+  return event;
+};
+
+export const isShiftSelectionReplayMouseEvent = (event: MouseEvent): boolean =>
+  (event as ShiftSelectionReplayMouseEvent)[SHIFT_SELECTION_REPLAY_EVENT_KEY] === true;
+
 export const shouldInterceptMouseTrackingContextMenu = ({
   event,
   mouseTracking,
   status,
 }: MouseTrackingContextMenuCaptureState): boolean =>
-  mouseTracking && status === "connected" && !isMiddleClickContextMenuEvent(event);
+  mouseTracking
+  && status === "connected"
+  && !event.shiftKey
+  && !isMiddleClickContextMenuEvent(event);
+
+export const shouldReplayShiftMouseSelectionAsMacOption = ({
+  event,
+  mouseTracking,
+  status,
+  isMacPlatform,
+}: ShiftMouseSelectionReplayState): boolean =>
+  isMacPlatform
+  && mouseTracking
+  && status === "connected"
+  && event.button === 0
+  && event.shiftKey
+  && !event.altKey
+  && !event.ctrlKey
+  && !event.metaKey
+  && !isShiftSelectionReplayMouseEvent(event);
+
+export const shouldStopShiftRightClickMouseTrackingMouseDown = ({
+  event,
+  mouseTracking,
+  status,
+}: ShiftRightClickMouseDownCaptureState): boolean =>
+  mouseTracking
+  && status === "connected"
+  && event.button === 2
+  && event.shiftKey;
+
+export const createMacOptionForcedSelectionMouseEvent = (event: MouseEvent): MouseEvent =>
+  markShiftSelectionReplayMouseEvent(new MouseEvent(event.type, {
+    bubbles: event.bubbles,
+    cancelable: event.cancelable,
+    composed: event.composed,
+    detail: event.detail,
+    view: event.view,
+    screenX: event.screenX,
+    screenY: event.screenY,
+    clientX: event.clientX,
+    clientY: event.clientY,
+    ctrlKey: event.ctrlKey,
+    altKey: true,
+    shiftKey: false,
+    metaKey: event.metaKey,
+    button: event.button,
+    buttons: event.buttons,
+    relatedTarget: event.relatedTarget,
+  }));
 
 export const captureMiddleClickTerminalMouseEvent = (event: MouseEvent): boolean => {
   if (event.button !== 1) return false;

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -2,8 +2,14 @@
 import { useRef } from 'react';
 import { resolveFontWeightBold } from '../../lib/fontWeightAvailability';
 import { bundledFamiliesInStack } from '../../lib/fontAvailability';
+import { isMacPlatform } from '../../lib/utils';
 import { resolveXTermScrollback } from '../../infrastructure/config/xtermPerformance';
-import { shouldInterceptMouseTrackingContextMenu } from './runtime/middleClickBehavior';
+import {
+  createMacOptionForcedSelectionMouseEvent,
+  shouldInterceptMouseTrackingContextMenu,
+  shouldReplayShiftMouseSelectionAsMacOption,
+  shouldStopShiftRightClickMouseTrackingMouseDown,
+} from './runtime/middleClickBehavior';
 import {
   hasOpenAppDialog,
   TERMINAL_SESSION_RESTORE_FOCUS_EVENT,
@@ -1360,6 +1366,11 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
   // Prevent xterm.js's built-in rightClickHandler and right-button mouseup
   // from interfering with tmux/vim popup menus when mouse tracking is active.
+  // On macOS, xterm forces selection with Option, while most terminal users
+  // expect Shift to bypass mouse reporting. Replay Shift+left-click as that
+  // native xterm force-selection gesture before xterm receives the original.
+  // - mousedown (button 2 + Shift): keep Shift+right-click local so the
+  //   terminal app does not also receive the right-button press
   // - contextmenu: xterm.js calls textarea.select() which steals focus
   // - mouseup (button 2): tmux interprets the right-button release as a
   //   dismiss action, closing the popup menu immediately after it appears
@@ -1398,15 +1409,44 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       // does not intercept.
     };
 
+    const handleMouseDownCapture = (e: MouseEvent) => {
+      if (shouldStopShiftRightClickMouseTrackingMouseDown({
+        event: e,
+        mouseTracking: mouseTrackingRef.current,
+        status: statusRef.current,
+      })) {
+        e.stopImmediatePropagation();
+        return;
+      }
+
+      if (!shouldReplayShiftMouseSelectionAsMacOption({
+        event: e,
+        mouseTracking: mouseTrackingRef.current,
+        status: statusRef.current,
+        isMacPlatform: isMacPlatform(),
+      })) {
+        return;
+      }
+
+      const target = e.target as EventTarget | null;
+      if (!target || typeof target.dispatchEvent !== 'function') return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      target.dispatchEvent(createMacOptionForcedSelectionMouseEvent(e));
+    };
+
     const handleMouseUpCapture = (e: MouseEvent) => {
       if (e.button === 2 && mouseTrackingRef.current && statusRef.current === 'connected') {
         e.stopImmediatePropagation();
       }
     };
 
+    el.addEventListener('mousedown', handleMouseDownCapture, true);
     el.addEventListener('contextmenu', handleContextMenuCapture, true);
     el.addEventListener('mouseup', handleMouseUpCapture, true);
     return () => {
+      el.removeEventListener('mousedown', handleMouseDownCapture, true);
       el.removeEventListener('contextmenu', handleContextMenuCapture, true);
       el.removeEventListener('mouseup', handleMouseUpCapture, true);
     };


### PR DESCRIPTION
## Summary

Fixes #1541.

This updates terminal mouse handling so users can still use local selection and Netcatty context-menu actions while a full-screen terminal app has mouse reporting enabled.

## What changed

- Allows Shift+right-click to open Netcatty's terminal context menu even when normal right-click menus are suppressed for full-screen terminal apps.
- Keeps Shift+right-click local so the remote app does not also receive the right-button press.
- Lets Shift+left-click/drag force local text selection on macOS by matching the terminal's existing forced-selection behavior.
- Adds regression coverage for Shift right-click, middle-click context menus, and Shift selection handling.

## Validation

- `node --test --import tsx components/terminal/runtime/middleClickBehavior.test.ts components/terminal/TerminalContextMenu.test.ts`
- `node --test --import tsx components/terminal/*.test.ts components/terminal/*.test.tsx components/terminal/runtime/*.test.ts`
- `npm run lint`
- `git diff --check`
- `npm test`
- `npm run build`