### PR TITLE
[codex] Default SSH auto reconnect off

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -489,7 +489,7 @@ export const enCoreMessages: Messages = {
   'settings.terminal.connection.verifyHostKeys': 'Verify SSH host keys',
   'settings.terminal.connection.verifyHostKeys.desc': 'Ask before connecting to a new or changed SSH host key. Turn this off only for trusted private networks.',
   'settings.terminal.connection.sshAutoReconnectEnabled': 'Automatically reconnect SSH sessions',
-  'settings.terminal.connection.sshAutoReconnectEnabled.desc': 'After an established SSH session drops unexpectedly, try to reconnect every 5 seconds until the tab is closed or the connection succeeds.',
+  'settings.terminal.connection.sshAutoReconnectEnabled.desc': 'When turned on, established SSH sessions that drop unexpectedly try to reconnect every 5 seconds until the tab is closed or the connection succeeds.',
   'settings.terminal.connection.keepaliveInterval': 'Keepalive Interval',
   'settings.terminal.connection.keepaliveInterval.desc': 'How often (in seconds) to send SSH-level keepalive packets. Set to 0 to disable globally — note that individual hosts can override this in their own settings.',
   'settings.terminal.connection.keepaliveCountMax': 'Max unanswered keepalives',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -336,7 +336,7 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.localShell.startDir.isFile': '路径是文件，不是目录',
   'settings.terminal.section.connection': '连接',
   'settings.terminal.connection.sshAutoReconnectEnabled': 'SSH 断线后自动重连',
-  'settings.terminal.connection.sshAutoReconnectEnabled.desc': '已连上的 SSH 会话意外断开后，每 5 秒尝试重新连接，直到关闭标签页或连接恢复。',
+  'settings.terminal.connection.sshAutoReconnectEnabled.desc': '打开后，已连上的 SSH 会话意外断开时会每 5 秒尝试重新连接，直到关闭标签页或连接恢复。',
   'settings.terminal.connection.keepaliveInterval': '会话保持间隔',
   'settings.terminal.connection.keepaliveInterval.desc': '向服务器发送 SSH 保活数据包的频率（秒）。设为 0 表示全局禁用——单个主机可在自己的设置里覆盖此值。',
   'settings.terminal.connection.keepaliveCountMax': '最大无响应保活次数',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -336,7 +336,7 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.localShell.startDir.isFile': '路徑是檔案，不是目錄',
   'settings.terminal.section.connection': '連線',
   'settings.terminal.connection.sshAutoReconnectEnabled': 'SSH 斷線後自動重連',
-  'settings.terminal.connection.sshAutoReconnectEnabled.desc': '已連上的 SSH 工作階段意外斷開後，每 5 秒嘗試重新連線，直到關閉標籤頁或連線恢復。',
+  'settings.terminal.connection.sshAutoReconnectEnabled.desc': '開啟後，已連上的 SSH 工作階段意外斷開時會每 5 秒嘗試重新連線，直到關閉標籤頁或連線恢復。',
   'settings.terminal.connection.keepaliveInterval': '工作階段保持間隔',
   'settings.terminal.connection.keepaliveInterval.desc': '向伺服器傳送 SSH 保活資料包的頻率（秒）。設為 0 表示全域停用——單個主機可在自己的設定裡覆蓋此值。',
   'settings.terminal.connection.keepaliveCountMax': '最大無響應保活次數',

--- a/application/state/terminalAutoReconnect.test.ts
+++ b/application/state/terminalAutoReconnect.test.ts
@@ -18,8 +18,8 @@ test("terminal auto reconnect uses a five second retry delay", () => {
   assert.equal(TERMINAL_AUTO_RECONNECT_DELAY_MS, 5000);
 });
 
-test("terminal auto reconnect is enabled unless the setting is explicitly false", () => {
-  assert.equal(isTerminalAutoReconnectEnabled(undefined), true);
+test("terminal auto reconnect is disabled unless the setting is explicitly true", () => {
+  assert.equal(isTerminalAutoReconnectEnabled(undefined), false);
   assert.equal(isTerminalAutoReconnectEnabled({ sshAutoReconnectEnabled: true }), true);
   assert.equal(isTerminalAutoReconnectEnabled({ sshAutoReconnectEnabled: false }), false);
 });

--- a/application/state/terminalAutoReconnect.ts
+++ b/application/state/terminalAutoReconnect.ts
@@ -13,7 +13,7 @@ type AutoReconnectHost = {
 type AutoReconnectSettings = Pick<TerminalSettings, "sshAutoReconnectEnabled"> | undefined | null;
 
 export function isTerminalAutoReconnectEnabled(settings: AutoReconnectSettings): boolean {
-  return settings?.sshAutoReconnectEnabled !== false;
+  return settings?.sshAutoReconnectEnabled === true;
 }
 
 export function isAutoReconnectableSshHost(host: AutoReconnectHost): boolean {

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -351,7 +351,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   verifyHostKeys: true,
   keepaliveInterval: 30,
   keepaliveCountMax: 10,
-  sshAutoReconnectEnabled: true,
+  sshAutoReconnectEnabled: false,
   x11Display: '', // Empty = use DISPLAY/default local X server
   moshClientPath: '', // Legacy mosh-client override; normal UI uses bundled mosh-client
   showServerStats: true, // Show server stats by default

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -34,11 +34,12 @@ test("normalizeTerminalSettings enables font smoothing by default", () => {
   assert.equal(normalizeTerminalSettings().fontSmoothing, true);
 });
 
-test("normalizeTerminalSettings enables SSH auto reconnect by default", () => {
-  assert.equal(normalizeTerminalSettings().sshAutoReconnectEnabled, true);
+test("normalizeTerminalSettings disables SSH auto reconnect by default", () => {
+  assert.equal(normalizeTerminalSettings().sshAutoReconnectEnabled, false);
 });
 
-test("normalizeTerminalSettings preserves disabled SSH auto reconnect", () => {
+test("normalizeTerminalSettings preserves explicit SSH auto reconnect settings", () => {
+  assert.equal(normalizeTerminalSettings({ sshAutoReconnectEnabled: true }).sshAutoReconnectEnabled, true);
   assert.equal(normalizeTerminalSettings({ sshAutoReconnectEnabled: false }).sshAutoReconnectEnabled, false);
 });
 


### PR DESCRIPTION
## Summary
- default SSH auto reconnect to off for new or missing terminal settings
- keep the existing settings toggle so users can opt in
- clarify the setting description in English, Simplified Chinese, and Traditional Chinese

## Validation
- `node --test --import tsx application/state/terminalAutoReconnect.test.ts domain/terminalSettings.test.ts components/settings/tabs/SettingsTerminalTab.test.ts components/terminal/restoredSessionGate.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`