### PR TITLE
[codex] Fix manual session log capture

### DIFF
--- a/electron/bridges/sessionLogStreamManager.cjs
+++ b/electron/bridges/sessionLogStreamManager.cjs
@@ -232,6 +232,8 @@ function createStreamEntry(sessionId, opts) {
     disabled: false,
     startToken,
     stopRequiresToken: Boolean(opts.stopRequiresToken),
+    separateInitialLineBeforeLeadingCarriageReturn: false,
+    pendingInitialLineLeadingCarriageReturn: false,
   };
 
   entry.flushTimer = setInterval(() => {
@@ -267,6 +269,10 @@ function startStreamToFile(sessionId, opts = {}) {
     });
     if (typeof initialLine === "string" && initialLine.length > 0) {
       appendData(sessionId, initialLine);
+      const entry = activeStreams.get(sessionId);
+      if (entry && opts.separateInitialLineBeforeLeadingCarriageReturn && !/[\r\n]$/.test(initialLine)) {
+        entry.separateInitialLineBeforeLeadingCarriageReturn = true;
+      }
     }
     return { ok: true, token };
   } catch (err) {
@@ -368,6 +374,24 @@ function appendData(sessionId, dataChunk) {
   const entry = activeStreams.get(sessionId);
   if (!entry || entry.disabled) return;
 
+  if (entry.pendingInitialLineLeadingCarriageReturn && dataChunk) {
+    entry.pendingInitialLineLeadingCarriageReturn = false;
+    dataChunk = dataChunk.startsWith("\n") ? `\r${dataChunk}` : `\n\r${dataChunk}`;
+  } else if (entry.separateInitialLineBeforeLeadingCarriageReturn && dataChunk) {
+    entry.separateInitialLineBeforeLeadingCarriageReturn = false;
+    if (dataChunk === "\r") {
+      entry.pendingInitialLineLeadingCarriageReturn = true;
+      return;
+    }
+    if (dataChunk.startsWith("\r") && !dataChunk.startsWith("\r\n")) {
+      dataChunk = `\n${dataChunk}`;
+    }
+  }
+
+  appendBufferedData(entry, dataChunk);
+}
+
+function appendBufferedData(entry, dataChunk) {
   const readableData = entry.programmaticCommandLogRewriter
     ? entry.programmaticCommandLogRewriter.append(dataChunk)
     : dataChunk;
@@ -417,6 +441,10 @@ async function stopStream(sessionId, expectedToken) {
   }
 
   // Flush remaining buffer
+  if (entry.pendingInitialLineLeadingCarriageReturn) {
+    entry.pendingInitialLineLeadingCarriageReturn = false;
+    appendBufferedData(entry, "\n\r");
+  }
   const readablePending = entry.programmaticCommandLogRewriter?.finish();
   if (readablePending) {
     entry.buffer += sanitizeSudoAutofillLogData(entry, readablePending);

--- a/electron/bridges/sessionLogStreamManager.test.cjs
+++ b/electron/bridges/sessionLogStreamManager.test.cjs
@@ -203,6 +203,142 @@ test("startStreamToFile writes to an explicit raw log file path", async () => {
   }
 });
 
+test("startStreamToFile keeps unterminated initial line joined to ordinary raw output", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-ordinary-raw-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "root@host:~# ",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "ls\r\nfile\r\n");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "root@host:~# ls\r\nfile\r\n");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile separates unterminated initial line before leading carriage return", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-leading-cr-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "H3C>",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "\rdisplay version\r\n");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "H3C>\n\rdisplay version\r\n");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile does not add a separator before leading CRLF", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-leading-crlf-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "root@host:~# command",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "\r\noutput\r\n");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "root@host:~# command\r\noutput\r\n");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile does not add a separator before split leading CRLF", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-split-leading-crlf-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "root@host:~# command",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "\r");
+    appendData(sessionId, "\noutput\r\n");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "root@host:~# command\r\noutput\r\n");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("startStreamToFile flushes a pending leading carriage return on stop", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-pending-leading-cr-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  try {
+    const result = startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      startTime: Date.UTC(2026, 0, 2, 3, 4, 5),
+      initialLine: "H3C>",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
+    });
+
+    assert.equal(result.ok, true);
+    appendData(sessionId, "\r");
+    const finalPath = await stopStream(sessionId);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "H3C>\n\r");
+  } finally {
+    await stopStream(sessionId);
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("startStreamToFile can write human-readable text logs from ANSI terminal output", async () => {
   const directory = path.join(TEMP_ROOT, `manual-txt-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const filePath = path.join(directory, "manual.log");

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -274,7 +274,6 @@ async function startManualSessionLog(event, payload = {}) {
       defaultPath,
       filters: [
         { name: "Log Files", extensions: ["log"] },
-        { name: "Text Files", extensions: ["txt"] },
         { name: "All Files", extensions: ["*"] },
       ],
     });
@@ -283,15 +282,18 @@ async function startManualSessionLog(event, payload = {}) {
       return { success: true, started: false, canceled: true };
     }
 
-    const filePath = path.extname(result.filePath)
-      ? result.filePath
-      : `${result.filePath}.log`;
+    const filePath = normalizeManualSessionLogFilePath(result.filePath);
+    if (filePath !== result.filePath && !(await confirmManualSessionLogOverwrite(filePath))) {
+      return { success: true, started: false, canceled: true };
+    }
+
     const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
       filePath,
-      format: "txt",
+      format: "raw",
       hostLabel: safeSessionName,
       startTime: Date.now(),
       initialLine: typeof initialLine === "string" ? initialLine : "",
+      separateInitialLineBeforeLeadingCarriageReturn: true,
       stopRequiresToken: true,
     });
 
@@ -304,6 +306,32 @@ async function startManualSessionLog(event, payload = {}) {
   } catch (err) {
     return { success: false, started: false, error: err?.message || String(err) };
   }
+}
+
+function normalizeManualSessionLogFilePath(filePath) {
+  return path.extname(filePath).toLowerCase() === ".log" ? filePath : `${filePath}.log`;
+}
+
+async function confirmManualSessionLogOverwrite(filePath) {
+  try {
+    await fs.promises.access(filePath, fs.constants.F_OK);
+  } catch (err) {
+    if (err?.code === "ENOENT") return true;
+    throw err;
+  }
+
+  const result = await dialog.showMessageBox({
+    type: "warning",
+    buttons: ["Overwrite", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+    title: "Overwrite session log?",
+    message: `"${path.basename(filePath)}" already exists.`,
+    detail: "Choose Overwrite to replace it, or Cancel to keep the existing file.",
+  });
+
+  return result.response === 0;
 }
 
 async function stopManualSessionLog(event, payload = {}) {

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -151,3 +151,207 @@ test("manual session logs survive tokenless stale stops and stop through the bri
     fs.rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("manual session logs preserve carriage-return output as a raw session stream", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-raw-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "H3C switch",
+      preferredDirectory: directory,
+      initialLine: "H3C>",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+
+    sessionLogStreamManager.appendData(sessionId, "\rdisplay version\r\nComware Software\r\nH3C>");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.equal(stopResult.success, true);
+    assert.equal(stopResult.stopped, true);
+    assert.equal(
+      fs.readFileSync(filePath, "utf8"),
+      "H3C>\n\rdisplay version\r\nComware Software\r\nH3C>",
+    );
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual session logs keep prompt and normal command echo on one line", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-normal-echo-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "Linux host",
+      preferredDirectory: directory,
+      initialLine: "root@host:~# ",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+
+    sessionLogStreamManager.appendData(sessionId, "ls\r\nfile\r\nroot@host:~# ");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.equal(stopResult.success, true);
+    assert.equal(stopResult.stopped, true);
+    assert.equal(
+      fs.readFileSync(filePath, "utf8"),
+      "root@host:~# ls\r\nfile\r\nroot@host:~# ",
+    );
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual session log save dialog only offers log files and normalizes extension", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-log-ext-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const selectedPath = path.join(directory, "manual.txt");
+  const expectedPath = `${selectedPath}.log`;
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let dialogOptions;
+  const dialogMock = {
+    showSaveDialog: async (options) => {
+      dialogOptions = options;
+      return { canceled: false, filePath: selectedPath };
+    },
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "H3C switch",
+      preferredDirectory: directory,
+      initialLine: "",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+    assert.equal(startResult.filePath, expectedPath);
+    assert.deepEqual(
+      dialogOptions.filters.map((filter) => filter.name),
+      ["Log Files", "All Files"],
+    );
+
+    sessionLogStreamManager.appendData(sessionId, "body\r\n");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.equal(stopResult.filePath, expectedPath);
+    assert.equal(fs.readFileSync(expectedPath, "utf8"), "body\r\n");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual session log canceling normalized overwrite keeps existing file", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-log-overwrite-cancel-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const selectedPath = path.join(directory, "manual.txt");
+  const expectedPath = `${selectedPath}.log`;
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let messageOptions;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath: selectedPath }),
+    showMessageBox: async (options) => {
+      messageOptions = options;
+      return { response: 1 };
+    },
+  };
+  const { startManualSessionLog } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(expectedPath, "old body", "utf8");
+
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "H3C switch",
+      preferredDirectory: directory,
+      initialLine: "",
+    });
+
+    assert.deepEqual(startResult, { success: true, started: false, canceled: true });
+    assert.equal(sessionLogStreamManager.hasStream(sessionId), false);
+    assert.equal(fs.readFileSync(expectedPath, "utf8"), "old body");
+    assert.deepEqual(messageOptions.buttons, ["Overwrite", "Cancel"]);
+    assert.equal(messageOptions.cancelId, 1);
+    assert.match(messageOptions.message, /manual\.txt\.log/);
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manual session log confirmed normalized overwrite replaces existing file", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-log-overwrite-confirm-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const selectedPath = path.join(directory, "manual.txt");
+  const expectedPath = `${selectedPath}.log`;
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  let messageShown = false;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath: selectedPath }),
+    showMessageBox: async () => {
+      messageShown = true;
+      return { response: 0 };
+    },
+  };
+  const {
+    startManualSessionLog,
+    stopManualSessionLog,
+  } = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(expectedPath, "old body", "utf8");
+
+    const startResult = await startManualSessionLog(null, {
+      sessionId,
+      sessionName: "H3C switch",
+      preferredDirectory: directory,
+      initialLine: "",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+    assert.equal(startResult.filePath, expectedPath);
+    assert.equal(messageShown, true);
+
+    sessionLogStreamManager.appendData(sessionId, "new body\r\n");
+    const stopResult = await stopManualSessionLog(null, { sessionId });
+
+    assert.equal(stopResult.filePath, expectedPath);
+    assert.equal(fs.readFileSync(expectedPath, "utf8"), "new body\r\n");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed
- Save manual toolbar session logs as raw `.log` streams instead of rendered text snapshots.
- Keep the existing prompt attached to ordinary command echoes while separating device output that starts with a carriage-return redraw.
- Avoid adding extra blank lines when the next terminal data already starts with a normal newline, including when that newline arrives split across chunks.
- Flush a pending first carriage return on stop so no terminal data is lost.
- Keep manual session-log saves on `.log` files, even if the selected path has another extension.
- Ask before overwriting an existing normalized `.log` path when the save dialog confirmed a different selected path.
- Add regression coverage for network-device carriage-return output, ordinary shell command echo output, leading newline output, split leading newline output, stop-after-carriage-return output, and normalized-path overwrite confirmation.

## Root cause
Manual session logging was added as a readable text snapshot path even though the save dialog defaults to `.log` and the toolbar action is expected to capture the full session stream. Terminal carriage-return rewrites and prompt redraws can collapse the rendered snapshot, leaving the saved file with only the prompt/hostname instead of the commands and output.

Fixes #1815.

## Validation
- `node --test electron/bridges/sessionLogsBridge.test.cjs electron/bridges/sessionLogStreamManager.test.cjs`
- `npx eslint electron/bridges/sessionLogsBridge.cjs electron/bridges/sessionLogsBridge.test.cjs electron/bridges/sessionLogStreamManager.cjs electron/bridges/sessionLogStreamManager.test.cjs`
- `git diff --check`
- `npm run build`