### PR TITLE
[codex] Update Nix release metadata for v1.1.57

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.56";
+  version = "1.1.57";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-MRgvd9kKeKXIp0GRAGtBpOxHYInZtHwbHaZKA9yexbY=";
+      hash = "sha256-XEl4ezmwuIXeGPXgnQv2S2JzWgF3/ki9ZmizCNtWYPo=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-0RFcN4LtsceI3ukD9OFwaEuwyTbSTYqr5oUss6ax6VA=";
+      hash = "sha256-0Wt9OB0QX2To2c0ohrlNqWpWLSbRXeHQn6W0E1JYbBk=";
     };
   };
 }


### PR DESCRIPTION
## Summary

Updates `nix/release.nix` for the v1.1.57 release after the release workflow could not push directly to the protected `main` branch.

## Validation

- `node --test scripts/update-nix-release.test.cjs`

## Notes

The v1.1.57 GitHub release and assets were already published successfully; this PR covers the post-release Nix metadata update only.