### PR TITLE
fix(ai): allow OpenCode native skill directories in permission rules

### DIFF
--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
@@ -72,6 +72,53 @@ function dedupePatterns(patterns) {
   return [...new Set(patterns.filter(Boolean))];
 }
 
+// OpenCode discovers native agent skills from these well-known directories:
+// its global config dirs (~/.opencode and ~/.config/opencode, both "skill"
+// and "skills" spellings), Claude/agents-compatible dirs, project-level
+// .opencode/.claude/.agents dirs, and the remote-skill download cache.
+// Reads inside them must stay allowed even though Netcatty otherwise locks
+// external directory access down, or loading a skill's reference files fails
+// with an OpenCode permission error (issue #1939).
+const OPENCODE_NATIVE_SKILL_DIR_SUFFIXES = [
+  ".opencode/skill",
+  ".opencode/skills",
+  ".config/opencode/skill",
+  ".config/opencode/skills",
+  ".claude/skills",
+  ".agents/skills",
+  ".cache/opencode/skills",
+];
+
+// OpenCode's `read` permission checks match worktree-relative paths (e.g.
+// "../../.opencode/skills/foo/references/doc.md") while `external_directory`
+// checks match absolute directory globs ("C:/Users/me/.opencode/skills/foo/*").
+// Anchoring each well-known suffix behind a leading wildcard covers both
+// forms on every platform (OpenCode normalizes "\\" to "/" before matching).
+function buildOpenCodeNativeSkillPermissionPatterns() {
+  return OPENCODE_NATIVE_SKILL_DIR_SUFFIXES.flatMap((suffix) => [
+    `*${suffix}`,
+    `*${suffix}/*`,
+    `*${suffix}/**`,
+  ]);
+}
+
+// Base rules shared by every tool-integration mode so OpenCode's native
+// skills keep working: allow loading skills and reading their files while
+// still denying all other external directory access.
+function buildOpenCodeNativeSkillsPermissionRules() {
+  const external_directory = { "*": "deny" };
+  const read = {};
+  for (const pattern of buildOpenCodeNativeSkillPermissionPatterns()) {
+    external_directory[pattern] = "allow";
+    read[pattern] = "allow";
+  }
+  return {
+    skill: "allow",
+    read,
+    external_directory,
+  };
+}
+
 function buildNetcattySkillsOpenCodePathAllowlist({
   launcherPath,
   cliScriptPath,
@@ -98,8 +145,7 @@ function buildNetcattySkillsOpenCodePathAllowlist({
 }
 
 function buildOpenCodeSkillsPermissionRules(pathAllowlist = []) {
-  const external_directory = { "*": "deny" };
-  const read = {};
+  const { read, external_directory } = buildOpenCodeNativeSkillsPermissionRules();
   for (const pattern of pathAllowlist) {
     external_directory[pattern] = "allow";
     read[pattern] = "allow";
@@ -118,6 +164,8 @@ function buildOpenCodeSkillsPermissionRules(pathAllowlist = []) {
 
 module.exports = {
   buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeNativeSkillPermissionPatterns,
+  buildOpenCodeNativeSkillsPermissionRules,
   buildOpenCodeSkillsPermissionRules,
   toOpenCodeDirectoryPermissionPatterns,
   toOpenCodeDirectoryGlob,

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.cjs
@@ -102,6 +102,17 @@ function buildOpenCodeNativeSkillPermissionPatterns() {
   ]);
 }
 
+// OpenCode's default rules gate `.env` secret files behind approval. The
+// broad skill-directory read allows above would win over those defaults
+// (last matching rule wins), so re-deny dot-env files inside skill dirs
+// after the allow entries to keep secret-file protection intact.
+function buildOpenCodeNativeSkillEnvDenyPatterns() {
+  return OPENCODE_NATIVE_SKILL_DIR_SUFFIXES.flatMap((suffix) => [
+    `*${suffix}/**.env`,
+    `*${suffix}/**.env.*`,
+  ]);
+}
+
 // Base rules shared by every tool-integration mode so OpenCode's native
 // skills keep working: allow loading skills and reading their files while
 // still denying all other external directory access.
@@ -111,6 +122,9 @@ function buildOpenCodeNativeSkillsPermissionRules() {
   for (const pattern of buildOpenCodeNativeSkillPermissionPatterns()) {
     external_directory[pattern] = "allow";
     read[pattern] = "allow";
+  }
+  for (const pattern of buildOpenCodeNativeSkillEnvDenyPatterns()) {
+    read[pattern] = "deny";
   }
   return {
     skill: "allow",
@@ -164,6 +178,7 @@ function buildOpenCodeSkillsPermissionRules(pathAllowlist = []) {
 
 module.exports = {
   buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeNativeSkillEnvDenyPatterns,
   buildOpenCodeNativeSkillPermissionPatterns,
   buildOpenCodeNativeSkillsPermissionRules,
   buildOpenCodeSkillsPermissionRules,

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
@@ -4,6 +4,7 @@ const path = require("node:path");
 
 const {
   buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeNativeSkillEnvDenyPatterns,
   buildOpenCodeNativeSkillPermissionPatterns,
   buildOpenCodeNativeSkillsPermissionRules,
   buildOpenCodeSkillsPermissionRules,
@@ -28,6 +29,16 @@ function openCodeWildcardMatch(input, pattern) {
 
 function matchesAnyPattern(input, patterns) {
   return patterns.some((pattern) => openCodeWildcardMatch(input, pattern));
+}
+
+// Mirrors OpenCode's Permission.evaluate: rules come from Object.entries of
+// the config map in insertion order, and the last matching rule wins.
+function evaluateOpenCodeRuleMap(input, ruleMap) {
+  let action;
+  for (const [pattern, ruleAction] of Object.entries(ruleMap)) {
+    if (openCodeWildcardMatch(input, pattern)) action = ruleAction;
+  }
+  return action;
 }
 
 test("toOpenCodeFileParentGlob maps files to parent directory globs", () => {
@@ -163,6 +174,23 @@ test("buildOpenCodeNativeSkillsPermissionRules keeps OpenCode native skill dirs 
     assert.equal(rules.external_directory[pattern], "allow");
     assert.equal(rules.read[pattern], "allow");
   }
+  for (const pattern of buildOpenCodeNativeSkillEnvDenyPatterns()) {
+    assert.equal(rules.read[pattern], "deny");
+  }
+});
+
+test("native skill read rules re-deny dot-env files inside skill dirs (last match wins)", () => {
+  const { read } = buildOpenCodeNativeSkillsPermissionRules();
+
+  // Regular skill files stay allowed.
+  assert.equal(evaluateOpenCodeRuleMap("../../.opencode/skills/foo/references/doc.md", read), "allow");
+  assert.equal(evaluateOpenCodeRuleMap("C:/Users/me/.config/opencode/skills/foo/SKILL.md", read), "allow");
+
+  // Dot-env secret files under skill dirs must not be silently readable.
+  assert.equal(evaluateOpenCodeRuleMap("../../.opencode/skills/foo/.env", read), "deny");
+  assert.equal(evaluateOpenCodeRuleMap("C:/Users/me/.config/opencode/skills/foo/.env", read), "deny");
+  assert.equal(evaluateOpenCodeRuleMap("/home/me/.claude/skills/foo/.env.local", read), "deny");
+  assert.equal(evaluateOpenCodeRuleMap("..\\..\\.agents\\skills\\foo\\references\\prod.env", read), "deny");
 });
 
 test("native skill patterns match OpenCode permission requests for skill files (issue #1939)", () => {

--- a/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
+++ b/electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs
@@ -4,12 +4,31 @@ const path = require("node:path");
 
 const {
   buildNetcattySkillsOpenCodePathAllowlist,
+  buildOpenCodeNativeSkillPermissionPatterns,
+  buildOpenCodeNativeSkillsPermissionRules,
   buildOpenCodeSkillsPermissionRules,
   toOpenCodeDirectoryPermissionPatterns,
   toOpenCodeDirectoryGlob,
   toOpenCodeFileParentPermissionPatterns,
   toOpenCodeFileParentGlob,
 } = require("./netcattySkillsOpenCodePermissions.cjs");
+
+// Mirrors OpenCode's Wildcard.match (packages/core/src/util/wildcard.ts):
+// inputs and patterns are normalized to forward slashes, "*" matches any
+// run of characters, and matching is anchored to the whole string.
+function openCodeWildcardMatch(input, pattern) {
+  const normalized = input.replaceAll("\\", "/");
+  const escaped = pattern
+    .replaceAll("\\", "/")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`, "s").test(normalized);
+}
+
+function matchesAnyPattern(input, patterns) {
+  return patterns.some((pattern) => openCodeWildcardMatch(input, pattern));
+}
 
 test("toOpenCodeFileParentGlob maps files to parent directory globs", () => {
   assert.equal(
@@ -125,13 +144,45 @@ test("buildOpenCodeSkillsPermissionRules allowlists Netcatty CLI paths and denie
   assert.equal(rules.bash, "allow");
   assert.equal(rules.skill, "allow");
   assert.equal(rules.list, "deny");
-  assert.deepEqual(rules.external_directory, {
-    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
-    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
-    "*": "deny",
-  });
-  assert.deepEqual(rules.read, {
-    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
-    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
-  });
+  assert.equal(rules.external_directory["*"], "deny");
+  assert.equal(rules.external_directory["/Applications/Netcatty.app/Contents/MacOS/**"], "allow");
+  assert.equal(rules.external_directory["/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**"], "allow");
+  assert.equal(rules.read["/Applications/Netcatty.app/Contents/MacOS/**"], "allow");
+  assert.equal(rules.read["/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**"], "allow");
+  assert.equal(rules.read["*"], undefined);
+  // Allowlist entries must come after the catch-all deny so OpenCode's
+  // last-matching-rule-wins evaluation keeps them effective.
+  assert.equal(Object.keys(rules.external_directory)[0], "*");
+});
+
+test("buildOpenCodeNativeSkillsPermissionRules keeps OpenCode native skill dirs readable", () => {
+  const rules = buildOpenCodeNativeSkillsPermissionRules();
+  assert.equal(rules.skill, "allow");
+  assert.equal(rules.external_directory["*"], "deny");
+  for (const pattern of buildOpenCodeNativeSkillPermissionPatterns()) {
+    assert.equal(rules.external_directory[pattern], "allow");
+    assert.equal(rules.read[pattern], "allow");
+  }
+});
+
+test("native skill patterns match OpenCode permission requests for skill files (issue #1939)", () => {
+  const patterns = buildOpenCodeNativeSkillPermissionPatterns();
+
+  // external_directory asks with an absolute parent-directory glob
+  // (forward slashes on Windows after FSUtil.normalizePathPattern).
+  assert.equal(matchesAnyPattern("C:/Users/me/.opencode/skills/my-skill/references/*", patterns), true);
+  assert.equal(matchesAnyPattern("/home/me/.config/opencode/skills/my-skill/*", patterns), true);
+  assert.equal(matchesAnyPattern("/Users/me/.claude/skills/my-skill/references/*", patterns), true);
+  assert.equal(matchesAnyPattern("/Users/me/.agents/skills/my-skill/*", patterns), true);
+  assert.equal(matchesAnyPattern("/Users/me/.cache/opencode/skills/abc123/my-skill/*", patterns), true);
+
+  // read asks with a worktree-relative path (Windows backslashes included).
+  assert.equal(matchesAnyPattern("..\\..\\.opencode\\skills\\my-skill\\references\\doc.md", patterns), true);
+  assert.equal(matchesAnyPattern("../.config/opencode/skills/my-skill/SKILL.md", patterns), true);
+  assert.equal(matchesAnyPattern(".opencode/skills/my-skill/references/doc.md", patterns), true);
+
+  // unrelated external paths stay denied
+  assert.equal(matchesAnyPattern("C:/Users/me/Documents/secret.txt/*", patterns), false);
+  assert.equal(matchesAnyPattern("../../etc/passwd", patterns), false);
+  assert.equal(matchesAnyPattern("C:/Users/me/.ssh/id_rsa", patterns), false);
 });

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { mcpEnvPairsToObject } = require("./injectMcp.cjs");
 const {
+  buildOpenCodeNativeSkillsPermissionRules,
   buildOpenCodeSkillsPermissionRules,
 } = require("./netcattySkillsOpenCodePermissions.cjs");
 
@@ -64,7 +65,10 @@ function buildOpenCodeConfig({ model, injectedMcpServers, toolIntegrationMode, s
     edit: "deny",
     bash: allowBash ? "allow" : "deny",
     webfetch: "deny",
-    external_directory: "deny",
+    // Keep external access locked down, but let OpenCode's native skills
+    // (e.g. ~/.opencode/skills, ~/.config/opencode/skills) read their own
+    // reference files in every mode (issue #1939).
+    ...buildOpenCodeNativeSkillsPermissionRules(),
   };
   if (allowBash && Array.isArray(skillsPathAllowlist) && skillsPathAllowlist.length > 0) {
     Object.assign(permission, buildOpenCodeSkillsPermissionRules(skillsPathAllowlist));

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -50,12 +50,15 @@ test("buildOpenCodeConfig isolates local tools and injects Netcatty MCP", () => 
   });
 
   assert.equal(cfg.model, "openai/gpt-5.1");
-  assert.deepEqual(cfg.permission, {
-    edit: "deny",
-    bash: "deny",
-    webfetch: "deny",
-    external_directory: "deny",
-  });
+  assert.equal(cfg.permission.edit, "deny");
+  assert.equal(cfg.permission.bash, "deny");
+  assert.equal(cfg.permission.webfetch, "deny");
+  assert.equal(cfg.permission.skill, "allow");
+  assert.equal(cfg.permission.external_directory["*"], "deny");
+  // Native OpenCode skill directories stay readable in MCP mode (issue #1939).
+  assert.equal(cfg.permission.external_directory["*.opencode/skills/**"], "allow");
+  assert.equal(cfg.permission.read["*.config/opencode/skills/**"], "allow");
+  assert.equal(cfg.permission.read["*"], undefined);
   assert.deepEqual(cfg.mcp["netcatty-remote-hosts"], {
     type: "local",
     command: ["/abs/electron", "/abs/server.cjs"],
@@ -76,11 +79,15 @@ test("buildOpenCodeConfig allowlists Netcatty CLI paths in skills mode", () => {
   assert.equal(cfg.permission.bash, "allow");
   assert.equal(cfg.permission.skill, "allow");
   assert.equal(cfg.permission.list, "deny");
-  assert.deepEqual(cfg.permission.external_directory, {
-    "/Applications/Netcatty.app/Contents/MacOS/**": "allow",
-    "/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**": "allow",
-    "*": "deny",
-  });
+  assert.equal(cfg.permission.external_directory["*"], "deny");
+  assert.equal(cfg.permission.external_directory["/Applications/Netcatty.app/Contents/MacOS/**"], "allow");
+  assert.equal(
+    cfg.permission.external_directory["/Users/me/Library/Application Support/netcatty/netcatty-tool-cli/**"],
+    "allow",
+  );
+  // Native OpenCode skill directories stay readable in skills mode too (issue #1939).
+  assert.equal(cfg.permission.external_directory["*.opencode/skills/**"], "allow");
+  assert.equal(cfg.permission.read["*.claude/skills/**"], "allow");
 });
 
 test("buildOpenCodePromptParts includes supported images as file parts", () => {


### PR DESCRIPTION
## Summary

Fixes #1939 — on Windows (and every platform), switching the agent to OpenCode and using a skill that lives in OpenCode's own skill directories (e.g. `~/.opencode/skills`) failed to read the skill's `references` files with:

> The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules [{"permission":"*","action":"allow","pattern":"*"}, …

### Root cause

- Netcatty passes a `permission` config when launching the OpenCode SDK server. In skills+cli mode it sets `external_directory: {"*": "deny", <Netcatty paths>: "allow"}`; in MCP mode it sets `external_directory: "deny"` outright.
- OpenCode's `read` tool requests `external_directory` approval for any path outside the working directory (verified against opencode v1.17.13 sources: `packages/opencode/src/tool/read.ts` → `assertExternalDirectoryEffect`). The user's skill files under `~/.opencode/skills/<skill>/references/` are not in Netcatty's allowlist, so the catch-all deny matches last and OpenCode raises `PermissionDeniedError` — exactly the message in the issue. The `{"permission":"*","action":"allow","pattern":"*"}` shown in the error is the user's own global allow rule, which loses because OpenCode evaluates rules **last-match-wins** and Netcatty's config is merged after the user's global config.
- This is why #1921 (Windows path-separator normalization of the allowlist) didn't resolve the issue: the denied paths were never in the allowlist to begin with. Additionally, OpenCode's `read` permission matches **worktree-relative** paths (e.g. `../../.opencode/skills/...`), which absolute-path allow rules can never match.

### Fix

Add wildcard-anchored allow patterns for all of OpenCode's native skill discovery locations (verified against v1.17.13 `packages/opencode/src/skill/index.ts`):

- `~/.opencode/skill{,s}` and `~/.config/opencode/skill{,s}` (global config dirs, both spellings per `OPENCODE_SKILL_PATTERN`)
- `~/.claude/skills` and `~/.agents/skills` (Claude/agents-compatible dirs)
- `~/.cache/opencode/skills` (remote skill download cache)

Patterns use a leading `*` (e.g. `*.opencode/skills/**`) so they match both the absolute directory globs used by `external_directory` checks and the worktree-relative paths used by `read` checks, on Windows and POSIX alike (OpenCode's `Wildcard.match` normalizes `\` to `/`). They are appended after the `"*": "deny"` catch-all so last-match-wins keeps them effective.

The rules are applied in **both** MCP and skills+cli modes (the issue reproduces in both), while everything else stays locked down: `edit`/`webfetch` remain denied, all other external directory access remains denied, and bash remains denied in MCP mode.

## Test plan

- [x] `node --test electron/bridges/aiBridge/sdk/netcattySkillsOpenCodePermissions.test.cjs` — new tests replicate OpenCode's `Wildcard.match` and assert that skill-file permission requests (absolute Windows globs, worktree-relative read paths) match, while unrelated paths (`~/.ssh`, `/etc/passwd`, arbitrary documents) stay denied
- [x] `node --test electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs` — config shape in both modes
- [x] `npm test` — full suite passes (4218 pass / 0 fail)
- [x] `npm run lint`
- [ ] Manual verification on Windows with opencode CLI 1.17.13 and a global skill with a `references` folder

Made with [Cursor](https://cursor.com)