### PR TITLE
Fix manual session log capture in terminal worker mode

### DIFF
--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -164,6 +164,10 @@ function writeToSession(sessionId, data, options = {}) {
   };
   const webContentsId = getMainWindow?.()?.webContents?.id;
   if (terminalWorkerManager) {
+    // Mirror input-based log rewrites into the main-process stream manager
+    // (see the netcatty:write forwarder in terminalBridge.registerHandlers);
+    // the real write handler runs in the terminal worker process.
+    sessionLogStreamManager.registerSudoAutofillInput(sessionId, data);
     terminalWorkerManager.send("netcatty:write", payload, { webContentsId });
   } else {
     terminalBridge?.writeToSession?.(

--- a/electron/bridges/sessionLogsBridge.cjs
+++ b/electron/bridges/sessionLogsBridge.cjs
@@ -373,7 +373,7 @@ async function getManualSessionLogStatus(event, payload = {}) {
 /**
  * Register IPC handlers for session logs operations
  */
-function registerHandlers(ipcMain) {
+function registerHandlers(ipcMain, options = {}) {
   ipcMain.handle("netcatty:sessionLogs:export", exportSessionLog);
   ipcMain.handle("netcatty:sessionLogs:selectDir", selectSessionLogsDir);
   ipcMain.handle("netcatty:sessionLogs:autoSave", autoSaveSessionLog);
@@ -381,6 +381,20 @@ function registerHandlers(ipcMain) {
   ipcMain.handle("netcatty:sessionLog:manualStart", startManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStop", stopManualSessionLog);
   ipcMain.handle("netcatty:sessionLog:manualStatus", getManualSessionLogStatus);
+
+  // In the default terminal-worker runtime, sessions run in a utilityProcess
+  // and call appendData() on the worker's own sessionLogStreamManager module
+  // instance. Manual session logs (and script session logs) are started in
+  // the *main* process, so without this tap their streams never receive any
+  // terminal output — the saved file would only contain the initial prompt
+  // line captured from the renderer buffer (issue #1938). The worker already
+  // mirrors every output chunk to the main process for script output buffers;
+  // feed that same stream into the main-process log streams. appendData() is
+  // a no-op for sessions without an active main-process stream.
+  options.terminalWorkerManager?.addOutputTap?.((sessionId, data) => {
+    if (typeof data !== "string" || data.length === 0) return;
+    require("./sessionLogStreamManager.cjs").appendData(sessionId, data);
+  });
 }
 
 module.exports = {

--- a/electron/bridges/sessionLogsBridge.test.cjs
+++ b/electron/bridges/sessionLogsBridge.test.cjs
@@ -272,6 +272,59 @@ test("manual session log save dialog only offers log files and normalizes extens
   }
 });
 
+test("registerHandlers taps terminal worker output into main-process manual session logs", async () => {
+  const directory = path.join(TEMP_ROOT, `manual-worker-tap-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const dialogMock = {
+    showSaveDialog: async () => ({ canceled: false, filePath }),
+  };
+  const bridge = loadBridgeWithDialog(dialogMock);
+  const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+  const handlers = new Map();
+  const ipcMainMock = {
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  };
+  let outputTap = null;
+  bridge.registerHandlers(ipcMainMock, {
+    terminalWorkerManager: {
+      addOutputTap(listener) {
+        outputTap = listener;
+        return () => {};
+      },
+    },
+  });
+  assert.equal(typeof outputTap, "function");
+
+  try {
+    const startResult = await handlers.get("netcatty:sessionLog:manualStart")(null, {
+      sessionId,
+      sessionName: "worker host",
+      preferredDirectory: directory,
+      initialLine: "root@host:~# ",
+    });
+    assert.equal(startResult.success, true);
+    assert.equal(startResult.started, true);
+
+    // Terminal output produced in the worker process reaches the main
+    // process only through the output tap.
+    outputTap(sessionId, "ls\r\nfile\r\n");
+    outputTap("other-session", "ignored\r\n");
+    outputTap(sessionId, undefined);
+
+    const stopResult = await handlers.get("netcatty:sessionLog:manualStop")(null, { sessionId });
+    assert.equal(stopResult.success, true);
+    assert.equal(stopResult.stopped, true);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "root@host:~# ls\r\nfile\r\n");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("manual session log canceling normalized overwrite keeps existing file", async () => {
   const directory = path.join(TEMP_ROOT, `manual-log-overwrite-cancel-${Date.now()}-${Math.random().toString(16).slice(2)}`);
   const selectedPath = path.join(directory, "manual.txt");

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -1394,8 +1394,21 @@ function registerHandlers(ipcMain, options = {}) {
       "netcatty:shells:discover",
       "netcatty:terminal:setEncoding",
     ].forEach((channel) => registerWorkerHandle(ipcMain, terminalWorkerManager, channel));
+    ipcMain.on("netcatty:write", (event, payload) => {
+      // Session log streams started in the main process (manual/script logs)
+      // sanitize sudo-autofill markers and programmatic command echoes based
+      // on the *input* that produced them. In worker mode the real write
+      // handler runs in the utilityProcess, so mirror the rewrite
+      // registrations into the main-process stream manager before
+      // forwarding. Both calls are no-ops without an active main-process
+      // stream for the session.
+      sessionLogStreamManager.registerSudoAutofillInput(payload?.sessionId, payload?.data);
+      sessionLogStreamManager.registerProgrammaticCommandLogRewrite(payload?.sessionId, payload?.logRewrite);
+      terminalWorkerManager.send("netcatty:write", payload, {
+        webContentsId: event?.sender?.id,
+      });
+    });
     [
-      "netcatty:write",
       "netcatty:interrupt",
       "netcatty:resize",
       "netcatty:flow",

--- a/electron/bridges/terminalBridge.workerSessionLogMirror.test.cjs
+++ b/electron/bridges/terminalBridge.workerSessionLogMirror.test.cjs
@@ -1,0 +1,112 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const terminalBridge = require("./terminalBridge.cjs");
+const sessionLogStreamManager = require("./sessionLogStreamManager.cjs");
+
+const TEMP_ROOT = path.join(__dirname, ".tmp-terminal-bridge-worker-log-mirror-tests");
+
+function registerWorkerHandlers(sent) {
+  const listeners = new Map();
+  const handlers = new Map();
+  terminalBridge.registerHandlers(
+    {
+      handle(channel, handler) {
+        handlers.set(channel, handler);
+      },
+      on(channel, listener) {
+        listeners.set(channel, listener);
+      },
+    },
+    {
+      terminalWorkerManager: {
+        request: async () => ({}),
+        send(channel, payload, options) {
+          sent.push([channel, payload, options]);
+        },
+      },
+    },
+  );
+  return { listeners, handlers };
+}
+
+test("worker-mode write forward still delivers the payload to the worker", () => {
+  const sent = [];
+  const { listeners } = registerWorkerHandlers(sent);
+  const write = listeners.get("netcatty:write");
+
+  write({ sender: { id: 7 } }, { sessionId: "session-x", data: "ls\r" });
+
+  assert.deepEqual(sent, [
+    ["netcatty:write", { sessionId: "session-x", data: "ls\r" }, { webContentsId: 7 }],
+  ]);
+});
+
+test("worker-mode write forward mirrors sudo autofill rewrites into main-process session logs", async () => {
+  const directory = path.join(TEMP_ROOT, `sudo-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const sent = [];
+  const { listeners } = registerWorkerHandlers(sent);
+  const write = listeners.get("netcatty:write");
+
+  try {
+    const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      stopRequiresToken: true,
+    });
+    assert.equal(startResult.ok, true);
+
+    const prepared = "sudo -p '[sudo] password for %p: __NETCATTY_SUDO_abc123__' apt update\r";
+    write({ sender: { id: 7 } }, { sessionId, data: prepared });
+    assert.equal(sent.length, 1);
+
+    // The remote echo of the prepared command arrives as terminal output.
+    sessionLogStreamManager.appendData(sessionId, `${prepared}\n`);
+    const finalPath = await sessionLogStreamManager.stopStream(sessionId, startResult.token);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "sudo apt update\r\n");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("worker-mode write forward mirrors programmatic command rewrites into main-process session logs", async () => {
+  const directory = path.join(TEMP_ROOT, `programmatic-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const filePath = path.join(directory, "manual.log");
+  const sessionId = `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const sent = [];
+  const { listeners } = registerWorkerHandlers(sent);
+  const write = listeners.get("netcatty:write");
+
+  try {
+    const startResult = sessionLogStreamManager.startStreamToFile(sessionId, {
+      filePath,
+      format: "raw",
+      hostLabel: "manual",
+      stopRequiresToken: true,
+    });
+    assert.equal(startResult.ok, true);
+
+    write({ sender: { id: 7 } }, {
+      sessionId,
+      data: " netcatty-internal-reload\r",
+      logRewrite: { sentCommand: " netcatty-internal-reload", displayCommand: "" },
+    });
+
+    sessionLogStreamManager.appendData(sessionId, " netcatty-internal-reload\r\nuser@host:~$ ");
+    const finalPath = await sessionLogStreamManager.stopStream(sessionId, startResult.token);
+
+    assert.equal(finalPath, filePath);
+    assert.equal(fs.readFileSync(filePath, "utf8"), "\r\nuser@host:~$ ");
+  } finally {
+    await sessionLogStreamManager.cleanupAll();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/electron/bridges/terminalWorkerManager.cjs
+++ b/electron/bridges/terminalWorkerManager.cjs
@@ -480,7 +480,14 @@ function createTerminalWorkerManager(options = {}) {
     }
     if (message.kind === "output") {
       if (closedSessions.has(message.sessionId)) return;
-      notifyOutputTaps(message.sessionId, message.data);
+      // Chunks sent through the runtime sender's port fallback were already
+      // announced via a dedicated output-tap message (message.tapped);
+      // notifying taps again here would double-write session logs and
+      // script output buffers. Plain output messages (e.g. from the early
+      // worker sender) still need the notification.
+      if (!message.tapped) {
+        notifyOutputTaps(message.sessionId, message.data);
+      }
       if (outputPortPending.has(message.sessionId)) {
         bufferOutput(message.sessionId, message.data, message.meta);
         return;

--- a/electron/bridges/terminalWorkerManager.test.cjs
+++ b/electron/bridges/terminalWorkerManager.test.cjs
@@ -686,6 +686,46 @@ test("worker output notifies output taps before renderer routing", () => {
   assert.deepEqual(routed, [{ sessionId: "session-1", data: "hello" }]);
 });
 
+test("worker fallback output already announced via output-tap does not notify taps twice", () => {
+  const child = new FakeChild();
+  const routed = [];
+  const tapped = [];
+  const manager = createTerminalWorkerManager({
+    utilityProcess: {
+      fork() {
+        return child;
+      },
+    },
+    terminalOutputChannel: {
+      send(sessionId, data) {
+        routed.push({ sessionId, data });
+        return true;
+      },
+    },
+    workerScriptPath: "/worker.cjs",
+  });
+
+  manager.addOutputTap((sessionId, data) => tapped.push({ sessionId, data }));
+  manager.ensureStarted();
+  // The runtime sender emits an output-tap message, then falls back to a
+  // plain output message for the same chunk when the output port is not
+  // usable. Taps must fire exactly once for that chunk.
+  child.emit("message", {
+    kind: "output-tap",
+    sessionId: "session-1",
+    data: "hello",
+  });
+  child.emit("message", {
+    kind: "output",
+    sessionId: "session-1",
+    data: "hello",
+    tapped: true,
+  });
+
+  assert.deepEqual(tapped, [{ sessionId: "session-1", data: "hello" }]);
+  assert.deepEqual(routed, [{ sessionId: "session-1", data: "hello" }]);
+});
+
 test("worker output-tap messages notify taps without duplicate renderer routing", () => {
   const child = new FakeChild();
   const routed = [];

--- a/electron/main/registerBridges.cjs
+++ b/electron/main/registerBridges.cjs
@@ -218,7 +218,7 @@ function createBridgeRegistrar(context) {
     cloudSyncBridge.registerHandlers(ipcMain);
     fileWatcherBridge.registerHandlers(ipcMain, { terminalWorkerManager });
     tempDirBridge.registerHandlers(ipcMain, shell);
-    sessionLogsBridge.registerHandlers(ipcMain);
+    sessionLogsBridge.registerHandlers(ipcMain, { terminalWorkerManager });
     compressUploadBridge.registerHandlers(ipcMain, { terminalWorkerManager });
     globalShortcutBridge.registerHandlers(ipcMain);
     credentialBridge.registerHandlers(ipcMain, electronModule);

--- a/electron/terminalWorker/runtime.cjs
+++ b/electron/terminalWorker/runtime.cjs
@@ -167,6 +167,11 @@ function createSender(parentPort, webContentsId, outputPorts) {
           kind: "output",
           sessionId: payload?.sessionId,
           data: payload?.data,
+          // The output-tap message above already notified main-process taps
+          // for this chunk; flag the fallback delivery so the worker manager
+          // does not notify them a second time (would double-write session
+          // logs and script output buffers).
+          tapped: true,
         };
         if (payload?.meta) outputMessage.meta = payload.meta;
         parentPort.postMessage(outputMessage);

--- a/electron/terminalWorker/runtime.test.cjs
+++ b/electron/terminalWorker/runtime.test.cjs
@@ -174,6 +174,7 @@ test("runtime routes terminal data over output messages", async () => {
     kind: "output",
     sessionId: "s1",
     data: "hello",
+    tapped: true,
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1938 — manual session logs ("开启会话日志") saved only the initial prompt line and no terminal output.

**Root cause:** In the default terminal worker runtime (`NETCATTY_TERMINAL_WORKER !== "0"`), terminal sessions run in an Electron `utilityProcess`, so every `sessionLogStreamManager.appendData()` call happens on the *worker's* module instance. The manual session log IPC handlers (`netcatty:sessionLog:manualStart/Stop/Status`) run in the *main* process and register the stream in the main process's `activeStreams` map. The two maps never meet, so the log file only ever received the `initialLine` captured from the renderer buffer — exactly the single prompt line reported in the issue. #1933 fixed prompt-line joining but was only exercised in-process, which is why the bug survived it. Script session logs (`startSessionLog` in script runtime) had the same gap.

**Fix:**
- `sessionLogsBridge.registerHandlers` now accepts the terminal worker manager and registers an output tap (the same worker→main output mirror scriptBridge already uses for its output buffers) that feeds worker session output into the main-process stream manager. `appendData()` is a no-op for sessions without an active main-process stream, so worker-owned auto session logs are unaffected and nothing is double-written.
- The main-process `netcatty:write` forwarder (and scriptBridge's worker write path) mirrors sudo-autofill and programmatic command log rewrites into the main-process stream manager, so manual/script logs keep sanitizing `__NETCATTY_SUDO_*__` markers and hidden programmatic command echoes exactly like the non-worker path does.

## Test plan

- [x] New test: `registerHandlers` wires the worker output tap into manual session logs (start → tap output → stop → file contains prompt + output).
- [x] New tests: worker-mode `netcatty:write` forwarding still delivers payloads and mirrors sudo-autofill / programmatic rewrites into main-process streams.
- [x] `npm test` — 4220 pass, 0 fail.
- [x] `npm run lint` — clean.
- [ ] Manual check on a packaged build: open SSH session → start session log → run commands → stop → file contains full output.

Made with [Cursor](https://cursor.com)