### PR TITLE
Fix directory tracking setup after su / sudo su

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -928,7 +928,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }).then((result) => {
       handleOsc7SetupOpenChange(false);
       if (result.success) {
-        toast.success(t("terminal.osc7Setup.configured"));
+        toast.success(result.sentToTerminal
+          ? t("terminal.osc7Setup.sent")
+          : t("terminal.osc7Setup.configured"));
         return;
       }
       toast.error(result.error || t("terminal.osc7Setup.failed"));

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -7,9 +7,11 @@ import { basename, join } from "node:path";
 
 import {
   OSC7_MARKER,
+  OSC7_SETUP_OTHER_USER_MARKER,
   buildOsc7ReloadCommand,
   buildOsc7SetupCommand,
   buildOsc7SetupExecCommand,
+  buildOsc7TypedSetupCommand,
   runOsc7SetupAction,
   shouldOfferOsc7SetupAction,
 } from "./osc7Setup";
@@ -125,6 +127,62 @@ test("runOsc7SetupAction configures in the background and only sends a small rel
   assert.deepEqual(localData, ["\u001b]7;file://host/home/me\u0007"]);
 });
 
+test("runOsc7SetupAction retypes the setup into the terminal for user-switched shells", async () => {
+  const writes: Array<{ sessionId: string; data: string; automated?: boolean }> = [];
+  const localData: string[] = [];
+
+  const result = await runOsc7SetupAction({
+    status: "connected",
+    sessionId: "session-1",
+    setupCommand: "printf setup-script",
+    setupOsc7Tracking: async () => ({
+      success: false,
+      stdout: `${OSC7_SETUP_OTHER_USER_MARKER}bash\n`,
+      stderr: "Netcatty OSC 7 setup: the active terminal shell belongs to another user\n",
+      code: 5,
+      error: "Netcatty OSC 7 setup: the active terminal shell belongs to another user",
+    }),
+    writeToSession: (sessionId, data, options) => {
+      writes.push({ sessionId, data, automated: options?.automated });
+    },
+    writeLocalTerminalData: (data) => {
+      localData.push(data);
+    },
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.sentToTerminal, true);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0].sessionId, "session-1");
+  assert.equal(writes[0].automated, true);
+  assert.match(writes[0].data, /NETCATTY_OSC7_FORCE_SHELL=bash/);
+  assert.match(writes[0].data, /\.bashrc/);
+  assert.deepEqual(localData, []);
+});
+
+test("runOsc7SetupAction reports unsupported user-switched shells instead of typing", async () => {
+  const writes: string[] = [];
+
+  const result = await runOsc7SetupAction({
+    status: "connected",
+    sessionId: "session-1",
+    setupCommand: "printf setup-script",
+    setupOsc7Tracking: async () => ({
+      success: false,
+      stdout: `${OSC7_SETUP_OTHER_USER_MARKER}dash\n`,
+      stderr: "",
+      code: 5,
+    }),
+    writeToSession: (_sessionId, data) => {
+      writes.push(data);
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error || "", /does not support/);
+  assert.deepEqual(writes, []);
+});
+
 test("runOsc7SetupAction fails without reload metadata instead of reporting a partial setup", async () => {
   const writes: string[] = [];
   const localData: string[] = [];
@@ -205,6 +263,76 @@ test("buildOsc7SetupExecCommand configures bash through a background exec shell"
     assert.match(output, new RegExp(`__NETCATTY_OSC7_SETUP_CONFIG__=${home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\.bashrc`));
     const bashrc = readFileSync(join(home, ".bashrc"), "utf8");
     assert.equal(markerCount(bashrc), 2);
+  });
+});
+
+test("buildOsc7TypedSetupCommand configures bash without leaking setup markers", () => {
+  withTempHome("netcatty-osc7-typed-bash-", (home) => {
+    const command = buildOsc7TypedSetupCommand("bash").replace(/\r/g, "\n");
+    const output = execFileSync("/bin/bash", ["-c", command], {
+      env: { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" },
+      stdio: "pipe",
+    }).toString("utf8");
+
+    const bashrc = readFileSync(join(home, ".bashrc"), "utf8");
+    assert.equal(markerCount(bashrc), 2);
+    assert.match(bashrc, /PROMPT_COMMAND/);
+    assert.doesNotMatch(output, /__NETCATTY_OSC7_SETUP_SHELL__|__NETCATTY_OSC7_SETUP_CONFIG__/);
+    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+  });
+});
+
+test("buildOsc7TypedSetupCommand stays idempotent for bash", () => {
+  withTempHome("netcatty-osc7-typed-bash-idempotent-", (home) => {
+    const command = buildOsc7TypedSetupCommand("bash").replace(/\r/g, "\n");
+    const env = { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" };
+    execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
+    execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
+
+    assert.equal(markerCount(readFileSync(join(home, ".bashrc"), "utf8")), 2);
+  });
+});
+
+test("buildOsc7TypedSetupCommand configures zsh through its typed fallback", (t) => {
+  const zshPath = existingShells(["/bin/zsh", "/usr/bin/zsh"])[0];
+  if (!zshPath) {
+    t.skip("zsh is not installed on this runner");
+    return;
+  }
+
+  withTempHome("netcatty-osc7-typed-zsh-", (home) => {
+    const zdotdir = join(home, ".config", "zsh");
+    const command = buildOsc7TypedSetupCommand("zsh").replace(/\r/g, "\n");
+    const output = execFileSync(zshPath, ["-c", command], {
+      env: { ...process.env, HOME: home, SHELL: zshPath, ZDOTDIR: zdotdir, XDG_CONFIG_HOME: "" },
+      stdio: "pipe",
+    }).toString("utf8");
+
+    const zshrc = readFileSync(join(zdotdir, ".zshrc"), "utf8");
+    assert.equal(markerCount(zshrc), 2);
+    assert.match(zshrc, /precmd_functions/);
+    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+  });
+});
+
+test("buildOsc7TypedSetupCommand configures fish through its typed fallback", (t) => {
+  const fishPath = existingShells(["/opt/homebrew/bin/fish", "/usr/bin/fish"])[0];
+  if (!fishPath) {
+    t.skip("fish is not installed on this runner");
+    return;
+  }
+
+  withTempHome("netcatty-osc7-typed-fish-", (home) => {
+    const command = buildOsc7TypedSetupCommand("fish").replace(/\r/g, "\n");
+    const output = execFileSync(fishPath, ["-c", command], {
+      env: { ...process.env, HOME: home, SHELL: fishPath, ZDOTDIR: "", XDG_CONFIG_HOME: "" },
+      stdio: "pipe",
+    }).toString("utf8");
+
+    const fishConfig = readFileSync(join(home, ".config", "fish", "config.fish"), "utf8");
+    assert.equal(markerCount(fishConfig), 2);
+    assert.match(fishConfig, /fish_prompt/);
+    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
   });
 });
 

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -14,6 +14,7 @@ import {
   buildOsc7SetupExecCommand,
   buildOsc7StageScriptCommand,
   buildOsc7TypedSetupCommand,
+  getOsc7StagedScriptSha256,
   parseOsc7SetupStagedPath,
   runOsc7SetupAction,
   shouldOfferOsc7SetupAction,
@@ -329,18 +330,20 @@ const withStagedSetupScript = (fn: (scriptPath: string) => void) => {
   }
 };
 
-test("buildOsc7TypedSetupCommand stays a single line for reliable history cleanup", () => {
+test("buildOsc7TypedSetupCommand stays a single line for reliable history cleanup", async () => {
+  const sha256 = await getOsc7StagedScriptSha256();
   for (const shell of ["bash", "zsh", "fish"] as const) {
-    const command = buildOsc7TypedSetupCommand(shell, "/tmp/.netcatty-osc7-setup.abc123");
+    const command = buildOsc7TypedSetupCommand(shell, "/tmp/.netcatty-osc7-setup.abc123", sha256);
     assert.ok(command.endsWith("\r"), shell);
     assert.doesNotMatch(command.slice(0, -1), /[\r\n]/, shell);
   }
 });
 
-test("buildOsc7TypedSetupCommand configures bash and removes the staged script", () => {
+test("buildOsc7TypedSetupCommand configures bash and removes the staged script", async () => {
+  const sha256 = await getOsc7StagedScriptSha256();
   withTempHome("netcatty-osc7-typed-bash-", (home) => {
     withStagedSetupScript((scriptPath) => {
-      const command = buildOsc7TypedSetupCommand("bash", scriptPath).replace(/\r/g, "\n");
+      const command = buildOsc7TypedSetupCommand("bash", scriptPath, sha256).replace(/\r/g, "\n");
       const output = execFileSync("/bin/bash", ["-c", command], {
         env: { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" },
         stdio: "pipe",
@@ -351,12 +354,33 @@ test("buildOsc7TypedSetupCommand configures bash and removes the staged script",
       assert.match(bashrc, /PROMPT_COMMAND/);
       assert.doesNotMatch(output, /__NETCATTY_OSC7_SETUP_SHELL__|__NETCATTY_OSC7_SETUP_CONFIG__/);
       assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
-      assert.equal(existsSync(scriptPath), false, "staged script should remove itself");
+      assert.equal(existsSync(scriptPath), false, "staged script should be removed");
     });
   });
 });
 
-test("buildOsc7TypedSetupCommand does not leave the typed runner in bash history", () => {
+test("buildOsc7TypedSetupCommand refuses to run a tampered staged script", async () => {
+  const sha256 = await getOsc7StagedScriptSha256();
+  withTempHome("netcatty-osc7-typed-tampered-", (home) => {
+    withStagedSetupScript((scriptPath) => {
+      writeFileSync(scriptPath, `echo pwned > "$HOME/pwned"\n`);
+      const command = buildOsc7TypedSetupCommand("bash", scriptPath, sha256).replace(/\r/g, "\n");
+      const result = spawnSync("/bin/bash", ["-c", command], {
+        env: { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" },
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stderr, /verification failed/);
+      assert.equal(existsSync(join(home, "pwned")), false, "tampered script must not run");
+      assert.equal(existsSync(join(home, ".bashrc")), false);
+      assert.equal(existsSync(scriptPath), false, "staged script should be removed before verification");
+    });
+  });
+});
+
+test("buildOsc7TypedSetupCommand does not leave the typed runner in bash history", async () => {
+  const sha256 = await getOsc7StagedScriptSha256();
   withTempHome("netcatty-osc7-typed-history-bash-", (home) => {
     withStagedSetupScript((scriptPath) => {
       const dumpPath = join(home, "bash-history-dump");
@@ -370,7 +394,7 @@ test("buildOsc7TypedSetupCommand does not leave the typed runner in bash history
           HISTFILE: join(home, ".bash_history"),
           SHELL: "/bin/bash",
         },
-        input: `echo keepme\n${buildOsc7TypedSetupCommand("bash", scriptPath)}`,
+        input: `echo keepme\n${buildOsc7TypedSetupCommand("bash", scriptPath, sha256)}`,
       });
 
       assert.match(output, /echo keepme/);
@@ -379,12 +403,13 @@ test("buildOsc7TypedSetupCommand does not leave the typed runner in bash history
   });
 });
 
-test("buildOsc7TypedSetupCommand stays idempotent for bash", () => {
+test("buildOsc7TypedSetupCommand stays idempotent for bash", async () => {
+  const sha256 = await getOsc7StagedScriptSha256();
   withTempHome("netcatty-osc7-typed-bash-idempotent-", (home) => {
     const env = { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" };
     for (let run = 0; run < 2; run += 1) {
       withStagedSetupScript((scriptPath) => {
-        const command = buildOsc7TypedSetupCommand("bash", scriptPath).replace(/\r/g, "\n");
+        const command = buildOsc7TypedSetupCommand("bash", scriptPath, sha256).replace(/\r/g, "\n");
         execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
       });
     }
@@ -393,17 +418,18 @@ test("buildOsc7TypedSetupCommand stays idempotent for bash", () => {
   });
 });
 
-test("buildOsc7TypedSetupCommand honors shell-local unexported zsh ZDOTDIR", (t) => {
+test("buildOsc7TypedSetupCommand honors shell-local unexported zsh ZDOTDIR", async (t) => {
   const zshPath = existingShells(["/bin/zsh", "/usr/bin/zsh"])[0];
   if (!zshPath) {
     t.skip("zsh is not installed on this runner");
     return;
   }
 
+  const sha256 = await getOsc7StagedScriptSha256();
   withTempHome("netcatty-osc7-typed-zsh-", (home) => {
     const zdotdir = join(home, ".config", "zsh");
     withStagedSetupScript((scriptPath) => {
-      const command = buildOsc7TypedSetupCommand("zsh", scriptPath).replace(/\r/g, "\n");
+      const command = buildOsc7TypedSetupCommand("zsh", scriptPath, sha256).replace(/\r/g, "\n");
       // ZDOTDIR is a shell-local (unexported) parameter, like a user setting
       // it in .zshenv without export; the typed wrapper must forward it.
       const output = execFileSync(zshPath, ["-c", `ZDOTDIR=${JSON.stringify(zdotdir)}; ${command}`], {
@@ -420,16 +446,17 @@ test("buildOsc7TypedSetupCommand honors shell-local unexported zsh ZDOTDIR", (t)
   });
 });
 
-test("buildOsc7TypedSetupCommand configures fish through its typed fallback", (t) => {
+test("buildOsc7TypedSetupCommand configures fish through its typed fallback", async (t) => {
   const fishPath = existingShells(["/opt/homebrew/bin/fish", "/usr/bin/fish"])[0];
   if (!fishPath) {
     t.skip("fish is not installed on this runner");
     return;
   }
 
+  const sha256 = await getOsc7StagedScriptSha256();
   withTempHome("netcatty-osc7-typed-fish-", (home) => {
     withStagedSetupScript((scriptPath) => {
-      const command = buildOsc7TypedSetupCommand("fish", scriptPath).replace(/\r/g, "\n");
+      const command = buildOsc7TypedSetupCommand("fish", scriptPath, sha256).replace(/\r/g, "\n");
       const output = execFileSync(fishPath, ["-c", command], {
         env: { ...process.env, HOME: home, SHELL: fishPath, ZDOTDIR: "", XDG_CONFIG_HOME: "" },
         stdio: "pipe",

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -8,10 +8,13 @@ import { basename, join } from "node:path";
 import {
   OSC7_MARKER,
   OSC7_SETUP_OTHER_USER_MARKER,
+  OSC7_SETUP_STAGED_MARKER,
   buildOsc7ReloadCommand,
   buildOsc7SetupCommand,
   buildOsc7SetupExecCommand,
+  buildOsc7StageScriptCommand,
   buildOsc7TypedSetupCommand,
+  parseOsc7SetupStagedPath,
   runOsc7SetupAction,
   shouldOfferOsc7SetupAction,
 } from "./osc7Setup";
@@ -127,21 +130,33 @@ test("runOsc7SetupAction configures in the background and only sends a small rel
   assert.deepEqual(localData, ["\u001b]7;file://host/home/me\u0007"]);
 });
 
-test("runOsc7SetupAction retypes the setup into the terminal for user-switched shells", async () => {
+test("runOsc7SetupAction stages the script and types a short runner for user-switched shells", async () => {
   const writes: Array<{ sessionId: string; data: string; automated?: boolean }> = [];
   const localData: string[] = [];
+  const setupCommands: string[] = [];
 
   const result = await runOsc7SetupAction({
     status: "connected",
     sessionId: "session-1",
     setupCommand: "printf setup-script",
-    setupOsc7Tracking: async () => ({
-      success: false,
-      stdout: `${OSC7_SETUP_OTHER_USER_MARKER}bash\n`,
-      stderr: "Netcatty OSC 7 setup: the active terminal shell belongs to another user\n",
-      code: 5,
-      error: "Netcatty OSC 7 setup: the active terminal shell belongs to another user",
-    }),
+    setupOsc7Tracking: async (_sessionId, command) => {
+      setupCommands.push(command);
+      if (setupCommands.length === 1) {
+        return {
+          success: false,
+          stdout: `${OSC7_SETUP_OTHER_USER_MARKER}bash\n`,
+          stderr: "Netcatty OSC 7 setup: the active terminal shell belongs to another user\n",
+          code: 5,
+          error: "Netcatty OSC 7 setup: the active terminal shell belongs to another user",
+        };
+      }
+      return {
+        success: true,
+        stdout: `${OSC7_SETUP_STAGED_MARKER}/tmp/.netcatty-osc7-setup.abc123\n`,
+        stderr: "",
+        code: 0,
+      };
+    },
     writeToSession: (sessionId, data, options) => {
       writes.push({ sessionId, data, automated: options?.automated });
     },
@@ -152,12 +167,47 @@ test("runOsc7SetupAction retypes the setup into the terminal for user-switched s
 
   assert.equal(result.success, true);
   assert.equal(result.sentToTerminal, true);
+  assert.equal(setupCommands.length, 2);
+  assert.match(setupCommands[1], /mktemp/);
   assert.equal(writes.length, 1);
   assert.equal(writes[0].sessionId, "session-1");
   assert.equal(writes[0].automated, true);
   assert.match(writes[0].data, /NETCATTY_OSC7_FORCE_SHELL=bash/);
+  assert.match(writes[0].data, /'\/tmp\/\.netcatty-osc7-setup\.abc123'/);
   assert.match(writes[0].data, /\.bashrc/);
+  // Single line: one history entry, so the appended bash cleanup deletes it.
+  assert.doesNotMatch(writes[0].data.slice(0, -1), /[\r\n]/);
   assert.deepEqual(localData, []);
+});
+
+test("runOsc7SetupAction fails when the setup script cannot be staged", async () => {
+  const writes: string[] = [];
+  let calls = 0;
+
+  const result = await runOsc7SetupAction({
+    status: "connected",
+    sessionId: "session-1",
+    setupCommand: "printf setup-script",
+    setupOsc7Tracking: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          success: false,
+          stdout: `${OSC7_SETUP_OTHER_USER_MARKER}bash\n`,
+          stderr: "",
+          code: 5,
+        };
+      }
+      return { success: false, stdout: "", stderr: "mktemp: failed", code: 1 };
+    },
+    writeToSession: (_sessionId, data) => {
+      writes.push(data);
+    },
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error || "", /mktemp: failed|setup failed/);
+  assert.deepEqual(writes, []);
 });
 
 test("runOsc7SetupAction reports unsupported user-switched shells instead of typing", async () => {
@@ -266,34 +316,84 @@ test("buildOsc7SetupExecCommand configures bash through a background exec shell"
   });
 });
 
-test("buildOsc7TypedSetupCommand configures bash without leaking setup markers", () => {
-  withTempHome("netcatty-osc7-typed-bash-", (home) => {
-    const command = buildOsc7TypedSetupCommand("bash").replace(/\r/g, "\n");
-    const output = execFileSync("/bin/bash", ["-c", command], {
-      env: { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" },
-      stdio: "pipe",
-    }).toString("utf8");
+const withStagedSetupScript = (fn: (scriptPath: string) => void) => {
+  const output = execFileSync("/bin/sh", ["-c", buildOsc7StageScriptCommand()], {
+    stdio: "pipe",
+  }).toString("utf8");
+  const scriptPath = parseOsc7SetupStagedPath(output);
+  assert.ok(scriptPath, "expected staged script path");
+  try {
+    fn(scriptPath);
+  } finally {
+    rmSync(scriptPath, { force: true });
+  }
+};
 
-    const bashrc = readFileSync(join(home, ".bashrc"), "utf8");
-    assert.equal(markerCount(bashrc), 2);
-    assert.match(bashrc, /PROMPT_COMMAND/);
-    assert.doesNotMatch(output, /__NETCATTY_OSC7_SETUP_SHELL__|__NETCATTY_OSC7_SETUP_CONFIG__/);
-    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+test("buildOsc7TypedSetupCommand stays a single line for reliable history cleanup", () => {
+  for (const shell of ["bash", "zsh", "fish"] as const) {
+    const command = buildOsc7TypedSetupCommand(shell, "/tmp/.netcatty-osc7-setup.abc123");
+    assert.ok(command.endsWith("\r"), shell);
+    assert.doesNotMatch(command.slice(0, -1), /[\r\n]/, shell);
+  }
+});
+
+test("buildOsc7TypedSetupCommand configures bash and removes the staged script", () => {
+  withTempHome("netcatty-osc7-typed-bash-", (home) => {
+    withStagedSetupScript((scriptPath) => {
+      const command = buildOsc7TypedSetupCommand("bash", scriptPath).replace(/\r/g, "\n");
+      const output = execFileSync("/bin/bash", ["-c", command], {
+        env: { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" },
+        stdio: "pipe",
+      }).toString("utf8");
+
+      const bashrc = readFileSync(join(home, ".bashrc"), "utf8");
+      assert.equal(markerCount(bashrc), 2);
+      assert.match(bashrc, /PROMPT_COMMAND/);
+      assert.doesNotMatch(output, /__NETCATTY_OSC7_SETUP_SHELL__|__NETCATTY_OSC7_SETUP_CONFIG__/);
+      assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+      assert.equal(existsSync(scriptPath), false, "staged script should remove itself");
+    });
+  });
+});
+
+test("buildOsc7TypedSetupCommand does not leave the typed runner in bash history", () => {
+  withTempHome("netcatty-osc7-typed-history-bash-", (home) => {
+    withStagedSetupScript((scriptPath) => {
+      const dumpPath = join(home, "bash-history-dump");
+      const output = runInteractiveHistoryProbe({
+        shellPath: "/bin/bash",
+        shellArgs: ["--noprofile", "--norc", "-i"],
+        dumpHistoryCommand: `history > ${quoteShellArg(dumpPath)}`,
+        dumpPath,
+        env: {
+          HOME: home,
+          HISTFILE: join(home, ".bash_history"),
+          SHELL: "/bin/bash",
+        },
+        input: `echo keepme\n${buildOsc7TypedSetupCommand("bash", scriptPath)}`,
+      });
+
+      assert.match(output, /echo keepme/);
+      assert.doesNotMatch(output, /NETCATTY_OSC7_FORCE_SHELL|__netcatty_osc7|history -d/);
+    });
   });
 });
 
 test("buildOsc7TypedSetupCommand stays idempotent for bash", () => {
   withTempHome("netcatty-osc7-typed-bash-idempotent-", (home) => {
-    const command = buildOsc7TypedSetupCommand("bash").replace(/\r/g, "\n");
     const env = { ...process.env, HOME: home, SHELL: "/bin/bash", ZDOTDIR: "", XDG_CONFIG_HOME: "" };
-    execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
-    execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
+    for (let run = 0; run < 2; run += 1) {
+      withStagedSetupScript((scriptPath) => {
+        const command = buildOsc7TypedSetupCommand("bash", scriptPath).replace(/\r/g, "\n");
+        execFileSync("/bin/bash", ["-c", command], { env, stdio: "pipe" });
+      });
+    }
 
     assert.equal(markerCount(readFileSync(join(home, ".bashrc"), "utf8")), 2);
   });
 });
 
-test("buildOsc7TypedSetupCommand configures zsh through its typed fallback", (t) => {
+test("buildOsc7TypedSetupCommand honors shell-local unexported zsh ZDOTDIR", (t) => {
   const zshPath = existingShells(["/bin/zsh", "/usr/bin/zsh"])[0];
   if (!zshPath) {
     t.skip("zsh is not installed on this runner");
@@ -302,16 +402,21 @@ test("buildOsc7TypedSetupCommand configures zsh through its typed fallback", (t)
 
   withTempHome("netcatty-osc7-typed-zsh-", (home) => {
     const zdotdir = join(home, ".config", "zsh");
-    const command = buildOsc7TypedSetupCommand("zsh").replace(/\r/g, "\n");
-    const output = execFileSync(zshPath, ["-c", command], {
-      env: { ...process.env, HOME: home, SHELL: zshPath, ZDOTDIR: zdotdir, XDG_CONFIG_HOME: "" },
-      stdio: "pipe",
-    }).toString("utf8");
+    withStagedSetupScript((scriptPath) => {
+      const command = buildOsc7TypedSetupCommand("zsh", scriptPath).replace(/\r/g, "\n");
+      // ZDOTDIR is a shell-local (unexported) parameter, like a user setting
+      // it in .zshenv without export; the typed wrapper must forward it.
+      const output = execFileSync(zshPath, ["-c", `ZDOTDIR=${JSON.stringify(zdotdir)}; ${command}`], {
+        env: { ...process.env, HOME: home, SHELL: zshPath, ZDOTDIR: undefined, XDG_CONFIG_HOME: "" },
+        stdio: "pipe",
+      }).toString("utf8");
 
-    const zshrc = readFileSync(join(zdotdir, ".zshrc"), "utf8");
-    assert.equal(markerCount(zshrc), 2);
-    assert.match(zshrc, /precmd_functions/);
-    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+      const zshrc = readFileSync(join(zdotdir, ".zshrc"), "utf8");
+      assert.equal(markerCount(zshrc), 2);
+      assert.match(zshrc, /precmd_functions/);
+      assert.equal(existsSync(join(home, ".zshrc")), false);
+      assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+    });
   });
 });
 
@@ -323,16 +428,18 @@ test("buildOsc7TypedSetupCommand configures fish through its typed fallback", (t
   }
 
   withTempHome("netcatty-osc7-typed-fish-", (home) => {
-    const command = buildOsc7TypedSetupCommand("fish").replace(/\r/g, "\n");
-    const output = execFileSync(fishPath, ["-c", command], {
-      env: { ...process.env, HOME: home, SHELL: fishPath, ZDOTDIR: "", XDG_CONFIG_HOME: "" },
-      stdio: "pipe",
-    }).toString("utf8");
+    withStagedSetupScript((scriptPath) => {
+      const command = buildOsc7TypedSetupCommand("fish", scriptPath).replace(/\r/g, "\n");
+      const output = execFileSync(fishPath, ["-c", command], {
+        env: { ...process.env, HOME: home, SHELL: fishPath, ZDOTDIR: "", XDG_CONFIG_HOME: "" },
+        stdio: "pipe",
+      }).toString("utf8");
 
-    const fishConfig = readFileSync(join(home, ".config", "fish", "config.fish"), "utf8");
-    assert.equal(markerCount(fishConfig), 2);
-    assert.match(fishConfig, /fish_prompt/);
-    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+      const fishConfig = readFileSync(join(home, ".config", "fish", "config.fish"), "utf8");
+      assert.equal(markerCount(fishConfig), 2);
+      assert.match(fishConfig, /fish_prompt/);
+      assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+    });
   });
 });
 

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -8,6 +8,11 @@ export const OSC7_SETUP_TARGETS = [
 
 export const OSC7_SETUP_SHELL_MARKER = "__NETCATTY_OSC7_SETUP_SHELL__=";
 export const OSC7_SETUP_CONFIG_MARKER = "__NETCATTY_OSC7_SETUP_CONFIG__=";
+// Emitted when the silent exec-channel setup finds the active terminal shell
+// owned by another user (after `su` / `sudo su`); the exec channel cannot
+// configure that shell, so the renderer retypes the setup inside the terminal
+// where it runs as the target user (#1942).
+export const OSC7_SETUP_OTHER_USER_MARKER = "__NETCATTY_OSC7_SETUP_OTHER_USER_SHELL__=";
 
 export type Osc7SetupActionContext = {
   protocol?: string;
@@ -31,6 +36,8 @@ export type Osc7SetupRunResult = {
   code?: number | null;
   error?: string;
   reloadCommand?: string;
+  /** Setup was retyped into the terminal for a user-switched (su/sudo) shell. */
+  sentToTerminal?: boolean;
 };
 
 export type RunOsc7SetupActionOptions = {
@@ -97,6 +104,7 @@ const POSIX_SETUP_SCRIPT = String.raw`set -eu
 marker="# >>> Netcatty OSC 7 cwd tracking >>>"
 SELF=$$
 expected_cwd="${DOLLAR}{NETCATTY_OSC7_EXPECTED_CWD:-}"
+forced_shell="${DOLLAR}{NETCATTY_OSC7_FORCE_SHELL:-}"
 
 find_login_shell() {
   _shell=$(ps -e -o pid=,ppid=,tty=,comm= 2>/dev/null | awk -v pp="$1" -v self="$SELF" '
@@ -158,11 +166,26 @@ read_proc_env_value() {
 
 active_shell_pid=""
 login_shell_pid=""
-if [ -d /proc ]; then
+if [ -z "$forced_shell" ] && [ -d /proc ]; then
   login_shell_pid=$(find_login_shell "$PPID" || true)
   if [ -n "$login_shell_pid" ]; then
     active_shell_pid=$(find_active_shell "$login_shell_pid" || true)
     [ -n "$active_shell_pid" ] || active_shell_pid="$login_shell_pid"
+  fi
+fi
+
+# After su / sudo su the foreground shell belongs to another user. This exec
+# channel runs as the login user, so it can neither verify nor configure that
+# shell (ptrace-scoped /proc access). Report the target shell so the caller
+# can retype the setup inside the terminal, where it runs as that user (#1942).
+if [ -n "$active_shell_pid" ]; then
+  active_uid=$(sed -n "s/^Uid:[[:space:]]*\([0-9]*\).*/\1/p" "/proc/$active_shell_pid/status" 2>/dev/null | head -n1 || true)
+  self_uid=$(id -u 2>/dev/null || true)
+  if [ -n "$active_uid" ] && [ -n "$self_uid" ] && [ "$active_uid" != "$self_uid" ]; then
+    other_shell=$(cat "/proc/$active_shell_pid/comm" 2>/dev/null | sed "s/^-//" | tr -d "[:space:]" || true)
+    printf '%s%s\n' '${OSC7_SETUP_OTHER_USER_MARKER}' "${DOLLAR}{other_shell:-unknown}"
+    printf "Netcatty OSC 7 setup: the active terminal shell belongs to another user\n" >&2
+    exit 5
   fi
 fi
 
@@ -205,6 +228,9 @@ case "$parent_shell" in
 esac
 case "$active_comm" in
   bash|zsh|fish) shell_name="$active_comm" ;;
+esac
+case "$forced_shell" in
+  bash|zsh|fish) shell_name="$forced_shell" ;;
 esac
 
 home_dir="${DOLLAR}{active_home:-$HOME}"
@@ -293,8 +319,10 @@ NETCATTY_OSC7_FISH
   esac
 fi
 
-printf '%s%s\n' '${OSC7_SETUP_SHELL_MARKER}' "$shell_name"
-printf '%s%s\n' '${OSC7_SETUP_CONFIG_MARKER}' "$config"
+if [ -z "$forced_shell" ]; then
+  printf '%s%s\n' '${OSC7_SETUP_SHELL_MARKER}' "$shell_name"
+  printf '%s%s\n' '${OSC7_SETUP_CONFIG_MARKER}' "$config"
+fi
 host=$(hostname 2>/dev/null || printf localhost)
 printf '\033]7;file://%s%s\a' "$host" "$(__netcatty_osc7_url_path "$PWD")"`;
 
@@ -306,6 +334,25 @@ export const buildOsc7SetupExecCommand = (expectedCwd?: string): string => {
     ? `env NETCATTY_OSC7_EXPECTED_CWD=${quoteForSingleQuotedShellString(expectedCwd)} `
     : "";
   return `exec ${envPrefix}sh -c ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)}\n`;
+};
+
+/**
+ * Setup command typed into the interactive terminal itself. Used when the
+ * silent exec-channel setup cannot configure the active shell because it is
+ * owned by another user (after `su` / `sudo su`, #1942): typed input runs as
+ * that user, so the config lands in the target user's rc file and OSC 7
+ * reporting resumes for this and every future user-switched shell.
+ */
+export const buildOsc7TypedSetupCommand = (shell: Osc7SetupShell): string => {
+  const pipe = `printf "%s\\n" ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)} | env NETCATTY_OSC7_FORCE_SHELL=${shell} sh`;
+  if (shell === "bash") {
+    return `${pipe}; . "${DOLLAR}HOME/.bashrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true; ${BASH_DELETE_MARKED_HISTORY_COMMAND}\r`;
+  }
+  if (shell === "zsh") {
+    // Leading space keeps the command out of history when HIST_IGNORE_SPACE is set.
+    return ` ${pipe}; . "${DOLLAR}{ZDOTDIR:-${DOLLAR}HOME}/.zshrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true\r`;
+  }
+  return ` ${pipe}; source (test -n "${DOLLAR}XDG_CONFIG_HOME"; and echo "${DOLLAR}XDG_CONFIG_HOME"; or echo "${DOLLAR}HOME/.config")/fish/config.fish >/dev/null 2>&1; __netcatty_osc7_cwd 2>/dev/null; true\r`;
 };
 
 const isOsc7SetupShell = (value: string): value is Osc7SetupShell =>
@@ -322,6 +369,10 @@ export const parseOsc7SetupMetadata = (stdout: string): Osc7SetupMetadata | null
   if (!shell || !isOsc7SetupShell(shell) || !configPath) return null;
   return { shell, configPath };
 };
+
+/** Shell of the other-user foreground shell reported by the setup script, if any. */
+export const parseOsc7SetupOtherUserShell = (stdout: string): string | null =>
+  readMarkerLine(stdout, OSC7_SETUP_OTHER_USER_MARKER);
 
 export const extractOsc7SetupTerminalData = (stdout: string): string => {
   const escape = String.fromCharCode(0x1b);
@@ -376,6 +427,27 @@ export const runOsc7SetupAction = async ({
   }
 
   const result = await setupOsc7Tracking(sessionId, setupCommand);
+
+  // The exec channel cannot configure a shell owned by another user (after
+  // su / sudo su). Fall back to typing the setup into the terminal, where it
+  // runs as that user (#1942).
+  const otherUserShell = parseOsc7SetupOtherUserShell(result.stdout || "");
+  if (otherUserShell) {
+    if (!isOsc7SetupShell(otherUserShell)) {
+      return {
+        ...result,
+        success: false,
+        error: `Directory tracking does not support the current shell (${otherUserShell})`,
+      };
+    }
+    const typedCommand = buildOsc7TypedSetupCommand(otherUserShell);
+    writeToSession(sessionId, typedCommand, {
+      automated: true,
+      logRewrite: { sentCommand: typedCommand, displayCommand: "" },
+    });
+    return { ...result, success: true, sentToTerminal: true };
+  }
+
   if (!result.success || (typeof result.code === "number" && result.code !== 0)) {
     return {
       ...result,

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -338,25 +338,59 @@ export const buildOsc7SetupExecCommand = (expectedCwd?: string): string => {
 
 export const OSC7_SETUP_STAGED_MARKER = "__NETCATTY_OSC7_SETUP_STAGED__=";
 
+/** Exact bytes the stage command writes (printf '%s\n' appends the newline). */
+const STAGED_SETUP_SCRIPT_BYTES = `${POSIX_SETUP_SCRIPT}\n`;
+
+let stagedScriptSha256Promise: Promise<string> | null = null;
+
+/**
+ * SHA-256 (hex) of the staged setup script bytes, computed locally so the
+ * typed runner can verify the remote file was not tampered with.
+ */
+export const getOsc7StagedScriptSha256 = (): Promise<string> => {
+  if (!stagedScriptSha256Promise) {
+    stagedScriptSha256Promise = crypto.subtle
+      .digest("SHA-256", new TextEncoder().encode(STAGED_SETUP_SCRIPT_BYTES))
+      .then((digest) =>
+        Array.from(new Uint8Array(digest))
+          .map((byte) => byte.toString(16).padStart(2, "0"))
+          .join(""),
+      );
+  }
+  return stagedScriptSha256Promise;
+};
+
 /**
  * Exec-channel command that stages the setup script into a world-readable
  * remote temp file. Typed fallback (#1942) runs that file instead of pasting
  * the multi-line script into the terminal: the typed command stays a single
  * line, so it is one history entry that the bash cleanup reliably deletes.
- * The staged file removes itself when executed (root can always unlink it;
- * for non-root su targets the sticky bit on /tmp may keep the 0644 file
- * around, which is harmless).
  */
 export const buildOsc7StageScriptCommand = (): string => {
-  const stagedScript = `rm -f -- "${DOLLAR}0" 2>/dev/null || true\n${POSIX_SETUP_SCRIPT}`;
   const stageScript = `set -eu
 umask 022
 file=$(mktemp /tmp/.netcatty-osc7-setup.XXXXXX)
-printf '%s\\n' ${quoteForSingleQuotedShellString(stagedScript)} > "$file"
+printf '%s\\n' ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)} > "$file"
 chmod 644 "$file"
 printf '%s%s\\n' '${OSC7_SETUP_STAGED_MARKER}' "$file"`;
   return `exec sh -c ${quoteForSingleQuotedShellString(stageScript)}\n`;
 };
+
+/**
+ * POSIX runner that executes the staged script without a TOCTOU window: it
+ * reads the file into memory ONCE, deletes it, verifies the local SHA-256 of
+ * the in-memory copy, and only then pipes that same copy to sh. The staged
+ * file stays writable by the login user until this runs, so a same-uid
+ * process could otherwise swap its contents and have the su-target shell
+ * (e.g. root) execute them.
+ */
+const buildVerifiedStagedRunner = (contentSha256: string): string =>
+  `c=$(cat -- "$1" 2>/dev/null); rm -f -- "$1" 2>/dev/null; `
+  + `h=$(printf "%s\\n" "$c" | sha256sum 2>/dev/null | cut -d" " -f1); `
+  + `[ -n "$h" ] || h=$(printf "%s\\n" "$c" | shasum -a 256 2>/dev/null | cut -d" " -f1); `
+  + `[ -n "$h" ] || h=$(printf "%s\\n" "$c" | openssl dgst -sha256 2>/dev/null | sed "s/^.* //"); `
+  + `if [ "x$h" = "x${contentSha256}" ]; then printf "%s\\n" "$c" | sh; `
+  + `else printf "%s\\n" "Netcatty OSC 7 setup: staged script verification failed" >&2; fi`;
 
 /**
  * Setup command typed into the interactive terminal itself. Used when the
@@ -365,23 +399,29 @@ printf '%s%s\\n' '${OSC7_SETUP_STAGED_MARKER}' "$file"`;
  * that user, so the config lands in the target user's rc file and OSC 7
  * reporting resumes for this and every future user-switched shell.
  *
- * The command runs the staged script file (see buildOsc7StageScriptCommand)
- * and forwards shell-local (possibly unexported) ZDOTDIR / XDG_CONFIG_HOME to
- * the child sh via the NETCATTY_* overrides the setup script already honors,
- * mirroring buildOsc7SetupCommand.
+ * The command hash-verifies and runs the staged script (see
+ * buildOsc7StageScriptCommand / buildVerifiedStagedRunner) inside a POSIX
+ * `sh -c` child, and forwards shell-local (possibly unexported) ZDOTDIR /
+ * XDG_CONFIG_HOME via the NETCATTY_* overrides the setup script already
+ * honors, mirroring buildOsc7SetupCommand.
  */
-export const buildOsc7TypedSetupCommand = (shell: Osc7SetupShell, scriptPath: string): string => {
+export const buildOsc7TypedSetupCommand = (
+  shell: Osc7SetupShell,
+  scriptPath: string,
+  contentSha256: string,
+): string => {
   const quotedPath = quoteForSingleQuotedShellString(scriptPath);
+  const quotedRunner = quoteForSingleQuotedShellString(buildVerifiedStagedRunner(contentSha256));
   if (shell === "bash") {
-    const run = `env NETCATTY_OSC7_FORCE_SHELL=bash sh ${quotedPath}`;
+    const run = `env NETCATTY_OSC7_FORCE_SHELL=bash sh -c ${quotedRunner} sh ${quotedPath}`;
     return `${run}; . "${DOLLAR}HOME/.bashrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true; ${BASH_DELETE_MARKED_HISTORY_COMMAND}\r`;
   }
   if (shell === "zsh") {
-    const run = `env NETCATTY_OSC7_FORCE_SHELL=zsh NETCATTY_ZDOTDIR="${DOLLAR}{ZDOTDIR:-}" sh ${quotedPath}`;
+    const run = `env NETCATTY_OSC7_FORCE_SHELL=zsh NETCATTY_ZDOTDIR="${DOLLAR}{ZDOTDIR:-}" sh -c ${quotedRunner} sh ${quotedPath}`;
     // Leading space keeps the command out of history when HIST_IGNORE_SPACE is set.
     return ` ${run}; . "${DOLLAR}{ZDOTDIR:-${DOLLAR}HOME}/.zshrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true\r`;
   }
-  const run = `env NETCATTY_OSC7_FORCE_SHELL=fish NETCATTY_XDG_CONFIG_HOME="${DOLLAR}XDG_CONFIG_HOME" sh ${quotedPath}`;
+  const run = `env NETCATTY_OSC7_FORCE_SHELL=fish NETCATTY_XDG_CONFIG_HOME="${DOLLAR}XDG_CONFIG_HOME" sh -c ${quotedRunner} sh ${quotedPath}`;
   return ` ${run}; source (test -n "${DOLLAR}XDG_CONFIG_HOME"; and echo "${DOLLAR}XDG_CONFIG_HOME"; or echo "${DOLLAR}HOME/.config")/fish/config.fish >/dev/null 2>&1; __netcatty_osc7_cwd 2>/dev/null; true\r`;
 };
 
@@ -489,7 +529,8 @@ export const runOsc7SetupAction = async ({
         error: stageResult.error || stageResult.stderr?.trim() || "Directory tracking setup failed",
       };
     }
-    const typedCommand = buildOsc7TypedSetupCommand(otherUserShell, stagedPath);
+    const contentSha256 = await getOsc7StagedScriptSha256();
+    const typedCommand = buildOsc7TypedSetupCommand(otherUserShell, stagedPath, contentSha256);
     writeToSession(sessionId, typedCommand, {
       automated: true,
       logRewrite: { sentCommand: typedCommand, displayCommand: "" },

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -336,23 +336,53 @@ export const buildOsc7SetupExecCommand = (expectedCwd?: string): string => {
   return `exec ${envPrefix}sh -c ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)}\n`;
 };
 
+export const OSC7_SETUP_STAGED_MARKER = "__NETCATTY_OSC7_SETUP_STAGED__=";
+
+/**
+ * Exec-channel command that stages the setup script into a world-readable
+ * remote temp file. Typed fallback (#1942) runs that file instead of pasting
+ * the multi-line script into the terminal: the typed command stays a single
+ * line, so it is one history entry that the bash cleanup reliably deletes.
+ * The staged file removes itself when executed (root can always unlink it;
+ * for non-root su targets the sticky bit on /tmp may keep the 0644 file
+ * around, which is harmless).
+ */
+export const buildOsc7StageScriptCommand = (): string => {
+  const stagedScript = `rm -f -- "${DOLLAR}0" 2>/dev/null || true\n${POSIX_SETUP_SCRIPT}`;
+  const stageScript = `set -eu
+umask 022
+file=$(mktemp /tmp/.netcatty-osc7-setup.XXXXXX)
+printf '%s\\n' ${quoteForSingleQuotedShellString(stagedScript)} > "$file"
+chmod 644 "$file"
+printf '%s%s\\n' '${OSC7_SETUP_STAGED_MARKER}' "$file"`;
+  return `exec sh -c ${quoteForSingleQuotedShellString(stageScript)}\n`;
+};
+
 /**
  * Setup command typed into the interactive terminal itself. Used when the
  * silent exec-channel setup cannot configure the active shell because it is
  * owned by another user (after `su` / `sudo su`, #1942): typed input runs as
  * that user, so the config lands in the target user's rc file and OSC 7
  * reporting resumes for this and every future user-switched shell.
+ *
+ * The command runs the staged script file (see buildOsc7StageScriptCommand)
+ * and forwards shell-local (possibly unexported) ZDOTDIR / XDG_CONFIG_HOME to
+ * the child sh via the NETCATTY_* overrides the setup script already honors,
+ * mirroring buildOsc7SetupCommand.
  */
-export const buildOsc7TypedSetupCommand = (shell: Osc7SetupShell): string => {
-  const pipe = `printf "%s\\n" ${quoteForSingleQuotedShellString(POSIX_SETUP_SCRIPT)} | env NETCATTY_OSC7_FORCE_SHELL=${shell} sh`;
+export const buildOsc7TypedSetupCommand = (shell: Osc7SetupShell, scriptPath: string): string => {
+  const quotedPath = quoteForSingleQuotedShellString(scriptPath);
   if (shell === "bash") {
-    return `${pipe}; . "${DOLLAR}HOME/.bashrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true; ${BASH_DELETE_MARKED_HISTORY_COMMAND}\r`;
+    const run = `env NETCATTY_OSC7_FORCE_SHELL=bash sh ${quotedPath}`;
+    return `${run}; . "${DOLLAR}HOME/.bashrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true; ${BASH_DELETE_MARKED_HISTORY_COMMAND}\r`;
   }
   if (shell === "zsh") {
+    const run = `env NETCATTY_OSC7_FORCE_SHELL=zsh NETCATTY_ZDOTDIR="${DOLLAR}{ZDOTDIR:-}" sh ${quotedPath}`;
     // Leading space keeps the command out of history when HIST_IGNORE_SPACE is set.
-    return ` ${pipe}; . "${DOLLAR}{ZDOTDIR:-${DOLLAR}HOME}/.zshrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true\r`;
+    return ` ${run}; . "${DOLLAR}{ZDOTDIR:-${DOLLAR}HOME}/.zshrc" >/dev/null 2>&1; osc7_cwd 2>/dev/null; true\r`;
   }
-  return ` ${pipe}; source (test -n "${DOLLAR}XDG_CONFIG_HOME"; and echo "${DOLLAR}XDG_CONFIG_HOME"; or echo "${DOLLAR}HOME/.config")/fish/config.fish >/dev/null 2>&1; __netcatty_osc7_cwd 2>/dev/null; true\r`;
+  const run = `env NETCATTY_OSC7_FORCE_SHELL=fish NETCATTY_XDG_CONFIG_HOME="${DOLLAR}XDG_CONFIG_HOME" sh ${quotedPath}`;
+  return ` ${run}; source (test -n "${DOLLAR}XDG_CONFIG_HOME"; and echo "${DOLLAR}XDG_CONFIG_HOME"; or echo "${DOLLAR}HOME/.config")/fish/config.fish >/dev/null 2>&1; __netcatty_osc7_cwd 2>/dev/null; true\r`;
 };
 
 const isOsc7SetupShell = (value: string): value is Osc7SetupShell =>
@@ -373,6 +403,12 @@ export const parseOsc7SetupMetadata = (stdout: string): Osc7SetupMetadata | null
 /** Shell of the other-user foreground shell reported by the setup script, if any. */
 export const parseOsc7SetupOtherUserShell = (stdout: string): string | null =>
   readMarkerLine(stdout, OSC7_SETUP_OTHER_USER_MARKER);
+
+/** Remote path of the staged setup script, if the stage command reported one. */
+export const parseOsc7SetupStagedPath = (stdout: string): string | null => {
+  const path = readMarkerLine(stdout, OSC7_SETUP_STAGED_MARKER);
+  return path && path.startsWith("/") ? path : null;
+};
 
 export const extractOsc7SetupTerminalData = (stdout: string): string => {
   const escape = String.fromCharCode(0x1b);
@@ -429,8 +465,9 @@ export const runOsc7SetupAction = async ({
   const result = await setupOsc7Tracking(sessionId, setupCommand);
 
   // The exec channel cannot configure a shell owned by another user (after
-  // su / sudo su). Fall back to typing the setup into the terminal, where it
-  // runs as that user (#1942).
+  // su / sudo su). Stage the setup script into a remote temp file over the
+  // exec channel, then type a short single-line command into the terminal to
+  // run it as that user (#1942).
   const otherUserShell = parseOsc7SetupOtherUserShell(result.stdout || "");
   if (otherUserShell) {
     if (!isOsc7SetupShell(otherUserShell)) {
@@ -440,7 +477,19 @@ export const runOsc7SetupAction = async ({
         error: `Directory tracking does not support the current shell (${otherUserShell})`,
       };
     }
-    const typedCommand = buildOsc7TypedSetupCommand(otherUserShell);
+    const stageResult = await setupOsc7Tracking(sessionId, buildOsc7StageScriptCommand());
+    const stagedPath =
+      stageResult.success && (typeof stageResult.code !== "number" || stageResult.code === 0)
+        ? parseOsc7SetupStagedPath(stageResult.stdout || "")
+        : null;
+    if (!stagedPath) {
+      return {
+        ...stageResult,
+        success: false,
+        error: stageResult.error || stageResult.stderr?.trim() || "Directory tracking setup failed",
+      };
+    }
+    const typedCommand = buildOsc7TypedSetupCommand(otherUserShell, stagedPath);
     writeToSession(sessionId, typedCommand, {
       automated: true,
       logRewrite: { sentCommand: typedCommand, displayCommand: "" },


### PR DESCRIPTION
## Summary

Fixes #1942 — SFTP 目录跟随在终端内 `sudo su -` 切换用户后失效。

**Root cause**
- 切换用户后，新用户（root）的 shell 没有 OSC 7 提示符配置，不再上报 cwd。
- 后端 pwd 探测通过 SSH exec 通道以登录用户身份运行，受 ptrace 权限限制无法读取其他用户进程的 `/proc/<pid>/cwd`，只能回退到登录 shell 的旧目录。
- 产品内为此场景准备的"配置目录追踪"（OSC 7 setup）同样走静默 exec 通道，检测到前台 shell 属于其他用户后直接失败（exit 3/4）——唯一的补救手段在最需要它的场景下必然失败。

**Fix**
- Setup 脚本新增前台 shell uid 检测：当前台 shell 属于其他用户时，通过 `/proc/<pid>/comm`（全局可读）上报目标 shell 类型（marker + exit 5）。
- 渲染层收到该 marker 后回退为把 setup 命令直接敲进终端（`buildOsc7TypedSetupCommand`），命令在目标用户（root）的 shell 里执行：配置写入目标用户的 rc 文件并立即 source，OSC 7 上报即刻恢复，且之后每次 `sudo su -` 都自动生效。
- 脚本新增 `NETCATTY_OSC7_FORCE_SHELL` 模式：typed 回退时跳过进程探测、按已知 shell 直接写配置，并抑制 marker 输出避免终端可见噪音；bash 路径复用现有的 history 清理，zsh/fish 沿用前导空格约定。
- 成功走 typed 回退时 toast 显示已有的 `terminal.osc7Setup.sent` 文案（四种语言均已存在）。

## Test plan

- [x] `node --test --import tsx components/terminal/*.test.ts` — 394 pass（含新增 6 个用例：typed 回退触发/不支持 shell 报错/bash 幂等与无 marker 泄漏/zsh/fish typed 配置）
- [x] `node --test --import tsx application/i18n/locales/terminalOsc7Locales.test.ts components/terminal/sftpCwd.test.ts`
- [x] `node --test electron/bridges/systemManagerBridge.processes.test.cjs`
- [x] `npx eslint` 改动文件无告警
- [ ] 手动验证：ssh 普通用户 → `sudo su -` → 运行"配置目录追踪" → root shell cd 后 SFTP 跟随恢复

Made with [Cursor](https://cursor.com)