### PR TITLE
fix(i18n): localize SSH auth-failure retry messages

### DIFF
--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -155,6 +155,8 @@ export const enTerminalMessages: Messages = {
   'terminal.auth.passphrase.placeholder': 'Optional passphrase for the selected private key',
   'terminal.auth.certificate': 'Certificate',
   'terminal.auth.selectKey': 'Select Key',
+  'terminal.auth.retryMessage': 'Authentication failed. Please check your credentials and try again.',
+  'terminal.auth.retryLog': 'Authentication failed. Please try again.',
   'terminal.auth.noKeysHint': 'No keys available. Add keys in Keychain.',
   'terminal.auth.continueSave': 'Continue & Save',
   'terminal.auth.credentialsUnavailable': 'Saved credentials cannot be decrypted on this device. Please re-enter and save them again.',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -175,6 +175,8 @@ export const ruTerminalMessages: Messages = {
   'terminal.auth.passphrase.placeholder': 'Необязательная парольная фраза для выбранного приватного ключа',
   'terminal.auth.certificate': 'Сертификат',
   'terminal.auth.selectKey': 'Выбрать ключ',
+  'terminal.auth.retryMessage': 'Ошибка аутентификации. Проверьте учётные данные и повторите попытку.',
+  'terminal.auth.retryLog': 'Ошибка аутентификации. Повторите попытку.',
   'terminal.auth.noKeysHint': 'Нет доступных ключей. Добавьте ключи в связке ключей.',
   'terminal.auth.continueSave': 'Продолжить и сохранить',
   'terminal.auth.credentialsUnavailable': 'Сохранённые учётные данные не могут быть расшифрованы на этом устройстве. Пожалуйста, введите и сохраните их заново.',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -437,6 +437,8 @@ export const zhCNVaultMessages: Messages = {
   'terminal.auth.passphrase.placeholder': '可选：所选私钥的密码短语',
   'terminal.auth.certificate': '证书',
   'terminal.auth.selectKey': '选择密钥',
+  'terminal.auth.retryMessage': '身份验证失败。请检查凭据后重试。',
+  'terminal.auth.retryLog': '身份验证失败，请重试。',
   'terminal.auth.noKeysHint': '暂无密钥，请先在钥匙串中添加。',
   'terminal.auth.continueSave': '继续并保存',
   'terminal.auth.credentialsUnavailable': '当前设备无法解密已保存凭据，请重新输入并再次保存。',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -437,6 +437,8 @@ export const zhTWVaultMessages: Messages = {
   'terminal.auth.passphrase.placeholder': '可選：所選私鑰的密碼短語',
   'terminal.auth.certificate': '憑證',
   'terminal.auth.selectKey': '選擇金鑰',
+  'terminal.auth.retryMessage': '驗證失敗。請檢查憑證後再試一次。',
+  'terminal.auth.retryLog': '驗證失敗，請再試一次。',
   'terminal.auth.noKeysHint': '暫無金鑰，請先在鑰匙串中新增。',
   'terminal.auth.continueSave': '繼續並儲存',
   'terminal.auth.credentialsUnavailable': '目前裝置無法解密已儲存憑證，請重新輸入並再次儲存。',

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -622,12 +622,15 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         ctx.setError(null);
         ctx.setNeedsAuth(true);
         ctx.setAuthRetryMessage(
-          "Authentication failed. Please check your credentials and try again.",
+          tr(
+            "terminal.auth.retryMessage",
+            "Authentication failed. Please check your credentials and try again.",
+          ),
         );
         ctx.setAuthPassword("");
         ctx.setProgressLogs((prev) => [
           ...prev,
-          "Authentication failed. Please try again.",
+          tr("terminal.auth.retryLog", "Authentication failed. Please try again."),
         ]);
         ctx.setStatus("connecting");
       } else {


### PR DESCRIPTION
## Summary
The SSH authentication-failure messages in `components/terminal/runtime/createTerminalSessionStarters.ts` were hardcoded English and never went through i18n, so they rendered in English in every locale (including zh-CN).

- Route both strings through the existing `tr(key, fallback)` helper.
- Add `terminal.auth.retryMessage` and `terminal.auth.retryLog` to **en**, **ru**, **zh-CN**, and **zh-TW**.

## Notes
- `npm run build` passes.
- zh-CN / zh-TW key parity maintained (2916 / 2916).