### PR TITLE
Fix script waits misjudging fresh multi-line output as stale

### DIFF
--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -267,6 +267,9 @@ class SessionOutputBuffer {
         if (typeof waiter.freshBoundary === "number") {
           waiter.freshBoundary = Math.max(0, waiter.freshBoundary - removedLength);
         }
+        if (waiter.custom && typeof waiter.custom.freshBoundary === "number") {
+          waiter.custom.freshBoundary = Math.max(0, waiter.custom.freshBoundary - removedLength);
+        }
       }
     }
     this.flushWaiters();
@@ -455,16 +458,17 @@ class SessionOutputBuffer {
     this.waiters = remaining;
   }
 
-  waitForWithMatcher({ pattern, timeoutMs, shouldAbort, consumeFreshMatch, timeoutLabel }) {
+  waitForWithMatcher({ pattern, timeoutMs, shouldAbort, consumeFreshMatch, timeoutLabel, freshBoundary }) {
     return new Promise((resolve, reject) => {
       const waiter = {
         pattern,
+        freshBoundary,
         resolve,
         reject,
         shouldAbort,
         timer: null,
         check: () => {
-          const matched = consumeFreshMatch();
+          const matched = consumeFreshMatch(waiter.freshBoundary);
           if (matched === null) return false;
           this.advanceScanOffset(matched.endOffset);
           clearTimeout(waiter.timer);
@@ -514,7 +518,8 @@ class SessionOutputBuffer {
         pattern,
         timeoutMs,
         shouldAbort,
-        consumeFreshMatch: () => this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute }),
+        freshBoundary: minFreshStartAbsolute,
+        consumeFreshMatch: (boundary) => this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute: boundary }),
         timeoutLabel: "waitFor",
       });
     }
@@ -564,7 +569,8 @@ class SessionOutputBuffer {
       pattern: text,
       timeoutMs,
       shouldAbort,
-      consumeFreshMatch: () => this.consumeFreshPendingText(text, freshBoundary),
+      freshBoundary,
+      consumeFreshMatch: (boundary) => this.consumeFreshPendingText(text, boundary),
       timeoutLabel: "waitForText",
     });
   }
@@ -584,7 +590,8 @@ class SessionOutputBuffer {
       pattern,
       timeoutMs,
       shouldAbort,
-      consumeFreshMatch: () => this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute }),
+      freshBoundary: minFreshStartAbsolute,
+      consumeFreshMatch: (boundary) => this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute: boundary }),
       timeoutLabel: "waitForRegex",
     });
   }
@@ -620,6 +627,7 @@ class SessionOutputBuffer {
     return new Promise((resolve, reject) => {
       const waiter = {
         patterns,
+        freshBoundary,
         resolve,
         reject,
         shouldAbort,
@@ -637,7 +645,7 @@ class SessionOutputBuffer {
               return true;
             }
           }
-          const fresh = this.consumeFreshPendingMatchAny(patterns, freshBoundary);
+          const fresh = this.consumeFreshPendingMatchAny(patterns, waiter.freshBoundary);
           if (fresh !== null) {
             this.advanceScanOffset(fresh.matched.endOffset);
             clearTimeout(waiter.timer);

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -263,6 +263,11 @@ class SessionOutputBuffer {
       const removedLength = removed.length;
       this.totalLength -= removedLength;
       this.scanOffset = Math.max(0, this.scanOffset - removedLength);
+      for (const waiter of this.waiters) {
+        if (typeof waiter.freshBoundary === "number") {
+          waiter.freshBoundary = Math.max(0, waiter.freshBoundary - removedLength);
+        }
+      }
     }
     this.flushWaiters();
   }
@@ -287,24 +292,28 @@ class SessionOutputBuffer {
     return tryRegexMatchWithEnd(this.getPendingText(), pattern);
   }
 
-  consumeFreshPendingMatch(pattern) {
+  currentFreshBoundary() {
+    return Math.max(this.scanOffset, this.getText().length - FRESH_MATCH_TAIL_SLACK);
+  }
+
+  consumeFreshPendingMatch(pattern, freshBoundary = this.currentFreshBoundary()) {
     while (true) {
       const matched = this.tryMatchPending(pattern);
       if (matched === null) return null;
       const absoluteEnd = this.scanOffset + matched.endOffset;
-      if (isFreshTailMatch(this.getText().length, absoluteEnd)) {
+      if (absoluteEnd >= freshBoundary) {
         return matched;
       }
       this.advanceScanOffset(staleAdvanceEndOffset(matched));
     }
   }
 
-  consumeFreshPendingText(text) {
+  consumeFreshPendingText(text, freshBoundary = this.currentFreshBoundary()) {
     while (true) {
       const matched = this.tryMatchPendingText(text);
       if (matched === null) return null;
       const absoluteEnd = this.scanOffset + matched.endOffset;
-      if (isFreshTailMatch(this.getText().length, absoluteEnd)) {
+      if (absoluteEnd >= freshBoundary) {
         return matched;
       }
       this.advanceScanOffset(staleAdvanceEndOffset(matched));
@@ -312,6 +321,7 @@ class SessionOutputBuffer {
   }
 
   consumeFreshPendingRegex(pattern, options = {}) {
+    const fallbackBoundary = this.currentFreshBoundary();
     const text = this.getText();
     const baseOffset = this.scanOffset;
     const pendingText = text.slice(baseOffset);
@@ -328,12 +338,9 @@ class SessionOutputBuffer {
         ? options.minFreshStartAbsolute
         : null;
       const absoluteStart = baseOffset + relativeOffset + matched.freshStartOffset;
-      const absoluteEnd = baseOffset + relativeOffset + matched.freshEndOffset;
       const matchStartAbsolute = baseOffset + relativeOffset + matched.startOffset;
-      if (
-        isFreshTailMatch(text.length, absoluteEnd)
-        && (minFreshStartAbsolute === null || absoluteStart >= minFreshStartAbsolute)
-      ) {
+      const freshBoundary = minFreshStartAbsolute === null ? fallbackBoundary : minFreshStartAbsolute;
+      if (absoluteStart >= freshBoundary) {
         let value = matched.value;
         if (minFreshStartAbsolute !== null && matchStartAbsolute < minFreshStartAbsolute) {
           const valueFreshStart = matched.freshStartOffset - matched.startOffset;
@@ -353,14 +360,14 @@ class SessionOutputBuffer {
     return null;
   }
 
-  consumeFreshPendingMatchAny(patterns) {
+  consumeFreshPendingMatchAny(patterns, freshBoundary = this.currentFreshBoundary()) {
     for (let index = 0; index < patterns.length; index += 1) {
       const pattern = patterns[index];
       while (true) {
         const matched = this.tryMatchPending(pattern);
         if (matched === null) break;
         const absoluteEnd = this.scanOffset + matched.endOffset;
-        if (isFreshTailMatch(this.getText().length, absoluteEnd)) {
+        if (absoluteEnd >= freshBoundary) {
           return { index, matched };
         }
         this.advanceScanOffset(staleAdvanceEndOffset(matched));
@@ -432,7 +439,10 @@ class SessionOutputBuffer {
         }
         continue;
       }
-      const matched = this.consumeFreshPendingMatch(waiter.pattern);
+      const matched = this.consumeFreshPendingMatch(
+        waiter.pattern,
+        waiter.freshBoundary ?? this.currentFreshBoundary(),
+      );
       if (matched !== null) {
         this.advanceScanOffset(matched.endOffset);
         clearTimeout(waiter.timer);
@@ -509,7 +519,8 @@ class SessionOutputBuffer {
       });
     }
 
-    const immediate = this.consumeFreshPendingMatch(pattern);
+    const freshBoundary = this.currentFreshBoundary();
+    const immediate = this.consumeFreshPendingMatch(pattern, freshBoundary);
     if (immediate !== null) {
       this.advanceScanOffset(immediate.endOffset);
       return Promise.resolve(immediate.value);
@@ -518,6 +529,7 @@ class SessionOutputBuffer {
     return new Promise((resolve, reject) => {
       const waiter = {
         pattern,
+        freshBoundary,
         resolve,
         reject,
         shouldAbort,
@@ -541,7 +553,8 @@ class SessionOutputBuffer {
   }
 
   waitForText(text, timeoutMs = 30000, shouldAbort) {
-    const immediate = this.consumeFreshPendingText(text);
+    const freshBoundary = this.currentFreshBoundary();
+    const immediate = this.consumeFreshPendingText(text, freshBoundary);
     if (immediate !== null) {
       this.advanceScanOffset(immediate.endOffset);
       return Promise.resolve(immediate.value);
@@ -551,7 +564,7 @@ class SessionOutputBuffer {
       pattern: text,
       timeoutMs,
       shouldAbort,
-      consumeFreshMatch: () => this.consumeFreshPendingText(text),
+      consumeFreshMatch: () => this.consumeFreshPendingText(text, freshBoundary),
       timeoutLabel: "waitForText",
     });
   }
@@ -597,7 +610,8 @@ class SessionOutputBuffer {
         return preserved.index;
       }
     }
-    const fresh = this.consumeFreshPendingMatchAny(patterns);
+    const freshBoundary = this.currentFreshBoundary();
+    const fresh = this.consumeFreshPendingMatchAny(patterns, freshBoundary);
     if (fresh !== null) {
       this.advanceScanOffset(fresh.matched.endOffset);
       return fresh.index;
@@ -623,7 +637,7 @@ class SessionOutputBuffer {
               return true;
             }
           }
-          const fresh = this.consumeFreshPendingMatchAny(patterns);
+          const fresh = this.consumeFreshPendingMatchAny(patterns, freshBoundary);
           if (fresh !== null) {
             this.advanceScanOffset(fresh.matched.endOffset);
             clearTimeout(waiter.timer);

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -423,6 +423,30 @@ test("SessionOutputBuffer waitForAny matches pattern followed by long multi-line
   assert.equal(await pending, 0);
 });
 
+test("SessionOutputBuffer waitForText survives buffer trimming while waiting", async () => {
+  const buffer = new SessionOutputBuffer("s1", 1024);
+  buffer.append("x".repeat(1000));
+  const pending = buffer.waitForText("TARGET", 1000);
+  buffer.append(`${"y".repeat(100)}TARGET${"z".repeat(500)}`);
+  assert.equal(await pending, "TARGET");
+});
+
+test("SessionOutputBuffer waitForRegex survives buffer trimming while waiting", async () => {
+  const buffer = new SessionOutputBuffer("s1", 1024);
+  buffer.append("x".repeat(1000));
+  const pending = buffer.waitForRegex("TARGET", 1000);
+  buffer.append(`${"y".repeat(100)}TARGET${"z".repeat(500)}`);
+  assert.equal(await pending, "TARGET");
+});
+
+test("SessionOutputBuffer waitForAny survives buffer trimming while waiting", async () => {
+  const buffer = new SessionOutputBuffer("s1", 1024);
+  buffer.append("x".repeat(1000));
+  const pending = buffer.waitForAny(["TARGET"], 1000);
+  buffer.append(`${"y".repeat(100)}TARGET${"z".repeat(500)}`);
+  assert.equal(await pending, 0);
+});
+
 test("SessionOutputBuffer waitFor still rejects pre-registration scrollback beyond tail slack", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.append(`TARGET${"x".repeat(600)}`);

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -393,6 +393,50 @@ test("SessionOutputBuffer preserved prompt can be consumed explicitly for waitFo
   );
 });
 
+test("SessionOutputBuffer waitFor slash regex matches output followed by long multi-line burst", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const pending = buffer.waitFor("/SSH资源\\(/", 1000);
+  const menu = Array.from({ length: 15 }, (_, i) => `  [${i}] menu entry line`).join("\n");
+  buffer.append(`user login success\n\nSSH资源(5) :\n${menu}\n\n> `);
+  assert.equal(await pending, "SSH资源(");
+});
+
+test("SessionOutputBuffer waitForText matches literal text followed by long multi-line burst", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const pending = buffer.waitForText("SSH资源(", 1000);
+  buffer.append(`SSH资源(5) :\n${"x".repeat(600)}`);
+  assert.equal(await pending, "SSH资源(");
+});
+
+test("SessionOutputBuffer waitForRegex matches core followed by long multi-line burst", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const pending = buffer.waitForRegex(".*SSH资源\\(.*", 1000);
+  const burst = `SSH资源(5) :\n${"x".repeat(600)}`;
+  buffer.append(burst);
+  assert.equal(await pending, burst);
+});
+
+test("SessionOutputBuffer waitForAny matches pattern followed by long multi-line burst", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const pending = buffer.waitForAny(["账户:", "密码:"], 1000);
+  buffer.append(`资源'[Empty]'账户:\n${"x".repeat(600)}`);
+  assert.equal(await pending, 0);
+});
+
+test("SessionOutputBuffer waitFor still rejects pre-registration scrollback beyond tail slack", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.append(`TARGET${"x".repeat(600)}`);
+  const pending = buffer.waitFor("TARGET", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+  buffer.append("\nTARGET");
+  assert.equal(await pending, "TARGET");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },


### PR DESCRIPTION
## Summary
- Fixes #1960: automation scripts stalled when the server replied with a large multi-line burst (e.g. a jump-host resource menu). The freshness heuristic in `SessionOutputBuffer` required a match to end within 512 bytes of the *current* buffer tail, so a target line followed by 500+ bytes of menu output in the same burst was misclassified as stale scrollback, skipped, and the wait timed out.
- Capture the freshness boundary once when the wait is registered (`max(scanOffset, length - FRESH_MATCH_TAIL_SLACK)`): everything appended after registration counts as fresh (expect-like semantics), while pre-registration scrollback beyond the tail window is still rejected. Applies to `waitFor`, `waitForText`, `waitForRegex`, and `waitForAny`; the preserved-tail prompt logic for `waitForPrompt` is unchanged.
- Waiter boundaries are adjusted when the 1MB buffer trims old chunks.

## Root cause detail
Minimal repro (all three timed out before this fix, all resolve after):

```js
const menu = /* 15 menu lines, > 512 bytes */;
const pending = buffer.waitForText("SSH资源(", 1000);
buffer.append(`user login success\n\nSSH资源(5) :\n${menu}\n\n> `);
```

Note for the reporter's script: `nct.screen.waitFor('.*SSH资源\(.*')` treats plain strings literally (since #1885), so wildcard patterns should use `nct.screen.waitForRegex(...)` or slash-delimited `'/SSH资源\(/'` — both of those forms were also affected by this staleness bug and now work with multi-line bursts.

## Test plan
- [x] 5 new regression tests in `sessionOutputBuffer.test.cjs` (multi-line burst for each wait API + stale-scrollback still rejected)
- [x] `node --test electron/scripts/sessionOutputBuffer.test.cjs electron/scripts/scriptRuntime.test.cjs electron/bridges/scriptBridge.test.cjs` — 63 pass
- [x] `npm test` — 4247 pass, 0 fail
- [x] `npx eslint` on touched files — clean

Made with [Cursor](https://cursor.com)