### PR TITLE
[codex] Fix input lock after delete confirmations

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,6 +57,7 @@ import {
 import { getEffectiveKnownHosts } from './infrastructure/syncHelpers';
 import { ToastProvider, toast } from './components/ui/toast';
 import { TooltipProvider } from './components/ui/tooltip';
+import { ConfirmDialog } from './components/ui/confirm-dialog';
 import { PortForwardHostKeyDialog } from './components/port-forwarding';
 import { VaultSection } from './components/VaultView';
 import { KeyboardInteractiveRequest } from './components/KeyboardInteractiveModal';
@@ -113,6 +114,7 @@ function App({ settings }: { settings: SettingsState }) {
   const [keyboardInteractiveQueue, setKeyboardInteractiveQueue] = useState<KeyboardInteractiveRequest[]>([]);
   // Passphrase request queue for encrypted SSH keys
   const [passphraseQueue, setPassphraseQueue] = useState<PassphraseRequest[]>([]);
+  const [deleteHostConfirm, setDeleteHostConfirm] = useState<{ hostId: string; name: string } | null>(null);
   const [pendingNewWindowSession, setPendingNewWindowSession] = useState<OpenSessionInNewWindowPayload | null>(null);
   const [pendingTrayPanelConnectHostIds, setPendingTrayPanelConnectHostIds] = useState<string[]>([]);
   const isPeerSessionWindow = typeof window !== 'undefined' && window.location.hash.startsWith('#/session-window');
@@ -904,10 +906,14 @@ function App({ settings }: { settings: SettingsState }) {
 
   const handleDeleteHost = useCallback((hostId: string) => {
     const target = hosts.find(h => h.id === hostId);
-    const confirmed = window.confirm(t('confirm.deleteHost', { name: target?.label || hostId }));
-    if (!confirmed) return;
-    updateHosts(hosts.filter(h => h.id !== hostId));
-  }, [hosts, updateHosts, t]);
+    setDeleteHostConfirm({ hostId, name: target?.label || hostId });
+  }, [hosts]);
+
+  const handleConfirmDeleteHost = useCallback(() => {
+    if (!deleteHostConfirm) return;
+    updateHosts(hosts.filter(h => h.id !== deleteHostConfirm.hostId));
+    setDeleteHostConfirm(null);
+  }, [deleteHostConfirm, hosts, updateHosts]);
 
   const handleAddKnownHost = useCallback((kh: KnownHost) => {
     const nextKnownHosts = upsertKnownHost(knownHostsRef.current, kh);
@@ -1189,6 +1195,16 @@ function App({ settings }: { settings: SettingsState }) {
   return (
     <>
       <PortForwardHostKeyDialog onAddKnownHost={handleAddKnownHost} />
+      <ConfirmDialog
+        open={deleteHostConfirm !== null}
+        title={deleteHostConfirm ? t('confirm.deleteHost', { name: deleteHostConfirm.name }) : ''}
+        confirmLabel={t('action.delete')}
+        destructive
+        onOpenChange={(open) => {
+          if (!open) setDeleteHostConfirm(null);
+        }}
+        onConfirm={handleConfirmDeleteHost}
+      />
       <AppActiveTabChrome
         showSftpTab={settings.showSftpTab}
         setActiveTabId={setActiveTabId}

--- a/components/confirmDialogRegression.test.ts
+++ b/components/confirmDialogRegression.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+function readProjectFile(path: string): string {
+  return readFileSync(join(root, path), "utf8");
+}
+
+function functionBody(source: string, functionName: string): string {
+  const start = source.indexOf(`const ${functionName} = useCallback`);
+  assert.notEqual(start, -1, `${functionName} should exist`);
+
+  const nextConst = source.indexOf("\n  const ", start + 1);
+  const nextHook = source.indexOf("\n  use", start + 1);
+  const candidates = [nextConst, nextHook].filter((index) => index > start);
+  const end = candidates.length > 0 ? Math.min(...candidates) : source.length;
+  return source.slice(start, end);
+}
+
+test("host and AI provider deletion use in-app confirmation dialogs", () => {
+  const appSource = readProjectFile("App.tsx");
+  const aiSettingsSource = readProjectFile("components/settings/tabs/SettingsAITab.tsx");
+
+  assert.match(appSource, /import \{ ConfirmDialog \} from '\.\/components\/ui\/confirm-dialog';/);
+  assert.match(appSource, /<ConfirmDialog[\s\S]*confirm\.deleteHost/);
+  assert.doesNotMatch(functionBody(appSource, "handleDeleteHost"), /window\.confirm|globalThis\.confirm|\bconfirm\(/);
+
+  assert.match(aiSettingsSource, /import \{ ConfirmDialog \} from "\.\.\/\.\.\/ui\/confirm-dialog";/);
+  assert.match(aiSettingsSource, /<ConfirmDialog[\s\S]*confirm\.removeProvider/);
+  assert.doesNotMatch(functionBody(aiSettingsSource, "handleRemoveProvider"), /window\.confirm|globalThis\.confirm|\bconfirm\(/);
+});

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -21,6 +21,7 @@ import type { ManagedAgentKey } from "../../../infrastructure/ai/managedAgents";
 import { PROVIDER_PRESETS } from "../../../infrastructure/ai/types";
 import { useI18n } from "../../../application/i18n/I18nProvider";
 import { Button } from "../../ui/button";
+import { ConfirmDialog } from "../../ui/confirm-dialog";
 import { Select, SettingCard, SettingsSection, SettingsTabContent, SettingRow, Toggle } from "../settings-ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
 import { AgentIconBadge } from "../../ai/AgentIconBadge";
@@ -199,6 +200,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
   } = useAIPermissionGrantsState();
   const { t } = useI18n();
   const [editingProviderId, setEditingProviderId] = useState<string | null>(null);
+  const [removeProviderConfirm, setRemoveProviderConfirm] = useState<{ id: string; name: string } | null>(null);
   const [codexIntegration, setCodexIntegration] = useState<CodexIntegrationStatus | null>(null);
   const [codexLoginSession, setCodexLoginSession] = useState<CodexLoginSession | null>(null);
   const [isCodexLoading, setIsCodexLoading] = useState(false);
@@ -512,16 +514,22 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     (id: string) => {
       const provider = providers.find((p) => p.id === id);
       const name = provider?.name || id;
-      const ok = window.confirm(
-        t('confirm.removeProvider', { name }),
-      );
-      if (!ok) return;
+      setRemoveProviderConfirm({ id, name });
+    },
+    [providers],
+  );
+
+  const handleConfirmRemoveProvider = useCallback(
+    () => {
+      if (!removeProviderConfirm) return;
+      const { id } = removeProviderConfirm;
       removeProvider(id);
       if (editingProviderId === id) {
         setEditingProviderId(null);
       }
+      setRemoveProviderConfirm(null);
     },
-    [removeProvider, editingProviderId, providers, t],
+    [removeProvider, editingProviderId, removeProviderConfirm],
   );
 
   // Agent options for default agent
@@ -1173,6 +1181,16 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
           />
         </TabsContent>
       </Tabs>
+      <ConfirmDialog
+        open={removeProviderConfirm !== null}
+        title={removeProviderConfirm ? t('confirm.removeProvider', { name: removeProviderConfirm.name }) : ''}
+        confirmLabel={t('action.remove')}
+        destructive
+        onOpenChange={(open) => {
+          if (!open) setRemoveProviderConfirm(null);
+        }}
+        onConfirm={handleConfirmRemoveProvider}
+      />
     </SettingsTabContent>
   );
 };

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,68 @@
+import React, { memo } from "react";
+
+import { useI18n } from "../../application/i18n/I18nProvider";
+import { Button } from "./button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message?: string;
+  confirmLabel: string;
+  busy?: boolean;
+  destructive?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export const ConfirmDialog = memo(function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  busy = false,
+  destructive = false,
+  onOpenChange,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const { t } = useI18n();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[380px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        {message ? (
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">{message}</p>
+        ) : null}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "default"}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #1967.

This replaces the native browser/Electron confirmation prompt on the two reported delete paths with an in-app confirmation dialog:

- deleting a host from the vault
- removing an AI provider from Settings

## Root cause

Both reported flows used `window.confirm`. The issue reproduces only after confirmation-backed deletes, and the project already documents that native confirms can leave Windows/Electron focus or modal state broken. The matching symptoms and matching code paths make this root cause deterministic for the reported cases.

## Validation

- `node --test --import tsx components/confirmDialogRegression.test.ts`
- `npm run lint`
- `npm run build`
- Browser preview: opened the built app, deleted a host through the context menu, confirmed the in-app dialog, then immediately focused and typed into the New Host label input.
- `npm run test` initially exposed a transient first-run Electron install race; after Electron finished installing, the failed files passed, then the full suite passed: 4243 passing, 0 failing, 3 skipped.