### PR TITLE
fix(terminal): detach stale keychain identity when saving retry credentials

### DIFF
--- a/components/terminal/hooks/useTerminalAuthState.ts
+++ b/components/terminal/hooks/useTerminalAuthState.ts
@@ -26,7 +26,10 @@ export const buildSavedAuthHostUpdate = (
       : undefined,
   // Detach stale Keychain identity on explicit credential save (#1956):
   // resolveHostAuth prefers identity credentials over host fields.
-  identityId: undefined,
+  // Empty string (not undefined) so applyGroupDefaults treats this as an explicit
+  // host-level override and does not re-inherit a group-level identity; consumers
+  // check host.identityId truthiness so "" behaves as "no identity".
+  identityId: "",
 });
 
 export const useTerminalAuthState = ({

--- a/components/terminal/hooks/useTerminalAuthState.ts
+++ b/components/terminal/hooks/useTerminalAuthState.ts
@@ -6,6 +6,29 @@ import type { PendingAuth } from "../runtime/createTerminalSessionStarters";
 import type { TerminalAuthMethod } from "../TerminalAuthDialog";
 import { logger } from "../../../lib/logger";
 
+export const buildSavedAuthHostUpdate = (
+  host: Host,
+  auth: {
+    authMethod: TerminalAuthMethod;
+    username: string;
+    password: string;
+    keyId: string | null;
+  },
+): Host => ({
+  ...host,
+  username: auth.username,
+  authMethod: auth.authMethod,
+  password: auth.authMethod === "password" ? auth.password : undefined,
+  savePassword: auth.authMethod === "password" ? true : host.savePassword,
+  identityFileId:
+    auth.authMethod === "key" || auth.authMethod === "certificate"
+      ? (auth.keyId ?? undefined)
+      : undefined,
+  // Detach stale Keychain identity on explicit credential save (#1956):
+  // resolveHostAuth prefers identity credentials over host fields.
+  identityId: undefined,
+});
+
 export const useTerminalAuthState = ({
   host,
   pendingAuthRef,
@@ -80,18 +103,14 @@ export const useTerminalAuthState = ({
       };
 
       if (shouldSave && onUpdateHost) {
-        const updatedHost: Host = {
-          ...host,
-          username: authUsername,
-          authMethod: authMethod,
-          password: authMethod === "password" ? authPassword : undefined,
-          savePassword: authMethod === "password" ? true : host.savePassword,
-          identityFileId:
-            authMethod === "key" || authMethod === "certificate"
-              ? (authKeyId ?? undefined)
-              : undefined,
-        };
-        onUpdateHost(updatedHost);
+        onUpdateHost(
+          buildSavedAuthHostUpdate(host, {
+            authMethod,
+            username: authUsername,
+            password: authPassword,
+            keyId: authKeyId,
+          }),
+        );
       }
 
       setNeedsAuth(false);

--- a/components/terminal/useTerminalAuthState.test.ts
+++ b/components/terminal/useTerminalAuthState.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { applyGroupDefaults } from "../../domain/groupConfig";
 import { resolveHostAuth } from "../../domain/sshAuth";
 import type { Host, Identity } from "../../types";
 import { buildSavedAuthHostUpdate } from "./hooks/useTerminalAuthState";
@@ -26,7 +27,7 @@ test("password save clears identityId and identityFileId", () => {
     keyId: null,
   });
 
-  assert.equal(updated.identityId, undefined);
+  assert.equal(updated.identityId, "");
   assert.equal(updated.identityFileId, undefined);
   assert.equal(updated.password, "secret");
   assert.equal(updated.savePassword, true);
@@ -42,7 +43,7 @@ test("key save clears identityId and sets identityFileId", () => {
     keyId: "key-2",
   });
 
-  assert.equal(updated.identityId, undefined);
+  assert.equal(updated.identityId, "");
   assert.equal(updated.identityFileId, "key-2");
   assert.equal(updated.password, undefined);
 });
@@ -69,6 +70,40 @@ test("resolveHostAuth uses saved host credentials after identityId is cleared", 
 
   const resolved = resolveHostAuth({
     host: updated,
+    keys: [],
+    identities: [identity],
+  });
+
+  assert.equal(resolved.username, "root");
+  assert.equal(resolved.password, "correct");
+});
+
+test("saved credentials override a group-inherited identity", () => {
+  const identity: Identity = {
+    id: "identity-1",
+    label: "old",
+    username: "olduser",
+    authMethod: "password",
+    password: "wrong",
+    created: 0,
+  };
+
+  const updated = buildSavedAuthHostUpdate(
+    { ...baseHost, identityId: undefined },
+    {
+      authMethod: "password",
+      username: "root",
+      password: "correct",
+      keyId: null,
+    },
+  );
+
+  const effective = applyGroupDefaults(updated, { identityId: "identity-1" });
+
+  assert.equal(effective.identityId, "");
+
+  const resolved = resolveHostAuth({
+    host: effective,
     keys: [],
     identities: [identity],
   });

--- a/components/terminal/useTerminalAuthState.test.ts
+++ b/components/terminal/useTerminalAuthState.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveHostAuth } from "../../domain/sshAuth";
+import type { Host, Identity } from "../../types";
+import { buildSavedAuthHostUpdate } from "./hooks/useTerminalAuthState";
+
+const baseHost: Host = {
+  id: "host-1",
+  label: "Test Host",
+  hostname: "example.com",
+  port: 22,
+  username: "olduser",
+  authMethod: "key",
+  identityId: "identity-1",
+  identityFileId: "key-1",
+  tags: [],
+  os: "linux",
+};
+
+test("password save clears identityId and identityFileId", () => {
+  const updated = buildSavedAuthHostUpdate(baseHost, {
+    authMethod: "password",
+    username: "root",
+    password: "secret",
+    keyId: null,
+  });
+
+  assert.equal(updated.identityId, undefined);
+  assert.equal(updated.identityFileId, undefined);
+  assert.equal(updated.password, "secret");
+  assert.equal(updated.savePassword, true);
+  assert.equal(updated.authMethod, "password");
+  assert.equal(updated.username, "root");
+});
+
+test("key save clears identityId and sets identityFileId", () => {
+  const updated = buildSavedAuthHostUpdate(baseHost, {
+    authMethod: "key",
+    username: "deploy",
+    password: "",
+    keyId: "key-2",
+  });
+
+  assert.equal(updated.identityId, undefined);
+  assert.equal(updated.identityFileId, "key-2");
+  assert.equal(updated.password, undefined);
+});
+
+test("resolveHostAuth uses saved host credentials after identityId is cleared", () => {
+  const identity: Identity = {
+    id: "identity-1",
+    label: "old",
+    username: "olduser",
+    authMethod: "password",
+    password: "wrong",
+    created: 0,
+  };
+
+  const updated = buildSavedAuthHostUpdate(
+    { ...baseHost, identityId: "identity-1" },
+    {
+      authMethod: "password",
+      username: "root",
+      password: "correct",
+      keyId: null,
+    },
+  );
+
+  const resolved = resolveHostAuth({
+    host: updated,
+    keys: [],
+    identities: [identity],
+  });
+
+  assert.equal(resolved.username, "root");
+  assert.equal(resolved.password, "correct");
+});

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -203,6 +203,24 @@ test("applyGroupDefaults still inherits telnet credentials when host fields are 
   assert.equal(resolveTelnetPassword(result), "group-telnet-password");
 });
 
+test("applyGroupDefaults preserves explicit empty identityId instead of inheriting group identity", () => {
+  const result = applyGroupDefaults(
+    host({ identityId: "" }),
+    { identityId: "group-identity" },
+  );
+
+  assert.equal(result.identityId, "");
+});
+
+test("applyGroupDefaults inherits group identityId when host identityId is unset", () => {
+  const result = applyGroupDefaults(
+    host({ identityId: undefined }),
+    { identityId: "group-identity" },
+  );
+
+  assert.equal(result.identityId, "group-identity");
+});
+
 test("applyGroupDefaults continues to inherit empty ssh username from the group", () => {
   const result = applyGroupDefaults(
     host({

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -98,6 +98,8 @@ const INHERITABLE_KEYS: (keyof GroupConfig)[] = [
 const EMPTY_STRING_OVERRIDES_GROUP_DEFAULT = new Set<keyof GroupConfig>([
   'telnetUsername',
   'telnetPassword',
+  // Empty-string host identityId = explicitly no identity (auth-retry save, #1956); do not re-inherit group identity.
+  'identityId',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Fixes #1956: when a host references a Keychain identity (`host.identityId`) whose credentials are wrong, entering new credentials in the auth-retry dialog and choosing "Continue & Save" saved them onto the host but kept the identity reference. Because `resolveHostAuth` prefers identity credentials over host fields, the stale keychain credentials were used again on every reconnect and auth kept failing.
- The credential-save path (`buildSavedAuthHostUpdate`, extracted from `useTerminalAuthState.submit`) now clears `identityId` when the user explicitly saves new credentials, so the newly saved username/password (or key) actually takes effect on reconnect.
- Added unit tests covering password save, key save, and a regression test through `resolveHostAuth` verifying the saved credentials win after the identity reference is detached.

## Test plan

- [x] `node --test --import tsx components/terminal/useTerminalAuthState.test.ts` — 3/3 pass
- [x] `node --test --import tsx components/terminal/*.test.ts domain/*.test.ts` — 938/938 pass
- [x] `npx eslint components/terminal/hooks/useTerminalAuthState.ts components/terminal/useTerminalAuthState.test.ts` — clean
- [ ] Manual: connect a host referencing a keychain identity with wrong password → auth-retry dialog → enter new credentials → Continue & Save → close session → reconnect succeeds with saved credentials

Made with [Cursor](https://cursor.com)