### PR TITLE
fix(ui): replace native confirm() with an in-app dialog

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,6 +57,7 @@ import {
 import { getEffectiveKnownHosts } from './infrastructure/syncHelpers';
 import { ToastProvider, toast } from './components/ui/toast';
 import { TooltipProvider } from './components/ui/tooltip';
+import { ConfirmProvider, useConfirm } from './components/ui/confirm';
 import { PortForwardHostKeyDialog } from './components/port-forwarding';
 import { VaultSection } from './components/VaultView';
 import { KeyboardInteractiveRequest } from './components/KeyboardInteractiveModal';
@@ -91,6 +92,7 @@ const HOTKEY_DEBUG =
 
 function App({ settings }: { settings: SettingsState }) {
   const { t } = useI18n();
+  const confirm = useConfirm();
 
   const [isQuickSwitcherOpen, setIsQuickSwitcherOpen] = useState(false);
   const [isCreateWorkspaceOpen, setIsCreateWorkspaceOpen] = useState(false);
@@ -902,12 +904,15 @@ function App({ settings }: { settings: SettingsState }) {
       .map((entry) => entry.host);
   }, [quickSearch, hosts, isQuickSwitcherOpen]);
 
-  const handleDeleteHost = useCallback((hostId: string) => {
+  const handleDeleteHost = useCallback(async (hostId: string) => {
     const target = hosts.find(h => h.id === hostId);
-    const confirmed = window.confirm(t('confirm.deleteHost', { name: target?.label || hostId }));
+    const confirmed = await confirm({
+      message: t('confirm.deleteHost', { name: target?.label || hostId }),
+      destructive: true,
+    });
     if (!confirmed) return;
     updateHosts(hosts.filter(h => h.id !== hostId));
-  }, [hosts, updateHosts, t]);
+  }, [hosts, updateHosts, t, confirm]);
 
   const handleAddKnownHost = useCallback((kh: KnownHost) => {
     const nextKnownHosts = upsertKnownHost(knownHostsRef.current, kh);
@@ -1238,8 +1243,10 @@ function AppWithProviders() {
     <I18nProvider locale={settings.uiLanguage}>
       <ToastProvider>
         <TooltipProvider delayDuration={300}>
-          <ScriptAutomationRoot />
-          <App settings={settings} />
+          <ConfirmProvider>
+            <ScriptAutomationRoot />
+            <App settings={settings} />
+          </ConfirmProvider>
         </TooltipProvider>
       </ToastProvider>
     </I18nProvider>

--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -4,6 +4,7 @@ export const enCoreMessages: Messages = {
   // Common
   'common.save': 'Save',
   'common.cancel': 'Cancel',
+  'common.confirm': 'Confirm',
   'common.close': 'Close',
   'common.reset': 'Reset',
   'common.zoomIn': 'Zoom in',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -4,6 +4,7 @@ export const ruCoreMessages: Messages = {
   // Common
   'common.save': 'Сохранить',
   'common.cancel': 'Отмена',
+  'common.confirm': 'Подтвердить',
   'common.close': 'Закрыть',
   'common.reset': 'Сбросить',
   'common.zoomIn': 'Увеличить',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -4,6 +4,7 @@ export const zhCNCoreMessages: Messages = {
   // Common
   'common.save': '保存',
   'common.cancel': '取消',
+  'common.confirm': '确认',
   'common.close': '关闭',
   'common.reset': '重置',
   'common.zoomIn': '放大',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -4,6 +4,7 @@ export const zhTWCoreMessages: Messages = {
   // Common
   'common.save': '儲存',
   'common.cancel': '取消',
+  'common.confirm': '確認',
   'common.close': '關閉',
   'common.reset': '重置',
   'common.zoomIn': '放大',

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -14,6 +14,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import React, { useCallback, useMemo, useRef, useState } from "react";
+import { useConfirm } from "./ui/confirm";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { useStoredViewMode } from "../application/state/useStoredViewMode";
 import type { GroupConfig } from "../domain/models";
@@ -112,6 +113,7 @@ const KeychainManager: React.FC<KeychainManagerProps> = ({
   onCreateGroup,
 }) => {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const { generateKeyPair, execCommand } = useKeychainBackend();
   const [activeFilter, setActiveFilter] = useState<FilterTab>("key");
   const [search, setSearch] = useState("");
@@ -837,12 +839,13 @@ echo $3 >> "$FILE"`);
                         <ContextMenuSeparator />
                         <ContextMenuItem
                           className="text-destructive"
-                          onClick={() => {
-                            const ok = window.confirm(
-                              t("confirm.deleteIdentity", {
+                          onClick={async () => {
+                            const ok = await confirm({
+                              message: t("confirm.deleteIdentity", {
                                 name: identity.label || "",
                               }),
-                            );
+                              destructive: true,
+                            });
                             if (!ok) return;
                             _handleDeleteIdentity(identity.id);
                           }}
@@ -875,12 +878,13 @@ echo $3 >> "$FILE"`);
                 <AsideActionMenuItem
                   variant="destructive"
                   icon={<Trash2 size={14} />}
-                  onClick={() => {
-                    const ok = window.confirm(
-                      t("confirm.deleteIdentity", {
+                  onClick={async () => {
+                    const ok = await confirm({
+                      message: t("confirm.deleteIdentity", {
                         name: panel.identity?.label || "",
                       }),
-                    );
+                      destructive: true,
+                    });
                     if (!ok || !panel.identity) return;
                     _handleDeleteIdentity(panel.identity.id);
                   }}

--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { useVaultState } from "../application/state/useVaultState";
 import { useWindowControls } from "../application/state/useWindowControls";
 import { useUpdateCheck } from "../application/state/useUpdateCheck";
 import { I18nProvider, useI18n } from "../application/i18n/I18nProvider";
+import { ConfirmProvider } from "./ui/confirm";
 import { sanitizePortForwardingRulesForSync } from "../application/syncPayload";
 import { toast } from "./ui/toast";
 import { SettingsTabContent } from "./settings/settings-ui";
@@ -580,7 +581,9 @@ export default function SettingsPage() {
 
     return (
         <I18nProvider locale={settings.uiLanguage}>
-            <SettingsPageContent settings={settings} />
+            <ConfirmProvider>
+                <SettingsPageContent settings={settings} />
+            </ConfirmProvider>
         </I18nProvider>
     );
 }

--- a/components/TerminalPopupPage.tsx
+++ b/components/TerminalPopupPage.tsx
@@ -1,6 +1,7 @@
 import { Copy, Minus, Square, Unplug, X } from 'lucide-react';
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { I18nProvider, useI18n } from '../application/i18n/I18nProvider';
+import { ConfirmProvider } from './ui/confirm';
 import { useSettingsState } from '../application/state/useSettingsState';
 import { useTerminalPopupWindow } from '../application/state/useTerminalPopupWindow';
 import { useVaultState } from '../application/state/useVaultState';
@@ -425,7 +426,9 @@ export default function TerminalPopupPage() {
   const settings = useSettingsState();
   return (
     <I18nProvider locale={settings.uiLanguage}>
-      <TerminalPopupPageInner />
+      <ConfirmProvider>
+        <TerminalPopupPageInner />
+      </ConfirmProvider>
     </I18nProvider>
   );
 }

--- a/components/TrayPanel.tsx
+++ b/components/TrayPanel.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { cn } from "../lib/utils";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { I18nProvider } from "../application/i18n/I18nProvider";
+import { ConfirmProvider } from "./ui/confirm";
 import { useSettingsState } from "../application/state/useSettingsState";
 import { useTrayPanelBackend } from "../application/state/useTrayPanelBackend";
 import { useActiveTabId } from "../application/state/activeTabStore";
@@ -451,7 +452,9 @@ const TrayPanel: React.FC = () => {
   const settings = useSettingsState();
   return (
     <I18nProvider locale={settings.uiLanguage}>
-      <TrayPanelContent terminalSettings={settings.terminalSettings} />
+      <ConfirmProvider>
+        <TrayPanelContent terminalSettings={settings.terminalSettings} />
+      </ConfirmProvider>
     </I18nProvider>
   );
 };

--- a/components/settings/tabs/SettingsAITab.tsx
+++ b/components/settings/tabs/SettingsAITab.tsx
@@ -20,6 +20,7 @@ import type {
 import type { ManagedAgentKey } from "../../../infrastructure/ai/managedAgents";
 import { PROVIDER_PRESETS } from "../../../infrastructure/ai/types";
 import { useI18n } from "../../../application/i18n/I18nProvider";
+import { useConfirm } from "../../ui/confirm";
 import { Button } from "../../ui/button";
 import { Select, SettingCard, SettingsSection, SettingsTabContent, SettingRow, Toggle } from "../settings-ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../ui/tabs";
@@ -198,6 +199,7 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
     exportGrants,
   } = useAIPermissionGrantsState();
   const { t } = useI18n();
+  const confirm = useConfirm();
   const [editingProviderId, setEditingProviderId] = useState<string | null>(null);
   const [codexIntegration, setCodexIntegration] = useState<CodexIntegrationStatus | null>(null);
   const [codexLoginSession, setCodexLoginSession] = useState<CodexLoginSession | null>(null);
@@ -509,19 +511,20 @@ const SettingsAITab: React.FC<SettingsAITabProps> = ({
 
   // Remove provider with confirmation
   const handleRemoveProvider = useCallback(
-    (id: string) => {
+    async (id: string) => {
       const provider = providers.find((p) => p.id === id);
       const name = provider?.name || id;
-      const ok = window.confirm(
-        t('confirm.removeProvider', { name }),
-      );
+      const ok = await confirm({
+        message: t('confirm.removeProvider', { name }),
+        destructive: true,
+      });
       if (!ok) return;
       removeProvider(id);
       if (editingProviderId === id) {
         setEditingProviderId(null);
       }
     },
-    [removeProvider, editingProviderId, providers, t],
+    [removeProvider, editingProviderId, providers, t, confirm],
   );
 
   // Agent options for default agent

--- a/components/settings/tabs/SettingsFileAssociationsTab.tsx
+++ b/components/settings/tabs/SettingsFileAssociationsTab.tsx
@@ -4,6 +4,7 @@
 import { FileType, Pencil, Trash2 } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useI18n } from "../../../application/i18n/I18nProvider";
+import { useConfirm } from "../../ui/confirm";
 import { useSftpFileAssociations } from "../../../application/state/useSftpFileAssociations";
 import { useSettingsState } from "../../../application/state/useSettingsState";
 import type { FileOpenerType, SystemAppInfo } from "../../../lib/sftpFileUtils";
@@ -34,6 +35,7 @@ const getOpenerLabel = (
 
 export default function SettingsFileAssociationsTab() {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const { getAllAssociations, removeAssociation, setOpenerForExtension, getDefaultOpener, setDefaultOpener, removeDefaultOpener } = useSftpFileAssociations();
   const { sftpDoubleClickBehavior, setSftpDoubleClickBehavior, sftpAutoSync, setSftpAutoSync, sftpShowHiddenFiles, setSftpShowHiddenFiles, sftpUseCompressedUpload, setSftpUseCompressedUpload, sftpAutoOpenSidebar, setSftpAutoOpenSidebar, sftpFollowTerminalCwd, setSftpFollowTerminalCwd, sftpDefaultViewMode, setSftpDefaultViewMode, sftpTransferConcurrency, setSftpTransferConcurrency } = useSettingsState();
   const associations = getAllAssociations();
@@ -47,11 +49,14 @@ export default function SettingsFileAssociationsTab() {
     return 'system-app';
   }, [defaultOpener]);
 
-  const handleRemove = useCallback((extension: string) => {
-    if (confirm(t('settings.sftpFileAssociations.removeConfirm', { ext: extension === 'file' ? t('sftp.opener.noExtension') : extension }))) {
+  const handleRemove = useCallback(async (extension: string) => {
+    if (await confirm({
+      message: t('settings.sftpFileAssociations.removeConfirm', { ext: extension === 'file' ? t('sftp.opener.noExtension') : extension }),
+      destructive: true,
+    })) {
       removeAssociation(extension);
     }
-  }, [removeAssociation, t]);
+  }, [removeAssociation, t, confirm]);
 
   const handleSelectDefaultSystemApp = useCallback(async () => {
     setIsSelectingDefaultApp(true);

--- a/components/settings/tabs/ai/QuickMessagesSettings.tsx
+++ b/components/settings/tabs/ai/QuickMessagesSettings.tsx
@@ -9,6 +9,7 @@ import {
   slugFromQuickMessageName,
 } from "../../../../infrastructure/ai/quickMessages";
 import { useI18n } from "../../../../application/i18n/I18nProvider";
+import { useConfirm } from "../../../ui/confirm";
 import { Button } from "../../../ui/button";
 import { SettingCard, SettingsSection } from "../../settings-ui";
 
@@ -38,6 +39,7 @@ export const QuickMessagesSettings: React.FC<QuickMessagesSettingsProps> = ({
   reservedUserSkillSlugs = [],
 }) => {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const [editingId, setEditingId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [draft, setDraft] = useState<DraftQuickMessage>(emptyDraft);
@@ -142,14 +144,17 @@ export const QuickMessagesSettings: React.FC<QuickMessagesSettingsProps> = ({
     resetEditor();
   }, [draft, editingId, resetEditor, setQuickMessages, validateDraft]);
 
-  const handleDelete = useCallback((message: AIQuickMessage) => {
-    const ok = window.confirm(t("ai.quickMessages.confirmDelete", { name: message.name }));
+  const handleDelete = useCallback(async (message: AIQuickMessage) => {
+    const ok = await confirm({
+      message: t("ai.quickMessages.confirmDelete", { name: message.name }),
+      destructive: true,
+    });
     if (!ok) return;
     setQuickMessages((prev) => prev.filter((item) => item.id !== message.id));
     if (editingId === message.id) {
       resetEditor();
     }
-  }, [editingId, resetEditor, setQuickMessages, t]);
+  }, [editingId, resetEditor, setQuickMessages, t, confirm]);
 
   const showEditor = isCreating || editingId != null;
 

--- a/components/systemManager/DockerContainersPanel.tsx
+++ b/components/systemManager/DockerContainersPanel.tsx
@@ -1,6 +1,7 @@
 import { Box, FileText, Play, RotateCcw, Square, Terminal } from 'lucide-react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { useConfirm } from '../ui/confirm';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { writeSystemManagerDiagnostic } from '../../application/state/systemManagerDiagnostics';
 import type { TerminalSession } from '../../types';
@@ -159,6 +160,7 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
   statsRefreshIntervalSec,
 }: DockerContainersPanelProps) {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const stableT = useStableTranslate();
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<ContainerFilter>('all');
@@ -285,11 +287,11 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
     newName?: string,
   ) => {
     if (action === 'rm') {
-      const ok = globalThis.confirm(t('systemManager.docker.confirmRemove'));
+      const ok = await confirm({ message: t('systemManager.docker.confirmRemove'), destructive: true });
       if (!ok) return;
     }
     if (action === 'kill') {
-      const ok = globalThis.confirm(t('systemManager.docker.confirmKill'));
+      const ok = await confirm({ message: t('systemManager.docker.confirmKill'), destructive: true });
       if (!ok) return;
     }
     setPendingAction({ id: containerId, action });
@@ -323,6 +325,7 @@ export const DockerContainersPanel = memo(function DockerContainersPanel({
     refreshContainerInspect,
     sessionId,
     t,
+    confirm,
   ]);
 
   const handleRowAction = useCallback((container: DockerContainerInfo, action: DockerContainerAction) => {

--- a/components/systemManager/DockerImagesPanel.tsx
+++ b/components/systemManager/DockerImagesPanel.tsx
@@ -1,6 +1,7 @@
 import { Layers, Loader2, Tag, Trash2 } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { useConfirm } from '../ui/confirm';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { dockerImageRowKey, type DockerImageInfo } from '../../domain/systemManager/types';
 import { dockerImageInfoEqual } from '../../domain/systemManager/pollEquals';
@@ -90,6 +91,7 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
   listRefreshIntervalSec,
 }: DockerImagesPanelProps) {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const stableT = useStableTranslate();
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -169,7 +171,10 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
 
   const handleRemove = useCallback(async (image: DockerImageInfo) => {
     const label = image.name || image.id.slice(0, 12);
-    const ok = window.confirm(t('systemManager.docker.confirmRemoveImage', { name: label }));
+    const ok = await confirm({
+      message: t('systemManager.docker.confirmRemoveImage', { name: label }),
+      destructive: true,
+    });
     if (!ok) return;
     const result = await backend.dockerImageAction({
       sessionId,
@@ -186,12 +191,15 @@ export const DockerImagesPanel = memo(function DockerImagesPanel({
     }
     invalidateImageInspect(getImageInspectKey(image));
     await refresh();
-  }, [backend, getImageInspectKey, invalidateImageInspect, refresh, selectedId, sessionId, t]);
+  }, [backend, getImageInspectKey, invalidateImageInspect, refresh, selectedId, sessionId, t, confirm]);
 
   const handlePrune = async (all: boolean) => {
-    const ok = window.confirm(all
-      ? t('systemManager.docker.confirmPruneAll')
-      : t('systemManager.docker.confirmPrune'));
+    const ok = await confirm({
+      message: all
+        ? t('systemManager.docker.confirmPruneAll')
+        : t('systemManager.docker.confirmPrune'),
+      destructive: true,
+    });
     if (!ok) return;
     const result = await backend.dockerImageAction({ sessionId, action: 'prune', all });
     if (!result.success) {

--- a/components/systemManager/ProcessManagerTab.tsx
+++ b/components/systemManager/ProcessManagerTab.tsx
@@ -3,6 +3,7 @@ import {
 } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { useConfirm } from '../ui/confirm';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import {
   getProcessFlags,
@@ -248,6 +249,7 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
   refreshIntervalSec,
 }: ProcessManagerTabProps) {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const stableT = useStableTranslate();
   const [query, setQuery] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('cpuPercent');
@@ -381,7 +383,10 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
     const confirmKey = signal === 'KILL'
       ? 'systemManager.processes.confirmKill'
       : 'systemManager.processes.confirmSignal';
-    const ok = window.confirm(t(confirmKey, { pid: String(pid), signal }));
+    const ok = await confirm({
+      message: t(confirmKey, { pid: String(pid), signal }),
+      destructive: true,
+    });
     if (!ok) return;
     setActionError(null);
     const result = await backend.signalSystemProcess({ sessionId, pid, signal });
@@ -390,7 +395,7 @@ export const ProcessManagerTab = memo(function ProcessManagerTab({
       return;
     }
     void refresh();
-  }, [backend, refresh, sessionId, t]);
+  }, [backend, refresh, sessionId, t, confirm]);
 
   const reniceProcess = useCallback(async (pid: number, nice: number) => {
     setActionError(null);

--- a/components/systemManager/TmuxSessionCard.tsx
+++ b/components/systemManager/TmuxSessionCard.tsx
@@ -3,6 +3,7 @@ import {
 } from 'lucide-react';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../application/i18n/I18nProvider';
+import { useConfirm } from '../ui/confirm';
 import type { useSystemManagerBackend } from '../../application/state/useSystemManagerBackend';
 import { buildTmuxAttachCommand } from '../../domain/systemManager/tmuxShell';
 import type {
@@ -85,6 +86,7 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
   onRequestTerminalFocus,
 }: TmuxSessionCardProps) {
   const { t } = useI18n();
+  const confirm = useConfirm();
   const [expanded, setExpanded] = useState(false);
   const [renamePrompt, setRenamePrompt] = useState<RenamePromptTarget | null>(null);
   const [detachConfirmOpen, setDetachConfirmOpen] = useState(false);
@@ -206,8 +208,8 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
               destructive
               disabled={busy}
               loading={isPending('killSession')}
-              onClick={() => {
-                if (globalThis.confirm(t('systemManager.tmux.confirmKillSession', { name: session.name }))) {
+              onClick={async () => {
+                if (await confirm({ message: t('systemManager.tmux.confirmKillSession', { name: session.name }), destructive: true })) {
                   void runAction({ action: 'killSession', sessionName: session.name });
                 }
               }}
@@ -282,10 +284,10 @@ export const TmuxSessionCard = memo(function TmuxSessionCard({
                   destructive
                   disabled={busy}
                   loading={isPending('killWindow', tmuxWindow.index)}
-                  onClick={() => {
-                    if (globalThis.confirm(t('systemManager.tmux.confirmKillWindow', {
+                  onClick={async () => {
+                    if (await confirm({ message: t('systemManager.tmux.confirmKillWindow', {
                       name: tmuxWindow.name || String(tmuxWindow.index),
-                    }))) {
+                    }), destructive: true })) {
                       void runAction({
                         action: 'killWindow',
                         sessionName: session.name,

--- a/components/ui/confirm.tsx
+++ b/components/ui/confirm.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+
+import { useI18n } from "../../application/i18n/I18nProvider";
+import { cn } from "../../lib/utils";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "./dialog";
+
+export interface ConfirmOptions {
+  /** Main prompt text. Shown as the title when no explicit `title` is given. */
+  message: string;
+  /** Optional heading rendered above the message. */
+  title?: string;
+  /** Label for the confirm button. Defaults to `common.confirm`. */
+  confirmLabel?: string;
+  /** Label for the cancel button. Defaults to `common.cancel`. */
+  cancelLabel?: string;
+  /** Render the confirm button in a destructive (red) style. */
+  destructive?: boolean;
+}
+
+export type ConfirmFn = (options: ConfirmOptions | string) => Promise<boolean>;
+
+const ConfirmContext = React.createContext<ConfirmFn | null>(null);
+
+/**
+ * In-app confirmation dialog exposed as a promise-returning `confirm()`.
+ *
+ * Prefer this over the native `window.confirm()` / `globalThis.confirm()`:
+ * native confirms can leave keyboard focus / modal state broken in the
+ * Electron renderer on Windows, which blocks typing in the next input and
+ * subsequent Radix dialogs until the tree re-renders.
+ */
+export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { t } = useI18n();
+  const [options, setOptions] = React.useState<ConfirmOptions | null>(null);
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = React.useCallback<ConfirmFn>((input) => {
+    const opts = typeof input === "string" ? { message: input } : input;
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+      // Defer opening to the next task. Confirms are frequently triggered from
+      // a Radix ContextMenu / DropdownMenu item (e.g. host delete); if the
+      // dialog mounts in the same tick the closing menu is still tearing down,
+      // and the two dismissable layers conflict so the dialog opens then
+      // instantly dismisses (overlay flashes, content never shows). Letting the
+      // menu finish closing first makes the dialog mount cleanly.
+      setTimeout(() => setOptions(opts), 0);
+    });
+  }, []);
+
+  const settle = React.useCallback((result: boolean) => {
+    setOptions(null);
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    resolve?.(result);
+  }, []);
+
+  const open = options !== null;
+  const message = options?.message ?? "";
+  const title = options?.title;
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <Dialog open={open} onOpenChange={(next) => { if (!next) settle(false); }}>
+        <DialogContent className="sm:max-w-[400px]" hideCloseButton>
+          <DialogHeader>
+            <DialogTitle className="whitespace-pre-wrap">{title ?? message}</DialogTitle>
+          </DialogHeader>
+          {title ? (
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">{message}</p>
+          ) : null}
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => settle(false)}
+              className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors"
+            >
+              {options?.cancelLabel ?? t("common.cancel")}
+            </button>
+            <button
+              type="button"
+              onClick={() => settle(true)}
+              className={cn(
+                "px-3 py-1.5 text-sm rounded-md transition-colors",
+                options?.destructive
+                  ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  : "bg-primary text-primary-foreground hover:bg-primary/90",
+              )}
+            >
+              {options?.confirmLabel ?? t("common.confirm")}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </ConfirmContext.Provider>
+  );
+};
+
+/**
+ * Returns a promise-returning `confirm(message | options)` bound to the
+ * nearest {@link ConfirmProvider}. Resolves `true` on confirm, `false` on
+ * cancel / dismiss.
+ */
+export function useConfirm(): ConfirmFn {
+  const ctx = React.useContext(ConfirmContext);
+  // Graceful fallback for trees rendered without a ConfirmProvider (e.g.
+  // isolated unit tests): defer to the native confirm so behavior matches a
+  // plain browser dialog. All real app windows are wrapped in a provider.
+  const fallback = React.useCallback<ConfirmFn>((input) => {
+    const message = typeof input === "string" ? input : input.message;
+    const ok = typeof globalThis.confirm === "function" ? globalThis.confirm(message) : true;
+    return Promise.resolve(ok);
+  }, []);
+  return ctx ?? fallback;
+}


### PR DESCRIPTION
## Problem
Destructive actions (delete host, delete identity, remove AI provider, Docker container/image remove, tmux kill, …) use the native `window.confirm()` / `globalThis.confirm()`. On Windows the native dialog can leave the Electron renderer with broken keyboard focus / modal state: after it is dismissed **the next input box silently ignores typing** until the tree re-renders (switching UI language or restarting "fixes" it). This is the same failure `SystemPanelConfirmDialog` was already created to avoid — but most call sites still use the native confirm.

Repro: right-click a host → **Delete** → confirm → the search / input box can no longer be typed into.

## Change
- Add a promise-based `useConfirm()` / `ConfirmProvider` (`components/ui/confirm.tsx`) that renders an in-app Radix dialog (same look as `SystemPanelConfirmDialog`).
- Wire `ConfirmProvider` into every window root that has its own `I18nProvider`: main app, settings, terminal-popup, tray.
- Migrate all native `confirm()` call sites: App host delete; KeychainManager identity delete (×2); settings (AI provider remove, quick-message delete, SFTP file-association remove); systemManager (Docker container remove/kill, image remove/prune, process signal/kill, tmux kill session/window).
- Opening the dialog is deferred to the next task so a triggering Radix **ContextMenu / DropdownMenu** finishes closing first — otherwise the two dismissable layers conflict and the dialog opens then instantly dismisses (overlay flashes, content never shows). This was the host-delete case, which is triggered from a context menu.
- `useConfirm()` falls back to native `confirm` when rendered without a provider, so isolated component tests keep passing unchanged.
- Adds `common.confirm` to en / ru / zh-CN / zh-TW.

## Verification
- `npm run build` passes; `eslint` clean on changed files; existing tests pass.
- Manually verified in a packaged Windows build: host delete now shows the in-app dialog and the input box keeps working afterward.