### PR TITLE
[codex] Add Finder folder open terminal support

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -940,7 +940,16 @@ function App({ settings }: { settings: SettingsState }) {
   }, []);
 
   // Wrapper to create local terminal with logging
-  const handleCreateLocalTerminal = useCallback((shell?: { command: string; args?: string[]; name?: string; icon?: string }) => { return handleCreateLocalTerminalImpl(() => ({ addConnectionLog, classifyLocalShellType, createLocalTerminal, discoveredShells, resolveShellSetting, shell, systemInfoRef, terminalSettings, undefined }), shell); }, [addConnectionLog, createLocalTerminal, terminalSettings, discoveredShells]);
+  const handleCreateLocalTerminal = useCallback((
+    shell?: { command: string; args?: string[]; name?: string; icon?: string },
+    options?: { localStartDir?: string },
+  ) => {
+    return handleCreateLocalTerminalImpl(
+      () => ({ addConnectionLog, classifyLocalShellType, createLocalTerminal, discoveredShells, resolveShellSetting, shell, systemInfoRef, terminalSettings, undefined }),
+      shell,
+      options,
+    );
+  }, [addConnectionLog, createLocalTerminal, terminalSettings, discoveredShells]);
 
   const proxyProfileIdSet = useMemo(
     () => new Set(proxyProfiles.map((profile) => profile.id)),
@@ -1016,6 +1025,21 @@ function App({ settings }: { settings: SettingsState }) {
     if (!bridge?.onSshDeepLink) return;
     return bridge.onSshDeepLink((payload) => {
       _handleSshDeepLink(payload);
+    });
+  }, [isPeerSessionWindow]);
+
+  const _handleOpenTerminalPath = useEffectEvent((payload: { path?: string }) => {
+    const localStartDir = typeof payload?.path === 'string' ? payload.path.trim() : '';
+    if (!localStartDir) return;
+    handleCreateLocalTerminal(undefined, { localStartDir });
+  });
+
+  useEffect(() => {
+    if (isPeerSessionWindow) return;
+    const bridge = netcattyBridge.get();
+    if (!bridge?.onOpenTerminalPath) return;
+    return bridge.onOpenTerminalPath((payload) => {
+      _handleOpenTerminalPath(payload);
     });
   }, [isPeerSessionWindow]);
 

--- a/App.tsx
+++ b/App.tsx
@@ -1029,8 +1029,8 @@ function App({ settings }: { settings: SettingsState }) {
   }, [isPeerSessionWindow]);
 
   const _handleOpenTerminalPath = useEffectEvent((payload: { path?: string }) => {
-    const localStartDir = typeof payload?.path === 'string' ? payload.path.trim() : '';
-    if (!localStartDir) return;
+    const localStartDir = typeof payload?.path === 'string' ? payload.path : '';
+    if (!localStartDir.trim()) return;
     handleCreateLocalTerminal(undefined, { localStartDir });
   });
 

--- a/application/AppHandlers.newWindow.test.ts
+++ b/application/AppHandlers.newWindow.test.ts
@@ -46,6 +46,42 @@ test("copySessionToNewWindowWithCurrentShellImpl asks Electron to open a peer wi
   });
 });
 
+test("copySessionToNewWindowWithCurrentShellImpl preserves local start directory in the source session", async () => {
+  const openedPayloads: unknown[] = [];
+  const localSession = sourceSession({
+    hostLabel: "Local Terminal",
+    hostname: "localhost",
+    protocol: "local",
+    localStartDir: "/Users/alice/project with spaces ",
+  });
+
+  await copySessionToNewWindowWithCurrentShellImpl(
+    () => ({
+      classifyLocalShellType: () => "zsh",
+      discoveredShells: [],
+      netcattyBridge: {
+        get: () => ({
+          openSessionInNewWindow: async (payload: unknown) => {
+            openedPayloads.push(payload);
+            return { success: true };
+          },
+        }),
+      },
+      resolveShellSetting: () => ({ command: "/bin/zsh" }),
+      sessions: [localSession],
+      terminalSettings: { localShell: "system-default" },
+    }),
+    "session-1",
+  );
+
+  assert.equal(openedPayloads.length, 1);
+  assert.deepEqual(openedPayloads[0], {
+    title: "Local Terminal",
+    sourceSession: localSession,
+    localShellType: "zsh",
+  });
+});
+
 test("copySessionToNewWindowWithCurrentShellImpl does nothing when the source session is gone", async () => {
   let called = false;
 

--- a/application/app/AppHandlers.ts
+++ b/application/app/AppHandlers.ts
@@ -745,7 +745,11 @@ export function executeHotkeyActionImpl(getCtx: AppContextGetter, action: string
   }
 }
 
-export function handleCreateLocalTerminalImpl(getCtx: AppContextGetter, shell?: { command: string; args?: string[]; name?: string; icon?: string }) {
+export function handleCreateLocalTerminalImpl(
+  getCtx: AppContextGetter,
+  shell?: { command: string; args?: string[]; name?: string; icon?: string },
+  options?: { localStartDir?: string },
+) {
   const { addConnectionLog, classifyLocalShellType, createLocalTerminal, discoveredShells, resolveShellSetting, systemInfoRef, terminalSettings } = getCtx();
 {
     const { username, hostname } = systemInfoRef.current;
@@ -760,6 +764,7 @@ export function handleCreateLocalTerminalImpl(getCtx: AppContextGetter, shell?: 
       shellArgs: resolved?.args,
       shellName,
       shellIcon,
+      localStartDir: options?.localStartDir,
     });
     addConnectionLog({
       sessionId,

--- a/application/state/sessionFactories.ts
+++ b/application/state/sessionFactories.ts
@@ -6,6 +6,7 @@ export interface LocalTerminalOptions {
   shellArgs?: string[];
   shellName?: string;
   shellIcon?: string;
+  localStartDir?: string;
 }
 
 export const createLocalTerminalSession = (
@@ -24,6 +25,7 @@ export const createLocalTerminalSession = (
   localShellArgs: options?.shellArgs,
   localShellName: options?.shellName,
   localShellIcon: options?.shellIcon,
+  localStartDir: options?.localStartDir,
 });
 
 export const createSerialTerminalSession = (

--- a/application/state/terminalConnectionReuse.test.ts
+++ b/application/state/terminalConnectionReuse.test.ts
@@ -60,3 +60,19 @@ test("copy session clones reuse SSH sources and preserve serial config", () => {
   assert.equal(copied.reuseConnectionFromSessionId, "session-1");
   assert.deepEqual(copied.serialConfig, { path: "/dev/tty.usbserial", baudRate: 115200 });
 });
+
+test("split and copy session clones preserve local start directory", () => {
+  const source = session({
+    protocol: "local",
+    localStartDir: "/Users/alice/project with spaces ",
+  });
+
+  assert.equal(
+    createSplitTerminalSessionClone(source, { id: "split-local" }).localStartDir,
+    "/Users/alice/project with spaces ",
+  );
+  assert.equal(
+    createCopiedTerminalSessionClone(source, { id: "copy-local" }).localStartDir,
+    "/Users/alice/project with spaces ",
+  );
+});

--- a/application/state/terminalConnectionReuse.ts
+++ b/application/state/terminalConnectionReuse.ts
@@ -43,6 +43,7 @@ function createTerminalSessionClone(
     localShellArgs: session.localShellArgs,
     localShellName: session.localShellName,
     localShellIcon: session.localShellIcon,
+    localStartDir: session.localStartDir,
     fontSize: session.fontSize,
     fontSizeOverride: session.fontSizeOverride,
     reuseConnectionFromSessionId: canReuseTerminalConnection(session) ? session.id : undefined,

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -1803,6 +1803,49 @@ test("restored local reconnect does not fall back to host startup command", asyn
   assert.deepEqual(sessionWrites, []);
 });
 
+test("local session start uses per-session directory before global default", async () => {
+  let capturedOptions: Record<string, unknown> | null = null;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => "ssh-session",
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async (options: Record<string, unknown>) => {
+      capturedOptions = options;
+      return "local-session";
+    },
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+
+  const ctx = createStarterContext({
+    host: {
+      id: "local-host",
+      label: "Local",
+      hostname: "local",
+      username: "",
+      protocol: "local",
+      localStartDir: "/Users/alice/project",
+    },
+    terminalSettings: { localStartDir: "/Users/alice/default" },
+    terminalBackend,
+  });
+
+  await createTerminalSessionStarters(ctx as never).startLocal(createTermStub() as never);
+
+  assert.equal(capturedOptions?.cwd, "/Users/alice/project");
+});
+
 test("local session restores cwd before startup command after attaching", async () => {
   const sessionWrites: Array<{ id: string; data: string; automated?: boolean }> = [];
   const executedCommands: string[] = [];

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -1273,7 +1273,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       // otherwise omit them so the backend uses its own default shell detection.
       const sessionShell = ctx.host.localShell;
       const sessionShellArgs = ctx.host.localShellArgs;
-      const localStartDir = ctx.terminalSettings?.localStartDir;
+      const localStartDir = ctx.host.localStartDir || ctx.terminalSettings?.localStartDir;
 
       const id = await ctx.terminalBackend.startLocalSession({
         sessionId: ctx.sessionId,

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -104,7 +104,7 @@ export type SessionLogConfig = {
 };
 
 export type TerminalSessionStartersContext = {
-  host: Host;
+  host: Host & Pick<Partial<TerminalSession>, "localStartDir">;
   keys: SSHKey[];
   identities?: Identity[];
   knownHosts?: KnownHost[];

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -246,6 +246,7 @@ export interface Host {
   localShellArgs?: string[];
   localShellName?: string;
   localShellIcon?: string;
+  localStartDir?: string;
   /** User-authored Markdown notes (project, hardware, region, etc.) */
   notes?: string;
   order?: number;

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -439,6 +439,7 @@ export interface TerminalSession {
   localShellArgs?: string[]; // Shell args for local terminals (from discovery)
   localShellName?: string;   // Display name for local shell (e.g., "Zsh", "Ubuntu (WSL)")
   localShellIcon?: string;   // Icon identifier for local shell (e.g., "zsh", "ubuntu")
+  localStartDir?: string;    // Per-session starting directory for local terminals
   // For sessions created from an existing SSH session: the id of the source
   // session whose already-authenticated connection should be reused so the new
   // shell channel does not trigger a second MFA prompt (issue #1204). The

--- a/domain/sessionRestore.test.ts
+++ b/domain/sessionRestore.test.ts
@@ -64,6 +64,22 @@ test("buildSessionRestorePayload only stores allowlisted session fields", () => 
   ].sort());
 });
 
+test("buildSessionRestorePayload preserves local terminal start directory", () => {
+  const payload = buildSessionRestorePayload({
+    sessions: [{
+      ...session("s1"),
+      protocol: "local",
+      localStartDir: "/Users/alice/project",
+    }],
+    workspaces: [],
+    tabOrder: ["s1"],
+    activeTabId: "s1",
+    now: 123,
+  });
+
+  assert.equal(payload.sessions[0].localStartDir, "/Users/alice/project");
+});
+
 test("buildSessionRestorePayload deeply allowlists serial config fields", () => {
   const payload = buildSessionRestorePayload({
     sessions: [{
@@ -214,6 +230,23 @@ test("sanitizeSessionRestorePayload drops malformed session and workspace record
   assert.deepEqual(sanitized.workspaces, []);
   assert.deepEqual(sanitized.tabOrder, ["s1"]);
   assert.equal(sanitized.activeTabId, "s1");
+});
+
+test("sanitizeSessionRestorePayload preserves local terminal start directory", () => {
+  const sanitized = sanitizeSessionRestorePayload({
+    version: 1,
+    savedAt: 1,
+    activeTabId: "s1",
+    tabOrder: ["s1"],
+    sessions: [{
+      ...session("s1"),
+      protocol: "local",
+      localStartDir: "/Users/alice/project",
+    }],
+    workspaces: [],
+  });
+
+  assert.equal(sanitized.sessions[0].localStartDir, "/Users/alice/project");
 });
 
 test("sanitizeSessionRestorePayload enforces workspace session ownership", () => {

--- a/domain/sessionRestore.ts
+++ b/domain/sessionRestore.ts
@@ -21,6 +21,7 @@ export type RestoredTerminalSession = {
   localShellArgs?: string[];
   localShellName?: string;
   localShellIcon?: string;
+  localStartDir?: string;
   fontSize?: number;
   fontSizeOverride?: boolean;
   customName?: string;
@@ -133,6 +134,7 @@ const restoreSession = (session: TerminalSession): RestoredTerminalSession => {
     ...(session.localShellArgs ? { localShellArgs: [...session.localShellArgs] } : {}),
     ...(session.localShellName ? { localShellName: session.localShellName } : {}),
     ...(session.localShellIcon ? { localShellIcon: session.localShellIcon } : {}),
+    ...(session.localStartDir ? { localStartDir: session.localStartDir } : {}),
     ...(session.fontSize !== undefined ? { fontSize: session.fontSize } : {}),
     ...(session.fontSizeOverride !== undefined ? { fontSizeOverride: session.fontSizeOverride } : {}),
     ...(session.customName ? { customName: session.customName } : {}),
@@ -172,6 +174,7 @@ const restoreSessionFromUnknown = (value: unknown): RestoredTerminalSession | nu
     ...(Array.isArray(value.localShellArgs) ? { localShellArgs: value.localShellArgs.filter((arg): arg is string => typeof arg === "string") } : {}),
     ...(readString(value, "localShellName") ? { localShellName: readString(value, "localShellName") } : {}),
     ...(readString(value, "localShellIcon") ? { localShellIcon: readString(value, "localShellIcon") } : {}),
+    ...(readString(value, "localStartDir") ? { localStartDir: readString(value, "localStartDir") } : {}),
     ...(readNumber(value, "fontSize") !== undefined ? { fontSize: readNumber(value, "fontSize") } : {}),
     ...(readBoolean(value, "fontSizeOverride") !== undefined ? { fontSizeOverride: readBoolean(value, "fontSizeOverride") } : {}),
     ...(readString(value, "customName") ? { customName: readString(value, "customName") } : {}),

--- a/domain/terminalHostResolution.test.ts
+++ b/domain/terminalHostResolution.test.ts
@@ -120,6 +120,25 @@ test("resolveTerminalSessionHost keeps explicit missing local sessions local", (
   assert.equal(resolved.os, "macos");
 });
 
+test("resolveTerminalSessionHost carries local session start directory into fallback host", () => {
+  const resolved = resolveTerminalSessionHost({
+    session: {
+      ...baseSession,
+      protocol: "local",
+      hostname: "localhost",
+      username: "local",
+      localStartDir: "/Users/alice/project",
+    },
+    hosts: [],
+    groupConfigs: [],
+    proxyProfiles,
+    localOs: "macos",
+  });
+
+  assert.equal(resolved.protocol, "local");
+  assert.equal(resolved.localStartDir, "/Users/alice/project");
+});
+
 test("resolveTerminalSessionHost suppresses inherited network device mode for Mosh sessions", () => {
   const host: Host = {
     id: "target",

--- a/domain/terminalHostResolution.ts
+++ b/domain/terminalHostResolution.ts
@@ -71,6 +71,7 @@ function buildFallbackHostFromSession(
     localShellArgs: session.localShellArgs,
     localShellName: session.localShellName,
     localShellIcon: session.localShellIcon,
+    localStartDir: session.localStartDir,
   };
 }
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -171,7 +171,15 @@ module.exports = {
         extendInfo: {
             NSCameraUsageDescription: 'Netcatty may use the camera for video calls',
             NSMicrophoneUsageDescription: 'Netcatty may use the microphone for audio',
-            NSLocalNetworkUsageDescription: 'Netcatty needs local network access for SSH connections'
+            NSLocalNetworkUsageDescription: 'Netcatty needs local network access for SSH connections',
+            CFBundleDocumentTypes: [
+                {
+                    CFBundleTypeName: 'Folder',
+                    CFBundleTypeRole: 'Viewer',
+                    LSHandlerRank: 'Alternate',
+                    LSItemContentTypes: ['public.folder']
+                }
+            ]
         },
         extraResources: [...moshExtraResources('darwin'), ...etExtraResources('darwin')]
     },

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -78,6 +78,7 @@ const {
   OPEN_TERMINAL_PATH_CHANNEL,
   collectOpenTerminalPathArgs,
   resolveOpenTerminalPath,
+  resolveOpenTerminalPathsFromArgs,
 } = require("./openTerminalPath.cjs");
 
 try {
@@ -529,9 +530,7 @@ async function createAndShowMainWindow() {
 
 let sshDeepLinkEnabled = readSshDeepLinkEnabledPreference({ app });
 const pendingSshDeepLinkUrls = sshDeepLinkEnabled ? collectSshDeepLinkUrls(process.argv) : [];
-const pendingOpenTerminalPaths = collectOpenTerminalPathArgs(process.argv)
-  .map((rawPath) => resolveOpenTerminalPath(rawPath))
-  .filter(Boolean);
+const pendingOpenTerminalPaths = resolveOpenTerminalPathsFromArgs(process.argv);
 let flushingSshDeepLinks = false;
 let flushingOpenTerminalPaths = false;
 let sshDeepLinkDeliveryGeneration = 0;
@@ -545,10 +544,18 @@ function queueSshDeepLink(rawUrl) {
   }
 }
 
-function queueOpenTerminalPath(rawPath) {
-  const resolvedPath = resolveOpenTerminalPath(rawPath);
+function queueOpenTerminalPath(rawPath, options = {}) {
+  const resolvedPath = resolveOpenTerminalPath(rawPath, options);
   if (!resolvedPath) return;
   pendingOpenTerminalPaths.push(resolvedPath);
+  if (app.isReady?.()) {
+    void flushPendingOpenTerminalPaths();
+  }
+}
+
+function queueResolvedOpenTerminalPaths(paths) {
+  if (!Array.isArray(paths) || paths.length === 0) return;
+  pendingOpenTerminalPaths.push(...paths);
   if (app.isReady?.()) {
     void flushPendingOpenTerminalPaths();
   }
@@ -700,7 +707,7 @@ if (!gotLock) {
     queueOpenTerminalPath(filePath);
   });
 
-  app.on("second-instance", (_event, argv) => {
+  app.on("second-instance", (_event, argv, workingDirectory) => {
     const deepLinkUrls = collectSshDeepLinkUrls(argv);
     if (deepLinkUrls.length > 0) {
       if (sshDeepLinkEnabled) {
@@ -708,9 +715,10 @@ if (!gotLock) {
       }
       return;
     }
-    const openTerminalPaths = collectOpenTerminalPathArgs(argv);
-    if (openTerminalPaths.length > 0) {
-      openTerminalPaths.forEach(queueOpenTerminalPath);
+    if (collectOpenTerminalPathArgs(argv).length > 0) {
+      const baseDirectory = typeof workingDirectory === "string" ? workingDirectory : undefined;
+      const openTerminalPaths = resolveOpenTerminalPathsFromArgs(argv, { baseDirectory });
+      queueResolvedOpenTerminalPaths(openTerminalPaths);
       return;
     }
     if (!focusMainWindow()) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -74,6 +74,11 @@ const {
   updateSshDeepLinkEnabledPreference,
   writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
+const {
+  OPEN_TERMINAL_PATH_CHANNEL,
+  collectOpenTerminalPathArgs,
+  resolveOpenTerminalPath,
+} = require("./openTerminalPath.cjs");
 
 try {
   protocol?.registerSchemesAsPrivileged?.([
@@ -524,7 +529,11 @@ async function createAndShowMainWindow() {
 
 let sshDeepLinkEnabled = readSshDeepLinkEnabledPreference({ app });
 const pendingSshDeepLinkUrls = sshDeepLinkEnabled ? collectSshDeepLinkUrls(process.argv) : [];
+const pendingOpenTerminalPaths = collectOpenTerminalPathArgs(process.argv)
+  .map((rawPath) => resolveOpenTerminalPath(rawPath))
+  .filter(Boolean);
 let flushingSshDeepLinks = false;
+let flushingOpenTerminalPaths = false;
 let sshDeepLinkDeliveryGeneration = 0;
 
 function queueSshDeepLink(rawUrl) {
@@ -533,6 +542,15 @@ function queueSshDeepLink(rawUrl) {
   pendingSshDeepLinkUrls.push(rawUrl);
   if (app.isReady?.()) {
     void flushPendingSshDeepLinks();
+  }
+}
+
+function queueOpenTerminalPath(rawPath) {
+  const resolvedPath = resolveOpenTerminalPath(rawPath);
+  if (!resolvedPath) return;
+  pendingOpenTerminalPaths.push(resolvedPath);
+  if (app.isReady?.()) {
+    void flushPendingOpenTerminalPaths();
   }
 }
 
@@ -606,6 +624,40 @@ async function flushPendingSshDeepLinks() {
   }
 }
 
+async function deliverOpenTerminalPath(targetPath) {
+  const win = await createAndShowMainWindow();
+  focusMainWindow();
+  const windowManager = getWindowManager();
+  const result = await windowManager.sendWhenRendererReady?.(
+    win,
+    OPEN_TERMINAL_PATH_CHANNEL,
+    { path: targetPath },
+    { timeoutMs: isDev ? 30000 : 15000 },
+  );
+  if (result && result.success === false) {
+    console.warn("[Main] Failed to deliver open terminal path:", result.error || result.reason);
+  }
+}
+
+async function flushPendingOpenTerminalPaths() {
+  if (flushingOpenTerminalPaths) return;
+  flushingOpenTerminalPaths = true;
+  try {
+    while (pendingOpenTerminalPaths.length > 0) {
+      const targetPath = pendingOpenTerminalPaths.shift();
+      if (!targetPath) continue;
+      await deliverOpenTerminalPath(targetPath);
+    }
+  } catch (err) {
+    console.warn("[Main] Failed to process open terminal path:", err);
+  } finally {
+    flushingOpenTerminalPaths = false;
+    if (pendingOpenTerminalPaths.length > 0) {
+      void flushPendingOpenTerminalPaths();
+    }
+  }
+}
+
 function hasUsableWindow() {
   try {
     const windowManager = getWindowManager();
@@ -643,12 +695,22 @@ if (!gotLock) {
     queueSshDeepLink(rawUrl);
   });
 
+  app.on("open-file", (event, filePath) => {
+    event.preventDefault();
+    queueOpenTerminalPath(filePath);
+  });
+
   app.on("second-instance", (_event, argv) => {
     const deepLinkUrls = collectSshDeepLinkUrls(argv);
     if (deepLinkUrls.length > 0) {
       if (sshDeepLinkEnabled) {
         deepLinkUrls.forEach(queueSshDeepLink);
       }
+      return;
+    }
+    const openTerminalPaths = collectOpenTerminalPathArgs(argv);
+    if (openTerminalPaths.length > 0) {
+      openTerminalPaths.forEach(queueOpenTerminalPath);
       return;
     }
     if (!focusMainWindow()) {
@@ -780,6 +842,7 @@ if (!gotLock) {
     // Create the main window
     void createAndShowMainWindow().then(() => {
       void flushPendingSshDeepLinks();
+      void flushPendingOpenTerminalPaths();
 
       // Trigger auto-update check 5 s after window creation.
       // startAutoCheck() is a no-op on unsupported platforms (Linux deb/rpm/snap).

--- a/electron/openTerminalPath.cjs
+++ b/electron/openTerminalPath.cjs
@@ -1,0 +1,67 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const OPEN_TERMINAL_PATH_CHANNEL = "netcatty:openTerminalPath";
+const OPEN_TERMINAL_PATH_ARG = "--open-terminal-path";
+
+function expandHomePath(targetPath, { osHomedir = os.homedir } = {}) {
+  if (!targetPath) return targetPath;
+  if (targetPath === "~") return osHomedir();
+  if (targetPath.startsWith("~/")) return path.join(osHomedir(), targetPath.slice(2));
+  return targetPath;
+}
+
+function collectOpenTerminalPathArgs(argv) {
+  if (!Array.isArray(argv)) return [];
+  const paths = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (typeof arg !== "string") continue;
+
+    if (arg === OPEN_TERMINAL_PATH_ARG) {
+      const next = argv[index + 1];
+      if (typeof next === "string" && next.trim()) {
+        paths.push(next);
+        index += 1;
+      }
+      continue;
+    }
+
+    const prefix = `${OPEN_TERMINAL_PATH_ARG}=`;
+    if (arg.startsWith(prefix)) {
+      const value = arg.slice(prefix.length);
+      if (value.trim()) paths.push(value);
+    }
+  }
+
+  return paths;
+}
+
+function resolveOpenTerminalPath(rawPath, {
+  fsModule = fs,
+  pathModule = path,
+  logWarn = console.warn,
+} = {}) {
+  if (typeof rawPath !== "string" || !rawPath.trim()) return null;
+
+  try {
+    const resolved = pathModule.resolve(expandHomePath(rawPath));
+    const stat = fsModule.statSync(resolved);
+    if (stat.isDirectory()) return resolved;
+    if (stat.isFile()) return pathModule.dirname(resolved);
+    return null;
+  } catch (err) {
+    logWarn?.("[Main] Ignoring invalid terminal open path:", rawPath, err?.message || err);
+    return null;
+  }
+}
+
+module.exports = {
+  OPEN_TERMINAL_PATH_ARG,
+  OPEN_TERMINAL_PATH_CHANNEL,
+  collectOpenTerminalPathArgs,
+  expandHomePath,
+  resolveOpenTerminalPath,
+};

--- a/electron/openTerminalPath.cjs
+++ b/electron/openTerminalPath.cjs
@@ -40,6 +40,7 @@ function collectOpenTerminalPathArgs(argv) {
 }
 
 function resolveOpenTerminalPath(rawPath, {
+  baseDirectory,
   fsModule = fs,
   pathModule = path,
   logWarn = console.warn,
@@ -47,7 +48,10 @@ function resolveOpenTerminalPath(rawPath, {
   if (typeof rawPath !== "string" || !rawPath.trim()) return null;
 
   try {
-    const resolved = pathModule.resolve(expandHomePath(rawPath));
+    const expanded = expandHomePath(rawPath);
+    const resolved = pathModule.isAbsolute(expanded)
+      ? pathModule.resolve(expanded)
+      : pathModule.resolve(baseDirectory || process.cwd(), expanded);
     const stat = fsModule.statSync(resolved);
     if (stat.isDirectory()) return resolved;
     if (stat.isFile()) return pathModule.dirname(resolved);
@@ -58,10 +62,17 @@ function resolveOpenTerminalPath(rawPath, {
   }
 }
 
+function resolveOpenTerminalPathsFromArgs(argv, options = {}) {
+  return collectOpenTerminalPathArgs(argv)
+    .map((rawPath) => resolveOpenTerminalPath(rawPath, options))
+    .filter(Boolean);
+}
+
 module.exports = {
   OPEN_TERMINAL_PATH_ARG,
   OPEN_TERMINAL_PATH_CHANNEL,
   collectOpenTerminalPathArgs,
   expandHomePath,
   resolveOpenTerminalPath,
+  resolveOpenTerminalPathsFromArgs,
 };

--- a/electron/openTerminalPath.test.cjs
+++ b/electron/openTerminalPath.test.cjs
@@ -1,0 +1,79 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  collectOpenTerminalPathArgs,
+  expandHomePath,
+  resolveOpenTerminalPath,
+} = require("./openTerminalPath.cjs");
+
+test("collectOpenTerminalPathArgs extracts explicit open terminal paths", () => {
+  assert.deepEqual(
+    collectOpenTerminalPathArgs([
+      "/Applications/Netcatty.app/Contents/MacOS/Netcatty",
+      "--open-terminal-path",
+      "/Users/alice/project",
+      "--open-terminal-path=/tmp/demo",
+      "--ignored",
+    ]),
+    ["/Users/alice/project", "/tmp/demo"],
+  );
+});
+
+test("resolveOpenTerminalPath accepts directories", () => {
+  const fsModule = {
+    statSync: (target) => ({
+      target,
+      isDirectory: () => true,
+      isFile: () => false,
+    }),
+  };
+
+  assert.equal(
+    resolveOpenTerminalPath("/tmp/project", { fsModule, logWarn: () => {} }),
+    "/tmp/project",
+  );
+});
+
+test("expandHomePath expands home-relative terminal paths", () => {
+  assert.equal(
+    expandHomePath("~/project", { osHomedir: () => "/Users/alice" }),
+    "/Users/alice/project",
+  );
+  assert.equal(
+    expandHomePath("~", { osHomedir: () => "/Users/alice" }),
+    "/Users/alice",
+  );
+});
+
+test("resolveOpenTerminalPath uses parent directory for files", () => {
+  const fsModule = {
+    statSync: () => ({
+      isDirectory: () => false,
+      isFile: () => true,
+    }),
+  };
+
+  assert.equal(
+    resolveOpenTerminalPath("/tmp/project/readme.md", { fsModule, logWarn: () => {} }),
+    "/tmp/project",
+  );
+});
+
+test("resolveOpenTerminalPath rejects missing paths", () => {
+  const warnings = [];
+  const fsModule = {
+    statSync: () => {
+      throw new Error("missing");
+    },
+  };
+
+  assert.equal(
+    resolveOpenTerminalPath("/tmp/missing", {
+      fsModule,
+      logWarn: (...args) => warnings.push(args),
+    }),
+    null,
+  );
+  assert.equal(warnings.length, 1);
+});

--- a/electron/openTerminalPath.test.cjs
+++ b/electron/openTerminalPath.test.cjs
@@ -5,6 +5,7 @@ const {
   collectOpenTerminalPathArgs,
   expandHomePath,
   resolveOpenTerminalPath,
+  resolveOpenTerminalPathsFromArgs,
 } = require("./openTerminalPath.cjs");
 
 test("collectOpenTerminalPathArgs extracts explicit open terminal paths", () => {
@@ -32,6 +33,51 @@ test("resolveOpenTerminalPath accepts directories", () => {
   assert.equal(
     resolveOpenTerminalPath("/tmp/project", { fsModule, logWarn: () => {} }),
     "/tmp/project",
+  );
+});
+
+test("resolveOpenTerminalPath resolves relative paths against the provided base directory", () => {
+  const seen = [];
+  const fsModule = {
+    statSync: (target) => {
+      seen.push(target);
+      return {
+        isDirectory: () => true,
+        isFile: () => false,
+      };
+    },
+  };
+
+  assert.equal(
+    resolveOpenTerminalPath("project", {
+      baseDirectory: "/Users/alice",
+      fsModule,
+      logWarn: () => {},
+    }),
+    "/Users/alice/project",
+  );
+  assert.deepEqual(seen, ["/Users/alice/project"]);
+});
+
+test("resolveOpenTerminalPathsFromArgs resolves second-instance relative paths against its working directory", () => {
+  const fsModule = {
+    statSync: () => ({
+      isDirectory: () => true,
+      isFile: () => false,
+    }),
+  };
+
+  assert.deepEqual(
+    resolveOpenTerminalPathsFromArgs([
+      "/Applications/Netcatty.app/Contents/MacOS/Netcatty",
+      "--open-terminal-path",
+      ".",
+    ], {
+      baseDirectory: "/Users/alice/project",
+      fsModule,
+      logWarn: () => {},
+    }),
+    ["/Users/alice/project"],
   );
 });
 

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -692,6 +692,11 @@ function createPreloadApi(ctx) {
     ipcRenderer.on("netcatty:deepLink:ssh", handler);
     return () => ipcRenderer.removeListener("netcatty:deepLink:ssh", handler);
   },
+  onOpenTerminalPath: (callback) => {
+    const handler = (_event, payload) => callback(payload);
+    ipcRenderer.on("netcatty:openTerminalPath", handler);
+    return () => ipcRenderer.removeListener("netcatty:openTerminalPath", handler);
+  },
   setSshDeepLinkEnabled: (enabled) =>
     ipcRenderer.invoke("netcatty:deepLink:ssh:setEnabled", { enabled }),
   getSshDeepLinkEnabled: () =>

--- a/types/global/netcatty-bridge-app.d.ts
+++ b/types/global/netcatty-bridge-app.d.ts
@@ -32,6 +32,7 @@ declare global {
     // Fired when an install was requested but blocked by unsaved editors (#1215).
     onUpdateNeedsSave?(cb: () => void): () => void;
     onSshDeepLink?(cb: (payload: { url?: string }) => void): () => void;
+    onOpenTerminalPath?(cb: (payload: { path?: string }) => void): () => void;
     setSshDeepLinkEnabled?(enabled: boolean): Promise<boolean | { success: boolean; enabled: boolean }>;
     getSshDeepLinkEnabled?(): Promise<boolean>;
 


### PR DESCRIPTION
## Summary
- register Netcatty as a macOS folder opener so Finder can hand folder paths to the app
- route opened folder paths through the main process to the renderer
- start a new local terminal in the selected folder, with tests for path handling and per-session start directories

Closes #1959

## Validation
- node --test --import tsx electron/openTerminalPath.test.cjs electron/deepLink.test.cjs components/terminal/runtime/createTerminalSessionStarters.test.ts
- npm run lint
- npm run build

Note: full `npm exec tsc -- --noEmit` still reports existing repository-wide type errors unrelated to this change; filtered output for this change had no matching errors.