### PR TITLE
Add Vault delete confirmations

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -723,6 +723,12 @@ export const enCoreMessages: Messages = {
   'vault.groups.errors.invalidChars': "Group name cannot include '/' or '\\\\'.",
   'vault.groups.errors.duplicatePath': 'A group with this name already exists at this location.',
 
+  'vault.deleteConfirm.title': 'Delete "{name}"?',
+  'vault.deleteConfirm.desc': 'This action cannot be undone.',
+  'vault.deleteConfirm.packageDesc': 'This will remove the script package. Scripts inside it will stay saved and move out of the package.',
+  'vault.deleteConfirm.noteGroupDesc': 'This will remove the folder. Notes inside it will stay saved and move out of the folder.',
+  'vault.deleteConfirm.portForwardingDesc': 'This will delete the port forwarding rule.',
+
   'vault.managedSource.unmanage': 'Unmanage',
   'vault.managedSource.unmanageSuccess': 'Successfully unmanaged group',
 

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -725,6 +725,12 @@ export const ruCoreMessages: Messages = {
   'vault.groups.errors.invalidChars': "Имя группы не может содержать '/' или '\\\\'.",
   'vault.groups.errors.duplicatePath': 'Группа с таким именем уже существует в этом расположении.',
 
+  'vault.deleteConfirm.title': 'Удалить "{name}"?',
+  'vault.deleteConfirm.desc': 'Это действие нельзя отменить.',
+  'vault.deleteConfirm.packageDesc': 'Пакет скриптов будет удалён. Скрипты внутри него сохранятся и будут вынесены из пакета.',
+  'vault.deleteConfirm.noteGroupDesc': 'Папка будет удалена. Заметки внутри неё сохранятся и будут вынесены из папки.',
+  'vault.deleteConfirm.portForwardingDesc': 'Правило проброса портов будет удалено.',
+
   'vault.managedSource.unmanage': 'Снять управление',
   'vault.managedSource.unmanageSuccess': 'Управление группой успешно снято',
 

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -450,6 +450,12 @@ export const zhCNCoreMessages: Messages = {
   'vault.groups.errors.invalidChars': "分组名称不能包含 '/' 或 '\\\\'.",
   'vault.groups.errors.duplicatePath': '该位置已存在同名分组。',
 
+  'vault.deleteConfirm.title': '删除“{name}”？',
+  'vault.deleteConfirm.desc': '此操作不可撤销。',
+  'vault.deleteConfirm.packageDesc': '这会删除脚本包，包内脚本会保留，并移出该脚本包。',
+  'vault.deleteConfirm.noteGroupDesc': '这会删除文件夹，文件夹内笔记会保留，并移出该文件夹。',
+  'vault.deleteConfirm.portForwardingDesc': '这会删除该端口转发规则。',
+
   'vault.managedSource.unmanage': '取消托管',
   'vault.managedSource.unmanageSuccess': '已取消托管分组',
 

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -450,6 +450,12 @@ export const zhTWCoreMessages: Messages = {
   'vault.groups.errors.invalidChars': "分組名稱不能包含 '/' 或 '\\\\'.",
   'vault.groups.errors.duplicatePath': '該位置已存在同名分組。',
 
+  'vault.deleteConfirm.title': '刪除「{name}」？',
+  'vault.deleteConfirm.desc': '此操作不可復原。',
+  'vault.deleteConfirm.packageDesc': '這會刪除程式碼包，包內程式碼片段會保留，並移出該程式碼包。',
+  'vault.deleteConfirm.noteGroupDesc': '這會刪除資料夾，資料夾內筆記會保留，並移出該資料夾。',
+  'vault.deleteConfirm.portForwardingDesc': '這會刪除此埠轉發規則。',
+
   'vault.managedSource.unmanage': '取消託管',
   'vault.managedSource.unmanageSuccess': '已取消託管分組',
 

--- a/components/KeychainManager.tsx
+++ b/components/KeychainManager.tsx
@@ -51,6 +51,7 @@ import {
   vaultHeaderIconButtonClass,
   vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
+import { VaultDeleteConfirmDialog } from "./vault/VaultDeleteConfirmDialog";
 import { useVaultItemReorder } from "./vault/vaultReorderDrag";
 
 // Import utilities and components from keychain module
@@ -115,6 +116,11 @@ const KeychainManager: React.FC<KeychainManagerProps> = ({
   const { generateKeyPair, execCommand } = useKeychainBackend();
   const [activeFilter, setActiveFilter] = useState<FilterTab>("key");
   const [search, setSearch] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{
+    type: "key" | "identity";
+    id: string;
+    name: string;
+  } | null>(null);
   const [viewMode, setViewMode] = useStoredViewMode(
     STORAGE_KEY_VAULT_KEYS_VIEW_MODE,
     "grid",
@@ -468,24 +474,49 @@ echo $3 >> "$FILE"`);
 
   // Handle delete
   const handleDelete = useCallback(
-    async (id: string) => {
-      onDelete(id);
-      if (panel.type === "view" && panel.key.id === id) {
-        closePanel();
-      }
+    (id: string) => {
+      const key = keys.find((item) => item.id === id);
+      setDeleteTarget({
+        type: "key",
+        id,
+        name: key?.label || t("keychain.panel.keyDetails"),
+      });
     },
-    [onDelete, panel, closePanel],
+    [keys, t],
   );
 
   // Handle delete identity
   const _handleDeleteIdentity = useCallback(
     (id: string) => {
-      onDeleteIdentity?.(id);
-      if (panel.type === "identity" && panel.identity?.id === id) {
-        closePanel();
-      }
+      const identity = identities.find((item) => item.id === id);
+      setDeleteTarget({
+        type: "identity",
+        id,
+        name: identity?.label || t("keychain.panel.editIdentity"),
+      });
     },
-    [onDeleteIdentity, panel, closePanel],
+    [identities, t],
+  );
+
+  const confirmDeleteTarget = useCallback(
+    () => {
+      if (!deleteTarget) return;
+
+      if (deleteTarget.type === "key") {
+        onDelete(deleteTarget.id);
+        if (panel.type === "view" && panel.key.id === deleteTarget.id) {
+          closePanel();
+        }
+      } else {
+        onDeleteIdentity?.(deleteTarget.id);
+        if (panel.type === "identity" && panel.identity?.id === deleteTarget.id) {
+          closePanel();
+        }
+      }
+
+      setDeleteTarget(null);
+    },
+    [closePanel, deleteTarget, onDelete, onDeleteIdentity, panel],
   );
 
   // Get icon for key source
@@ -837,15 +868,7 @@ echo $3 >> "$FILE"`);
                         <ContextMenuSeparator />
                         <ContextMenuItem
                           className="text-destructive"
-                          onClick={() => {
-                            const ok = window.confirm(
-                              t("confirm.deleteIdentity", {
-                                name: identity.label || "",
-                              }),
-                            );
-                            if (!ok) return;
-                            _handleDeleteIdentity(identity.id);
-                          }}
+                          onClick={() => _handleDeleteIdentity(identity.id)}
                         >
                           <Trash2 className="mr-2 h-4 w-4" />{" "}
                           {t("action.delete")}
@@ -876,13 +899,7 @@ echo $3 >> "$FILE"`);
                   variant="destructive"
                   icon={<Trash2 size={14} />}
                   onClick={() => {
-                    const ok = window.confirm(
-                      t("confirm.deleteIdentity", {
-                        name: panel.identity?.label || "",
-                      }),
-                    );
-                    if (!ok || !panel.identity) return;
-                    _handleDeleteIdentity(panel.identity.id);
+                    if (panel.identity) _handleDeleteIdentity(panel.identity.id);
                   }}
                 >
                   {t("common.delete")}
@@ -1031,6 +1048,18 @@ echo $3 >> "$FILE"`);
           )}
         </AsidePanel>
       )}
+
+      <VaultDeleteConfirmDialog
+        open={Boolean(deleteTarget)}
+        title={t("vault.deleteConfirm.title", {
+          name: deleteTarget?.name ?? "",
+        })}
+        description={t("vault.deleteConfirm.desc")}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={confirmDeleteTarget}
+      />
     </div>
   );
 };

--- a/components/KnownHostsManager.tsx
+++ b/components/KnownHostsManager.tsx
@@ -45,6 +45,7 @@ import {
   vaultHeaderIconButtonClass,
   vaultHeaderSecondaryButtonClass,
 } from "./vault/VaultPageHeader";
+import { VaultDeleteConfirmDialog } from "./vault/VaultDeleteConfirmDialog";
 import { VaultEntityIcon, vaultPrimaryIconClass } from "./vault/VaultEntityIcon";
 import { useVaultItemReorder } from "./vault/vaultReorderDrag";
 
@@ -294,6 +295,7 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
   const [search, setSearch] = useState("");
   const deferredSearch = useDeferredValue(search);
   const [isScanning, setIsScanning] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useStoredViewMode(
     STORAGE_KEY_VAULT_KNOWN_HOSTS_VIEW_MODE,
     "grid",
@@ -471,9 +473,23 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
   // Memoized handlers to prevent re-renders
   const handleDelete = useCallback(
     (id: string) => {
-      onDelete(id);
+      setDeleteTargetId(id);
     },
-    [onDelete],
+    [],
+  );
+
+  const deleteTarget = useMemo(
+    () => knownHosts.find((knownHost) => knownHost.id === deleteTargetId) ?? null,
+    [deleteTargetId, knownHosts],
+  );
+
+  const confirmDelete = useCallback(
+    () => {
+      if (!deleteTargetId) return;
+      onDelete(deleteTargetId);
+      setDeleteTargetId(null);
+    },
+    [deleteTargetId, onDelete],
   );
 
   const handleConvertToHost = useCallback(
@@ -670,6 +686,17 @@ const KnownHostsManager: React.FC<KnownHostsManagerProps> = ({
           )}
         </div>
       </ScrollArea>
+      <VaultDeleteConfirmDialog
+        open={Boolean(deleteTargetId)}
+        title={t("vault.deleteConfirm.title", {
+          name: deleteTarget?.hostname ?? "",
+        })}
+        description={t("vault.deleteConfirm.desc")}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTargetId(null);
+        }}
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 };

--- a/components/PortForwardingNew.tsx
+++ b/components/PortForwardingNew.tsx
@@ -1,5 +1,4 @@
 import {
-  AlertTriangle,
   Check,
   ChevronDown,
   Globe,
@@ -32,14 +31,6 @@ import {
   AsidePanelFooter,
 } from "./ui/aside-panel";
 import { Button } from "./ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "./ui/dialog";
 import { Dropdown, DropdownContent, DropdownTrigger } from "./ui/dropdown";
 import { SortDropdown } from "./ui/sort-dropdown";
 import { toast } from "./ui/toast";
@@ -50,6 +41,7 @@ import {
   vaultHeaderSecondaryButtonClass,
   vaultSectionTitleClass,
 } from "./vault/VaultPageHeader";
+import { VaultDeleteConfirmDialog } from "./vault/VaultDeleteConfirmDialog";
 import { useVaultItemReorder } from "./vault/vaultReorderDrag";
 
 // Import components and utilities from port-forwarding module
@@ -436,33 +428,24 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
     setSelectedRuleId(null);
   }, [setSelectedRuleId]);
 
-  // Handle delete with confirmation for active tunnels
+  // Handle delete with confirmation
   const handleDeleteRule = useCallback(
     (rule: PortForwardingRule) => {
-      // If tunnel is active or connecting, show confirmation dialog
-      if (rule.status === "active" || rule.status === "connecting") {
-        setRuleToDelete(rule);
-        setShowDeleteConfirm(true);
-      } else {
-        // If inactive, delete directly
-        if (editingRule?.id === rule.id) {
-          closeEditPanel();
-        }
-        deleteRule(rule.id);
-      }
+      setRuleToDelete(rule);
+      setShowDeleteConfirm(true);
     },
-    [editingRule, deleteRule, closeEditPanel],
+    [],
   );
 
-  // Confirm delete of active tunnel: stop first, then delete
-  const confirmDeleteActiveRule = useCallback(async () => {
+  // Confirm delete; active tunnels are stopped first.
+  const confirmDeleteRule = useCallback(async () => {
     if (!ruleToDelete) return;
 
     setIsDeleting(true);
     try {
-      // Stop the tunnel first
-      await stopTunnel(ruleToDelete.id);
-      // Then delete the rule
+      if (ruleToDelete.status === "active" || ruleToDelete.status === "connecting") {
+        await stopTunnel(ruleToDelete.id);
+      }
       if (editingRule?.id === ruleToDelete.id) {
         closeEditPanel();
       }
@@ -473,6 +456,8 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
       setRuleToDelete(null);
     }
   }, [ruleToDelete, stopTunnel, deleteRule, editingRule, closeEditPanel]);
+
+  const deleteTargetIsActive = ruleToDelete?.status === "active" || ruleToDelete?.status === "connecting";
 
   // Handle wizard navigation
   // Flow for local: type -> local-config -> destination -> host-selection
@@ -923,44 +908,26 @@ const PortForwarding: React.FC<PortForwardingProps> = ({
         />
       )}
 
-      {/* Delete Active Tunnel Confirmation Dialog */}
-      <Dialog open={showDeleteConfirm} onOpenChange={(open) => {
-        if (!isDeleting) {
+      <VaultDeleteConfirmDialog
+        open={showDeleteConfirm}
+        title={t("vault.deleteConfirm.title", {
+          name: ruleToDelete?.label ?? "",
+        })}
+        description={
+          deleteTargetIsActive
+            ? t("pf.deleteActive.desc", { label: ruleToDelete?.label ?? "" })
+            : t("vault.deleteConfirm.portForwardingDesc")
+        }
+        confirmLabel={deleteTargetIsActive ? t("pf.deleteActive.confirm") : undefined}
+        disabled={isDeleting}
+        onOpenChange={(open) => {
           setShowDeleteConfirm(open);
           if (!open) setRuleToDelete(null);
-        }
-      }}>
-        <DialogContent className="sm:max-w-[400px]">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-destructive">
-              <AlertTriangle size={20} />
-              {t("pf.deleteActive.title")}
-            </DialogTitle>
-            <DialogDescription>
-              {t("pf.deleteActive.desc", { label: ruleToDelete?.label ?? "" })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              onClick={() => {
-                setShowDeleteConfirm(false);
-                setRuleToDelete(null);
-              }}
-              disabled={isDeleting}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={confirmDeleteActiveRule}
-              disabled={isDeleting}
-            >
-              {t("pf.deleteActive.confirm")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        }}
+        onConfirm={() => {
+          void confirmDeleteRule();
+        }}
+      />
     </div>
   );
 };

--- a/components/SnippetsManager.tsx
+++ b/components/SnippetsManager.tsx
@@ -43,6 +43,7 @@ import {
   vaultPrimaryIconClass,
   vaultSnippetIconClass,
 } from './vault/VaultEntityIcon';
+import { VaultDeleteConfirmDialog } from './vault/VaultDeleteConfirmDialog';
 import {
   clearVaultDropIndicator as clearSnippetDropIndicator,
   getVaultDropIntent as getPackageDropIntent,
@@ -498,6 +499,11 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
   const [draggingPackagePath, setDraggingPackagePath] = useState<string | null>(null);
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [selectedSnippetIds, setSelectedSnippetIds] = useState<Set<string>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<{
+    type: 'snippet' | 'package';
+    id: string;
+    name: string;
+  } | null>(null);
   const [isSnippetImportDialogOpen, setIsSnippetImportDialogOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<PendingSnippetImport | null>(null);
   const prepareGridLayoutAnimation = useVaultGridLayoutAnimation(listRef);
@@ -1189,7 +1195,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     setIsPackageDialogOpen(false);
   };
 
-  const deletePackage = (path: string) => {
+  const performDeletePackage = (path: string) => {
     const keep = packages.filter((p) => !(p === path || p.startsWith(path + '/')));
     
     const updatedSnippets = snippets.map((s) => {
@@ -1207,6 +1213,44 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
     if (selectedPackage && (selectedPackage === path || selectedPackage.startsWith(path + '/'))) {
       setSelectedPackage(null);
     }
+  };
+
+  const requestDeletePackage = (path: string) => {
+    setDeleteTarget({
+      type: 'package',
+      id: path,
+      name: path,
+    });
+  };
+
+  const requestDeleteSnippet = (id: string) => {
+    const snippet = snippets.find((item) => item.id === id);
+    setDeleteTarget({
+      type: 'snippet',
+      id,
+      name: snippet?.label || t('snippets.panel.editTitle'),
+    });
+  };
+
+  const confirmDeleteTarget = () => {
+    if (!deleteTarget) return;
+
+    if (deleteTarget.type === 'package') {
+      performDeletePackage(deleteTarget.id);
+    } else {
+      onDelete(deleteTarget.id);
+      setSelectedSnippetIds((prev) => {
+        if (!prev.has(deleteTarget.id)) return prev;
+        const next = new Set(prev);
+        next.delete(deleteTarget.id);
+        return next;
+      });
+      if (editingSnippet.id === deleteTarget.id) {
+        handleClosePanel();
+      }
+    }
+
+    setDeleteTarget(null);
   };
 
   const movePackage = (source: string, target: string | null) => {
@@ -1581,7 +1625,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
       t={t}
       handleClosePanel={handleClosePanel}
       editingSnippet={editingSnippet}
-      onDelete={onDelete}
+      onDelete={requestDeleteSnippet}
       handleSave={handleSave}
       handleSaveAndRun={handleSaveAndRun}
       setEditingSnippet={setEditingSnippet}
@@ -1869,7 +1913,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                         <Download className="mr-2 h-4 w-4" /> {t('snippets.export.package')}
                       </ContextMenuItem>
                       <ContextMenuItem onClick={() => openRenameDialog(pkg.path)}>{t('common.rename')}</ContextMenuItem>
-                      <ContextMenuItem className="text-destructive" onClick={() => deletePackage(pkg.path)}>{t('action.delete')}</ContextMenuItem>
+                      <ContextMenuItem className="text-destructive" onClick={() => requestDeletePackage(pkg.path)}>{t('action.delete')}</ContextMenuItem>
                     </ContextMenuContent>
                   </ContextMenu>
                 ))}
@@ -2007,7 +2051,7 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
                       <ContextMenuItem onClick={() => exportSingleSnippet(snippet)}>
                         <Download className="mr-2 h-4 w-4" /> {t('snippets.export.snippet')}
                       </ContextMenuItem>
-                      <ContextMenuItem className="text-destructive" onClick={() => onDelete(snippet.id)}>
+                      <ContextMenuItem className="text-destructive" onClick={() => requestDeleteSnippet(snippet.id)}>
                         <Trash2 className="mr-2 h-4 w-4" /> {t('action.delete')}
                       </ContextMenuItem>
                     </ContextMenuContent>
@@ -2069,6 +2113,22 @@ const SnippetsManager: React.FC<SnippetsManagerProps> = ({
         onConfirmOverwrite={() => {
           if (pendingImport) applySnippetImport(pendingImport.payload, 'overwrite');
         }}
+      />
+
+      <VaultDeleteConfirmDialog
+        open={Boolean(deleteTarget)}
+        title={t('vault.deleteConfirm.title', {
+          name: deleteTarget?.name ?? '',
+        })}
+        description={
+          deleteTarget?.type === 'package'
+            ? t('vault.deleteConfirm.packageDesc')
+            : t('vault.deleteConfirm.desc')
+        }
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={confirmDeleteTarget}
       />
 
       {renderRightPanel()}

--- a/components/SnippetsRightPanel.tsx
+++ b/components/SnippetsRightPanel.tsx
@@ -156,7 +156,6 @@ export const SnippetsRightPanel: React.FC<SnippetsRightPanelProps> = ({
                         const id = editingSnippet.id;
                         if (!id) return;
                         onDelete(id);
-                        handleClosePanel();
                       }}
                       aria-label={t('common.delete')}
                     >

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -65,6 +65,7 @@ import {
   VaultTreeInlineRenameInput,
   VaultTreeItemRow,
 } from "../vault/VaultTreeRow";
+import { VaultDeleteConfirmDialog } from "../vault/VaultDeleteConfirmDialog";
 import {
   clearVaultDropIndicator,
   getVaultDropIntent,
@@ -362,6 +363,11 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
   const [isTreeResizing, setIsTreeResizing] = useState(false);
   const [draggingNoteId, setDraggingNoteId] = useState<string | null>(null);
   const [draggingGroupPath, setDraggingGroupPath] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    type: "note" | "group";
+    id: string;
+    name: string;
+  } | null>(null);
   const [treeWidth, setTreeWidth, persistTreeWidth] = useStoredNumber(
     STORAGE_KEY_VAULT_NOTES_TREE_WIDTH,
     NOTES_TREE_DEFAULT_WIDTH,
@@ -710,7 +716,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     setOverlayNoteId(nextSelection.overlayNoteId);
   };
 
-  const deleteNoteById = (noteId: string) => {
+  const performDeleteNoteById = (noteId: string) => {
     const next = sortedNotes.filter((note) => note.id !== noteId);
     commitNotes(next);
     if (selectedNoteId === noteId) {
@@ -721,6 +727,15 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
       setEditingNoteId(null);
     }
     if (overlayNoteId === noteId) setOverlayNoteId(null);
+  };
+
+  const requestDeleteNoteById = (noteId: string) => {
+    const note = sortedNotes.find((item) => item.id === noteId);
+    setDeleteTarget({
+      type: "note",
+      id: noteId,
+      name: note?.title || t("notes.title.placeholder"),
+    });
   };
 
   const startCreateGroup = () => {
@@ -771,11 +786,29 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     }
   };
 
-  const deleteGroup = (group: string) => {
+  const performDeleteGroup = (group: string) => {
     onUpdateNoteGroups(groups.filter((item) => !isNoteGroupInside(item, group)));
     commitNotes(sortedNotes.map((note) => isNoteGroupInside(note.group, group) ? { ...note, group: undefined } : note));
     if (selectedGroup && isNoteGroupInside(selectedGroup, group)) setSelectedGroup(null);
     setEditingGroupPath(null);
+  };
+
+  const requestDeleteGroup = (group: string) => {
+    setDeleteTarget({
+      type: "group",
+      id: group,
+      name: group,
+    });
+  };
+
+  const confirmDeleteTarget = () => {
+    if (!deleteTarget) return;
+    if (deleteTarget.type === "note") {
+      performDeleteNoteById(deleteTarget.id);
+    } else {
+      performDeleteGroup(deleteTarget.id);
+    }
+    setDeleteTarget(null);
   };
 
   const resetTreeDragState = () => {
@@ -920,7 +953,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
       },
       {
         label: t("action.delete"),
-        action: () => deleteNoteById(note.id),
+        action: () => requestDeleteNoteById(note.id),
         destructive: true,
       },
     ];
@@ -981,7 +1014,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
       },
       {
         label: t("action.delete"),
-        action: () => deleteGroup(groupPath),
+        action: () => requestDeleteGroup(groupPath),
         destructive: true,
       },
     ];
@@ -1601,6 +1634,21 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
           </div>
         </div>
       )}
+      <VaultDeleteConfirmDialog
+        open={Boolean(deleteTarget)}
+        title={t("vault.deleteConfirm.title", {
+          name: deleteTarget?.name ?? "",
+        })}
+        description={
+          deleteTarget?.type === "group"
+            ? t("vault.deleteConfirm.noteGroupDesc")
+            : t("vault.deleteConfirm.desc")
+        }
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={confirmDeleteTarget}
+      />
     </div>
   );
 };

--- a/components/vault/VaultDeleteConfirmDialog.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.tsx
@@ -1,0 +1,91 @@
+import { AlertTriangle } from "lucide-react";
+import React from "react";
+import { useI18n } from "../../application/i18n/I18nProvider";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+
+interface VaultDeleteConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  disabled?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+const VaultDeleteConfirmDialogContent: React.FC<Omit<
+  VaultDeleteConfirmDialogProps,
+  "open" | "onOpenChange"
+> & { onCancel: () => void }> = ({
+  title,
+  description,
+  confirmLabel,
+  disabled = false,
+  onCancel,
+  onConfirm,
+}) => {
+  const { t } = useI18n();
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2 text-destructive">
+          <AlertTriangle size={20} />
+          {title}
+        </DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogFooter className="gap-2 sm:gap-0">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          disabled={disabled}
+        >
+          {t("common.cancel")}
+        </Button>
+        <Button
+          variant="destructive"
+          onClick={onConfirm}
+          disabled={disabled}
+        >
+          {confirmLabel ?? t("action.delete")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+export const VaultDeleteConfirmDialog: React.FC<VaultDeleteConfirmDialogProps> = ({
+  open,
+  title,
+  description,
+  confirmLabel,
+  disabled = false,
+  onOpenChange,
+  onConfirm,
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => {
+      if (!disabled) onOpenChange(nextOpen);
+    }}>
+      <DialogContent className="sm:max-w-[400px]">
+        <VaultDeleteConfirmDialogContent
+          title={title}
+          description={description}
+          confirmLabel={confirmLabel}
+          disabled={disabled}
+          onCancel={() => onOpenChange(false)}
+          onConfirm={onConfirm}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary
- Add confirmation prompts before deleting keychain items, known hosts, port forwarding rules, snippets, script packages, notes, and note folders
- Reuse one Vault delete confirmation dialog for consistent wording and behavior
- Add matching locale strings

Closes #1971

## Verification
- npm run lint
- node --test --import tsx components/KeychainCardLayout.test.tsx components/VaultView.sortPersistence.test.tsx components/notes/NotesManager.test.tsx application/i18n/locales/settingsLocales.test.ts
- npm run build