### PR TITLE
Address Vault delete confirmation review feedback

### DIFF
--- a/components/aside-panel.test.ts
+++ b/components/aside-panel.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { invokeAsideActionMenuItemClick } from "./ui/aside-panel.tsx";
+
+test("AsideActionMenuItem closes its menu before running the action", () => {
+  const events: string[] = [];
+
+  invokeAsideActionMenuItemClick(
+    () => events.push("close"),
+    () => events.push("action"),
+  );
+
+  assert.deepEqual(events, ["close", "action"]);
+});
+
+test("AsideActionMenuItem still closes when no action is provided", () => {
+  const events: string[] = [];
+
+  invokeAsideActionMenuItemClick(() => events.push("close"));
+
+  assert.deepEqual(events, ["close"]);
+});

--- a/components/notes/NotesManager.tsx
+++ b/components/notes/NotesManager.tsx
@@ -127,7 +127,7 @@ export interface NotesManagerProps {
 }
 
 type HoverActionMenuProps = {
-  children: React.ReactNode;
+  children: React.ReactNode | ((closeMenu: () => void) => React.ReactNode);
   className?: string;
 };
 
@@ -148,6 +148,11 @@ const HoverActionMenu: React.FC<HoverActionMenuProps> = ({ children, className }
   };
 
   useEffect(() => () => cancelClose(), []);
+
+  const closeMenu = () => {
+    cancelClose();
+    setOpen(false);
+  };
 
   return (
     <Dropdown open={open} onOpenChange={setOpen}>
@@ -180,7 +185,7 @@ const HoverActionMenu: React.FC<HoverActionMenuProps> = ({ children, className }
         onMouseEnter={cancelClose}
         onMouseLeave={scheduleClose}
       >
-        {children}
+        {typeof children === "function" ? children(closeMenu) : children}
       </DropdownContent>
     </Dropdown>
   );
@@ -937,7 +942,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     resetTreeDragState();
   };
 
-  const renderNoteActions = (note: VaultNote, mode: "dropdown" | "context") => {
+  const renderNoteActions = (note: VaultNote, mode: "dropdown" | "context", closeMenu?: () => void) => {
     const actions = [
       {
         label: t("common.rename"),
@@ -979,6 +984,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         className={cn(menuItemClass, action.destructive && "text-destructive hover:bg-destructive/10")}
         onClick={(event) => {
           event.stopPropagation();
+          closeMenu?.();
           action.action();
         }}
       >
@@ -987,7 +993,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     ));
   };
 
-  const renderGroupActions = (groupPath: string, mode: "dropdown" | "context") => {
+  const renderGroupActions = (groupPath: string, mode: "dropdown" | "context", closeMenu?: () => void) => {
     const actions = [
       {
         label: t("notes.action.newNote"),
@@ -1040,6 +1046,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
         className={cn(menuItemClass, action.destructive && "text-destructive hover:bg-destructive/10")}
         onClick={(event) => {
           event.stopPropagation();
+          closeMenu?.();
           action.action();
         }}
       >
@@ -1076,7 +1083,7 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
     return (
       <ContextMenu key={note.id}>
         <ContextMenuTrigger asChild>
-          <VaultTreeItemRow
+            <VaultTreeItemRow
             label={noteDisplayTitle(note.title)}
             depth={depth}
             selected={selectedNoteId === note.id}
@@ -1127,11 +1134,11 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
               setSelectedGroup(nextSelection.selectedGroup);
               setOverlayNoteId(nextSelection.overlayNoteId);
             }}
-            actions={(
-              <HoverActionMenu>
-                {renderNoteActions(note, "dropdown")}
-              </HoverActionMenu>
-            )}
+              actions={(
+                <HoverActionMenu>
+                  {(closeMenu) => renderNoteActions(note, "dropdown", closeMenu)}
+                </HoverActionMenu>
+              )}
           />
         </ContextMenuTrigger>
         <ContextMenuContent data-notes-context-menu="note">
@@ -1229,11 +1236,11 @@ export const NotesManager: React.FC<NotesManagerProps> = ({
                 setOverlayNoteId(nextSelection.overlayNoteId);
                 if (hasChildren) toggleGroup(node.path);
               }}
-              actions={(
-                <HoverActionMenu>
-                  {renderGroupActions(node.path, "dropdown")}
-                </HoverActionMenu>
-              )}
+                actions={(
+                  <HoverActionMenu>
+                    {(closeMenu) => renderGroupActions(node.path, "dropdown", closeMenu)}
+                  </HoverActionMenu>
+                )}
             />
           </ContextMenuTrigger>
           <ContextMenuContent data-notes-context-menu="group">

--- a/components/ui/aside-panel.tsx
+++ b/components/ui/aside-panel.tsx
@@ -62,6 +62,7 @@ interface AsidePanelContextType {
 }
 
 const AsidePanelContext = createContext<AsidePanelContextType | null>(null);
+const AsideActionMenuContext = createContext<(() => void) | null>(null);
 
 export const useAsidePanel = () => {
     const context = useContext(AsidePanelContext);
@@ -172,18 +173,31 @@ interface AsideActionMenuProps {
 }
 
 export const AsideActionMenu: React.FC<AsideActionMenuProps> = ({ children }) => {
+    const [open, setOpen] = useState(false);
+    const close = useCallback(() => setOpen(false), []);
+
     return (
-        <Popover>
+        <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
                 <button className="p-1.5 hover:bg-muted rounded-md transition-colors cursor-pointer">
                     <MoreVertical size={18} />
                 </button>
             </PopoverTrigger>
             <PopoverContent className="w-40 p-1" align="end">
-                {children}
+                <AsideActionMenuContext.Provider value={close}>
+                    {children}
+                </AsideActionMenuContext.Provider>
             </PopoverContent>
         </Popover>
     );
+};
+
+export const invokeAsideActionMenuItemClick = (
+    closeMenu: (() => void) | null,
+    onClick?: () => void,
+) => {
+    closeMenu?.();
+    onClick?.();
 };
 
 // Action Menu Item
@@ -193,9 +207,11 @@ export const AsideActionMenuItem: React.FC<{
     onClick?: () => void;
     variant?: 'default' | 'destructive';
 }> = ({ icon, children, onClick, variant = 'default' }) => {
+    const closeMenu = useContext(AsideActionMenuContext);
+
     return (
         <button
-            onClick={onClick}
+            onClick={() => invokeAsideActionMenuItemClick(closeMenu, onClick)}
             className={cn(
                 "w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md transition-colors cursor-pointer",
                 variant === 'destructive'

--- a/components/vault/VaultDeleteConfirmDialog.test.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.test.tsx
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+
+import { VaultDeleteConfirmDialogContent } from "./VaultDeleteConfirmDialog.tsx";
+
+const getElementChildren = (element: React.ReactElement): React.ReactNode =>
+  (element.props as { children?: React.ReactNode }).children;
+
+const findElement = (
+  node: React.ReactNode,
+  predicate: (element: React.ReactElement) => boolean,
+): React.ReactElement | null => {
+  if (
+    node === null ||
+    node === undefined ||
+    typeof node === "boolean" ||
+    typeof node === "string" ||
+    typeof node === "number" ||
+    typeof node === "bigint"
+  ) {
+    return null;
+  }
+
+  if (React.isValidElement(node)) {
+    if (predicate(node)) return node;
+    return findElement(getElementChildren(node), predicate);
+  }
+
+  const children = React.Children.toArray(node);
+  for (const child of children) {
+    const found = findElement(child, predicate);
+    if (found) return found;
+  }
+
+  return null;
+};
+
+const findButtonByLabel = (
+  root: React.ReactElement,
+  label: string,
+): React.ReactElement<{ onClick?: () => void; disabled?: boolean }> => {
+  const button = findElement(
+    root,
+    (element) => getElementChildren(element) === label,
+  );
+
+  assert.ok(button, `Expected to find button labeled ${label}`);
+  return button as React.ReactElement<{ onClick?: () => void; disabled?: boolean }>;
+};
+
+test("VaultDeleteConfirmDialogContent cancels without confirming", () => {
+  const events: string[] = [];
+  const root = VaultDeleteConfirmDialogContent({
+    title: 'Delete "Office Key"?',
+    description: "This action cannot be undone.",
+    cancelLabel: "Cancel",
+    confirmLabel: "Delete",
+    onCancel: () => events.push("cancel"),
+    onConfirm: () => events.push("confirm"),
+  }) as React.ReactElement;
+
+  findButtonByLabel(root, "Cancel").props.onClick?.();
+
+  assert.deepEqual(events, ["cancel"]);
+});
+
+test("VaultDeleteConfirmDialogContent confirms only from the destructive button", () => {
+  const events: string[] = [];
+  const root = VaultDeleteConfirmDialogContent({
+    title: 'Delete "Office Key"?',
+    description: "This action cannot be undone.",
+    cancelLabel: "Cancel",
+    confirmLabel: "Delete",
+    onCancel: () => events.push("cancel"),
+    onConfirm: () => events.push("confirm"),
+  }) as React.ReactElement;
+
+  findButtonByLabel(root, "Delete").props.onClick?.();
+
+  assert.deepEqual(events, ["confirm"]);
+});
+
+test("VaultDeleteConfirmDialogContent disables both actions while busy", () => {
+  const root = VaultDeleteConfirmDialogContent({
+    title: 'Delete "Forward 8080"?',
+    description: "This action cannot be undone.",
+    descriptionId: "delete-confirm-description",
+    cancelLabel: "Cancel",
+    confirmLabel: "Stop & Delete",
+    disabled: true,
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+  }) as React.ReactElement;
+
+  assert.equal(findButtonByLabel(root, "Cancel").props.disabled, true);
+  assert.equal(findButtonByLabel(root, "Stop & Delete").props.disabled, true);
+  assert.ok(findElement(
+    root,
+    (element) => (element.props as { id?: string }).id === "delete-confirm-description",
+  ));
+});

--- a/components/vault/VaultDeleteConfirmDialog.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.tsx
@@ -21,19 +21,27 @@ interface VaultDeleteConfirmDialogProps {
   onConfirm: () => void;
 }
 
-const VaultDeleteConfirmDialogContent: React.FC<Omit<
-  VaultDeleteConfirmDialogProps,
-  "open" | "onOpenChange"
-> & { onCancel: () => void }> = ({
+interface VaultDeleteConfirmDialogContentProps {
+  title: string;
+  description: string;
+  descriptionId?: string;
+  cancelLabel: string;
+  confirmLabel: string;
+  disabled?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const VaultDeleteConfirmDialogContent: React.FC<VaultDeleteConfirmDialogContentProps> = ({
   title,
   description,
+  descriptionId,
+  cancelLabel,
   confirmLabel,
   disabled = false,
   onCancel,
   onConfirm,
 }) => {
-  const { t } = useI18n();
-
   return (
     <>
       <DialogHeader>
@@ -41,7 +49,7 @@ const VaultDeleteConfirmDialogContent: React.FC<Omit<
           <AlertTriangle size={20} />
           {title}
         </DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
+        <DialogDescription id={descriptionId}>{description}</DialogDescription>
       </DialogHeader>
       <DialogFooter className="gap-2 sm:gap-0">
         <Button
@@ -49,14 +57,14 @@ const VaultDeleteConfirmDialogContent: React.FC<Omit<
           onClick={onCancel}
           disabled={disabled}
         >
-          {t("common.cancel")}
+          {cancelLabel}
         </Button>
         <Button
           variant="destructive"
           onClick={onConfirm}
           disabled={disabled}
         >
-          {confirmLabel ?? t("action.delete")}
+          {confirmLabel}
         </Button>
       </DialogFooter>
     </>
@@ -72,15 +80,20 @@ export const VaultDeleteConfirmDialog: React.FC<VaultDeleteConfirmDialogProps> =
   onOpenChange,
   onConfirm,
 }) => {
+  const { t } = useI18n();
+  const descriptionId = React.useId();
+
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => {
       if (!disabled) onOpenChange(nextOpen);
     }}>
-      <DialogContent className="sm:max-w-[400px]">
+      <DialogContent className="sm:max-w-[400px]" aria-describedby={descriptionId}>
         <VaultDeleteConfirmDialogContent
           title={title}
           description={description}
-          confirmLabel={confirmLabel}
+          descriptionId={descriptionId}
+          cancelLabel={t("common.cancel")}
+          confirmLabel={confirmLabel ?? t("action.delete")}
           disabled={disabled}
           onCancel={() => onOpenChange(false)}
           onConfirm={onConfirm}


### PR DESCRIPTION
## Summary
- Close panel and notes action menus before opening delete confirmation dialogs
- Add regression tests for menu action ordering and delete confirmation cancel/confirm behavior
- Connect delete confirmation descriptions for assistive technology

Follow-up to #1974.

## Verification
- npm run lint
- node --test --import tsx components/aside-panel.test.ts components/vault/VaultDeleteConfirmDialog.test.tsx components/KeychainCardLayout.test.tsx components/VaultView.sortPersistence.test.tsx components/notes/NotesManager.test.tsx application/i18n/locales/settingsLocales.test.ts
- npm run build