### PR TITLE
Prevent JMS tokens from sudo autofill

### DIFF
--- a/domain/jmsDeepLink.test.ts
+++ b/domain/jmsDeepLink.test.ts
@@ -5,6 +5,7 @@ import {
   isSupportedJmsProtocol,
   parseJmsDeepLink,
 } from "./jmsDeepLink";
+import { resolveHostAutofillPassword } from "./sshAuth";
 
 const encodePayload = (payload: Record<string, unknown>): string =>
   `jms://${Buffer.from(JSON.stringify(payload), "utf8").toString("base64")}`;
@@ -138,6 +139,8 @@ test("buildJmsDeepLinkEphemeralHost builds password ssh host with mosh and et di
   assert.equal(host.username, "JMS-token-id");
   assert.equal(host.password, "token-secret");
   assert.equal(host.authMethod, "password");
+  assert.equal(host.savePassword, false);
+  assert.equal(resolveHostAutofillPassword({ host, keys: [] }), undefined);
   assert.equal(host.protocol, "ssh");
   assert.equal(host.moshEnabled, false);
   assert.equal(host.ephemeral, true);

--- a/domain/jmsDeepLink.ts
+++ b/domain/jmsDeepLink.ts
@@ -111,6 +111,7 @@ export const buildJmsDeepLinkEphemeralHost = (
     port: target.port,
     password: target.password,
     authMethod: "password",
+    savePassword: false,
     ephemeral: true,
     protocol: "ssh",
     // JumpServer sftp payloads target file transfer: connect the gateway


### PR DESCRIPTION
## Summary
- mark JumpServer jms:// ephemeral passwords as non-reusable
- add coverage that JMS tokens are not used for sudo autofill

## Tests
- node --test --import tsx domain/jmsDeepLink.test.ts domain/sshDeepLink.test.ts domain/sshAuth.test.ts
- npm run lint