### PR TITLE
Update Nix release metadata for v1.1.59

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.58";
+  version = "1.1.59";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-OQq0B+83Kz+Kx3X+iP5ScnAREN27ehkWCqJ8UqMh4Qs=";
+      hash = "sha256-kWU33p9b6R2m293uzZUOa+yV1ZKrG/uFu+9SbEqUIx0=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-x+ToqwYr/nzX8GmBLU5icrUsTFxSt14wdw5eYfp2iEo=";
+      hash = "sha256-GhwyNJVidpzXmDpUEYV3oanESy9PvPAmO3RGzLnyqrM=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update Nix release metadata for v1.1.59 AppImage assets

## Tests
- node --test scripts/update-nix-release.test.cjs