### PR TITLE
[codex] Fix delete dialog overflow

### DIFF
--- a/components/confirmDialogRegression.test.ts
+++ b/components/confirmDialogRegression.test.ts
@@ -33,3 +33,19 @@ test("host and AI provider deletion use in-app confirmation dialogs", () => {
   assert.match(aiSettingsSource, /<ConfirmDialog[\s\S]*confirm\.removeProvider/);
   assert.doesNotMatch(functionBody(aiSettingsSource, "handleRemoveProvider"), /window\.confirm|globalThis\.confirm|\bconfirm\(/);
 });
+
+test("delete confirmation dialogs constrain long names", () => {
+  const confirmDialogSource = readProjectFile("components/ui/confirm-dialog.tsx");
+  const vaultDeleteDialogSource = readProjectFile("components/vault/VaultDeleteConfirmDialog.tsx");
+  const sftpDialogSource = readProjectFile("components/sftp/SftpPaneDialogs.tsx");
+
+  assert.match(confirmDialogSource, /DialogTitle className="truncate"/);
+  assert.match(confirmDialogSource, /overflow-hidden sm:max-w-\[380px\]/);
+
+  assert.match(vaultDeleteDialogSource, /<span className="min-w-0 truncate">\{title\}<\/span>/);
+  assert.match(vaultDeleteDialogSource, /overflow-hidden sm:max-w-\[400px\]/);
+
+  assert.match(sftpDialogSource, /<DialogTitle className="truncate">/);
+  assert.match(sftpDialogSource, /<span className="min-w-0 truncate">\{name\}<\/span>/);
+  assert.match(sftpDialogSource, /overflow-hidden sm:max-w-sm/);
+});

--- a/components/confirmDialogRegression.test.ts
+++ b/components/confirmDialogRegression.test.ts
@@ -38,6 +38,8 @@ test("delete confirmation dialogs constrain long names", () => {
   const confirmDialogSource = readProjectFile("components/ui/confirm-dialog.tsx");
   const vaultDeleteDialogSource = readProjectFile("components/vault/VaultDeleteConfirmDialog.tsx");
   const sftpDialogSource = readProjectFile("components/sftp/SftpPaneDialogs.tsx");
+  const hostTreeGroupDeleteSource = readProjectFile("components/host/HostTreeGroupDeleteDialog.tsx");
+  const vaultViewLayoutSource = readProjectFile("components/vault/VaultViewLayout.tsx");
 
   assert.match(confirmDialogSource, /DialogTitle className="truncate"/);
   assert.match(confirmDialogSource, /overflow-hidden sm:max-w-\[380px\]/);
@@ -48,4 +50,10 @@ test("delete confirmation dialogs constrain long names", () => {
   assert.match(sftpDialogSource, /<DialogTitle className="truncate">/);
   assert.match(sftpDialogSource, /<span className="min-w-0 truncate">\{name\}<\/span>/);
   assert.match(sftpDialogSource, /overflow-hidden sm:max-w-sm/);
+
+  assert.match(hostTreeGroupDeleteSource, /overflow-hidden sm:max-w-lg/);
+  assert.match(hostTreeGroupDeleteSource, /break-words text-sm text-muted-foreground \[overflow-wrap:anywhere\]/);
+
+  assert.match(vaultViewLayoutSource, /overflow-hidden sm:max-w-lg/);
+  assert.match(vaultViewLayoutSource, /break-words text-sm text-muted-foreground \[overflow-wrap:anywhere\]/);
 });

--- a/components/host/HostTreeGroupDeleteDialog.tsx
+++ b/components/host/HostTreeGroupDeleteDialog.tsx
@@ -43,19 +43,19 @@ export const HostTreeGroupDeleteDialog: React.FC<HostTreeGroupDeleteDialogProps>
         if (!open) hostTreeInlineGroupDeleteStore.close();
       }}
     >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t('vault.groups.deleteDialogTitle')}</DialogTitle>
-          <DialogDescription>
+      <DialogContent className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-lg">
+        <DialogHeader className="min-w-0 pr-6">
+          <DialogTitle className="truncate">{t('vault.groups.deleteDialogTitle')}</DialogTitle>
+          <DialogDescription className="break-words [overflow-wrap:anywhere]">
             {isManaged
               ? t('vault.groups.deleteDialog.managedDesc')
               : t('vault.groups.deleteDialog.desc')}
           </DialogDescription>
         </DialogHeader>
-        <div className="py-4 space-y-4">
+        <div className="min-w-0 space-y-4 py-4">
           {targetPath && (
             <>
-              <p className="text-sm text-muted-foreground">
+              <p className="min-w-0 break-words text-sm text-muted-foreground [overflow-wrap:anywhere]">
                 {t('vault.groups.pathLabel')}:{' '}
                 <span className="font-mono">{targetPath}</span>
               </p>

--- a/components/sftp/SftpPaneDialogs.tsx
+++ b/components/sftp/SftpPaneDialogs.tsx
@@ -302,46 +302,46 @@ export const SftpPaneDialogs: React.FC<SftpPaneDialogsProps> = ({
 
     <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
       <DialogContent
-        className="max-w-sm"
+        className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-sm"
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           deleteConfirmButtonRef.current?.focus();
         }}
       >
-        <DialogHeader>
-          <DialogTitle>
+        <DialogHeader className="min-w-0 pr-6">
+          <DialogTitle className="truncate">
             {t("sftp.deleteConfirm.title", { count: deleteTargets.length })}
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className="break-words [overflow-wrap:anywhere]">
             {t(showDeleteList ? "sftp.deleteConfirm.desc" : "sftp.deleteConfirm.descSingle")}
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-3">
+        <div className="min-w-0 space-y-3">
           {hostLabel || deletePath ? (
-            <div className="text-xs text-muted-foreground space-y-1.5">
+            <div className="min-w-0 space-y-1.5 text-xs text-muted-foreground">
               {hostLabel ? (
-                <div className="flex items-start gap-2">
+                <div className="flex min-w-0 items-start gap-2">
                   <span className="font-medium text-foreground/80 shrink-0">{t("sftp.deleteConfirm.host")}:</span>
-                  <span className="break-all">{hostLabel}</span>
+                  <span className="min-w-0 break-words [overflow-wrap:anywhere]">{hostLabel}</span>
                 </div>
               ) : null}
               {deletePath ? (
-                <div className="flex items-start gap-2">
+                <div className="flex min-w-0 items-start gap-2">
                   <span className="font-medium text-foreground/80 shrink-0">{t("sftp.deleteConfirm.path")}:</span>
-                  <span className="break-all">{deletePath}</span>
+                  <span className="min-w-0 break-words [overflow-wrap:anywhere]">{deletePath}</span>
                 </div>
               ) : null}
             </div>
           ) : null}
           {showDeleteList ? (
-            <div className="max-h-32 overflow-auto text-sm space-y-1">
+            <div className="max-h-32 min-w-0 space-y-1 overflow-auto text-sm">
               {deleteListItems.map((name) => (
                 <div
                   key={name}
-                  className="flex items-center gap-2 text-muted-foreground"
+                  className="flex min-w-0 items-center gap-2 text-muted-foreground"
                 >
-                  <Trash2 size={12} />
-                  <span className="truncate">{name}</span>
+                  <Trash2 size={12} className="shrink-0" />
+                  <span className="min-w-0 truncate">{name}</span>
                 </div>
               ))}
             </div>

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -35,13 +35,13 @@ export const ConfirmDialog = memo(function ConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[380px]">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+      <DialogContent className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-[380px]">
+        <DialogHeader className="min-w-0 pr-6">
+          <DialogTitle className="truncate">{title}</DialogTitle>
         </DialogHeader>
 
         {message ? (
-          <p className="text-sm text-muted-foreground whitespace-pre-wrap">{message}</p>
+          <p className="min-w-0 whitespace-pre-wrap break-words text-sm text-muted-foreground [overflow-wrap:anywhere]">{message}</p>
         ) : null}
 
         <DialogFooter>

--- a/components/vault/VaultDeleteConfirmDialog.tsx
+++ b/components/vault/VaultDeleteConfirmDialog.tsx
@@ -44,12 +44,17 @@ export const VaultDeleteConfirmDialogContent: React.FC<VaultDeleteConfirmDialogC
 }) => {
   return (
     <>
-      <DialogHeader>
-        <DialogTitle className="flex items-center gap-2 text-destructive">
-          <AlertTriangle size={20} />
-          {title}
+      <DialogHeader className="min-w-0 pr-6">
+        <DialogTitle className="flex min-w-0 items-center gap-2 text-destructive">
+          <AlertTriangle size={20} className="shrink-0" />
+          <span className="min-w-0 truncate">{title}</span>
         </DialogTitle>
-        <DialogDescription id={descriptionId}>{description}</DialogDescription>
+        <DialogDescription
+          id={descriptionId}
+          className="break-words [overflow-wrap:anywhere]"
+        >
+          {description}
+        </DialogDescription>
       </DialogHeader>
       <DialogFooter className="gap-2 sm:gap-0">
         <Button
@@ -87,7 +92,10 @@ export const VaultDeleteConfirmDialog: React.FC<VaultDeleteConfirmDialogProps> =
     <Dialog open={open} onOpenChange={(nextOpen) => {
       if (!disabled) onOpenChange(nextOpen);
     }}>
-      <DialogContent className="sm:max-w-[400px]" aria-describedby={descriptionId}>
+      <DialogContent
+        className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-[400px]"
+        aria-describedby={descriptionId}
+      >
         <VaultDeleteConfirmDialogContent
           title={title}
           description={description}

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -954,19 +954,19 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
           }
         }}
       >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t("vault.groups.deleteDialogTitle")}</DialogTitle>
-            <DialogDescription>
+        <DialogContent className="max-w-[calc(100vw-2rem)] overflow-hidden sm:max-w-lg">
+          <DialogHeader className="min-w-0 pr-6">
+            <DialogTitle className="truncate">{t("vault.groups.deleteDialogTitle")}</DialogTitle>
+            <DialogDescription className="break-words [overflow-wrap:anywhere]">
               {deleteTargetPath && managedGroupPaths.has(deleteTargetPath)
                 ? t("vault.groups.deleteDialog.managedDesc")
                 : t("vault.groups.deleteDialog.desc")}
             </DialogDescription>
           </DialogHeader>
-          <div className="py-4 space-y-4">
+          <div className="min-w-0 space-y-4 py-4">
             {deleteTargetPath && (
               <>
-                <p className="text-sm text-muted-foreground">
+                <p className="min-w-0 break-words text-sm text-muted-foreground [overflow-wrap:anywhere]">
                   {t("vault.groups.pathLabel")}:{" "}
                   <span className="font-mono">{deleteTargetPath}</span>
                 </p>


### PR DESCRIPTION
## Summary
- Prevent long delete-confirmation titles from stretching the dialog
- Keep long descriptions, hosts, paths, and SFTP delete items inside the dialog bounds
- Add a regression check for delete confirmation overflow handling

Closes #1981

## Validation
- node --test --import tsx components/confirmDialogRegression.test.ts components/vault/VaultDeleteConfirmDialog.test.tsx
- npm run lint
- npm run build
