### PR TITLE
[codex] Reuse main window for deep links

### DIFF
--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -685,6 +685,11 @@ function resolveRendererReady(wcId) {
   }
 }
 
+function clearRendererReadyForWebContents(wcId) {
+  if (!wcId) return;
+  rendererReadySeenByWebContentsId.delete(wcId);
+}
+
 function isWindowUsable(win, options = {}) {
   const requireVisible = options.requireVisible === true;
   if (!win || typeof win.isDestroyed !== "function" || win.isDestroyed()) {
@@ -881,6 +886,7 @@ const mainWindowApi = createMainWindowApi({
   queueWindowStateSave,
   saveWindowStateSync,
   setupDeferredShow,
+  clearRendererReadyForWebContents,
   createExternalOnlyWindowOpenHandler,
   createAppWindowOpenHandler,
   attachOAuthLoadingOverlay,

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -150,7 +150,7 @@ function createMainWindowApi(ctx) {
       const isAllowedTopLevelUrl = (targetUrl) => {
         try {
           const parsedUrl = new URL(String(targetUrl));
-          if (parsedUrl.protocol === "app:" && parsedUrl.hostname === "netcatty") return true;
+          if (parsedUrl.protocol === "app:" && parsedUrl.host === "netcatty") return true;
           return allowedOrigins.has(parsedUrl.origin);
         } catch {
           return false;

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -137,17 +137,6 @@ function createMainWindowApi(ctx) {
         console.error("[WindowManager] Renderer process gone:", details);
       });
 
-      win.webContents.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
-        if (isMainFrame === false || isInPlace === true) return;
-        try {
-          if (typeof clearRendererReadyForWebContents === "function") {
-            clearRendererReadyForWebContents(win.webContents?.id);
-          }
-        } catch {
-          // ignore
-        }
-      });
-    
       // Prevent top-level navigation away from the app origin. If a remote origin ever
       // loads in a privileged window (with preload), it can become an RCE vector.
       const allowedOrigins = new Set(["app://netcatty"]);
@@ -160,11 +149,23 @@ function createMainWindowApi(ctx) {
       }
       const isAllowedTopLevelUrl = (targetUrl) => {
         try {
-          return allowedOrigins.has(new URL(String(targetUrl)).origin);
+          const parsedUrl = new URL(String(targetUrl));
+          if (parsedUrl.protocol === "app:" && parsedUrl.hostname === "netcatty") return true;
+          return allowedOrigins.has(parsedUrl.origin);
         } catch {
           return false;
         }
       };
+      win.webContents.on("did-start-navigation", (_event, targetUrl, isInPlace, isMainFrame) => {
+        if (isMainFrame === false || isInPlace === true || !isAllowedTopLevelUrl(targetUrl)) return;
+        try {
+          if (typeof clearRendererReadyForWebContents === "function") {
+            clearRendererReadyForWebContents(win.webContents?.id);
+          }
+        } catch {
+          // ignore
+        }
+      });
       const blockUntrustedNavigation = (event, targetUrl) => {
         if (isAllowedTopLevelUrl(targetUrl)) return;
         try {

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -136,6 +136,17 @@ function createMainWindowApi(ctx) {
         } catch {}
         console.error("[WindowManager] Renderer process gone:", details);
       });
+
+      win.webContents.on("did-start-navigation", (_event, _url, _isInPlace, isMainFrame) => {
+        if (isMainFrame === false) return;
+        try {
+          if (typeof clearRendererReadyForWebContents === "function") {
+            clearRendererReadyForWebContents(win.webContents?.id);
+          }
+        } catch {
+          // ignore
+        }
+      });
     
       // Prevent top-level navigation away from the app origin. If a remote origin ever
       // loads in a privileged window (with preload), it can become an RCE vector.

--- a/electron/bridges/windowManager/mainWindow.cjs
+++ b/electron/bridges/windowManager/mainWindow.cjs
@@ -137,8 +137,8 @@ function createMainWindowApi(ctx) {
         console.error("[WindowManager] Renderer process gone:", details);
       });
 
-      win.webContents.on("did-start-navigation", (_event, _url, _isInPlace, isMainFrame) => {
-        if (isMainFrame === false) return;
+      win.webContents.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
+        if (isMainFrame === false || isInPlace === true) return;
         try {
           if (typeof clearRendererReadyForWebContents === "function") {
             clearRendererReadyForWebContents(win.webContents?.id);

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -747,12 +747,24 @@ test("main window clears renderer readiness when the main frame starts navigatin
 
   assert.equal(rendererReadyIds.has(7), true);
   assert.equal(typeof webContentsHandlers["did-start-navigation"], "function");
+  assert.equal(typeof webContentsHandlers["will-navigate"], "function");
 
   webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html", false, false);
   assert.equal(rendererReadyIds.has(7), true);
   assert.deepEqual(clearedReadyIds, []);
 
   webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html#/vault", true, true);
+  assert.equal(rendererReadyIds.has(7), true);
+  assert.deepEqual(clearedReadyIds, []);
+
+  let blockedNavigation = false;
+  webContentsHandlers["will-navigate"](
+    { preventDefault() { blockedNavigation = true; } },
+    "https://example.com/",
+  );
+  assert.equal(blockedNavigation, true);
+
+  webContentsHandlers["did-start-navigation"]({}, "https://example.com/", false, true);
   assert.equal(rendererReadyIds.has(7), true);
   assert.deepEqual(clearedReadyIds, []);
 

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -639,6 +639,124 @@ test("main window leaves primary-modifier reload-like shortcuts available to ren
   assert.deepEqual(ignoreMenuShortcutValues, [false]);
 });
 
+test("main window clears renderer readiness when the main frame starts navigating", async () => {
+  const webContentsHandlers = {};
+  const rendererReadyIds = new Set([7]);
+  const clearedReadyIds = [];
+
+  class BrowserWindowStub {
+    constructor() {
+      this.webContents = {
+        id: 7,
+        on(channel, handler) {
+          webContentsHandlers[channel] = handler;
+        },
+        once() {},
+        isDestroyed() {
+          return false;
+        },
+        isCrashed() {
+          return false;
+        },
+        setIgnoreMenuShortcuts() {},
+        setWindowOpenHandler() {},
+        openDevTools() {},
+      };
+    }
+
+    on() {}
+    once() {}
+    isDestroyed() { return false; }
+    isMaximized() { return false; }
+    isFullScreen() { return false; }
+    getBounds() { return { x: 0, y: 0, width: 1400, height: 900 }; }
+    setBackgroundColor() {}
+    setOpacity() {}
+    async loadURL() {}
+    close() {}
+  }
+
+  const api = createMainWindowApi({
+    mainWindow: null,
+    electronApp: null,
+    currentTheme: "light",
+    isQuitting: false,
+    pendingWindowStateWrite: null,
+    queuedWindowState: null,
+    windowStateCloseRequested: false,
+    DEFAULT_WINDOW_WIDTH: 1400,
+    DEFAULT_WINDOW_HEIGHT: 900,
+    MIN_WINDOW_WIDTH: 1100,
+    MIN_WINDOW_HEIGHT: 640,
+    V8_CACHE_OPTIONS: "bypassHeatCheck",
+    THEME_COLORS: { light: { background: "#fff" } },
+    unhealthyWebContentsIds: new Set(),
+    rendererReadySeenByWebContentsId: rendererReadyIds,
+    __dirname,
+    URL,
+    require,
+    console,
+    setTimeout,
+    clearTimeout,
+    getGlobalShortcutBridge() {
+      return { handleWindowClose: () => false };
+    },
+    debugLog() {},
+    resolveFrontendBackgroundColor() { return null; },
+    loadWindowState() { return null; },
+    getDevRendererBaseUrl(url) { return url; },
+    getWindowBoundsState() { return null; },
+    queueWindowStateSave() {},
+    saveWindowStateSync() {},
+    setupDeferredShow() {},
+    clearRendererReadyForWebContents(id) {
+      clearedReadyIds.push(id);
+      rendererReadyIds.delete(id);
+    },
+    createExternalOnlyWindowOpenHandler() { return {}; },
+    createAppWindowOpenHandler() { return {}; },
+    attachOAuthLoadingOverlay() {},
+    registerWindowHandlers() {},
+    requestWindowCommandClose() {
+      return true;
+    },
+    shouldCloseWindowFromInput,
+    applyWindowOpacityToWindow() {},
+    closeSettingsWindow() {},
+    hideSettingsWindow() {},
+  });
+
+  await api.createWindow(
+    {
+      BrowserWindow: BrowserWindowStub,
+      nativeTheme: {},
+      app: {},
+      screen: {},
+      shell: {},
+      ipcMain: {},
+    },
+    {
+      preload: "/tmp/preload.cjs",
+      devServerUrl: "http://localhost:5173",
+      isDev: true,
+      appIcon: null,
+      isMac: false,
+      electronDir: __dirname,
+    },
+  );
+
+  assert.equal(rendererReadyIds.has(7), true);
+  assert.equal(typeof webContentsHandlers["did-start-navigation"], "function");
+
+  webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html", false, false);
+  assert.equal(rendererReadyIds.has(7), true);
+  assert.deepEqual(clearedReadyIds, []);
+
+  webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html", false, true);
+  assert.equal(rendererReadyIds.has(7), false);
+  assert.deepEqual(clearedReadyIds, [7]);
+});
+
 test("createWindow registers each main window as an independent app window", async () => {
   const registered = [];
   const unregistered = [];

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -768,6 +768,17 @@ test("main window clears renderer readiness when the main frame starts navigatin
   assert.equal(rendererReadyIds.has(7), true);
   assert.deepEqual(clearedReadyIds, []);
 
+  let blockedAppPortNavigation = false;
+  webContentsHandlers["will-navigate"](
+    { preventDefault() { blockedAppPortNavigation = true; } },
+    "app://netcatty:123/index.html",
+  );
+  assert.equal(blockedAppPortNavigation, true);
+
+  webContentsHandlers["did-start-navigation"]({}, "app://netcatty:123/index.html", false, true);
+  assert.equal(rendererReadyIds.has(7), true);
+  assert.deepEqual(clearedReadyIds, []);
+
   webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html", false, true);
   assert.equal(rendererReadyIds.has(7), false);
   assert.deepEqual(clearedReadyIds, [7]);

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -752,6 +752,10 @@ test("main window clears renderer readiness when the main frame starts navigatin
   assert.equal(rendererReadyIds.has(7), true);
   assert.deepEqual(clearedReadyIds, []);
 
+  webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html#/vault", true, true);
+  assert.equal(rendererReadyIds.has(7), true);
+  assert.deepEqual(clearedReadyIds, []);
+
   webContentsHandlers["did-start-navigation"]({}, "app://netcatty/index.html", false, true);
   assert.equal(rendererReadyIds.has(7), false);
   assert.deepEqual(clearedReadyIds, [7]);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -83,6 +83,7 @@ const {
   writeJmsDeepLinkEnabledPreference,
   writeSshDeepLinkEnabledPreference,
 } = require("./deepLink.cjs");
+const { getReusableMainWindow } = require("./mainWindowReuse.cjs");
 const {
   OPEN_TERMINAL_PATH_CHANNEL,
   collectOpenTerminalPathArgs,
@@ -345,18 +346,8 @@ function registerAppProtocol() {
 
 function focusMainWindow() {
   try {
-    const mainWin = getWindowManager().getMainWindow?.();
-    const win = mainWin && !mainWin.isDestroyed?.() ? mainWin : null;
+    const win = getReusableMainWindow({ getWindowManager });
     if (!win) return false;
-
-    // Check if the webContents has crashed or been destroyed
-    try {
-      if (win.webContents?.isCrashed?.()) {
-        console.warn('[Main] Main window webContents has crashed, destroying window');
-        win.destroy();
-        return false;
-      }
-    } catch {}
 
     // Cancel any in-flight close-to-tray hide so second-instance / dock-click
     // re-entry beats a pending leave-full-screen → hide sequence.
@@ -513,6 +504,12 @@ let mainWindowStartupPromise = null;
 
 async function createAndShowMainWindow() {
   if (mainWindowStartupPromise) return mainWindowStartupPromise;
+
+  const existingWin = getReusableMainWindow({ getWindowManager });
+  if (existingWin) {
+    focusMainWindow();
+    return existingWin;
+  }
 
   mainWindowStartupPromise = (async () => {
     processErrorController.beginMainWindowStartup();

--- a/electron/mainWindowReuse.cjs
+++ b/electron/mainWindowReuse.cjs
@@ -1,14 +1,26 @@
 function getReusableMainWindow({ getWindowManager, logWarn = console.warn } = {}) {
   if (typeof getWindowManager !== "function") return null;
 
+  let windowManager = null;
   let win = null;
   try {
-    win = getWindowManager()?.getMainWindow?.() || null;
+    windowManager = getWindowManager();
+    win = windowManager?.getMainWindow?.() || null;
   } catch {
     return null;
   }
 
   if (!win || win.isDestroyed?.()) return null;
+
+  if (typeof windowManager?.isWindowUsable === "function") {
+    let usable = false;
+    try {
+      usable = windowManager.isWindowUsable(win);
+    } catch {
+      return null;
+    }
+    if (usable) return win;
+  }
 
   try {
     if (win.webContents?.isCrashed?.()) {
@@ -23,6 +35,8 @@ function getReusableMainWindow({ getWindowManager, logWarn = console.warn } = {}
   } catch {
     // If the crash check itself fails, keep the existing window path best-effort.
   }
+
+  if (typeof windowManager?.isWindowUsable === "function") return null;
 
   return win;
 }

--- a/electron/mainWindowReuse.cjs
+++ b/electron/mainWindowReuse.cjs
@@ -1,0 +1,30 @@
+function getReusableMainWindow({ getWindowManager, logWarn = console.warn } = {}) {
+  if (typeof getWindowManager !== "function") return null;
+
+  let win = null;
+  try {
+    win = getWindowManager()?.getMainWindow?.() || null;
+  } catch {
+    return null;
+  }
+
+  if (!win || win.isDestroyed?.()) return null;
+
+  try {
+    if (win.webContents?.isCrashed?.()) {
+      logWarn?.("[Main] Main window webContents has crashed, destroying window");
+      try {
+        win.destroy?.();
+      } catch {
+        // ignore
+      }
+      return null;
+    }
+  } catch {
+    // If the crash check itself fails, keep the existing window path best-effort.
+  }
+
+  return win;
+}
+
+module.exports = { getReusableMainWindow };

--- a/electron/mainWindowReuse.test.cjs
+++ b/electron/mainWindowReuse.test.cjs
@@ -1,0 +1,99 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { getReusableMainWindow } = require("./mainWindowReuse.cjs");
+
+test("getReusableMainWindow returns the tracked healthy main window", () => {
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      isCrashed() {
+        return false;
+      },
+    },
+  };
+
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => ({
+        getMainWindow: () => win,
+      }),
+    }),
+    win,
+  );
+});
+
+test("getReusableMainWindow ignores destroyed windows", () => {
+  const win = {
+    isDestroyed() {
+      return true;
+    },
+  };
+
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => ({
+        getMainWindow: () => win,
+      }),
+    }),
+    null,
+  );
+});
+
+test("getReusableMainWindow destroys and ignores crashed windows", () => {
+  const calls = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    destroy() {
+      calls.push("destroy");
+    },
+    webContents: {
+      isCrashed() {
+        return true;
+      },
+    },
+  };
+
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => ({
+        getMainWindow: () => win,
+      }),
+      logWarn: (...args) => calls.push(["warn", ...args]),
+    }),
+    null,
+  );
+  assert.equal(calls[0][0], "warn");
+  assert.deepEqual(calls.slice(1), ["destroy"]);
+});
+
+test("getReusableMainWindow returns null when the window manager is unavailable", () => {
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => {
+        throw new Error("not ready");
+      },
+    }),
+    null,
+  );
+  assert.equal(getReusableMainWindow(), null);
+});
+
+test("createAndShowMainWindow reuses a main window before creating another one", () => {
+  const source = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  const functionStart = source.indexOf("async function createAndShowMainWindow()");
+  const reuseIndex = source.indexOf("const existingWin = getReusableMainWindow", functionStart);
+  const createIndex = source.indexOf("mainWindowStartupPromise = (async () =>", functionStart);
+
+  assert.notEqual(functionStart, -1);
+  assert.ok(reuseIndex > functionStart);
+  assert.ok(createIndex > functionStart);
+  assert.ok(reuseIndex < createIndex);
+  assert.match(source.slice(reuseIndex, createIndex), /return existingWin;/);
+});

--- a/electron/mainWindowReuse.test.cjs
+++ b/electron/mainWindowReuse.test.cjs
@@ -27,6 +27,59 @@ test("getReusableMainWindow returns the tracked healthy main window", () => {
   );
 });
 
+test("getReusableMainWindow uses the window manager health check before reusing", () => {
+  const checked = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      isCrashed() {
+        return false;
+      },
+    },
+  };
+
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => ({
+        getMainWindow: () => win,
+        isWindowUsable(candidate) {
+          checked.push(candidate);
+          return true;
+        },
+      }),
+    }),
+    win,
+  );
+  assert.deepEqual(checked, [win]);
+});
+
+test("getReusableMainWindow ignores windows rejected by the window manager health check", () => {
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      isCrashed() {
+        return false;
+      },
+    },
+  };
+
+  assert.equal(
+    getReusableMainWindow({
+      getWindowManager: () => ({
+        getMainWindow: () => win,
+        isWindowUsable() {
+          return false;
+        },
+      }),
+    }),
+    null,
+  );
+});
+
 test("getReusableMainWindow ignores destroyed windows", () => {
   const win = {
     isDestroyed() {


### PR DESCRIPTION
## Summary

Follow-up to #1890: external `ssh://` and `jms://` links now reuse an existing main Netcatty window when one is already open, so each link opens as another terminal tab instead of spawning another main window.

## Why

The deep link delivery path always went through the main-window creation helper. That helper created a new main window even when a healthy main window was already available.

## Changes

- Add a shared helper for finding a reusable main window.
- Use it before creating a main window for deep links and related main-window entry points.
- Preserve the existing fallback for missing or crashed windows.
- Add focused tests for healthy, destroyed, crashed, and unavailable window-manager cases.

## Validation

- `node --test electron/mainWindowReuse.test.cjs electron/deepLink.test.cjs electron/openTerminalPath.test.cjs`
- `npm run lint`
- `npm test`