### PR TITLE
Follow up terminal tail performance fixes

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -155,6 +155,7 @@ import {
   flushTerminalSessionFlowAck,
 } from "./terminal/runtime/terminalFlowAckBuffer";
 import { releaseTerminalFlowBeforeHibernate } from "./terminal/runtime/terminalSessionAttachment";
+import { flushPendingTerminalWritesBeforeHibernate } from "./terminal/runtime/terminalUnfocusedRepaint";
 import {
   isTerminalFileTransferActive,
   resolveHibernateKeepRendererCount,
@@ -186,6 +187,8 @@ import {
   type TerminalProps,
 } from "./terminal/terminalHelpers";
 import { terminalPropsAreEqual } from "./terminal/terminalMemo";
+
+const HIBERNATE_RETRY_AFTER_DRAIN_MS = 250;
 
 const TerminalComponent: React.FC<TerminalProps> = ({
   host,
@@ -358,6 +361,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const hibernateContextScrollbackSnapshotRef = useRef("");
   const hibernatePendingBufferRef = useRef("");
   const hibernateAlternateScreenRef = useRef(false);
+  const hibernateRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fullHibernateRuntimeRef = useRef<(() => Promise<void>) | null>(null);
   const wakeInProgressRef = useRef(false);
   const sessionRef = useRef<string | null>(null);
   const isBootActiveRef = useRef(false);
@@ -389,6 +394,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const terminalSettingsRef = useRef(terminalSettings);
   terminalSettingsRef.current = terminalSettings;
+  const isSearchOpenRef = useRef(isSearchOpen);
+  isSearchOpenRef.current = isSearchOpen;
+  const hibernateFileTransferActiveRef = useRef(false);
   const handleUpdateHostFromTerminal = useCallback((hostUpdate: TerminalHostUpdate) => {
     onUpdateHost?.(hostUpdate as Host);
   }, [onUpdateHost]);
@@ -1245,6 +1253,32 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     });
   }, [onSessionExit, scheduleAutoReconnect, sessionId, terminalBackend]);
 
+  const clearHibernateRetry = useCallback(() => {
+    if (hibernateRetryTimerRef.current === null) return;
+    clearTimeout(hibernateRetryTimerRef.current);
+    hibernateRetryTimerRef.current = null;
+  }, []);
+
+  const scheduleHibernateRetry = useCallback(() => {
+    if (hibernateRetryTimerRef.current !== null) return;
+    hibernateRetryTimerRef.current = setTimeout(() => {
+      hibernateRetryTimerRef.current = null;
+      if (
+        isVisibleRef.current
+        || hibernatedRef.current
+        || softHiddenRef.current
+        || !hasRuntimeRef.current
+        || statusRef.current !== "connected"
+        || isSearchOpenRef.current
+        || hibernateFileTransferActiveRef.current
+        || !resolveTerminalHibernateEnabled(terminalSettingsRef.current)
+      ) {
+        return;
+      }
+      void fullHibernateRuntimeRef.current?.();
+    }, HIBERNATE_RETRY_AFTER_DRAIN_MS);
+  }, []);
+
   const applyHibernateSnapshot = useCallback((
     snapshot: {
       snapshot: string;
@@ -1265,16 +1299,47 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     hibernateAlternateScreenRef.current = snapshot.alternateScreen;
   }, []);
 
+  const shouldSkipHibernateForActiveAlternateScreen = useCallback((term: XTerm): boolean => {
+    if (
+      !isTerminalAlternateScreenActive(term)
+      || !resolveHibernateSkipAltScreen(terminalSettings)
+    ) {
+      return false;
+    }
+    logger.info("[Terminal] Skipping hibernate: alternate screen active", { sessionId });
+    return true;
+  }, [sessionId, terminalSettings]);
+
   const fullHibernateRuntime = useCallback(async () => {
     if (hibernatedRef.current || softHiddenRef.current || !termRef.current || !serializeAddonRef.current) return;
+    clearHibernateRetry();
     const backendId = sessionRef.current;
     if (!backendId) return;
+    const term = termRef.current;
 
     terminalHiddenRendererStore.clearSoftHidden(sessionId);
     softHiddenRef.current = false;
+    const flushedBeforeHibernate = await flushPendingTerminalWritesBeforeHibernate(term);
+    if (!flushedBeforeHibernate) {
+      logger.info("[Terminal] Skipping hibernate: terminal output is still draining", { sessionId });
+      scheduleHibernateRetry();
+      return;
+    }
+    if (
+      isVisibleRef.current
+      || hibernatedRef.current
+      || termRef.current !== term
+      || sessionRef.current !== backendId
+      || !serializeAddonRef.current
+    ) {
+      return;
+    }
+    if (shouldSkipHibernateForActiveAlternateScreen(term)) {
+      return;
+    }
 
     const snapshot = await serializeTerminalForHibernate(
-      termRef.current,
+      term,
       serializeAddonRef.current,
       { preferWasm: resolveHibernatePreferWasmSerialize(terminalSettings) },
     );
@@ -1286,9 +1351,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
     applyHibernateSnapshot(snapshot);
     isBootActiveRef.current = false;
-    if (termRef.current) {
-      releaseTerminalFlowBeforeHibernate(terminalBackend, termRef.current, backendId);
-    }
+    releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId);
     disposeDataRef.current?.();
     disposeDataRef.current = null;
     disposeExitRef.current?.();
@@ -1306,10 +1369,14 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   }, [
     applyHibernateSnapshot,
     beginHibernatedSessionListeners,
+    clearHibernateRetry,
+    scheduleHibernateRetry,
     sessionId,
+    shouldSkipHibernateForActiveAlternateScreen,
     terminalBackend,
     terminalSettings,
   ]);
+  fullHibernateRuntimeRef.current = fullHibernateRuntime;
 
   const hideRuntimeOnly = useCallback(() => {
     if (hibernatedRef.current || softHiddenRef.current || !hasRuntimeRef.current) return;
@@ -1322,11 +1389,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const hibernateRuntime = useCallback(() => {
     if (hibernatedRef.current || softHiddenRef.current || !termRef.current) return;
 
-    if (
-      isTerminalAlternateScreenActive(termRef.current)
-      && resolveHibernateSkipAltScreen(terminalSettings)
-    ) {
-      logger.info("[Terminal] Skipping hibernate: alternate screen active", { sessionId });
+    if (shouldSkipHibernateForActiveAlternateScreen(termRef.current)) {
       return;
     }
 
@@ -1344,7 +1407,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     void fullHibernateRuntime();
-  }, [fullHibernateRuntime, hideRuntimeOnly, sessionId, terminalSettings]);
+  }, [fullHibernateRuntime, hideRuntimeOnly, sessionId, shouldSkipHibernateForActiveAlternateScreen, terminalSettings]);
 
   const terminalRuntimeRefs = useMemo<TerminalRuntimeRefs>(() => ({
     xtermRuntimeRef,
@@ -1362,6 +1425,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     retryTokenRef.current = null;
     restoreCwdIntentRef.current = null;
     suppressHostStartupCommandRef.current = false;
+    clearHibernateRetry();
     clearAutoReconnect();
     cleanupSession();
     disposeRuntimeOnly();
@@ -2621,6 +2685,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     return true;
   };
 
+  const hibernateFileTransferActive = isTerminalFileTransferActive({
+    zmodemActive: zmodem.active,
+    ymodemInProgress,
+    isDraggingOver,
+  });
+  hibernateFileTransferActiveRef.current = hibernateFileTransferActive;
+
   useTerminalHibernateEffect({
     sessionId,
     isVisible,
@@ -2630,11 +2701,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isSearchOpen,
     hibernateEnabled: resolveTerminalHibernateEnabled(terminalSettings),
     hibernateDelayMs: resolveTerminalHibernateDelayMs(terminalSettings),
-    fileTransferActive: isTerminalFileTransferActive({
-      zmodemActive: zmodem.active,
-      ymodemInProgress,
-      isDraggingOver,
-    }),
+    fileTransferActive: hibernateFileTransferActive,
     hibernatedRef,
     softHiddenRef,
     hibernatePendingBufferRef,

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -6,6 +6,7 @@ import {
   formatTerminalLineTimestamp,
   onTerminalLineTimestampsChange,
   resolveTerminalTimestampGutterRows,
+  type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
 
@@ -19,7 +20,26 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
   let wraparoundMode = options.wraparoundMode ?? true;
   const isCombiningMark = (char: string): boolean => {
     const code = char.codePointAt(0);
-    return code !== undefined && code >= 0x300 && code <= 0x36f;
+    return code !== undefined && /\p{Mark}/u.test(String.fromCodePoint(code));
+  };
+  const cellWidth = (char: string): number => {
+    const code = char.codePointAt(0);
+    if (code === undefined) return 1;
+    if (isCombiningMark(char)) return 0;
+    if (
+      (code >= 0x1100 && code <= 0x115f)
+      || (code >= 0x2e80 && code <= 0x303e)
+      || (code >= 0x3041 && code <= 0x33ff)
+      || (code >= 0x3400 && code <= 0x4dbf)
+      || (code >= 0x4e00 && code <= 0x9fff)
+      || (code >= 0xac00 && code <= 0xd7a3)
+      || (code >= 0xf900 && code <= 0xfaff)
+      || (code >= 0xff00 && code <= 0xff60)
+      || (code >= 0x1f300 && code <= 0x1faff)
+    ) {
+      return 2;
+    }
+    return 1;
   };
   const readCsiSequence = (data: string, startIndex: number): { sequence: string; endIndex: number } | null => {
     if (data[startIndex] !== "\x1b" || data[startIndex + 1] !== "[") return null;
@@ -32,10 +52,17 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
     return null;
   };
   const applyCsiSequence = (sequence: string): void => {
+    const final = sequence.at(-1);
+    const firstParam = Number.parseInt(sequence.slice(2, -1).split(";")[0] || "1", 10);
+    const count = Number.isFinite(firstParam) && firstParam > 0 ? firstParam : 1;
     if (sequence === "\x1b[?7h") {
       wraparoundMode = true;
     } else if (sequence === "\x1b[?7l") {
       wraparoundMode = false;
+    } else if (final === "A") {
+      cursorLine = Math.max(0, cursorLine - count);
+    } else if (final === "B") {
+      cursorLine += count;
     }
   };
   const term = {
@@ -76,13 +103,19 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
         } else if (char < " " || char === "\u007f") {
           continue;
         } else {
-          if (wraparoundMode && cursorColumn + 1 > cols) {
+          const code = data.codePointAt(index);
+          const isEmojiVariationSequence = code === 0x2764 && data.codePointAt(index + 1) === 0xfe0f;
+          const width = isEmojiVariationSequence ? 2 : cellWidth(char);
+          if (isEmojiVariationSequence) {
+            index += 1;
+          }
+          if (wraparoundMode && cursorColumn + width > cols) {
             cursorLine += 1;
             cursorColumn = 0;
           }
           cursorColumn = Number.isFinite(cols)
-            ? Math.min(cols, cursorColumn + 1)
-            : cursorColumn + 1;
+            ? Math.min(cols, cursorColumn + width)
+            : cursorColumn + width;
         }
       }
       callback?.();
@@ -276,6 +309,56 @@ test("respects disabled autowrap when batching timestamp markers", () => {
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
 });
 
+test("falls back from batched timestamp markers for cursor-moving escape sequences", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  const steps: string[] = [];
+  const lines = [
+    "line-0",
+    "line-1",
+    "\x1b[Aline-1-again",
+    ...Array.from({ length: 77 }, (_, index) => `line-${index + 3}`),
+  ].join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.notDeepEqual(writes, [lines]);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  assert.deepEqual(markerLines, [
+    0,
+    1,
+    1,
+    ...Array.from({ length: 77 }, (_, index) => index + 2),
+  ]);
+});
+
+test("falls back from batched timestamp markers for combined alternate-screen sequences", () => {
+  const { term, writes, markerLines } = createFakeTerm();
+  const steps: string[] = [];
+  const lines = [
+    "line-0",
+    `\x1b[?7;1049h${"vim".repeat(1400)}`,
+    "\x1b[?1049lline-1",
+  ].join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.notDeepEqual(writes, [lines]);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  assert.deepEqual(markerLines, [0, 2]);
+});
+
 test("accounts for backspace cursor movement when batching timestamp markers", () => {
   const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
   const lines = Array.from({ length: 80 }, () => "abc\b\b\bdef").join("\r\n");
@@ -304,6 +387,69 @@ test("keeps batched timestamp markers aligned for combining characters", () => {
 
   assert.deepEqual(writes, [lines]);
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
+});
+
+test("accounts for wide character soft wraps when batching timestamp markers", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const lines = Array.from({ length: 80 }, () => "界界界").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+
+  assert.deepEqual(writes, [lines]);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
+});
+
+test("accounts for non-Latin combining marks when batching timestamp markers", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, () => "س\u0651س\u0651س\u0651").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.deepEqual(writes, [lines]);
+  assert.equal(steps.includes("batched-write"), true);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
+});
+
+test("falls back from batched timestamp markers for zero-width format characters", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, () => "xx\u200bxx").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
+});
+
+test("falls back from batched timestamp markers for emoji variation sequences", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, () => "❤️❤️❤️").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
 });
 
 test("keeps recording and preserves existing timestamps when the gutter is hidden", () => {
@@ -339,15 +485,30 @@ test("does not withhold output when an OSC sequence is split across chunks", () 
 
 test("keeps timestamps for visible text before a split OSC sequence", () => {
   const { term, writes, markerLines } = createFakeTerm();
+  const steps: TerminalLineTimestampPerfStep[] = [];
+  const tail = "\x1b]7;file://server/home/alice";
 
   writeTerminalDataWithLineTimestamps(
     term as never,
-    "hello \x1b]7;file://server/home/alice",
+    `hello ${tail}`,
     () => {},
+    { onStep: (step) => steps.push(step) },
   );
 
-  assert.equal(writes.join(""), "hello \x1b]7;file://server/home/alice");
+  assert.equal(writes.join(""), `hello ${tail}`);
   assert.deepEqual(markerLines, [0]);
+  assert.equal(
+    steps.some((step) => (
+      step.kind === "segmented-write"
+      && step.writeCalls === 1
+      && step.writeChars === "hello ".length
+    )),
+    true,
+  );
+  assert.equal(
+    steps.some((step) => step.kind === "fallback-write" && step.dataChars === tail.length),
+    true,
+  );
 });
 
 test("keeps fallback timestamps on the matching multiline rows", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -27,7 +27,9 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
     if (code === undefined) return 1;
     if (isCombiningMark(char)) return 0;
     if (
-      (code >= 0x1100 && code <= 0x115f)
+      code === 0x2329
+      || code === 0x232a
+      || (code >= 0x1100 && code <= 0x115f)
       || (code >= 0x2e80 && code <= 0x303e)
       || (code >= 0x3041 && code <= 0x33ff)
       || (code >= 0x3400 && code <= 0x4dbf)
@@ -35,6 +37,7 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
       || (code >= 0xac00 && code <= 0xd7a3)
       || (code >= 0xf900 && code <= 0xfaff)
       || (code >= 0xff00 && code <= 0xff60)
+      || (code >= 0x1f000 && code <= 0x1f02f)
       || (code >= 0x1f300 && code <= 0x1faff)
     ) {
       return 2;
@@ -65,7 +68,18 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
       cursorLine += count;
     }
   };
+  const unicodeService = {
+    wcwidth(codePoint: number) {
+      if (this !== unicodeService) {
+        throw new Error("wcwidth must be called with its unicode service receiver");
+      }
+      return cellWidth(String.fromCodePoint(codePoint));
+    },
+  };
   const term = {
+    _core: {
+      unicodeService,
+    },
     buffer: {
       active: { type: "normal", viewportY: 0 },
     },
@@ -379,13 +393,21 @@ test("accounts for tab stops without soft wrapping timestamp markers", () => {
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
 });
 
-test("keeps batched timestamp markers aligned for combining characters", () => {
+test("falls back from batched timestamp markers for combining characters", () => {
   const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
   const lines = Array.from({ length: 80 }, () => "e\u0301e\u0301e\u0301").join("\r\n");
 
-  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
 
-  assert.deepEqual(writes, [lines]);
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
 });
 
@@ -399,7 +421,24 @@ test("accounts for wide character soft wraps when batching timestamp markers", (
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
 });
 
-test("accounts for non-Latin combining marks when batching timestamp markers", () => {
+test("uses xterm unicode widths for less common wide characters", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, () => "🀄〈🀄").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.deepEqual(writes, [lines]);
+  assert.equal(steps.includes("batched-write"), true);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
+});
+
+test("falls back from batched timestamp markers for non-Latin combining marks", () => {
   const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
   const steps: string[] = [];
   const lines = Array.from({ length: 80 }, () => "س\u0651س\u0651س\u0651").join("\r\n");
@@ -411,9 +450,28 @@ test("accounts for non-Latin combining marks when batching timestamp markers", (
     { onStep: (step) => steps.push(step.kind) },
   );
 
-  assert.deepEqual(writes, [lines]);
-  assert.equal(steps.includes("batched-write"), true);
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
   assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index));
+});
+
+test("falls back from batched timestamp markers for Hangul jamo joins", () => {
+  const { term, writes, markerLines } = createFakeTerm({ cols: 5 });
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, () => "\u1100\u1161\u1100\u1161").join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.equal(writes.join(""), lines);
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  assert.deepEqual(markerLines, Array.from({ length: 80 }, (_, index) => index * 2));
 });
 
 test("falls back from batched timestamp markers for zero-width format characters", () => {

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -35,6 +35,14 @@ type TimestampStore = {
   timestampOnlyPrefix: string;
 };
 
+type XTermWithUnicodeService = XTerm & {
+  _core?: {
+    unicodeService?: {
+      wcwidth?: (codePoint: number) => 0 | 1 | 2;
+    };
+  };
+};
+
 export type TerminalTimestampGutterEntry = {
   marker: { line: number; isDisposed?: boolean };
   label: string;
@@ -451,28 +459,6 @@ const getTerminalWraparoundMode = (term: XTerm): boolean => (
   ((term as XTerm & { modes?: { wraparoundMode?: boolean } }).modes?.wraparoundMode) !== false
 );
 
-const unicodeMarkPattern = /\p{Mark}/u;
-
-const isCombiningCodePoint = (codePoint: number): boolean => (
-  unicodeMarkPattern.test(String.fromCodePoint(codePoint))
-);
-
-const isWideCodePoint = (codePoint: number): boolean => (
-  (codePoint >= 0x1100 && codePoint <= 0x115f)
-  || (codePoint >= 0x2e80 && codePoint <= 0x303e)
-  || (codePoint >= 0x3041 && codePoint <= 0x33ff)
-  || (codePoint >= 0x3400 && codePoint <= 0x4dbf)
-  || (codePoint >= 0x4e00 && codePoint <= 0x9fff)
-  || (codePoint >= 0xa000 && codePoint <= 0xa4cf)
-  || (codePoint >= 0xac00 && codePoint <= 0xd7a3)
-  || (codePoint >= 0xf900 && codePoint <= 0xfaff)
-  || (codePoint >= 0xfe30 && codePoint <= 0xfe4f)
-  || (codePoint >= 0xff00 && codePoint <= 0xff60)
-  || (codePoint >= 0xffe0 && codePoint <= 0xffe6)
-  || (codePoint >= 0x1f300 && codePoint <= 0x1faff)
-  || (codePoint >= 0x20000 && codePoint <= 0x3fffd)
-);
-
 const isUnsafeGraphemeSequenceCodePoint = (codePoint: number): boolean => (
   codePoint === 0x200d
   || codePoint === 0x20e3
@@ -491,12 +477,32 @@ const isUnsafeFormatCodePoint = (codePoint: number): boolean => (
   || (codePoint >= 0xfff9 && codePoint <= 0xfffb)
 );
 
-const getCodePointCellWidth = (codePoint: number): number => {
-  if (isCombiningCodePoint(codePoint)) return 0;
-  return isWideCodePoint(codePoint) ? 2 : 1;
+const unicodeMarkPattern = /\p{Mark}/u;
+
+const isHangulJamoCodePoint = (codePoint: number): boolean => (
+  (codePoint >= 0x1100 && codePoint <= 0x11ff)
+  || (codePoint >= 0xa960 && codePoint <= 0xa97f)
+  || (codePoint >= 0xd7b0 && codePoint <= 0xd7ff)
+);
+
+const isContextSensitiveGraphemeCodePoint = (codePoint: number): boolean => (
+  unicodeMarkPattern.test(String.fromCodePoint(codePoint))
+  || isHangulJamoCodePoint(codePoint)
+);
+
+const getCodePointCellWidth = (term: XTerm, codePoint: number): 0 | 1 | 2 | null => {
+  if (codePoint < 0x80) return 1;
+  const unicodeService = (term as XTermWithUnicodeService)._core?.unicodeService;
+  if (typeof unicodeService?.wcwidth !== "function") return null;
+  try {
+    const width = unicodeService.wcwidth(codePoint);
+    return width === 0 || width === 1 || width === 2 ? width : null;
+  } catch {
+    return null;
+  }
 };
 
-const canMeasureVisualRows = (data: string): boolean => {
+const canMeasureVisualRows = (term: XTerm, data: string): boolean => {
   for (let index = 0; index < data.length; index += 1) {
     const char = data[index];
     const codePoint = data.codePointAt(index);
@@ -518,7 +524,11 @@ const canMeasureVisualRows = (data: string): boolean => {
       || (codePoint >= 0x80 && codePoint <= 0x9f)
       || isUnsafeGraphemeSequenceCodePoint(codePoint)
       || isUnsafeFormatCodePoint(codePoint)
+      || isContextSensitiveGraphemeCodePoint(codePoint)
     ) {
+      return false;
+    }
+    if (getCodePointCellWidth(term, codePoint) === null) {
       return false;
     }
     if (codePoint > 0xffff) {
@@ -571,6 +581,7 @@ const advanceMeasuredTab = (
 };
 
 const measureTerminalRows = (
+  term: XTerm,
   data: string,
   startColumn: number,
   columns: number,
@@ -615,11 +626,15 @@ const measureTerminalRows = (
     if (codePoint === undefined) {
       continue;
     }
+    const width = getCodePointCellWidth(term, codePoint);
+    if (width === null) {
+      continue;
+    }
     ({ column, rowOffset } = advanceMeasuredColumns(
       column,
       rowOffset,
       columns,
-      getCodePointCellWidth(codePoint),
+      width,
       wraparoundMode,
     ));
     if (codePoint > 0xffff) {
@@ -651,8 +666,8 @@ const writeBatchedTimestampSegments = (
       timestamps.push({ label: segment.label, rowOffset });
       continue;
     }
-    const measured = canMeasureVisualRows(segment.data)
-      ? measureTerminalRows(segment.data, column, columns, wraparoundMode)
+    const measured = canMeasureVisualRows(term, segment.data)
+      ? measureTerminalRows(term, segment.data, column, columns, wraparoundMode)
       : { rowOffset: countLineFeeds(segment.data), column, wraparoundMode };
     rowOffset += measured.rowOffset;
     column = measured.column;
@@ -848,7 +863,7 @@ export const writeTerminalDataWithLineTimestamps = (
   if (
     timestampOnlyPrefix.length === 0
     && parsedData === dataForTimestamps
-    && canMeasureVisualRows(data)
+    && canMeasureVisualRows(term, data)
     && (
       dataSegmentCount > MAX_SEGMENTED_TIMESTAMP_WRITES
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -207,6 +207,13 @@ const getWraparoundAction = (sequence: string): boolean | null => {
   return modes.includes(7) ? final === "h" : null;
 };
 
+const isSgrSequence = (sequence: string): boolean =>
+  getCsiFinal(sequence) === "m";
+
+const isBulkMeasurableEscapeSequence = (sequence: string): boolean =>
+  getAlternateScreenAction(sequence) === null
+  && (getWraparoundAction(sequence) !== null || isSgrSequence(sequence));
+
 const isPotentialAlternateScreenSequence = (sequence: string): boolean => {
   if (!sequence.startsWith("\x1b[?")) return false;
 
@@ -444,9 +451,79 @@ const getTerminalWraparoundMode = (term: XTerm): boolean => (
   ((term as XTerm & { modes?: { wraparoundMode?: boolean } }).modes?.wraparoundMode) !== false
 );
 
+const unicodeMarkPattern = /\p{Mark}/u;
+
+const isCombiningCodePoint = (codePoint: number): boolean => (
+  unicodeMarkPattern.test(String.fromCodePoint(codePoint))
+);
+
+const isWideCodePoint = (codePoint: number): boolean => (
+  (codePoint >= 0x1100 && codePoint <= 0x115f)
+  || (codePoint >= 0x2e80 && codePoint <= 0x303e)
+  || (codePoint >= 0x3041 && codePoint <= 0x33ff)
+  || (codePoint >= 0x3400 && codePoint <= 0x4dbf)
+  || (codePoint >= 0x4e00 && codePoint <= 0x9fff)
+  || (codePoint >= 0xa000 && codePoint <= 0xa4cf)
+  || (codePoint >= 0xac00 && codePoint <= 0xd7a3)
+  || (codePoint >= 0xf900 && codePoint <= 0xfaff)
+  || (codePoint >= 0xfe30 && codePoint <= 0xfe4f)
+  || (codePoint >= 0xff00 && codePoint <= 0xff60)
+  || (codePoint >= 0xffe0 && codePoint <= 0xffe6)
+  || (codePoint >= 0x1f300 && codePoint <= 0x1faff)
+  || (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+);
+
+const isUnsafeGraphemeSequenceCodePoint = (codePoint: number): boolean => (
+  codePoint === 0x200d
+  || codePoint === 0x20e3
+  || (codePoint >= 0x1f1e6 && codePoint <= 0x1f1ff)
+  || (codePoint >= 0x1f3fb && codePoint <= 0x1f3ff)
+  || (codePoint >= 0xfe00 && codePoint <= 0xfe0f)
+  || (codePoint >= 0xe0020 && codePoint <= 0xe007f)
+  || (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+);
+
+const isUnsafeFormatCodePoint = (codePoint: number): boolean => (
+  (codePoint >= 0x200b && codePoint <= 0x200f)
+  || (codePoint >= 0x202a && codePoint <= 0x202e)
+  || (codePoint >= 0x2060 && codePoint <= 0x206f)
+  || codePoint === 0xfeff
+  || (codePoint >= 0xfff9 && codePoint <= 0xfffb)
+);
+
+const getCodePointCellWidth = (codePoint: number): number => {
+  if (isCombiningCodePoint(codePoint)) return 0;
+  return isWideCodePoint(codePoint) ? 2 : 1;
+};
+
 const canMeasureVisualRows = (data: string): boolean => {
   for (let index = 0; index < data.length; index += 1) {
-    if (data.charCodeAt(index) > 0x7f) return false;
+    const char = data[index];
+    const codePoint = data.codePointAt(index);
+    if (codePoint === undefined) return false;
+    if (char === "\x1b") {
+      const sequence = readEscapeSequence(data, index);
+      if (!sequence?.complete || !isBulkMeasurableEscapeSequence(sequence.sequence)) {
+        return false;
+      }
+      index = sequence.endIndex;
+      continue;
+    }
+    if (char === "\n" || char === "\r" || char === "\b" || char === "\t") {
+      continue;
+    }
+    if (
+      codePoint < 0x20
+      || codePoint === 0x7f
+      || (codePoint >= 0x80 && codePoint <= 0x9f)
+      || isUnsafeGraphemeSequenceCodePoint(codePoint)
+      || isUnsafeFormatCodePoint(codePoint)
+    ) {
+      return false;
+    }
+    if (codePoint > 0xffff) {
+      index += 1;
+    }
   }
   return true;
 };
@@ -534,7 +611,20 @@ const measureTerminalRows = (
     if (char < " " || char === "\u007f") {
       continue;
     }
-    ({ column, rowOffset } = advanceMeasuredColumns(column, rowOffset, columns, 1, wraparoundMode));
+    const codePoint = data.codePointAt(index);
+    if (codePoint === undefined) {
+      continue;
+    }
+    ({ column, rowOffset } = advanceMeasuredColumns(
+      column,
+      rowOffset,
+      columns,
+      getCodePointCellWidth(codePoint),
+      wraparoundMode,
+    ));
+    if (codePoint > 0xffff) {
+      index += 1;
+    }
   }
 
   return { rowOffset, column, wraparoundMode };
@@ -561,7 +651,7 @@ const writeBatchedTimestampSegments = (
       timestamps.push({ label: segment.label, rowOffset });
       continue;
     }
-    const measured = Number.isFinite(columns) && canMeasureVisualRows(segment.data)
+    const measured = canMeasureVisualRows(segment.data)
       ? measureTerminalRows(segment.data, column, columns, wraparoundMode)
       : { rowOffset: countLineFeeds(segment.data), column, wraparoundMode };
     rowOffset += measured.rowOffset;
@@ -742,12 +832,26 @@ export const writeTerminalDataWithLineTimestamps = (
       parsedChars: parsedData.length,
     });
   }
+  const writeFallbackData = (fallbackData: string, onComplete: () => void): void => {
+    const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
+    term.write(fallbackData, () => {
+      if (diagnostics) {
+        diagnostics.onStep?.({
+          kind: "fallback-write",
+          dataChars: fallbackData.length,
+          writeCallbackMs: performance.now() - writeStartedAt,
+        });
+      }
+      onComplete();
+    });
+  };
   if (
     timestampOnlyPrefix.length === 0
     && parsedData === dataForTimestamps
+    && canMeasureVisualRows(data)
     && (
       dataSegmentCount > MAX_SEGMENTED_TIMESTAMP_WRITES
-      || (data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES && canMeasureVisualRows(data))
+      || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
     )
   ) {
     writeBatchedTimestampSegments(term, store, data, segments, done, diagnostics);
@@ -833,23 +937,14 @@ export const writeTerminalDataWithLineTimestamps = (
       store.timestampOnlyPrefix = pendingEscapeSequence;
     }
     if (!parsedData || !dataForTimestamps.startsWith(parsedData)) {
-      const writeStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
-      term.write(data, () => {
-        if (diagnostics) {
-          diagnostics.onStep?.({
-            kind: "fallback-write",
-            dataChars: data.length,
-            writeCallbackMs: performance.now() - writeStartedAt,
-          });
-        }
-        done();
-      });
+      writeFallbackData(data, done);
       return;
     }
 
     const parsedCurrentDataLength = Math.max(0, parsedData.length - timestampOnlyPrefix.length);
+    const trailingData = data.slice(parsedCurrentDataLength);
     writeSegments(
-      () => term.write(data.slice(parsedCurrentDataLength), done),
+      () => writeFallbackData(trailingData, done),
       timestampOnlyPrefix.length,
     );
     return;

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -7,6 +7,7 @@ import {
   FLOW_CHAR_COUNT_ACK_SIZE,
   FLOW_LOW_WATER_MARK,
   MAX_TERMINAL_PLAIN_WRITE_CHUNK_BYTES,
+  XTERM_WRITE_CALLBACK_FAST_PATH_MAX_BYTES,
   XTERM_WRITE_CALLBACK_BATCH_BYTES,
 } from "./terminalFlowConstants.ts";
 import {
@@ -20,7 +21,13 @@ import {
   clearTerminalSessionFlowAck,
   flushTerminalSessionFlowAck,
 } from "./terminalFlowAckBuffer.ts";
-import { flushTerminalWriteCoalescer } from "./terminalWriteCoalescer.ts";
+import {
+  flushTerminalWriteCoalescer,
+  resetTerminalWriteCoalescer,
+} from "./terminalWriteCoalescer.ts";
+import {
+  flushPendingTerminalWritesOnResume,
+} from "./terminalUnfocusedRepaint.ts";
 import {
   clearDeferredTerminalWriteAck,
   getDeferredTerminalWriteAckBytes,
@@ -384,6 +391,134 @@ test("hidden tab output is written completely while the tab remains hidden", () 
 
   assert.equal(writes.join(""), payload);
   assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
+  clearTerminalSessionFlowAck("session-1");
+});
+
+test("writeSessionData keeps the current perf trace when hidden output is flushed", () => {
+  const payload = "hidden current output\n";
+  const writes: string[] = [];
+  const logs: string[] = [];
+  const originalInfo = console.info;
+  const term = {
+    buffer: { active: { type: "normal" } },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      callback?.();
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {},
+  };
+
+  console.info = (message?: unknown) => {
+    logs.push(String(message));
+  };
+  try {
+    withDocumentVisibility("hidden", () => {
+      writeSessionData(ctx as never, term, payload, payload.length, {
+        terminalPerf: {
+          id: "hidden-current",
+          emittedAt: Date.now(),
+          chars: payload.length,
+          lineFeeds: 1,
+        },
+      });
+    });
+  } finally {
+    console.info = originalInfo;
+  }
+
+  assert.deepEqual(writes, [payload]);
+  assert.equal(logs.some((log) => log.includes('"event":"renderer-receive"') && log.includes('"id":"hidden-current"')), true);
+  assert.equal(logs.some((log) => log.includes('"event":"renderer-write-done"') && log.includes('"id":"hidden-current"')), true);
+});
+
+test("writeSessionData skips the visible idle flush after the pane becomes hidden", async () => {
+  const payload = "pending while visible\n";
+  const writes: string[] = [];
+  const term = {
+    buffer: { active: { type: "normal" } },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      callback?.();
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {},
+  };
+  let queuedFrames = 0;
+
+  withAnimationFrameQueue((frames) => {
+    withDocumentVisibility("visible", () => {
+      writeSessionData(ctx as never, term, payload);
+    });
+    queuedFrames = frames.length;
+    ctx.isVisibleRef.current = false;
+    frames[0]?.(0);
+  });
+
+  await new Promise((resolve) => { setTimeout(resolve, 90); });
+
+  assert.equal(queuedFrames, 1);
+  assert.deepEqual(writes, []);
+
+  flushTerminalWriteCoalescer(term);
+  flushTerminalWriteQueueBypassingTimers(term);
+});
+
+test("writeSessionData keeps the hidden flush gate after coalescer reset and flushes on reveal", () => {
+  clearTerminalSessionFlowAck("session-1");
+  const payload = "x".repeat(XTERM_WRITE_CALLBACK_FAST_PATH_MAX_BYTES + 1);
+  const writes: string[] = [];
+  const term = {
+    buffer: { active: { type: "normal" } },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      callback?.();
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const acked: number[] = [];
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: true },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      ackSessionFlow: (_sessionId: string, bytes: number) => {
+        acked.push(bytes);
+      },
+    },
+  };
+
+  getFlowController(ctx as never, term);
+  resetTerminalWriteCoalescer(term);
+  withAnimationFrameQueue((frames) => {
+    withDocumentVisibility("visible", () => {
+      writeSessionData(ctx as never, term, payload);
+    });
+    assert.equal(frames.length, 1);
+
+    ctx.isVisibleRef.current = false;
+    frames[0]?.(0);
+    assert.deepEqual(writes, []);
+
+    ctx.isVisibleRef.current = true;
+    flushPendingTerminalWritesOnResume(term);
+  });
+  flushTerminalSessionFlowAck("session-1");
+
+  assert.deepEqual(writes, [payload]);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  assert.equal(getDeferredTerminalWriteAckBytes(term), 0);
   assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
   clearTerminalSessionFlowAck("session-1");
 });

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -419,15 +419,18 @@ test("writeSessionData keeps the current perf trace when hidden output is flushe
     logs.push(String(message));
   };
   try {
-    withDocumentVisibility("hidden", () => {
-      writeSessionData(ctx as never, term, payload, payload.length, {
-        terminalPerf: {
-          id: "hidden-current",
-          emittedAt: Date.now(),
-          chars: payload.length,
-          lineFeeds: 1,
-        },
+    withAnimationFrameQueue((frames) => {
+      withDocumentVisibility("hidden", () => {
+        writeSessionData(ctx as never, term, payload, payload.length, {
+          terminalPerf: {
+            id: "hidden-current",
+            emittedAt: Date.now(),
+            chars: payload.length,
+            lineFeeds: 1,
+          },
+        });
       });
+      assert.equal(frames.length, 1);
     });
   } finally {
     console.info = originalInfo;
@@ -438,8 +441,9 @@ test("writeSessionData keeps the current perf trace when hidden output is flushe
   assert.equal(logs.some((log) => log.includes('"event":"renderer-write-done"') && log.includes('"id":"hidden-current"')), true);
 });
 
-test("writeSessionData skips the visible idle flush after the pane becomes hidden", async () => {
-  const payload = "pending while visible\n";
+test("writeSessionData drains output after the pane hides before the scheduled frame", async () => {
+  clearTerminalSessionFlowAck("session-1");
+  const payload = "x".repeat(XTERM_WRITE_CALLBACK_BATCH_BYTES);
   const writes: string[] = [];
   const term = {
     buffer: { active: { type: "normal" } },
@@ -453,7 +457,9 @@ test("writeSessionData skips the visible idle flush after the pane becomes hidde
     ...createContext(false),
     isVisibleRef: { current: true },
     sessionRef: { current: "session-1" },
-    terminalBackend: {},
+    terminalBackend: {
+      ackSessionFlow() {},
+    },
   };
   let queuedFrames = 0;
 
@@ -469,10 +475,42 @@ test("writeSessionData skips the visible idle flush after the pane becomes hidde
   await new Promise((resolve) => { setTimeout(resolve, 90); });
 
   assert.equal(queuedFrames, 1);
-  assert.deepEqual(writes, []);
+  assert.equal(writes.join(""), payload);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  clearTerminalSessionFlowAck("session-1");
+});
 
-  flushTerminalWriteCoalescer(term);
-  flushTerminalWriteQueueBypassingTimers(term);
+test("writeSessionData drains hidden pane output without waiting for reveal", () => {
+  clearTerminalSessionFlowAck("session-1");
+  const payload = "x".repeat(XTERM_WRITE_CALLBACK_FAST_PATH_MAX_BYTES + 1);
+  const writes: string[] = [];
+  const term = {
+    buffer: { active: { type: "normal" } },
+    write(data: string, callback?: () => void) {
+      writes.push(data);
+      callback?.();
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+  const acked: number[] = [];
+  const ctx = {
+    ...createContext(false),
+    isVisibleRef: { current: false },
+    sessionRef: { current: "session-1" },
+    terminalBackend: {
+      ackSessionFlow: (_sessionId: string, bytes: number) => {
+        acked.push(bytes);
+      },
+    },
+  };
+
+  writeSessionData(ctx as never, term, payload);
+  flushTerminalSessionFlowAck("session-1");
+
+  assert.equal(writes.join(""), payload);
+  assert.equal(getFlowController(ctx as never, term).pendingBytes(), 0);
+  assert.equal(acked.reduce((total, bytes) => total + bytes, 0), payload.length);
+  clearTerminalSessionFlowAck("session-1");
 });
 
 test("writeSessionData keeps the hidden flush gate after coalescer reset and flushes on reveal", () => {

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -43,6 +43,7 @@ import {
   flushTerminalWriteCoalescer,
   resolveFloodCoalescerByteCap,
   setTerminalWriteCoalescerByteCapResolver,
+  setTerminalWriteCoalescerFlushGate,
 } from "./terminalWriteCoalescer";
 import {
   accumulateDeferredTerminalWriteAck,
@@ -233,8 +234,8 @@ const flushTerminalWritesForBackgroundOutput = (term: XTerm): void => {
   }
 };
 
-const scheduleVisibleTerminalWriteIdleFlush = (term: XTerm, isPaneVisible: boolean): void => {
-  if (!isPaneVisible) return;
+const scheduleVisibleTerminalWriteIdleFlush = (term: XTerm, isPaneVisible: () => boolean): void => {
+  if (!isPaneVisible()) return;
   const existingTimer = visibleWriteIdleFlushTimers.get(term);
   if (existingTimer !== undefined) {
     clearTimeout(existingTimer);
@@ -242,6 +243,7 @@ const scheduleVisibleTerminalWriteIdleFlush = (term: XTerm, isPaneVisible: boole
 
   const timer = setTimeout(() => {
     visibleWriteIdleFlushTimers.delete(term);
+    if (!isPaneVisible()) return;
     flushTerminalWriteCoalescer(term);
     flushTerminalWriteBufferBypassingTimers(term);
     flushTerminalWriteQueueBypassingTimers(term);
@@ -275,12 +277,6 @@ export const getFlowController = (
       },
     });
     terminalFlowControllers.set(term, controller);
-    setTerminalWriteCoalescerByteCapResolver(term, () => (
-      resolveFloodCoalescerByteCap(
-        controller!.isPaused(),
-        isTerminalWriteQueueInFloodMode(term),
-      )
-    ));
     setTerminalWriteQueueDropHandler(term, (bytes) => {
       if (bytes <= 0) return;
       controller?.written(bytes);
@@ -291,6 +287,13 @@ export const getFlowController = (
       }
     });
   }
+  setTerminalWriteCoalescerByteCapResolver(term, () => (
+    resolveFloodCoalescerByteCap(
+      controller!.isPaused(),
+      isTerminalWriteQueueInFloodMode(term),
+    )
+  ));
+  setTerminalWriteCoalescerFlushGate(term, () => ctx.isVisibleRef?.current !== false);
   return controller;
 };
 
@@ -346,10 +349,12 @@ export const writeSessionData = (
     const writeBackgroundOutputData = (
       batch: string,
       batchIngress: number,
+      writeOptions?: CoalescedTerminalWriteOptions,
     ): void => {
       writeSessionDataImmediate(ctx, term, batch, batchIngress, {
+        ...writeOptions,
         flushXtermWriteBuffer: true,
-        perfTrace,
+        perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
       });
       flushTerminalWritesForBackgroundOutput(term);
     };
@@ -363,10 +368,10 @@ export const writeSessionData = (
   enqueueCoalescedTerminalWrite(term, data, (batch, batchIngress, writeOptions) => {
     writeSessionDataImmediate(ctx, term, batch, batchIngress, {
       ...writeOptions,
-      perfTrace,
+      perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
     });
   }, ingressBytes);
-  scheduleVisibleTerminalWriteIdleFlush(term, isPaneVisible);
+  scheduleVisibleTerminalWriteIdleFlush(term, () => ctx.isVisibleRef?.current !== false);
   maybeFlushTerminalWriteCoalescerWhenUnfocused(
     term,
     isPaneVisible,
@@ -382,8 +387,9 @@ const writeSessionDataImmediate = (
 ) => {
   const flow = getFlowController(ctx, term);
   enqueueTerminalWrite(term, ingressBytes, (done) => {
-    const queueItemStartedAt = performance.now();
-    const prepareStartedAt = performance.now();
+    const shouldMeasurePerf = Boolean(writeOptions.perfTrace);
+    const queueItemStartedAt = shouldMeasurePerf ? performance.now() : 0;
+    const prepareStartedAt = shouldMeasurePerf ? performance.now() : 0;
     const settings = ctx.terminalSettingsRef?.current ?? ctx.terminalSettings;
     const filteredData = filterTerminalSessionData(term, data);
     const displayData = appendEraseScrollbackAfterFullErases(filteredData, {
@@ -402,7 +408,7 @@ const writeSessionDataImmediate = (
       ctx.promptLineBreakStateRef?.current,
       forcePromptNewLine,
     );
-    const prepareMs = performance.now() - prepareStartedAt;
+    const prepareMs = shouldMeasurePerf ? performance.now() - prepareStartedAt : 0;
     ctx.onTerminalLogData?.(pasteDisplayData);
     const clearPasteResidualAndCapture = () => {
       const cleanupData = clearPasteResidualAfterTerminalWrite(term);
@@ -451,7 +457,6 @@ const writeSessionDataImmediate = (
       );
 
     const writePreparedDisplayData = (callback: () => void): void => {
-      const shouldMeasurePerf = Boolean(writeOptions.perfTrace);
       const lineTimestampPerf = shouldMeasurePerf ? createLineTimestampPerfTotals() : null;
       const writeStartedAt = shouldMeasurePerf ? performance.now() : 0;
       let completed = false;

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -76,6 +76,7 @@ import {
 } from "./terminalOutputPipeline";
 import {
   flushTerminalWriteBufferBypassingTimers,
+  hasPendingTerminalWrites,
   maybeFlushTerminalWriteCoalescerWhenUnfocused,
   scheduleTerminalRepaintWhenUnfocused,
   shouldFlushTerminalWritesForBackgroundOutput,
@@ -135,7 +136,9 @@ const BACKGROUND_OUTPUT_FLUSH_MAX_PASSES = 64;
 const LARGE_WRITE_FLUSH_WATCHDOG_BYTES = 64 * 1024;
 const LARGE_WRITE_FLUSH_WATCHDOG_MS = 250;
 const VISIBLE_WRITE_IDLE_FLUSH_MS = 64;
+const HIDDEN_PANE_DRAIN_MS = 160;
 const visibleWriteIdleFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
+const hiddenPaneDrainTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 
 type LineTimestampPerfTotals = {
   segmentCalls: number;
@@ -234,6 +237,36 @@ const flushTerminalWritesForBackgroundOutput = (term: XTerm): void => {
   }
 };
 
+const cancelHiddenPaneDrain = (term: XTerm): void => {
+  const timer = hiddenPaneDrainTimers.get(term);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  hiddenPaneDrainTimers.delete(term);
+};
+
+function flushHiddenPaneWritesNow(term: XTerm, isPaneVisible: () => boolean): void {
+  if (isPaneVisible()) return;
+  flushTerminalWriteCoalescer(term);
+  flushTerminalWritesForBackgroundOutput(term);
+  if (!isPaneVisible() && hasPendingTerminalWrites(term)) {
+    scheduleHiddenPaneDrain(term, isPaneVisible);
+  }
+}
+
+function scheduleHiddenPaneDrain(term: XTerm, isPaneVisible: () => boolean): void {
+  if (isPaneVisible()) return;
+  if (hiddenPaneDrainTimers.has(term)) return;
+
+  const timer = setTimeout(() => {
+    hiddenPaneDrainTimers.delete(term);
+    flushHiddenPaneWritesNow(term, isPaneVisible);
+  }, HIDDEN_PANE_DRAIN_MS);
+  if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
+    timer.unref();
+  }
+  hiddenPaneDrainTimers.set(term, timer);
+}
+
 const scheduleVisibleTerminalWriteIdleFlush = (term: XTerm, isPaneVisible: () => boolean): void => {
   if (!isPaneVisible()) return;
   const existingTimer = visibleWriteIdleFlushTimers.get(term);
@@ -243,7 +276,10 @@ const scheduleVisibleTerminalWriteIdleFlush = (term: XTerm, isPaneVisible: () =>
 
   const timer = setTimeout(() => {
     visibleWriteIdleFlushTimers.delete(term);
-    if (!isPaneVisible()) return;
+    if (!isPaneVisible()) {
+      flushHiddenPaneWritesNow(term, isPaneVisible);
+      return;
+    }
     flushTerminalWriteCoalescer(term);
     flushTerminalWriteBufferBypassingTimers(term);
     flushTerminalWriteQueueBypassingTimers(term);
@@ -332,7 +368,8 @@ export const writeSessionData = (
   meta?: TerminalSessionDataMeta,
 ) => {
   const flow = getFlowController(ctx, term);
-  const isPaneVisible = ctx.isVisibleRef?.current !== false;
+  const isPaneCurrentlyVisible = () => ctx.isVisibleRef?.current !== false;
+  const isPaneVisible = isPaneCurrentlyVisible();
   const perfTrace = createTerminalOutputPerfTrace({
     sessionId: ctx.sessionRef.current ?? ctx.sessionId,
     data,
@@ -371,7 +408,8 @@ export const writeSessionData = (
       perfTrace: writeOptions?.preservePerfTrace === false ? null : perfTrace,
     });
   }, ingressBytes);
-  scheduleVisibleTerminalWriteIdleFlush(term, () => ctx.isVisibleRef?.current !== false);
+  scheduleVisibleTerminalWriteIdleFlush(term, isPaneCurrentlyVisible);
+  scheduleHiddenPaneDrain(term, isPaneCurrentlyVisible);
   maybeFlushTerminalWriteCoalescerWhenUnfocused(
     term,
     isPaneVisible,
@@ -580,8 +618,10 @@ export const releaseTerminalFlowBeforeHibernate = (
   options?: { resumeBackend?: boolean },
 ): void => {
   const flow = terminalFlowControllers.get(term);
+  cancelHiddenPaneDrain(term);
   releaseTerminalFlowOutputForTerm(term, backend, sessionId, flow, options);
   setTerminalWriteCoalescerByteCapResolver(term);
+  setTerminalWriteCoalescerFlushGate(term);
   resetDeferredTerminalWriteAck(term);
   terminalFlowControllers.delete(term);
 };

--- a/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
+import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
   cancelScheduledUnfocusedRepaint,
+  flushPendingTerminalWritesBeforeHibernate,
   flushTerminalWriteBufferBypassingTimers,
   forceTerminalRepaintBypassingAnimationFrame,
+  hasPendingTerminalWrites,
   scheduleTerminalRepaintWhenUnfocused,
   shouldFlushTerminalWritesForBackgroundOutput,
 } from "./terminalUnfocusedRepaint.ts";
@@ -58,6 +61,41 @@ const withDocumentVisibilityAsync = async (
       Reflect.deleteProperty(globalThis, "document");
     }
   }
+};
+
+const createBufferedFakeTerm = () => {
+  const writes: string[] = [];
+  const writeBuffer = {
+    _bufferOffset: 0,
+    _callbacks: [] as Array<(() => void) | undefined>,
+    _pendingData: 0,
+    _writeBuffer: [] as string[],
+    flushSync() {
+      const offset = Math.min(this._bufferOffset, this._writeBuffer.length);
+      const chunks = this._writeBuffer.slice(offset);
+      const callbacks = this._callbacks.slice(offset);
+      this._bufferOffset = 0;
+      this._callbacks = [];
+      this._pendingData = 0;
+      this._writeBuffer = [];
+      for (let index = 0; index < chunks.length; index += 1) {
+        writes.push(chunks[index]!);
+        callbacks[index]?.();
+      }
+    },
+  };
+  const term = {
+    buffer: { active: { type: "normal" } },
+    _core: { _writeBuffer: writeBuffer },
+    write(data: string, callback?: () => void) {
+      writeBuffer._writeBuffer.push(data);
+      writeBuffer._callbacks.push(callback);
+      writeBuffer._pendingData += data.length;
+    },
+    scrollToBottom() {},
+  } as unknown as XTerm;
+
+  return { term, writes };
 };
 
 test("isTerminalWindowUnfocusedButVisible checks visible page without focus", () => {
@@ -170,6 +208,22 @@ test("flushPendingTerminalWritesOnResume drains coalescer, queue, and xterm writ
   assert.match(source, /flushTerminalWriteCoalescer\(term\)/);
   assert.match(source, /flushTerminalWriteQueueBypassingTimers\(term\)/);
   assert.match(source, /flushTerminalWriteBufferBypassingTimers\(term\)/);
+});
+
+test("flushPendingTerminalWritesBeforeHibernate drains pending xterm output completely", async () => {
+  const { term, writes } = createBufferedFakeTerm();
+  const payload = "x".repeat(300000);
+
+  term.write(payload);
+
+  assert.equal(writes.join("").length, 0);
+  assert.equal(hasPendingTerminalWrites(term), true);
+
+  const flushed = await flushPendingTerminalWritesBeforeHibernate(term);
+
+  assert.equal(flushed, true);
+  assert.equal(writes.join(""), payload);
+  assert.equal(hasPendingTerminalWrites(term), false);
 });
 
 test("maybeFlushTerminalWriteCoalescerWhenUnfocused throttles coalescer flushes", () => {

--- a/components/terminal/runtime/terminalUnfocusedRepaint.ts
+++ b/components/terminal/runtime/terminalUnfocusedRepaint.ts
@@ -5,12 +5,20 @@ import {
   isTerminalAlternateScreenActive,
   refreshTerminalViewport,
 } from "../terminalHibernateRuntime";
-import { flushTerminalWriteCoalescer } from "./terminalWriteCoalescer";
-import { flushTerminalWriteQueueBypassingTimers } from "./terminalWriteQueue";
+import {
+  flushTerminalWriteCoalescer,
+  getTerminalWriteCoalescerPendingBytes,
+} from "./terminalWriteCoalescer";
+import {
+  flushTerminalWriteQueueBypassingTimers,
+  hasPendingTerminalWriteQueueWork,
+} from "./terminalWriteQueue";
 
 const UNFOCUSED_REPAINT_DEBOUNCE_MS = 16;
 const UNFOCUSED_FLUSH_DEBOUNCE_MS = 67;
 const RESUME_FLUSH_MAX_PASSES = 64;
+const HIBERNATE_FLUSH_MAX_PASSES = 4096;
+const HIBERNATE_FLUSH_YIELD_EVERY_PASSES = 64;
 const unfocusedRepaintTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 const unfocusedFlushTimers = new WeakMap<XTerm, ReturnType<typeof setTimeout>>();
 
@@ -81,6 +89,45 @@ export function flushTerminalWriteBufferBypassingTimers(term: XTerm): void {
   }
 }
 
+function getPendingTerminalWriteBufferBytes(term: XTerm): number {
+  const writeBuffer = (term as XTermWithPrivateWriteBuffer)._core?._writeBuffer;
+  if (!writeBuffer) return 0;
+
+  if (
+    typeof writeBuffer._pendingData === "number"
+    && Number.isFinite(writeBuffer._pendingData)
+    && writeBuffer._pendingData > 0
+  ) {
+    return writeBuffer._pendingData;
+  }
+
+  const buffer = writeBuffer._writeBuffer;
+  if (!Array.isArray(buffer) || buffer.length === 0) return 0;
+  const offset = typeof writeBuffer._bufferOffset === "number"
+    && Number.isFinite(writeBuffer._bufferOffset)
+    ? Math.max(0, writeBuffer._bufferOffset)
+    : 0;
+
+  let bytes = 0;
+  for (let index = Math.min(offset, buffer.length); index < buffer.length; index += 1) {
+    const chunk = buffer[index];
+    if (typeof chunk === "string") {
+      bytes += chunk.length;
+    } else if (chunk instanceof Uint8Array) {
+      bytes += chunk.byteLength;
+    }
+  }
+  return bytes;
+}
+
+export function hasPendingTerminalWrites(term: XTerm): boolean {
+  return (
+    getTerminalWriteCoalescerPendingBytes(term) > 0
+    || hasPendingTerminalWriteQueueWork(term)
+    || getPendingTerminalWriteBufferBytes(term) > 0
+  );
+}
+
 export function forceTerminalRepaintBypassingAnimationFrame(term: XTerm): void {
   if (isTerminalAlternateScreenActive(term)) {
     refreshTerminalViewport(term);
@@ -123,6 +170,32 @@ export function flushPendingTerminalWritesOnResume(term: XTerm): void {
     }
     flushTerminalWriteBufferBypassingTimers(term);
   }
+}
+
+const waitForTerminalWriteCallbacks = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+export async function flushPendingTerminalWritesBeforeHibernate(term: XTerm): Promise<boolean> {
+  for (let pass = 0; pass < HIBERNATE_FLUSH_MAX_PASSES; pass += 1) {
+    flushTerminalWriteCoalescer(term);
+    flushTerminalWriteQueueBypassingTimers(term);
+    flushTerminalWriteBufferBypassingTimers(term);
+
+    if (!hasPendingTerminalWrites(term)) {
+      return true;
+    }
+
+    if ((pass + 1) % HIBERNATE_FLUSH_YIELD_EVERY_PASSES === 0) {
+      await waitForTerminalWriteCallbacks();
+    }
+  }
+
+  flushTerminalWriteCoalescer(term);
+  flushTerminalWriteQueueBypassingTimers(term);
+  flushTerminalWriteBufferBypassingTimers(term);
+  return !hasPendingTerminalWrites(term);
 }
 
 export function maybeFlushTerminalWriteCoalescerWhenUnfocused(

--- a/components/terminal/runtime/terminalWriteCoalescer.test.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.test.ts
@@ -4,10 +4,12 @@ import test from "node:test";
 import type { Terminal as XTerm } from "@xterm/xterm";
 
 import {
+  abortTerminalWriteCoalescer,
   enqueueCoalescedTerminalWrite,
   flushTerminalWriteCoalescer,
   resetTerminalWriteCoalescer,
   setTerminalWriteCoalescerByteCapResolver,
+  setTerminalWriteCoalescerFlushGate,
   type CoalescedTerminalWriteOptions,
 } from "./terminalWriteCoalescer.ts";
 import {
@@ -29,6 +31,37 @@ const withAnimationFrameQueue = (run: () => void) => {
   });
   try {
     run();
+  } finally {
+    if (originalRequest) {
+      Object.defineProperty(globalThis, "requestAnimationFrame", originalRequest);
+    } else {
+      Reflect.deleteProperty(globalThis, "requestAnimationFrame");
+    }
+    if (originalCancel) {
+      Object.defineProperty(globalThis, "cancelAnimationFrame", originalCancel);
+    } else {
+      Reflect.deleteProperty(globalThis, "cancelAnimationFrame");
+    }
+  }
+};
+
+const withQueuedAnimationFrame = (run: (frames: Array<FrameRequestCallback>) => void) => {
+  const originalRequest = Object.getOwnPropertyDescriptor(globalThis, "requestAnimationFrame");
+  const originalCancel = Object.getOwnPropertyDescriptor(globalThis, "cancelAnimationFrame");
+  const frames: Array<FrameRequestCallback> = [];
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: () => {},
+  });
+  try {
+    run(frames);
   } finally {
     if (originalRequest) {
       Object.defineProperty(globalThis, "requestAnimationFrame", originalRequest);
@@ -65,6 +98,189 @@ test("splits a single flood-sized terminal batch before it reaches xterm", () =>
     writes.map((write) => write.ingressBytes),
     [12, 12, 6],
   );
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("marks merged coalesced output as not preserving single-chunk perf metadata", () => {
+  const term = createFakeTerm();
+  const writes: Array<{ data: string; options?: CoalescedTerminalWriteOptions }> = [];
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 100);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "first",
+      () => {},
+      "first".length,
+    );
+    enqueueCoalescedTerminalWrite(
+      term,
+      "second",
+      (data, _ingressBytes, options) => {
+        writes.push({ data, options });
+      },
+      "second".length,
+    );
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(writes, [{
+    data: "firstsecond",
+    options: { preservePerfTrace: false },
+  }]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("uses the pending writer when a new chunk forces an old single chunk flush", () => {
+  const term = createFakeTerm();
+  const firstWriter: string[] = [];
+  const secondWriter: string[] = [];
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 10);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "old",
+      (data) => {
+        firstWriter.push(data);
+      },
+      "old".length,
+    );
+    enqueueCoalescedTerminalWrite(
+      term,
+      "new-data",
+      (data) => {
+        secondWriter.push(data);
+      },
+      "new-data".length,
+    );
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(firstWriter, ["old"]);
+  assert.deepEqual(secondWriter, ["new-data"]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("aborting pending coalesced output clears merge bookkeeping for the next write", () => {
+  const term = createFakeTerm();
+  const writes: Array<{ data: string; options?: CoalescedTerminalWriteOptions }> = [];
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 100);
+  withAnimationFrameQueue(() => {
+    enqueueCoalescedTerminalWrite(term, "dropped", () => {}, "dropped".length);
+    enqueueCoalescedTerminalWrite(term, " output", () => {}, " output".length);
+    abortTerminalWriteCoalescer(term);
+    enqueueCoalescedTerminalWrite(
+      term,
+      "next",
+      (data, _ingressBytes, options) => {
+        writes.push({ data, options });
+      },
+      "next".length,
+    );
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(writes, [{ data: "next", options: undefined }]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("pending output skipped while hidden can be flushed after the pane is shown", () => {
+  const term = createFakeTerm();
+  const writes: string[] = [];
+  let isPaneVisible = true;
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 100);
+  setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
+  withQueuedAnimationFrame((frames) => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "hidden output",
+      (data) => {
+        writes.push(data);
+      },
+      "hidden output".length,
+    );
+
+    isPaneVisible = false;
+    frames.shift()?.(0);
+    assert.deepEqual(writes, []);
+
+    isPaneVisible = true;
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(writes, ["hidden output"]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("cap-triggered coalescer flushes wait until a hidden pane is visible", () => {
+  const term = createFakeTerm();
+  const writes: string[] = [];
+  let isPaneVisible = false;
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 10);
+  setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
+  withQueuedAnimationFrame((frames) => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "123456",
+      () => {},
+      "123456".length,
+    );
+    enqueueCoalescedTerminalWrite(
+      term,
+      "abcdef",
+      (data) => {
+        writes.push(data);
+      },
+      "abcdef".length,
+    );
+    frames.splice(0).forEach((frame) => frame(0));
+
+    assert.deepEqual(writes, []);
+
+    isPaneVisible = true;
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.equal(writes.join(""), "123456abcdef");
+  assert.deepEqual(writes.map((write) => write.length), [10, 2]);
+
+  resetTerminalWriteCoalescer(term);
+});
+
+test("oversized coalesced output waits while hidden instead of writing directly", () => {
+  const term = createFakeTerm();
+  const writes: string[] = [];
+  let isPaneVisible = false;
+
+  setTerminalWriteCoalescerByteCapResolver(term, () => 4);
+  setTerminalWriteCoalescerFlushGate(term, () => isPaneVisible);
+  withQueuedAnimationFrame((frames) => {
+    enqueueCoalescedTerminalWrite(
+      term,
+      "oversized",
+      (data) => {
+        writes.push(data);
+      },
+      "oversized".length,
+    );
+    frames.splice(0).forEach((frame) => frame(0));
+
+    assert.deepEqual(writes, []);
+
+    isPaneVisible = true;
+    flushTerminalWriteCoalescer(term);
+  });
+
+  assert.deepEqual(writes.join(""), "oversized");
 
   resetTerminalWriteCoalescer(term);
 });

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -237,13 +237,13 @@ export const flushTerminalWriteCoalescer = (
   }
   coalescer.flushSync((batch) => {
     const batchIngress = takePendingIngressBytes(term, batch.length);
-    takePendingChunkCount(term);
+    const chunkCount = takePendingChunkCount(term);
     writeLargeTerminalBatch(
       batch,
       batchIngress,
       resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
       writeNow,
-      { preservePerfTrace: false },
+      chunkCount === 1 ? {} : { preservePerfTrace: false },
     );
   });
 };

--- a/components/terminal/runtime/terminalWriteCoalescer.ts
+++ b/components/terminal/runtime/terminalWriteCoalescer.ts
@@ -9,9 +9,11 @@ import {
 import { createWriteCoalescer, type WriteCoalescer } from "./writeCoalescer.ts";
 
 type CoalescerByteCapResolver = () => number;
+type CoalescerFlushGate = () => boolean;
 export type CoalescedTerminalWriteOptions = {
   deferStart?: boolean;
   yieldAfter?: boolean;
+  preservePerfTrace?: boolean;
 };
 type CoalescedTerminalWriteNow = (
   data: string,
@@ -21,7 +23,9 @@ type CoalescedTerminalWriteNow = (
 
 const terminalWriteCoalescers = new WeakMap<XTerm, WriteCoalescer>();
 const terminalWriteCoalescerIngress = new WeakMap<XTerm, number>();
+const terminalWriteCoalescerChunkCounts = new WeakMap<XTerm, number>();
 const terminalWriteCoalescerByteCapResolvers = new WeakMap<XTerm, CoalescerByteCapResolver>();
+const terminalWriteCoalescerFlushGates = new WeakMap<XTerm, CoalescerFlushGate>();
 const terminalWriteCoalescerWriters = new WeakMap<XTerm, CoalescedTerminalWriteNow>();
 
 const defaultCoalescerByteCap = (): number => MAX_PENDING_WRITE_COALESCE_BYTES;
@@ -42,6 +46,9 @@ const resolveCoalescerByteCap = (term: XTerm): number => {
   return resolver?.() ?? defaultCoalescerByteCap();
 };
 
+const shouldAutoFlushCoalescer = (term: XTerm): boolean =>
+  terminalWriteCoalescerFlushGates.get(term)?.() ?? true;
+
 const getPendingCoalescedBytes = (term: XTerm): number =>
   terminalWriteCoalescers.get(term)?.pendingBytes() ?? 0;
 
@@ -49,6 +56,23 @@ const takePendingIngressBytes = (term: XTerm, fallback = 0): number => {
   const pending = terminalWriteCoalescerIngress.get(term) ?? fallback;
   terminalWriteCoalescerIngress.delete(term);
   return pending;
+};
+
+const takePendingChunkCount = (term: XTerm): number => {
+  const count = terminalWriteCoalescerChunkCounts.get(term) ?? 1;
+  terminalWriteCoalescerChunkCounts.delete(term);
+  return count;
+};
+
+export const setTerminalWriteCoalescerFlushGate = (
+  term: XTerm,
+  gate?: CoalescerFlushGate,
+): void => {
+  if (gate) {
+    terminalWriteCoalescerFlushGates.set(term, gate);
+  } else {
+    terminalWriteCoalescerFlushGates.delete(term);
+  }
 };
 
 const splitIngressBytes = (
@@ -113,6 +137,7 @@ const writeLargeTerminalBatch = (
     ingressBytes: number,
     options?: CoalescedTerminalWriteOptions,
   ) => void,
+  options: CoalescedTerminalWriteOptions = {},
 ): void => {
   const batchSize = Math.max(1, maxBatchBytes);
   const isSliced = data.length > batchSize;
@@ -131,10 +156,18 @@ const writeLargeTerminalBatch = (
         remainingIngressBytes,
       );
     remainingIngressBytes -= sliceIngress;
-    writeNow(slice, sliceIngress, isSliced ? {
-      deferStart: true,
-      yieldAfter: true,
-    } : undefined);
+    const nextOptions = {
+      ...options,
+      ...(isSliced ? {
+        deferStart: true,
+        yieldAfter: true,
+      } : {}),
+    };
+    writeNow(
+      slice,
+      sliceIngress,
+      Object.keys(nextOptions).length > 0 ? nextOptions : undefined,
+    );
     offset = end;
   }
 };
@@ -145,12 +178,13 @@ export const enqueueCoalescedTerminalWrite = (
   writeNow: CoalescedTerminalWriteNow,
   ingressBytes: number = data.length,
 ): void => {
-  terminalWriteCoalescerWriters.set(term, writeNow);
   const maxPendingBytes = resolveCoalescerByteCap(term);
-  if (getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {
+  const canAutoFlush = shouldAutoFlushCoalescer(term);
+  if (canAutoFlush && getPendingCoalescedBytes(term) + data.length > maxPendingBytes) {
     flushTerminalWriteCoalescer(term);
   }
-  if (data.length > maxPendingBytes) {
+  terminalWriteCoalescerWriters.set(term, writeNow);
+  if (canAutoFlush && data.length > maxPendingBytes) {
     writeLargeTerminalBatch(
       data,
       ingressBytes,
@@ -164,20 +198,27 @@ export const enqueueCoalescedTerminalWrite = (
     term,
     (terminalWriteCoalescerIngress.get(term) ?? 0) + ingressBytes,
   );
+  terminalWriteCoalescerChunkCounts.set(
+    term,
+    (terminalWriteCoalescerChunkCounts.get(term) ?? 0) + 1,
+  );
 
   let coalescer = terminalWriteCoalescers.get(term);
   if (!coalescer) {
     coalescer = createWriteCoalescer((batch) => {
       const batchIngress = takePendingIngressBytes(term, batch.length);
+      const chunkCount = takePendingChunkCount(term);
       const activeWriteNow = terminalWriteCoalescerWriters.get(term) ?? writeNow;
       writeLargeTerminalBatch(
         batch,
         batchIngress,
         resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
         activeWriteNow,
+        chunkCount === 1 ? {} : { preservePerfTrace: false },
       );
     }, {
       getMaxPendingBytes: () => resolveCoalescerByteCap(term),
+      shouldFlushScheduledFrame: () => terminalWriteCoalescerFlushGates.get(term)?.() ?? true,
     });
     terminalWriteCoalescers.set(term, coalescer);
   }
@@ -196,11 +237,13 @@ export const flushTerminalWriteCoalescer = (
   }
   coalescer.flushSync((batch) => {
     const batchIngress = takePendingIngressBytes(term, batch.length);
+    takePendingChunkCount(term);
     writeLargeTerminalBatch(
       batch,
       batchIngress,
       resolveTerminalWriteBatchBytes(batch, resolveCoalescerByteCap(term)),
       writeNow,
+      { preservePerfTrace: false },
     );
   });
 };
@@ -209,7 +252,9 @@ export const resetTerminalWriteCoalescer = (term: XTerm): void => {
   terminalWriteCoalescers.get(term)?.dispose();
   terminalWriteCoalescers.delete(term);
   terminalWriteCoalescerIngress.delete(term);
+  terminalWriteCoalescerChunkCounts.delete(term);
   terminalWriteCoalescerByteCapResolvers.delete(term);
+  terminalWriteCoalescerFlushGates.delete(term);
   terminalWriteCoalescerWriters.delete(term);
 };
 
@@ -229,6 +274,7 @@ export const abortTerminalWriteCoalescer = (
     term,
     coalescer.pendingBytes(),
   );
+  takePendingChunkCount(term);
   coalescer.abort();
   if (ingressDropped > 0) {
     onDropped?.(ingressDropped);

--- a/components/terminal/runtime/terminalWriteQueue.ts
+++ b/components/terminal/runtime/terminalWriteQueue.ts
@@ -269,6 +269,20 @@ export const setTerminalWriteQueueDropHandler = (
 export const getTerminalWriteQueueDepth = (term: XTerm): number =>
   terminalWriteQueues.get(term)?.pending.length ?? 0;
 
+export const hasPendingTerminalWriteQueueWork = (term: XTerm): boolean => {
+  const queue = terminalWriteQueues.get(term);
+  if (!queue) return false;
+  return (
+    queue.writing
+    || queue.active !== undefined
+    || queue.pending.length > 0
+    || queue.pendingBytes > 0
+    || queue.drainTimer !== undefined
+    || queue.stepTimer !== undefined
+    || queue.stepContinuation !== undefined
+  );
+};
+
 export const isTerminalWriteQueueInFloodMode = (term: XTerm): boolean =>
   terminalWriteQueues.get(term)?.floodMode ?? false;
 

--- a/components/terminal/runtime/writeCoalescer.test.ts
+++ b/components/terminal/runtime/writeCoalescer.test.ts
@@ -117,6 +117,27 @@ test("uses a tighter pending-byte cap when getMaxPendingBytes is set", () => {
   assert.equal(writes[0]?.length, cap + 1);
 });
 
+test("does not flush cap-sized pending bytes while automatic flushing is gated", () => {
+  const writes: string[] = [];
+  let canFlush = false;
+  const cap = 8;
+  const coalescer = createTestCoalescer((data) => writes.push(data), {
+    getMaxPendingBytes: () => cap,
+    shouldFlushScheduledFrame: () => canFlush,
+  });
+
+  coalescer.push("x".repeat(cap));
+  coalescer.push("y");
+  fireFrame();
+
+  assert.deepEqual(writes, []);
+
+  canFlush = true;
+  coalescer.flushSync();
+
+  assert.deepEqual(writes, ["x".repeat(cap) + "y"]);
+});
+
 test("dispose flushes remaining bytes and stops accepting new chunks", () => {
   const writes: string[] = [];
   const coalescer = createTestCoalescer((data) => writes.push(data));

--- a/components/terminal/runtime/writeCoalescer.ts
+++ b/components/terminal/runtime/writeCoalescer.ts
@@ -35,6 +35,7 @@ type ScheduleWriteFrame = (callback: () => void) => (() => void) | null;
 export type WriteCoalescerOptions = {
   scheduleFrame?: ScheduleWriteFrame;
   getMaxPendingBytes?: () => number;
+  shouldFlushScheduledFrame?: () => boolean;
 };
 
 const scheduleWriteFrame = (callback: () => void): (() => void) | null => {
@@ -61,6 +62,7 @@ export const createWriteCoalescer = (
   const scheduleFrame = options.scheduleFrame ?? scheduleWriteFrame;
   const getMaxPendingBytes = options.getMaxPendingBytes
     ?? (() => MAX_PENDING_WRITE_COALESCE_BYTES);
+  const shouldFlushScheduledFrame = options.shouldFlushScheduledFrame ?? (() => true);
 
   const cancelScheduledFrame = (): void => {
     if (cancelPendingFrame !== null) {
@@ -98,15 +100,24 @@ export const createWriteCoalescer = (
     pending.push(chunk);
     pendingBytes += chunk.length;
     if (pendingBytes > getMaxPendingBytes()) {
+      if (!shouldFlushScheduledFrame()) {
+        return;
+      }
       flushSync();
       return;
     }
     if (cancelPendingFrame === null) {
       const cancelFrame = scheduleFrame(() => {
         cancelPendingFrame = null;
+        if (!shouldFlushScheduledFrame()) {
+          return;
+        }
         flushSync();
       });
       if (cancelFrame === null) {
+        if (!shouldFlushScheduledFrame()) {
+          return;
+        }
         flushSync();
         return;
       }

--- a/components/terminal/terminalHibernateFlush.test.ts
+++ b/components/terminal/terminalHibernateFlush.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const readFunctionBody = (source: string, marker: string): string => {
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} must exist`);
+
+  const bodyStart = source.indexOf("{", start);
+  assert.notEqual(bodyStart, -1, `${marker} must have a body`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(bodyStart, index + 1);
+      }
+    }
+  }
+
+  assert.fail(`${marker} body must close`);
+};
+
+test("full hibernate flushes pending hidden output before taking the snapshot", () => {
+  const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const body = readFunctionBody(source, "const fullHibernateRuntime = useCallback(async () =>");
+
+  const termCaptureIndex = body.indexOf("const term = termRef.current");
+  const clearHiddenIndex = body.indexOf("terminalHiddenRendererStore.clearSoftHidden(sessionId)");
+  const flushIndex = body.indexOf("flushPendingTerminalWritesBeforeHibernate(term)");
+  const retryIndex = body.indexOf("scheduleHibernateRetry()");
+  const alternateScreenSkipIndex = body.indexOf("shouldSkipHibernateForActiveAlternateScreen(term)");
+  const snapshotIndex = body.indexOf("serializeTerminalForHibernate(");
+  const releaseIndex = body.indexOf("releaseTerminalFlowBeforeHibernate(terminalBackend, term, backendId)");
+
+  assert.notEqual(termCaptureIndex, -1, "hibernate must capture the active terminal once");
+  assert.notEqual(clearHiddenIndex, -1, "hibernate must clear hidden renderer state");
+  assert.notEqual(flushIndex, -1, "hibernate must flush pending terminal writes completely");
+  assert.notEqual(retryIndex, -1, "hibernate must retry when pending writes are still draining");
+  assert.notEqual(alternateScreenSkipIndex, -1, "hibernate must re-check alternate screen after draining output");
+  assert.notEqual(snapshotIndex, -1, "hibernate must serialize a terminal snapshot");
+  assert.notEqual(releaseIndex, -1, "hibernate must release flow after snapshot");
+  assert.ok(termCaptureIndex < flushIndex, "flush must use the captured terminal");
+  assert.ok(clearHiddenIndex < flushIndex, "clear hidden state before flushing pending writes");
+  assert.ok(flushIndex < retryIndex, "retry can only be scheduled after the drain attempt");
+  assert.ok(retryIndex < snapshotIndex, "retry branch must happen before snapshot");
+  assert.ok(flushIndex < alternateScreenSkipIndex, "alternate screen must be checked after pending writes are drained");
+  assert.ok(retryIndex < alternateScreenSkipIndex, "retry branch must run before the alternate-screen re-check");
+  assert.ok(alternateScreenSkipIndex < snapshotIndex, "alternate-screen skip must happen before snapshot");
+  assert.ok(flushIndex < snapshotIndex, "flush pending writes before snapshot");
+  assert.ok(snapshotIndex < releaseIndex, "release flow only after snapshot");
+});
+
+test("hibernate retry preserves normal hibernate blockers", () => {
+  const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const body = readFunctionBody(source, "const scheduleHibernateRetry = useCallback(() =>");
+
+  const searchBlockerIndex = body.indexOf("isSearchOpenRef.current");
+  const transferBlockerIndex = body.indexOf("hibernateFileTransferActiveRef.current");
+  const retryIndex = body.indexOf("fullHibernateRuntimeRef.current?.()");
+
+  assert.notEqual(searchBlockerIndex, -1, "retry must skip hibernate while search is open");
+  assert.notEqual(transferBlockerIndex, -1, "retry must skip hibernate while file transfer is active");
+  assert.notEqual(retryIndex, -1, "retry must be able to resume hibernation");
+  assert.ok(searchBlockerIndex < retryIndex, "search blocker must run before retrying hibernate");
+  assert.ok(transferBlockerIndex < retryIndex, "file-transfer blocker must run before retrying hibernate");
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -14,6 +14,9 @@ const {
 const {
   createTerminalUrgentInputPortRegistry,
 } = require("./preload/terminalUrgentInputPorts.cjs");
+const {
+  mergeTerminalDataMeta,
+} = require("./preload/terminalDataMeta.cjs");
 
 const dataListeners = new Map();
 const displayDataListeners = new Map();
@@ -73,23 +76,6 @@ const _mcpPendingMetas = new Map(); // sessionId -> metadata from filtered-empty
 const _mcpFlushTimers = new Map(); // sessionId -> delayed-flush timer
 const _mcpDroppingWrappedLine = new Set(); // sessionIds with a split marker echo line in progress
 
-function mergeTerminalDataMeta(first, second) {
-  const droppedOutputMayAffectTerminalState = Boolean(
-    first?.droppedOutputMayAffectTerminalState
-    || second?.droppedOutputMayAffectTerminalState
-  );
-  const droppedOutputAlternateScreenAction = second?.droppedOutputMayAffectTerminalState
-    ? second?.droppedOutputAlternateScreenAction
-    : (second?.droppedOutputAlternateScreenAction ?? first?.droppedOutputAlternateScreenAction);
-  if (!droppedOutputMayAffectTerminalState && !droppedOutputAlternateScreenAction) {
-    return undefined;
-  }
-  return {
-    ...(droppedOutputMayAffectTerminalState ? { droppedOutputMayAffectTerminalState: true } : {}),
-    ...(droppedOutputAlternateScreenAction ? { droppedOutputAlternateScreenAction } : {}),
-  };
-}
-
 // Returns true if `s` ends with a non-empty prefix of "__NCMCP_"
 // (i.e. the next chunk might complete it into a marker-containing line).
 function _endsWithMarkerPrefix(s) {
@@ -112,7 +98,10 @@ function filterMcpChunk(sessionId, chunk, meta) {
   const held = _mcpLineBufs.get(sessionId) || "";
   const heldMeta = _mcpLineMetas.get(sessionId);
   const pendingMeta = _mcpPendingMetas.get(sessionId);
-  const combinedMeta = mergeTerminalDataMeta(mergeTerminalDataMeta(pendingMeta, heldMeta), meta);
+  const stateMeta = mergeTerminalDataMeta(mergeTerminalDataMeta(pendingMeta, heldMeta), meta);
+  const sameChunkMeta = mergeTerminalDataMeta(mergeTerminalDataMeta(pendingMeta, heldMeta), meta, {
+    preserveTerminalPerf: true,
+  });
   const data = held + chunk;
   _mcpLineBufs.delete(sessionId);
   _mcpLineMetas.delete(sessionId);
@@ -120,7 +109,7 @@ function filterMcpChunk(sessionId, chunk, meta) {
 
   // Fast path: nothing suspicious in the combined data
   if (!_mcpDroppingWrappedLine.has(sessionId) && !data.includes("__NCMCP_") && !_endsWithMarkerPrefix(data)) {
-    return { data, meta: combinedMeta };
+    return { data, meta: held ? stateMeta : sameChunkMeta };
   }
 
   // Slow path: scan line by line
@@ -138,7 +127,8 @@ function filterMcpChunk(sessionId, chunk, meta) {
       const tail = data.slice(pos);
       if (droppedAny || tail.includes("__NCMCP_") || _endsWithMarkerPrefix(tail)) {
         _mcpLineBufs.set(sessionId, tail);
-        if (combinedMeta) _mcpLineMetas.set(sessionId, combinedMeta);
+        const tailMeta = !held && tail === chunk ? sameChunkMeta : stateMeta;
+        if (tailMeta) _mcpLineMetas.set(sessionId, tailMeta);
         if (droppedAny) _mcpDroppingWrappedLine.add(sessionId);
       } else {
         result += tail; // safe to display immediately
@@ -155,7 +145,7 @@ function filterMcpChunk(sessionId, chunk, meta) {
     pos = nlIdx + 1;
   }
 
-  return { data: result, meta: combinedMeta };
+  return { data: result, meta: !held && result === chunk ? sameChunkMeta : stateMeta };
 }
 
 /**
@@ -183,7 +173,9 @@ function scheduleMcpBufferedFlush(sessionId) {
       return;
     }
     if (held) {
-      _deliverToListeners(sessionId, held, mergeTerminalDataMeta(_mcpPendingMetas.get(sessionId), heldMeta));
+      _deliverToListeners(sessionId, held, mergeTerminalDataMeta(_mcpPendingMetas.get(sessionId), heldMeta, {
+        preserveTerminalPerf: true,
+      }));
       _mcpPendingMetas.delete(sessionId);
     }
   }, 80));

--- a/electron/preload/terminalDataBacklog.cjs
+++ b/electron/preload/terminalDataBacklog.cjs
@@ -1,5 +1,7 @@
 "use strict";
 
+const { mergeTerminalDataMeta } = require("./terminalDataMeta.cjs");
+
 function createTerminalDataBacklog(options = {}) {
   const maxBytesPerSession = options.maxBytesPerSession ?? 64 * 1024;
   const pendingBySession = new Map();
@@ -12,21 +14,11 @@ function createTerminalDataBacklog(options = {}) {
   function append(sessionId, data, meta) {
     if (!sessionId || !data) return;
     const previous = pendingBySession.get(sessionId) || { data: "", meta: undefined };
-    const droppedOutputMayAffectTerminalState = Boolean(
-      previous.meta?.droppedOutputMayAffectTerminalState
-      || meta?.droppedOutputMayAffectTerminalState
-    );
-    const droppedOutputAlternateScreenAction = meta?.droppedOutputMayAffectTerminalState
-      ? meta?.droppedOutputAlternateScreenAction
-      : (meta?.droppedOutputAlternateScreenAction ?? previous.meta?.droppedOutputAlternateScreenAction);
-    const nextMeta = droppedOutputMayAffectTerminalState || droppedOutputAlternateScreenAction
-      ? {
-        ...(droppedOutputMayAffectTerminalState ? { droppedOutputMayAffectTerminalState: true } : {}),
-        ...(droppedOutputAlternateScreenAction ? { droppedOutputAlternateScreenAction } : {}),
-      }
-      : undefined;
+    const nextData = trimToLimit(previous.data + data);
+    const preserveTerminalPerf = previous.data.length === 0 && nextData === data;
+    const nextMeta = mergeTerminalDataMeta(previous.meta, meta, { preserveTerminalPerf });
     pendingBySession.set(sessionId, {
-      data: trimToLimit(previous.data + data),
+      data: nextData,
       meta: nextMeta,
     });
   }

--- a/electron/preload/terminalDataMeta.cjs
+++ b/electron/preload/terminalDataMeta.cjs
@@ -1,0 +1,51 @@
+"use strict";
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeTerminalDataMeta(meta) {
+  if (!isRecord(meta)) return undefined;
+  return { ...meta };
+}
+
+function hasMetaFields(meta) {
+  return Boolean(meta && Object.keys(meta).length > 0);
+}
+
+function mergeTerminalDataMeta(first, second, options = {}) {
+  const merged = {
+    ...(normalizeTerminalDataMeta(first) || {}),
+    ...(normalizeTerminalDataMeta(second) || {}),
+  };
+
+  const droppedOutputMayAffectTerminalState = Boolean(
+    first?.droppedOutputMayAffectTerminalState
+    || second?.droppedOutputMayAffectTerminalState
+  );
+  const droppedOutputAlternateScreenAction = second?.droppedOutputMayAffectTerminalState
+    ? second?.droppedOutputAlternateScreenAction
+    : (second?.droppedOutputAlternateScreenAction ?? first?.droppedOutputAlternateScreenAction);
+
+  if (droppedOutputMayAffectTerminalState) {
+    merged.droppedOutputMayAffectTerminalState = true;
+  } else {
+    delete merged.droppedOutputMayAffectTerminalState;
+  }
+
+  if (droppedOutputAlternateScreenAction) {
+    merged.droppedOutputAlternateScreenAction = droppedOutputAlternateScreenAction;
+  } else {
+    delete merged.droppedOutputAlternateScreenAction;
+  }
+
+  if (options.preserveTerminalPerf !== true) {
+    delete merged.terminalPerf;
+  }
+
+  return hasMetaFields(merged) ? merged : undefined;
+}
+
+module.exports = {
+  mergeTerminalDataMeta,
+};

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -11,6 +11,24 @@ const {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const createTerminalPerfMeta = (id = "perf-1") => ({
+  id,
+  emittedAt: 1234,
+  sessionId: "session-1",
+  chars: 5,
+  lineFeeds: 0,
+});
+
+function createFakePort() {
+  return {
+    onmessage: null,
+    close() {},
+    emit(data) {
+      this.onmessage?.({ data });
+    },
+  };
+}
+
 function loadPreloadWithFakeElectron() {
   const handlers = new Map();
   let exposedApi = null;
@@ -114,6 +132,33 @@ test("keeps terminal output metadata while trimming backlog data", () => {
 
   assert.deepEqual(backlog.takeEntry("session-1"), {
     data: "world",
+    meta: { droppedOutputMayAffectTerminalState: true },
+  });
+});
+
+test("keeps terminal perf metadata for a single backlog chunk", () => {
+  const backlog = createTerminalDataBacklog({ maxBytesPerSession: 64 });
+  const terminalPerf = createTerminalPerfMeta();
+
+  backlog.append("session-1", "hello", { terminalPerf });
+
+  assert.deepEqual(backlog.takeEntry("session-1"), {
+    data: "hello",
+    meta: { terminalPerf },
+  });
+});
+
+test("drops terminal perf metadata after backlog data is merged or trimmed", () => {
+  const backlog = createTerminalDataBacklog({ maxBytesPerSession: 8 });
+
+  backlog.append("session-1", "hello", { terminalPerf: createTerminalPerfMeta("perf-1") });
+  backlog.append("session-1", " world", {
+    terminalPerf: createTerminalPerfMeta("perf-2"),
+    droppedOutputMayAffectTerminalState: true,
+  });
+
+  assert.deepEqual(backlog.takeEntry("session-1"), {
+    data: "lo world",
     meta: { droppedOutputMayAffectTerminalState: true },
   });
 });
@@ -223,8 +268,10 @@ test("onSessionData replays pending terminal data metadata on subscribe", () => 
   const dataListeners = new Map();
   const displayDataListeners = new Map();
   const terminalDataBacklog = createTerminalDataBacklog();
+  const terminalPerf = createTerminalPerfMeta();
   terminalDataBacklog.append("session-1", "early output", {
     droppedOutputMayAffectTerminalState: true,
+    terminalPerf,
   });
 
   const api = createPreloadApi({
@@ -249,8 +296,85 @@ test("onSessionData replays pending terminal data metadata on subscribe", () => 
 
   assert.deepEqual(received, [{
     chunk: "early output",
-    meta: { droppedOutputMayAffectTerminalState: true },
+    meta: { droppedOutputMayAffectTerminalState: true, terminalPerf },
   }]);
+});
+
+test("legacy terminal data delivery preserves terminal perf metadata", () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const terminalPerf = createTerminalPerfMeta();
+    const received = [];
+    preload.api.onSessionData("session-1", (chunk, meta) => {
+      received.push({ chunk, meta });
+    });
+
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "hello",
+      meta: { terminalPerf },
+    });
+
+    assert.deepEqual(received, [{
+      chunk: "hello",
+      meta: { terminalPerf },
+    }]);
+  } finally {
+    preload.cleanup();
+  }
+});
+
+test("terminal output port delivery preserves terminal perf metadata", () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const terminalPerf = createTerminalPerfMeta();
+    const received = [];
+    const port = createFakePort();
+    preload.api.onSessionData("session-1", (chunk, meta) => {
+      received.push({ chunk, meta });
+    });
+
+    preload.handlers.get("netcatty:terminal-output-port")?.({ ports: [port] }, { sessionId: "session-1" });
+    port.emit({
+      sessionId: "session-1",
+      data: "hello",
+      meta: { terminalPerf },
+    });
+
+    assert.deepEqual(received, [{
+      chunk: "hello",
+      meta: { terminalPerf },
+    }]);
+  } finally {
+    preload.cleanup();
+  }
+});
+
+test("MCP-filtered terminal perf metadata is not carried to later output", () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const received = [];
+    preload.api.onSessionData("session-1", (chunk, meta) => {
+      received.push({ chunk, meta });
+    });
+
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "__NCMCP_TEST\n",
+      meta: { terminalPerf: createTerminalPerfMeta() },
+    });
+    preload.handlers.get("netcatty:data")?.({}, {
+      sessionId: "session-1",
+      data: "READY\n",
+    });
+
+    assert.deepEqual(received, [{
+      chunk: "READY\n",
+      meta: undefined,
+    }]);
+  } finally {
+    preload.cleanup();
+  }
 });
 
 test("delayed MCP terminal data flush preserves metadata", async () => {


### PR DESCRIPTION
Follow-up to #1994. This PR contains the review follow-up work that was pushed after #1994 had already been merged.

Summary:
- Keep hidden terminal panes from flushing large pending output until visible again.
- Flush pending hidden terminal writes before hibernating so buffered output is not lost.
- Preserve terminal performance metadata only when it still maps to a single original chunk.
- Make timestamp batching safer for wide characters, combining marks, and terminal control sequences.
- Preserve terminal output metadata through preload backlog paths when safe.

Verification:
- git diff --check origin/main...HEAD
- targeted terminal/preload tests: 136 passed
- rerun of previously failing Electron subset after local Electron install completed: 119 passed
- npm test: 4397 passed, 0 failed, 3 skipped
- npm run build

Refs #1992
Refs #1994