### PR TITLE
Add terminal word separator setting

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -397,6 +397,9 @@ export const enCoreMessages: Messages = {
   'settings.terminal.behavior.middleClick.menu': 'Show menu',
   'settings.terminal.behavior.middleClick.paste': 'Paste',
   'settings.terminal.behavior.middleClick.disabled': 'Do nothing',
+  'settings.terminal.behavior.wordSeparators': 'Word separators',
+  'settings.terminal.behavior.wordSeparators.desc':
+    'Characters treated as word boundaries for double-click selection. Spaces count too; add =, comma, or : for strings like uid=name.',
   'settings.terminal.behavior.bracketedPaste': 'Bracketed paste mode',
   'settings.terminal.behavior.bracketedPaste.desc':
     'Wrap pasted text with escape sequences so the shell can distinguish paste from typed input. Disable if you see ^[[200~ artifacts.',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -374,6 +374,9 @@ export const ruCoreMessages: Messages = {
   'settings.terminal.behavior.middleClick.menu': 'Показать меню',
   'settings.terminal.behavior.middleClick.paste': 'Вставить',
   'settings.terminal.behavior.middleClick.disabled': 'Ничего не делать',
+  'settings.terminal.behavior.wordSeparators': 'Разделители слов',
+  'settings.terminal.behavior.wordSeparators.desc':
+    'Символы, которые считаются границами слова при выделении двойным щелчком. Пробел тоже учитывается; добавьте =, запятую или : для строк вроде uid=name.',
   'settings.terminal.behavior.bracketedPaste': 'Режим bracketed paste',
   'settings.terminal.behavior.bracketedPaste.desc':
     'Оборачивать вставляемый текст escape-последовательностями, чтобы оболочка отличала вставку от обычного ввода. Отключите, если видите артефакты вида ^[[200~.',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -253,6 +253,9 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.behavior.middleClick.menu': '显示菜单',
   'settings.terminal.behavior.middleClick.paste': '粘贴',
   'settings.terminal.behavior.middleClick.disabled': '无动作',
+  'settings.terminal.behavior.wordSeparators': '单词分隔符',
+  'settings.terminal.behavior.wordSeparators.desc':
+    '双击选择文本时作为边界的字符。空格也算；可添加 =、逗号或 :，方便选择 uid=name 里的部分内容。',
   'settings.terminal.behavior.bracketedPaste': '括号粘贴模式',
   'settings.terminal.behavior.bracketedPaste.desc':
     '粘贴文本时使用转义序列包裹，以便终端区分粘贴和键入。如果出现 ^[[200~ 字样请关闭此选项。',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -253,6 +253,9 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.behavior.middleClick.menu': '顯示選單',
   'settings.terminal.behavior.middleClick.paste': '貼上',
   'settings.terminal.behavior.middleClick.disabled': '無動作',
+  'settings.terminal.behavior.wordSeparators': '單字分隔符',
+  'settings.terminal.behavior.wordSeparators.desc':
+    '雙擊選取文字時作為邊界的字元。空格也算；可加入 =、逗號或 :，方便選取 uid=name 裡的部分內容。',
   'settings.terminal.behavior.bracketedPaste': '括號貼上模式',
   'settings.terminal.behavior.bracketedPaste.desc':
     '貼上文字時使用轉義序列包裹，以便終端區分貼上和鍵入。如果出現 ^[[200~ 字樣請關閉此選項。',

--- a/components/settings/TerminalBehaviorSettings.test.tsx
+++ b/components/settings/TerminalBehaviorSettings.test.tsx
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import * as terminalBehaviorSettings from "./tabs/TerminalBehaviorSettings.tsx";
+
+const source = readFileSync(new URL("./tabs/TerminalBehaviorSettings.tsx", import.meta.url), "utf8");
 
 const middleClickBehaviorOptions = (
   terminalBehaviorSettings as {
@@ -29,4 +32,10 @@ test("dynamic tab title settings expose off, agent-only, and all modes", () => {
     dynamicTabTitleModeOptions.map((option) => option.value),
     ["off", "agent", "all"],
   );
+});
+
+test("terminal behavior settings expose word separator editing", () => {
+  assert.match(source, /settings\.terminal\.behavior\.wordSeparators/);
+  assert.match(source, /terminalSettings\.wordSeparators/);
+  assert.match(source, /updateTerminalSetting\("wordSeparators", e\.target\.value\)/);
 });

--- a/components/settings/tabs/TerminalBehaviorSettings.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { DEFAULT_TERMINAL_WORD_SEPARATORS } from "../../../domain/models";
 import type { DynamicTabTitleMode, LinkModifier, MiddleClickBehavior, RightClickBehavior, TerminalSettings } from "../../../domain/models";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
@@ -73,6 +74,19 @@ export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> =
             }))}
             onChange={(v) => updateTerminalSetting("middleClickBehavior", v as MiddleClickBehavior)}
             className="w-36"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label={t("settings.terminal.behavior.wordSeparators")}
+          description={t("settings.terminal.behavior.wordSeparators.desc")}
+        >
+          <Input
+            value={terminalSettings.wordSeparators}
+            onChange={(e) => updateTerminalSetting("wordSeparators", e.target.value)}
+            placeholder={`${DEFAULT_TERMINAL_WORD_SEPARATORS}=,:`}
+            className="w-56 font-mono"
+            spellCheck={false}
           />
         </SettingRow>
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -105,7 +105,11 @@ import type {
   TerminalSettings,
   TerminalTheme,
 } from "../../../types";
-import { matchesKeyBinding, type Snippet } from "../../../domain/models";
+import {
+  DEFAULT_TERMINAL_WORD_SEPARATORS,
+  matchesKeyBinding,
+  type Snippet,
+} from "../../../domain/models";
 
 type TerminalBackendApi = {
   openExternalAvailable: () => boolean;
@@ -330,7 +334,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     ? performanceConfig.options.smoothScrollDuration
     : 0;
   const altIsMeta = settings?.altAsMeta ?? false;
-  const wordSeparator = settings?.wordSeparators ?? " ()[]{}'\"";
+  const wordSeparator = settings?.wordSeparators ?? DEFAULT_TERMINAL_WORD_SEPARATORS;
   const keywordHighlightRules = settings?.keywordHighlightRules ?? [];
   const keywordHighlightEnabled = settings?.keywordHighlightEnabled ?? false;
   const kittyKeyboardMode = createKittyKeyboardModeState();

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -15,6 +15,8 @@ export type LinkModifier = 'none' | 'ctrl' | 'alt' | 'meta';
 export type TerminalEmulationType = 'xterm-256color' | 'xterm-16color' | 'xterm';
 export type DynamicTabTitleMode = 'off' | 'agent' | 'all';
 
+export const DEFAULT_TERMINAL_WORD_SEPARATORS = ' ()[]{}\'"';
+
 // Keyword highlighting configuration
 export interface KeywordHighlightRule {
   id: string;
@@ -275,11 +277,15 @@ export const normalizeTerminalSettings = (
   settings?: Partial<TerminalSettings> | null,
 ): TerminalSettings => {
   const middleClickBehavior = resolveMiddleClickBehavior(settings);
+  const wordSeparators = typeof settings?.wordSeparators === 'string'
+    ? settings.wordSeparators
+    : DEFAULT_TERMINAL_SETTINGS.wordSeparators;
   const mergedSettings = {
     ...DEFAULT_TERMINAL_SETTINGS,
     ...(settings ?? {}),
     middleClickBehavior,
     middleClickPaste: middleClickBehavior === 'paste',
+    wordSeparators,
     dynamicTabTitleMode: isDynamicTabTitleMode(settings?.dynamicTabTitleMode)
       ? settings.dynamicTabTitleMode
       : DEFAULT_TERMINAL_SETTINGS.dynamicTabTitleMode,
@@ -336,7 +342,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   middleClickBehavior: 'paste',
   copyOnSelect: false,
   middleClickPaste: true,
-  wordSeparators: ' ()[]{}\'"',
+  wordSeparators: DEFAULT_TERMINAL_WORD_SEPARATORS,
   linkModifier: 'none',
   keywordHighlightEnabled: true,
   keywordHighlightRules: DEFAULT_KEYWORD_HIGHLIGHT_RULES,

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -80,6 +80,23 @@ test("normalizeTerminalSettings defaults middle-click behavior to paste", () => 
   assert.equal(settings.middleClickPaste, true);
 });
 
+test("normalizeTerminalSettings defaults word separators to xterm-compatible boundaries", () => {
+  assert.equal(normalizeTerminalSettings().wordSeparators, " ()[]{}'\"");
+});
+
+test("normalizeTerminalSettings preserves custom word separators", () => {
+  const custom = " ()[]{}'\"=,:";
+
+  assert.equal(normalizeTerminalSettings({ wordSeparators: custom }).wordSeparators, custom);
+});
+
+test("normalizeTerminalSettings falls back when word separators are not a string", () => {
+  assert.equal(
+    normalizeTerminalSettings({ wordSeparators: null as never }).wordSeparators,
+    " ()[]{}'\"",
+  );
+});
+
 test("normalizeTerminalSettings migrates disabled legacy middle-click paste", () => {
   const settings = normalizeTerminalSettings({ middleClickPaste: false });
 


### PR DESCRIPTION
## Summary
- Add a Terminal behavior setting for double-click word separators.
- Preserve the existing default separators while allowing custom separators such as `=`, `,`, and `:`.
- Add localized settings copy and regression coverage for default/custom values.

Closes #1991

## Validation
- `node --test --import tsx domain/terminalSettings.test.ts components/settings/TerminalBehaviorSettings.test.tsx`
- `npm run lint`
- `npm run build`
- `npm test` initially hit a local Electron binary install issue; after `npm exec -- install-electron --no`, the previously failing Electron test files were rerun and passed.