### PR TITLE
Improve vault edit button placement

### DIFF
--- a/components/HostTreeView.test.tsx
+++ b/components/HostTreeView.test.tsx
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import type { GroupConfig, Host } from "../types.ts";
-import { getHostTreeDisplayDetails } from "./HostTreeView.tsx";
+import type { GroupConfig, GroupNode, Host } from "../types.ts";
+import { getHostTreeDisplayDetails, HostTreeView } from "./HostTreeView.tsx";
 
 const baseHost: Host = {
   id: "host-1",
@@ -14,6 +16,22 @@ const baseHost: Host = {
   tags: [],
   os: "linux",
   createdAt: 1,
+};
+
+const installLocalStorageMock = () => {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+  });
 };
 
 test("HostTreeView display details include inherited telnet defaults", () => {
@@ -55,4 +73,80 @@ test("HostTreeView display details keep explicit cleared telnet username", () =>
     username: "",
     port: 2325,
   });
+});
+
+test("HostTreeView renders the host edit action beside the host label", () => {
+  installLocalStorageMock();
+
+  const markup = renderToStaticMarkup(
+    <HostTreeView
+      groupTree={[]}
+      hosts={[{
+        ...baseHost,
+        notes: "Maintenance notes",
+        tags: ["edge"],
+      }]}
+      onConnect={() => undefined}
+      onEditHost={() => undefined}
+      onDuplicateHost={() => undefined}
+      onDeleteHost={() => undefined}
+      onCopyCredentials={() => undefined}
+      onNewGroup={() => undefined}
+      onRenameGroup={() => undefined}
+      onEditGroup={() => undefined}
+      onDeleteGroup={() => undefined}
+      moveHostToGroup={() => undefined}
+      moveGroup={() => undefined}
+    />,
+  );
+
+  const labelIndex = markup.indexOf("Router");
+  const editButtonIndex = markup.indexOf('data-host-tree-host-edit-button="host-1"');
+  const notesIndex = markup.indexOf('aria-label="Host notes"', labelIndex);
+  const protocolIndex = markup.indexOf("TELNET", labelIndex);
+
+  assert.ok(labelIndex >= 0);
+  assert.ok(editButtonIndex > labelIndex);
+  assert.ok(notesIndex > editButtonIndex);
+  assert.ok(protocolIndex > notesIndex);
+});
+
+test("HostTreeView renders the group edit action beside the group label", () => {
+  installLocalStorageMock();
+
+  const groupNode: GroupNode = {
+    name: "Production",
+    path: "production",
+    children: {},
+    hosts: [],
+    totalHostCount: 2,
+  };
+
+  const markup = renderToStaticMarkup(
+    <HostTreeView
+      groupTree={[groupNode]}
+      hosts={[]}
+      expandedPaths={new Set<string>()}
+      onTogglePath={() => undefined}
+      onConnect={() => undefined}
+      onEditHost={() => undefined}
+      onDuplicateHost={() => undefined}
+      onDeleteHost={() => undefined}
+      onCopyCredentials={() => undefined}
+      onNewGroup={() => undefined}
+      onRenameGroup={() => undefined}
+      onEditGroup={() => undefined}
+      onDeleteGroup={() => undefined}
+      moveHostToGroup={() => undefined}
+      moveGroup={() => undefined}
+    />,
+  );
+
+  const labelIndex = markup.indexOf("Production");
+  const editButtonIndex = markup.indexOf('data-host-tree-group-edit-button="production"');
+  const countIndex = markup.indexOf(">2<", editButtonIndex);
+
+  assert.ok(labelIndex >= 0);
+  assert.ok(editButtonIndex > labelIndex);
+  assert.ok(countIndex > editButtonIndex);
 });

--- a/components/HostTreeView.tsx
+++ b/components/HostTreeView.tsx
@@ -272,15 +272,17 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                     Managed
                   </span>
                 )}
-                actions={(
+                labelActions={(
                   <button
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
+                    aria-label={`Edit ${node.name}`}
+                    data-host-tree-group-edit-button={node.path}
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded opacity-0 transition-colors hover:bg-secondary/80 group-hover:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation();
                       onEditGroup(node.path);
                     }}
                   >
-                    <Edit2 size={13} />
+                    <Edit2 size={12} />
                   </button>
                 )}
               />
@@ -463,6 +465,17 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
             <div className="min-w-0 flex-1 leading-tight">
               <div className="flex items-center gap-1.5 truncate font-medium leading-4">
                 <span className="truncate">{host.label}</span>
+                <button
+                  aria-label={`Edit ${host.label}`}
+                  data-host-tree-host-edit-button={host.id}
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded transition-colors opacity-0 hover:bg-secondary/80 group-hover:opacity-100"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEditHost(host);
+                  }}
+                >
+                  <Edit2 size={12} />
+                </button>
                 <HostNotesIndicator notes={host.notes} />
               </div>
               <div className="truncate text-[11px] leading-4 text-muted-foreground">
@@ -470,7 +483,7 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
               </div>
             </div>
           )}
-          actions={(
+          actions={(displayProtocol && displayProtocol !== 'ssh') || tags.length > 0 ? (
             <div className="ml-2 flex shrink-0 items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100">
               {displayProtocol && displayProtocol !== 'ssh' && (
                 <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] leading-none text-primary">
@@ -483,17 +496,8 @@ const HostTreeItem: React.FC<HostTreeItemProps> = ({
                   {tags.length > 2 && '...'}
                 </span>
               )}
-              <button
-                className="flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-secondary/80"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEditHost(host);
-                }}
-              >
-                <Edit2 size={12} />
-              </button>
             </div>
-          )}
+          ) : undefined}
         />
       </ContextMenuTrigger>
       <HostTreeHostContextMenuContent

--- a/components/vault/VaultHostListSection.test.tsx
+++ b/components/vault/VaultHostListSection.test.tsx
@@ -1,0 +1,302 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  CheckSquare,
+  ClipboardCopy,
+  Clock,
+  Copy,
+  Edit2,
+  FileSymlink,
+  FolderPlus,
+  FolderTree,
+  LayoutGrid,
+  Pin,
+  Plug,
+  Square,
+  Star,
+  Trash2,
+} from "lucide-react";
+
+import { getEffectiveHostDistro, sanitizeHost } from "../../domain/host.ts";
+import type { GroupNode, Host } from "../../types.ts";
+import { DistroAvatar } from "../DistroAvatar.tsx";
+import { HostTreeView } from "../HostTreeView.tsx";
+import { Badge } from "../ui/badge.tsx";
+import { Button } from "../ui/button.tsx";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "../ui/context-menu.tsx";
+import { cn } from "../../lib/utils.ts";
+import { VaultHostListSection } from "./VaultHostListSection.tsx";
+
+const makeHost = (id: string, label: string): Host => ({
+  id,
+  label,
+  hostname: "router.example.com",
+  username: "netops",
+  port: 22,
+  os: "linux",
+  tags: [],
+  notes: "Maintenance notes",
+  createdAt: 1,
+});
+
+const mainHost = makeHost("main-host", "Main Router");
+const pinnedHost = makeHost("pinned-host", "Pinned Router");
+const recentHost = makeHost("recent-host", "Recent Router");
+const groupedHost = makeHost("grouped-host", "Grouped Router");
+
+const group: GroupNode = {
+  name: "Production",
+  path: "production",
+  children: {},
+  hosts: [mainHost],
+  totalHostCount: 1,
+};
+
+const noop = () => undefined;
+
+type RenderHostListOptions = {
+  displayedGroups?: GroupNode[];
+  displayedHosts?: Host[];
+  groupedDisplayHosts?: Array<{ name: string; hosts: Host[] }>;
+  pinnedHosts?: Host[];
+  pinnedRecentIds?: Set<string>;
+  recentHosts?: Host[];
+  showRecentHosts?: boolean;
+  sortMode?: string;
+  treeViewGroupTree?: GroupNode[];
+  treeViewHosts?: Host[];
+  viewMode: "list" | "grid" | "tree";
+  visibleDisplayedHosts?: Host[];
+};
+
+const renderHostList = ({
+  displayedGroups = [group],
+  displayedHosts = [mainHost],
+  groupedDisplayHosts,
+  pinnedHosts = [],
+  pinnedRecentIds = new Set<string>(),
+  recentHosts = [],
+  showRecentHosts = false,
+  sortMode = "az",
+  treeViewGroupTree = [],
+  treeViewHosts = [],
+  viewMode,
+  visibleDisplayedHosts = [mainHost],
+}: RenderHostListOptions) => renderToStaticMarkup(
+  <VaultHostListSection
+    ctx={{
+      Badge,
+      Boolean,
+      Button,
+      cancelInlineGroupEdit: noop,
+      CheckSquare,
+      ClipboardCopy,
+      Clock,
+      cn,
+      commitInlineGroupRename: noop,
+      ContextMenu,
+      ContextMenuContent,
+      ContextMenuItem,
+      ContextMenuTrigger,
+      Copy,
+      displayedGroups,
+      displayedHosts,
+      DistroAvatar,
+      Edit2,
+      FileSymlink,
+      FolderPlus,
+      FolderTree,
+      getDropTargetClasses: () => "",
+      getEffectiveHostDistro,
+      groupConfigs: [],
+      groupedDisplayHosts,
+      handleCopyCredentials: noop,
+      handleDuplicateHost: noop,
+      handleEditGroupConfig: noop,
+      handleEditHost: noop,
+      handleHostConnect: noop,
+      handleUnmanageGroup: noop,
+      hasHostsSidePanel: false,
+      hostListScrollRef: React.createRef<HTMLDivElement>(),
+      HostTreeView,
+      isHostsSectionActive: true,
+      isMultiSelectMode: false,
+      lastPinnedId: null,
+      LayoutGrid,
+      managedGroupPaths: new Set<string>(),
+      moveGroup: noop,
+      moveHostToGroup: noop,
+      onDeleteHost: noop,
+      Pin,
+      pinnedHosts,
+      pinnedRecentIds,
+      Plug,
+      recentHosts,
+      reorderGroup: noop,
+      reorderHost: noop,
+      sanitizeHost,
+      selectedGroupPath: null,
+      selectedHostIds: new Set<string>(),
+      sessionCount: 0,
+      setDeleteTargetPath: noop,
+      setDragOverDropTarget: noop,
+      setGroupDragOverDropTarget: noop,
+      setIsDeleteGroupOpen: noop,
+      setIsNewFolderOpen: noop,
+      setLastPinnedId: noop,
+      setNewFolderName: noop,
+      setSelectedGroupPath: noop,
+      setTargetParentPath: noop,
+      shouldHideEmptyRootHostsSection: false,
+      showRecentHosts,
+      sortMode,
+      splitViewGridStyle: undefined,
+      Square,
+      Star,
+      startInlineDeleteGroup: noop,
+      startInlineNewGroup: noop,
+      startInlineRenameGroup: noop,
+      t: (key: string) => key,
+      toggleHostPinned: noop,
+      toggleHostSelection: noop,
+      Trash2,
+      treeExpandedState: {
+        expandedPaths: new Set<string>(),
+        togglePath: noop,
+        expandAll: noop,
+        collapseAll: noop,
+      },
+      treeViewGroupTree,
+      treeViewHosts,
+      viewMode,
+      visibleDisplayedHosts,
+    }}
+  />,
+);
+
+const editButtonIndexForHost = (markup: string, hostId: string) =>
+  markup.indexOf(`data-vault-host-edit-button="${hostId}"`);
+
+const editButtonIndexForGroup = (markup: string, groupPath: string) =>
+  markup.indexOf(`data-vault-group-edit-button="${groupPath}"`);
+
+const assertListHostPlacement = (markup: string, host: Host) => {
+  const listLabelIndex = markup.indexOf(host.label);
+  const listEditIndex = editButtonIndexForHost(markup, host.id);
+  const listNotesIndex = markup.indexOf('aria-label="Host notes"', listLabelIndex);
+
+  assert.ok(listLabelIndex >= 0);
+  assert.ok(listEditIndex > listLabelIndex);
+  assert.ok(listNotesIndex > listEditIndex);
+};
+
+const assertGridHostPlacement = (markup: string, host: Host) => {
+  const gridLabelIndex = markup.indexOf(host.label);
+  const gridNotesIndex = markup.indexOf('aria-label="Host notes"', gridLabelIndex);
+  const gridEditIndex = editButtonIndexForHost(markup, host.id);
+
+  assert.ok(gridLabelIndex >= 0);
+  assert.ok(gridNotesIndex > gridLabelIndex);
+  assert.ok(gridEditIndex > gridNotesIndex);
+};
+
+const assertListGroupPlacement = (markup: string, groupNode: GroupNode) => {
+  const listLabelIndex = markup.indexOf(groupNode.name);
+  const listEditIndex = editButtonIndexForGroup(markup, groupNode.path);
+  const listCountIndex = markup.indexOf("vault.groups.hostsCount", listLabelIndex);
+
+  assert.ok(listLabelIndex >= 0);
+  assert.ok(listEditIndex > listLabelIndex);
+  assert.ok(listCountIndex > listEditIndex);
+};
+
+const assertGridGroupPlacement = (markup: string, groupNode: GroupNode) => {
+  const gridLabelIndex = markup.indexOf(groupNode.name);
+  const gridCountIndex = markup.indexOf("vault.groups.hostsCount", gridLabelIndex);
+  const gridEditIndex = editButtonIndexForGroup(markup, groupNode.path);
+
+  assert.ok(gridLabelIndex >= 0);
+  assert.ok(gridCountIndex > gridLabelIndex);
+  assert.ok(gridEditIndex > gridCountIndex);
+};
+
+test("VaultHostListSection keeps list edit actions beside host labels in all list sections without changing grid", () => {
+  const listMarkup = renderHostList({
+    viewMode: "list",
+    displayedGroups: [],
+    displayedHosts: [mainHost, pinnedHost, recentHost],
+    pinnedHosts: [pinnedHost],
+    recentHosts: [recentHost],
+    showRecentHosts: true,
+    visibleDisplayedHosts: [mainHost],
+  });
+
+  assertListHostPlacement(listMarkup, pinnedHost);
+  assertListHostPlacement(listMarkup, recentHost);
+  assertListHostPlacement(listMarkup, mainHost);
+
+  const gridMarkup = renderHostList({
+    viewMode: "grid",
+    displayedGroups: [],
+    displayedHosts: [mainHost, pinnedHost, recentHost],
+    pinnedHosts: [pinnedHost],
+    recentHosts: [recentHost],
+    showRecentHosts: true,
+    visibleDisplayedHosts: [mainHost],
+  });
+
+  assertGridHostPlacement(gridMarkup, pinnedHost);
+  assertGridHostPlacement(gridMarkup, recentHost);
+  assertGridHostPlacement(gridMarkup, mainHost);
+});
+
+test("VaultHostListSection keeps grouped host edit actions beside labels without changing grid", () => {
+  const listMarkup = renderHostList({
+    viewMode: "list",
+    displayedGroups: [],
+    displayedHosts: [groupedHost],
+    groupedDisplayHosts: [{ name: "Routers", hosts: [groupedHost] }],
+    sortMode: "group",
+    visibleDisplayedHosts: [],
+  });
+
+  assertListHostPlacement(listMarkup, groupedHost);
+
+  const gridMarkup = renderHostList({
+    viewMode: "grid",
+    displayedGroups: [],
+    displayedHosts: [groupedHost],
+    groupedDisplayHosts: [{ name: "Routers", hosts: [groupedHost] }],
+    sortMode: "group",
+    visibleDisplayedHosts: [],
+  });
+
+  assertGridHostPlacement(gridMarkup, groupedHost);
+});
+
+test("VaultHostListSection keeps list group edit action beside the group label without changing grid", () => {
+  const listMarkup = renderHostList({
+    viewMode: "list",
+    displayedGroups: [group],
+    displayedHosts: [],
+    visibleDisplayedHosts: [],
+  });
+
+  assertListGroupPlacement(listMarkup, group);
+
+  const gridMarkup = renderHostList({
+    viewMode: "grid",
+    displayedGroups: [group],
+    displayedHosts: [],
+    visibleDisplayedHosts: [],
+  });
+
+  assertGridGroupPlacement(gridMarkup, group);
+});

--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -47,6 +47,44 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
     setDragOverDropTarget(null);
   }, [setDragOverDropTarget]);
 
+  const renderHostEditButton = (host: any, compact = false) => (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={`Edit ${host.label || "host"}`}
+      data-vault-host-edit-button={host.id}
+      className={cn(
+        "opacity-0 group-hover:opacity-100 transition-opacity shrink-0",
+        compact ? "h-6 w-6" : "h-8 w-8",
+      )}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        handleEditHost(host);
+      }}
+    >
+      <Edit2 size={compact ? 13 : 14} />
+    </Button>
+  );
+
+  const renderGroupEditButton = (groupPath: string, compact = false) => (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label={`Edit ${groupPath || "group"}`}
+      data-vault-group-edit-button={groupPath}
+      className={cn(
+        "opacity-0 group-hover:opacity-100 transition-opacity shrink-0",
+        compact ? "h-6 w-6" : "h-8 w-8",
+      )}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        handleEditGroupConfig(groupPath);
+      }}
+    >
+      <Edit2 size={compact ? 13 : 14} />
+    </Button>
+  );
+
   return <div
           ref={hostListScrollRef}
           className={cn(
@@ -276,23 +314,14 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         <span className="text-sm font-semibold truncate leading-5">
                                           {safeHost.label}
                                         </span>
+                                        {viewMode !== "grid" && renderHostEditButton(host, true)}
                                         <HostNotesIndicator notes={safeHost.notes} />
                                       </div>
                                       <div className="text-[11px] text-muted-foreground font-mono truncate leading-4">
                                         {safeHost.username}@{safeHost.hostname}
                                       </div>
                                     </div>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleEditHost(host);
-                                      }}
-                                    >
-                                      <Edit2 size={14} />
-                                    </Button>
+                                    {viewMode === "grid" && renderHostEditButton(host)}
                                   </div>
                                 </div>
                               </ContextMenuTrigger>
@@ -386,23 +415,14 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         <span className="text-sm font-semibold truncate leading-5">
                                           {safeHost.label}
                                         </span>
+                                        {viewMode !== "grid" && renderHostEditButton(host, true)}
                                         <HostNotesIndicator notes={safeHost.notes} />
                                       </div>
                                       <div className="text-[11px] text-muted-foreground font-mono truncate leading-4">
                                         {safeHost.username}@{safeHost.hostname}
                                       </div>
                                     </div>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleEditHost(host);
-                                      }}
-                                    >
-                                      <Edit2 size={14} />
-                                    </Button>
+                                    {viewMode === "grid" && renderHostEditButton(host)}
                                   </div>
                                 </div>
                               </ContextMenuTrigger>
@@ -532,8 +552,9 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                   icon={<FolderTree size={20} />}
                                 />
                                 <div className="flex-1 min-w-0">
-                                  <div className="text-sm font-semibold truncate flex items-center gap-2">
-                                    {node.name}
+                                  <div className="text-sm font-semibold flex items-center gap-1.5 min-w-0">
+                                    <span className="truncate">{node.name}</span>
+                                    {viewMode !== "grid" && renderGroupEditButton(node.path, true)}
                                     {managedGroupPaths.has(node.path) && (
                                       <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-primary/15 text-primary shrink-0">
                                         <FileSymlink size={10} />
@@ -545,17 +566,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                     {t("vault.groups.hostsCount", { count: node.totalHostCount ?? node.hosts.length })}
                                   </div>
                                 </div>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleEditGroupConfig(node.path);
-                                  }}
-                                >
-                                  <Edit2 size={14} />
-                                </Button>
+                                {viewMode === "grid" && renderGroupEditButton(node.path)}
                               </div>
                             </div>
                           </ContextMenuTrigger>
@@ -724,6 +735,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                               <span className="text-sm font-semibold truncate leading-5">
                                                 {safeHost.label}
                                               </span>
+                                              {viewMode !== "grid" && renderHostEditButton(host, true)}
                                               {safeHost.managedSourceId && (
                                                 <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 shrink-0">
                                                   managed
@@ -735,17 +747,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                               {safeHost.username}@{safeHost.hostname}
                                             </div>
                                           </div>
-                                          <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              handleEditHost(host);
-                                            }}
-                                          >
-                                            <Edit2 size={14} />
-                                          </Button>
+                                          {viewMode === "grid" && renderHostEditButton(host)}
                                         </div>
                                       </div>
                                     </ContextMenuTrigger>
@@ -873,6 +875,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         <span className="text-sm font-semibold truncate leading-5">
                                           {safeHost.label}
                                         </span>
+                                        {viewMode !== "grid" && renderHostEditButton(host, true)}
                                         {safeHost.managedSourceId && (
                                           <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 shrink-0">
                                             managed
@@ -884,17 +887,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                         {safeHost.username}@{safeHost.hostname}
                                       </div>
                                     </div>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleEditHost(host);
-                                      }}
-                                    >
-                                      <Edit2 size={14} />
-                                    </Button>
+                                    {viewMode === "grid" && renderHostEditButton(host)}
                                   </div>
                                 </div>
                               </ContextMenuTrigger>

--- a/components/vault/VaultTreeRow.test.tsx
+++ b/components/vault/VaultTreeRow.test.tsx
@@ -29,6 +29,29 @@ test("VaultTreeGroupRow exposes shared selected and expanded tree row state", ()
   assert.match(markup, /3/);
 });
 
+test("VaultTreeGroupRow can render an action beside the group label", () => {
+  const markup = renderToStaticMarkup(
+    <VaultTreeGroupRow
+      name="Production"
+      depth={1}
+      count={3}
+      labelActions={<button data-label-action="edit">Edit</button>}
+      actions={<span data-row-action="count">Row action</span>}
+    />,
+  );
+
+  const labelIndex = markup.indexOf("Production");
+  const labelActionIndex = markup.indexOf('data-label-action="edit"');
+  const countIndex = markup.indexOf(">3<", labelActionIndex);
+  const rowActionIndex = markup.indexOf('data-row-action="count"', countIndex);
+
+  assert.ok(labelIndex >= 0);
+  assert.ok(labelActionIndex > labelIndex);
+  assert.ok(countIndex > labelActionIndex);
+  assert.ok(rowActionIndex > countIndex);
+});
+
+
 test("VaultTreeItemRow exposes shared selected item state", () => {
   const markup = renderToStaticMarkup(
     <VaultTreeItemRow

--- a/components/vault/VaultTreeRow.tsx
+++ b/components/vault/VaultTreeRow.tsx
@@ -94,6 +94,7 @@ type VaultTreeGroupRowProps = Omit<React.HTMLAttributes<HTMLDivElement>, "childr
   onRenameCommit?: (name: string) => void;
   onRenameCancel?: () => void;
   actions?: React.ReactNode;
+  labelActions?: React.ReactNode;
   icon?: React.ReactNode;
   iconSize?: number;
   meta?: React.ReactNode;
@@ -113,6 +114,7 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
   onRenameCommit,
   onRenameCancel,
   actions,
+  labelActions,
   icon,
   iconSize = 18,
   meta,
@@ -161,7 +163,10 @@ export const VaultTreeGroupRow: React.FC<VaultTreeGroupRowProps> = ({
           className="flex-1 font-semibold"
         />
       ) : (
-        <span className="flex h-5 min-w-0 flex-1 translate-y-px items-center truncate leading-none">{name}</span>
+        <span className="flex h-5 min-w-0 flex-1 translate-y-px items-center gap-1.5 leading-none">
+          <span className="min-w-0 truncate">{name}</span>
+          {labelActions}
+        </span>
       )}
       {meta}
       {typeof count === "number" && count > 0 && (


### PR DESCRIPTION
## Summary
- move host edit buttons next to names in list and tree views
- move group edit buttons next to names in list and tree views
- keep grid placement unchanged

Closes #1993

## Checks
- node --test --import tsx components/HostTreeView.test.tsx components/vault/VaultTreeRow.test.tsx components/vault/VaultHostListSection.test.tsx
- npx eslint components/HostTreeView.tsx components/HostTreeView.test.tsx components/vault/VaultTreeRow.tsx components/vault/VaultTreeRow.test.tsx components/vault/VaultHostListSection.tsx components/vault/VaultHostListSection.test.tsx
- npm run build