### PR TITLE
Fix terminal search state hibernate guard

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -394,8 +394,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const terminalSettingsRef = useRef(terminalSettings);
   terminalSettingsRef.current = terminalSettings;
-  const isSearchOpenRef = useRef(isSearchOpen);
-  isSearchOpenRef.current = isSearchOpen;
+  const isSearchOpenRef = useRef(false);
   const hibernateFileTransferActiveRef = useRef(false);
   const handleUpdateHostFromTerminal = useCallback((hostUpdate: TerminalHostUpdate) => {
     onUpdateHost?.(hostUpdate as Host);
@@ -657,6 +656,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     handleFindPrevious,
     handleCloseSearch,
   } = terminalSearch;
+  isSearchOpenRef.current = isSearchOpen;
 
   const prepareProgrammaticSudoInput = useCallback((data: string): string => {
     if (


### PR DESCRIPTION
## Summary
- avoid reading terminal search state before the search hook initializes
- keep the hibernate retry guard using the current search-open state

## Verification
- git diff --check
- npm run lint -- --quiet
- npm run build
- codex review --base origin/main