### PR TITLE
fix: clarify MCP terminal tools in environment context

### DIFF
--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -800,6 +800,7 @@ const {
 } = require("../capabilities/policy.cjs");
 const { CAPABILITY_SURFACES } = require("../capabilities/constants.cjs");
 const { getCapabilityByRpcMethod } = require("../capabilities/registry.cjs");
+const { listMcpTools } = require("../capabilities/codegen/toolSurfaces.cjs");
 const {
   createCapabilityRpcDispatcher,
   UNROUTED,
@@ -877,6 +878,39 @@ function buildHostFromMetadata(sessionId, meta) {
     hostId: meta.hostId || "",
     hostChain: Array.isArray(meta.hostChain) ? meta.hostChain : [],
     activePortForwards: Array.isArray(meta.activePortForwards) ? meta.activePortForwards : [],
+  };
+}
+
+function pickToolHints(toolMap, hints) {
+  return Object.fromEntries(
+    Object.entries(hints)
+      .map(([key, capabilityId]) => [key, toolMap.get(capabilityId)])
+      .filter(([, toolName]) => Boolean(toolName)),
+  );
+}
+
+function buildMcpToolHints() {
+  const toolMap = new Map(listMcpTools().map((tool) => [tool.capabilityId, tool.mcpTool]));
+
+  return {
+    environment: toolMap.get("session.environment"),
+    terminal: pickToolHints(toolMap, {
+      execute: "terminal.execute",
+      start: "terminal.start",
+      poll: "terminal.poll",
+      stop: "terminal.stop",
+    }),
+    attachments: pickToolHints(toolMap, {
+      list: "attachment.list",
+      read: "attachment.read",
+    }),
+    sftp: pickToolHints(toolMap, {
+      list: "sftp.list",
+      read: "sftp.read",
+      write: "sftp.write",
+      download: "sftp.download",
+      upload: "sftp.upload",
+    }),
   };
 }
 
@@ -1151,7 +1185,13 @@ async function dispatch(method, params) {
 
 async function handleGetContext(params) {
   debugLog("handleGetContext:start", { params, sessionCount: sessions?.size || 0 });
-  if (!sessions) return { hosts: [], instructions: "No sessions available." };
+  if (!sessions) {
+    return {
+      hosts: [],
+      instructions: "No sessions available.",
+      tools: buildMcpToolHints(),
+    };
+  }
 
   // chatSessionId may be passed via env for per-scope metadata lookup
   const chatSessionId = params?.chatSessionId || null;
@@ -1175,6 +1215,7 @@ async function handleGetContext(params) {
       description: "No hosts are available in the current scope.",
       hosts: [],
       hostCount: 0,
+      tools: buildMcpToolHints(),
     };
   }
   for (const [sessionId, session] of sessions.entries()) {
@@ -1228,6 +1269,7 @@ async function handleGetContext(params) {
       "You are operating inside Netcatty, a multi-session terminal manager. " +
       "The available sessions may be remote hosts, local terminals, Mosh-backed shells, or serial port connections (network devices, embedded systems). " +
       "Use the provided tools to execute commands through the sessions exposed by Netcatty. " +
+      "For terminal commands, use `terminal_execute` for short commands and `terminal_start`, `terminal_poll`, and `terminal_stop` for long-running commands. " +
       "Serial sessions (protocol: serial, shellType: raw) do not run a standard shell — commands are sent as-is. " +
       "Network device sessions (deviceType: network) use vendor CLIs (Huawei VRP, Cisco IOS, etc.) — commands are sent as-is without shell wrapping, and exit codes are unavailable. " +
       "Vault snippets, port forwarding rules/tunnels, and SFTP read/write tools are available when exposed in the tool list. " +
@@ -1236,6 +1278,7 @@ async function handleGetContext(params) {
     hosts,
     hostCount: hosts.length,
     activePortForwardTunnels,
+    tools: buildMcpToolHints(),
   };
 }
 

--- a/electron/bridges/mcpServerBridge.cjs
+++ b/electron/bridges/mcpServerBridge.cjs
@@ -914,6 +914,17 @@ function buildMcpToolHints() {
   };
 }
 
+function buildTerminalToolGuidance(toolHints) {
+  const terminal = toolHints?.terminal || {};
+  if (terminal.execute && terminal.start && terminal.poll && terminal.stop) {
+    return `For terminal commands, use \`${terminal.execute}\` for short commands and \`${terminal.start}\`, \`${terminal.poll}\`, and \`${terminal.stop}\` for long-running commands. `;
+  }
+  if (Object.keys(terminal).length > 0) {
+    return "For terminal commands, use the terminal tools listed in tools.terminal. ";
+  }
+  return "";
+}
+
 async function handleWorkerTerminalExec(params = {}) {
   const { sessionId, command } = params;
   if (!sessionId || !command) throw new Error("sessionId and command are required");
@@ -1185,11 +1196,12 @@ async function dispatch(method, params) {
 
 async function handleGetContext(params) {
   debugLog("handleGetContext:start", { params, sessionCount: sessions?.size || 0 });
+  const toolHints = buildMcpToolHints();
   if (!sessions) {
     return {
       hosts: [],
       instructions: "No sessions available.",
-      tools: buildMcpToolHints(),
+      tools: toolHints,
     };
   }
 
@@ -1215,7 +1227,7 @@ async function handleGetContext(params) {
       description: "No hosts are available in the current scope.",
       hosts: [],
       hostCount: 0,
-      tools: buildMcpToolHints(),
+      tools: toolHints,
     };
   }
   for (const [sessionId, session] of sessions.entries()) {
@@ -1269,7 +1281,7 @@ async function handleGetContext(params) {
       "You are operating inside Netcatty, a multi-session terminal manager. " +
       "The available sessions may be remote hosts, local terminals, Mosh-backed shells, or serial port connections (network devices, embedded systems). " +
       "Use the provided tools to execute commands through the sessions exposed by Netcatty. " +
-      "For terminal commands, use `terminal_execute` for short commands and `terminal_start`, `terminal_poll`, and `terminal_stop` for long-running commands. " +
+      buildTerminalToolGuidance(toolHints) +
       "Serial sessions (protocol: serial, shellType: raw) do not run a standard shell — commands are sent as-is. " +
       "Network device sessions (deviceType: network) use vendor CLIs (Huawei VRP, Cisco IOS, etc.) — commands are sent as-is without shell wrapping, and exit codes are unavailable. " +
       "Vault snippets, port forwarding rules/tunnels, and SFTP read/write tools are available when exposed in the tool list. " +
@@ -1278,7 +1290,7 @@ async function handleGetContext(params) {
     hosts,
     hostCount: hosts.length,
     activePortForwardTunnels,
-    tools: buildMcpToolHints(),
+    tools: toolHints,
   };
 }
 

--- a/electron/bridges/mcpServerBridge.workerTerminal.test.cjs
+++ b/electron/bridges/mcpServerBridge.workerTerminal.test.cjs
@@ -38,6 +38,9 @@ test("MCP/Catty capability context uses scoped metadata when terminal sessions l
   });
 
   assert.equal(result.hostCount, 1);
+  assert.equal(result.tools.terminal.execute, "terminal_execute");
+  assert.equal(result.tools.terminal.start, "terminal_start");
+  assert.match(result.description, /terminal_execute/);
   assert.deepEqual(result.hosts[0], {
     sessionId: "ssh-1",
     hostname: "host.example",

--- a/electron/capabilities/codegen/mcpResourceContext.test.cjs
+++ b/electron/capabilities/codegen/mcpResourceContext.test.cjs
@@ -1,0 +1,79 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+function loadFreshBridge() {
+  const bridgePath = require.resolve("../../bridges/mcpServerBridge.cjs");
+  delete require.cache[bridgePath];
+  return require("../../bridges/mcpServerBridge.cjs");
+}
+
+function envPairsToObject(envPairs) {
+  const env = { ...process.env };
+  for (const pair of envPairs || []) {
+    if (!pair?.name) continue;
+    env[pair.name] = String(pair.value ?? "");
+  }
+  return env;
+}
+
+test("MCP environment resource serializes terminal tool hints from Netcatty context", async (t) => {
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+
+  const bridge = loadFreshBridge();
+  const chatSessionId = `chat-resource-${Date.now()}`;
+  let client = null;
+
+  t.after(async () => {
+    try {
+      await client?.close();
+    } catch {
+      // Ignore teardown failures after a failed connect.
+    }
+    bridge.cleanup();
+  });
+
+  bridge.init({
+    sessions: new Map(),
+    electronModule: null,
+    terminalWorkerManager: {
+      request() {
+        throw new Error("resource context should not need a worker round trip");
+      },
+    },
+  });
+  bridge.setPermissionMode("auto");
+  bridge.updateSessionMetadata([
+    {
+      sessionId: "ssh-1",
+      hostname: "host.example",
+      label: "Prod",
+      username: "root",
+      protocol: "ssh",
+      shellType: "bash",
+      connected: true,
+    },
+  ], chatSessionId);
+
+  const port = await bridge.getOrCreateHost();
+  const config = bridge.buildMcpServerConfig(port, [], chatSessionId);
+  const transport = new StdioClientTransport({
+    command: config.command,
+    args: config.args,
+    env: envPairsToObject(config.env),
+  });
+  client = new Client({ name: "netcatty-resource-test", version: "1.0.0" });
+  await client.connect(transport);
+
+  const resource = await client.readResource({ uri: "netcatty://context" });
+  const text = resource.contents?.[0]?.text || "";
+  const context = JSON.parse(text);
+
+  assert.equal(context.hostCount, 1);
+  assert.equal(context.hosts[0].sessionId, "ssh-1");
+  assert.equal(context.tools.terminal.execute, "terminal_execute");
+  assert.equal(context.tools.terminal.start, "terminal_start");
+  assert.match(context.description, /terminal_execute/);
+});


### PR DESCRIPTION
## Summary

Addresses #2001 by making Netcatty's environment context explicitly name the terminal command tools that external agents should use.

## What changed

- Adds tool hints to the Netcatty environment context so agents that read context/resources can see the terminal execution entry points.
- Keeps the tool names sourced from the capability catalog so the hints stay aligned with the registered tools.
- Adds coverage for the worker-backed terminal context path.

## Why

The reported Codex flow could read Netcatty context and see the connected session, but concluded that terminal execution tools were unavailable. This makes the execution tools explicit in the same context path.

## Validation

- Simulated external MCP client listed terminal tools, read environment context, and called `terminal_execute` successfully.
- `node --test --import tsx electron/bridges/mcpServerBridge.workerTerminal.test.cjs electron/capabilities/codegen/toolSurfaces.test.cjs electron/capabilities/adapters/mcpAdapter.test.cjs electron/bridges/aiBridge/sdk/codexDriver.test.cjs`
- `npm test`
- `npm run lint`