### PR TITLE
Fix vault host drag state after grouping

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -7,6 +7,7 @@ import {
   getVaultDropIntent,
   getVaultDropPosition,
   hasVaultDragType,
+  handleVaultHostDropToGroup,
   handleVaultRootDrop,
   markVaultDropIndicator,
   useVaultGridLayoutAnimation,
@@ -480,9 +481,13 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                       onDrop={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        const hostId = e.dataTransfer.getData("host-id");
+                        if (handleVaultHostDropToGroup({
+                          dataTransfer: e.dataTransfer,
+                          groupPath: selectedGroupPath,
+                          moveHostToGroup,
+                          resetHostDragState,
+                        })) return;
                         const groupPath = e.dataTransfer.getData("group-path");
-                        if (hostId) moveHostToGroup(hostId, selectedGroupPath);
                         if (groupPath && selectedGroupPath !== null)
                           moveGroup(groupPath, selectedGroupPath);
                       }}
@@ -535,11 +540,14 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
                                 e.preventDefault();
                                 e.stopPropagation();
                                 setDragOverDropTarget(null);
-                                const hostId =
-                                  e.dataTransfer.getData("host-id");
+                                if (handleVaultHostDropToGroup({
+                                  dataTransfer: e.dataTransfer,
+                                  groupPath: node.path,
+                                  moveHostToGroup,
+                                  resetHostDragState,
+                                })) return;
                                 const groupPath =
                                   e.dataTransfer.getData("group-path");
-                                if (hostId) moveHostToGroup(hostId, node.path);
                                 if (groupPath) {
                                   const intent = getVaultDropIntent(e.currentTarget, e.clientX, e.clientY, viewMode === "grid");
                                   if (intent === "inside") moveGroup(groupPath, node.path);

--- a/components/vault/vaultReorderDrag.test.ts
+++ b/components/vault/vaultReorderDrag.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getVaultDropIntent,
   getVaultDropPosition,
+  handleVaultHostDropToGroup,
   handleVaultRootDrop,
 } from "./vaultReorderDrag.ts";
 
@@ -91,4 +92,43 @@ test("root group drop moves the group to all hosts without resetting host drag s
     "drop:null",
     "group:team/prod:null",
   ]);
+});
+
+test("group host drop resets host drag state after moving the host to the group", () => {
+  const calls: string[] = [];
+
+  const handled = handleVaultHostDropToGroup({
+    dataTransfer: {
+      getData: (type: string) => (type === "host-id" ? "host-1" : ""),
+    },
+    groupPath: "team/prod",
+    moveHostToGroup: (hostId, targetPath) => {
+      calls.push(`host:${hostId}:${String(targetPath)}`);
+    },
+    resetHostDragState: () => calls.push("resetHostDragState"),
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(calls, [
+    "host:host-1:team/prod",
+    "resetHostDragState",
+  ]);
+});
+
+test("group drop without a host leaves host drag state alone", () => {
+  const calls: string[] = [];
+
+  const handled = handleVaultHostDropToGroup({
+    dataTransfer: {
+      getData: () => "",
+    },
+    groupPath: "team/prod",
+    moveHostToGroup: (hostId, targetPath) => {
+      calls.push(`host:${hostId}:${String(targetPath)}`);
+    },
+    resetHostDragState: () => calls.push("resetHostDragState"),
+  });
+
+  assert.equal(handled, false);
+  assert.deepEqual(calls, []);
 });

--- a/components/vault/vaultReorderDrag.ts
+++ b/components/vault/vaultReorderDrag.ts
@@ -67,6 +67,25 @@ export const handleVaultRootDrop = ({
   }
 };
 
+export const handleVaultHostDropToGroup = ({
+  dataTransfer,
+  groupPath,
+  moveHostToGroup,
+  resetHostDragState,
+}: {
+  dataTransfer: Pick<DataTransfer, "getData">;
+  groupPath: string | null;
+  moveHostToGroup: (hostId: string, targetPath: string | null) => void;
+  resetHostDragState: () => void;
+}) => {
+  const hostId = dataTransfer.getData("host-id");
+  if (!hostId) return false;
+
+  moveHostToGroup(hostId, groupPath);
+  resetHostDragState();
+  return true;
+};
+
 let activeVaultDropIndicator: HTMLElement | null = null;
 
 export const clearVaultDropIndicator = () => {


### PR DESCRIPTION
## Summary

Fixes #2006.

- Clear the host drag state after dropping a host into a vault group.
- Reuse the same cleanup path for group drop targets so moved hosts do not stay visually dimmed in grid view.
- Add regression coverage for host drops into groups and non-host group drops.

## Root Cause

Grid host cards use a dimmed style while they are being dragged. When an ungrouped host is dropped into a group, the host can move to a different rendered section before the original card receives the normal drag-end cleanup, leaving the moved card in the dimmed state.

## Validation

- `node --test --import tsx components/vault/vaultReorderDrag.test.ts components/vault/VaultHostListSection.test.tsx`
- `npm run lint`