### PR TITLE
Fix main window focus stealing

### DIFF
--- a/application/state/useMainWindowInputFocusRecovery.test.ts
+++ b/application/state/useMainWindowInputFocusRecovery.test.ts
@@ -43,6 +43,7 @@ test("main-window input focus recovery ignores generic focus and visible visibil
   let cancelFocusCalls = 0;
   let hiddenCalls = 0;
   let shownHandler: Listener | null = null;
+  let focusRequestedHandler: Listener | null = null;
   let willHideHandler: Listener | null = null;
 
   const documentTarget = createEventTargetStub();
@@ -62,6 +63,10 @@ test("main-window input focus recovery ignores generic focus and visible visibil
         onWindowShown(cb: Listener) {
           shownHandler = cb;
           return () => { shownHandler = null; };
+        },
+        onWindowFocusRequested(cb: Listener) {
+          focusRequestedHandler = cb;
+          return () => { focusRequestedHandler = null; };
         },
         onWindowWillHide(cb: Listener) {
           willHideHandler = cb;
@@ -85,6 +90,10 @@ test("main-window input focus recovery ignores generic focus and visible visibil
 
   shownHandler?.();
 
+  assert.equal(scheduleFocusCalls, 0);
+
+  focusRequestedHandler?.();
+
   assert.equal(scheduleFocusCalls, 1);
 
   willHideHandler?.();
@@ -93,6 +102,10 @@ test("main-window input focus recovery ignores generic focus and visible visibil
   assert.equal(cancelFocusCalls, 1);
 
   shownHandler?.();
+
+  assert.equal(scheduleFocusCalls, 1);
+
+  focusRequestedHandler?.();
 
   assert.equal(scheduleFocusCalls, 2);
 
@@ -105,11 +118,11 @@ test("main-window input focus recovery ignores generic focus and visible visibil
   cleanup();
 });
 
-test("main-window input focus recovery retries an explicit show when visibility catches up", () => {
+test("main-window input focus recovery retries an explicit foreground request when visibility catches up", () => {
   let visibilityState: DocumentVisibilityState = "hidden";
   let scheduleFocusCalls = 0;
   let hiddenCalls = 0;
-  let shownHandler: Listener | null = null;
+  let focusRequestedHandler: Listener | null = null;
 
   const documentTarget = createEventTargetStub();
 
@@ -123,9 +136,9 @@ test("main-window input focus recovery retries an explicit show when visibility 
         },
       },
       bridge: {
-        onWindowShown(cb: Listener) {
-          shownHandler = cb;
-          return () => { shownHandler = null; };
+        onWindowFocusRequested(cb: Listener) {
+          focusRequestedHandler = cb;
+          return () => { focusRequestedHandler = null; };
         },
       },
       scheduleFocus: () => {
@@ -135,7 +148,7 @@ test("main-window input focus recovery retries an explicit show when visibility 
     },
   );
 
-  shownHandler?.();
+  focusRequestedHandler?.();
 
   assert.equal(scheduleFocusCalls, 0);
 
@@ -152,12 +165,13 @@ test("main-window input focus recovery retries an explicit show when visibility 
   cleanup();
 });
 
-test("useMainWindowInputFocusRecovery restores input focus only after explicit window-shown IPC", () => {
+test("useMainWindowInputFocusRecovery restores input focus only after explicit foreground IPC", () => {
   const source = readProjectFile("application/state/useMainWindowInputFocusRecovery.ts");
 
   assert.match(source, /visibilityState !== "visible"/);
   assert.match(source, /scheduleFocus\(\)/);
-  assert.match(source, /onWindowShown\?\.\(\(\) => \{\s*pendingExplicitShowRecovery = true;\s*recoverFocus\(\);\s*\}\)/);
+  assert.match(source, /onWindowFocusRequested\?\.\(\(\) => \{\s*pendingExplicitFocusRecovery = true;\s*recoverFocus\(\);\s*\}\)/);
+  assert.doesNotMatch(source, /onWindowShown\?\.\(\(\) => \{[\s\S]*recoverFocus\(\)/);
   assert.doesNotMatch(source, /window\.addEventListener\("focus"/);
   assert.doesNotMatch(source, /window\.removeEventListener\("focus"/);
 });

--- a/application/state/useMainWindowInputFocusRecovery.ts
+++ b/application/state/useMainWindowInputFocusRecovery.ts
@@ -26,6 +26,7 @@ type MainWindowInputFocusRecoveryWindow = {
 
 type MainWindowInputFocusRecoveryBridge = {
   onWindowShown?: (callback: Listener) => Listener;
+  onWindowFocusRequested?: (callback: Listener) => Listener;
   onWindowWillHide?: (callback: Listener) => Listener;
 };
 
@@ -53,7 +54,7 @@ export function startMainWindowInputFocusRecovery(
   } = dependencies;
 
   let pendingFocusRecovery: ScheduledWindowInputFocus | null = null;
-  let pendingExplicitShowRecovery = false;
+  let pendingExplicitFocusRecovery = false;
 
   const cancelPendingFocusRecovery = () => {
     pendingFocusRecovery?.cancel();
@@ -62,14 +63,14 @@ export function startMainWindowInputFocusRecovery(
 
   const recoverFocus = (): boolean => {
     if (documentRef.visibilityState !== "visible") return false;
-    pendingExplicitShowRecovery = false;
+    pendingExplicitFocusRecovery = false;
     cancelPendingFocusRecovery();
     pendingFocusRecovery = scheduleFocus();
     return true;
   };
 
   const dismissTransientUi = () => {
-    pendingExplicitShowRecovery = false;
+    pendingExplicitFocusRecovery = false;
     cancelPendingFocusRecovery();
     onPageHidden?.();
   };
@@ -79,15 +80,15 @@ export function startMainWindowInputFocusRecovery(
       dismissTransientUi();
       return;
     }
-    if (pendingExplicitShowRecovery) {
+    if (pendingExplicitFocusRecovery) {
       recoverFocus();
     }
   };
 
   documentRef.addEventListener("visibilitychange", onVisibilityChange);
 
-  const unsubscribeShown = bridge?.onWindowShown?.(() => {
-    pendingExplicitShowRecovery = true;
+  const unsubscribeFocusRequested = bridge?.onWindowFocusRequested?.(() => {
+    pendingExplicitFocusRecovery = true;
     recoverFocus();
   });
   const unsubscribeWillHide = bridge?.onWindowWillHide?.(() => {
@@ -95,16 +96,16 @@ export function startMainWindowInputFocusRecovery(
   });
 
   return () => {
-    pendingExplicitShowRecovery = false;
+    pendingExplicitFocusRecovery = false;
     cancelPendingFocusRecovery();
     documentRef.removeEventListener("visibilitychange", onVisibilityChange);
-    unsubscribeShown?.();
+    unsubscribeFocusRequested?.();
     unsubscribeWillHide?.();
   };
 }
 
 /**
- * Recover OS/renderer input focus when the main process explicitly shows the
+ * Recover OS/renderer input focus when the main process explicitly foregrounds the
  * main window (#760, #1714, #1722).
  */
 export function useMainWindowInputFocusRecovery(

--- a/electron/bridges/windowManager.cjs
+++ b/electron/bridges/windowManager.cjs
@@ -1276,7 +1276,19 @@ function showAndFocusMainWindow(win) {
       // ignore
     }
   }
-  return restoreWindowInputFocus(win, { show: true });
+  const restored = restoreWindowInputFocus(win, { show: true });
+  if (restored) notifyWindowFocusRequested(win);
+  return restored;
+}
+
+/**
+ * Renderer input-focus recovery is only valid after an explicit foreground
+ * request (hotkey, tray, Dock, deep link). Plain BrowserWindow "show" events
+ * can also come from OS window/space transitions and must not steal focus.
+ */
+function notifyWindowFocusRequested(win) {
+  if (!win || win.isDestroyed?.()) return;
+  safeSend(win.webContents, "netcatty:window:focus-requested");
 }
 
 /**
@@ -1310,6 +1322,7 @@ module.exports = {
   registerWindowHandlers,
   restoreWindowInputFocus,
   showAndFocusMainWindow,
+  notifyWindowFocusRequested,
   notifyWindowWillHide,
   requestWindowCommandClose,
   shouldCloseWindowFromInput,

--- a/electron/bridges/windowManagerReadiness.test.cjs
+++ b/electron/bridges/windowManagerReadiness.test.cjs
@@ -11,6 +11,7 @@ const {
   resolveSettingsWindowBounds,
   restoreWindowInputFocus,
   showAndFocusMainWindow,
+  notifyWindowFocusRequested,
   notifyWindowWillHide,
   requestWindowCommandClose,
   sendWhenRendererReady,
@@ -209,6 +210,9 @@ test("restoreWindowInputFocus can show the window when requested", () => {
       focus() {
         calls.push("webContents.focus");
       },
+      send(channel) {
+        calls.push(`send:${channel}`);
+      },
     },
   };
 
@@ -243,13 +247,43 @@ test("showAndFocusMainWindow restores minimized windows before focusing", () => 
       focus() {
         calls.push("webContents.focus");
       },
+      send(channel) {
+        calls.push(`send:${channel}`);
+      },
     },
   };
 
   const restored = showAndFocusMainWindow(win);
 
   assert.equal(restored, true);
-  assert.deepEqual(calls, ["restore", "show", "focus", "webContents.focus"]);
+  assert.deepEqual(calls, [
+    "restore",
+    "show",
+    "focus",
+    "webContents.focus",
+    "send:netcatty:window:focus-requested",
+  ]);
+});
+
+test("notifyWindowFocusRequested sends only the explicit focus IPC", () => {
+  const sent = [];
+  const win = {
+    isDestroyed() {
+      return false;
+    },
+    webContents: {
+      isDestroyed() {
+        return false;
+      },
+      send(channel) {
+        sent.push(channel);
+      },
+    },
+  };
+
+  notifyWindowFocusRequested(win);
+
+  assert.deepEqual(sent, ["netcatty:window:focus-requested"]);
 });
 
 test("notifyWindowWillHide sends will-hide IPC before native hide", () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1209,10 +1209,10 @@ if (!gotLock) {
           commitQuit();
           return;
         }
+        const wm = getWindowManager();
         for (const win of dirtyWindows) {
           try {
-            if (typeof win.show === "function" && !win.isVisible?.()) win.show();
-            if (typeof win.focus === "function") win.focus();
+            wm.showAndFocusMainWindow?.(win);
           } catch {
             // ignore
           }
@@ -1228,7 +1228,6 @@ if (!gotLock) {
         // autoUpdateBridge's watchdog; otherwise close-to-tray and other
         // !isQuitting-gated behavior stay bypassed while the app keeps running
         // (#1215 review).
-        const wm = getWindowManager();
         if (wm.isQuittingForUpdate?.()) wm.setQuittingForUpdate(false);
       })
       .catch((err) => {

--- a/electron/mainQuitGuardSource.test.cjs
+++ b/electron/mainQuitGuardSource.test.cjs
@@ -16,3 +16,22 @@ test("before-quit dirty editor guard queries hidden app content windows", () => 
   assert.match(source.slice(queryableIndex, queryCallIndex), /queryableWindows\s*\n?\s*\.map\(\(candidate\) => candidate\.webContents\)/);
   assert.doesNotMatch(guardSetup, /isVisible|isMinimized/);
 });
+
+test("before-quit dirty editor guard foregrounds dirty windows through the focus recovery helper", () => {
+  const source = readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  const beforeQuitIndex = source.indexOf('app.on("before-quit"');
+  const dirtyResultsIndex = source.indexOf(".then((dirtyResults) => {", beforeQuitIndex);
+  const loopIndex = source.indexOf("for (const win of dirtyWindows)", dirtyResultsIndex);
+  const hasDirtyCommentIndex = source.indexOf("// hasDirty:", loopIndex);
+  const foregroundBlock = source.slice(loopIndex, hasDirtyCommentIndex);
+
+  assert.notEqual(beforeQuitIndex, -1);
+  assert.notEqual(dirtyResultsIndex, -1);
+  assert.notEqual(loopIndex, -1);
+  assert.notEqual(hasDirtyCommentIndex, -1);
+  assert.match(foregroundBlock, /wm\.showAndFocusMainWindow\?\.\(win\)/);
+  assert.match(foregroundBlock, /try\s*\{[\s\S]*wm\.showAndFocusMainWindow\?\.\(win\);[\s\S]*\}\s*catch\s*\{/);
+  assert.doesNotMatch(foregroundBlock, /commitQuit\(\)/);
+  assert.doesNotMatch(foregroundBlock, /win\.show\(\)/);
+  assert.doesNotMatch(foregroundBlock, /win\.focus\(\)/);
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -39,6 +39,7 @@ const telnetEchoModeListeners = new Map();
 const languageChangeListeners = new Set();
 const fullscreenChangeListeners = new Set();
 const windowShownListeners = new Set();
+const windowFocusRequestedListeners = new Set();
 const windowWillHideListeners = new Set();
 const keyboardInteractiveListeners = new Set();
 const hostKeyVerificationListeners = new Set();
@@ -371,6 +372,16 @@ ipcRenderer.on("netcatty:window:shown", () => {
       cb();
     } catch (err) {
       console.error("Window shown callback failed", err);
+    }
+  });
+});
+
+ipcRenderer.on("netcatty:window:focus-requested", () => {
+  windowFocusRequestedListeners.forEach((cb) => {
+    try {
+      cb();
+    } catch (err) {
+      console.error("Window focus-requested callback failed", err);
     }
   });
 });
@@ -784,6 +795,7 @@ const api = createPreloadApi({
   languageChangeListeners,
   fullscreenChangeListeners,
   windowShownListeners,
+  windowFocusRequestedListeners,
   windowWillHideListeners,
   keyboardInteractiveListeners,
   hostKeyVerificationListeners,

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -598,6 +598,10 @@ function createPreloadApi(ctx) {
     windowShownListeners.add(cb);
     return () => windowShownListeners.delete(cb);
   },
+  onWindowFocusRequested: (cb) => {
+    windowFocusRequestedListeners.add(cb);
+    return () => windowFocusRequestedListeners.delete(cb);
+  },
   onWindowWillHide: (cb) => {
     windowWillHideListeners.add(cb);
     return () => windowWillHideListeners.delete(cb);

--- a/electron/preloadDataBacklog.test.cjs
+++ b/electron/preloadDataBacklog.test.cjs
@@ -786,6 +786,27 @@ test("zmodem listeners survive reconnect-style closeSession and resume after res
   }
 });
 
+test("onWindowFocusRequested is wired to the focus-requested IPC", () => {
+  const preload = loadPreloadWithFakeElectron();
+  try {
+    const calls = [];
+    const unsubscribe = preload.api.onWindowFocusRequested(() => {
+      calls.push("focus");
+    });
+
+    preload.handlers.get("netcatty:window:focus-requested")?.();
+
+    assert.deepEqual(calls, ["focus"]);
+
+    unsubscribe();
+    preload.handlers.get("netcatty:window:focus-requested")?.();
+
+    assert.deepEqual(calls, ["focus"]);
+  } finally {
+    preload.cleanup();
+  }
+});
+
 test("onZmodemEvent unsubscribe removes empty listener set", () => {
   const zmodemListeners = new Map();
   const api = createPreloadApi({

--- a/types/global/netcatty-bridge-sync.d.ts
+++ b/types/global/netcatty-bridge-sync.d.ts
@@ -28,6 +28,7 @@ declare global {
     onWindowCommandCloseRequested?(cb: () => void): () => void;
     onWindowFullScreenChanged?(cb: (isFullscreen: boolean) => void): () => void;
     onWindowShown?(cb: () => void): () => void;
+    onWindowFocusRequested?(cb: () => void): () => void;
     onWindowWillHide?(cb: () => void): () => void;
 
     // Settings window


### PR DESCRIPTION
## Summary
- keep main-window reuse and explicit foreground actions intact
- add a separate foreground-request IPC for renderer input focus recovery
- stop generic BrowserWindow show events from triggering input focus recovery

## Root cause
The renderer input-focus recovery treated the generic window-shown notification as explicit user intent to foreground the app. BrowserWindow show can also be emitted during OS window/space transitions, which could pull Netcatty back to the front after the user backgrounded it.

## Validation
- node --test --import tsx application/state/useMainWindowInputFocusRecovery.test.ts electron/bridges/windowManagerReadiness.test.cjs components/terminal/appResumeWebglRecovery.test.ts
- npm run lint
- npm test