### PR TITLE
Update Nix release metadata for v1.1.60

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.59";
+  version = "1.1.60";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-kWU33p9b6R2m293uzZUOa+yV1ZKrG/uFu+9SbEqUIx0=";
+      hash = "sha256-kCu2PVOIbePVnBgvffpCLxHUhvfFapeW8vOJnmGv7ug=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-GhwyNJVidpzXmDpUEYV3oanESy9PvPAmO3RGzLnyqrM=";
+      hash = "sha256-y50rjGwkkbBORkVXlaO7wqKb1fCVs0Rkfa2+SfXrKeA=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update Nix release metadata to v1.1.60
- refresh x64 and arm64 AppImage hashes from the published release assets

## Validation
- node --test scripts/update-nix-release.test.cjs scripts/generate-release-note.test.cjs

Context: the v1.1.60 release workflow published the release successfully, but the automatic Nix metadata push was blocked by main branch protection.