### PR TITLE
Add spam comment cleanup workflow

### DIFF
--- a/.github/workflows/spam-comments.yml
+++ b/.github/workflows/spam-comments.yml
@@ -1,0 +1,50 @@
+name: spam-comments
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  delete-spam:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout filter rules
+        uses: actions/checkout@v4
+
+      - name: Delete suspected malware spam
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('node:path');
+            const { detectSpamComment } = require(
+              path.join(process.env.GITHUB_WORKSPACE, 'scripts/spam-comment-filter.cjs')
+            );
+
+            const comment = context.payload.comment;
+            const result = detectSpamComment({
+              body: comment.body || '',
+              authorAssociation: comment.author_association,
+              userType: comment.user && comment.user.type,
+            });
+
+            core.info(JSON.stringify(result, null, 2));
+
+            if (!result.spam) {
+              core.info('Comment did not match the high-confidence spam filter.');
+              return;
+            }
+
+            await github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+            });
+
+            core.notice(
+              `Deleted suspected malware spam comment by @${comment.user.login} on #${context.payload.issue.number}: ${result.reasons.join('; ')}`
+            );

--- a/scripts/spam-comment-filter.cjs
+++ b/scripts/spam-comment-filter.cjs
@@ -1,0 +1,106 @@
+"use strict";
+
+const TRUSTED_AUTHOR_ASSOCIATIONS = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+
+const DANGEROUS_FILE_EXTENSION =
+  "(?:zip|7z|rar|tar\\.gz|tgz|exe|msi|dmg|pkg|deb|rpm|appimage|bat|cmd|ps1|scr|vbs)";
+
+const dangerousFilePattern = new RegExp(
+  `(?:^|[\\s([<"'=])([^\\s()[\\]<>\"']+\\.${DANGEROUS_FILE_EXTENSION})(?=$|[\\s)\\]>\"'])`,
+  "gi"
+);
+
+const suspiciousFileNamePattern = new RegExp(
+  `\\b(?:patch|hotfix|fix|update|repair|solution|workaround|netcatty)[\\w.-]*\\.${DANGEROUS_FILE_EXTENSION}\\b`,
+  "i"
+);
+
+const baitPatterns = [
+  /\bquick\s+(?:patch|fix|hotfix)\b/i,
+  /\bi\s+found\s+(?:a\s+)?(?:quick\s+)?(?:patch|fix|hotfix|solution)\b/i,
+  /\b(?:download|use|try|install|apply)\s+(?:this|the)\s+(?:patch|fix|hotfix|update|zip|file)\b/i,
+  /\b(?:fixes|fixed|patches|repairs)\s+(?:the|this|that|those)\b/i,
+  /\b(?:backend|encoding|character mapping|black boxes|terminal rendering|sftp module)\b/i,
+];
+
+function normalizeAssociation(authorAssociation) {
+  return String(authorAssociation || "").trim().toUpperCase();
+}
+
+function isTrustedAuthor(authorAssociation) {
+  return TRUSTED_AUTHOR_ASSOCIATIONS.has(normalizeAssociation(authorAssociation));
+}
+
+function extractDangerousFiles(body) {
+  const files = [];
+  for (const match of body.matchAll(dangerousFilePattern)) {
+    files.push(match[1]);
+  }
+  return [...new Set(files)];
+}
+
+function matchingBaitPatterns(body) {
+  return baitPatterns
+    .filter((pattern) => pattern.test(body))
+    .map((pattern) => pattern.source);
+}
+
+function detectSpamComment({ body, authorAssociation, userType } = {}) {
+  const normalizedBody = String(body || "").replace(/\s+/g, " ").trim();
+  const dangerousFiles = extractDangerousFiles(normalizedBody);
+  const baitMatches = matchingBaitPatterns(normalizedBody);
+  const hasSuspiciousFileName = dangerousFiles.some((file) =>
+    suspiciousFileNamePattern.test(file)
+  );
+  const trustedAuthor = isTrustedAuthor(authorAssociation);
+  const botAuthor = String(userType || "").toLowerCase() === "bot";
+
+  const reasons = [];
+  let score = 0;
+
+  if (dangerousFiles.length > 0) {
+    score += 3;
+    reasons.push(`dangerous downloadable file: ${dangerousFiles.join(", ")}`);
+  }
+
+  if (hasSuspiciousFileName) {
+    score += 2;
+    reasons.push("download name looks like a patch or hotfix");
+  }
+
+  if (baitMatches.length > 0) {
+    score += Math.min(3, baitMatches.length);
+    reasons.push("comment uses patch/fix bait language");
+  }
+
+  if (normalizedBody.length > 0 && normalizedBody.length < 700) {
+    score += 1;
+    reasons.push("short drive-by comment");
+  }
+
+  const spam =
+    !trustedAuthor &&
+    !botAuthor &&
+    dangerousFiles.length > 0 &&
+    score >= 6 &&
+    (baitMatches.length >= 2 || (hasSuspiciousFileName && baitMatches.length >= 1));
+
+  return {
+    spam,
+    score,
+    reasons: spam ? reasons : [],
+    dangerousFiles,
+    trustedAuthor,
+    botAuthor,
+  };
+}
+
+module.exports = {
+  detectSpamComment,
+  extractDangerousFiles,
+  isTrustedAuthor,
+};

--- a/scripts/spam-comment-filter.test.cjs
+++ b/scripts/spam-comment-filter.test.cjs
@@ -1,0 +1,42 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { detectSpamComment, extractDangerousFiles } = require("./spam-comment-filter.cjs");
+
+test("flags the fake Netcatty patch spam pattern", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "User",
+    body: "[netcatty_patch.zip](https://example.com/netcatty_patch.zip)\n\nMan, that terminal rendering bug is such a pain. It looks like the sftp module is tripping over the encoding when it tries to sync the current path. I found a quick patch that fixes the character mapping in the backend so those black boxes finally disappear.",
+  });
+
+  assert.equal(result.spam, true);
+});
+
+test("does not flag ordinary log attachments from outside users", () => {
+  const result = detectSpamComment({
+    authorAssociation: "FIRST_TIME_CONTRIBUTOR",
+    userType: "User",
+    body: "I attached debug-logs.zip from a failed connection. The app hangs after I click connect, and the logs show the SSH handshake timing out.",
+  });
+
+  assert.equal(result.spam, false);
+});
+
+test("does not flag trusted maintainers even when sharing patch archives", () => {
+  const result = detectSpamComment({
+    authorAssociation: "OWNER",
+    userType: "User",
+    body: "Try this temporary netcatty_patch.zip while I prepare the signed release. It fixes the rendering issue.",
+  });
+
+  assert.equal(result.spam, false);
+});
+
+test("extracts risky file names from markdown links and plain text", () => {
+  assert.deepEqual(
+    extractDangerousFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg"),
+    ["fix.zip", "https://example.com/fix.zip", "hotfix.dmg"]
+  );
+});


### PR DESCRIPTION
## Summary

- Add a GitHub workflow that deletes high-confidence malware-style issue comments when they are created.
- Add a small reusable filter and tests so the rules can be adjusted safely.
- Keep the filter conservative so normal user attachments and maintainer comments are not deleted.

## Validation

- `node --test scripts/spam-comment-filter.test.cjs`
- workflow YAML parse check
- `npm test`