### PR TITLE
Handle trailing punctuation in spam links

### DIFF
--- a/scripts/spam-comment-filter.cjs
+++ b/scripts/spam-comment-filter.cjs
@@ -10,7 +10,7 @@ const DANGEROUS_FILE_EXTENSION =
   "(?:zip|7z|rar|tar\\.gz|tgz|exe|msi|dmg|pkg|deb|rpm|appimage|bat|cmd|ps1|scr|vbs)";
 
 const dangerousFilePattern = new RegExp(
-  `(?:^|[\\s([<"'=])([^\\s()[\\]<>\"']+\\.${DANGEROUS_FILE_EXTENSION})(?=$|[\\s)\\]>\"'])`,
+  `(?:^|[\\s([<"'=])([^\\s()[\\]<>\"']+\\.${DANGEROUS_FILE_EXTENSION})(?=$|[\\s)\\]>\"']|[.,!?;:](?:$|\\s))`,
   "gi"
 );
 

--- a/scripts/spam-comment-filter.test.cjs
+++ b/scripts/spam-comment-filter.test.cjs
@@ -14,6 +14,17 @@ test("flags the fake Netcatty patch spam pattern", () => {
   assert.equal(result.spam, true);
 });
 
+test("flags fake patch spam when the filename ends a sentence", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "User",
+    body: "Download this patch.zip. It fixes the backend encoding so the terminal rendering black boxes disappear.",
+  });
+
+  assert.equal(result.spam, true);
+  assert.deepEqual(result.dangerousFiles, ["patch.zip"]);
+});
+
 test("does not flag ordinary log attachments from outside users", () => {
   const result = detectSpamComment({
     authorAssociation: "FIRST_TIME_CONTRIBUTOR",
@@ -36,7 +47,7 @@ test("does not flag trusted maintainers even when sharing patch archives", () =>
 
 test("extracts risky file names from markdown links and plain text", () => {
   assert.deepEqual(
-    extractDangerousFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg"),
+    extractDangerousFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg."),
     ["fix.zip", "https://example.com/fix.zip", "hotfix.dmg"]
   );
 });


### PR DESCRIPTION
## Summary

- Follow up on the Codex review comment from #2014.
- Recognize suspicious filenames when they end a sentence, such as `patch.zip.`.
- Add a regression test for that exact spam shape.

## Validation

- `node --test scripts/spam-comment-filter.test.cjs`
- direct sample check for `Download this patch.zip. ...`
- `npm test`