### PR TITLE
fix: gate Telnet NAWS resize updates

### DIFF
--- a/electron/bridges/telnetProtocol.cjs
+++ b/electron/bridges/telnetProtocol.cjs
@@ -286,6 +286,7 @@ function createTelnetNegotiator({
   const localEchoSink = typeof onLocalEchoChange === "function" ? onLocalEchoChange : () => {};
 
   const naws = () => {
+    if (!enabledLocalOptions.has(OPT.NAWS)) return false;
     const { cols, rows } = sizeFn() || {};
     const safeCols = Number.isFinite(cols) && cols > 0 ? cols : 80;
     const safeRows = Number.isFinite(rows) && rows > 0 ? rows : 24;
@@ -294,6 +295,7 @@ function createTelnetNegotiator({
       (safeRows >> 8) & 0xff, safeRows & 0xff,
     ]);
     sbSink(OPT.NAWS, escapeIacForWire(payload));
+    return true;
   };
 
   const sendTerminalType = () => {

--- a/electron/bridges/telnetProtocol.test.cjs
+++ b/electron/bridges/telnetProtocol.test.cjs
@@ -315,6 +315,16 @@ test("peer's independent DO NAWS (no WILL pending) replies WILL + size subneg", 
   assert.equal(subnegs[0].opt, OPT.NAWS);
 });
 
+test("sendWindowSize is silent until the peer enables NAWS", () => {
+  const { negotiator, subnegs } = recordNegotiator();
+  negotiator.start();
+
+  const sent = negotiator.sendWindowSize();
+
+  assert.equal(sent, false);
+  assert.equal(subnegs.length, 0);
+});
+
 test("peer's repeated DO for enabled local options is ignored", () => {
   const { negotiator, commands, subnegs } = recordNegotiator();
   negotiator.handleCommand(DO, OPT.NAWS);
@@ -463,7 +473,10 @@ test("sendWindowSize falls back to 80x24 when getWindowSize returns garbage", ()
   const { negotiator, subnegs } = recordNegotiator({
     getWindowSize: () => ({ cols: NaN, rows: -3 }),
   });
-  negotiator.sendWindowSize();
+  negotiator.handleCommand(DO, OPT.NAWS);
+  subnegs.length = 0;
+  const sent = negotiator.sendWindowSize();
+  assert.equal(sent, true);
   assert.deepEqual([...subnegs[0].payload], [0, 80, 0, 24]);
 });
 

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -1241,18 +1241,10 @@ function resizeSession(event, payload) {
     } else if (session.socket && session.type === 'telnet-native') {
       session.cols = payload.cols;
       session.rows = payload.rows;
-      // Only push a NAWS update once the peer has activated the protocol;
-      // sending an IAC sequence to a raw-TCP server would corrupt its stream.
+      // Only push a NAWS update once Telnet is active and the peer has enabled
+      // NAWS with DO NAWS; partial console wrappers may leak SB payload bytes.
       if (session.telnetProtocolActive) {
-        const colsByte = Buffer.from([
-          (payload.cols >> 8) & 0xff, payload.cols & 0xff,
-          (payload.rows >> 8) & 0xff, payload.rows & 0xff,
-        ]);
-        session.socket.write(Buffer.concat([
-          Buffer.from([telnetProtocol.IAC, telnetProtocol.SB, telnetProtocol.OPT.NAWS]),
-          telnetProtocol.escapeIacForWire(colsByte),
-          Buffer.from([telnetProtocol.IAC, telnetProtocol.SE]),
-        ]));
+        session.sendTelnetWindowSize?.();
       }
     }
   } catch (err) {

--- a/electron/bridges/terminalBridge.telnetResize.test.cjs
+++ b/electron/bridges/terminalBridge.telnetResize.test.cjs
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const terminalBridge = require("./terminalBridge.cjs");
+
+test("Telnet resize does not write NAWS bytes before the peer enables NAWS", () => {
+  const sessionId = "telnet-resize-naws-disabled";
+  const writes = [];
+  let windowSizeRequests = 0;
+  const sessions = new Map();
+
+  sessions.set(sessionId, {
+    type: "telnet-native",
+    socket: {
+      write(buf) {
+        writes.push(Buffer.from(buf));
+      },
+      destroy() {},
+    },
+    telnetProtocolActive: true,
+    sendTelnetWindowSize() {
+      windowSizeRequests++;
+      return false;
+    },
+  });
+
+  terminalBridge.init({
+    sessions,
+    electronModule: {
+      webContents: {
+        fromId: () => ({ send() {} }),
+      },
+    },
+  });
+
+  try {
+    terminalBridge.resizeSession(
+      { sender: { id: 1 } },
+      { sessionId, cols: 94, rows: 55 },
+    );
+
+    assert.equal(windowSizeRequests, 1);
+    assert.equal(writes.length, 0);
+    assert.equal(sessions.get(sessionId).cols, 94);
+    assert.equal(sessions.get(sessionId).rows, 55);
+  } finally {
+    terminalBridge.cleanupAllSessions();
+  }
+});

--- a/electron/bridges/terminalBridge/telnetSession.cjs
+++ b/electron/bridges/terminalBridge/telnetSession.cjs
@@ -215,9 +215,9 @@ function createTelnetSessionApi(ctx) {
               remoteEcho: remoteEchoEnabled,
               localEcho: localEchoEnabled,
             },
+            sendTelnetWindowSize: () => negotiator.sendWindowSize(),
             // Mirror of the closure-local `telnetProtocolActive` so the resize
-            // handler (which only sees the session record) can decide whether
-            // to push a NAWS subnegotiation.
+            // handler can avoid sending Telnet control bytes to raw-TCP peers.
             get telnetProtocolActive() {
               return telnetProtocolActive;
             },


### PR DESCRIPTION
## Summary

- Gate Telnet NAWS window-size payloads behind peer `DO NAWS` negotiation.
- Route Telnet resize updates through the negotiator instead of writing raw NAWS bytes from the resize handler.
- Add regression coverage for resize updates before NAWS is enabled.

## Root cause

The resize handler sent `IAC SB NAWS ... IAC SE` whenever Telnet protocol mode was active. PNETLab/EVE-NG console wrappers can emit Telnet commands but never enable NAWS, so those NAWS payload bytes were forwarded into the router console as literal input.

Closes #2011

## Verification

- `node --test electron/bridges/telnetProtocol.test.cjs electron/bridges/terminalBridge.telnetResize.test.cjs`
- `npx eslint electron/bridges/telnetProtocol.cjs electron/bridges/terminalBridge.cjs electron/bridges/terminalBridge/telnetSession.cjs electron/bridges/telnetProtocol.test.cjs electron/bridges/terminalBridge.telnetResize.test.cjs`
- `npm test`