### PR TITLE
Catch suspicious GitHub spam attachments

### DIFF
--- a/scripts/spam-comment-filter.cjs
+++ b/scripts/spam-comment-filter.cjs
@@ -27,6 +27,9 @@ const baitPatterns = [
   /\b(?:backend|encoding|character mapping|black boxes|terminal rendering|sftp module)\b/i,
 ];
 
+const githubUserAttachmentPattern =
+  /^https:\/\/github\.com\/user-attachments\/files\/\d+\//i;
+
 function normalizeAssociation(authorAssociation) {
   return String(authorAssociation || "").trim().toUpperCase();
 }
@@ -49,6 +52,10 @@ function matchingBaitPatterns(body) {
     .map((pattern) => pattern.source);
 }
 
+function isGitHubUserAttachment(file) {
+  return githubUserAttachmentPattern.test(file);
+}
+
 function detectSpamComment({ body, authorAssociation, userType } = {}) {
   const normalizedBody = String(body || "").replace(/\s+/g, " ").trim();
   const dangerousFiles = extractDangerousFiles(normalizedBody);
@@ -56,6 +63,8 @@ function detectSpamComment({ body, authorAssociation, userType } = {}) {
   const hasSuspiciousFileName = dangerousFiles.some((file) =>
     suspiciousFileNamePattern.test(file)
   );
+  const hasSuspiciousGitHubAttachment =
+    hasSuspiciousFileName && dangerousFiles.some(isGitHubUserAttachment);
   const trustedAuthor = isTrustedAuthor(authorAssociation);
   const botAuthor = String(userType || "").toLowerCase() === "bot";
 
@@ -70,6 +79,11 @@ function detectSpamComment({ body, authorAssociation, userType } = {}) {
   if (hasSuspiciousFileName) {
     score += 2;
     reasons.push("download name looks like a patch or hotfix");
+  }
+
+  if (hasSuspiciousGitHubAttachment) {
+    score += 1;
+    reasons.push("GitHub attachment uses a patch/fix-style archive name");
   }
 
   if (baitMatches.length > 0) {
@@ -87,7 +101,9 @@ function detectSpamComment({ body, authorAssociation, userType } = {}) {
     !botAuthor &&
     dangerousFiles.length > 0 &&
     score >= 6 &&
-    (baitMatches.length >= 2 || (hasSuspiciousFileName && baitMatches.length >= 1));
+    (baitMatches.length >= 2 ||
+      (hasSuspiciousFileName && baitMatches.length >= 1) ||
+      hasSuspiciousGitHubAttachment);
 
   return {
     spam,
@@ -102,5 +118,6 @@ function detectSpamComment({ body, authorAssociation, userType } = {}) {
 module.exports = {
   detectSpamComment,
   extractDangerousFiles,
+  isGitHubUserAttachment,
   isTrustedAuthor,
 };

--- a/scripts/spam-comment-filter.test.cjs
+++ b/scripts/spam-comment-filter.test.cjs
@@ -2,7 +2,11 @@
 
 const assert = require("node:assert/strict");
 const test = require("node:test");
-const { detectSpamComment, extractDangerousFiles } = require("./spam-comment-filter.cjs");
+const {
+  detectSpamComment,
+  extractDangerousFiles,
+  isGitHubUserAttachment,
+} = require("./spam-comment-filter.cjs");
 
 test("flags the fake Netcatty patch spam pattern", () => {
   const result = detectSpamComment({
@@ -25,11 +29,21 @@ test("flags fake patch spam when the filename ends a sentence", () => {
   assert.deepEqual(result.dangerousFiles, ["patch.zip"]);
 });
 
+test("flags suspicious GitHub attachment spam without bait wording", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "User",
+    body: "[netcatty_fix.zip](https://github.com/user-attachments/files/29784176/netcatty_fix.zip)\nI attached the fix I used.",
+  });
+
+  assert.equal(result.spam, true);
+});
+
 test("does not flag ordinary log attachments from outside users", () => {
   const result = detectSpamComment({
     authorAssociation: "FIRST_TIME_CONTRIBUTOR",
     userType: "User",
-    body: "I attached debug-logs.zip from a failed connection. The app hangs after I click connect, and the logs show the SSH handshake timing out.",
+    body: "[debug-logs.zip](https://github.com/user-attachments/files/29784176/debug-logs.zip)\nI attached logs from a failed connection. The app hangs after I click connect, and the logs show the SSH handshake timing out.",
   });
 
   assert.equal(result.spam, false);
@@ -50,4 +64,12 @@ test("extracts risky file names from markdown links and plain text", () => {
     extractDangerousFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg."),
     ["fix.zip", "https://example.com/fix.zip", "hotfix.dmg"]
   );
+});
+
+test("identifies GitHub user attachment URLs", () => {
+  assert.equal(
+    isGitHubUserAttachment("https://github.com/user-attachments/files/29784176/netcatty_fix.zip"),
+    true
+  );
+  assert.equal(isGitHubUserAttachment("https://example.com/netcatty_fix.zip"), false);
 });


### PR DESCRIPTION
## Summary

- Explain and fix the missed spam case from Actions run 28918602800.
- Treat GitHub user attachment archives with patch/fix-style names as high-confidence spam for untrusted, non-bot commenters.
- Keep ordinary log archive attachments allowed with a regression test.

## Validation

- `node --test scripts/spam-comment-filter.test.cjs`
- direct reproduction using `netcatty_fix.zip` from a GitHub user attachment link
- `npm test`