### PR TITLE
fix: default passphrase remember checkbox off (#2024)

### DIFF
--- a/components/PassphraseModal.test.ts
+++ b/components/PassphraseModal.test.ts
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_REMEMBER_PASSPHRASE } from "./PassphraseModal.tsx";
+
+test("passphrase remember checkbox defaults to unchecked for security", () => {
+  assert.equal(DEFAULT_REMEMBER_PASSPHRASE, false);
+});

--- a/components/PassphraseModal.tsx
+++ b/components/PassphraseModal.tsx
@@ -23,6 +23,9 @@ export interface PassphraseRequest {
   hostname?: string;
 }
 
+/** Opt-in only: do not default to remembering key passphrases (#2024). */
+export const DEFAULT_REMEMBER_PASSPHRASE = false;
+
 interface PassphraseModalProps {
   request: PassphraseRequest | null;
   onSubmit: (requestId: string, passphrase: string, remember: boolean) => void;
@@ -40,7 +43,7 @@ export const PassphraseModal: React.FC<PassphraseModalProps> = ({
   const [passphrase, setPassphrase] = useState("");
   const [showPassphrase, setShowPassphrase] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [rememberPassphrase, setRememberPassphrase] = useState(true);
+  const [rememberPassphrase, setRememberPassphrase] = useState(DEFAULT_REMEMBER_PASSPHRASE);
 
   // Reset state when request changes
   useEffect(() => {
@@ -48,7 +51,7 @@ export const PassphraseModal: React.FC<PassphraseModalProps> = ({
       setPassphrase("");
       setShowPassphrase(false);
       setIsSubmitting(false);
-      setRememberPassphrase(true);
+      setRememberPassphrase(DEFAULT_REMEMBER_PASSPHRASE);
     }
   }, [request]);
 


### PR DESCRIPTION
## Summary
- SSH key passphrase modal no longer checks "Remember this passphrase" by default (opt-in for safer defaults).
- Aligns with keyboard-interactive password prompts, which already default to unchecked.
- Adds a regression test for the default.

Fixes #2024

## Test plan
- [ ] Connect with an encrypted SSH key that has no saved passphrase
- [ ] Confirm the passphrase dialog opens with "Remember this passphrase" unchecked
- [ ] Manually check the box, unlock, and confirm passphrase is remembered on next connect
- [ ] Leave unchecked, unlock, and confirm passphrase is not remembered on next connect
- [ ] `node --test --import tsx components/PassphraseModal.test.ts`


Made with [Cursor](https://cursor.com)