### PR TITLE
fix(sftp): prevent corrupt uploads from oversized fastPut chunks

### DIFF
--- a/electron/bridges/sftpBridge/fileOps.cjs
+++ b/electron/bridges/sftpBridge/fileOps.cjs
@@ -313,6 +313,24 @@ function createFileOpsApi(ctx) {
     
       try {
         await client.put(readableStream, encodedPath);
+
+        // Guard against silent truncation on servers that mishandle large writes (#2022).
+        if (typeof client.stat === "function") {
+          const attrs = await client.stat(encodedPath);
+          const remoteSize = Number(attrs?.size);
+          if (Number.isFinite(remoteSize) && remoteSize !== totalBytes) {
+            try {
+              if (typeof client.delete === "function") {
+                await client.delete(encodedPath);
+              }
+            } catch {
+              // Best-effort cleanup of the corrupt remote file.
+            }
+            throw new Error(
+              `Upload size mismatch for ${remotePath}: expected ${totalBytes} bytes, got ${remoteSize}`,
+            );
+          }
+        }
     
         // Call the complete callback if provided, otherwise send IPC event
         if (typeof onComplete === 'function') {

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -10,6 +10,42 @@ const { encodePathForSession, ensureRemoteDirForSession, requireSftpChannel, res
 const { TRANSFER_CHUNK_SIZE, TRANSFER_CONCURRENCY } = require("./transferLimits.cjs");
 
 /**
+ * Verify a completed remote upload matches the expected byte count.
+ * Without this check, fastPut/stream uploads can report success while leaving
+ * a truncated file on servers that mishandle large WRITE packets (#2022).
+ */
+async function assertRemoteUploadSize(client, remotePath, expectedSize) {
+  if (!Number.isFinite(expectedSize) || expectedSize < 0) return;
+  if (!client || typeof client.stat !== "function") return;
+
+  let attrs;
+  try {
+    attrs = await client.stat(remotePath);
+  } catch (err) {
+    throw new Error(
+      `Upload completed but remote file could not be verified (${remotePath}): ${err.message || String(err)}`,
+    );
+  }
+
+  const remoteSize = Number(attrs?.size);
+  if (!Number.isFinite(remoteSize)) {
+    throw new Error(`Upload completed but remote file size is unavailable (${remotePath})`);
+  }
+  if (remoteSize !== expectedSize) {
+    try {
+      if (typeof client.delete === "function") {
+        await client.delete(remotePath);
+      }
+    } catch {
+      // Best-effort cleanup of the corrupt remote file.
+    }
+    throw new Error(
+      `Upload size mismatch for ${remotePath}: expected ${expectedSize} bytes, got ${remoteSize}`,
+    );
+  }
+}
+
+/**
  * Safely ensure a local directory exists.
  * On Windows, `mkdir("E:\\", { recursive: true })` throws EPERM for drive roots.
  * We catch that and verify the directory already exists before re-throwing.
@@ -305,7 +341,7 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     }
 
     if (fastSftp && typeof fastSftp.fastPut === "function") {
-      return new Promise((resolve, reject) => {
+      await new Promise((resolve, reject) => {
         let settled = false;
         let onFastSftpError = null;
         const finish = (err) => {
@@ -348,6 +384,8 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
           },
         }, finish);
       });
+      await assertRemoteUploadSize(client, remotePath, fileSize);
+      return;
     }
 
     if (fastSftp && typeof fastSftp.end === "function") {
@@ -355,8 +393,10 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     }
   }
 
-  // Fallback: sequential stream piping
-  return new Promise((resolve, reject) => {
+  // Fallback: sequential stream piping.
+  // Wait for writeStream 'finish' (all bytes flushed) — 'close' alone can fire
+  // after an early destroy and would otherwise report a truncated upload as success.
+  await new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     const writeStream = sftp.createWriteStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     let transferred = 0;
@@ -386,12 +426,16 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     });
     readStream.on('error', cleanup);
     writeStream.on('error', cleanup);
-    writeStream.on('close', () => {
+    writeStream.on('finish', () => {
       if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
       else cleanup(null);
     });
+    writeStream.on('close', () => {
+      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
+    });
     readStream.pipe(writeStream);
   });
+  await assertRemoteUploadSize(client, remotePath, fileSize);
 }
 
 /**

--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -394,20 +394,22 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   }
 
   // Fallback: sequential stream piping.
-  // Wait for writeStream 'finish' (all bytes flushed) — 'close' alone can fire
-  // after an early destroy and would otherwise report a truncated upload as success.
+  // Require both 'finish' (bytes flushed) and 'close' (remote handle closed).
+  // Resolving on finish alone can miss close-time server errors (quota/disk full);
+  // resolving on close alone can treat a premature destroy as success (#2022).
   await new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     const writeStream = sftp.createWriteStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     let transferred = 0;
-    let finished = false;
+    let settled = false;
+    let sawFinish = false;
 
     transfer.readStream = readStream;
     transfer.writeStream = writeStream;
 
     const cleanup = (err) => {
-      if (finished) return;
-      finished = true;
+      if (settled) return;
+      settled = true;
       readStream.removeAllListeners();
       writeStream.removeAllListeners();
       if (err) {
@@ -427,11 +429,22 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     readStream.on('error', cleanup);
     writeStream.on('error', cleanup);
     writeStream.on('finish', () => {
-      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
-      else cleanup(null);
+      if (transfer.cancelled) {
+        cleanup(new Error('Transfer cancelled'));
+        return;
+      }
+      sawFinish = true;
     });
     writeStream.on('close', () => {
-      if (transfer.cancelled) cleanup(new Error('Transfer cancelled'));
+      if (transfer.cancelled) {
+        cleanup(new Error('Transfer cancelled'));
+        return;
+      }
+      if (!sawFinish) {
+        cleanup(new Error('Upload stream closed before finish'));
+        return;
+      }
+      cleanup(null);
     });
     readStream.pipe(writeStream);
   });

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -129,6 +129,145 @@ test("SFTP uploads fail when remote size does not match local size", async (t) =
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
 });
 
+test("SFTP stream-fallback uploads wait for close after finish", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-stream-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "payload.bin");
+  const payload = Buffer.alloc(64 * 1024, 7);
+  await fs.promises.writeFile(localPath, payload);
+
+  let resolveClose;
+  const closeGate = new Promise((resolve) => {
+    resolveClose = resolve;
+  });
+  let sawFinishBeforeClose = false;
+  let remoteBytes = 0;
+
+  const streamSftp = createFastSftp({
+    createWriteStream() {
+      const { Writable } = require("node:stream");
+      const writeStream = new Writable({
+        autoDestroy: false,
+        emitClose: false,
+        write(chunk, _encoding, callback) {
+          remoteBytes += chunk.length;
+          callback();
+        },
+      });
+      // Match ssh2 WriteStream: finish does not imply the remote handle is closed yet.
+      writeStream.on("finish", () => {
+        sawFinishBeforeClose = true;
+        setTimeout(() => {
+          writeStream.emit("close");
+          resolveClose();
+        }, 25);
+      });
+      return writeStream;
+    },
+  });
+
+  const client = {
+    // Force the sequential stream fallback (no isolated fastPut channel).
+    __netcattySudoMode: true,
+    sftp: streamSftp,
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  let transferSettled = false;
+  const transferPromise = transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "upload-stream-fallback",
+      sourcePath: localPath,
+      targetPath: "/tmp/payload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+    },
+  ).finally(() => {
+    transferSettled = true;
+  });
+
+  // Wait until finish has been observed, then confirm we have not completed yet.
+  const finishDeadline = Date.now() + 1000;
+  while (!sawFinishBeforeClose && Date.now() < finishDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.equal(sawFinishBeforeClose, true);
+  assert.equal(transferSettled, false);
+
+  await closeGate;
+  // Give the close handler a turn to settle the transfer.
+  const result = await transferPromise;
+  assert.equal(result.error, undefined);
+  assert.equal(remoteBytes, payload.length);
+  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"));
+});
+
+test("SFTP stream-fallback uploads fail on premature close", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-premature-close-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "payload.bin");
+  await fs.promises.writeFile(localPath, Buffer.alloc(8 * 1024, 3));
+
+  const streamSftp = createFastSftp({
+    createWriteStream() {
+      const { Writable } = require("node:stream");
+      const writeStream = new Writable({
+        autoDestroy: false,
+        emitClose: false,
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      });
+      writeStream.on("finish", () => {
+        // Intentionally skip finish-before-close ordering by closing without finish first
+        // is covered by destroying before end; here emit close without marking finish path
+        // via an early close from the producer side.
+      });
+      // Close before any finish event.
+      queueMicrotask(() => writeStream.emit("close"));
+      return writeStream;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: streamSftp,
+    stat() {
+      return Promise.resolve({ size: 0 });
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const result = await transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "upload-premature-close",
+      sourcePath: localPath,
+      targetPath: "/tmp/payload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+    },
+  );
+
+  assert.match(result.error || "", /closed before finish/);
+  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
+});
+
 test("SFTP downloads use conservative per-file request concurrency", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-test-"));
   t.after(async () => {

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -37,15 +37,20 @@ test("SFTP uploads use conservative per-file request concurrency", async (t) => 
   await fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024));
 
   let observedConcurrency = 0;
+  let observedChunkSize = 0;
   const fastSftp = createFastSftp({
     fastPut(_localPath, _remotePath, options, done) {
       observedConcurrency = options.concurrency;
+      observedChunkSize = options.chunkSize;
       options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
       queueMicrotask(() => done());
     },
   });
   const client = {
     sftp: createFastSftp({}),
+    stat() {
+      return Promise.resolve({ size: 1024 * 1024 });
+    },
     client: {
       sftp(callback) {
         callback(null, fastSftp);
@@ -69,6 +74,59 @@ test("SFTP uploads use conservative per-file request concurrency", async (t) => 
 
   assert.equal(result.error, undefined);
   assert.equal(observedConcurrency, 4);
+  assert.equal(observedChunkSize, 32 * 1024);
+});
+
+test("SFTP uploads fail when remote size does not match local size", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-size-test-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "archive.zip");
+  await fs.promises.writeFile(localPath, Buffer.alloc(1024 * 1024));
+
+  let deletedRemotePath = null;
+  const fastSftp = createFastSftp({
+    fastPut(_localPath, _remotePath, options, done) {
+      options.step?.(1024 * 1024, 1024 * 1024, 1024 * 1024);
+      queueMicrotask(() => done());
+    },
+  });
+  const client = {
+    sftp: createFastSftp({}),
+    stat() {
+      // Simulate a truncated remote file after a "successful" fastPut.
+      return Promise.resolve({ size: 512 * 1024 });
+    },
+    delete(remotePath) {
+      deletedRemotePath = remotePath;
+      return Promise.resolve();
+    },
+    client: {
+      sftp(callback) {
+        callback(null, fastSftp);
+      },
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const result = await transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "upload-truncated",
+      sourcePath: localPath,
+      targetPath: "/tmp/archive.zip",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+    },
+  );
+
+  assert.match(result.error || "", /Upload size mismatch/);
+  assert.equal(deletedRemotePath, "/tmp/archive.zip");
+  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:error"));
 });
 
 test("SFTP downloads use conservative per-file request concurrency", async (t) => {

--- a/electron/bridges/transferLimits.cjs
+++ b/electron/bridges/transferLimits.cjs
@@ -3,7 +3,11 @@
 // ssh2's fastPut/fastGet send multiple SFTP read/write requests in parallel.
 // Keep defaults conservative so one file transfer does not monopolize a shared
 // SSH/SFTP path used by interactive terminals.
-const TRANSFER_CHUNK_SIZE = 512 * 1024;
+//
+// chunkSize must stay at ssh2's default (32KB). Larger values (e.g. 512KB) can
+// exceed what some SFTP servers accept and silently produce truncated/corrupt
+// remote files — see GitHub #2022 and ssh2-sftp-client's fastPut warnings.
+const TRANSFER_CHUNK_SIZE = 32 * 1024;
 const TRANSFER_CONCURRENCY = 4;
 
 module.exports = {

--- a/electron/bridges/transferLimits.test.cjs
+++ b/electron/bridges/transferLimits.test.cjs
@@ -8,5 +8,7 @@ const {
 
 test("SFTP transfer limits keep default per-file request fanout conservative", () => {
   assert.equal(TRANSFER_CONCURRENCY, 4);
-  assert.equal(TRANSFER_CHUNK_SIZE, 512 * 1024);
+  // Keep ssh2's default chunk size — larger packets can corrupt uploads on
+  // servers that do not honour non-default WRITE sizes (#2022).
+  assert.equal(TRANSFER_CHUNK_SIZE, 32 * 1024);
 });

--- a/lib/uploadService.ts
+++ b/lib/uploadService.ts
@@ -806,7 +806,9 @@ async function uploadEntries(
     settle(taskId);
   };
 
-  const UPLOAD_CONCURRENCY = 4;
+  // Keep external multi-file uploads conservative: each file may open an
+  // isolated fastPut channel with its own in-flight WRITE fanout.
+  const UPLOAD_CONCURRENCY = 2;
 
   try {
     let entryIndex = 0;


### PR DESCRIPTION
## Summary
- Fixes [#2022](https://github.com/binaricat/Netcatty/issues/2022): SFTP uploads of zip/tar.gz could arrive truncated/corrupt (bad CRC, unexpected EOF) while FileZilla worked.
- Root cause: UI transfer path used `fastPut` with `chunkSize: 512KB` (introduced for throughput). ssh2 defaults to 32KB; non-default WRITE sizes are known to produce truncated/corrupt files on some SFTP servers. Uploads also reported success on stream `close` without verifying remote size.
- Changes:
  - Restore `TRANSFER_CHUNK_SIZE` to ssh2's 32KB default
  - After upload, `stat` remote size and fail (plus best-effort delete) on mismatch
  - Stream fallback waits for `finish`, not only `close`
  - Lower external multi-file `UPLOAD_CONCURRENCY` from 4 → 2

## Test plan
- [x] `node --test electron/bridges/transferLimits.test.cjs electron/bridges/transferBridge.test.cjs electron/bridges/registerBridgesTransferLimits.test.cjs`
- [ ] Upload several large zip/tar.gz via terminal SFTP side panel (deep-link / normal host)
- [ ] Confirm remote `ls -l` size matches local; `unzip -t` / `gzip -t` succeed
- [ ] Cancel mid-upload and confirm UI reports failure (no silent “success” truncated file)


Made with [Cursor](https://cursor.com)