### PR TITLE
fix: stop window opacity slider oscillation (#2018)

### DIFF
--- a/application/state/settingsIpcSync.ts
+++ b/application/state/settingsIpcSync.ts
@@ -48,7 +48,6 @@ import {
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
 import {
-  clampWindowOpacity,
   isValidUiFontId,
   migrateIncomingTerminalFontId,
 } from './settingsStateDefaults';
@@ -79,7 +78,7 @@ interface UseSettingsIpcSyncParams {
   applyIncomingCustomKeyBindings: (incoming: { bindings: CustomKeyBindings; version: number; origin: string }) => void;
   setIsHotkeyRecordingState: Dispatch<SetStateAction<boolean>>;
   setGlobalHotkeyEnabled: Dispatch<SetStateAction<boolean>>;
-  setWindowOpacity: Dispatch<SetStateAction<number>>;
+  setWindowOpacity: (raw: unknown) => void;
   setAppIconVariant: Dispatch<SetStateAction<AppIconVariant>>;
   setAutoUpdateEnabled: Dispatch<SetStateAction<boolean>>;
   setSftpAutoOpenSidebar: Dispatch<SetStateAction<boolean>>;
@@ -239,9 +238,8 @@ export function useSettingsIpcSync({
       if (key === STORAGE_KEY_GLOBAL_HOTKEY_ENABLED && typeof value === 'boolean') {
         setGlobalHotkeyEnabled((prev) => (prev === value ? prev : value));
       }
-      if (key === STORAGE_KEY_WINDOW_OPACITY && (typeof value === 'number' || typeof value === 'string')) {
-        const nextOpacity = clampWindowOpacity(value);
-        setWindowOpacity((prev) => (prev === nextOpacity ? prev : nextOpacity));
+      if (key === STORAGE_KEY_WINDOW_OPACITY) {
+        setWindowOpacity(value);
       }
       if (key === STORAGE_KEY_APP_ICON_VARIANT) {
         const nextVariant = resolveAppIconVariant(value);

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -54,7 +54,6 @@ import {
 } from '../../infrastructure/config/storageKeys';
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
 import {
-  clampWindowOpacity,
   isValidHslToken,
   isValidTheme,
   isValidUiFontId,
@@ -148,7 +147,7 @@ interface UseSettingsStorageSyncParams {
   setSshDeepLinkEnabledState: (enabled: boolean) => void;
   setJmsDeepLinkEnabledState: (enabled: boolean) => void;
   setGlobalHotkeyEnabled: Dispatch<SetStateAction<boolean>>;
-  setWindowOpacity: Dispatch<SetStateAction<number>>;
+  setWindowOpacity: (raw: unknown) => void;
   setAppIconVariant: Dispatch<SetStateAction<AppIconVariant>>;
   setAutoUpdateEnabled: Dispatch<SetStateAction<boolean>>;
   setWorkspaceFocusStyleState: Dispatch<SetStateAction<'dim' | 'border'>>;
@@ -474,10 +473,7 @@ export function useSettingsStorageSync({
         }
       }
       if (e.key === STORAGE_KEY_WINDOW_OPACITY && e.newValue !== null) {
-        const newValue = clampWindowOpacity(e.newValue);
-        if (newValue !== s.windowOpacity) {
-          setWindowOpacity(newValue);
-        }
+        setWindowOpacity(e.newValue);
       }
       if (e.key === STORAGE_KEY_APP_ICON_VARIANT && e.newValue !== null) {
         const newValue = resolveAppIconVariant(e.newValue);

--- a/application/state/systemSettingsEffects.ts
+++ b/application/state/systemSettingsEffects.ts
@@ -10,13 +10,22 @@ import {
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
 import { localStorageAdapter } from '../../infrastructure/persistence/localStorageAdapter';
 import { netcattyBridge } from '../../infrastructure/services/netcattyBridge';
+import {
+  parseWindowOpacityRecord,
+  serializeWindowOpacityRecord,
+  shouldApplyWindowOpacityRecord,
+  shouldBroadcastWindowOpacityChange,
+  type WindowOpacityMutationSource,
+  type WindowOpacityRecord,
+} from './windowOpacitySync';
 
 interface UseSystemSettingsEffectsParams {
   enabled?: boolean;
   toggleWindowHotkey: string;
   globalHotkeyEnabled: boolean;
   closeToTray: boolean;
-  windowOpacity: number;
+  windowOpacityRecord: WindowOpacityRecord;
+  windowOpacityMutationSourceRef: MutableRefObject<WindowOpacityMutationSource>;
   appIconVariant: AppIconVariant;
   autoUpdateEnabled: boolean;
   persistMountedRef: MutableRefObject<boolean>;
@@ -31,7 +40,8 @@ export function useSystemSettingsEffects({
   toggleWindowHotkey,
   globalHotkeyEnabled,
   closeToTray,
-  windowOpacity,
+  windowOpacityRecord,
+  windowOpacityMutationSourceRef,
   appIconVariant,
   autoUpdateEnabled,
   persistMountedRef,
@@ -110,13 +120,36 @@ export function useSystemSettingsEffects({
   useEffect(() => {
     if (!enabled) return;
     const bridge = netcattyBridge.get();
-    bridge?.setWindowOpacity?.(windowOpacity).catch((err) => {
+    bridge?.setWindowOpacity?.(windowOpacityRecord.opacity).catch((err) => {
       console.warn('[WindowOpacity] Failed to apply window opacity:', err);
     });
-    localStorageAdapter.writeString(STORAGE_KEY_WINDOW_OPACITY, String(windowOpacity));
-    if (!persistMountedRef.current) return;
-    notifySettingsChanged(STORAGE_KEY_WINDOW_OPACITY, windowOpacity);
-  }, [enabled, windowOpacity, notifySettingsChanged, persistMountedRef]);
+    // Never let a stale effect overwrite a newer revision already on disk.
+    const stored = parseWindowOpacityRecord(
+      localStorageAdapter.readString(STORAGE_KEY_WINDOW_OPACITY),
+    );
+    if (
+      shouldApplyWindowOpacityRecord(stored, windowOpacityRecord)
+      || stored.version === windowOpacityRecord.version
+    ) {
+      localStorageAdapter.writeString(
+        STORAGE_KEY_WINDOW_OPACITY,
+        serializeWindowOpacityRecord(windowOpacityRecord),
+      );
+    }
+    const decision = shouldBroadcastWindowOpacityChange(
+      windowOpacityMutationSourceRef.current,
+      persistMountedRef.current,
+    );
+    windowOpacityMutationSourceRef.current = decision.nextSource;
+    if (!decision.shouldBroadcast) return;
+    notifySettingsChanged(STORAGE_KEY_WINDOW_OPACITY, windowOpacityRecord);
+  }, [
+    enabled,
+    windowOpacityRecord,
+    windowOpacityMutationSourceRef,
+    notifySettingsChanged,
+    persistMountedRef,
+  ]);
 
   // Persist and sync app icon variant
   useEffect(() => {

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -132,6 +132,12 @@ import {
   isTerminalSidePanelAutoOpenTab,
   type TerminalSidePanelAutoOpenTab,
 } from '../../domain/terminalSidePanelAutoOpen';
+import {
+  parseWindowOpacityRecord,
+  shouldApplyWindowOpacityRecord,
+  type WindowOpacityMutationSource,
+  type WindowOpacityRecord,
+} from './windowOpacitySync';
 
 export const useSettingsState = (options: { enableSettingsSync?: boolean; enableSystemEffects?: boolean } = {}) => {
   const enableSettingsSync = options.enableSettingsSync !== false;
@@ -354,17 +360,34 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     if (stored === null) return true; // Default to enabled
     return stored === 'true';
   });
-  const [windowOpacity, setWindowOpacityState] = useState<number>(() => {
+  const [windowOpacityRecord, setWindowOpacityRecord] = useState<WindowOpacityRecord>(() => {
     const stored = readStoredString(STORAGE_KEY_WINDOW_OPACITY);
-    if (stored === null) return DEFAULT_WINDOW_OPACITY;
-    return clampWindowOpacity(stored);
+    if (stored === null) return { opacity: DEFAULT_WINDOW_OPACITY, version: 0 };
+    return parseWindowOpacityRecord(stored);
   });
+  const windowOpacity = windowOpacityRecord.opacity;
+  const windowOpacityMutationSourceRef = useRef<WindowOpacityMutationSource>('local');
   const setWindowOpacity = useCallback((nextValue: SetStateAction<number>) => {
-    setWindowOpacityState((prev) => {
+    windowOpacityMutationSourceRef.current = 'local';
+    setWindowOpacityRecord((prev) => {
       const candidate = typeof nextValue === 'function'
-        ? (nextValue as (prevState: number) => number)(prev)
+        ? (nextValue as (prevState: number) => number)(prev.opacity)
         : nextValue;
-      return clampWindowOpacity(candidate);
+      const nextOpacity = clampWindowOpacity(candidate);
+      if (nextOpacity === prev.opacity) return prev;
+      return { opacity: nextOpacity, version: prev.version + 1 };
+    });
+  }, []);
+  const applyIncomingWindowOpacity = useCallback((raw: unknown) => {
+    const incoming = parseWindowOpacityRecord(raw);
+    // Version gate so stale IPC/storage echoes cannot clobber a newer local
+    // drag revision (see #2018).
+    setWindowOpacityRecord((prev) => {
+      if (!shouldApplyWindowOpacityRecord(prev, incoming)) {
+        return prev;
+      }
+      windowOpacityMutationSourceRef.current = 'incoming';
+      return incoming;
     });
   }, []);
   const [appIconVariant, setAppIconVariantState] = useState<AppIconVariant>(() => {
@@ -749,7 +772,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     applyIncomingCustomKeyBindings,
     setIsHotkeyRecordingState,
     setGlobalHotkeyEnabled,
-    setWindowOpacity,
+    setWindowOpacity: applyIncomingWindowOpacity,
     setAppIconVariant,
     setAutoUpdateEnabled,
     setSftpAutoOpenSidebar,
@@ -801,7 +824,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     setSftpUseCompressedUpload, setSftpAutoOpenSidebar, setSftpFollowTerminalCwd, setSftpDefaultViewMode,
     setShowRecentHostsState, setShowOnlyUngroupedHostsInRootState, setShowSftpTabState, setShowHostTreeSidebarState, setTerminalSidePanelAutoOpenState, setTerminalSidePanelAutoOpenTabState, setShellOnlyTabNumberShortcutsState, setDisableTerminalFontZoomState, setRestorePreviousSessionState, setRestoreTerminalCwdState,
     setEditorWordWrapState, setSessionLogsEnabled, setSessionLogsDir, setSessionLogsFormat, setSessionLogsTimestampsEnabled, setSshDebugLogsEnabled, setSshDeepLinkEnabledState: applyIncomingSshDeepLinkEnabled, setJmsDeepLinkEnabledState: applyIncomingJmsDeepLinkEnabled,
-    setGlobalHotkeyEnabled, setWindowOpacity, setAppIconVariant, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
+    setGlobalHotkeyEnabled, setWindowOpacity: applyIncomingWindowOpacity, setAppIconVariant, setAutoUpdateEnabled, setWorkspaceFocusStyleState,
     setSftpTransferConcurrencyState, applyIncomingCustomKeyBindings, mergeIncomingTerminalSettings,
   });
 
@@ -1173,7 +1196,8 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     toggleWindowHotkey,
     globalHotkeyEnabled,
     closeToTray,
-    windowOpacity,
+    windowOpacityRecord,
+    windowOpacityMutationSourceRef,
     appIconVariant,
     autoUpdateEnabled,
     persistMountedRef,

--- a/application/state/windowOpacitySync.test.ts
+++ b/application/state/windowOpacitySync.test.ts
@@ -1,0 +1,199 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseWindowOpacityRecord,
+  serializeWindowOpacityRecord,
+  shouldApplyWindowOpacityRecord,
+  shouldBroadcastWindowOpacityChange,
+  type WindowOpacityMutationSource,
+  type WindowOpacityRecord,
+} from './windowOpacitySync.ts';
+
+/**
+ * Minimal model of the settings ↔ main opacity sync loop that caused #2018.
+ * Models both IPC rebroadcast and stale localStorage overwrites.
+ */
+function simulateOpacityDrag(options: {
+  shouldBroadcast: (
+    source: WindowOpacityMutationSource,
+    persistMounted: boolean,
+  ) => { shouldBroadcast: boolean; nextSource: WindowOpacityMutationSource };
+  shouldApply: (current: WindowOpacityRecord, incoming: WindowOpacityRecord) => boolean;
+  versioned: boolean;
+}): { settingsValues: number[]; mainValues: number[]; storageWrites: string[] } {
+  let settings: WindowOpacityRecord = { opacity: 1, version: 0 };
+  let main: WindowOpacityRecord = { opacity: 1, version: 0 };
+  let settingsSource: WindowOpacityMutationSource = 'local';
+  let mainSource: WindowOpacityMutationSource = 'local';
+  let storage = serializeWindowOpacityRecord(settings);
+  const settingsValues: number[] = [];
+  const mainValues: number[] = [];
+  const storageWrites: string[] = [];
+
+  const pendingIpc: Array<{ to: 'settings' | 'main'; record: WindowOpacityRecord }> = [];
+
+  const writeStorage = (record: WindowOpacityRecord) => {
+    const next = options.versioned
+      ? serializeWindowOpacityRecord(record)
+      : String(record.opacity);
+    if (next === storage) return;
+    storage = next;
+    storageWrites.push(next);
+    // Cross-window StorageEvent: deliver to the other window.
+  };
+
+  const applyLocal = (window: 'settings' | 'main', opacity: number) => {
+    const bump = (prev: WindowOpacityRecord): WindowOpacityRecord => (
+      options.versioned
+        ? { opacity, version: prev.version + 1 }
+        : { opacity, version: 0 }
+    );
+
+    if (window === 'settings') {
+      settingsSource = 'local';
+      settings = bump(settings);
+      settingsValues.push(settings.opacity);
+      writeStorage(settings);
+      const decision = options.shouldBroadcast(settingsSource, true);
+      settingsSource = decision.nextSource;
+      if (decision.shouldBroadcast) pendingIpc.push({ to: 'main', record: { ...settings } });
+      return;
+    }
+
+    mainSource = 'local';
+    main = bump(main);
+    mainValues.push(main.opacity);
+    writeStorage(main);
+    const decision = options.shouldBroadcast(mainSource, true);
+    mainSource = decision.nextSource;
+    if (decision.shouldBroadcast) pendingIpc.push({ to: 'settings', record: { ...main } });
+  };
+
+  const applyIncoming = (window: 'settings' | 'main', record: WindowOpacityRecord) => {
+    if (window === 'settings') {
+      if (!options.shouldApply(settings, record)) return;
+      settingsSource = 'incoming';
+      settings = { ...record };
+      settingsValues.push(settings.opacity);
+      writeStorage(settings);
+      const decision = options.shouldBroadcast(settingsSource, true);
+      settingsSource = decision.nextSource;
+      if (decision.shouldBroadcast) pendingIpc.push({ to: 'main', record: { ...settings } });
+      return;
+    }
+
+    if (!options.shouldApply(main, record)) return;
+    mainSource = 'incoming';
+    main = { ...record };
+    mainValues.push(main.opacity);
+    writeStorage(main);
+    const decision = options.shouldBroadcast(mainSource, true);
+    mainSource = decision.nextSource;
+    if (decision.shouldBroadcast) pendingIpc.push({ to: 'settings', record: { ...main } });
+  };
+
+  const flushIpc = () => {
+    while (pendingIpc.length > 0) {
+      const next = pendingIpc.shift()!;
+      applyIncoming(next.to, next.record);
+      if (settingsValues.length > 40) break;
+    }
+  };
+
+  // Replay storage writes onto the peer after each local burst, matching
+  // Electron's cross-window StorageEvent delivery.
+  const deliverStorageTo = (window: 'settings' | 'main') => {
+    const record = options.versioned
+      ? parseWindowOpacityRecord(JSON.parse(storage))
+      : parseWindowOpacityRecord(storage);
+    applyIncoming(window, record);
+  };
+
+  applyLocal('settings', 0.5);
+  deliverStorageTo('main');
+  applyLocal('settings', 0.65);
+  // Delayed IPC for the older 0.5 update arrives after 0.65 was already local.
+  const delayed = pendingIpc.shift();
+  flushIpc();
+  if (delayed) applyIncoming(delayed.to, delayed.record);
+  deliverStorageTo('settings');
+  flushIpc();
+
+  return { settingsValues, mainValues, storageWrites };
+}
+
+test('parseWindowOpacityRecord accepts legacy plain numbers and versioned JSON', () => {
+  assert.deepEqual(parseWindowOpacityRecord('0.85'), { opacity: 0.85, version: 0 });
+  assert.deepEqual(parseWindowOpacityRecord(0.7), { opacity: 0.7, version: 0 });
+  assert.deepEqual(
+    parseWindowOpacityRecord({ opacity: 0.5, version: 3 }),
+    { opacity: 0.5, version: 3 },
+  );
+  assert.deepEqual(
+    parseWindowOpacityRecord('{"opacity":0.55,"version":9}'),
+    { opacity: 0.55, version: 9 },
+  );
+  assert.equal(parseWindowOpacityRecord('bad').opacity, 1);
+});
+
+test('shouldApplyWindowOpacityRecord ignores stale revisions', () => {
+  const current = { opacity: 0.65, version: 2 };
+  assert.equal(shouldApplyWindowOpacityRecord(current, { opacity: 0.5, version: 1 }), false);
+  assert.equal(shouldApplyWindowOpacityRecord(current, { opacity: 0.7, version: 3 }), true);
+  assert.equal(shouldApplyWindowOpacityRecord(current, { opacity: 0.65, version: 2 }), false);
+});
+
+test('shouldBroadcastWindowOpacityChange suppresses incoming rebroadcasts', () => {
+  assert.deepEqual(
+    shouldBroadcastWindowOpacityChange('incoming', true),
+    { shouldBroadcast: false, nextSource: 'local' },
+  );
+  assert.deepEqual(
+    shouldBroadcastWindowOpacityChange('local', true),
+    { shouldBroadcast: true, nextSource: 'local' },
+  );
+  assert.deepEqual(
+    shouldBroadcastWindowOpacityChange('local', false),
+    { shouldBroadcast: false, nextSource: 'local' },
+  );
+});
+
+test('legacy unversioned always-broadcast opacity sync oscillates during a fast drag', () => {
+  const alwaysBroadcast = (
+    _source: WindowOpacityMutationSource,
+    persistMounted: boolean,
+  ) => ({
+    shouldBroadcast: persistMounted,
+    nextSource: 'local' as const,
+  });
+  const alwaysApply = () => true;
+
+  const { settingsValues } = simulateOpacityDrag({
+    shouldBroadcast: alwaysBroadcast,
+    shouldApply: alwaysApply,
+    versioned: false,
+  });
+  const unique = new Set(settingsValues);
+  assert.ok(
+    unique.has(0.5) && unique.has(0.65) && settingsValues.length > 2,
+    `expected oscillation between 0.5 and 0.65, got ${settingsValues.join(',')}`,
+  );
+});
+
+test('versioned opacity sync ignores stale peer echoes during a fast drag', () => {
+  const { settingsValues, mainValues } = simulateOpacityDrag({
+    shouldBroadcast: shouldBroadcastWindowOpacityChange,
+    shouldApply: shouldApplyWindowOpacityRecord,
+    versioned: true,
+  });
+
+  assert.deepEqual(settingsValues, [0.5, 0.65]);
+  assert.ok(mainValues.includes(0.65));
+  assert.equal(mainValues.includes(0.5) && mainValues[mainValues.length - 1] === 0.5, false);
+});
+
+test('serializeWindowOpacityRecord round-trips through parse', () => {
+  const raw = serializeWindowOpacityRecord({ opacity: 0.55, version: 9 });
+  assert.deepEqual(parseWindowOpacityRecord(JSON.parse(raw)), { opacity: 0.55, version: 9 });
+});

--- a/application/state/windowOpacitySync.ts
+++ b/application/state/windowOpacitySync.ts
@@ -1,0 +1,88 @@
+import {
+  DEFAULT_WINDOW_OPACITY,
+  clampWindowOpacity,
+} from './settingsStateDefaults';
+
+export { DEFAULT_WINDOW_OPACITY, clampWindowOpacity };
+
+export type WindowOpacityMutationSource = 'local' | 'incoming';
+
+export type WindowOpacityRecord = {
+  opacity: number;
+  version: number;
+};
+
+/**
+ * Parse persisted / IPC window-opacity payloads.
+ * Accepts legacy plain numbers ("0.85") and versioned records.
+ */
+export function parseWindowOpacityRecord(raw: unknown): WindowOpacityRecord {
+  if (typeof raw === 'number' || typeof raw === 'string') {
+    const trimmed = typeof raw === 'string' ? raw.trim() : raw;
+    // Prefer JSON object payloads written by serializeWindowOpacityRecord.
+    if (typeof trimmed === 'string' && trimmed.startsWith('{')) {
+      try {
+        return parseWindowOpacityRecord(JSON.parse(trimmed));
+      } catch {
+        // fall through to Number()
+      }
+    }
+    const asNumber = Number(trimmed);
+    if (Number.isFinite(asNumber)) {
+      return { opacity: clampWindowOpacity(asNumber), version: 0 };
+    }
+  }
+
+  if (raw && typeof raw === 'object') {
+    const record = raw as { opacity?: unknown; version?: unknown };
+    const opacity = clampWindowOpacity(record.opacity);
+    const version = Number(record.version);
+    return {
+      opacity,
+      version: Number.isFinite(version) && version > 0 ? Math.floor(version) : 0,
+    };
+  }
+
+  return { opacity: DEFAULT_WINDOW_OPACITY, version: 0 };
+}
+
+export function serializeWindowOpacityRecord(record: WindowOpacityRecord): string {
+  return JSON.stringify({
+    opacity: clampWindowOpacity(record.opacity),
+    version: Math.max(0, Math.floor(record.version) || 0),
+  });
+}
+
+/**
+ * Incoming peer updates must not clobber a newer local/drag revision.
+ * Equal versions are treated as already-applied (no state thrash).
+ */
+export function shouldApplyWindowOpacityRecord(
+  current: WindowOpacityRecord,
+  incoming: WindowOpacityRecord,
+): boolean {
+  if (incoming.version > current.version) return true;
+  if (incoming.version < current.version) return false;
+  // Same version: only apply when the opacity itself differs and both are
+  // legacy/unversioned (version 0), so first-load plain strings still sync.
+  if (incoming.version === 0 && current.version === 0) {
+    return incoming.opacity !== current.opacity;
+  }
+  return false;
+}
+
+/**
+ * Decide whether a window-opacity state change should be rebroadcast to peer
+ * windows. Incoming IPC/storage updates must not notify again — otherwise a
+ * fast slider drag in the settings window ping-pongs with the main window and
+ * the controlled range input oscillates (see #2018).
+ */
+export function shouldBroadcastWindowOpacityChange(
+  mutationSource: WindowOpacityMutationSource,
+  persistMounted: boolean,
+): { shouldBroadcast: boolean; nextSource: WindowOpacityMutationSource } {
+  if (mutationSource === 'incoming') {
+    return { shouldBroadcast: false, nextSource: 'local' };
+  }
+  return { shouldBroadcast: persistMounted, nextSource: 'local' };
+}


### PR DESCRIPTION
## Summary
- Fast-dragging the window opacity slider in Settings could oscillate between two percentages because the main window echoed stale opacity values back over IPC/localStorage.
- Persist opacity as a versioned `{opacity, version}` record, ignore older peer revisions, and skip rebroadcasting incoming updates (same pattern as other settings mutation sources).
- Adds a regression model that reproduces the legacy ping-pong and asserts the versioned path stays stable.

Fixes #2018

## Test plan
- [ ] Open Settings → Appearance → Window opacity on Windows
- [ ] Yank the slider hard to the left (50%) and keep dragging; confirm the value settles instead of bouncing between two percentages
- [ ] Change opacity from the top-tab droplet popover and confirm Settings reflects the new value
- [ ] Restart the app and confirm the last opacity is restored
- [ ] `node --test --import tsx application/state/windowOpacitySync.test.ts`


Made with [Cursor](https://cursor.com)