### PR TITLE
fix(ai): resolve nvmd Windows Codex shims for SDK turns

### DIFF
--- a/electron/bridges/ai/shellUtils.cjs
+++ b/electron/bridges/ai/shellUtils.cjs
@@ -349,6 +349,74 @@ function resolveCodexNativeExecutableWin32(moduleSearchDirs, arch = process.arch
   return null;
 }
 
+function getNvmdHomeFromShimDir(shimDir) {
+  const normalized = String(shimDir || "").trim();
+  if (!normalized) return null;
+  if (path.basename(normalized).toLowerCase() !== "bin") return null;
+  const home = path.dirname(normalized);
+  // nvm-desktop / nvmd-command layout: $NVMD_HOME/{bin,versions,default,packages.json}
+  if (
+    existsSync(path.join(home, "versions")) ||
+    existsSync(path.join(home, "packages.json")) ||
+    existsSync(path.join(home, "default"))
+  ) {
+    return home;
+  }
+  return null;
+}
+
+function readNvmdDefaultVersion(nvmdHome) {
+  try {
+    const raw = readFileSync(path.join(nvmdHome, "default"), "utf8").trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}
+
+function readNvmdPackageVersions(nvmdHome, packageBinName) {
+  try {
+    const raw = readFileSync(path.join(nvmdHome, "packages.json"), "utf8");
+    const data = JSON.parse(raw);
+    const versions = data && data[packageBinName];
+    if (!Array.isArray(versions)) return [];
+    return versions.map((v) => String(v || "").trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function getNvmdVersionsDirectory(nvmdHome) {
+  try {
+    const raw = readFileSync(path.join(nvmdHome, "setting.json"), "utf8");
+    const data = JSON.parse(raw);
+    const custom = data && typeof data.directory === "string" ? data.directory.trim() : "";
+    if (custom) return custom;
+  } catch {
+    // Fall back to the default versions/ directory.
+  }
+  return path.join(nvmdHome, "versions");
+}
+
+function getNvmdCodexVersionRoots(nvmdHome) {
+  if (!nvmdHome) return [];
+  const versionsDir = getNvmdVersionsDirectory(nvmdHome);
+  const candidates = [
+    ...readNvmdPackageVersions(nvmdHome, "codex").reverse(),
+    readNvmdDefaultVersion(nvmdHome),
+  ].filter(Boolean);
+
+  const roots = [];
+  const seen = new Set();
+  for (const version of candidates) {
+    const root = path.join(versionsDir, version);
+    if (seen.has(root) || !existsSync(root)) continue;
+    seen.add(root);
+    roots.push(root);
+  }
+  return roots;
+}
+
 function getCodexNativeSearchDirsForShim(shimDir) {
   const dirs = [shimDir];
   const parentDir = path.dirname(shimDir);
@@ -359,6 +427,17 @@ function getCodexNativeSearchDirsForShim(shimDir) {
     dirs.push(path.dirname(parentDir));
   }
   dirs.push(path.join(shimDir, "node_modules", "@openai", "codex"));
+
+  // nvm-desktop installs global CLIs under $NVMD_HOME/versions/<ver>/, while
+  // $NVMD_HOME/bin/codex{.cmd,.exe} are only nvmd router shims. Expand search
+  // into the active/recorded Node version roots so the SDK can spawn the real
+  // native codex.exe (codexPathOverride) instead of falling back to bundled
+  // optional deps that Netcatty deliberately does not ship.
+  const nvmdHome = getNvmdHomeFromShimDir(shimDir);
+  for (const versionRoot of getNvmdCodexVersionRoots(nvmdHome)) {
+    dirs.push(versionRoot);
+    dirs.push(path.join(versionRoot, "node_modules", "@openai", "codex"));
+  }
   return dirs;
 }
 
@@ -411,10 +490,19 @@ function resolveCodexExecutableForSdk(codexExecutablePath, platform = process.pl
   if (platform !== "win32") return normalized;
 
   const ext = path.extname(normalized).toLowerCase();
-  if (ext === ".exe") return normalized;
-
   const baseDir = path.dirname(normalized);
   const moduleSearchDirs = getCodexNativeSearchDirsForShim(baseDir);
+  const nvmdHome = getNvmdHomeFromShimDir(baseDir);
+
+  // nvmd's Windows package shim is a copy of nvmd.exe named codex.exe. Prefer
+  // the real native binary under versions/<ver>/ when that layout is present.
+  if (ext === ".exe") {
+    if (nvmdHome) {
+      const nativeExe = resolveCodexNativeExecutableWin32(moduleSearchDirs);
+      if (nativeExe) return nativeExe;
+    }
+    return normalized;
+  }
 
   if (ext === ".js" && /[\\/]codex\.js$/i.test(normalized)) {
     const codexPackageRoot = path.dirname(path.dirname(normalized));

--- a/electron/bridges/ai/shellUtils.test.cjs
+++ b/electron/bridges/ai/shellUtils.test.cjs
@@ -313,6 +313,55 @@ test("resolveCodexExecutableForSdk returns null for Windows cmd shim when native
   }
 });
 
+test("resolveCodexExecutableForSdk maps Windows nvmd bin shim to native codex.exe", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-nvmd-shim-"));
+  try {
+    const nvmdHome = path.join(tmp, ".nvmd");
+    const binDir = path.join(nvmdHome, "bin");
+    const versionRoot = path.join(nvmdHome, "versions", "22.14.0");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(nvmdHome, "default"), "22.14.0\n", "utf8");
+    fs.writeFileSync(
+      path.join(nvmdHome, "packages.json"),
+      JSON.stringify({ codex: ["22.14.0"] }),
+      "utf8",
+    );
+
+    // nvmd Windows package shims are copies of npm.cmd / nvmd.exe, not npm's
+    // @openai/codex launcher. The real install lives under versions/<ver>/.
+    const shimPath = path.join(binDir, "codex.cmd");
+    fs.writeFileSync(shimPath, '@echo off\r\n"%~dpn0.exe" %*\r\n', "utf8");
+    fs.writeFileSync(path.join(binDir, "codex.exe"), "", "utf8");
+    fs.writeFileSync(path.join(binDir, "nvmd.exe"), "", "utf8");
+
+    const nativeExe = writeCodexWin32NativeLayout(versionRoot);
+
+    assert.equal(resolveCodexExecutableForSdk(shimPath, "win32"), nativeExe);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveCodexExecutableForSdk maps Windows nvmd.exe package shim to native codex.exe", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-nvmd-exe-"));
+  try {
+    const nvmdHome = path.join(tmp, ".nvmd");
+    const binDir = path.join(nvmdHome, "bin");
+    const versionRoot = path.join(nvmdHome, "versions", "20.18.0");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(nvmdHome, "default"), "20.18.0\n", "utf8");
+
+    const shimPath = path.join(binDir, "codex.exe");
+    fs.writeFileSync(shimPath, "", "utf8");
+    fs.writeFileSync(path.join(binDir, "nvmd.exe"), "", "utf8");
+    const nativeExe = writeCodexWin32NativeLayout(versionRoot);
+
+    assert.equal(resolveCodexExecutableForSdk(shimPath, "win32"), nativeExe);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("resolveCodexExecutableForSdk maps Windows PowerShell shim to native codex.exe", () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "netcatty-codex-ps1-shim-"));
   try {


### PR DESCRIPTION
## Summary
- Settings can detect and probe `~\.nvmd\bin\codex.cmd`, but SDK turns were dropping that path when the Windows shim could not be rewritten to a native `codex.exe`.
- Without `codexPathOverride`, `@openai/codex-sdk` falls back to bundled optional platform packages that Netcatty deliberately excludes from the app package, producing: `Unable to locate Codex CLI binaries...`
- Expand Windows Codex SDK path resolution to follow nvm-desktop / nvmd layout (`$NVMD_HOME/versions/<ver>/...`) and rewrite both `.cmd` and nvmd-copied `.exe` shims to the real native binary.

## Test plan
- [x] `node --test electron/bridges/ai/shellUtils.test.cjs`
- [x] `node --test electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs`
- [ ] On Windows with nvm-desktop: Settings → AI → Codex shows `...\nvmd\bin\codex.cmd` and connected status
- [ ] Send a Codex chat turn and confirm it no longer errors with `Unable to locate Codex CLI binaries`

Fixes #2027

Made with [Cursor](https://cursor.com)