### PR TITLE
fix(terminal): clear WebGL atlas on pixel-only side-panel resize

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1833,6 +1833,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         if (term.cols !== dimensions.cols || term.rows !== dimensions.rows) {
           term.resize(dimensions.cols, dimensions.rows);
           forceSyncRenderAfterResize(term);
+        } else {
+          // Pixel-only layout changes (opening the SFTP side panel, compose
+          // bar, etc.) shrink the container without changing cols/rows, so
+          // term.onResize — which clears the WebGL atlas — never fires.
+          // Stale atlas glyphs then paint as black squares (#2013).
+          xtermRuntimeRef.current?.clearTextureAtlas();
+          forceSyncRenderAfterResize(term);
         }
 
         // Preserve scroll position across resize (superset/Tabby pattern).

--- a/components/terminal/terminalSafeFitVisibility.test.ts
+++ b/components/terminal/terminalSafeFitVisibility.test.ts
@@ -18,3 +18,13 @@ test('safeFit can run synchronously for first-frame tab recovery', () => {
     /XTERM_PERFORMANCE_CONFIG\.resize\.useRAF &&\s*typeof requestAnimationFrame === "function" &&\s*!options\?\.immediate/,
   );
 });
+
+test('safeFit clears the WebGL atlas on pixel-only layout changes', () => {
+  // Opening the SFTP side panel often changes container px without changing
+  // cols/rows, so term.onResize (which clears the atlas) never fires. Without
+  // this else-branch recovery, WebGL paints stale glyphs as black squares (#2013).
+  assert.match(
+    source,
+    /if \(term\.cols !== dimensions\.cols \|\| term\.rows !== dimensions\.rows\) \{\s*term\.resize\(dimensions\.cols, dimensions\.rows\);\s*forceSyncRenderAfterResize\(term\);\s*\} else \{\s*[\s\S]*?xtermRuntimeRef\.current\?\.clearTextureAtlas\(\);\s*forceSyncRenderAfterResize\(term\);\s*\}/,
+  );
+});


### PR DESCRIPTION
## Summary
- Confirmed #2013 is a Netcatty WebGL rendering bug (not remote/SSH data corruption): vim content turns into black squares after opening SFTP and jumping to the terminal cwd, with WebGL + Hack Nerd Font Mono.
- Root cause: opening the SFTP side panel often changes container pixel size without changing `cols`/`rows`, so `term.onResize` (which clears the WebGL texture atlas) never fires and stale glyphs keep painting.
- Fix `safeFit` to clear the atlas and force a sync repaint on these pixel-only layout changes; add a regression guard in `terminalSafeFitVisibility.test.ts`.

## Test plan
- [x] `node --test --import tsx components/terminal/terminalSafeFitVisibility.test.ts components/terminal/appResumeWebglRecovery.test.ts components/terminal/terminalTabVisibilityRecovery.test.ts components/terminal/runtime/rendererDprWatch.test.ts`
- [ ] On Linux with WebGL + a Nerd Font: SSH in, open a file in vim, select text, open SFTP, click “定位到终端当前目录”, confirm glyphs stay readable
- [ ] Toggle SFTP / compose bar / search bar and confirm no black-square corruption when cols/rows stay the same
- [ ] Confirm DOM renderer path is unchanged / still healthy

Fixes #2013


Made with [Cursor](https://cursor.com)