### PR TITLE
fix: keep sudo password prompts during Ctrl+C drain (#2010)

### DIFF
--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -576,6 +576,35 @@ test("interrupt display drain does not peel restore suffix from later password p
   );
 });
 
+test("interrupt display drain does not leak incomplete SGR CSI into shell prompts", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 6270,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "old\x1b[31", { now: 6271 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "old\x1b[31".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 6400 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain preserves split alternate-screen exit controls", () => {
   clearTerminalSessionFlowAck("sess-1");
   const term = createFakeTerm();

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -915,3 +915,31 @@ test("interrupt display drain accepts localized password prompts (#2010)", () =>
     );
   }
 });
+
+test("interrupt display drain holds a split Password: prompt across chunks (#2010)", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 8300,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8301 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Pass", { now: 8302 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "word: ", { now: 8303 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1032,3 +1032,36 @@ test("interrupt display drain holds split password prompts with leading text", (
     },
   );
 });
+
+test("interrupt display drain keeps quiet-gap for fresh password-looking lines", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 9100,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "old flood\n", { now: 9101 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Password: ", { now: 9110 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "Password: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 9300 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -547,6 +547,35 @@ test("interrupt display drain excludes preserved restore from held password pref
   );
 });
 
+test("interrupt display drain excludes last of multiple restores from password prefixes", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 6255,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "\x1b[?25hstale\n\x1b[?1049lPass", { now: 6256 }),
+    {
+      accepted: true,
+      data: "\x1b[?25h\x1b[?1049l",
+      droppedBytes: "stale\n".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "word: ", { now: 6257 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain does not peel restore suffix from later password prefixes", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1033,6 +1033,36 @@ test("interrupt display drain holds a password prefix split before trailing ANSI
   );
 });
 
+test("interrupt display drain holds a password prefix split mid CSI parameter", () => {
+  const term = createFakeTerm();
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+  armTerminalInterruptDisplayGate(term, {
+    now: 8380,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8381 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `${red}Pass\x1b[0`, { now: 8382 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `mword: `, { now: 8383 }),
+    {
+      accepted: true,
+      data: `${red}Pass${reset}word: `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain discards a held password prefix that does not complete", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -944,6 +944,36 @@ test("interrupt display drain holds a split Password: prompt across chunks (#201
   );
 });
 
+test("interrupt display drain holds a split ANSI-colored Password: prompt", () => {
+  const term = createFakeTerm();
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+  armTerminalInterruptDisplayGate(term, {
+    now: 8350,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8351 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `${red}Pass`, { now: 8352 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `word:${reset} `, { now: 8353 }),
+    {
+      accepted: true,
+      data: `${red}Password:${reset} `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain discards a held password prefix that does not complete", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -547,6 +547,35 @@ test("interrupt display drain excludes preserved restore from held password pref
   );
 });
 
+test("interrupt display drain does not peel restore suffix from later password prefixes", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 6260,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "\x1b[?1049l\nlogin pass", { now: 6261 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: 1,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "word: ", { now: 6262 }),
+    {
+      accepted: true,
+      data: "login password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain preserves split alternate-screen exit controls", () => {
   clearTerminalSessionFlowAck("sess-1");
   const term = createFakeTerm();
@@ -1086,6 +1115,34 @@ test("interrupt display drain discards a held password prefix that does not comp
       accepted: true,
       data: "$ ",
       droppedBytes: 4,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("interrupt display drain discards CSI finals when mid-CSI password prefix fails", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 8420,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8421 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Pass\x1b[0", { now: 8422 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "m$ ", { now: 8600 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: "Pass\x1b[0".length + 1,
       reason: "prompt-gap",
     },
   );

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1291,6 +1291,32 @@ test("interrupt display drain accepts a fresh one-chunk password prompt before t
   );
 });
 
+test("interrupt display drain accepts a last-line password prompt after a large stale prefix", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 9120,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+    promptCandidateBytes: 512,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 9121 }).accepted,
+    false,
+  );
+  const largeChunk = `${"x".repeat(600)}\n[sudo] password for alice: `;
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, largeChunk, { now: 9130 }),
+    {
+      accepted: true,
+      data: "[sudo] password for alice: ",
+      droppedBytes: 601,
+      reason: "password-prompt",
+    },
+  );
+});
+
 test("interrupt display drain does not hold short ASCII trailing letters as password prefixes", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -5,6 +5,7 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 
 import { createOutputFlowController } from "./outputFlowController.ts";
 import {
+  armTerminalInterruptDisplayGate,
   filterTerminalInterruptDisplayOutput,
   prioritizeTerminalInput,
   releaseTerminalFlowOutputForTerm,
@@ -863,4 +864,54 @@ test("interrupt priority leaves display output alone below pressure threshold", 
     },
   );
   clearTerminalSessionFlowAck("sess-low-pressure");
+});
+
+test("interrupt display drain accepts a sudo password prompt (#2010)", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 8000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "Reading package lists...\n", { now: 8001 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "[sudo] password for alice: ", { now: 8100 }),
+    {
+      accepted: true,
+      data: "[sudo] password for alice: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("interrupt display drain accepts localized password prompts (#2010)", () => {
+  for (const prompt of ["Password: ", "[sudo] alice 的密码：", "输入密码"]) {
+    const term = createFakeTerm();
+    armTerminalInterruptDisplayGate(term, {
+      now: 8100,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 2500,
+    });
+    assert.equal(
+      filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8101 }).accepted,
+      false,
+    );
+    assert.deepEqual(
+      filterTerminalInterruptDisplayOutput(term, prompt, { now: 8200 }),
+      {
+        accepted: true,
+        data: prompt,
+        droppedBytes: 0,
+        reason: "prompt-gap",
+      },
+      `expected password prompt to resume drain: ${JSON.stringify(prompt)}`,
+    );
+  }
 });

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -974,6 +974,36 @@ test("interrupt display drain holds a split ANSI-colored Password: prompt", () =
   );
 });
 
+test("interrupt display drain holds a password prefix split before trailing ANSI", () => {
+  const term = createFakeTerm();
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+  armTerminalInterruptDisplayGate(term, {
+    now: 8370,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8371 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `${red}Pass\x1b[`, { now: 8372 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, `0mword: `, { now: 8373 }),
+    {
+      accepted: true,
+      data: `${red}Pass${reset}word: `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain discards a held password prefix that does not complete", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -880,12 +880,12 @@ test("interrupt display drain accepts a sudo password prompt (#2010)", () => {
     false,
   );
   assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "[sudo] password for alice: ", { now: 8100 }),
+    filterTerminalInterruptDisplayOutput(term, "[sudo] password for alice: ", { now: 8010 }),
     {
       accepted: true,
       data: "[sudo] password for alice: ",
       droppedBytes: 0,
-      reason: "prompt-gap",
+      reason: "password-prompt",
     },
   );
 });
@@ -904,12 +904,12 @@ test("interrupt display drain accepts localized password prompts (#2010)", () =>
       false,
     );
     assert.deepEqual(
-      filterTerminalInterruptDisplayOutput(term, prompt, { now: 8200 }),
+      filterTerminalInterruptDisplayOutput(term, prompt, { now: 8110 }),
       {
         accepted: true,
         data: prompt,
         droppedBytes: 0,
-        reason: "prompt-gap",
+        reason: "password-prompt",
       },
       `expected password prompt to resume drain: ${JSON.stringify(prompt)}`,
     );
@@ -1063,7 +1063,7 @@ test("interrupt display drain holds split password prompts with leading text", (
   );
 });
 
-test("interrupt display drain keeps quiet-gap for fresh password-looking lines", () => {
+test("interrupt display drain accepts a fresh one-chunk password prompt before the quiet gap", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {
     now: 9100,
@@ -1079,19 +1079,10 @@ test("interrupt display drain keeps quiet-gap for fresh password-looking lines",
   assert.deepEqual(
     filterTerminalInterruptDisplayOutput(term, "Password: ", { now: 9110 }),
     {
-      accepted: false,
-      data: "",
-      droppedBytes: "Password: ".length,
-      reason: "draining",
-    },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 9300 }),
-    {
       accepted: true,
-      data: "$ ",
+      data: "Password: ",
       droppedBytes: 0,
-      reason: "prompt-gap",
+      reason: "password-prompt",
     },
   );
 });
@@ -1157,24 +1148,15 @@ test("interrupt display drain rejects held password-prefix completion across a l
     filterTerminalInterruptDisplayOutput(term, "Pass", { now: 9202 }),
     { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
   );
-  // A newline before Password: means a fresh flood line, not a same-line
-  // completion of the held "Pass" prefix — keep quiet-gap.
+  // A newline before Password: discards the held "Pass" prefix (not a same-line
+  // completion), but the fresh complete password line is still preserved.
   assert.deepEqual(
     filterTerminalInterruptDisplayOutput(term, "\nPassword: ", { now: 9210 }),
     {
-      accepted: false,
-      data: "",
-      droppedBytes: 4 + "\nPassword: ".length,
-      reason: "draining",
-    },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 9400 }),
-    {
       accepted: true,
-      data: "$ ",
-      droppedBytes: 0,
-      reason: "prompt-gap",
+      data: "Password: ",
+      droppedBytes: 4 + 1,
+      reason: "password-prompt",
     },
   );
 });

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1004,3 +1004,31 @@ test("interrupt display drain does not hold ordinary password-related output", (
     },
   );
 });
+
+test("interrupt display drain holds split password prompts with leading text", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 9000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 9001 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "alice@host's pass", { now: 9002 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "word: ", { now: 9003 }),
+    {
+      accepted: true,
+      data: "alice@host's password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -518,6 +518,35 @@ test("interrupt display drain preserves alternate-screen exit controls", () => {
   );
 });
 
+test("interrupt display drain excludes preserved restore from held password prefixes", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 6250,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "stale\n\x1b[?1049lPass", { now: 6251 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: "stale\n".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "word: ", { now: 6252 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain preserves split alternate-screen exit controls", () => {
   clearTerminalSessionFlowAck("sess-1");
   const term = createFakeTerm();

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1066,6 +1066,50 @@ test("interrupt display drain keeps quiet-gap for fresh password-looking lines",
   );
 });
 
+test("interrupt display drain does not hold short ASCII trailing letters as password prefixes", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 9300,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 9301 }).accepted,
+    false,
+  );
+  // Full-width "password：" must not lower ASCII minLen to 1, or "copy p" is held
+  // and a later "assword:" chunk can bypass quiet-gap.
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "copy p", { now: 9302 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "copy p".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "assword: ", { now: 9310 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "assword: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 9500 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("interrupt display drain rejects held password-prefix completion across a line break", () => {
   const term = createFakeTerm();
   armTerminalInterruptDisplayGate(term, {

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -891,7 +891,7 @@ test("interrupt display drain accepts a sudo password prompt (#2010)", () => {
 });
 
 test("interrupt display drain accepts localized password prompts (#2010)", () => {
-  for (const prompt of ["Password: ", "[sudo] alice 的密码：", "输入密码"]) {
+  for (const prompt of ["Password: ", "[sudo] alice 的密码：", "输入密码", "用户 的密码"]) {
     const term = createFakeTerm();
     armTerminalInterruptDisplayGate(term, {
       now: 8100,

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -1065,3 +1065,42 @@ test("interrupt display drain keeps quiet-gap for fresh password-looking lines",
     },
   );
 });
+
+test("interrupt display drain rejects held password-prefix completion across a line break", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 9200,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 9201 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Pass", { now: 9202 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  // A newline before Password: means a fresh flood line, not a same-line
+  // completion of the held "Pass" prefix — keep quiet-gap.
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "\nPassword: ", { now: 9210 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: 4 + "\nPassword: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 9400 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -966,6 +966,39 @@ test("interrupt display drain discards a held password prefix that does not comp
     {
       accepted: true,
       data: "$ ",
+      droppedBytes: 4,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("interrupt display drain does not hold ordinary password-related output", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 8700,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8701 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Password authentication failed", { now: 8702 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "Password authentication failed".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 8900 }),
+    {
+      accepted: true,
+      data: "$ ",
       droppedBytes: 0,
       reason: "prompt-gap",
     },

--- a/components/terminal/runtime/terminalOutputPipeline.test.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.test.ts
@@ -943,3 +943,31 @@ test("interrupt display drain holds a split Password: prompt across chunks (#201
     },
   );
 });
+
+test("interrupt display drain discards a held password prefix that does not complete", () => {
+  const term = createFakeTerm();
+  armTerminalInterruptDisplayGate(term, {
+    now: 8400,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptDisplayOutput(term, "stale\n", { now: 8401 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "Pass", { now: 8402 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptDisplayOutput(term, "$ ", { now: 8600 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -465,6 +465,21 @@ const consumeTrailingCsiCompletion = (
   return { text, extraDroppedBytes: 0 };
 };
 
+const isStandaloneHoldableControlPrefix = (pending: string): boolean => {
+  if (!pending) return false;
+  if (pending === ANSI_ESCAPE || pending === `${ANSI_ESCAPE}[`) return true;
+  // Incomplete private-mode restore CSI and OSC title prefixes are safe to hold
+  // alone; incomplete SGR CSI (ESC[31) is not — it can leak into "$ ".
+  if (
+    pending.startsWith(`${ANSI_ESCAPE}[?`)
+    && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(pending)
+  ) {
+    return true;
+  }
+  if (pending.startsWith(`${ANSI_ESCAPE}]`)) return true;
+  return false;
+};
+
 const extractDrainHold = (
   text: string,
   options: { holdTrailingPartial?: boolean } = {},
@@ -487,6 +502,19 @@ const extractDrainHold = (
     restoreControls.preserved,
   );
   if (!passwordPending || !isProbablePasswordPromptPrefix(passwordPending)) {
+    // Incomplete SGR CSI (ESC[31) must not be held alone — otherwise the next
+    // shell prompt can be accepted as "\x1b[31$ " and leak stale color bytes.
+    // Restore/OSC prefixes stay held as before.
+    if (controlPending && !isStandaloneHoldableControlPrefix(controlPending)) {
+      return {
+        preserved: restoreControls.preserved,
+        pending: "",
+        droppedBytes: Math.max(
+          0,
+          charLength(text) - charLength(restoreControls.preserved),
+        ),
+      };
+    }
     return restoreControls;
   }
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -268,6 +268,11 @@ const finalizeAcceptedTextAfterPendingDisplayControl = (
   if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
     return { data: combined, droppedBytes: 0 };
   }
+  // Held password-prompt prefixes are plain text (never ESC). Keep them when
+  // quiet/max-drain resumes so a split "Pass"+"word: " is not lost.
+  if (!pending.includes(ANSI_ESCAPE) && isProbablePasswordPromptPrefix(pending)) {
+    return { data: combined, droppedBytes: 0 };
+  }
   return { data: text, droppedBytes: charLength(pending) };
 };
 
@@ -276,6 +281,79 @@ export const shouldArmTerminalInterruptDisplayGateForProtocol = (
 ): boolean => {
   const normalized = String(protocol || "ssh").toLowerCase();
   return normalized === "ssh";
+};
+
+const isCompletePasswordPrompt = (candidate: string): boolean => {
+  const trimmed = candidate.trimEnd();
+  if (!trimmed) return false;
+  return (
+    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(trimmed)
+    && (
+      /[:：]\s*$/.test(trimmed)
+      || /\[sudo/i.test(trimmed)
+      || /^(?:输入\s*)?密码\s*$/.test(trimmed)
+      || /^input\s+password\s*$/i.test(trimmed)
+    )
+  );
+};
+
+const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
+  const trimmed = candidate.trimEnd();
+  if (!trimmed || trimmed.length > 160) return false;
+  if (/[\r\n]/.test(trimmed)) return false;
+  if (isCompletePasswordPrompt(trimmed)) return false;
+
+  const lower = trimmed.toLowerCase();
+  const prefixTargets = [
+    "password",
+    "password:",
+    "password：",
+    "[sudo",
+    "密码",
+    "密码：",
+    "口令",
+    "口令：",
+    "输入密码",
+    "输入密码：",
+    "input password",
+    "input password:",
+  ];
+  if (prefixTargets.some((target) => target.startsWith(lower))) return true;
+
+  if (/^\[sudo/i.test(trimmed)) return true;
+  if (/^(?:password|密\s*码|口\s*令|输入\s*密码|input\s+password)\b/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+};
+
+const getTrailingPasswordPromptPrefix = (text: string): string => {
+  const lastBreak = Math.max(text.lastIndexOf("\n"), text.lastIndexOf("\r"));
+  const trailing = text.slice(lastBreak + 1);
+  if (!trailing) return "";
+  return isProbablePasswordPromptPrefix(trailing) ? trailing : "";
+};
+
+const extractDrainHold = (
+  text: string,
+  options: { holdTrailingPartial?: boolean } = {},
+): { preserved: string; pending: string; droppedBytes: number } => {
+  const restoreControls = extractTerminalStateRestoreControls(text, options);
+  if (!options.holdTrailingPartial || restoreControls.pending) {
+    return restoreControls;
+  }
+
+  const passwordPending = getTrailingPasswordPromptPrefix(text);
+  if (!passwordPending) return restoreControls;
+
+  return {
+    preserved: restoreControls.preserved,
+    pending: passwordPending,
+    droppedBytes: Math.max(
+      0,
+      charLength(text) - charLength(restoreControls.preserved) - charLength(passwordPending),
+    ),
+  };
 };
 
 const getPromptCandidateSuffix = (text: string): string | null => {
@@ -288,17 +366,8 @@ const getPromptCandidateSuffix = (text: string): string | null => {
   // Password prompts are interactive resume points too. Without this, Ctrl+C
   // drain treats "[sudo] password for …:" as stale flood and drops it, so the
   // remote waits for a password while the terminal shows nothing (#2010).
-  const looksLikePasswordPrompt = (
-    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(candidate)
-    && (
-      /[:：]\s*$/.test(candidate)
-      || /\[sudo/i.test(candidate)
-      || /^(?:输入\s*)?密码\s*$/.test(candidate)
-      || /^input\s+password\s*$/i.test(candidate)
-    )
-  );
   const looksLikePrompt = (
-    looksLikePasswordPrompt
+    isCompletePasswordPrompt(candidate)
     || /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
     || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
@@ -411,6 +480,24 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
+  // Password prompts are specific enough to resume immediately even after we
+  // already dropped stale flood — including when a held "Pass" prefix completes
+  // as "Password: " in the next chunk before promptQuietMs elapses.
+  if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
+    const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+    const droppedBytes = restoreControls.droppedBytes;
+    gate.droppedBytes += droppedBytes;
+    gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+    disarmTerminalInterruptDisplayGate(term);
+    return {
+      accepted: true,
+      data: `${restoreControls.preserved}${promptCandidate}`,
+      droppedBytes,
+      reason: "prompt-gap",
+    };
+  }
+
   if (promptCandidate && quietGapMs >= gate.promptQuietMs) {
     const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
     const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
@@ -452,7 +539,7 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
-  const restoreControls = extractTerminalStateRestoreControls(combinedText, {
+  const restoreControls = extractDrainHold(combinedText, {
     holdTrailingPartial: true,
   });
   const droppedBytes = restoreControls.droppedBytes;

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -285,8 +285,21 @@ const getPromptCandidateSuffix = (text: string): string | null => {
   if (!candidate) return null;
   if (candidate.length > 160) return null;
 
+  // Password prompts are interactive resume points too. Without this, Ctrl+C
+  // drain treats "[sudo] password for …:" as stale flood and drops it, so the
+  // remote waits for a password while the terminal shows nothing (#2010).
+  const looksLikePasswordPrompt = (
+    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(candidate)
+    && (
+      /[:：]\s*$/.test(candidate)
+      || /\[sudo/i.test(candidate)
+      || /^(?:输入\s*)?密码\s*$/.test(candidate)
+      || /^input\s+password\s*$/i.test(candidate)
+    )
+  );
   const looksLikePrompt = (
-    /^[#$>%]\s*$/.test(candidate)
+    looksLikePasswordPrompt
+    || /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
     || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
     || /^<[^>\r\n]{1,80}>\s*$/.test(candidate)

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -305,7 +305,13 @@ const isCompletePasswordPrompt = (candidate: string): boolean => {
 const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
   // Strip SGR/OSC for matching so styled chunks like "\x1b[31mPass" still hold,
   // while callers keep the raw pending bytes for display.
-  const trimmed = stripAnsi(candidate).trimEnd();
+  let trimmed = stripAnsi(candidate).trimEnd();
+  // Incomplete CSI/OSC left after stripAnsi (e.g. trailing "\x1b[") must not
+  // prevent matching a held password prefix.
+  const trailingControl = getTrailingDisplayControlPrefix(trimmed);
+  if (trailingControl) {
+    trimmed = trimmed.slice(0, -trailingControl.length).trimEnd();
+  }
   if (!trimmed || trimmed.length > 160) return false;
   if (/[\r\n]/.test(trimmed)) return false;
   if (isCompletePasswordPrompt(trimmed)) return false;
@@ -412,19 +418,29 @@ const extractDrainHold = (
   options: { holdTrailingPartial?: boolean } = {},
 ): { preserved: string; pending: string; droppedBytes: number } => {
   const restoreControls = extractTerminalStateRestoreControls(text, options);
-  if (!options.holdTrailingPartial || restoreControls.pending) {
+  if (!options.holdTrailingPartial) {
     return restoreControls;
   }
 
-  const passwordPending = getTrailingPasswordPromptPrefix(text);
-  if (!passwordPending) return restoreControls;
+  // A styled prompt can split mid-CSI, e.g. "\x1b[31mPass\x1b[" + "0mword: ".
+  // Keep both the password-prefix body and the trailing control prefix so the
+  // next chunk can still complete "Password:" (#2010 Codex follow-up).
+  const controlPending = restoreControls.pending;
+  const textWithoutControl = controlPending
+    ? text.slice(0, -controlPending.length)
+    : text;
+  const passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
+  if (!passwordPending) {
+    return restoreControls;
+  }
 
+  const pending = `${passwordPending}${controlPending}`;
   return {
     preserved: restoreControls.preserved,
-    pending: passwordPending,
+    pending,
     droppedBytes: Math.max(
       0,
-      charLength(text) - charLength(restoreControls.preserved) - charLength(passwordPending),
+      charLength(text) - charLength(restoreControls.preserved) - charLength(pending),
     ),
   };
 };

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -172,6 +172,10 @@ const PRIVATE_MODE_PATTERN = new RegExp(`^${ANSI_ESCAPE}\\[\\?([0-9;:]*)([hl])$`
 const TRAILING_RESTORE_CONTROL_PREFIX_PATTERN = new RegExp(
   `^${ANSI_ESCAPE}\\[\\?[0-9;:]*$`,
 );
+// Incomplete CSI (params/intermediates, no final byte) — e.g. ESC[0 or ESC[31
+const TRAILING_CSI_CONTROL_PREFIX_PATTERN = new RegExp(
+  `^${ANSI_ESCAPE}\\[[0-?]*[ -/]*$`,
+);
 
 const getPrivateModeParams = (raw: string): { params: number[]; final: "h" | "l" } | null => {
   const match = PRIVATE_MODE_PATTERN.exec(raw);
@@ -199,7 +203,9 @@ const getTrailingRestoreControlPrefix = (text: string): string => {
   if (escapeIndex < 0) return "";
   const suffix = text.slice(escapeIndex);
   if (suffix === ANSI_ESCAPE) return suffix;
-  if (suffix === `${ANSI_ESCAPE}[`) return suffix;
+  // Hold any incomplete CSI (ESC[ / ESC[0 / ESC[31 / ESC[?1049), not only
+  // private-mode restore prefixes — styled password prompts can split mid-SGR.
+  if (TRAILING_CSI_CONTROL_PREFIX_PATTERN.test(suffix)) return suffix;
   if (
     suffix.startsWith(`${ANSI_ESCAPE}[?`)
     && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(suffix)

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -714,6 +714,37 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
+  // Complete password prompts resume immediately — including one-chunk prompts
+  // before promptQuietMs, held-prefix completions, and last-line prompts that
+  // arrive after a large stale prefix. Unlike shell prompts, password prompts
+  // often emit nothing further until the user types; dropping them leaves a
+  // blank terminal while the remote waits (#2010). Detect the last-line
+  // password candidate independently of the whole-chunk promptCandidateBytes
+  // cap used for ordinary shell prompts.
+  {
+    const passwordPromptCandidate = getPromptCandidateSuffix(combinedText);
+    if (
+      passwordPromptCandidate
+      && isCompletePasswordPrompt(stripAnsi(passwordPromptCandidate))
+    ) {
+      const droppedPrefix = combinedText.slice(
+        0,
+        combinedText.length - passwordPromptCandidate.length,
+      );
+      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+      const droppedBytes = restoreControls.droppedBytes;
+      gate.droppedBytes += droppedBytes;
+      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+      disarmTerminalInterruptDisplayGate(term);
+      return {
+        accepted: true,
+        data: `${restoreControls.preserved}${passwordPromptCandidate}`,
+        droppedBytes: withPrefixDrop(droppedBytes),
+        reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
+      };
+    }
+  }
+
   const promptCandidate = bytes <= gate.promptCandidateBytes
     ? getPromptCandidateSuffix(combinedText)
     : null;
@@ -729,28 +760,6 @@ export const filterTerminalInterruptDisplayOutput = (
       data: `${restoreControls.preserved}${promptCandidate}`,
       droppedBytes: withPrefixDrop(droppedBytes),
       reason: "prompt-candidate",
-    };
-  }
-
-  // Complete password prompts resume immediately — including one-chunk prompts
-  // before promptQuietMs, and held-prefix completions on the same line. Unlike
-  // shell prompts, password prompts often emit nothing further until the user
-  // types; dropping them leaves a blank terminal while the remote waits (#2010).
-  if (
-    promptCandidate
-    && isCompletePasswordPrompt(stripAnsi(promptCandidate))
-  ) {
-    const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
-    const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
-    const droppedBytes = restoreControls.droppedBytes;
-    gate.droppedBytes += droppedBytes;
-    gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
-    disarmTerminalInterruptDisplayGate(term);
-    return {
-      accepted: true,
-      data: `${restoreControls.preserved}${promptCandidate}`,
-      droppedBytes: withPrefixDrop(droppedBytes),
-      reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
     };
   }
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -268,9 +268,9 @@ const finalizeAcceptedTextAfterPendingDisplayControl = (
   if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
     return { data: combined, droppedBytes: 0 };
   }
-  // Held password-prompt prefixes are plain text (never ESC). Keep them when
+  // Held password-prompt prefixes (plain or SGR-styled). Keep them when
   // quiet/max-drain resumes so a split "Pass"+"word: " is not lost.
-  if (!pending.includes(ANSI_ESCAPE) && isProbablePasswordPromptPrefix(pending)) {
+  if (isProbablePasswordPromptPrefix(pending)) {
     return { data: combined, droppedBytes: 0 };
   }
   return { data: text, droppedBytes: charLength(pending) };
@@ -302,7 +302,9 @@ const isCompletePasswordPrompt = (candidate: string): boolean => {
 };
 
 const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
-  const trimmed = candidate.trimEnd();
+  // Strip SGR/OSC for matching so styled chunks like "\x1b[31mPass" still hold,
+  // while callers keep the raw pending bytes for display.
+  const trimmed = stripAnsi(candidate).trimEnd();
   if (!trimmed || trimmed.length > 160) return false;
   if (/[\r\n]/.test(trimmed)) return false;
   if (isCompletePasswordPrompt(trimmed)) return false;
@@ -427,9 +429,7 @@ const extractDrainHold = (
 };
 
 const isPasswordPrefixPending = (pending: string): boolean =>
-  Boolean(pending)
-  && !pending.includes(ANSI_ESCAPE)
-  && isProbablePasswordPromptPrefix(pending);
+  Boolean(pending) && isProbablePasswordPromptPrefix(pending);
 
 const getLastVisibleLine = (text: string): string => {
   const normalized = stripAnsi(text).replace(/\r/g, "\n");

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -375,7 +375,14 @@ const hasTrailingPasswordKeywordPrefix = (trimmed: string): boolean => {
     const maxLen = Math.min(lower.length, target.length);
     // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
     // noise is not held. CJK keywords can match a single character ("密").
-    const minLen = /^[\x00-\x7f]+$/.test(target) ? 3 : 1;
+    let isAsciiTarget = true;
+    for (let i = 0; i < target.length; i += 1) {
+      if (target.charCodeAt(i) > 0x7f) {
+        isAsciiTarget = false;
+        break;
+      }
+    }
+    const minLen = isAsciiTarget ? 3 : 1;
     for (let len = maxLen; len >= minLen; len -= 1) {
       const suffix = lower.slice(-len);
       if (!target.startsWith(suffix)) continue;

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -529,6 +529,7 @@ export const filterTerminalInterruptDisplayOutput = (
 
   const now = nowFromPriorityOptions(options);
   const rawPendingDisplayControl = takePendingDisplayControl(gate);
+  const heldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
   const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
     rawPendingDisplayControl,
     incomingText,
@@ -597,10 +598,15 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
-  // Password prompts are specific enough to resume immediately even after we
-  // already dropped stale flood — including when a held "Pass" prefix completes
-  // as "Password: " in the next chunk before promptQuietMs elapses.
-  if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
+  // Only bypass the quiet gap when a held password-prefix chunk completes.
+  // Fresh password-looking lines in the flood must wait like shell prompts,
+  // otherwise a canceled "Password:" from the interrupted program resumes
+  // drain too early and lets more stale output through.
+  if (
+    heldPasswordPrefix
+    && promptCandidate
+    && isCompletePasswordPrompt(stripAnsi(promptCandidate))
+  ) {
     const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
     const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
     const droppedBytes = restoreControls.droppedBytes;

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -421,22 +421,48 @@ const getTrailingPasswordPromptPrefix = (text: string): string => {
 
 /**
  * Restore sequences already counted in `preserved` can also sit at the start of
- * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip that
- * overlap so droppedBytes stays accurate and the restore is not re-emitted.
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip only
+ * when the full preserved string is a real prefix — never peel single chars
+ * like the final "l" of "\x1b[?1049l" off "login pass".
  */
 const stripLeadingPreservedOverlap = (
   passwordPending: string,
   preserved: string,
 ): string => {
   if (!passwordPending || !preserved) return passwordPending;
-  const max = Math.min(preserved.length, passwordPending.length);
-  for (let len = max; len > 0; len -= 1) {
-    const suffix = preserved.slice(-len);
-    if (passwordPending.startsWith(suffix)) {
-      return passwordPending.slice(len);
-    }
+  if (passwordPending.startsWith(preserved)) {
+    return passwordPending.slice(preserved.length);
   }
   return passwordPending;
+};
+
+/**
+ * When discarding a held prefix that ends mid-CSI, also drop the CSI final
+ * byte(s) from the next chunk so "Pass\x1b[0" + "m$ " does not leak as "m$ ".
+ */
+const consumeTrailingCsiCompletion = (
+  pending: string,
+  text: string,
+): { text: string; extraDroppedBytes: number } => {
+  const control = getTrailingDisplayControlPrefix(pending);
+  if (!control || !control.startsWith(`${ANSI_ESCAPE}[`)) {
+    return { text, extraDroppedBytes: 0 };
+  }
+  let i = 0;
+  while (i < text.length) {
+    const code = text.charCodeAt(i);
+    // CSI parameter bytes 0–? and intermediate bytes SP–/
+    if ((code >= 0x30 && code <= 0x3f) || (code >= 0x20 && code <= 0x2f)) {
+      i += 1;
+      continue;
+    }
+    // CSI final byte @–~
+    if (code >= 0x40 && code <= 0x7e) {
+      return { text: text.slice(i + 1), extraDroppedBytes: i + 1 };
+    }
+    break;
+  }
+  return { text, extraDroppedBytes: 0 };
 };
 
 const extractDrainHold = (
@@ -514,10 +540,11 @@ const resolveHeldPasswordPrefix = (
     return { pending: "", text: combined, droppedPendingBytes: 0 };
   }
 
+  const consumed = consumeTrailingCsiCompletion(pending, text);
   return {
     pending: "",
-    text,
-    droppedPendingBytes: charLength(pending),
+    text: consumed.text,
+    droppedPendingBytes: charLength(pending) + consumed.extraDroppedBytes,
   };
 };
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -46,6 +46,7 @@ export type TerminalInterruptDisplayFilterReason =
   | "interrupt-echo"
   | "prompt-candidate"
   | "prompt-gap"
+  | "password-prompt"
   | "quiet-gap"
   | "max-drain";
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -421,19 +421,31 @@ const getTrailingPasswordPromptPrefix = (text: string): string => {
 
 /**
  * Restore sequences already counted in `preserved` can also sit at the start of
- * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip only
- * when the full preserved string is a real prefix — never peel single chars
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass", or multiple
+ * restores "\x1b[?25hstale\n\x1b[?1049lPass"). Strip only complete leading
+ * restore sequences that are a real suffix of `preserved` — never peel chars
  * like the final "l" of "\x1b[?1049l" off "login pass".
  */
 const stripLeadingPreservedOverlap = (
   passwordPending: string,
   preserved: string,
 ): string => {
-  if (!passwordPending || !preserved) return passwordPending;
-  if (passwordPending.startsWith(preserved)) {
-    return passwordPending.slice(preserved.length);
+  let pending = passwordPending;
+  let keep = preserved;
+  if (!pending || !keep) return pending;
+  if (pending.startsWith(keep)) return pending.slice(keep.length);
+
+  while (pending && keep) {
+    TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+    const match = TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.exec(pending);
+    TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+    if (!match || match.index !== 0) break;
+    const seq = match[0];
+    if (!shouldPreserveTerminalStateRestore(seq) || !keep.endsWith(seq)) break;
+    pending = pending.slice(seq.length);
+    keep = keep.slice(0, -seq.length);
   }
-  return passwordPending;
+  return pending;
 };
 
 /**

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -413,6 +413,26 @@ const getTrailingPasswordPromptPrefix = (text: string): string => {
   return isProbablePasswordPromptPrefix(trailing) ? trailing : "";
 };
 
+/**
+ * Restore sequences already counted in `preserved` can also sit at the start of
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip that
+ * overlap so droppedBytes stays accurate and the restore is not re-emitted.
+ */
+const stripLeadingPreservedOverlap = (
+  passwordPending: string,
+  preserved: string,
+): string => {
+  if (!passwordPending || !preserved) return passwordPending;
+  const max = Math.min(preserved.length, passwordPending.length);
+  for (let len = max; len > 0; len -= 1) {
+    const suffix = preserved.slice(-len);
+    if (passwordPending.startsWith(suffix)) {
+      return passwordPending.slice(len);
+    }
+  }
+  return passwordPending;
+};
+
 const extractDrainHold = (
   text: string,
   options: { holdTrailingPartial?: boolean } = {},
@@ -429,8 +449,12 @@ const extractDrainHold = (
   const textWithoutControl = controlPending
     ? text.slice(0, -controlPending.length)
     : text;
-  const passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
-  if (!passwordPending) {
+  let passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
+  passwordPending = stripLeadingPreservedOverlap(
+    passwordPending,
+    restoreControls.preserved,
+  );
+  if (!passwordPending || !isProbablePasswordPromptPrefix(passwordPending)) {
     return restoreControls;
   }
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -286,13 +286,17 @@ export const shouldArmTerminalInterruptDisplayGateForProtocol = (
 const isCompletePasswordPrompt = (candidate: string): boolean => {
   const trimmed = candidate.trimEnd();
   if (!trimmed) return false;
+  // Align with terminalSudoAutofill's Kylin coverage (#1293): prompts may end
+  // with 密码/口令 and no colon (e.g. "用户 的密码"). Still require a password
+  // keyword so ordinary lines like "Password authentication failed" stay out.
   return (
     /(?:\bpassword\b|密\s*码|口\s*令)/i.test(trimmed)
     && (
       /[:：]\s*$/.test(trimmed)
       || /\[sudo/i.test(trimmed)
-      || /^(?:输入\s*)?密码\s*$/.test(trimmed)
+      || /(?:密\s*码|口\s*令)\s*$/.test(trimmed)
       || /^input\s+password\s*$/i.test(trimmed)
+      || /^password\s*$/i.test(trimmed)
     )
   );
 };

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -448,6 +448,17 @@ const resolveHeldPasswordPrefix = (
     return { pending, text, droppedPendingBytes: 0 };
   }
 
+  // Held prefixes must continue on the same line. A leading line break means
+  // the next chunk is a fresh line (e.g. "Pass" then "\nPassword: "), not a
+  // completion of the held prefix — discard so quiet-gap still applies.
+  if (/^[\r\n]/.test(text)) {
+    return {
+      pending: "",
+      text,
+      droppedPendingBytes: charLength(pending),
+    };
+  }
+
   const combined = `${pending}${text}`;
   const lastLine = getLastVisibleLine(combined);
   if (isCompletePasswordPrompt(lastLine) || isProbablePasswordPromptPrefix(lastLine)) {
@@ -529,12 +540,19 @@ export const filterTerminalInterruptDisplayOutput = (
 
   const now = nowFromPriorityOptions(options);
   const rawPendingDisplayControl = takePendingDisplayControl(gate);
-  const heldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
+  const hadHeldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
   const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
     rawPendingDisplayControl,
     incomingText,
   );
   const prefixDropBytes = resolvedPasswordPrefix.droppedPendingBytes;
+  // Only treat the held prefix as continued when it was merged into this chunk
+  // (not discarded across a line break / non-prompt continuation).
+  const heldPasswordPrefixContinued = (
+    hadHeldPasswordPrefix
+    && prefixDropBytes === 0
+    && resolvedPasswordPrefix.pending === ""
+  );
   if (prefixDropBytes > 0) {
     gate.droppedBytes += prefixDropBytes;
     gate.droppedChunks += 1;
@@ -598,12 +616,12 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
-  // Only bypass the quiet gap when a held password-prefix chunk completes.
-  // Fresh password-looking lines in the flood must wait like shell prompts,
-  // otherwise a canceled "Password:" from the interrupted program resumes
-  // drain too early and lets more stale output through.
+  // Only bypass the quiet gap when a held password-prefix chunk completes on
+  // the same line. Fresh password-looking lines in the flood must wait like
+  // shell prompts, otherwise a canceled "Password:" from the interrupted
+  // program resumes drain too early and lets more stale output through.
   if (
-    heldPasswordPrefix
+    heldPasswordPrefixContinued
     && promptCandidate
     && isCompletePasswordPrompt(stripAnsi(promptCandidate))
   ) {

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -618,13 +618,12 @@ export const filterTerminalInterruptDisplayOutput = (
     };
   }
 
-  // Only bypass the quiet gap when a held password-prefix chunk completes on
-  // the same line. Fresh password-looking lines in the flood must wait like
-  // shell prompts, otherwise a canceled "Password:" from the interrupted
-  // program resumes drain too early and lets more stale output through.
+  // Complete password prompts resume immediately — including one-chunk prompts
+  // before promptQuietMs, and held-prefix completions on the same line. Unlike
+  // shell prompts, password prompts often emit nothing further until the user
+  // types; dropping them leaves a blank terminal while the remote waits (#2010).
   if (
-    heldPasswordPrefixContinued
-    && promptCandidate
+    promptCandidate
     && isCompletePasswordPrompt(stripAnsi(promptCandidate))
   ) {
     const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
@@ -637,7 +636,7 @@ export const filterTerminalInterruptDisplayOutput = (
       accepted: true,
       data: `${restoreControls.preserved}${promptCandidate}`,
       droppedBytes: withPrefixDrop(droppedBytes),
-      reason: "prompt-gap",
+      reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
     };
   }
 

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -325,15 +325,39 @@ const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
   if (prefixTargets.some((target) => target.startsWith(lower))) return true;
 
   // Allow an unfinished "[sudo…]" tag, or "[sudo…] " + a password-word prefix.
-  // Do NOT keep arbitrary lines that merely start with "password" / "[sudo]"
-  // (e.g. "Password authentication failed").
   const sudoTag = trimmed.match(/^\[sudo[^\]]*\]?\s*/i);
-  if (!sudoTag) return false;
-  const remainder = trimmed.slice(sudoTag[0].length);
-  if (!remainder) {
-    return /^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed);
+  if (sudoTag) {
+    const remainder = trimmed.slice(sudoTag[0].length);
+    if (!remainder) {
+      if (/^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed)) return true;
+    } else {
+      const remLower = remainder.toLowerCase();
+      const remTargets = [
+        "password",
+        "password:",
+        "password：",
+        "密码",
+        "密码：",
+        "口令",
+        "口令：",
+        "输入密码",
+        "输入密码：",
+        "input password",
+        "input password:",
+      ];
+      if (remTargets.some((target) => target.startsWith(remLower))) return true;
+    }
   }
-  const remTargets = [
+
+  // Prompts with leading text split mid-keyword, e.g. `alice@host's pass` +
+  // `word:` or `用户 的密` + `码`. Hold when a trailing suffix is a real
+  // password-keyword prefix at a word boundary.
+  return hasTrailingPasswordKeywordPrefix(trimmed);
+};
+
+const hasTrailingPasswordKeywordPrefix = (trimmed: string): boolean => {
+  const lower = trimmed.toLowerCase();
+  const keywordTargets = [
     "password",
     "password:",
     "password：",
@@ -346,8 +370,22 @@ const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
     "input password",
     "input password:",
   ];
-  const remLower = remainder.toLowerCase();
-  return remTargets.some((target) => target.startsWith(remLower));
+
+  for (const target of keywordTargets) {
+    const maxLen = Math.min(lower.length, target.length);
+    // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
+    // noise is not held. CJK keywords can match a single character ("密").
+    const minLen = /^[\x00-\x7f]+$/.test(target) ? 3 : 1;
+    for (let len = maxLen; len >= minLen; len -= 1) {
+      const suffix = lower.slice(-len);
+      if (!target.startsWith(suffix)) continue;
+      const before = lower.slice(0, -len);
+      if (before.length === 0) return true;
+      const prev = before[before.length - 1]!;
+      if (!/[a-z0-9]/i.test(prev)) return true;
+    }
+  }
+  return false;
 };
 
 const getTrailingPasswordPromptPrefix = (text: string): string => {

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -375,14 +375,16 @@ const hasTrailingPasswordKeywordPrefix = (trimmed: string): boolean => {
     const maxLen = Math.min(lower.length, target.length);
     // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
     // noise is not held. CJK keywords can match a single character ("密").
-    let isAsciiTarget = true;
-    for (let i = 0; i < target.length; i += 1) {
-      if (target.charCodeAt(i) > 0x7f) {
-        isAsciiTarget = false;
+    // Ignore punctuation (incl. full-width ：) so "password：" stays ASCII minLen.
+    const keywordBody = target.replace(/[:：\s]/g, "");
+    let isAsciiKeyword = true;
+    for (let i = 0; i < keywordBody.length; i += 1) {
+      if (keywordBody.charCodeAt(i) > 0x7f) {
+        isAsciiKeyword = false;
         break;
       }
     }
-    const minLen = isAsciiTarget ? 3 : 1;
+    const minLen = isAsciiKeyword ? 3 : 1;
     for (let len = maxLen; len >= minLen; len -= 1) {
       const suffix = lower.slice(-len);
       if (!target.startsWith(suffix)) continue;

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -320,11 +320,30 @@ const isProbablePasswordPromptPrefix = (candidate: string): boolean => {
   ];
   if (prefixTargets.some((target) => target.startsWith(lower))) return true;
 
-  if (/^\[sudo/i.test(trimmed)) return true;
-  if (/^(?:password|密\s*码|口\s*令|输入\s*密码|input\s+password)\b/i.test(trimmed)) {
-    return true;
+  // Allow an unfinished "[sudo…]" tag, or "[sudo…] " + a password-word prefix.
+  // Do NOT keep arbitrary lines that merely start with "password" / "[sudo]"
+  // (e.g. "Password authentication failed").
+  const sudoTag = trimmed.match(/^\[sudo[^\]]*\]?\s*/i);
+  if (!sudoTag) return false;
+  const remainder = trimmed.slice(sudoTag[0].length);
+  if (!remainder) {
+    return /^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed);
   }
-  return false;
+  const remTargets = [
+    "password",
+    "password:",
+    "password：",
+    "密码",
+    "密码：",
+    "口令",
+    "口令：",
+    "输入密码",
+    "输入密码：",
+    "input password",
+    "input password:",
+  ];
+  const remLower = remainder.toLowerCase();
+  return remTargets.some((target) => target.startsWith(remLower));
 };
 
 const getTrailingPasswordPromptPrefix = (text: string): string => {
@@ -465,8 +484,9 @@ export const filterTerminalInterruptDisplayOutput = (
     rawPendingDisplayControl,
     incomingText,
   );
-  if (resolvedPasswordPrefix.droppedPendingBytes > 0) {
-    gate.droppedBytes += resolvedPasswordPrefix.droppedPendingBytes;
+  const prefixDropBytes = resolvedPasswordPrefix.droppedPendingBytes;
+  if (prefixDropBytes > 0) {
+    gate.droppedBytes += prefixDropBytes;
     gate.droppedChunks += 1;
   }
   const pendingDisplayControl = resolvedPasswordPrefix.pending;
@@ -474,6 +494,7 @@ export const filterTerminalInterruptDisplayOutput = (
   const combinedText = `${pendingDisplayControl}${text}`;
   const bytes = charLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;
+  const withPrefixDrop = (droppedBytes: number): number => droppedBytes + prefixDropBytes;
 
   if (gate.pendingInterruptCaret) {
     gate.pendingInterruptCaret = false;
@@ -486,7 +507,7 @@ export const filterTerminalInterruptDisplayOutput = (
       return {
         accepted: true,
         data: `${restoreControls.preserved}^${text}`,
-        droppedBytes,
+        droppedBytes: withPrefixDrop(droppedBytes),
         acceptedBytes: bytes,
         reason: "interrupt-echo",
       };
@@ -504,7 +525,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: `${restoreControls.preserved}${combinedText.slice(interruptEchoIndex)}`,
-      droppedBytes,
+      droppedBytes: withPrefixDrop(droppedBytes),
       reason: "interrupt-echo",
     };
   }
@@ -522,7 +543,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: `${restoreControls.preserved}${promptCandidate}`,
-      droppedBytes,
+      droppedBytes: withPrefixDrop(droppedBytes),
       reason: "prompt-candidate",
     };
   }
@@ -540,7 +561,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: `${restoreControls.preserved}${promptCandidate}`,
-      droppedBytes,
+      droppedBytes: withPrefixDrop(droppedBytes),
       reason: "prompt-gap",
     };
   }
@@ -555,7 +576,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: `${restoreControls.preserved}${promptCandidate}`,
-      droppedBytes,
+      droppedBytes: withPrefixDrop(droppedBytes),
       reason: "prompt-gap",
     };
   }
@@ -568,7 +589,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: accepted.data,
-      droppedBytes: accepted.droppedBytes,
+      droppedBytes: withPrefixDrop(accepted.droppedBytes),
       reason: "quiet-gap",
     };
   }
@@ -581,7 +602,7 @@ export const filterTerminalInterruptDisplayOutput = (
     return {
       accepted: true,
       data: accepted.data,
-      droppedBytes: accepted.droppedBytes,
+      droppedBytes: withPrefixDrop(accepted.droppedBytes),
       reason: "max-drain",
     };
   }
@@ -596,9 +617,19 @@ export const filterTerminalInterruptDisplayOutput = (
   gate.droppedBytes += droppedBytes;
   gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
   if (restoreControls.preserved) {
-    return { accepted: true, data: restoreControls.preserved, droppedBytes, reason: "draining" };
+    return {
+      accepted: true,
+      data: restoreControls.preserved,
+      droppedBytes: withPrefixDrop(droppedBytes),
+      reason: "draining",
+    };
   }
-  return { accepted: false, data: "", droppedBytes, reason: "draining" };
+  return {
+    accepted: false,
+    data: "",
+    droppedBytes: withPrefixDrop(droppedBytes),
+    reason: "draining",
+  };
 };
 
 const resolvePrioritizeTerminalInputArgs = (

--- a/components/terminal/runtime/terminalOutputPipeline.ts
+++ b/components/terminal/runtime/terminalOutputPipeline.ts
@@ -356,6 +356,43 @@ const extractDrainHold = (
   };
 };
 
+const isPasswordPrefixPending = (pending: string): boolean =>
+  Boolean(pending)
+  && !pending.includes(ANSI_ESCAPE)
+  && isProbablePasswordPromptPrefix(pending);
+
+const getLastVisibleLine = (text: string): string => {
+  const normalized = stripAnsi(text).replace(/\r/g, "\n");
+  const lastLineStart = normalized.lastIndexOf("\n") + 1;
+  return normalized.slice(lastLineStart).trimEnd();
+};
+
+/**
+ * A held "Pass" / "[sudo] pass" must only survive when the next chunk continues
+ * or completes a password prompt. Otherwise discard it before the generic
+ * shell-prompt matcher can accept junk like "Pass$ " (#2010 Codex follow-up).
+ */
+const resolveHeldPasswordPrefix = (
+  pending: string,
+  text: string,
+): { pending: string; text: string; droppedPendingBytes: number } => {
+  if (!isPasswordPrefixPending(pending)) {
+    return { pending, text, droppedPendingBytes: 0 };
+  }
+
+  const combined = `${pending}${text}`;
+  const lastLine = getLastVisibleLine(combined);
+  if (isCompletePasswordPrompt(lastLine) || isProbablePasswordPromptPrefix(lastLine)) {
+    return { pending: "", text: combined, droppedPendingBytes: 0 };
+  }
+
+  return {
+    pending: "",
+    text,
+    droppedPendingBytes: charLength(pending),
+  };
+};
+
 const getPromptCandidateSuffix = (text: string): string | null => {
   const normalized = stripAnsi(text).replace(/\r/g, "\n");
   const lastLineStart = normalized.lastIndexOf("\n") + 1;
@@ -416,14 +453,24 @@ export const filterTerminalInterruptDisplayOutput = (
   data: string,
   options: Pick<TerminalInputPriorityOptions, "now"> = {},
 ): TerminalInterruptDisplayFilterResult => {
-  const text = String(data || "");
+  const incomingText = String(data || "");
   const gate = readTerminalInterruptDisplayGate(term);
   if (!gate?.active) {
-    return { accepted: true, data: text, droppedBytes: 0, reason: "inactive" };
+    return { accepted: true, data: incomingText, droppedBytes: 0, reason: "inactive" };
   }
 
   const now = nowFromPriorityOptions(options);
-  const pendingDisplayControl = takePendingDisplayControl(gate);
+  const rawPendingDisplayControl = takePendingDisplayControl(gate);
+  const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
+    rawPendingDisplayControl,
+    incomingText,
+  );
+  if (resolvedPasswordPrefix.droppedPendingBytes > 0) {
+    gate.droppedBytes += resolvedPasswordPrefix.droppedPendingBytes;
+    gate.droppedChunks += 1;
+  }
+  const pendingDisplayControl = resolvedPasswordPrefix.pending;
+  const text = resolvedPasswordPrefix.text;
   const combinedText = `${pendingDisplayControl}${text}`;
   const bytes = charLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -144,7 +144,84 @@ function finalizeAcceptedTextAfterPendingDisplayControl(pending, text) {
   if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
     return { data: combined, droppedBytes: 0 };
   }
+  // Held password-prompt prefixes are plain text (never ESC). Keep them when
+  // quiet/max-drain resumes so a split "Pass"+"word: " is not lost.
+  if (!pending.includes(ESC) && isProbablePasswordPromptPrefix(pending)) {
+    return { data: combined, droppedBytes: 0 };
+  }
   return { data: rawText, droppedBytes: byteLength(pending) };
+}
+
+function isCompletePasswordPrompt(candidate) {
+  const trimmed = String(candidate || "").trimEnd();
+  if (!trimmed) return false;
+  return (
+    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(trimmed)
+    && (
+      /[:：]\s*$/.test(trimmed)
+      || /\[sudo/i.test(trimmed)
+      || /^(?:输入\s*)?密码\s*$/.test(trimmed)
+      || /^input\s+password\s*$/i.test(trimmed)
+    )
+  );
+}
+
+function isProbablePasswordPromptPrefix(candidate) {
+  const trimmed = String(candidate || "").trimEnd();
+  if (!trimmed || trimmed.length > 160) return false;
+  if (/[\r\n]/.test(trimmed)) return false;
+  if (isCompletePasswordPrompt(trimmed)) return false;
+
+  const lower = trimmed.toLowerCase();
+  const prefixTargets = [
+    "password",
+    "password:",
+    "password：",
+    "[sudo",
+    "密码",
+    "密码：",
+    "口令",
+    "口令：",
+    "输入密码",
+    "输入密码：",
+    "input password",
+    "input password:",
+  ];
+  if (prefixTargets.some((target) => target.startsWith(lower))) return true;
+
+  // Incomplete sudo / password lines that have started but not finished yet.
+  if (/^\[sudo/i.test(trimmed)) return true;
+  if (/^(?:password|密\s*码|口\s*令|输入\s*密码|input\s+password)\b/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+function getTrailingPasswordPromptPrefix(text) {
+  const raw = String(text || "");
+  const lastBreak = Math.max(raw.lastIndexOf("\n"), raw.lastIndexOf("\r"));
+  const trailing = raw.slice(lastBreak + 1);
+  if (!trailing) return "";
+  return isProbablePasswordPromptPrefix(trailing) ? trailing : "";
+}
+
+function extractDrainHold(text, options = {}) {
+  const restoreControls = extractTerminalStateRestoreControls(text, options);
+  if (!options.holdTrailingPartial || restoreControls.pending) {
+    return restoreControls;
+  }
+
+  const passwordPending = getTrailingPasswordPromptPrefix(text);
+  if (!passwordPending) return restoreControls;
+
+  return {
+    preserved: restoreControls.preserved,
+    pending: passwordPending,
+    droppedBytes: Math.max(
+      0,
+      byteLength(text) - byteLength(restoreControls.preserved) - byteLength(passwordPending),
+    ),
+  };
 }
 
 function getPromptCandidateSuffix(text) {
@@ -158,17 +235,8 @@ function getPromptCandidateSuffix(text) {
   // Password prompts are interactive resume points too. Without this, Ctrl+C
   // drain treats "[sudo] password for …:" as stale flood and drops it, so the
   // remote waits for a password while the terminal shows nothing (#2010).
-  const looksLikePasswordPrompt = (
-    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(candidate)
-    && (
-      /[:：]\s*$/.test(candidate)
-      || /\[sudo/i.test(candidate)
-      || /^(?:输入\s*)?密码\s*$/.test(candidate)
-      || /^input\s+password\s*$/i.test(candidate)
-    )
-  );
   const looksLikePrompt = (
-    looksLikePasswordPrompt
+    isCompletePasswordPrompt(candidate)
     || /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
     || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
@@ -319,6 +387,28 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
       };
     }
   }
+
+  // Password prompts are specific enough to resume immediately even after we
+  // already dropped stale flood — including when a held "Pass" prefix completes
+  // as "Password: " in the next chunk before promptQuietMs elapses.
+  if (bytes <= gate.promptCandidateBytes) {
+    const promptCandidate = getPromptCandidateSuffix(combinedText);
+    if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
+      const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
+      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+      const droppedBytes = restoreControls.droppedBytes;
+      gate.droppedBytes += droppedBytes;
+      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+      disarmTerminalInterruptOutputGate(session);
+      return {
+        accepted: true,
+        data: `${restoreControls.preserved}${promptCandidate}`,
+        droppedBytes,
+        reason: "prompt-gap",
+      };
+    }
+  }
+
   if (quietGapMs >= gate.promptQuietMs && bytes <= gate.promptCandidateBytes) {
     const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate) {
@@ -363,7 +453,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     };
   }
 
-  const restoreControls = extractTerminalStateRestoreControls(combinedText, {
+  const restoreControls = extractDrainHold(combinedText, {
     holdTrailingPartial: true,
   });
   const droppedBytes = restoreControls.droppedBytes;

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -327,6 +327,19 @@ function consumeTrailingCsiCompletion(pending, text) {
   return { text: raw, extraDroppedBytes: 0 };
 }
 
+function isStandaloneHoldableControlPrefix(pending) {
+  const raw = String(pending || "");
+  if (!raw) return false;
+  if (raw === ESC || raw === `${ESC}[`) return true;
+  // Incomplete private-mode restore CSI and OSC title prefixes are safe to hold
+  // alone; incomplete SGR CSI (ESC[31) is not — it can leak into "$ ".
+  if (raw.startsWith(`${ESC}[?`) && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(raw)) {
+    return true;
+  }
+  if (raw.startsWith(`${ESC}]`)) return true;
+  return false;
+}
+
 function extractDrainHold(text, options = {}) {
   const restoreControls = extractTerminalStateRestoreControls(text, options);
   if (!options.holdTrailingPartial) {
@@ -346,6 +359,19 @@ function extractDrainHold(text, options = {}) {
     restoreControls.preserved,
   );
   if (!passwordPending || !isProbablePasswordPromptPrefix(passwordPending)) {
+    // Incomplete SGR CSI (ESC[31) must not be held alone — otherwise the next
+    // shell prompt can be accepted as "\x1b[31$ " and leak stale color bytes.
+    // Restore/OSC prefixes stay held as before.
+    if (controlPending && !isStandaloneHoldableControlPrefix(controlPending)) {
+      return {
+        preserved: restoreControls.preserved,
+        pending: "",
+        droppedBytes: Math.max(
+          0,
+          byteLength(text) - byteLength(restoreControls.preserved),
+        ),
+      };
+    }
     return restoreControls;
   }
 

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -173,7 +173,13 @@ function isCompletePasswordPrompt(candidate) {
 function isProbablePasswordPromptPrefix(candidate) {
   // Strip SGR/OSC for matching so styled chunks like "\x1b[31mPass" still hold,
   // while callers keep the raw pending bytes for display.
-  const trimmed = stripAnsi(String(candidate || "")).trimEnd();
+  let trimmed = stripAnsi(String(candidate || "")).trimEnd();
+  // Incomplete CSI/OSC left after stripAnsi (e.g. trailing "\x1b[") must not
+  // prevent matching a held password prefix.
+  const trailingControl = getTrailingDisplayControlPrefix(trimmed);
+  if (trailingControl) {
+    trimmed = trimmed.slice(0, -trailingControl.length).trimEnd();
+  }
   if (!trimmed || trimmed.length > 160) return false;
   if (/[\r\n]/.test(trimmed)) return false;
   if (isCompletePasswordPrompt(trimmed)) return false;
@@ -278,19 +284,29 @@ function getTrailingPasswordPromptPrefix(text) {
 
 function extractDrainHold(text, options = {}) {
   const restoreControls = extractTerminalStateRestoreControls(text, options);
-  if (!options.holdTrailingPartial || restoreControls.pending) {
+  if (!options.holdTrailingPartial) {
     return restoreControls;
   }
 
-  const passwordPending = getTrailingPasswordPromptPrefix(text);
-  if (!passwordPending) return restoreControls;
+  // A styled prompt can split mid-CSI, e.g. "\x1b[31mPass\x1b[" + "0mword: ".
+  // Keep both the password-prefix body and the trailing control prefix so the
+  // next chunk can still complete "Password:" (#2010 Codex follow-up).
+  const controlPending = restoreControls.pending;
+  const textWithoutControl = controlPending
+    ? String(text || "").slice(0, -controlPending.length)
+    : String(text || "");
+  const passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
+  if (!passwordPending) {
+    return restoreControls;
+  }
 
+  const pending = `${passwordPending}${controlPending}`;
   return {
     preserved: restoreControls.preserved,
-    pending: passwordPending,
+    pending,
     droppedBytes: Math.max(
       0,
-      byteLength(text) - byteLength(restoreControls.preserved) - byteLength(passwordPending),
+      byteLength(text) - byteLength(restoreControls.preserved) - byteLength(pending),
     ),
   };
 }

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -244,7 +244,14 @@ function hasTrailingPasswordKeywordPrefix(trimmed) {
     const maxLen = Math.min(lower.length, target.length);
     // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
     // noise is not held. CJK keywords can match a single character ("密").
-    const minLen = /^[\x00-\x7f]+$/.test(target) ? 3 : 1;
+    let isAsciiTarget = true;
+    for (let i = 0; i < target.length; i += 1) {
+      if (target.charCodeAt(i) > 0x7f) {
+        isAsciiTarget = false;
+        break;
+      }
+    }
+    const minLen = isAsciiTarget ? 3 : 1;
     for (let len = maxLen; len >= minLen; len -= 1) {
       const suffix = lower.slice(-len);
       if (!target.startsWith(suffix)) continue;

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -288,15 +288,27 @@ function getTrailingPasswordPromptPrefix(text) {
 
 /**
  * Restore sequences already counted in `preserved` can also sit at the start of
- * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip only
- * when the full preserved string is a real prefix — never peel single chars
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass", or multiple
+ * restores "\x1b[?25hstale\n\x1b[?1049lPass"). Strip only complete leading
+ * restore sequences that are a real suffix of `preserved` — never peel chars
  * like the final "l" of "\x1b[?1049l" off "login pass".
  */
 function stripLeadingPreservedOverlap(passwordPending, preserved) {
-  const pending = String(passwordPending || "");
-  const keep = String(preserved || "");
+  let pending = String(passwordPending || "");
+  let keep = String(preserved || "");
   if (!pending || !keep) return pending;
   if (pending.startsWith(keep)) return pending.slice(keep.length);
+
+  while (pending && keep) {
+    TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+    const match = TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.exec(pending);
+    TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN.lastIndex = 0;
+    if (!match || match.index !== 0) break;
+    const seq = match[0];
+    if (!shouldPreserveTerminalStateRestore(seq) || !keep.endsWith(seq)) break;
+    pending = pending.slice(seq.length);
+    keep = keep.slice(0, -seq.length);
+  }
   return pending;
 }
 

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -435,6 +435,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
 
   const now = nowFromOptions(options);
   const rawPendingDisplayControl = takePendingDisplayControl(gate);
+  const heldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
   const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
     rawPendingDisplayControl,
     incomingText,
@@ -502,10 +503,11 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     }
   }
 
-  // Password prompts are specific enough to resume immediately even after we
-  // already dropped stale flood — including when a held "Pass" prefix completes
-  // as "Password: " in the next chunk before promptQuietMs elapses.
-  if (bytes <= gate.promptCandidateBytes) {
+  // Only bypass the quiet gap when a held password-prefix chunk completes.
+  // Fresh password-looking lines in the flood must wait like shell prompts,
+  // otherwise a canceled "Password:" from the interrupted program resumes
+  // drain too early and lets more stale output through.
+  if (heldPasswordPrefix && bytes <= gate.promptCandidateBytes) {
     const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
       const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -609,6 +609,37 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     };
   }
 
+  // Complete password prompts resume immediately — including one-chunk prompts
+  // before promptQuietMs, held-prefix completions, and last-line prompts that
+  // arrive after a large stale prefix. Unlike shell prompts, password prompts
+  // often emit nothing further until the user types; dropping them leaves a
+  // blank terminal while the remote waits (#2010). Detect the last-line
+  // password candidate independently of the whole-chunk promptCandidateBytes
+  // cap used for ordinary shell prompts.
+  {
+    const passwordPromptCandidate = getPromptCandidateSuffix(combinedText);
+    if (
+      passwordPromptCandidate
+      && isCompletePasswordPrompt(stripAnsi(passwordPromptCandidate))
+    ) {
+      const droppedPrefix = combinedText.slice(
+        0,
+        combinedText.length - passwordPromptCandidate.length,
+      );
+      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
+      const droppedBytes = restoreControls.droppedBytes;
+      gate.droppedBytes += droppedBytes;
+      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
+      disarmTerminalInterruptOutputGate(session);
+      return {
+        accepted: true,
+        data: `${restoreControls.preserved}${passwordPromptCandidate}`,
+        droppedBytes: withPrefixDrop(droppedBytes),
+        reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
+      };
+    }
+  }
+
   if (gate.droppedBytes === 0 && bytes <= gate.promptCandidateBytes) {
     const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate) {
@@ -623,29 +654,6 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
         data: `${restoreControls.preserved}${promptCandidate}`,
         droppedBytes: withPrefixDrop(droppedBytes),
         reason: "prompt-candidate",
-      };
-    }
-  }
-
-  // Complete password prompts resume immediately — including one-chunk prompts
-  // before promptQuietMs, and held-prefix completions on the same line. Unlike
-  // shell prompts, password prompts often emit nothing further until the user
-  // types; dropping them leaves a blank terminal while the remote waits (#2010).
-  // heldPasswordPrefixContinued is retained for clarity/tests around split holds.
-  if (bytes <= gate.promptCandidateBytes) {
-    const promptCandidate = getPromptCandidateSuffix(combinedText);
-    if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
-      const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
-      const restoreControls = extractTerminalStateRestoreControls(droppedPrefix);
-      const droppedBytes = restoreControls.droppedBytes;
-      gate.droppedBytes += droppedBytes;
-      gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
-      disarmTerminalInterruptOutputGate(session);
-      return {
-        accepted: true,
-        data: `${restoreControls.preserved}${promptCandidate}`,
-        droppedBytes: withPrefixDrop(droppedBytes),
-        reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
       };
     }
   }

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -12,6 +12,8 @@ const TERMINAL_STATE_RESTORE_SEQUENCE_PATTERN = new RegExp(
 );
 const PRIVATE_MODE_PATTERN = new RegExp(`^${ESC}\\[\\?([0-9;:]*)([hl])$`);
 const TRAILING_RESTORE_CONTROL_PREFIX_PATTERN = new RegExp(`^${ESC}\\[\\?[0-9;:]*$`);
+// Incomplete CSI (params/intermediates, no final byte) — e.g. ESC[0 or ESC[31
+const TRAILING_CSI_CONTROL_PREFIX_PATTERN = new RegExp(`^${ESC}\\[[0-?]*[ -/]*$`);
 const RESTORE_PRIVATE_MODE_PARAMS = new Set([
   1,
   47,
@@ -80,7 +82,9 @@ function getTrailingRestoreControlPrefix(text) {
   if (escapeIndex < 0) return "";
   const suffix = raw.slice(escapeIndex);
   if (suffix === ESC) return suffix;
-  if (suffix === `${ESC}[`) return suffix;
+  // Hold any incomplete CSI (ESC[ / ESC[0 / ESC[31 / ESC[?1049), not only
+  // private-mode restore prefixes — styled password prompts can split mid-SGR.
+  if (TRAILING_CSI_CONTROL_PREFIX_PATTERN.test(suffix)) return suffix;
   if (suffix.startsWith(`${ESC}[?`) && TRAILING_RESTORE_CONTROL_PREFIX_PATTERN.test(suffix)) {
     return suffix;
   }

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -144,9 +144,9 @@ function finalizeAcceptedTextAfterPendingDisplayControl(pending, text) {
   if (oscMatch?.index === 0 && oscMatch[0].length > pending.length) {
     return { data: combined, droppedBytes: 0 };
   }
-  // Held password-prompt prefixes are plain text (never ESC). Keep them when
+  // Held password-prompt prefixes (plain or SGR-styled). Keep them when
   // quiet/max-drain resumes so a split "Pass"+"word: " is not lost.
-  if (!pending.includes(ESC) && isProbablePasswordPromptPrefix(pending)) {
+  if (isProbablePasswordPromptPrefix(pending)) {
     return { data: combined, droppedBytes: 0 };
   }
   return { data: rawText, droppedBytes: byteLength(pending) };
@@ -171,7 +171,9 @@ function isCompletePasswordPrompt(candidate) {
 }
 
 function isProbablePasswordPromptPrefix(candidate) {
-  const trimmed = String(candidate || "").trimEnd();
+  // Strip SGR/OSC for matching so styled chunks like "\x1b[31mPass" still hold,
+  // while callers keep the raw pending bytes for display.
+  const trimmed = stripAnsi(String(candidate || "")).trimEnd();
   if (!trimmed || trimmed.length > 160) return false;
   if (/[\r\n]/.test(trimmed)) return false;
   if (isCompletePasswordPrompt(trimmed)) return false;
@@ -394,9 +396,7 @@ function clearPendingInterruptOutputMeta(session) {
 }
 
 function isPasswordPrefixPending(pending) {
-  return Boolean(pending)
-    && !pending.includes(ESC)
-    && isProbablePasswordPromptPrefix(pending);
+  return Boolean(pending) && isProbablePasswordPromptPrefix(pending);
 }
 
 function getLastVisibleLine(text) {

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -288,21 +288,43 @@ function getTrailingPasswordPromptPrefix(text) {
 
 /**
  * Restore sequences already counted in `preserved` can also sit at the start of
- * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip that
- * overlap so droppedBytes stays accurate and the restore is not re-emitted.
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip only
+ * when the full preserved string is a real prefix — never peel single chars
+ * like the final "l" of "\x1b[?1049l" off "login pass".
  */
 function stripLeadingPreservedOverlap(passwordPending, preserved) {
   const pending = String(passwordPending || "");
   const keep = String(preserved || "");
   if (!pending || !keep) return pending;
-  const max = Math.min(keep.length, pending.length);
-  for (let len = max; len > 0; len -= 1) {
-    const suffix = keep.slice(-len);
-    if (pending.startsWith(suffix)) {
-      return pending.slice(len);
-    }
-  }
+  if (pending.startsWith(keep)) return pending.slice(keep.length);
   return pending;
+}
+
+/**
+ * When discarding a held prefix that ends mid-CSI, also drop the CSI final
+ * byte(s) from the next chunk so "Pass\x1b[0" + "m$ " does not leak as "m$ ".
+ */
+function consumeTrailingCsiCompletion(pending, text) {
+  const control = getTrailingDisplayControlPrefix(pending);
+  if (!control || !control.startsWith(`${ESC}[`)) {
+    return { text, extraDroppedBytes: 0 };
+  }
+  let i = 0;
+  const raw = String(text || "");
+  while (i < raw.length) {
+    const code = raw.charCodeAt(i);
+    // CSI parameter bytes 0–? and intermediate bytes SP–/
+    if ((code >= 0x30 && code <= 0x3f) || (code >= 0x20 && code <= 0x2f)) {
+      i += 1;
+      continue;
+    }
+    // CSI final byte @–~
+    if (code >= 0x40 && code <= 0x7e) {
+      return { text: raw.slice(i + 1), extraDroppedBytes: i + 1 };
+    }
+    break;
+  }
+  return { text: raw, extraDroppedBytes: 0 };
 }
 
 function extractDrainHold(text, options = {}) {
@@ -475,10 +497,11 @@ function resolveHeldPasswordPrefix(pending, text) {
     return { pending: "", text: combined, droppedPendingBytes: 0 };
   }
 
+  const consumed = consumeTrailingCsiCompletion(pending, text);
   return {
     pending: "",
-    text,
-    droppedPendingBytes: byteLength(pending),
+    text: consumed.text,
+    droppedPendingBytes: byteLength(pending) + consumed.extraDroppedBytes,
   };
 }
 

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -155,8 +155,21 @@ function getPromptCandidateSuffix(text) {
   if (!candidate) return null;
   if (candidate.length > 160) return null;
 
+  // Password prompts are interactive resume points too. Without this, Ctrl+C
+  // drain treats "[sudo] password for …:" as stale flood and drops it, so the
+  // remote waits for a password while the terminal shows nothing (#2010).
+  const looksLikePasswordPrompt = (
+    /(?:\bpassword\b|密\s*码|口\s*令)/i.test(candidate)
+    && (
+      /[:：]\s*$/.test(candidate)
+      || /\[sudo/i.test(candidate)
+      || /^(?:输入\s*)?密码\s*$/.test(candidate)
+      || /^input\s+password\s*$/i.test(candidate)
+    )
+  );
   const looksLikePrompt = (
-    /^[#$>%]\s*$/.test(candidate)
+    looksLikePasswordPrompt
+    || /^[#$>%]\s*$/.test(candidate)
     || /^[^ \t\r\n<>]{1,80}[#$>%]\s*$/.test(candidate)
     || /^[^\r\n<>]{1,120}[#$>%]\s*$/.test(candidate)
     || /^<[^>\r\n]{1,80}>\s*$/.test(candidate)

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -523,11 +523,12 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     }
   }
 
-  // Only bypass the quiet gap when a held password-prefix chunk completes on
-  // the same line. Fresh password-looking lines in the flood must wait like
-  // shell prompts, otherwise a canceled "Password:" from the interrupted
-  // program resumes drain too early and lets more stale output through.
-  if (heldPasswordPrefixContinued && bytes <= gate.promptCandidateBytes) {
+  // Complete password prompts resume immediately — including one-chunk prompts
+  // before promptQuietMs, and held-prefix completions on the same line. Unlike
+  // shell prompts, password prompts often emit nothing further until the user
+  // types; dropping them leaves a blank terminal while the remote waits (#2010).
+  // heldPasswordPrefixContinued is retained for clarity/tests around split holds.
+  if (bytes <= gate.promptCandidateBytes) {
     const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
       const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);
@@ -540,7 +541,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
         accepted: true,
         data: `${restoreControls.preserved}${promptCandidate}`,
         droppedBytes: withPrefixDrop(droppedBytes),
-        reason: "prompt-gap",
+        reason: heldPasswordPrefixContinued ? "prompt-gap" : "password-prompt",
       };
     }
   }

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -244,14 +244,16 @@ function hasTrailingPasswordKeywordPrefix(trimmed) {
     const maxLen = Math.min(lower.length, target.length);
     // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
     // noise is not held. CJK keywords can match a single character ("密").
-    let isAsciiTarget = true;
-    for (let i = 0; i < target.length; i += 1) {
-      if (target.charCodeAt(i) > 0x7f) {
-        isAsciiTarget = false;
+    // Ignore punctuation/spaces (incl. full-width ：) so "password：" stays ASCII minLen.
+    const keywordBody = target.replace(/[:：\s]/g, "");
+    let isAsciiKeyword = true;
+    for (let i = 0; i < keywordBody.length; i += 1) {
+      if (keywordBody.charCodeAt(i) > 0x7f) {
+        isAsciiKeyword = false;
         break;
       }
     }
-    const minLen = isAsciiTarget ? 3 : 1;
+    const minLen = isAsciiKeyword ? 3 : 1;
     for (let len = maxLen; len >= minLen; len -= 1) {
       const suffix = lower.slice(-len);
       if (!target.startsWith(suffix)) continue;

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -155,13 +155,17 @@ function finalizeAcceptedTextAfterPendingDisplayControl(pending, text) {
 function isCompletePasswordPrompt(candidate) {
   const trimmed = String(candidate || "").trimEnd();
   if (!trimmed) return false;
+  // Align with terminalSudoAutofill's Kylin coverage (#1293): prompts may end
+  // with 密码/口令 and no colon (e.g. "用户 的密码"). Still require a password
+  // keyword so ordinary lines like "Password authentication failed" stay out.
   return (
     /(?:\bpassword\b|密\s*码|口\s*令)/i.test(trimmed)
     && (
       /[:：]\s*$/.test(trimmed)
       || /\[sudo/i.test(trimmed)
-      || /^(?:输入\s*)?密码\s*$/.test(trimmed)
+      || /(?:密\s*码|口\s*令)\s*$/.test(trimmed)
       || /^input\s+password\s*$/i.test(trimmed)
+      || /^password\s*$/i.test(trimmed)
     )
   );
 }

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -194,16 +194,39 @@ function isProbablePasswordPromptPrefix(candidate) {
   if (prefixTargets.some((target) => target.startsWith(lower))) return true;
 
   // Allow an unfinished "[sudo…]" tag, or "[sudo…] " + a password-word prefix.
-  // Do NOT keep arbitrary lines that merely start with "password" / "[sudo]"
-  // (e.g. "Password authentication failed").
   const sudoTag = trimmed.match(/^\[sudo[^\]]*\]?\s*/i);
-  if (!sudoTag) return false;
-  const remainder = trimmed.slice(sudoTag[0].length);
-  if (!remainder) {
-    return /^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed);
+  if (sudoTag) {
+    const remainder = trimmed.slice(sudoTag[0].length);
+    if (!remainder) {
+      if (/^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed)) return true;
+    } else {
+      const remLower = remainder.toLowerCase();
+      const remTargets = [
+        "password",
+        "password:",
+        "password：",
+        "密码",
+        "密码：",
+        "口令",
+        "口令：",
+        "输入密码",
+        "输入密码：",
+        "input password",
+        "input password:",
+      ];
+      if (remTargets.some((target) => target.startsWith(remLower))) return true;
+    }
   }
-  const remLower = remainder.toLowerCase();
-  const remTargets = [
+
+  // Prompts with leading text split mid-keyword, e.g. `alice@host's pass` +
+  // `word:` or `用户 的密` + `码`. Hold when a trailing suffix is a real
+  // password-keyword prefix at a word boundary.
+  return hasTrailingPasswordKeywordPrefix(trimmed);
+}
+
+function hasTrailingPasswordKeywordPrefix(trimmed) {
+  const lower = String(trimmed || "").toLowerCase();
+  const keywordTargets = [
     "password",
     "password:",
     "password：",
@@ -216,7 +239,22 @@ function isProbablePasswordPromptPrefix(candidate) {
     "input password",
     "input password:",
   ];
-  return remTargets.some((target) => target.startsWith(remLower));
+
+  for (const target of keywordTargets) {
+    const maxLen = Math.min(lower.length, target.length);
+    // ASCII keywords: require >= 3 chars ("pas"/"pass") so lone "p"/"pa" mid-line
+    // noise is not held. CJK keywords can match a single character ("密").
+    const minLen = /^[\x00-\x7f]+$/.test(target) ? 3 : 1;
+    for (let len = maxLen; len >= minLen; len -= 1) {
+      const suffix = lower.slice(-len);
+      if (!target.startsWith(suffix)) continue;
+      const before = lower.slice(0, -len);
+      if (before.length === 0) return true;
+      const prev = before[before.length - 1];
+      if (!/[a-z0-9]/i.test(prev)) return true;
+    }
+  }
+  return false;
 }
 
 function getTrailingPasswordPromptPrefix(text) {

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -413,6 +413,17 @@ function resolveHeldPasswordPrefix(pending, text) {
     return { pending, text, droppedPendingBytes: 0 };
   }
 
+  // Held prefixes must continue on the same line. A leading line break means
+  // the next chunk is a fresh line (e.g. "Pass" then "\nPassword: "), not a
+  // completion of the held prefix — discard so quiet-gap still applies.
+  if (/^[\r\n]/.test(text)) {
+    return {
+      pending: "",
+      text,
+      droppedPendingBytes: byteLength(pending),
+    };
+  }
+
   const combined = `${pending}${text}`;
   const lastLine = getLastVisibleLine(combined);
   if (isCompletePasswordPrompt(lastLine) || isProbablePasswordPromptPrefix(lastLine)) {
@@ -435,12 +446,19 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
 
   const now = nowFromOptions(options);
   const rawPendingDisplayControl = takePendingDisplayControl(gate);
-  const heldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
+  const hadHeldPasswordPrefix = isPasswordPrefixPending(rawPendingDisplayControl);
   const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
     rawPendingDisplayControl,
     incomingText,
   );
   const prefixDropBytes = resolvedPasswordPrefix.droppedPendingBytes;
+  // Only treat the held prefix as continued when it was merged into this chunk
+  // (not discarded across a line break / non-prompt continuation).
+  const heldPasswordPrefixContinued = (
+    hadHeldPasswordPrefix
+    && prefixDropBytes === 0
+    && resolvedPasswordPrefix.pending === ""
+  );
   if (prefixDropBytes > 0) {
     gate.droppedBytes += prefixDropBytes;
     gate.droppedChunks += 1;
@@ -503,11 +521,11 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     }
   }
 
-  // Only bypass the quiet gap when a held password-prefix chunk completes.
-  // Fresh password-looking lines in the flood must wait like shell prompts,
-  // otherwise a canceled "Password:" from the interrupted program resumes
-  // drain too early and lets more stale output through.
-  if (heldPasswordPrefix && bytes <= gate.promptCandidateBytes) {
+  // Only bypass the quiet gap when a held password-prefix chunk completes on
+  // the same line. Fresh password-looking lines in the flood must wait like
+  // shell prompts, otherwise a canceled "Password:" from the interrupted
+  // program resumes drain too early and lets more stale output through.
+  if (heldPasswordPrefixContinued && bytes <= gate.promptCandidateBytes) {
     const promptCandidate = getPromptCandidateSuffix(combinedText);
     if (promptCandidate && isCompletePasswordPrompt(stripAnsi(promptCandidate))) {
       const droppedPrefix = combinedText.slice(0, combinedText.length - promptCandidate.length);

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -282,6 +282,25 @@ function getTrailingPasswordPromptPrefix(text) {
   return isProbablePasswordPromptPrefix(trailing) ? trailing : "";
 }
 
+/**
+ * Restore sequences already counted in `preserved` can also sit at the start of
+ * the trailing password-prefix line (e.g. "stale\n\x1b[?1049lPass"). Strip that
+ * overlap so droppedBytes stays accurate and the restore is not re-emitted.
+ */
+function stripLeadingPreservedOverlap(passwordPending, preserved) {
+  const pending = String(passwordPending || "");
+  const keep = String(preserved || "");
+  if (!pending || !keep) return pending;
+  const max = Math.min(keep.length, pending.length);
+  for (let len = max; len > 0; len -= 1) {
+    const suffix = keep.slice(-len);
+    if (pending.startsWith(suffix)) {
+      return pending.slice(len);
+    }
+  }
+  return pending;
+}
+
 function extractDrainHold(text, options = {}) {
   const restoreControls = extractTerminalStateRestoreControls(text, options);
   if (!options.holdTrailingPartial) {
@@ -295,8 +314,12 @@ function extractDrainHold(text, options = {}) {
   const textWithoutControl = controlPending
     ? String(text || "").slice(0, -controlPending.length)
     : String(text || "");
-  const passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
-  if (!passwordPending) {
+  let passwordPending = getTrailingPasswordPromptPrefix(textWithoutControl);
+  passwordPending = stripLeadingPreservedOverlap(
+    passwordPending,
+    restoreControls.preserved,
+  );
+  if (!passwordPending || !isProbablePasswordPromptPrefix(passwordPending)) {
     return restoreControls;
   }
 

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -324,15 +324,60 @@ function clearPendingInterruptOutputMeta(session) {
   }
 }
 
+function isPasswordPrefixPending(pending) {
+  return Boolean(pending)
+    && !pending.includes(ESC)
+    && isProbablePasswordPromptPrefix(pending);
+}
+
+function getLastVisibleLine(text) {
+  const normalized = stripAnsi(String(text || "")).replace(/\r/g, "\n");
+  const lastLineStart = normalized.lastIndexOf("\n") + 1;
+  return normalized.slice(lastLineStart).trimEnd();
+}
+
+/**
+ * A held "Pass" / "[sudo] pass" must only survive when the next chunk continues
+ * or completes a password prompt. Otherwise discard it before the generic
+ * shell-prompt matcher can accept junk like "Pass$ " (#2010 Codex follow-up).
+ */
+function resolveHeldPasswordPrefix(pending, text) {
+  if (!isPasswordPrefixPending(pending)) {
+    return { pending, text, droppedPendingBytes: 0 };
+  }
+
+  const combined = `${pending}${text}`;
+  const lastLine = getLastVisibleLine(combined);
+  if (isCompletePasswordPrompt(lastLine) || isProbablePasswordPromptPrefix(lastLine)) {
+    return { pending: "", text: combined, droppedPendingBytes: 0 };
+  }
+
+  return {
+    pending: "",
+    text,
+    droppedPendingBytes: byteLength(pending),
+  };
+}
+
 function filterTerminalInterruptOutput(session, data, options = {}) {
   const gate = session?._interruptOutputGate;
-  const text = String(data || "");
+  const incomingText = String(data || "");
   if (!gate?.active) {
-    return { accepted: true, data: text, droppedBytes: 0, reason: "inactive" };
+    return { accepted: true, data: incomingText, droppedBytes: 0, reason: "inactive" };
   }
 
   const now = nowFromOptions(options);
-  const pendingDisplayControl = takePendingDisplayControl(gate);
+  const rawPendingDisplayControl = takePendingDisplayControl(gate);
+  const resolvedPasswordPrefix = resolveHeldPasswordPrefix(
+    rawPendingDisplayControl,
+    incomingText,
+  );
+  if (resolvedPasswordPrefix.droppedPendingBytes > 0) {
+    gate.droppedBytes += resolvedPasswordPrefix.droppedPendingBytes;
+    gate.droppedChunks += 1;
+  }
+  const pendingDisplayControl = resolvedPasswordPrefix.pending;
+  const text = resolvedPasswordPrefix.text;
   const combinedText = `${pendingDisplayControl}${text}`;
   const bytes = byteLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;

--- a/electron/bridges/terminalInterruptOutputGate.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.cjs
@@ -189,12 +189,30 @@ function isProbablePasswordPromptPrefix(candidate) {
   ];
   if (prefixTargets.some((target) => target.startsWith(lower))) return true;
 
-  // Incomplete sudo / password lines that have started but not finished yet.
-  if (/^\[sudo/i.test(trimmed)) return true;
-  if (/^(?:password|密\s*码|口\s*令|输入\s*密码|input\s+password)\b/i.test(trimmed)) {
-    return true;
+  // Allow an unfinished "[sudo…]" tag, or "[sudo…] " + a password-word prefix.
+  // Do NOT keep arbitrary lines that merely start with "password" / "[sudo]"
+  // (e.g. "Password authentication failed").
+  const sudoTag = trimmed.match(/^\[sudo[^\]]*\]?\s*/i);
+  if (!sudoTag) return false;
+  const remainder = trimmed.slice(sudoTag[0].length);
+  if (!remainder) {
+    return /^\[sudo(?:[^\]]*)\]?\s*$/i.test(trimmed);
   }
-  return false;
+  const remLower = remainder.toLowerCase();
+  const remTargets = [
+    "password",
+    "password:",
+    "password：",
+    "密码",
+    "密码：",
+    "口令",
+    "口令：",
+    "输入密码",
+    "输入密码：",
+    "input password",
+    "input password:",
+  ];
+  return remTargets.some((target) => target.startsWith(remLower));
 }
 
 function getTrailingPasswordPromptPrefix(text) {
@@ -372,8 +390,9 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     rawPendingDisplayControl,
     incomingText,
   );
-  if (resolvedPasswordPrefix.droppedPendingBytes > 0) {
-    gate.droppedBytes += resolvedPasswordPrefix.droppedPendingBytes;
+  const prefixDropBytes = resolvedPasswordPrefix.droppedPendingBytes;
+  if (prefixDropBytes > 0) {
+    gate.droppedBytes += prefixDropBytes;
     gate.droppedChunks += 1;
   }
   const pendingDisplayControl = resolvedPasswordPrefix.pending;
@@ -381,6 +400,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
   const combinedText = `${pendingDisplayControl}${text}`;
   const bytes = byteLength(combinedText);
   const quietGapMs = gate.lastDroppedAt > 0 ? now - gate.lastDroppedAt : 0;
+  const withPrefixDrop = (droppedBytes) => droppedBytes + prefixDropBytes;
 
   if (gate.pendingInterruptCaret) {
     gate.pendingInterruptCaret = false;
@@ -393,7 +413,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
       return {
         accepted: true,
         data: `${restoreControls.preserved}^${text}`,
-        droppedBytes,
+        droppedBytes: withPrefixDrop(droppedBytes),
         reason: "interrupt-echo",
       };
     }
@@ -410,7 +430,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     return {
       accepted: true,
       data: `${restoreControls.preserved}${combinedText.slice(interruptEchoIndex)}`,
-      droppedBytes,
+      droppedBytes: withPrefixDrop(droppedBytes),
       reason: "interrupt-echo",
     };
   }
@@ -427,7 +447,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
       return {
         accepted: true,
         data: `${restoreControls.preserved}${promptCandidate}`,
-        droppedBytes,
+        droppedBytes: withPrefixDrop(droppedBytes),
         reason: "prompt-candidate",
       };
     }
@@ -448,7 +468,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
       return {
         accepted: true,
         data: `${restoreControls.preserved}${promptCandidate}`,
-        droppedBytes,
+        droppedBytes: withPrefixDrop(droppedBytes),
         reason: "prompt-gap",
       };
     }
@@ -466,7 +486,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
       return {
         accepted: true,
         data: `${restoreControls.preserved}${promptCandidate}`,
-        droppedBytes,
+        droppedBytes: withPrefixDrop(droppedBytes),
         reason: "prompt-gap",
       };
     }
@@ -480,7 +500,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     return {
       accepted: true,
       data: accepted.data,
-      droppedBytes: accepted.droppedBytes,
+      droppedBytes: withPrefixDrop(accepted.droppedBytes),
       reason: "quiet-gap",
     };
   }
@@ -493,7 +513,7 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
     return {
       accepted: true,
       data: accepted.data,
-      droppedBytes: accepted.droppedBytes,
+      droppedBytes: withPrefixDrop(accepted.droppedBytes),
       reason: "max-drain",
     };
   }
@@ -508,9 +528,19 @@ function filterTerminalInterruptOutput(session, data, options = {}) {
   gate.droppedBytes += droppedBytes;
   gate.droppedChunks += droppedBytes > 0 ? 1 : 0;
   if (restoreControls.preserved) {
-    return { accepted: true, data: restoreControls.preserved, droppedBytes, reason: "draining" };
+    return {
+      accepted: true,
+      data: restoreControls.preserved,
+      droppedBytes: withPrefixDrop(droppedBytes),
+      reason: "draining",
+    };
   }
-  return { accepted: false, data: "", droppedBytes, reason: "draining" };
+  return {
+    accepted: false,
+    data: "",
+    droppedBytes: withPrefixDrop(droppedBytes),
+    reason: "draining",
+  };
 }
 
 module.exports = {

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -352,3 +352,55 @@ test("does not treat password mentions in ordinary output as prompts", () => {
     { accepted: false, data: "", droppedBytes: 24, reason: "draining" },
   );
 });
+
+test("holds a split Password: prompt across chunks while draining (#2010)", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9001 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Pass", { now: 9002 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "word: ", { now: 9003 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("holds a split [sudo] password prompt across chunks while draining (#2010)", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9100,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9101 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "[sudo] pass", { now: 9102 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "word for alice: ", { now: 9103 }),
+    {
+      accepted: true,
+      data: "[sudo] password for alice: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -218,6 +218,37 @@ test("does not peel preserved restore suffix chars from a later password prefix"
   );
 });
 
+test("does not leak held incomplete SGR CSI into a later shell prompt", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 3950,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  // Incomplete SGR without a password prefix must be dropped, not held into "$ ".
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "old\x1b[31", { now: 3951 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "old\x1b[31".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 4100 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("preserves split alternate-screen exit controls while draining stale output", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -473,6 +473,35 @@ test("holds a password prefix split before a trailing ANSI control while drainin
   );
 });
 
+test("holds a password prefix split mid CSI parameter while draining", () => {
+  const session = {};
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9080,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9081 }).accepted, false);
+  // Incomplete CSI params (ESC[0) must also hold with the password prefix.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `${red}Pass\x1b[0`, { now: 9082 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `mword: `, { now: 9083 }),
+    {
+      accepted: true,
+      data: `${red}Pass${reset}word: `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("holds a split [sudo] password prompt across chunks while draining (#2010)", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -509,3 +509,34 @@ test("holds split password prompts that have leading text before the keyword", (
     },
   );
 });
+
+test("keeps the quiet-gap guard for fresh password-looking lines in the flood", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9800,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "old flood\n", { now: 9801 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Password: ", { now: 9810 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "Password: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 10000 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -187,6 +187,36 @@ test("excludes preserved restore controls from held password prefixes", () => {
   );
 });
 
+test("excludes the last of multiple preserved restores from held password prefixes", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 3855,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "\x1b[?25hstale\n\x1b[?1049lPass", { now: 3856 }),
+    {
+      accepted: true,
+      data: "\x1b[?25h\x1b[?1049l",
+      droppedBytes: "stale\n".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "word: ", { now: 3857 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("does not peel preserved restore suffix chars from a later password prefix", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -381,6 +381,34 @@ test("holds a split Password: prompt across chunks while draining (#2010)", () =
   );
 });
 
+test("holds a split ANSI-colored Password: prompt across chunks while draining", () => {
+  const session = {};
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9050,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9051 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `${red}Pass`, { now: 9052 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `word:${reset} `, { now: 9053 }),
+    {
+      accepted: true,
+      data: `${red}Password:${reset} `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("holds a split [sudo] password prompt across chunks while draining (#2010)", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -187,6 +187,37 @@ test("excludes preserved restore controls from held password prefixes", () => {
   );
 });
 
+test("does not peel preserved restore suffix chars from a later password prefix", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 3860,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  // Preserve restore on its own line; next line "login pass" must keep the "l".
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "\x1b[?1049l\nlogin pass", { now: 3861 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: 1,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "word: ", { now: 3862 }),
+    {
+      accepted: true,
+      data: "login password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("preserves split alternate-screen exit controls while draining stale output", () => {
   const session = {};
 
@@ -549,6 +580,33 @@ test("discards a held password prefix that does not complete as a password promp
       accepted: true,
       data: "$ ",
       droppedBytes: 4,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("discards CSI final bytes when a held mid-CSI password prefix does not complete", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9220,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9221 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Pass\x1b[0", { now: 9222 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  // Discard held prefix and the completing "m" so the shell prompt is clean.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "m$ ", { now: 9400 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: "Pass\x1b[0".length + 1,
       reason: "prompt-gap",
     },
   );

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -411,6 +411,36 @@ test("holds a split ANSI-colored Password: prompt across chunks while draining",
   );
 });
 
+test("holds a password prefix split before a trailing ANSI control while draining", () => {
+  const session = {};
+  const red = "\x1b[31m";
+  const reset = "\x1b[0m";
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9070,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9071 }).accepted, false);
+  // Mid-CSI split: keep both "Pass" and the trailing "\x1b[" so the next chunk
+  // can complete the reset + "word:" into a password prompt.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `${red}Pass\x1b[`, { now: 9072 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, `0mword: `, { now: 9073 }),
+    {
+      accepted: true,
+      data: `${red}Pass${reset}word: `,
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("holds a split [sudo] password prompt across chunks while draining (#2010)", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -772,6 +772,30 @@ test("accepts a fresh one-chunk password prompt before the quiet gap", () => {
   );
 });
 
+test("accepts a last-line password prompt after a large stale prefix", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9820,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+    promptCandidateBytes: 512,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9821 }).accepted, false);
+  const largeChunk = `${"x".repeat(600)}\n[sudo] password for alice: `;
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, largeChunk, { now: 9830 }),
+    {
+      accepted: true,
+      data: "[sudo] password for alice: ",
+      droppedBytes: 601,
+      reason: "password-prompt",
+    },
+  );
+});
+
 test("does not hold short ASCII trailing letters as password prefixes", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -282,3 +282,73 @@ test("keeps draining large chunks after a short quiet gap", () => {
     { accepted: true, data: "$ ", droppedBytes: 0, reason: "prompt-gap" },
   );
 });
+
+test("accepts a sudo password prompt while draining after Ctrl+C (#2010)", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 6000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(
+    filterTerminalInterruptOutput(session, "Reading package lists...\n", { now: 6001 }).accepted,
+    false,
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "[sudo] password for alice: ", { now: 6100 }),
+    {
+      accepted: true,
+      data: "[sudo] password for alice: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("accepts bare and localized password prompts while draining (#2010)", () => {
+  for (const prompt of [
+    "Password: ",
+    "[sudo] alice 的密码：",
+    "输入密码",
+    "Input Password",
+  ]) {
+    const session = {};
+    armTerminalInterruptOutputGate(session, {
+      now: 7000,
+      quietMs: 500,
+      promptQuietMs: 80,
+      maxDrainMs: 2500,
+    });
+    assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 7001 }).accepted, false);
+    assert.deepEqual(
+      filterTerminalInterruptOutput(session, prompt, { now: 7100 }),
+      {
+        accepted: true,
+        data: prompt,
+        droppedBytes: 0,
+        reason: "prompt-gap",
+      },
+      `expected password prompt to resume drain: ${JSON.stringify(prompt)}`,
+    );
+  }
+});
+
+test("does not treat password mentions in ordinary output as prompts", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 8000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 8001 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "the password was changed", { now: 8100 }),
+    { accepted: false, data: "", droppedBytes: 24, reason: "draining" },
+  );
+});

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -541,6 +541,48 @@ test("keeps the quiet-gap guard for fresh password-looking lines in the flood", 
   );
 });
 
+test("does not hold short ASCII trailing letters as password prefixes", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 10000,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 10001 }).accepted, false);
+  // Full-width "password：" must not lower ASCII minLen to 1, or "copy p" is held
+  // and a later "assword:" chunk can bypass quiet-gap.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "copy p", { now: 10002 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "copy p".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "assword: ", { now: 10010 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "assword: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 10200 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("rejects held password-prefix completion across a line break", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -314,6 +314,8 @@ test("accepts bare and localized password prompts while draining (#2010)", () =>
     "[sudo] alice 的密码：",
     "输入密码",
     "Input Password",
+    "用户 的密码",
+    "密码",
   ]) {
     const session = {};
     armTerminalInterruptOutputGate(session, {

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -297,13 +297,15 @@ test("accepts a sudo password prompt while draining after Ctrl+C (#2010)", () =>
     filterTerminalInterruptOutput(session, "Reading package lists...\n", { now: 6001 }).accepted,
     false,
   );
+  // One-chunk password prompts must resume before promptQuietMs — they often
+  // emit nothing further until the user types (#2010 / Codex P1).
   assert.deepEqual(
-    filterTerminalInterruptOutput(session, "[sudo] password for alice: ", { now: 6100 }),
+    filterTerminalInterruptOutput(session, "[sudo] password for alice: ", { now: 6010 }),
     {
       accepted: true,
       data: "[sudo] password for alice: ",
       droppedBytes: 0,
-      reason: "prompt-gap",
+      reason: "password-prompt",
     },
   );
 });
@@ -326,12 +328,12 @@ test("accepts bare and localized password prompts while draining (#2010)", () =>
     });
     assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 7001 }).accepted, false);
     assert.deepEqual(
-      filterTerminalInterruptOutput(session, prompt, { now: 7100 }),
+      filterTerminalInterruptOutput(session, prompt, { now: 7010 }),
       {
         accepted: true,
         data: prompt,
         droppedBytes: 0,
-        reason: "prompt-gap",
+        reason: "password-prompt",
       },
       `expected password prompt to resume drain: ${JSON.stringify(prompt)}`,
     );
@@ -538,7 +540,7 @@ test("holds split password prompts that have leading text before the keyword", (
   );
 });
 
-test("keeps the quiet-gap guard for fresh password-looking lines in the flood", () => {
+test("accepts a fresh one-chunk password prompt before the quiet gap", () => {
   const session = {};
 
   armTerminalInterruptOutputGate(session, {
@@ -552,19 +554,10 @@ test("keeps the quiet-gap guard for fresh password-looking lines in the flood", 
   assert.deepEqual(
     filterTerminalInterruptOutput(session, "Password: ", { now: 9810 }),
     {
-      accepted: false,
-      data: "",
-      droppedBytes: "Password: ".length,
-      reason: "draining",
-    },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptOutput(session, "$ ", { now: 10000 }),
-    {
       accepted: true,
-      data: "$ ",
+      data: "Password: ",
       droppedBytes: 0,
-      reason: "prompt-gap",
+      reason: "password-prompt",
     },
   );
 });
@@ -626,24 +619,15 @@ test("rejects held password-prefix completion across a line break", () => {
     filterTerminalInterruptOutput(session, "Pass", { now: 9902 }),
     { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
   );
-  // A newline before Password: means a fresh flood line, not a same-line
-  // completion of the held "Pass" prefix — keep quiet-gap.
+  // A newline before Password: discards the held "Pass" prefix (not a same-line
+  // completion), but the fresh complete password line is still preserved.
   assert.deepEqual(
     filterTerminalInterruptOutput(session, "\nPassword: ", { now: 9910 }),
     {
-      accepted: false,
-      data: "",
-      droppedBytes: 4 + "\nPassword: ".length,
-      reason: "draining",
-    },
-  );
-  assert.deepEqual(
-    filterTerminalInterruptOutput(session, "$ ", { now: 10100 }),
-    {
       accepted: true,
-      data: "$ ",
-      droppedBytes: 0,
-      reason: "prompt-gap",
+      data: "Password: ",
+      droppedBytes: 4 + 1,
+      reason: "password-prompt",
     },
   );
 });

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -463,3 +463,49 @@ test("does not hold ordinary password-related output as a prompt prefix", () => 
     },
   );
 });
+
+test("holds split password prompts that have leading text before the keyword", () => {
+  const ssh = {};
+  armTerminalInterruptOutputGate(ssh, {
+    now: 9600,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+  assert.equal(filterTerminalInterruptOutput(ssh, "stale\n", { now: 9601 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(ssh, "alice@host's pass", { now: 9602 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(ssh, "word: ", { now: 9603 }),
+    {
+      accepted: true,
+      data: "alice@host's password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+
+  const kylin = {};
+  armTerminalInterruptOutputGate(kylin, {
+    now: 9700,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+  assert.equal(filterTerminalInterruptOutput(kylin, "stale\n", { now: 9701 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(kylin, "用户 的密", { now: 9702 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(kylin, "码", { now: 9703 }),
+    {
+      accepted: true,
+      data: "用户 的密码",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -155,6 +155,38 @@ test("preserves alternate-screen exit controls while draining stale output", () 
   );
 });
 
+test("excludes preserved restore controls from held password prefixes", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 3850,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  // Restore sequence is preserved once; password prefix hold must not re-count
+  // it, or stale bytes report as 0 dropped and the restore is re-emitted.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "stale\n\x1b[?1049lPass", { now: 3851 }),
+    {
+      accepted: true,
+      data: "\x1b[?1049l",
+      droppedBytes: "stale\n".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "word: ", { now: 3852 }),
+    {
+      accepted: true,
+      data: "Password: ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});
+
 test("preserves split alternate-screen exit controls while draining stale output", () => {
   const session = {};
 

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -540,3 +540,40 @@ test("keeps the quiet-gap guard for fresh password-looking lines in the flood", 
     },
   );
 });
+
+test("rejects held password-prefix completion across a line break", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9900,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9901 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Pass", { now: 9902 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  // A newline before Password: means a fresh flood line, not a same-line
+  // completion of the held "Pass" prefix — keep quiet-gap.
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "\nPassword: ", { now: 9910 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: 4 + "\nPassword: ".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 10100 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -425,6 +425,37 @@ test("discards a held password prefix that does not complete as a password promp
     {
       accepted: true,
       data: "$ ",
+      droppedBytes: 4,
+      reason: "prompt-gap",
+    },
+  );
+});
+
+test("does not hold ordinary password-related output as a prompt prefix", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9300,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9301 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Password authentication failed", { now: 9302 }),
+    {
+      accepted: false,
+      data: "",
+      droppedBytes: "Password authentication failed".length,
+      reason: "draining",
+    },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 9500 }),
+    {
+      accepted: true,
+      data: "$ ",
       droppedBytes: 0,
       reason: "prompt-gap",
     },

--- a/electron/bridges/terminalInterruptOutputGate.test.cjs
+++ b/electron/bridges/terminalInterruptOutputGate.test.cjs
@@ -404,3 +404,29 @@ test("holds a split [sudo] password prompt across chunks while draining (#2010)"
     },
   );
 });
+
+test("discards a held password prefix that does not complete as a password prompt", () => {
+  const session = {};
+
+  armTerminalInterruptOutputGate(session, {
+    now: 9200,
+    quietMs: 500,
+    promptQuietMs: 80,
+    maxDrainMs: 2500,
+  });
+
+  assert.equal(filterTerminalInterruptOutput(session, "stale\n", { now: 9201 }).accepted, false);
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "Pass", { now: 9202 }),
+    { accepted: false, data: "", droppedBytes: 0, reason: "draining" },
+  );
+  assert.deepEqual(
+    filterTerminalInterruptOutput(session, "$ ", { now: 9400 }),
+    {
+      accepted: true,
+      data: "$ ",
+      droppedBytes: 0,
+      reason: "prompt-gap",
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Ctrl+C interrupt output gates only resumed on shell-style prompts (`$` / `#` / `user@host:~$`), so a sudo/password prompt arriving in the quiet drain window was dropped as stale flood.
- That left the remote waiting for a password while the terminal showed nothing — matching [#2010](https://github.com/binaricat/Netcatty/issues/2010).
- Treat sudo/password prompts (including localized / Kylin-style forms) as resume points on both the main-process and renderer gates, with regression tests.

## Test plan
- [x] `node --test electron/bridges/terminalInterruptOutputGate.test.cjs`
- [x] `node --test --import tsx components/terminal/runtime/terminalOutputPipeline.test.ts`
- [ ] Manual: SSH session → flood output → Ctrl+C → immediately run `sudo -k true` / `sudo whoami` and confirm `[sudo] password for …:` is visible
- [ ] Manual: same path with Chinese locale / Kylin-style `输入密码` if available


Made with [Cursor](https://cursor.com)