### PR TITLE
fix: let script waits match the visible startup screen

### DIFF
--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -269,35 +269,42 @@ function showWaitForTimeoutDialog(pattern, timeoutMs) {
 async function syncOutputBufferFromSnapshot(sessionId) {
   const buffer = getOrCreateBuffer(sessionId);
   const syncStartText = buffer.getText();
-  let consumedLength = syncStartText.length;
   try {
     const snapshot = await requestScreenSnapshot(sessionId);
     const screenText = (snapshot.lines || []).join("\n");
-    if (!screenText) return;
-    if (buffer.getText() !== syncStartText) return;
-    const existing = buffer.getText();
-    if (!existing) {
-      buffer.append(screenText.endsWith("\n") ? screenText : `${screenText}\n`);
-      consumedLength = buffer.getText().length;
+    if (!screenText) {
+      // Blank viewport: ignore prior scrollback so waits only see new output.
+      buffer.markOutputConsumedThrough(buffer.getText().length, {
+        preserveTailPatterns: shellPromptPatterns(),
+      });
       return;
     }
-    const tail = screenText.slice(-8192);
-    if (!tail) return;
-    const existingTail = existing.slice(-8192);
-    if (tail === existingTail || existing.endsWith(tail)) return;
-    if (existingTail && tail.includes(existingTail)) {
-      buffer.append(tail.slice(tail.indexOf(existingTail) + existingTail.length));
-      consumedLength = buffer.getText().length;
+
+    const currentText = buffer.getText();
+    if (currentText !== syncStartText) {
+      // Output arrived while the snapshot was in flight — keep that fresh
+      // tail matchable, but do not rematch pre-sync scrollback.
+      buffer.markOutputConsumedThrough(syncStartText.length, {
+        preserveTailPatterns: shellPromptPatterns(),
+      });
       return;
     }
-    if (!existing.includes(tail.trim())) {
-      buffer.append(tail.startsWith("\n") ? tail : `\n${tail}`);
-      consumedLength = buffer.getText().length;
-    }
+
+    // Replace the script buffer with the current visible screen. Auto-login
+    // and menu scripts need to waitFor text that is already on screen
+    // (e.g. bastion "SSH资源" near the top of a multi-line menu). Marking the
+    // whole buffer consumed made those waits time out (#1960). Using only the
+    // viewport also avoids rematching older scrollback that has left the screen.
+    const normalized = screenText.endsWith("\n") ? screenText : `${screenText}\n`;
+    buffer.clear();
+    buffer.append(normalized);
   } catch {
-    // Keep startup synchronization best-effort; the current buffer is still baselined below.
-  } finally {
-    buffer.markOutputConsumedThrough(consumedLength, { preserveTailPatterns: shellPromptPatterns() });
+    // Snapshot failed: baseline existing buffer so waits require new output.
+    if (buffer.getText() === syncStartText) {
+      buffer.markOutputConsumedThrough(syncStartText.length, {
+        preserveTailPatterns: shellPromptPatterns(),
+      });
+    }
   }
 }
 

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -300,7 +300,7 @@ async function syncOutputBufferFromSnapshot(sessionId) {
     const trailingFresh = currentText.startsWith(syncStartText)
       ? currentText.slice(syncStartText.length)
       : "";
-    buffer.replaceWithVisibleScreen(screenText, trailingFresh);
+    buffer.replaceWithVisibleScreen(screenText, trailingFresh, syncStartText);
   } catch {
     // Snapshot failed: baseline existing buffer so waits require new output.
     if (buffer.getText() === syncStartText) {

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -280,9 +280,11 @@ async function syncOutputBufferFromSnapshot(sessionId) {
 
     // Buffer-fallback snapshots are the full script output/scrollback, not the
     // visible viewport. Seeding them as waitable would rematch scrolled-off
-    // text (#1821). Keep the consumed baseline for that path.
+    // text (#1821). Keep the consumed baseline for that path — but only through
+    // the pre-sync length so bytes that arrived during the await stay fresh
+    // (same trailingFresh idea as the viewport path).
     if (!isViewportSnapshot(snapshot) || !screenText) {
-      buffer.markOutputConsumedThrough(buffer.getText().length, {
+      buffer.markOutputConsumedThrough(syncStartText.length, {
         preserveTailPatterns: shellPromptPatterns(),
       });
       return;

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -176,6 +176,9 @@ function writeToSession(sessionId, data, options = {}) {
     );
   }
   if (options.automated !== false && data && data !== "\x03") {
+    // Sending a command means later waits must observe post-input output, not
+    // the startup viewport / preserved prompt that was seeded for #1960.
+    getOrCreateBuffer(sessionId).invalidateStartupSeed();
     notifyScriptSessionInput(sessionId, data);
   }
 }

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -180,30 +180,35 @@ function writeToSession(sessionId, data, options = {}) {
   }
 }
 
+function bufferFallbackSnapshot(sessionId) {
+  return {
+    rows: 24,
+    cols: 80,
+    currentRow: 0,
+    lines: getOrCreateBuffer(sessionId).getText().split("\n"),
+    // Not a real terminal viewport — full script buffer / scrollback only.
+    source: "buffer-fallback",
+  };
+}
+
+function isViewportSnapshot(snapshot) {
+  return snapshot?.source !== "buffer-fallback";
+}
+
 async function requestScreenSnapshot(sessionId) {
   const session = sessions?.get(sessionId);
   const webContents = session?.webContentsId
     ? electronModule.webContents.fromId(session.webContentsId)
     : getMainWindow?.()?.webContents;
   if (!webContents) {
-    return {
-      rows: 24,
-      cols: 80,
-      currentRow: 0,
-      lines: getOrCreateBuffer(sessionId).getText().split("\n"),
-    };
+    return bufferFallbackSnapshot(sessionId);
   }
 
   const requestId = randomUUID();
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       pendingScreenSnapshots.delete(requestId);
-      resolve({
-        rows: 24,
-        cols: 80,
-        currentRow: 0,
-        lines: getOrCreateBuffer(sessionId).getText().split("\n"),
-      });
+      resolve(bufferFallbackSnapshot(sessionId));
     }, 3000);
     pendingScreenSnapshots.set(requestId, {
       sessionId,
@@ -272,8 +277,11 @@ async function syncOutputBufferFromSnapshot(sessionId) {
   try {
     const snapshot = await requestScreenSnapshot(sessionId);
     const screenText = (snapshot.lines || []).join("\n");
-    if (!screenText) {
-      // Blank viewport: ignore prior scrollback so waits only see new output.
+
+    // Buffer-fallback snapshots are the full script output/scrollback, not the
+    // visible viewport. Seeding them as waitable would rematch scrolled-off
+    // text (#1821). Keep the consumed baseline for that path.
+    if (!isViewportSnapshot(snapshot) || !screenText) {
       buffer.markOutputConsumedThrough(buffer.getText().length, {
         preserveTailPatterns: shellPromptPatterns(),
       });
@@ -536,12 +544,7 @@ function handleScriptScreenSnapshotResponse(_event, payload = {}) {
   const pending = pendingScreenSnapshots.get(payload.requestId);
   if (!pending) return { ok: false };
   pendingScreenSnapshots.delete(payload.requestId);
-  pending.resolve(payload.snapshot || {
-    rows: 24,
-    cols: 80,
-    currentRow: 0,
-    lines: getOrCreateBuffer(pending.sessionId).getText().split("\n"),
-  });
+  pending.resolve(payload.snapshot || bufferFallbackSnapshot(pending.sessionId));
   return { ok: true };
 }
 

--- a/electron/bridges/scriptBridge.cjs
+++ b/electron/bridges/scriptBridge.cjs
@@ -280,24 +280,17 @@ async function syncOutputBufferFromSnapshot(sessionId) {
       return;
     }
 
+    // Seed the script buffer from the current visible screen so waits can match
+    // text already on screen (e.g. bastion "SSH资源" near the top of a long menu).
+    // Marking the whole buffer consumed made those waits time out (#1960).
+    // If live output arrived during the snapshot IPC round-trip (BEL keepalives,
+    // etc.), keep that trailing fresh data after the viewport instead of
+    // discarding the snapshot.
     const currentText = buffer.getText();
-    if (currentText !== syncStartText) {
-      // Output arrived while the snapshot was in flight — keep that fresh
-      // tail matchable, but do not rematch pre-sync scrollback.
-      buffer.markOutputConsumedThrough(syncStartText.length, {
-        preserveTailPatterns: shellPromptPatterns(),
-      });
-      return;
-    }
-
-    // Replace the script buffer with the current visible screen. Auto-login
-    // and menu scripts need to waitFor text that is already on screen
-    // (e.g. bastion "SSH资源" near the top of a multi-line menu). Marking the
-    // whole buffer consumed made those waits time out (#1960). Using only the
-    // viewport also avoids rematching older scrollback that has left the screen.
-    const normalized = screenText.endsWith("\n") ? screenText : `${screenText}\n`;
-    buffer.clear();
-    buffer.append(normalized);
+    const trailingFresh = currentText.startsWith(syncStartText)
+      ? currentText.slice(syncStartText.length)
+      : "";
+    buffer.replaceWithVisibleScreen(screenText, trailingFresh);
   } catch {
     // Snapshot failed: baseline existing buffer so waits require new output.
     if (buffer.getText() === syncStartText) {

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -591,6 +591,78 @@ test("script waitFor ignores keywords that have scrolled off the visible screen"
   scriptBridge.removeSessionBuffer(sessionId);
 });
 
+test("script waitFor does not seed buffer-fallback scrollback as visible screen", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-buffer-fallback-scrollback";
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  // When the session's webContents is missing, requestScreenSnapshot falls back
+  // to the full script buffer. That must stay consumed so scrolled-off keywords
+  // do not rematch (#1821 / Codex review on #2035).
+  scriptBridge.appendSessionOutput(sessionId, "old deployment READY marker\nuser@host:~$ \n");
+  scriptBridge.init({
+    sessions: new Map([
+      [sessionId, { webContentsId: 999 }],
+    ]),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "buffer-fallback",
+    scriptLabel: "Buffer fallback",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitFor('READY', 1000);
+      nct.log('matched ' + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(50);
+  const earlyRun = sentRunUpdates.at(-1)?.find((run) => run.scriptId === "buffer-fallback");
+  assert.notEqual(earlyRun?.status, "completed");
+  assert.doesNotMatch(
+    (earlyRun?.logs || []).map((entry) => entry.message).join("\n"),
+    /matched READY/,
+  );
+
+  scriptBridge.appendSessionOutput(sessionId, "fresh READY\n");
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "buffer-fallback");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
 test("script waitForRegex matches bastion menu already on screen at script start", async () => {
   const handlers = new Map();
   const sentRunUpdates = [];

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -442,12 +442,14 @@ test("script run treats cancelled form dialogs as script failures", async () => 
   scriptBridge.removeSessionBuffer(sessionId);
 });
 
-test("script waitFor ignores keywords from the startup screen snapshot until new output arrives", async () => {
+test("script waitFor matches text already visible on the startup screen", async () => {
   const handlers = new Map();
   const sentRunUpdates = [];
-  const sessionId = "session-stale-startup-output";
+  const sessionId = "session-visible-startup-output";
 
   scriptBridge.removeSessionBuffer(sessionId);
+  // Prior scrollback that has left the viewport must not rematch.
+  scriptBridge.appendSessionOutput(sessionId, "scrolled-off READY marker\n");
   scriptBridge.init({
     sessions: new Map(),
     electronModule: {
@@ -479,7 +481,7 @@ test("script waitFor ignores keywords from the startup screen snapshot until new
                   cols: 80,
                   currentRow: 1,
                   lines: [
-                    "old deployment READY marker",
+                    "visible READY marker",
                     "user@host:~$ ",
                   ],
                 },
@@ -496,9 +498,9 @@ test("script waitFor ignores keywords from the startup screen snapshot until new
     },
   });
 
-  const runPromise = handlers.get("netcatty:script:run")({}, {
-    scriptId: "stale-output",
-    scriptLabel: "Stale output",
+  await handlers.get("netcatty:script:run")({}, {
+    scriptId: "visible-output",
+    scriptLabel: "Visible output",
     sessionId,
     content: `
       const value = await nct.screen.waitFor('READY', 1000);
@@ -507,20 +509,174 @@ test("script waitFor ignores keywords from the startup screen snapshot until new
     permissionMode: "auto",
   });
 
-  await delay(50);
-  const earlyRun = sentRunUpdates.at(-1)?.find((run) => run.scriptId === "stale-output");
-  assert.notEqual(earlyRun?.status, "completed");
-  assert.doesNotMatch(
-    (earlyRun?.logs || []).map((entry) => entry.message).join("\n"),
-    /matched READY/,
-  );
-
-  scriptBridge.appendSessionOutput(sessionId, "fresh READY\n");
-  await runPromise;
-
-  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "stale-output");
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "visible-output");
   assert.equal(finalRun.status, "completed");
   assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
+test("script waitFor ignores keywords that have scrolled off the visible screen", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-scrolled-off-startup-output";
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.appendSessionOutput(sessionId, "old deployment READY marker\nuser@host:~$ \n");
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:screen-snapshot-response")({}, {
+                requestId: payload.requestId,
+                snapshot: {
+                  rows: 24,
+                  cols: 80,
+                  currentRow: 0,
+                  lines: ["user@host:~$ "],
+                },
+              });
+            });
+          }
+          if (channel === "netcatty:script:dialog-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:dialog-response")({}, {
+                requestId: payload.requestId,
+                value: "abort",
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  await handlers.get("netcatty:script:run")({}, {
+    scriptId: "scrolled-off-output",
+    scriptLabel: "Scrolled off output",
+    sessionId,
+    content: `
+      await nct.screen.waitFor('READY', 200);
+    `,
+    permissionMode: "auto",
+  });
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "scrolled-off-output");
+  assert.equal(finalRun.status, "failed");
+  assert.match(String(finalRun.error || ""), /timed out|stopped/i);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
+test("script waitForRegex matches bastion menu already on screen at script start", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-bastion-menu-startup";
+  const menuLines = [
+    "Welcome to SSHD",
+    "",
+    "user login success",
+    "",
+    "SSH资源(5) :",
+    "  [1] [Empty]@192.168.233.11  (联通助理自研NLP01) ",
+    "  [2] [Empty]@192.168.238.34  (192.168.238.34) ",
+    "  [3] [Empty]@192.168.242.11  (192.168.242.11) ",
+    "  [4] [Empty]@192.168.80.18",
+    "  [5] [Empty]@192.168.80.19",
+    "",
+    "Telnet资源(0) :",
+    "",
+    "Rlogin资源(0) :",
+    "",
+    "操作命令:",
+    "[l] 显示SSH资源列表",
+    "[e] 退出",
+  ];
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.appendSessionOutput(sessionId, `${menuLines.join("\n")}\n`);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:screen-snapshot-response")({}, {
+                requestId: payload.requestId,
+                snapshot: {
+                  rows: 24,
+                  cols: 80,
+                  currentRow: menuLines.length - 1,
+                  lines: menuLines,
+                },
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  await handlers.get("netcatty:script:run")({}, {
+    scriptId: "bastion-menu",
+    scriptLabel: "Bastion menu",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitForRegex("SSH资源\\\\s*\\\\(\\\\d+\\\\)\\\\s*:", 1000);
+      nct.log("matched " + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "bastion-menu");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched SSH资源\(5\) :/);
   scriptBridge.removeSessionBuffer(sessionId);
 });
 

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -1078,3 +1078,99 @@ test("script waitForPrompt can still use the current startup prompt", async () =
   assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /prompt index/);
   scriptBridge.removeSessionBuffer(sessionId);
 });
+
+test("script sendLine invalidates startup seed before later waits", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-send-invalidates-seed";
+  const writes = [];
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession(_event, payload) {
+        writes.push(payload.data);
+      },
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:screen-snapshot-response")({}, {
+                requestId: payload.requestId,
+                snapshot: {
+                  rows: 24,
+                  cols: 80,
+                  currentRow: 0,
+                  lines: ["root@host:~# ", "old READY"],
+                },
+              });
+            });
+          }
+          if (channel === "netcatty:script:dialog-request") {
+            setImmediate(() => {
+              handlers.get("netcatty:script:dialog-response")({}, {
+                requestId: payload.requestId,
+                value: "abort",
+              });
+            });
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "send-invalidates-seed",
+    scriptLabel: "Send invalidates seed",
+    sessionId,
+    content: `
+      await nct.screen.sendLine('echo hi');
+      const prompt = await nct.screen.waitForPrompt(1000);
+      nct.log('prompt ' + prompt);
+      const value = await nct.screen.waitForText('READY', 1000);
+      nct.log('matched ' + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(40);
+  assert.ok(writes.some((data) => String(data).includes("echo hi")));
+
+  // Startup seed must be gone: waits should not resolve on old READY / old prompt.
+  await delay(80);
+  const midRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "send-invalidates-seed");
+  assert.equal(midRun.status, "running");
+
+  // Prompt first, then post-command READY — matching the common send-then-wait flow.
+  scriptBridge.appendSessionOutput(sessionId, "\necho hi\nroot@host:~# \nfresh READY\n");
+
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "send-invalidates-seed");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /prompt 0/);
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -595,6 +595,8 @@ test("script waitForRegex matches bastion menu already on screen at script start
   const handlers = new Map();
   const sentRunUpdates = [];
   const sessionId = "session-bastion-menu-startup";
+  // Keep the header near the top and pad past the 512-byte freshness slack so
+  // the whole seeded viewport must stay waitable (#1960 / Codex review).
   const menuLines = [
     "Welcome to SSHD",
     "",
@@ -613,8 +615,17 @@ test("script waitForRegex matches bastion menu already on screen at script start
     "",
     "操作命令:",
     "[l] 显示SSH资源列表",
+    "[i] 显示Telnet资源列表",
+    "[r] 显示Rlogin资源列表",
+    "[s] 搜索资源，根据IP/name/account/label",
+    "[k] 显示历史会话列表",
+    "[x] English",
+    "[n] encoding UTF8",
+    "[h] 显示帮助",
     "[e] 退出",
+    ...Array.from({ length: 20 }, (_, i) => `  filler line ${i} ${"x".repeat(24)}`),
   ];
+  assert.ok(menuLines.join("\n").length > 512);
 
   scriptBridge.removeSessionBuffer(sessionId);
   scriptBridge.appendSessionOutput(sessionId, `${menuLines.join("\n")}\n`);
@@ -645,7 +656,7 @@ test("script waitForRegex matches bastion menu already on screen at script start
               handlers.get("netcatty:script:screen-snapshot-response")({}, {
                 requestId: payload.requestId,
                 snapshot: {
-                  rows: 24,
+                  rows: 40,
                   cols: 80,
                   currentRow: menuLines.length - 1,
                   lines: menuLines,
@@ -675,6 +686,95 @@ test("script waitForRegex matches bastion menu already on screen at script start
   });
 
   const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "bastion-menu");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched SSH资源\(5\) :/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
+test("script waitForRegex keeps visible menu when BEL arrives during startup snapshot sync", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-bastion-menu-bel-during-sync";
+  const menuLines = [
+    "Welcome to SSHD",
+    "",
+    "user login success",
+    "",
+    "SSH资源(5) :",
+    "  [1] [Empty]@192.168.233.11",
+    "  [2] [Empty]@192.168.238.34",
+    "  [3] [Empty]@192.168.242.11",
+    ...Array.from({ length: 25 }, (_, i) => `  filler ${i} ${"y".repeat(20)}`),
+  ];
+  assert.ok(menuLines.join("\n").length > 512);
+  let snapshotRequestId;
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.appendSessionOutput(sessionId, `${menuLines.join("\n")}\n`);
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            snapshotRequestId = payload.requestId;
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "bastion-bel",
+    scriptLabel: "Bastion BEL during sync",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitForRegex("SSH资源\\\\s*\\\\(\\\\d+\\\\)\\\\s*:", 1000);
+      nct.log("matched " + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(20);
+  assert.ok(snapshotRequestId);
+  // Bastion keepalives / BEL can land while the snapshot IPC is in flight.
+  scriptBridge.appendSessionOutput(sessionId, "\x07");
+  scriptBridge.appendSessionOutput(sessionId, "\x07");
+  handlers.get("netcatty:script:screen-snapshot-response")({}, {
+    requestId: snapshotRequestId,
+    snapshot: {
+      rows: 40,
+      cols: 80,
+      currentRow: menuLines.length - 1,
+      lines: menuLines,
+    },
+  });
+
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "bastion-bel");
   assert.equal(finalRun.status, "completed");
   assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched SSH资源\(5\) :/);
   scriptBridge.removeSessionBuffer(sessionId);

--- a/electron/bridges/scriptBridge.test.cjs
+++ b/electron/bridges/scriptBridge.test.cjs
@@ -663,6 +663,83 @@ test("script waitFor does not seed buffer-fallback scrollback as visible screen"
   scriptBridge.removeSessionBuffer(sessionId);
 });
 
+test("script waitFor keeps output that arrives during empty/fallback snapshot sync", async () => {
+  const handlers = new Map();
+  const sentRunUpdates = [];
+  const sessionId = "session-output-during-empty-snapshot";
+  let snapshotRequestId;
+
+  scriptBridge.removeSessionBuffer(sessionId);
+  scriptBridge.appendSessionOutput(sessionId, "old scrollback without keyword\n");
+  scriptBridge.init({
+    sessions: new Map(),
+    electronModule: {
+      app: {
+        getVersion: () => "test",
+        getPath: () => process.cwd(),
+      },
+      webContents: {
+        fromId: () => null,
+      },
+    },
+    terminalBridge: {
+      writeToSession() {},
+    },
+    terminalWorkerManager: null,
+    getMainWindow: () => ({
+      webContents: {
+        id: 1,
+        send(channel, payload) {
+          if (channel === "netcatty:script:runs-updated") {
+            sentRunUpdates.push(payload.runs);
+          }
+          if (channel === "netcatty:script:screen-snapshot-request") {
+            snapshotRequestId = payload.requestId;
+          }
+        },
+      },
+    }),
+  });
+  scriptBridge.registerHandlers({
+    handle(channel, handler) {
+      handlers.set(channel, handler);
+    },
+  });
+
+  const runPromise = handlers.get("netcatty:script:run")({}, {
+    scriptId: "empty-snapshot-race",
+    scriptLabel: "Empty snapshot race",
+    sessionId,
+    content: `
+      const value = await nct.screen.waitFor('READY', 1000);
+      nct.log('matched ' + value);
+    `,
+    permissionMode: "auto",
+  });
+
+  await delay(20);
+  assert.ok(snapshotRequestId);
+  // Live output during the snapshot wait must stay matchable even when the
+  // snapshot is empty / falls through to the consumed-baseline path.
+  scriptBridge.appendSessionOutput(sessionId, "fresh READY\n");
+  handlers.get("netcatty:script:screen-snapshot-response")({}, {
+    requestId: snapshotRequestId,
+    snapshot: {
+      rows: 24,
+      cols: 80,
+      currentRow: 0,
+      lines: [],
+    },
+  });
+
+  await runPromise;
+
+  const finalRun = sentRunUpdates.at(-1).find((run) => run.scriptId === "empty-snapshot-race");
+  assert.equal(finalRun.status, "completed");
+  assert.match(finalRun.logs.map((entry) => entry.message).join("\n"), /matched READY/);
+  scriptBridge.removeSessionBuffer(sessionId);
+});
+
 test("script waitForRegex matches bastion menu already on screen at script start", async () => {
   const handlers = new Map();
   const sentRunUpdates = [];

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -10,6 +10,36 @@ function isFreshTailMatch(textLength, matchEndAbsolute) {
   return matchEndAbsolute >= textLength - FRESH_MATCH_TAIL_SLACK;
 }
 
+function stripTrailingBlankLines(text) {
+  return String(text || "").replace(/(?:[ \t]*\r?\n)*$/u, "");
+}
+
+/**
+ * Drop any prefix of trailingFresh that the viewport snapshot already shows.
+ * Handles blank-padded full-viewport snapshots and partial overlaps where the
+ * snapshot captured only the start of the sync-race bytes.
+ */
+function trimOverlappingTrailingFresh(viewportText, trailingFresh) {
+  const trailing = String(trailingFresh || "");
+  if (!trailing) return "";
+  const viewport = String(viewportText || "");
+  const viewportCore = stripTrailingBlankLines(viewport);
+  const trailingCore = stripTrailingBlankLines(trailing);
+  if (
+    viewport.endsWith(trailing)
+    || (trailingCore && viewportCore.endsWith(trailingCore))
+  ) {
+    return "";
+  }
+  const max = Math.min(viewportCore.length, trailing.length);
+  for (let len = max; len > 0; len -= 1) {
+    if (viewportCore.endsWith(trailing.slice(0, len))) {
+      return trailing.slice(len);
+    }
+  }
+  return trailing;
+}
+
 function isRegExpLike(pattern) {
   return Boolean(
     pattern
@@ -341,21 +371,10 @@ class SessionOutputBuffer {
     const normalized = String(screenText || "").endsWith("\n")
       ? String(screenText || "")
       : `${String(screenText || "")}\n`;
-    let trailing = String(trailingFresh || "");
     // Snapshot and live taps can both observe the same suffix. Full-viewport
-    // snapshots often pad with blank rows after the live content, so a plain
-    // endsWith check misses duplicates — also compare after stripping trailing
-    // blank lines.
-    if (trailing) {
-      const trailingCore = trailing.replace(/(?:[ \t]*\r?\n)*$/u, "");
-      const viewportCore = normalized.replace(/(?:[ \t]*\r?\n)*$/u, "");
-      if (
-        normalized.endsWith(trailing)
-        || (trailingCore && viewportCore.endsWith(trailingCore))
-      ) {
-        trailing = "";
-      }
-    }
+    // snapshots often pad with blank rows, and the snapshot may only include a
+    // prefix of trailingFresh — trim any overlapping prefix before appending.
+    const trailing = trimOverlappingTrailingFresh(normalized, trailingFresh);
     this.clear();
     this.append(normalized);
     // Seed only the visible viewport — not sync-race trailing bytes.

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -18,25 +18,44 @@ function stripTrailingBlankLines(text) {
  * Drop any prefix of trailingFresh that the viewport snapshot already shows.
  * Handles blank-padded full-viewport snapshots and partial overlaps where the
  * snapshot captured only the start of the sync-race bytes.
+ *
+ * `syncStartText` is the live buffer at snapshot-request time. When the
+ * viewport still matches that pre-sync content, trailingFresh is genuinely new
+ * even if it happens to equal the visible suffix (e.g. a second READY).
  */
-function trimOverlappingTrailingFresh(viewportText, trailingFresh) {
+function trimOverlappingTrailingFresh(viewportText, trailingFresh, syncStartText = "") {
   const trailing = String(trailingFresh || "");
   if (!trailing) return "";
   const viewport = String(viewportText || "");
   const viewportCore = stripTrailingBlankLines(viewport);
   const trailingCore = stripTrailingBlankLines(trailing);
+  const syncCore = stripTrailingBlankLines(syncStartText);
+
+  // Stale snapshot: still showing pre-sync content → keep all trailingFresh.
+  if (syncCore && viewportCore === syncCore) {
+    return trailing;
+  }
+
   if (
     viewport.endsWith(trailing)
     || (trailingCore && viewportCore.endsWith(trailingCore))
   ) {
     return "";
   }
-  // Prefer the full viewport for partial overlap so a trailing newline that is
-  // part of the overlapped text is not left behind as a phantom blank line.
-  const max = Math.min(viewport.length, trailing.length);
-  for (let len = max; len > 0; len -= 1) {
-    if (viewport.endsWith(trailing.slice(0, len))) {
-      return trailing.slice(len);
+
+  // Partial overlap: prefer the unpadded core so blank-padded snapshots still
+  // trim, then fall back to the full viewport for newline-accurate matches.
+  const candidates = [viewportCore, viewport].filter(Boolean);
+  for (const candidate of candidates) {
+    const max = Math.min(candidate.length, trailing.length);
+    for (let len = max; len > 0; len -= 1) {
+      if (!candidate.endsWith(trailing.slice(0, len))) continue;
+      let remainder = trailing.slice(len);
+      // Avoid turning blank padding + overlapped newline into an extra blank.
+      while (remainder.startsWith("\n") && viewport.endsWith("\n")) {
+        remainder = remainder.slice(1);
+      }
+      return remainder;
     }
   }
   return trailing;
@@ -376,14 +395,14 @@ class SessionOutputBuffer {
    * window. `trailingFresh` (bytes that arrived during snapshot sync) stays
    * outside seededLength so consuming a startup prompt does not discard it.
    */
-  replaceWithVisibleScreen(screenText, trailingFresh = "") {
+  replaceWithVisibleScreen(screenText, trailingFresh = "", syncStartText = "") {
     const normalized = String(screenText || "").endsWith("\n")
       ? String(screenText || "")
       : `${String(screenText || "")}\n`;
     // Snapshot and live taps can both observe the same suffix. Full-viewport
     // snapshots often pad with blank rows, and the snapshot may only include a
     // prefix of trailingFresh — trim any overlapping prefix before appending.
-    const trailing = trimOverlappingTrailingFresh(normalized, trailingFresh);
+    const trailing = trimOverlappingTrailingFresh(normalized, trailingFresh, syncStartText);
     this.clear();
     this.append(normalized);
     // Seed only the visible viewport — not sync-race trailing bytes.

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -251,6 +251,8 @@ class SessionOutputBuffer {
     this.scanOffset = 0;
     this.waiters = [];
     this.preservedTailMatch = null;
+    /** @type {number | null} Absolute end of a seeded visible viewport that stays fully waitable. */
+    this.seededLength = null;
   }
 
   append(data) {
@@ -263,6 +265,9 @@ class SessionOutputBuffer {
       const removedLength = removed.length;
       this.totalLength -= removedLength;
       this.scanOffset = Math.max(0, this.scanOffset - removedLength);
+      if (typeof this.seededLength === "number") {
+        this.seededLength = Math.max(0, this.seededLength - removedLength);
+      }
       for (const waiter of this.waiters) {
         if (typeof waiter.freshBoundary === "number") {
           waiter.freshBoundary = Math.max(0, waiter.freshBoundary - removedLength);
@@ -296,7 +301,38 @@ class SessionOutputBuffer {
   }
 
   currentFreshBoundary() {
-    return Math.max(this.scanOffset, this.getText().length - FRESH_MATCH_TAIL_SLACK);
+    const textLength = this.getText().length;
+    const normalBoundary = Math.max(this.scanOffset, textLength - FRESH_MATCH_TAIL_SLACK);
+    if (typeof this.seededLength === "number" && this.scanOffset < this.seededLength) {
+      // Startup viewport rows must all be waitable, even when the visible screen
+      // is longer than FRESH_MATCH_TAIL_SLACK (bastion menus, etc.).
+      return this.scanOffset;
+    }
+    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+      this.seededLength = null;
+    }
+    return normalBoundary;
+  }
+
+  /**
+   * Replace buffer contents with the current visible terminal screen.
+   * The entire seeded viewport is treated as fresh for waitFor* matching.
+   */
+  replaceWithVisibleScreen(screenText, trailingFresh = "") {
+    const normalized = String(screenText || "").endsWith("\n")
+      ? String(screenText || "")
+      : `${String(screenText || "")}\n`;
+    let trailing = String(trailingFresh || "");
+    // Snapshot and live taps can both observe the same suffix; don't duplicate it.
+    if (trailing && normalized.endsWith(trailing)) {
+      trailing = "";
+    }
+    this.clear();
+    this.append(normalized);
+    if (trailing) {
+      this.append(trailing);
+    }
+    this.seededLength = this.getText().length;
   }
 
   consumeFreshPendingMatch(pattern, freshBoundary = this.currentFreshBoundary()) {
@@ -394,6 +430,9 @@ class SessionOutputBuffer {
     const consumedText = text.slice(0, consumedLength);
     this.scanOffset = consumedLength;
     this.preservedTailMatch = null;
+    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+      this.seededLength = null;
+    }
 
     const preserveTailPatterns = Array.isArray(options.preserveTailPatterns)
       ? options.preserveTailPatterns
@@ -430,6 +469,7 @@ class SessionOutputBuffer {
     this.totalLength = 0;
     this.scanOffset = 0;
     this.preservedTailMatch = null;
+    this.seededLength = null;
   }
 
   flushWaiters() {
@@ -504,10 +544,7 @@ class SessionOutputBuffer {
 
   waitFor(pattern, timeoutMs = 30000, shouldAbort) {
     if (isRegexCompatibleWaitPattern(pattern)) {
-      const minFreshStartAbsolute = Math.max(
-        this.scanOffset,
-        this.getText().length - FRESH_MATCH_TAIL_SLACK,
-      );
+      const minFreshStartAbsolute = this.currentFreshBoundary();
       const immediate = this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute });
       if (immediate !== null) {
         this.advanceScanOffset(immediate.endOffset);
@@ -576,10 +613,7 @@ class SessionOutputBuffer {
   }
 
   waitForRegex(pattern, timeoutMs = 30000, shouldAbort) {
-    const minFreshStartAbsolute = Math.max(
-      this.scanOffset,
-      this.getText().length - FRESH_MATCH_TAIL_SLACK,
-    );
+    const minFreshStartAbsolute = this.currentFreshBoundary();
     const immediate = this.consumeFreshPendingRegex(pattern, { minFreshStartAbsolute });
     if (immediate !== null) {
       this.advanceScanOffset(immediate.endOffset);
@@ -700,6 +734,7 @@ class SessionOutputBuffer {
     this.totalLength = 0;
     this.scanOffset = 0;
     this.preservedTailMatch = null;
+    this.seededLength = null;
   }
 }
 

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -489,6 +489,13 @@ class SessionOutputBuffer {
     if (fresh === null) return null;
 
     this.preservedTailMatch = null;
+    // Consuming the startup prompt must also consume the seeded viewport above
+    // it; otherwise waitForText can rematch older visible lines (e.g. READY)
+    // that were already on screen before the prompt.
+    this.scanOffset = Math.max(this.scanOffset, fresh.matched.endOffset);
+    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+      this.seededLength = null;
+    }
     return fresh;
   }
 

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -318,9 +318,10 @@ class SessionOutputBuffer {
   }
 
   /**
-   * Freshness for waitForAny / waitForPrompt: always the live tail window.
-   * Seeded full-viewport freshness must not make every visible prompt-looking
-   * line a readiness signal (e.g. an older `user@host:~$` above a long job).
+   * Freshness for waitForPrompt (allowPreservedTailMatch): always the live
+   * tail window. Seeded full-viewport freshness must not make every visible
+   * prompt-looking line a readiness signal (e.g. an older `user@host:~$`
+   * above a long job). Generic waitForAny uses currentFreshBoundary instead.
    */
   currentTailFreshBoundary() {
     if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
@@ -332,9 +333,9 @@ class SessionOutputBuffer {
   /**
    * Replace buffer contents with the current visible terminal screen.
    * The entire seeded viewport is treated as fresh for waitFor / waitForText /
-   * waitForRegex. waitForAny / waitForPrompt still use the live tail window.
-   * `trailingFresh` (bytes that arrived during snapshot sync) stays outside
-   * seededLength so consuming a startup prompt does not discard it.
+   * waitForRegex / generic waitForAny. waitForPrompt still uses the live tail
+   * window. `trailingFresh` (bytes that arrived during snapshot sync) stays
+   * outside seededLength so consuming a startup prompt does not discard it.
    */
   replaceWithVisibleScreen(screenText, trailingFresh = "") {
     const normalized = String(screenText || "").endsWith("\n")
@@ -703,7 +704,12 @@ class SessionOutputBuffer {
         return preserved.index;
       }
     }
-    const freshBoundary = this.currentTailFreshBoundary();
+    // Generic waitForAny must see the full seeded viewport (menu labels near
+    // the top). waitForPrompt passes allowPreservedTailMatch and stays on the
+    // live-tail window so older visible prompts are not readiness signals.
+    const freshBoundary = options.allowPreservedTailMatch === true
+      ? this.currentTailFreshBoundary()
+      : this.currentFreshBoundary();
     const fresh = this.consumeFreshPendingMatchAny(patterns, freshBoundary);
     if (fresh !== null) {
       this.advanceScanOffset(fresh.matched.endOffset);

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -438,14 +438,13 @@ class SessionOutputBuffer {
   /**
    * After the script sends automated input, startup snapshot content must not
    * satisfy later waits (sendLine then waitForPrompt / waitForText). Consume
-   * through the seeded viewport only so sync-race trailingFresh stays matchable.
+   * everything currently buffered — including sync-race trailingFresh that
+   * arrived before the input — so waits require post-command output.
    */
   invalidateStartupSeed() {
-    if (typeof this.seededLength === "number") {
-      this.scanOffset = Math.max(this.scanOffset, this.seededLength);
-      this.seededLength = null;
-    }
+    this.seededLength = null;
     this.preservedTailMatch = null;
+    this.scanOffset = this.getText().length;
   }
 
   consumeFreshPendingMatch(pattern, freshBoundary = this.currentFreshBoundary()) {
@@ -591,7 +590,13 @@ class SessionOutputBuffer {
       ? Math.max(fresh.matched.endOffset, this.seededLength)
       : Math.max(fresh.matched.endOffset, preserved.textLength);
     this.scanOffset = Math.max(this.scanOffset, consumeThrough);
-    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+    // Sync-race trailingFresh sits past the original seededLength. Keep it fully
+    // waitable even when longer than FRESH_MATCH_TAIL_SLACK; otherwise a marker
+    // near the start of a large burst (READY + long menu) times out after prompt.
+    const textLength = this.getText().length;
+    if (textLength > this.scanOffset) {
+      this.seededLength = textLength;
+    } else {
       this.seededLength = null;
     }
     return fresh;

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -341,9 +341,19 @@ class SessionOutputBuffer {
       ? String(screenText || "")
       : `${String(screenText || "")}\n`;
     let trailing = String(trailingFresh || "");
-    // Snapshot and live taps can both observe the same suffix; don't duplicate it.
-    if (trailing && normalized.endsWith(trailing)) {
-      trailing = "";
+    // Snapshot and live taps can both observe the same suffix. Full-viewport
+    // snapshots often pad with blank rows after the live content, so a plain
+    // endsWith check misses duplicates — also compare after stripping trailing
+    // blank lines.
+    if (trailing) {
+      const trailingCore = trailing.replace(/(?:[ \t]*\r?\n)*$/u, "");
+      const viewportCore = normalized.replace(/(?:[ \t]*\r?\n)*$/u, "");
+      if (
+        normalized.endsWith(trailing)
+        || (trailingCore && viewportCore.endsWith(trailingCore))
+      ) {
+        trailing = "";
+      }
     }
     this.clear();
     this.append(normalized);

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -435,6 +435,19 @@ class SessionOutputBuffer {
     }
   }
 
+  /**
+   * After the script sends automated input, startup snapshot content must not
+   * satisfy later waits (sendLine then waitForPrompt / waitForText). Consume
+   * through the seeded viewport only so sync-race trailingFresh stays matchable.
+   */
+  invalidateStartupSeed() {
+    if (typeof this.seededLength === "number") {
+      this.scanOffset = Math.max(this.scanOffset, this.seededLength);
+      this.seededLength = null;
+    }
+    this.preservedTailMatch = null;
+  }
+
   consumeFreshPendingMatch(pattern, freshBoundary = this.currentFreshBoundary()) {
     while (true) {
       const matched = this.tryMatchPending(pattern);

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -489,10 +489,14 @@ class SessionOutputBuffer {
     if (fresh === null) return null;
 
     this.preservedTailMatch = null;
-    // Consuming the startup prompt must also consume the seeded viewport above
-    // it; otherwise waitForText can rematch older visible lines (e.g. READY)
-    // that were already on screen before the prompt.
-    this.scanOffset = Math.max(this.scanOffset, fresh.matched.endOffset);
+    // Consuming the startup prompt must also consume the whole seeded viewport
+    // from that snapshot. Advancing only to the prompt end leaves later bytes
+    // from the same screen (e.g. `root@host:~# \nold READY`) waitable for the
+    // next waitForText/waitForRegex.
+    const consumeThrough = typeof this.seededLength === "number"
+      ? Math.max(fresh.matched.endOffset, this.seededLength)
+      : Math.max(fresh.matched.endOffset, preserved.textLength);
+    this.scanOffset = Math.max(this.scanOffset, consumeThrough);
     if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
       this.seededLength = null;
     }

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -333,6 +333,8 @@ class SessionOutputBuffer {
    * Replace buffer contents with the current visible terminal screen.
    * The entire seeded viewport is treated as fresh for waitFor / waitForText /
    * waitForRegex. waitForAny / waitForPrompt still use the live tail window.
+   * `trailingFresh` (bytes that arrived during snapshot sync) stays outside
+   * seededLength so consuming a startup prompt does not discard it.
    */
   replaceWithVisibleScreen(screenText, trailingFresh = "") {
     const normalized = String(screenText || "").endsWith("\n")
@@ -345,18 +347,19 @@ class SessionOutputBuffer {
     }
     this.clear();
     this.append(normalized);
+    // Seed only the visible viewport — not sync-race trailing bytes.
+    this.seededLength = this.getText().length;
+    // Preserve a live-tail shell prompt from the viewport for waitForPrompt,
+    // matching the old markOutputConsumedThrough(preserveTailPatterns) behavior.
+    this.preservedTailMatch = null;
+    const viewportText = this.getText();
+    const fresh = findFreshTailMatchAny(viewportText, shellPromptPatterns());
     if (trailing) {
       this.append(trailing);
     }
-    this.seededLength = this.getText().length;
-    // Preserve a live-tail shell prompt for waitForPrompt, matching the old
-    // markOutputConsumedThrough(preserveTailPatterns) startup behavior.
-    this.preservedTailMatch = null;
-    const text = this.getText();
-    const fresh = findFreshTailMatchAny(text, shellPromptPatterns());
     if (fresh !== null) {
       this.preservedTailMatch = {
-        textLength: text.length,
+        textLength: this.getText().length,
         value: fresh.matched.value,
         endOffset: fresh.matched.endOffset,
       };

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -32,7 +32,18 @@ function trimOverlappingTrailingFresh(viewportText, trailingFresh, syncStartText
   const syncCore = stripTrailingBlankLines(syncStartText);
 
   // Stale snapshot: still showing pre-sync content → keep all trailingFresh.
-  if (syncCore && viewportCore === syncCore) {
+  // Exact match covers a second identical marker while the snapshot IPC is in
+  // flight. Proper-suffix match covers scrollback-backed buffers where the
+  // visible viewport is only the tail of syncStartText (e.g. banner\nREADY vs
+  // READY) so equality alone would miss the stale case and trim a real duplicate.
+  if (
+    syncCore
+    && viewportCore
+    && (
+      viewportCore === syncCore
+      || (syncCore.length > viewportCore.length && syncCore.endsWith(viewportCore))
+    )
+  ) {
     return trailing;
   }
 

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -31,9 +31,11 @@ function trimOverlappingTrailingFresh(viewportText, trailingFresh) {
   ) {
     return "";
   }
-  const max = Math.min(viewportCore.length, trailing.length);
+  // Prefer the full viewport for partial overlap so a trailing newline that is
+  // part of the overlapped text is not left behind as a phantom blank line.
+  const max = Math.min(viewport.length, trailing.length);
   for (let len = max; len > 0; len -= 1) {
-    if (viewportCore.endsWith(trailing.slice(0, len))) {
+    if (viewport.endsWith(trailing.slice(0, len))) {
       return trailing.slice(len);
     }
   }

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -488,6 +488,15 @@ class SessionOutputBuffer {
   advanceScanOffset(endOffset) {
     const absoluteEnd = this.scanOffset + endOffset;
     this.scanOffset = Math.min(absoluteEnd, this.getText().length);
+    // Normal waits that consume past a preserved startup prompt invalidate it
+    // (e.g. waitForText matched trailingFresh after the prompt). Baseline via
+    // markOutputConsumedThrough sets scanOffset directly and keeps the prompt.
+    if (this.preservedTailMatch && this.scanOffset > this.preservedTailMatch.endOffset) {
+      this.preservedTailMatch = null;
+    }
+    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+      this.seededLength = null;
+    }
   }
 
   markCurrentOutputConsumed(options = {}) {

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -1,5 +1,7 @@
 "use strict";
 
+const { shellPromptPatterns } = require("./shellPromptPatterns.cjs");
+
 const DEFAULT_BUFFER_SIZE = 1024 * 1024;
 /** Matches within this many bytes of buffer end count as live terminal output. */
 const FRESH_MATCH_TAIL_SLACK = 512;
@@ -304,8 +306,9 @@ class SessionOutputBuffer {
     const textLength = this.getText().length;
     const normalBoundary = Math.max(this.scanOffset, textLength - FRESH_MATCH_TAIL_SLACK);
     if (typeof this.seededLength === "number" && this.scanOffset < this.seededLength) {
-      // Startup viewport rows must all be waitable, even when the visible screen
-      // is longer than FRESH_MATCH_TAIL_SLACK (bastion menus, etc.).
+      // Startup viewport rows must all be waitable for waitFor / waitForText /
+      // waitForRegex, even when the visible screen is longer than
+      // FRESH_MATCH_TAIL_SLACK (bastion menus, etc.).
       return this.scanOffset;
     }
     if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
@@ -315,8 +318,21 @@ class SessionOutputBuffer {
   }
 
   /**
+   * Freshness for waitForAny / waitForPrompt: always the live tail window.
+   * Seeded full-viewport freshness must not make every visible prompt-looking
+   * line a readiness signal (e.g. an older `user@host:~$` above a long job).
+   */
+  currentTailFreshBoundary() {
+    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
+      this.seededLength = null;
+    }
+    return Math.max(this.scanOffset, this.getText().length - FRESH_MATCH_TAIL_SLACK);
+  }
+
+  /**
    * Replace buffer contents with the current visible terminal screen.
-   * The entire seeded viewport is treated as fresh for waitFor* matching.
+   * The entire seeded viewport is treated as fresh for waitFor / waitForText /
+   * waitForRegex. waitForAny / waitForPrompt still use the live tail window.
    */
   replaceWithVisibleScreen(screenText, trailingFresh = "") {
     const normalized = String(screenText || "").endsWith("\n")
@@ -333,6 +349,18 @@ class SessionOutputBuffer {
       this.append(trailing);
     }
     this.seededLength = this.getText().length;
+    // Preserve a live-tail shell prompt for waitForPrompt, matching the old
+    // markOutputConsumedThrough(preserveTailPatterns) startup behavior.
+    this.preservedTailMatch = null;
+    const text = this.getText();
+    const fresh = findFreshTailMatchAny(text, shellPromptPatterns());
+    if (fresh !== null) {
+      this.preservedTailMatch = {
+        textLength: text.length,
+        value: fresh.matched.value,
+        endOffset: fresh.matched.endOffset,
+      };
+    }
   }
 
   consumeFreshPendingMatch(pattern, freshBoundary = this.currentFreshBoundary()) {
@@ -651,7 +679,7 @@ class SessionOutputBuffer {
         return preserved.index;
       }
     }
-    const freshBoundary = this.currentFreshBoundary();
+    const freshBoundary = this.currentTailFreshBoundary();
     const fresh = this.consumeFreshPendingMatchAny(patterns, freshBoundary);
     if (fresh !== null) {
       this.advanceScanOffset(fresh.matched.endOffset);

--- a/electron/scripts/sessionOutputBuffer.cjs
+++ b/electron/scripts/sessionOutputBuffer.cjs
@@ -350,16 +350,23 @@ class SessionOutputBuffer {
   }
 
   /**
-   * Freshness for waitForPrompt (allowPreservedTailMatch): always the live
-   * tail window. Seeded full-viewport freshness must not make every visible
-   * prompt-looking line a readiness signal (e.g. an older `user@host:~$`
-   * above a long job). Generic waitForAny uses currentFreshBoundary instead.
+   * Freshness for waitForPrompt (allowPreservedTailMatch): live tail only, and
+   * never rematch prompts that only exist inside the still-unconsumed seeded
+   * viewport. After live output clears preservedTailMatch, a short seed like
+   * `root# ` must not satisfy waitForPrompt via the normal 512-byte window.
+   * Generic waitForAny uses currentFreshBoundary instead.
    */
   currentTailFreshBoundary() {
-    if (typeof this.seededLength === "number" && this.scanOffset >= this.seededLength) {
-      this.seededLength = null;
+    const textLength = this.getText().length;
+    let boundary = Math.max(this.scanOffset, textLength - FRESH_MATCH_TAIL_SLACK);
+    if (typeof this.seededLength === "number") {
+      if (this.scanOffset >= this.seededLength) {
+        this.seededLength = null;
+      } else {
+        boundary = Math.max(boundary, this.seededLength);
+      }
     }
-    return Math.max(this.scanOffset, this.getText().length - FRESH_MATCH_TAIL_SLACK);
+    return boundary;
   }
 
   /**

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -544,6 +544,33 @@ test("SessionOutputBuffer consuming startup prompt also consumes seeded viewport
   assert.equal(await pending, "READY");
 });
 
+test("SessionOutputBuffer consuming startup prompt also consumes seeded text after the prompt", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Short snapshot where the live-tail prompt is not the final visible text.
+  buffer.replaceWithVisibleScreen("root@host:~# \nold READY\n");
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    0,
+  );
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("fresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -480,6 +480,44 @@ test("SessionOutputBuffer replaceWithVisibleScreen keeps trailing fresh output f
   assert.match(buffer.getText(), /\x07\x07$/);
 });
 
+test("SessionOutputBuffer seeded viewport does not make mid-screen prompts waitable via waitForAny", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const screen = [
+    "user@host:~$ ",
+    "running long job...",
+    ...Array.from({ length: 30 }, (_, i) => `output line ${i} ${"x".repeat(20)}`),
+  ].join("\n");
+  assert.ok(screen.length > 512);
+
+  buffer.replaceWithVisibleScreen(screen);
+
+  const pending = buffer.waitForAny(shellPromptPatterns(), 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\nuser@host:~$ ");
+  assert.equal(await pending, 1);
+});
+
+test("SessionOutputBuffer seeded viewport still preserves a live-tail prompt for waitForPrompt", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen(`menu header\n${"x".repeat(600)}\nroot@host:~# `);
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    0,
+  );
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -571,6 +571,23 @@ test("SessionOutputBuffer consuming startup prompt also consumes seeded text aft
   assert.equal(await pending, "READY");
 });
 
+test("SessionOutputBuffer waitForPrompt does not consume sync-race trailingFresh", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# ", "\nfresh READY\n");
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    0,
+  );
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -588,6 +588,28 @@ test("SessionOutputBuffer waitForPrompt does not consume sync-race trailingFresh
   assert.equal(await buffer.waitForText("READY", 200), "READY");
 });
 
+test("SessionOutputBuffer does not duplicate trailingFresh already in blank-padded viewport", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Renderer snapshots include the full viewport, often with blank rows after
+  // the live content. Sync-race trailingFresh that is already painted must not
+  // be appended again or waitForText can match a phantom second copy.
+  buffer.replaceWithVisibleScreen("READY\n\n\n", "READY\n");
+  assert.equal(buffer.getText(), "READY\n\n\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\nfresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -645,6 +645,28 @@ test("SessionOutputBuffer trims partial overlap from sync-race trailingFresh", a
   assert.equal(await pending, "READY");
 });
 
+test("SessionOutputBuffer waitForPrompt does not rematch short seeded prompt after live output", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# ");
+
+  // Live output clears preservedTailMatch; the old prompt must not win via the
+  // normal 512-byte window on a short seeded screen.
+  buffer.append("echo hi\nhi\n");
+
+  const pending = buffer.waitForAny(shellPromptPatterns(), 200, undefined, {
+    allowPreservedTailMatch: true,
+  });
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("root@host:~# ");
+  assert.equal(await pending, 0);
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -721,11 +721,37 @@ test("SessionOutputBuffer invalidateStartupSeed blocks seeded waits after input"
   assert.equal(await pendingText, "READY");
 });
 
-test("SessionOutputBuffer invalidateStartupSeed keeps sync-race trailingFresh matchable", async () => {
+test("SessionOutputBuffer invalidateStartupSeed also consumes pre-input trailingFresh", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.replaceWithVisibleScreen("root@host:~# ", "\nfresh READY\n");
 
   buffer.invalidateStartupSeed();
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\npost-command READY\n");
+  assert.equal(await pending, "READY");
+});
+
+test("SessionOutputBuffer waitForPrompt keeps long sync-race trailingFresh matchable", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# ", `\nREADY\n${"x".repeat(600)}`);
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    0,
+  );
 
   assert.equal(await buffer.waitForText("READY", 200), "READY");
 });

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -480,7 +480,7 @@ test("SessionOutputBuffer replaceWithVisibleScreen keeps trailing fresh output f
   assert.match(buffer.getText(), /\x07\x07$/);
 });
 
-test("SessionOutputBuffer seeded viewport does not make mid-screen prompts waitable via waitForAny", async () => {
+test("SessionOutputBuffer seeded viewport does not make mid-screen prompts waitable via waitForPrompt", async () => {
   const buffer = new SessionOutputBuffer("s1");
   const screen = [
     "user@host:~$ ",
@@ -491,7 +491,10 @@ test("SessionOutputBuffer seeded viewport does not make mid-screen prompts waita
 
   buffer.replaceWithVisibleScreen(screen);
 
-  const pending = buffer.waitForAny(shellPromptPatterns(), 200);
+  // waitForPrompt uses allowPreservedTailMatch — mid-screen prompts must not win.
+  const pending = buffer.waitForAny(shellPromptPatterns(), 200, undefined, {
+    allowPreservedTailMatch: true,
+  });
   let resolvedEarly = false;
   void pending.then(() => {
     resolvedEarly = true;
@@ -501,6 +504,17 @@ test("SessionOutputBuffer seeded viewport does not make mid-screen prompts waita
 
   buffer.append("\nuser@host:~$ ");
   assert.equal(await pending, 1);
+});
+
+test("SessionOutputBuffer seeded viewport keeps generic waitForAny matches outside the live tail", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const header = "Option A\nOption B\n";
+  const body = Array.from({ length: 40 }, (_, i) => `filler ${i} ${"x".repeat(20)}`).join("\n");
+  const screen = `${header}${body}\n`;
+  assert.ok(screen.length > 512);
+
+  buffer.replaceWithVisibleScreen(screen);
+  assert.equal(await buffer.waitForAny(["Option A", "Option B"], 200), 0);
 });
 
 test("SessionOutputBuffer seeded viewport still preserves a live-tail prompt for waitForPrompt", async () => {

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -461,6 +461,25 @@ test("SessionOutputBuffer waitFor still rejects pre-registration scrollback beyo
   assert.equal(await pending, "TARGET");
 });
 
+test("SessionOutputBuffer replaceWithVisibleScreen makes the whole viewport waitable", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const header = "Welcome\n\nSSH资源(5) :\n";
+  const body = Array.from({ length: 40 }, (_, i) => `  [${i}] host-${i} ${"x".repeat(20)}`).join("\n");
+  const menu = `${header}${body}\n`;
+  assert.ok(menu.length > 512);
+
+  buffer.replaceWithVisibleScreen(menu);
+  assert.equal(await buffer.waitForRegex("SSH资源\\s*\\(\\d+\\)\\s*:", 200), "SSH资源(5) :");
+});
+
+test("SessionOutputBuffer replaceWithVisibleScreen keeps trailing fresh output from sync race", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  const menu = `SSH资源(5) :\n${"x".repeat(600)}\n`;
+  buffer.replaceWithVisibleScreen(menu, "\x07\x07");
+  assert.equal(await buffer.waitForRegex("SSH资源\\s*\\(\\d+\\)\\s*:", 200), "SSH资源(5) :");
+  assert.match(buffer.getText(), /\x07\x07$/);
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -677,6 +677,18 @@ test("SessionOutputBuffer keeps duplicate trailingFresh when snapshot is still p
   assert.equal(await buffer.waitForText("READY", 200), "READY");
 });
 
+test("SessionOutputBuffer keeps duplicate trailingFresh when stale viewport is a syncStart suffix", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Pre-sync buffer had scrollback; stale snapshot still shows only the old
+  // visible suffix while a second READY arrived during the IPC round-trip.
+  buffer.replaceWithVisibleScreen("READY\n", "READY\nNEXT\n", "banner\nREADY\n");
+  assert.equal(buffer.getText(), "READY\nREADY\nNEXT\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.equal(await buffer.waitForText("NEXT", 200), "NEXT");
+});
+
 test("SessionOutputBuffer waitForPrompt does not rematch short seeded prompt after live output", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.replaceWithVisibleScreen("root@host:~# ");

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -667,6 +667,27 @@ test("SessionOutputBuffer waitForPrompt does not rematch short seeded prompt aft
   assert.equal(await pending, 0);
 });
 
+test("SessionOutputBuffer waitForPrompt ignores preserved prompt after newer output is consumed", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# ", "\nfresh READY\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.ok(buffer.scanOffset > 0);
+
+  const pending = buffer.waitForAny(shellPromptPatterns(), 200, undefined, {
+    allowPreservedTailMatch: true,
+  });
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("root@host:~# ");
+  assert.equal(await pending, 0);
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -645,6 +645,38 @@ test("SessionOutputBuffer trims partial overlap from sync-race trailingFresh", a
   assert.equal(await pending, "READY");
 });
 
+test("SessionOutputBuffer trims blank-padded partial overlap from trailingFresh", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Full-viewport snapshot often pads with blank rows after live content.
+  buffer.replaceWithVisibleScreen("READY\n\n", "READY\nNEXT\n");
+  assert.equal(buffer.getText(), "READY\n\nNEXT\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.equal(await buffer.waitForText("NEXT", 200), "NEXT");
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\nfresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
+test("SessionOutputBuffer keeps duplicate trailingFresh when snapshot is still pre-sync", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Viewport still matches syncStart while an identical READY arrived during
+  // the snapshot IPC — that second marker must stay matchable.
+  buffer.replaceWithVisibleScreen("READY\n", "READY\n", "READY\n");
+  assert.equal(buffer.getText(), "READY\nREADY\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+});
+
 test("SessionOutputBuffer waitForPrompt does not rematch short seeded prompt after live output", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.replaceWithVisibleScreen("root@host:~# ");

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -518,6 +518,32 @@ test("SessionOutputBuffer seeded viewport still preserves a live-tail prompt for
   );
 });
 
+test("SessionOutputBuffer consuming startup prompt also consumes seeded viewport above it", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen(`old READY marker\n${"x".repeat(80)}\nuser@host:~$ `);
+
+  assert.equal(
+    await buffer.waitForAny(
+      shellPromptPatterns(),
+      1000,
+      undefined,
+      { allowPreservedTailMatch: true },
+    ),
+    1,
+  );
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\nfresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -624,6 +624,27 @@ test("SessionOutputBuffer does not duplicate trailingFresh already in blank-padd
   assert.equal(await pending, "READY");
 });
 
+test("SessionOutputBuffer trims partial overlap from sync-race trailingFresh", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  // Snapshot captured READY\\n while the live buffer already has READY\\nNEXT\\n.
+  buffer.replaceWithVisibleScreen("READY\n", "READY\nNEXT\n");
+  assert.equal(buffer.getText(), "READY\nNEXT\n");
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+  assert.equal(await buffer.waitForText("NEXT", 200), "NEXT");
+
+  const pending = buffer.waitForText("READY", 200);
+  let resolvedEarly = false;
+  void pending.then(() => {
+    resolvedEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(resolvedEarly, false);
+
+  buffer.append("\nfresh READY\n");
+  assert.equal(await pending, "READY");
+});
+
 test("stepsToJavaScript sends sensitive prompt result", () => {
   const code = stepsToJavaScript([
     { type: "send", value: "secret", sensitive: true },

--- a/electron/scripts/sessionOutputBuffer.test.cjs
+++ b/electron/scripts/sessionOutputBuffer.test.cjs
@@ -689,6 +689,47 @@ test("SessionOutputBuffer keeps duplicate trailingFresh when stale viewport is a
   assert.equal(await buffer.waitForText("NEXT", 200), "NEXT");
 });
 
+test("SessionOutputBuffer invalidateStartupSeed blocks seeded waits after input", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# \nold READY\n");
+
+  buffer.invalidateStartupSeed();
+
+  const pendingPrompt = buffer.waitForAny(
+    shellPromptPatterns(),
+    200,
+    undefined,
+    { allowPreservedTailMatch: true },
+  );
+  const pendingText = buffer.waitForText("READY", 200);
+  let promptEarly = false;
+  let textEarly = false;
+  void pendingPrompt.then(() => {
+    promptEarly = true;
+  });
+  void pendingText.then(() => {
+    textEarly = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.equal(promptEarly, false);
+  assert.equal(textEarly, false);
+
+  buffer.append("command output\nroot@host:~# ");
+  assert.equal(await pendingPrompt, 0);
+
+  buffer.append("\nfresh READY\n");
+  assert.equal(await pendingText, "READY");
+});
+
+test("SessionOutputBuffer invalidateStartupSeed keeps sync-race trailingFresh matchable", async () => {
+  const buffer = new SessionOutputBuffer("s1");
+  buffer.replaceWithVisibleScreen("root@host:~# ", "\nfresh READY\n");
+
+  buffer.invalidateStartupSeed();
+
+  assert.equal(await buffer.waitForText("READY", 200), "READY");
+});
+
 test("SessionOutputBuffer waitForPrompt does not rematch short seeded prompt after live output", async () => {
   const buffer = new SessionOutputBuffer("s1");
   buffer.replaceWithVisibleScreen("root@host:~# ");


### PR DESCRIPTION
## Summary
- Fixes #1960: auto-login / bastion-menu scripts timed out on `waitForRegex("SSH资源...")` even though the menu was already on screen. Startup snapshot sync (`syncOutputBufferFromSnapshot`) marked the entire buffer as consumed, so waits only saw later BEL (`\x07`) noise and never rematched the visible menu.
- Replace the script output buffer with the current terminal viewport at run start. Visible text (including multi-line menus) is matchable immediately; text that has scrolled off the viewport is still ignored (preserves the intent of #1821). Concurrent output that arrives during the snapshot request remains matchable.
- Adds regression coverage for visible-screen waits, scrolled-off keywords, and the bastion `SSH资源(5)` menu case from the issue comments.

## Test plan
- [x] `node --test electron/bridges/scriptBridge.test.cjs` — 12 pass
- [x] `node --test electron/scripts/sessionOutputBuffer.test.cjs electron/scripts/scriptRuntime.test.cjs` — 56 pass
- [ ] Repro from #1960: connect to bastion, wait until `SSH资源(5)` menu is visible, run:
  ```js
  await nct.screen.waitForRegex("SSH资源\\s*\\(\\d+\\)\\s*:", 30000);
  await nct.screen.sendLine("3");
  ```
  Expect immediate match (no timeout / no stuck BEL-only wait).


Made with [Cursor](https://cursor.com)