### PR TITLE
Tighten spam filter to delete any untrusted zip comments

### DIFF
--- a/.github/workflows/spam-comments.yml
+++ b/.github/workflows/spam-comments.yml
@@ -35,7 +35,7 @@ jobs:
             core.info(JSON.stringify(result, null, 2));
 
             if (!result.spam) {
-              core.info('Comment did not match the high-confidence spam filter.');
+              core.info('Comment did not match the zip/dangerous-file spam filter.');
               return;
             }
 
@@ -46,5 +46,5 @@ jobs:
             });
 
             core.notice(
-              `Deleted suspected malware spam comment by @${comment.user.login} on #${context.payload.issue.number}: ${result.reasons.join('; ')}`
+              `Deleted comment with zip/dangerous attachment by @${comment.user.login} on #${context.payload.issue.number}: ${result.reasons.join('; ')}`
             );

--- a/scripts/spam-comment-filter.cjs
+++ b/scripts/spam-comment-filter.cjs
@@ -14,18 +14,10 @@ const dangerousFilePattern = new RegExp(
   "gi"
 );
 
-const suspiciousFileNamePattern = new RegExp(
-  `\\b(?:patch|hotfix|fix|update|repair|solution|workaround|netcatty)[\\w.-]*\\.${DANGEROUS_FILE_EXTENSION}\\b`,
-  "i"
+const zipFilePattern = new RegExp(
+  `(?:^|[\\s([<"'=])([^\\s()[\\]<>\"']+\\.zip)(?=$|[\\s)\\]>\"']|[.,!?;:](?:$|\\s))`,
+  "gi"
 );
-
-const baitPatterns = [
-  /\bquick\s+(?:patch|fix|hotfix)\b/i,
-  /\bi\s+found\s+(?:a\s+)?(?:quick\s+)?(?:patch|fix|hotfix|solution)\b/i,
-  /\b(?:download|use|try|install|apply)\s+(?:this|the)\s+(?:patch|fix|hotfix|update|zip|file)\b/i,
-  /\b(?:fixes|fixed|patches|repairs)\s+(?:the|this|that|those)\b/i,
-  /\b(?:backend|encoding|character mapping|black boxes|terminal rendering|sftp module)\b/i,
-];
 
 const githubUserAttachmentPattern =
   /^https:\/\/github\.com\/user-attachments\/files\/\d+\//i;
@@ -38,18 +30,20 @@ function isTrustedAuthor(authorAssociation) {
   return TRUSTED_AUTHOR_ASSOCIATIONS.has(normalizeAssociation(authorAssociation));
 }
 
-function extractDangerousFiles(body) {
+function extractMatches(body, pattern) {
   const files = [];
-  for (const match of body.matchAll(dangerousFilePattern)) {
+  for (const match of body.matchAll(pattern)) {
     files.push(match[1]);
   }
   return [...new Set(files)];
 }
 
-function matchingBaitPatterns(body) {
-  return baitPatterns
-    .filter((pattern) => pattern.test(body))
-    .map((pattern) => pattern.source);
+function extractDangerousFiles(body) {
+  return extractMatches(body, dangerousFilePattern);
+}
+
+function extractZipFiles(body) {
+  return extractMatches(body, zipFilePattern);
 }
 
 function isGitHubUserAttachment(file) {
@@ -59,57 +53,33 @@ function isGitHubUserAttachment(file) {
 function detectSpamComment({ body, authorAssociation, userType } = {}) {
   const normalizedBody = String(body || "").replace(/\s+/g, " ").trim();
   const dangerousFiles = extractDangerousFiles(normalizedBody);
-  const baitMatches = matchingBaitPatterns(normalizedBody);
-  const hasSuspiciousFileName = dangerousFiles.some((file) =>
-    suspiciousFileNamePattern.test(file)
-  );
-  const hasSuspiciousGitHubAttachment =
-    hasSuspiciousFileName && dangerousFiles.some(isGitHubUserAttachment);
+  const zipFiles = extractZipFiles(normalizedBody);
   const trustedAuthor = isTrustedAuthor(authorAssociation);
   const botAuthor = String(userType || "").toLowerCase() === "bot";
 
   const reasons = [];
   let score = 0;
 
-  if (dangerousFiles.length > 0) {
-    score += 3;
+  if (zipFiles.length > 0) {
+    score += 10;
+    reasons.push(`zip attachment or link: ${zipFiles.join(", ")}`);
+  } else if (dangerousFiles.length > 0) {
+    score += 10;
     reasons.push(`dangerous downloadable file: ${dangerousFiles.join(", ")}`);
   }
 
-  if (hasSuspiciousFileName) {
-    score += 2;
-    reasons.push("download name looks like a patch or hotfix");
-  }
-
-  if (hasSuspiciousGitHubAttachment) {
-    score += 1;
-    reasons.push("GitHub attachment uses a patch/fix-style archive name");
-  }
-
-  if (baitMatches.length > 0) {
-    score += Math.min(3, baitMatches.length);
-    reasons.push("comment uses patch/fix bait language");
-  }
-
-  if (normalizedBody.length > 0 && normalizedBody.length < 700) {
-    score += 1;
-    reasons.push("short drive-by comment");
-  }
-
+  // Hard rule: any zip (or other dangerous downloadable) from an untrusted
+  // human is deleted. Maintainers and bots are exempt.
   const spam =
     !trustedAuthor &&
     !botAuthor &&
-    dangerousFiles.length > 0 &&
-    score >= 6 &&
-    (baitMatches.length >= 2 ||
-      (hasSuspiciousFileName && baitMatches.length >= 1) ||
-      hasSuspiciousGitHubAttachment);
+    (zipFiles.length > 0 || dangerousFiles.length > 0);
 
   return {
     spam,
-    score,
+    score: spam ? score : 0,
     reasons: spam ? reasons : [],
-    dangerousFiles,
+    dangerousFiles: zipFiles.length > 0 ? zipFiles : dangerousFiles,
     trustedAuthor,
     botAuthor,
   };
@@ -118,6 +88,7 @@ function detectSpamComment({ body, authorAssociation, userType } = {}) {
 module.exports = {
   detectSpamComment,
   extractDangerousFiles,
+  extractZipFiles,
   isGitHubUserAttachment,
   isTrustedAuthor,
 };

--- a/scripts/spam-comment-filter.test.cjs
+++ b/scripts/spam-comment-filter.test.cjs
@@ -5,6 +5,7 @@ const test = require("node:test");
 const {
   detectSpamComment,
   extractDangerousFiles,
+  extractZipFiles,
   isGitHubUserAttachment,
 } = require("./spam-comment-filter.cjs");
 
@@ -29,31 +30,65 @@ test("flags fake patch spam when the filename ends a sentence", () => {
   assert.deepEqual(result.dangerousFiles, ["patch.zip"]);
 });
 
-test("flags suspicious GitHub attachment spam without bait wording", () => {
+test("flags any zip from an outside user, including hash-named soft bait", () => {
   const result = detectSpamComment({
     authorAssociation: "NONE",
     userType: "User",
-    body: "[netcatty_fix.zip](https://github.com/user-attachments/files/29784176/netcatty_fix.zip)\nI attached the fix I used.",
+    body: "[63bf1862b52422e38b8cb170.zip](https://github.com/user-attachments/files/29784176/63bf1862b52422e38b8cb170.zip)\nI'd start with the docs inside",
   });
 
   assert.equal(result.spam, true);
+  assert.ok(
+    result.dangerousFiles.some((file) => file.includes("63bf1862b52422e38b8cb170.zip"))
+  );
 });
 
-test("does not flag ordinary log attachments from outside users", () => {
+test("flags ordinary zip log attachments from outside users", () => {
   const result = detectSpamComment({
     authorAssociation: "FIRST_TIME_CONTRIBUTOR",
     userType: "User",
     body: "[debug-logs.zip](https://github.com/user-attachments/files/29784176/debug-logs.zip)\nI attached logs from a failed connection. The app hangs after I click connect, and the logs show the SSH handshake timing out.",
   });
 
-  assert.equal(result.spam, false);
+  assert.equal(result.spam, true);
 });
 
-test("does not flag trusted maintainers even when sharing patch archives", () => {
+test("flags other dangerous archives from outside users", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "User",
+    body: "See hotfix.dmg for the workaround.",
+  });
+
+  assert.equal(result.spam, true);
+  assert.deepEqual(result.dangerousFiles, ["hotfix.dmg"]);
+});
+
+test("does not flag trusted maintainers even when sharing zip archives", () => {
   const result = detectSpamComment({
     authorAssociation: "OWNER",
     userType: "User",
     body: "Try this temporary netcatty_patch.zip while I prepare the signed release. It fixes the rendering issue.",
+  });
+
+  assert.equal(result.spam, false);
+});
+
+test("does not flag bot comments that mention zip files", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "Bot",
+    body: "Uploaded build-artifacts.zip for CI.",
+  });
+
+  assert.equal(result.spam, false);
+});
+
+test("does not flag comments without downloadable archives", () => {
+  const result = detectSpamComment({
+    authorAssociation: "NONE",
+    userType: "User",
+    body: "I attached screenshots of the hang after connect. The SSH handshake times out.",
   });
 
   assert.equal(result.spam, false);
@@ -64,6 +99,10 @@ test("extracts risky file names from markdown links and plain text", () => {
     extractDangerousFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg."),
     ["fix.zip", "https://example.com/fix.zip", "hotfix.dmg"]
   );
+  assert.deepEqual(extractZipFiles("[fix.zip](https://example.com/fix.zip) also hotfix.dmg."), [
+    "fix.zip",
+    "https://example.com/fix.zip",
+  ]);
 });
 
 test("identifies GitHub user attachment URLs", () => {


### PR DESCRIPTION
## Summary
- Attackers switched to hash-named `.zip` attachments with soft bait like "I'd start with the docs inside", which bypassed the old scoring heuristics.
- Hard-delete any comment from non-maintainers that contains a `.zip` (or other dangerous downloadable such as `.dmg`/`.exe`). Maintainers and bots remain exempt.

## Test plan
- [x] `node --test scripts/spam-comment-filter.test.cjs`
- [x] Confirmed the `63bf1862...zip` sample now returns `spam: true`
- [ ] After merge, verify `spam-comments` workflow on `main` picks up the new filter


Made with [Cursor](https://cursor.com)