### PR TITLE
fix(terminal): keep tab visibility in sync for output recovery

### DIFF
--- a/components/terminal/terminalMemo.test.ts
+++ b/components/terminal/terminalMemo.test.ts
@@ -17,6 +17,15 @@ const baseProps = {
   showSelectionAIAction: true,
 } as unknown as TerminalProps;
 
+test("terminal memo refreshes when pane visibility changes", () => {
+  // Solo tab switches only flip isVisible. Skipping that comparison leaves
+  // isVisibleRef stale and skips tab-return recovery (#1985).
+  assert.equal(
+    terminalPropsAreEqual(baseProps, { ...baseProps, isVisible: false }),
+    false,
+  );
+});
+
 test("terminal memo refreshes when selection AI action visibility changes", () => {
   assert.equal(
     terminalPropsAreEqual(baseProps, { ...baseProps, showSelectionAIAction: false }),

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -18,10 +18,10 @@ export const terminalPropsAreEqual = (
   && prev.chainHosts === next.chainHosts
   && themeFingerprint(prev.appearanceTheme ?? prev.terminalTheme) === themeFingerprint(next.appearanceTheme ?? next.terminalTheme)
   && prev.knownHosts === next.knownHosts
-  // TerminalPane owns the actual visibility style and publishes per-session
-  // visibility to paneVisibilityStore. Let Terminal skip visibility-only tab
-  // switches so the expensive terminal subtree is not re-rendered for every
-  // pane when returning to a workspace.
+  // Solo tab switches only flip isVisible. Skipping it leaves isVisibleRef
+  // stale, so hidden panes keep the visible write path and tab-return recovery
+  // in useTerminalEffects never runs (#1985).
+  && prev.isVisible === next.isVisible
   && prev.paneLayoutKey === next.paneLayoutKey
   && prev.inWorkspace === next.inWorkspace
   && prev.isResizing === next.isResizing

--- a/components/terminal/terminalPaneVisibilityPublish.test.ts
+++ b/components/terminal/terminalPaneVisibilityPublish.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+test("TerminalPane publishes visibility before paint", () => {
+  const source = readFileSync(
+    new URL("../terminalLayer/TerminalLayerSupport.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /useLayoutEffect\(\(\) => \{\s*setPaneVisible\(session\.id, isVisible\);\s*\}, \[session\.id, isVisible\]\);/,
+  );
+  assert.doesNotMatch(
+    source,
+    /useEffect\(\(\) => \{\s*setPaneVisible\(session\.id, isVisible\);\s*\}, \[session\.id, isVisible\]\);/,
+  );
+});

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -166,6 +166,16 @@ export function useTerminalHibernateEffect({
       }
     };
 
+    if (!hibernateEnabled) {
+      // Turning hibernate off must wake already soft-hidden / hibernated panes
+      // immediately; waiting for the next tab select would leave the setting
+      // ineffective for currently hidden sessions.
+      clearHibernateTimer();
+      if (hibernatedRef.current || softHiddenRef.current) {
+        tryWake();
+      }
+    }
+
     applyVisibility(resolveVisible());
 
     const unsubscribe = subscribePaneVisible(sessionId, () => {

--- a/components/terminal/useTerminalHibernateEffect.ts
+++ b/components/terminal/useTerminalHibernateEffect.ts
@@ -148,23 +148,10 @@ export function useTerminalHibernateEffect({
       });
     };
 
-    if (!hibernateEnabled) {
-      clearHibernateTimer();
-      if (hibernatedRef.current || softHiddenRef.current) {
-        tryWake();
-      }
-      const unsubscribeDisabled = subscribePaneVisible(sessionId, () => {
-        if ((hibernatedRef.current || softHiddenRef.current) && resolveVisible()) {
-          tryWake();
-        }
-      });
-      return () => {
-        unsubscribeDisabled();
-      };
-    }
-
     const applyVisibility = (visible: boolean) => {
       paneVisibleRef.current = visible;
+      // Keep the write/recovery ref current even when Terminal memo used to skip
+      // isVisible-only updates, and even when hibernate itself is disabled.
       isVisibleRef.current = visible;
 
       if (visible) {
@@ -174,7 +161,9 @@ export function useTerminalHibernateEffect({
         return;
       }
 
-      scheduleHibernate();
+      if (hibernateEnabled) {
+        scheduleHibernate();
+      }
     };
 
     applyVisibility(resolveVisible());

--- a/components/terminal/useTerminalHibernateEffect.visibility.test.ts
+++ b/components/terminal/useTerminalHibernateEffect.visibility.test.ts
@@ -19,3 +19,23 @@ test("hibernate effect keeps isVisibleRef current even when hibernate is disable
     /if \(hibernateEnabled\) \{\s*scheduleHibernate\(\);\s*\}/,
   );
 });
+
+test("disabling hibernate wakes already soft-hidden or hibernated panes", () => {
+  const source = readFileSync(
+    new URL("./useTerminalHibernateEffect.ts", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /if \(!hibernateEnabled\) \{[\s\S]*?clearHibernateTimer\(\);[\s\S]*?if \(hibernatedRef\.current \|\| softHiddenRef\.current\) \{\s*tryWake\(\);\s*\}/,
+  );
+  // Must not early-return before visibility sync after the disable wake path.
+  const disableWakeIndex = source.indexOf("Turning hibernate off must wake");
+  const applyVisibilityCallIndex = source.indexOf(
+    "applyVisibility(resolveVisible());",
+    disableWakeIndex,
+  );
+  assert.ok(disableWakeIndex !== -1);
+  assert.ok(applyVisibilityCallIndex !== -1);
+  assert.ok(applyVisibilityCallIndex > disableWakeIndex);
+});

--- a/components/terminal/useTerminalHibernateEffect.visibility.test.ts
+++ b/components/terminal/useTerminalHibernateEffect.visibility.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+test("hibernate effect keeps isVisibleRef current even when hibernate is disabled", () => {
+  const source = readFileSync(
+    new URL("./useTerminalHibernateEffect.ts", import.meta.url),
+    "utf8",
+  );
+  // Visibility sync must not early-return when hibernate is off; otherwise
+  // solo tab switches leave write/recovery paths on a stale isVisibleRef.
+  assert.doesNotMatch(
+    source,
+    /if \(!hibernateEnabled\) \{\s*clearHibernateTimer\(\);[\s\S]*return \(\) => \{\s*unsubscribeDisabled\(\);\s*\};\s*\}/,
+  );
+  assert.match(source, /isVisibleRef\.current = visible;/);
+  assert.match(
+    source,
+    /if \(hibernateEnabled\) \{\s*scheduleHibernate\(\);\s*\}/,
+  );
+});

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -977,10 +977,9 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   const paneElementRef = useRef<HTMLDivElement | null>(null);
   const lastVisiblePaneSizeRef = useRef<TerminalPaneHiddenSize | null>(null);
 
-  // Publish visibility to the per-session store so TerminalServerStats /
-  // TerminalAutocomplete can self-subscribe — keeping isVisible out of the
-  // TerminalView ctx so visibility toggles don't re-render TerminalView.
-  useEffect(() => {
+  // Publish visibility before paint so hibernate / write-path readers see the
+  // new value in the same frame as the CSS hide/show (#1985).
+  useLayoutEffect(() => {
     setPaneVisible(session.id, isVisible);
   }, [session.id, isVisible]);
   useEffect(() => () => removePaneVisible(session.id), [session.id]);


### PR DESCRIPTION
## Summary
- Solo tab switches only flip `isVisible`. `terminalPropsAreEqual` intentionally skipped that prop, so `Terminal` never re-rendered on tab hide/show.
- That left `isVisibleRef` stuck on the last rendered value: hidden panes kept the visible write path, and the #1995/#1996 tab-return flush/recovery in `useTerminalEffects` never ran.
- Also publish pane visibility in `useLayoutEffect` and keep hibernate's visibility sync active even when hibernate itself is disabled.

Fixes #1985

## Root cause
`#1995` / `#1996` fixed the write/flush/recovery machinery, but the solo-tab path never fed visibility changes into that machinery because Terminal memo treated `isVisible`-only updates as equal.

## Test plan
- [x] `node --test --import tsx components/terminal/terminalMemo.test.ts components/terminal/terminalPaneVisibilityPublish.test.ts components/terminal/useTerminalHibernateEffect.visibility.test.ts components/terminal/paneVisibilityStore.test.ts components/terminal/terminalTabVisibilityRecovery.test.ts components/terminal/appResumeWebglRecovery.test.ts components/terminal/runtime/terminalUnfocusedRepaint.test.ts components/terminal/runtime/terminalSessionAttachment.test.ts` — 68 passed
- [x] eslint on touched files
- [ ] Manual: two SSH tabs on Windows; run `history` in tab 2, Claude Code Chinese chat in tab 1; switch repeatedly and confirm neither output truncates / leaves the cursor mid-history


Made with [Cursor](https://cursor.com)