### PR TITLE
fix: accept whitespace-only SSH passwords

### DIFF
--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -188,7 +188,8 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
         return true;
       case "auth":
         if (authMethod === "password") {
-          return password.trim().length > 0;
+          // Whitespace-only passwords are valid SSH secrets (issue #2036).
+          return password.length > 0;
         }
         return !!selectedKeyId;
     }
@@ -434,7 +435,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               className="pr-10"
               autoFocus
               onKeyDown={(e) => {
-                if (e.key === "Enter" && password.trim()) {
+                if (e.key === "Enter" && password.length > 0) {
                   handleConnect();
                 }
               }}

--- a/components/terminal/hooks/useTerminalAuthState.ts
+++ b/components/terminal/hooks/useTerminalAuthState.ts
@@ -6,6 +6,14 @@ import type { PendingAuth } from "../runtime/createTerminalSessionStarters";
 import type { TerminalAuthMethod } from "../TerminalAuthDialog";
 import { logger } from "../../../lib/logger";
 
+/**
+ * Password auth is valid when the user typed something — including a single
+ * space. SSH passwords may be whitespace-only; do not trim before this check
+ * (issue #2036).
+ */
+export const isAuthPasswordProvided = (password: string): boolean =>
+  password.length > 0;
+
 export const buildSavedAuthHostUpdate = (
   host: Host,
   auth: {
@@ -74,7 +82,7 @@ export const useTerminalAuthState = ({
 
   const isValid = useMemo(() => {
     if (!authUsername.trim()) return false;
-    if (authMethod === "password") return authPassword.trim().length > 0;
+    if (authMethod === "password") return isAuthPasswordProvided(authPassword);
     if (authMethod === "key" || authMethod === "certificate") return !!authKeyId;
     return false;
   }, [authKeyId, authMethod, authPassword, authUsername]);

--- a/components/terminal/useTerminalAuthState.test.ts
+++ b/components/terminal/useTerminalAuthState.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import { applyGroupDefaults } from "../../domain/groupConfig";
 import { resolveHostAuth } from "../../domain/sshAuth";
 import type { Host, Identity } from "../../types";
-import { buildSavedAuthHostUpdate } from "./hooks/useTerminalAuthState";
+import {
+  buildSavedAuthHostUpdate,
+  isAuthPasswordProvided,
+} from "./hooks/useTerminalAuthState";
 
 const baseHost: Host = {
   id: "host-1",
@@ -18,6 +21,13 @@ const baseHost: Host = {
   tags: [],
   os: "linux",
 };
+
+test("isAuthPasswordProvided accepts whitespace-only passwords (#2036)", () => {
+  assert.equal(isAuthPasswordProvided(""), false);
+  assert.equal(isAuthPasswordProvided(" "), true);
+  assert.equal(isAuthPasswordProvided("  "), true);
+  assert.equal(isAuthPasswordProvided("secret"), true);
+});
 
 test("password save clears identityId and identityFileId", () => {
   const updated = buildSavedAuthHostUpdate(baseHost, {
@@ -33,6 +43,18 @@ test("password save clears identityId and identityFileId", () => {
   assert.equal(updated.savePassword, true);
   assert.equal(updated.authMethod, "password");
   assert.equal(updated.username, "root");
+});
+
+test("password save preserves a single-space password (#2036)", () => {
+  const updated = buildSavedAuthHostUpdate(baseHost, {
+    authMethod: "password",
+    username: "root",
+    password: " ",
+    keyId: null,
+  });
+
+  assert.equal(updated.password, " ");
+  assert.equal(updated.savePassword, true);
 });
 
 test("key save clears identityId and sets identityFileId", () => {

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -512,6 +512,16 @@ function hasUserConfiguredKey(options) {
 }
 
 /**
+ * True when a password string should be attached to SSH connect options.
+ * Whitespace-only passwords are valid SSH secrets (issue #2036) — do not trim.
+ * @param {unknown} password
+ * @returns {boolean}
+ */
+function isPasswordProvided(password) {
+  return typeof password === "string" && password.length > 0;
+}
+
+/**
  * Build authentication handler with default key fallback support
  * @param {Object} options
  * @param {string} [options.privateKey] - Explicitly configured private key
@@ -1041,6 +1051,7 @@ module.exports = {
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
   hasUserConfiguredKey,
+  isPasswordProvided,
   PassphraseCancelledError,
   isPassphraseCancelledError,
 };

--- a/electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs
+++ b/electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs
@@ -36,3 +36,13 @@ test("hasUserConfiguredKey prefers explicit inline key over empty paths", () => 
     true,
   );
 });
+
+test("isPasswordProvided accepts whitespace-only passwords (#2036)", () => {
+  const { isPasswordProvided } = require("./sshAuthHelper.cjs");
+  assert.equal(isPasswordProvided(""), false);
+  assert.equal(isPasswordProvided(" "), true);
+  assert.equal(isPasswordProvided("  "), true);
+  assert.equal(isPasswordProvided("secret"), true);
+  assert.equal(isPasswordProvided(null), false);
+  assert.equal(isPasswordProvided(undefined), false);
+});

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -34,6 +34,7 @@ const {
   loadIdentityFileForAuth,
   loadFirstIdentityFileForAuth,
   hasUserConfiguredKey,
+  isPasswordProvided,
   PassphraseCancelledError,
   isPassphraseCancelledError,
 } = require("./sshAuthHelper.cjs");
@@ -878,7 +879,7 @@ const startSessionApi = createStartSessionApi({
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
   get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
-  preparePrivateKeyForAuth, loadFirstIdentityFileForAuth, hasUserConfiguredKey, createKeyboardInteractiveHandler,
+  preparePrivateKeyForAuth, loadFirstIdentityFileForAuth, hasUserConfiguredKey, isPasswordProvided, createKeyboardInteractiveHandler,
   createConnectionRef, acquireConnectionRef, releaseConnectionRef, findReusableSession,
   get probeReceiveConflicts() { return probeReceiveConflicts; },
   get removeRemoteFiles() { return removeRemoteFiles; },

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -699,7 +699,8 @@ function createStartSessionApi(ctx) {
           }
         }
 
-        if (options.password && typeof options.password === "string" && options.password.trim().length > 0) {
+        // Whitespace-only passwords are valid SSH secrets (issue #2036).
+        if (isPasswordProvided(options.password)) {
           connectOpts.password = options.password;
         }
 


### PR DESCRIPTION
## Summary
- Fixes [#2036](https://github.com/binaricat/Netcatty/issues/2036): a single-space (or other whitespace-only) SSH password is valid, but auth UI and SSH connect previously treated `password.trim()` as empty.
- Stop trimming when validating Terminal Auth / Quick Connect and when attaching the password to SSH `connectOpts`.
- Add regression coverage for `isAuthPasswordProvided` / `isPasswordProvided` and space-password save.

## Test plan
- [ ] Open auth dialog, enter a single space as password → **Continue & Save** is enabled
- [ ] Connect to a host whose password is a single space → login succeeds
- [ ] Quick Connect with space password → can proceed / Enter submits
- [ ] `node --test --import tsx components/terminal/useTerminalAuthState.test.ts`
- [ ] `node --test electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs`
- [x] `codex review --base main` → no actionable bugs

Closes #2036


Made with [Cursor](https://cursor.com)