### PR TITLE
fix(terminal): seed Local Terminal autocomplete from shell histfiles

### DIFF
--- a/application/state/sessionFactories.localHostId.test.ts
+++ b/application/state/sessionFactories.localHostId.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LOCAL_TERMINAL_HOST_ID,
+  createLocalTerminalSession,
+} from "./sessionFactories.ts";
+
+test("createLocalTerminalSession uses a stable hostId across sessions", () => {
+  const a = createLocalTerminalSession("session-a");
+  const b = createLocalTerminalSession("session-b");
+
+  assert.equal(a.hostId, LOCAL_TERMINAL_HOST_ID);
+  assert.equal(b.hostId, LOCAL_TERMINAL_HOST_ID);
+  assert.notEqual(a.id, b.id);
+  assert.equal(a.protocol, "local");
+});

--- a/application/state/sessionFactories.ts
+++ b/application/state/sessionFactories.ts
@@ -9,12 +9,21 @@ export interface LocalTerminalOptions {
   localStartDir?: string;
 }
 
+/**
+ * Stable hostId for all Local Terminal sessions.
+ *
+ * Autocomplete command history is keyed by hostId. Using `local-${sessionId}`
+ * made every new Local Terminal look like a brand-new host, so history
+ * suggestions never accumulated across opens (issue #2037).
+ */
+export const LOCAL_TERMINAL_HOST_ID = "local-terminal";
+
 export const createLocalTerminalSession = (
   sessionId: string,
   options?: LocalTerminalOptions,
 ): TerminalSession => ({
   id: sessionId,
-  hostId: `local-${sessionId}`,
+  hostId: LOCAL_TERMINAL_HOST_ID,
   hostLabel: options?.shellName || "Local Terminal",
   hostname: "localhost",
   username: "local",

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -630,20 +630,13 @@ export const useSessionState = ({
     const newSessions: TerminalSession[] = targets.map((target) => {
       if (target.kind === 'local') {
         const sessionId = crypto.randomUUID();
-        return {
-          id: sessionId,
-          hostId: `local-${sessionId}`,
-          hostLabel: target.shellName || 'Local Terminal',
-          hostname: 'localhost',
-          username: 'local',
-          status: 'connecting',
-          protocol: 'local',
+        return createLocalTerminalSession(sessionId, {
           shellType: target.shellType,
-          localShell: target.shell,
-          localShellArgs: target.shellArgs,
-          localShellName: target.shellName,
-          localShellIcon: target.shellIcon,
-        };
+          shell: target.shell,
+          shellArgs: target.shellArgs,
+          shellName: target.shellName,
+          shellIcon: target.shellIcon,
+        });
       }
       const host = target.host;
       if (host.protocol === 'serial') {
@@ -821,20 +814,14 @@ export const useSessionState = ({
     if (!workspacesRef.current.some(w => w.id === workspaceId)) return null;
 
     const newSessionId = crypto.randomUUID();
-    const localHostId = `local-${newSessionId}`;
     const newSession: TerminalSession = {
-      id: newSessionId,
-      hostId: localHostId,
-      hostLabel: options?.shellName || 'Local Terminal',
-      hostname: 'localhost',
-      username: 'local',
-      status: 'connecting',
-      protocol: 'local',
-      shellType: options?.shellType,
-      localShell: options?.shell,
-      localShellArgs: options?.shellArgs,
-      localShellName: options?.shellName,
-      localShellIcon: options?.shellIcon,
+      ...createLocalTerminalSession(newSessionId, {
+        shellType: options?.shellType,
+        shell: options?.shell,
+        shellArgs: options?.shellArgs,
+        shellName: options?.shellName,
+        shellIcon: options?.shellIcon,
+      }),
       workspaceId,
     };
 

--- a/components/terminal/autocomplete/commandHistoryStore.ts
+++ b/components/terminal/autocomplete/commandHistoryStore.ts
@@ -47,21 +47,39 @@ function loadStore(): HistoryStore {
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
+function persistStoreNow(store: HistoryStore): boolean {
+  const ok = localStorageAdapter.write(STORAGE_KEY, store);
+  if (ok) return true;
+  // Storage full — evict lowest scored entries (not just oldest by insertion)
+  const now = Date.now();
+  store.entries.sort((a, b) => scoreEntryAt(b, now) - scoreEntryAt(a, now));
+  store.entries = store.entries.slice(0, Math.floor(MAX_ENTRIES / 2));
+  return localStorageAdapter.write(STORAGE_KEY, store);
+}
+
 function saveStore(store: HistoryStore): void {
   cachedStore = store;
   // Debounce saves to avoid excessive writes
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
-    const ok = localStorageAdapter.write(STORAGE_KEY, store);
-    if (!ok) {
-      // Storage full — evict lowest scored entries (not just oldest by insertion)
-      const now = Date.now();
-      store.entries.sort((a, b) => scoreEntryAt(b, now) - scoreEntryAt(a, now));
-      store.entries = store.entries.slice(0, Math.floor(MAX_ENTRIES / 2));
-      localStorageAdapter.write(STORAGE_KEY, store);
-    }
+    persistStoreNow(store);
     saveTimer = null;
   }, 500);
+}
+
+/**
+ * Flush any pending debounced history write immediately.
+ * Used after bulk imports (e.g. local histfile seeding) so a seed-complete
+ * flag is not persisted before the imported commands land in storage.
+ * Returns false when the write could not be persisted.
+ */
+export function flushCommandHistoryStore(): boolean {
+  if (!cachedStore) return true;
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  return persistStoreNow(cachedStore);
 }
 
 /**

--- a/components/terminal/autocomplete/localShellHistorySeed.test.ts
+++ b/components/terminal/autocomplete/localShellHistorySeed.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+type LocalStorageMock = {
+  clear(): void;
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+function installLocalStorage(): LocalStorageMock {
+  const store = new Map<string, string>();
+  const localStorage: LocalStorageMock = {
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorage,
+    configurable: true,
+  });
+  return localStorage;
+}
+
+const localStorage = installLocalStorage();
+
+const files = new Map<string, string>();
+let bridgeEnabled = true;
+const bridge = {
+  getHomeDir: async () => (bridgeEnabled ? "/Users/demo" : Promise.reject(new Error("no bridge"))),
+  readLocalFile: async (path: string, options?: { maxBytes?: number }) => {
+    if (!bridgeEnabled) throw new Error("no bridge");
+    const text = files.get(path);
+    if (text === undefined) throw new Error(`ENOENT: ${path}`);
+    let bytes = new TextEncoder().encode(text);
+    if (options?.maxBytes && bytes.byteLength > options.maxBytes) {
+      bytes = bytes.subarray(bytes.byteLength - options.maxBytes);
+    }
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  },
+};
+
+Object.defineProperty(globalThis, "window", {
+  value: { electron: bridge, netcatty: bridge },
+  configurable: true,
+});
+
+const { clearHistory, queryHistory } = await import("./commandHistoryStore.ts");
+const { seedLocalShellHistoryFromHistfiles } = await import("./localShellHistorySeed.ts");
+const { getCompletions } = await import("./completionEngine.ts");
+
+test.beforeEach(() => {
+  localStorage.clear();
+  clearHistory();
+  files.clear();
+  bridgeEnabled = true;
+  (window as Window & { netcatty?: unknown }).netcatty = bridge;
+});
+
+test("seedLocalShellHistoryFromHistfiles imports zsh history for autocomplete prefix match", async () => {
+  const hostId = "local-terminal";
+  files.set(
+    "/Users/demo/.zsh_history",
+    ": 1700000000:0;sudo xattr -rd com.apple.quarantine /Applications/ClashX\\ Meta.app\n",
+  );
+
+  const seeded = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.ok(seeded > 0);
+
+  const matches = queryHistory("sudo xattr", { hostId, limit: 5 });
+  assert.equal(matches.length, 1);
+  assert.match(matches[0].command, /ClashX/);
+
+  const completions = await getCompletions("sudo xattr", {
+    hostId,
+    os: "macos",
+    protocol: "local",
+  });
+  assert.ok(
+    completions.some((c) => c.source === "history" && c.text.includes("ClashX")),
+    `expected history completion, got ${JSON.stringify(completions.map((c) => ({ s: c.source, t: c.text })))}`,
+  );
+});
+
+test("seedLocalShellHistoryFromHistfiles is idempotent for the same host after a successful import", async () => {
+  const hostId = "local-terminal";
+  files.set("/Users/demo/.zsh_history", ": 1700000000:0;pwd\n: 1700000001:0;ls\n");
+
+  const first = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  const second = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.equal(first, 2);
+  assert.equal(second, 0);
+});
+
+test("seedLocalShellHistoryFromHistfiles retries when histfiles were empty", async () => {
+  const hostId = "local-terminal";
+
+  const first = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.equal(first, 0);
+
+  files.set("/Users/demo/.zsh_history", ": 1700000000:0;echo later\n");
+  const second = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.equal(second, 1);
+  assert.equal(queryHistory("echo", { hostId, limit: 5 }).length, 1);
+});
+
+test("seedLocalShellHistoryFromHistfiles no-ops without a bridge and stays retryable", async () => {
+  const hostId = "local-terminal";
+  (window as Window & { netcatty?: unknown }).netcatty = undefined;
+
+  const first = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.equal(first, 0);
+
+  (window as Window & { netcatty?: unknown }).netcatty = bridge;
+  files.set("/Users/demo/.zsh_history", ": 1700000000:0;pwd\n");
+  const second = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.equal(second, 1);
+});
+
+test("seedLocalShellHistoryFromHistfiles dedupes concurrent calls for the same host", async () => {
+  const hostId = "local-terminal";
+  files.set("/Users/demo/.zsh_history", ": 1700000000:0;pwd\n");
+
+  // Start the first seed without awaiting so the second call overlaps in-flight.
+  const firstPromise = seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  const secondPromise = seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  const [a, b] = await Promise.all([firstPromise, secondPromise]);
+  assert.equal(a, 1);
+  assert.equal(b, 1);
+  assert.equal(queryHistory("pw", { hostId, limit: 5 }).length, 1);
+});
+
+test("seedLocalShellHistoryFromHistfiles drops a partial first line from a full-budget histfile tail", async () => {
+  const hostId = "local-terminal";
+  // Simulate a main-process maxBytes tail: exactly 512KiB ending mid-command,
+  // then a complete command on the next line.
+  const maxBytes = 512 * 1024;
+  const complete = ": 1700000001:0;echo complete\n";
+  const partialPrefix = "PARTIAL_TRUNCATED_COMMAND_WITHOUT_NEWLINE";
+  const overhead = Buffer.byteLength(`${partialPrefix}\n\n${complete}`, "utf8");
+  const filler = "x".repeat(maxBytes - overhead);
+  const tail = `${partialPrefix}\n${filler}\n${complete}`;
+  assert.equal(Buffer.byteLength(tail, "utf8"), maxBytes);
+
+  files.set("/Users/demo/.zsh_history", tail);
+  const seeded = await seedLocalShellHistoryFromHistfiles(hostId, "macos");
+  assert.ok(seeded >= 1);
+  assert.equal(queryHistory("echo", { hostId, limit: 5 })[0]?.command, "echo complete");
+  assert.equal(queryHistory("PARTIAL", { hostId, limit: 5 }).length, 0);
+});
+
+test("seedLocalShellHistoryFromHistfiles joins Windows home paths for fish history", async () => {
+  const hostId = "local-terminal";
+  const previousHome = bridge.getHomeDir;
+  bridge.getHomeDir = async () => "C:\\Users\\demo";
+  try {
+    files.set(
+      "C:\\Users\\demo\\.config\\fish\\fish_history",
+      "- cmd: echo fish\n  when: 1700000000\n",
+    );
+
+    const seeded = await seedLocalShellHistoryFromHistfiles(hostId, "windows");
+    assert.equal(seeded, 1);
+    assert.equal(queryHistory("echo", { hostId, limit: 5 })[0]?.command, "echo fish");
+  } finally {
+    bridge.getHomeDir = previousHome;
+  }
+});

--- a/components/terminal/autocomplete/localShellHistorySeed.ts
+++ b/components/terminal/autocomplete/localShellHistorySeed.ts
@@ -1,0 +1,163 @@
+/**
+ * Seed autocomplete command history from the local machine's shell histfiles.
+ *
+ * Local Terminal sessions previously used a per-session hostId (`local-${sessionId}`),
+ * so Netcatty's autocomplete history never accumulated across opens. Even with a
+ * stable hostId, a fresh install / new machine has an empty store until the user
+ * types commands inside Netcatty — while Ghostty (and similar terminals) surface
+ * suggestions from ~/.zsh_history / ~/.bash_history immediately.
+ *
+ * This module imports those histfiles once per hostId into commandHistoryStore
+ * so prefix autocomplete can match them.
+ */
+
+import {
+  isNetcattyAiHistoryCommand,
+  isNetcattyManagedStartupHistoryCommand,
+  mergeRemoteHistory,
+  parseBashHistory,
+  parseFishHistory,
+  parseZshHistory,
+} from "../../../domain/remoteHistory";
+import { localStorageAdapter } from "../../../infrastructure/persistence/localStorageAdapter";
+import { flushCommandHistoryStore, recordCommand } from "./commandHistoryStore";
+
+const SEED_FLAG_PREFIX = "netcatty:localHistSeeded:";
+const MAX_SEED_COMMANDS = 500;
+/** Cap histfile reads so a multi-MB history does not stall Local Terminal mount. */
+const MAX_HISTFILE_BYTES = 512 * 1024;
+
+type LocalFsBridge = {
+  getHomeDir?: () => Promise<string>;
+  readLocalFile?: (
+    path: string,
+    options?: { maxBytes?: number },
+  ) => Promise<ArrayBuffer | Buffer | Uint8Array | string>;
+};
+
+const inFlightSeeds = new Map<string, Promise<number>>();
+
+function getBridge(): LocalFsBridge | undefined {
+  return (window as Window & { netcatty?: LocalFsBridge }).netcatty;
+}
+
+function joinHomePath(home: string, relativeUnix: string): string {
+  const normalizedHome = home.replace(/[/\\]+$/, "");
+  const sep = home.includes("\\") && !home.includes("/") ? "\\" : "/";
+  const relative = sep === "\\" ? relativeUnix.replace(/\//g, "\\") : relativeUnix;
+  return `${normalizedHome}${sep}${relative}`;
+}
+
+function decodeHistfileBytes(bytes: Uint8Array): string {
+  // Main-process reads already return at most MAX_HISTFILE_BYTES. A buffer that
+  // fills the budget is treated as a truncated tail, so drop the first
+  // (possibly partial) line before parsing.
+  let text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  if (bytes.byteLength >= MAX_HISTFILE_BYTES) {
+    const firstNewline = text.indexOf("\n");
+    if (firstNewline >= 0) text = text.slice(firstNewline + 1);
+  }
+  return text;
+}
+
+async function readTextFile(bridge: LocalFsBridge, path: string): Promise<string | null> {
+  if (!bridge.readLocalFile) return null;
+  try {
+    // Ask the main process to return only the trailing bytes so multi-MB
+    // histfiles never cross the IPC boundary in full.
+    const raw = await bridge.readLocalFile(path, { maxBytes: MAX_HISTFILE_BYTES });
+    if (typeof raw === "string") {
+      // Bridge returned a string (tests / alternate adapters). Cap by UTF-8
+      // byte length so this path matches the binary branch.
+      const encoded = new TextEncoder().encode(raw);
+      return decodeHistfileBytes(encoded);
+    }
+    const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
+    return decodeHistfileBytes(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function alreadySeeded(hostId: string): boolean {
+  return localStorageAdapter.readBoolean(`${SEED_FLAG_PREFIX}${hostId}`) === true;
+}
+
+function markSeeded(hostId: string): void {
+  localStorageAdapter.writeBoolean(`${SEED_FLAG_PREFIX}${hostId}`, true);
+}
+
+async function seedLocalShellHistoryFromHistfilesOnce(
+  hostId: string,
+  os: "linux" | "windows" | "macos",
+): Promise<number> {
+  if (!hostId || alreadySeeded(hostId)) return 0;
+
+  const bridge = getBridge();
+  if (!bridge?.getHomeDir || !bridge.readLocalFile) return 0;
+
+  let home: string;
+  try {
+    home = await bridge.getHomeDir();
+  } catch {
+    return 0;
+  }
+  if (!home) return 0;
+
+  const [zshText, bashText, fishText, fishAltText] = await Promise.all([
+    readTextFile(bridge, joinHomePath(home, ".zsh_history")),
+    readTextFile(bridge, joinHomePath(home, ".bash_history")),
+    readTextFile(bridge, joinHomePath(home, ".local/share/fish/fish_history")),
+    readTextFile(bridge, joinHomePath(home, ".config/fish/fish_history")),
+  ]);
+
+  const lists = [
+    zshText ? parseZshHistory(zshText) : [],
+    bashText ? parseBashHistory(bashText) : [],
+    fishText ? parseFishHistory(fishText) : [],
+    !fishText && fishAltText ? parseFishHistory(fishAltText) : [],
+  ];
+
+  const merged = mergeRemoteHistory(lists, MAX_SEED_COMMANDS);
+  let recorded = 0;
+  // mergeRemoteHistory returns newest-first; record oldest-first so frequency /
+  // lastUsedAt ordering stays sensible if the same command appears later.
+  for (const entry of [...merged].reverse()) {
+    const command = entry.command.trim();
+    if (!command) continue;
+    if (isNetcattyAiHistoryCommand(command)) continue;
+    if (isNetcattyManagedStartupHistoryCommand(command)) continue;
+    recordCommand(command, hostId, os);
+    recorded += 1;
+  }
+
+  // Only persist the seeded flag after we actually imported commands and
+  // flushed the store. An empty/missing histfile must remain retryable so a
+  // later Local Terminal open can pick up history once it exists (#2037).
+  if (recorded > 0 && flushCommandHistoryStore()) {
+    markSeeded(hostId);
+  }
+  return recorded;
+}
+
+/**
+ * Import local shell histfiles into the autocomplete history store for `hostId`.
+ * Returns the number of commands newly recorded. No-ops when already seeded for
+ * this hostId, when the local FS bridge is unavailable, or when histfiles are
+ * empty/missing (those cases stay retryable on the next Local Terminal open).
+ */
+export async function seedLocalShellHistoryFromHistfiles(
+  hostId: string,
+  os: "linux" | "windows" | "macos" = "macos",
+): Promise<number> {
+  if (!hostId || alreadySeeded(hostId)) return 0;
+
+  const existing = inFlightSeeds.get(hostId);
+  if (existing) return existing;
+
+  const pending = seedLocalShellHistoryFromHistfilesOnce(hostId, os).finally(() => {
+    inFlightSeeds.delete(hostId);
+  });
+  inFlightSeeds.set(hostId, pending);
+  return pending;
+}

--- a/components/terminal/autocomplete/useTerminalAutocomplete.ts
+++ b/components/terminal/autocomplete/useTerminalAutocomplete.ts
@@ -18,6 +18,7 @@ import {
 import { getCompletions, parseCommandLine, type CompletionSuggestion } from "./completionEngine";
 import type { Snippet } from "../../../domain/models";
 import { recordCommand } from "./commandHistoryStore";
+import { seedLocalShellHistoryFromHistfiles } from "./localShellHistorySeed";
 import { shellEscape } from "./completionEngine";
 import { preloadCommonSpecs } from "./figSpecLoader";
 import {
@@ -244,6 +245,16 @@ export function useTerminalAutocomplete(
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Local Terminal: seed autocomplete history from ~/.zsh_history (etc.) once
+  // per stable hostId so prefix suggestions match Ghostty-style histfile recall
+  // (#2037). Remote sessions keep reading history via the side panel instead.
+  useEffect(() => {
+    if (!settings.enabled) return;
+    if (protocol !== "local") return;
+    if (!hostId) return;
+    void seedLocalShellHistoryFromHistfiles(hostId, hostOs);
+  }, [settings.enabled, protocol, hostId, hostOs]);
 
   // Initialize ghost text addon — poll for termRef since it's set after xterm runtime creation
   // Also clears popup/ghost when autocomplete is disabled at runtime

--- a/electron/bridges/localFsBridge.cjs
+++ b/electron/bridges/localFsBridge.cjs
@@ -180,11 +180,35 @@ async function listLocalDir(event, payload) {
 }
 
 /**
- * Read a local file
+ * Read a local file.
+ *
+ * Optional `maxBytes` returns only the trailing bytes of the file (used by
+ * Local Terminal histfile seeding so multi-MB shell histories do not stall
+ * the renderer IPC path).
  */
 async function readLocalFile(event, payload) {
-  const buffer = await fs.promises.readFile(payload.path);
-  return buffer;
+  const maxBytes =
+    Number.isFinite(payload?.maxBytes) && payload.maxBytes > 0
+      ? Math.floor(payload.maxBytes)
+      : null;
+  if (!maxBytes) {
+    return fs.promises.readFile(payload.path);
+  }
+
+  const handle = await fs.promises.open(payload.path, "r");
+  try {
+    const { size } = await handle.stat();
+    if (size <= maxBytes) {
+      const buffer = Buffer.alloc(size);
+      await handle.read(buffer, 0, size, 0);
+      return buffer;
+    }
+    const buffer = Buffer.alloc(maxBytes);
+    await handle.read(buffer, 0, maxBytes, size - maxBytes);
+    return buffer;
+  } finally {
+    await handle.close();
+  }
 }
 
 /**

--- a/electron/bridges/localFsBridge.test.cjs
+++ b/electron/bridges/localFsBridge.test.cjs
@@ -170,3 +170,21 @@ test("collectLocalTreeEntries preserves empty directories in selected folders", 
     await fs.promises.rm(root, { recursive: true, force: true });
   }
 });
+
+test("readLocalFile returns only the trailing maxBytes when requested", async () => {
+  const { readLocalFile } = require("./localFsBridge.cjs");
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-local-read-"));
+  const filePath = path.join(root, "hist.txt");
+  const body = "AAAA\nBBBB\nCCCC\nDDDD\n";
+  await fs.promises.writeFile(filePath, body);
+
+  try {
+    const full = await readLocalFile(null, { path: filePath });
+    assert.equal(Buffer.from(full).toString("utf8"), body);
+
+    const tailed = await readLocalFile(null, { path: filePath, maxBytes: 10 });
+    assert.equal(Buffer.from(tailed).toString("utf8"), body.slice(-10));
+  } finally {
+    await fs.promises.rm(root, { recursive: true, force: true });
+  }
+});

--- a/electron/preload/api.cjs
+++ b/electron/preload/api.cjs
@@ -481,8 +481,11 @@ function createPreloadApi(ctx) {
   listLocalDir: async (path) => {
     return ipcRenderer.invoke("netcatty:local:list", { path });
   },
-  readLocalFile: async (path) => {
-    return ipcRenderer.invoke("netcatty:local:read", { path });
+  readLocalFile: async (path, options) => {
+    return ipcRenderer.invoke("netcatty:local:read", {
+      path,
+      maxBytes: options?.maxBytes,
+    });
   },
   writeLocalFile: async (path, content) => {
     return ipcRenderer.invoke("netcatty:local:write", { path, content });

--- a/types/global/netcatty-bridge-sftp.d.ts
+++ b/types/global/netcatty-bridge-sftp.d.ts
@@ -84,7 +84,7 @@ declare global {
 
     // Local filesystem operations
     listLocalDir?(path: string): Promise<RemoteFile[]>;
-    readLocalFile?(path: string): Promise<ArrayBuffer>;
+    readLocalFile?(path: string, options?: { maxBytes?: number }): Promise<ArrayBuffer>;
     writeLocalFile?(path: string, content: ArrayBuffer): Promise<void>;
     deleteLocalFile?(path: string): Promise<void>;
     renameLocalFile?(oldPath: string, newPath: string): Promise<void>;


### PR DESCRIPTION
## Summary
- Stabilize Local Terminal `hostId` as `local-terminal` so autocomplete history accumulates across sessions (was `local-${sessionId}`).
- Seed autocomplete history once from local `~/.zsh_history` / bash / fish histfiles so prefix suggestions match Ghostty-style recall.
- Cap histfile IPC reads to a trailing 512KiB, flush before marking seeded, and keep empty/missing histfiles retryable.

Closes #2037

## Test plan
- [ ] Open Local Terminal, type a prefix of a command that exists in `~/.zsh_history` (e.g. `sudo xattr`) and confirm the full historical command appears in autocomplete.
- [ ] Close and reopen Local Terminal; confirm suggestions still appear (stable hostId).
- [ ] With autocomplete enabled, open two Local Terminal panes at once; confirm no duplicate seed / frequency inflation.
- [ ] Fresh profile with empty histfiles: open Local Terminal, then create histfile entries outside Netcatty, reopen Local Terminal and confirm seeding retries.
- [ ] Run: `tsx --test application/state/sessionFactories.localHostId.test.ts components/terminal/autocomplete/localShellHistorySeed.test.ts electron/bridges/localFsBridge.test.cjs`


Made with [Cursor](https://cursor.com)