### PR TITLE
feat(settings): finer window opacity steps (96–99%)

### DIFF
--- a/components/WindowOpacityButton.tsx
+++ b/components/WindowOpacityButton.tsx
@@ -63,7 +63,7 @@ export const WindowOpacityButton: React.FC<WindowOpacityButtonProps> = ({
               type="range"
               min={50}
               max={100}
-              step={5}
+              step={1}
               value={percent}
               onChange={(e) => setWindowOpacity(Number(e.target.value) / 100)}
               className="flex-1 accent-primary"

--- a/components/settings/tabs/SettingsAppearanceTab.tsx
+++ b/components/settings/tabs/SettingsAppearanceTab.tsx
@@ -213,7 +213,7 @@ function SettingsAppearanceTab(props: {
                 type="range"
                 min={50}
                 max={100}
-                step={5}
+                step={1}
                 value={Math.round(windowOpacity * 100)}
                 onChange={(e) => setWindowOpacity(Number(e.target.value) / 100)}
                 className="w-28 accent-primary"


### PR DESCRIPTION
## Summary
- Change the window opacity slider step from 5% to 1% so users can pick 96–99% (and any other 1% increment between 50–100%).
- No clamp/backend changes needed — values in `[0.5, 1]` were already supported; only the UI step blocked finer control.
- Closes #2019

## Test plan
- [ ] Open Settings → Appearance → Window opacity
- [ ] Drag the slider near the top and confirm 96%, 97%, 98%, 99% are selectable
- [ ] Confirm 50% and 100% still work, and preset buttons (100% / 85% / 70%) still apply correctly
- [ ] On Windows, verify 96–99% looks less see-through than 95% as expected


Made with [Cursor](https://cursor.com)