### PR TITLE
fix(ai): buffer early bridge stream events

### DIFF
--- a/infrastructure/ai/providersBridgeFetch.test.ts
+++ b/infrastructure/ai/providersBridgeFetch.test.ts
@@ -5,6 +5,55 @@ import { z } from 'zod';
 import { createBridgeFetchForSDK, createModelFromConfig } from './sdk/providers';
 import type { OpenAIChatAssistantFields } from './providerContinuation';
 
+test('buffers stream events emitted before the Response stream starts', async (t) => {
+  const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+  t.after(() => {
+    (globalThis as typeof globalThis & { window?: unknown }).window = originalWindow;
+  });
+
+  const dataHandlers = new Map<string, (data: string) => void>();
+  const endHandlers = new Map<string, () => void>();
+
+  (globalThis as typeof globalThis & { window?: unknown }).window = {
+    netcatty: {
+      aiFetch: async () => ({ ok: true, status: 200, data: '{}' }),
+      aiChatCancel: async () => true,
+      onAiStreamData: (requestId: string, cb: (data: string) => void) => {
+        dataHandlers.set(requestId, cb);
+        return () => dataHandlers.delete(requestId);
+      },
+      onAiStreamEnd: (requestId: string, cb: () => void) => {
+        endHandlers.set(requestId, cb);
+        return () => endHandlers.delete(requestId);
+      },
+      onAiStreamError: () => () => undefined,
+      aiChatStream: async (requestId: string) => {
+        const emit = dataHandlers.get(requestId);
+        assert.ok(emit, 'stream data handler should be registered before aiChatStream starts');
+        emit(JSON.stringify({
+          id: 'chatcmpl-fast-stream',
+          object: 'chat.completion.chunk',
+          choices: [{ index: 0, delta: { content: 'fast' } }],
+        }));
+        endHandlers.get(requestId)?.();
+        return { ok: true, statusCode: 200, statusText: 'OK' };
+      },
+    },
+  };
+
+  const fetch = createBridgeFetchForSDK('deepseek-custom');
+  const response = await fetch('https://api.example.test/v1/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({
+      stream: true,
+      messages: [{ role: 'user', content: 'hello' }],
+    }),
+  });
+
+  const text = await response.text();
+  assert.match(text, /"content":"fast"/);
+});
+
 test('captures OpenAI-compatible reasoning_content before the tool follow-up request', async (t) => {
   const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
   t.after(() => {

--- a/infrastructure/ai/sdk/providers.ts
+++ b/infrastructure/ai/sdk/providers.ts
@@ -461,23 +461,60 @@ export function createBridgeFetchForSDK(
       // Set up IPC event listeners BEFORE starting the stream to avoid
       // missing early events.
       const encoder = new TextEncoder();
-      let streamController: ReadableStreamDefaultController<Uint8Array>;
+      let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+      const pendingChunks: Uint8Array[] = [];
+      let pendingClose = false;
+      let pendingError: Error | null = null;
       let cleanedUp = false;
+
+      const enqueueChunk = (chunk: Uint8Array) => {
+        if (streamController) {
+          streamController.enqueue(chunk);
+          return;
+        }
+        pendingChunks.push(chunk);
+      };
+      const closeStream = () => {
+        if (streamController) {
+          try { streamController.close(); } catch { /* already closed */ }
+          return;
+        }
+        pendingClose = true;
+      };
+      const errorStream = (error: Error) => {
+        if (streamController) {
+          try { streamController.error(error); } catch { /* already errored */ }
+          return;
+        }
+        pendingError = error;
+      };
+      const flushPendingStreamEvents = (controller: ReadableStreamDefaultController<Uint8Array>) => {
+        for (const chunk of pendingChunks.splice(0)) {
+          controller.enqueue(chunk);
+        }
+        if (pendingError) {
+          controller.error(pendingError);
+          return;
+        }
+        if (pendingClose) {
+          controller.close();
+        }
+      };
 
       const unsubData = bridge.onAiStreamData(requestId, (data: string) => {
         const normalizedData = normalizeOpenAIChatToolCalls(data);
         captureOpenAIChatFields(normalizedData);
         // Re-wrap as SSE so the SDK can parse it
-        streamController?.enqueue(encoder.encode(`data: ${normalizedData}\n\n`));
+        enqueueChunk(encoder.encode(`data: ${normalizedData}\n\n`));
       });
       const unsubEnd = bridge.onAiStreamEnd(requestId, () => {
-        try { streamController?.close(); } catch { /* already closed */ }
+        closeStream();
         cleanup();
       });
       const unsubError = bridge.onAiStreamError(
         requestId,
         (error: string) => {
-          try { streamController?.error(new Error(error)); } catch { /* already errored */ }
+          errorStream(new Error(error));
           cleanup();
         },
       );
@@ -496,7 +533,7 @@ export function createBridgeFetchForSDK(
           'abort',
           () => {
             bridge.aiChatCancel(requestId).catch(() => {});
-            try { streamController?.error(new DOMException('Aborted', 'AbortError')); } catch { /* already errored */ }
+            errorStream(new DOMException('Aborted', 'AbortError'));
             cleanup();
           },
           { once: true },
@@ -543,6 +580,7 @@ export function createBridgeFetchForSDK(
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           streamController = controller;
+          flushPendingStreamEvents(controller);
         },
       });
 


### PR DESCRIPTION
## 变更说明

修复 AI SDK bridge fetch 流式请求中的一个竞态问题。

renderer 会在发起主进程流式请求前注册 IPC stream 监听器，但 `ReadableStream` 的 controller 只有在 `aiChatStream()` 返回响应头之后才会创建。如果某些 OpenAI 兼容 provider 或代理很快返回 `stream:data` 和 `stream:end`，这些事件可能会早于 `ReadableStream.start()` 到达。

之前这类早到事件会因为 `streamController` 尚未初始化而被丢弃，导致上游响应已经结束，但 AI SDK 仍在等待流数据，表现为聊天长时间无响应或卡住。

本次改动会临时缓冲早到的 data / end / error 事件，并在 `ReadableStream` controller 可用后统一 flush。

## 主要改动

- 在 AI bridge fetch streaming path 中缓存早到的 stream chunk。
- 缓存早到的 close / error 状态，避免流结束事件丢失。
- 增加回归测试，覆盖 `aiChatStream()` 返回前就收到 data/end 的场景。

## 验证

已执行：

```bash
node --test --import tsx infrastructure/ai/providersBridgeFetch.test.ts
npm run build
```