### PR TITLE
Fix group host list search scoping

### DIFF
--- a/components/vault/useVaultHostCollections.test.ts
+++ b/components/vault/useVaultHostCollections.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { Host } from "../../types.ts";
+import { filterVaultHostsForDisplay } from "./useVaultHostCollections.tsx";
+
+const host = (id: string, label: string, group = ""): Host => ({
+  id,
+  label,
+  hostname: `${id}.example.com`,
+  username: "root",
+  port: 22,
+  os: "linux",
+  tags: [],
+  createdAt: 1,
+  group,
+});
+
+test("root host search can still show matches from any group", () => {
+  const matchingHost = host("prod-db", "Prod DB", "Production");
+
+  const result = filterVaultHostsForDisplay({
+    filteredHosts: [matchingHost],
+    searchTerm: "prod",
+    selectedGroupPath: null,
+    showOnlyUngroupedHostsInRoot: true,
+  });
+
+  assert.deepEqual(result.map((item) => item.id), ["prod-db"]);
+});
+
+test("selected group view does not show search matches from another group", () => {
+  const matchingHostInOtherGroup = host("prod-db", "Prod DB", "Production");
+
+  const result = filterVaultHostsForDisplay({
+    filteredHosts: [matchingHostInOtherGroup],
+    searchTerm: "prod",
+    selectedGroupPath: "Staging",
+    showOnlyUngroupedHostsInRoot: false,
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test("selected General group includes ungrouped hosts while search is active", () => {
+  const ungroupedHost = host("local", "Local");
+
+  const result = filterVaultHostsForDisplay({
+    filteredHosts: [ungroupedHost],
+    searchTerm: "local",
+    selectedGroupPath: "General",
+    showOnlyUngroupedHostsInRoot: false,
+  });
+
+  assert.deepEqual(result.map((item) => item.id), ["local"]);
+});

--- a/components/vault/useVaultHostCollections.tsx
+++ b/components/vault/useVaultHostCollections.tsx
@@ -24,6 +24,41 @@ interface UseVaultHostCollectionsOptions {
   viewMode: "grid" | "list" | "tree";
 }
 
+export function hostBelongsToSelectedVaultGroup(host: Host, selectedGroupPath: string): boolean {
+  const hostGroup = host.group || "";
+  if (selectedGroupPath === "General") {
+    return hostGroup === "" || hostGroup === "General";
+  }
+  return hostGroup === selectedGroupPath;
+}
+
+export function filterVaultHostsForDisplay({
+  filteredHosts,
+  searchTerm,
+  selectedGroupPath,
+  showOnlyUngroupedHostsInRoot,
+}: {
+  filteredHosts: Host[];
+  searchTerm: string;
+  selectedGroupPath: string | null;
+  showOnlyUngroupedHostsInRoot: boolean;
+}): Host[] {
+  if (selectedGroupPath) {
+    return filteredHosts.filter((host) =>
+      hostBelongsToSelectedVaultGroup(host, selectedGroupPath),
+    );
+  }
+
+  if (!searchTerm && showOnlyUngroupedHostsInRoot) {
+    return filteredHosts.filter((host) => {
+      const hostGroup = (host.group || "").trim();
+      return hostGroup === "";
+    });
+  }
+
+  return filteredHosts;
+}
+
 export function useVaultHostCollections({
   customGroups,
   groupConfigs,
@@ -192,32 +227,14 @@ export function useVaultHostCollections({
     };
   
   const displayedHosts = useMemo(() => {
-      let filtered = filteredHosts;
-      // Search spans all groups (#777): when the user types in the search box
-      // we skip group/ungrouped-root scoping, so a matching host in another
-      // group is still reachable without having to navigate into it first.
-      // The tree view already uses this shape — see `treeViewHosts` below.
-      const hasSearch = searchTerm.length > 0;
-      if (!hasSearch) {
-        if (selectedGroupPath) {
-          // Match hosts whose group equals the selected path
-          // For "General" group, also match hosts with empty/undefined group
-          filtered = filtered.filter((h) => {
-            const hostGroup = h.group || "";
-            if (selectedGroupPath === "General") {
-              return hostGroup === "" || hostGroup === "General";
-            }
-            return hostGroup === selectedGroupPath;
-          });
-        } else if (showOnlyUngroupedHostsInRoot) {
-          filtered = filtered.filter((h) => {
-            const hostGroup = (h.group || "").trim();
-            return hostGroup === "";
-          });
-        }
-      }
+      const filtered = filterVaultHostsForDisplay({
+        filteredHosts,
+        searchTerm,
+        selectedGroupPath,
+        showOnlyUngroupedHostsInRoot,
+      });
       return sortHosts(filtered);
-    }, [filteredHosts, searchTerm.length, selectedGroupPath, showOnlyUngroupedHostsInRoot, sortHosts]);
+    }, [filteredHosts, searchTerm, selectedGroupPath, showOnlyUngroupedHostsInRoot, sortHosts]);
   
   // Pinned hosts for root-level display (not inside a subgroup)
     // Respects active search and tag filters


### PR DESCRIPTION
## Summary
- Fixes #2051.
- Keeps root-level host search global, while group pages no longer show matching hosts from other groups.
- Adds coverage for root search, selected group scoping, and General group behavior.

## Verification
- node --test --import tsx components/vault/useVaultHostCollections.test.ts
- node --test --import tsx components/vault/VaultHostListSection.test.tsx components/VaultView.sortPersistence.test.tsx components/VaultHostListSection.test.ts
- npm run lint
- npm run build

## Review
- review-until-clean completed with two independent reviewers over two rounds; final round CLEAN from both.
