### PR TITLE
Fix quick switcher local shell setting

### DIFF
--- a/application/app/AppView.tsx
+++ b/application/app/AppView.tsx
@@ -558,6 +558,7 @@ export function AppView({ ctx }: { ctx: AppViewContext }) {
                 setQuickSearch('');
               }}
               keyBindings={keyBindings}
+              terminalSettings={terminalSettings}
             />
           </Suspense>
         </LazyLoadBoundary>

--- a/components/QuickSwitcher.tsx
+++ b/components/QuickSwitcher.tsx
@@ -9,10 +9,10 @@ import {
 } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
-import { Host, TerminalSession, Workspace } from "../types";
+import { Host, TerminalSession, TerminalSettings, Workspace } from "../types";
 import { KeyBinding } from "../domain/models";
 import { matchesSearchQuery } from "../lib/searchMatcher";
-import { useDiscoveredShells, getShellIconPath, isMonochromeShellIcon } from "../lib/useDiscoveredShells";
+import { buildQuickSwitcherShells, useDiscoveredShells, getShellIconPath, isMonochromeShellIcon } from "../lib/useDiscoveredShells";
 
 type QuickSwitcherItem = {
   type: "host" | "tab" | "workspace" | "action" | "shell";
@@ -73,6 +73,7 @@ interface QuickSwitcherProps {
   onCreateWorkspace?: () => void;
   keyBindings?: KeyBinding[];
   showSftpTab: boolean;
+  terminalSettings?: Pick<TerminalSettings, "localShell" | "localShellArgs">;
 }
 
 const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
@@ -89,19 +90,27 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
   onCreateWorkspace,
   keyBindings,
   showSftpTab,
+  terminalSettings,
 }) => {
   const { t } = useI18n();
   const discoveredShells = useDiscoveredShells();
+  const quickSwitcherShells = useMemo(() => (
+    buildQuickSwitcherShells(
+      discoveredShells,
+      terminalSettings?.localShell ?? "",
+      terminalSettings?.localShellArgs,
+    )
+  ), [discoveredShells, terminalSettings?.localShell, terminalSettings?.localShellArgs]);
 
   const filteredShells = useMemo(() => {
     const list = !query.trim()
-      ? discoveredShells
-      : discoveredShells.filter(
-          (s) => matchesSearchQuery(query, s.name, s.id)
+      ? quickSwitcherShells
+      : quickSwitcherShells.filter(
+          (s) => matchesSearchQuery(query, s.name, s.id, s.command)
         );
     // Default shell first
     return [...list].sort((a, b) => (a.isDefault === b.isDefault ? 0 : a.isDefault ? -1 : 1));
-  }, [discoveredShells, query]);
+  }, [quickSwitcherShells, query]);
 
   // Get hotkey display strings
   const getHotkeyLabel = useCallback((actionId: string) => {
@@ -270,7 +279,7 @@ const QuickSwitcherInner: React.FC<QuickSwitcherProps> = ({
         }
         break;
       case "shell": {
-        const shell = discoveredShells.find(s => s.id === item.id);
+        const shell = quickSwitcherShells.find(s => s.id === item.id);
         if (shell && onCreateLocalTerminal) {
           onCreateLocalTerminal({ command: shell.command, args: shell.args, name: shell.name, icon: shell.icon });
           onClose();

--- a/lib/useDiscoveredShells.test.ts
+++ b/lib/useDiscoveredShells.test.ts
@@ -1,10 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveShellSetting } from "./useDiscoveredShells";
+import { matchesSearchQuery } from "./searchMatcher";
+import { buildQuickSwitcherShells, resolveShellSetting } from "./useDiscoveredShells";
 
 const DISCOVERED: DiscoveredShell[] = [
   { id: "git-bash", name: "Git Bash", command: "C:\\Git\\bin\\bash.exe", args: ["--login", "-i"], icon: "git-bash" },
+];
+
+const WINDOWS_SHELLS: DiscoveredShell[] = [
+  { id: "cmd", name: "CMD", command: "cmd.exe", args: [], icon: "cmd" },
+  { id: "powershell", name: "Windows PowerShell", command: "powershell.exe", args: ["-NoLogo"], icon: "powershell", isDefault: true },
+  { id: "pwsh", name: "PowerShell 7", command: "C:\\Program Files\\PowerShell\\7\\pwsh.exe", args: ["-NoLogo"], icon: "pwsh" },
 ];
 
 test("resolveShellSetting returns null for empty value", () => {
@@ -39,4 +46,52 @@ test("resolveShellSetting prefers explicit custom args when value collides with 
   const resolved = resolveShellSetting("git-bash", DISCOVERED, ["--private"]);
   assert.equal(resolved?.command, "C:\\Git\\bin\\bash.exe");
   assert.deepEqual(resolved?.args, ["--private"]);
+});
+
+test("buildQuickSwitcherShells keeps discovered defaults when no local shell is configured", () => {
+  const shells = buildQuickSwitcherShells(WINDOWS_SHELLS, "");
+  assert.equal(shells.find((shell) => shell.id === "powershell")?.isDefault, true);
+  assert.equal(shells.find((shell) => shell.id === "pwsh")?.isDefault, undefined);
+});
+
+test("buildQuickSwitcherShells marks a configured discovered shell as default", () => {
+  const shells = buildQuickSwitcherShells(WINDOWS_SHELLS, "pwsh");
+  const pwsh = shells.find((shell) => shell.id === "pwsh");
+  assert.equal(pwsh?.isDefault, true);
+  assert.equal(pwsh?.command, "C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+  assert.deepEqual(pwsh?.args, ["-NoLogo"]);
+  assert.equal(shells.find((shell) => shell.id === "powershell")?.isDefault, false);
+});
+
+test("buildQuickSwitcherShells maps a custom pwsh.exe setting onto the PowerShell quick switch entry", () => {
+  const shells = buildQuickSwitcherShells(
+    WINDOWS_SHELLS.filter((shell) => shell.id !== "pwsh"),
+    "pwsh.exe",
+  );
+  const powershell = shells.find((shell) => shell.id === "powershell");
+  assert.equal(powershell?.isDefault, true);
+  assert.equal(powershell?.name, "PowerShell 7");
+  assert.equal(powershell?.command, "pwsh.exe");
+  assert.equal(powershell?.icon, "pwsh");
+  assert.equal(shells.find((shell) => shell.id === "cmd")?.isDefault, false);
+});
+
+test("custom quick switch shells remain searchable by executable name", () => {
+  const shells = buildQuickSwitcherShells(
+    WINDOWS_SHELLS.filter((shell) => shell.id !== "pwsh"),
+    "pwsh.exe",
+  );
+  const powershell = shells.find((shell) => shell.id === "powershell");
+  assert.ok(powershell);
+  assert.equal(matchesSearchQuery("pwsh", powershell.name, powershell.id, powershell.command), true);
+});
+
+test("buildQuickSwitcherShells matches custom shell paths by full command before basename fallback", () => {
+  const shells = buildQuickSwitcherShells([
+    { id: "bash-system", name: "Bash (/bin/bash)", command: "/bin/bash", args: ["-l"], icon: "bash", isDefault: true },
+    { id: "bash-homebrew", name: "Bash (/opt/homebrew/bin/bash)", command: "/opt/homebrew/bin/bash", args: ["-l"], icon: "bash" },
+  ], "/opt/homebrew/bin/bash");
+
+  assert.equal(shells.find((shell) => shell.id === "bash-system")?.isDefault, false);
+  assert.equal(shells.find((shell) => shell.id === "bash-homebrew")?.isDefault, true);
 });

--- a/lib/useDiscoveredShells.ts
+++ b/lib/useDiscoveredShells.ts
@@ -69,6 +69,108 @@ export function resolveShellSetting(
   return { command: localShell, args: customArgs?.length ? customArgs : undefined };
 }
 
+const CONFIGURED_LOCAL_SHELL_ID = "__configured-local-shell__";
+
+function getShellBaseName(command: string | undefined): string {
+  const parts = String(command || "").trim().split(/[\\/]/);
+  return (parts[parts.length - 1] || "").toLowerCase();
+}
+
+function normalizeShellCommand(command: string | undefined): string {
+  return String(command || "").trim().replace(/\\/g, "/").toLowerCase();
+}
+
+function getFriendlyCustomShell(shell: string): Pick<DiscoveredShell, "name" | "icon"> {
+  const base = getShellBaseName(shell);
+  const stem = base.endsWith(".exe") ? base.slice(0, -4) : base;
+  switch (stem) {
+    case "pwsh":
+      return { name: "PowerShell 7", icon: "pwsh" };
+    case "powershell":
+      return { name: "Windows PowerShell", icon: "powershell" };
+    case "cmd":
+      return { name: "CMD", icon: "cmd" };
+    case "bash":
+      return { name: "Bash", icon: "bash" };
+    case "zsh":
+      return { name: "Zsh", icon: "zsh" };
+    case "fish":
+      return { name: "Fish", icon: "fish" };
+    case "nu":
+      return { name: "Nushell", icon: "nushell" };
+    default:
+      return { name: shell || "Local Terminal", icon: "terminal" };
+  }
+}
+
+function findConfiguredShellTarget(
+  discoveredShells: DiscoveredShell[],
+  localShell: string,
+  resolvedCommand: string,
+): DiscoveredShell | undefined {
+  const matchedById = discoveredShells.find((shell) => shell.id === localShell);
+  if (matchedById) return matchedById;
+
+  const configuredCommand = normalizeShellCommand(resolvedCommand || localShell);
+  const matchedByCommand = discoveredShells.find((shell) => (
+    normalizeShellCommand(shell.command) === configuredCommand
+  ));
+  if (matchedByCommand) return matchedByCommand;
+
+  const configuredBase = getShellBaseName(resolvedCommand || localShell);
+  if (configuredBase === "pwsh.exe" || configuredBase === "pwsh") {
+    return (
+      discoveredShells.find((shell) => shell.id === "pwsh") ??
+      discoveredShells.find((shell) => shell.id === "powershell")
+    );
+  }
+
+  if (configuredBase === "powershell.exe" || configuredBase === "powershell") {
+    return (
+      discoveredShells.find((shell) => shell.id === "powershell") ??
+      discoveredShells.find((shell) => shell.id === "pwsh")
+    );
+  }
+
+  return undefined;
+}
+
+export function buildQuickSwitcherShells(
+  discoveredShells: DiscoveredShell[],
+  localShell: string,
+  customArgs?: string[],
+): DiscoveredShell[] {
+  const configured = resolveShellSetting(localShell, discoveredShells, customArgs);
+  if (!configured) return discoveredShells;
+
+  const target = findConfiguredShellTarget(discoveredShells, localShell, configured.command);
+  const friendly = getFriendlyCustomShell(configured.command || localShell);
+  const configuredShell: DiscoveredShell = {
+    ...(target ?? {
+      id: CONFIGURED_LOCAL_SHELL_ID,
+      args: undefined,
+    }),
+    name: target && target.id === localShell ? target.name : friendly.name,
+    command: configured.command,
+    args: configured.args,
+    icon: target && target.id === localShell ? target.icon : friendly.icon,
+    isDefault: true,
+  };
+
+  if (!target) {
+    return [
+      configuredShell,
+      ...discoveredShells.map((shell) => ({ ...shell, isDefault: false })),
+    ];
+  }
+
+  return discoveredShells.map((shell) => (
+    shell.id === target.id
+      ? configuredShell
+      : { ...shell, isDefault: false }
+  ));
+}
+
 const DISTRO_ICONS = new Set([
   "ubuntu", "debian", "kali", "alpine", "opensuse",
   "fedora", "arch", "oracle", "linux",


### PR DESCRIPTION
Fixes #2054

## Summary
- Make the quick switcher honor the configured local shell executable for Windows PowerShell entries.
- Keep the existing default behavior when no local shell override is set.
- Add coverage for configured PowerShell and custom shell matching.

## Validation
- node --test --import tsx lib/useDiscoveredShells.test.ts
- npm run lint
- npm run build
- npm test (4532 tests: 4529 passed, 3 skipped)
- review-until-clean with two independent reviewers, final round clean