### PR TITLE
Fix jump host auth failure attribution

### DIFF
--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -289,6 +289,206 @@ test("startSSH resolves jump host proxy credentials from an identity", async () 
   });
 });
 
+test("startSSH shows jump-host auth failures without opening target auth retry", async () => {
+  let error = "";
+  let needsAuth = false;
+  let retryMessage: string | null = "previous retry";
+  let status = "";
+  const progressLogs: string[] = [];
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => {
+      const err = new Error('Jump host authentication failed for "Bastion": All configured authentication methods failed');
+      (err as Error & { isJumpHostAuthError?: boolean }).isJumpHostAuthError = true;
+      throw err;
+    },
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    terminalBackend,
+    host: {
+      id: "host-1",
+      label: "Target",
+      hostname: "target.example.test",
+      username: "alice",
+      hostChain: { hostIds: ["jump-1"] },
+    },
+    resolvedChainHosts: [{
+      id: "jump-1",
+      label: "Bastion",
+      hostname: "bastion.example.test",
+      username: "jump",
+      password: "wrong-secret",
+    }],
+    setError: (message: string) => { error = message; },
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setAuthRetryMessage: (message: string | null) => { retryMessage = message; },
+    setStatus: (next: string) => { status = next; },
+    updateStatus: (next: string) => { status = next; },
+    setProgressLogs: (next: string[] | ((prev: string[]) => string[])) => {
+      if (typeof next === "function") {
+        progressLogs.splice(0, progressLogs.length, ...next(progressLogs));
+      } else {
+        progressLogs.splice(0, progressLogs.length, ...next);
+      }
+    },
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(needsAuth, false);
+  assert.equal(retryMessage, null);
+  assert.equal(status, "disconnected");
+  assert.match(error, /Jump host authentication failed for "Bastion"/);
+  assert.equal(progressLogs.some((line) => /Authentication failed\. Please try again/.test(line)), false);
+});
+
+test("startSSH recognizes Electron-prefixed jump-host auth failures", async () => {
+  let error = "";
+  let needsAuth = false;
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => {
+      throw new Error(
+        'Error invoking remote method "netcatty:start": Error: Jump host authentication failed for "Bastion": All configured authentication methods failed',
+      );
+    },
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    terminalBackend,
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setError: (message: string) => { error = message; },
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(needsAuth, false);
+  assert.match(error, /Jump host authentication failed for "Bastion"/);
+});
+
+test("startSSH does not open auth retry for socket errors mentioning auth in hostnames", async () => {
+  let error = "";
+  let needsAuth = false;
+  let retryMessage: string | null = "previous retry";
+  let status = "";
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => {
+      const err = new Error("Connection reset by auth-bastion.example.com");
+      throw err;
+    },
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    terminalBackend,
+    host: {
+      id: "host-1",
+      label: "Target",
+      hostname: "target.example.test",
+      username: "alice",
+      hostChain: { hostIds: ["jump-1"] },
+    },
+    resolvedChainHosts: [{
+      id: "jump-1",
+      label: "Auth Bastion",
+      hostname: "auth-bastion.example.com",
+      username: "jump",
+      password: "secret",
+    }],
+    setError: (message: string) => { error = message; },
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setAuthRetryMessage: (message: string | null) => { retryMessage = message; },
+    setStatus: (next: string) => { status = next; },
+    updateStatus: (next: string) => { status = next; },
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(needsAuth, false);
+  assert.equal(retryMessage, null);
+  assert.equal(status, "disconnected");
+  assert.equal(error, "Connection reset by auth-bastion.example.com");
+});
+
+test("startSSH does not open auth retry for non-login permission denied errors", async () => {
+  let needsAuth = false;
+  let error = "";
+  const terminalBackend = {
+    backendAvailable: () => true,
+    telnetAvailable: () => true,
+    moshAvailable: () => true,
+    localAvailable: () => true,
+    serialAvailable: () => true,
+    execAvailable: () => true,
+    startSSHSession: async () => {
+      throw new Error("Permission denied opening channel to auth-bastion.example.com");
+    },
+    startTelnetSession: async () => "telnet-session",
+    startMoshSession: async () => "mosh-session",
+    startLocalSession: async () => "local-session",
+    startSerialSession: async () => "serial-session",
+    execCommand: async () => ({}),
+    onSessionData: () => noop,
+    onSessionExit: () => noop,
+    onChainProgress: () => noop,
+    writeToSession: noop,
+    resizeSession: noop,
+  };
+  const ctx = createStarterContext({
+    terminalBackend,
+    setNeedsAuth: (value: boolean) => { needsAuth = value; },
+    setError: (message: string) => { error = message; },
+  });
+
+  await createTerminalSessionStarters(ctx as never).startSSH(createTermStub() as never);
+
+  assert.equal(needsAuth, false);
+  assert.equal(error, "Permission denied opening channel to auth-bastion.example.com");
+});
+
 test("startSSH rejects missing saved proxy profiles before connecting", async () => {
   let started = false;
   let error = "";

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -50,6 +50,22 @@ import {
 import { hasConnectionPassedTcpDial } from "../connectionTimeouts";
 
 const TELNET_SESSION_REPLACED_ERROR = "Telnet session start was replaced";
+const JUMP_HOST_AUTH_FAILED_PREFIX = "Jump host authentication failed";
+
+const isAuthFailureMessage = (message: string): boolean => {
+  const normalized = message.toLowerCase();
+  return normalized.includes("all configured authentication methods failed") ||
+    normalized.includes("authentication failed") ||
+    normalized.includes("too many authentication failures") ||
+    /permission denied\s*\(/.test(normalized) ||
+    normalized.includes("no authentication methods available");
+};
+
+const isJumpHostAuthError = (err: unknown, message: string): boolean =>
+  Boolean(
+    err instanceof Error &&
+    (err as Error & { isJumpHostAuthError?: boolean }).isJumpHostAuthError,
+  ) || message.includes(JUMP_HOST_AUTH_FAILED_PREFIX);
 
 export const getMissingChainHostIds = (
   host: Host,
@@ -189,13 +205,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
 
     const isAuthError = (err: unknown): boolean => {
       if (!(err instanceof Error)) return false;
-      const msg = err.message.toLowerCase();
-      return (
-        msg.includes("authentication") ||
-        msg.includes("auth") ||
-        msg.includes("password") ||
-        msg.includes("permission denied")
-      );
+      return isAuthFailureMessage(err.message);
     };
 
     if (ctx.host.proxyProfileId && !ctx.host.proxyConfig) {
@@ -618,7 +628,14 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
       const message = err instanceof Error ? err.message : String(err);
       const authError = isAuthError(err);
 
-      if (authError) {
+      if (isJumpHostAuthError(err, message)) {
+        ctx.setNeedsAuth(false);
+        ctx.setAuthRetryMessage(null);
+        ctx.setAuthPassword("");
+        ctx.setError(message);
+        writeTerminalLine(ctx, term, `\r\n[Failed to start SSH: ${message}]`);
+        ctx.updateStatus("disconnected");
+      } else if (authError) {
         ctx.setError(null);
         ctx.setNeedsAuth(true);
         ctx.setAuthRetryMessage(
@@ -634,6 +651,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         ]);
         ctx.setStatus("connecting");
       } else {
+        ctx.setNeedsAuth(false);
+        ctx.setAuthRetryMessage(null);
+        ctx.setAuthPassword("");
         ctx.setError(message);
         writeTerminalLine(ctx, term, `\r\n[Failed to start SSH: ${message}]`);
         ctx.updateStatus("disconnected");

--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -97,6 +97,23 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
           this.emit("error", err);
           return;
         }
+        if (eventName === "socket-error") {
+          const err = new Error("Connection reset by auth-bastion.example.com");
+          err.level = "client-socket";
+          this.emit("error", err);
+          return;
+        }
+        if (eventName === "permission-denied-socket-error") {
+          const err = new Error("Permission denied opening channel to auth-bastion.example.com");
+          err.level = "client-socket";
+          this.emit("error", err);
+          return;
+        }
+        if (eventName === "too-many-auth") {
+          const err = new Error("Too many authentication failures");
+          this.emit("error", err);
+          return;
+        }
         if (eventName === "ready") {
           this.emit("connect");
           this.emit("handshake");
@@ -374,6 +391,245 @@ test("jump-host auth failure does not emit exit before encrypted-key retry succe
       && message.payload.sessionId === "jump-retry-session"
     )),
     false,
+  );
+});
+
+test("jump-host auth failure is attributed to the failing jump host", async (t) => {
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error"],
+    encryptedKeys: [],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "jump-auth-failed-session",
+        hostname: "target.example",
+        username: "target-user",
+        port: 22,
+        knownHosts: [],
+        jumpHosts: [{
+          hostname: "jump.example",
+          username: "jump-user",
+          port: 22,
+          label: "Bastion",
+        }],
+      },
+    ),
+    (err) => {
+      assert.equal(err.isJumpHostAuthError, true);
+      assert.equal(err.jumpHostLabel, "Bastion");
+      assert.match(err.message, /Jump host authentication failed for "Bastion"/);
+      return true;
+    },
+  );
+});
+
+test("jump-host too-many-auth failures are attributed to the failing jump host", async (t) => {
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["too-many-auth"],
+    encryptedKeys: [],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "jump-too-many-auth-session",
+        hostname: "target.example",
+        username: "target-user",
+        port: 22,
+        knownHosts: [],
+        jumpHosts: [{
+          hostname: "jump.example",
+          username: "jump-user",
+          port: 22,
+          label: "Bastion",
+        }],
+      },
+    ),
+    (err) => {
+      assert.equal(err.isJumpHostAuthError, true);
+      assert.equal(err.jumpHostLabel, "Bastion");
+      assert.match(err.message, /Jump host authentication failed for "Bastion": Too many authentication failures/);
+      return true;
+    },
+  );
+});
+
+test("jump-host auth attribution survives encrypted-key retry failure", async (t) => {
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["auth-error", "auth-error"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    passphraseResult: {
+      cancelled: false,
+      keys: [
+        {
+          keyPath: "/Users/test/.ssh/id_ed25519",
+          keyName: "id_ed25519",
+          privateKey: "UNLOCKED_PRIVATE_KEY",
+          passphrase: "secret",
+        },
+      ],
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+
+  await assert.rejects(
+    start(
+      { sender: makeSender() },
+      {
+        sessionId: "jump-auth-retry-failed-session",
+        hostname: "target.example",
+        username: "target-user",
+        port: 22,
+        knownHosts: [],
+        jumpHosts: [{
+          hostname: "jump.example",
+          username: "jump-user",
+          port: 22,
+          label: "Bastion",
+        }],
+      },
+    ),
+    (err) => {
+      assert.equal(err.isJumpHostAuthError, true);
+      assert.equal(err.jumpHostLabel, "Bastion");
+      assert.match(err.message, /Jump host authentication failed for "Bastion"/);
+      return true;
+    },
+  );
+});
+
+test("jump-host socket errors with auth in hostname are not wrapped as auth failures", async (t) => {
+  let passphraseRequests = 0;
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["socket-error"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    onPassphraseRequest: () => {
+      passphraseRequests += 1;
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await assert.rejects(
+    start(
+      { sender },
+      {
+        sessionId: "jump-socket-error-session",
+        hostname: "target.example",
+        username: "target-user",
+        port: 22,
+        knownHosts: [],
+        jumpHosts: [{
+          hostname: "auth-bastion.example.com",
+          username: "jump-user",
+          port: 22,
+          label: "Auth Bastion",
+        }],
+      },
+    ),
+    (err) => {
+      assert.equal(err.isAuthError, undefined);
+      assert.equal(err.isJumpHostAuthError, undefined);
+      assert.equal(err.level, "client-socket");
+      assert.equal(err.message, "Connection reset by auth-bastion.example.com");
+      return true;
+    },
+  );
+  assert.equal(passphraseRequests, 0);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "jump-socket-error-session"
+      && message.payload.error === "Connection reset by auth-bastion.example.com"
+    )),
+    true,
+  );
+});
+
+test("jump-host permission-denied socket errors are not wrapped as auth failures", async (t) => {
+  let passphraseRequests = 0;
+  const { bridge } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["permission-denied-socket-error"],
+    encryptedKeys: [
+      {
+        keyPath: "/Users/test/.ssh/id_ed25519",
+        keyName: "id_ed25519",
+        isEncrypted: true,
+      },
+    ],
+    onPassphraseRequest: () => {
+      passphraseRequests += 1;
+    },
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+  const start = ipcMain.handlers.get("netcatty:start");
+  const sender = makeSender();
+
+  await assert.rejects(
+    start(
+      { sender },
+      {
+        sessionId: "jump-permission-denied-socket-error-session",
+        hostname: "target.example",
+        username: "target-user",
+        port: 22,
+        knownHosts: [],
+        jumpHosts: [{
+          hostname: "auth-bastion.example.com",
+          username: "jump-user",
+          port: 22,
+          label: "Auth Bastion",
+        }],
+      },
+    ),
+    (err) => {
+      assert.equal(err.isAuthError, undefined);
+      assert.equal(err.isJumpHostAuthError, undefined);
+      assert.equal(err.level, "client-socket");
+      assert.equal(err.message, "Permission denied opening channel to auth-bastion.example.com");
+      return true;
+    },
+  );
+  assert.equal(passphraseRequests, 0);
+  assert.equal(
+    sender.sent.some((message) => (
+      message.channel === "netcatty:exit"
+      && message.payload.sessionId === "jump-permission-denied-socket-error-session"
+      && message.payload.error === "Permission denied opening channel to auth-bastion.example.com"
+    )),
+    true,
   );
 });
 

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -754,6 +754,12 @@ async function connectThroughChain(event, options, jumpHosts, targetHost, target
         conn.once('error', (err) => {
           console.error(`[Chain] Hop ${i + 1}/${totalHops}: ${hopLabel} error:`, err.message);
           sendProgress(i + 1, totalHops + 1, hopLabel, 'error', err.message);
+          if (isChainAuthError(err)) {
+            err.isJumpHostAuthError = true;
+            err.jumpHostLabel = hopLabel;
+            err.jumpHostHostname = jump.hostname;
+            err.message = `Jump host authentication failed for "${hopLabel}": ${err.message}`;
+          }
           reject(err);
         });
         conn.once('timeout', () => {
@@ -947,11 +953,23 @@ async function generateKeyPair(event, options) {
  * Wrapper for SSH session handler to suppress noisy auth error stack traces
  * Auth failures are expected when fallback to password is available
  */
+function isAuthFailureMessage(message) {
+  const normalized = message?.toLowerCase() || '';
+  return normalized.includes('all configured authentication methods failed') ||
+    normalized.includes('authentication failed') ||
+    normalized.includes('too many authentication failures') ||
+    /permission denied\s*\(/.test(normalized) ||
+    normalized.includes('no authentication methods available');
+}
+
 function isStartAuthError(err) {
-  return err?.message?.toLowerCase().includes('authentication') ||
-    err?.message?.toLowerCase().includes('auth') ||
-    err?.message?.toLowerCase().includes('password') ||
-    err?.level === 'client-authentication';
+  return err?.level === 'client-authentication' ||
+    isAuthFailureMessage(err?.message);
+}
+
+function isChainAuthError(err) {
+  return err?.level === 'client-authentication' ||
+    isAuthFailureMessage(err?.message);
 }
 
 function canRetryWithEncryptedDefaultKeys(options) {
@@ -1070,6 +1088,11 @@ async function startSSHSessionWrapper(event, options) {
                 const authError = new Error(retryErr.message);
                 authError.level = 'client-authentication';
                 authError.isAuthError = true;
+                if (retryErr.isJumpHostAuthError) {
+                  authError.isJumpHostAuthError = true;
+                  authError.jumpHostLabel = retryErr.jumpHostLabel;
+                  authError.jumpHostHostname = retryErr.jumpHostHostname;
+                }
                 throw authError;
               }
               // Wrap non-auth retry errors as connection errors to prevent crash
@@ -1093,6 +1116,11 @@ async function startSSHSessionWrapper(event, options) {
       const authError = new Error(err.message);
       authError.level = 'client-authentication';
       authError.isAuthError = true;
+      if (err.isJumpHostAuthError) {
+        authError.isJumpHostAuthError = true;
+        authError.jumpHostLabel = err.jumpHostLabel;
+        authError.jumpHostHostname = err.jumpHostHostname;
+      }
       throw authError;
     }
 

--- a/electron/bridges/sshBridge.hostKeyChain.test.cjs
+++ b/electron/bridges/sshBridge.hostKeyChain.test.cjs
@@ -27,6 +27,10 @@ function loadBridgeWithMockedSsh2(t) {
 
     connect(opts) {
       this.connectOpts = opts;
+      if (MockSSHClient.connectionErrorsByHost.has(opts.host)) {
+        setImmediate(() => this.emit("error", MockSSHClient.connectionErrorsByHost.get(opts.host)));
+        return;
+      }
       if (MockSSHClient.timeoutHosts.has(opts.host)) {
         setImmediate(() => this.emit("timeout"));
         return;
@@ -76,6 +80,7 @@ function loadBridgeWithMockedSsh2(t) {
   MockSSHClient.hostKeysByHost = new Map();
   MockSSHClient.timeoutHosts = new Set();
   MockSSHClient.stalledForwardTargets = new Set();
+  MockSSHClient.connectionErrorsByHost = new Map();
   MockSSHClient.defaultHostKey = makeRawPublicKey("ssh-ed25519", "default untrusted key");
 
   Module._load = function patchedLoad(request, parent, isMain) {
@@ -203,6 +208,36 @@ test("jump-host chain destroys timed-out hop connections", async (t) => {
   assert.equal(MockSSHClient.instances.length, 1);
   assert.equal(MockSSHClient.instances[0].connectOpts.timeout, 20_000);
   assert.equal(MockSSHClient.instances[0].ended, true);
+});
+
+test("jump-host chain does not classify host-name auth substrings as auth failures", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithMockedSsh2(t);
+  const sender = makeSender();
+  const err = new Error("Connection reset by auth-bastion.example.com");
+  err.level = "client-socket";
+  MockSSHClient.connectionErrorsByHost.set("auth-bastion.example.com", err);
+
+  await assert.rejects(
+    bridge.connectThroughChain(
+      { sender },
+      { knownHosts: [], _defaultKeys: [] },
+      [{
+        hostname: "auth-bastion.example.com",
+        port: 22,
+        username: "alice",
+        password: "secret",
+        label: "Auth Bastion",
+      }],
+      "target.example.com",
+      22,
+      "session-1",
+    ),
+    (error) => {
+      assert.equal(error.isJumpHostAuthError, undefined);
+      assert.equal(error.message, "Connection reset by auth-bastion.example.com");
+      return true;
+    },
+  );
 });
 
 test("jump-host chain times out stalled forwarding to the next target", async (t) => {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -17,6 +17,16 @@ const {
 const SSH_TCP_CONNECT_TIMEOUT_MS = 20000;
 const SSH_AUTH_READY_TIMEOUT_MS = 120000;
 
+function isSshAuthFailure(err) {
+  const message = err?.message?.toLowerCase() || "";
+  return err?.level === "client-authentication" ||
+    message.includes("all configured authentication methods failed") ||
+    message.includes("authentication failed") ||
+    message.includes("too many authentication failures") ||
+    /permission denied\s*\(/.test(message) ||
+    message.includes("no authentication methods available");
+}
+
 function createStartSessionApi(ctx) {
   with (ctx) {
     /**
@@ -1274,10 +1284,7 @@ function createStartSessionApi(ctx) {
 
             const contents = event.sender;
 
-            const isAuthError = err.message?.toLowerCase().includes('authentication') ||
-              err.message?.toLowerCase().includes('auth') ||
-              err.message?.toLowerCase().includes('password') ||
-              err.level === 'client-authentication';
+            const isAuthError = isSshAuthFailure(err);
 
             // Clear cached auth method on auth failure so next attempt tries all methods
             if (isAuthError) {
@@ -1461,10 +1468,7 @@ function createStartSessionApi(ctx) {
         });
       } catch (err) {
         console.error("[Chain] SSH chain connection error:", err.message);
-        const isAuthError = err.message?.toLowerCase().includes('authentication') ||
-          err.message?.toLowerCase().includes('auth') ||
-          err.message?.toLowerCase().includes('password') ||
-          err.level === 'client-authentication';
+        const isAuthError = isSshAuthFailure(err);
         const suppressPreShellAuthExit = Boolean(options._suppressPreShellAuthExit && isAuthError);
         if (!suppressPreShellAuthExit) {
           const contents = event.sender;


### PR DESCRIPTION
## Summary
- Related to #2053.
- When authentication fails on a jump host, report it as a jump-host login failure instead of opening the target host password retry dialog.
- Preserve that attribution through retry/error wrapping, and avoid treating unrelated connection errors as password failures just because their text contains words like `auth`.

## Validation
- `node --test --import tsx components/terminal/runtime/createTerminalSessionStarters.test.ts electron/bridges/sshBridge.authRetryExit.test.cjs electron/bridges/sshAuthHelper.userConfiguredKey.test.cjs`
- `node --test electron/bridges/sshBridge.hostKeyChain.test.cjs`
- `npm run lint`
- `npm run build`
- Reviewed with two independent review passes until clean.
