### PR TITLE
fix(ai): probe remote login shell so fish AI exec works (#1854)

### DIFF
--- a/electron/bridges/ai/ptyExec.cjs
+++ b/electron/bridges/ai/ptyExec.cjs
@@ -30,6 +30,7 @@ function startPtyJob(ptyStream, command, options) {
     trackForCancellation = null,
     timeoutMs = 60000,
     shellKind,
+    loginShellHint,
     chatSessionId,
     abortSignal,
     expectedPrompt,
@@ -41,7 +42,9 @@ function startPtyJob(ptyStream, command, options) {
   } = options || {};
 
   const marker = `__NCMCP_${Date.now().toString(36)}_${crypto.randomBytes(16).toString('hex')}__`;
-  const resolvedShellKind = resolveEffectiveShellKind(shellKind, expectedPrompt);
+  const resolvedShellKind = resolveEffectiveShellKind(shellKind, expectedPrompt, {
+    loginShellHint,
+  });
   const CANCEL_RETRY_MS = 5000;
   const CANCEL_WALL_TIMEOUT_MS = 30000;
 

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -103,29 +103,42 @@ test("treats a CR-redrawn last line as the effective prompt, not the doubled str
 });
 
 test("rejects spoofed `PS >` (literal space then `>`) — default PowerShell never emits this", () => {
-  assert.equal(resolveEffectiveShellKind(undefined, "PS >"), "posix_sh");
+  assert.equal(resolveEffectiveShellKind(undefined, "PS >"), "posix");
 });
 
-test("falls back to posix_sh when neither shell kind nor prompt is informative", () => {
-  // Dual-compatible default for unset remote shellKind (fish + bash).
-  assert.equal(resolveEffectiveShellKind(undefined, ""), "posix_sh");
-  assert.equal(resolveEffectiveShellKind(null, undefined), "posix_sh");
+test("falls back to posix when neither shell kind nor prompt is informative", () => {
+  assert.equal(resolveEffectiveShellKind(undefined, ""), "posix");
+  assert.equal(resolveEffectiveShellKind(null, undefined), "posix");
 });
 
 test("does not misclassify command output that happens to contain 'PS'", () => {
-  assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix_sh");
-  assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix_sh");
+  assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix");
+  assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix");
 });
 
-test("posix_sh wrapper is fish-parseable and emits markers under real sh", () => {
-  const marker = "__NCMCP_TEST__";
-  const wrapped = buildWrappedCommand("echo dual-ok", "posix_sh", marker);
-  assert.match(wrapped, /^ sh -c '/);
-  assert.match(wrapped, new RegExp(marker));
-  const result = spawnSync("sh", ["-c", wrapped.trim()], { encoding: "utf8" });
-  assert.equal(result.error, undefined);
-  assert.match(result.stdout, /dual-ok/);
-  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+test("loginShellHint selects fish/posix without pinning confirmed shellKind", () => {
+  assert.equal(
+    resolveEffectiveShellKind(undefined, "user@host:~$", { loginShellHint: "fish" }),
+    "fish",
+  );
+  assert.equal(
+    resolveEffectiveShellKind(undefined, "user@host:~$", { loginShellHint: "posix" }),
+    "posix",
+  );
+  // Live PowerShell prompt still wins over a posix/fish login hint.
+  assert.equal(
+    resolveEffectiveShellKind(undefined, "PS C:\\Users\\alice>", { loginShellHint: "posix" }),
+    "powershell",
+  );
+  assert.equal(
+    resolveEffectiveShellKind(undefined, "PS C:\\Users\\alice>", { loginShellHint: "fish" }),
+    "powershell",
+  );
+  // Confirmed shellKind is never overridden by a login hint.
+  assert.equal(
+    resolveEffectiveShellKind("posix", "user@host:~$", { loginShellHint: "fish" }),
+    "posix",
+  );
 });
 
 test("cmd wrapper uses interactive cmd variable expansion", () => {

--- a/electron/bridges/ai/ptyExec.test.cjs
+++ b/electron/bridges/ai/ptyExec.test.cjs
@@ -102,18 +102,30 @@ test("treats a CR-redrawn last line as the effective prompt, not the doubled str
   );
 });
 
-test("rejects spoofed `PS >` (literal space then `>`) ù default PowerShell never emits this", () => {
-  assert.equal(resolveEffectiveShellKind(undefined, "PS >"), "posix");
+test("rejects spoofed `PS >` (literal space then `>`) ‚Äî default PowerShell never emits this", () => {
+  assert.equal(resolveEffectiveShellKind(undefined, "PS >"), "posix_sh");
 });
 
-test("falls back to posix when neither shell kind nor prompt is informative", () => {
-  assert.equal(resolveEffectiveShellKind(undefined, ""), "posix");
-  assert.equal(resolveEffectiveShellKind(null, undefined), "posix");
+test("falls back to posix_sh when neither shell kind nor prompt is informative", () => {
+  // Dual-compatible default for unset remote shellKind (fish + bash).
+  assert.equal(resolveEffectiveShellKind(undefined, ""), "posix_sh");
+  assert.equal(resolveEffectiveShellKind(null, undefined), "posix_sh");
 });
 
 test("does not misclassify command output that happens to contain 'PS'", () => {
-  assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix");
-  assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix");
+  assert.equal(resolveEffectiveShellKind(undefined, "PSO>"), "posix_sh");
+  assert.equal(resolveEffectiveShellKind(undefined, "ZIPS>"), "posix_sh");
+});
+
+test("posix_sh wrapper is fish-parseable and emits markers under real sh", () => {
+  const marker = "__NCMCP_TEST__";
+  const wrapped = buildWrappedCommand("echo dual-ok", "posix_sh", marker);
+  assert.match(wrapped, /^ sh -c '/);
+  assert.match(wrapped, new RegExp(marker));
+  const result = spawnSync("sh", ["-c", wrapped.trim()], { encoding: "utf8" });
+  assert.equal(result.error, undefined);
+  assert.match(result.stdout, /dual-ok/);
+  assert.match(result.stdout, new RegExp(`${marker}_E:0`));
 });
 
 test("cmd wrapper uses interactive cmd variable expansion", () => {
@@ -209,7 +221,7 @@ test("execViaChannel registers a pending-cancel marker before the SSH channel op
   let execCallback;
   const fakeClient = {
     exec(_command, callback) {
-      // Capture but do not invoke yet ù simulates the channel-open
+      // Capture but do not invoke yet ÔøΩ simulates the channel-open
       // delay where the race window lives.
       execCallback = callback;
     },
@@ -263,7 +275,7 @@ test("execViaChannel short-circuits when cancel fires before the SSH channel ope
     if (entry.chatSessionId === "chat-2") entry.cancel();
   }
 
-  // Now the channel "opens" ù even though `sshClient.exec` would
+  // Now the channel "opens" ÔøΩ even though `sshClient.exec` would
   // hand us a working stream, we must short-circuit because the user
   // already cancelled.
   const fakeExecStream = {

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -101,16 +101,17 @@ function isPowerShellPrompt(prompt) {
 // `PS ...>` line on a real bash/zsh/fish/cmd session to coerce a single
 // mis-wrapped command.
 //
-// Remote fish (and other non-posix login shells) are handled separately:
-// ensureSessionShellKind() probes the remote login shell once before AI
-// exec and caches session.shellKind (issue #1854). Once set, the probe
-// result is treated as confirmed and is never overridden here.
+// Remote Unix sessions leave shellKind unset after login-shell probing
+// (sessionShellKind.cjs). The default is then `posix_sh`: a `sh -c '...'`
+// outer form that both fish and bash interactive shells can parse, so we
+// do not need to permanently pin login shell = fish (issue #1854 + Codex
+// "don't pin login shell as active shell" on PR #2061).
 //
 // Universe of shellKind values (see lib/localShell.cjs:23-33 and
 // terminalBridge.cjs:368, :932, :1074):
-//   "posix" | "powershell" | "cmd" | "fish" | "unknown" | "raw" | "" | undefined
+//   "posix" | "posix_sh" | "powershell" | "cmd" | "fish" | "unknown" | "raw" | "" | undefined
 // Excluded on purpose:
-//   - "posix" / "fish" / "cmd": confirmed POSIX-family or cmd.exe — never override.
+//   - "posix" / "posix_sh" / "fish" / "cmd": confirmed kinds — never override.
 //   - "powershell": already correct; no override needed (would be a no-op).
 //   - "raw": serial / network device — execViaRawPty bypasses buildWrappedCommand.
 const SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE = new Set([
@@ -126,7 +127,20 @@ function resolveEffectiveShellKind(shellKind, expectedPrompt) {
   ) {
     return "powershell";
   }
-  return baseKind || "posix";
+  // Unset remote/local-unknown → dual-compatible wrapper (fish + bash).
+  // Confirmed local shells set shellKind at spawn and never hit this.
+  return baseKind || "posix_sh";
+}
+
+function buildPosixWrapperBody(command, marker) {
+  const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
+  const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
+  const cmdAssign = commandLines.length > 1
+    ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
+    : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
+  return (
+    `${marker}=0; ${cmdAssign}; { printf '%s\\n' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }`
+  );
 }
 
 function buildWrappedCommand(command, shellKind, marker) {
@@ -158,6 +172,17 @@ function buildWrappedCommand(command, shellKind, marker) {
         `printf '%s\\n' '${marker}_S'; eval \$${marker}_cmd; set __NCMCP_rc $status; ` +
         `functions -e __ncmcp_int; printf '%s\\n' '${marker}_E:'\$__NCMCP_rc; end\n`
       );
+
+    case "posix_sh": {
+      // Dual-compatible outer form: both fish and bash interactive shells can
+      // parse `sh -c '...'`. The inner body is the normal POSIX wrapper, so
+      // fish never has to parse `VAR=0` assignment syntax (issue #1854) and we
+      // do not permanently assume login shell === active shell (Codex P2).
+      // Leading space: history ignorespace (see posix branch). The typed line
+      // still contains __NCMCP_ for preload echo filtering.
+      const body = buildPosixWrapperBody(command, marker);
+      return ` sh -c '${escapePosixSingleQuoted(body)}'\n`;
+    }
 
     case "posix":
     default: {
@@ -196,17 +221,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       //    Earlier attempts (PRs #1852/#1882) that instead tried to detect
       //    dangerous commands grew into shell parsing and were abandoned —
       //    do not reintroduce detection here.
-      const noPager = "PAGER=cat SYSTEMD_PAGER= GIT_PAGER=cat LESS= ";
-      // Multi-line commands must not embed raw newlines in the typed
-      // wrapper: the interactive shell would echo PS2 continuation lines
-      // ("> cd ...") that don't contain the marker and leak past the
-      // preload filter. Rebuild the newlines inside the shell instead via
-      // printf so the wrapper stays one physical line. Single-line
-      // commands keep the plain assignment.
-      const commandLines = String(command || "").replace(/\r\n?/g, "\n").split("\n");
-      const cmdAssign = commandLines.length > 1
-        ? `${marker}_cmd=$(printf '%s\\n' ${commandLines.map((line) => `'${escapePosixSingleQuoted(line)}'`).join(" ")})`
-        : `${marker}_cmd='${escapePosixSingleQuoted(command)}'`;
+      //
       // Leading single space: lets bash/zsh skip recording this command
       // in history when the user already has HISTCONTROL=ignorespace
       // (bash) or HIST_IGNORE_SPACE (zsh) configured — Debian/Ubuntu and
@@ -214,9 +229,7 @@ function buildWrappedCommand(command, shellKind, marker) {
       // can opt in by adding `HISTCONTROL=ignoreboth` to ~/.bashrc.
       // Without that config the prefix is harmless; it just doesn't
       // suppress history recording.
-      return (
-        ` ${marker}=0; ${cmdAssign}; { printf '%s\\n' '${marker}_S'; trap ':' INT; ( ${noPager}eval "$${marker}_cmd" ); __NCMCP_rc=$?; trap - INT; printf '%s\\n' '${marker}_E:'\"$__NCMCP_rc\"; (exit $__NCMCP_rc); }\n`
-      );
+      return ` ${buildPosixWrapperBody(command, marker)}\n`;
     }
   }
 }

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -96,10 +96,15 @@ function isPowerShellPrompt(prompt) {
 
 // Prompt-driven override is intentionally narrow: only flip to PowerShell
 // when the session has no confirmed shell type. This keeps the issue #841
-// fix working (SSH/Telnet sessions never set shellKind — see
-// sshBridge.cjs:1265) while preventing a malicious remote process from
-// spoofing a `PS ...>` line on a real bash/zsh/fish/cmd session to coerce
-// a single mis-wrapped command.
+// fix working for remote Windows shells that never set shellKind at connect
+// time, while preventing a malicious remote process from spoofing a
+// `PS ...>` line on a real bash/zsh/fish/cmd session to coerce a single
+// mis-wrapped command.
+//
+// Remote fish (and other non-posix login shells) are handled separately:
+// ensureSessionShellKind() probes the remote login shell once before AI
+// exec and caches session.shellKind (issue #1854). Once set, the probe
+// result is treated as confirmed and is never overridden here.
 //
 // Universe of shellKind values (see lib/localShell.cjs:23-33 and
 // terminalBridge.cjs:368, :932, :1074):

--- a/electron/bridges/ai/ptyExecHelpers.cjs
+++ b/electron/bridges/ai/ptyExecHelpers.cjs
@@ -101,17 +101,18 @@ function isPowerShellPrompt(prompt) {
 // `PS ...>` line on a real bash/zsh/fish/cmd session to coerce a single
 // mis-wrapped command.
 //
-// Remote Unix sessions leave shellKind unset after login-shell probing
-// (sessionShellKind.cjs). The default is then `posix_sh`: a `sh -c '...'`
-// outer form that both fish and bash interactive shells can parse, so we
-// do not need to permanently pin login shell = fish (issue #1854 + Codex
-// "don't pin login shell as active shell" on PR #2061).
+// Remote login-shell probing stores a *soft* hint (`loginShellHint` /
+// session._loginShellKind) without pinning session.shellKind for fish/posix:
+//   - hint "fish"  → fish wrapper (issue #1854) without permanent pin
+//   - hint "posix" → native posix wrapper evaluated by interactive bash/zsh
+//                    (NOT sh -c / dash — Codex P2 on #2061)
+//   - live PS ...> still overrides when base kind is open
 //
 // Universe of shellKind values (see lib/localShell.cjs:23-33 and
 // terminalBridge.cjs:368, :932, :1074):
-//   "posix" | "posix_sh" | "powershell" | "cmd" | "fish" | "unknown" | "raw" | "" | undefined
-// Excluded on purpose:
-//   - "posix" / "posix_sh" / "fish" / "cmd": confirmed kinds — never override.
+//   "posix" | "powershell" | "cmd" | "fish" | "unknown" | "raw" | "" | undefined
+// Excluded on purpose from prompt override:
+//   - "posix" / "fish" / "cmd": confirmed — never override.
 //   - "powershell": already correct; no override needed (would be a no-op).
 //   - "raw": serial / network device — execViaRawPty bypasses buildWrappedCommand.
 const SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE = new Set([
@@ -119,7 +120,9 @@ const SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE = new Set([
   "unknown",
 ]);
 
-function resolveEffectiveShellKind(shellKind, expectedPrompt) {
+const LOGIN_SHELL_HINTS = new Set(["posix", "fish", "powershell", "cmd"]);
+
+function resolveEffectiveShellKind(shellKind, expectedPrompt, options = {}) {
   const baseKind = shellKind || "";
   if (
     SHELL_KINDS_OPEN_TO_PROMPT_OVERRIDE.has(baseKind) &&
@@ -127,9 +130,13 @@ function resolveEffectiveShellKind(shellKind, expectedPrompt) {
   ) {
     return "powershell";
   }
-  // Unset remote/local-unknown → dual-compatible wrapper (fish + bash).
-  // Confirmed local shells set shellKind at spawn and never hit this.
-  return baseKind || "posix_sh";
+  if (baseKind) return baseKind;
+
+  // Soft login-shell hint from remote probe (not a permanent pin).
+  const hint = options.loginShellHint || "";
+  if (LOGIN_SHELL_HINTS.has(hint)) return hint;
+
+  return "posix";
 }
 
 function buildPosixWrapperBody(command, marker) {
@@ -172,17 +179,6 @@ function buildWrappedCommand(command, shellKind, marker) {
         `printf '%s\\n' '${marker}_S'; eval \$${marker}_cmd; set __NCMCP_rc $status; ` +
         `functions -e __ncmcp_int; printf '%s\\n' '${marker}_E:'\$__NCMCP_rc; end\n`
       );
-
-    case "posix_sh": {
-      // Dual-compatible outer form: both fish and bash interactive shells can
-      // parse `sh -c '...'`. The inner body is the normal POSIX wrapper, so
-      // fish never has to parse `VAR=0` assignment syntax (issue #1854) and we
-      // do not permanently assume login shell === active shell (Codex P2).
-      // Leading space: history ignorespace (see posix branch). The typed line
-      // still contains __NCMCP_ for preload echo filtering.
-      const body = buildPosixWrapperBody(command, marker);
-      return ` sh -c '${escapePosixSingleQuoted(body)}'\n`;
-    }
 
     case "posix":
     default: {

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -12,6 +12,7 @@
  */
 "use strict";
 
+const crypto = require("node:crypto");
 const { classifyLocalShellType } = require("../../../lib/localShell.cjs");
 
 // Kinds that buildWrappedCommand / resolveEffectiveShellKind already trust.
@@ -272,6 +273,65 @@ async function ensureSessionShellKind(session, options = {}) {
   return session._shellKindProbePromise;
 }
 
+/**
+ * Probe shell kind while remaining cancellable via activePtyExecs.
+ *
+ * The first AI exec on a remote session may await ensureSessionShellKind for up
+ * to the probe timeout before execViaPty registers a real marker. Stop during
+ * that window would otherwise find nothing in activePtyExecs and the command
+ * would still be typed after the probe resolves (Codex P2 on PR #2061).
+ *
+ * Mirrors the pending-marker pattern used by execViaChannel: register a
+ * cancel latch synchronously, await the probe, then short-circuit if Stop
+ * fired before we write to the PTY.
+ *
+ * @returns {Promise<{ ok: true, shellKind: string|undefined } | { ok: false, cancelled: true, error: string, exitCode: number, stdout: string, stderr: string }>}
+ */
+async function ensureSessionShellKindForExec(session, options = {}) {
+  const {
+    trackForCancellation = null,
+    chatSessionId = null,
+    execProbe,
+    timeoutMs,
+  } = options;
+
+  let cancelled = false;
+  const pendingMarker = trackForCancellation
+    ? `__NCMCP_SK_PENDING_${Date.now().toString(36)}_${crypto.randomBytes(8).toString("hex")}__`
+    : null;
+
+  if (pendingMarker) {
+    trackForCancellation.set(pendingMarker, {
+      chatSessionId: chatSessionId || null,
+      cancel: () => {
+        cancelled = true;
+      },
+      cleanup: () => {
+        // Nothing to tear down before the real PTY job starts.
+      },
+    });
+  }
+
+  try {
+    await ensureSessionShellKind(session, { execProbe, timeoutMs });
+    if (cancelled) {
+      return {
+        ok: false,
+        cancelled: true,
+        stdout: "",
+        stderr: "",
+        exitCode: 130,
+        error: "Cancelled",
+      };
+    }
+    return { ok: true, shellKind: session.shellKind };
+  } finally {
+    if (pendingMarker && trackForCancellation) {
+      trackForCancellation.delete(pendingMarker);
+    }
+  }
+}
+
 module.exports = {
   CONFIRMED_SHELL_KINDS,
   DEFAULT_PROBE_TIMEOUT_MS,
@@ -284,4 +344,5 @@ module.exports = {
   createSessionExecProbe,
   applyProbedShellKind,
   ensureSessionShellKind,
+  ensureSessionShellKindForExec,
 };

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -176,6 +176,32 @@ function withProbeTimeout(promise, timeoutMs) {
 }
 
 /**
+ * Apply a successful remote probe result onto the session.
+ *
+ * Non-posix kinds (fish / powershell / cmd) are pinned on session.shellKind so
+ * wrappers stay correct. Posix login shells are intentionally NOT pinned:
+ * resolveEffectiveShellKind already defaults unset → posix, and leaving
+ * shellKind open preserves the live PowerShell prompt override for the case
+ * "login shell is bash/zsh but the interactive shell is now pwsh" (issue #841
+ * path; Codex P2 on PR #2061). Mark the probe settled so we do not re-probe
+ * every AI exec.
+ */
+function applyProbedShellKind(session, kind) {
+  if (!kind) return session.shellKind;
+  session._shellKindProbeSettled = true;
+  if (kind === "posix") {
+    return session.shellKind;
+  }
+  session.shellKind = kind;
+  return session.shellKind;
+}
+
+function isShellKindProbeSettled(session) {
+  return Boolean(session?._shellKindProbeSettled)
+    || isConfirmedShellKind(session?.shellKind);
+}
+
+/**
  * Ensure session.shellKind is set when we can detect it. Safe to call on every
  * AI exec — confirmed kinds short-circuit; concurrent callers share one probe.
  *
@@ -187,6 +213,13 @@ async function ensureSessionShellKind(session, options = {}) {
   if (!session || typeof session !== "object") return undefined;
 
   if (isConfirmedShellKind(session.shellKind)) {
+    return session.shellKind;
+  }
+
+  // Probe already decided "generic posix login shell" (or pinned a kind).
+  // Do not re-hit the network; leave shellKind unset for the posix case so
+  // resolveEffectiveShellKind can still honor a live PowerShell prompt.
+  if (session._shellKindProbeSettled) {
     return session.shellKind;
   }
 
@@ -225,15 +258,12 @@ async function ensureSessionShellKind(session, options = {}) {
         timeoutMs,
       );
       const kind = parseRemoteLoginShellProbeOutput(stdout);
-      if (kind) {
-        session.shellKind = kind;
-      }
-      return session.shellKind;
+      return applyProbedShellKind(session, kind);
     } catch {
       return session.shellKind;
     } finally {
-      // Allow a later retry only when we still have no confirmed kind.
-      if (!isConfirmedShellKind(session.shellKind)) {
+      // Retry only when the probe failed to classify anything.
+      if (!isShellKindProbeSettled(session)) {
         session._shellKindProbePromise = null;
       }
     }
@@ -252,5 +282,6 @@ module.exports = {
   parseRemoteLoginShellProbeOutput,
   createSshConnExecProbe,
   createSessionExecProbe,
+  applyProbedShellKind,
   ensureSessionShellKind,
 };

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -1,0 +1,220 @@
+/**
+ * Resolve and cache the interactive shell kind used by AI PTY exec wrappers.
+ *
+ * Local terminals set shellKind from the executable path at spawn time. SSH /
+ * Telnet (and similar remote) sessions historically left shellKind unset, so
+ * resolveEffectiveShellKind fell through to "posix" and typed a bash-style
+ * wrapper into fish login shells (issue #1854).
+ *
+ * Before AI exec we probe the remote login shell once via a separate SSH exec
+ * channel (silent — does not touch the interactive PTY), classify it, and
+ * cache session.shellKind for subsequent commands.
+ */
+"use strict";
+
+const { classifyLocalShellType } = require("../../../lib/localShell.cjs");
+
+// Kinds that buildWrappedCommand / resolveEffectiveShellKind already trust.
+// "unknown" is intentionally excluded: local unknown shells are unsupported
+// for AI exec, and we do not invent a remote kind without a successful probe.
+const CONFIRMED_SHELL_KINDS = new Set([
+  "posix",
+  "fish",
+  "powershell",
+  "cmd",
+  "raw",
+]);
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3000;
+
+function isConfirmedShellKind(shellKind) {
+  return CONFIRMED_SHELL_KINDS.has(shellKind);
+}
+
+function quoteShellArg(value) {
+  return `'${String(value ?? "").replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Map a remote shell path / basename to a wrapper kind.
+ * Returns null when we cannot classify (leave session.shellKind unset).
+ * Empty / missing paths return null (classifyLocalShellType would default to
+ * platform shell — that is wrong for a failed remote probe).
+ */
+function classifyShellKindFromRemotePath(shellPath) {
+  const trimmed = String(shellPath || "").trim();
+  if (!trimmed) return null;
+  const kind = classifyLocalShellType(trimmed, "linux");
+  if (!kind || kind === "unknown") return null;
+  return kind;
+}
+
+/**
+ * Silent remote probe: force POSIX sh so fish/zsh login shells can still run it
+ * when sshd invokes the command through the user's login shell (`$SHELL -c`).
+ * Prints a single line: absolute login-shell path (or empty).
+ */
+function buildRemoteLoginShellProbeCommand() {
+  const script = [
+    'SH="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"',
+    '[ -n "$SH" ] || SH="${SHELL:-}"',
+    'printf "%s\\n" "$SH"',
+  ].join("; ");
+  return `exec sh -c ${quoteShellArg(script)}`;
+}
+
+function parseRemoteLoginShellProbeOutput(stdout) {
+  const firstLine = String(stdout || "")
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!firstLine) return null;
+  return classifyShellKindFromRemotePath(firstLine);
+}
+
+/**
+ * Build an execProbe(command, timeoutMs) => Promise<string|null> from an
+ * ssh2-like connection (conn.exec(command, cb)).
+ */
+function createSshConnExecProbe(conn) {
+  if (!conn || typeof conn.exec !== "function") return null;
+  return function execProbe(command, timeoutMs = DEFAULT_PROBE_TIMEOUT_MS) {
+    return new Promise((resolve) => {
+      let settled = false;
+      let activeStream = null;
+      const settle = (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const timer = setTimeout(() => {
+        try {
+          activeStream?.close?.();
+        } catch {
+          // ignore
+        }
+        settle(null);
+      }, timeoutMs);
+
+      try {
+        conn.exec(command, (err, stream) => {
+          if (err || !stream) {
+            settle(null);
+            return;
+          }
+          activeStream = stream;
+          let stdout = "";
+          stream.on("data", (chunk) => {
+            stdout += chunk.toString("utf8");
+          });
+          if (stream.stderr && typeof stream.stderr.on === "function") {
+            stream.stderr.on("data", () => {
+              // swallow — probe only needs stdout
+            });
+          }
+          stream.on("close", () => {
+            settle(stdout);
+          });
+          stream.on("error", () => {
+            settle(null);
+          });
+        });
+      } catch {
+        settle(null);
+      }
+    });
+  };
+}
+
+/**
+ * Prefer the live SSH connection, then any companion stats connection
+ * (mosh/et) that still speaks ssh2 exec.
+ */
+function createSessionExecProbe(session) {
+  if (!session || typeof session !== "object") return null;
+  return (
+    createSshConnExecProbe(session.conn)
+    || createSshConnExecProbe(session.sshClient)
+    || createSshConnExecProbe(session.moshStatsConn)
+    || createSshConnExecProbe(session.etStatsConn)
+    || null
+  );
+}
+
+/**
+ * Ensure session.shellKind is set when we can detect it. Safe to call on every
+ * AI exec — confirmed kinds short-circuit; concurrent callers share one probe.
+ *
+ * @param {object} session
+ * @param {{ execProbe?: (command: string, timeoutMs?: number) => Promise<string|null>, timeoutMs?: number }} [options]
+ * @returns {Promise<string|undefined>}
+ */
+async function ensureSessionShellKind(session, options = {}) {
+  if (!session || typeof session !== "object") return undefined;
+
+  if (isConfirmedShellKind(session.shellKind)) {
+    return session.shellKind;
+  }
+
+  // Local shells with an unrecognised executable stay "unknown"; do not probe.
+  if (
+    (session.protocol === "local" || session.type === "local")
+    && session.shellKind === "unknown"
+  ) {
+    return session.shellKind;
+  }
+
+  if (session._shellKindProbePromise) {
+    return session._shellKindProbePromise;
+  }
+
+  const execProbe =
+    typeof options.execProbe === "function"
+      ? options.execProbe
+      : createSessionExecProbe(session);
+
+  if (typeof execProbe !== "function") {
+    return session.shellKind;
+  }
+
+  const timeoutMs = Number.isFinite(options.timeoutMs)
+    ? options.timeoutMs
+    : DEFAULT_PROBE_TIMEOUT_MS;
+
+  session._shellKindProbePromise = (async () => {
+    try {
+      const stdout = await execProbe(
+        buildRemoteLoginShellProbeCommand(),
+        timeoutMs,
+      );
+      const kind = parseRemoteLoginShellProbeOutput(stdout);
+      if (kind) {
+        session.shellKind = kind;
+      }
+      return session.shellKind;
+    } catch {
+      return session.shellKind;
+    } finally {
+      // Allow a later retry only when we still have no confirmed kind.
+      if (!isConfirmedShellKind(session.shellKind)) {
+        session._shellKindProbePromise = null;
+      }
+    }
+  })();
+
+  return session._shellKindProbePromise;
+}
+
+module.exports = {
+  CONFIRMED_SHELL_KINDS,
+  DEFAULT_PROBE_TIMEOUT_MS,
+  isConfirmedShellKind,
+  classifyShellKindFromRemotePath,
+  buildRemoteLoginShellProbeCommand,
+  parseRemoteLoginShellProbeOutput,
+  createSshConnExecProbe,
+  createSessionExecProbe,
+  ensureSessionShellKind,
+};

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -7,8 +7,11 @@
  * wrapper into fish login shells (issue #1854).
  *
  * Before AI exec we probe the remote login shell once via a separate SSH exec
- * channel (silent — does not touch the interactive PTY), classify it, and
- * cache session.shellKind for subsequent commands.
+ * channel (silent — does not touch the interactive PTY). Only Windows login
+ * shells (powershell/cmd) are pinned on session.shellKind. Unix login shells
+ * (fish/posix) only settle the probe: the default typed wrapper is dual-
+ * compatible `posix_sh` so fish login works without assuming login shell ===
+ * active interactive shell.
  */
 "use strict";
 
@@ -179,21 +182,25 @@ function withProbeTimeout(promise, timeoutMs) {
 /**
  * Apply a successful remote probe result onto the session.
  *
- * Non-posix kinds (fish / powershell / cmd) are pinned on session.shellKind so
- * wrappers stay correct. Posix login shells are intentionally NOT pinned:
- * resolveEffectiveShellKind already defaults unset → posix, and leaving
- * shellKind open preserves the live PowerShell prompt override for the case
- * "login shell is bash/zsh but the interactive shell is now pwsh" (issue #841
- * path; Codex P2 on PR #2061). Mark the probe settled so we do not re-probe
- * every AI exec.
+ * Login-shell probe is NOT treated as the active interactive shell:
+ * - posix / fish: never pin session.shellKind. Unset shellKind defaults to the
+ *   dual-compatible `posix_sh` wrapper (parseable by both bash and fish), and
+ *   live PowerShell prompts can still override (issue #841 / #1854; Codex P2
+ *   on PR #2061: login fish but interactive bash must not get fish syntax).
+ * - powershell / cmd: pin — these are not recoverable from Unix dual wrappers
+ *   and match Windows remote shells where the login shell is the interactive one.
+ *
+ * Always mark the probe settled so we do not re-probe every AI exec.
  */
 function applyProbedShellKind(session, kind) {
   if (!kind) return session.shellKind;
   session._shellKindProbeSettled = true;
-  if (kind === "posix") {
+  session._loginShellKind = kind;
+  if (kind === "powershell" || kind === "cmd") {
+    session.shellKind = kind;
     return session.shellKind;
   }
-  session.shellKind = kind;
+  // fish / posix — leave shellKind unset for dual-compatible default + PS override.
   return session.shellKind;
 }
 

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -26,6 +26,7 @@ const CONFIRMED_SHELL_KINDS = new Set([
 ]);
 
 const DEFAULT_PROBE_TIMEOUT_MS = 3000;
+const PROBE_OUTPUT_MARKER = "__NETCATTY_SHELL_KIND__:";
 
 function isConfirmedShellKind(shellKind) {
   return CONFIRMED_SHELL_KINDS.has(shellKind);
@@ -58,19 +59,24 @@ function buildRemoteLoginShellProbeCommand() {
   const script = [
     'SH="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"',
     '[ -n "$SH" ] || SH="${SHELL:-}"',
-    'printf "%s\\n" "$SH"',
+    `printf "${PROBE_OUTPUT_MARKER}%s\\n" "$SH"`,
   ].join("; ");
   return `exec sh -c ${quoteShellArg(script)}`;
 }
 
 function parseRemoteLoginShellProbeOutput(stdout) {
-  const firstLine = String(stdout || "")
+  const lines = String(stdout || "")
     .replace(/\r/g, "")
     .split("\n")
     .map((line) => line.trim())
-    .find(Boolean);
-  if (!firstLine) return null;
-  return classifyShellKindFromRemotePath(firstLine);
+    .filter(Boolean);
+
+  for (const line of lines) {
+    if (!line.startsWith(PROBE_OUTPUT_MARKER)) continue;
+    const kind = classifyShellKindFromRemotePath(line.slice(PROBE_OUTPUT_MARKER.length));
+    if (kind) return kind;
+  }
+  return null;
 }
 
 /**
@@ -104,6 +110,14 @@ function createSshConnExecProbe(conn) {
             settle(null);
             return;
           }
+          if (settled) {
+            try {
+              stream.close?.();
+            } catch {
+              // ignore
+            }
+            return;
+          }
           activeStream = stream;
           let stdout = "";
           stream.on("data", (chunk) => {
@@ -134,6 +148,9 @@ function createSshConnExecProbe(conn) {
  */
 function createSessionExecProbe(session) {
   if (!session || typeof session !== "object") return null;
+  if (typeof session._shellKindExecProbe === "function") {
+    return (command, timeoutMs) => session._shellKindExecProbe(command, timeoutMs);
+  }
   return (
     createSshConnExecProbe(session.conn)
     || createSshConnExecProbe(session.sshClient)
@@ -141,6 +158,21 @@ function createSessionExecProbe(session) {
     || createSshConnExecProbe(session.etStatsConn)
     || null
   );
+}
+
+function withProbeTimeout(promise, timeoutMs) {
+  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? timeoutMs
+    : DEFAULT_PROBE_TIMEOUT_MS;
+  let timer = null;
+  return Promise.race([
+    Promise.resolve(promise),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve(null), ms);
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 /**
@@ -185,8 +217,11 @@ async function ensureSessionShellKind(session, options = {}) {
 
   session._shellKindProbePromise = (async () => {
     try {
-      const stdout = await execProbe(
-        buildRemoteLoginShellProbeCommand(),
+      const stdout = await withProbeTimeout(
+        execProbe(
+          buildRemoteLoginShellProbeCommand(),
+          timeoutMs,
+        ),
         timeoutMs,
       );
       const kind = parseRemoteLoginShellProbeOutput(stdout);
@@ -210,6 +245,7 @@ async function ensureSessionShellKind(session, options = {}) {
 module.exports = {
   CONFIRMED_SHELL_KINDS,
   DEFAULT_PROBE_TIMEOUT_MS,
+  PROBE_OUTPUT_MARKER,
   isConfirmedShellKind,
   classifyShellKindFromRemotePath,
   buildRemoteLoginShellProbeCommand,

--- a/electron/bridges/ai/sessionShellKind.cjs
+++ b/electron/bridges/ai/sessionShellKind.cjs
@@ -9,9 +9,10 @@
  * Before AI exec we probe the remote login shell once via a separate SSH exec
  * channel (silent — does not touch the interactive PTY). Only Windows login
  * shells (powershell/cmd) are pinned on session.shellKind. Unix login shells
- * (fish/posix) only settle the probe: the default typed wrapper is dual-
- * compatible `posix_sh` so fish login works without assuming login shell ===
- * active interactive shell.
+ * (fish/posix) are stored as session._loginShellKind (soft hint) so
+ * resolveEffectiveShellKind can pick fish vs native posix wrappers without
+ * permanently assuming login shell === active interactive shell, and without
+ * routing bash sessions through /bin/sh (dash).
  */
 "use strict";
 
@@ -182,13 +183,12 @@ function withProbeTimeout(promise, timeoutMs) {
 /**
  * Apply a successful remote probe result onto the session.
  *
- * Login-shell probe is NOT treated as the active interactive shell:
- * - posix / fish: never pin session.shellKind. Unset shellKind defaults to the
- *   dual-compatible `posix_sh` wrapper (parseable by both bash and fish), and
- *   live PowerShell prompts can still override (issue #841 / #1854; Codex P2
- *   on PR #2061: login fish but interactive bash must not get fish syntax).
- * - powershell / cmd: pin — these are not recoverable from Unix dual wrappers
- *   and match Windows remote shells where the login shell is the interactive one.
+ * Login-shell probe is a soft hint, not a permanent active-shell pin:
+ * - posix / fish: store on session._loginShellKind only. resolveEffectiveShellKind
+ *   uses the hint for the wrapper (native posix for bash/zsh, fish for fish)
+ *   while leaving session.shellKind unset so live PowerShell prompts can still
+ *   override (issue #841 / #1854; Codex P2s on PR #2061).
+ * - powershell / cmd: also pin session.shellKind (Windows remote shells).
  *
  * Always mark the probe settled so we do not re-probe every AI exec.
  */
@@ -200,7 +200,7 @@ function applyProbedShellKind(session, kind) {
     session.shellKind = kind;
     return session.shellKind;
   }
-  // fish / posix — leave shellKind unset for dual-compatible default + PS override.
+  // fish / posix — soft hint only; do not pin session.shellKind.
   return session.shellKind;
 }
 

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -1,0 +1,285 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
+
+const {
+  isConfirmedShellKind,
+  classifyShellKindFromRemotePath,
+  buildRemoteLoginShellProbeCommand,
+  parseRemoteLoginShellProbeOutput,
+  createSshConnExecProbe,
+  createSessionExecProbe,
+  ensureSessionShellKind,
+} = require("./sessionShellKind.cjs");
+
+const {
+  buildWrappedCommand,
+  resolveEffectiveShellKind,
+} = require("./ptyExecHelpers.cjs");
+
+test("classifies remote login shell paths", () => {
+  assert.equal(classifyShellKindFromRemotePath("/usr/bin/fish"), "fish");
+  assert.equal(classifyShellKindFromRemotePath("/usr/local/bin/fish"), "fish");
+  assert.equal(classifyShellKindFromRemotePath("fish"), "fish");
+  assert.equal(classifyShellKindFromRemotePath("/bin/bash"), "posix");
+  assert.equal(classifyShellKindFromRemotePath("/bin/zsh"), "posix");
+  assert.equal(classifyShellKindFromRemotePath("/usr/bin/pwsh"), "powershell");
+  assert.equal(classifyShellKindFromRemotePath("/bin/cmd.exe"), "cmd");
+  assert.equal(classifyShellKindFromRemotePath("/usr/bin/nu"), null);
+  assert.equal(classifyShellKindFromRemotePath(""), null);
+});
+
+test("parseRemoteLoginShellProbeOutput reads the first non-empty line", () => {
+  assert.equal(
+    parseRemoteLoginShellProbeOutput("\n/usr/bin/fish\n"),
+    "fish",
+  );
+  assert.equal(
+    parseRemoteLoginShellProbeOutput("  /bin/bash\r\n"),
+    "posix",
+  );
+  assert.equal(parseRemoteLoginShellProbeOutput("   \n"), null);
+});
+
+test("probe command is fish-parseable and forces POSIX sh", () => {
+  const command = buildRemoteLoginShellProbeCommand();
+  // Outer form: fish and bash both accept `exec sh -c '...'` when sshd
+  // routes the remote command through the login shell.
+  assert.match(command, /^exec sh -c '/);
+  assert.match(command, /getent passwd/);
+  // ${SHELL:-} lives inside the single-quoted sh script body, not as an
+  // outer-shell expansion — fish must not see it unquoted.
+  assert.match(command, /\$\{SHELL:-\}/);
+  assert.equal(command.startsWith("exec sh -c '"), true);
+  assert.equal(command.endsWith("'"), true);
+});
+
+test("isConfirmedShellKind covers wrapper kinds only", () => {
+  assert.equal(isConfirmedShellKind("fish"), true);
+  assert.equal(isConfirmedShellKind("posix"), true);
+  assert.equal(isConfirmedShellKind("unknown"), false);
+  assert.equal(isConfirmedShellKind(undefined), false);
+  assert.equal(isConfirmedShellKind(""), false);
+});
+
+test("ensureSessionShellKind short-circuits confirmed kinds without probing", async () => {
+  let probes = 0;
+  const session = { shellKind: "posix", protocol: "ssh" };
+  const kind = await ensureSessionShellKind(session, {
+    execProbe: async () => {
+      probes += 1;
+      return "/usr/bin/fish";
+    },
+  });
+  assert.equal(kind, "posix");
+  assert.equal(probes, 0);
+});
+
+test("ensureSessionShellKind does not probe local unknown shells", async () => {
+  let probes = 0;
+  const session = { shellKind: "unknown", protocol: "local", type: "local" };
+  const kind = await ensureSessionShellKind(session, {
+    execProbe: async () => {
+      probes += 1;
+      return "/usr/bin/fish";
+    },
+  });
+  assert.equal(kind, "unknown");
+  assert.equal(probes, 0);
+});
+
+test("ensureSessionShellKind probes once and caches fish on SSH sessions", async () => {
+  let probes = 0;
+  const session = { protocol: "ssh" };
+  const probe = async () => {
+    probes += 1;
+    return "/usr/bin/fish\n";
+  };
+
+  const first = await ensureSessionShellKind(session, { execProbe: probe });
+  const second = await ensureSessionShellKind(session, { execProbe: probe });
+
+  assert.equal(first, "fish");
+  assert.equal(second, "fish");
+  assert.equal(session.shellKind, "fish");
+  assert.equal(probes, 1);
+  // After a confirmed kind, resolveEffectiveShellKind must keep fish wrapping
+  // even if the idle prompt looks empty/custom.
+  assert.equal(resolveEffectiveShellKind(session.shellKind, ""), "fish");
+});
+
+test("ensureSessionShellKind shares one in-flight probe across concurrent callers", async () => {
+  let probes = 0;
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const session = { protocol: "ssh" };
+  const probe = async () => {
+    probes += 1;
+    await gate;
+    return "/bin/zsh\n";
+  };
+
+  const p1 = ensureSessionShellKind(session, { execProbe: probe });
+  const p2 = ensureSessionShellKind(session, { execProbe: probe });
+  release();
+  const [a, b] = await Promise.all([p1, p2]);
+
+  assert.equal(a, "posix");
+  assert.equal(b, "posix");
+  assert.equal(probes, 1);
+});
+
+test("ensureSessionShellKind allows retry after a failed probe", async () => {
+  let probes = 0;
+  const session = { protocol: "ssh" };
+  const failThenSucceed = async () => {
+    probes += 1;
+    if (probes === 1) return null;
+    return "/usr/bin/fish\n";
+  };
+
+  const first = await ensureSessionShellKind(session, {
+    execProbe: failThenSucceed,
+  });
+  assert.equal(first, undefined);
+  assert.equal(session.shellKind, undefined);
+
+  const second = await ensureSessionShellKind(session, {
+    execProbe: failThenSucceed,
+  });
+  assert.equal(second, "fish");
+  assert.equal(probes, 2);
+});
+
+test("createSshConnExecProbe returns stdout from conn.exec", async () => {
+  let seenCommand = "";
+  const conn = {
+    exec(command, cb) {
+      seenCommand = command;
+      const listeners = new Map();
+      const stream = {
+        on(event, fn) {
+          if (!listeners.has(event)) listeners.set(event, []);
+          listeners.get(event).push(fn);
+          return stream;
+        },
+        stderr: { on() { return this; } },
+        close() {},
+      };
+      // Deliver data after the probe has subscribed (next tick).
+      queueMicrotask(() => {
+        for (const fn of listeners.get("data") || []) {
+          fn(Buffer.from("/usr/bin/fish\n"));
+        }
+        for (const fn of listeners.get("close") || []) {
+          fn(0);
+        }
+      });
+      cb(null, stream);
+    },
+  };
+  const probe = createSshConnExecProbe(conn);
+  const command = buildRemoteLoginShellProbeCommand();
+  assert.equal(await probe(command, 1000), "/usr/bin/fish\n");
+  assert.equal(seenCommand, command);
+});
+
+test("createSessionExecProbe prefers session.conn over companions", () => {
+  const session = {
+    conn: { exec() {} },
+    moshStatsConn: { exec() {} },
+  };
+  const probe = createSessionExecProbe(session);
+  assert.equal(typeof probe, "function");
+  // Prefer primary conn: a probe built only from moshStatsConn is a different
+  // function identity; we just need a usable probe here.
+  assert.equal(createSessionExecProbe({}), null);
+});
+
+// --- Real fish binary: wrapper must produce markers (issue #1854) -----------
+
+function resolveFishBinary() {
+  const candidates = [
+    process.env.FISH_PATH,
+    "/opt/homebrew/bin/fish",
+    "/usr/local/bin/fish",
+    "/usr/bin/fish",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  const which = spawnSync("which", ["fish"], { encoding: "utf8" });
+  if (which.status === 0 && which.stdout.trim()) return which.stdout.trim();
+  return null;
+}
+
+const fishBinary = resolveFishBinary();
+
+test(
+  "fish wrapper runs under real fish and emits start/end markers",
+  { skip: !fishBinary ? "fish binary not available" : false },
+  () => {
+    const marker = "__NCMCP_FISHTEST__";
+    const wrapped = buildWrappedCommand("echo hello-fish-wrapper", "fish", marker);
+    // fish -c runs the wrapper as a script body (same grammar as interactive
+    // command line for this single-line form).
+    const result = spawnSync(
+      fishBinary,
+      ["--no-config", "-c", wrapped.trim()],
+      { encoding: "utf8", timeout: 10000 },
+    );
+    assert.equal(result.error, undefined, result.stderr || result.error);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, new RegExp(`${marker}_S`));
+    assert.match(result.stdout, /hello-fish-wrapper/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  },
+);
+
+test(
+  "posix wrapper fails under real fish (regression guard for #1854)",
+  { skip: !fishBinary ? "fish binary not available" : false },
+  () => {
+    const marker = "__NCMCP_FISHTEST__";
+    const wrapped = buildWrappedCommand("echo should-not-run", "posix", marker);
+    const result = spawnSync(
+      fishBinary,
+      ["--no-config", "-c", wrapped.trim()],
+      { encoding: "utf8", timeout: 10000 },
+    );
+    // fish rejects `VAR=0` assignment syntax.
+    assert.notEqual(result.status, 0);
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /Unsupported use of '='|Unknown command/,
+    );
+  },
+);
+
+test(
+  "after ensureSessionShellKind(fish), wrapped AI command succeeds in fish",
+  { skip: !fishBinary ? "fish binary not available" : false },
+  async () => {
+    const session = { protocol: "ssh" };
+    await ensureSessionShellKind(session, {
+      execProbe: async () => "/usr/bin/fish\n",
+    });
+    assert.equal(session.shellKind, "fish");
+
+    const marker = "__NCMCP_FISHTEST__";
+    const effective = resolveEffectiveShellKind(session.shellKind, "root at host # ");
+    assert.equal(effective, "fish");
+    const wrapped = buildWrappedCommand("printf 'ok\\n'", effective, marker);
+    const result = spawnSync(
+      fishBinary,
+      ["--no-config", "-c", wrapped.trim()],
+      { encoding: "utf8", timeout: 10000 },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /ok/);
+    assert.match(result.stdout, new RegExp(`${marker}_E:0`));
+  },
+);

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -182,6 +182,12 @@ test("probed posix login shell does not block live PowerShell prompt override (C
     }),
     "posix",
   );
+  const marker = "__NCMCP_POSIX_NATIVE__";
+  const wrapped = buildWrappedCommand("echo native-posix", "posix", marker);
+  assert.doesNotMatch(wrapped, /\bsh\s+-c\b/);
+  assert.doesNotMatch(wrapped, /posix_sh/);
+  assert.match(wrapped, new RegExp(`${marker}=0;`));
+  assert.match(wrapped, new RegExp(`${marker}_cmd=`));
 });
 
 test("probed fish login shell is a soft hint, not a permanent pin (Codex P2)", async () => {

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -12,6 +12,7 @@ const {
   createSshConnExecProbe,
   createSessionExecProbe,
   ensureSessionShellKind,
+  ensureSessionShellKindForExec,
 } = require("./sessionShellKind.cjs");
 
 const {
@@ -210,6 +211,65 @@ test("ensureSessionShellKind uses a session-level exec probe when provided", asy
   assert.equal(kind, "fish");
   assert.equal(session.shellKind, "fish");
   assert.equal(probes, 1);
+});
+
+test("ensureSessionShellKindForExec cancels when Stop fires during the probe", async () => {
+  // Codex P2 on #2061: probe can take up to the timeout before execViaPty
+  // registers a real marker. Pending marker must latch cancel so the command
+  // is not typed after the probe resolves.
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const session = { protocol: "ssh" };
+  const activePtyExecs = new Map();
+  const probe = async () => {
+    await gate;
+    return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
+  };
+
+  const pending = ensureSessionShellKindForExec(session, {
+    execProbe: probe,
+    trackForCancellation: activePtyExecs,
+    chatSessionId: "chat-cancel-probe",
+  });
+
+  // Wait until the pending marker is registered.
+  for (let i = 0; i < 20 && activePtyExecs.size === 0; i += 1) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  assert.equal(activePtyExecs.size, 1);
+  const [marker, entry] = [...activePtyExecs.entries()][0];
+  assert.match(marker, /^__NCMCP_SK_PENDING_/);
+  assert.equal(entry.chatSessionId, "chat-cancel-probe");
+
+  // Simulate cancelPtyExecsForSession during the probe window.
+  entry.cancel();
+  release();
+
+  const result = await pending;
+  assert.equal(result.ok, false);
+  assert.equal(result.cancelled, true);
+  assert.equal(result.error, "Cancelled");
+  assert.equal(result.exitCode, 130);
+  assert.equal(activePtyExecs.size, 0, "pending marker cleaned up after probe");
+  // Probe still settled fish on the session (harmless); we must not have
+  // started a PTY write — callers check probed.ok before execViaPty.
+  assert.equal(session.shellKind, "fish");
+});
+
+test("ensureSessionShellKindForExec proceeds when not cancelled", async () => {
+  const session = { protocol: "ssh" };
+  const activePtyExecs = new Map();
+  const result = await ensureSessionShellKindForExec(session, {
+    execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
+    trackForCancellation: activePtyExecs,
+    chatSessionId: "chat-ok",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.shellKind, "fish");
+  assert.equal(session.shellKind, "fish");
+  assert.equal(activePtyExecs.size, 0);
 });
 
 test("ensureSessionShellKind times out a hanging session-level exec probe", async () => {

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -134,9 +134,43 @@ test("ensureSessionShellKind shares one in-flight probe across concurrent caller
   release();
   const [a, b] = await Promise.all([p1, p2]);
 
-  assert.equal(a, "posix");
-  assert.equal(b, "posix");
+  // Posix login shells are not pinned on session.shellKind (see below).
+  assert.equal(a, undefined);
+  assert.equal(b, undefined);
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._shellKindProbeSettled, true);
   assert.equal(probes, 1);
+});
+
+test("probed posix login shell does not block live PowerShell prompt override (Codex P2)", async () => {
+  // Login shell is bash/zsh, but the user may have entered pwsh interactively
+  // (or startup files exec'd it). Previously unset shellKind let
+  // resolveEffectiveShellKind honor PS ...> prompts (#841). Pinning posix
+  // permanently would type the bash wrapper into PowerShell.
+  let probes = 0;
+  const session = { protocol: "ssh" };
+  const probe = async () => {
+    probes += 1;
+    return `${PROBE_OUTPUT_MARKER}/bin/bash\n`;
+  };
+
+  await ensureSessionShellKind(session, { execProbe: probe });
+  await ensureSessionShellKind(session, { execProbe: probe });
+
+  assert.equal(probes, 1, "posix probe should settle without re-probing");
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._shellKindProbeSettled, true);
+
+  // Live PowerShell prompt still wins when shellKind is unset.
+  assert.equal(
+    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>"),
+    "powershell",
+  );
+  // And a normal bash-style prompt still falls through to posix wrapping.
+  assert.equal(
+    resolveEffectiveShellKind(session.shellKind, "alice@host:~$"),
+    "posix",
+  );
 });
 
 test("ensureSessionShellKind allows retry after a failed probe", async () => {

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -98,9 +98,8 @@ test("ensureSessionShellKind does not probe local unknown shells", async () => {
 });
 
 test("ensureSessionShellKind probes fish once but does not pin it as active shell", async () => {
-  // Login shell = fish must not permanently set session.shellKind: the user
-  // may have switched to bash/pwsh in the interactive PTY (Codex P2).
-  // Unset → posix_sh dual wrapper still works when the interactive shell is fish.
+  // Login shell = fish must not permanently set session.shellKind (Codex P2).
+  // Soft hint still selects the fish wrapper for the common fish-login case.
   let probes = 0;
   const session = { protocol: "ssh" };
   const probe = async () => {
@@ -117,7 +116,10 @@ test("ensureSessionShellKind probes fish once but does not pin it as active shel
   assert.equal(session._loginShellKind, "fish");
   assert.equal(session._shellKindProbeSettled, true);
   assert.equal(probes, 1);
-  assert.equal(resolveEffectiveShellKind(session.shellKind, ""), "posix_sh");
+  assert.equal(
+    resolveEffectiveShellKind(session.shellKind, "", { loginShellHint: session._loginShellKind }),
+    "fish",
+  );
 });
 
 test("ensureSessionShellKind shares one in-flight probe across concurrent callers", async () => {
@@ -167,28 +169,40 @@ test("probed posix login shell does not block live PowerShell prompt override (C
 
   // Live PowerShell prompt still wins when shellKind is unset.
   assert.equal(
-    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>"),
+    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>", {
+      loginShellHint: session._loginShellKind,
+    }),
     "powershell",
   );
-  // Normal bash-style prompt → dual-compatible posix_sh (not native posix).
+  // Soft posix hint → native posix wrapper (evaluated by interactive bash/zsh,
+  // NOT routed through /bin/sh / dash).
   assert.equal(
-    resolveEffectiveShellKind(session.shellKind, "alice@host:~$"),
-    "posix_sh",
+    resolveEffectiveShellKind(session.shellKind, "alice@host:~$", {
+      loginShellHint: session._loginShellKind,
+    }),
+    "posix",
   );
 });
 
-test("probed fish login shell does not pin fish when interactive shell may differ (Codex P2)", async () => {
+test("probed fish login shell is a soft hint, not a permanent pin (Codex P2)", async () => {
   const session = { protocol: "ssh" };
   await ensureSessionShellKind(session, {
     execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
   });
   assert.equal(session.shellKind, undefined);
   assert.equal(session._loginShellKind, "fish");
-  // Unset + non-PS prompt → posix_sh, not fish-native wrapper.
-  assert.equal(resolveEffectiveShellKind(session.shellKind, "root@host ~# "), "posix_sh");
-  // And PS prompt still overrides to powershell.
+  // Soft hint selects fish wrapper for the common case.
   assert.equal(
-    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>"),
+    resolveEffectiveShellKind(session.shellKind, "root@host ~# ", {
+      loginShellHint: session._loginShellKind,
+    }),
+    "fish",
+  );
+  // PS prompt still overrides the fish login hint.
+  assert.equal(
+    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>", {
+      loginShellHint: session._loginShellKind,
+    }),
     "powershell",
   );
 });
@@ -451,10 +465,10 @@ test(
 );
 
 test(
-  "after ensureSessionShellKind(fish login), posix_sh wrapper succeeds under real fish",
+  "after ensureSessionShellKind(fish login), fish wrapper succeeds under real fish",
   { skip: !fishBinary ? "fish binary not available" : false },
   async () => {
-    // Remote fish login is not pinned; default posix_sh must still run in fish.
+    // Soft login hint selects fish wrapper without pinning session.shellKind.
     const session = { protocol: "ssh" };
     await ensureSessionShellKind(session, {
       execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
@@ -463,10 +477,11 @@ test(
     assert.equal(session._loginShellKind, "fish");
 
     const marker = "__NCMCP_FISHTEST__";
-    const effective = resolveEffectiveShellKind(session.shellKind, "root at host # ");
-    assert.equal(effective, "posix_sh");
+    const effective = resolveEffectiveShellKind(session.shellKind, "root at host # ", {
+      loginShellHint: session._loginShellKind,
+    });
+    assert.equal(effective, "fish");
     const wrapped = buildWrappedCommand("printf 'ok\\n'", effective, marker);
-    assert.match(wrapped, /^ sh -c '/);
     const result = spawnSync(
       fishBinary,
       ["--no-config", "-c", wrapped.trim()],

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -5,6 +5,7 @@ const { existsSync } = require("node:fs");
 
 const {
   isConfirmedShellKind,
+  PROBE_OUTPUT_MARKER,
   classifyShellKindFromRemotePath,
   buildRemoteLoginShellProbeCommand,
   parseRemoteLoginShellProbeOutput,
@@ -30,15 +31,20 @@ test("classifies remote login shell paths", () => {
   assert.equal(classifyShellKindFromRemotePath(""), null);
 });
 
-test("parseRemoteLoginShellProbeOutput reads the first non-empty line", () => {
+test("parseRemoteLoginShellProbeOutput reads classifiable probe output lines", () => {
   assert.equal(
-    parseRemoteLoginShellProbeOutput("\n/usr/bin/fish\n"),
+    parseRemoteLoginShellProbeOutput(`\n${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`),
     "fish",
   );
   assert.equal(
-    parseRemoteLoginShellProbeOutput("  /bin/bash\r\n"),
+    parseRemoteLoginShellProbeOutput(`  ${PROBE_OUTPUT_MARKER}/bin/bash\r\n`),
     "posix",
   );
+  assert.equal(
+    parseRemoteLoginShellProbeOutput(`SHELL=/bin/bash\n${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`),
+    "fish",
+  );
+  assert.equal(parseRemoteLoginShellProbeOutput("SHELL=/bin/bash\n"), null);
   assert.equal(parseRemoteLoginShellProbeOutput("   \n"), null);
 });
 
@@ -48,6 +54,7 @@ test("probe command is fish-parseable and forces POSIX sh", () => {
   // routes the remote command through the login shell.
   assert.match(command, /^exec sh -c '/);
   assert.match(command, /getent passwd/);
+  assert.match(command, new RegExp(PROBE_OUTPUT_MARKER));
   // ${SHELL:-} lives inside the single-quoted sh script body, not as an
   // outer-shell expansion — fish must not see it unquoted.
   assert.match(command, /\$\{SHELL:-\}/);
@@ -69,7 +76,7 @@ test("ensureSessionShellKind short-circuits confirmed kinds without probing", as
   const kind = await ensureSessionShellKind(session, {
     execProbe: async () => {
       probes += 1;
-      return "/usr/bin/fish";
+      return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
     },
   });
   assert.equal(kind, "posix");
@@ -82,7 +89,7 @@ test("ensureSessionShellKind does not probe local unknown shells", async () => {
   const kind = await ensureSessionShellKind(session, {
     execProbe: async () => {
       probes += 1;
-      return "/usr/bin/fish";
+      return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
     },
   });
   assert.equal(kind, "unknown");
@@ -94,7 +101,7 @@ test("ensureSessionShellKind probes once and caches fish on SSH sessions", async
   const session = { protocol: "ssh" };
   const probe = async () => {
     probes += 1;
-    return "/usr/bin/fish\n";
+    return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
   };
 
   const first = await ensureSessionShellKind(session, { execProbe: probe });
@@ -119,7 +126,7 @@ test("ensureSessionShellKind shares one in-flight probe across concurrent caller
   const probe = async () => {
     probes += 1;
     await gate;
-    return "/bin/zsh\n";
+    return `${PROBE_OUTPUT_MARKER}/bin/zsh\n`;
   };
 
   const p1 = ensureSessionShellKind(session, { execProbe: probe });
@@ -138,7 +145,7 @@ test("ensureSessionShellKind allows retry after a failed probe", async () => {
   const failThenSucceed = async () => {
     probes += 1;
     if (probes === 1) return null;
-    return "/usr/bin/fish\n";
+    return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
   };
 
   const first = await ensureSessionShellKind(session, {
@@ -152,6 +159,41 @@ test("ensureSessionShellKind allows retry after a failed probe", async () => {
   });
   assert.equal(second, "fish");
   assert.equal(probes, 2);
+});
+
+test("ensureSessionShellKind uses a session-level exec probe when provided", async () => {
+  let probes = 0;
+  const session = {
+    protocol: "mosh",
+    _shellKindExecProbe: async () => {
+      probes += 1;
+      return `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`;
+    },
+  };
+
+  const kind = await ensureSessionShellKind(session);
+
+  assert.equal(kind, "fish");
+  assert.equal(session.shellKind, "fish");
+  assert.equal(probes, 1);
+});
+
+test("ensureSessionShellKind times out a hanging session-level exec probe", async () => {
+  let probes = 0;
+  const session = {
+    protocol: "mosh",
+    _shellKindExecProbe: async () => {
+      probes += 1;
+      return new Promise(() => {});
+    },
+  };
+
+  const kind = await ensureSessionShellKind(session, { timeoutMs: 1 });
+
+  assert.equal(kind, undefined);
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._shellKindProbePromise, null);
+  assert.equal(probes, 1);
 });
 
 test("createSshConnExecProbe returns stdout from conn.exec", async () => {
@@ -185,6 +227,29 @@ test("createSshConnExecProbe returns stdout from conn.exec", async () => {
   const command = buildRemoteLoginShellProbeCommand();
   assert.equal(await probe(command, 1000), "/usr/bin/fish\n");
   assert.equal(seenCommand, command);
+});
+
+test("createSshConnExecProbe closes a channel that arrives after timeout", async () => {
+  let execCallback;
+  let closed = false;
+  const conn = {
+    exec(_command, cb) {
+      execCallback = cb;
+    },
+  };
+  const probe = createSshConnExecProbe(conn);
+  const result = await probe(buildRemoteLoginShellProbeCommand(), 1);
+  assert.equal(result, null);
+
+  const stream = {
+    on() { return stream; },
+    stderr: { on() { return this; } },
+    close() {
+      closed = true;
+    },
+  };
+  execCallback(null, stream);
+  assert.equal(closed, true);
 });
 
 test("createSessionExecProbe prefers session.conn over companions", () => {
@@ -265,7 +330,7 @@ test(
   async () => {
     const session = { protocol: "ssh" };
     await ensureSessionShellKind(session, {
-      execProbe: async () => "/usr/bin/fish\n",
+      execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
     });
     assert.equal(session.shellKind, "fish");
 

--- a/electron/bridges/ai/sessionShellKind.test.cjs
+++ b/electron/bridges/ai/sessionShellKind.test.cjs
@@ -97,7 +97,10 @@ test("ensureSessionShellKind does not probe local unknown shells", async () => {
   assert.equal(probes, 0);
 });
 
-test("ensureSessionShellKind probes once and caches fish on SSH sessions", async () => {
+test("ensureSessionShellKind probes fish once but does not pin it as active shell", async () => {
+  // Login shell = fish must not permanently set session.shellKind: the user
+  // may have switched to bash/pwsh in the interactive PTY (Codex P2).
+  // Unset → posix_sh dual wrapper still works when the interactive shell is fish.
   let probes = 0;
   const session = { protocol: "ssh" };
   const probe = async () => {
@@ -108,13 +111,13 @@ test("ensureSessionShellKind probes once and caches fish on SSH sessions", async
   const first = await ensureSessionShellKind(session, { execProbe: probe });
   const second = await ensureSessionShellKind(session, { execProbe: probe });
 
-  assert.equal(first, "fish");
-  assert.equal(second, "fish");
-  assert.equal(session.shellKind, "fish");
+  assert.equal(first, undefined);
+  assert.equal(second, undefined);
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._loginShellKind, "fish");
+  assert.equal(session._shellKindProbeSettled, true);
   assert.equal(probes, 1);
-  // After a confirmed kind, resolveEffectiveShellKind must keep fish wrapping
-  // even if the idle prompt looks empty/custom.
-  assert.equal(resolveEffectiveShellKind(session.shellKind, ""), "fish");
+  assert.equal(resolveEffectiveShellKind(session.shellKind, ""), "posix_sh");
 });
 
 test("ensureSessionShellKind shares one in-flight probe across concurrent callers", async () => {
@@ -167,10 +170,26 @@ test("probed posix login shell does not block live PowerShell prompt override (C
     resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>"),
     "powershell",
   );
-  // And a normal bash-style prompt still falls through to posix wrapping.
+  // Normal bash-style prompt → dual-compatible posix_sh (not native posix).
   assert.equal(
     resolveEffectiveShellKind(session.shellKind, "alice@host:~$"),
-    "posix",
+    "posix_sh",
+  );
+});
+
+test("probed fish login shell does not pin fish when interactive shell may differ (Codex P2)", async () => {
+  const session = { protocol: "ssh" };
+  await ensureSessionShellKind(session, {
+    execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
+  });
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._loginShellKind, "fish");
+  // Unset + non-PS prompt → posix_sh, not fish-native wrapper.
+  assert.equal(resolveEffectiveShellKind(session.shellKind, "root@host ~# "), "posix_sh");
+  // And PS prompt still overrides to powershell.
+  assert.equal(
+    resolveEffectiveShellKind(session.shellKind, "PS C:\\Users\\alice>"),
+    "powershell",
   );
 });
 
@@ -192,7 +211,9 @@ test("ensureSessionShellKind allows retry after a failed probe", async () => {
   const second = await ensureSessionShellKind(session, {
     execProbe: failThenSucceed,
   });
-  assert.equal(second, "fish");
+  assert.equal(second, undefined);
+  assert.equal(session._loginShellKind, "fish");
+  assert.equal(session._shellKindProbeSettled, true);
   assert.equal(probes, 2);
 });
 
@@ -208,9 +229,19 @@ test("ensureSessionShellKind uses a session-level exec probe when provided", asy
 
   const kind = await ensureSessionShellKind(session);
 
-  assert.equal(kind, "fish");
-  assert.equal(session.shellKind, "fish");
+  assert.equal(kind, undefined);
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._loginShellKind, "fish");
   assert.equal(probes, 1);
+});
+
+test("ensureSessionShellKind pins powershell login shells", async () => {
+  const session = { protocol: "ssh" };
+  await ensureSessionShellKind(session, {
+    execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/pwsh\n`,
+  });
+  assert.equal(session.shellKind, "powershell");
+  assert.equal(session._loginShellKind, "powershell");
 });
 
 test("ensureSessionShellKindForExec cancels when Stop fires during the probe", async () => {
@@ -253,9 +284,9 @@ test("ensureSessionShellKindForExec cancels when Stop fires during the probe", a
   assert.equal(result.error, "Cancelled");
   assert.equal(result.exitCode, 130);
   assert.equal(activePtyExecs.size, 0, "pending marker cleaned up after probe");
-  // Probe still settled fish on the session (harmless); we must not have
-  // started a PTY write — callers check probed.ok before execViaPty.
-  assert.equal(session.shellKind, "fish");
+  // Login fish is recorded but not pinned as active shellKind.
+  assert.equal(session._loginShellKind, "fish");
+  assert.equal(session.shellKind, undefined);
 });
 
 test("ensureSessionShellKindForExec proceeds when not cancelled", async () => {
@@ -267,8 +298,9 @@ test("ensureSessionShellKindForExec proceeds when not cancelled", async () => {
     chatSessionId: "chat-ok",
   });
   assert.equal(result.ok, true);
-  assert.equal(result.shellKind, "fish");
-  assert.equal(session.shellKind, "fish");
+  assert.equal(result.shellKind, undefined);
+  assert.equal(session.shellKind, undefined);
+  assert.equal(session._loginShellKind, "fish");
   assert.equal(activePtyExecs.size, 0);
 });
 
@@ -419,19 +451,22 @@ test(
 );
 
 test(
-  "after ensureSessionShellKind(fish), wrapped AI command succeeds in fish",
+  "after ensureSessionShellKind(fish login), posix_sh wrapper succeeds under real fish",
   { skip: !fishBinary ? "fish binary not available" : false },
   async () => {
+    // Remote fish login is not pinned; default posix_sh must still run in fish.
     const session = { protocol: "ssh" };
     await ensureSessionShellKind(session, {
       execProbe: async () => `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`,
     });
-    assert.equal(session.shellKind, "fish");
+    assert.equal(session.shellKind, undefined);
+    assert.equal(session._loginShellKind, "fish");
 
     const marker = "__NCMCP_FISHTEST__";
     const effective = resolveEffectiveShellKind(session.shellKind, "root at host # ");
-    assert.equal(effective, "fish");
+    assert.equal(effective, "posix_sh");
     const wrapped = buildWrappedCommand("printf 'ok\\n'", effective, marker);
+    assert.match(wrapped, /^ sh -c '/);
     const result = spawnSync(
       fishBinary,
       ["--no-config", "-c", wrapped.trim()],

--- a/electron/bridges/aiBridge/cattyExecHandlers.cjs
+++ b/electron/bridges/aiBridge/cattyExecHandlers.cjs
@@ -3,7 +3,7 @@
 // runs under `with (ctx)` where bare `require` resolves to ctx.require
 // (based in electron/bridges/). Requiring here keeps the path unambiguous.
 const { formatSyntheticEcho } = require("../ai/shellUtils.cjs");
-const { ensureSessionShellKind } = require("../ai/sessionShellKind.cjs");
+const { ensureSessionShellKindForExec } = require("../ai/sessionShellKind.cjs");
 
 function getWorkerExecutionMeta(mcpServerBridge, sessionId, chatSessionId) {
   return mcpServerBridge.getSessionMeta?.(sessionId, chatSessionId) || {};
@@ -159,9 +159,15 @@ function registerCattyExecHandlers(ctx) {
       if (ptyStream && typeof ptyStream.write === "function") {
         const timeoutMs = mcpServerBridge.getCommandTimeoutMs ? mcpServerBridge.getCommandTimeoutMs() : 60000;
         // Remote sessions historically left shellKind unset → posix wrapper
-        // was typed into fish login shells (issue #1854). Probe once first.
+        // was typed into fish login shells (issue #1854). Probe once first,
+        // cancellably so Stop during the probe window does not still type
+        // the command after the probe resolves (Codex P2 on #2061).
         return withLockRelease(async () => {
-          await ensureSessionShellKind(session);
+          const probed = await ensureSessionShellKindForExec(session, {
+            trackForCancellation: mcpServerBridge.activePtyExecs,
+            chatSessionId,
+          });
+          if (!probed.ok) return probed;
           return execViaPty(ptyStream, command, {
             stripMarkers: true,
             trackForCancellation: mcpServerBridge.activePtyExecs,

--- a/electron/bridges/aiBridge/cattyExecHandlers.cjs
+++ b/electron/bridges/aiBridge/cattyExecHandlers.cjs
@@ -3,6 +3,7 @@
 // runs under `with (ctx)` where bare `require` resolves to ctx.require
 // (based in electron/bridges/). Requiring here keeps the path unambiguous.
 const { formatSyntheticEcho } = require("../ai/shellUtils.cjs");
+const { ensureSessionShellKind } = require("../ai/sessionShellKind.cjs");
 
 function getWorkerExecutionMeta(mcpServerBridge, sessionId, chatSessionId) {
   return mcpServerBridge.getSessionMeta?.(sessionId, chatSessionId) || {};
@@ -157,27 +158,32 @@ function registerCattyExecHandlers(ctx) {
       // Prefer PTY stream (visible in terminal)
       if (ptyStream && typeof ptyStream.write === "function") {
         const timeoutMs = mcpServerBridge.getCommandTimeoutMs ? mcpServerBridge.getCommandTimeoutMs() : 60000;
-        return withLockRelease(() => execViaPty(ptyStream, command, {
-          stripMarkers: true,
-          trackForCancellation: mcpServerBridge.activePtyExecs,
-          timeoutMs,
-          shellKind: session.shellKind,
-          chatSessionId,
-          expectedPrompt: getFreshIdlePrompt(session),
-          typedInput: true,
-          echoCommand: (rawCommand) => {
-            const contents = electronModule?.webContents?.fromId?.(session.webContentsId);
-            safeSend(contents, "netcatty:data", {
-              sessionId,
-              data: formatSyntheticEcho(rawCommand),
-              syntheticEcho: true,
-            });
-          },
-          // Catty Agent has no terminal_start fallback for long-running
-          // commands, so do NOT enforce a hard wall-clock timeout here.
-          // The inactivity timeout still applies, so genuinely hung
-          // processes are still terminated.
-        }));
+        // Remote sessions historically left shellKind unset → posix wrapper
+        // was typed into fish login shells (issue #1854). Probe once first.
+        return withLockRelease(async () => {
+          await ensureSessionShellKind(session);
+          return execViaPty(ptyStream, command, {
+            stripMarkers: true,
+            trackForCancellation: mcpServerBridge.activePtyExecs,
+            timeoutMs,
+            shellKind: session.shellKind,
+            chatSessionId,
+            expectedPrompt: getFreshIdlePrompt(session),
+            typedInput: true,
+            echoCommand: (rawCommand) => {
+              const contents = electronModule?.webContents?.fromId?.(session.webContentsId);
+              safeSend(contents, "netcatty:data", {
+                sessionId,
+                data: formatSyntheticEcho(rawCommand),
+                syntheticEcho: true,
+              });
+            },
+            // Catty Agent has no terminal_start fallback for long-running
+            // commands, so do NOT enforce a hard wall-clock timeout here.
+            // The inactivity timeout still applies, so genuinely hung
+            // processes are still terminated.
+          });
+        });
       }
 
       // Network devices require an interactive PTY for raw command execution.

--- a/electron/bridges/aiBridge/cattyExecHandlers.cjs
+++ b/electron/bridges/aiBridge/cattyExecHandlers.cjs
@@ -173,6 +173,7 @@ function registerCattyExecHandlers(ctx) {
             trackForCancellation: mcpServerBridge.activePtyExecs,
             timeoutMs,
             shellKind: session.shellKind,
+            loginShellHint: session._loginShellKind,
             chatSessionId,
             expectedPrompt: getFreshIdlePrompt(session),
             typedInput: true,

--- a/electron/bridges/mcpServerBridge.execHandlers.test.cjs
+++ b/electron/bridges/mcpServerBridge.execHandlers.test.cjs
@@ -1,0 +1,126 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { EventEmitter } = require("node:events");
+const test = require("node:test");
+
+const { createBackgroundJobApi } = require("./mcpServerBridge/backgroundJobs.cjs");
+const { createExecHandlerApi } = require("./mcpServerBridge/execHandlers.cjs");
+const { PROBE_OUTPUT_MARKER } = require("./ai/sessionShellKind.cjs");
+
+class FakePty extends EventEmitter {
+  constructor() {
+    super();
+    this.writes = [];
+  }
+
+  write(data) {
+    this.writes.push(String(data));
+  }
+}
+
+function nextTick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createDeferredShellProbeConn(stdout = `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`) {
+  let execCallback = null;
+  const conn = {
+    exec(_command, callback) {
+      execCallback = callback;
+    },
+  };
+  return {
+    conn,
+    release() {
+      assert.equal(typeof execCallback, "function", "probe should be waiting for ssh exec callback");
+      const stream = new EventEmitter();
+      stream.stderr = new EventEmitter();
+      stream.close = () => stream.emit("close");
+      execCallback(null, stream);
+      queueMicrotask(() => {
+        stream.emit("data", Buffer.from(stdout));
+        stream.emit("close");
+      });
+    },
+  };
+}
+
+function createExecHandlerTestContext({ sessions, backgroundJobs }) {
+  const ctx = {
+    sessions,
+    backgroundJobs,
+    activeSessionSftpOps: new Map(),
+    activeSessionExecutions: new Map(),
+    activePtyExecs: new Map(),
+    crypto,
+    sftpBridge: {},
+    BACKGROUND_JOB_RETENTION_MS: 10 * 60 * 1000,
+    DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS: 30 * 1000,
+    MAX_BACKGROUND_JOB_OUTPUT_CHARS: 256 * 1024,
+    DEFAULT_BACKGROUND_JOB_TIMEOUT_MS: 60 * 60 * 1000,
+    commandTimeoutMs: 5000,
+    activeSftpOpSeq: 0,
+    debugLog() {},
+    getSessionMeta() {
+      return {};
+    },
+    checkCommandSafety() {
+      return { blocked: false };
+    },
+    beginChatExecution() {
+      return { ok: true, release() {} };
+    },
+    getFreshIdlePrompt() {
+      return "";
+    },
+    echoCommandToSession() {},
+    validateSessionScope() {
+      return null;
+    },
+  };
+  Object.assign(ctx, createBackgroundJobApi(ctx));
+  return ctx;
+}
+
+test("MCP terminal_start chat cancel during shellKind probe aborts before PTY write", async () => {
+  const pty = new FakePty();
+  const deferred = createDeferredShellProbeConn();
+  const sessions = new Map([
+    ["ssh-fish", {
+      protocol: "ssh",
+      stream: pty,
+      conn: deferred.conn,
+    }],
+  ]);
+  const backgroundJobs = new Map();
+  const ctx = createExecHandlerTestContext({ sessions, backgroundJobs });
+  const api = createExecHandlerApi(ctx);
+
+  const pendingStart = api.handleJobStart({
+    sessionId: "ssh-fish",
+    command: "sleep 999",
+    chatSessionId: "chat-cancel-probe",
+  });
+  await nextTick();
+
+  assert.equal(backgroundJobs.size, 1, "job should be registered while probe is pending");
+  ctx.cancelBackgroundJobsForSession("chat-cancel-probe");
+
+  deferred.release();
+  const started = await pendingStart;
+
+  assert.equal(started.ok, false);
+  assert.equal(started.error, "Cancelled");
+  assert.equal(started.status, "cancelled");
+  assert.equal(
+    pty.writes.filter((entry) => entry.includes("__NCMCP_")).length,
+    0,
+    "cancelled pending start must not type a wrapper into the PTY",
+  );
+  const [job] = backgroundJobs.values();
+  assert.equal(job.status, "cancelled");
+  assert.equal(job.pendingShellProbe, false);
+  assert.equal(ctx.activeSessionExecutions.size, 0);
+});

--- a/electron/bridges/mcpServerBridge/execHandlers.cjs
+++ b/electron/bridges/mcpServerBridge/execHandlers.cjs
@@ -1,7 +1,10 @@
 /* eslint-disable no-undef */
 // Module-level require: code inside createExecHandlerApi runs under `with (ctx)`
 // where bare `require` resolves to ctx.require (based in electron/bridges/).
-const { ensureSessionShellKind } = require("../ai/sessionShellKind.cjs");
+const {
+  ensureSessionShellKind,
+  ensureSessionShellKindForExec,
+} = require("../ai/sessionShellKind.cjs");
 
 function createExecHandlerApi(ctx) {
   with (ctx) {
@@ -134,8 +137,13 @@ function createExecHandlerApi(ctx) {
       if (ptyStream && typeof ptyStream.write === "function") {
         // Probe remote login shell once when shellKind is unset so fish
         // sessions get the fish wrapper instead of the posix default (#1854).
+        // Cancellable: Stop during the probe must not still type the command.
         return runExecution(async () => {
-          await ensureSessionShellKind(session);
+          const probed = await ensureSessionShellKindForExec(session, {
+            trackForCancellation: activePtyExecs,
+            chatSessionId,
+          });
+          if (!probed.ok) return probed;
           return execViaPty(ptyStream, command, {
             trackForCancellation: activePtyExecs,
             timeoutMs: commandTimeoutMs,
@@ -227,6 +235,9 @@ function createExecHandlerApi(ctx) {
 
       // Background jobs use the same wrapper selection as foreground exec.
       // Probe before startPtyJob so a fish login shell is not mis-wrapped.
+      // Job start is not chat-cancellable the same way foreground exec is
+      // (terminal_start survives SDK Stop), but still use the settled probe
+      // path so shellKind is consistent with foreground.
       return Promise.resolve(ensureSessionShellKind(session)).then(() => {
         let handle;
         try {

--- a/electron/bridges/mcpServerBridge/execHandlers.cjs
+++ b/electron/bridges/mcpServerBridge/execHandlers.cjs
@@ -232,13 +232,56 @@ function createExecHandlerApi(ctx) {
     
       const jobId = createBackgroundJobId();
       const timeoutMs = Math.max(commandTimeoutMs, DEFAULT_BACKGROUND_JOB_TIMEOUT_MS);
+      const startedAt = Date.now();
 
-      // Background jobs use the same wrapper selection as foreground exec.
-      // Probe before startPtyJob so a fish login shell is not mis-wrapped.
-      // Job start is not chat-cancellable the same way foreground exec is
-      // (terminal_start survives SDK Stop), but still use the settled probe
-      // path so shellKind is consistent with foreground.
+      // Register the job *before* the shell-kind probe so chat-delete /
+      // cancelBackgroundJobsForSession can see it while we await. Without
+      // this, the first terminal_start on an unprobed remote session has no
+      // backgroundJobs entry during the probe and still starts the PTY job
+      // after cancel (Codex P2 on #2061). Not registered in activePtyExecs —
+      // terminal_start is designed to survive SDK Stop; only chat cancel
+      // (which walks backgroundJobs) should abort a pending start.
+      let probeCancelRequested = false;
+      const job = {
+        id: jobId,
+        sessionId,
+        chatSessionId: chatSessionId || null,
+        command,
+        status: "running",
+        startedAt,
+        updatedAt: startedAt,
+        exitCode: null,
+        error: null,
+        stdout: "",
+        outputBaseOffset: 0,
+        totalOutputChars: 0,
+        outputTruncated: false,
+        pendingShellProbe: true,
+        handle: {
+          cancel: () => {
+            probeCancelRequested = true;
+          },
+        },
+      };
+      backgroundJobs.set(jobId, job);
+
+      // Probe so fish login shells are not mis-wrapped as posix (#1854).
       return Promise.resolve(ensureSessionShellKind(session)).then(() => {
+        if (probeCancelRequested || job.status === "stopping") {
+          job.status = "cancelled";
+          job.error = "Cancelled";
+          job.updatedAt = Date.now();
+          job.pendingShellProbe = false;
+          releaseSessionExecution(sessionId, sessionToken);
+          return {
+            ok: false,
+            error: "Cancelled",
+            jobId,
+            sessionId,
+            status: "cancelled",
+          };
+        }
+
         let handle;
         try {
           handle = startPtyJob(ptyStream, command, {
@@ -256,28 +299,16 @@ function createExecHandlerApi(ctx) {
             normalizeFinalOutput: false,
           });
         } catch (err) {
+          job.status = "failed";
+          job.error = err?.message || String(err);
+          job.updatedAt = Date.now();
+          job.pendingShellProbe = false;
           releaseSessionExecution(sessionId, sessionToken);
           return { ok: false, error: err?.message || String(err) };
         }
 
-        const startedAt = Date.now();
-        const job = {
-          id: jobId,
-          sessionId,
-          chatSessionId: chatSessionId || null,
-          command,
-          status: "running",
-          startedAt,
-          updatedAt: startedAt,
-          exitCode: null,
-          error: null,
-          stdout: "",
-          outputBaseOffset: 0,
-          totalOutputChars: 0,
-          outputTruncated: false,
-          handle,
-        };
-        backgroundJobs.set(jobId, job);
+        job.handle = handle;
+        job.pendingShellProbe = false;
 
         handle.resultPromise.then((result) => {
           job.updatedAt = Date.now();
@@ -333,6 +364,10 @@ function createExecHandlerApi(ctx) {
         };
       }).catch((err) => {
         // Probe (or unexpected rejection) must not leave the session lock held.
+        job.status = "failed";
+        job.error = err?.message || String(err);
+        job.updatedAt = Date.now();
+        job.pendingShellProbe = false;
         releaseSessionExecution(sessionId, sessionToken);
         return { ok: false, error: err?.message || String(err) };
       });

--- a/electron/bridges/mcpServerBridge/execHandlers.cjs
+++ b/electron/bridges/mcpServerBridge/execHandlers.cjs
@@ -331,6 +331,10 @@ function createExecHandlerApi(ctx) {
           outputMode: "foreground-mirrored",
           recommendedPollIntervalMs: DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS,
         };
+      }).catch((err) => {
+        // Probe (or unexpected rejection) must not leave the session lock held.
+        releaseSessionExecution(sessionId, sessionToken);
+        return { ok: false, error: err?.message || String(err) };
       });
     }
     

--- a/electron/bridges/mcpServerBridge/execHandlers.cjs
+++ b/electron/bridges/mcpServerBridge/execHandlers.cjs
@@ -1,4 +1,8 @@
 /* eslint-disable no-undef */
+// Module-level require: code inside createExecHandlerApi runs under `with (ctx)`
+// where bare `require` resolves to ctx.require (based in electron/bridges/).
+const { ensureSessionShellKind } = require("../ai/sessionShellKind.cjs");
+
 function createExecHandlerApi(ctx) {
   with (ctx) {
     function resolveExecContext(params) {
@@ -128,18 +132,23 @@ function createExecHandlerApi(ctx) {
     
       // Prefer the interactive PTY so the user sees command/output in-session.
       if (ptyStream && typeof ptyStream.write === "function") {
-        return runExecution(() => execViaPty(ptyStream, command, {
-          trackForCancellation: activePtyExecs,
-          timeoutMs: commandTimeoutMs,
-          shellKind: session.shellKind,
-          expectedPrompt: getFreshIdlePrompt(session),
-          typedInput: true,
-          echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
-          chatSessionId,
-          // MCP callers have terminal_start as a fallback for long commands,
-          // so enforce a hard wall-clock timeout here to match the MCP budget.
-          enforceWallTimeout: true,
-        }));
+        // Probe remote login shell once when shellKind is unset so fish
+        // sessions get the fish wrapper instead of the posix default (#1854).
+        return runExecution(async () => {
+          await ensureSessionShellKind(session);
+          return execViaPty(ptyStream, command, {
+            trackForCancellation: activePtyExecs,
+            timeoutMs: commandTimeoutMs,
+            shellKind: session.shellKind,
+            expectedPrompt: getFreshIdlePrompt(session),
+            typedInput: true,
+            echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
+            chatSessionId,
+            // MCP callers have terminal_start as a fallback for long commands,
+            // so enforce a hard wall-clock timeout here to match the MCP budget.
+            enforceWallTimeout: true,
+          });
+        });
       }
     
       // Network devices require an interactive PTY for raw command execution.
@@ -215,98 +224,103 @@ function createExecHandlerApi(ctx) {
     
       const jobId = createBackgroundJobId();
       const timeoutMs = Math.max(commandTimeoutMs, DEFAULT_BACKGROUND_JOB_TIMEOUT_MS);
-      let handle;
-      try {
-        handle = startPtyJob(ptyStream, command, {
-          // Intentionally do NOT register in activePtyExecs: terminal_start jobs
-          // are designed to survive SDK agent "Stop" so the model can stop polling
-          // without aborting a long-running build/scan/log stream. The job is
-          // managed via terminal_stop and the per-session execution lock.
-          timeoutMs,
-          shellKind: session.shellKind,
-          chatSessionId,
-          expectedPrompt: getFreshIdlePrompt(session),
-          typedInput: true,
-          echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
-          maxBufferedChars: MAX_BACKGROUND_JOB_OUTPUT_CHARS,
-          normalizeFinalOutput: false,
+
+      // Background jobs use the same wrapper selection as foreground exec.
+      // Probe before startPtyJob so a fish login shell is not mis-wrapped.
+      return Promise.resolve(ensureSessionShellKind(session)).then(() => {
+        let handle;
+        try {
+          handle = startPtyJob(ptyStream, command, {
+            // Intentionally do NOT register in activePtyExecs: terminal_start jobs
+            // are designed to survive SDK agent "Stop" so the model can stop polling
+            // without aborting a long-running build/scan/log stream. The job is
+            // managed via terminal_stop and the per-session execution lock.
+            timeoutMs,
+            shellKind: session.shellKind,
+            chatSessionId,
+            expectedPrompt: getFreshIdlePrompt(session),
+            typedInput: true,
+            echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
+            maxBufferedChars: MAX_BACKGROUND_JOB_OUTPUT_CHARS,
+            normalizeFinalOutput: false,
+          });
+        } catch (err) {
+          releaseSessionExecution(sessionId, sessionToken);
+          return { ok: false, error: err?.message || String(err) };
+        }
+
+        const startedAt = Date.now();
+        const job = {
+          id: jobId,
+          sessionId,
+          chatSessionId: chatSessionId || null,
+          command,
+          status: "running",
+          startedAt,
+          updatedAt: startedAt,
+          exitCode: null,
+          error: null,
+          stdout: "",
+          outputBaseOffset: 0,
+          totalOutputChars: 0,
+          outputTruncated: false,
+          handle,
+        };
+        backgroundJobs.set(jobId, job);
+
+        handle.resultPromise.then((result) => {
+          job.updatedAt = Date.now();
+          job.exitCode = result.exitCode ?? null;
+          storeCompletedJobOutput(job, result.stdout || "", result);
+          const isForcedCancel = typeof result.error === "string" && result.error.includes("forced");
+          if (result.error === "Cancelled" || isForcedCancel) {
+            // Forced cancel means the process ignored SIGINT for the cancel
+            // wall-clock window. We mark the job as cancelled and release the
+            // lock so the session is reusable; the error message tells the
+            // caller the process may still be running so subsequent commands
+            // should be considered carefully. This is consistent: callers see
+            // completed=true exactly when the lock is no longer held.
+            job.status = "cancelled";
+            job.error = result.error;
+            releaseSessionExecution(sessionId, sessionToken);
+            return;
+          }
+          if (result.error) {
+            job.status = "failed";
+            job.error = result.error;
+            releaseSessionExecution(sessionId, sessionToken);
+            return;
+          }
+          // A non-zero exit code without an error message still represents a
+          // failed command (e.g. a build/test that returned 1). Mark it as failed
+          // so callers don't have to special-case exitCode against status.
+          if (typeof result.exitCode === "number" && result.exitCode !== 0) {
+            job.status = "failed";
+            job.error = `Command exited with code ${result.exitCode}`;
+            releaseSessionExecution(sessionId, sessionToken);
+            return;
+          }
+          job.status = "completed";
+          releaseSessionExecution(sessionId, sessionToken);
+        }).catch((err) => {
+          job.updatedAt = Date.now();
+          job.status = "failed";
+          job.error = err?.message || String(err);
+          storeCompletedJobOutput(job, job.stdout || "");
+          releaseSessionExecution(sessionId, sessionToken);
         });
-      } catch (err) {
-        releaseSessionExecution(sessionId, sessionToken);
-        return { ok: false, error: err?.message || String(err) };
-      }
-    
-      const startedAt = Date.now();
-      const job = {
-        id: jobId,
-        sessionId,
-        chatSessionId: chatSessionId || null,
-        command,
-        status: "running",
-        startedAt,
-        updatedAt: startedAt,
-        exitCode: null,
-        error: null,
-        stdout: "",
-        outputBaseOffset: 0,
-        totalOutputChars: 0,
-        outputTruncated: false,
-        handle,
-      };
-      backgroundJobs.set(jobId, job);
-    
-      handle.resultPromise.then((result) => {
-        job.updatedAt = Date.now();
-        job.exitCode = result.exitCode ?? null;
-        storeCompletedJobOutput(job, result.stdout || "", result);
-        const isForcedCancel = typeof result.error === "string" && result.error.includes("forced");
-        if (result.error === "Cancelled" || isForcedCancel) {
-          // Forced cancel means the process ignored SIGINT for the cancel
-          // wall-clock window. We mark the job as cancelled and release the
-          // lock so the session is reusable; the error message tells the
-          // caller the process may still be running so subsequent commands
-          // should be considered carefully. This is consistent: callers see
-          // completed=true exactly when the lock is no longer held.
-          job.status = "cancelled";
-          job.error = result.error;
-          releaseSessionExecution(sessionId, sessionToken);
-          return;
-        }
-        if (result.error) {
-          job.status = "failed";
-          job.error = result.error;
-          releaseSessionExecution(sessionId, sessionToken);
-          return;
-        }
-        // A non-zero exit code without an error message still represents a
-        // failed command (e.g. a build/test that returned 1). Mark it as failed
-        // so callers don't have to special-case exitCode against status.
-        if (typeof result.exitCode === "number" && result.exitCode !== 0) {
-          job.status = "failed";
-          job.error = `Command exited with code ${result.exitCode}`;
-          releaseSessionExecution(sessionId, sessionToken);
-          return;
-        }
-        job.status = "completed";
-        releaseSessionExecution(sessionId, sessionToken);
-      }).catch((err) => {
-        job.updatedAt = Date.now();
-        job.status = "failed";
-        job.error = err?.message || String(err);
-        storeCompletedJobOutput(job, job.stdout || "");
-        releaseSessionExecution(sessionId, sessionToken);
+
+        return {
+          ok: true,
+          jobId,
+          sessionId,
+          command,
+          status: "running",
+          startedAt,
+          outputMode: "foreground-mirrored",
+          recommendedPollIntervalMs: DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS,
+        };
       });
-    
-      return {
-        ok: true,
-        jobId,
-        sessionId,
-        command,
-        status: "running",
-        startedAt,
-        outputMode: "foreground-mirrored",
-        recommendedPollIntervalMs: DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS,
-      };
     }
     
     function getScopedJob(jobId, chatSessionId) {

--- a/electron/bridges/mcpServerBridge/execHandlers.cjs
+++ b/electron/bridges/mcpServerBridge/execHandlers.cjs
@@ -148,6 +148,7 @@ function createExecHandlerApi(ctx) {
             trackForCancellation: activePtyExecs,
             timeoutMs: commandTimeoutMs,
             shellKind: session.shellKind,
+            loginShellHint: session._loginShellKind,
             expectedPrompt: getFreshIdlePrompt(session),
             typedInput: true,
             echoCommand: (rawCommand) => echoCommandToSession(session, sessionId, rawCommand),
@@ -291,6 +292,7 @@ function createExecHandlerApi(ctx) {
             // managed via terminal_stop and the per-session execution lock.
             timeoutMs,
             shellKind: session.shellKind,
+            loginShellHint: session._loginShellKind,
             chatSessionId,
             expectedPrompt: getFreshIdlePrompt(session),
             typedInput: true,

--- a/electron/bridges/terminalBridge.cjs
+++ b/electron/bridges/terminalBridge.cjs
@@ -575,6 +575,7 @@ const moshSessionApi = createMoshSessionApi({
   openTerminalOutputSession, closeTerminalOutputSession,
   get selectZmodemUploadFiles() { return selectZmodemUploadFiles; },
   get selectZmodemDownloadDirectory() { return selectZmodemDownloadDirectory; },
+  ensureMoshStatsConnection: (...args) => require("./sshBridge.cjs").ensureMoshStatsConnection(...args),
   bundledMoshClient: (...args) => bundledMoshClient(...args),
 });
 const {

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -783,7 +783,9 @@ main();
           hostname: options.hostname || "",
           username: options.username || "",
           label: options.label || options.hostname || "ET Session",
-          shellKind: "posix",
+          // Leave unset so ensureSessionShellKind can probe via companion SSH
+          // exec before AI wrappers (fish login shells — issue #1854).
+          shellKind: undefined,
           shellExecutable: "remote-shell",
           externalAuthArtifacts: sshEnvironment?.artifacts || [],
           externalAuthArtifactsCleaned: false,

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -786,6 +786,13 @@ main();
           // Leave unset so ensureSessionShellKind can probe via companion SSH
           // exec before AI wrappers (fish login shells — issue #1854).
           shellKind: undefined,
+          _shellKindExecProbe: async (command, timeoutMs) => {
+            const result = await execOnEtSession(session, command, timeoutMs, {
+              requireTrustedHost: true,
+              knownHosts: session.etStatsAuth?.knownHosts,
+            });
+            return result?.success ? (result.stdout || "") : null;
+          },
           shellExecutable: "remote-shell",
           externalAuthArtifacts: sshEnvironment?.artifacts || [],
           externalAuthArtifactsCleaned: false,

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -5,6 +5,20 @@ const {
   shouldAcceptSessionOutput,
   shouldProcessSessionOutput,
 } = require("../terminalFlowAck.cjs");
+const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
+
+function withShellProbeTimeout(promise, timeoutMs) {
+  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 3000;
+  let timer = null;
+  return Promise.race([
+    Promise.resolve(promise),
+    new Promise((resolve) => {
+      timer = setTimeout(() => resolve(null), ms);
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
 
 function createMoshSessionApi(ctx) {
   with (ctx) {
@@ -435,6 +449,16 @@ function createMoshSessionApi(ctx) {
         // Leave unset so ensureSessionShellKind can probe via companion SSH
         // exec before AI wrappers (fish login shells — issue #1854).
         shellKind: undefined,
+        _shellKindExecProbe: async (command, timeoutMs) => {
+          if (typeof ensureMoshStatsConnection !== "function") return null;
+          const contents = electronModule?.webContents?.fromId?.(session.webContentsId);
+          const conn = await withShellProbeTimeout(
+            ensureMoshStatsConnection(session, sessionId, contents),
+            timeoutMs,
+          );
+          const probe = createSshConnExecProbe(conn);
+          return probe ? probe(command, timeoutMs) : null;
+        },
         shellExecutable: "remote-shell",
         flushPendingData: null,
         lastIdlePrompt: "",

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -432,7 +432,9 @@ function createMoshSessionApi(ctx) {
         hostname: options.hostname || "",
         username: options.username || "",
         label: options.label || options.hostname || "Mosh Session",
-        shellKind: "posix",
+        // Leave unset so ensureSessionShellKind can probe via companion SSH
+        // exec before AI wrappers (fish login shells — issue #1854).
+        shellKind: undefined,
         shellExecutable: "remote-shell",
         flushPendingData: null,
         lastIdlePrompt: "",

--- a/electron/terminalWorker/aiExec.cjs
+++ b/electron/terminalWorker/aiExec.cjs
@@ -8,7 +8,10 @@ const {
   execViaRawPty,
 } = require("../bridges/ai/ptyExec.cjs");
 const { getFreshIdlePrompt, formatSyntheticEcho } = require("../bridges/ai/shellUtils.cjs");
-const { ensureSessionShellKind } = require("../bridges/ai/sessionShellKind.cjs");
+const {
+  ensureSessionShellKind,
+  ensureSessionShellKindForExec,
+} = require("../bridges/ai/sessionShellKind.cjs");
 
 const DEFAULT_BACKGROUND_JOB_TIMEOUT_MS = 60 * 60 * 1000;
 const DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS = 30 * 1000;
@@ -261,8 +264,13 @@ function createWorkerAiExecHandler({
 
     if (ptyStream && typeof ptyStream.write === "function") {
       // Remote sessions may not set shellKind at connect time; probe once so
-      // fish login shells get the fish wrapper (issue #1854).
-      await ensureSessionShellKind(session);
+      // fish login shells get the fish wrapper (issue #1854). Cancellable so
+      // Stop during the probe window does not still type the command.
+      const probed = await ensureSessionShellKindForExec(session, {
+        trackForCancellation: activePtyExecs,
+        chatSessionId,
+      });
+      if (!probed.ok) return probed;
       return execViaPty(ptyStream, command, {
         stripMarkers: true,
         trackForCancellation: activePtyExecs,

--- a/electron/terminalWorker/aiExec.cjs
+++ b/electron/terminalWorker/aiExec.cjs
@@ -363,11 +363,19 @@ function createWorkerAiJobStartHandler({
       };
     }
 
-    // Same shellKind probe as foreground exec so background jobs on fish
-    // remote shells are not wrapped as posix (issue #1854).
-    await ensureSessionShellKind(session);
-
     const jobId = createWorkerBackgroundJobId();
+    activeSessionJobs.set(sessionId, jobId);
+
+    // Same shellKind probe as foreground exec so background jobs on fish
+    // remote shells are not wrapped as posix (issue #1854). Reserve the
+    // session before awaiting so concurrent starts cannot pass the busy check.
+    try {
+      await ensureSessionShellKind(session);
+    } catch (err) {
+      if (activeSessionJobs.get(sessionId) === jobId) activeSessionJobs.delete(sessionId);
+      return { ok: false, error: err?.message || String(err) };
+    }
+
     const timeoutMs = Math.max(
       Number.isFinite(commandTimeoutMs) ? commandTimeoutMs : 60000,
       DEFAULT_BACKGROUND_JOB_TIMEOUT_MS,
@@ -391,6 +399,7 @@ function createWorkerAiJobStartHandler({
         normalizeFinalOutput: false,
       });
     } catch (err) {
+      if (activeSessionJobs.get(sessionId) === jobId) activeSessionJobs.delete(sessionId);
       return { ok: false, error: err?.message || String(err) };
     }
 
@@ -412,7 +421,6 @@ function createWorkerAiJobStartHandler({
       handle,
     };
     backgroundJobs.set(jobId, job);
-    activeSessionJobs.set(sessionId, jobId);
 
     handle.resultPromise.then((result) => {
       job.updatedAt = Date.now();

--- a/electron/terminalWorker/aiExec.cjs
+++ b/electron/terminalWorker/aiExec.cjs
@@ -8,6 +8,7 @@ const {
   execViaRawPty,
 } = require("../bridges/ai/ptyExec.cjs");
 const { getFreshIdlePrompt, formatSyntheticEcho } = require("../bridges/ai/shellUtils.cjs");
+const { ensureSessionShellKind } = require("../bridges/ai/sessionShellKind.cjs");
 
 const DEFAULT_BACKGROUND_JOB_TIMEOUT_MS = 60 * 60 * 1000;
 const DEFAULT_BACKGROUND_JOB_POLL_INTERVAL_MS = 30 * 1000;
@@ -259,6 +260,9 @@ function createWorkerAiExecHandler({
     }
 
     if (ptyStream && typeof ptyStream.write === "function") {
+      // Remote sessions may not set shellKind at connect time; probe once so
+      // fish login shells get the fish wrapper (issue #1854).
+      await ensureSessionShellKind(session);
       return execViaPty(ptyStream, command, {
         stripMarkers: true,
         trackForCancellation: activePtyExecs,
@@ -312,7 +316,7 @@ function createWorkerAiJobStartHandler({
   backgroundJobs = new Map(),
   activeSessionJobs = new Map(),
 }) {
-  return function handleWorkerAiJobStart(event, payload = {}) {
+  return async function handleWorkerAiJobStart(event, payload = {}) {
     const {
       sessionId,
       command,
@@ -358,6 +362,10 @@ function createWorkerAiJobStartHandler({
         error: "Background execution requires a writable PTY-backed terminal session.",
       };
     }
+
+    // Same shellKind probe as foreground exec so background jobs on fish
+    // remote shells are not wrapped as posix (issue #1854).
+    await ensureSessionShellKind(session);
 
     const jobId = createWorkerBackgroundJobId();
     const timeoutMs = Math.max(

--- a/electron/terminalWorker/aiExec.cjs
+++ b/electron/terminalWorker/aiExec.cjs
@@ -276,6 +276,7 @@ function createWorkerAiExecHandler({
         trackForCancellation: activePtyExecs,
         timeoutMs,
         shellKind: session.shellKind,
+        loginShellHint: session._loginShellKind,
         chatSessionId,
         expectedPrompt: getFreshIdlePrompt(session),
         typedInput: true,
@@ -442,6 +443,7 @@ function createWorkerAiJobStartHandler({
       handle = startPtyJob(ptyStream, command, {
         timeoutMs,
         shellKind: session.shellKind,
+        loginShellHint: session._loginShellKind,
         chatSessionId,
         expectedPrompt: getFreshIdlePrompt(session),
         typedInput: true,

--- a/electron/terminalWorker/aiExec.cjs
+++ b/electron/terminalWorker/aiExec.cjs
@@ -372,16 +372,65 @@ function createWorkerAiJobStartHandler({
     }
 
     const jobId = createWorkerBackgroundJobId();
+    const startedAt = Date.now();
     activeSessionJobs.set(sessionId, jobId);
 
+    // Insert into backgroundJobs *before* the shell-kind probe so
+    // netcatty:ai:catty:cancel / cancelWorkerBackgroundJobsForSession can
+    // latch cancellation while we await. Without this, the first job on an
+    // unprobed remote session has no map entry during the probe and still
+    // writes to the PTY after chat cancel (Codex P2 on #2061).
+    let probeCancelRequested = false;
+    const job = {
+      id: jobId,
+      sessionId,
+      chatSessionId: chatSessionId || null,
+      command,
+      status: "running",
+      startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      error: null,
+      stdout: "",
+      outputBaseOffset: 0,
+      totalOutputChars: 0,
+      outputTruncated: false,
+      pendingShellProbe: true,
+      handle: {
+        cancel: () => {
+          probeCancelRequested = true;
+        },
+      },
+    };
+    backgroundJobs.set(jobId, job);
+
     // Same shellKind probe as foreground exec so background jobs on fish
-    // remote shells are not wrapped as posix (issue #1854). Reserve the
-    // session before awaiting so concurrent starts cannot pass the busy check.
+    // remote shells are not wrapped as posix (issue #1854). Session is
+    // reserved above so concurrent starts cannot pass the busy check.
     try {
       await ensureSessionShellKind(session);
     } catch (err) {
+      job.status = "failed";
+      job.error = err?.message || String(err);
+      job.updatedAt = Date.now();
+      job.pendingShellProbe = false;
       if (activeSessionJobs.get(sessionId) === jobId) activeSessionJobs.delete(sessionId);
       return { ok: false, error: err?.message || String(err) };
+    }
+
+    if (probeCancelRequested || job.status === "stopping") {
+      job.status = "cancelled";
+      job.error = "Cancelled";
+      job.updatedAt = Date.now();
+      job.pendingShellProbe = false;
+      if (activeSessionJobs.get(sessionId) === jobId) activeSessionJobs.delete(sessionId);
+      return {
+        ok: false,
+        error: "Cancelled",
+        jobId,
+        sessionId,
+        status: "cancelled",
+      };
     }
 
     const timeoutMs = Math.max(
@@ -407,28 +456,16 @@ function createWorkerAiJobStartHandler({
         normalizeFinalOutput: false,
       });
     } catch (err) {
+      job.status = "failed";
+      job.error = err?.message || String(err);
+      job.updatedAt = Date.now();
+      job.pendingShellProbe = false;
       if (activeSessionJobs.get(sessionId) === jobId) activeSessionJobs.delete(sessionId);
       return { ok: false, error: err?.message || String(err) };
     }
 
-    const startedAt = Date.now();
-    const job = {
-      id: jobId,
-      sessionId,
-      chatSessionId: chatSessionId || null,
-      command,
-      status: "running",
-      startedAt,
-      updatedAt: startedAt,
-      exitCode: null,
-      error: null,
-      stdout: "",
-      outputBaseOffset: 0,
-      totalOutputChars: 0,
-      outputTruncated: false,
-      handle,
-    };
-    backgroundJobs.set(jobId, job);
+    job.handle = handle;
+    job.pendingShellProbe = false;
 
     handle.resultPromise.then((result) => {
       job.updatedAt = Date.now();

--- a/electron/terminalWorker/aiExec.test.cjs
+++ b/electron/terminalWorker/aiExec.test.cjs
@@ -251,13 +251,12 @@ test("worker background job probes unset remote shellKind before wrapping", asyn
   });
 
   assert.equal(started.ok, true);
-  // Login fish is recorded but not pinned; dual-compatible posix_sh is used.
+  // Login fish is a soft hint (not pinned); wrapper should be fish-native.
   assert.equal(sessions.get("ssh-fish").shellKind, undefined);
   assert.equal(sessions.get("ssh-fish")._loginShellKind, "fish");
   const wrapper = pty.writes.find((entry) => entry.includes("__NCMCP_"));
-  assert.match(wrapper, / sh -c '/);
-  // Must not type native fish syntax (would break if interactive shell is bash).
-  assert.doesNotMatch(wrapper, /set -l __NCMCP_/);
+  assert.match(wrapper, /set -l __NCMCP_.*_cmd/);
+  assert.doesNotMatch(wrapper, / sh -c '/);
 
   const marker = extractMarker(pty.writes);
   pty.emit("data", `${marker}_S\r\n${marker}_E:0\r\n`);

--- a/electron/terminalWorker/aiExec.test.cjs
+++ b/electron/terminalWorker/aiExec.test.cjs
@@ -5,6 +5,7 @@ const { EventEmitter } = require("node:events");
 const test = require("node:test");
 
 const { registerWorkerAiExecHandlers } = require("./aiExec.cjs");
+const { PROBE_OUTPUT_MARKER } = require("../bridges/ai/sessionShellKind.cjs");
 
 class FakePty extends EventEmitter {
   constructor() {
@@ -54,6 +55,46 @@ function extractMarker(writes) {
 
 function nextTick() {
   return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createShellProbeConn(stdout = `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`) {
+  const conn = {
+    exec(_command, callback) {
+      const stream = new EventEmitter();
+      stream.stderr = new EventEmitter();
+      stream.close = () => stream.emit("close");
+      queueMicrotask(() => {
+        callback(null, stream);
+        queueMicrotask(() => {
+          stream.emit("data", Buffer.from(stdout));
+          stream.emit("close");
+        });
+      });
+    },
+  };
+  return conn;
+}
+
+function createDeferredShellProbeConn(stdout = `${PROBE_OUTPUT_MARKER}/usr/bin/fish\n`) {
+  let execCallback;
+  const conn = {
+    exec(_command, callback) {
+      execCallback = callback;
+    },
+  };
+  return {
+    conn,
+    release() {
+      const stream = new EventEmitter();
+      stream.stderr = new EventEmitter();
+      stream.close = () => stream.emit("close");
+      execCallback(null, stream);
+      queueMicrotask(() => {
+        stream.emit("data", Buffer.from(stdout));
+        stream.emit("close");
+      });
+    },
+  };
 }
 
 test("worker AI background jobs start, poll, stop, and block overlapping exec", async () => {
@@ -187,4 +228,75 @@ test("worker chat cancellation stops matching background jobs", async () => {
   });
   assert.equal(cancelled.status, "cancelled");
   assert.equal(cancelled.completed, true);
+});
+
+test("worker background job probes unset remote shellKind before wrapping", async () => {
+  const pty = new FakePty();
+  const sessions = new Map([
+    ["ssh-fish", {
+      protocol: "ssh",
+      stream: pty,
+      conn: createShellProbeConn(),
+    }],
+  ]);
+  const ipcMain = createFakeIpcMain();
+  registerWorkerAiExecHandlers(ipcMain, { sessions });
+
+  const event = createFakeEvent();
+  const started = await ipcMain.handlers.get("netcatty:ai:jobStart")(event, {
+    sessionId: "ssh-fish",
+    command: "echo fish",
+    chatSessionId: "chat-1",
+    commandTimeoutMs: 5000,
+  });
+
+  assert.equal(started.ok, true);
+  assert.equal(sessions.get("ssh-fish").shellKind, "fish");
+  const wrapper = pty.writes.find((entry) => entry.includes("__NCMCP_"));
+  assert.match(wrapper, /set -l __NCMCP_.*_cmd/);
+  assert.doesNotMatch(wrapper, /__NCMCP_.*_cmd=/);
+
+  const marker = extractMarker(pty.writes);
+  pty.emit("data", `${marker}_S\r\n${marker}_E:0\r\n`);
+  await nextTick();
+});
+
+test("worker background job reserves the session while shellKind probe is pending", async () => {
+  const pty = new FakePty();
+  const deferred = createDeferredShellProbeConn();
+  const sessions = new Map([
+    ["ssh-fish", {
+      protocol: "ssh",
+      stream: pty,
+      conn: deferred.conn,
+    }],
+  ]);
+  const ipcMain = createFakeIpcMain();
+  registerWorkerAiExecHandlers(ipcMain, { sessions });
+
+  const event = createFakeEvent();
+  const firstStart = ipcMain.handlers.get("netcatty:ai:jobStart")(event, {
+    sessionId: "ssh-fish",
+    command: "sleep 1",
+    chatSessionId: "chat-1",
+    commandTimeoutMs: 5000,
+  });
+  await nextTick();
+
+  const second = await ipcMain.handlers.get("netcatty:ai:jobStart")(event, {
+    sessionId: "ssh-fish",
+    command: "pwd",
+    chatSessionId: "chat-1",
+    commandTimeoutMs: 5000,
+  });
+  assert.equal(second.ok, false);
+  assert.match(second.error, /already has a long-running command in progress/);
+
+  deferred.release();
+  const first = await firstStart;
+  assert.equal(first.ok, true);
+
+  const marker = extractMarker(pty.writes);
+  pty.emit("data", `${marker}_S\r\n${marker}_E:0\r\n`);
+  await nextTick();
 });

--- a/electron/terminalWorker/aiExec.test.cjs
+++ b/electron/terminalWorker/aiExec.test.cjs
@@ -251,10 +251,13 @@ test("worker background job probes unset remote shellKind before wrapping", asyn
   });
 
   assert.equal(started.ok, true);
-  assert.equal(sessions.get("ssh-fish").shellKind, "fish");
+  // Login fish is recorded but not pinned; dual-compatible posix_sh is used.
+  assert.equal(sessions.get("ssh-fish").shellKind, undefined);
+  assert.equal(sessions.get("ssh-fish")._loginShellKind, "fish");
   const wrapper = pty.writes.find((entry) => entry.includes("__NCMCP_"));
-  assert.match(wrapper, /set -l __NCMCP_.*_cmd/);
-  assert.doesNotMatch(wrapper, /__NCMCP_.*_cmd=/);
+  assert.match(wrapper, / sh -c '/);
+  // Must not type native fish syntax (would break if interactive shell is bash).
+  assert.doesNotMatch(wrapper, /set -l __NCMCP_/);
 
   const marker = extractMarker(pty.writes);
   pty.emit("data", `${marker}_S\r\n${marker}_E:0\r\n`);

--- a/electron/terminalWorker/aiExec.test.cjs
+++ b/electron/terminalWorker/aiExec.test.cjs
@@ -300,3 +300,45 @@ test("worker background job reserves the session while shellKind probe is pendin
   pty.emit("data", `${marker}_S\r\n${marker}_E:0\r\n`);
   await nextTick();
 });
+
+test("worker chat cancel during shellKind probe aborts job start before PTY write", async () => {
+  // Codex P2 on #2061: first jobStart on an unprobed remote session awaits
+  // ensureSessionShellKind with no backgroundJobs entry historically, so
+  // catty:cancel missed it and the command was still typed after the probe.
+  const pty = new FakePty();
+  const deferred = createDeferredShellProbeConn();
+  const sessions = new Map([
+    ["ssh-fish", {
+      protocol: "ssh",
+      stream: pty,
+      conn: deferred.conn,
+    }],
+  ]);
+  const ipcMain = createFakeIpcMain();
+  registerWorkerAiExecHandlers(ipcMain, { sessions });
+
+  const event = createFakeEvent();
+  const pendingStart = ipcMain.handlers.get("netcatty:ai:jobStart")(event, {
+    sessionId: "ssh-fish",
+    command: "sleep 999",
+    chatSessionId: "chat-cancel-probe",
+    commandTimeoutMs: 5000,
+  });
+  await nextTick();
+
+  // Cancel while the shell probe is still in-flight.
+  ipcMain.listeners.get("netcatty:ai:catty:cancel")(event, {
+    chatSessionId: "chat-cancel-probe",
+  });
+
+  deferred.release();
+  const started = await pendingStart;
+
+  assert.equal(started.ok, false);
+  assert.equal(started.error, "Cancelled");
+  assert.equal(
+    pty.writes.filter((entry) => entry.includes("__NCMCP_")).length,
+    0,
+    "cancelled pending start must not type a wrapper into the PTY",
+  );
+});


### PR DESCRIPTION
## Summary
- AI PTY exec defaulted to the **posix** command wrapper when `session.shellKind` was unset. SSH/Telnet sessions never set it, so remote **fish** login shells received bash syntax (`VAR=0; ...`) and failed with `Unsupported use of '='` (issue #1854).
- Before Catty / MCP / worker AI PTY execution, probe the remote login shell once via a silent SSH exec channel (`getent passwd` / `$SHELL`), classify it (`fish` / `posix` / …), and cache `session.shellKind`.
- Leave et/mosh `shellKind` unset so they can take the same probe path when a companion connection is available.
- Existing fish wrapper path is unchanged and still works when `shellKind === "fish"`.

## Root cause
Fish wrapper code was already present (`buildWrappedCommand` `case "fish"`). Local terminals set `shellKind` from the executable path. Remote sessions fell through `resolveEffectiveShellKind` → `"posix"`.

## Test plan
- [x] `node --test electron/bridges/ai/sessionShellKind.test.cjs` (includes real `/opt/homebrew/bin/fish` marker e2e)
- [x] `node --test electron/bridges/ai/ptyExec.test.cjs`
- [x] `node --test electron/terminalWorker/aiExec.test.cjs`
- [ ] Manual: SSH into a host with fish as login shell → Catty/MCP `exec` simple command (`tmux ls` / `echo hi`) → markers succeed, no `Unsupported use of '='`
- [ ] Manual: SSH into bash/zsh host → still works (probe caches `posix`)
- [ ] Manual: local fish terminal → still works without remote probe

Fixes #1854