### PR TITLE
fix: build Linux x64 packages on Debian Buster for glibc 2.28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,12 +407,14 @@ jobs:
         # Container jobs default to /bin/sh; Buster's dash rejects `[[`.
         shell: bash
         run: |
-          # Buster is archived; redirect apt to archive.debian.org.
+          # Buster is archived; redirect apt to archive.debian.org and
+          # disable Valid-Until so expired security metadata still works.
           if [[ -f /etc/apt/sources.list ]]; then
             sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
             sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
             sed -i '/buster-updates/d' /etc/apt/sources.list || true
           fi
+          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update
           apt-get install -y curl ca-certificates build-essential python3 git libfuse2 file rpm \
             libarchive-tools xz-utils \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,8 +439,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Buster ships Python 3.7; node-gyp 12 uses 3.8+ syntax (walrus) and
+      # fails during npm ci / electron-rebuild without a newer interpreter.
+      - name: Setup Python for node-gyp
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install deps
-        run: npm ci
+        env:
+          PYTHON: python3
+          npm_config_python: python3
+        run: |
+          python3 --version
+          npm ci
 
       - name: Set version
         shell: bash
@@ -459,6 +471,8 @@ jobs:
       - name: Prepare node-pty Linux runtime
         env:
           npm_config_arch: x64
+          PYTHON: python3
+          npm_config_python: python3
         run: bash scripts/ensure-node-pty-linux.sh prepare x64
 
       - name: Fetch bundled mosh-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,11 +354,13 @@ jobs:
             release/*.blockmap
           if-no-files-found: ignore
 
-  # Linux x64 — pin to ubuntu-22.04 for broader glibc compatibility.
-  # ubuntu-latest (24.04) links native modules against glibc 2.39 which
-  # can cause dlopen failures on some distros. 22.04 uses glibc 2.35,
-  # compatible with most current Linux distributions including Arch.
-  # See #264.
+  # Dedicated job for Linux x64 — builds inside Debian Buster (GLIBC 2.28)
+  # so native modules (node-pty, serialport) stay compatible with RHEL 8 /
+  # CentOS 8 / UOS / Deepin. Ubuntu 22.04 links against GLIBC 2.32–2.35,
+  # which crashes on those older hosts (see #2062). Buster is preferred over
+  # Bullseye (2.31) because some RHEL 8 derivatives only export symbols up
+  # through GLIBC_2.30 even when `ldd --version` reports 2.31.
+  # Key: GLIBC < 2.34 also avoids the libpthread-merge symbol requirement.
   build-linux-x64:
     name: ${{ needs.dedupe.outputs.skip_heavy_ci == 'true' && 'deduped build-linux-x64' || 'build-linux-x64' }}
     needs: [dedupe, resolve-mosh, resolve-et]
@@ -366,7 +368,9 @@ jobs:
       always()
       && needs.dedupe.result == 'success'
       && needs.dedupe.outputs.skip_heavy_ci != 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: debian:buster
     env:
       MOSH_BIN_RELEASE: ${{ needs.resolve-mosh.outputs.mosh_bin_release }}
       ET_BIN_RELEASE: ${{ needs.resolve-et.outputs.et_bin_release }}
@@ -399,20 +403,40 @@ jobs:
             exit 1
           fi
 
+      - name: Install build dependencies
+        run: |
+          # Buster is archived; redirect apt to archive.debian.org.
+          if [[ -f /etc/apt/sources.list ]]; then
+            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+            sed -i '/buster-updates/d' /etc/apt/sources.list || true
+          fi
+          apt-get update
+          apt-get install -y curl ca-certificates build-essential python3 git libfuse2 file rpm \
+            libarchive-tools xz-utils \
+            libglib2.0-0 libgtk-3-0 libnss3 libxss1 libxtst6 libasound2 \
+            libatk-bridge2.0-0 libdrm2 libgbm1 libx11-xcb1 libxcb-dri3-0
+          # NodeSource no longer ships Node 22 for Buster; install the
+          # official linux-x64 binary tarball instead (matches major 22
+          # used by the other package jobs).
+          NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
+            | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
+            | sed -E 's/^node-(v[0-9.]+)-linux-x64\.tar\.xz$/\1/')"
+          if [[ -z "${NODE_VERSION}" ]]; then
+            echo "::error::Could not resolve latest Node 22 linux-x64 tarball version."
+            exit 1
+          fi
+          echo "Installing Node ${NODE_VERSION} from nodejs.org"
+          curl -fsSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" \
+            | tar -xJ -C /usr/local --strip-components=1
+          node -v
+          npm -v
+
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
       - name: Install deps
         run: npm ci
-
-      - name: Install Linux packaging dependencies
-        run: sudo apt-get update && sudo apt-get install -y libarchive-tools rpm
 
       - name: Set version
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,6 +404,8 @@ jobs:
           fi
 
       - name: Install build dependencies
+        # Container jobs default to /bin/sh; Buster's dash rejects `[[`.
+        shell: bash
         run: |
           # Buster is archived; redirect apt to archive.debian.org.
           if [[ -f /etc/apt/sources.list ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,21 +435,23 @@ jobs:
             | tar -xJ -C /usr/local --strip-components=1
           node -v
           npm -v
+          # Buster ships Python 3.7; node-gyp 12 needs >=3.8 (walrus syntax).
+          # actions/setup-python is not reliable inside this old glibc container,
+          # so install a manylinux-compatible CPython via uv instead.
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="${HOME}/.local/bin:${PATH}"
+          uv python install 3.11
+          PYTHON_BIN="$(uv python find 3.11)"
+          ln -sfn "${PYTHON_BIN}" /usr/local/bin/python3.11
+          ln -sfn python3.11 /usr/local/bin/python3
+          python3 --version
+          echo "PYTHON=${PYTHON_BIN}" >> "${GITHUB_ENV}"
+          echo "npm_config_python=${PYTHON_BIN}" >> "${GITHUB_ENV}"
 
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Buster ships Python 3.7; node-gyp 12 uses 3.8+ syntax (walrus) and
-      # fails during npm ci / electron-rebuild without a newer interpreter.
-      - name: Setup Python for node-gyp
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Install deps
-        env:
-          PYTHON: python3
-          npm_config_python: python3
         run: |
           python3 --version
           npm ci
@@ -471,8 +473,6 @@ jobs:
       - name: Prepare node-pty Linux runtime
         env:
           npm_config_arch: x64
-          PYTHON: python3
-          npm_config_python: python3
         run: bash scripts/ensure-node-pty-linux.sh prepare x64
 
       - name: Fetch bundled mosh-client

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -84,4 +84,9 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
     /name:\s*Install build dependencies[\s\S]*?\n\s+shell:\s*bash\n\s+run:/,
     "Linux x64 install step must use bash so archive-mirror rewrite works under Buster",
   );
+  assert.match(
+    x64Job[0],
+    /uses:\s*actions\/setup-python@v5[\s\S]*?python-version:\s*["']3\.11["']/,
+    "Linux x64 job must install Python >=3.8 for node-gyp 12 on Buster",
+  );
 });

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -79,4 +79,9 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
     false,
     "Linux x64 package job must install Node inside the container like arm64",
   );
+  assert.match(
+    x64Job[0],
+    /name:\s*Install build dependencies[\s\S]*?\n\s+shell:\s*bash\n\s+run:/,
+    "Linux x64 install step must use bash so archive-mirror rewrite works under Buster",
+  );
 });

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -55,3 +55,28 @@ test("build workflow verifies RPM artifacts for both Linux architectures", () =>
     "Linux arm64 package job must verify the RPM artifact",
   );
 });
+
+test("build workflow builds Linux x64 native modules in a glibc 2.28 container", () => {
+  // Keep x64 packages loadable on RHEL 8 / UOS / Deepin (see #2062).
+  // Buster (2.28) is stricter than the prior ubuntu-22.04 host (2.35) and
+  // slightly older than the arm64 Bullseye container (2.31).
+  const x64Job = buildWorkflow.match(
+    /build-linux-x64:[\s\S]*?(?=\n  build-linux-arm64:)/,
+  );
+  assert.ok(x64Job, "build-linux-x64 job must be present before build-linux-arm64");
+  assert.match(
+    x64Job[0],
+    /container:\s*\n\s*image:\s*debian:buster/,
+    "Linux x64 package job must build inside debian:buster for glibc 2.28",
+  );
+  assert.equal(
+    x64Job[0].includes("ubuntu-22.04"),
+    false,
+    "Linux x64 package job must not build on the host ubuntu-22.04 glibc",
+  );
+  assert.equal(
+    x64Job[0].includes("actions/setup-node@"),
+    false,
+    "Linux x64 package job must install Node inside the container like arm64",
+  );
+});

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -86,7 +86,12 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
   );
   assert.match(
     x64Job[0],
-    /uses:\s*actions\/setup-python@v5[\s\S]*?python-version:\s*["']3\.11["']/,
+    /uv python install 3\.11/,
     "Linux x64 job must install Python >=3.8 for node-gyp 12 on Buster",
+  );
+  assert.equal(
+    x64Job[0].includes("actions/setup-python@"),
+    false,
+    "Linux x64 job must not rely on actions/setup-python inside Buster",
   );
 });


### PR DESCRIPTION
## Summary
- Move `build-linux-x64` into a `debian:buster` container (glibc 2.28) so rebuilt `node-pty` / serialport natives load on RHEL 8, CentOS 8, UOS, and Deepin instead of requiring glibc 2.32–2.35 from ubuntu-22.04.
- Mirror the arm64 containerized install pattern: install build deps + Node inside the container (official Node 22 linux-x64 tarball, since NodeSource dropped Buster), keep prepare/pack/verify steps.
- Harden the archived-Buster apt path (`shell: bash`, `archive.debian.org`, `Acquire::Check-Valid-Until false`) and lock the container choice in workflow unit tests.

Fixes #2062

## Test plan
- [x] `node --test scripts/github-workflow-build.test.cjs`
- [x] Local `codex review --base main` (clean after bash + apt Valid-Until fixes)
- [ ] CI `build-linux-x64` job succeeds on this PR
- [ ] On a RHEL 8 / glibc ≤ 2.30 host, install the produced x64 package and confirm startup (no `GLIBC_2.3x not found` from `pty.node`)
- [ ] Optional: `ldd` / `objdump -T` on packaged `prebuilds/linux-x64/pty.node` shows max required GLIBC ≤ 2.28