### PR TITLE
fix(ci): build Linux x64 natives on AlmaLinux 8 for Electron C++20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,12 +354,16 @@ jobs:
             release/*.blockmap
           if-no-files-found: ignore
 
-  # Dedicated job for Linux x64 — builds inside Debian Buster (GLIBC 2.28)
+  # Dedicated job for Linux x64 — builds inside AlmaLinux 8 (GLIBC 2.28)
   # so native modules (node-pty, serialport) stay compatible with RHEL 8 /
   # CentOS 8 / UOS / Deepin. Ubuntu 22.04 links against GLIBC 2.32–2.35,
-  # which crashes on those older hosts (see #2062). Buster is preferred over
-  # Bullseye (2.31) because some RHEL 8 derivatives only export symbols up
-  # through GLIBC_2.30 even when `ldd --version` reports 2.31.
+  # which crashes on those older hosts (see #2062).
+  #
+  # We previously used debian:buster for the same glibc floor, but Buster's
+  # g++ 8 cannot compile Electron 42 natives (`-std=gnu++20`). AlmaLinux 8
+  # keeps glibc 2.28 while gcc-toolset-13 provides a real C++20 toolchain.
+  # Link natives with -static-libstdc++ so the result does not require a
+  # newer system libstdc++ on RHEL 8 derivatives.
   # Key: GLIBC < 2.34 also avoids the libpthread-merge symbol requirement.
   build-linux-x64:
     name: ${{ needs.dedupe.outputs.skip_heavy_ci == 'true' && 'deduped build-linux-x64' || 'build-linux-x64' }}
@@ -370,12 +374,14 @@ jobs:
       && needs.dedupe.outputs.skip_heavy_ci != 'true'
     runs-on: ubuntu-latest
     container:
-      image: debian:buster
+      image: almalinux:8
     env:
       MOSH_BIN_RELEASE: ${{ needs.resolve-mosh.outputs.mosh_bin_release }}
       ET_BIN_RELEASE: ${{ needs.resolve-et.outputs.et_bin_release }}
       npm_config_arch: x64
       npm_config_target_arch: x64
+      # Keep rebuilt natives portable to stock RHEL 8 libstdc++.
+      LDFLAGS: "-static-libstdc++ -static-libgcc"
       VITE_SYNC_GITHUB_CLIENT_ID: ${{ secrets.VITE_SYNC_GITHUB_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_ID: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_ID }}
       VITE_SYNC_GOOGLE_CLIENT_SECRET: ${{ secrets.VITE_SYNC_GOOGLE_CLIENT_SECRET }}
@@ -404,25 +410,29 @@ jobs:
           fi
 
       - name: Install build dependencies
-        # Container jobs default to /bin/sh; Buster's dash rejects `[[`.
         shell: bash
         run: |
-          # Buster is archived; redirect apt to archive.debian.org and
-          # disable Valid-Until so expired security metadata still works.
-          if [[ -f /etc/apt/sources.list ]]; then
-            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i '/buster-updates/d' /etc/apt/sources.list || true
-          fi
-          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
-          apt-get update
-          apt-get install -y curl ca-certificates build-essential python3 git libfuse2 file rpm \
-            libarchive-tools xz-utils \
-            libglib2.0-0 libgtk-3-0 libnss3 libxss1 libxtst6 libasound2 \
-            libatk-bridge2.0-0 libdrm2 libgbm1 libx11-xcb1 libxcb-dri3-0
-          # NodeSource no longer ships Node 22 for Buster; install the
-          # official linux-x64 binary tarball instead (matches major 22
-          # used by the other package jobs).
+          set -euo pipefail
+          dnf -y install epel-release
+          dnf -y install \
+            curl ca-certificates \
+            gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make \
+            python3.11 python3.11-pip \
+            git file rpm-build libarchive xz tar which findutils \
+            dpkg fakeroot \
+            fuse fuse-libs gtk3 nss libXScrnSaver libXtst alsa-lib \
+            at-spi2-atk libdrm mesa-libgbm libX11 libX11-xcb libxcb \
+            mesa-libGL pango cairo
+          # gcc-toolset-13: C++20 for Electron 42 natives; still links glibc 2.28.
+          GCC_TOOLSET_ROOT="/opt/rh/gcc-toolset-13/root"
+          echo "PATH=${GCC_TOOLSET_ROOT}/usr/bin:${PATH}" >> "${GITHUB_ENV}"
+          echo "CC=${GCC_TOOLSET_ROOT}/usr/bin/gcc" >> "${GITHUB_ENV}"
+          echo "CXX=${GCC_TOOLSET_ROOT}/usr/bin/g++" >> "${GITHUB_ENV}"
+          echo "DEVTOOLSET_ROOTPATH=${GCC_TOOLSET_ROOT}" >> "${GITHUB_ENV}"
+          export PATH="${GCC_TOOLSET_ROOT}/usr/bin:${PATH}"
+          gcc --version
+          g++ --version
+          # Official Node 22 linux-x64 tarball (same major as other package jobs).
           NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
             | sed -E 's/^node-(v[0-9.]+)-linux-x64\.tar\.xz$/\1/')"
@@ -435,18 +445,11 @@ jobs:
             | tar -xJ -C /usr/local --strip-components=1
           node -v
           npm -v
-          # Buster ships Python 3.7; node-gyp 12 needs >=3.8 (walrus syntax).
-          # actions/setup-python is not reliable inside this old glibc container,
-          # so install a manylinux-compatible CPython via uv instead.
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          export PATH="${HOME}/.local/bin:${PATH}"
-          uv python install 3.11
-          PYTHON_BIN="$(uv python find 3.11)"
-          ln -sfn "${PYTHON_BIN}" /usr/local/bin/python3.11
-          ln -sfn python3.11 /usr/local/bin/python3
+          # node-gyp 12 needs Python >=3.8; AlmaLinux 8 default is older.
+          alternatives --set python3 /usr/bin/python3.11 || ln -sfn /usr/bin/python3.11 /usr/local/bin/python3
           python3 --version
-          echo "PYTHON=${PYTHON_BIN}" >> "${GITHUB_ENV}"
-          echo "npm_config_python=${PYTHON_BIN}" >> "${GITHUB_ENV}"
+          echo "PYTHON=/usr/bin/python3.11" >> "${GITHUB_ENV}"
+          echo "npm_config_python=/usr/bin/python3.11" >> "${GITHUB_ENV}"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -454,6 +457,7 @@ jobs:
       - name: Install deps
         run: |
           python3 --version
+          g++ --version
           npm ci
 
       - name: Set version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,7 +418,8 @@ jobs:
             curl ca-certificates \
             gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make \
             python3.11 python3.11-pip \
-            git file rpm-build libarchive xz tar which findutils \
+            git file rpm-build binutils cpio elfutils \
+            libarchive xz tar which findutils \
             dpkg fakeroot \
             fuse fuse-libs gtk3 nss libXScrnSaver libXtst alsa-lib \
             at-spi2-atk libdrm mesa-libgbm libX11 libX11-xcb libxcb \
@@ -432,6 +433,10 @@ jobs:
           export PATH="${GCC_TOOLSET_ROOT}/usr/bin:${PATH}"
           gcc --version
           g++ --version
+          # rpmbuild helpers used by fpm; fail early if packaging tools are missing.
+          command -v rpmbuild
+          command -v strip
+          command -v xz
           # Official Node 22 linux-x64 tarball (same major as other package jobs).
           NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,12 +437,25 @@ jobs:
           # compression is gzip; provide a multi-thread xz shim.
           printf '%s\n' '#!/bin/sh' 'exec xz -T0 "$@"' > /usr/local/bin/xzmt
           chmod +x /usr/local/bin/xzmt
+          # electron-builder's portable fpm injects its own LD_LIBRARY_PATH.
+          # Spawning system rpmbuild under that path can make the dynamic
+          # linker fail immediately (exit 127). Prefer a clean-env wrapper.
+          if [[ -x /usr/bin/rpmbuild && ! -e /usr/local/bin/rpmbuild ]]; then
+            cat > /usr/local/bin/rpmbuild <<'EOF'
+#!/bin/bash
+unset LD_LIBRARY_PATH
+exec /usr/bin/rpmbuild "$@"
+EOF
+            chmod +x /usr/local/bin/rpmbuild
+          fi
           # rpmbuild helpers used by fpm; fail early if packaging tools are missing.
           command -v rpmbuild
           command -v strip
           command -v gzip
           command -v xz
           command -v xzmt
+          # Smoke-test: system rpmbuild must actually start under a clean env.
+          rpmbuild --version
           # Official Node 22 linux-x64 tarball (same major as other package jobs).
           NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
@@ -503,7 +516,8 @@ jobs:
           npm_config_arch: x64
           ELECTRON_BUILDER_PUBLISH: "never"
           # Natives are already rebuilt. Prefer system packaging tools so
-          # rpmbuild brp scripts do not pick up a toolset-only binary.
+          # rpmbuild brp scripts do not pick up a toolset-only binary, and so
+          # /usr/local/bin/rpmbuild (clean-env wrapper) wins over /usr/bin.
           PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         run: |
           set -euo pipefail
@@ -511,6 +525,10 @@ jobs:
           command -v rpmbuild
           command -v gzip
           command -v xzmt
+          # Confirm the wrapper is the one on PATH (portable fpm LD_LIBRARY_PATH issue).
+          if ! head -n 2 "$(command -v rpmbuild)" | grep -q 'unset LD_LIBRARY_PATH'; then
+            echo "::warning::rpmbuild on PATH is not the clean-env wrapper; rpm packaging may fail with exit 127"
+          fi
           npm run pack:linux-x64
 
       - name: Verify packaged node-pty Linux runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,31 +433,90 @@ jobs:
           export PATH="${GCC_TOOLSET_ROOT}/usr/bin:${PATH}"
           gcc --version
           g++ --version
+          # AlmaLinux 8's libarchive package is often library-only in minimal
+          # images (no /usr/bin/bsdtar). electron-builder pacman packaging needs
+          # bsdtar; pull the Debian Buster CLI package (also glibc 2.28).
+          if [[ ! -x /usr/bin/bsdtar ]]; then
+            echo "bsdtar missing; installing CLI from Debian Buster libarchive-tools"
+            mkdir -p /tmp/bsdtar-deb
+            curl -fsSL -o /tmp/libarchive-tools.deb \
+              "http://archive.debian.org/debian/pool/main/liba/libarchive/libarchive-tools_3.3.3-4+deb10u3_amd64.deb"
+            dpkg-deb -x /tmp/libarchive-tools.deb /tmp/bsdtar-deb
+            install -m 0755 /tmp/bsdtar-deb/usr/bin/bsdtar /usr/local/bin/bsdtar-bin
+            # Prefer system libarchive.so if present; fall back to the deb's.
+            if [[ ! -e /usr/lib64/libarchive.so.13 && -d /tmp/bsdtar-deb/usr/lib/x86_64-linux-gnu ]]; then
+              mkdir -p /usr/local/lib/bsdtar-libs
+              cp -a /tmp/bsdtar-deb/usr/lib/x86_64-linux-gnu/libarchive.so* /usr/local/lib/bsdtar-libs/ 2>/dev/null || true
+            fi
+            printf '%s\n' \
+              '#!/bin/bash' \
+              'unset LD_LIBRARY_PATH' \
+              'if [[ -d /usr/local/lib/bsdtar-libs ]]; then' \
+              '  export LD_LIBRARY_PATH=/usr/local/lib/bsdtar-libs' \
+              'fi' \
+              'exec /usr/local/bin/bsdtar-bin "$@"' \
+              > /usr/local/bin/bsdtar
+            chmod +x /usr/local/bin/bsdtar
+          fi
           # Some fpm paths still look for xzmt even when payload compression
           # is gzip; provide a multi-thread xz shim.
-          printf '%s\n' '#!/bin/sh' 'exec xz -T0 "$@"' > /usr/local/bin/xzmt
+          printf '%s\n' '#!/bin/sh' 'exec /usr/bin/xz -T0 "$@"' > /usr/local/bin/xzmt
           chmod +x /usr/local/bin/xzmt
           # electron-builder's portable fpm injects its own LD_LIBRARY_PATH.
           # System tools (rpmbuild, bsdtar, ...) then exit 127 under that path.
           # Wrap every packaging helper so child processes see a clean env.
           # Use printf (not a bare heredoc): unindented heredoc body breaks GHA YAML.
-          for cmd in rpmbuild bsdtar bsdcpio tar gzip xz strip; do
-            if [[ -x "/usr/bin/${cmd}" ]]; then
-              printf '%s\n' \
-                '#!/bin/bash' \
-                'unset LD_LIBRARY_PATH' \
-                "exec /usr/bin/${cmd} \"\$@\"" \
-                > "/usr/local/bin/${cmd}"
-              chmod +x "/usr/local/bin/${cmd}"
+          wrap_clean_env() {
+            local name="$1"
+            local real=""
+            if [[ -x "/usr/bin/${name}" ]]; then
+              real="/usr/bin/${name}"
+            elif [[ -x "/usr/local/bin/${name}-bin" ]]; then
+              real="/usr/local/bin/${name}-bin"
+            elif command -v "${name}" >/dev/null 2>&1; then
+              real="$(command -v "${name}")"
+            else
+              return 0
             fi
+            # Don't wrap our own wrapper recursively.
+            if [[ "${real}" == /usr/local/bin/* && "${name}" != "bsdtar" ]]; then
+              return 0
+            fi
+            if [[ "${name}" == "bsdtar" && -x /usr/local/bin/bsdtar-bin ]]; then
+              real="/usr/local/bin/bsdtar-bin"
+            fi
+            printf '%s\n' \
+              '#!/bin/bash' \
+              'unset LD_LIBRARY_PATH' \
+              "exec ${real} \"\$@\"" \
+              > "/usr/local/bin/${name}"
+            chmod +x "/usr/local/bin/${name}"
+          }
+          for cmd in rpmbuild bsdtar bsdcpio tar gzip xz strip cpio; do
+            wrap_clean_env "${cmd}"
           done
-          # rpm/pacman helpers used by fpm; fail early if packaging tools are missing.
-          command -v rpmbuild
-          command -v bsdtar
-          command -v strip
-          command -v gzip
-          command -v xz
-          command -v xzmt
+          # Re-apply bsdtar wrapper with optional lib path for the deb-extracted binary.
+          if [[ -x /usr/local/bin/bsdtar-bin ]]; then
+            printf '%s\n' \
+              '#!/bin/bash' \
+              'unset LD_LIBRARY_PATH' \
+              'if [[ -d /usr/local/lib/bsdtar-libs ]]; then' \
+              '  export LD_LIBRARY_PATH=/usr/local/lib/bsdtar-libs' \
+              'fi' \
+              'exec /usr/local/bin/bsdtar-bin "$@"' \
+              > /usr/local/bin/bsdtar
+            chmod +x /usr/local/bin/bsdtar
+          fi
+          # Fail early with diagnostics if packaging tools are missing.
+          for tool in rpmbuild bsdtar strip gzip xz xzmt; do
+            if ! command -v "${tool}" >/dev/null 2>&1; then
+              echo "::error::Required packaging tool not found: ${tool}"
+              ls -la /usr/bin/bsd* /usr/local/bin/bsd* 2>/dev/null || true
+              rpm -ql libarchive 2>/dev/null | head -n 40 || true
+              exit 1
+            fi
+            echo "found ${tool}: $(command -v "${tool}")"
+          done
           rpmbuild --version
           bsdtar --version | head -n 1
           # Official Node 22 linux-x64 tarball (same major as other package jobs).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,7 +419,7 @@ jobs:
             gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make \
             python3.11 python3.11-pip \
             git file rpm-build binutils cpio elfutils \
-            libarchive xz tar which findutils \
+            libarchive gzip bzip2 xz zstd tar which findutils \
             dpkg fakeroot \
             fuse fuse-libs gtk3 nss libXScrnSaver libXtst alsa-lib \
             at-spi2-atk libdrm mesa-libgbm libX11 libX11-xcb libxcb \
@@ -433,10 +433,16 @@ jobs:
           export PATH="${GCC_TOOLSET_ROOT}/usr/bin:${PATH}"
           gcc --version
           g++ --version
+          # Some fpm/rpmbuild paths still look for xzmt even when payload
+          # compression is gzip; provide a multi-thread xz shim.
+          printf '%s\n' '#!/bin/sh' 'exec xz -T0 "$@"' > /usr/local/bin/xzmt
+          chmod +x /usr/local/bin/xzmt
           # rpmbuild helpers used by fpm; fail early if packaging tools are missing.
           command -v rpmbuild
           command -v strip
+          command -v gzip
           command -v xz
+          command -v xzmt
           # Official Node 22 linux-x64 tarball (same major as other package jobs).
           NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
@@ -496,7 +502,16 @@ jobs:
         env:
           npm_config_arch: x64
           ELECTRON_BUILDER_PUBLISH: "never"
-        run: npm run pack:linux-x64
+          # Natives are already rebuilt. Prefer system packaging tools so
+          # rpmbuild brp scripts do not pick up a toolset-only binary.
+          PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        run: |
+          set -euo pipefail
+          command -v node
+          command -v rpmbuild
+          command -v gzip
+          command -v xzmt
+          npm run pack:linux-x64
 
       - name: Verify packaged node-pty Linux runtime
         run: bash scripts/ensure-node-pty-linux.sh verify x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,12 +435,28 @@ jobs:
           g++ --version
           # AlmaLinux 8's libarchive package is often library-only in minimal
           # images (no /usr/bin/bsdtar). electron-builder pacman packaging needs
-          # bsdtar; pull the Debian Buster CLI package (also glibc 2.28).
+          # bsdtar; pull a Debian tools package that runs on glibc 2.28.
+          # Prefer Buster (published as +deb10u1 on archive.debian.org).
           if [[ ! -x /usr/bin/bsdtar ]]; then
-            echo "bsdtar missing; installing CLI from Debian Buster libarchive-tools"
+            echo "bsdtar missing; installing CLI from Debian libarchive-tools"
             mkdir -p /tmp/bsdtar-deb
-            curl -fsSL -o /tmp/libarchive-tools.deb \
-              "http://archive.debian.org/debian/pool/main/liba/libarchive/libarchive-tools_3.3.3-4+deb10u3_amd64.deb"
+            BSDTAR_DEB_URLS=(
+              "http://archive.debian.org/debian/pool/main/liba/libarchive/libarchive-tools_3.3.3-4+deb10u1_amd64.deb"
+              "http://archive.debian.org/debian/pool/main/liba/libarchive/libarchive-tools_3.2.2-2+deb9u2_amd64.deb"
+            )
+            BSDTAR_DEB_OK=0
+            for url in "${BSDTAR_DEB_URLS[@]}"; do
+              echo "trying ${url}"
+              if curl -fsSL -o /tmp/libarchive-tools.deb "${url}"; then
+                BSDTAR_DEB_OK=1
+                break
+              fi
+              echo "download failed for ${url}"
+            done
+            if [[ "${BSDTAR_DEB_OK}" -ne 1 ]]; then
+              echo "::error::Could not download Debian libarchive-tools for bsdtar"
+              exit 1
+            fi
             dpkg-deb -x /tmp/libarchive-tools.deb /tmp/bsdtar-deb
             install -m 0755 /tmp/bsdtar-deb/usr/bin/bsdtar /usr/local/bin/bsdtar-bin
             # Prefer system libarchive.so if present; fall back to the deb's.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,12 +440,13 @@ jobs:
           # electron-builder's portable fpm injects its own LD_LIBRARY_PATH.
           # Spawning system rpmbuild under that path can make the dynamic
           # linker fail immediately (exit 127). Prefer a clean-env wrapper.
+          # Use printf (not a bare heredoc): unindented heredoc body breaks GHA YAML.
           if [[ -x /usr/bin/rpmbuild && ! -e /usr/local/bin/rpmbuild ]]; then
-            cat > /usr/local/bin/rpmbuild <<'EOF'
-#!/bin/bash
-unset LD_LIBRARY_PATH
-exec /usr/bin/rpmbuild "$@"
-EOF
+            printf '%s\n' \
+              '#!/bin/bash' \
+              'unset LD_LIBRARY_PATH' \
+              'exec /usr/bin/rpmbuild "$@"' \
+              > /usr/local/bin/rpmbuild
             chmod +x /usr/local/bin/rpmbuild
           fi
           # rpmbuild helpers used by fpm; fail early if packaging tools are missing.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,30 +433,33 @@ jobs:
           export PATH="${GCC_TOOLSET_ROOT}/usr/bin:${PATH}"
           gcc --version
           g++ --version
-          # Some fpm/rpmbuild paths still look for xzmt even when payload
-          # compression is gzip; provide a multi-thread xz shim.
+          # Some fpm paths still look for xzmt even when payload compression
+          # is gzip; provide a multi-thread xz shim.
           printf '%s\n' '#!/bin/sh' 'exec xz -T0 "$@"' > /usr/local/bin/xzmt
           chmod +x /usr/local/bin/xzmt
           # electron-builder's portable fpm injects its own LD_LIBRARY_PATH.
-          # Spawning system rpmbuild under that path can make the dynamic
-          # linker fail immediately (exit 127). Prefer a clean-env wrapper.
+          # System tools (rpmbuild, bsdtar, ...) then exit 127 under that path.
+          # Wrap every packaging helper so child processes see a clean env.
           # Use printf (not a bare heredoc): unindented heredoc body breaks GHA YAML.
-          if [[ -x /usr/bin/rpmbuild && ! -e /usr/local/bin/rpmbuild ]]; then
-            printf '%s\n' \
-              '#!/bin/bash' \
-              'unset LD_LIBRARY_PATH' \
-              'exec /usr/bin/rpmbuild "$@"' \
-              > /usr/local/bin/rpmbuild
-            chmod +x /usr/local/bin/rpmbuild
-          fi
-          # rpmbuild helpers used by fpm; fail early if packaging tools are missing.
+          for cmd in rpmbuild bsdtar bsdcpio tar gzip xz strip; do
+            if [[ -x "/usr/bin/${cmd}" ]]; then
+              printf '%s\n' \
+                '#!/bin/bash' \
+                'unset LD_LIBRARY_PATH' \
+                "exec /usr/bin/${cmd} \"\$@\"" \
+                > "/usr/local/bin/${cmd}"
+              chmod +x "/usr/local/bin/${cmd}"
+            fi
+          done
+          # rpm/pacman helpers used by fpm; fail early if packaging tools are missing.
           command -v rpmbuild
+          command -v bsdtar
           command -v strip
           command -v gzip
           command -v xz
           command -v xzmt
-          # Smoke-test: system rpmbuild must actually start under a clean env.
           rpmbuild --version
+          bsdtar --version | head -n 1
           # Official Node 22 linux-x64 tarball (same major as other package jobs).
           NODE_VERSION="$(curl -fsSL https://nodejs.org/dist/latest-v22.x/SHASUMS256.txt \
             | awk '/node-v[0-9.]+-linux-x64\.tar\.xz$/{print $2; exit}' \
@@ -524,12 +527,14 @@ jobs:
           set -euo pipefail
           command -v node
           command -v rpmbuild
+          command -v bsdtar
           command -v gzip
           command -v xzmt
-          # Confirm the wrapper is the one on PATH (portable fpm LD_LIBRARY_PATH issue).
-          if ! head -n 2 "$(command -v rpmbuild)" | grep -q 'unset LD_LIBRARY_PATH'; then
-            echo "::warning::rpmbuild on PATH is not the clean-env wrapper; rpm packaging may fail with exit 127"
-          fi
+          for cmd in rpmbuild bsdtar; do
+            if ! head -n 2 "$(command -v "${cmd}")" | grep -q 'unset LD_LIBRARY_PATH'; then
+              echo "::warning::${cmd} on PATH is not the clean-env wrapper; packaging may fail with exit 127"
+            fi
+          done
           npm run pack:linux-x64
 
       - name: Verify packaged node-pty Linux runtime

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -256,9 +256,15 @@ module.exports = {
         // rpmbuild fails with exit 127 during packaging. gzip is portable and
         // matches our deb preference for older distros.
         compression: 'gzip',
-        // Avoid rpm's generated /usr/lib/.build-id symlinks. Those hashes are
-        // global on the host, so owning them can conflict with other RPMs.
-        fpm: ['--rpm-rpmbuild-define', '_build_id_links none']
+        fpm: [
+            // Avoid rpm's generated /usr/lib/.build-id symlinks. Those hashes
+            // are global on the host, so owning them can conflict with other RPMs.
+            '--rpm-rpmbuild-define', '_build_id_links none',
+            // Electron ships prebuilt binaries. RHEL/Alma brp post-install
+            // scripts (strip/compress/etc.) can exit 127 when a helper is
+            // missing or a gcc-toolset `strip` is on PATH; skip them.
+            '--rpm-rpmbuild-define', '__os_install_post %{nil}',
+        ]
     },
     pacman: {
         // FPM-generated .pacman packages bypass Arch's alpm hooks that

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -251,6 +251,11 @@ module.exports = {
         compression: 'gz'
     },
     rpm: {
+        // Default fpm/electron-builder RPM compression is "xzmt" (multi-threaded
+        // xz). AlmaLinux/RHEL 8 images provide `xz` but not the `xzmt` shim, so
+        // rpmbuild fails with exit 127 during packaging. gzip is portable and
+        // matches our deb preference for older distros.
+        compression: 'gzip',
         // Avoid rpm's generated /usr/lib/.build-id symlinks. Those hashes are
         // global on the host, so owning them can conflict with other RPMs.
         fpm: ['--rpm-rpmbuild-define', '_build_id_links none']

--- a/scripts/build-et/build-linux.sh
+++ b/scripts/build-et/build-linux.sh
@@ -65,6 +65,23 @@ python3 -m pip install --quiet --upgrade pip
 # cleanly under cmake 4.x. ninja is unconstrained.
 python3 -m pip install --quiet "cmake>=3.25,<4" ninja
 export PATH="$(python3 -c 'import sysconfig,os;print(os.path.join(sysconfig.get_path("scripts")))'):$PATH"
+NINJA_BIN=$(command -v ninja)
+
+retry_command() {
+  local attempt=1
+  local max_attempts=4
+  local delay=15
+  until "$@"; do
+    local status=$?
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return "$status"
+    fi
+    echo "WARN: command failed with exit $status; retrying in ${delay}s (attempt $((attempt + 1))/$max_attempts): $*" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 cd "$WORK"
 
@@ -115,8 +132,9 @@ BUILD_DIR="$WORK/et/build"
 # link line omits -lanl, so linking `et` fails with "undefined reference to
 # getaddrinfo_a". STANDARD_LIBRARIES is appended after all other libraries —
 # exactly where the linker needs it to resolve those symbols.
-cmake -S "$WORK/et" -B "$BUILD_DIR" \
+retry_command cmake -S "$WORK/et" -B "$BUILD_DIR" \
   -GNinja \
+  -DCMAKE_MAKE_PROGRAM="$NINJA_BIN" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DDISABLE_TELEMETRY=ON \
   -DCMAKE_CXX_STANDARD_LIBRARIES=-lanl

--- a/scripts/build-et/build-macos.sh
+++ b/scripts/build-et/build-macos.sh
@@ -33,6 +33,23 @@ validate_et_ref
 command -v ninja >/dev/null 2>&1 || brew install ninja
 command -v cmake >/dev/null 2>&1 || brew install cmake
 command -v autoconf >/dev/null 2>&1 || brew install automake autoconf libtool
+NINJA_BIN=$(command -v ninja)
+
+retry_command() {
+  local attempt=1
+  local max_attempts=4
+  local delay=15
+  until "$@"; do
+    local status=$?
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return "$status"
+    fi
+    echo "WARN: command failed with exit $status; retrying in ${delay}s (attempt $((attempt + 1))/$max_attempts): $*" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -72,9 +89,10 @@ build_arch() {
   local arch="$1"       # arm64 | x86_64
   local triplet="$2"    # arm64-osx | x64-osx
   local build_dir="$WORK/build-$arch"
-  echo "=== building et for $arch ($triplet) ==="
-  cmake -S "$WORK/et" -B "$build_dir" \
+  echo "=== building et for $arch ($triplet) ===" >&2
+  retry_command cmake -S "$WORK/et" -B "$build_dir" \
     -GNinja \
+    -DCMAKE_MAKE_PROGRAM="$NINJA_BIN" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DDISABLE_TELEMETRY=ON \
     -DCMAKE_OSX_ARCHITECTURES="$arch" \

--- a/scripts/build-mosh/build-linux.sh
+++ b/scripts/build-mosh/build-linux.sh
@@ -44,6 +44,12 @@ OPENSSL_VER=3.0.13
 PROTOBUF_VER=21.12
 NCURSES_VER=6.4
 
+curl_retry() {
+  local url="$1"
+  local dest="$2"
+  curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 600 "$url" -o "$dest"
+}
+
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 PREFIX="$WORK/prefix"
@@ -54,21 +60,24 @@ yum install -y -q autoconf automake libtool perl perl-IPC-Cmd make gcc gcc-c++ p
 cd "$WORK"
 
 # OpenSSL static
-curl -fsSL "https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz" | tar xz
+curl_retry "https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz" openssl.tgz
+tar xzf openssl.tgz
 ( cd "openssl-$OPENSSL_VER"
   ./config no-shared no-tests --prefix="$PREFIX" --openssldir="$PREFIX/ssl"
   make -j"$(nproc)"
   make install_sw )
 
 # protobuf static (3.x stays compatible with mosh's generated proto code)
-curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VER/protobuf-cpp-3.$PROTOBUF_VER.tar.gz" | tar xz
+curl_retry "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VER/protobuf-cpp-3.$PROTOBUF_VER.tar.gz" protobuf.tgz
+tar xzf protobuf.tgz
 ( cd "protobuf-3.$PROTOBUF_VER"
   ./configure --prefix="$PREFIX" --enable-static --disable-shared --with-pic
   make -j"$(nproc)"
   make install )
 
 # ncurses static
-curl -fsSL "https://invisible-island.net/archives/ncurses/ncurses-$NCURSES_VER.tar.gz" | tar xz
+curl_retry "https://invisible-island.net/archives/ncurses/ncurses-$NCURSES_VER.tar.gz" ncurses.tgz
+tar xzf ncurses.tgz
 ( cd "ncurses-$NCURSES_VER"
   CFLAGS="-fPIC -O2" CXXFLAGS="-fPIC -O2" \
   ./configure --prefix="$PREFIX" --without-shared --without-debug --without-cxx-shared --without-tests --disable-pc-files --enable-widec

--- a/scripts/build-mosh/build-macos.sh
+++ b/scripts/build-mosh/build-macos.sh
@@ -42,6 +42,12 @@ OPENSSL_VER=3.0.13
 PROTOBUF_VER=21.12
 NCURSES_VER=6.4
 
+curl_retry() {
+  local url="$1"
+  local dest="$2"
+  curl -fsSL --retry 8 --retry-delay 5 --retry-max-time 600 "$url" -o "$dest"
+}
+
 # Install build tools when they are not already present on the runner.
 brew list autoconf >/dev/null 2>&1 || brew install autoconf
 brew list automake >/dev/null 2>&1 || brew install automake
@@ -55,9 +61,9 @@ NATIVE_PROTOC_DIR=""
 
 # Pre-fetch sources once.
 cd "$WORK"
-curl -fsSL "https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz" -o openssl.tgz
-curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VER/protobuf-cpp-3.$PROTOBUF_VER.tar.gz" -o protobuf.tgz
-curl -fsSL "https://invisible-island.net/archives/ncurses/ncurses-$NCURSES_VER.tar.gz" -o ncurses.tgz
+curl_retry "https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz" openssl.tgz
+curl_retry "https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOBUF_VER/protobuf-cpp-3.$PROTOBUF_VER.tar.gz" protobuf.tgz
+curl_retry "https://invisible-island.net/archives/ncurses/ncurses-$NCURSES_VER.tar.gz" ncurses.tgz
 git init mosh-src
 git -C mosh-src remote add origin https://github.com/mobile-shell/mosh.git
 git -C mosh-src fetch --depth 1 origin "$MOSH_REF"

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -178,6 +178,16 @@ test("rpm packaging disables generated build-id symlinks", () => {
   );
 });
 
+test("rpm packaging uses gzip compression for RHEL-family package hosts", () => {
+  // Default electron-builder/fpm RPM compression is xzmt. AlmaLinux/RHEL 8 CI
+  // images provide `xz` but not the `xzmt` shim, which makes rpmbuild exit 127.
+  assert.equal(
+    config.rpm?.compression,
+    "gzip",
+    "RPM compression must avoid xzmt on RHEL 8 / AlmaLinux 8 package builders",
+  );
+});
+
 test("windows packaging includes a zip archive target", () => {
   const winTargets = config.win.target.map((entry) => entry.target);
   assert.ok(

--- a/scripts/electron-builder-config.test.cjs
+++ b/scripts/electron-builder-config.test.cjs
@@ -173,8 +173,13 @@ test("linux packaging includes an Arch Linux pacman package target", () => {
 test("rpm packaging disables generated build-id symlinks", () => {
   assert.deepEqual(
     config.rpm?.fpm,
-    ["--rpm-rpmbuild-define", "_build_id_links none"],
-    "RPM packages must not own /usr/lib/.build-id links that can conflict with other RPMs",
+    [
+      "--rpm-rpmbuild-define",
+      "_build_id_links none",
+      "--rpm-rpmbuild-define",
+      "__os_install_post %{nil}",
+    ],
+    "RPM packages must skip build-id links and host brp post scripts on RHEL builders",
   );
 });
 

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -7,6 +7,10 @@ const buildWorkflow = fs.readFileSync(
   path.join(__dirname, "..", ".github", "workflows", "build.yml"),
   "utf8",
 );
+const moshLinuxScript = fs.readFileSync(path.join(__dirname, "build-mosh", "build-linux.sh"), "utf8");
+const moshMacScript = fs.readFileSync(path.join(__dirname, "build-mosh", "build-macos.sh"), "utf8");
+const etLinuxScript = fs.readFileSync(path.join(__dirname, "build-et", "build-linux.sh"), "utf8");
+const etMacScript = fs.readFileSync(path.join(__dirname, "build-et", "build-macos.sh"), "utf8");
 
 test("build workflow no longer installs removed legacy agent binaries", () => {
   for (const stale of [
@@ -128,4 +132,27 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
     false,
     "Linux x64 job must not rely on actions/setup-python inside the glibc container",
   );
+});
+
+test("mosh binary build scripts retry source downloads before failing CI", () => {
+  for (const [name, script] of [
+    ["linux", moshLinuxScript],
+    ["macos", moshMacScript],
+  ]) {
+    assert.match(script, /curl_retry\(\)/, `${name} mosh build must use retrying downloads`);
+    assert.match(script, /--retry 8/, `${name} mosh build must retry transient HTTP failures`);
+    assert.match(script, /--retry-max-time 600/, `${name} mosh build must bound retry time`);
+  }
+});
+
+test("et binary build scripts retry dependency configure and pin ninja", () => {
+  for (const [name, script] of [
+    ["linux", etLinuxScript],
+    ["macos", etMacScript],
+  ]) {
+    assert.match(script, /retry_command\(\)/, `${name} et build must retry transient dependency failures`);
+    assert.match(script, /retry_command cmake -S/, `${name} et build must retry CMake configure`);
+    assert.match(script, /NINJA_BIN=\$\(command -v ninja\)/, `${name} et build must resolve ninja before configure`);
+    assert.match(script, /-DCMAKE_MAKE_PROGRAM="\$NINJA_BIN"/, `${name} et build must pass the resolved ninja path`);
+  }
 });

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -37,11 +37,17 @@ test("build workflow uploads and releases Arch pacman artifacts", () => {
 });
 
 test("build workflow installs bsdtar for Arch pacman packaging", () => {
-  const installMentions = buildWorkflow.match(/libarchive-tools/g) ?? [];
-  assert.equal(
-    installMentions.length,
-    2,
-    "both Linux package jobs must install libarchive-tools for pacman metadata generation",
+  // arm64 (Debian) uses libarchive-tools; x64 (AlmaLinux 8) uses libarchive.
+  // Both packages provide bsdtar for electron-builder pacman metadata.
+  assert.match(
+    buildWorkflow,
+    /build-linux-arm64:[\s\S]*libarchive-tools/,
+    "Linux arm64 package job must install libarchive-tools for pacman metadata generation",
+  );
+  assert.match(
+    buildWorkflow,
+    /build-linux-x64:[\s\S]*\blibarchive\b/,
+    "Linux x64 package job must install libarchive (bsdtar) for pacman metadata generation",
   );
 });
 
@@ -58,16 +64,22 @@ test("build workflow verifies RPM artifacts for both Linux architectures", () =>
 
 test("build workflow builds Linux x64 native modules in a glibc 2.28 container", () => {
   // Keep x64 packages loadable on RHEL 8 / UOS / Deepin (see #2062).
-  // Buster (2.28) is stricter than the prior ubuntu-22.04 host (2.35) and
-  // slightly older than the arm64 Bullseye container (2.31).
+  // AlmaLinux 8 (glibc 2.28) replaces debian:buster so we still target the
+  // same glibc floor, but gcc-toolset-13 can compile Electron 42's -std=gnu++20
+  // (Buster's g++ 8 cannot).
   const x64Job = buildWorkflow.match(
     /build-linux-x64:[\s\S]*?(?=\n  build-linux-arm64:)/,
   );
   assert.ok(x64Job, "build-linux-x64 job must be present before build-linux-arm64");
   assert.match(
     x64Job[0],
-    /container:\s*\n\s*image:\s*debian:buster/,
-    "Linux x64 package job must build inside debian:buster for glibc 2.28",
+    /container:\s*\n\s*image:\s*almalinux:8/,
+    "Linux x64 package job must build inside almalinux:8 for glibc 2.28 + modern GCC",
+  );
+  assert.equal(
+    x64Job[0].includes("debian:buster"),
+    false,
+    "Linux x64 package job must not use debian:buster (g++ 8 cannot build gnu++20 natives)",
   );
   assert.equal(
     x64Job[0].includes("ubuntu-22.04"),
@@ -81,17 +93,22 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
   );
   assert.match(
     x64Job[0],
-    /name:\s*Install build dependencies[\s\S]*?\n\s+shell:\s*bash\n\s+run:/,
-    "Linux x64 install step must use bash so archive-mirror rewrite works under Buster",
+    /gcc-toolset-13-gcc-c\+\+/,
+    "Linux x64 job must install gcc-toolset-13 for C++20 native rebuilds",
   );
   assert.match(
     x64Job[0],
-    /uv python install 3\.11/,
-    "Linux x64 job must install Python >=3.8 for node-gyp 12 on Buster",
+    /static-libstdc\+\+/,
+    "Linux x64 job must static-link libstdc++ so RHEL 8 stock libstdc++ is enough",
+  );
+  assert.match(
+    x64Job[0],
+    /python3\.11/,
+    "Linux x64 job must use Python >=3.8 for node-gyp 12",
   );
   assert.equal(
     x64Job[0].includes("actions/setup-python@"),
     false,
-    "Linux x64 job must not rely on actions/setup-python inside Buster",
+    "Linux x64 job must not rely on actions/setup-python inside the glibc container",
   );
 });

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -104,7 +104,12 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
   assert.match(
     x64Job[0],
     /unset LD_LIBRARY_PATH/,
-    "Linux x64 job must wrap rpmbuild to clear portable-fpm LD_LIBRARY_PATH",
+    "Linux x64 job must wrap packaging tools to clear portable-fpm LD_LIBRARY_PATH",
+  );
+  assert.match(
+    x64Job[0],
+    /for cmd in rpmbuild bsdtar/,
+    "Linux x64 job must wrap both rpmbuild and bsdtar for rpm/pacman targets",
   );
   assert.match(
     x64Job[0],

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -103,6 +103,11 @@ test("build workflow builds Linux x64 native modules in a glibc 2.28 container",
   );
   assert.match(
     x64Job[0],
+    /unset LD_LIBRARY_PATH/,
+    "Linux x64 job must wrap rpmbuild to clear portable-fpm LD_LIBRARY_PATH",
+  );
+  assert.match(
+    x64Job[0],
     /python3\.11/,
     "Linux x64 job must use Python >=3.8 for node-gyp 12",
   );

--- a/scripts/github-workflow-build.test.cjs
+++ b/scripts/github-workflow-build.test.cjs
@@ -49,6 +49,13 @@ test("build workflow installs bsdtar for Arch pacman packaging", () => {
     /build-linux-x64:[\s\S]*\blibarchive\b/,
     "Linux x64 package job must install libarchive (bsdtar) for pacman metadata generation",
   );
+  // Pin a filename that actually exists on archive.debian.org so CI does not
+  // 404 when AlmaLinux's libarchive RPM ships without /usr/bin/bsdtar.
+  assert.match(
+    buildWorkflow,
+    /libarchive-tools_3\.3\.3-4\+deb10u1_amd64\.deb/,
+    "Linux x64 job must download a published Buster libarchive-tools deb for bsdtar",
+  );
 });
 
 test("build workflow verifies RPM artifacts for both Linux architectures", () => {


### PR DESCRIPTION
## Summary

Linux x64 packaging has been red since **#2063** moved `build-linux-x64` to `debian:buster` for glibc 2.28.

### Root cause (not related to host_open / External MCP UI)

```
g++: error: unrecognized command line option '-std=gnu++20'; did you mean '-std=gnu++2a'?
node-gyp failed to rebuild '@serialport/bindings-cpp'
```

- **#2063** correctly targeted glibc 2.28 (RHEL 8 / UOS / Deepin).
- **Electron 42** headers force `-std=gnu++20` for native rebuilds.
- **Buster’s g++ 8** does not accept `gnu++20` → every postinstall/`npm ci` fails.
- macOS / Windows / Linux arm64 (Bullseye, g++ 10+) still pass.

### Fix

| Before | After |
|--------|--------|
| `debian:buster` + g++ 8 | `almalinux:8` + **gcc-toolset-13** |
| glibc 2.28 | glibc 2.28 (same floor) |
| cannot build C++20 natives | C++20 OK |
| dynamic libstdc++ from toolset risk | `LDFLAGS=-static-libstdc++ -static-libgcc` |

Also installs `dpkg`/`fakeroot`/`libarchive` for deb/pacman packaging on RHEL-family images.

### Test plan

- [x] `node --test scripts/github-workflow-build.test.cjs`
- [ ] CI `build-linux-x64` green on this PR
- [ ] Optional: on RHEL 8 / glibc 2.28 host, install produced `.rpm`/`.deb` and confirm no `GLIBC_2.3x` / missing `GLIBCXX` from `pty.node` / serialport

Fixes packaging breakage from #2063 / #2062 follow-up.