### PR TITLE
Update Nix release metadata for v1.1.61

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.60";
+  version = "1.1.61";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-kCu2PVOIbePVnBgvffpCLxHUhvfFapeW8vOJnmGv7ug=";
+      hash = "sha256-bCj+VfZQeaLbPWrJERItbpdKnMtXei8EnUmIm+BUKhI=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-y50rjGwkkbBORkVXlaO7wqKb1fCVs0Rkfa2+SfXrKeA=";
+      hash = "sha256-DboC2DPmby+xjy6NoM2QO9+KyIIhOoJHyMYAJhqclNI=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update nix/release.nix to v1.1.61
- use the AppImage hashes from the published v1.1.61 release assets

## Verification
- git diff --check
- confirmed nix/release.nix contains the v1.1.61 version and expected SRI hashes

This mirrors the release workflow output; the workflow could not push directly because main requires changes through a pull request.