### PR TITLE
Measure actual SSH network latency

### DIFF
--- a/application/i18n/locales/en/systemManager.ts
+++ b/application/i18n/locales/en/systemManager.ts
@@ -41,7 +41,7 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'System',
   'systemManager.overview.kernel': 'Kernel',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'Network latency',
+  'systemManager.overview.latency': 'SSH network latency',
   'systemManager.overview.cpuCores': 'CPU cores',
   'systemManager.overview.disks': 'Disks',
   'systemManager.overview.interfaces': 'Network interfaces',

--- a/application/i18n/locales/en/systemManager.ts
+++ b/application/i18n/locales/en/systemManager.ts
@@ -41,7 +41,7 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'System',
   'systemManager.overview.kernel': 'Kernel',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'Latency',
+  'systemManager.overview.latency': 'SSH stats response time',
   'systemManager.overview.cpuCores': 'CPU cores',
   'systemManager.overview.disks': 'Disks',
   'systemManager.overview.interfaces': 'Network interfaces',

--- a/application/i18n/locales/en/systemManager.ts
+++ b/application/i18n/locales/en/systemManager.ts
@@ -41,7 +41,7 @@ export const enSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'System',
   'systemManager.overview.kernel': 'Kernel',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'SSH stats response time',
+  'systemManager.overview.latency': 'Network latency',
   'systemManager.overview.cpuCores': 'CPU cores',
   'systemManager.overview.disks': 'Disks',
   'systemManager.overview.interfaces': 'Network interfaces',

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -88,7 +88,7 @@ export const enTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Disk Usage (Root)',
   'terminal.serverStats.diskDetails': 'Mounted Disks',
   'terminal.serverStats.network': 'Network Speed',
-  'terminal.serverStats.latency': 'SSH stats response time',
+  'terminal.serverStats.latency': 'Network latency',
   'terminal.serverStats.networkDetails': 'Network Interfaces',
   'terminal.serverStats.noData': 'No data available',
   'terminal.dragDrop.localTitle': 'Drop to Insert Paths',

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -88,7 +88,7 @@ export const enTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Disk Usage (Root)',
   'terminal.serverStats.diskDetails': 'Mounted Disks',
   'terminal.serverStats.network': 'Network Speed',
-  'terminal.serverStats.latency': 'Network latency',
+  'terminal.serverStats.latency': 'SSH network latency',
   'terminal.serverStats.networkDetails': 'Network Interfaces',
   'terminal.serverStats.noData': 'No data available',
   'terminal.dragDrop.localTitle': 'Drop to Insert Paths',

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -88,7 +88,7 @@ export const enTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Disk Usage (Root)',
   'terminal.serverStats.diskDetails': 'Mounted Disks',
   'terminal.serverStats.network': 'Network Speed',
-  'terminal.serverStats.latency': 'Latency',
+  'terminal.serverStats.latency': 'SSH stats response time',
   'terminal.serverStats.networkDetails': 'Network Interfaces',
   'terminal.serverStats.noData': 'No data available',
   'terminal.dragDrop.localTitle': 'Drop to Insert Paths',

--- a/application/i18n/locales/ru/systemManager.ts
+++ b/application/i18n/locales/ru/systemManager.ts
@@ -41,7 +41,7 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'Система',
   'systemManager.overview.kernel': 'Ядро',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'Время ответа статистики SSH',
+  'systemManager.overview.latency': 'Сетевая задержка',
   'systemManager.overview.cpuCores': 'Ядра CPU',
   'systemManager.overview.disks': 'Диски',
   'systemManager.overview.interfaces': 'Сетевые интерфейсы',

--- a/application/i18n/locales/ru/systemManager.ts
+++ b/application/i18n/locales/ru/systemManager.ts
@@ -41,7 +41,7 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'Система',
   'systemManager.overview.kernel': 'Ядро',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'Задержка',
+  'systemManager.overview.latency': 'Время ответа статистики SSH',
   'systemManager.overview.cpuCores': 'Ядра CPU',
   'systemManager.overview.disks': 'Диски',
   'systemManager.overview.interfaces': 'Сетевые интерфейсы',

--- a/application/i18n/locales/ru/systemManager.ts
+++ b/application/i18n/locales/ru/systemManager.ts
@@ -41,7 +41,7 @@ export const ruSystemManagerMessages: Messages = {
   'systemManager.overview.system': 'Система',
   'systemManager.overview.kernel': 'Ядро',
   'systemManager.overview.swap': 'Swap',
-  'systemManager.overview.latency': 'Сетевая задержка',
+  'systemManager.overview.latency': 'Сетевая задержка SSH',
   'systemManager.overview.cpuCores': 'Ядра CPU',
   'systemManager.overview.disks': 'Диски',
   'systemManager.overview.interfaces': 'Сетевые интерфейсы',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -109,6 +109,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Использование диска (корень)',
   'terminal.serverStats.diskDetails': 'Смонтированные диски',
   'terminal.serverStats.network': 'Скорость сети',
+  'terminal.serverStats.latency': 'Время ответа статистики SSH',
   'terminal.serverStats.networkDetails': 'Сетевые интерфейсы',
   'terminal.serverStats.noData': 'Данные недоступны',
   'terminal.dragDrop.localTitle': 'Перетащите для вставки путей',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -109,7 +109,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Использование диска (корень)',
   'terminal.serverStats.diskDetails': 'Смонтированные диски',
   'terminal.serverStats.network': 'Скорость сети',
-  'terminal.serverStats.latency': 'Сетевая задержка',
+  'terminal.serverStats.latency': 'Сетевая задержка SSH',
   'terminal.serverStats.networkDetails': 'Сетевые интерфейсы',
   'terminal.serverStats.noData': 'Данные недоступны',
   'terminal.dragDrop.localTitle': 'Перетащите для вставки путей',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -109,7 +109,7 @@ export const ruTerminalMessages: Messages = {
   'terminal.serverStats.disk': 'Использование диска (корень)',
   'terminal.serverStats.diskDetails': 'Смонтированные диски',
   'terminal.serverStats.network': 'Скорость сети',
-  'terminal.serverStats.latency': 'Время ответа статистики SSH',
+  'terminal.serverStats.latency': 'Сетевая задержка',
   'terminal.serverStats.networkDetails': 'Сетевые интерфейсы',
   'terminal.serverStats.noData': 'Данные недоступны',
   'terminal.dragDrop.localTitle': 'Перетащите для вставки путей',

--- a/application/i18n/locales/serverStatsLatency.test.ts
+++ b/application/i18n/locales/serverStatsLatency.test.ts
@@ -10,12 +10,12 @@ import { zhCNVaultMessages } from "./zh-CN/vault";
 import { zhTwSystemManagerMessages } from "./zh-TW/systemManager";
 import { zhTWVaultMessages } from "./zh-TW/vault";
 
-test("SSH stats response time is explicit in every locale and UI surface", () => {
+test("network latency is explicit in every locale and UI surface", () => {
   const labels = [
-    [enTerminalMessages, enSystemManagerMessages, "SSH stats response time"],
-    [ruTerminalMessages, ruSystemManagerMessages, "Время ответа статистики SSH"],
-    [zhCNVaultMessages, zhCnSystemManagerMessages, "SSH 统计响应时间"],
-    [zhTWVaultMessages, zhTwSystemManagerMessages, "SSH 統計回應時間"],
+    [enTerminalMessages, enSystemManagerMessages, "Network latency"],
+    [ruTerminalMessages, ruSystemManagerMessages, "Сетевая задержка"],
+    [zhCNVaultMessages, zhCnSystemManagerMessages, "网络延迟"],
+    [zhTWVaultMessages, zhTwSystemManagerMessages, "網路延遲"],
   ] as const;
 
   for (const [terminalMessages, systemManagerMessages, expected] of labels) {

--- a/application/i18n/locales/serverStatsLatency.test.ts
+++ b/application/i18n/locales/serverStatsLatency.test.ts
@@ -1,21 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { enSystemManagerMessages } from "./en/systemManager";
 import { enTerminalMessages } from "./en/terminal";
+import { ruSystemManagerMessages } from "./ru/systemManager";
+import { ruTerminalMessages } from "./ru/terminal";
+import { zhCnSystemManagerMessages } from "./zh-CN/systemManager";
 import { zhCNVaultMessages } from "./zh-CN/vault";
+import { zhTwSystemManagerMessages } from "./zh-TW/systemManager";
 import { zhTWVaultMessages } from "./zh-TW/vault";
 
-test("server stats response time is not labeled as generic network latency", () => {
-  assert.equal(
-    enTerminalMessages["terminal.serverStats.latency"],
-    "SSH stats response time",
-  );
-  assert.equal(
-    zhCNVaultMessages["terminal.serverStats.latency"],
-    "SSH 统计响应时间",
-  );
-  assert.equal(
-    zhTWVaultMessages["terminal.serverStats.latency"],
-    "SSH 統計回應時間",
-  );
+test("SSH stats response time is explicit in every locale and UI surface", () => {
+  const labels = [
+    [enTerminalMessages, enSystemManagerMessages, "SSH stats response time"],
+    [ruTerminalMessages, ruSystemManagerMessages, "Время ответа статистики SSH"],
+    [zhCNVaultMessages, zhCnSystemManagerMessages, "SSH 统计响应时间"],
+    [zhTWVaultMessages, zhTwSystemManagerMessages, "SSH 統計回應時間"],
+  ] as const;
+
+  for (const [terminalMessages, systemManagerMessages, expected] of labels) {
+    assert.equal(terminalMessages["terminal.serverStats.latency"], expected);
+    assert.equal(systemManagerMessages["systemManager.overview.latency"], expected);
+  }
 });

--- a/application/i18n/locales/serverStatsLatency.test.ts
+++ b/application/i18n/locales/serverStatsLatency.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { enTerminalMessages } from "./en/terminal";
+import { zhCNVaultMessages } from "./zh-CN/vault";
+import { zhTWVaultMessages } from "./zh-TW/vault";
+
+test("server stats response time is not labeled as generic network latency", () => {
+  assert.equal(
+    enTerminalMessages["terminal.serverStats.latency"],
+    "SSH stats response time",
+  );
+  assert.equal(
+    zhCNVaultMessages["terminal.serverStats.latency"],
+    "SSH 统计响应时间",
+  );
+  assert.equal(
+    zhTWVaultMessages["terminal.serverStats.latency"],
+    "SSH 統計回應時間",
+  );
+});

--- a/application/i18n/locales/serverStatsLatency.test.ts
+++ b/application/i18n/locales/serverStatsLatency.test.ts
@@ -10,12 +10,12 @@ import { zhCNVaultMessages } from "./zh-CN/vault";
 import { zhTwSystemManagerMessages } from "./zh-TW/systemManager";
 import { zhTWVaultMessages } from "./zh-TW/vault";
 
-test("network latency is explicit in every locale and UI surface", () => {
+test("SSH network latency is explicit in every locale and UI surface", () => {
   const labels = [
-    [enTerminalMessages, enSystemManagerMessages, "Network latency"],
-    [ruTerminalMessages, ruSystemManagerMessages, "Сетевая задержка"],
-    [zhCNVaultMessages, zhCnSystemManagerMessages, "网络延迟"],
-    [zhTWVaultMessages, zhTwSystemManagerMessages, "網路延遲"],
+    [enTerminalMessages, enSystemManagerMessages, "SSH network latency"],
+    [ruTerminalMessages, ruSystemManagerMessages, "Сетевая задержка SSH"],
+    [zhCNVaultMessages, zhCnSystemManagerMessages, "SSH 网络延迟"],
+    [zhTWVaultMessages, zhTwSystemManagerMessages, "SSH 網路延遲"],
   ] as const;
 
   for (const [terminalMessages, systemManagerMessages, expected] of labels) {

--- a/application/i18n/locales/zh-CN/systemManager.ts
+++ b/application/i18n/locales/zh-CN/systemManager.ts
@@ -41,7 +41,7 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系统',
   'systemManager.overview.kernel': '内核',
   'systemManager.overview.swap': '交换区',
-  'systemManager.overview.latency': '网络延迟',
+  'systemManager.overview.latency': 'SSH 网络延迟',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁盘',
   'systemManager.overview.interfaces': '网络接口',

--- a/application/i18n/locales/zh-CN/systemManager.ts
+++ b/application/i18n/locales/zh-CN/systemManager.ts
@@ -41,7 +41,7 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系统',
   'systemManager.overview.kernel': '内核',
   'systemManager.overview.swap': '交换区',
-  'systemManager.overview.latency': '延迟',
+  'systemManager.overview.latency': 'SSH 统计响应时间',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁盘',
   'systemManager.overview.interfaces': '网络接口',

--- a/application/i18n/locales/zh-CN/systemManager.ts
+++ b/application/i18n/locales/zh-CN/systemManager.ts
@@ -41,7 +41,7 @@ export const zhCnSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系统',
   'systemManager.overview.kernel': '内核',
   'systemManager.overview.swap': '交换区',
-  'systemManager.overview.latency': 'SSH 统计响应时间',
+  'systemManager.overview.latency': '网络延迟',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁盘',
   'systemManager.overview.interfaces': '网络接口',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -382,7 +382,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁盘使用（根分区）',
   'terminal.serverStats.diskDetails': '已挂载磁盘',
   'terminal.serverStats.network': '网络速度',
-  'terminal.serverStats.latency': '延迟',
+  'terminal.serverStats.latency': 'SSH 统计响应时间',
   'terminal.serverStats.networkDetails': '网络接口',
   'terminal.serverStats.noData': '暂无数据',
   'terminal.dragDrop.localTitle': '拖放以插入路径',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -382,7 +382,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁盘使用（根分区）',
   'terminal.serverStats.diskDetails': '已挂载磁盘',
   'terminal.serverStats.network': '网络速度',
-  'terminal.serverStats.latency': 'SSH 统计响应时间',
+  'terminal.serverStats.latency': '网络延迟',
   'terminal.serverStats.networkDetails': '网络接口',
   'terminal.serverStats.noData': '暂无数据',
   'terminal.dragDrop.localTitle': '拖放以插入路径',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -382,7 +382,7 @@ export const zhCNVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁盘使用（根分区）',
   'terminal.serverStats.diskDetails': '已挂载磁盘',
   'terminal.serverStats.network': '网络速度',
-  'terminal.serverStats.latency': '网络延迟',
+  'terminal.serverStats.latency': 'SSH 网络延迟',
   'terminal.serverStats.networkDetails': '网络接口',
   'terminal.serverStats.noData': '暂无数据',
   'terminal.dragDrop.localTitle': '拖放以插入路径',

--- a/application/i18n/locales/zh-TW/systemManager.ts
+++ b/application/i18n/locales/zh-TW/systemManager.ts
@@ -41,7 +41,7 @@ export const zhTwSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系統',
   'systemManager.overview.kernel': '核心',
   'systemManager.overview.swap': '交換區',
-  'systemManager.overview.latency': '延遲',
+  'systemManager.overview.latency': 'SSH 統計回應時間',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁碟',
   'systemManager.overview.interfaces': '網路介面',

--- a/application/i18n/locales/zh-TW/systemManager.ts
+++ b/application/i18n/locales/zh-TW/systemManager.ts
@@ -41,7 +41,7 @@ export const zhTwSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系統',
   'systemManager.overview.kernel': '核心',
   'systemManager.overview.swap': '交換區',
-  'systemManager.overview.latency': 'SSH 統計回應時間',
+  'systemManager.overview.latency': '網路延遲',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁碟',
   'systemManager.overview.interfaces': '網路介面',

--- a/application/i18n/locales/zh-TW/systemManager.ts
+++ b/application/i18n/locales/zh-TW/systemManager.ts
@@ -41,7 +41,7 @@ export const zhTwSystemManagerMessages: Messages = {
   'systemManager.overview.system': '系統',
   'systemManager.overview.kernel': '核心',
   'systemManager.overview.swap': '交換區',
-  'systemManager.overview.latency': '網路延遲',
+  'systemManager.overview.latency': 'SSH 網路延遲',
   'systemManager.overview.cpuCores': 'CPU 核心',
   'systemManager.overview.disks': '磁碟',
   'systemManager.overview.interfaces': '網路介面',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -382,7 +382,7 @@ export const zhTWVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁碟使用（根分割槽）',
   'terminal.serverStats.diskDetails': '已掛載磁碟',
   'terminal.serverStats.network': '網路速度',
-  'terminal.serverStats.latency': '延遲',
+  'terminal.serverStats.latency': 'SSH 統計回應時間',
   'terminal.serverStats.networkDetails': '網路介面',
   'terminal.serverStats.noData': '暫無資料',
   'terminal.dragDrop.localTitle': '拖放以插入路徑',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -382,7 +382,7 @@ export const zhTWVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁碟使用（根分割槽）',
   'terminal.serverStats.diskDetails': '已掛載磁碟',
   'terminal.serverStats.network': '網路速度',
-  'terminal.serverStats.latency': '網路延遲',
+  'terminal.serverStats.latency': 'SSH 網路延遲',
   'terminal.serverStats.networkDetails': '網路介面',
   'terminal.serverStats.noData': '暫無資料',
   'terminal.dragDrop.localTitle': '拖放以插入路徑',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -382,7 +382,7 @@ export const zhTWVaultMessages: Messages = {
   'terminal.serverStats.disk': '磁碟使用（根分割槽）',
   'terminal.serverStats.diskDetails': '已掛載磁碟',
   'terminal.serverStats.network': '網路速度',
-  'terminal.serverStats.latency': 'SSH 統計回應時間',
+  'terminal.serverStats.latency': '網路延遲',
   'terminal.serverStats.networkDetails': '網路介面',
   'terminal.serverStats.noData': '暫無資料',
   'terminal.dragDrop.localTitle': '拖放以插入路徑',

--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -45,7 +45,7 @@ export interface ServerStats {
   disks: DiskInfo[];            // All mounted disks
   netRxSpeed: number;           // Total network receive speed (bytes/sec)
   netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-  latencyMs: number | null;     // Approximate SSH stats round-trip latency
+  latencyMs: number | null;     // SSH stats response time: channel open through first output
   netInterfaces: NetInterfaceInfo[];  // Per-interface network stats
   lastUpdated: number | null;   // Timestamp of last successful update
 }

--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -45,7 +45,7 @@ export interface ServerStats {
   disks: DiskInfo[];            // All mounted disks
   netRxSpeed: number;           // Total network receive speed (bytes/sec)
   netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-  latencyMs: number | null;     // SSH stats response time: channel open through first output
+  latencyMs: number | null;     // Stats request start through its first observable output
   netInterfaces: NetInterfaceInfo[];  // Per-interface network stats
   lastUpdated: number | null;   // Timestamp of last successful update
 }

--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -45,7 +45,7 @@ export interface ServerStats {
   disks: DiskInfo[];            // All mounted disks
   netRxSpeed: number;           // Total network receive speed (bytes/sec)
   netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-  latencyMs: number | null;     // Stats request start through its first observable output
+  latencyMs: number | null;     // Approximate network round-trip over the SSH stats channel
   netInterfaces: NetInterfaceInfo[];  // Per-interface network stats
   lastUpdated: number | null;   // Timestamp of last successful update
 }

--- a/electron/bridges/sshBridge.sessionOps.et.test.cjs
+++ b/electron/bridges/sshBridge.sessionOps.et.test.cjs
@@ -4,14 +4,21 @@ const { EventEmitter } = require("node:events");
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");
 
-function fakeStream(stdout) {
+function fakeStream(stdout, waitForWrite = false) {
   const stream = new EventEmitter();
   stream.stderr = new EventEmitter();
-  stream.write = () => true;
-  setImmediate(() => {
+  let sent = false;
+  const send = () => {
+    if (sent) return;
+    sent = true;
     if (stdout) stream.emit("data", Buffer.from(stdout));
     stream.emit("close", 0);
-  });
+  };
+  stream.write = () => {
+    if (waitForWrite) setImmediate(send);
+    return true;
+  };
+  if (!waitForWrite) setImmediate(send);
   return stream;
 }
 
@@ -21,7 +28,7 @@ function fakeConn(stdout) {
       const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
         ? `NC_LATENCY_MARK|${stdout}`
         : stdout;
-      cb(null, fakeStream(output));
+      cb(null, fakeStream(output, command.includes("NC_LATENCY_MARK")));
     },
   };
 }

--- a/electron/bridges/sshBridge.sessionOps.et.test.cjs
+++ b/electron/bridges/sshBridge.sessionOps.et.test.cjs
@@ -7,6 +7,7 @@ const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");
 function fakeStream(stdout) {
   const stream = new EventEmitter();
   stream.stderr = new EventEmitter();
+  stream.write = () => true;
   setImmediate(() => {
     if (stdout) stream.emit("data", Buffer.from(stdout));
     stream.emit("close", 0);
@@ -16,8 +17,11 @@ function fakeStream(stdout) {
 
 function fakeConn(stdout) {
   return {
-    exec(_command, cb) {
-      cb(null, fakeStream(stdout));
+    exec(command, cb) {
+      const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
+        ? `NC_LATENCY_MARK|${stdout}`
+        : stdout;
+      cb(null, fakeStream(output));
     },
   };
 }
@@ -97,6 +101,7 @@ test("getServerStats opens an ET stats companion connection for direct ET sessio
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.cpuCores, 4);
+  assert.equal(typeof result.stats.latencyMs, "number");
 });
 
 test("getServerStats falls back to execOnEtSession for jumped ET sessions", async () => {
@@ -128,6 +133,8 @@ test("getServerStats falls back to execOnEtSession for jumped ET sessions", asyn
   assert.match(command, /CPURAW|UNSUPPORTED_OS/);
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
+  assert.equal(result.stats.latencyMs, null);
+  assert.doesNotMatch(command, /read -r nc_latency_probe/);
 });
 
 test("getServerStats falls back to execOnEtSession when the direct ET companion is unavailable", async () => {
@@ -157,6 +164,7 @@ test("getServerStats falls back to execOnEtSession when the direct ET companion 
   assert.equal(execFallbackCalls, 1);
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
+  assert.equal(result.stats.latencyMs, null);
 });
 
 test("readRemoteHistory probes ET sessions and parses the detected shell", async () => {

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -710,8 +710,9 @@ function createSessionOpsApi(ctx) {
         typeof execOnEtSession === "function" &&
         !!session.sshUserHost &&
         !session.externalAuthArtifactsCleaned;
-      const conn = session.conn || session.moshStatsConn || session.etStatsConn ||
-        (canExecEtStats ? createEtStatsExecConn(session) : null);
+      const sshStatsConn = session.conn || session.moshStatsConn || session.etStatsConn;
+      const usesEtStatsFallback = !sshStatsConn && canExecEtStats;
+      const conn = sshStatsConn || (usesEtStatsFallback ? createEtStatsExecConn(session) : null);
       if (!conn) {
         // A Mosh session can be marked "connected" (and start polling) from
         // the SSH bootstrap's visible output before swapToMoshClient stores
@@ -797,12 +798,16 @@ function createSessionOpsApi(ctx) {
     
       // Auto-detect OS via uname — only Linux and macOS are supported
       const latencyMarker = "NC_LATENCY_MARK";
-      const statsCommand = `printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
+      // On an ssh2 channel, wait for a one-byte client probe before printing
+      // the marker. Timing that data round-trip excludes channel setup and the
+      // stats command itself. The buffered system-ssh ET fallback cannot expose
+      // first-byte timing, so it reports no latency instead of a misleading one.
+      const latencyProbeCommand = usesEtStatsFallback ? '' : 'read -r nc_latency_probe; ';
+      const statsCommand = `${latencyProbeCommand}printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
       return new Promise((resolve) => {
         const timeout = setTimeout(() => {
           resolve({ success: false, error: 'Timeout getting server stats' });
         }, 10000);
-        const latencyStartedAt = Date.now();
     
         conn.exec(statsCommand, (err, stream) => {
           if (err) {
@@ -814,12 +819,17 @@ function createSessionOpsApi(ctx) {
           let stdout = '';
           let stderr = '';
           let latencyMs = null;
+          let latencyStartedAt = null;
     
           stream.on('data', (data) => {
-            if (latencyMs === null) {
+            stdout += data.toString();
+            if (
+              latencyMs === null &&
+              latencyStartedAt !== null &&
+              stdout.includes(latencyMarker)
+            ) {
               latencyMs = Math.max(0, Date.now() - latencyStartedAt);
             }
-            stdout += data.toString();
           });
     
           stream.stderr.on('data', (data) => {
@@ -1129,7 +1139,7 @@ function createSessionOpsApi(ctx) {
                 disks,         // Array of all mounted disks
                 netRxSpeed,    // Total network receive speed (bytes/sec)
                 netTxSpeed,    // Total network transmit speed (bytes/sec)
-                latencyMs,      // Stats request start through its first observable output (ms)
+                latencyMs,      // Approximate network round-trip over the SSH stats channel (ms)
                 netInterfaces, // Per-interface network stats
                 hostname,
                 osName,
@@ -1139,6 +1149,11 @@ function createSessionOpsApi(ctx) {
               },
             });
           });
+
+          if (!usesEtStatsFallback) {
+            latencyStartedAt = Date.now();
+            stream.write('\n');
+          }
         });
       });
     }

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -1129,7 +1129,7 @@ function createSessionOpsApi(ctx) {
                 disks,         // Array of all mounted disks
                 netRxSpeed,    // Total network receive speed (bytes/sec)
                 netTxSpeed,    // Total network transmit speed (bytes/sec)
-                latencyMs,      // Approximate SSH stats round-trip latency (ms)
+                latencyMs,      // SSH stats response time: channel open through first output (ms)
                 netInterfaces, // Per-interface network stats
                 hostname,
                 osName,

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -805,16 +805,43 @@ function createSessionOpsApi(ctx) {
       const latencyProbeCommand = usesEtStatsFallback ? '' : 'read -r nc_latency_probe; ';
       const statsCommand = `${latencyProbeCommand}printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
       return new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-          resolve({ success: false, error: 'Timeout getting server stats' });
+        let activeStream = null;
+        let settled = false;
+        let timeout = null;
+        const disposeStream = (stream) => {
+          if (!stream) return;
+          try {
+            if (typeof stream.close === 'function') stream.close();
+            else if (typeof stream.destroy === 'function') stream.destroy();
+          } catch {
+            try { stream.destroy?.(); } catch { /* ignore cleanup errors */ }
+          }
+        };
+        const settle = (result) => {
+          if (settled) return false;
+          settled = true;
+          if (timeout) clearTimeout(timeout);
+          resolve(result);
+          return true;
+        };
+        timeout = setTimeout(() => {
+          const stream = activeStream;
+          activeStream = null;
+          if (settle({ success: false, error: 'Timeout getting server stats' })) {
+            disposeStream(stream);
+          }
         }, 10000);
     
         conn.exec(statsCommand, (err, stream) => {
-          if (err) {
-            clearTimeout(timeout);
-            resolve({ success: false, error: err.message });
+          if (settled) {
+            disposeStream(stream);
             return;
           }
+          if (err) {
+            settle({ success: false, error: err.message });
+            return;
+          }
+          activeStream = stream;
     
           let stdout = '';
           let stderr = '';
@@ -837,14 +864,15 @@ function createSessionOpsApi(ctx) {
           });
     
           stream.on('close', () => {
-            clearTimeout(timeout);
+            if (settled) return;
+            activeStream = null;
     
             // Parse the output
             const output = stdout.trim().replace(new RegExp(`^${latencyMarker}\\|?`), '');
     
             // Unsupported OS — stop polling this session
             if (output.startsWith('UNSUPPORTED_OS:')) {
-              resolve({ success: false, error: `Server stats not supported on this OS (${output.substring(15)})` });
+              settle({ success: false, error: `Server stats not supported on this OS (${output.substring(15)})` });
               return;
             }
     
@@ -1115,11 +1143,11 @@ function createSessionOpsApi(ctx) {
     
             // If no meaningful data was parsed, treat as failure to stop futile polling
             if (cpu === null && memTotal === null && cpuCores === null) {
-              resolve({ success: false, error: 'Unable to parse server stats (unsupported OS or shell)' });
+              settle({ success: false, error: 'Unable to parse server stats (unsupported OS or shell)' });
               return;
             }
     
-            resolve({
+            settle({
               success: true,
               stats: {
                 cpu,           // CPU usage percentage (0-100)
@@ -1151,8 +1179,14 @@ function createSessionOpsApi(ctx) {
           });
 
           if (!usesEtStatsFallback) {
-            latencyStartedAt = Date.now();
-            stream.write('\n');
+            try {
+              latencyStartedAt = Date.now();
+              stream.write('\n');
+            } catch (err) {
+              if (settle({ success: false, error: err?.message || String(err) })) {
+                disposeStream(stream);
+              }
+            }
           }
         });
       });

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -1129,7 +1129,7 @@ function createSessionOpsApi(ctx) {
                 disks,         // Array of all mounted disks
                 netRxSpeed,    // Total network receive speed (bytes/sec)
                 netTxSpeed,    // Total network transmit speed (bytes/sec)
-                latencyMs,      // SSH stats response time: channel open through first output (ms)
+                latencyMs,      // Stats request start through its first observable output (ms)
                 netInterfaces, // Per-interface network stats
                 hostname,
                 osName,

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -8,6 +8,7 @@ const { createSessionOpsApi } = require("./sessionOps.cjs");
 function fakeStream(stdout) {
   const stream = new EventEmitter();
   stream.stderr = new EventEmitter();
+  stream.write = () => true;
   setImmediate(() => {
     if (stdout) stream.emit("data", Buffer.from(stdout));
     stream.emit("close", 0);
@@ -19,8 +20,11 @@ function fakeStream(stdout) {
 // line so getServerStats parses a successful result.
 function fakeConn(stdout) {
   return {
-    exec(_command, cb) {
-      cb(null, fakeStream(stdout));
+    exec(command, cb) {
+      const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
+        ? `NC_LATENCY_MARK|${stdout}`
+        : stdout;
+      cb(null, fakeStream(output));
     },
   };
 }
@@ -124,6 +128,50 @@ test("getServerStats does not touch the companion path for a normal SSH session"
 
   assert.equal(ensureCalls, 0);
   assert.equal(result.success, true);
+});
+
+test("getServerStats reports network round-trip without SSH stats channel setup time", async () => {
+  let now = 1_000;
+  let command = "";
+  let probeWrites = 0;
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  stream.write = (data) => {
+    probeWrites += 1;
+    assert.equal(data, "\n");
+    now += 1;
+    stream.emit("data", Buffer.from("remote shell notice\n"));
+    now += 4;
+    stream.emit("data", Buffer.from(`NC_LATENCY_MARK|${LINUX_STATS}`));
+    stream.emit("close", 0);
+    return true;
+  };
+  const sessions = new Map([
+    ["sid", {
+      type: "ssh",
+      conn: {
+        exec(statsCommand, callback) {
+          command = statsCommand;
+          now += 75;
+          callback(null, stream);
+        },
+      },
+    }],
+  ]);
+  const api = createSessionOpsApi({
+    sessions,
+    Date: { now: () => now },
+    setTimeout,
+    clearTimeout,
+    Buffer,
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, true);
+  assert.equal(result.stats.latencyMs, 5);
+  assert.equal(probeWrites, 1);
+  assert.match(command, /^read -r nc_latency_probe; printf "NC_LATENCY_MARK\|";/);
 });
 
 test("getServerStats includes host identity, load average, and uptime", async () => {

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -8,11 +8,17 @@ const { createSessionOpsApi } = require("./sessionOps.cjs");
 function fakeStream(stdout) {
   const stream = new EventEmitter();
   stream.stderr = new EventEmitter();
-  stream.write = () => true;
-  setImmediate(() => {
+  let sent = false;
+  const send = () => {
+    if (sent) return;
+    sent = true;
     if (stdout) stream.emit("data", Buffer.from(stdout));
     stream.emit("close", 0);
-  });
+  };
+  stream.write = () => {
+    setImmediate(send);
+    return true;
+  };
   return stream;
 }
 
@@ -141,8 +147,10 @@ test("getServerStats reports network round-trip without SSH stats channel setup 
     assert.equal(data, "\n");
     now += 1;
     stream.emit("data", Buffer.from("remote shell notice\n"));
-    now += 4;
-    stream.emit("data", Buffer.from(`NC_LATENCY_MARK|${LINUX_STATS}`));
+    now += 2;
+    stream.emit("data", Buffer.from("NC_LATENCY_"));
+    now += 2;
+    stream.emit("data", Buffer.from(`MARK|${LINUX_STATS}`));
     stream.emit("close", 0);
     return true;
   };
@@ -172,6 +180,78 @@ test("getServerStats reports network round-trip without SSH stats channel setup 
   assert.equal(result.stats.latencyMs, 5);
   assert.equal(probeWrites, 1);
   assert.match(command, /^read -r nc_latency_probe; printf "NC_LATENCY_MARK\|";/);
+});
+
+test("getServerStats closes a blocked probe channel when stats time out", async () => {
+  let fireTimeout;
+  let closeCalls = 0;
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  stream.write = () => true;
+  stream.close = () => { closeCalls += 1; };
+  const api = createSessionOpsApi({
+    sessions: new Map([["sid", { type: "ssh", conn: { exec: (_command, cb) => cb(null, stream) } }]]),
+    Date,
+    setTimeout: (callback) => {
+      fireTimeout = callback;
+      return 1;
+    },
+    clearTimeout: () => {},
+    Buffer,
+  });
+
+  const pending = api.getServerStats({ sender: {} }, { sessionId: "sid" });
+  fireTimeout();
+  const result = await pending;
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /Timeout/);
+  assert.equal(closeCalls, 1);
+});
+
+test("getServerStats closes a stats stream delivered after timeout", async () => {
+  let execCallback;
+  let fireTimeout;
+  let closeCalls = 0;
+  const api = createSessionOpsApi({
+    sessions: new Map([["sid", {
+      type: "ssh",
+      conn: { exec: (_command, callback) => { execCallback = callback; } },
+    }]]),
+    Date,
+    setTimeout: (callback) => {
+      fireTimeout = callback;
+      return 1;
+    },
+    clearTimeout: () => {},
+    Buffer,
+  });
+
+  const pending = api.getServerStats({ sender: {} }, { sessionId: "sid" });
+  fireTimeout();
+  const result = await pending;
+  const lateStream = new EventEmitter();
+  lateStream.stderr = new EventEmitter();
+  lateStream.close = () => { closeCalls += 1; };
+  execCallback(null, lateStream);
+
+  assert.equal(result.success, false);
+  assert.equal(closeCalls, 1);
+});
+
+test("getServerStats closes the channel when the latency probe cannot be written", async () => {
+  let closeCalls = 0;
+  const stream = new EventEmitter();
+  stream.stderr = new EventEmitter();
+  stream.write = () => { throw new Error("probe write failed"); };
+  stream.close = () => { closeCalls += 1; };
+  const api = makeSessionOps(new Map([["sid", { type: "ssh", conn: { exec: (_command, cb) => cb(null, stream) } }]]));
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /probe write failed/);
+  assert.equal(closeCalls, 1);
 });
 
 test("getServerStats includes host identity, load average, and uptime", async () => {

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -246,7 +246,7 @@ declare global {
         }>;
         netRxSpeed: number;           // Total network receive speed (bytes/sec)
         netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-        latencyMs: number | null;     // SSH stats response time: channel open through first output
+        latencyMs: number | null;     // Stats request start through its first observable output
         netInterfaces: Array<{        // Per-interface network stats
           name: string;               // Interface name (e.g., eth0, ens33)
           rxBytes: number;            // Total received bytes

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -246,7 +246,7 @@ declare global {
         }>;
         netRxSpeed: number;           // Total network receive speed (bytes/sec)
         netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-        latencyMs: number | null;     // Stats request start through its first observable output
+        latencyMs: number | null;     // Approximate network round-trip over the SSH stats channel
         netInterfaces: Array<{        // Per-interface network stats
           name: string;               // Interface name (e.g., eth0, ens33)
           rxBytes: number;            // Total received bytes

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -246,7 +246,7 @@ declare global {
         }>;
         netRxSpeed: number;           // Total network receive speed (bytes/sec)
         netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-        latencyMs: number | null;     // Approximate SSH stats round-trip latency
+        latencyMs: number | null;     // SSH stats response time: channel open through first output
         netInterfaces: Array<{        // Per-interface network stats
           name: string;               // Interface name (e.g., eth0, ens33)
           rxBytes: number;            // Total received bytes


### PR DESCRIPTION
## Summary

- measure a small bidirectional probe only after the SSH statistics channel is ready
- exclude channel opening and server-statistics execution from the displayed value
- label the result as SSH network latency in the terminal and System Overview across all supported languages
- keep Mosh and EternalTerminal wording honest: their value follows the companion SSH path
- return no latency for the buffered EternalTerminal fallback instead of reporting a misleading value
- close blocked or late probe channels cleanly on timeouts and failures
- add regression coverage for the 5ms-network / 75ms-channel-setup case and failure paths

## Root cause

Netcatty 1.1.60 started timing before opening a fresh SSH statistics channel and stopped on the first output. The displayed number therefore included channel setup and server request handling. A 5ms network path could consequently appear as roughly 80ms.

The updated path first opens the existing statistics channel. It then starts the timer, sends a one-byte probe over that channel, and stops only when the remote marker returns. This measures the bidirectional path used by the active SSH connection while excluding the expensive setup and statistics command. It does not depend on ICMP, a second TCP connection, or direct target reachability, so proxy and jump-host routes continue to use their actual SSH path.

The buffered system-SSH fallback for some EternalTerminal sessions cannot expose first-byte timing. That path now returns no latency instead of a false high value.

## Verification

- deterministic regression: 75ms channel setup plus 5ms network round trip now reports 5ms; the same test failed as 80ms before the fix
- split markers and pre-marker output are handled correctly
- timeouts, late callbacks, and probe-write failures close their channels and return a clean failure
- direct SSH, Mosh companion, direct ET companion, and buffered ET fallback tests pass
- targeted tests passed consistently across three runs
- full suite: 4667 passed, 3 skipped, 0 failed
- lint passed
- production build passed
- browser visual check confirmed the terminal shows 5ms and the expanded panel labels it SSH network latency without layout regressions

Closes #2074