### PR TITLE
Fix OpenWrt process listing

### DIFF
--- a/electron/bridges/systemManagerBridge.cjs
+++ b/electron/bridges/systemManagerBridge.cjs
@@ -16,7 +16,7 @@ const CAPABILITY_SCRIPT_POSIX = [
 const PROCESS_LIST_SCRIPT_POSIX = [
   "exec sh -c ",
   "'",
-  "ps -eo pid= -o ppid= -o user= -o stat= -o pcpu= -o pmem= -o rss= -o vsz= -o etime= -o args= 2>/dev/null",
+  "ps -eo pid= -o ppid= -o user= -o stat= -o pcpu= -o pmem= -o rss= -o vsz= -o etime= -o args= 2>/dev/null || ps ww 2>/dev/null || ps 2>/dev/null",
   "'",
 ].join("");
 const PROCESS_LIST_MAX_BUFFER = 64 * 1024 * 1024;
@@ -46,18 +46,38 @@ function parseProcessLines(stdout) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const m = trimmed.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
-    if (!m) continue;
+    if (m) {
+      processes.push({
+        pid: Number(m[1]),
+        ppid: Number(m[2]),
+        user: m[3],
+        stat: m[4],
+        cpuPercent: Number(m[5]),
+        memPercent: Number(m[6]),
+        rssKb: Number(m[7]),
+        vszKb: Number(m[8]),
+        elapsed: m[9],
+        command: m[10],
+      });
+      continue;
+    }
+
+    const busyBoxMatch = trimmed.match(/^(\d+)\s+(\S+)\s+(\d+(?:\.\d+)?[mgtpezy]?)\s+(\S+)\s+(.+)$/i);
+    if (!busyBoxMatch) continue;
+    const suffix = busyBoxMatch[3].slice(-1).toLowerCase();
+    const multipliers = { m: 1024, g: 1024 ** 2, t: 1024 ** 3, p: 1024 ** 4, e: 1024 ** 5, z: 1024 ** 6, y: 1024 ** 7 };
+    const multiplier = multipliers[suffix] || 1;
     processes.push({
-      pid: Number(m[1]),
-      ppid: Number(m[2]),
-      user: m[3],
-      stat: m[4],
-      cpuPercent: Number(m[5]),
-      memPercent: Number(m[6]),
-      rssKb: Number(m[7]),
-      vszKb: Number(m[8]),
-      elapsed: m[9],
-      command: m[10],
+      pid: Number(busyBoxMatch[1]),
+      ppid: 0,
+      user: busyBoxMatch[2],
+      stat: busyBoxMatch[4],
+      cpuPercent: 0,
+      memPercent: 0,
+      rssKb: 0,
+      vszKb: Math.round(Number.parseFloat(busyBoxMatch[3]) * multiplier),
+      elapsed: "",
+      command: busyBoxMatch[5],
     });
   }
   return processes;

--- a/electron/bridges/systemManagerBridge.processes.test.cjs
+++ b/electron/bridges/systemManagerBridge.processes.test.cjs
@@ -2,6 +2,7 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 const path = require("node:path");
@@ -16,6 +17,51 @@ function createFakeExecStream(stdout, options = {}) {
     stream.emit("close", options.code ?? 0);
   });
   return stream;
+}
+
+function runProcessCommandWithBusyBoxPs(command, { supportsWide = true } = {}) {
+  const prefix = "exec sh -c '";
+  assert.ok(command.startsWith(prefix) && command.endsWith("'"));
+  const innerScript = command.slice(prefix.length, -1);
+  const processOutput = [
+    "  PID USER       VSZ STAT COMMAND",
+    "    1 root      1356 S    /sbin/procd",
+    "  411 root     97.6m S    /sbin/ubusd",
+  ];
+  const printProcessOutput = processOutput
+    .map((line) => `printf '%s\\n' '${line}'`)
+    .join("\n");
+  const fakePs = [
+    "exec 3>&2",
+    "ps() {",
+    "  printf '__PS_CALL__=%s\\n' \"$*\" >&3",
+    "  if [ \"$1\" = '-eo' ]; then",
+    "    printf '%s\\n' 'ps: unrecognized option: e' >&2",
+    "    return 1",
+    "  fi",
+    "  if [ \"$#\" -eq 1 ] && [ \"$1\" = 'ww' ]; then",
+    supportsWide ? printProcessOutput : "    return 1",
+    "    return 0",
+    "  fi",
+    "  if [ \"$#\" -eq 0 ]; then",
+    printProcessOutput,
+    "    return 0",
+    "  fi",
+    "  return 1",
+    "}",
+    innerScript,
+  ].join("\n");
+  const result = spawnSync("sh", ["-c", fakePs], { encoding: "utf8" });
+  const calls = String(result.stderr || "")
+    .split("\n")
+    .filter((line) => line.startsWith("__PS_CALL__="))
+    .map((line) => line.slice("__PS_CALL__=".length));
+  return {
+    stdout: String(result.stdout || ""),
+    stderr: String(result.stderr || ""),
+    code: result.status ?? 1,
+    calls,
+  };
 }
 
 test("listProcesses uses a ps format that works on CentOS 7 procps", async () => {
@@ -54,28 +100,14 @@ test("listProcesses uses a ps format that works on CentOS 7 procps", async () =>
 });
 
 test("listProcesses returns processes from the default OpenWrt BusyBox ps format", async () => {
-  const openWrtOutput = [
-    "  PID USER       VSZ STAT COMMAND",
-    "    1 root      1356 S    /sbin/procd",
-    "  411 root      1216 S    /sbin/ubusd",
-  ].join("\n");
-  const unsupportedProcpsError = [
-    "ps: unrecognized option: e",
-    "BusyBox v1.36.1 multi-call binary.",
-    "Usage: ps",
-  ].join("\n");
-
   let seenCommand = "";
+  let seenPsCalls = [];
   const conn = {
     exec(command, callback) {
       seenCommand = command;
-      const hasBusyBoxFallback = /ps ww/.test(command);
-      callback(null, createFakeExecStream(
-        hasBusyBoxFallback ? openWrtOutput : "",
-        hasBusyBoxFallback
-          ? { code: 0 }
-          : { code: 1, stderr: unsupportedProcpsError },
-      ));
+      const execution = runProcessCommandWithBusyBoxPs(command);
+      seenPsCalls = execution.calls;
+      callback(null, createFakeExecStream(execution.stdout, execution));
     },
   };
   const sessions = new Map([["openwrt", { conn, type: "ssh" }]]);
@@ -100,7 +132,38 @@ test("listProcesses returns processes from the default OpenWrt BusyBox ps format
     elapsed: "",
     command: "/sbin/procd",
   });
+  assert.equal(result.processes[1].vszKb, 99942);
   assert.match(seenCommand, /ps ww/);
+  assert.equal(seenPsCalls.length, 2);
+  assert.match(seenPsCalls[0], /^-eo pid=/);
+  assert.equal(seenPsCalls[1], "ww");
+});
+
+test("listProcesses falls back to plain BusyBox ps when wide output is unavailable", async () => {
+  let seenPsCalls = [];
+  const conn = {
+    exec(command, callback) {
+      const execution = runProcessCommandWithBusyBoxPs(command, { supportsWide: false });
+      seenPsCalls = execution.calls;
+      callback(null, createFakeExecStream(execution.stdout, execution));
+    },
+  };
+  const sessions = new Map([["openwrt", { conn, type: "ssh" }]]);
+  const bridge = createSystemManagerBridge({
+    getSessions: () => sessions,
+    process,
+  });
+
+  const result = await bridge.listProcesses(null, { sessionId: "openwrt" });
+
+  assert.equal(result.success, true);
+  assert.equal(result.processes.length, 2);
+  assert.equal(result.processes[0].command, "/sbin/procd");
+  assert.equal(result.processes[1].vszKb, 99942);
+  assert.equal(seenPsCalls.length, 3);
+  assert.match(seenPsCalls[0], /^-eo pid=/);
+  assert.equal(seenPsCalls[1], "ww");
+  assert.equal(seenPsCalls[2], "");
 });
 
 test("process listing commands do not hard-cap the visible list at 2000 entries", () => {

--- a/electron/bridges/systemManagerBridge.processes.test.cjs
+++ b/electron/bridges/systemManagerBridge.processes.test.cjs
@@ -53,6 +53,56 @@ test("listProcesses uses a ps format that works on CentOS 7 procps", async () =>
   assert.doesNotMatch(seenCommand, /head\s+-n\s+2000/);
 });
 
+test("listProcesses returns processes from the default OpenWrt BusyBox ps format", async () => {
+  const openWrtOutput = [
+    "  PID USER       VSZ STAT COMMAND",
+    "    1 root      1356 S    /sbin/procd",
+    "  411 root      1216 S    /sbin/ubusd",
+  ].join("\n");
+  const unsupportedProcpsError = [
+    "ps: unrecognized option: e",
+    "BusyBox v1.36.1 multi-call binary.",
+    "Usage: ps",
+  ].join("\n");
+
+  let seenCommand = "";
+  const conn = {
+    exec(command, callback) {
+      seenCommand = command;
+      const hasBusyBoxFallback = /ps ww/.test(command);
+      callback(null, createFakeExecStream(
+        hasBusyBoxFallback ? openWrtOutput : "",
+        hasBusyBoxFallback
+          ? { code: 0 }
+          : { code: 1, stderr: unsupportedProcpsError },
+      ));
+    },
+  };
+  const sessions = new Map([["openwrt", { conn, type: "ssh" }]]);
+  const bridge = createSystemManagerBridge({
+    getSessions: () => sessions,
+    process,
+  });
+
+  const result = await bridge.listProcesses(null, { sessionId: "openwrt" });
+
+  assert.equal(result.success, true);
+  assert.equal(result.processes.length, 2);
+  assert.deepEqual(result.processes[0], {
+    pid: 1,
+    ppid: 0,
+    user: "root",
+    stat: "S",
+    cpuPercent: 0,
+    memPercent: 0,
+    rssKb: 0,
+    vszKb: 1356,
+    elapsed: "",
+    command: "/sbin/procd",
+  });
+  assert.match(seenCommand, /ps ww/);
+});
+
 test("process listing commands do not hard-cap the visible list at 2000 entries", () => {
   const source = fs.readFileSync(path.join(__dirname, "systemManagerBridge.cjs"), "utf8");
 


### PR DESCRIPTION
Fixes #2078.

## What changed

- Fall back to the process command supported by OpenWrt/ImmortalWrt BusyBox when the full procps command is unavailable.
- Parse BusyBox's default `PID USER VSZ STAT COMMAND` output while leaving unavailable metrics at neutral values.
- Add regression coverage at the real SSH process-collection seam for both BusyBox fallbacks and compact memory-size suffixes.

## Root cause

Netcatty always ran a procps-style `ps -eo ...` command. The default BusyBox build shipped by OpenWrt and ImmortalWrt does not enable those flags, so it exits with `ps: unrecognized option: e` and no stdout. Netcatty ignored the remote exit code, parsed the empty stdout, and returned a successful empty process list. BusyBox's fallback five-column output also did not match the existing ten-column parser.

The relevant code is identical in v1.1.60, v1.1.61, and current main.

## Verification

- Regression test confirmed failing before the fix and passing after it.
- Ran the process collector end-to-end against the official OpenWrt 24.10.2 arm64 rootfs; it returned live processes.
- Connected the development app to that OpenWrt environment and visually confirmed System > Processes rendered five rows.
- `npm run lint`
- `npm test` — 4667 tests, 0 failures, 3 skipped
- `npm run build`
- Review round 1: one reviewer clean; one test-coverage finding fixed.
- Review round 2: both independent reviewers clean.