### PR TITLE
Fix System to Dark theme race

### DIFF
--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -2,10 +2,15 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
+import { idleThemeUserIntent, resolveGlobalTerminalAppearance } from "../../domain/terminalAppearanceRuntime.ts";
 import {
   hasPersistedAppearanceChanged,
+  resolveAppearanceStorageEvent,
+  resolveAppearanceSyncState,
   resolveIncomingAppearanceValue,
+  type AppearanceState,
   type AppearanceRenderSnapshot,
+  type StoredAppearanceValues,
 } from "./appearanceSync.ts";
 import { STORAGE_KEY_THEME } from "../../infrastructure/config/storageKeys.ts";
 
@@ -66,69 +71,93 @@ test("an appearance IPC value wins over stale local storage for the changed key"
 });
 
 test("System on a light OS changes to Dark in every open follow-app terminal", () => {
-  type Theme = AppearanceRenderSnapshot["theme"];
-  type Peer = {
-    render: AppearanceRenderSnapshot;
-    followsApp: boolean;
-    openTerminalBackground: "light" | "dark";
+  const initialState: AppearanceState = {
+    theme: systemLight.theme,
+    lightUiThemeId: systemLight.lightUiThemeId,
+    darkUiThemeId: systemLight.darkUiThemeId,
+    accentMode: systemLight.accentMode,
+    customAccent: systemLight.customAccent,
   };
-
-  const createPeer = (): Peer => ({
-    render: { ...systemLight },
-    followsApp: true,
-    openTerminalBackground: "light",
-  });
-  const settings = createPeer();
-  const main = createPeer();
-  const detachedTerminal = createPeer();
-  let storedTheme: Theme = "system";
-
-  const persistAppearance = (
+  const terminalAppearance = (appearance: AppearanceState, resolvedTheme: "light" | "dark") => (
+    resolveGlobalTerminalAppearance({
+      userIntent: idleThemeUserIntent(),
+      settings: {
+        terminalThemeId: "netcatty-dark",
+        terminalThemeDarkId: "auto",
+        terminalThemeLightId: "auto",
+        followAppTerminalTheme: true,
+        resolvedTheme,
+        lightUiThemeId: appearance.lightUiThemeId,
+        darkUiThemeId: appearance.darkUiThemeId,
+        accentMode: appearance.accentMode,
+        customAccent: appearance.customAccent,
+      },
+      customThemes: [],
+    })
+  );
+  const persistRender = (
+    stored: StoredAppearanceValues,
     previous: AppearanceRenderSnapshot,
     current: AppearanceRenderSnapshot,
-  ) => {
-    if (hasPersistedAppearanceChanged(previous, current)) {
-      storedTheme = current.theme;
-    }
-  };
-  const applyTheme = (peer: Peer, theme: Theme) => {
-    peer.render = {
-      ...peer.render,
-      theme,
-      resolvedTheme: theme === "system" ? "light" : theme,
+  ): StoredAppearanceValues => {
+    if (!hasPersistedAppearanceChanged(previous, current)) return stored;
+    return {
+      theme: current.theme,
+      lightUiThemeId: current.lightUiThemeId,
+      darkUiThemeId: current.darkUiThemeId,
+      accentMode: current.accentMode,
+      customAccent: current.customAccent,
     };
-    if (peer.followsApp) peer.openTerminalBackground = peer.render.resolvedTheme;
   };
 
-  const settingsBefore = settings.render;
-  applyTheme(settings, "dark");
-  persistAppearance(settingsBefore, settings.render);
+  let stored: StoredAppearanceValues = { ...initialState };
+  let main = { ...initialState };
+  let detachedTerminal = { ...initialState };
+  const initialMainTerminal = terminalAppearance(main, "light");
+  const initialDetachedTerminal = terminalAppearance(detachedTerminal, "light");
+
+  const settingsDark: AppearanceRenderSnapshot = {
+    ...systemLight,
+    theme: "dark",
+    resolvedTheme: "dark",
+  };
+  stored = persistRender(stored, systemLight, settingsDark);
   const darkSelection = { key: STORAGE_KEY_THEME, value: "dark" };
 
   // A stale peer receives an OS color event before the Dark IPC message. Its
   // semantic choice is still System, so it must not write System back.
-  const staleMainBefore = main.render;
-  main.render = { ...main.render, resolvedTheme: "dark" };
-  persistAppearance(staleMainBefore, main.render);
+  stored = persistRender(stored, systemLight, { ...systemLight, resolvedTheme: "dark" });
 
-  // Main windows use the ordered IPC value even if their storage read lags.
-  applyTheme(main, resolveIncomingAppearanceValue(
-    darkSelection,
-    STORAGE_KEY_THEME,
-    "system" as Theme,
-    (value): value is Theme => value === "light" || value === "dark" || value === "system",
-  ));
+  // Main windows run the production IPC reducer. Deliberately pass its lagging
+  // System storage read so only the ordered Dark payload can win.
+  main = resolveAppearanceSyncState(main, {
+    ...stored,
+    theme: "system",
+  }, darkSelection);
 
-  // Detached terminal and tray renderers are not IPC broadcast targets; they
-  // still receive the authoritative storage event.
-  applyTheme(detachedTerminal, storedTheme);
+  // Detached terminal and tray renderers run the production storage-event
+  // reducer because they are not direct IPC broadcast targets.
+  const detachedUpdate = resolveAppearanceStorageEvent(
+    detachedTerminal,
+    darkSelection.key,
+    String(stored.theme),
+  );
+  detachedTerminal = detachedUpdate.next;
 
-  assert.equal(storedTheme, "dark");
-  assert.equal(settings.render.theme, "dark");
-  assert.equal(main.render.theme, "dark");
-  assert.equal(main.render.resolvedTheme, "dark");
-  assert.equal(detachedTerminal.render.theme, "dark");
-  assert.equal(detachedTerminal.openTerminalBackground, "dark");
+  const finalMainTerminal = terminalAppearance(main, "dark");
+  const finalDetachedTerminal = terminalAppearance(detachedTerminal, "dark");
+
+  assert.equal(stored.theme, "dark");
+  assert.equal(settingsDark.theme, "dark");
+  assert.equal(main.theme, "dark");
+  assert.equal(detachedUpdate.handled, true);
+  assert.equal(detachedTerminal.theme, "dark");
+  assert.equal(initialMainTerminal.theme.type, "light");
+  assert.equal(initialDetachedTerminal.theme.type, "light");
+  assert.equal(finalMainTerminal.theme.type, "dark");
+  assert.equal(finalDetachedTerminal.theme.type, "dark");
+  assert.notEqual(finalMainTerminal.theme.colors.background, initialMainTerminal.theme.colors.background);
+  assert.notEqual(finalDetachedTerminal.theme.colors.background, initialDetachedTerminal.theme.colors.background);
 });
 
 test("the race guards are wired into the real settings paths", () => {
@@ -144,6 +173,7 @@ test("the race guards are wired into the real settings paths", () => {
   assert.ok(guardIndex >= 0, "the settings effect must compare persisted appearance fields");
   assert.ok(returnIndex > guardIndex && returnIndex < writeIndex, "the stale render must stop before storage is written");
   assert.match(ipcSource, /syncAppearanceFromStorage\(\{ key, value \}\)/);
-  assert.doesNotMatch(storageSource, /isAppearanceStorageKey\(e\.key\).*return/);
-  assert.match(popupSource, /useSettingsState\(\)/);
+  assert.match(storageSource, /resolveAppearanceStorageEvent\(s, e\.key, e\.newValue\)/);
+  assert.match(popupSource, /terminalTheme=\{settings\.currentTerminalTheme\}/);
+  assert.match(popupSource, /followAppTerminalTheme=\{settings\.followAppTerminalTheme\}/);
 });

--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -12,7 +12,13 @@ import {
   type AppearanceRenderSnapshot,
   type StoredAppearanceValues,
 } from "./appearanceSync.ts";
-import { STORAGE_KEY_THEME } from "../../infrastructure/config/storageKeys.ts";
+import {
+  STORAGE_KEY_ACCENT_MODE,
+  STORAGE_KEY_COLOR,
+  STORAGE_KEY_THEME,
+  STORAGE_KEY_UI_THEME_DARK,
+  STORAGE_KEY_UI_THEME_LIGHT,
+} from "../../infrastructure/config/storageKeys.ts";
 
 const systemLight: AppearanceRenderSnapshot = {
   theme: "system",
@@ -46,12 +52,12 @@ test("an explicit theme choice remains a persisted appearance change", () => {
 });
 
 test("an appearance IPC value wins over stale local storage for the changed key", () => {
-  const incoming = { key: "netcatty_theme_v1", value: "dark" };
+  const incoming = { key: STORAGE_KEY_THEME, value: "dark" };
 
   assert.equal(
     resolveIncomingAppearanceValue(
       incoming,
-      "netcatty_theme_v1",
+      STORAGE_KEY_THEME,
       "system",
       (value): value is "light" | "dark" | "system" => (
         value === "light" || value === "dark" || value === "system"
@@ -62,12 +68,81 @@ test("an appearance IPC value wins over stale local storage for the changed key"
   assert.equal(
     resolveIncomingAppearanceValue(
       incoming,
-      "netcatty_ui_theme_dark_v1",
+      STORAGE_KEY_UI_THEME_DARK,
       "midnight",
       (value): value is string => typeof value === "string",
     ),
     "midnight",
   );
+});
+
+test("a non-theme appearance IPC value wins over stale local storage for that key", () => {
+  const current: AppearanceState = {
+    theme: "dark",
+    lightUiThemeId: "snow",
+    darkUiThemeId: "midnight",
+    accentMode: "theme",
+    customAccent: "208 100% 50%",
+  };
+  // Storage still lags for every non-theme field (the race the review covers).
+  const staleStored: StoredAppearanceValues = {
+    theme: "dark",
+    lightUiThemeId: "snow",
+    darkUiThemeId: "midnight",
+    accentMode: "theme",
+    customAccent: "208 100% 50%",
+  };
+
+  // Picking a follow-app terminal theme updates darkUiThemeId; only that key is
+  // announced on the IPC payload, so the reducer must prefer the payload.
+  const darkUiSelection = {
+    key: STORAGE_KEY_UI_THEME_DARK,
+    value: "github",
+  };
+  const nextDarkUi = resolveAppearanceSyncState(current, {
+    ...staleStored,
+    darkUiThemeId: "midnight",
+  }, darkUiSelection);
+  assert.equal(nextDarkUi.darkUiThemeId, "github");
+  assert.equal(nextDarkUi.theme, "dark");
+  assert.equal(nextDarkUi.lightUiThemeId, "snow");
+
+  const lightUiSelection = {
+    key: STORAGE_KEY_UI_THEME_LIGHT,
+    value: "flexoki",
+  };
+  const nextLightUi = resolveAppearanceSyncState(current, {
+    ...staleStored,
+    lightUiThemeId: "snow",
+  }, lightUiSelection);
+  assert.equal(nextLightUi.lightUiThemeId, "flexoki");
+
+  const accentModeSelection = {
+    key: STORAGE_KEY_ACCENT_MODE,
+    value: "custom",
+  };
+  const nextAccentMode = resolveAppearanceSyncState(current, {
+    ...staleStored,
+    accentMode: "theme",
+  }, accentModeSelection);
+  assert.equal(nextAccentMode.accentMode, "custom");
+
+  const customAccentSelection = {
+    key: STORAGE_KEY_COLOR,
+    value: "221.2 83.2% 53.3%",
+  };
+  const nextCustomAccent = resolveAppearanceSyncState(current, {
+    ...staleStored,
+    customAccent: "208 100% 50%",
+  }, customAccentSelection);
+  assert.equal(nextCustomAccent.customAccent, "221.2 83.2% 53.3%");
+
+  // Without an announced key, a stale storage read must not invent a change.
+  const noIncoming = resolveAppearanceSyncState(current, {
+    ...staleStored,
+    darkUiThemeId: "midnight",
+  });
+  assert.equal(noIncoming.darkUiThemeId, "midnight");
 });
 
 test("System on a light OS changes to Dark in every open follow-app terminal", () => {
@@ -169,9 +244,32 @@ test("the race guards are wired into the real settings paths", () => {
   const guardIndex = stateSource.indexOf("hasPersistedAppearanceChanged(");
   const returnIndex = stateSource.indexOf("if (!persistedAppearanceChanged && persistMountedRef.current)", guardIndex);
   const writeIndex = stateSource.indexOf("localStorageAdapter.writeString(STORAGE_KEY_THEME", guardIndex);
+  const themeNotifyIndex = stateSource.indexOf("notifySettingsChanged(STORAGE_KEY_THEME, theme)", writeIndex);
+  const lightNotifyIndex = stateSource.indexOf("notifySettingsChanged(STORAGE_KEY_UI_THEME_LIGHT, lightUiThemeId)", writeIndex);
+  const darkNotifyIndex = stateSource.indexOf("notifySettingsChanged(STORAGE_KEY_UI_THEME_DARK, darkUiThemeId)", writeIndex);
+  const accentModeNotifyIndex = stateSource.indexOf("notifySettingsChanged(STORAGE_KEY_ACCENT_MODE, accentMode)", writeIndex);
+  const colorNotifyIndex = stateSource.indexOf("notifySettingsChanged(STORAGE_KEY_COLOR, customAccent)", writeIndex);
 
   assert.ok(guardIndex >= 0, "the settings effect must compare persisted appearance fields");
   assert.ok(returnIndex > guardIndex && returnIndex < writeIndex, "the stale render must stop before storage is written");
+  assert.ok(themeNotifyIndex > writeIndex, "theme changes must be announced over IPC with the new value");
+  assert.ok(lightNotifyIndex > writeIndex, "light UI theme changes must be announced over IPC with the new value");
+  assert.ok(darkNotifyIndex > writeIndex, "dark UI theme changes must be announced over IPC with the new value");
+  assert.ok(accentModeNotifyIndex > writeIndex, "accent mode changes must be announced over IPC with the new value");
+  assert.ok(colorNotifyIndex > writeIndex, "custom accent changes must be announced over IPC with the new value");
+  // Source still only notifies fields that actually changed (keyed, not a single theme-only broadcast).
+  assert.match(
+    stateSource,
+    /previousAppearance\.theme !== theme[\s\S]*notifySettingsChanged\(STORAGE_KEY_THEME, theme\)/,
+  );
+  assert.match(
+    stateSource,
+    /previousAppearance\.lightUiThemeId !== lightUiThemeId[\s\S]*notifySettingsChanged\(STORAGE_KEY_UI_THEME_LIGHT, lightUiThemeId\)/,
+  );
+  assert.match(
+    stateSource,
+    /previousAppearance\.darkUiThemeId !== darkUiThemeId[\s\S]*notifySettingsChanged\(STORAGE_KEY_UI_THEME_DARK, darkUiThemeId\)/,
+  );
   assert.match(ipcSource, /syncAppearanceFromStorage\(\{ key, value \}\)/);
   assert.match(storageSource, /resolveAppearanceStorageEvent\(s, e\.key, e\.newValue\)/);
   assert.match(popupSource, /terminalTheme=\{settings\.currentTerminalTheme\}/);

--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -59,20 +59,34 @@ test("an appearance IPC value wins over stale local storage for the changed key"
       incoming,
       STORAGE_KEY_THEME,
       "system",
+      "system",
       (value): value is "light" | "dark" | "system" => (
         value === "light" || value === "dark" || value === "system"
       ),
     ),
     "dark",
   );
+  // Non-matching keyed IPC must keep the current in-memory value, not storage.
   assert.equal(
     resolveIncomingAppearanceValue(
       incoming,
       STORAGE_KEY_UI_THEME_DARK,
+      "stale-from-storage",
       "midnight",
       (value): value is string => typeof value === "string",
     ),
     "midnight",
+  );
+  // Full rehydrate (no incoming) still prefers storage.
+  assert.equal(
+    resolveIncomingAppearanceValue(
+      undefined,
+      STORAGE_KEY_UI_THEME_DARK,
+      "from-storage",
+      "midnight",
+      (value): value is string => typeof value === "string",
+    ),
+    "from-storage",
   );
 });
 
@@ -137,12 +151,42 @@ test("a non-theme appearance IPC value wins over stale local storage for that ke
   }, customAccentSelection);
   assert.equal(nextCustomAccent.customAccent, "221.2 83.2% 53.3%");
 
-  // Without an announced key, a stale storage read must not invent a change.
+  // Without an announced key, full rehydrate still reads storage.
   const noIncoming = resolveAppearanceSyncState(current, {
     ...staleStored,
-    darkUiThemeId: "midnight",
+    darkUiThemeId: "github",
   });
-  assert.equal(noIncoming.darkUiThemeId, "midnight");
+  assert.equal(noIncoming.darkUiThemeId, "github");
+});
+
+test("sequential keyed appearance IPC updates compose without stale-storage clobber", () => {
+  // One action changes theme + dark UI theme; the sender emits two keyed notifies.
+  // Storage still holds the pre-change values for the entire sequence.
+  const initial: AppearanceState = {
+    theme: "system",
+    lightUiThemeId: "snow",
+    darkUiThemeId: "midnight",
+    accentMode: "theme",
+    customAccent: "208 100% 50%",
+  };
+  const staleStored: StoredAppearanceValues = { ...initial };
+
+  let next = resolveAppearanceSyncState(initial, staleStored, {
+    key: STORAGE_KEY_THEME,
+    value: "dark",
+  });
+  assert.equal(next.theme, "dark");
+  assert.equal(next.darkUiThemeId, "midnight");
+
+  // Later theme-id message must not revert theme back to the stale stored System.
+  next = resolveAppearanceSyncState(next, staleStored, {
+    key: STORAGE_KEY_UI_THEME_DARK,
+    value: "github",
+  });
+  assert.equal(next.theme, "dark");
+  assert.equal(next.darkUiThemeId, "github");
+  assert.equal(next.lightUiThemeId, "snow");
+  assert.equal(next.accentMode, "theme");
 });
 
 test("System on a light OS changes to Dark in every open follow-app terminal", () => {
@@ -270,6 +314,8 @@ test("the race guards are wired into the real settings paths", () => {
     stateSource,
     /previousAppearance\.darkUiThemeId !== darkUiThemeId[\s\S]*notifySettingsChanged\(STORAGE_KEY_UI_THEME_DARK, darkUiThemeId\)/,
   );
+  // Sequential keyed IPC must compose via a ref, not a render-stale closure.
+  assert.match(stateSource, /appearanceStateRef\.current = nextAppearance/);
   assert.match(ipcSource, /syncAppearanceFromStorage\(\{ key, value \}\)/);
   assert.match(storageSource, /resolveAppearanceStorageEvent\(s, e\.key, e\.newValue\)/);
   assert.match(popupSource, /terminalTheme=\{settings\.currentTerminalTheme\}/);

--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  hasPersistedAppearanceChanged,
+  isAppearanceStorageKey,
+  resolveIncomingAppearanceValue,
+  type AppearanceRenderSnapshot,
+} from "./appearanceSync.ts";
+
+const systemLight: AppearanceRenderSnapshot = {
+  theme: "system",
+  resolvedTheme: "light",
+  lightUiThemeId: "snow",
+  darkUiThemeId: "midnight",
+  accentMode: "theme",
+  customAccent: "208 100% 50%",
+};
+
+test("an OS color event cannot persist a stale System choice over a newer Dark choice", () => {
+  const systemDark = { ...systemLight, resolvedTheme: "dark" as const };
+  let storedTheme: "light" | "dark" | "system" = "dark";
+
+  if (hasPersistedAppearanceChanged(systemLight, systemDark)) {
+    storedTheme = systemDark.theme;
+  }
+
+  assert.equal(storedTheme, "dark");
+});
+
+test("an explicit theme choice remains a persisted appearance change", () => {
+  assert.equal(
+    hasPersistedAppearanceChanged(systemLight, {
+      ...systemLight,
+      theme: "dark",
+      resolvedTheme: "dark",
+    }),
+    true,
+  );
+});
+
+test("an appearance IPC value wins over stale local storage for the changed key", () => {
+  const incoming = { key: "netcatty_theme_v1", value: "dark" };
+
+  assert.equal(
+    resolveIncomingAppearanceValue(
+      incoming,
+      "netcatty_theme_v1",
+      "system",
+      (value): value is "light" | "dark" | "system" => (
+        value === "light" || value === "dark" || value === "system"
+      ),
+    ),
+    "dark",
+  );
+  assert.equal(
+    resolveIncomingAppearanceValue(
+      incoming,
+      "netcatty_ui_theme_dark_v1",
+      "midnight",
+      (value): value is string => typeof value === "string",
+    ),
+    "midnight",
+  );
+});
+
+test("appearance storage echoes are left to the ordered IPC sync path", () => {
+  assert.equal(isAppearanceStorageKey("netcatty_theme_v1"), true);
+  assert.equal(isAppearanceStorageKey("netcatty_ui_theme_dark_v1"), true);
+  assert.equal(isAppearanceStorageKey("netcatty_term_theme_v1"), false);
+});

--- a/application/state/appearanceSync.test.ts
+++ b/application/state/appearanceSync.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
   hasPersistedAppearanceChanged,
-  isAppearanceStorageKey,
   resolveIncomingAppearanceValue,
   type AppearanceRenderSnapshot,
 } from "./appearanceSync.ts";
+import { STORAGE_KEY_THEME } from "../../infrastructure/config/storageKeys.ts";
 
 const systemLight: AppearanceRenderSnapshot = {
   theme: "system",
@@ -64,8 +65,85 @@ test("an appearance IPC value wins over stale local storage for the changed key"
   );
 });
 
-test("appearance storage echoes are left to the ordered IPC sync path", () => {
-  assert.equal(isAppearanceStorageKey("netcatty_theme_v1"), true);
-  assert.equal(isAppearanceStorageKey("netcatty_ui_theme_dark_v1"), true);
-  assert.equal(isAppearanceStorageKey("netcatty_term_theme_v1"), false);
+test("System on a light OS changes to Dark in every open follow-app terminal", () => {
+  type Theme = AppearanceRenderSnapshot["theme"];
+  type Peer = {
+    render: AppearanceRenderSnapshot;
+    followsApp: boolean;
+    openTerminalBackground: "light" | "dark";
+  };
+
+  const createPeer = (): Peer => ({
+    render: { ...systemLight },
+    followsApp: true,
+    openTerminalBackground: "light",
+  });
+  const settings = createPeer();
+  const main = createPeer();
+  const detachedTerminal = createPeer();
+  let storedTheme: Theme = "system";
+
+  const persistAppearance = (
+    previous: AppearanceRenderSnapshot,
+    current: AppearanceRenderSnapshot,
+  ) => {
+    if (hasPersistedAppearanceChanged(previous, current)) {
+      storedTheme = current.theme;
+    }
+  };
+  const applyTheme = (peer: Peer, theme: Theme) => {
+    peer.render = {
+      ...peer.render,
+      theme,
+      resolvedTheme: theme === "system" ? "light" : theme,
+    };
+    if (peer.followsApp) peer.openTerminalBackground = peer.render.resolvedTheme;
+  };
+
+  const settingsBefore = settings.render;
+  applyTheme(settings, "dark");
+  persistAppearance(settingsBefore, settings.render);
+  const darkSelection = { key: STORAGE_KEY_THEME, value: "dark" };
+
+  // A stale peer receives an OS color event before the Dark IPC message. Its
+  // semantic choice is still System, so it must not write System back.
+  const staleMainBefore = main.render;
+  main.render = { ...main.render, resolvedTheme: "dark" };
+  persistAppearance(staleMainBefore, main.render);
+
+  // Main windows use the ordered IPC value even if their storage read lags.
+  applyTheme(main, resolveIncomingAppearanceValue(
+    darkSelection,
+    STORAGE_KEY_THEME,
+    "system" as Theme,
+    (value): value is Theme => value === "light" || value === "dark" || value === "system",
+  ));
+
+  // Detached terminal and tray renderers are not IPC broadcast targets; they
+  // still receive the authoritative storage event.
+  applyTheme(detachedTerminal, storedTheme);
+
+  assert.equal(storedTheme, "dark");
+  assert.equal(settings.render.theme, "dark");
+  assert.equal(main.render.theme, "dark");
+  assert.equal(main.render.resolvedTheme, "dark");
+  assert.equal(detachedTerminal.render.theme, "dark");
+  assert.equal(detachedTerminal.openTerminalBackground, "dark");
+});
+
+test("the race guards are wired into the real settings paths", () => {
+  const stateSource = readFileSync(new URL("./useSettingsState.ts", import.meta.url), "utf8");
+  const ipcSource = readFileSync(new URL("./settingsIpcSync.ts", import.meta.url), "utf8");
+  const storageSource = readFileSync(new URL("./settingsStorageSync.ts", import.meta.url), "utf8");
+  const popupSource = readFileSync(new URL("../../components/TerminalPopupPage.tsx", import.meta.url), "utf8");
+
+  const guardIndex = stateSource.indexOf("hasPersistedAppearanceChanged(");
+  const returnIndex = stateSource.indexOf("if (!persistedAppearanceChanged && persistMountedRef.current)", guardIndex);
+  const writeIndex = stateSource.indexOf("localStorageAdapter.writeString(STORAGE_KEY_THEME", guardIndex);
+
+  assert.ok(guardIndex >= 0, "the settings effect must compare persisted appearance fields");
+  assert.ok(returnIndex > guardIndex && returnIndex < writeIndex, "the stale render must stop before storage is written");
+  assert.match(ipcSource, /syncAppearanceFromStorage\(\{ key, value \}\)/);
+  assert.doesNotMatch(storageSource, /isAppearanceStorageKey\(e\.key\).*return/);
+  assert.match(popupSource, /useSettingsState\(\)/);
 });

--- a/application/state/appearanceSync.ts
+++ b/application/state/appearanceSync.ts
@@ -1,0 +1,56 @@
+import {
+  STORAGE_KEY_ACCENT_MODE,
+  STORAGE_KEY_COLOR,
+  STORAGE_KEY_THEME,
+  STORAGE_KEY_UI_THEME_DARK,
+  STORAGE_KEY_UI_THEME_LIGHT,
+} from '../../infrastructure/config/storageKeys';
+
+export type AppearanceRenderSnapshot = {
+  theme: "light" | "dark" | "system";
+  resolvedTheme: "light" | "dark";
+  lightUiThemeId: string;
+  darkUiThemeId: string;
+  accentMode: "theme" | "custom";
+  customAccent: string;
+};
+
+export type AppearanceSyncEvent = {
+  key: string;
+  value: unknown;
+};
+
+const APPEARANCE_STORAGE_KEYS = new Set([
+  STORAGE_KEY_THEME,
+  STORAGE_KEY_UI_THEME_LIGHT,
+  STORAGE_KEY_UI_THEME_DARK,
+  STORAGE_KEY_ACCENT_MODE,
+  STORAGE_KEY_COLOR,
+]);
+
+export function isAppearanceStorageKey(key: string | null): boolean {
+  return key !== null && APPEARANCE_STORAGE_KEYS.has(key);
+}
+
+export function hasPersistedAppearanceChanged(
+  previous: AppearanceRenderSnapshot,
+  current: AppearanceRenderSnapshot,
+): boolean {
+  return previous.theme !== current.theme
+    || previous.lightUiThemeId !== current.lightUiThemeId
+    || previous.darkUiThemeId !== current.darkUiThemeId
+    || previous.accentMode !== current.accentMode
+    || previous.customAccent !== current.customAccent;
+}
+
+export function resolveIncomingAppearanceValue<T>(
+  incoming: AppearanceSyncEvent | undefined,
+  key: string,
+  storedValue: T,
+  isValid: (value: unknown) => value is T,
+): T {
+  if (incoming?.key === key && isValid(incoming.value)) {
+    return incoming.value;
+  }
+  return storedValue;
+}

--- a/application/state/appearanceSync.ts
+++ b/application/state/appearanceSync.ts
@@ -1,11 +1,3 @@
-import {
-  STORAGE_KEY_ACCENT_MODE,
-  STORAGE_KEY_COLOR,
-  STORAGE_KEY_THEME,
-  STORAGE_KEY_UI_THEME_DARK,
-  STORAGE_KEY_UI_THEME_LIGHT,
-} from '../../infrastructure/config/storageKeys';
-
 export type AppearanceRenderSnapshot = {
   theme: "light" | "dark" | "system";
   resolvedTheme: "light" | "dark";
@@ -19,18 +11,6 @@ export type AppearanceSyncEvent = {
   key: string;
   value: unknown;
 };
-
-const APPEARANCE_STORAGE_KEYS = new Set([
-  STORAGE_KEY_THEME,
-  STORAGE_KEY_UI_THEME_LIGHT,
-  STORAGE_KEY_UI_THEME_DARK,
-  STORAGE_KEY_ACCENT_MODE,
-  STORAGE_KEY_COLOR,
-]);
-
-export function isAppearanceStorageKey(key: string | null): boolean {
-  return key !== null && APPEARANCE_STORAGE_KEYS.has(key);
-}
 
 export function hasPersistedAppearanceChanged(
   previous: AppearanceRenderSnapshot,

--- a/application/state/appearanceSync.ts
+++ b/application/state/appearanceSync.ts
@@ -57,10 +57,18 @@ export function resolveIncomingAppearanceValue<T>(
   incoming: AppearanceSyncEvent | undefined,
   key: string,
   storedValue: T,
+  currentValue: T,
   isValid: (value: unknown) => value is T,
 ): T {
   if (incoming?.key === key && isValid(incoming.value)) {
     return incoming.value;
+  }
+  // Keyed IPC updates only trust the announced key. Non-matching fields keep
+  // the in-memory current value so sequential notifies for one multi-field
+  // change cannot clobber each other with a still-stale storage read.
+  // Full rehydrate (no incoming) continues to prefer shared storage.
+  if (incoming) {
+    return currentValue;
   }
   return storedValue;
 }
@@ -74,30 +82,35 @@ export function resolveAppearanceSyncState(
     incoming,
     STORAGE_KEY_THEME,
     stored.theme,
+    current.theme,
     isValidTheme,
   );
   const lightUiThemeId = resolveIncomingAppearanceValue(
     incoming,
     STORAGE_KEY_UI_THEME_LIGHT,
     stored.lightUiThemeId,
+    current.lightUiThemeId,
     (value): value is string => typeof value === 'string' && isValidUiThemeId('light', value),
   );
   const darkUiThemeId = resolveIncomingAppearanceValue(
     incoming,
     STORAGE_KEY_UI_THEME_DARK,
     stored.darkUiThemeId,
+    current.darkUiThemeId,
     (value): value is string => typeof value === 'string' && isValidUiThemeId('dark', value),
   );
   const accentMode = resolveIncomingAppearanceValue(
     incoming,
     STORAGE_KEY_ACCENT_MODE,
     stored.accentMode,
+    current.accentMode,
     (value): value is AppearanceState['accentMode'] => value === 'theme' || value === 'custom',
   );
   const customAccent = resolveIncomingAppearanceValue(
     incoming,
     STORAGE_KEY_COLOR,
     stored.customAccent,
+    current.customAccent,
     (value): value is string => typeof value === 'string' && isValidHslToken(value),
   );
 

--- a/application/state/appearanceSync.ts
+++ b/application/state/appearanceSync.ts
@@ -1,15 +1,45 @@
-export type AppearanceRenderSnapshot = {
+import {
+  STORAGE_KEY_ACCENT_MODE,
+  STORAGE_KEY_COLOR,
+  STORAGE_KEY_THEME,
+  STORAGE_KEY_UI_THEME_DARK,
+  STORAGE_KEY_UI_THEME_LIGHT,
+} from '../../infrastructure/config/storageKeys';
+import {
+  isValidHslToken,
+  isValidTheme,
+  isValidUiThemeId,
+} from './settingsStateDefaults';
+
+export type AppearanceState = {
   theme: "light" | "dark" | "system";
-  resolvedTheme: "light" | "dark";
   lightUiThemeId: string;
   darkUiThemeId: string;
   accentMode: "theme" | "custom";
   customAccent: string;
 };
 
+export type AppearanceRenderSnapshot = {
+  theme: AppearanceState["theme"];
+  resolvedTheme: "light" | "dark";
+} & Omit<AppearanceState, "theme">;
+
 export type AppearanceSyncEvent = {
   key: string;
   value: unknown;
+};
+
+export type StoredAppearanceValues = {
+  theme: unknown;
+  lightUiThemeId: unknown;
+  darkUiThemeId: unknown;
+  accentMode: unknown;
+  customAccent: unknown;
+};
+
+export type AppearanceStorageEventResolution = {
+  handled: boolean;
+  next: AppearanceState;
 };
 
 export function hasPersistedAppearanceChanged(
@@ -33,4 +63,101 @@ export function resolveIncomingAppearanceValue<T>(
     return incoming.value;
   }
   return storedValue;
+}
+
+export function resolveAppearanceSyncState(
+  current: AppearanceState,
+  stored: StoredAppearanceValues,
+  incoming?: AppearanceSyncEvent,
+): AppearanceState {
+  const theme = resolveIncomingAppearanceValue(
+    incoming,
+    STORAGE_KEY_THEME,
+    stored.theme,
+    isValidTheme,
+  );
+  const lightUiThemeId = resolveIncomingAppearanceValue(
+    incoming,
+    STORAGE_KEY_UI_THEME_LIGHT,
+    stored.lightUiThemeId,
+    (value): value is string => typeof value === 'string' && isValidUiThemeId('light', value),
+  );
+  const darkUiThemeId = resolveIncomingAppearanceValue(
+    incoming,
+    STORAGE_KEY_UI_THEME_DARK,
+    stored.darkUiThemeId,
+    (value): value is string => typeof value === 'string' && isValidUiThemeId('dark', value),
+  );
+  const accentMode = resolveIncomingAppearanceValue(
+    incoming,
+    STORAGE_KEY_ACCENT_MODE,
+    stored.accentMode,
+    (value): value is AppearanceState['accentMode'] => value === 'theme' || value === 'custom',
+  );
+  const customAccent = resolveIncomingAppearanceValue(
+    incoming,
+    STORAGE_KEY_COLOR,
+    stored.customAccent,
+    (value): value is string => typeof value === 'string' && isValidHslToken(value),
+  );
+
+  return {
+    theme: isValidTheme(theme) ? theme : current.theme,
+    lightUiThemeId: typeof lightUiThemeId === 'string' && isValidUiThemeId('light', lightUiThemeId)
+      ? lightUiThemeId
+      : current.lightUiThemeId,
+    darkUiThemeId: typeof darkUiThemeId === 'string' && isValidUiThemeId('dark', darkUiThemeId)
+      ? darkUiThemeId
+      : current.darkUiThemeId,
+    accentMode: accentMode === 'theme' || accentMode === 'custom' ? accentMode : current.accentMode,
+    customAccent: typeof customAccent === 'string' && isValidHslToken(customAccent)
+      ? customAccent.trim()
+      : current.customAccent,
+  };
+}
+
+export function resolveAppearanceStorageEvent(
+  current: AppearanceState,
+  key: string | null,
+  newValue: string | null,
+): AppearanceStorageEventResolution {
+  if (key === STORAGE_KEY_THEME) {
+    return {
+      handled: true,
+      next: newValue && isValidTheme(newValue) ? { ...current, theme: newValue } : current,
+    };
+  }
+  if (key === STORAGE_KEY_UI_THEME_LIGHT) {
+    return {
+      handled: true,
+      next: newValue && isValidUiThemeId('light', newValue)
+        ? { ...current, lightUiThemeId: newValue }
+        : current,
+    };
+  }
+  if (key === STORAGE_KEY_UI_THEME_DARK) {
+    return {
+      handled: true,
+      next: newValue && isValidUiThemeId('dark', newValue)
+        ? { ...current, darkUiThemeId: newValue }
+        : current,
+    };
+  }
+  if (key === STORAGE_KEY_ACCENT_MODE) {
+    return {
+      handled: true,
+      next: newValue === 'theme' || newValue === 'custom'
+        ? { ...current, accentMode: newValue }
+        : current,
+    };
+  }
+  if (key === STORAGE_KEY_COLOR) {
+    return {
+      handled: true,
+      next: newValue && isValidHslToken(newValue)
+        ? { ...current, customAccent: newValue.trim() }
+        : current,
+    };
+  }
+  return { handled: false, next: current };
 }

--- a/application/state/settingsIpcSync.ts
+++ b/application/state/settingsIpcSync.ts
@@ -58,10 +58,11 @@ import {
   migrateIncomingTerminalFontId,
 } from './settingsStateDefaults';
 import { isTerminalSidePanelAutoOpenTab, type TerminalSidePanelAutoOpenTab } from '../../domain/terminalSidePanelAutoOpen';
+import type { AppearanceSyncEvent } from './appearanceSync';
 
 interface UseSettingsIpcSyncParams {
   enabled?: boolean;
-  syncAppearanceFromStorage: () => void;
+  syncAppearanceFromStorage: (incoming?: AppearanceSyncEvent) => void;
   syncCustomCssFromStorage: () => void;
   setUiLanguage: Dispatch<SetStateAction<UILanguage>>;
   setUiFontFamilyId: Dispatch<SetStateAction<string>>;
@@ -156,7 +157,7 @@ export function useSettingsIpcSync({
         key === STORAGE_KEY_ACCENT_MODE ||
         key === STORAGE_KEY_COLOR
       ) {
-        syncAppearanceFromStorage();
+        syncAppearanceFromStorage({ key, value });
         return;
       }
       if (key === STORAGE_KEY_UI_LANGUAGE && typeof value === 'string') {

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -3,9 +3,7 @@ import type { CustomKeyBindings, HotkeyScheme, SessionLogFormat, TerminalSetting
 import { parseCustomKeyBindingsStorageRecord } from '../../domain/customKeyBindings';
 import { resolveSupportedLocale } from '../../infrastructure/config/i18n';
 import {
-  STORAGE_KEY_ACCENT_MODE,
   STORAGE_KEY_AUTO_UPDATE_ENABLED,
-  STORAGE_KEY_COLOR,
   STORAGE_KEY_CUSTOM_CSS,
   STORAGE_KEY_CUSTOM_KEY_BINDINGS,
   STORAGE_KEY_EDITOR_WORD_WRAP,
@@ -43,21 +41,16 @@ import {
   STORAGE_KEY_TERM_THEME,
   STORAGE_KEY_TERM_THEME_DARK,
   STORAGE_KEY_TERM_THEME_LIGHT,
-  STORAGE_KEY_THEME,
   STORAGE_KEY_UI_FONT_FAMILY,
   STORAGE_KEY_UI_LANGUAGE,
-  STORAGE_KEY_UI_THEME_DARK,
-  STORAGE_KEY_UI_THEME_LIGHT,
   STORAGE_KEY_WORKSPACE_FOCUS_STYLE,
   STORAGE_KEY_WINDOW_OPACITY,
   STORAGE_KEY_APP_ICON_VARIANT,
 } from '../../infrastructure/config/storageKeys';
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
+import { resolveAppearanceStorageEvent } from './appearanceSync';
 import {
-  isValidHslToken,
-  isValidTheme,
   isValidUiFontId,
-  isValidUiThemeId,
   migrateIncomingTerminalFontId,
 } from './settingsStateDefaults';
 import { isTerminalSidePanelAutoOpenTab, type TerminalSidePanelAutoOpenTab } from '../../domain/terminalSidePanelAutoOpen';
@@ -206,30 +199,14 @@ export function useSettingsStorageSync({
     if (!enabled) return;
     const handleStorageChange = (e: StorageEvent) => {
       const s = settingsSnapshotRef.current;
-      if (e.key === STORAGE_KEY_THEME && e.newValue) {
-        if (isValidTheme(e.newValue) && e.newValue !== s.theme) {
-          setTheme(e.newValue);
-        }
-      }
-      if (e.key === STORAGE_KEY_UI_THEME_LIGHT && e.newValue) {
-        if (isValidUiThemeId('light', e.newValue) && e.newValue !== s.lightUiThemeId) {
-          setLightUiThemeId(e.newValue);
-        }
-      }
-      if (e.key === STORAGE_KEY_UI_THEME_DARK && e.newValue) {
-        if (isValidUiThemeId('dark', e.newValue) && e.newValue !== s.darkUiThemeId) {
-          setDarkUiThemeId(e.newValue);
-        }
-      }
-      if (e.key === STORAGE_KEY_ACCENT_MODE && e.newValue) {
-        if ((e.newValue === 'theme' || e.newValue === 'custom') && e.newValue !== s.accentMode) {
-          setAccentMode(e.newValue);
-        }
-      }
-      if (e.key === STORAGE_KEY_COLOR && e.newValue) {
-        if (isValidHslToken(e.newValue) && e.newValue !== s.customAccent) {
-          setCustomAccent(e.newValue.trim());
-        }
+      const appearance = resolveAppearanceStorageEvent(s, e.key, e.newValue);
+      if (appearance.handled) {
+        if (appearance.next.theme !== s.theme) setTheme(appearance.next.theme);
+        if (appearance.next.lightUiThemeId !== s.lightUiThemeId) setLightUiThemeId(appearance.next.lightUiThemeId);
+        if (appearance.next.darkUiThemeId !== s.darkUiThemeId) setDarkUiThemeId(appearance.next.darkUiThemeId);
+        if (appearance.next.accentMode !== s.accentMode) setAccentMode(appearance.next.accentMode);
+        if (appearance.next.customAccent !== s.customAccent) setCustomAccent(appearance.next.customAccent);
+        return;
       }
       if (e.key === STORAGE_KEY_CUSTOM_CSS && e.newValue !== null) {
         if (e.newValue !== s.customCSS) {

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -53,7 +53,6 @@ import {
   STORAGE_KEY_APP_ICON_VARIANT,
 } from '../../infrastructure/config/storageKeys';
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
-import { isAppearanceStorageKey } from './appearanceSync';
 import {
   isValidHslToken,
   isValidTheme,
@@ -206,10 +205,6 @@ export function useSettingsStorageSync({
   useEffect(() => {
     if (!enabled) return;
     const handleStorageChange = (e: StorageEvent) => {
-      // Appearance changes already carry their authoritative value over IPC.
-      // Handling the unordered storage echo as a second source can replay an
-      // older System value after a newer explicit Light/Dark selection.
-      if (isAppearanceStorageKey(e.key)) return;
       const s = settingsSnapshotRef.current;
       if (e.key === STORAGE_KEY_THEME && e.newValue) {
         if (isValidTheme(e.newValue) && e.newValue !== s.theme) {

--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -53,6 +53,7 @@ import {
   STORAGE_KEY_APP_ICON_VARIANT,
 } from '../../infrastructure/config/storageKeys';
 import { resolveAppIconVariant, type AppIconVariant } from '../../domain/appIconVariant';
+import { isAppearanceStorageKey } from './appearanceSync';
 import {
   isValidHslToken,
   isValidTheme,
@@ -205,6 +206,10 @@ export function useSettingsStorageSync({
   useEffect(() => {
     if (!enabled) return;
     const handleStorageChange = (e: StorageEvent) => {
+      // Appearance changes already carry their authoritative value over IPC.
+      // Handling the unordered storage echo as a second source can replay an
+      // older System value after a newer explicit Light/Dark selection.
+      if (isAppearanceStorageKey(e.key)) return;
       const s = settingsSnapshotRef.current;
       if (e.key === STORAGE_KEY_THEME && e.newValue) {
         if (isValidTheme(e.newValue) && e.newValue !== s.theme) {

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -782,8 +782,8 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     localStorageAdapter.writeString(STORAGE_KEY_COLOR, customAccent);
     // Fix 1: Skip IPC broadcast on initial mount (values already match localStorage)
     if (!persistMountedRef.current) return;
-    // Fix 3: Send a single IPC instead of 5 — the receiver calls syncAppearanceFromStorage()
-    // which re-reads ALL appearance values from localStorage.
+    // Send one ordered notification. The receiver uses this theme value
+    // directly and reads the other appearance fields from shared storage.
     notifySettingsChanged(STORAGE_KEY_THEME, theme);
   }, [theme, resolvedTheme, lightUiThemeId, darkUiThemeId, accentMode, customAccent, notifySettingsChanged]);
 

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -147,7 +147,7 @@ import {
 } from './windowOpacitySync';
 import {
   hasPersistedAppearanceChanged,
-  resolveIncomingAppearanceValue,
+  resolveAppearanceSyncState,
   type AppearanceRenderSnapshot,
   type AppearanceSyncEvent,
 } from './appearanceSync';
@@ -575,41 +575,24 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   }, [notifySettingsChanged]);
 
   const syncAppearanceFromStorage = useCallback((incoming?: AppearanceSyncEvent) => {
-    const storedTheme = resolveIncomingAppearanceValue(
+    const nextAppearance = resolveAppearanceSyncState(
+      { theme, lightUiThemeId, darkUiThemeId, accentMode, customAccent },
+      {
+        theme: readStoredString(STORAGE_KEY_THEME),
+        lightUiThemeId: readStoredString(STORAGE_KEY_UI_THEME_LIGHT),
+        darkUiThemeId: readStoredString(STORAGE_KEY_UI_THEME_DARK),
+        accentMode: readStoredString(STORAGE_KEY_ACCENT_MODE),
+        customAccent: readStoredString(STORAGE_KEY_COLOR),
+      },
       incoming,
-      STORAGE_KEY_THEME,
-      readStoredString(STORAGE_KEY_THEME),
-      (value): value is string => typeof value === 'string' && isValidTheme(value),
     );
-    const nextTheme = storedTheme && isValidTheme(storedTheme) ? storedTheme : theme;
-    const storedLightId = resolveIncomingAppearanceValue(
-      incoming,
-      STORAGE_KEY_UI_THEME_LIGHT,
-      readStoredString(STORAGE_KEY_UI_THEME_LIGHT),
-      (value): value is string => typeof value === 'string' && isValidUiThemeId('light', value),
-    );
-    const nextLightId = storedLightId && isValidUiThemeId('light', storedLightId) ? storedLightId : lightUiThemeId;
-    const storedDarkId = resolveIncomingAppearanceValue(
-      incoming,
-      STORAGE_KEY_UI_THEME_DARK,
-      readStoredString(STORAGE_KEY_UI_THEME_DARK),
-      (value): value is string => typeof value === 'string' && isValidUiThemeId('dark', value),
-    );
-    const nextDarkId = storedDarkId && isValidUiThemeId('dark', storedDarkId) ? storedDarkId : darkUiThemeId;
-    const storedAccentMode = resolveIncomingAppearanceValue(
-      incoming,
-      STORAGE_KEY_ACCENT_MODE,
-      readStoredString(STORAGE_KEY_ACCENT_MODE),
-      (value): value is 'theme' | 'custom' => value === 'theme' || value === 'custom',
-    );
-    const nextAccentMode = storedAccentMode === 'theme' || storedAccentMode === 'custom' ? storedAccentMode : accentMode;
-    const storedAccent = resolveIncomingAppearanceValue(
-      incoming,
-      STORAGE_KEY_COLOR,
-      readStoredString(STORAGE_KEY_COLOR),
-      (value): value is string => typeof value === 'string' && isValidHslToken(value),
-    );
-    const nextAccent = storedAccent && isValidHslToken(storedAccent) ? storedAccent.trim() : customAccent;
+    const {
+      theme: nextTheme,
+      lightUiThemeId: nextLightId,
+      darkUiThemeId: nextDarkId,
+      accentMode: nextAccentMode,
+      customAccent: nextAccent,
+    } = nextAppearance;
 
     // Fix 2: Skip expensive DOM operations if nothing actually changed
     if (

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -449,6 +449,22 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   const persistMountedRef = useRef(false);
   const appearanceTransitionModeRef = useRef<ThemeTransitionMode>('view');
   const previousAppearanceRenderRef = useRef<AppearanceRenderSnapshot | null>(null);
+  // Latest appearance kept in a ref so sequential keyed IPC updates (one multi-field
+  // change -> multiple notifies) can compose without waiting for a React re-render.
+  const appearanceStateRef = useRef({
+    theme,
+    lightUiThemeId,
+    darkUiThemeId,
+    accentMode,
+    customAccent,
+  });
+  appearanceStateRef.current = {
+    theme,
+    lightUiThemeId,
+    darkUiThemeId,
+    accentMode,
+    customAccent,
+  };
 
   const setTerminalSettings = useCallback((nextValue: SetStateAction<TerminalSettings>) => {
     setTerminalSettingsState((prev) => {
@@ -575,8 +591,9 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   }, [notifySettingsChanged]);
 
   const syncAppearanceFromStorage = useCallback((incoming?: AppearanceSyncEvent) => {
+    const current = appearanceStateRef.current;
     const nextAppearance = resolveAppearanceSyncState(
-      { theme, lightUiThemeId, darkUiThemeId, accentMode, customAccent },
+      current,
       {
         theme: readStoredString(STORAGE_KEY_THEME),
         lightUiThemeId: readStoredString(STORAGE_KEY_UI_THEME_LIGHT),
@@ -596,15 +613,17 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
 
     // Fix 2: Skip expensive DOM operations if nothing actually changed
     if (
-      nextTheme === theme &&
-      nextLightId === lightUiThemeId &&
-      nextDarkId === darkUiThemeId &&
-      nextAccentMode === accentMode &&
-      nextAccent === customAccent
+      nextTheme === current.theme &&
+      nextLightId === current.lightUiThemeId &&
+      nextDarkId === current.darkUiThemeId &&
+      nextAccentMode === current.accentMode &&
+      nextAccent === current.customAccent
     ) {
       return;
     }
 
+    // Publish synchronously so a later keyed IPC in the same turn composes on top.
+    appearanceStateRef.current = nextAppearance;
     setTheme(nextTheme);
     setLightUiThemeId(nextLightId);
     setDarkUiThemeId(nextDarkId);
@@ -616,7 +635,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     runThemeTransition(() => {
       applyThemeTokens(nextTheme, effective, tokens, nextAccentMode, nextAccent);
     });
-  }, [theme, lightUiThemeId, darkUiThemeId, accentMode, customAccent]);
+  }, []);
 
   const syncCustomCssFromStorage = useCallback(() => {
     const storedCss = localStorageAdapter.readString(STORAGE_KEY_CUSTOM_CSS) || '';

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -145,6 +145,12 @@ import {
   type WindowOpacityMutationSource,
   type WindowOpacityRecord,
 } from './windowOpacitySync';
+import {
+  hasPersistedAppearanceChanged,
+  resolveIncomingAppearanceValue,
+  type AppearanceRenderSnapshot,
+  type AppearanceSyncEvent,
+} from './appearanceSync';
 
 export const useSettingsState = (options: { enableSettingsSync?: boolean; enableSystemEffects?: boolean } = {}) => {
   const enableSettingsSync = options.enableSettingsSync !== false;
@@ -442,6 +448,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   // Set to true by the LAST useEffect declaration; all persist effects see false on first render.
   const persistMountedRef = useRef(false);
   const appearanceTransitionModeRef = useRef<ThemeTransitionMode>('view');
+  const previousAppearanceRenderRef = useRef<AppearanceRenderSnapshot | null>(null);
 
   const setTerminalSettings = useCallback((nextValue: SetStateAction<TerminalSettings>) => {
     setTerminalSettingsState((prev) => {
@@ -567,16 +574,41 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     notifySettingsChanged(STORAGE_KEY_WORKSPACE_FOCUS_STYLE, style);
   }, [notifySettingsChanged]);
 
-  const syncAppearanceFromStorage = useCallback(() => {
-    const storedTheme = readStoredString(STORAGE_KEY_THEME);
+  const syncAppearanceFromStorage = useCallback((incoming?: AppearanceSyncEvent) => {
+    const storedTheme = resolveIncomingAppearanceValue(
+      incoming,
+      STORAGE_KEY_THEME,
+      readStoredString(STORAGE_KEY_THEME),
+      (value): value is string => typeof value === 'string' && isValidTheme(value),
+    );
     const nextTheme = storedTheme && isValidTheme(storedTheme) ? storedTheme : theme;
-    const storedLightId = readStoredString(STORAGE_KEY_UI_THEME_LIGHT);
+    const storedLightId = resolveIncomingAppearanceValue(
+      incoming,
+      STORAGE_KEY_UI_THEME_LIGHT,
+      readStoredString(STORAGE_KEY_UI_THEME_LIGHT),
+      (value): value is string => typeof value === 'string' && isValidUiThemeId('light', value),
+    );
     const nextLightId = storedLightId && isValidUiThemeId('light', storedLightId) ? storedLightId : lightUiThemeId;
-    const storedDarkId = readStoredString(STORAGE_KEY_UI_THEME_DARK);
+    const storedDarkId = resolveIncomingAppearanceValue(
+      incoming,
+      STORAGE_KEY_UI_THEME_DARK,
+      readStoredString(STORAGE_KEY_UI_THEME_DARK),
+      (value): value is string => typeof value === 'string' && isValidUiThemeId('dark', value),
+    );
     const nextDarkId = storedDarkId && isValidUiThemeId('dark', storedDarkId) ? storedDarkId : darkUiThemeId;
-    const storedAccentMode = readStoredString(STORAGE_KEY_ACCENT_MODE);
+    const storedAccentMode = resolveIncomingAppearanceValue(
+      incoming,
+      STORAGE_KEY_ACCENT_MODE,
+      readStoredString(STORAGE_KEY_ACCENT_MODE),
+      (value): value is 'theme' | 'custom' => value === 'theme' || value === 'custom',
+    );
     const nextAccentMode = storedAccentMode === 'theme' || storedAccentMode === 'custom' ? storedAccentMode : accentMode;
-    const storedAccent = readStoredString(STORAGE_KEY_COLOR);
+    const storedAccent = resolveIncomingAppearanceValue(
+      incoming,
+      STORAGE_KEY_COLOR,
+      readStoredString(STORAGE_KEY_COLOR),
+      (value): value is string => typeof value === 'string' && isValidHslToken(value),
+    );
     const nextAccent = storedAccent && isValidHslToken(storedAccent) ? storedAccent.trim() : customAccent;
 
     // Fix 2: Skip expensive DOM operations if nothing actually changed
@@ -722,6 +754,17 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
   }, [applyIncomingCustomKeyBindings, applyIncomingJmsDeepLinkEnabled, applyIncomingSshDeepLinkEnabled, syncAppearanceFromStorage, syncCustomCssFromStorage, setTerminalSettings]);
 
   useLayoutEffect(() => {
+    const appearanceRender: AppearanceRenderSnapshot = {
+      theme,
+      resolvedTheme,
+      lightUiThemeId,
+      darkUiThemeId,
+      accentMode,
+      customAccent,
+    };
+    const persistedAppearanceChanged = previousAppearanceRenderRef.current === null
+      || hasPersistedAppearanceChanged(previousAppearanceRenderRef.current, appearanceRender);
+    previousAppearanceRenderRef.current = appearanceRender;
     const tokens = getUiThemeById(resolvedTheme, resolvedTheme === 'dark' ? darkUiThemeId : lightUiThemeId).tokens;
     const apply = () => applyThemeTokens(theme, resolvedTheme, tokens, accentMode, customAccent);
     const transitionMode = appearanceTransitionModeRef.current;
@@ -731,6 +774,7 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     } else {
       apply();
     }
+    if (!persistedAppearanceChanged && persistMountedRef.current) return;
     localStorageAdapter.writeString(STORAGE_KEY_THEME, theme);
     localStorageAdapter.writeString(STORAGE_KEY_UI_THEME_LIGHT, lightUiThemeId);
     localStorageAdapter.writeString(STORAGE_KEY_UI_THEME_DARK, darkUiThemeId);

--- a/application/state/useSettingsState.ts
+++ b/application/state/useSettingsState.ts
@@ -745,8 +745,11 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
       accentMode,
       customAccent,
     };
-    const persistedAppearanceChanged = previousAppearanceRenderRef.current === null
-      || hasPersistedAppearanceChanged(previousAppearanceRenderRef.current, appearanceRender);
+    // Capture previous snapshot before overwrite so we can notify only the
+    // appearance fields that actually changed on this render.
+    const previousAppearance = previousAppearanceRenderRef.current;
+    const persistedAppearanceChanged = previousAppearance === null
+      || hasPersistedAppearanceChanged(previousAppearance, appearanceRender);
     previousAppearanceRenderRef.current = appearanceRender;
     const tokens = getUiThemeById(resolvedTheme, resolvedTheme === 'dark' ? darkUiThemeId : lightUiThemeId).tokens;
     const apply = () => applyThemeTokens(theme, resolvedTheme, tokens, accentMode, customAccent);
@@ -765,9 +768,25 @@ export const useSettingsState = (options: { enableSettingsSync?: boolean; enable
     localStorageAdapter.writeString(STORAGE_KEY_COLOR, customAccent);
     // Fix 1: Skip IPC broadcast on initial mount (values already match localStorage)
     if (!persistMountedRef.current) return;
-    // Send one ordered notification. The receiver uses this theme value
-    // directly and reads the other appearance fields from shared storage.
-    notifySettingsChanged(STORAGE_KEY_THEME, theme);
+    // Emit a keyed IPC notification for each changed appearance field so the
+    // receiver can apply the payload value even if shared storage is still stale.
+    // resolveAppearanceSyncState only trusts the announced key's value; other
+    // fields fall back to storage, so every changed field must be announced.
+    if (!previousAppearance || previousAppearance.theme !== theme) {
+      notifySettingsChanged(STORAGE_KEY_THEME, theme);
+    }
+    if (!previousAppearance || previousAppearance.lightUiThemeId !== lightUiThemeId) {
+      notifySettingsChanged(STORAGE_KEY_UI_THEME_LIGHT, lightUiThemeId);
+    }
+    if (!previousAppearance || previousAppearance.darkUiThemeId !== darkUiThemeId) {
+      notifySettingsChanged(STORAGE_KEY_UI_THEME_DARK, darkUiThemeId);
+    }
+    if (!previousAppearance || previousAppearance.accentMode !== accentMode) {
+      notifySettingsChanged(STORAGE_KEY_ACCENT_MODE, accentMode);
+    }
+    if (!previousAppearance || previousAppearance.customAccent !== customAccent) {
+      notifySettingsChanged(STORAGE_KEY_COLOR, customAccent);
+    }
   }, [theme, resolvedTheme, lightUiThemeId, darkUiThemeId, accentMode, customAccent, notifySettingsChanged]);
 
   // Listen for OS color scheme changes to keep systemPreference in sync


### PR DESCRIPTION
Fixes #2073.

## What changed

- Prevent OS color-scheme updates from persisting an unchanged System selection over a newer explicit theme choice.
- Use the value carried by the ordered cross-window appearance notification instead of re-reading a potentially stale local copy.
- Keep storage synchronization available to detached terminal and tray windows that are not direct notification targets.
- Add regression coverage for the System (light OS) to Dark transition, stale cross-window values, and an already-open detached follow-app terminal.

## Root cause

Theme application and theme persistence shared one effect. While the app was set to System, a Windows color-scheme notification could rerun that effect in a peer window that still held the old System state. That peer rewrote storage and emitted another notification after the Settings window had selected Dark. Appearance IPC then ignored its own Dark payload and re-read the overwritten System value, so Settings could flash back to light or an already-open terminal could remain light.

## Verification

- Deterministic Electron state-transition reproduction: System on a light OS, persisted follow-app terminal setting, Settings window, and already-open main and detached terminals. It failed on v1.1.61 and passes with this branch.
- Regression and targeted theme tests.
- Full test suite passes with no failures.
- ESLint passes.
- Production build passes.
- Visual check of the Settings selection, main terminal, and detached terminal after switching directly from System to Dark.