### PR TITLE
Preserve remote locale for SSH sessions

### DIFF
--- a/electron/bridges/sshBridge.authRetryExit.test.cjs
+++ b/electron/bridges/sshBridge.authRetryExit.test.cjs
@@ -126,7 +126,8 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
       setImmediate(() => cb(null, new EventEmitter()));
     }
 
-    shell(_pty, _opts, cb) {
+    shell(_pty, shellOptions, cb) {
+      this.shellOptions = shellOptions;
       setImmediate(() => cb(null, createShellStream()));
     }
 
@@ -178,6 +179,34 @@ function loadBridgeWithAuthRetryMocks(t, options = {}) {
 
   return { bridge, MockSSHClient };
 }
+
+test("fresh SSH sessions preserve the server locale for the default UTF-8 charset", async (t) => {
+  const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {
+    connectEvents: ["ready"],
+  });
+  const ipcMain = makeIpcMain();
+  bridge.init({ sessions: new Map(), electronModule: {} });
+  bridge.registerHandlers(ipcMain);
+
+  const result = await ipcMain.handlers.get("netcatty:start")(
+    { sender: makeSender() },
+    {
+      sessionId: "default-locale-session",
+      hostname: "example.test",
+      username: "alice",
+      port: 22,
+      charset: "UTF-8",
+      env: { TERM: "xterm-256color" },
+      knownHosts: [],
+    },
+  );
+
+  assert.deepEqual(result, { sessionId: "default-locale-session" });
+  assert.deepEqual(MockSSHClient.instances[0].shellOptions.env, {
+    COLORTERM: "truecolor",
+    TERM: "xterm-256color",
+  });
+});
 
 test("retryable encrypted-key auth failure does not emit exit before retry success", async (t) => {
   const { bridge, MockSSHClient } = loadBridgeWithAuthRetryMocks(t, {

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -450,20 +450,6 @@ function clearCachedAuthMethod(username, hostname, port) {
   authMethodCache.delete(key);
 }
 
-// Normalize charset inputs (often provided as bare encodings like "UTF-8")
-// into a usable LANG locale for remote shells.
-function resolveLangFromCharset(charset) {
-  if (!charset) return "en_US.UTF-8";
-  const trimmed = String(charset).trim();
-  if (/^utf-?8$/i.test(trimmed) || /^utf8$/i.test(trimmed)) {
-    return "en_US.UTF-8";
-  }
-  if (normalizeTerminalEncoding(trimmed) === "gb18030" && !trimmed.includes(".")) {
-    return "zh_CN.GB18030";
-  }
-  return trimmed;
-}
-
 const { safeSend } = require("./ipcUtils.cjs");
 const {
   createConnectionRef,
@@ -879,7 +865,7 @@ const startSessionApi = createStartSessionApi({
   iconv, getSessionDecoder, resetSessionDecoders, sessionEncodings, sessionDecoders, encodeTerminalInput,
   normalizeTerminalEncoding,
   connectThroughChain, getAvailableAgentSocket, getCachedAuthMethod, setCachedAuthMethod, clearCachedAuthMethod,
-  attachSshDebugLogger, logSshAlgorithms, resolveLangFromCharset, safeSend, zmodemOverwritePending,
+  attachSshDebugLogger, logSshAlgorithms, safeSend, zmodemOverwritePending,
   shouldLogSshDebugMessage, log, createSshDiagnosticLogger,
   buildAlgorithms, randomUUID, findDefaultPrivateKey, findAllDefaultPrivateKeys,
   openTerminalOutputSession, closeTerminalOutputSession,
@@ -1174,7 +1160,7 @@ const sessionOpsApi = createSessionOpsApi({
   get electronModule() { return electronModule; },
   fs, path, os, exec, randomUUID, iconv, Buffer, process, console, setTimeout, clearTimeout,
   getSessionDecoder, resetSessionDecoders, sessionEncodings, normalizeTerminalEncoding,
-  resolveLangFromCharset, safeSend,
+  safeSend,
   quoteShellArg, log, ensureMoshStatsConnection, ensureEtStatsConnection,
   execOnEtSession: (...args) => require("./terminalBridge.cjs").execOnEtSession(...args),
   getServerStats: undefined,

--- a/electron/bridges/sshBridge.connectionReuse.test.cjs
+++ b/electron/bridges/sshBridge.connectionReuse.test.cjs
@@ -81,11 +81,13 @@ function makeReusableConn() {
   conn._remoteVer = "OpenSSH_9.0";
   conn.ended = 0;
   conn.openedShells = [];
+  conn.openedShellOptions = [];
   conn.end = () => { conn.ended += 1; };
   conn.destroy = () => {};
-  conn.shell = (_opts, _shellOpts, cb) => {
+  conn.shell = (_opts, shellOpts, cb) => {
     const stream = makeStream();
     conn.openedShells.push(stream);
+    conn.openedShellOptions.push(shellOpts);
     // ssh2 invokes the callback asynchronously.
     setImmediate(() => cb(null, stream));
   };
@@ -186,6 +188,46 @@ test("Copy Tab reuses the source connection instead of dialing fresh", async (t)
   const progress = sender.sent.filter((m) => m.channel === "netcatty:chain:progress");
   assert.ok(progress.some((m) => m.payload.status === "connected"));
   assert.equal(getConnectionReuseFallbackEvents(sender).length, 0, "successful reuse should not emit fallback");
+});
+
+test("Copy Tab preserves the server locale unless the host explicitly overrides it", async (t) => {
+  const { bridge } = loadBridgeWithMockedSsh2(t);
+  const sessions = new Map();
+  const sourceConn = makeReusableConn();
+  sessions.set("source", makeSourceSession(sourceConn, { hostname: "10.0.0.1", username: "alice" }));
+
+  const start = registerStartHandler(bridge, sessions);
+
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy-default-locale",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+      charset: "UTF-8",
+      env: { TERM: "xterm-256color" },
+    },
+  );
+
+  assert.deepEqual(sourceConn.openedShellOptions[0].env, {
+    COLORTERM: "truecolor",
+    TERM: "xterm-256color",
+  });
+
+  await start(
+    { sender: makeSender() },
+    {
+      sessionId: "copy-explicit-locale",
+      hostname: "10.0.0.1",
+      username: "alice",
+      sourceSessionId: "source",
+      charset: "UTF-8",
+      env: { LANG: "zh_CN.UTF-8" },
+    },
+  );
+
+  assert.equal(sourceConn.openedShellOptions[1].env.LANG, "zh_CN.UTF-8");
 });
 
 test("closing the reused channel keeps the source connection alive", async (t) => {

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -404,7 +404,6 @@ function createStartSessionApi(ctx) {
 
       const shellOptions = {
         env: {
-          LANG: resolveLangFromCharset(options.charset),
           COLORTERM: "truecolor",
           ...(options.env || {}),
         },
@@ -1180,7 +1179,6 @@ function createStartSessionApi(ctx) {
 
             const shellOptions = {
               env: {
-                LANG: resolveLangFromCharset(options.charset),
                 COLORTERM: "truecolor",
                 ...(options.env || {}),
               },


### PR DESCRIPTION
## What changed

- Stop deriving and sending `LANG` from the terminal character-set setting for SSH shells.
- Preserve an explicitly configured `LANG` environment variable.
- Cover both fresh SSH sessions and reused connections with regression tests.

## Why

Netcatty mapped the default `UTF-8` character set to `en_US.UTF-8` and sent it to every SSH shell. On servers where that locale is not installed, this overrides the server's valid locale, causes locale errors, and makes tools such as `ls` replace UTF-8 Chinese filename characters with question marks.

Leaving `LANG` unset unless the user explicitly configures it allows the remote host to keep its own installed locale while terminal byte encoding remains controlled independently.

## User impact

SSH sessions no longer replace a server's working locale with a locale that may not exist. Explicit host environment-variable overrides continue to work.

## Validation

- `node --test electron/bridges/sshBridge.authRetryExit.test.cjs`
- `node --test electron/bridges/sshBridge.connectionReuse.test.cjs`
- `npx eslint electron/bridges/sshBridge.cjs electron/bridges/sshBridge/startSession.cjs electron/bridges/sshBridge.authRetryExit.test.cjs electron/bridges/sshBridge.connectionReuse.test.cjs`
- `npm run build`
- `npm test` — 4,672 tests; 4,669 passed, 3 skipped, 0 failed
- Two independent final reviewers returned CLEAN

Fixes #2086
