### PR TITLE
Fix SFTP upload close false failure

### DIFF
--- a/electron/bridges/transferBridge.cjs
+++ b/electron/bridges/transferBridge.cjs
@@ -394,15 +394,14 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
   }
 
   // Fallback: sequential stream piping.
-  // Require both 'finish' (bytes flushed) and 'close' (remote handle closed).
-  // Resolving on finish alone can miss close-time server errors (quota/disk full);
-  // resolving on close alone can treat a premature destroy as success (#2022).
+  // ssh2 closes the remote handle from _final and may suppress Node's normal
+  // 'finish' event. Treat a successful close after the complete local read as
+  // completion, then verify the persisted remote size below.
   await new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(localPath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     const writeStream = sftp.createWriteStream(remotePath, { highWaterMark: TRANSFER_CHUNK_SIZE });
     let transferred = 0;
     let settled = false;
-    let sawFinish = false;
 
     transfer.readStream = readStream;
     transfer.writeStream = writeStream;
@@ -428,19 +427,12 @@ async function uploadFile(localPath, remotePath, client, fileSize, transfer, sen
     });
     readStream.on('error', cleanup);
     writeStream.on('error', cleanup);
-    writeStream.on('finish', () => {
-      if (transfer.cancelled) {
-        cleanup(new Error('Transfer cancelled'));
-        return;
-      }
-      sawFinish = true;
-    });
     writeStream.on('close', () => {
       if (transfer.cancelled) {
         cleanup(new Error('Transfer cancelled'));
         return;
       }
-      if (!sawFinish) {
+      if (!readStream.readableEnded || transferred !== fileSize) {
         cleanup(new Error('Upload stream closed before finish'));
         return;
       }

--- a/electron/bridges/transferBridge.test.cjs
+++ b/electron/bridges/transferBridge.test.cjs
@@ -212,6 +212,77 @@ test("SFTP stream-fallback uploads wait for close after finish", async (t) => {
   assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"));
 });
 
+test("SFTP stream-fallback uploads accept ssh2 close without finish", async (t) => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-ssh2-close-"));
+  t.after(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const localPath = path.join(tempDir, "payload.bin");
+  const payload = Buffer.alloc(64 * 1024, 9);
+  await fs.promises.writeFile(localPath, payload);
+
+  let remoteBytes = 0;
+  let sawFinish = false;
+  const streamSftp = createFastSftp({
+    createWriteStream() {
+      const { Writable } = require("node:stream");
+      const writeStream = new Writable({
+        autoDestroy: false,
+        emitClose: false,
+        write(chunk, _encoding, callback) {
+          remoteBytes += chunk.length;
+          callback();
+        },
+        final(callback) {
+          // ssh2 closes the remote handle from _final. On current Node versions,
+          // destroying here suppresses the normal Writable "finish" event.
+          this.destroy();
+          callback();
+        },
+        destroy(error, callback) {
+          queueMicrotask(() => {
+            callback(error);
+            if (!error) this.emit("close");
+          });
+        },
+      });
+      writeStream.on("finish", () => {
+        sawFinish = true;
+      });
+      return writeStream;
+    },
+  });
+
+  const client = {
+    __netcattySudoMode: true,
+    sftp: streamSftp,
+    stat() {
+      return Promise.resolve({ size: remoteBytes });
+    },
+  };
+  transferBridge.init({ sftpClients: new Map([["target", client]]) });
+
+  const sender = createSender();
+  const result = await transferBridge.startTransfer(
+    { sender },
+    {
+      transferId: "upload-stream-close-only",
+      sourcePath: localPath,
+      targetPath: "/tmp/payload.bin",
+      sourceType: "local",
+      targetType: "sftp",
+      targetSftpId: "target",
+      totalBytes: payload.length,
+    },
+  );
+
+  assert.equal(sawFinish, false);
+  assert.equal(remoteBytes, payload.length);
+  assert.equal(result.error, undefined);
+  assert.ok(sender.sent.some((entry) => entry.channel === "netcatty:transfer:complete"));
+});
+
 test("SFTP stream-fallback uploads fail on premature close", async (t) => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "netcatty-transfer-premature-close-"));
   t.after(async () => {


### PR DESCRIPTION
## Summary

- Treat an SFTP stream-fallback upload as complete when the remote handle closes successfully after the local file has been fully read.
- Keep the remote file-size verification that detects truncated uploads.
- Add regression coverage for ssh2 write streams that close without emitting `finish`.

## Root cause

The v1.1.61 upload hardening required the fallback write stream to emit `finish` before `close`. With ssh2 1.17.0 on Netcatty's bundled Node 24.15.0 runtime, ssh2 closes the remote handle from its finalization path and destroys the writable stream. The full payload is written and `close` is emitted, but Node suppresses `finish`, so Netcatty reported a false failure even when the remote file matched.

The updated completion check requires the local read to have ended and the transferred byte count to match the expected size before accepting `close`. The existing remote `stat` verification then confirms the persisted size. Premature closes, cancellations, write errors, and size mismatches still fail.

## User impact

Successful SFTP uploads through the stream fallback no longer show `Upload stream closed before finish` when the remote file is complete.

## Validation

- `node --test electron/bridges/transferBridge.test.cjs` — 6 passed
- `npm test` — 4,668 passed, 0 failed, 3 skipped
- `npm run lint`
- `npm run build`
- Bundled Electron runtime probe confirmed Node 24.15.0 writes the full payload and emits `close` without `finish`
- Two independent local reviewers returned `CLEAN`

Issue: #2087
