### PR TITLE
Fix MobaXterm host imports

### DIFF
--- a/domain/vaultImport.test.ts
+++ b/domain/vaultImport.test.ts
@@ -4,6 +4,12 @@ import assert from "node:assert/strict";
 import { importVaultHostsFromText, detectVaultImportFormat, applyVaultHostImport } from "./vaultImport.ts";
 import type { Host } from "./models.ts";
 
+const mobaXtermSshSession = (
+  hostname: string,
+  port = 22,
+  username = "root",
+) => `#109#0%${hostname}%${port}%${username}%%-1%-1%%%%%0%0%0%%%-1%0%0%0%%1080%%0%0%1%#MobaFont%10%0%0%-1#0# #-1`;
+
 test("ssh_config import maps ForwardX11 yes to host X11 forwarding", () => {
   const result = importVaultHostsFromText("ssh_config", [
     "Host x11-host",
@@ -37,6 +43,151 @@ test("detectVaultImportFormat recognizes csv and ssh_config exports", () => {
     detectVaultImportFormat(["Host prod", "  HostName prod.example.com", "  User deploy"].join("\n")),
     "ssh_config",
   );
+});
+
+test("detectVaultImportFormat recognizes MobaXterm bookmark exports", () => {
+  assert.equal(
+    detectVaultImportFormat([
+      "[Bookmarks]",
+      "SubRep=",
+      "ImgNum=42",
+      `server=${mobaXtermSshSession("10.0.0.1")}`,
+    ].join("\n")),
+    "mobaxterm",
+  );
+  assert.equal(
+    detectVaultImportFormat([
+      "[Bookmarks_1]",
+      "SubRep=Production",
+      "ImgNum=41",
+      `server=${mobaXtermSshSession("10.0.0.1")}`,
+    ].join("\n")),
+    "mobaxterm",
+  );
+});
+
+test("detectVaultImportFormat does not treat generic bookmark INI sections as MobaXterm", () => {
+  assert.equal(
+    detectVaultImportFormat([
+      "[Bookmarks]",
+      "home=https://example.com",
+    ].join("\n")),
+    null,
+  );
+});
+
+test("MobaXterm import reads standard session fields and bookmark groups", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    `root-server=${mobaXtermSshSession("root.example.com", 22, "<default>")}`,
+    "",
+    "[Bookmarks_1]",
+    "SubRep=Production\\Linux",
+    "ImgNum=41",
+    `web-server=${mobaXtermSshSession("10.0.0.20", 2222, "deploy")}`,
+  ].join("\n"));
+
+  assert.deepEqual(result.stats, {
+    parsed: 2,
+    imported: 2,
+    skipped: 0,
+    duplicates: 0,
+  });
+  assert.deepEqual(
+    result.hosts.map(({ label, hostname, port, username, group, protocol }) => ({
+      label,
+      hostname,
+      port,
+      username,
+      group,
+      protocol,
+    })),
+    [
+      {
+        label: "root-server",
+        hostname: "root.example.com",
+        port: 22,
+        username: "",
+        group: undefined,
+        protocol: "ssh",
+      },
+      {
+        label: "web-server",
+        hostname: "10.0.0.20",
+        port: 2222,
+        username: "deploy",
+        group: "Production/Linux",
+        protocol: "ssh",
+      },
+    ],
+  );
+  assert.deepEqual(result.groups, ["Production/Linux"]);
+});
+
+test("MobaXterm import does not mistake icon metadata for duplicate hosts", () => {
+  const sessions = Array.from(
+    { length: 40 },
+    (_, index) => `host-${index + 1}=${mobaXtermSshSession(`10.0.0.${index + 1}`)}`,
+  );
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    ...sessions,
+  ].join("\n"));
+
+  assert.deepEqual(result.stats, {
+    parsed: 40,
+    imported: 40,
+    skipped: 0,
+    duplicates: 0,
+  });
+  assert.equal(result.hosts[0].hostname, "10.0.0.1");
+  assert.equal(result.hosts[39].hostname, "10.0.0.40");
+});
+
+test("MobaXterm import preserves path-based groups when SubRep is absent", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Bookmarks]",
+    "Legacy\\server=deploy@legacy.example.com:2222#ssh",
+  ].join("\n"));
+
+  assert.deepEqual(result.stats, {
+    parsed: 1,
+    imported: 1,
+    skipped: 0,
+    duplicates: 0,
+  });
+  assert.equal(result.hosts[0].label, "server");
+  assert.equal(result.hosts[0].group, "Legacy");
+  assert.equal(result.hosts[0].hostname, "legacy.example.com");
+  assert.equal(result.hosts[0].port, 2222);
+  assert.equal(result.hosts[0].username, "deploy");
+});
+
+test("MobaXterm import handles incomplete standard session records safely", () => {
+  const result = importVaultHostsFromText("mobaxterm", [
+    "[Bookmarks]",
+    "SubRep=",
+    "ImgNum=42",
+    "short=#109#0%short.example.com",
+    "missing-host=#109#0",
+    "missing-type=#109#",
+    "unsupported=#91#4",
+  ].join("\n"));
+
+  assert.deepEqual(result.stats, {
+    parsed: 4,
+    imported: 1,
+    skipped: 3,
+    duplicates: 0,
+  });
+  assert.equal(result.hosts[0].hostname, "short.example.com");
+  assert.equal(result.hosts[0].port, 22);
+  assert.equal(result.hosts[0].label, "short");
+  assert.equal(result.issues.length, 3);
 });
 
 test("applyVaultHostImport skips duplicates by default", () => {

--- a/domain/vaultImport.ts
+++ b/domain/vaultImport.ts
@@ -798,6 +798,7 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
 
   type Entry = { section: string; key: string; value: string };
   const entries: Entry[] = [];
+  const sectionGroups = new Map<string, string | undefined>();
 
   let section = "";
   for (const line of lines) {
@@ -813,11 +814,21 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
 
     const mKv = trimmed.match(/^([^=]+)=(.*)$/);
     if (!mKv) continue;
-    entries.push({ section, key: mKv[1].trim(), value: mKv[2].trim() });
+    const key = mKv[1].trim();
+    const value = mKv[2].trim();
+    const isBookmarkSection = /^bookmarks(?:_\d+)?$/i.test(section.trim());
+
+    if (isBookmarkSection && key.toLowerCase() === "subrep") {
+      sectionGroups.set(section, normalizeGroupPath(value));
+      continue;
+    }
+    if (isBookmarkSection && key.toLowerCase() === "imgnum") continue;
+
+    entries.push({ section, key, value });
   }
 
   const candidateEntries = entries.filter((e) =>
-    ["sessions", "bookmarks", "bookmarks2", "bookmark"].includes(e.section.trim().toLowerCase()),
+    /^(?:sessions|bookmarks(?:_\d+)?|bookmarks2|bookmark)$/i.test(e.section.trim()),
   );
 
   const parsedHosts: Host[] = [];
@@ -831,55 +842,81 @@ const importFromMobaXterm = (text: string): VaultImportResult => {
 
     parsed++;
 
+    const isBookmarkSection = /^bookmarks(?:_\d+)?$/i.test(e.section.trim());
+    const hasBookmarkGroup = sectionGroups.has(e.section);
     const keyParts = rawKey.replace(/\\/g, "/").split("/").filter(Boolean);
-    const label = keyParts[keyParts.length - 1] || rawKey;
-    const group =
-      keyParts.length > 1 ? keyParts.slice(0, -1).join("/") : undefined;
+    const label = isBookmarkSection && hasBookmarkGroup
+      ? rawKey
+      : keyParts[keyParts.length - 1] || rawKey;
+    const group = isBookmarkSection && hasBookmarkGroup
+      ? sectionGroups.get(e.section)
+      : keyParts.length > 1
+        ? keyParts.slice(0, -1).join("/")
+        : undefined;
 
     let protocol: Exclude<HostProtocol, "mosh" | "et"> | undefined;
     let hostname: string | undefined;
     let username: string | undefined;
     let port: number | undefined;
 
-    const tokens = rawValue
-      .split("#")
-      .map((t) => t.trim())
-      .filter(Boolean);
+    const outerFields = rawValue.split("#");
+    const sessionFields = outerFields.length >= 3 ? outerFields[2].split("%") : [];
+    const sessionType = sessionFields[0]?.trim();
+    const isStandardSession = /^(?:;\s*logout)?\s*#\d+(?:#|$)/i.test(rawValue);
 
-    if (tokens.length > 0) {
-      protocol =
-        normalizeProtocol(tokens[0]) ??
-        tokens.map((t) => normalizeProtocol(t)).find(Boolean);
-
-      // Find a token that looks like [user@]host[:port]
-      for (const tok of tokens) {
-        const t = tok.replace(/^ssh:/i, "").trim();
-        const target = parseTarget(t);
-        if (target) {
-          hostname = target.hostname;
-          username = target.username ?? username;
-          port = target.port ?? port;
-          protocol = target.protocol ?? protocol;
-          break;
-        }
+    if (isStandardSession) {
+      if (!/^\d+$/.test(sessionType ?? "")) {
+        skipped++;
+        issues.push({
+          level: "warning",
+          message: `MobaXterm entry "${label}": invalid session type.`,
+        });
+        continue;
+      }
+      if (sessionType !== "0" && sessionType !== "7") {
+        skipped++;
+        issues.push({
+          level: "warning",
+          message: `MobaXterm entry "${label}": unsupported session type.`,
+        });
+        continue;
       }
 
-      if (!hostname) {
-        const hostToken = tokens.find(looksLikeHostnameToken);
-        if (hostToken) {
-          const target = parseTarget(hostToken);
-          hostname = target?.hostname;
-          username = target?.username;
-          port = target?.port;
+      protocol = "ssh";
+      hostname = sessionFields[1]?.trim() || undefined;
+      port = parsePort(sessionFields[2]);
+      const rawUsername = sessionFields[3]?.trim();
+      username = rawUsername && rawUsername !== "<default>" ? rawUsername : undefined;
+    } else {
+      // Retain support for the simpler token layouts accepted by older imports.
+      const tokens = rawValue
+        .split("#")
+        .map((t) => t.trim())
+        .filter(Boolean);
+
+      if (tokens.length > 0) {
+        protocol =
+          normalizeProtocol(tokens[0]) ??
+          tokens.map((t) => normalizeProtocol(t)).find(Boolean);
+
+        for (const tok of tokens) {
+          const target = parseTarget(tok.replace(/^ssh:/i, "").trim());
+          if (target) {
+            hostname = target.hostname;
+            username = target.username ?? username;
+            port = target.port ?? port;
+            protocol = target.protocol ?? protocol;
+            break;
+          }
         }
-      }
 
-      const numericPort = tokens.map((t) => parsePort(t)).find(Boolean);
-      if (numericPort) port = numericPort;
+        const numericPort = tokens.map((t) => parsePort(t)).find(Boolean);
+        if (numericPort) port = numericPort;
 
-      if (!username) {
-        const userToken = tokens.find((t) => t.includes("@"));
-        if (userToken) username = userToken.split("@")[0];
+        if (!username) {
+          const userToken = tokens.find((t) => t.includes("@"));
+          if (userToken) username = userToken.split("@")[0];
+        }
       }
     }
 
@@ -949,7 +986,13 @@ export function detectVaultImportFormat(text: string): VaultImportFormat | null 
     return "putty";
   }
 
-  if (/\[Bookmarks_\]/m.test(input) || /\[MobaXterm\]/i.test(input)) {
+  const hasMobaBookmarkSection = /^\[Bookmarks(?:_\d+)?\]\s*$/im.test(input);
+  const hasMobaBookmarkMetadata = /^SubRep=.*$/im.test(input) && /^ImgNum=\d+\s*$/im.test(input);
+  const hasMobaSessionLine = /^[^=\r\n]+=\s*(?:; logout)?\s*#\d+#\d+%[^%\r\n]+%\d+/im.test(input);
+  if (
+    /\[MobaXterm\]/i.test(input)
+    || (hasMobaBookmarkSection && (hasMobaBookmarkMetadata || hasMobaSessionLine))
+  ) {
     return "mobaxterm";
   }
 


### PR DESCRIPTION
## Summary

- Parse standard MobaXterm bookmark sections and their session field layout.
- Preserve session names, folders, hostnames, ports, and usernames during import.
- Ignore bookmark metadata and safely skip malformed or unsupported session records instead of creating false hosts.
- Keep compatibility with older path-based bookmark groups and tighten automatic format detection.

## Root cause

The importer split each MobaXterm entry on `#` and treated the first value resembling a connection target as the hostname. In standard exports, those early values are icon IDs such as `109` and `42`, while the actual SSH fields are stored in the following `%`-separated group. Numbered bookmark sections and `SubRep` folders were also ignored. This reproduces the reporter's exact result of 2 imported hosts and 39 duplicates from 40 sessions.

## User impact

Standard MobaXterm exports now import the actual SSH/SFTP hosts with their saved folder, port, and username. Corrupt or unsupported records are reported as skipped rather than silently creating unusable connections.

## Validation

- `node --test --import tsx domain/vaultImport.test.ts` (10 passed)
- `npm test` (4673 passed, 3 skipped, 0 failed)
- `npx eslint domain/vaultImport.ts domain/vaultImport.test.ts`
- `npm run build`
- Parsed a public real-world MobaXterm configuration: 10 imported, 0 skipped, 0 duplicates
- Four independent review rounds; both reviewers returned CLEAN in the final round

Fixes #2088
