### PR TITLE
fix(terminal): side panel tooltips avoid macOS traffic lights

### DIFF
--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -353,7 +353,8 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
                       {item.icon}
                     </Btn>
                   </TooltipTrigger>
-                  <TooltipContent>{item.label}</TooltipContent>
+                  {/* bottom: left-docked panel tooltips must not cover macOS traffic lights (#2095) */}
+                  <TooltipContent side="bottom">{item.label}</TooltipContent>
                 </Tooltip>
               );
             })}
@@ -370,7 +371,7 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
                   {sidePanelPosition === 'left' ? <PanelRight size={15} /> : <PanelLeft size={15} />}
                 </Btn>
               </TooltipTrigger>
-              <TooltipContent>
+              <TooltipContent side="bottom">
                 {sidePanelPosition === 'left' ? t('terminal.layer.movePanelRight') : t('terminal.layer.movePanelLeft')}
               </TooltipContent>
             </Tooltip>
@@ -386,7 +387,7 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
                   <X size={15} />
                 </Btn>
               </TooltipTrigger>
-              <TooltipContent>{t('terminal.layer.closePanel')}</TooltipContent>
+              <TooltipContent side="bottom">{t('terminal.layer.closePanel')}</TooltipContent>
             </Tooltip>
           </div>
         )}


### PR DESCRIPTION
## Summary
- When the terminal side panel is docked on the **left**, tab rail tooltips default to `side="top"` and render under the macOS traffic lights (red/yellow/green), making labels like “SFTP” unreadable.
- Force those tooltips to open **below** the tab bar (same pattern as host-tree toolbar buttons).

Fixes #2095

## Test plan
- [ ] On macOS, open a terminal session and dock the side panel on the **left**
- [ ] Hover the first few side-panel tabs (SFTP, Scripts, …) and confirm tooltips appear **below** the icons, fully readable and not covered by traffic lights
- [ ] Hover Move panel / Close panel buttons — same bottom placement
- [ ] Dock the panel on the **right** and confirm tooltips still look fine below the tab rail