### PR TITLE
Update Nix release metadata for v1.1.62

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.61";
+  version = "1.1.62";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-bCj+VfZQeaLbPWrJERItbpdKnMtXei8EnUmIm+BUKhI=";
+      hash = "sha256-EluROlFPZFPe2RVb4GODHHsuS0R4LlNcG5QksmCzHe0=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-DboC2DPmby+xjy6NoM2QO9+KyIIhOoJHyMYAJhqclNI=";
+      hash = "sha256-FgDLL1ycIDLp1CeV6qK/MyS/NyvzREUaRjQuoA+XFk8=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update nix/release.nix to v1.1.62
- use the AppImage hashes from the published v1.1.62 release assets

## Verification
- `node .github/scripts/update-nix-release.js --artifacts … --version 1.1.62`
- confirmed nix/release.nix contains the v1.1.62 version and expected SRI hashes

This mirrors the release workflow output; the workflow could not push directly because main requires changes through a pull request.