### PR TITLE
fix(sftp): opaque theme background over continuous terminal layer

### DIFF
--- a/components/SftpView.tsx
+++ b/components/SftpView.tsx
@@ -455,7 +455,7 @@ const SftpViewInner: React.FC<SftpViewProps> = ({
       <div
         ref={rootRef}
         className={cn(
-          "absolute inset-0 min-h-0 flex flex-col",
+          "absolute inset-0 min-h-0 flex flex-col bg-background",
           isActive ? "z-20" : "",
         )}
         style={containerStyle}


### PR DESCRIPTION
## Summary
- Add `bg-background` on the SFTP root surface so it fully covers the continuously rendered terminal layer underneath.
- Background still follows the active app theme.

## Why
After #2096, inactive terminal panes remain `visibility: visible` under non-terminal surfaces when hidden-tab hibernation is off. SFTP's root had no opaque fill, so terminal content leaked into the SFTP UI when switching tabs.

## Test plan
- [x] Open a terminal session with visible output
- [x] Switch to SFTP without hibernation enabled
- [x] Confirm terminal glyphs no longer show through the SFTP panels
- [ ] Spot-check light/dark themes still look correct on SFTP