### PR TITLE
Update Nix release metadata for v1.1.62

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -4,11 +4,11 @@
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-EluROlFPZFPe2RVb4GODHHsuS0R4LlNcG5QksmCzHe0=";
+      hash = "sha256-iHdsQJwA6dFWvGgxWaCt5rnPYydpIOXNr2PsqyWWFlY=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-FgDLL1ycIDLp1CeV6qK/MyS/NyvzREUaRjQuoA+XFk8=";
+      hash = "sha256-kyno1P82t1x6xU+T1iTBRYptTe1pv5jQkWsLXp+h0HQ=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- update nix/release.nix hashes for the re-published v1.1.62 AppImage assets
- version stays 1.1.62 (release was re-cut after #2101)

## Verification
- `node .github/scripts/update-nix-release.js --artifacts … --version 1.1.62`
- confirmed nix/release.nix contains v1.1.62 and new SRI hashes

Mirrors the release workflow output; bot cannot push to protected main.