### PR TITLE
fix(terminal): restore split geometry when viewMode is unset

### DIFF
--- a/components/terminalPaneVisibility.test.tsx
+++ b/components/terminalPaneVisibility.test.tsx
@@ -168,6 +168,39 @@ test("hidden focus workspaces keep the focused pane full-size and other panes sp
   }), false);
 });
 
+test("default and explicit split workspaces always use split layout geometry", () => {
+  // Drag-to-split workspaces omit viewMode (undefined means tiled split).
+  const defaultSplit: Workspace = {
+    ...createWorkspace("ws-default", ["d-1", "d-2"], { focusedSessionId: "d-1" }),
+    viewMode: undefined,
+  };
+  const explicitSplit = createWorkspace("ws-split", ["s-1", "s-2"], {
+    viewMode: "split",
+    focusedSessionId: "s-1",
+  });
+
+  for (const workspace of [defaultSplit, explicitSplit]) {
+    assert.equal(shouldUseTerminalPaneSplitLayout({
+      workspace,
+      sessionId: workspace.focusedSessionId ?? "x",
+      isVisible: true,
+      hibernateHiddenTabs: false,
+    }), true);
+    assert.equal(shouldUseTerminalPaneSplitLayout({
+      workspace,
+      sessionId: "other",
+      isVisible: false,
+      hibernateHiddenTabs: false,
+    }), true);
+    assert.equal(shouldUseTerminalPaneSplitLayout({
+      workspace,
+      sessionId: "other",
+      isVisible: false,
+      hibernateHiddenTabs: true,
+    }), true);
+  }
+});
+
 test("hidden terminal layers measure once only when hibernation is disabled", () => {
   assert.equal(shouldMeasureTerminalLayerLayout({
     isTerminalLayerVisible: false,

--- a/components/terminalPaneVisibility.ts
+++ b/components/terminalPaneVisibility.ts
@@ -38,10 +38,15 @@ export function shouldUseTerminalPaneSplitLayout({
   hibernateHiddenTabs: boolean;
 }): boolean {
   if (!workspace) return false;
-  if (workspace.viewMode === "split") return true;
-  return !isVisible
-    && !hibernateHiddenTabs
-    && workspace.focusedSessionId !== sessionId;
+  // Default viewMode is tiled split (including undefined from createWorkspaceFromSessions).
+  // Only focus mode uses a full-size focused pane; other panes keep split geometry while
+  // continuously rendered in the background.
+  if (workspace.viewMode === "focus") {
+    return !isVisible
+      && !hibernateHiddenTabs
+      && workspace.focusedSessionId !== sessionId;
+  }
+  return true;
 }
 
 export function shouldMeasureTerminalLayerLayout({


### PR DESCRIPTION
## Summary
- Fix `shouldUseTerminalPaneSplitLayout` so default/undefined `viewMode` uses tiled split geometry again.
- Only focus mode keeps the focused pane full-size and parks other panes at split rects for continuous rendering.

## Why
#2096 required `viewMode === "split"`. Drag-to-split workspaces created by `createWorkspaceFromSessions` omit `viewMode` (undefined means tiled split elsewhere in the app). Visible panes then used 100% full-size layout and stacked on top of each other.

Before #2096, layout used `paneState.mode === 'split'` from the visibility snapshot, which already treated non-focus workspaces as split.

## Test plan
- [x] Unit tests for undefined + explicit split + focus mode
- [ ] Drag one terminal onto another to create a side-by-side split; both panes tile correctly
- [ ] Toggle focus/split view still works
- [ ] Switch tabs with continuous rendering (hibernate off) still keeps background geometry