### PR TITLE
fix(terminal): restore workspace pane X to standalone tab

### DIFF
--- a/application/state/sessionWorkspaceDetach.test.ts
+++ b/application/state/sessionWorkspaceDetach.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { TerminalSession, Workspace } from "../../domain/models";
 import {
+  applyCloseSessionToSessions,
   closeSessionWorkspaceLayoutState,
   detachSessionFromWorkspaceState,
   replaceDissolvedWorkspaceTabOrder,
+  resolveActiveTabAfterCloseSession,
 } from "./sessionWorkspaceDetach";
 
 const session = (id: string, workspaceId = "ws-1"): TerminalSession => ({
@@ -119,5 +121,59 @@ test("closing a workspace session dissolves the workspace when one terminal rema
       result.lastRemainingSessionId ? [result.lastRemainingSessionId] : undefined,
     ),
     ["log-1", "s2", "session-3"],
+  );
+});
+
+test("closing one split pane keeps the other terminal as an orphan tab", () => {
+  const layoutResult = closeSessionWorkspaceLayoutState(
+    [workspace(["s1", "s2"])],
+    "ws-1",
+    "s1",
+  );
+  const nextSessions = applyCloseSessionToSessions(
+    [session("s1"), session("s2")],
+    "s1",
+    layoutResult,
+  );
+
+  assert.deepEqual(nextSessions.map((s) => [s.id, s.workspaceId]), [
+    ["s2", undefined],
+  ]);
+  assert.equal(
+    resolveActiveTabAfterCloseSession({
+      currentActiveTabId: "ws-1",
+      closedSessionId: "s1",
+      workspaceId: "ws-1",
+      layoutResult,
+      remainingSessions: nextSessions,
+    }),
+    "s2",
+  );
+});
+
+test("closing the last workspace session does not invent a surviving terminal", () => {
+  const layoutResult = closeSessionWorkspaceLayoutState(
+    [workspace(["s1"])],
+    "ws-1",
+    "s1",
+  );
+  const nextSessions = applyCloseSessionToSessions(
+    [session("s1")],
+    "s1",
+    layoutResult,
+  );
+
+  assert.deepEqual(nextSessions, []);
+  assert.equal(layoutResult.removedWorkspaceId, "ws-1");
+  assert.equal(layoutResult.lastRemainingSessionId, undefined);
+  assert.equal(
+    resolveActiveTabAfterCloseSession({
+      currentActiveTabId: "ws-1",
+      closedSessionId: "s1",
+      workspaceId: "ws-1",
+      layoutResult,
+      remainingSessions: nextSessions,
+    }),
+    "vault",
   );
 });

--- a/application/state/sessionWorkspaceDetach.ts
+++ b/application/state/sessionWorkspaceDetach.ts
@@ -101,6 +101,59 @@ export function closeSessionWorkspaceLayoutState(
   };
 }
 
+/**
+ * Apply a close-session action to the session list using the layout result.
+ * When a 2-pane workspace dissolves to one terminal, that remaining session
+ * must become an orphan tab — not stay bound to a deleted workspaceId.
+ */
+export function applyCloseSessionToSessions(
+  sessions: readonly TerminalSession[],
+  sessionId: string,
+  layoutResult: Pick<CloseSessionWorkspaceLayoutResult, "lastRemainingSessionId">,
+): TerminalSession[] {
+  const remaining = sessions.filter((session) => session.id !== sessionId);
+  const lastRemainingSessionId = layoutResult.lastRemainingSessionId;
+  if (!lastRemainingSessionId) return remaining;
+
+  return remaining.map((session) => (
+    session.id === lastRemainingSessionId
+      ? { ...session, workspaceId: undefined }
+      : session
+  ));
+}
+
+export function resolveActiveTabAfterCloseSession({
+  currentActiveTabId,
+  closedSessionId,
+  workspaceId,
+  layoutResult,
+  remainingSessions,
+}: {
+  currentActiveTabId: string | null;
+  closedSessionId: string;
+  workspaceId: string | undefined;
+  layoutResult: CloseSessionWorkspaceLayoutResult;
+  remainingSessions: readonly TerminalSession[];
+}): string | null {
+  const fallbackWorkspace = layoutResult.workspaces[layoutResult.workspaces.length - 1];
+  const fallbackSolo = remainingSessions.filter((session) => !session.workspaceId).slice(-1)[0];
+  const fallback = layoutResult.lastRemainingSessionId
+    ?? fallbackWorkspace?.id
+    ?? fallbackSolo?.id
+    ?? "vault";
+
+  if (
+    currentActiveTabId === closedSessionId
+    || (layoutResult.dissolvedWorkspaceId && currentActiveTabId === layoutResult.dissolvedWorkspaceId)
+    || (layoutResult.removedWorkspaceId && currentActiveTabId === layoutResult.removedWorkspaceId)
+    || (workspaceId && currentActiveTabId === workspaceId && !layoutResult.workspaces.some((ws) => ws.id === workspaceId))
+  ) {
+    return fallback;
+  }
+
+  return null;
+}
+
 export function detachSessionFromWorkspaceState({
   sessions,
   workspaces,

--- a/application/state/useSessionState.ts
+++ b/application/state/useSessionState.ts
@@ -11,7 +11,6 @@ createWorkspaceFromSessionIds,
 FocusDirection,
 getNextFocusSessionId,
 insertPaneIntoWorkspace,
-pruneWorkspaceNode,
 reorderWorkspaceFocusSessionOrder,
 SplitDirection,
 SplitHint,
@@ -21,9 +20,11 @@ import { clearSessionFontSizeOverride as clearSessionFontSizeOverrideFields } fr
 import { buildOrderedWorkTabIds, reorderWorkTabIds } from '../app/workTabSurface';
 import { activeTabStore } from './activeTabStore';
 import {
+  applyCloseSessionToSessions,
   closeSessionWorkspaceLayoutState,
   detachSessionFromWorkspaceState,
   replaceDissolvedWorkspaceTabOrder,
+  resolveActiveTabAfterCloseSession,
 } from './sessionWorkspaceDetach';
 import {
   createCopiedTerminalSessionClone,
@@ -390,85 +391,46 @@ export const useSessionState = ({
   const closeSession = useCallback((sessionId: string, e?: MouseEvent) => {
     e?.stopPropagation();
 
-    // Pre-compute outside the setSessions updater so we don't depend on React
-    // having run the updater by the time we queue the microtask. React 18+ does
-    // not guarantee updater execution timing under concurrent scheduling.
-    const sessionBeingClosed = sessions.find(s => s.id === sessionId);
-    const workspaceIdToMaybeClose =
-      sessionBeingClosed?.workspaceId &&
-      sessions.every(s => s.id === sessionId || s.workspaceId !== sessionBeingClosed.workspaceId)
-        ? sessionBeingClosed.workspaceId
-        : undefined;
+    // Compute layout from the latest refs so dissolve/remove cannot desync from
+    // a stale workspaces/sessions render snapshot. Empty workspaces are already
+    // removed by closeSessionWorkspaceLayoutState — do NOT follow up with
+    // closeWorkspace(), which would race and delete remaining terminals that
+    // still briefly carry the old workspaceId.
+    const targetSession = sessionsRef.current.find((session) => session.id === sessionId);
+    const wsId = targetSession?.workspaceId;
+    const layoutResult = closeSessionWorkspaceLayoutState(
+      workspacesRef.current,
+      wsId,
+      sessionId,
+    );
+    const nextSessions = applyCloseSessionToSessions(
+      sessionsRef.current,
+      sessionId,
+      layoutResult,
+    );
 
-    setSessions(prevSessions => {
-      const targetSession = prevSessions.find(s => s.id === sessionId);
-      const wsId = targetSession?.workspaceId;
+    setWorkspaces(layoutResult.workspaces);
+    setSessions(nextSessions);
 
-      setWorkspaces(prevWorkspaces => {
-        const {
-          workspaces: nextWorkspaces,
-          removedWorkspaceId,
-          dissolvedWorkspaceId,
-          lastRemainingSessionId,
-        } = closeSessionWorkspaceLayoutState(prevWorkspaces, wsId, sessionId);
-
-        const remainingSessions = prevSessions.filter(s => s.id !== sessionId);
-        const fallbackWorkspace = nextWorkspaces[nextWorkspaces.length - 1];
-        const fallbackSolo = remainingSessions.filter(s => !s.workspaceId).slice(-1)[0];
-
-        const currentActiveTabId = activeTabStore.getActiveTabId();
-        const getFallback = () => {
-          if (lastRemainingSessionId) return lastRemainingSessionId;
-          if (fallbackWorkspace) return fallbackWorkspace.id;
-          if (fallbackSolo) return fallbackSolo.id;
-          return 'vault';
-        };
-
-        if (dissolvedWorkspaceId && lastRemainingSessionId) {
-          setTabOrder(prevTabOrder => replaceDissolvedWorkspaceTabOrder(
-            prevTabOrder,
-            dissolvedWorkspaceId,
-            [lastRemainingSessionId],
-          ));
-        }
-
-        if (dissolvedWorkspaceId && currentActiveTabId === dissolvedWorkspaceId) {
-          setActiveTabId(getFallback());
-        } else if (currentActiveTabId === sessionId) {
-          setActiveTabId(getFallback());
-        } else if (removedWorkspaceId && currentActiveTabId === removedWorkspaceId) {
-          setActiveTabId(getFallback());
-        } else if (wsId && currentActiveTabId === wsId && !nextWorkspaces.find(w => w.id === wsId)) {
-          setActiveTabId(getFallback());
-        }
-
-        return nextWorkspaces;
-      });
-
-      // Check if we need to dissolve a workspace (convert remaining session to orphan)
-      if (targetSession?.workspaceId) {
-        const ws = workspaces.find(w => w.id === targetSession.workspaceId);
-        if (ws) {
-          const pruned = pruneWorkspaceNode(ws.root, sessionId);
-          if (pruned) {
-            const remainingSessionIds = collectSessionIds(pruned);
-            if (remainingSessionIds.length === 1) {
-              // Dissolve: remove workspaceId from the remaining session
-              return prevSessions
-                .filter(s => s.id !== sessionId)
-                .map(s => remainingSessionIds.includes(s.id) ? { ...s, workspaceId: undefined } : s);
-            }
-          }
-        }
-      }
-
-      return prevSessions.filter(s => s.id !== sessionId);
-    });
-
-    if (workspaceIdToMaybeClose) {
-      queueMicrotask(() => closeWorkspace(workspaceIdToMaybeClose!));
+    if (layoutResult.dissolvedWorkspaceId && layoutResult.lastRemainingSessionId) {
+      setTabOrder((prevTabOrder) => replaceDissolvedWorkspaceTabOrder(
+        prevTabOrder,
+        layoutResult.dissolvedWorkspaceId,
+        [layoutResult.lastRemainingSessionId!],
+      ));
     }
-  }, [sessions, workspaces, setActiveTabId, closeWorkspace]);
+
+    const nextActiveTabId = resolveActiveTabAfterCloseSession({
+      currentActiveTabId: activeTabStore.getActiveTabId(),
+      closedSessionId: sessionId,
+      workspaceId: wsId,
+      layoutResult,
+      remainingSessions: nextSessions,
+    });
+    if (nextActiveTabId) {
+      setActiveTabId(nextActiveTabId);
+    }
+  }, [setActiveTabId]);
 
   const startSessionRename = useCallback((sessionId: string) => {
     setSessions(prevSessions => {
@@ -701,23 +663,38 @@ export const useSessionState = ({
   ) => {
     if (!hint || baseSessionId === joiningSessionId) return;
     const newWorkspace = createWorkspaceEntity(baseSessionId, joiningSessionId, hint);
-    
-	    setSessions(prevSessions => {
-      const base = prevSessions.find(s => s.id === baseSessionId);
-      const joining = prevSessions.find(s => s.id === joiningSessionId);
+
+    setSessions((prevSessions) => {
+      const base = prevSessions.find((s) => s.id === baseSessionId);
+      const joining = prevSessions.find((s) => s.id === joiningSessionId);
       if (!base || !joining || base.workspaceId || joining.workspaceId) return prevSessions;
 
-      setWorkspaces(prev => addWorkspaceIfMissing(prev, newWorkspace));
+      setWorkspaces((prev) => addWorkspaceIfMissing(prev, newWorkspace));
+      // Collapse the two session tab slots into the workspace tab so later
+      // detach/close can replace `ws-*` with session ids again.
+      setTabOrder((prevTabOrder) => {
+        const withoutSessions = prevTabOrder.filter(
+          (id) => id !== baseSessionId && id !== joiningSessionId,
+        );
+        if (withoutSessions.includes(newWorkspace.id)) return withoutSessions;
+        const indexes = [baseSessionId, joiningSessionId]
+          .map((id) => prevTabOrder.indexOf(id))
+          .filter((index) => index >= 0);
+        const insertAt = indexes.length > 0 ? Math.min(...indexes) : withoutSessions.length;
+        const next = [...withoutSessions];
+        next.splice(Math.min(insertAt, next.length), 0, newWorkspace.id);
+        return next;
+      });
       setActiveTabId(newWorkspace.id);
-      
-      return prevSessions.map(s => {
+
+      return prevSessions.map((s) => {
         if (s.id === baseSessionId || s.id === joiningSessionId) {
           return { ...s, workspaceId: newWorkspace.id };
         }
         return s;
       });
-	    });
-	  }, [setActiveTabId]);
+    });
+  }, [setActiveTabId]);
 
   const addSessionToWorkspace = useCallback((
     workspaceId: string,
@@ -1139,40 +1116,41 @@ export const useSessionState = ({
       additionalTabIds?: readonly string[];
     },
   ) => {
-    setSessions(prevSessions => {
-      const result = detachSessionFromWorkspaceState({
-        sessions: prevSessions,
-        workspaces: workspacesRef.current,
-        sessionId,
-      });
-
-      if (!result.changed) return prevSessions;
-      setWorkspaces(result.workspaces);
-      setTabOrder(prevTabOrder => {
-        const replacedOrder = replaceDissolvedWorkspaceTabOrder(
-          prevTabOrder,
-          result.dissolvedWorkspaceId,
-          result.replacementTabIds,
-        );
-        if (!tabInsertionTarget) return replacedOrder;
-
-        const allTabIds = [
-          ...result.sessions.filter(s => !s.workspaceId).map(s => s.id),
-          ...result.workspaces.map(w => w.id),
-          ...logViews.map(lv => lv.id),
-          ...(tabInsertionTarget.additionalTabIds ?? []),
-        ];
-        return reorderWorkTabIds(
-          replacedOrder,
-          allTabIds,
-          sessionId,
-          tabInsertionTarget.tabId,
-          tabInsertionTarget.position,
-        );
-      });
-      if (result.activeTabId) setActiveTabId(result.activeTabId);
-      return result.sessions;
+    // Detach from latest refs so continuous-render / memoized panes cannot
+    // act on a stale workspace snapshot and drop the terminal instead of
+    // restoring it as a standalone tab.
+    const result = detachSessionFromWorkspaceState({
+      sessions: sessionsRef.current,
+      workspaces: workspacesRef.current,
+      sessionId,
     });
+    if (!result.changed) return;
+
+    setWorkspaces(result.workspaces);
+    setSessions(result.sessions);
+    setTabOrder((prevTabOrder) => {
+      const replacedOrder = replaceDissolvedWorkspaceTabOrder(
+        prevTabOrder,
+        result.dissolvedWorkspaceId,
+        result.replacementTabIds,
+      );
+      if (!tabInsertionTarget) return replacedOrder;
+
+      const allTabIds = [
+        ...result.sessions.filter((s) => !s.workspaceId).map((s) => s.id),
+        ...result.workspaces.map((w) => w.id),
+        ...logViews.map((lv) => lv.id),
+        ...(tabInsertionTarget.additionalTabIds ?? []),
+      ];
+      return reorderWorkTabIds(
+        replacedOrder,
+        allTabIds,
+        sessionId,
+        tabInsertionTarget.tabId,
+        tabInsertionTarget.position,
+      );
+    });
+    if (result.activeTabId) setActiveTabId(result.activeTabId);
   }, [logViews, setActiveTabId]);
 
   const reorderTabs = useCallback((

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2472,7 +2472,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }) ? () => setOsc7SetupOpen(true) : undefined}
       onUpdateHost={handleUpdateHostFromTerminal}
       showClose={opts?.showClose}
-      onClose={() => onCloseSession?.(sessionId)}
+      // In a workspace, the toolbar X means "return this pane to its own tab"
+      // (detach), not destroy the session. Context-menu Close still kills it.
+      onClose={() => {
+        if (inWorkspace && onDetach) {
+          onDetach();
+          return;
+        }
+        onCloseSession?.(sessionId);
+      }}
+      closeRestoresTab={Boolean(inWorkspace && onDetach)}
       isSearchOpen={isSearchOpen}
       onToggleSearch={handleToggleSearch}
       showLogButton
@@ -2519,6 +2528,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isSessionLogging,
     isWorkspaceComposeBarOpen,
     onCloseSession,
+    onDetach,
     onOpenScripts,
     onOpenHistory,
     onOpenTheme,

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -31,6 +31,8 @@ export interface TerminalToolbarProps {
     onUpdateHost?: (host: Host) => void;
     showClose?: boolean;
     onClose?: () => void;
+    /** When true, close is "return pane to its own tab" rather than kill the session. */
+    closeRestoresTab?: boolean;
     // Search functionality
     isSearchOpen?: boolean;
     onToggleSearch?: () => void;
@@ -66,6 +68,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     onUpdateHost,
     showClose,
     onClose,
+    closeRestoresTab = false,
     isSearchOpen,
     onToggleSearch,
     showLogButton = false,
@@ -482,7 +485,11 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <X size={11} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{t("terminal.toolbar.closeSession")}</TooltipContent>
+                    <TooltipContent>
+                        {closeRestoresTab
+                            ? t("terminal.toolbar.detach")
+                            : t("terminal.toolbar.closeSession")}
+                    </TooltipContent>
                 </Tooltip>
             )}
         </TooltipProvider>


### PR DESCRIPTION
## Summary
- Workspace toolbar **X** now **detaches** the pane back to its own tab (does not destroy the session). Context-menu Close still kills the session.
- Harden `closeSession` / `removeSessionFromWorkspace` so dissolve/detach cannot desync and drop terminals.
- When drag-to-split creates a workspace, collapse the two session tab slots into the workspace id in `tabOrder`.

## Why
After continuous-render / split fixes, clicking X inside a workspace made the terminal vanish instead of returning as a top-level tab. Expected behavior is “move out of workspace,” same as detach.

## Test plan
- [x] Unit tests for dissolve/detach helpers
- [ ] Drag two terminals into a workspace, click X on one pane → that session reappears as a tab
- [ ] Remaining session becomes its own tab when only one remains
- [ ] Context-menu Close still ends the session
- [ ] SFTP / split layout regressions from earlier fixes still OK