### PR TITLE
fix Mosh shortcuts, highlighting, and scrollback

### DIFF
--- a/docs/designs/native-mosh-client.md
+++ b/docs/designs/native-mosh-client.md
@@ -49,6 +49,12 @@ Enforced upstream from `moshcatty-0.1.2` via MoshCatty release CI
 (`scripts/assert-max-glibc.sh`). Do not pin packaging to pre-0.1.2 Linux
 assets (they require GLIBC 2.34).
 
+## Windows compatibility floor
+
+Netcatty requires `moshcatty-0.1.4+`. That release preserves arrow keys,
+Ctrl/Alt-modified shortcuts, and Ctrl+C through Windows ConPTY. Packaging must
+not resolve or accept an older MoshCatty release.
+
 ## Decision log
 
 - **2026-07-10:** Feasibility accepted; client extracted to `binaricat/MoshCatty`.
@@ -58,3 +64,6 @@ assets (they require GLIBC 2.34).
   (`moshcatty-0.1.1`: ConPTY Ctrl+C + static MSVC CRT).
 - **2026-07-10:** Require `moshcatty-0.1.2+` for Linux glibc floors matching
   Netcatty (x64 ≤ 2.28, arm64 ≤ 2.31).
+- **2026-07-11:** Require `moshcatty-0.1.4+` for Windows ConPTY shortcut input;
+  keep Mosh sessions on Netcatty's primary terminal screen so highlighting and
+  scrollback remain available.

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -393,6 +393,30 @@ test("startMoshSession keeps MoshCatty on Netcatty's primary terminal screen", a
   assert.equal(h.spawns[1].opts.env.MOSH_NO_TERM_INIT, "1");
 });
 
+test("startMoshSession restores terminal modes on exit without leaving the primary screen", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+  h.spawns[1].emitData("\x1b[?25l\x1b[?1000h");
+  h.spawns[1].emitExit({ exitCode: 1, signal: 0 });
+
+  const terminalData = h.sent
+    .filter((evt) => evt.channel === "netcatty:data")
+    .map((evt) => evt.payload.data)
+    .join("");
+  const exitIndex = h.sent.findIndex((evt) => evt.channel === "netcatty:exit");
+  const cleanupIndex = h.sent.findIndex(
+    (evt) => evt.channel === "netcatty:data" && evt.payload.data.includes("\x1b[?25h"),
+  );
+
+  assert.match(terminalData, /\x1b\[\?25h/);
+  assert.match(terminalData, /\x1b\[\?1000l/);
+  assert.doesNotMatch(terminalData, /\x1b\[\?1049l/);
+  assert.ok(cleanupIndex >= 0 && cleanupIndex < exitIndex);
+});
+
 test("startMoshSession forwards terminal shortcut escape sequences after the client swap", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -382,6 +382,43 @@ test("startMoshSession handshake path sends the existing exit event after mosh-c
   assert.equal(exit.payload.reason, "exited");
 });
 
+test("startMoshSession keeps MoshCatty on Netcatty's primary terminal screen", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+
+  assert.equal(h.spawns.length, 2);
+  assert.equal(h.spawns[1].opts.env.MOSH_NO_TERM_INIT, "1");
+});
+
+test("startMoshSession forwards terminal shortcut escape sequences after the client swap", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+
+  const shortcuts = [
+    "\x1b[A",
+    "\x1b[B",
+    "\x1b[C",
+    "\x1b[D",
+    "\x1b[1;5A",
+    "\x1b[1;5B",
+    "\x1b[1;5C",
+    "\x1b[1;5D",
+    "\x1b.",
+  ];
+  for (const data of shortcuts) {
+    h.bridge.writeToSession(h.event, { sessionId: h.options.sessionId, data });
+  }
+
+  assert.deepEqual(h.spawns[1].writes, shortcuts);
+  assert.deepEqual(h.spawns[0].writes, []);
+});
+
 test("startMoshSession stashes stats-companion auth after a successful handshake", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -7,6 +7,13 @@ const {
 } = require("../terminalFlowAck.cjs");
 const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 
+// MoshCatty normally emits this cleanup together with an alternate-screen
+// exit. Netcatty keeps the primary screen, so restore only terminal modes that
+// can leak from a full-screen remote program and leave scrollback untouched.
+const MOSH_PRIMARY_SCREEN_RESET = "\x1b[?1l\x1b[0m\x1b[?25h"
+  + "\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l"
+  + "\x1b[?1015l\x1b[?1006l\x1b[?1005l";
+
 function withShellProbeTimeout(promise, timeoutMs) {
   const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 3000;
   let timer = null;
@@ -584,6 +591,7 @@ function createMoshSessionApi(ctx) {
         // #1198) if one was opened — it lives on moshStatsConn and outlives
         // the mosh-client PTY otherwise.
         try { session.moshStatsConn?.end(); } catch { /* ignore */ }
+        bufferData(MOSH_PRIMARY_SCREEN_RESET);
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, session.logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -472,6 +472,10 @@ function createMoshSessionApi(ctx) {
         key: parsed.key,
         lang,
       });
+      // Netcatty owns the terminal buffer. Keeping MoshCatty on the primary
+      // screen preserves scrollback and lets renderer features such as keyword
+      // highlighting keep observing the active buffer.
+      env.MOSH_NO_TERM_INIT = "1";
       addBundledMoshRuntimeEnv(env, bareClient);
       if (options.agentForwarding && process.env.SSH_AUTH_SOCK) {
         env.SSH_AUTH_SOCK = process.env.SSH_AUTH_SOCK;

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -18,7 +18,7 @@ Netcatty runs SSH + `mosh-server` bootstrap itself, then launches this binary
 Each tarball contains **only** the client binary (no Cygwin DLLs, no terminfo).
 Windows builds static-link the MSVC CRT (`moshcatty-0.1.1+`).
 
-Release tags: `moshcatty-*` (prefer `moshcatty-0.1.2+`) from
+Release tags: `moshcatty-*` (require `moshcatty-0.1.4+`) from
 `binaricat/MoshCatty`, with `SHA256SUMS`.
 
 ### Linux glibc floors
@@ -37,8 +37,8 @@ were built on Ubuntu runners and require GLIBC 2.34.
 ## Fetch
 
 ```sh
-# Optional pin (prefer 0.1.2+ for Linux glibc floors)
-export MOSH_BIN_RELEASE=moshcatty-0.1.2
+# Optional pin (0.1.4+ includes the Windows shortcut-input fix)
+export MOSH_BIN_RELEASE=moshcatty-0.1.4
 npm run fetch:mosh
 
 # Dev: host platform; resolves latest moshcatty-* if unset

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -313,10 +313,10 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     release = await resolveMoshBinRelease(env);
   }
   if (!release) {
-    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.2) to bundle mosh-client into the package.");
+    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.4) to bundle mosh-client into the package.");
     return 0;
   }
-  // Reject pre-0.1.2 pins (Linux GLIBC 2.34) even when MOSH_BIN_RELEASE is set
+  // Reject pre-0.1.4 pins (missing the Windows ConPTY shortcut-input fix) even when MOSH_BIN_RELEASE is set
   // without going through --resolve-release.
   release = validateReleaseTag(release);
 

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -138,7 +138,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
     {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -148,6 +148,24 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
   );
 
   assert.match(stderr, /No bundled mosh-client target for win32-arm64/);
+  assert.equal(fs.existsSync(resDir), false);
+});
+
+test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.4", async (t) => {
+  const resDir = path.join(makeTmp(t), "resources", "mosh");
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
+      env: {
+        ...process.env,
+        MOSH_BIN_RELEASE: "moshcatty-0.1.3",
+        MOSH_BIN_RES_DIR: resDir,
+        CI: "true",
+      },
+      stdio: "pipe",
+    }),
+    /below minimum moshcatty-0\.1\.4/,
+  );
   assert.equal(fs.existsSync(resDir), false);
 });
 
@@ -164,7 +182,7 @@ test("fetch-mosh-binaries unpacks pure Windows MoshCatty tarball", async (t) => 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -195,7 +213,7 @@ test("fetch-mosh-binaries strips accidental dll/terminfo from Windows tarball", 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -221,7 +239,7 @@ test("fetch-mosh-binaries unpacks pure Linux MoshCatty tarball", async (t) => {
   await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -247,7 +265,7 @@ test("fetch-mosh-binaries rejects tarball without mosh-client", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -270,7 +288,7 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the asset", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -298,7 +316,7 @@ test("fetch-mosh-binaries rejects symlinks inside tarballs", { skip: process.pla
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -14,10 +14,11 @@ const fs = require("node:fs");
 const https = require("node:https");
 
 // MoshCatty pure-Rust releases only.
-// Minimum 0.1.2: earlier Linux builds linked GLIBC 2.34 (above Netcatty floors).
+// Minimum 0.1.4: includes the Windows ConPTY shortcut-input fix. Linux builds
+// have matched Netcatty's GLIBC floors since 0.1.2.
 // Allow semver prerelease (-rc1) and build metadata (+meta); no path separators.
 const TAG_RE = /^moshcatty-[A-Za-z0-9._+-]+$/;
-const MIN_VERSION = { major: 0, minor: 1, patch: 2 };
+const MIN_VERSION = { major: 0, minor: 1, patch: 4 };
 const MIN_TAG = `moshcatty-${MIN_VERSION.major}.${MIN_VERSION.minor}.${MIN_VERSION.patch}`;
 
 function log(msg) {
@@ -37,7 +38,7 @@ function parseMoshCattyVersion(tag) {
     major: Number(match[1]),
     minor: Number(match[2]),
     patch: Number(match[3]),
-    // Present when tag is e.g. moshcatty-0.1.2-rc1 (semver: prerelease < final).
+    // Present when tag is e.g. moshcatty-0.1.4-rc1 (semver: prerelease < final).
     prerelease: match[4] || null,
   };
 }
@@ -70,8 +71,8 @@ function validateReleaseTag(tag) {
   if (!isAtLeastMinRelease(value)) {
     throw new Error(
       `mosh binary release ${value} is below minimum ${MIN_TAG} `
-        + "(Linux glibc floors: x64 ≤ 2.28, arm64 ≤ 2.31; 0.1.0/0.1.1 require GLIBC 2.34; "
-        + "prereleases of the floor e.g. 0.1.2-rc1 are not accepted)",
+        + "(0.1.4 includes the Windows ConPTY shortcut-input fix; "
+        + "prereleases of the floor e.g. 0.1.4-rc1 are not accepted)",
     );
   }
   return value;

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -22,28 +22,30 @@ function makeTmp(t) {
 }
 
 test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
-  assert.equal(validateReleaseTag("moshcatty-0.1.2"), "moshcatty-0.1.2");
+  assert.equal(validateReleaseTag("moshcatty-0.1.4"), "moshcatty-0.1.4");
   assert.equal(validateReleaseTag("moshcatty-0.2.0"), "moshcatty-0.2.0");
-  assert.equal(validateReleaseTag("moshcatty-0.1.3-rc1"), "moshcatty-0.1.3-rc1");
-  assert.equal(validateReleaseTag("moshcatty-0.1.2+build.1"), "moshcatty-0.1.2+build.1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.5-rc1"), "moshcatty-0.1.5-rc1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.4+build.1"), "moshcatty-0.1.4+build.1");
   assert.throws(() => validateReleaseTag("mosh-bin-1.4.0-1"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("v1.2.3"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-../bad"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-not-a-version"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.0"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.1"), /below minimum/);
-  assert.throws(() => validateReleaseTag("moshcatty-0.1.2-rc1"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.2"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.3"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.4-rc1"), /below minimum/);
 });
 
-test("isAtLeastMinRelease enforces moshcatty-0.1.2 floor with semver prerelease rules", () => {
-  assert.equal(MIN_TAG, "moshcatty-0.1.2");
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.1"), false);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.2"), true);
+test("isAtLeastMinRelease enforces moshcatty-0.1.4 floor with semver prerelease rules", () => {
+  assert.equal(MIN_TAG, "moshcatty-0.1.4");
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.3"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4"), true);
   // Prerelease of the floor sorts below the final floor release.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.2-rc1"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4-rc1"), false);
   // Above the floor, prereleases are fine.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.3-rc1"), true);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.2+build.1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5-rc1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4+build.1"), true);
   assert.equal(isAtLeastMinRelease("moshcatty-not-a-version"), false);
 });
 
@@ -59,17 +61,17 @@ test("parseRepository defaults to binaricat/MoshCatty (ignores GITHUB_REPOSITORY
   );
 });
 
-test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.2 tags", () => {
+test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.4 tags", () => {
   const got = pickLatestMoshBinRelease([
     { tag_name: "v1.0.0", published_at: "2026-03-01T00:00:00Z" },
     { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-06-01T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.2", draft: true, published_at: "2026-07-11T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.0", published_at: "2026-05-01T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.1", published_at: "2026-07-10T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T12:00:00Z" },
+    { tag_name: "moshcatty-0.1.4", draft: true, published_at: "2026-07-11T00:00:00Z" },
+    { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
+    { tag_name: "moshcatty-0.1.3", published_at: "2026-07-10T12:00:00Z" },
+    { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T13:00:00Z" },
   ]);
 
-  assert.equal(got, "moshcatty-0.1.2");
+  assert.equal(got, "moshcatty-0.1.4");
 });
 
 test("parseNextLink reads the next GitHub pagination URL", () => {
@@ -92,7 +94,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     requested.push(url);
     if (url.includes("page=2")) {
       return {
-        json: [{ tag_name: "moshcatty-0.1.2", published_at: "2026-01-01T00:00:00Z" }],
+        json: [{ tag_name: "moshcatty-0.1.4", published_at: "2026-01-01T00:00:00Z" }],
         headers: {},
       };
     }
@@ -104,7 +106,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     };
   });
 
-  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.2"]);
+  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.4"]);
   assert.equal(requested.length, 2);
 });
 
@@ -122,17 +124,17 @@ test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {
   const githubEnv = path.join(makeTmp(t), "github-env");
 
   const got = await main({
-    MOSH_BIN_RELEASE: "moshcatty-0.1.2",
+    MOSH_BIN_RELEASE: "moshcatty-0.1.4",
     GITHUB_ENV: githubEnv,
   });
 
-  assert.equal(got, "moshcatty-0.1.2");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.2\n");
+  assert.equal(got, "moshcatty-0.1.4");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.4\n");
 });
 
-test("main rejects explicit pre-0.1.2 MOSH_BIN_RELEASE", async () => {
+test("main rejects explicit pre-0.1.4 MOSH_BIN_RELEASE", async () => {
   await assert.rejects(
-    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.1" }),
+    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.3" }),
     /below minimum/,
   );
 });
@@ -143,14 +145,15 @@ test("main resolves the latest moshcatty release from the list and exports it", 
     GITHUB_ENV: githubEnv,
     MOSH_BIN_RELEASES_JSON: JSON.stringify([
       { tag_name: "moshcatty-0.1.0", published_at: "2026-01-01T00:00:00Z" },
-      { tag_name: "moshcatty-0.1.1", published_at: "2026-07-10T00:00:00Z" },
-      { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T12:00:00Z" },
+      { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
+      { tag_name: "moshcatty-0.1.3", published_at: "2026-07-10T12:00:00Z" },
+      { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T13:00:00Z" },
       { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-08-01T00:00:00Z" },
     ]),
   });
 
-  assert.equal(got, "moshcatty-0.1.2");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.2\n");
+  assert.equal(got, "moshcatty-0.1.4");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.4\n");
 });
 
 test("main fails when no usable moshcatty release exists", async () => {
@@ -159,8 +162,8 @@ test("main fails when no usable moshcatty release exists", async () => {
       MOSH_BIN_RELEASES_JSON: JSON.stringify([
         { tag_name: "v1.0.0", published_at: "2026-01-01T00:00:00Z" },
         { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.1", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.2", draft: true, published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.3", published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.4", draft: true, published_at: "2026-02-01T00:00:00Z" },
       ]),
     }),
     /could not find/,


### PR DESCRIPTION
## What changed

- keep Mosh sessions on Netcatty's primary terminal screen so keyword highlighting and scrollback remain available
- restore cursor, mouse, and styling modes whenever Mosh exits without discarding primary-screen scrollback
- forward terminal shortcut sequences unchanged after the SSH-to-Mosh client swap
- require MoshCatty 0.1.4 or newer so Windows packages include the ConPTY shortcut-input fix
- update packaging tests and integration documentation

## Cross-repository dependency

This PR consumes the published MoshCatty 0.1.4 release from:
- https://github.com/binaricat/MoshCatty/pull/3
- https://github.com/binaricat/MoshCatty/releases/tag/moshcatty-0.1.4

## Validation

- downloaded and checksum-verified the real MoshCatty 0.1.4 macOS universal asset
- launched the downloaded `mosh-client --help`
- `npm test`: 4,693 passed, 3 skipped, 0 failed
- `npm run lint`
- `npm run build`
- focused Mosh session and packaging tests: 42 passed
- two independent local Codex review passes: clean
- GitHub checks: passed

Fixes #2104
Fixes #2105
