### PR TITLE
Update Nix release metadata for v1.1.63

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.62";
+  version = "1.1.63";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-iHdsQJwA6dFWvGgxWaCt5rnPYydpIOXNr2PsqyWWFlY=";
+      hash = "sha256-IGvi4/57VddiZJSQa4HJz0PC8tKU3bQbQk7MXpVua+E=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-kyno1P82t1x6xU+T1iTBRYptTe1pv5jQkWsLXp+h0HQ=";
+      hash = "sha256-gnLIvXISnWbPyPKNZCp8veevoh9Gn5Ec/uULzsc0ivM=";
     };
   };
 }


### PR DESCRIPTION
## What changed

- update Nix release metadata to v1.1.63
- use the published x64 and ARM64 AppImage hashes

## Why

The v1.1.63 release job generated this update successfully, but the automatic direct push was rejected because `main` is protected and requires a pull request.

## Validation

- Nix metadata test passed
- both hashes match the SHA-256 digests on the published v1.1.63 AppImage assets
