### PR TITLE
Fix silent SFTP copy when destination pane is unavailable

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -186,6 +186,7 @@ export const enVaultMessages: Messages = {
   'sftp.moveTo.pathNotFound': 'Directory not found or inaccessible',
   'sftp.context.download': 'Download',
   'sftp.context.copyToOtherPane': 'Copy to other pane',
+  'sftp.copyToOtherPane.unavailable': 'Open the two-pane SFTP view and connect the destination pane before copying files.',
   'sftp.copyCurrentPath': 'Copy current path',
   'sftp.copyCurrentPath.success': 'Current path copied',
   'sftp.copyCurrentPath.error': 'Could not copy current path',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -221,6 +221,7 @@ export const ruVaultMessages: Messages = {
   'sftp.moveTo.pathNotFound': 'Каталог не найден или недоступен',
   'sftp.context.download': 'Скачать',
   'sftp.context.copyToOtherPane': 'Копировать в другую панель',
+  'sftp.copyToOtherPane.unavailable': 'Откройте двухпанельный режим SFTP и подключите панель назначения перед копированием файлов.',
   'sftp.copyCurrentPath': 'Копировать текущий путь',
   'sftp.copyCurrentPath.success': 'Текущий путь скопирован',
   'sftp.copyCurrentPath.error': 'Не удалось скопировать текущий путь',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -642,6 +642,7 @@ export const zhCNCoreMessages: Messages = {
   'sftp.moveTo.pathNotFound': '目录不存在或无法访问',
   'sftp.context.download': '下载',
   'sftp.context.copyToOtherPane': '复制到另一侧',
+  'sftp.copyToOtherPane.unavailable': '请打开双栏 SFTP 文件管理，并连接目标侧后再复制文件。',
   'sftp.copyCurrentPath': '复制当前路径',
   'sftp.copyCurrentPath.success': '已复制当前路径',
   'sftp.copyCurrentPath.error': '无法复制当前路径',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -642,6 +642,7 @@ export const zhTWCoreMessages: Messages = {
   'sftp.moveTo.pathNotFound': '目錄不存在或無法存取',
   'sftp.context.download': '下載',
   'sftp.context.copyToOtherPane': '複製到另一側',
+  'sftp.copyToOtherPane.unavailable': '請開啟雙欄 SFTP 檔案管理，並連線目標側後再複製檔案。',
   'sftp.copyCurrentPath': '複製目前路徑',
   'sftp.copyCurrentPath.success': '已複製目前路徑',
   'sftp.copyCurrentPath.error': '無法複製目前路徑',

--- a/components/sftp/copyToOtherPane.test.ts
+++ b/components/sftp/copyToOtherPane.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canCopyToOtherPane,
+  requireCopyToOtherPaneTarget,
+  type SftpPaneSide,
+} from "./copyToOtherPane";
+
+test("copy to other pane is unavailable when the destination pane is missing or disconnected", () => {
+  assert.equal(canCopyToOtherPane({ getActivePane: () => null }, "right"), false);
+  assert.equal(canCopyToOtherPane({ getActivePane: () => ({}) }, "right"), false);
+});
+
+test("copy to other pane is available when the requested destination is connected", () => {
+  const requestedSides: SftpPaneSide[] = [];
+  const state = {
+    getActivePane: (side: SftpPaneSide) => {
+      requestedSides.push(side);
+      return { connection: { id: "destination" } };
+    },
+  };
+
+  assert.equal(canCopyToOtherPane(state, "left"), true);
+  assert.deepEqual(requestedSides, ["left"]);
+});
+
+test("copy to other pane reports why it cannot start instead of silently returning", () => {
+  let unavailableCount = 0;
+  const disconnectedState = { getActivePane: () => ({}) };
+  const connectedState = { getActivePane: () => ({ connection: { id: "destination" } }) };
+
+  assert.equal(
+    requireCopyToOtherPaneTarget(disconnectedState, "right", () => { unavailableCount += 1; }),
+    false,
+  );
+  assert.equal(unavailableCount, 1);
+
+  assert.equal(
+    requireCopyToOtherPaneTarget(connectedState, "right", () => { unavailableCount += 1; }),
+    true,
+  );
+  assert.equal(unavailableCount, 1);
+});

--- a/components/sftp/copyToOtherPane.test.ts
+++ b/components/sftp/copyToOtherPane.test.ts
@@ -20,6 +20,18 @@ test("copy to other pane is unavailable until the destination connection is read
   }
 });
 
+test("copy to other pane is unavailable while the destination is reconnecting", () => {
+  assert.equal(
+    canCopyToOtherPane({
+      getActivePane: () => ({
+        connection: { status: "connected" },
+        reconnecting: true,
+      }),
+    }, "right"),
+    false,
+  );
+});
+
 test("copy to other pane is available when the requested destination is connected", () => {
   const requestedSides: SftpPaneSide[] = [];
   const state = {

--- a/components/sftp/copyToOtherPane.test.ts
+++ b/components/sftp/copyToOtherPane.test.ts
@@ -6,9 +6,18 @@ import {
   type SftpPaneSide,
 } from "./copyToOtherPane";
 
-test("copy to other pane is unavailable when the destination pane is missing or disconnected", () => {
+test("copy to other pane is unavailable when the destination pane is missing", () => {
   assert.equal(canCopyToOtherPane({ getActivePane: () => null }, "right"), false);
   assert.equal(canCopyToOtherPane({ getActivePane: () => ({}) }, "right"), false);
+});
+
+test("copy to other pane is unavailable until the destination connection is ready", () => {
+  for (const status of ["connecting", "disconnected", "error"] as const) {
+    assert.equal(
+      canCopyToOtherPane({ getActivePane: () => ({ connection: { status } }) }, "right"),
+      false,
+    );
+  }
 });
 
 test("copy to other pane is available when the requested destination is connected", () => {
@@ -16,7 +25,7 @@ test("copy to other pane is available when the requested destination is connecte
   const state = {
     getActivePane: (side: SftpPaneSide) => {
       requestedSides.push(side);
-      return { connection: { id: "destination" } };
+      return { connection: { status: "connected" as const } };
     },
   };
 
@@ -27,7 +36,7 @@ test("copy to other pane is available when the requested destination is connecte
 test("copy to other pane reports why it cannot start instead of silently returning", () => {
   let unavailableCount = 0;
   const disconnectedState = { getActivePane: () => ({}) };
-  const connectedState = { getActivePane: () => ({ connection: { id: "destination" } }) };
+  const connectedState = { getActivePane: () => ({ connection: { status: "connected" as const } }) };
 
   assert.equal(
     requireCopyToOtherPaneTarget(disconnectedState, "right", () => { unavailableCount += 1; }),

--- a/components/sftp/copyToOtherPane.ts
+++ b/components/sftp/copyToOtherPane.ts
@@ -1,0 +1,20 @@
+export type SftpPaneSide = "left" | "right";
+
+type CopyTargetState = {
+  getActivePane: (side: SftpPaneSide) => { connection?: unknown } | null | undefined;
+};
+
+export const canCopyToOtherPane = (
+  state: CopyTargetState,
+  targetSide: SftpPaneSide,
+): boolean => Boolean(state.getActivePane(targetSide)?.connection);
+
+export const requireCopyToOtherPaneTarget = (
+  state: CopyTargetState,
+  targetSide: SftpPaneSide,
+  onUnavailable: () => void,
+): boolean => {
+  if (canCopyToOtherPane(state, targetSide)) return true;
+  onUnavailable();
+  return false;
+};

--- a/components/sftp/copyToOtherPane.ts
+++ b/components/sftp/copyToOtherPane.ts
@@ -3,13 +3,17 @@ export type SftpPaneSide = "left" | "right";
 type CopyTargetState = {
   getActivePane: (side: SftpPaneSide) => {
     connection?: { status?: "connecting" | "connected" | "disconnected" | "error" } | null;
+    reconnecting?: boolean;
   } | null | undefined;
 };
 
 export const canCopyToOtherPane = (
   state: CopyTargetState,
   targetSide: SftpPaneSide,
-): boolean => state.getActivePane(targetSide)?.connection?.status === "connected";
+): boolean => {
+  const targetPane = state.getActivePane(targetSide);
+  return targetPane?.connection?.status === "connected" && targetPane.reconnecting !== true;
+};
 
 export const requireCopyToOtherPaneTarget = (
   state: CopyTargetState,

--- a/components/sftp/copyToOtherPane.ts
+++ b/components/sftp/copyToOtherPane.ts
@@ -1,13 +1,15 @@
 export type SftpPaneSide = "left" | "right";
 
 type CopyTargetState = {
-  getActivePane: (side: SftpPaneSide) => { connection?: unknown } | null | undefined;
+  getActivePane: (side: SftpPaneSide) => {
+    connection?: { status?: "connecting" | "connected" | "disconnected" | "error" } | null;
+  } | null | undefined;
 };
 
 export const canCopyToOtherPane = (
   state: CopyTargetState,
   targetSide: SftpPaneSide,
-): boolean => Boolean(state.getActivePane(targetSide)?.connection);
+): boolean => state.getActivePane(targetSide)?.connection?.status === "connected";
 
 export const requireCopyToOtherPaneTarget = (
   state: CopyTargetState,

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { MutableRefObject } from "react";
 import type { SftpStateApi } from "../../../application/state/useSftpState";
 import type { SftpDragCallbacks, SftpTransferSource } from "../SftpContext";
@@ -76,6 +76,9 @@ export const useSftpViewPaneActions = ({
   sftpRef,
   t,
 }: UseSftpViewPaneActionsParams): UseSftpViewPaneActionsResult => {
+  const tRef = useRef(t);
+  tRef.current = t;
+
   const [draggedFiles, setDraggedFiles] = useState<
     (SftpTransferSource & { side: "left" | "right" })[] | null
   >(null);
@@ -99,7 +102,7 @@ export const useSftpViewPaneActions = ({
       if (!requireCopyToOtherPaneTarget(
         sftpRef.current,
         targetSide,
-        () => toast.info(t("sftp.copyToOtherPane.unavailable"), "SFTP"),
+        () => toast.info(tRef.current("sftp.copyToOtherPane.unavailable"), "SFTP"),
       )) {
         return;
       }
@@ -121,7 +124,7 @@ export const useSftpViewPaneActions = ({
         });
       }
     },
-    [sftpRef, t],
+    [sftpRef],
   );
 
   const onCopyToOtherPaneLeft = useCallback(

--- a/components/sftp/hooks/useSftpViewPaneActions.ts
+++ b/components/sftp/hooks/useSftpViewPaneActions.ts
@@ -7,9 +7,12 @@ import { editorTabStore } from "../../../application/state/editorTabStore";
 import type { EditorTab, EditorTabId } from "../../../application/state/editorTabStore";
 import { releaseEditorTabSaveCoordinator, saveEditorTab } from "../../../application/state/editorTabSave";
 import { promptUnsavedChanges } from "../../editor/UnsavedChangesDialog";
+import { toast } from "../../ui/toast";
+import { requireCopyToOtherPaneTarget } from "../copyToOtherPane";
 
 interface UseSftpViewPaneActionsParams {
   sftpRef: MutableRefObject<SftpStateApi>;
+  t: (key: string, vars?: Record<string, string | number>) => string;
 }
 
 interface UseSftpViewPaneActionsResult {
@@ -71,6 +74,7 @@ interface UseSftpViewPaneActionsResult {
 
 export const useSftpViewPaneActions = ({
   sftpRef,
+  t,
 }: UseSftpViewPaneActionsParams): UseSftpViewPaneActionsResult => {
   const [draggedFiles, setDraggedFiles] = useState<
     (SftpTransferSource & { side: "left" | "right" })[] | null
@@ -92,6 +96,14 @@ export const useSftpViewPaneActions = ({
 
   const startGroupedTransfer = useCallback(
     (files: SftpTransferSource[], sourceSide: "left" | "right", targetSide: "left" | "right") => {
+      if (!requireCopyToOtherPaneTarget(
+        sftpRef.current,
+        targetSide,
+        () => toast.info(t("sftp.copyToOtherPane.unavailable"), "SFTP"),
+      )) {
+        return;
+      }
+
       const groups = new Map<string, SftpTransferSource[]>();
       for (const file of files) {
         const key = `${file.sourceConnectionId ?? ""}::${file.sourcePath ?? ""}`;
@@ -109,7 +121,7 @@ export const useSftpViewPaneActions = ({
         });
       }
     },
-    [sftpRef],
+    [sftpRef, t],
   );
 
   const onCopyToOtherPaneLeft = useCallback(

--- a/components/sftp/hooks/useSftpViewPaneCallbacks.ts
+++ b/components/sftp/hooks/useSftpViewPaneCallbacks.ts
@@ -66,7 +66,7 @@ export const useSftpViewPaneCallbacks = ({
   listLocalFiles,
   listDrives,
 }: UseSftpViewPaneCallbacksParams) => {
-  const paneActions = useSftpViewPaneActions({ sftpRef });
+  const paneActions = useSftpViewPaneActions({ sftpRef, t });
   const fileOps = useSftpViewFileOps({
     sftpRef,
     behaviorRef,


### PR DESCRIPTION
## Summary

- detect when the other SFTP pane is missing, not fully connected, or reconnecting
- show a clear localized explanation instead of silently doing nothing
- preserve the existing copy flow when the destination pane is ready
- add regression coverage for unavailable and connected destination states

## Root cause

The copy action always called the transfer flow. When the destination pane had no usable connection, the transfer returned without creating work or showing feedback. The single-pane terminal SFTP sidebar therefore reproduced the issue every time, while the full SFTP view could reproduce it with an unconnected or reconnecting destination.

## Verification

- `npm run lint`
- `npm run build`
- `npm test` (4701 tests: 4698 passed, 3 skipped, 0 failed)
- targeted copy-destination tests (5 passed)
- three independent review rounds; final round clean from both reviewers

Closes #2120