### PR TITLE
Improve group SSH and Telnet defaults

### DIFF
--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -48,3 +48,11 @@ test("GroupDetailsPanel replaces manual Telnet credentials with a reusable ident
   assert.equal(result.telnetUsername, undefined);
   assert.equal(result.telnetPassword, undefined);
 });
+
+test("GroupDetailsPanel explicitly clears inherited identities for manual credentials", () => {
+  const ssh = selectGroupSshIdentity({}, undefined, "", "parent-ssh-identity");
+  const telnet = selectGroupTelnetIdentity({}, "", "parent-telnet-identity");
+
+  assert.equal(ssh.identityId, "");
+  assert.equal(telnet.telnetIdentityId, "");
+});

--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -1,10 +1,50 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { hasGroupTelnetFields } from "./GroupDetailsPanel.tsx";
+import {
+  hasGroupTelnetFields,
+  selectGroupSshIdentity,
+  selectGroupTelnetIdentity,
+} from "./GroupDetailsPanel.tsx";
 
 test("GroupDetailsPanel treats cleared telnet credentials as explicit settings", () => {
   assert.equal(hasGroupTelnetFields({ telnetUsername: "" }), true);
   assert.equal(hasGroupTelnetFields({ telnetPassword: "" }), true);
+  assert.equal(hasGroupTelnetFields({ telnetIdentityId: "identity-1" }), true);
   assert.equal(hasGroupTelnetFields({}), false);
+});
+
+test("GroupDetailsPanel replaces manual SSH credentials with a reusable identity", () => {
+  const result = selectGroupSshIdentity(
+    {
+      username: "manual",
+      password: "secret",
+      identityFileId: "key-1",
+      identityFilePaths: ["~/.ssh/id_ed25519"],
+    },
+    {
+      id: "identity-1",
+      label: "Shared admin",
+      username: "admin",
+      authMethod: "password",
+      created: 1,
+    },
+  );
+
+  assert.equal(result.identityId, "identity-1");
+  assert.equal(result.username, "admin");
+  assert.equal(result.password, undefined);
+  assert.equal(result.identityFileId, undefined);
+  assert.equal(result.identityFilePaths, undefined);
+});
+
+test("GroupDetailsPanel replaces manual Telnet credentials with a reusable identity", () => {
+  const result = selectGroupTelnetIdentity(
+    { telnetUsername: "manual", telnetPassword: "secret" },
+    "identity-1",
+  );
+
+  assert.equal(result.telnetIdentityId, "identity-1");
+  assert.equal(result.telnetUsername, undefined);
+  assert.equal(result.telnetPassword, undefined);
 });

--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -58,6 +58,27 @@ test("GroupDetailsPanel explicitly clears inherited identities for manual creden
   assert.equal(telnet.telnetIdentityId, "");
 });
 
+test("GroupDetailsPanel clears key authentication before switching to a manual password", () => {
+  const selected = selectGroupSshIdentity(
+    {},
+    {
+      id: "key-identity",
+      label: "Key identity",
+      username: "admin",
+      authMethod: "key",
+      keyId: "key-1",
+      created: 1,
+    },
+  );
+  const cleared = selectGroupSshIdentity(selected, undefined);
+  const manual = { ...cleared, username: "operator", password: "secret" };
+
+  assert.equal(manual.identityId, undefined);
+  assert.equal(manual.authMethod, undefined);
+  assert.equal(manual.username, "operator");
+  assert.equal(manual.password, "secret");
+});
+
 test("GroupDetailsPanel keeps a deleted identity visible so it can be cleared", () => {
   const options = includeMissingIdentityOption([], "deleted-identity", "Identity not found");
 

--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -2,12 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  hasGroupSshFields,
   hasGroupTelnetFields,
   includeMissingIdentityOption,
   resolveGroupFormIdentityId,
   selectGroupSshIdentity,
   selectGroupTelnetIdentity,
 } from "./GroupDetailsPanel.tsx";
+
+test("GroupDetailsPanel treats an empty SSH identity as an explicit setting", () => {
+  assert.equal(hasGroupSshFields({ identityId: "" }), true);
+  assert.equal(hasGroupSshFields({}), false);
+});
 
 test("GroupDetailsPanel treats cleared telnet credentials as explicit settings", () => {
   assert.equal(hasGroupTelnetFields({ telnetUsername: "" }), true);

--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   hasGroupTelnetFields,
   includeMissingIdentityOption,
+  resolveGroupFormIdentityId,
   selectGroupSshIdentity,
   selectGroupTelnetIdentity,
 } from "./GroupDetailsPanel.tsx";
@@ -83,4 +84,23 @@ test("GroupDetailsPanel keeps a deleted identity visible so it can be cleared", 
   const options = includeMissingIdentityOption([], "deleted-identity", "Identity not found");
 
   assert.deepEqual(options, [{ value: "deleted-identity", label: "Identity not found" }]);
+});
+
+test("GroupDetailsPanel shows saved child manual credentials instead of a parent identity", () => {
+  assert.equal(
+    resolveGroupFormIdentityId(
+      { username: "child-user", password: "child-password" },
+      "parent-ssh-identity",
+      "ssh",
+    ),
+    undefined,
+  );
+  assert.equal(
+    resolveGroupFormIdentityId(
+      { telnetUsername: "child-user", telnetPassword: "child-password" },
+      "parent-telnet-identity",
+      "telnet",
+    ),
+    undefined,
+  );
 });

--- a/components/GroupDetailsPanel.test.tsx
+++ b/components/GroupDetailsPanel.test.tsx
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   hasGroupTelnetFields,
+  includeMissingIdentityOption,
   selectGroupSshIdentity,
   selectGroupTelnetIdentity,
 } from "./GroupDetailsPanel.tsx";
@@ -55,4 +56,10 @@ test("GroupDetailsPanel explicitly clears inherited identities for manual creden
 
   assert.equal(ssh.identityId, "");
   assert.equal(telnet.telnetIdentityId, "");
+});
+
+test("GroupDetailsPanel keeps a deleted identity visible so it can be cleared", () => {
+  const options = includeMissingIdentityOption([], "deleted-identity", "Identity not found");
+
+  assert.deepEqual(options, [{ value: "deleted-identity", label: "Identity not found" }]);
 });

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -54,6 +54,7 @@ import { useAvailableFonts } from "../application/state/fontStore";
 import { toast } from "./ui/toast";
 import { GroupSshSettingsSection } from "./GroupSshSettingsSection";
 import { prepareProxyConfigForSave } from "./HostDetailsPanel.helpers";
+import { TerminalEncodingSelect } from "./TerminalEncodingSelect";
 
 type SubPanel = "none" | "proxy" | "chain" | "env-vars" | "theme-select";
 
@@ -85,9 +86,38 @@ type GroupDetailsPanelPropsWithResize = GroupDetailsPanelProps & AsidePanelResiz
 
 export const hasGroupTelnetFields = (c: Partial<GroupConfig>): boolean =>
   c.telnetPort !== undefined ||
+  c.telnetIdentityId !== undefined ||
   c.telnetUsername !== undefined ||
   c.telnetPassword !== undefined ||
   c.telnetEnabled === true;
+
+export const selectGroupSshIdentity = (
+  form: Partial<GroupConfig>,
+  identity: Identity | undefined,
+  identityId = identity?.id || "",
+): Partial<GroupConfig> => {
+  if (!identityId) return { ...form, identityId: undefined };
+  if (!identity) return { ...form, identityId };
+  return {
+    ...form,
+    identityId,
+    username: identity.username,
+    authMethod: identity.authMethod,
+    password: undefined,
+    savePassword: undefined,
+    identityFileId: undefined,
+    identityFilePaths: undefined,
+  };
+};
+
+export const selectGroupTelnetIdentity = (
+  form: Partial<GroupConfig>,
+  identityId: string,
+): Partial<GroupConfig> => ({
+  ...form,
+  telnetIdentityId: identityId || undefined,
+  ...(identityId ? { telnetUsername: undefined, telnetPassword: undefined } : {}),
+});
 
 const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
   groupPath,
@@ -220,6 +250,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
       const next = { ...prev };
       delete next.telnetEnabled;
       delete next.telnetPort;
+      delete next.telnetIdentityId;
       delete next.telnetUsername;
       delete next.telnetPassword;
       return next;
@@ -319,6 +350,29 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
       certificate: availableKeys.filter((k) => k.category === "certificate"),
     };
   }, [availableKeys]);
+
+  const identityOptions = useMemo(
+    () => identities.map((identity) => ({
+      value: identity.id,
+      label: identity.label,
+      sublabel: identity.username,
+    })),
+    [identities],
+  );
+
+  const updateSshIdentity = useCallback((identityId: string) => {
+    setForm((prev) => selectGroupSshIdentity(
+      prev,
+      identities.find((item) => item.id === identityId),
+      identityId,
+    ));
+    setSelectedCredentialType(null);
+    setCredentialPopoverOpen(false);
+  }, [identities]);
+
+  const updateTelnetIdentity = useCallback((identityId: string) => {
+    setForm((prev) => selectGroupTelnetIdentity(prev, identityId));
+  }, []);
 
   // Parent group options — exclude self and children
   const parentGroupOptions = useMemo(() => {
@@ -453,6 +507,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
       ...(telnetEnabled && {
         telnetEnabled: true,
         ...(form.telnetPort !== undefined && { telnetPort: form.telnetPort }),
+        ...(form.telnetIdentityId !== undefined && { telnetIdentityId: form.telnetIdentityId }),
         ...(form.telnetUsername !== undefined && { telnetUsername: form.telnetUsername }),
         ...(form.telnetPassword !== undefined && { telnetPassword: form.telnetPassword }),
       }),
@@ -630,6 +685,9 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
           showPassword={showPassword}
           setShowPassword={setShowPassword}
           availableKeys={availableKeys}
+          identities={identities}
+          identityOptions={identityOptions}
+          updateSshIdentity={updateSshIdentity}
           setSelectedCredentialType={setSelectedCredentialType}
           selectedCredentialType={selectedCredentialType}
           credentialPopoverOpen={credentialPopoverOpen}
@@ -715,28 +773,40 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
               </div>
             </div>
 
-            <Input
-              placeholder={t("hostDetails.username.placeholder")}
-              value={form.telnetUsername || ""}
-              onChange={(e) => update("telnetUsername", e.target.value)}
-              className="h-10"
-            />
-            <div className="relative">
-              <Input
-                placeholder={t("hostDetails.password.placeholder")}
-                type={showTelnetPassword ? "text" : "password"}
-                value={form.telnetPassword || ""}
-                onChange={(e) => update("telnetPassword", e.target.value)}
-                className="h-10 pr-10"
+            {identities.length > 0 && (
+              <Combobox
+                options={identityOptions}
+                value={form.telnetIdentityId || ""}
+                onValueChange={updateTelnetIdentity}
+                placeholder={t("hostDetails.identity.suggestions")}
+                emptyText={t("common.noResultsFound")}
+                className="w-full"
               />
-              <button
-                type="button"
-                onClick={() => setShowTelnetPassword(!showTelnetPassword)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {showTelnetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-              </button>
-            </div>
+            )}
+            {!form.telnetIdentityId && (<>
+              <Input
+                placeholder={t("hostDetails.username.placeholder")}
+                value={form.telnetUsername || ""}
+                onChange={(e) => update("telnetUsername", e.target.value)}
+                className="h-10"
+              />
+              <div className="relative">
+                <Input
+                  placeholder={t("hostDetails.password.placeholder")}
+                  type={showTelnetPassword ? "text" : "password"}
+                  value={form.telnetPassword || ""}
+                  onChange={(e) => update("telnetPassword", e.target.value)}
+                  className="h-10 pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowTelnetPassword(!showTelnetPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showTelnetPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+            </>)}
           </HostDetailsSection>
         )}
 
@@ -746,11 +816,9 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
           icon={<Globe size={14} className="text-muted-foreground" />}
           title={t("vault.groups.details.advanced")}
         >
-          <Input
-            placeholder="UTF-8"
-            value={form.charset || ""}
-            onChange={(e) => update("charset", e.target.value || undefined)}
-            className="h-10"
+          <TerminalEncodingSelect
+            value={form.charset}
+            onValueChange={(value) => update("charset", value)}
           />
         </HostDetailsSection>
 

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -96,6 +96,17 @@ export const hasGroupTelnetFields = (c: Partial<GroupConfig>): boolean =>
   c.telnetPassword !== undefined ||
   c.telnetEnabled === true;
 
+export const hasGroupSshFields = (c: Partial<GroupConfig>): boolean =>
+  c.protocol === 'ssh' ||
+  c.port !== undefined || !!c.username || !!c.password || !!c.identityFileId ||
+  c.deviceType !== undefined ||
+  c.agentForwarding !== undefined || c.authMethod !== undefined || c.identityId !== undefined ||
+  !!c.proxyProfileId || !!c.proxyConfig || !!c.hostChain || !!c.startupCommand || c.startupCommandRunMode !== undefined || c.legacyAlgorithms !== undefined || c.skipEcdsaHostKey !== undefined || c.algorithms !== undefined || c.backspaceBehavior !== undefined ||
+  Boolean(c.environmentVariables && c.environmentVariables.length > 0) ||
+  c.moshEnabled !== undefined || !!c.moshServerPath ||
+  c.etEnabled !== undefined || c.etPort !== undefined ||
+  Boolean(c.identityFilePaths && c.identityFilePaths.length > 0);
+
 export const selectGroupSshIdentity = (
   form: Partial<GroupConfig>,
   identity: Identity | undefined,
@@ -196,18 +207,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
   const [nameError, setNameError] = useState<string | null>(null);
 
   // Protocol sections enabled state
-  const hasSshFields = (c: Partial<GroupConfig>) =>
-    c.protocol === 'ssh' ||
-    c.port !== undefined || !!c.username || !!c.password || !!c.identityFileId ||
-    c.deviceType !== undefined ||
-    c.agentForwarding !== undefined || c.authMethod !== undefined || !!c.identityId ||
-    !!c.proxyProfileId || !!c.proxyConfig || !!c.hostChain || !!c.startupCommand || c.startupCommandRunMode !== undefined || c.legacyAlgorithms !== undefined || c.skipEcdsaHostKey !== undefined || c.algorithms !== undefined || c.backspaceBehavior !== undefined ||
-    (c.environmentVariables && c.environmentVariables.length > 0) ||
-    c.moshEnabled !== undefined || !!c.moshServerPath ||
-    c.etEnabled !== undefined || c.etPort !== undefined ||
-    (c.identityFilePaths && c.identityFilePaths.length > 0);
-
-  const [sshEnabled, setSshEnabled] = useState(() => hasSshFields(config || {}));
+  const [sshEnabled, setSshEnabled] = useState(() => hasGroupSshFields(config || {}));
   const [telnetEnabled, setTelnetEnabled] = useState(() => hasGroupTelnetFields(config || {}));
 
   // Sub-panel state

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -97,7 +97,14 @@ export const selectGroupSshIdentity = (
   identityId = identity?.id || "",
   inheritedIdentityId?: string,
 ): Partial<GroupConfig> => {
-  if (!identityId) return { ...form, identityId: inheritedIdentityId ? "" : undefined };
+  if (!identityId) {
+    return {
+      ...form,
+      identityId: inheritedIdentityId ? "" : undefined,
+      username: undefined,
+      authMethod: undefined,
+    };
+  }
   if (!identity) return { ...form, identityId };
   return {
     ...form,

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -121,6 +121,15 @@ export const selectGroupTelnetIdentity = (
   ...(identityId ? { telnetUsername: undefined, telnetPassword: undefined } : {}),
 });
 
+export const includeMissingIdentityOption = (
+  options: Array<{ value: string; label: string; sublabel?: string }>,
+  identityId: string | undefined,
+  missingLabel: string,
+): Array<{ value: string; label: string; sublabel?: string }> => {
+  if (!identityId || options.some((option) => option.value === identityId)) return options;
+  return [{ value: identityId, label: missingLabel }, ...options];
+};
+
 const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
   groupPath,
   config,
@@ -372,6 +381,22 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
   const effectiveTelnetIdentityId = form.telnetIdentityId !== undefined
     ? form.telnetIdentityId
     : inheritedConnectionDefaults.telnetIdentityId;
+  const sshIdentityOptions = useMemo(
+    () => includeMissingIdentityOption(
+      identityOptions,
+      effectiveSshIdentityId,
+      t("hostDetails.identity.missing"),
+    ),
+    [effectiveSshIdentityId, identityOptions, t],
+  );
+  const telnetIdentityOptions = useMemo(
+    () => includeMissingIdentityOption(
+      identityOptions,
+      effectiveTelnetIdentityId,
+      t("hostDetails.identity.missing"),
+    ),
+    [effectiveTelnetIdentityId, identityOptions, t],
+  );
 
   const updateSshIdentity = useCallback((identityId: string) => {
     setForm((prev) => selectGroupSshIdentity(
@@ -704,7 +729,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
           setShowPassword={setShowPassword}
           availableKeys={availableKeys}
           identities={identities}
-          identityOptions={identityOptions}
+          identityOptions={sshIdentityOptions}
           updateSshIdentity={updateSshIdentity}
           effectiveSshIdentityId={effectiveSshIdentityId}
           setSelectedCredentialType={setSelectedCredentialType}
@@ -792,9 +817,9 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
               </div>
             </div>
 
-            {identities.length > 0 && (
+            {(identities.length > 0 || effectiveTelnetIdentityId) && (
               <Combobox
-                options={identityOptions}
+                options={telnetIdentityOptions}
                 value={effectiveTelnetIdentityId || ""}
                 onValueChange={updateTelnetIdentity}
                 placeholder={t("hostDetails.identity.suggestions")}

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -14,7 +14,12 @@ import {
 import React, { useCallback, useMemo, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import { customThemeStore } from "../application/state/customThemeStore";
-import { resolveGroupDefaults, resolveGroupTerminalThemeId } from "../domain/groupConfig";
+import {
+  hasManualGroupSshCredentials,
+  hasManualGroupTelnetCredentials,
+  resolveGroupDefaults,
+  resolveGroupTerminalThemeId,
+} from "../domain/groupConfig";
 import {
   formatProxyConfigEndpoint,
   formatProxyConfigType,
@@ -135,6 +140,19 @@ export const includeMissingIdentityOption = (
 ): Array<{ value: string; label: string; sublabel?: string }> => {
   if (!identityId || options.some((option) => option.value === identityId)) return options;
   return [{ value: identityId, label: missingLabel }, ...options];
+};
+
+export const resolveGroupFormIdentityId = (
+  form: Partial<GroupConfig>,
+  inheritedIdentityId: string | undefined,
+  protocol: "ssh" | "telnet",
+): string | undefined => {
+  const formIdentityId = protocol === "ssh" ? form.identityId : form.telnetIdentityId;
+  if (formIdentityId !== undefined) return formIdentityId;
+  const hasManualCredentials = protocol === "ssh"
+    ? hasManualGroupSshCredentials(form)
+    : hasManualGroupTelnetCredentials(form);
+  return hasManualCredentials ? undefined : inheritedIdentityId;
 };
 
 const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
@@ -382,12 +400,16 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
     if (!parentGroup || groupConfigs.length === 0) return {};
     return resolveGroupDefaults(parentGroup, groupConfigs);
   }, [groupConfigs, parentGroup]);
-  const effectiveSshIdentityId = form.identityId !== undefined
-    ? form.identityId
-    : inheritedConnectionDefaults.identityId;
-  const effectiveTelnetIdentityId = form.telnetIdentityId !== undefined
-    ? form.telnetIdentityId
-    : inheritedConnectionDefaults.telnetIdentityId;
+  const effectiveSshIdentityId = resolveGroupFormIdentityId(
+    form,
+    inheritedConnectionDefaults.identityId,
+    "ssh",
+  );
+  const effectiveTelnetIdentityId = resolveGroupFormIdentityId(
+    form,
+    inheritedConnectionDefaults.telnetIdentityId,
+    "telnet",
+  );
   const sshIdentityOptions = useMemo(
     () => includeMissingIdentityOption(
       identityOptions,

--- a/components/GroupDetailsPanel.tsx
+++ b/components/GroupDetailsPanel.tsx
@@ -95,8 +95,9 @@ export const selectGroupSshIdentity = (
   form: Partial<GroupConfig>,
   identity: Identity | undefined,
   identityId = identity?.id || "",
+  inheritedIdentityId?: string,
 ): Partial<GroupConfig> => {
-  if (!identityId) return { ...form, identityId: undefined };
+  if (!identityId) return { ...form, identityId: inheritedIdentityId ? "" : undefined };
   if (!identity) return { ...form, identityId };
   return {
     ...form,
@@ -113,9 +114,10 @@ export const selectGroupSshIdentity = (
 export const selectGroupTelnetIdentity = (
   form: Partial<GroupConfig>,
   identityId: string,
+  inheritedIdentityId?: string,
 ): Partial<GroupConfig> => ({
   ...form,
-  telnetIdentityId: identityId || undefined,
+  telnetIdentityId: identityId || (inheritedIdentityId ? "" : undefined),
   ...(identityId ? { telnetUsername: undefined, telnetPassword: undefined } : {}),
 });
 
@@ -360,19 +362,35 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
     [identities],
   );
 
+  const inheritedConnectionDefaults = useMemo(() => {
+    if (!parentGroup || groupConfigs.length === 0) return {};
+    return resolveGroupDefaults(parentGroup, groupConfigs);
+  }, [groupConfigs, parentGroup]);
+  const effectiveSshIdentityId = form.identityId !== undefined
+    ? form.identityId
+    : inheritedConnectionDefaults.identityId;
+  const effectiveTelnetIdentityId = form.telnetIdentityId !== undefined
+    ? form.telnetIdentityId
+    : inheritedConnectionDefaults.telnetIdentityId;
+
   const updateSshIdentity = useCallback((identityId: string) => {
     setForm((prev) => selectGroupSshIdentity(
       prev,
       identities.find((item) => item.id === identityId),
       identityId,
+      inheritedConnectionDefaults.identityId,
     ));
     setSelectedCredentialType(null);
     setCredentialPopoverOpen(false);
-  }, [identities]);
+  }, [identities, inheritedConnectionDefaults.identityId]);
 
   const updateTelnetIdentity = useCallback((identityId: string) => {
-    setForm((prev) => selectGroupTelnetIdentity(prev, identityId));
-  }, []);
+    setForm((prev) => selectGroupTelnetIdentity(
+      prev,
+      identityId,
+      inheritedConnectionDefaults.telnetIdentityId,
+    ));
+  }, [inheritedConnectionDefaults.telnetIdentityId]);
 
   // Parent group options — exclude self and children
   const parentGroupOptions = useMemo(() => {
@@ -688,6 +706,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
           identities={identities}
           identityOptions={identityOptions}
           updateSshIdentity={updateSshIdentity}
+          effectiveSshIdentityId={effectiveSshIdentityId}
           setSelectedCredentialType={setSelectedCredentialType}
           selectedCredentialType={selectedCredentialType}
           credentialPopoverOpen={credentialPopoverOpen}
@@ -776,14 +795,14 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
             {identities.length > 0 && (
               <Combobox
                 options={identityOptions}
-                value={form.telnetIdentityId || ""}
+                value={effectiveTelnetIdentityId || ""}
                 onValueChange={updateTelnetIdentity}
                 placeholder={t("hostDetails.identity.suggestions")}
                 emptyText={t("common.noResultsFound")}
                 className="w-full"
               />
             )}
-            {!form.telnetIdentityId && (<>
+            {!effectiveTelnetIdentityId && (<>
               <Input
                 placeholder={t("hostDetails.username.placeholder")}
                 value={form.telnetUsername || ""}
@@ -818,6 +837,7 @@ const GroupDetailsPanel: React.FC<GroupDetailsPanelPropsWithResize> = ({
         >
           <TerminalEncodingSelect
             value={form.charset}
+            inheritedValue={inheritedConnectionDefaults.charset}
             onValueChange={(value) => update("charset", value)}
           />
         </HostDetailsSection>

--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -37,6 +37,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
   identities,
   identityOptions,
   updateSshIdentity,
+  effectiveSshIdentityId,
   setSelectedCredentialType,
   selectedCredentialType,
   credentialPopoverOpen,
@@ -106,7 +107,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             {identities.length > 0 && (
               <Combobox
                 options={identityOptions}
-                value={form.identityId || ""}
+                value={effectiveSshIdentityId || ""}
                 onValueChange={updateSshIdentity}
                 placeholder={t("hostDetails.identity.suggestions")}
                 emptyText={t("common.noResultsFound")}
@@ -114,7 +115,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
               />
             )}
 
-            {!form.identityId && (<>
+            {!effectiveSshIdentityId && (<>
               <Input
                 placeholder={t("hostDetails.username.placeholder")}
                 value={form.username || ""}
@@ -141,7 +142,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             </>)}
 
             {/* Selected credential display */}
-            {!form.identityId && form.identityFileId && (
+            {!effectiveSshIdentityId && form.identityFileId && (
               <div className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60">
                 {form.authMethod === "certificate" ? (
                   <Shield size={14} className="text-primary" />
@@ -167,7 +168,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             )}
 
             {/* Local key file paths display */}
-            {!form.identityId && !form.identityFileId && form.identityFilePaths && form.identityFilePaths.length > 0 && (
+            {!effectiveSshIdentityId && !form.identityFileId && form.identityFilePaths && form.identityFilePaths.length > 0 && (
               <div className="space-y-1">
                 {form.identityFilePaths.map((keyPath, idx) => (
                   <div key={idx} className="flex items-center gap-2 h-8 px-2 rounded-md bg-secondary/50 border border-border/60" style={{ maxWidth: '100%' }}>
@@ -191,7 +192,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             )}
 
             {/* Credential type selection with inline popover - hidden when credential is selected */}
-            {!form.identityId && !form.identityFileId &&
+            {!effectiveSshIdentityId && !form.identityFileId &&
               !selectedCredentialType && (
                 <Popover
                   open={credentialPopoverOpen}
@@ -260,7 +261,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             {/* Key selection combobox - appears after selecting "Key" type */}
             {selectedCredentialType === "key" &&
-              !form.identityId && !form.identityFileId && (
+              !effectiveSshIdentityId && !form.identityFileId && (
                 <div className="flex items-center gap-1">
                   <Combobox
                     options={keysByCategory.key.map((k) => ({
@@ -293,7 +294,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             {/* Certificate selection combobox - appears after selecting "Certificate" type */}
             {selectedCredentialType === "certificate" &&
-              !form.identityId && !form.identityFileId && (
+              !effectiveSshIdentityId && !form.identityFileId && (
                 <div className="flex items-center gap-1">
                   <Combobox
                     options={keysByCategory.certificate.map((k) => ({
@@ -328,7 +329,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
               )}
 
             {/* Local key file path input - appears after selecting "Local Key File" type */}
-            {!form.identityId && !form.identityFileId && selectedCredentialType === "localKeyFile" && (
+            {!effectiveSshIdentityId && !form.identityFileId && selectedCredentialType === "localKeyFile" && (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1 w-full">
                   <input

--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -34,6 +34,9 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
   showPassword,
   setShowPassword,
   availableKeys,
+  identities,
+  identityOptions,
+  updateSshIdentity,
   setSelectedCredentialType,
   selectedCredentialType,
   credentialPopoverOpen,
@@ -100,32 +103,45 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
               </div>
             </div>
 
-            <Input
-              placeholder={t("hostDetails.username.placeholder")}
-              value={form.username || ""}
-              onChange={(e) => update("username", e.target.value || undefined)}
-              className="h-10"
-            />
-
-            <div className="relative">
-              <Input
-                placeholder={t("hostDetails.password.placeholder")}
-                type={showPassword ? "text" : "password"}
-                value={form.password || ""}
-                onChange={(e) => update("password", e.target.value || undefined)}
-                className="h-10 pr-10"
+            {identities.length > 0 && (
+              <Combobox
+                options={identityOptions}
+                value={form.identityId || ""}
+                onValueChange={updateSshIdentity}
+                placeholder={t("hostDetails.identity.suggestions")}
+                emptyText={t("common.noResultsFound")}
+                className="w-full"
               />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-              </button>
-            </div>
+            )}
+
+            {!form.identityId && (<>
+              <Input
+                placeholder={t("hostDetails.username.placeholder")}
+                value={form.username || ""}
+                onChange={(e) => update("username", e.target.value || undefined)}
+                className="h-10"
+              />
+
+              <div className="relative">
+                <Input
+                  placeholder={t("hostDetails.password.placeholder")}
+                  type={showPassword ? "text" : "password"}
+                  value={form.password || ""}
+                  onChange={(e) => update("password", e.target.value || undefined)}
+                  className="h-10 pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+            </>)}
 
             {/* Selected credential display */}
-            {form.identityFileId && (
+            {!form.identityId && form.identityFileId && (
               <div className="flex items-center gap-2 p-2 rounded-md bg-secondary/50 border border-border/60">
                 {form.authMethod === "certificate" ? (
                   <Shield size={14} className="text-primary" />
@@ -151,7 +167,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             )}
 
             {/* Local key file paths display */}
-            {!form.identityFileId && form.identityFilePaths && form.identityFilePaths.length > 0 && (
+            {!form.identityId && !form.identityFileId && form.identityFilePaths && form.identityFilePaths.length > 0 && (
               <div className="space-y-1">
                 {form.identityFilePaths.map((keyPath, idx) => (
                   <div key={idx} className="flex items-center gap-2 h-8 px-2 rounded-md bg-secondary/50 border border-border/60" style={{ maxWidth: '100%' }}>
@@ -175,7 +191,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
             )}
 
             {/* Credential type selection with inline popover - hidden when credential is selected */}
-            {!form.identityFileId &&
+            {!form.identityId && !form.identityFileId &&
               !selectedCredentialType && (
                 <Popover
                   open={credentialPopoverOpen}
@@ -244,7 +260,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             {/* Key selection combobox - appears after selecting "Key" type */}
             {selectedCredentialType === "key" &&
-              !form.identityFileId && (
+              !form.identityId && !form.identityFileId && (
                 <div className="flex items-center gap-1">
                   <Combobox
                     options={keysByCategory.key.map((k) => ({
@@ -277,7 +293,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
 
             {/* Certificate selection combobox - appears after selecting "Certificate" type */}
             {selectedCredentialType === "certificate" &&
-              !form.identityFileId && (
+              !form.identityId && !form.identityFileId && (
                 <div className="flex items-center gap-1">
                   <Combobox
                     options={keysByCategory.certificate.map((k) => ({
@@ -312,7 +328,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
               )}
 
             {/* Local key file path input - appears after selecting "Local Key File" type */}
-            {!form.identityFileId && selectedCredentialType === "localKeyFile" && (
+            {!form.identityId && !form.identityFileId && selectedCredentialType === "localKeyFile" && (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1 w-full">
                   <input

--- a/components/GroupSshSettingsSection.tsx
+++ b/components/GroupSshSettingsSection.tsx
@@ -104,7 +104,7 @@ export const GroupSshSettingsSection: React.FC<GroupSshSettingsSectionProps> = (
               </div>
             </div>
 
-            {identities.length > 0 && (
+            {(identities.length > 0 || effectiveSshIdentityId) && (
               <Combobox
                 options={identityOptions}
                 value={effectiveSshIdentityId || ""}

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -1097,7 +1097,7 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
 
             <TerminalEncodingSelect
               value={form.charset}
-              inheritedValue={groupDefaults?.charset}
+              inheritedValue={effectiveGroupDefaults?.charset}
               onValueChange={(value) => update("charset", value)}
             />
 

--- a/components/HostDetailsPanel.tsx
+++ b/components/HostDetailsPanel.tsx
@@ -53,6 +53,7 @@ import {
   prepareProxyConfigForSave,
 } from "./HostDetailsPanel.helpers";
 export { parseOptionalPortInput } from "./HostDetailsPanel.helpers";
+import { TerminalEncodingSelect } from "./TerminalEncodingSelect";
 import { Button } from "./ui/button";
 import { Combobox, ComboboxOption, MultiCombobox } from "./ui/combobox";
 import { Input } from "./ui/input";
@@ -1094,11 +1095,10 @@ const HostDetailsPanel: React.FC<HostDetailsPanelPropsWithResize> = ({
               </>
             )}
 
-            <Input
-              placeholder={groupDefaults?.charset || t("hostDetails.charset.placeholder")}
-              value={form.charset || "UTF-8"}
-              onChange={(e) => update("charset", e.target.value)}
-              className="h-10"
+            <TerminalEncodingSelect
+              value={form.charset}
+              inheritedValue={groupDefaults?.charset}
+              onValueChange={(value) => update("charset", value)}
             />
 
             <button

--- a/components/TerminalEncodingSelect.test.ts
+++ b/components/TerminalEncodingSelect.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getTerminalEncodingOptions,
+  resolveTerminalEncodingSelectValue,
+} from "./TerminalEncodingSelect.tsx";
+
+test("terminal encoding selector advertises the supported encodings", () => {
+  assert.deepEqual(getTerminalEncodingOptions(), ["UTF-8", "GB18030"]);
+});
+
+test("terminal encoding selector preserves an existing custom encoding", () => {
+  assert.deepEqual(getTerminalEncodingOptions("Shift_JIS"), ["Shift_JIS", "UTF-8", "GB18030"]);
+});
+
+test("terminal encoding selector normalizes supported values to their displayed option", () => {
+  assert.equal(resolveTerminalEncodingSelectValue("utf-8"), "UTF-8");
+  assert.equal(resolveTerminalEncodingSelectValue("gb18030"), "GB18030");
+  assert.equal(resolveTerminalEncodingSelectValue("Shift_JIS"), "Shift_JIS");
+});

--- a/components/TerminalEncodingSelect.tsx
+++ b/components/TerminalEncodingSelect.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useI18n } from "../application/i18n/I18nProvider";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+
+interface TerminalEncodingSelectProps {
+  value?: string;
+  inheritedValue?: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}
+
+const SUPPORTED_ENCODINGS = ["UTF-8", "GB18030"] as const;
+
+export const resolveTerminalEncodingSelectValue = (value?: string): string => {
+  const normalized = value?.trim() || "UTF-8";
+  return SUPPORTED_ENCODINGS.find(
+    (encoding) => encoding.toLowerCase() === normalized.toLowerCase(),
+  ) || normalized;
+};
+
+export const getTerminalEncodingOptions = (currentValue?: string): string[] => {
+  const normalizedCurrent = currentValue?.trim();
+  if (!normalizedCurrent) return [...SUPPORTED_ENCODINGS];
+  if (SUPPORTED_ENCODINGS.some((encoding) => encoding.toLowerCase() === normalizedCurrent.toLowerCase())) {
+    return [...SUPPORTED_ENCODINGS];
+  }
+  return [normalizedCurrent, ...SUPPORTED_ENCODINGS];
+};
+
+export const TerminalEncodingSelect: React.FC<TerminalEncodingSelectProps> = ({
+  value,
+  inheritedValue,
+  onValueChange,
+  className = "h-10 w-full",
+}) => {
+  const { t } = useI18n();
+  const effectiveValue = resolveTerminalEncodingSelectValue(value || inheritedValue);
+  const options = getTerminalEncodingOptions(effectiveValue);
+
+  return (
+    <Select value={effectiveValue} onValueChange={onValueChange}>
+      <SelectTrigger className={className}>
+        <SelectValue placeholder={t("terminal.toolbar.encoding")} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((encoding) => (
+          <SelectItem key={encoding} value={encoding}>
+            {encoding}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/components/TerminalEncodingSelect.tsx
+++ b/components/TerminalEncodingSelect.tsx
@@ -5,7 +5,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 interface TerminalEncodingSelectProps {
   value?: string;
   inheritedValue?: string;
-  onValueChange: (value: string) => void;
+  onValueChange: (value: string | undefined) => void;
   className?: string;
 }
 
@@ -36,13 +36,24 @@ export const TerminalEncodingSelect: React.FC<TerminalEncodingSelectProps> = ({
   const { t } = useI18n();
   const effectiveValue = resolveTerminalEncodingSelectValue(value || inheritedValue);
   const options = getTerminalEncodingOptions(effectiveValue);
+  const fallbackValue = "__fallback__";
+  const selectedValue = value ? resolveTerminalEncodingSelectValue(value) : fallbackValue;
+  const fallbackLabel = inheritedValue
+    ? `${t("vault.groups.details.inherited")} (${resolveTerminalEncodingSelectValue(inheritedValue)})`
+    : value
+      ? `${t("common.reset")} (UTF-8)`
+      : "UTF-8";
 
   return (
-    <Select value={effectiveValue} onValueChange={onValueChange}>
+    <Select
+      value={selectedValue}
+      onValueChange={(nextValue) => onValueChange(nextValue === fallbackValue ? undefined : nextValue)}
+    >
       <SelectTrigger className={className}>
         <SelectValue placeholder={t("terminal.toolbar.encoding")} />
       </SelectTrigger>
       <SelectContent>
+        <SelectItem value={fallbackValue}>{fallbackLabel}</SelectItem>
         {options.map((encoding) => (
           <SelectItem key={encoding} value={encoding}>
             {encoding}

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -276,11 +276,21 @@ test("applyGroupDefaults preserves explicit empty identityId instead of inheriti
 
 test("applyGroupDefaults inherits group identityId when host identityId is unset", () => {
   const result = applyGroupDefaults(
-    host({ identityId: undefined, username: "" }),
+    host({ identityId: undefined, username: "", authMethod: "password" }),
     { identityId: "group-identity" },
   );
 
   assert.equal(result.identityId, "group-identity");
+});
+
+test("applyGroupDefaults treats an explicit empty identity as a host opt-out", () => {
+  const result = applyGroupDefaults(
+    host({ identityId: "", username: "host-user", authMethod: "password" }),
+    { identityId: "group-identity", username: "group-user" },
+  );
+
+  assert.equal(result.identityId, "");
+  assert.equal(result.username, "host-user");
 });
 
 test("applyGroupDefaults continues to inherit empty ssh username from the group", () => {

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -295,12 +295,69 @@ test("resolveGroupDefaults clears parent identity credentials for an empty child
 test("applyGroupDefaults keeps host manual SSH credentials instead of a group identity", () => {
   const result = applyGroupDefaults(
     host({ username: "host-user", password: "host-password" }),
-    { identityId: "group-identity", username: "group-user" },
+    {
+      identityId: "group-identity",
+      username: "group-user",
+      password: "group-password",
+      savePassword: false,
+      authMethod: "key",
+      identityFileId: "group-key",
+      identityFilePaths: ["~/.ssh/group-key"],
+    },
   );
 
   assert.equal(result.identityId, undefined);
   assert.equal(result.username, "host-user");
   assert.equal(result.password, "host-password");
+  assert.equal(result.savePassword, undefined);
+  assert.equal(result.authMethod, undefined);
+  assert.equal(result.identityFileId, undefined);
+  assert.equal(result.identityFilePaths, undefined);
+});
+
+test("applyGroupDefaults lets a host password inherit a manual group username", () => {
+  const result = applyGroupDefaults(
+    host({ username: "", password: "host-password" }),
+    { username: "group-user" },
+  );
+
+  assert.equal(result.identityId, undefined);
+  assert.equal(result.username, "group-user");
+  assert.equal(result.password, "host-password");
+});
+
+test("applyGroupDefaults lets an empty host identity inherit manual group credentials", () => {
+  const result = applyGroupDefaults(
+    host({ identityId: "", username: "", authMethod: undefined }),
+    {
+      username: "group-user",
+      password: "group-password",
+      authMethod: "password",
+    },
+  );
+
+  assert.equal(result.identityId, "");
+  assert.equal(result.username, "group-user");
+  assert.equal(result.password, "group-password");
+  assert.equal(result.authMethod, "password");
+});
+
+test("applyGroupDefaults does not bypass a host no-save choice with a group identity", () => {
+  const result = applyGroupDefaults(
+    host({ username: "", password: undefined, savePassword: false }),
+    {
+      identityId: "group-identity",
+      username: "group-user",
+      password: "group-password",
+      authMethod: "password",
+    },
+  );
+
+  assert.equal(result.identityId, undefined);
+  assert.equal(result.username, "");
+  assert.equal(result.password, undefined);
+  assert.equal(result.savePassword, false);
+  assert.equal(result.authMethod, undefined);
 });
 
 test("applyGroupDefaults keeps host manual Telnet credentials instead of a group identity", () => {

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -203,6 +203,24 @@ test("applyGroupDefaults still inherits telnet credentials when host fields are 
   assert.equal(resolveTelnetPassword(result), "group-telnet-password");
 });
 
+test("applyGroupDefaults inherits a reusable Telnet identity from the group", () => {
+  const result = applyGroupDefaults(
+    host({ telnetIdentityId: undefined }),
+    { telnetIdentityId: "group-telnet-identity" },
+  );
+
+  assert.equal(result.telnetIdentityId, "group-telnet-identity");
+});
+
+test("applyGroupDefaults preserves an explicitly cleared Telnet identity", () => {
+  const result = applyGroupDefaults(
+    host({ telnetIdentityId: "" }),
+    { telnetIdentityId: "group-telnet-identity" },
+  );
+
+  assert.equal(result.telnetIdentityId, "");
+});
+
 test("applyGroupDefaults preserves explicit empty identityId instead of inheriting group identity", () => {
   const result = applyGroupDefaults(
     host({ identityId: "" }),

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -323,13 +323,14 @@ test("applyGroupDefaults preserves explicit empty identityId instead of inheriti
   assert.equal(result.identityId, "");
 });
 
-test("applyGroupDefaults inherits group identityId when host identityId is unset", () => {
+test("applyGroupDefaults inherits group identityId when host only has default SSH fields", () => {
   const result = applyGroupDefaults(
-    host({ identityId: undefined, username: "", authMethod: "password" }),
+    host({ identityId: undefined, authMethod: "password" }),
     { identityId: "group-identity" },
   );
 
   assert.equal(result.identityId, "group-identity");
+  assert.equal(result.username, "root");
 });
 
 test("applyGroupDefaults treats an explicit empty identity as a host opt-out", () => {

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -371,6 +371,36 @@ test("applyGroupDefaults keeps host manual Telnet credentials instead of a group
   assert.equal(result.telnetPassword, "host-password");
 });
 
+test("applyGroupDefaults preserves imported primary Telnet credentials", () => {
+  const result = applyGroupDefaults(
+    host({
+      protocol: "telnet",
+      username: "operator",
+      password: "host-password",
+      telnetIdentityId: undefined,
+    }),
+    { telnetIdentityId: "group-telnet-identity" },
+  );
+
+  assert.equal(result.telnetIdentityId, undefined);
+  assert.equal(resolveTelnetUsername(result), "operator");
+  assert.equal(resolveTelnetPassword(result), "host-password");
+});
+
+test("applyGroupDefaults lets a default primary Telnet host inherit a group identity", () => {
+  const result = applyGroupDefaults(
+    host({
+      protocol: "telnet",
+      username: "root",
+      password: undefined,
+      telnetIdentityId: undefined,
+    }),
+    { telnetIdentityId: "group-telnet-identity" },
+  );
+
+  assert.equal(result.telnetIdentityId, "group-telnet-identity");
+});
+
 test("applyGroupDefaults preserves explicit empty identityId instead of inheriting group identity", () => {
   const result = applyGroupDefaults(
     host({ identityId: "" }),
@@ -388,6 +418,23 @@ test("applyGroupDefaults inherits group identityId when host only has default SS
 
   assert.equal(result.identityId, "group-identity");
   assert.equal(result.username, "root");
+});
+
+test("applyGroupDefaults preserves a custom username instead of inheriting a group identity", () => {
+  const result = applyGroupDefaults(
+    host({ identityId: undefined, username: "ubuntu", authMethod: "password" }),
+    {
+      identityId: "group-identity",
+      username: "group-user",
+      password: "group-password",
+      authMethod: "password",
+    },
+  );
+
+  assert.equal(result.identityId, undefined);
+  assert.equal(result.username, "ubuntu");
+  assert.equal(result.password, undefined);
+  assert.equal(result.authMethod, "password");
 });
 
 test("applyGroupDefaults treats an explicit empty identity as a host opt-out", () => {

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -221,6 +221,50 @@ test("applyGroupDefaults preserves an explicitly cleared Telnet identity", () =>
   assert.equal(result.telnetIdentityId, "");
 });
 
+test("resolveGroupDefaults lets child manual SSH credentials replace a parent identity", () => {
+  const resolved = resolveGroupDefaults("prod/manual", [
+    { path: "prod", identityId: "parent-identity", username: "parent-user" },
+    { path: "prod/manual", username: "child-user", password: "child-password" },
+  ]);
+
+  assert.equal(resolved.identityId, undefined);
+  assert.equal(resolved.username, "child-user");
+  assert.equal(resolved.password, "child-password");
+});
+
+test("resolveGroupDefaults lets child manual Telnet credentials replace a parent identity", () => {
+  const resolved = resolveGroupDefaults("prod/manual", [
+    { path: "prod", telnetIdentityId: "parent-identity" },
+    { path: "prod/manual", telnetUsername: "child-user", telnetPassword: "child-password" },
+  ]);
+
+  assert.equal(resolved.telnetIdentityId, undefined);
+  assert.equal(resolved.telnetUsername, "child-user");
+  assert.equal(resolved.telnetPassword, "child-password");
+});
+
+test("applyGroupDefaults keeps host manual SSH credentials instead of a group identity", () => {
+  const result = applyGroupDefaults(
+    host({ username: "host-user", password: "host-password" }),
+    { identityId: "group-identity", username: "group-user" },
+  );
+
+  assert.equal(result.identityId, undefined);
+  assert.equal(result.username, "host-user");
+  assert.equal(result.password, "host-password");
+});
+
+test("applyGroupDefaults keeps host manual Telnet credentials instead of a group identity", () => {
+  const result = applyGroupDefaults(
+    host({ telnetUsername: "host-user", telnetPassword: "host-password" }),
+    { telnetIdentityId: "group-identity" },
+  );
+
+  assert.equal(result.telnetIdentityId, undefined);
+  assert.equal(result.telnetUsername, "host-user");
+  assert.equal(result.telnetPassword, "host-password");
+});
+
 test("applyGroupDefaults preserves explicit empty identityId instead of inheriting group identity", () => {
   const result = applyGroupDefaults(
     host({ identityId: "" }),
@@ -232,7 +276,7 @@ test("applyGroupDefaults preserves explicit empty identityId instead of inheriti
 
 test("applyGroupDefaults inherits group identityId when host identityId is unset", () => {
   const result = applyGroupDefaults(
-    host({ identityId: undefined }),
+    host({ identityId: undefined, username: "" }),
     { identityId: "group-identity" },
   );
 

--- a/domain/groupConfig.test.ts
+++ b/domain/groupConfig.test.ts
@@ -243,6 +243,55 @@ test("resolveGroupDefaults lets child manual Telnet credentials replace a parent
   assert.equal(resolved.telnetPassword, "child-password");
 });
 
+test("resolveGroupDefaults clears a parent key identity bundle for a child password opt-out", () => {
+  const resolved = resolveGroupDefaults("prod/manual", [
+    {
+      path: "prod",
+      identityId: "parent-identity",
+      username: "parent-user",
+      authMethod: "key",
+      identityFileId: "parent-key",
+    },
+    {
+      path: "prod/manual",
+      identityId: "",
+      username: "child-user",
+      password: "child-password",
+      authMethod: "password",
+    },
+  ]);
+
+  assert.equal(resolved.identityId, "");
+  assert.equal(resolved.username, "child-user");
+  assert.equal(resolved.password, "child-password");
+  assert.equal(resolved.authMethod, "password");
+  assert.equal(resolved.identityFileId, undefined);
+});
+
+test("resolveGroupDefaults clears parent identity credentials for an empty child marker", () => {
+  const resolved = resolveGroupDefaults("prod/manual", [
+    {
+      path: "prod",
+      identityId: "parent-identity",
+      username: "parent-user",
+      authMethod: "key",
+      telnetIdentityId: "parent-telnet-identity",
+      telnetUsername: "parent-telnet-user",
+    },
+    {
+      path: "prod/manual",
+      identityId: "",
+      telnetIdentityId: "",
+    },
+  ]);
+
+  assert.equal(resolved.identityId, "");
+  assert.equal(resolved.username, undefined);
+  assert.equal(resolved.authMethod, undefined);
+  assert.equal(resolved.telnetIdentityId, "");
+  assert.equal(resolved.telnetUsername, undefined);
+});
+
 test("applyGroupDefaults keeps host manual SSH credentials instead of a group identity", () => {
   const result = applyGroupDefaults(
     host({ username: "host-user", password: "host-password" }),

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -153,6 +153,16 @@ const EMPTY_STRING_OVERRIDES_GROUP_DEFAULT = new Set<keyof GroupConfig>([
   'identityId',
 ]);
 
+const SSH_CREDENTIAL_KEYS = new Set<keyof GroupConfig>([
+  'username',
+  'password',
+  'savePassword',
+  'authMethod',
+  'identityId',
+  'identityFileId',
+  'identityFilePaths',
+]);
+
 /**
  * Apply group defaults to a host. Only fills in fields the host doesn't already have.
  * Returns a new host object — does NOT mutate the original.
@@ -166,15 +176,20 @@ export function applyGroupDefaults(
   const hostHasUsableProxyProfile = hasUsableProxyProfileId(host.proxyProfileId, options);
   const hostHasManualSshCredentials = !host.identityId && Boolean(
     host.password !== undefined ||
+    host.savePassword === false ||
     host.identityFileId ||
     host.identityFilePaths?.length,
+  );
+  const shouldSkipGroupSshCredentialBundle = Boolean(host.identityId) || (
+    Boolean(groupDefaults.identityId) &&
+    (host.identityId === '' || hostHasManualSshCredentials)
   );
   const hostHasManualTelnetCredentials = !host.telnetIdentityId && (
     host.telnetUsername !== undefined || host.telnetPassword !== undefined
   );
 
   for (const key of INHERITABLE_KEYS) {
-    if (key === 'identityId' && hostHasManualSshCredentials) continue;
+    if (shouldSkipGroupSshCredentialBundle && SSH_CREDENTIAL_KEYS.has(key)) continue;
     if (key === 'telnetIdentityId' && hostHasManualTelnetCredentials) continue;
     if (key === 'proxyProfileId') {
       if (host.proxyConfig !== undefined || !groupDefaults.proxyProfileId) continue;

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -50,12 +50,23 @@ export function resolveGroupDefaults(
         config.identityFilePaths,
       ].some((value) => value !== undefined);
       if (hasSshIdentitySetting && config.identityId) {
+        delete merged.username;
         delete merged.password;
         delete merged.savePassword;
+        delete merged.authMethod;
         delete merged.identityFileId;
         delete merged.identityFilePaths;
       } else if (!hasSshIdentitySetting && hasManualSshCredentials) {
+        const replacesInheritedIdentity = Boolean(merged.identityId);
         delete merged.identityId;
+        if (replacesInheritedIdentity) {
+          delete merged.username;
+          delete merged.password;
+          delete merged.savePassword;
+          delete merged.authMethod;
+          delete merged.identityFileId;
+          delete merged.identityFilePaths;
+        }
       }
 
       const hasTelnetIdentitySetting = config.telnetIdentityId !== undefined;
@@ -67,7 +78,12 @@ export function resolveGroupDefaults(
         delete merged.telnetUsername;
         delete merged.telnetPassword;
       } else if (!hasTelnetIdentitySetting && hasManualTelnetCredentials) {
+        const replacesInheritedIdentity = Boolean(merged.telnetIdentityId);
         delete merged.telnetIdentityId;
+        if (replacesInheritedIdentity) {
+          delete merged.telnetUsername;
+          delete merged.telnetPassword;
+        }
       }
 
       for (const [key, value] of Object.entries(config)) {
@@ -147,7 +163,6 @@ export function applyGroupDefaults(
   const hostHasManualSshCredentials = !host.identityId && Boolean(
     host.username?.trim() ||
     host.password !== undefined ||
-    host.authMethod !== undefined ||
     host.identityFileId ||
     host.identityFilePaths?.length,
   );

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -174,7 +174,9 @@ export function applyGroupDefaults(
 ): Host {
   const effective = { ...host };
   const hostHasUsableProxyProfile = hasUsableProxyProfileId(host.proxyProfileId, options);
+  const hostUsername = host.username?.trim();
   const hostHasManualSshCredentials = !host.identityId && Boolean(
+    (hostUsername && hostUsername !== 'root') ||
     host.password !== undefined ||
     host.savePassword === false ||
     host.identityFileId ||
@@ -184,8 +186,15 @@ export function applyGroupDefaults(
     Boolean(groupDefaults.identityId) &&
     (host.identityId === '' || hostHasManualSshCredentials)
   );
+  const primaryTelnetHasManualSharedCredentials = host.protocol === 'telnet' && Boolean(
+    (hostUsername && hostUsername !== 'root') ||
+    host.password !== undefined ||
+    host.savePassword === false
+  );
   const hostHasManualTelnetCredentials = !host.telnetIdentityId && (
-    host.telnetUsername !== undefined || host.telnetPassword !== undefined
+    host.telnetUsername !== undefined ||
+    host.telnetPassword !== undefined ||
+    primaryTelnetHasManualSharedCredentials
   );
 
   for (const key of INHERITABLE_KEYS) {

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -165,7 +165,6 @@ export function applyGroupDefaults(
   const effective = { ...host };
   const hostHasUsableProxyProfile = hasUsableProxyProfileId(host.proxyProfileId, options);
   const hostHasManualSshCredentials = !host.identityId && Boolean(
-    host.username?.trim() ||
     host.password !== undefined ||
     host.identityFileId ||
     host.identityFilePaths?.length,

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -15,6 +15,20 @@ export interface ApplyGroupDefaultsOptions {
   validProxyProfileIds?: ReadonlySet<string>;
 }
 
+export const hasManualGroupSshCredentials = (config: Partial<GroupConfig>): boolean => [
+  config.username,
+  config.password,
+  config.savePassword,
+  config.authMethod,
+  config.identityFileId,
+  config.identityFilePaths,
+].some((value) => value !== undefined);
+
+export const hasManualGroupTelnetCredentials = (config: Partial<GroupConfig>): boolean => [
+  config.telnetUsername,
+  config.telnetPassword,
+].some((value) => value !== undefined);
+
 const hasUsableProxyProfileId = (
   proxyProfileId: string | undefined,
   options?: ApplyGroupDefaultsOptions,
@@ -41,14 +55,7 @@ export function resolveGroupDefaults(
     const config = configMap.get(ancestorPath);
     if (config) {
       const hasSshIdentitySetting = config.identityId !== undefined;
-      const hasManualSshCredentials = [
-        config.username,
-        config.password,
-        config.savePassword,
-        config.authMethod,
-        config.identityFileId,
-        config.identityFilePaths,
-      ].some((value) => value !== undefined);
+      const hasManualSshCredentials = hasManualGroupSshCredentials(config);
       if (hasSshIdentitySetting) {
         delete merged.username;
         delete merged.password;
@@ -70,10 +77,7 @@ export function resolveGroupDefaults(
       }
 
       const hasTelnetIdentitySetting = config.telnetIdentityId !== undefined;
-      const hasManualTelnetCredentials = [
-        config.telnetUsername,
-        config.telnetPassword,
-      ].some((value) => value !== undefined);
+      const hasManualTelnetCredentials = hasManualGroupTelnetCredentials(config);
       if (hasTelnetIdentitySetting) {
         delete merged.telnetUsername;
         delete merged.telnetPassword;

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -40,6 +40,36 @@ export function resolveGroupDefaults(
     const ancestorPath = parts.slice(0, i + 1).join('/');
     const config = configMap.get(ancestorPath);
     if (config) {
+      const hasSshIdentitySetting = config.identityId !== undefined;
+      const hasManualSshCredentials = [
+        config.username,
+        config.password,
+        config.savePassword,
+        config.authMethod,
+        config.identityFileId,
+        config.identityFilePaths,
+      ].some((value) => value !== undefined);
+      if (hasSshIdentitySetting && config.identityId) {
+        delete merged.password;
+        delete merged.savePassword;
+        delete merged.identityFileId;
+        delete merged.identityFilePaths;
+      } else if (!hasSshIdentitySetting && hasManualSshCredentials) {
+        delete merged.identityId;
+      }
+
+      const hasTelnetIdentitySetting = config.telnetIdentityId !== undefined;
+      const hasManualTelnetCredentials = [
+        config.telnetUsername,
+        config.telnetPassword,
+      ].some((value) => value !== undefined);
+      if (hasTelnetIdentitySetting && config.telnetIdentityId) {
+        delete merged.telnetUsername;
+        delete merged.telnetPassword;
+      } else if (!hasTelnetIdentitySetting && hasManualTelnetCredentials) {
+        delete merged.telnetIdentityId;
+      }
+
       for (const [key, value] of Object.entries(config)) {
         if (
           key === 'proxyProfileId' &&
@@ -114,8 +144,20 @@ export function applyGroupDefaults(
 ): Host {
   const effective = { ...host };
   const hostHasUsableProxyProfile = hasUsableProxyProfileId(host.proxyProfileId, options);
+  const hostHasManualSshCredentials = !host.identityId && Boolean(
+    host.username?.trim() ||
+    host.password !== undefined ||
+    host.authMethod !== undefined ||
+    host.identityFileId ||
+    host.identityFilePaths?.length,
+  );
+  const hostHasManualTelnetCredentials = !host.telnetIdentityId && (
+    host.telnetUsername !== undefined || host.telnetPassword !== undefined
+  );
 
   for (const key of INHERITABLE_KEYS) {
+    if (key === 'identityId' && hostHasManualSshCredentials) continue;
+    if (key === 'telnetIdentityId' && hostHasManualTelnetCredentials) continue;
     if (key === 'proxyProfileId') {
       if (host.proxyConfig !== undefined || !groupDefaults.proxyProfileId) continue;
     }

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -49,7 +49,7 @@ export function resolveGroupDefaults(
         config.identityFileId,
         config.identityFilePaths,
       ].some((value) => value !== undefined);
-      if (hasSshIdentitySetting && config.identityId) {
+      if (hasSshIdentitySetting) {
         delete merged.username;
         delete merged.password;
         delete merged.savePassword;
@@ -74,7 +74,7 @@ export function resolveGroupDefaults(
         config.telnetUsername,
         config.telnetPassword,
       ].some((value) => value !== undefined);
-      if (hasTelnetIdentitySetting && config.telnetIdentityId) {
+      if (hasTelnetIdentitySetting) {
         delete merged.telnetUsername;
         delete merged.telnetPassword;
       } else if (!hasTelnetIdentitySetting && hasManualTelnetCredentials) {

--- a/domain/groupConfig.ts
+++ b/domain/groupConfig.ts
@@ -90,7 +90,7 @@ const INHERITABLE_KEYS: (keyof GroupConfig)[] = [
   'legacyAlgorithms', 'skipEcdsaHostKey', 'algorithms',
   'environmentVariables', 'charset', 'moshEnabled', 'moshServerPath',
   'etEnabled', 'etPort',
-  'telnetEnabled', 'telnetPort', 'telnetUsername', 'telnetPassword',
+  'telnetEnabled', 'telnetPort', 'telnetIdentityId', 'telnetUsername', 'telnetPassword',
   'theme', 'themeOverride', 'fontFamily', 'fontFamilyOverride', 'fontSize', 'fontSizeOverride', 'fontWeight', 'fontWeightOverride',
   'backspaceBehavior',
 ];
@@ -98,6 +98,7 @@ const INHERITABLE_KEYS: (keyof GroupConfig)[] = [
 const EMPTY_STRING_OVERRIDES_GROUP_DEFAULT = new Set<keyof GroupConfig>([
   'telnetUsername',
   'telnetPassword',
+  'telnetIdentityId',
   // Empty-string host identityId = explicitly no identity (auth-retry save, #1956); do not re-inherit group identity.
   'identityId',
 ]);

--- a/domain/models/connection.ts
+++ b/domain/models/connection.ts
@@ -383,6 +383,7 @@ export interface GroupConfig {
   etPort?: number;
   telnetEnabled?: boolean;
   telnetPort?: number;
+  telnetIdentityId?: string;
   telnetUsername?: string;
   telnetPassword?: string;
   theme?: string;


### PR DESCRIPTION
Closes #2114

## What changed
- let group SSH and Telnet settings reuse saved identities
- keep manual host and child-group credentials from being replaced by inherited identities
- replace free-form terminal encoding fields with a shared selector that supports inheritance and existing custom values
- add regression coverage for selection, inheritance, manual overrides, and encoding compatibility

## Why
Group connection settings received saved identities but did not expose them, and the free-form encoding field did not show supported choices. Nested groups also needed an explicit way to stop inheriting a parent identity.

## Checks
- npm run lint
- targeted group and encoding tests
- npm run build
- browser preview smoke check; preview-only local storage reset was not treated as a product failure