### PR TITLE
fix(sftp): preserve hidden relative paths

### DIFF
--- a/electron/bridges/sftpBridge.cjs
+++ b/electron/bridges/sftpBridge.cjs
@@ -364,11 +364,19 @@ const closeFileAsync = (sftp, handle) =>
 
 const normalizeRemotePathString = async (client, inputPath) => {
   if (typeof inputPath !== "string") return inputPath;
-  if (inputPath.startsWith("..")) {
+  if (inputPath === "..") {
+    const root = await client.realPath("..");
+    return `${root}/`;
+  }
+  if (inputPath.startsWith("../") || inputPath.startsWith("..\\")) {
     const root = await client.realPath("..");
     return `${root}/${inputPath.slice(3)}`;
   }
-  if (inputPath.startsWith(".")) {
+  if (inputPath === ".") {
+    const root = await client.realPath(".");
+    return `${root}/`;
+  }
+  if (inputPath.startsWith("./") || inputPath.startsWith(".\\")) {
     const root = await client.realPath(".");
     return `${root}/${inputPath.slice(2)}`;
   }

--- a/electron/bridges/sftpBridge.relativePaths.test.cjs
+++ b/electron/bridges/sftpBridge.relativePaths.test.cjs
@@ -1,0 +1,132 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const sftpBridge = require("./sftpBridge.cjs");
+
+function createSftpChannel(existingPaths = []) {
+  const existing = new Set(existingPaths);
+  const calls = {
+    mkdir: [],
+    realpath: [],
+    rmdir: [],
+    stat: [],
+  };
+  const channel = {
+    readdir(_targetPath, callback) {
+      callback(null, []);
+    },
+    stat(targetPath, callback) {
+      calls.stat.push(targetPath);
+      if (existing.has(targetPath)) {
+        callback(null, { isDirectory: () => true });
+        return;
+      }
+      const error = new Error(`No such file: ${targetPath}`);
+      error.code = 2;
+      callback(error);
+    },
+    mkdir(targetPath, callback) {
+      calls.mkdir.push(targetPath);
+      existing.add(targetPath);
+      callback(null);
+    },
+    rmdir(targetPath, callback) {
+      calls.rmdir.push(targetPath);
+      existing.delete(targetPath);
+      callback(null);
+    },
+    unlink(_targetPath, callback) {
+      callback(null);
+    },
+    realpath(targetPath, callback) {
+      calls.realpath.push(targetPath);
+      callback(null, targetPath === ".." ? "/home" : "/home/alice");
+    },
+  };
+  return { calls, channel };
+}
+
+test("mkdir preserves hidden relative names and resolves explicit dot segments", async () => {
+  const { calls, channel } = createSftpChannel(["/home", "/home/alice"]);
+  const client = {
+    sftp: channel,
+    realPath: (targetPath) => new Promise((resolve, reject) => {
+      channel.realpath(targetPath, (error, resolvedPath) => (
+        error ? reject(error) : resolve(resolvedPath)
+      ));
+    }),
+  };
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map(),
+    sftpClients: new Map([["mkdir-test", client]]),
+  });
+
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: ".config/app",
+    encoding: "utf-8",
+  });
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: "..staging/cache",
+    encoding: "utf-8",
+  });
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: "./logs",
+    encoding: "utf-8",
+  });
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: "../shared",
+    encoding: "utf-8",
+  });
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: ".\\windows-logs",
+    encoding: "utf-8",
+  });
+  await sftpBridge.mkdirSftp(null, {
+    sftpId: "mkdir-test",
+    path: "..\\windows-shared",
+    encoding: "utf-8",
+  });
+
+  assert.deepEqual(calls.realpath, [".", "..", ".", ".."]);
+  assert.deepEqual(calls.mkdir, [
+    ".config",
+    ".config/app",
+    "..staging",
+    "..staging/cache",
+    "/home/alice/logs",
+    "/home/shared",
+    "/home/alice/windows-logs",
+    "/home/windows-shared",
+  ]);
+});
+
+test("session-backed recursive delete preserves a hidden directory name", async () => {
+  const { calls, channel } = createSftpChannel([".cache"]);
+  const connection = {
+    sftp(callback) {
+      callback(null, channel);
+    },
+  };
+  const sftpClients = new Map();
+  sftpBridge.init({
+    electronModule: {},
+    sessions: new Map([["session-1", { conn: connection }]]),
+    sftpClients,
+  });
+  const opened = await sftpBridge.openSftpForSession(null, { sessionId: "session-1" });
+
+  await sftpBridge.deleteSftp(null, {
+    sftpId: opened.sftpId,
+    path: ".cache",
+    encoding: "utf-8",
+  });
+
+  assert.deepEqual(calls.realpath, []);
+  assert.deepEqual(calls.rmdir, [".cache"]);
+});


### PR DESCRIPTION
## Summary

- preserve hidden relative names such as `.config` and `..staging`
- expand only explicit `.` and `..` path segments, including slash and backslash forms
- cover mkdir and session-backed recursive delete with regression tests

## Root cause

The remote path normalizer matched every string beginning with one or two dots, then removed characters as if the path started with `./` or `../`. For example, `.cache` could become `/home/user/ache`, causing recursive delete to operate on a different path from the one requested.

## Validation

- `node --test electron/bridges/sftpBridge.relativePaths.test.cjs electron/bridges/sftpBridge.cleanup.test.cjs electron/bridges/sftpBridge.hostKeyVerification.test.cjs electron/bridges/sftpBridge.reuseOnly.test.cjs`
- `npx eslint electron/bridges/sftpBridge.cjs electron/bridges/sftpBridge.relativePaths.test.cjs`
- `npm run build`
