### PR TITLE
fix(mosh): clarify handshake failure when MOSH CONNECT is missing

### DIFF
--- a/docs/designs/native-mosh-client.md
+++ b/docs/designs/native-mosh-client.md
@@ -67,3 +67,7 @@ not resolve or accept an older MoshCatty release.
 - **2026-07-11:** Require `moshcatty-0.1.4+` for Windows ConPTY shortcut input;
   keep Mosh sessions on Netcatty's primary terminal screen so highlighting and
   scrollback remain available.
+- **2026-07-11:** Speculative local echo (prediction underlines) lives in
+  MoshCatty (`LocalPredictor`, `MOSH_PREDICTION_DISPLAY`). Prefer
+  `moshcatty-0.1.5+` so high-latency typing matches stock mosh / Termius
+  (Netcatty #2121). Netcatty does not implement prediction in the renderer.

--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -204,6 +204,18 @@ test("startMoshSession handshake path sends the existing exit event on failure",
   assert.ok(exit);
   assert.equal(exit.payload.sessionId, "mosh-test-session");
   assert.equal(exit.payload.reason, "error");
+  assert.match(
+    String(exit.payload.error || ""),
+    /no MOSH CONNECT/i,
+    "exit payload should name the handshake failure",
+  );
+  const dataChunks = h.sent
+    .filter((evt) => evt.channel === "netcatty:data" || evt.channel === "netcatty:session-data")
+    .map((evt) => String(evt.payload?.data ?? evt.payload ?? ""));
+  assert.ok(
+    dataChunks.some((chunk) => /Mosh handshake failed/i.test(chunk)),
+    "renderer should receive an explicit handshake-failure hint",
+  );
 });
 
 test("startMoshSession writes the saved password when ssh prompts for one", async (t) => {

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -444,9 +444,21 @@ function createMoshSessionApi(ctx) {
         }
     
         // Handshake failed before MOSH CONNECT — ssh exited without parse.
-        // The user has already seen the failure output (auth error, host
-        // key warning, etc). Just surface a session-exit with the code so
-        // the renderer can label the session "disconnected".
+        // Common on Windows when ConPTY mangled the magic line (#2025) or when
+        // mosh-server never started. Surface an explicit hint so the banner +
+        // "[mosh-server detached]" alone is not mistaken for a successful
+        // session that immediately closed (Netcatty #2121 residual connect).
+        const handshakeHint =
+          "\r\n[Mosh handshake failed: did not receive a valid MOSH CONNECT "
+          + "line from mosh-server. Confirm mosh-server is installed on the "
+          + "remote host, the SSH login succeeded, and UDP ports for mosh "
+          + "are reachable from this machine.]\r\n";
+        try {
+          bufferData(handshakeHint);
+          sessionLogStreamManager.appendData(sessionId, handshakeHint);
+        } catch {
+          // Best-effort diagnostics; still tear the session down below.
+        }
         flushPaced(() => {
           sessionLogStreamManager.stopStream(sessionId, logStreamToken);
           const contents = electronModule.webContents.fromId(session.webContentsId);
@@ -455,6 +467,7 @@ function createMoshSessionApi(ctx) {
             exitCode,
             signal,
             reason: "error",
+            error: "Mosh handshake failed: no MOSH CONNECT from mosh-server",
           });
           closeTerminalOutputSession?.(sessionId);
           sessions.delete(sessionId);


### PR DESCRIPTION
## Summary

Addresses the residual **connect failure** reports in #2121 where the terminal shows:

```
mosh-server (mosh 1.4.0) …
[mosh-server detached, pid = …]
[Mosh session closed (code 0)]
```

That pattern usually means the SSH bootstrap ran `mosh-server` but Netcatty **never parsed a `MOSH CONNECT` line**, so it never swapped to `mosh-client`. Exit code 0 is the SSH process succeeding — not a healthy Mosh session.

### This PR
- Prints an explicit handshake-failure hint into the terminal
- Puts a clear `error` on the `netcatty:exit` payload
- Documents that **prediction / local echo** is owned by MoshCatty (`0.1.5+`), not the renderer

### Related (main UX fix for #2121 typing)
Character doubling, missing underline, and “feels like SSH on high latency” are caused by MoshCatty missing speculative local echo. That is fixed in:

- https://github.com/binaricat/MoshCatty/pull/4 → release `moshcatty-0.1.5`
- Netcatty packaging should then resolve / pin that release

## Test plan
- [x] `node --test electron/bridges/terminalBridge.moshHandshakeSession.test.cjs` (18 pass)
- [ ] Manual: force handshake fail (remote without mosh-server) → see new hint text

Fixes part of #2121 (diagnostics). Full typing UX depends on MoshCatty #4 + release.