### PR TITLE
chore(mosh): require moshcatty-0.1.5 for local prediction (#2121)

### DIFF
--- a/docs/designs/native-mosh-client.md
+++ b/docs/designs/native-mosh-client.md
@@ -51,9 +51,10 @@ assets (they require GLIBC 2.34).
 
 ## Windows compatibility floor
 
-Netcatty requires `moshcatty-0.1.4+`. That release preserves arrow keys,
-Ctrl/Alt-modified shortcuts, and Ctrl+C through Windows ConPTY. Packaging must
-not resolve or accept an older MoshCatty release.
+Netcatty requires `moshcatty-0.1.5+`. That release includes stock-aligned
+speculative local echo (Diff path) for high-latency typing (#2121), plus the
+0.1.4 ConPTY shortcut-input fixes. Packaging must not resolve or accept an
+older MoshCatty release.
 
 ## Decision log
 
@@ -68,6 +69,8 @@ not resolve or accept an older MoshCatty release.
   keep Mosh sessions on Netcatty's primary terminal screen so highlighting and
   scrollback remain available.
 - **2026-07-11:** Speculative local echo (prediction underlines) lives in
-  MoshCatty (`LocalPredictor`, `MOSH_PREDICTION_DISPLAY`). Prefer
+  MoshCatty (`DisplayPipeline`, `MOSH_PREDICTION_DISPLAY`). Prefer
   `moshcatty-0.1.5+` so high-latency typing matches stock mosh / Termius
   (Netcatty #2121). Netcatty does not implement prediction in the renderer.
+- **2026-07-12:** Require `moshcatty-0.1.5+` for #2121 prediction; handshake
+  failure messaging when `MOSH CONNECT` is missing (#2128).

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -18,7 +18,7 @@ Netcatty runs SSH + `mosh-server` bootstrap itself, then launches this binary
 Each tarball contains **only** the client binary (no Cygwin DLLs, no terminfo).
 Windows builds static-link the MSVC CRT (`moshcatty-0.1.1+`).
 
-Release tags: `moshcatty-*` (require `moshcatty-0.1.4+`) from
+Release tags: `moshcatty-*` (require `moshcatty-0.1.5+`) from
 `binaricat/MoshCatty`, with `SHA256SUMS`.
 
 ### Linux glibc floors
@@ -37,8 +37,8 @@ were built on Ubuntu runners and require GLIBC 2.34.
 ## Fetch
 
 ```sh
-# Optional pin (0.1.4+ includes the Windows shortcut-input fix)
-export MOSH_BIN_RELEASE=moshcatty-0.1.4
+# Optional pin (0.1.5+ includes local prediction for #2121)
+export MOSH_BIN_RELEASE=moshcatty-0.1.5
 npm run fetch:mosh
 
 # Dev: host platform; resolves latest moshcatty-* if unset

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -313,10 +313,10 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     release = await resolveMoshBinRelease(env);
   }
   if (!release) {
-    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.4) to bundle mosh-client into the package.");
+    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.5) to bundle mosh-client into the package.");
     return 0;
   }
-  // Reject pre-0.1.4 pins (missing the Windows ConPTY shortcut-input fix) even when MOSH_BIN_RELEASE is set
+  // Reject pre-0.1.5 pins (missing local prediction for #2121) even when MOSH_BIN_RELEASE is set
   // without going through --resolve-release.
   release = validateReleaseTag(release);
 

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -138,7 +138,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
     {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -151,7 +151,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
   assert.equal(fs.existsSync(resDir), false);
 });
 
-test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.4", async (t) => {
+test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.5", async (t) => {
   const resDir = path.join(makeTmp(t), "resources", "mosh");
 
   await assert.rejects(
@@ -164,7 +164,7 @@ test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.4", async (t) =>
       },
       stdio: "pipe",
     }),
-    /below minimum moshcatty-0\.1\.4/,
+    /below minimum moshcatty-0\.1\.5/,
   );
   assert.equal(fs.existsSync(resDir), false);
 });
@@ -182,7 +182,7 @@ test("fetch-mosh-binaries unpacks pure Windows MoshCatty tarball", async (t) => 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -213,7 +213,7 @@ test("fetch-mosh-binaries strips accidental dll/terminfo from Windows tarball", 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -239,7 +239,7 @@ test("fetch-mosh-binaries unpacks pure Linux MoshCatty tarball", async (t) => {
   await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -265,7 +265,7 @@ test("fetch-mosh-binaries rejects tarball without mosh-client", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -288,7 +288,7 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the asset", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -316,7 +316,7 @@ test("fetch-mosh-binaries rejects symlinks inside tarballs", { skip: process.pla
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -14,11 +14,11 @@ const fs = require("node:fs");
 const https = require("node:https");
 
 // MoshCatty pure-Rust releases only.
-// Minimum 0.1.4: includes the Windows ConPTY shortcut-input fix. Linux builds
-// have matched Netcatty's GLIBC floors since 0.1.2.
+// Minimum 0.1.5: stock-aligned local prediction (Diff path) for #2121.
+// 0.1.4 had ConPTY shortcut fix; 0.1.2+ Linux glibc floors match Netcatty.
 // Allow semver prerelease (-rc1) and build metadata (+meta); no path separators.
 const TAG_RE = /^moshcatty-[A-Za-z0-9._+-]+$/;
-const MIN_VERSION = { major: 0, minor: 1, patch: 4 };
+const MIN_VERSION = { major: 0, minor: 1, patch: 5 };
 const MIN_TAG = `moshcatty-${MIN_VERSION.major}.${MIN_VERSION.minor}.${MIN_VERSION.patch}`;
 
 function log(msg) {
@@ -71,8 +71,8 @@ function validateReleaseTag(tag) {
   if (!isAtLeastMinRelease(value)) {
     throw new Error(
       `mosh binary release ${value} is below minimum ${MIN_TAG} `
-        + "(0.1.4 includes the Windows ConPTY shortcut-input fix; "
-        + "prereleases of the floor e.g. 0.1.4-rc1 are not accepted)",
+        + "(0.1.5 includes local prediction for #2121; "
+        + "prereleases of the floor e.g. 0.1.5-rc1 are not accepted)",
     );
   }
   return value;

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -22,10 +22,10 @@ function makeTmp(t) {
 }
 
 test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
-  assert.equal(validateReleaseTag("moshcatty-0.1.4"), "moshcatty-0.1.4");
+  assert.equal(validateReleaseTag("moshcatty-0.1.5"), "moshcatty-0.1.5");
   assert.equal(validateReleaseTag("moshcatty-0.2.0"), "moshcatty-0.2.0");
-  assert.equal(validateReleaseTag("moshcatty-0.1.5-rc1"), "moshcatty-0.1.5-rc1");
-  assert.equal(validateReleaseTag("moshcatty-0.1.4+build.1"), "moshcatty-0.1.4+build.1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.6-rc1"), "moshcatty-0.1.6-rc1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.5+build.1"), "moshcatty-0.1.5+build.1");
   assert.throws(() => validateReleaseTag("mosh-bin-1.4.0-1"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("v1.2.3"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-../bad"), /invalid mosh binary release tag/);
@@ -34,18 +34,20 @@ test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
   assert.throws(() => validateReleaseTag("moshcatty-0.1.1"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.2"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.3"), /below minimum/);
-  assert.throws(() => validateReleaseTag("moshcatty-0.1.4-rc1"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.4"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.5-rc1"), /below minimum/);
 });
 
-test("isAtLeastMinRelease enforces moshcatty-0.1.4 floor with semver prerelease rules", () => {
-  assert.equal(MIN_TAG, "moshcatty-0.1.4");
+test("isAtLeastMinRelease enforces moshcatty-0.1.5 floor with semver prerelease rules", () => {
+  assert.equal(MIN_TAG, "moshcatty-0.1.5");
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.3"), false);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5"), true);
   // Prerelease of the floor sorts below the final floor release.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4-rc1"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5-rc1"), false);
   // Above the floor, prereleases are fine.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5-rc1"), true);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.4+build.1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.6-rc1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5+build.1"), true);
   assert.equal(isAtLeastMinRelease("moshcatty-not-a-version"), false);
 });
 
@@ -61,17 +63,17 @@ test("parseRepository defaults to binaricat/MoshCatty (ignores GITHUB_REPOSITORY
   );
 });
 
-test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.4 tags", () => {
+test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.5 tags", () => {
   const got = pickLatestMoshBinRelease([
     { tag_name: "v1.0.0", published_at: "2026-03-01T00:00:00Z" },
     { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-06-01T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.4", draft: true, published_at: "2026-07-11T00:00:00Z" },
+    { tag_name: "moshcatty-0.1.5", draft: true, published_at: "2026-07-11T00:00:00Z" },
     { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.3", published_at: "2026-07-10T12:00:00Z" },
-    { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T13:00:00Z" },
+    { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T12:00:00Z" },
+    { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
   ]);
 
-  assert.equal(got, "moshcatty-0.1.4");
+  assert.equal(got, "moshcatty-0.1.5");
 });
 
 test("parseNextLink reads the next GitHub pagination URL", () => {
@@ -94,7 +96,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     requested.push(url);
     if (url.includes("page=2")) {
       return {
-        json: [{ tag_name: "moshcatty-0.1.4", published_at: "2026-01-01T00:00:00Z" }],
+        json: [{ tag_name: "moshcatty-0.1.5", published_at: "2026-01-01T00:00:00Z" }],
         headers: {},
       };
     }
@@ -106,7 +108,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     };
   });
 
-  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.4"]);
+  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.5"]);
   assert.equal(requested.length, 2);
 });
 
@@ -124,17 +126,17 @@ test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {
   const githubEnv = path.join(makeTmp(t), "github-env");
 
   const got = await main({
-    MOSH_BIN_RELEASE: "moshcatty-0.1.4",
+    MOSH_BIN_RELEASE: "moshcatty-0.1.5",
     GITHUB_ENV: githubEnv,
   });
 
-  assert.equal(got, "moshcatty-0.1.4");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.4\n");
+  assert.equal(got, "moshcatty-0.1.5");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.5\n");
 });
 
-test("main rejects explicit pre-0.1.4 MOSH_BIN_RELEASE", async () => {
+test("main rejects explicit pre-0.1.5 MOSH_BIN_RELEASE", async () => {
   await assert.rejects(
-    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.3" }),
+    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.4" }),
     /below minimum/,
   );
 });
@@ -146,14 +148,14 @@ test("main resolves the latest moshcatty release from the list and exports it", 
     MOSH_BIN_RELEASES_JSON: JSON.stringify([
       { tag_name: "moshcatty-0.1.0", published_at: "2026-01-01T00:00:00Z" },
       { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
-      { tag_name: "moshcatty-0.1.3", published_at: "2026-07-10T12:00:00Z" },
-      { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T13:00:00Z" },
+      { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T12:00:00Z" },
+      { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
       { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-08-01T00:00:00Z" },
     ]),
   });
 
-  assert.equal(got, "moshcatty-0.1.4");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.4\n");
+  assert.equal(got, "moshcatty-0.1.5");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.5\n");
 });
 
 test("main fails when no usable moshcatty release exists", async () => {
@@ -162,8 +164,8 @@ test("main fails when no usable moshcatty release exists", async () => {
       MOSH_BIN_RELEASES_JSON: JSON.stringify([
         { tag_name: "v1.0.0", published_at: "2026-01-01T00:00:00Z" },
         { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.3", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.4", draft: true, published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.4", published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.5", draft: true, published_at: "2026-02-01T00:00:00Z" },
       ]),
     }),
     /could not find/,


### PR DESCRIPTION
## Summary

- Raise MoshCatty packaging floor to **`moshcatty-0.1.5`** (local prediction Diff path for #2121)
- Reject pins of 0.1.4 and older in resolve/fetch scripts + tests
- Docs: `resources/mosh/README.md`, `docs/designs/native-mosh-client.md`

## Related

- MoshCatty [PR #4](https://github.com/binaricat/MoshCatty/pull/4) merged → [release 0.1.5](https://github.com/binaricat/MoshCatty/releases/tag/moshcatty-0.1.5)
- Netcatty #2128 handshake diagnostics (merged)
- Issue #2121

## Verification

- [x] `node --test scripts/resolve-mosh-bin-release.test.cjs scripts/fetch-mosh-binaries.test.cjs` (24 pass)
- [x] `MOSH_BIN_RELEASE=moshcatty-0.1.5 npm run fetch:mosh:dev`
- [x] Live mosh-server + packaged darwin client: typed `hello` once, no double glyph

## Test plan

- [ ] Package Windows Netcatty with 0.1.5 and retest #2121 high-latency session
- [ ] Confirm repo var `MOSH_BIN_RELEASE` is not stuck on 0.1.4