### PR TITLE
Allow hiding SFTP file list columns

### DIFF
--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -166,6 +166,7 @@ export const enVaultMessages: Messages = {
   'sftp.columns.modified': 'Modified',
   'sftp.columns.size': 'Size',
   'sftp.columns.kind': 'Kind',
+  'sftp.columns.configure': 'Choose visible columns',
   'sftp.columns.actions': 'Actions',
   'sftp.emptyDirectory': 'Empty directory',
   'sftp.nav.up': 'Go up',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -201,6 +201,7 @@ export const ruVaultMessages: Messages = {
   'sftp.columns.modified': 'Изменён',
   'sftp.columns.size': 'Размер',
   'sftp.columns.kind': 'Тип',
+  'sftp.columns.configure': 'Выбрать видимые столбцы',
   'sftp.columns.actions': 'Действия',
   'sftp.emptyDirectory': 'Пустой каталог',
   'sftp.nav.up': 'Наверх',

--- a/application/i18n/locales/zh-CN/core.ts
+++ b/application/i18n/locales/zh-CN/core.ts
@@ -619,6 +619,7 @@ export const zhCNCoreMessages: Messages = {
   'sftp.bookmark.addGlobalTooltip': '保存为全局收藏（所有主机共享）',
   'sftp.bookmark.empty': '暂无收藏路径',
   'sftp.columns.name': '名称',
+  'sftp.columns.configure': '选择显示的列',
   'sftp.columns.modified': '修改时间',
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '类型',

--- a/application/i18n/locales/zh-TW/core.ts
+++ b/application/i18n/locales/zh-TW/core.ts
@@ -619,6 +619,7 @@ export const zhTWCoreMessages: Messages = {
   'sftp.bookmark.addGlobalTooltip': '儲存為全域收藏（所有主機共享）',
   'sftp.bookmark.empty': '暫無收藏路徑',
   'sftp.columns.name': '名稱',
+  'sftp.columns.configure': '選擇顯示的欄位',
   'sftp.columns.modified': '修改時間',
   'sftp.columns.size': '大小',
   'sftp.columns.kind': '型別',

--- a/components/sftp/SftpFileRow.tsx
+++ b/components/sftp/SftpFileRow.tsx
@@ -7,7 +7,7 @@ import React, { memo, useCallback } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { cn } from '../../lib/utils';
 import { SftpFileEntry } from '../../types';
-import { buildSftpColumnTemplate, ColumnWidths, formatBytes, formatDate, getFileIcon, isNavigableDirectory } from './utils';
+import { buildSftpColumnTemplate, formatBytes, formatDate, getFileIcon, isNavigableDirectory, type ColumnWidths, type SftpColumnVisibility } from './utils';
 
 interface SftpFileRowProps {
     entry: SftpFileEntry;
@@ -16,6 +16,7 @@ interface SftpFileRowProps {
     showSelectionHighlight: boolean;
     isDragOver: boolean;
     columnWidths: ColumnWidths;
+    visibleColumns: SftpColumnVisibility;
     onSelect: (entry: SftpFileEntry, index: number, e: React.MouseEvent) => void;
     onOpen: (entry: SftpFileEntry) => void;
     onDragStart: (entry: SftpFileEntry, e: React.DragEvent) => void;
@@ -32,6 +33,7 @@ const SftpFileRowInner: React.FC<SftpFileRowProps> = ({
     showSelectionHighlight,
     isDragOver,
     columnWidths,
+    visibleColumns,
     onSelect,
     onOpen,
     onDragStart,
@@ -86,7 +88,7 @@ const SftpFileRowInner: React.FC<SftpFileRowProps> = ({
                     : "hover:bg-accent/50",
                 isDragOver && isNavDir && "bg-primary/25 ring-1 ring-primary/50"
             )}
-            style={{ display: 'grid', gridTemplateColumns: buildSftpColumnTemplate(columnWidths) }}
+            style={{ display: 'grid', gridTemplateColumns: buildSftpColumnTemplate(columnWidths, visibleColumns) }}
         >
             <div className="flex items-center gap-3 min-w-0">
                 <div className={cn(
@@ -126,13 +128,19 @@ const SftpFileRowInner: React.FC<SftpFileRowProps> = ({
                     <TooltipContent>{entry.name}</TooltipContent>
                 </Tooltip>
             </div>
-            <span className={cn("text-xs truncate", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>{modifiedLabel}</span>
-            <span className={cn("text-xs truncate text-right", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>
-                {isNavDir ? '--' : sizeLabel}
-            </span>
-            <span className={cn("text-xs truncate capitalize text-right", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>
-                {isSymlinkToDirectory ? 'link → folder' : entry.type === 'directory' ? 'folder' : entry.type === 'symlink' ? 'link' : entry.name.split('.').pop()?.toLowerCase() || 'file'}
-            </span>
+            {visibleColumns.modified && (
+                <span className={cn("text-xs truncate", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>{modifiedLabel}</span>
+            )}
+            {visibleColumns.size && (
+                <span className={cn("text-xs truncate text-right", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>
+                    {isNavDir ? '--' : sizeLabel}
+                </span>
+            )}
+            {visibleColumns.type && (
+                <span className={cn("text-xs truncate capitalize text-right", isSelectionVisible ? "text-accent-foreground/85" : "text-muted-foreground")}>
+                    {isSymlinkToDirectory ? 'link → folder' : entry.type === 'directory' ? 'folder' : entry.type === 'symlink' ? 'link' : entry.name.split('.').pop()?.toLowerCase() || 'file'}
+                </span>
+            )}
         </div>
     );
 };
@@ -147,6 +155,9 @@ const areEqual = (prev: SftpFileRowProps, next: SftpFileRowProps): boolean => {
     if (prev.columnWidths.modified !== next.columnWidths.modified) return false;
     if (prev.columnWidths.size !== next.columnWidths.size) return false;
     if (prev.columnWidths.type !== next.columnWidths.type) return false;
+    if (prev.visibleColumns.modified !== next.visibleColumns.modified) return false;
+    if (prev.visibleColumns.size !== next.visibleColumns.size) return false;
+    if (prev.visibleColumns.type !== next.visibleColumns.type) return false;
     // Compare callbacks - important for ".." entry which has static properties
     if (prev.onOpen !== next.onOpen) return false;
     if (prev.onSelect !== next.onSelect) return false;

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -15,7 +15,7 @@ import type { SftpFileEntry } from "../../types";
 import type { SftpPane } from "../../application/state/sftp/types";
 import type { SftpTransferSource } from "./SftpContext";
 import { sftpListOrderStore } from "./hooks/useSftpListOrderStore";
-import { buildSftpColumnTemplate, isNavigableDirectory, type ColumnWidths, type SftpColumnVisibility, type SortField, type SortOrder } from "./utils";
+import { buildSftpColumnTemplate, isNavigableDirectory, isSftpColumnMenuKey, type ColumnWidths, type SftpColumnVisibility, type SortField, type SortOrder } from "./utils";
 import { isKnownBinaryFile } from "../../lib/sftpFileUtils";
 import { SftpFileRow } from "./SftpFileRow";
 import {
@@ -514,6 +514,19 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
         <div
           className="text-[11px] uppercase tracking-wide text-muted-foreground px-4 py-2 border-b border-border/40 bg-secondary/10 select-none"
           data-section="terminal-sftp-list-header"
+          tabIndex={0}
+          aria-label={t("sftp.columns.configure")}
+          onKeyDown={(e) => {
+            if (!isSftpColumnMenuKey(e.key, e.shiftKey)) return;
+            e.preventDefault();
+            const rect = e.currentTarget.getBoundingClientRect();
+            e.currentTarget.dispatchEvent(new MouseEvent("contextmenu", {
+              bubbles: true,
+              cancelable: true,
+              clientX: rect.left + 16,
+              clientY: rect.top + rect.height / 2,
+            }));
+          }}
           style={{
             display: "grid",
             gridTemplateColumns: buildSftpColumnTemplate(columnWidths, visibleColumns),

--- a/components/sftp/SftpPaneFileList.tsx
+++ b/components/sftp/SftpPaneFileList.tsx
@@ -3,6 +3,7 @@ import { AppWindow, ArrowDown, ArrowRight, ArrowUp, ChevronDown, ClipboardCopy, 
 import { Button } from "../ui/button";
 import {
   ContextMenu,
+  ContextMenuCheckboxItem,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
@@ -14,7 +15,7 @@ import type { SftpFileEntry } from "../../types";
 import type { SftpPane } from "../../application/state/sftp/types";
 import type { SftpTransferSource } from "./SftpContext";
 import { sftpListOrderStore } from "./hooks/useSftpListOrderStore";
-import { buildSftpColumnTemplate, isNavigableDirectory, type ColumnWidths, type SortField, type SortOrder } from "./utils";
+import { buildSftpColumnTemplate, isNavigableDirectory, type ColumnWidths, type SftpColumnVisibility, type SortField, type SortOrder } from "./utils";
 import { isKnownBinaryFile } from "../../lib/sftpFileUtils";
 import { SftpFileRow } from "./SftpFileRow";
 import {
@@ -31,10 +32,12 @@ interface SftpPaneFileListProps {
   side: "left" | "right";
   isPaneFocused: boolean;
   columnWidths: ColumnWidths;
+  visibleColumns: SftpColumnVisibility;
   sortField: SortField;
   sortOrder: SortOrder;
   handleSort: (field: SortField) => void;
   handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
+  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
   fileListRef: React.RefObject<HTMLDivElement>;
   handleFileListScroll: (e: React.UIEvent<HTMLDivElement>) => void;
   shouldVirtualize: boolean;
@@ -124,10 +127,12 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
   side,
   isPaneFocused,
   columnWidths,
+  visibleColumns,
   sortField,
   sortOrder,
   handleSort,
   handleResizeStart,
+  toggleColumnVisibility,
   fileListRef,
   handleFileListScroll,
   shouldVirtualize,
@@ -258,6 +263,7 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
             showSelectionHighlight={isPaneFocused}
             isDragOver={dragOverEntry === entry.name}
             columnWidths={columnWidths}
+            visibleColumns={visibleColumns}
             onSelect={handleRowSelect}
             onOpen={handleRowOpen}
             onDragStart={handleFileDragStart}
@@ -438,6 +444,7 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
     ),
     [
       columnWidths,
+      visibleColumns,
       filesByName,
       handleEntryDragOver,
       handleEntryDrop,
@@ -502,71 +509,95 @@ export const SftpPaneFileList: React.FC<SftpPaneFileListProps> = React.memo(({
   return (
     <>
       {/* File list header */}
-    <div
-      className="text-[11px] uppercase tracking-wide text-muted-foreground px-4 py-2 border-b border-border/40 bg-secondary/10 select-none"
-      data-section="terminal-sftp-list-header"
-      style={{
-        display: "grid",
-        gridTemplateColumns: buildSftpColumnTemplate(columnWidths),
-      }}
-    >
-      <div
-        className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 overflow-hidden"
-        onClick={() => handleSort("name")}
-      >
-        <span className="truncate whitespace-nowrap">{t("sftp.columns.name")}</span>
-        {sortField === "name" && (
-          <span className="shrink-0 text-primary">
-            {sortOrder === "asc" ? "↑" : "↓"}
-          </span>
-        )}
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
         <div
-          className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-          onMouseDown={(e) => handleResizeStart("name", e)}
-        />
-      </div>
-      <div
-        className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 overflow-hidden"
-        onClick={() => handleSort("modified")}
-      >
-        <span className="truncate whitespace-nowrap">{t("sftp.columns.modified")}</span>
-        {sortField === "modified" && (
-          <span className="shrink-0 text-primary">
-            {sortOrder === "asc" ? "↑" : "↓"}
-          </span>
-        )}
-        <div
-          className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-          onMouseDown={(e) => handleResizeStart("modified", e)}
-        />
-      </div>
-      <div
-        className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 justify-end overflow-hidden"
-        onClick={() => handleSort("size")}
-      >
-        {sortField === "size" && (
-          <span className="shrink-0 text-primary">
-            {sortOrder === "asc" ? "↑" : "↓"}
-          </span>
-        )}
-        <span className="truncate whitespace-nowrap">{t("sftp.columns.size")}</span>
-        <div
-          className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-          onMouseDown={(e) => handleResizeStart("size", e)}
-        />
-      </div>
-      <div
-        className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground justify-end overflow-hidden"
-        onClick={() => handleSort("type")}
-      >
-        {sortField === "type" && (
-          <span className="shrink-0 text-primary">
-            {sortOrder === "asc" ? "↑" : "↓"}
-          </span>
-        )}
-        <span className="truncate whitespace-nowrap">{t("sftp.columns.kind")}</span>
-      </div>
-    </div>
+          className="text-[11px] uppercase tracking-wide text-muted-foreground px-4 py-2 border-b border-border/40 bg-secondary/10 select-none"
+          data-section="terminal-sftp-list-header"
+          style={{
+            display: "grid",
+            gridTemplateColumns: buildSftpColumnTemplate(columnWidths, visibleColumns),
+          }}
+        >
+          <div
+            className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 overflow-hidden"
+            onClick={() => handleSort("name")}
+          >
+            <span className="truncate whitespace-nowrap">{t("sftp.columns.name")}</span>
+            {sortField === "name" && (
+              <span className="shrink-0 text-primary">
+                {sortOrder === "asc" ? "↑" : "↓"}
+              </span>
+            )}
+            <div
+              className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+              onMouseDown={(e) => handleResizeStart("name", e)}
+            />
+          </div>
+          {visibleColumns.modified && (
+            <div
+              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 overflow-hidden"
+              onClick={() => handleSort("modified")}
+            >
+              <span className="truncate whitespace-nowrap">{t("sftp.columns.modified")}</span>
+              {sortField === "modified" && (
+                <span className="shrink-0 text-primary">
+                  {sortOrder === "asc" ? "↑" : "↓"}
+                </span>
+              )}
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                onMouseDown={(e) => handleResizeStart("modified", e)}
+              />
+            </div>
+          )}
+          {visibleColumns.size && (
+            <div
+              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 justify-end overflow-hidden"
+              onClick={() => handleSort("size")}
+            >
+              {sortField === "size" && (
+                <span className="shrink-0 text-primary">
+                  {sortOrder === "asc" ? "↑" : "↓"}
+                </span>
+              )}
+              <span className="truncate whitespace-nowrap">{t("sftp.columns.size")}</span>
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                onMouseDown={(e) => handleResizeStart("size", e)}
+              />
+            </div>
+          )}
+          {visibleColumns.type && (
+            <div
+              className="flex min-w-0 items-center gap-1 cursor-pointer hover:text-foreground justify-end overflow-hidden"
+              onClick={() => handleSort("type")}
+            >
+              {sortField === "type" && (
+                <span className="shrink-0 text-primary">
+                  {sortOrder === "asc" ? "↑" : "↓"}
+                </span>
+              )}
+              <span className="truncate whitespace-nowrap">{t("sftp.columns.kind")}</span>
+            </div>
+          )}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuCheckboxItem checked disabled>
+          {t("sftp.columns.name")}
+        </ContextMenuCheckboxItem>
+        {(["modified", "size", "type"] as const).map((field) => (
+          <ContextMenuCheckboxItem
+            key={field}
+            checked={visibleColumns[field]}
+            onCheckedChange={() => toggleColumnVisibility(field)}
+          >
+            {t(field === "type" ? "sftp.columns.kind" : `sftp.columns.${field}`)}
+          </ContextMenuCheckboxItem>
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
 
     {/* File list with empty area context menu */}
     <ContextMenu>

--- a/components/sftp/SftpPaneTreeNode.tsx
+++ b/components/sftp/SftpPaneTreeNode.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ChevronRight, CornerUpLeft, Folder, FolderOpen, Loader2 } from 'lucide-react';
 import type { SftpFileEntry } from '../../types';
-import { formatBytes, formatDate, getFileIcon, isNavigableDirectory } from './utils';
+import { formatBytes, formatDate, getFileIcon, isNavigableDirectory, type SftpColumnVisibility } from './utils';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { cn } from '../../lib/utils';
 
@@ -16,6 +16,7 @@ interface TreeNodeProps {
   entryPath: string;
   depth: number;
   columnTemplate: string;
+  visibleColumns: SftpColumnVisibility;
   isSelected: boolean;
   isExpanded: boolean;
   isLoading: boolean;
@@ -34,7 +35,7 @@ interface TreeNodeProps {
 export const TREE_ROW_HEIGHT = 28;
 
 export const TreeNode = React.memo<TreeNodeProps>(({
-  entry, entryPath, depth, columnTemplate, isSelected,
+  entry, entryPath, depth, columnTemplate, visibleColumns, isSelected,
   isExpanded, isLoading, isDragOver,
   onToggleExpand, onNodeClick, onOpenEntry, onDragStart, onDragEnd,
   onDragOverEntry, onDropEntry, onDragLeaveEntry,
@@ -105,15 +106,21 @@ export const TreeNode = React.memo<TreeNodeProps>(({
         {!isParentEntry && <span className="shrink-0">{icon}</span>}
         <span className="min-w-0 flex-1 truncate">{entry.name}</span>
       </div>
-      <span className="min-w-0 text-muted-foreground text-xs truncate">
-        {isParentEntry ? '' : formatDate(entry.lastModified)}
-      </span>
-      <span className="min-w-0 text-right text-muted-foreground text-xs truncate">
-        {isParentEntry ? '' : (isDir ? '--' : formatBytes(entry.size ?? 0))}
-      </span>
-      <span className="min-w-0 text-right text-muted-foreground text-xs truncate">
-        {isParentEntry ? '' : (isDir ? t('sftp.kind.folder') : (entry.name.split('.').pop()?.toUpperCase() ?? '--'))}
-      </span>
+      {visibleColumns.modified && (
+        <span className="min-w-0 text-muted-foreground text-xs truncate">
+          {isParentEntry ? '' : formatDate(entry.lastModified)}
+        </span>
+      )}
+      {visibleColumns.size && (
+        <span className="min-w-0 text-right text-muted-foreground text-xs truncate">
+          {isParentEntry ? '' : (isDir ? '--' : formatBytes(entry.size ?? 0))}
+        </span>
+      )}
+      {visibleColumns.type && (
+        <span className="min-w-0 text-right text-muted-foreground text-xs truncate">
+          {isParentEntry ? '' : (isDir ? t('sftp.kind.folder') : (entry.name.split('.').pop()?.toUpperCase() ?? '--'))}
+        </span>
+      )}
     </div>
   );
 });

--- a/components/sftp/SftpPaneTreeView.tsx
+++ b/components/sftp/SftpPaneTreeView.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { AlertCircle, Loader2, RefreshCw } from 'lucide-react';
 import { Button } from '../ui/button';
-import { ContextMenu, ContextMenuTrigger } from '../ui/context-menu';
+import { ContextMenu, ContextMenuCheckboxItem, ContextMenuContent, ContextMenuTrigger } from '../ui/context-menu';
 import { type NodeDescriptor } from './SftpPaneTreeNode';
 import { INITIAL_TREE_PATHS_STATE, treePathsReducer } from './sftpTreePathsReducer';
 import { useSftpPaneTreeContextMenu } from './useSftpPaneTreeContextMenu';
@@ -9,7 +9,7 @@ import { useSftpPaneTreeRows } from './useSftpPaneTreeRows';
 import { SftpMoveToDialog } from './SftpMoveToDialog';
 import type { SftpFileEntry } from '../../types';
 import { getParentPath, joinPath } from '../../application/state/sftp/utils';
-import { buildSftpColumnTemplate, filterHiddenFiles, isNavigableDirectory, sortSftpEntries } from './utils';
+import { buildSftpColumnTemplate, filterHiddenFiles, isNavigableDirectory, isSftpColumnMenuKey, sortSftpEntries } from './utils';
 import type { SftpTransferSource } from './SftpContext';
 import type { SftpPaneTreeViewProps } from './SftpPaneTreeView.types';
 import { sftpTreeSelectionStore, useSftpTreeSelectionState } from './hooks/useSftpTreeSelectionStore';
@@ -51,14 +51,16 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
   onUploadExternalFileList,
   onUploadExternalFolder,
   columnWidths,
+  visibleColumns,
   handleSort,
   handleResizeStart,
+  toggleColumnVisibility,
   sortField,
   sortOrder,
   reloadRequest,
 }) => {
   const { t } = useI18n();
-  const columnTemplate = buildSftpColumnTemplate(columnWidths);
+  const columnTemplate = buildSftpColumnTemplate(columnWidths, visibleColumns);
   const tRef = useRef(t);
   tRef.current = t;
   const [dragOverNodePath, setDragOverNodePath] = useState<string | null>(null);
@@ -794,6 +796,7 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
     viewportHeight,
     tRef,
     columnTemplate,
+    visibleColumns,
     selectedPaths,
     dragOverNodePath,
     toggleExpand,
@@ -841,67 +844,105 @@ export const SftpPaneTreeView = React.memo<SftpPaneTreeViewProps>(({
   });
   return (
     <div className="relative flex-1 min-h-0 flex flex-col text-sm">
-      <div
-        className="text-[11px] uppercase tracking-wide text-muted-foreground px-4 py-2 border-b border-border/40 bg-secondary/10 select-none shrink-0"
-        style={{ display: 'grid', gridTemplateColumns: columnTemplate }}
-      >
-        <div
-          className="flex items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
-          onClick={() => handleSort('name')}
-        >
-          <span className="truncate whitespace-nowrap">{t('sftp.columns.name')}</span>
-          {sortField === 'name' && (
-            <span className="shrink-0 text-primary">
-              {sortOrder === 'asc' ? '↑' : '↓'}
-            </span>
-          )}
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
           <div
-            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-            onMouseDown={(e) => handleResizeStart('name', e)}
-          />
-        </div>
-        <div
-          className="flex items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
-          onClick={() => handleSort('modified')}
-        >
-          <span className="truncate whitespace-nowrap">{t('sftp.columns.modified')}</span>
-          {sortField === 'modified' && (
-            <span className="shrink-0 text-primary">
-              {sortOrder === 'asc' ? '↑' : '↓'}
-            </span>
-          )}
-          <div
-            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-            onMouseDown={(e) => handleResizeStart('modified', e)}
-          />
-        </div>
-        <div
-          className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
-          onClick={() => handleSort('size')}
-        >
-          {sortField === 'size' && (
-            <span className="shrink-0 text-primary">
-              {sortOrder === 'asc' ? '↑' : '↓'}
-            </span>
-          )}
-          <span className="truncate whitespace-nowrap">{t('sftp.columns.size')}</span>
-          <div
-            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
-            onMouseDown={(e) => handleResizeStart('size', e)}
-          />
-        </div>
-        <div
-          className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground min-w-0 overflow-hidden"
-          onClick={() => handleSort('type')}
-        >
-          {sortField === 'type' && (
-            <span className="shrink-0 text-primary">
-              {sortOrder === 'asc' ? '↑' : '↓'}
-            </span>
-          )}
-          <span className="truncate whitespace-nowrap">{t('sftp.columns.kind')}</span>
-        </div>
-      </div>
+            className="text-[11px] uppercase tracking-wide text-muted-foreground px-4 py-2 border-b border-border/40 bg-secondary/10 select-none shrink-0"
+            data-section="terminal-sftp-tree-header"
+            tabIndex={0}
+            aria-label={t('sftp.columns.configure')}
+            onKeyDown={(e) => {
+              if (!isSftpColumnMenuKey(e.key, e.shiftKey)) return;
+              e.preventDefault();
+              const rect = e.currentTarget.getBoundingClientRect();
+              e.currentTarget.dispatchEvent(new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: rect.left + 16,
+                clientY: rect.top + rect.height / 2,
+              }));
+            }}
+            style={{ display: 'grid', gridTemplateColumns: columnTemplate }}
+          >
+            <div
+              className="flex items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
+              onClick={() => handleSort('name')}
+            >
+              <span className="truncate whitespace-nowrap">{t('sftp.columns.name')}</span>
+              {sortField === 'name' && (
+                <span className="shrink-0 text-primary">
+                  {sortOrder === 'asc' ? '↑' : '↓'}
+                </span>
+              )}
+              <div
+                className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                onMouseDown={(e) => handleResizeStart('name', e)}
+              />
+            </div>
+            {visibleColumns.modified && (
+              <div
+                className="flex items-center gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
+                onClick={() => handleSort('modified')}
+              >
+                <span className="truncate whitespace-nowrap">{t('sftp.columns.modified')}</span>
+                {sortField === 'modified' && (
+                  <span className="shrink-0 text-primary">
+                    {sortOrder === 'asc' ? '↑' : '↓'}
+                  </span>
+                )}
+                <div
+                  className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                  onMouseDown={(e) => handleResizeStart('modified', e)}
+                />
+              </div>
+            )}
+            {visibleColumns.size && (
+              <div
+                className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground relative pr-2 min-w-0 overflow-hidden"
+                onClick={() => handleSort('size')}
+              >
+                {sortField === 'size' && (
+                  <span className="shrink-0 text-primary">
+                    {sortOrder === 'asc' ? '↑' : '↓'}
+                  </span>
+                )}
+                <span className="truncate whitespace-nowrap">{t('sftp.columns.size')}</span>
+                <div
+                  className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+                  onMouseDown={(e) => handleResizeStart('size', e)}
+                />
+              </div>
+            )}
+            {visibleColumns.type && (
+              <div
+                className="flex items-center justify-end gap-1 cursor-pointer hover:text-foreground min-w-0 overflow-hidden"
+                onClick={() => handleSort('type')}
+              >
+                {sortField === 'type' && (
+                  <span className="shrink-0 text-primary">
+                    {sortOrder === 'asc' ? '↑' : '↓'}
+                  </span>
+                )}
+                <span className="truncate whitespace-nowrap">{t('sftp.columns.kind')}</span>
+              </div>
+            )}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuCheckboxItem checked disabled>
+            {t('sftp.columns.name')}
+          </ContextMenuCheckboxItem>
+          {(['modified', 'size', 'type'] as const).map((field) => (
+            <ContextMenuCheckboxItem
+              key={field}
+              checked={visibleColumns[field]}
+              onCheckedChange={() => toggleColumnVisibility(field)}
+            >
+              {t(field === 'type' ? 'sftp.columns.kind' : `sftp.columns.${field}`)}
+            </ContextMenuCheckboxItem>
+          ))}
+        </ContextMenuContent>
+      </ContextMenu>
       <ContextMenu>
         <ContextMenuTrigger asChild>
           <div

--- a/components/sftp/SftpPaneTreeView.types.ts
+++ b/components/sftp/SftpPaneTreeView.types.ts
@@ -2,7 +2,7 @@ import type React from 'react';
 import type { SftpFileEntry } from '../../types';
 import type { SftpPane } from '../../application/state/sftp/types';
 import type { SftpTransferSource } from './SftpContext';
-import type { ColumnWidths, SortField, SortOrder } from './utils';
+import type { ColumnWidths, SftpColumnVisibility, SortField, SortOrder } from './utils';
 
 export interface SftpPaneTreeViewProps {
   pane: SftpPane;
@@ -32,8 +32,10 @@ export interface SftpPaneTreeViewProps {
   onUploadExternalFileList?: (fileList: FileList, targetPath?: string) => Promise<void>;
   onUploadExternalFolder?: (targetPath?: string) => Promise<void>;
   columnWidths: ColumnWidths;
+  visibleColumns: SftpColumnVisibility;
   handleSort: (field: SortField) => void;
   handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
+  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
   sortField: SortField;
   sortOrder: SortOrder;
   reloadRequest: { token: number; paths?: string[]; full?: boolean };

--- a/components/sftp/SftpPaneView.tsx
+++ b/components/sftp/SftpPaneView.tsx
@@ -157,7 +157,15 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
     draggedFilesCount: draggedFiles?.length ?? 0,
   });
 
-  const { sortField, sortOrder, columnWidths, handleSort, handleResizeStart } = useSftpPaneSorting();
+  const {
+    sortField,
+    sortOrder,
+    columnWidths,
+    visibleColumns,
+    handleSort,
+    handleResizeStart,
+    toggleColumnVisibility,
+  } = useSftpPaneSorting();
 
   // Bookmark support
   const updateHosts = useSftpUpdateHosts();
@@ -573,8 +581,10 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
             onUploadExternalFileList={handleUploadExternalFileList}
             onUploadExternalFolder={handleUploadExternalFolder}
             columnWidths={columnWidths}
+            visibleColumns={visibleColumns}
             handleSort={handleSortWithTransition}
             handleResizeStart={handleResizeStart}
+            toggleColumnVisibility={toggleColumnVisibility}
             sortField={sortField}
             sortOrder={sortOrder}
             reloadRequest={treeReloadRequest}
@@ -590,10 +600,12 @@ const SftpPaneViewInner: React.FC<SftpPaneViewProps> = ({
           side={side}
           isPaneFocused={isPaneFocused}
           columnWidths={columnWidths}
+          visibleColumns={visibleColumns}
           sortField={sortField}
           sortOrder={sortOrder}
           handleSort={handleSortWithTransition}
           handleResizeStart={handleResizeStart}
+          toggleColumnVisibility={toggleColumnVisibility}
           fileListRef={fileListRef}
           handleFileListScroll={handleFileListScroll}
           shouldVirtualize={shouldVirtualize}

--- a/components/sftp/hooks/useSftpPaneSorting.ts
+++ b/components/sftp/hooks/useSftpPaneSorting.ts
@@ -1,12 +1,26 @@
-import React, { useCallback, useRef, useState } from "react";
-import type { ColumnWidths, SortField, SortOrder } from "../utils";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  DEFAULT_SFTP_COLUMN_VISIBILITY,
+  normalizeSftpColumnVisibility,
+  type ColumnWidths,
+  type SftpColumnVisibility,
+  type SortField,
+  type SortOrder,
+} from "../utils";
+import { STORAGE_KEY_SFTP_VISIBLE_COLUMNS } from "../../../infrastructure/config/storageKeys";
+import {
+  LOCAL_STORAGE_ADAPTER_CHANGED_EVENT,
+  localStorageAdapter,
+} from "../../../infrastructure/persistence/localStorageAdapter";
 
 interface UseSftpPaneSortingResult {
   sortField: SortField;
   sortOrder: SortOrder;
   columnWidths: ColumnWidths;
+  visibleColumns: SftpColumnVisibility;
   handleSort: (field: SortField) => void;
   handleResizeStart: (field: keyof ColumnWidths, e: React.MouseEvent) => void;
+  toggleColumnVisibility: (field: keyof ColumnWidths) => void;
 }
 
 export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
@@ -18,6 +32,49 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
     size: 7,
     type: 9,
   });
+  const [visibleColumns, setVisibleColumns] = useState<SftpColumnVisibility>(() =>
+    normalizeSftpColumnVisibility(
+      localStorageAdapter.read<Partial<SftpColumnVisibility>>(STORAGE_KEY_SFTP_VISIBLE_COLUMNS),
+    ),
+  );
+
+  useEffect(() => {
+    const syncVisibleColumns = (event: Event) => {
+      if (event instanceof StorageEvent && event.key !== STORAGE_KEY_SFTP_VISIBLE_COLUMNS) return;
+      if (event instanceof CustomEvent && event.detail?.key !== STORAGE_KEY_SFTP_VISIBLE_COLUMNS) return;
+      const next = normalizeSftpColumnVisibility(
+        localStorageAdapter.read<Partial<SftpColumnVisibility>>(STORAGE_KEY_SFTP_VISIBLE_COLUMNS),
+      );
+      setVisibleColumns(next);
+    };
+
+    window.addEventListener("storage", syncVisibleColumns);
+    window.addEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, syncVisibleColumns);
+    return () => {
+      window.removeEventListener("storage", syncVisibleColumns);
+      window.removeEventListener(LOCAL_STORAGE_ADAPTER_CHANGED_EVENT, syncVisibleColumns);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (visibleColumns[sortField]) return;
+    setSortField("name");
+    setSortOrder("asc");
+  }, [sortField, visibleColumns]);
+
+  const toggleColumnVisibility = useCallback((field: keyof ColumnWidths) => {
+    if (field === "name") return;
+    setVisibleColumns((current) => {
+      const next = {
+        ...DEFAULT_SFTP_COLUMN_VISIBILITY,
+        ...current,
+        name: true,
+        [field]: !current[field],
+      };
+      localStorageAdapter.write(STORAGE_KEY_SFTP_VISIBLE_COLUMNS, next);
+      return next;
+    });
+  }, []);
 
   const resizingRef = useRef<{
     field: keyof ColumnWidths;
@@ -97,7 +154,9 @@ export const useSftpPaneSorting = (): UseSftpPaneSortingResult => {
     sortField,
     sortOrder,
     columnWidths,
+    visibleColumns,
     handleSort,
     handleResizeStart,
+    toggleColumnVisibility,
   };
 };

--- a/components/sftp/sftpColumnVisibility.test.ts
+++ b/components/sftp/sftpColumnVisibility.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   buildSftpColumnTemplate,
   DEFAULT_SFTP_COLUMN_VISIBILITY,
+  isSftpColumnMenuKey,
   normalizeSftpColumnVisibility,
   type ColumnWidths,
 } from './utils.ts';
@@ -48,4 +49,11 @@ test('can reduce the SFTP file list to only the name column', () => {
     }),
     'minmax(140px, 56fr)',
   );
+});
+
+test('recognizes standard keyboard shortcuts for opening the column menu', () => {
+  assert.equal(isSftpColumnMenuKey('ContextMenu', false), true);
+  assert.equal(isSftpColumnMenuKey('F10', true), true);
+  assert.equal(isSftpColumnMenuKey('F10', false), false);
+  assert.equal(isSftpColumnMenuKey('Enter', false), false);
 });

--- a/components/sftp/sftpColumnVisibility.test.ts
+++ b/components/sftp/sftpColumnVisibility.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildSftpColumnTemplate,
+  DEFAULT_SFTP_COLUMN_VISIBILITY,
+  normalizeSftpColumnVisibility,
+  type ColumnWidths,
+} from './utils.ts';
+
+const widths: ColumnWidths = {
+  name: 56,
+  modified: 28,
+  size: 7,
+  type: 9,
+};
+
+test('normalizes missing and invalid SFTP column preferences to all columns', () => {
+  assert.deepEqual(normalizeSftpColumnVisibility(null), DEFAULT_SFTP_COLUMN_VISIBILITY);
+  assert.deepEqual(normalizeSftpColumnVisibility('invalid'), DEFAULT_SFTP_COLUMN_VISIBILITY);
+});
+
+test('keeps the name column visible while restoring optional column preferences', () => {
+  assert.deepEqual(
+    normalizeSftpColumnVisibility({ name: false, modified: false, size: true, type: false }),
+    { name: true, modified: false, size: true, type: false },
+  );
+});
+
+test('builds a grid containing only visible SFTP columns', () => {
+  const template = buildSftpColumnTemplate(widths, {
+    name: true,
+    modified: false,
+    size: true,
+    type: false,
+  });
+
+  assert.equal(template, 'minmax(140px, 56fr) minmax(52px, 7fr)');
+});
+
+test('can reduce the SFTP file list to only the name column', () => {
+  assert.equal(
+    buildSftpColumnTemplate(widths, {
+      name: true,
+      modified: false,
+      size: false,
+      type: false,
+    }),
+    'minmax(140px, 56fr)',
+  );
+});

--- a/components/sftp/sftpColumnVisibilityIntegration.test.ts
+++ b/components/sftp/sftpColumnVisibilityIntegration.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const readSource = (fileName: string): string =>
+  readFileSync(new URL(fileName, import.meta.url), 'utf8');
+
+test('list and tree SFTP views share column visibility and keyboard-accessible menus', () => {
+  const listSource = readSource('./SftpPaneFileList.tsx');
+  const treeSource = readSource('./SftpPaneTreeView.tsx');
+  const treeNodeSource = readSource('./SftpPaneTreeNode.tsx');
+
+  for (const source of [listSource, treeSource]) {
+    assert.match(source, /buildSftpColumnTemplate\(columnWidths, visibleColumns\)/);
+    assert.match(source, /ContextMenuCheckboxItem/);
+    assert.match(source, /isSftpColumnMenuKey/);
+    assert.match(source, /tabIndex=\{0\}/);
+  }
+
+  assert.match(treeNodeSource, /visibleColumns\.modified/);
+  assert.match(treeNodeSource, /visibleColumns\.size/);
+  assert.match(treeNodeSource, /visibleColumns\.type/);
+});

--- a/components/sftp/useSftpPaneTreeRows.tsx
+++ b/components/sftp/useSftpPaneTreeRows.tsx
@@ -7,7 +7,7 @@ type SftpPaneTreeRowsProps = Record<string, any>;
 
 export function useSftpPaneTreeRows(props: SftpPaneTreeRowsProps) {
   const {
-    nodeDescriptors, scrollTop, viewportHeight, tRef, columnTemplate, selectedPaths, dragOverNodePath,
+    nodeDescriptors, scrollTop, viewportHeight, tRef, columnTemplate, visibleColumns, selectedPaths, dragOverNodePath,
     toggleExpand, handleNodeClick, stableOnOpenEntry, stableOnDragStart, stableOnDragEnd,
     handleNodeDragOver, handleNodeDrop, handleNodeDragLeave, handleNodeContextMenu,
   } = props;
@@ -62,6 +62,7 @@ export function useSftpPaneTreeRows(props: SftpPaneTreeRowsProps) {
             entryPath={descriptor.entryPath}
             depth={descriptor.depth}
             columnTemplate={columnTemplate}
+            visibleColumns={visibleColumns}
             isSelected={selectedPaths.has(descriptor.entryPath)}
             isExpanded={descriptor.isExpanded}
             isLoading={descriptor.isLoading}
@@ -100,6 +101,7 @@ export function useSftpPaneTreeRows(props: SftpPaneTreeRowsProps) {
     visibleRange,
     nodeDescriptors,
     columnTemplate,
+    visibleColumns,
     selectedPaths,
     dragOverNodePath,
     toggleExpand,

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -280,6 +280,9 @@ export const normalizeSftpColumnVisibility = (value: unknown): SftpColumnVisibil
     };
 };
 
+export const isSftpColumnMenuKey = (key: string, shiftKey: boolean): boolean =>
+    key === 'ContextMenu' || (key === 'F10' && shiftKey);
+
 export const buildSftpColumnTemplate = (
     columnWidths: ColumnWidths,
     visibleColumns: SftpColumnVisibility = DEFAULT_SFTP_COLUMN_VISIBILITY,

--- a/components/sftp/utils.ts
+++ b/components/sftp/utils.ts
@@ -257,13 +257,38 @@ export interface ColumnWidths {
     type: number;
 }
 
-export const buildSftpColumnTemplate = (columnWidths: ColumnWidths): string => {
-    return [
-        `minmax(140px, ${columnWidths.name}fr)`,
-        `minmax(0, ${columnWidths.modified}fr)`,
-        `minmax(52px, ${columnWidths.size}fr)`,
-        `minmax(64px, ${columnWidths.type}fr)`,
-    ].join(' ');
+export type SftpColumnVisibility = Record<keyof ColumnWidths, boolean>;
+
+export const DEFAULT_SFTP_COLUMN_VISIBILITY: SftpColumnVisibility = {
+    name: true,
+    modified: true,
+    size: true,
+    type: true,
+};
+
+export const normalizeSftpColumnVisibility = (value: unknown): SftpColumnVisibility => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return DEFAULT_SFTP_COLUMN_VISIBILITY;
+    }
+
+    const stored = value as Partial<Record<keyof ColumnWidths, unknown>>;
+    return {
+        name: true,
+        modified: stored.modified !== false,
+        size: stored.size !== false,
+        type: stored.type !== false,
+    };
+};
+
+export const buildSftpColumnTemplate = (
+    columnWidths: ColumnWidths,
+    visibleColumns: SftpColumnVisibility = DEFAULT_SFTP_COLUMN_VISIBILITY,
+): string => {
+    const columns = [`minmax(140px, ${columnWidths.name}fr)`];
+    if (visibleColumns.modified) columns.push(`minmax(0, ${columnWidths.modified}fr)`);
+    if (visibleColumns.size) columns.push(`minmax(52px, ${columnWidths.size}fr)`);
+    if (visibleColumns.type) columns.push(`minmax(64px, ${columnWidths.type}fr)`);
+    return columns.join(' ');
 };
 
 export const sortSftpEntries = (

--- a/infrastructure/config/storageKeys.ts
+++ b/infrastructure/config/storageKeys.ts
@@ -118,6 +118,7 @@ export const STORAGE_KEY_SFTP_AUTO_OPEN_SIDEBAR = 'netcatty_sftp_auto_open_sideb
 export const STORAGE_KEY_SFTP_FOLLOW_TERMINAL_CWD = 'netcatty_sftp_follow_terminal_cwd_v1';
 export const STORAGE_KEY_SFTP_DEFAULT_VIEW_MODE = 'netcatty_sftp_default_view_mode_v1';
 export const STORAGE_KEY_SFTP_HOST_VIEW_MODES = 'netcatty_sftp_host_view_modes_v1';
+export const STORAGE_KEY_SFTP_VISIBLE_COLUMNS = 'netcatty_sftp_visible_columns_v1';
 export const STORAGE_KEY_SFTP_TRANSFER_PANEL_HEIGHT = 'netcatty_sftp_transfer_panel_height_v1';
 export const STORAGE_KEY_SFTP_TRANSFER_CHILD_NAME_WIDTH = 'netcatty_sftp_transfer_child_name_width_v1';
 


### PR DESCRIPTION
Closes #2127

## What changed

- Added a column chooser to both SFTP list and tree-view headers.
- Kept the Name column always visible while allowing Modified, Size, and Kind to be hidden independently.
- Saved the preference and synchronized it between SFTP panes and windows.
- Reset sorting to Name when the active sort column is hidden.
- Added keyboard access through the Context Menu key and Shift+F10.

## Validation

- Added focused tests for preference normalization, grid layout, keyboard shortcuts, and list/tree parity.
- Ran 17 focused and localization tests successfully.
- Ran targeted lint checks successfully.
- Ran the production build successfully.
- Verified right-click and keyboard menu opening, each hidden-column state, Name-only mode, list/tree parity, and persistence after reload in the app UI.
- Ran two review rounds with three independent reviewers; the final round was clean.

## Repository baseline notes

- The full TypeScript check currently reports existing errors outside this change.
- The full test command reached the broader suite, but Electron-dependent tests failed after concurrent workers corrupted the local Electron install. The focused tests, lint, build, and UI verification for this change all pass.