### PR TITLE
fix: measure connectivity latency before protocol handshake

### DIFF
--- a/components/terminal/hooks/useServerStats.ts
+++ b/components/terminal/hooks/useServerStats.ts
@@ -45,7 +45,7 @@ export interface ServerStats {
   disks: DiskInfo[];            // All mounted disks
   netRxSpeed: number;           // Total network receive speed (bytes/sec)
   netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-  latencyMs: number | null;     // Approximate network round-trip over the SSH stats channel
+  latencyMs: number | null;     // TCP connection establishment latency to the SSH endpoint
   netInterfaces: NetInterfaceInfo[];  // Per-interface network stats
   lastUpdated: number | null;   // Timestamp of last successful update
 }

--- a/electron/bridges/sshBridge.cjs
+++ b/electron/bridges/sshBridge.cjs
@@ -47,6 +47,7 @@ const {
   _resetAlgorithmSupportCacheForTests,
 } = require("./sshAlgorithms.cjs");
 const { enableSshNoDelay, enableTcpNoDelay } = require("./tcpNoDelay.cjs");
+const { createTcpConnectLatencyProbe } = require("./tcpConnectLatency.cjs");
 const {
   configureTerminalSessionDataEmitter,
 } = require("./emitTerminalSessionData.cjs");
@@ -1155,6 +1156,7 @@ const { ensureMoshStatsConnection, ensureEtStatsConnection } = createMoshStatsCo
 });
 
 const { createSessionOpsApi } = require("./sshBridge/sessionOps.cjs");
+const measureTcpConnectLatency = createTcpConnectLatencyProbe({ net });
 const sessionOpsApi = createSessionOpsApi({
   get sessions() { return sessions; },
   get electronModule() { return electronModule; },
@@ -1162,6 +1164,7 @@ const sessionOpsApi = createSessionOpsApi({
   getSessionDecoder, resetSessionDecoders, sessionEncodings, normalizeTerminalEncoding,
   safeSend,
   quoteShellArg, log, ensureMoshStatsConnection, ensureEtStatsConnection,
+  measureTcpConnectLatency,
   execOnEtSession: (...args) => require("./terminalBridge.cjs").execOnEtSession(...args),
   getServerStats: undefined,
 });

--- a/electron/bridges/sshBridge.sessionOps.et.test.cjs
+++ b/electron/bridges/sshBridge.sessionOps.et.test.cjs
@@ -28,7 +28,7 @@ function fakeConn(stdout) {
       const output = command.includes("NC_LATENCY_MARK") && !stdout.includes("NC_LATENCY_MARK")
         ? `NC_LATENCY_MARK|${stdout}`
         : stdout;
-      cb(null, fakeStream(output, command.includes("NC_LATENCY_MARK")));
+      cb(null, fakeStream(output));
     },
   };
 }
@@ -52,6 +52,7 @@ function makeApi(session, execOnEtSession, extra = {}) {
     iconv: { encodingExists: () => true },
     sessionEncodings: new Map(),
     resetSessionDecoders: () => {},
+    measureTcpConnectLatency: async () => 3,
     ...extra,
   });
 }
@@ -171,7 +172,7 @@ test("getServerStats falls back to execOnEtSession when the direct ET companion 
   assert.equal(execFallbackCalls, 1);
   assert.equal(result.success, true);
   assert.equal(result.stats.memTotal, 8000);
-  assert.equal(result.stats.latencyMs, null);
+  assert.equal(result.stats.latencyMs, 3);
 });
 
 test("readRemoteHistory probes ET sessions and parses the detected shell", async () => {

--- a/electron/bridges/sshBridge.sessionOps.et.test.cjs
+++ b/electron/bridges/sshBridge.sessionOps.et.test.cjs
@@ -80,10 +80,12 @@ test("getServerStats opens an ET stats companion connection for direct ET sessio
     sshUserHost: "alice@example.test",
     sshOptions: [],
     sshEnv: {},
+    tcpLatencyTarget: { hostname: "example.test", port: 2022 },
     etStatsAuth: { hostname: "example.test", username: "alice" },
   };
   let ensureCalls = 0;
   let execFallbackCalls = 0;
+  const latencyTargets = [];
   const api = makeApi(
     session,
     async () => {
@@ -98,6 +100,10 @@ test("getServerStats opens an ET stats companion connection for direct ET sessio
         s.etStatsConn = fakeConn(LINUX_STATS);
         return s.etStatsConn;
       },
+      measureTcpConnectLatency: async (target) => {
+        latencyTargets.push(target);
+        return 3;
+      },
     },
   );
 
@@ -110,6 +116,7 @@ test("getServerStats opens an ET stats companion connection for direct ET sessio
   assert.equal(result.stats.memTotal, 8000);
   assert.equal(result.stats.cpuCores, 4);
   assert.equal(typeof result.stats.latencyMs, "number");
+  assert.deepEqual(latencyTargets, [{ hostname: "example.test", port: 2022 }]);
 });
 
 test("getServerStats falls back to execOnEtSession for jumped ET sessions", async () => {

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -1,6 +1,19 @@
 /* eslint-disable no-undef */
 function createSessionOpsApi(ctx) {
   with (ctx) {
+    function getTcpLatencyTarget(session) {
+      if (session.tcpLatencyDirect === false) return null;
+
+      const auth = session.moshStatsAuth || session.etStatsAuth || session._reuseEndpoint || null;
+      if (auth?.hasJumpHost || auth?.hasProxy) return null;
+
+      const hostname = auth?.hostname || session.hostname;
+      const rawPort = auth?.port ?? 22;
+      const port = Number(rawPort);
+      if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) return null;
+      return { hostname, port };
+    }
+
     async function getSessionRemoteInfo(_event, payload) {
       const { sessionId } = payload || {};
       const session = sessions.get(sessionId);
@@ -798,12 +811,11 @@ function createSessionOpsApi(ctx) {
     
       // Auto-detect OS via uname — only Linux and macOS are supported
       const latencyMarker = "NC_LATENCY_MARK";
-      // On an ssh2 channel, wait for a one-byte client probe before printing
-      // the marker. Timing that data round-trip excludes channel setup and the
-      // stats command itself. The buffered system-ssh ET fallback cannot expose
-      // first-byte timing, so it reports no latency instead of a misleading one.
-      const latencyProbeCommand = usesEtStatsFallback ? '' : 'read -r nc_latency_probe; ';
-      const statsCommand = `${latencyProbeCommand}printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
+      const statsCommand = `printf "${latencyMarker}|"; ostype=$(uname -s 2>/dev/null || echo "Unknown"); if [ "$ostype" = "Darwin" ]; then ${macosStatsCommand}; elif [ "$ostype" = "Linux" ]; then ${linuxStatsCommand}; else echo "UNSUPPORTED_OS:$ostype"; fi`;
+      const tcpLatencyTarget = getTcpLatencyTarget(session);
+      const tcpLatencyPromise = tcpLatencyTarget && typeof measureTcpConnectLatency === 'function'
+        ? Promise.resolve(measureTcpConnectLatency(tcpLatencyTarget)).catch(() => null)
+        : Promise.resolve(null);
       return new Promise((resolve) => {
         let activeStream = null;
         let settled = false;
@@ -845,27 +857,21 @@ function createSessionOpsApi(ctx) {
     
           let stdout = '';
           let stderr = '';
-          let latencyMs = null;
-          let latencyStartedAt = null;
     
           stream.on('data', (data) => {
             stdout += data.toString();
-            if (
-              latencyMs === null &&
-              latencyStartedAt !== null &&
-              stdout.includes(latencyMarker)
-            ) {
-              latencyMs = Math.max(0, Date.now() - latencyStartedAt);
-            }
           });
     
           stream.stderr.on('data', (data) => {
             stderr += data.toString();
           });
     
-          stream.on('close', () => {
+          stream.on('close', async () => {
             if (settled) return;
             activeStream = null;
+            const measuredLatency = await tcpLatencyPromise;
+            if (settled) return;
+            const latencyMs = Number.isFinite(measuredLatency) ? measuredLatency : null;
     
             // Parse the output
             const output = stdout.trim().replace(new RegExp(`^${latencyMarker}\\|?`), '');
@@ -1167,7 +1173,7 @@ function createSessionOpsApi(ctx) {
                 disks,         // Array of all mounted disks
                 netRxSpeed,    // Total network receive speed (bytes/sec)
                 netTxSpeed,    // Total network transmit speed (bytes/sec)
-                latencyMs,      // Approximate network round-trip over the SSH stats channel (ms)
+                latencyMs,      // TCP connection establishment latency to the SSH endpoint (ms)
                 netInterfaces, // Per-interface network stats
                 hostname,
                 osName,
@@ -1178,16 +1184,6 @@ function createSessionOpsApi(ctx) {
             });
           });
 
-          if (!usesEtStatsFallback) {
-            try {
-              latencyStartedAt = Date.now();
-              stream.write('\n');
-            } catch (err) {
-              if (settle({ success: false, error: err?.message || String(err) })) {
-                disposeStream(stream);
-              }
-            }
-          }
         });
       });
     }

--- a/electron/bridges/sshBridge/sessionOps.cjs
+++ b/electron/bridges/sshBridge/sessionOps.cjs
@@ -4,7 +4,7 @@ function createSessionOpsApi(ctx) {
     function getTcpLatencyTarget(session) {
       if (session.tcpLatencyDirect === false) return null;
 
-      const auth = session.moshStatsAuth || session.etStatsAuth || session._reuseEndpoint || null;
+      const auth = session.tcpLatencyTarget || session.moshStatsAuth || session.etStatsAuth || session._reuseEndpoint || null;
       if (auth?.hasJumpHost || auth?.hasProxy) return null;
 
       const hostname = auth?.hostname || session.hostname;

--- a/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
+++ b/electron/bridges/sshBridge/sessionOps.serverStats.test.cjs
@@ -15,10 +15,8 @@ function fakeStream(stdout) {
     if (stdout) stream.emit("data", Buffer.from(stdout));
     stream.emit("close", 0);
   };
-  stream.write = () => {
-    setImmediate(send);
-    return true;
-  };
+  stream.write = () => true;
+  setImmediate(send);
   return stream;
 }
 
@@ -51,6 +49,7 @@ function makeSessionOps(sessions) {
     setTimeout,
     clearTimeout,
     Buffer,
+    measureTcpConnectLatency: async () => 3,
     // The rest of the sessionOps surface isn't exercised by getServerStats.
   });
 }
@@ -77,6 +76,7 @@ test("getServerStats opens a Mosh stats companion connection when session.conn i
       s.moshStatsConn = fakeConn(LINUX_STATS);
       return s.moshStatsConn;
     },
+    measureTcpConnectLatency: async () => 3,
   });
 
   const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
@@ -136,50 +136,58 @@ test("getServerStats does not touch the companion path for a normal SSH session"
   assert.equal(result.success, true);
 });
 
-test("getServerStats reports network round-trip without SSH stats channel setup time", async () => {
-  let now = 1_000;
-  let command = "";
-  let probeWrites = 0;
-  const stream = new EventEmitter();
-  stream.stderr = new EventEmitter();
-  stream.write = (data) => {
-    probeWrites += 1;
-    assert.equal(data, "\n");
-    now += 1;
-    stream.emit("data", Buffer.from("remote shell notice\n"));
-    now += 2;
-    stream.emit("data", Buffer.from("NC_LATENCY_"));
-    now += 2;
-    stream.emit("data", Buffer.from(`MARK|${LINUX_STATS}`));
-    stream.emit("close", 0);
-    return true;
+test("getServerStats measures TCP connectivity instead of SSH protocol latency", async () => {
+  const sessions = new Map();
+  const session = {
+    type: "mosh",
+    hostname: "vm.example.test",
+    moshStatsAuth: { hostname: "vm.example.test", port: 2222 },
+    moshStatsConn: fakeConn(LINUX_STATS),
   };
-  const sessions = new Map([
-    ["sid", {
-      type: "ssh",
-      conn: {
-        exec(statsCommand, callback) {
-          command = statsCommand;
-          now += 75;
-          callback(null, stream);
-        },
-      },
-    }],
-  ]);
+  sessions.set("sid", session);
+
+  const probes = [];
   const api = createSessionOpsApi({
     sessions,
-    Date: { now: () => now },
     setTimeout,
     clearTimeout,
     Buffer,
+    measureTcpConnectLatency: async (target) => {
+      probes.push(target);
+      return 2;
+    },
   });
 
   const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
 
   assert.equal(result.success, true);
-  assert.equal(result.stats.latencyMs, 5);
-  assert.equal(probeWrites, 1);
-  assert.match(command, /^read -r nc_latency_probe; printf "NC_LATENCY_MARK\|";/);
+  assert.equal(result.stats.latencyMs, 2);
+  assert.deepEqual(probes, [{ hostname: "vm.example.test", port: 2222 }]);
+});
+
+test("getServerStats skips a misleading direct probe for jump-host sessions", async () => {
+  const sessions = new Map([["sid", {
+    type: "mosh",
+    moshStatsAuth: { hostname: "private.example.test", port: 22, hasJumpHost: true },
+    moshStatsConn: fakeConn(LINUX_STATS),
+  }]]);
+  let probeCalls = 0;
+  const api = createSessionOpsApi({
+    sessions,
+    setTimeout,
+    clearTimeout,
+    Buffer,
+    measureTcpConnectLatency: async () => {
+      probeCalls += 1;
+      return 2;
+    },
+  });
+
+  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
+
+  assert.equal(result.success, true);
+  assert.equal(result.stats.latencyMs, null);
+  assert.equal(probeCalls, 0);
 });
 
 test("getServerStats closes a blocked probe channel when stats time out", async () => {
@@ -239,21 +247,6 @@ test("getServerStats closes a stats stream delivered after timeout", async () =>
   assert.equal(closeCalls, 1);
 });
 
-test("getServerStats closes the channel when the latency probe cannot be written", async () => {
-  let closeCalls = 0;
-  const stream = new EventEmitter();
-  stream.stderr = new EventEmitter();
-  stream.write = () => { throw new Error("probe write failed"); };
-  stream.close = () => { closeCalls += 1; };
-  const api = makeSessionOps(new Map([["sid", { type: "ssh", conn: { exec: (_command, cb) => cb(null, stream) } }]]));
-
-  const result = await api.getServerStats({ sender: {} }, { sessionId: "sid" });
-
-  assert.equal(result.success, false);
-  assert.match(result.error, /probe write failed/);
-  assert.equal(closeCalls, 1);
-});
-
 test("getServerStats includes host identity, load average, and uptime", async () => {
   const sessions = new Map();
   const session = {
@@ -298,6 +291,7 @@ test("getServerStats parses macOS stats and avoids blocking top command", async 
   let command = "";
   const session = {
     type: "ssh",
+    _reuseEndpoint: { hostname: "mac.example.test", port: 22 },
     conn: {
       exec(cmd, cb) {
         command = cmd;

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -89,6 +89,10 @@ function createStartSessionApi(ctx) {
           port: options.port || 22,
           username: options.username || 'root',
         },
+        tcpLatencyDirect:
+          !Array.isArray(options.jumpHosts) || options.jumpHosts.length === 0
+            ? !options.proxy
+            : false,
         cols: options.cols || 80,
         rows: options.rows || 24,
       };

--- a/electron/bridges/tcpConnectLatency.cjs
+++ b/electron/bridges/tcpConnectLatency.cjs
@@ -1,0 +1,52 @@
+"use strict";
+
+const dns = require("node:dns");
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+function createTcpConnectLatencyProbe({
+  net,
+  lookup = dns.lookup,
+  now = () => performance.now(),
+}) {
+  return function measureTcpConnectLatency({ hostname, port, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) {
+      return Promise.resolve(null);
+    }
+
+    return new Promise((resolve) => {
+      let startedAt = net.isIP?.(hostname) ? now() : null;
+      let settled = false;
+      let socket = null;
+
+      const finish = (latencyMs) => {
+        if (settled) return;
+        settled = true;
+        try { socket?.destroy(); } catch { /* best-effort cleanup */ }
+        resolve(latencyMs);
+      };
+
+      try {
+        const connectOptions = { host: hostname, port };
+        if (startedAt === null) {
+          connectOptions.lookup = (host, options, callback) => {
+            lookup(host, options, (err, address, family) => {
+              startedAt = now();
+              callback(err, address, family);
+            });
+          };
+        }
+        socket = net.createConnection(connectOptions, () => {
+          const connectedAt = now();
+          finish(Math.max(0, Math.round(connectedAt - (startedAt ?? connectedAt))));
+        });
+        socket.once("error", () => finish(null));
+        socket.setTimeout(timeoutMs, () => finish(null));
+      } catch {
+        finish(null);
+      }
+    });
+  };
+}
+
+module.exports = { createTcpConnectLatencyProbe, DEFAULT_TIMEOUT_MS };

--- a/electron/bridges/tcpConnectLatency.cjs
+++ b/electron/bridges/tcpConnectLatency.cjs
@@ -3,17 +3,21 @@
 const dns = require("node:dns");
 
 const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_CACHE_TTL_MS = 30000;
+const DEFAULT_FAILURE_CACHE_TTL_MS = 5000;
+const MAX_CACHE_ENTRIES = 256;
 
 function createTcpConnectLatencyProbe({
   net,
   lookup = dns.lookup,
   now = () => performance.now(),
+  cacheNow = () => Date.now(),
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  failureCacheTtlMs = DEFAULT_FAILURE_CACHE_TTL_MS,
 }) {
-  return function measureTcpConnectLatency({ hostname, port, timeoutMs = DEFAULT_TIMEOUT_MS }) {
-    if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) {
-      return Promise.resolve(null);
-    }
+  const cache = new Map();
 
+  function runProbe({ hostname, port, timeoutMs }) {
     return new Promise((resolve) => {
       let startedAt = net.isIP?.(hostname) ? now() : null;
       let settled = false;
@@ -46,7 +50,43 @@ function createTcpConnectLatencyProbe({
         finish(null);
       }
     });
+  }
+
+  return function measureTcpConnectLatency({ hostname, port, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) {
+      return Promise.resolve(null);
+    }
+
+    const key = `${String(hostname).toLowerCase()}\u0000${port}`;
+    const cached = cache.get(key);
+    const checkedAt = cacheNow();
+    if (cached?.promise || (cached && cached.expiresAt > checkedAt)) {
+      return cached.promise || Promise.resolve(cached.value);
+    }
+
+    if (cache.size >= MAX_CACHE_ENTRIES) {
+      for (const [cachedKey, entry] of cache) {
+        if (!entry.promise && entry.expiresAt <= checkedAt) cache.delete(cachedKey);
+      }
+      while (cache.size >= MAX_CACHE_ENTRIES) {
+        cache.delete(cache.keys().next().value);
+      }
+    }
+
+    const promise = runProbe({ hostname, port, timeoutMs }).then((value) => {
+      cache.set(key, {
+        value,
+        expiresAt: cacheNow() + (value === null ? failureCacheTtlMs : cacheTtlMs),
+      });
+      return value;
+    });
+    cache.set(key, { promise, expiresAt: Number.POSITIVE_INFINITY });
+    return promise;
   };
 }
 
-module.exports = { createTcpConnectLatencyProbe, DEFAULT_TIMEOUT_MS };
+module.exports = {
+  createTcpConnectLatencyProbe,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_CACHE_TTL_MS,
+};

--- a/electron/bridges/tcpConnectLatency.cjs
+++ b/electron/bridges/tcpConnectLatency.cjs
@@ -7,6 +7,7 @@ const DEFAULT_CACHE_TTL_MS = 30000;
 const DEFAULT_FAILURE_CACHE_TTL_MS = 5000;
 const MAX_CACHE_ENTRIES = 256;
 const MAX_CONCURRENT_PROBES = 8;
+const MAX_QUEUED_PROBES = 64;
 
 function createTcpConnectLatencyProbe({
   net,
@@ -17,11 +18,16 @@ function createTcpConnectLatencyProbe({
   failureCacheTtlMs = DEFAULT_FAILURE_CACHE_TTL_MS,
   maxCacheEntries = MAX_CACHE_ENTRIES,
   maxConcurrentProbes = MAX_CONCURRENT_PROBES,
+  maxQueuedProbes = MAX_QUEUED_PROBES,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
 }) {
   const resultCache = new Map();
   const inFlight = new Map();
   const queue = [];
   let activeProbeCount = 0;
+  const concurrentLimit = Math.max(1, Math.floor(maxConcurrentProbes));
+  const queueLimit = Math.max(0, Math.floor(maxQueuedProbes));
 
   function runProbe({ hostname, port, timeoutMs }) {
     return new Promise((resolve) => {
@@ -68,16 +74,38 @@ function createTcpConnectLatencyProbe({
     }
     return result.finally(() => {
       activeProbeCount -= 1;
-      while (activeProbeCount < maxConcurrentProbes && queue.length > 0) {
+      while (activeProbeCount < concurrentLimit && queue.length > 0) {
         const next = queue.shift();
-        startScheduledProbe(next.task).then(next.resolve, next.reject);
+        clearTimer(next.timer);
+        const remainingMs = next.deadline - cacheNow();
+        if (remainingMs <= 0) {
+          next.resolve(null);
+          continue;
+        }
+        startScheduledProbe(() => next.task(remainingMs)).then(next.resolve, next.reject);
       }
     });
   }
 
-  function scheduleProbe(task) {
-    if (activeProbeCount < maxConcurrentProbes) return startScheduledProbe(task);
-    return new Promise((resolve, reject) => queue.push({ task, resolve, reject }));
+  function scheduleProbe(task, timeoutMs) {
+    if (activeProbeCount < concurrentLimit) return startScheduledProbe(() => task(timeoutMs));
+    if (queue.length >= queueLimit) return Promise.resolve(null);
+
+    return new Promise((resolve, reject) => {
+      const entry = {
+        task,
+        resolve,
+        reject,
+        deadline: cacheNow() + timeoutMs,
+        timer: null,
+      };
+      entry.timer = setTimer(() => {
+        const index = queue.indexOf(entry);
+        if (index >= 0) queue.splice(index, 1);
+        resolve(null);
+      }, timeoutMs);
+      queue.push(entry);
+    });
   }
 
   function cacheResult(key, value) {
@@ -109,7 +137,10 @@ function createTcpConnectLatencyProbe({
     }
     resultCache.delete(key);
 
-    const promise = scheduleProbe(() => runProbe({ hostname, port, timeoutMs }))
+    const promise = scheduleProbe(
+      (remainingMs) => runProbe({ hostname, port, timeoutMs: remainingMs }),
+      timeoutMs,
+    )
       .catch(() => null)
       .then((value) => {
         inFlight.delete(key);
@@ -126,4 +157,5 @@ module.exports = {
   DEFAULT_TIMEOUT_MS,
   DEFAULT_CACHE_TTL_MS,
   MAX_CONCURRENT_PROBES,
+  MAX_QUEUED_PROBES,
 };

--- a/electron/bridges/tcpConnectLatency.cjs
+++ b/electron/bridges/tcpConnectLatency.cjs
@@ -6,6 +6,7 @@ const DEFAULT_TIMEOUT_MS = 3000;
 const DEFAULT_CACHE_TTL_MS = 30000;
 const DEFAULT_FAILURE_CACHE_TTL_MS = 5000;
 const MAX_CACHE_ENTRIES = 256;
+const MAX_CONCURRENT_PROBES = 8;
 
 function createTcpConnectLatencyProbe({
   net,
@@ -14,8 +15,13 @@ function createTcpConnectLatencyProbe({
   cacheNow = () => Date.now(),
   cacheTtlMs = DEFAULT_CACHE_TTL_MS,
   failureCacheTtlMs = DEFAULT_FAILURE_CACHE_TTL_MS,
+  maxCacheEntries = MAX_CACHE_ENTRIES,
+  maxConcurrentProbes = MAX_CONCURRENT_PROBES,
 }) {
-  const cache = new Map();
+  const resultCache = new Map();
+  const inFlight = new Map();
+  const queue = [];
+  let activeProbeCount = 0;
 
   function runProbe({ hostname, port, timeoutMs }) {
     return new Promise((resolve) => {
@@ -52,35 +58,65 @@ function createTcpConnectLatencyProbe({
     });
   }
 
+  function startScheduledProbe(task) {
+    activeProbeCount += 1;
+    let result;
+    try {
+      result = Promise.resolve(task());
+    } catch (err) {
+      result = Promise.reject(err);
+    }
+    return result.finally(() => {
+      activeProbeCount -= 1;
+      while (activeProbeCount < maxConcurrentProbes && queue.length > 0) {
+        const next = queue.shift();
+        startScheduledProbe(next.task).then(next.resolve, next.reject);
+      }
+    });
+  }
+
+  function scheduleProbe(task) {
+    if (activeProbeCount < maxConcurrentProbes) return startScheduledProbe(task);
+    return new Promise((resolve, reject) => queue.push({ task, resolve, reject }));
+  }
+
+  function cacheResult(key, value) {
+    resultCache.delete(key);
+    resultCache.set(key, {
+      value,
+      expiresAt: cacheNow() + (value === null ? failureCacheTtlMs : cacheTtlMs),
+    });
+    while (resultCache.size > maxCacheEntries) {
+      resultCache.delete(resultCache.keys().next().value);
+    }
+  }
+
   return function measureTcpConnectLatency({ hostname, port, timeoutMs = DEFAULT_TIMEOUT_MS }) {
     if (!hostname || !Number.isInteger(port) || port < 1 || port > 65535) {
       return Promise.resolve(null);
     }
 
     const key = `${String(hostname).toLowerCase()}\u0000${port}`;
-    const cached = cache.get(key);
+    const pending = inFlight.get(key);
+    if (pending) return pending;
+
+    const cached = resultCache.get(key);
     const checkedAt = cacheNow();
-    if (cached?.promise || (cached && cached.expiresAt > checkedAt)) {
-      return cached.promise || Promise.resolve(cached.value);
+    if (cached && cached.expiresAt > checkedAt) {
+      resultCache.delete(key);
+      resultCache.set(key, cached);
+      return Promise.resolve(cached.value);
     }
+    resultCache.delete(key);
 
-    if (cache.size >= MAX_CACHE_ENTRIES) {
-      for (const [cachedKey, entry] of cache) {
-        if (!entry.promise && entry.expiresAt <= checkedAt) cache.delete(cachedKey);
-      }
-      while (cache.size >= MAX_CACHE_ENTRIES) {
-        cache.delete(cache.keys().next().value);
-      }
-    }
-
-    const promise = runProbe({ hostname, port, timeoutMs }).then((value) => {
-      cache.set(key, {
-        value,
-        expiresAt: cacheNow() + (value === null ? failureCacheTtlMs : cacheTtlMs),
+    const promise = scheduleProbe(() => runProbe({ hostname, port, timeoutMs }))
+      .catch(() => null)
+      .then((value) => {
+        inFlight.delete(key);
+        cacheResult(key, value);
+        return value;
       });
-      return value;
-    });
-    cache.set(key, { promise, expiresAt: Number.POSITIVE_INFINITY });
+    inFlight.set(key, promise);
     return promise;
   };
 }
@@ -89,4 +125,5 @@ module.exports = {
   createTcpConnectLatencyProbe,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_CACHE_TTL_MS,
+  MAX_CONCURRENT_PROBES,
 };

--- a/electron/bridges/tcpConnectLatency.test.cjs
+++ b/electron/bridges/tcpConnectLatency.test.cjs
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+
+const { createTcpConnectLatencyProbe } = require("./tcpConnectLatency.cjs");
+
+function createSocket() {
+  const socket = new EventEmitter();
+  socket.setTimeout = (_ms, callback) => { socket.timeoutCallback = callback; };
+  socket.destroy = () => { socket.destroyedByProbe = true; };
+  return socket;
+}
+
+test("TCP latency stops timing as soon as the socket connects", async () => {
+  const socket = createSocket();
+  let connected;
+  const times = [100, 102.4];
+  const measure = createTcpConnectLatencyProbe({
+    net: {
+      createConnection(options, callback) {
+        assert.equal(options.host, "vm.test");
+        assert.equal(options.port, 22);
+        options.lookup("vm.test", {}, () => {});
+        connected = callback;
+        return socket;
+      },
+    },
+    lookup: (_host, _options, callback) => callback(null, "192.0.2.10", 4),
+    now: () => times.shift(),
+  });
+
+  const pending = measure({ hostname: "vm.test", port: 22 });
+  connected();
+
+  assert.equal(await pending, 2);
+  assert.equal(socket.destroyedByProbe, true);
+});
+
+test("TCP latency excludes hostname lookup time", async () => {
+  const socket = createSocket();
+  let connected;
+  let finishLookup;
+  const times = [500, 503];
+  const measure = createTcpConnectLatencyProbe({
+    net: {
+      createConnection(options, callback) {
+        options.lookup("slow-dns.test", {}, () => {});
+        connected = callback;
+        return socket;
+      },
+    },
+    lookup: (_host, _options, callback) => { finishLookup = callback; },
+    now: () => times.shift(),
+  });
+
+  const pending = measure({ hostname: "slow-dns.test", port: 22 });
+  finishLookup(null, "192.0.2.20", 4);
+  connected();
+
+  assert.equal(await pending, 3);
+});
+
+test("TCP latency returns no value when the endpoint cannot be reached", async () => {
+  const socket = createSocket();
+  const measure = createTcpConnectLatencyProbe({
+    net: { createConnection: () => socket },
+    now: () => 100,
+  });
+
+  const pending = measure({ hostname: "offline.test", port: 22 });
+  socket.emit("error", new Error("unreachable"));
+
+  assert.equal(await pending, null);
+  assert.equal(socket.destroyedByProbe, true);
+});

--- a/electron/bridges/tcpConnectLatency.test.cjs
+++ b/electron/bridges/tcpConnectLatency.test.cjs
@@ -158,3 +158,45 @@ test("TCP latency caps concurrent probes without evicting pending deduplication"
   connectCallbacks[3]();
   await firstAgain;
 });
+
+test("TCP latency bounds queued work and includes queue wait in the timeout", async () => {
+  const connectCallbacks = [];
+  const timeoutCallbacks = [];
+  let clock = 1_000;
+  const measure = createTcpConnectLatencyProbe({
+    net: {
+      isIP: () => 4,
+      createConnection(_options, callback) {
+        connectCallbacks.push(callback);
+        return createSocket();
+      },
+    },
+    now: () => 100,
+    cacheNow: () => clock,
+    maxConcurrentProbes: 1,
+    maxQueuedProbes: 1,
+    setTimer: (callback) => {
+      timeoutCallbacks.push(callback);
+      return callback;
+    },
+    clearTimer: () => {},
+  });
+
+  const active = measure({ hostname: "192.0.2.1", port: 22, timeoutMs: 3_000 });
+  const queued = measure({ hostname: "192.0.2.2", port: 22, timeoutMs: 3_000 });
+  const overflow = measure({ hostname: "192.0.2.3", port: 22, timeoutMs: 3_000 });
+  assert.equal(await overflow, null);
+  assert.equal(connectCallbacks.length, 1);
+
+  timeoutCallbacks[0]();
+  assert.equal(await queued, null);
+  connectCallbacks[0]();
+  await active;
+  assert.equal(connectCallbacks.length, 1, "expired queued probe must not start later");
+
+  clock += 5_001;
+  const retried = measure({ hostname: "192.0.2.2", port: 22, timeoutMs: 3_000 });
+  assert.equal(connectCallbacks.length, 2);
+  connectCallbacks[1]();
+  await retried;
+});

--- a/electron/bridges/tcpConnectLatency.test.cjs
+++ b/electron/bridges/tcpConnectLatency.test.cjs
@@ -110,3 +110,51 @@ test("TCP latency deduplicates concurrent probes and reuses a recent result", as
   connectCallbacks[1]();
   assert.equal(await refreshed, 5);
 });
+
+test("TCP latency caps concurrent probes without evicting pending deduplication", async () => {
+  const connectCallbacks = [];
+  let activeSockets = 0;
+  let maxActiveSockets = 0;
+  const measure = createTcpConnectLatencyProbe({
+    net: {
+      isIP: () => 4,
+      createConnection(_options, callback) {
+        const socket = createSocket();
+        activeSockets += 1;
+        maxActiveSockets = Math.max(maxActiveSockets, activeSockets);
+        socket.destroy = () => {
+          if (!socket.destroyedByProbe) activeSockets -= 1;
+          socket.destroyedByProbe = true;
+        };
+        connectCallbacks.push(callback);
+        return socket;
+      },
+    },
+    now: () => 100,
+    cacheNow: () => 1_000,
+    maxCacheEntries: 2,
+    maxConcurrentProbes: 2,
+  });
+
+  const first = measure({ hostname: "192.0.2.1", port: 22 });
+  const duplicate = measure({ hostname: "192.0.2.1", port: 22 });
+  const second = measure({ hostname: "192.0.2.2", port: 22 });
+  const third = measure({ hostname: "192.0.2.3", port: 22 });
+  assert.equal(first, duplicate);
+  assert.equal(connectCallbacks.length, 2);
+  assert.equal(maxActiveSockets, 2);
+
+  connectCallbacks[0]();
+  await first;
+  assert.equal(connectCallbacks.length, 3);
+  assert.equal(maxActiveSockets, 2);
+
+  connectCallbacks[1]();
+  connectCallbacks[2]();
+  await Promise.all([second, third]);
+
+  const firstAgain = measure({ hostname: "192.0.2.1", port: 22 });
+  assert.equal(connectCallbacks.length, 4, "oldest settled result should be evicted");
+  connectCallbacks[3]();
+  await firstAgain;
+});

--- a/electron/bridges/tcpConnectLatency.test.cjs
+++ b/electron/bridges/tcpConnectLatency.test.cjs
@@ -73,3 +73,40 @@ test("TCP latency returns no value when the endpoint cannot be reached", async (
   assert.equal(await pending, null);
   assert.equal(socket.destroyedByProbe, true);
 });
+
+test("TCP latency deduplicates concurrent probes and reuses a recent result", async () => {
+  const sockets = [];
+  const connectCallbacks = [];
+  const probeTimes = [100, 104, 200, 205];
+  let clock = 1_000;
+  const measure = createTcpConnectLatencyProbe({
+    net: {
+      isIP: () => 4,
+      createConnection(_options, callback) {
+        const socket = createSocket();
+        sockets.push(socket);
+        connectCallbacks.push(callback);
+        return socket;
+      },
+    },
+    now: () => probeTimes.shift(),
+    cacheNow: () => clock,
+    cacheTtlMs: 30_000,
+  });
+
+  const first = measure({ hostname: "192.0.2.30", port: 22 });
+  const concurrent = measure({ hostname: "192.0.2.30", port: 22 });
+  assert.equal(first, concurrent);
+  assert.equal(sockets.length, 1);
+
+  connectCallbacks[0]();
+  assert.equal(await first, 4);
+  assert.equal(await measure({ hostname: "192.0.2.30", port: 22 }), 4);
+  assert.equal(sockets.length, 1);
+
+  clock += 30_001;
+  const refreshed = measure({ hostname: "192.0.2.30", port: 22 });
+  assert.equal(sockets.length, 2);
+  connectCallbacks[1]();
+  assert.equal(await refreshed, 5);
+});

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -816,6 +816,7 @@ main();
             knownHosts: options.knownHosts,
             verifyHostKeys: options.verifyHostKeys,
             hasJumpHost: Array.isArray(options.jumpHosts) && options.jumpHosts.length > 0,
+            hasProxy: !!options.proxy,
           },
           systemManagerSudoPassword: typeof options.sudoAutofillPassword === "string" && options.sudoAutofillPassword.length > 0
             ? options.sudoAutofillPassword

--- a/electron/bridges/terminalBridge/etSession.cjs
+++ b/electron/bridges/terminalBridge/etSession.cjs
@@ -800,6 +800,12 @@ main();
           sshEnv: sshEnvironment?.env || {},
           sshOptions: sshEnvironment?.sshOptions || [],
           sshUserHost: sshEnvironment?.userHost || "",
+          tcpLatencyTarget: {
+            hostname: options.hostname,
+            port: options.etPort || 2022,
+          },
+          tcpLatencyDirect:
+            (!Array.isArray(options.jumpHosts) || options.jumpHosts.length === 0) && !options.proxy,
           etStatsAuth: {
             hostname: options.hostname,
             port: options.port || 22,

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -551,6 +551,8 @@ function createMoshSessionApi(ctx) {
         // does not depend on this.
         knownHosts: options.knownHosts,
         verifyHostKeys: options.verifyHostKeys,
+        hasJumpHost: Array.isArray(options.jumpHosts) && options.jumpHosts.length > 0,
+        hasProxy: !!options.proxy,
       };
       session.systemManagerSudoPassword = typeof options.sudoAutofillPassword === "string" && options.sudoAutofillPassword.length > 0
         ? options.sudoAutofillPassword

--- a/types/global/netcatty-bridge-session.d.ts
+++ b/types/global/netcatty-bridge-session.d.ts
@@ -246,7 +246,7 @@ declare global {
         }>;
         netRxSpeed: number;           // Total network receive speed (bytes/sec)
         netTxSpeed: number;           // Total network transmit speed (bytes/sec)
-        latencyMs: number | null;     // Approximate network round-trip over the SSH stats channel
+        latencyMs: number | null;     // TCP connection establishment latency to the SSH endpoint
         netInterfaces: Array<{        // Per-interface network stats
           name: string;               // Interface name (e.g., eth0, ens33)
           rxBytes: number;            // Total received bytes


### PR DESCRIPTION
## What changed

- measure latency only until the target service accepts a connection
- exclude hostname lookup, SSH channel setup, authentication, and protocol handshake time
- use the actual ET service port for ET sessions
- deduplicate and rate-limit repeated probes so multiple tabs do not create connection bursts
- bound probe concurrency and queueing so latency checks cannot delay server stats
- avoid showing a misleading value when a jump host or proxy prevents a direct measurement

## Why

Mosh and ET sessions could report much higher latency than SSH because the previous value included protocol-layer work. This made local and low-latency hosts appear much slower than they were.

Closes #2108

## Validation

- `npm run lint`
- `npm run build`
- `npm test` — 4,745 tests, 0 failures (3 skipped)
- focused SSH, Mosh, ET, cache, concurrency, queue, and timeout tests
- four local review rounds; final round clean from three independent reviewers