### PR TITLE
Add credential presets to Quick Connect

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1008,7 +1008,16 @@ function App({ settings }: { settings: SettingsState }) {
   }, [groupConfigs, proxyProfileIdSet, proxyProfiles]);
 
   // Wrapper to connect to host with logging
-  const handleConnectToHost = useCallback((host: Host) => { return handleConnectToHostImpl(() => ({ addConnectionLog, connectToHost, host, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef }), host); }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
+  const handleConnectToHost = useCallback((host: Host) => {
+    if (host.ephemeral) {
+      setEphemeralHosts((previous) => {
+        const existingIndex = previous.findIndex((candidate) => candidate.id === host.id);
+        if (existingIndex < 0) return [...previous, host];
+        return previous.map((candidate, index) => index === existingIndex ? host : candidate);
+      });
+    }
+    return handleConnectToHostImpl(() => ({ addConnectionLog, connectToHost, host, identities, keys, resolveEffectiveHost, resolveHostAuth, systemInfoRef }), host);
+  }, [addConnectionLog, connectToHost, resolveEffectiveHost, identities, keys]);
 
   const openHostForVaultAgent = useCallback((hostId: string) => {
     const host = hosts.find((item) => item.id === hostId);

--- a/application/i18n/locales/en/vault.ts
+++ b/application/i18n/locales/en/vault.ts
@@ -479,6 +479,17 @@ export const enVaultMessages: Messages = {
   'quickConnect.knownHost.addAndContinue': 'Add and continue',
   'quickConnect.addKey': 'Add key',
   'quickConnect.warning.unparsedOptions': 'Some SSH arguments were ignored: {options}',
+  'quickConnect.identity.label': 'Credential preset',
+  'quickConnect.identity.placeholder': 'Choose a saved identity',
+  'quickConnect.identity.empty': 'No saved identities found',
+  'quickConnect.identity.hint': 'Choose an identity to fill in its username and authentication automatically.',
+  'quickConnect.identity.selectedHint': 'Ready to connect as {username}.',
+  'quickConnect.identity.method.password': 'Password',
+  'quickConnect.identity.method.key': 'SSH key',
+  'quickConnect.identity.method.certificate': 'Certificate',
+  'quickConnect.identity.unavailable': 'This identity is missing usable credentials on this device.',
+  'quickConnect.identity.useCustom': 'Use custom credentials',
+  'quickConnect.identity.connect': 'Connect with preset',
 
   // Terminal
   'terminal.connectionErrorTitle': 'Connection Error',

--- a/application/i18n/locales/ru/vault.ts
+++ b/application/i18n/locales/ru/vault.ts
@@ -514,6 +514,17 @@ export const ruVaultMessages: Messages = {
   'quickConnect.knownHost.addAndContinue': 'Добавить и продолжить',
   'quickConnect.addKey': 'Добавить ключ',
   'quickConnect.warning.unparsedOptions': 'Некоторые аргументы SSH были проигнорированы: {options}',
+  'quickConnect.identity.label': 'Набор учётных данных',
+  'quickConnect.identity.placeholder': 'Выберите сохранённый профиль',
+  'quickConnect.identity.empty': 'Сохранённые профили не найдены',
+  'quickConnect.identity.hint': 'Выберите профиль, чтобы автоматически подставить имя пользователя и способ входа.',
+  'quickConnect.identity.selectedHint': 'Готово к подключению как {username}.',
+  'quickConnect.identity.method.password': 'Пароль',
+  'quickConnect.identity.method.key': 'Ключ SSH',
+  'quickConnect.identity.method.certificate': 'Сертификат',
+  'quickConnect.identity.unavailable': 'Для этого профиля нет доступных учётных данных на устройстве.',
+  'quickConnect.identity.useCustom': 'Использовать другие данные',
+  'quickConnect.identity.connect': 'Подключиться с профилем',
 
   // Terminal
   'terminal.connectionErrorTitle': 'Ошибка подключения',

--- a/application/i18n/locales/zh-CN/vault.ts
+++ b/application/i18n/locales/zh-CN/vault.ts
@@ -50,6 +50,17 @@ export const zhCNVaultMessages: Messages = {
   'quickConnect.knownHost.addAndContinue': '加入并继续',
   'quickConnect.addKey': '添加 key',
   'quickConnect.warning.unparsedOptions': '部分 SSH 参数已被忽略: {options}',
+  'quickConnect.identity.label': '凭据预设',
+  'quickConnect.identity.placeholder': '选择已保存的身份',
+  'quickConnect.identity.empty': '没有可用的身份',
+  'quickConnect.identity.hint': '选择身份后会自动带入用户名和认证信息。',
+  'quickConnect.identity.selectedHint': '将以 {username} 连接。',
+  'quickConnect.identity.method.password': '密码',
+  'quickConnect.identity.method.key': 'SSH 密钥',
+  'quickConnect.identity.method.certificate': '证书',
+  'quickConnect.identity.unavailable': '此身份在当前设备上缺少可用凭据。',
+  'quickConnect.identity.useCustom': '改用自定义凭据',
+  'quickConnect.identity.connect': '使用预设连接',
 
   // Protocol select dialog
   'protocolSelect.chooseProtocol': '选择协议',

--- a/application/i18n/locales/zh-TW/vault.ts
+++ b/application/i18n/locales/zh-TW/vault.ts
@@ -50,6 +50,17 @@ export const zhTWVaultMessages: Messages = {
   'quickConnect.knownHost.addAndContinue': '加入並繼續',
   'quickConnect.addKey': '新增 key',
   'quickConnect.warning.unparsedOptions': '部分 SSH 引數已被忽略: {options}',
+  'quickConnect.identity.label': '憑據預設',
+  'quickConnect.identity.placeholder': '選擇已儲存的身分',
+  'quickConnect.identity.empty': '沒有可用的身分',
+  'quickConnect.identity.hint': '選擇身分後會自動帶入使用者名稱和驗證資訊。',
+  'quickConnect.identity.selectedHint': '將以 {username} 連線。',
+  'quickConnect.identity.method.password': '密碼',
+  'quickConnect.identity.method.key': 'SSH 金鑰',
+  'quickConnect.identity.method.certificate': '憑證',
+  'quickConnect.identity.unavailable': '此身分在目前裝置上缺少可用憑據。',
+  'quickConnect.identity.useCustom': '改用自訂憑據',
+  'quickConnect.identity.connect': '使用預設連線',
 
   // Protocol select dialog
   'protocolSelect.chooseProtocol': '選擇協定',

--- a/components/QuickConnectWizard.test.tsx
+++ b/components/QuickConnectWizard.test.tsx
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { I18nProvider } from "../application/i18n/I18nProvider";
+import QuickConnectWizard from "./QuickConnectWizard";
+
+test("quick connect shows saved identities as credential presets", () => {
+  const markup = renderToStaticMarkup(
+    <I18nProvider locale="en">
+      <QuickConnectWizard
+        open
+        target={{ hostname: "192.0.2.10" }}
+        keys={[]}
+        identities={[{
+          id: "identity-root",
+          label: "Root devices",
+          username: "root",
+          authMethod: "password",
+          password: "secret",
+          created: 1,
+        }]}
+        onConnect={() => undefined}
+        onClose={() => undefined}
+      />
+    </I18nProvider>,
+  );
+
+  assert.match(markup, /Credential preset/);
+  assert.match(markup, /Choose a saved identity/);
+});

--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -14,15 +14,22 @@ import React, { useMemo, useState } from "react";
 import { useI18n } from "../application/i18n/I18nProvider";
 import type { QuickConnectTarget } from "../domain/quickConnect";
 import { formatHostPort } from "../domain/host";
+import {
+  buildQuickConnectHost,
+  isQuickConnectIdentityUsable,
+  type QuickConnectAuthMethod,
+  type QuickConnectProtocol,
+} from "../domain/quickConnectHost";
 import { cn } from "../lib/utils";
-import { Host, SSHKey } from "../types";
+import { Host, Identity, SSHKey } from "../types";
 import { Button } from "./ui/button";
+import { Combobox } from "./ui/combobox";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { ScrollArea } from "./ui/scroll-area";
 
 // Protocol types supported for quick connect
-type Protocol = "ssh" | "mosh" | "telnet";
+type Protocol = QuickConnectProtocol;
 
 // Wizard steps
 type WizardStep = "protocol" | "username" | "knownhost" | "auth";
@@ -31,6 +38,7 @@ interface QuickConnectWizardProps {
   open: boolean;
   target: QuickConnectTarget;
   keys: SSHKey[];
+  identities: Identity[];
   warnings?: string[];
   onConnect: (host: Host) => void;
   onSaveHost?: (host: Host) => void;
@@ -42,6 +50,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   open,
   target,
   keys,
+  identities,
   warnings,
   onConnect,
   onSaveHost,
@@ -64,9 +73,10 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   } | null>(null);
 
   // Auth state
-  const [authMethod, setAuthMethod] = useState<"password" | "key">("password");
+  const [authMethod, setAuthMethod] = useState<QuickConnectAuthMethod>("password");
   const [password, setPassword] = useState("");
   const [selectedKeyId, setSelectedKeyId] = useState<string | null>(null);
+  const [selectedIdentityId, setSelectedIdentityId] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
   const [saveCredentials] = useState(true);
 
@@ -79,10 +89,55 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
       setPort(target.port || 22);
       setPassword("");
       setSelectedKeyId(null);
+      setSelectedIdentityId(null);
       setShowPassword(false);
       setKnownHostInfo(null);
     }
   }, [open, target]);
+
+  const selectedIdentity = useMemo(
+    () => identities.find((identity) => identity.id === selectedIdentityId),
+    [identities, selectedIdentityId],
+  );
+  const canUseSelectedIdentity = useMemo(
+    () => isQuickConnectIdentityUsable(selectedIdentity, keys, protocol),
+    [keys, protocol, selectedIdentity],
+  );
+  const identityOptions = useMemo(
+    () => identities.map((identity) => ({
+      value: identity.id,
+      label: identity.label,
+      sublabel: identity.username,
+      icon: <User size={14} />,
+    })),
+    [identities],
+  );
+
+  const detachSelectedIdentity = () => {
+    setSelectedIdentityId(null);
+    setAuthMethod("password");
+    setPassword("");
+    setSelectedKeyId(null);
+  };
+
+  const clearSelectedIdentity = () => {
+    detachSelectedIdentity();
+    setUsername(target.username || "");
+  };
+
+  const handleIdentitySelect = (identityId: string) => {
+    if (!identityId) {
+      clearSelectedIdentity();
+      return;
+    }
+    const identity = identities.find((candidate) => candidate.id === identityId);
+    if (!identity) return;
+    setSelectedIdentityId(identity.id);
+    setUsername(identity.username);
+    setAuthMethod(identity.authMethod);
+    setPassword("");
+    setSelectedKeyId(identity.keyId || null);
+  };
 
   // Get default port for protocol
   const getDefaultPort = (proto: Protocol) => {
@@ -100,6 +155,9 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
 
   // Handle protocol selection
   const handleProtocolSelect = (proto: Protocol) => {
+    if (proto === "telnet" && selectedIdentityId) {
+      clearSelectedIdentity();
+    }
     setProtocol(proto);
     // Update port to default for protocol if unchanged
     if (port === getDefaultPort(protocol)) {
@@ -111,6 +169,10 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   const handleContinue = () => {
     switch (step) {
       case "protocol":
+        if (canUseSelectedIdentity) {
+          handleConnect();
+          break;
+        }
         // Always go to username step to let user confirm/edit username
         setStep("username");
         break;
@@ -146,30 +208,24 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   const handleConnect = () => {
     const effectiveUsername = username || target.username || "root";
     const effectivePort = port || getDefaultPort(protocol);
+    const activeIdentityId = selectedIdentity?.id || null;
 
-    const tempHost: Host = {
-      id: `quick-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      label: `${target.hostname}`,
-      hostname: target.hostname,
+    const now = Date.now();
+    const tempHost = buildQuickConnectHost({
+      id: `quick-${now}-${Math.random().toString(36).slice(2, 11)}`,
+      createdAt: now,
+      target,
+      protocol,
       port: effectivePort,
       username: effectiveUsername,
-      group: "",
-      tags: [],
-      os: "linux",
-      protocol: protocol === "mosh" ? "ssh" : protocol,
-      authMethod: authMethod,
-      password: authMethod === "password" ? password : undefined,
-      identityFileId:
-        authMethod === "key" ? selectedKeyId || undefined : undefined,
-      moshEnabled: protocol === "mosh",
-      // Set telnet-specific fields when using telnet protocol
-      telnetEnabled: protocol === "telnet",
-      telnetPort: protocol === "telnet" ? effectivePort : undefined,
-      createdAt: Date.now(),
-    };
+      authMethod,
+      password,
+      selectedKeyId,
+      selectedIdentityId: activeIdentityId,
+    });
 
     // Save host if requested
-    if (saveCredentials && onSaveHost) {
+    if (saveCredentials && onSaveHost && !activeIdentityId) {
       onSaveHost(tempHost);
     }
 
@@ -187,13 +243,14 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
       case "knownhost":
         return true;
       case "auth":
+        if (selectedIdentity) return canUseSelectedIdentity;
         if (authMethod === "password") {
           // Whitespace-only passwords are valid SSH secrets (issue #2036).
           return password.length > 0;
         }
-        return !!selectedKeyId;
+        return Boolean(selectedKeyId && keys.some((key) => key.id === selectedKeyId));
     }
-  }, [step, username, authMethod, password, selectedKeyId]);
+  }, [step, username, authMethod, password, selectedKeyId, selectedIdentity, canUseSelectedIdentity, keys]);
 
   // Render protocol selection step
   const renderProtocolStep = () => (
@@ -332,8 +389,8 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               type="number"
               value={protocol === "telnet" ? port : 23}
               onChange={(e) => {
+                handleProtocolSelect("telnet");
                 setPort(parseInt(e.target.value) || 23);
-                setProtocol("telnet");
               }}
               onClick={(e) => e.stopPropagation()}
               className="w-16 h-7 text-xs text-center"
@@ -343,6 +400,25 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
           </div>
         </button>
       </div>
+
+      {protocol !== "telnet" && identities.length > 0 && (
+        <div className="space-y-2 pt-1">
+          <Label>{t("quickConnect.identity.label")}</Label>
+          <Combobox
+            options={identityOptions}
+            value={selectedIdentityId || undefined}
+            onValueChange={handleIdentitySelect}
+            placeholder={t("quickConnect.identity.placeholder")}
+            emptyText={t("quickConnect.identity.empty")}
+            icon={<User size={14} />}
+          />
+          <p className="text-xs text-muted-foreground">
+            {selectedIdentity
+              ? t("quickConnect.identity.selectedHint", { username: selectedIdentity.username })
+              : t("quickConnect.identity.hint")}
+          </p>
+        </div>
+      )}
     </div>
   );
 
@@ -354,7 +430,10 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
         <Input
           id="quick-username"
           value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          onChange={(e) => {
+            if (selectedIdentityId) detachSelectedIdentity();
+            setUsername(e.target.value);
+          }}
           placeholder={t("terminal.auth.username.placeholder")}
           autoFocus
           onKeyDown={(e) => {
@@ -393,6 +472,30 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
   // Render auth step
   const renderAuthStep = () => (
     <div className="space-y-4">
+      {selectedIdentity ? (
+        <div className="rounded-xl border border-primary/40 bg-primary/5 p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-9 w-9 rounded-lg bg-primary/15 text-primary flex items-center justify-center">
+              <User size={16} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="font-medium truncate">{selectedIdentity.label}</div>
+              <div className="text-xs text-muted-foreground truncate">
+                {selectedIdentity.username} · {t(`quickConnect.identity.method.${selectedIdentity.authMethod}`)}
+              </div>
+            </div>
+          </div>
+          {!canUseSelectedIdentity && (
+            <p className="text-xs text-destructive">
+              {t("quickConnect.identity.unavailable")}
+            </p>
+          )}
+          <Button variant="outline" size="sm" className="w-full" onClick={detachSelectedIdentity}>
+            {t("quickConnect.identity.useCustom")}
+          </Button>
+        </div>
+      ) : (
+        <>
       {/* Auth method tabs */}
       <div className="flex gap-1 p-1 bg-secondary/80 rounded-lg border border-border/60">
         <button
@@ -402,7 +505,10 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
               ? "bg-primary text-primary-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground hover:bg-secondary",
           )}
-          onClick={() => setAuthMethod("password")}
+          onClick={() => {
+            setSelectedIdentityId(null);
+            setAuthMethod("password");
+          }}
         >
           <Lock size={14} />
           {t("terminal.auth.password")}
@@ -410,11 +516,14 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
         <button
           className={cn(
             "flex-1 flex items-center justify-center gap-2 py-2 text-sm font-medium rounded-md transition-all",
-            authMethod === "key"
+            authMethod !== "password"
               ? "bg-primary text-primary-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground hover:bg-secondary",
           )}
-          onClick={() => setAuthMethod("key")}
+          onClick={() => {
+            setSelectedIdentityId(null);
+            setAuthMethod("key");
+          }}
         >
           <Key size={14} />
           {t("terminal.auth.sshKey")}
@@ -472,7 +581,10 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
                           ? "border-primary bg-primary/5"
                           : "border-border/50 hover:bg-secondary/50",
                       )}
-                      onClick={() => setSelectedKeyId(key.id)}
+                      onClick={() => {
+                        setSelectedIdentityId(null);
+                        setSelectedKeyId(key.id);
+                      }}
                     >
                       <div
                         className={cn(
@@ -508,6 +620,8 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
             </Button>
           )}
         </div>
+      )}
+        </>
       )}
     </div>
   );
@@ -701,7 +815,9 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
             </div>
           ) : (
             <Button onClick={handleContinue} disabled={!canProceed}>
-              {t("common.continue")}
+              {step === "protocol" && canUseSelectedIdentity
+                ? t("quickConnect.identity.connect")
+                : t("common.continue")}
             </Button>
           )}
         </div>

--- a/components/vault/VaultViewLayout.tsx
+++ b/components/vault/VaultViewLayout.tsx
@@ -1017,6 +1017,7 @@ export function VaultViewLayout({ ctx }: { ctx: VaultViewLayoutContext }) {
           open={isQuickConnectOpen}
           target={quickConnectTarget}
           keys={keys}
+          identities={identities}
           onConnect={handleQuickConnect}
           onSaveHost={handleQuickConnectSaveHost}
           onClose={() => {

--- a/domain/quickConnectHost.test.ts
+++ b/domain/quickConnectHost.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildQuickConnectHost,
+  isQuickConnectIdentityUsable,
+} from "./quickConnectHost.ts";
+import { resolveHostAuth } from "./sshAuth.ts";
+
+test("quick connect keeps a selected credential preset as the host identity", () => {
+  const host = buildQuickConnectHost({
+    id: "quick-1",
+    createdAt: 123,
+    target: { hostname: "192.0.2.10" },
+    protocol: "ssh",
+    port: 22,
+    username: "root",
+    authMethod: "password",
+    password: "must-not-be-copied",
+    selectedIdentityId: "identity-root",
+  });
+
+  assert.equal(host.identityId, "identity-root");
+  assert.equal(host.username, "root");
+  assert.equal(host.authMethod, "password");
+  assert.equal(host.password, undefined);
+  assert.equal(host.identityFileId, undefined);
+  assert.equal(host.ephemeral, true);
+
+  const resolved = resolveHostAuth({
+    host,
+    keys: [],
+    identities: [{
+      id: "identity-root",
+      label: "Root",
+      username: "root",
+      authMethod: "password",
+      password: "resolved-secret",
+      created: 1,
+    }],
+  });
+  assert.equal(resolved.password, "resolved-secret");
+});
+
+test("quick connect only offers one-click connection for usable credential presets", () => {
+  assert.equal(isQuickConnectIdentityUsable({
+    id: "password",
+    label: "Root",
+    username: "root",
+    authMethod: "password",
+    password: "secret",
+    created: 1,
+  }, []), true);
+
+  assert.equal(isQuickConnectIdentityUsable({
+    id: "missing-key",
+    label: "Deploy",
+    username: "deploy",
+    authMethod: "key",
+    keyId: "key-that-is-not-here",
+    created: 2,
+  }, []), false);
+
+  assert.equal(isQuickConnectIdentityUsable({
+    id: "telnet-key",
+    label: "Network key",
+    username: "admin",
+    authMethod: "key",
+    keyId: "key-1",
+    created: 3,
+  }, [{
+    id: "key-1",
+    label: "Key",
+    type: "ED25519",
+    privateKey: "private",
+    source: "imported",
+    category: "key",
+    created: 3,
+  }], "telnet"), false);
+});
+
+test("quick connect preserves manually entered password authentication", () => {
+  const host = buildQuickConnectHost({
+    id: "quick-2",
+    createdAt: 456,
+    target: { hostname: "example.test" },
+    protocol: "ssh",
+    port: 2222,
+    username: "operator",
+    authMethod: "password",
+    password: "manual-secret",
+  });
+
+  assert.equal(host.identityId, undefined);
+  assert.equal(host.username, "operator");
+  assert.equal(host.password, "manual-secret");
+  assert.equal(host.port, 2222);
+  assert.equal(host.ephemeral, undefined);
+});

--- a/domain/quickConnectHost.ts
+++ b/domain/quickConnectHost.ts
@@ -1,0 +1,72 @@
+import { sanitizeCredentialValue } from "./credentials";
+import type { Host, Identity, SSHKey } from "./models";
+import type { QuickConnectTarget } from "./quickConnect";
+
+export type QuickConnectProtocol = "ssh" | "mosh" | "telnet";
+export type QuickConnectAuthMethod = "password" | "key" | "certificate";
+
+export const isQuickConnectIdentityUsable = (
+  identity: Identity | undefined,
+  keys: SSHKey[],
+  protocol: QuickConnectProtocol = "ssh",
+): boolean => {
+  if (!identity?.username.trim()) return false;
+  if (protocol === "telnet" && identity.authMethod !== "password") return false;
+  if (identity.authMethod === "password") {
+    return Boolean(sanitizeCredentialValue(identity.password));
+  }
+  return Boolean(identity.keyId && keys.some((key) => key.id === identity.keyId));
+};
+
+type BuildQuickConnectHostInput = {
+  id: string;
+  createdAt: number;
+  target: QuickConnectTarget;
+  protocol: QuickConnectProtocol;
+  port: number;
+  username: string;
+  authMethod: QuickConnectAuthMethod;
+  password?: string;
+  selectedKeyId?: string | null;
+  selectedIdentityId?: string | null;
+};
+
+export const buildQuickConnectHost = ({
+  id,
+  createdAt,
+  target,
+  protocol,
+  port,
+  username,
+  authMethod,
+  password,
+  selectedKeyId,
+  selectedIdentityId,
+}: BuildQuickConnectHostInput): Host => {
+  const usesIdentity = Boolean(selectedIdentityId);
+  const isTelnet = protocol === "telnet";
+
+  return {
+    id,
+    label: target.hostname,
+    hostname: target.hostname,
+    port,
+    username,
+    group: "",
+    tags: [],
+    os: "linux",
+    protocol: protocol === "mosh" ? "ssh" : protocol,
+    authMethod,
+    ...(usesIdentity ? { ephemeral: true } : {}),
+    ...(usesIdentity && !isTelnet ? { identityId: selectedIdentityId! } : {}),
+    ...(usesIdentity && isTelnet ? { telnetIdentityId: selectedIdentityId! } : {}),
+    ...(!usesIdentity && authMethod === "password" ? { password } : {}),
+    ...(!usesIdentity && authMethod !== "password" && selectedKeyId
+      ? { identityFileId: selectedKeyId }
+      : {}),
+    moshEnabled: protocol === "mosh",
+    telnetEnabled: isTelnet,
+    telnetPort: isTelnet ? port : undefined,
+    createdAt,
+  };
+};


### PR DESCRIPTION
## What changed

- Add a saved Identity picker to the Quick Connect flow for SSH and Mosh
- Connect immediately with a usable password, key, or certificate preset
- Keep preset-based quick connections temporary so they do not add hosts to the vault
- Preserve manual username/password and key flows, with safe handling for missing or concurrently removed credentials
- Add localized copy for all bundled languages

## Why

Operators managing many temporary devices can now enter only an address, choose an existing Keychain identity, and connect without repeatedly entering the same username and password or saving a permanent host.

Closes #2113

## Validation

- Targeted Quick Connect tests
- Scoped ESLint checks
- Production build
- Full test suite: 4,740 passed, 0 failed, 3 skipped
- Browser walkthrough: address → preset → connect, with the vault host list remaining unchanged
- Five review-until-clean rounds; final correctness and spec reviews both clean