### PR TITLE
Fix terminal side panel and accent theme contrast

### DIFF
--- a/components/ScriptsSidePanel.test.ts
+++ b/components/ScriptsSidePanel.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import { buildScriptsSidePanelRows } from "./ScriptsSidePanel.tsx";
 import type { Snippet } from "../types";
@@ -11,6 +12,8 @@ const snippet = (overrides: Partial<Snippet>): Snippet => ({
   package: overrides.package ?? "",
   order: overrides.order,
 });
+
+const source = readFileSync(new URL("./ScriptsSidePanel.tsx", import.meta.url), "utf8");
 
 test("scripts side panel rows keep manual snippet order inside a package", () => {
   const rows = buildScriptsSidePanelRows({
@@ -27,4 +30,8 @@ test("scripts side panel rows keep manual snippet order inside a package", () =>
     rows.filter((row) => row.type === "snippet").map((row) => row.id),
     ["zulu", "beta", "alpha"],
   );
+});
+
+test("scripts side panel active tabs pair the accent background with its foreground", () => {
+  assert.equal(source.match(/bg-accent text-accent-foreground/g)?.length, 2);
 });

--- a/components/ScriptsSidePanel.tsx
+++ b/components/ScriptsSidePanel.tsx
@@ -616,7 +616,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
           type="button"
           className={cn(
             'flex-1 h-7 rounded-md text-xs',
-            subView === 'library' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+            subView === 'library' ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-muted/50',
           )}
           onClick={() => setSubView('library')}
         >
@@ -626,7 +626,7 @@ const ScriptsSidePanelInner: React.FC<ScriptsSidePanelProps> = ({
           type="button"
           className={cn(
             'flex-1 h-7 rounded-md text-xs',
-            subView === 'running' ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+            subView === 'running' ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-muted/50',
           )}
           onClick={() => setSubView('running')}
         >

--- a/components/cloud-sync/CloudSyncDialogs.tsx
+++ b/components/cloud-sync/CloudSyncDialogs.tsx
@@ -348,7 +348,7 @@ export const CloudSyncDialogs: React.FC<CloudSyncDialogsProps> = ({
                                             disabled={historyPreviewLoading}
                                             className={cn(
                                                 "w-full flex items-center justify-between p-2.5 rounded-lg text-left text-sm transition-colors",
-                                                "hover:bg-accent/50 border border-transparent hover:border-border",
+                                                "hover:bg-muted/50 border border-transparent hover:border-border",
                                                 index === 0 && "bg-primary/5 border-primary/20",
                                             )}
                                         >

--- a/components/cloud-sync/CloudSyncDialogs.tsx
+++ b/components/cloud-sync/CloudSyncDialogs.tsx
@@ -348,7 +348,7 @@ export const CloudSyncDialogs: React.FC<CloudSyncDialogsProps> = ({
                                             disabled={historyPreviewLoading}
                                             className={cn(
                                                 "w-full flex items-center justify-between p-2.5 rounded-lg text-left text-sm transition-colors",
-                                                "hover:bg-accent border border-transparent hover:border-border",
+                                                "hover:bg-accent/50 border border-transparent hover:border-border",
                                                 index === 0 && "bg-primary/5 border-primary/20",
                                             )}
                                         >

--- a/components/settings/tabs/ai/AddProviderDropdown.tsx
+++ b/components/settings/tabs/ai/AddProviderDropdown.tsx
@@ -44,7 +44,7 @@ export const AddProviderDropdown: React.FC<{
                   onAdd(pid);
                   setIsOpen(false);
                 }}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-accent transition-colors text-left"
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors text-left"
               >
                 <ProviderIconBadge providerId={pid} size="sm" />
                 {PROVIDER_PRESETS[pid].name}

--- a/components/settings/tabs/ai/ModelSelector.tsx
+++ b/components/settings/tabs/ai/ModelSelector.tsx
@@ -79,6 +79,13 @@ export function getModelSuggestionsPresentation({
   };
 }
 
+export function getModelSuggestionClassName(isSelected: boolean): string {
+  return cn(
+    "w-full text-left px-3 py-1.5 text-xs hover:bg-accent hover:text-accent-foreground transition-colors flex items-center justify-between gap-2",
+    isSelected && "bg-accent text-accent-foreground",
+  );
+}
+
 export const ModelSelector: React.FC<{
   value: string;
   onChange: (value: string) => void;
@@ -267,13 +274,10 @@ export const ModelSelector: React.FC<{
                     onModelMetadata?.(m);
                     setIsOpen(false);
                   }}
-                  className={cn(
-                    "w-full text-left px-3 py-1.5 text-xs hover:bg-accent transition-colors flex items-center justify-between gap-2",
-                    m.id === value && "bg-accent",
-                  )}
+                  className={getModelSuggestionClassName(m.id === value)}
                 >
                   <span className="font-mono truncate">{m.id}</span>
-                  {m.id === value && <Check size={12} className="text-primary shrink-0" />}
+                  {m.id === value && <Check size={12} className="text-accent-foreground shrink-0" />}
                 </button>
               ))
             )}

--- a/components/settings/tabs/ai/dropdownLayout.test.ts
+++ b/components/settings/tabs/ai/dropdownLayout.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { ADD_PROVIDER_MENU_CLASS } from "./AddProviderDropdown.tsx";
-import { getModelSuggestionsPresentation } from "./ModelSelector.tsx";
+import { getModelSuggestionClassName, getModelSuggestionsPresentation } from "./ModelSelector.tsx";
+
+const modelSelectorSource = readFileSync(new URL("./ModelSelector.tsx", import.meta.url), "utf8");
 
 test("add provider menu opens toward the left edge of the button and stays width-bounded", () => {
   assert.match(ADD_PROVIDER_MENU_CLASS, /right-0/);
@@ -34,4 +37,11 @@ test("preset model suggestions stay visible when remote model discovery fails", 
     }),
     { showSuggestions: true, emptyState: null, footerState: "error" },
   );
+});
+
+test("selected model suggestions use the matching accent foreground", () => {
+  assert.match(getModelSuggestionClassName(true), /bg-accent/);
+  assert.match(getModelSuggestionClassName(true), /text-accent-foreground/);
+  assert.match(getModelSuggestionClassName(false), /hover:text-accent-foreground/);
+  assert.match(modelSelectorSource, /<Check size=\{12\} className="text-accent-foreground shrink-0" \/>/);
 });

--- a/components/terminal/ThemeCustomizeModal.tsx
+++ b/components/terminal/ThemeCustomizeModal.tsx
@@ -716,7 +716,7 @@ export const ThemeCustomizeModal: React.FC<ThemeCustomizeModalProps> = ({
                                         <button
                                             onClick={() => handleFontSizeChange(-1)}
                                             disabled={fontSize <= MIN_FONT_SIZE}
-                                            className="w-8 h-8 rounded-md flex items-center justify-center bg-background hover:bg-accent text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors border border-border"
+                                            className="w-8 h-8 rounded-md flex items-center justify-center bg-background hover:bg-accent text-foreground hover:text-accent-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors border border-border"
                                         >
                                             <Minus size={14} />
                                         </button>
@@ -727,7 +727,7 @@ export const ThemeCustomizeModal: React.FC<ThemeCustomizeModalProps> = ({
                                         <button
                                             onClick={() => handleFontSizeChange(1)}
                                             disabled={fontSize >= MAX_FONT_SIZE}
-                                            className="w-8 h-8 rounded-md flex items-center justify-center bg-background hover:bg-accent text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors border border-border"
+                                            className="w-8 h-8 rounded-md flex items-center justify-center bg-background hover:bg-accent text-foreground hover:text-accent-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors border border-border"
                                         >
                                             <Plus size={14} />
                                         </button>

--- a/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.test.ts
@@ -102,3 +102,10 @@ test('side panel tab bar and borders use inline resolved terminal theme colors',
   assert.doesNotMatch(sectionSource, /terminalAppearanceSidePanelStyle/);
   assert.doesNotMatch(sectionSource, /var\(--terminal-sidepanel-border\)/);
 });
+
+test('side panel content scopes app color utilities to the resolved terminal theme', () => {
+  const sectionSource = readFileSync(new URL('./TerminalLayerSidePanelSection.tsx', import.meta.url), 'utf8');
+
+  assert.match(sectionSource, /buildTerminalSidePanelCssVars/);
+  assert.match(sectionSource, /\.\.\.sidePanelCssVars/);
+});

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Activity, FolderTree, History, MessageSquare, NotebookText, Palette, PanelLeft, PanelRight, Play, X } from 'lucide-react';
-import { buildSidePanelChromeThemeFromTerminalTheme } from '../../infrastructure/theme/terminalAppearanceTokens';
+import {
+  buildSidePanelChromeThemeFromTerminalTheme,
+  buildTerminalSidePanelCssVars,
+} from '../../infrastructure/theme/terminalAppearanceTokens';
 import { injectTerminalLayerChromeSurfaceVars } from '../../infrastructure/theme/terminalAppearanceVars';
 import React, { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
@@ -111,12 +114,19 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
 
   const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
   const { sidePanelTabOrder, setSidePanelTabOrder } = useTerminalSidePanelTabOrder();
-  const sidePanelTheme = useMemo(() => {
-    const chromeTheme = followAppTerminalTheme
+  const resolvedSidePanelTerminalTheme = useMemo(() => (
+    followAppTerminalTheme
       ? terminalTheme
-      : (resolvedPreviewTheme ?? terminalTheme);
-    return buildSidePanelChromeThemeFromTerminalTheme(chromeTheme);
-  }, [followAppTerminalTheme, resolvedPreviewTheme, terminalTheme]);
+      : (resolvedPreviewTheme ?? terminalTheme)
+  ), [followAppTerminalTheme, resolvedPreviewTheme, terminalTheme]);
+  const sidePanelTheme = useMemo(
+    () => buildSidePanelChromeThemeFromTerminalTheme(resolvedSidePanelTerminalTheme),
+    [resolvedSidePanelTerminalTheme],
+  );
+  const sidePanelCssVars = useMemo(
+    () => buildTerminalSidePanelCssVars(resolvedSidePanelTerminalTheme),
+    [resolvedSidePanelTerminalTheme],
+  );
 
   useLayoutEffect(() => {
     if (!isSidePanelOpenForCurrentTab) return;
@@ -285,6 +295,7 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
         data-open={isSidePanelOpenForCurrentTab ? 'true' : 'false'}
         data-side-panel-tab={isSidePanelOpenForCurrentTab ? (activeSidePanelTab ?? undefined) : undefined}
         style={{
+          ...sidePanelCssVars,
           backgroundColor: sidePanelTheme.termBg,
           color: sidePanelTheme.termFg,
           ...(isSidePanelOpenForCurrentTab && sidePanelPosition === 'left'

--- a/components/themeContrastRegression.test.ts
+++ b/components/themeContrastRegression.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const cloudSyncDialogsSource = readFileSync(
+  new URL('./cloud-sync/CloudSyncDialogs.tsx', import.meta.url),
+  'utf8',
+);
+
+test('cloud revision rows use a neutral hover surface for arbitrary accent colors', () => {
+  assert.match(cloudSyncDialogsSource, /hover:bg-muted\/50/);
+  assert.doesNotMatch(cloudSyncDialogsSource, /hover:bg-accent(?:\/50)?/);
+});

--- a/infrastructure/theme/terminalAppearanceTokens.test.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.test.ts
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildSidePanelChromeThemeFromTerminalTheme, buildTerminalAppearanceCssVars } from './terminalAppearanceTokens';
+import { getContrastRatio, getHslTokenRelativeLuminance } from '../../domain/colorContrast';
+import { TERMINAL_THEMES } from '../config/terminalThemes';
+import {
+  buildSidePanelChromeThemeFromTerminalTheme,
+  buildTerminalAppearanceCssVars,
+  buildTerminalSidePanelCssVars,
+} from './terminalAppearanceTokens';
 
 test('buildTerminalAppearanceCssVars maps core terminal colors', () => {
   const vars = buildTerminalAppearanceCssVars({
@@ -71,4 +77,62 @@ test('buildSidePanelChromeThemeFromTerminalTheme uses resolved terminal colors',
   assert.equal(theme.termFg, '#100f0f');
   assert.equal(theme.accent, '#24837b');
   assert.match(theme.separator, /^color-mix\(/);
+});
+
+test('terminal side panel variables follow the terminal palette with readable selected text', () => {
+  const vars = buildTerminalSidePanelCssVars({
+    id: 'high-contrast-mismatch',
+    name: 'High contrast mismatch',
+    type: 'dark',
+    colors: {
+      background: '#000000',
+      foreground: '#ffffff',
+      cursor: '#ffffff',
+      selection: '#ffffff44',
+      black: '#000000',
+      red: '#ff0000',
+      green: '#00ff00',
+      yellow: '#ffff00',
+      blue: '#0000ff',
+      magenta: '#ff00ff',
+      cyan: '#00ffff',
+      white: '#ffffff',
+      brightBlack: '#000000',
+      brightRed: '#ff0000',
+      brightGreen: '#00ff00',
+      brightYellow: '#ffff00',
+      brightBlue: '#0000ff',
+      brightMagenta: '#ff00ff',
+      brightCyan: '#00ffff',
+      brightWhite: '#ffffff',
+    },
+  });
+
+  assert.equal(vars['--background'], '0 0% 0%');
+  assert.equal(vars['--foreground'], '0 0% 100%');
+  assert.notEqual(vars['--accent'], vars['--accent-foreground']);
+  assert.equal(vars['--accent-foreground'], vars['--foreground']);
+});
+
+test('every built-in terminal theme keeps side panel text readable', () => {
+  const pairs = [
+    ['--foreground', '--background'],
+    ['--accent-foreground', '--accent'],
+    ['--primary-foreground', '--primary'],
+    ['--destructive-foreground', '--destructive'],
+  ] as const;
+
+  for (const theme of TERMINAL_THEMES) {
+    const vars = buildTerminalSidePanelCssVars(theme);
+    for (const [foregroundKey, backgroundKey] of pairs) {
+      const foregroundLuminance = getHslTokenRelativeLuminance(vars[foregroundKey]);
+      const backgroundLuminance = getHslTokenRelativeLuminance(vars[backgroundKey]);
+      assert.notEqual(foregroundLuminance, null, `${theme.id} ${foregroundKey}`);
+      assert.notEqual(backgroundLuminance, null, `${theme.id} ${backgroundKey}`);
+      assert.ok(
+        getContrastRatio(foregroundLuminance as number, backgroundLuminance as number) >= 4.5,
+        `${theme.id} ${foregroundKey}/${backgroundKey}`,
+      );
+    }
+  }
 });

--- a/infrastructure/theme/terminalAppearanceTokens.test.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.test.ts
@@ -117,8 +117,13 @@ test('terminal side panel variables follow the terminal palette with readable se
 test('every built-in terminal theme keeps side panel text readable', () => {
   const pairs = [
     ['--foreground', '--background'],
+    ['--muted-foreground', '--background'],
+    ['--muted-foreground', '--muted'],
+    ['--secondary-foreground', '--secondary'],
+    ['--primary', '--background'],
     ['--accent-foreground', '--accent'],
     ['--primary-foreground', '--primary'],
+    ['--destructive', '--background'],
     ['--destructive-foreground', '--destructive'],
   ] as const;
 

--- a/infrastructure/theme/terminalAppearanceTokens.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.ts
@@ -83,11 +83,6 @@ const rgbToHslToken = ({ red, green, blue }: RgbColor): string => {
   return `${format(hue)} ${format(saturation * 100)}% ${format(lightness * 100)}%`;
 };
 
-const hexToHslToken = (value: string, fallback: string): string => {
-  const rgb = parseHexColor(value);
-  return rgb ? rgbToHslToken(rgb) : fallback;
-};
-
 const relativeLuminance = ({ red, green, blue }: RgbColor): number => {
   const linearize = (channel: number) => {
     const normalized = channel / 255;
@@ -108,12 +103,50 @@ const contrastRatio = (first: RgbColor, second: RgbColor): number => {
 
 const BLACK_RGB: RgbColor = { red: 0, green: 0, blue: 0 };
 const WHITE_RGB: RgbColor = { red: 255, green: 255, blue: 255 };
+const SAFE_TEXT_CONTRAST = 4.55;
 
 const readableForegroundRgb = (background: RgbColor, preferred?: RgbColor): RgbColor => {
-  if (preferred && contrastRatio(preferred, background) >= 4.5) return preferred;
+  if (preferred && contrastRatio(preferred, background) >= SAFE_TEXT_CONTRAST) return preferred;
   return contrastRatio(WHITE_RGB, background) >= contrastRatio(BLACK_RGB, background)
     ? WHITE_RGB
     : BLACK_RGB;
+};
+
+const minimumContrastRatio = (foreground: RgbColor, backgrounds: RgbColor[]): number => (
+  Math.min(...backgrounds.map((background) => contrastRatio(foreground, background)))
+);
+
+const ensureReadableRgb = (
+  preferred: RgbColor,
+  backgrounds: RgbColor[],
+  fallbackCandidates: RgbColor[] = [BLACK_RGB, WHITE_RGB],
+): RgbColor => {
+  if (minimumContrastRatio(preferred, backgrounds) >= SAFE_TEXT_CONTRAST) return preferred;
+
+  const fallback = fallbackCandidates.reduce((best, candidate) => (
+    minimumContrastRatio(candidate, backgrounds) > minimumContrastRatio(best, backgrounds)
+      ? candidate
+      : best
+  ));
+
+  for (let step = 1; step <= 100; step += 1) {
+    const candidate = mixRgb(fallback, preferred, step / 100);
+    if (minimumContrastRatio(candidate, backgrounds) >= SAFE_TEXT_CONTRAST) return candidate;
+  }
+  return fallback;
+};
+
+const keepSurfaceReadableBy = (
+  preferredSurface: RgbColor,
+  background: RgbColor,
+  foreground: RgbColor,
+): RgbColor => {
+  if (contrastRatio(foreground, preferredSurface) >= SAFE_TEXT_CONTRAST) return preferredSurface;
+  for (let step = 1; step <= 100; step += 1) {
+    const candidate = mixRgb(background, preferredSurface, step / 100);
+    if (contrastRatio(foreground, candidate) >= SAFE_TEXT_CONTRAST) return candidate;
+  }
+  return background;
 };
 
 export type TerminalSidePanelCssVars = Record<
@@ -143,16 +176,36 @@ export function buildTerminalSidePanelCssVars(theme: TerminalTheme): TerminalSid
   const backgroundRgb = parseHexColor(theme.colors.background) ?? BLACK_RGB;
   const preferredForegroundRgb = parseHexColor(theme.colors.foreground) ?? WHITE_RGB;
   const foregroundRgb = readableForegroundRgb(backgroundRgb, preferredForegroundRgb);
-  const cursorRgb = parseHexColor(theme.colors.cursor) ?? foregroundRgb;
-  const redRgb = parseHexColor(theme.colors.red) ?? { red: 220, green: 38, blue: 38 };
-  const secondaryRgb = mixRgb(foregroundRgb, backgroundRgb, 0.12);
-  const mutedRgb = mixRgb(foregroundRgb, backgroundRgb, 0.08);
-  const mutedForegroundRgb = mixRgb(foregroundRgb, backgroundRgb, 0.58);
+  const preferredCursorRgb = parseHexColor(theme.colors.cursor) ?? foregroundRgb;
+  const preferredRedRgb = parseHexColor(theme.colors.red) ?? { red: 220, green: 38, blue: 38 };
+  const cursorRgb = ensureReadableRgb(preferredCursorRgb, [backgroundRgb], [foregroundRgb, BLACK_RGB, WHITE_RGB]);
+  const redRgb = ensureReadableRgb(preferredRedRgb, [backgroundRgb], [foregroundRgb, BLACK_RGB, WHITE_RGB]);
+  const secondaryRgb = keepSurfaceReadableBy(
+    mixRgb(foregroundRgb, backgroundRgb, 0.12),
+    backgroundRgb,
+    foregroundRgb,
+  );
+  const mutedRgb = keepSurfaceReadableBy(
+    mixRgb(foregroundRgb, backgroundRgb, 0.08),
+    backgroundRgb,
+    foregroundRgb,
+  );
+  const preferredMutedForegroundRgb = mixRgb(foregroundRgb, backgroundRgb, 0.58);
+  const mutedForegroundRgb = ensureReadableRgb(
+    preferredMutedForegroundRgb,
+    [backgroundRgb, mutedRgb],
+    [foregroundRgb, BLACK_RGB, WHITE_RGB],
+  );
+  const secondaryForegroundRgb = ensureReadableRgb(
+    foregroundRgb,
+    [secondaryRgb],
+    [BLACK_RGB, WHITE_RGB],
+  );
   const accentRgb = mixRgb(foregroundRgb, backgroundRgb, 0.16);
   const borderRgb = mixRgb(foregroundRgb, backgroundRgb, 0.12);
   const background = rgbToHslToken(backgroundRgb);
   const foreground = rgbToHslToken(foregroundRgb);
-  const primary = hexToHslToken(theme.colors.cursor, foreground);
+  const primary = rgbToHslToken(cursorRgb);
   const secondary = rgbToHslToken(secondaryRgb);
   const muted = rgbToHslToken(mutedRgb);
   const mutedForeground = rgbToHslToken(mutedForegroundRgb);
@@ -171,7 +224,7 @@ export function buildTerminalSidePanelCssVars(theme: TerminalTheme): TerminalSid
     '--primary': primary,
     '--primary-foreground': rgbToHslToken(readableForegroundRgb(cursorRgb)),
     '--secondary': secondary,
-    '--secondary-foreground': foreground,
+    '--secondary-foreground': rgbToHslToken(secondaryForegroundRgb),
     '--muted': muted,
     '--muted-foreground': mutedForeground,
     '--accent': accent,

--- a/infrastructure/theme/terminalAppearanceTokens.ts
+++ b/infrastructure/theme/terminalAppearanceTokens.ts
@@ -39,6 +39,151 @@ function mix(fg: string, bg: string, fgPercent: number): string {
   return `color-mix(in srgb, ${fg} ${fgPercent}%, ${bg} ${100 - fgPercent}%)`;
 }
 
+type RgbColor = { red: number; green: number; blue: number };
+
+const parseHexColor = (value: string): RgbColor | null => {
+  const normalized = value.trim().replace(/^#/, '');
+  const expanded = normalized.length === 3
+    ? normalized.split('').map((part) => `${part}${part}`).join('')
+    : normalized;
+  if (!/^[0-9a-f]{6}$/i.test(expanded)) return null;
+  return {
+    red: Number.parseInt(expanded.slice(0, 2), 16),
+    green: Number.parseInt(expanded.slice(2, 4), 16),
+    blue: Number.parseInt(expanded.slice(4, 6), 16),
+  };
+};
+
+const mixRgb = (foreground: RgbColor, background: RgbColor, foregroundRatio: number): RgbColor => ({
+  red: foreground.red * foregroundRatio + background.red * (1 - foregroundRatio),
+  green: foreground.green * foregroundRatio + background.green * (1 - foregroundRatio),
+  blue: foreground.blue * foregroundRatio + background.blue * (1 - foregroundRatio),
+});
+
+const rgbToHslToken = ({ red, green, blue }: RgbColor): string => {
+  const r = red / 255;
+  const g = green / 255;
+  const b = blue / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const lightness = (max + min) / 2;
+  let hue = 0;
+  let saturation = 0;
+
+  if (delta > 0) {
+    saturation = delta / (1 - Math.abs(2 * lightness - 1));
+    if (max === r) hue = 60 * (((g - b) / delta) % 6);
+    else if (max === g) hue = 60 * (((b - r) / delta) + 2);
+    else hue = 60 * (((r - g) / delta) + 4);
+  }
+
+  if (hue < 0) hue += 360;
+  const format = (value: number) => Number(value.toFixed(2));
+  return `${format(hue)} ${format(saturation * 100)}% ${format(lightness * 100)}%`;
+};
+
+const hexToHslToken = (value: string, fallback: string): string => {
+  const rgb = parseHexColor(value);
+  return rgb ? rgbToHslToken(rgb) : fallback;
+};
+
+const relativeLuminance = ({ red, green, blue }: RgbColor): number => {
+  const linearize = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue);
+};
+
+const contrastRatio = (first: RgbColor, second: RgbColor): number => {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const BLACK_RGB: RgbColor = { red: 0, green: 0, blue: 0 };
+const WHITE_RGB: RgbColor = { red: 255, green: 255, blue: 255 };
+
+const readableForegroundRgb = (background: RgbColor, preferred?: RgbColor): RgbColor => {
+  if (preferred && contrastRatio(preferred, background) >= 4.5) return preferred;
+  return contrastRatio(WHITE_RGB, background) >= contrastRatio(BLACK_RGB, background)
+    ? WHITE_RGB
+    : BLACK_RGB;
+};
+
+export type TerminalSidePanelCssVars = Record<
+  | '--background'
+  | '--foreground'
+  | '--card'
+  | '--card-foreground'
+  | '--popover'
+  | '--popover-foreground'
+  | '--primary'
+  | '--primary-foreground'
+  | '--secondary'
+  | '--secondary-foreground'
+  | '--muted'
+  | '--muted-foreground'
+  | '--accent'
+  | '--accent-foreground'
+  | '--destructive'
+  | '--destructive-foreground'
+  | '--border'
+  | '--input'
+  | '--ring',
+  string
+>;
+
+export function buildTerminalSidePanelCssVars(theme: TerminalTheme): TerminalSidePanelCssVars {
+  const backgroundRgb = parseHexColor(theme.colors.background) ?? BLACK_RGB;
+  const preferredForegroundRgb = parseHexColor(theme.colors.foreground) ?? WHITE_RGB;
+  const foregroundRgb = readableForegroundRgb(backgroundRgb, preferredForegroundRgb);
+  const cursorRgb = parseHexColor(theme.colors.cursor) ?? foregroundRgb;
+  const redRgb = parseHexColor(theme.colors.red) ?? { red: 220, green: 38, blue: 38 };
+  const secondaryRgb = mixRgb(foregroundRgb, backgroundRgb, 0.12);
+  const mutedRgb = mixRgb(foregroundRgb, backgroundRgb, 0.08);
+  const mutedForegroundRgb = mixRgb(foregroundRgb, backgroundRgb, 0.58);
+  const accentRgb = mixRgb(foregroundRgb, backgroundRgb, 0.16);
+  const borderRgb = mixRgb(foregroundRgb, backgroundRgb, 0.12);
+  const background = rgbToHslToken(backgroundRgb);
+  const foreground = rgbToHslToken(foregroundRgb);
+  const primary = hexToHslToken(theme.colors.cursor, foreground);
+  const secondary = rgbToHslToken(secondaryRgb);
+  const muted = rgbToHslToken(mutedRgb);
+  const mutedForeground = rgbToHslToken(mutedForegroundRgb);
+  const accent = rgbToHslToken(accentRgb);
+  const accentForeground = rgbToHslToken(readableForegroundRgb(accentRgb, foregroundRgb));
+  const border = rgbToHslToken(borderRgb);
+  const destructive = rgbToHslToken(redRgb);
+
+  return {
+    '--background': background,
+    '--foreground': foreground,
+    '--card': background,
+    '--card-foreground': foreground,
+    '--popover': background,
+    '--popover-foreground': foreground,
+    '--primary': primary,
+    '--primary-foreground': rgbToHslToken(readableForegroundRgb(cursorRgb)),
+    '--secondary': secondary,
+    '--secondary-foreground': foreground,
+    '--muted': muted,
+    '--muted-foreground': mutedForeground,
+    '--accent': accent,
+    '--accent-foreground': accentForeground,
+    '--destructive': destructive,
+    '--destructive-foreground': rgbToHslToken(readableForegroundRgb(redRgb)),
+    '--border': border,
+    '--input': border,
+    '--ring': primary,
+  };
+}
+
 export function buildTerminalAppearanceCssVars(theme: TerminalTheme): TerminalAppearanceCssVars {
   const bg = theme.colors.background;
   const fg = theme.colors.foreground;


### PR DESCRIPTION
## What changed

- Scope terminal side panel content colors to the active terminal theme, matching the already-correct Theme panel behavior.
- Pair solid accent backgrounds with their matching foreground color in Scripts, the AI model selector, provider menus, and related controls.
- Keep primary, secondary, muted, accent, and destructive text readable for low-contrast palettes while preserving theme colors whenever they are already clear.
- Use a neutral hover surface where nested labels should not inherit an arbitrary accent color.
- Add regression coverage for Scripts tabs, model suggestions, side panel scoping, cloud revision rows, and every bundled terminal theme.

## Root cause

Most terminal side panel content still consumed the application theme variables, while the side panel chrome and Theme panel consumed the active terminal palette. Mixed light/dark combinations therefore produced light content inside a dark terminal panel. A few selected and hover states also changed only their background to the accent color, leaving the previous text color in place.

## Validation

- `npm test` — 4,850 passed, 3 skipped, 0 failed
- `npm run lint`
- `npm run build`
- Bundled theme contrast sweep — 198 terminal themes, 1,782 key color pairs, 0 failures
- Two-round independent review loop — final round clean