### PR TITLE
chore(mosh): require moshcatty-0.1.6 for prediction hardening

### DIFF
--- a/docs/designs/native-mosh-client.md
+++ b/docs/designs/native-mosh-client.md
@@ -51,9 +51,9 @@ assets (they require GLIBC 2.34).
 
 ## Windows compatibility floor
 
-Netcatty requires `moshcatty-0.1.5+`. That release includes stock-aligned
-speculative local echo (Diff path) for high-latency typing (#2121), plus the
-0.1.4 ConPTY shortcut-input fixes. Packaging must not resolve or accept an
+Netcatty requires `moshcatty-0.1.6+`. That release includes stock-aligned speculative local echo hardening
+(host-before-ack Confirm, Pending-continue, geometry vs content redraw)
+on top of the 0.1.5 Diff path (#2121) and 0.1.4 ConPTY fixes. Packaging must not resolve or accept an
 older MoshCatty release.
 
 ## Decision log
@@ -70,7 +70,7 @@ older MoshCatty release.
   scrollback remain available.
 - **2026-07-11:** Speculative local echo (prediction underlines) lives in
   MoshCatty (`DisplayPipeline`, `MOSH_PREDICTION_DISPLAY`). Prefer
-  `moshcatty-0.1.5+` so high-latency typing matches stock mosh / Termius
+  `moshcatty-0.1.6+` so high-latency typing matches stock mosh / Termius
   (Netcatty #2121). Netcatty does not implement prediction in the renderer.
-- **2026-07-12:** Require `moshcatty-0.1.5+` for #2121 prediction; handshake
+- **2026-07-12:** Require `moshcatty-0.1.6+` for #2121 prediction; handshake
   failure messaging when `MOSH CONNECT` is missing (#2128).

--- a/resources/mosh/README.md
+++ b/resources/mosh/README.md
@@ -18,7 +18,7 @@ Netcatty runs SSH + `mosh-server` bootstrap itself, then launches this binary
 Each tarball contains **only** the client binary (no Cygwin DLLs, no terminfo).
 Windows builds static-link the MSVC CRT (`moshcatty-0.1.1+`).
 
-Release tags: `moshcatty-*` (require `moshcatty-0.1.5+`) from
+Release tags: `moshcatty-*` (require `moshcatty-0.1.6+`) from
 `binaricat/MoshCatty`, with `SHA256SUMS`.
 
 ### Linux glibc floors
@@ -37,8 +37,8 @@ were built on Ubuntu runners and require GLIBC 2.34.
 ## Fetch
 
 ```sh
-# Optional pin (0.1.5+ includes local prediction for #2121)
-export MOSH_BIN_RELEASE=moshcatty-0.1.5
+# Optional pin (0.1.6+ includes prediction hardening (host-before-ack, Pending-continue, …))
+export MOSH_BIN_RELEASE=moshcatty-0.1.6
 npm run fetch:mosh
 
 # Dev: host platform; resolves latest moshcatty-* if unset

--- a/scripts/fetch-mosh-binaries.cjs
+++ b/scripts/fetch-mosh-binaries.cjs
@@ -313,10 +313,10 @@ async function main(argv = process.argv.slice(2), env = process.env) {
     release = await resolveMoshBinRelease(env);
   }
   if (!release) {
-    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.5) to bundle mosh-client into the package.");
+    log("MOSH_BIN_RELEASE is unset - skipping. Set it (e.g. moshcatty-0.1.6) to bundle mosh-client into the package.");
     return 0;
   }
-  // Reject pre-0.1.5 pins (missing local prediction for #2121) even when MOSH_BIN_RELEASE is set
+  // Reject pre-0.1.6 pins (missing prediction hardening after #2121) even when MOSH_BIN_RELEASE is set
   // without going through --resolve-release.
   release = validateReleaseTag(release);
 

--- a/scripts/fetch-mosh-binaries.test.cjs
+++ b/scripts/fetch-mosh-binaries.test.cjs
@@ -138,7 +138,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
     {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.6",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -151,7 +151,7 @@ test("fetch-mosh-binaries host mode skips unsupported local targets", async (t) 
   assert.equal(fs.existsSync(resDir), false);
 });
 
-test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.5", async (t) => {
+test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.6", async (t) => {
   const resDir = path.join(makeTmp(t), "resources", "mosh");
 
   await assert.rejects(
@@ -164,7 +164,7 @@ test("fetch-mosh-binaries rejects MoshCatty releases before 0.1.5", async (t) =>
       },
       stdio: "pipe",
     }),
-    /below minimum moshcatty-0\.1\.5/,
+    /below minimum moshcatty-0\.1\.6/,
   );
   assert.equal(fs.existsSync(resDir), false);
 });
@@ -182,7 +182,7 @@ test("fetch-mosh-binaries unpacks pure Windows MoshCatty tarball", async (t) => 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.6",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -213,7 +213,7 @@ test("fetch-mosh-binaries strips accidental dll/terminfo from Windows tarball", 
   await execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.6",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -239,7 +239,7 @@ test("fetch-mosh-binaries unpacks pure Linux MoshCatty tarball", async (t) => {
   await execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
     env: {
       ...process.env,
-      MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+      MOSH_BIN_RELEASE: "moshcatty-0.1.6",
       MOSH_BIN_BASE_URL: baseUrl,
       MOSH_BIN_RES_DIR: resDir,
       CI: "true",
@@ -265,7 +265,7 @@ test("fetch-mosh-binaries rejects tarball without mosh-client", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=linux", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.6",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -288,7 +288,7 @@ test("fetch-mosh-binaries fails when SHA256SUMS lacks the asset", async (t) => {
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.6",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",
@@ -316,7 +316,7 @@ test("fetch-mosh-binaries rejects symlinks inside tarballs", { skip: process.pla
     execFileAsync(process.execPath, [script, "--platform=win32", "--arch=x64"], {
       env: {
         ...process.env,
-        MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+        MOSH_BIN_RELEASE: "moshcatty-0.1.6",
         MOSH_BIN_BASE_URL: baseUrl,
         MOSH_BIN_RES_DIR: resDir,
         CI: "true",

--- a/scripts/resolve-mosh-bin-release.cjs
+++ b/scripts/resolve-mosh-bin-release.cjs
@@ -14,11 +14,12 @@ const fs = require("node:fs");
 const https = require("node:https");
 
 // MoshCatty pure-Rust releases only.
-// Minimum 0.1.5: stock-aligned local prediction (Diff path) for #2121.
-// 0.1.4 had ConPTY shortcut fix; 0.1.2+ Linux glibc floors match Netcatty.
+// Minimum 0.1.6: prediction hardening (host-before-ack Confirm, Pending-continue,
+// geometry vs content redraw, kill_epoch/ESC/scroll fixes). 0.1.5 introduced Diff path.
+// 0.1.4 ConPTY shortcut; 0.1.2+ Linux glibc floors match Netcatty.
 // Allow semver prerelease (-rc1) and build metadata (+meta); no path separators.
 const TAG_RE = /^moshcatty-[A-Za-z0-9._+-]+$/;
-const MIN_VERSION = { major: 0, minor: 1, patch: 5 };
+const MIN_VERSION = { major: 0, minor: 1, patch: 6 };
 const MIN_TAG = `moshcatty-${MIN_VERSION.major}.${MIN_VERSION.minor}.${MIN_VERSION.patch}`;
 
 function log(msg) {
@@ -71,8 +72,8 @@ function validateReleaseTag(tag) {
   if (!isAtLeastMinRelease(value)) {
     throw new Error(
       `mosh binary release ${value} is below minimum ${MIN_TAG} `
-        + "(0.1.5 includes local prediction for #2121; "
-        + "prereleases of the floor e.g. 0.1.5-rc1 are not accepted)",
+        + "(0.1.6 includes prediction hardening after 0.1.5 Diff path; "
+        + "prereleases of the floor e.g. 0.1.6-rc1 are not accepted)",
     );
   }
   return value;

--- a/scripts/resolve-mosh-bin-release.test.cjs
+++ b/scripts/resolve-mosh-bin-release.test.cjs
@@ -22,10 +22,10 @@ function makeTmp(t) {
 }
 
 test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
-  assert.equal(validateReleaseTag("moshcatty-0.1.5"), "moshcatty-0.1.5");
+  assert.equal(validateReleaseTag("moshcatty-0.1.6"), "moshcatty-0.1.6");
   assert.equal(validateReleaseTag("moshcatty-0.2.0"), "moshcatty-0.2.0");
-  assert.equal(validateReleaseTag("moshcatty-0.1.6-rc1"), "moshcatty-0.1.6-rc1");
-  assert.equal(validateReleaseTag("moshcatty-0.1.5+build.1"), "moshcatty-0.1.5+build.1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.7-rc1"), "moshcatty-0.1.7-rc1");
+  assert.equal(validateReleaseTag("moshcatty-0.1.6+build.1"), "moshcatty-0.1.6+build.1");
   assert.throws(() => validateReleaseTag("mosh-bin-1.4.0-1"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("v1.2.3"), /invalid mosh binary release tag/);
   assert.throws(() => validateReleaseTag("moshcatty-../bad"), /invalid mosh binary release tag/);
@@ -35,19 +35,21 @@ test("validateReleaseTag accepts only moshcatty-* tags at min version", () => {
   assert.throws(() => validateReleaseTag("moshcatty-0.1.2"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.3"), /below minimum/);
   assert.throws(() => validateReleaseTag("moshcatty-0.1.4"), /below minimum/);
-  assert.throws(() => validateReleaseTag("moshcatty-0.1.5-rc1"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.5"), /below minimum/);
+  assert.throws(() => validateReleaseTag("moshcatty-0.1.6-rc1"), /below minimum/);
 });
 
-test("isAtLeastMinRelease enforces moshcatty-0.1.5 floor with semver prerelease rules", () => {
-  assert.equal(MIN_TAG, "moshcatty-0.1.5");
+test("isAtLeastMinRelease enforces moshcatty-0.1.6 floor with semver prerelease rules", () => {
+  assert.equal(MIN_TAG, "moshcatty-0.1.6");
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.3"), false);
   assert.equal(isAtLeastMinRelease("moshcatty-0.1.4"), false);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.6"), true);
   // Prerelease of the floor sorts below the final floor release.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5-rc1"), false);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.6-rc1"), false);
   // Above the floor, prereleases are fine.
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.6-rc1"), true);
-  assert.equal(isAtLeastMinRelease("moshcatty-0.1.5+build.1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.7-rc1"), true);
+  assert.equal(isAtLeastMinRelease("moshcatty-0.1.6+build.1"), true);
   assert.equal(isAtLeastMinRelease("moshcatty-not-a-version"), false);
 });
 
@@ -63,17 +65,17 @@ test("parseRepository defaults to binaricat/MoshCatty (ignores GITHUB_REPOSITORY
   );
 });
 
-test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.5 tags", () => {
+test("pickLatestMoshBinRelease ignores non-moshcatty and pre-0.1.6 tags", () => {
   const got = pickLatestMoshBinRelease([
     { tag_name: "v1.0.0", published_at: "2026-03-01T00:00:00Z" },
     { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-06-01T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.5", draft: true, published_at: "2026-07-11T00:00:00Z" },
+    { tag_name: "moshcatty-0.1.6", draft: true, published_at: "2026-07-13T00:00:00Z" },
     { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
-    { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T12:00:00Z" },
     { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
+    { tag_name: "moshcatty-0.1.6", published_at: "2026-07-13T01:00:00Z" },
   ]);
 
-  assert.equal(got, "moshcatty-0.1.5");
+  assert.equal(got, "moshcatty-0.1.6");
 });
 
 test("parseNextLink reads the next GitHub pagination URL", () => {
@@ -96,7 +98,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     requested.push(url);
     if (url.includes("page=2")) {
       return {
-        json: [{ tag_name: "moshcatty-0.1.5", published_at: "2026-01-01T00:00:00Z" }],
+        json: [{ tag_name: "moshcatty-0.1.6", published_at: "2026-01-01T00:00:00Z" }],
         headers: {},
       };
     }
@@ -108,7 +110,7 @@ test("loadReleases follows GitHub pagination until the last page", async () => {
     };
   });
 
-  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.5"]);
+  assert.deepEqual(got.map((release) => release.tag_name), ["v1.0.0", "moshcatty-0.1.6"]);
   assert.equal(requested.length, 2);
 });
 
@@ -126,17 +128,17 @@ test("main keeps an explicit MOSH_BIN_RELEASE and exports it", async (t) => {
   const githubEnv = path.join(makeTmp(t), "github-env");
 
   const got = await main({
-    MOSH_BIN_RELEASE: "moshcatty-0.1.5",
+    MOSH_BIN_RELEASE: "moshcatty-0.1.6",
     GITHUB_ENV: githubEnv,
   });
 
-  assert.equal(got, "moshcatty-0.1.5");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.5\n");
+  assert.equal(got, "moshcatty-0.1.6");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.6\n");
 });
 
-test("main rejects explicit pre-0.1.5 MOSH_BIN_RELEASE", async () => {
+test("main rejects explicit pre-0.1.6 MOSH_BIN_RELEASE", async () => {
   await assert.rejects(
-    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.4" }),
+    main({ MOSH_BIN_RELEASE: "moshcatty-0.1.5" }),
     /below minimum/,
   );
 });
@@ -148,14 +150,14 @@ test("main resolves the latest moshcatty release from the list and exports it", 
     MOSH_BIN_RELEASES_JSON: JSON.stringify([
       { tag_name: "moshcatty-0.1.0", published_at: "2026-01-01T00:00:00Z" },
       { tag_name: "moshcatty-0.1.2", published_at: "2026-07-10T00:00:00Z" },
-      { tag_name: "moshcatty-0.1.4", published_at: "2026-07-10T12:00:00Z" },
       { tag_name: "moshcatty-0.1.5", published_at: "2026-07-10T13:00:00Z" },
+      { tag_name: "moshcatty-0.1.6", published_at: "2026-07-13T01:00:00Z" },
       { tag_name: "mosh-bin-1.4.0-2", published_at: "2026-08-01T00:00:00Z" },
     ]),
   });
 
-  assert.equal(got, "moshcatty-0.1.5");
-  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.5\n");
+  assert.equal(got, "moshcatty-0.1.6");
+  assert.equal(fs.readFileSync(githubEnv, "utf8"), "MOSH_BIN_RELEASE=moshcatty-0.1.6\n");
 });
 
 test("main fails when no usable moshcatty release exists", async () => {
@@ -164,8 +166,8 @@ test("main fails when no usable moshcatty release exists", async () => {
       MOSH_BIN_RELEASES_JSON: JSON.stringify([
         { tag_name: "v1.0.0", published_at: "2026-01-01T00:00:00Z" },
         { tag_name: "mosh-bin-1.4.0-1", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.4", published_at: "2026-02-01T00:00:00Z" },
-        { tag_name: "moshcatty-0.1.5", draft: true, published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.5", published_at: "2026-02-01T00:00:00Z" },
+        { tag_name: "moshcatty-0.1.6", draft: true, published_at: "2026-02-01T00:00:00Z" },
       ]),
     }),
     /could not find/,


### PR DESCRIPTION
## Summary
- Raise MoshCatty packaging floor from `moshcatty-0.1.5` to **`moshcatty-0.1.6+`**.
- Release: https://github.com/binaricat/MoshCatty/releases/tag/moshcatty-0.1.6
- Includes host-before-ack Confirm, Pending-continue, geometry vs content redraw, kill_epoch/ESC/scroll fixes (pure Diff path, no system mosh).

## Changes
- `scripts/resolve-mosh-bin-release.cjs` + tests: `MIN_VERSION` 0.1.6
- `scripts/fetch-mosh-binaries.cjs` + tests
- `resources/mosh/README.md`, `docs/designs/native-mosh-client.md`

## Test plan
- [x] `node --test scripts/resolve-mosh-bin-release.test.cjs scripts/fetch-mosh-binaries.test.cjs` (24 pass)
- [x] Local `MOSH_BIN_RELEASE=moshcatty-0.1.6 node scripts/fetch-mosh-binaries.cjs` (4/4 platforms)
- [ ] Pack/dev smoke: Mosh session uses new client (host-before-ack path)

Binaries remain gitignored; CI/pack jobs resolve/fetch `moshcatty-0.1.6+`.