### PR TITLE
fix(terminal): host keyword highlight popover under compact toolbar

### DIFF
--- a/components/terminal/HostKeywordHighlightPopover.tsx
+++ b/components/terminal/HostKeywordHighlightPopover.tsx
@@ -126,7 +126,10 @@ export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverPr
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <Tooltip>
+      {/* Force-close tooltip while the panel is open so the blue label does not
+          sit on top of the trigger/panel (especially in the compact top-right
+          cluster when the host info bar is hidden). */}
+      <Tooltip open={isOpen ? false : undefined}>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <Button
@@ -140,11 +143,16 @@ export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverPr
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent>{t('terminal.toolbar.hostHighlight.title')}</TooltipContent>
+        {/* Toolbar sits at the top of the terminal pane; open below the trigger
+            so the label is not clipped by the window/title edge (especially in
+            compact top-right action cluster when the host info bar is hidden). */}
+        <TooltipContent side="bottom" sideOffset={8} className="whitespace-nowrap max-w-none">
+          {t('terminal.toolbar.hostHighlight.title')}
+        </TooltipContent>
       </Tooltip>
-      <PopoverContent className="w-80 p-0" align="start" side="top">
-        <div className="px-3 py-2 border-b bg-muted/30 flex items-center justify-between">
-          <span className="text-xs font-semibold uppercase text-muted-foreground">
+      <PopoverContent className="w-80 p-0" align="end" side="bottom" sideOffset={8} collisionPadding={12}>
+        <div className="px-3 py-2 border-b bg-muted/30 flex items-center justify-between gap-2 min-w-0">
+          <span className="text-xs font-semibold uppercase text-muted-foreground truncate min-w-0">
             {t('terminal.toolbar.hostHighlight.title')}
           </span>
           <label className="flex items-center gap-2 cursor-pointer">
@@ -199,7 +207,9 @@ export const HostKeywordHighlightPopover: React.FC<HostKeywordHighlightPopoverPr
                         `}
                       />
                     </TooltipTrigger>
-                    <TooltipContent>{rule.enabled ? t('common.enabled') : t('common.disabled')}</TooltipContent>
+                    <TooltipContent side="bottom">
+                      {rule.enabled ? t('common.enabled') : t('common.disabled')}
+                    </TooltipContent>
                   </Tooltip>
                   <div className="flex-1 min-w-0">
                     <div 

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -131,7 +131,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <TextCursorInput size={12} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{t("terminal.toolbar.composeBar")}</TooltipContent>
+                    <TooltipContent side="bottom">{t("terminal.toolbar.composeBar")}</TooltipContent>
                 </Tooltip>
 
                 <Tooltip>
@@ -148,7 +148,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <Search size={12} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
+                    <TooltipContent side="bottom">{t("terminal.toolbar.searchTerminal")}</TooltipContent>
                 </Tooltip>
 
                 <Popover open={scriptsPopoverOpen} onOpenChange={setScriptsPopoverOpen}>
@@ -167,7 +167,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                                 </Button>
                             </PopoverTrigger>
                         </TooltipTrigger>
-                        <TooltipContent>{t("terminal.toolbar.scripts")}</TooltipContent>
+                        <TooltipContent side="bottom">{t("terminal.toolbar.scripts")}</TooltipContent>
                     </Tooltip>
                     <PopoverContent className="w-80 p-0 h-80 flex flex-col overflow-hidden" align="end">
                         <ScriptsSidePanel
@@ -209,7 +209,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <FolderInput size={12} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>
+                    <TooltipContent side="bottom">
                         {status === 'connected' ? t("terminal.toolbar.openSftp") : t("terminal.toolbar.availableAfterConnect")}
                     </TooltipContent>
                 </Tooltip>
@@ -230,7 +230,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                                 <Upload size={12} />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom">
                             {status === 'connected' ? t("terminal.toolbar.sendYmodem") : t("terminal.toolbar.availableAfterConnect")}
                         </TooltipContent>
                     </Tooltip>
@@ -248,7 +248,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                                 <Download size={12} />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom">
                             {status === 'connected' ? t("terminal.toolbar.receiveYmodem") : t("terminal.toolbar.availableAfterConnect")}
                         </TooltipContent>
                     </Tooltip>
@@ -270,7 +270,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                         <TextCursorInput size={12} />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.composeBar")}</TooltipContent>
+                <TooltipContent side="bottom">{t("terminal.toolbar.composeBar")}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -288,7 +288,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                         <Search size={12} />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.searchTerminal")}</TooltipContent>
+                <TooltipContent side="bottom">{t("terminal.toolbar.searchTerminal")}</TooltipContent>
             </Tooltip>
 
             {showLogButton && (
@@ -308,7 +308,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <FileText size={12} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>
+                    <TooltipContent side="bottom">
                         {isSessionLogging ? t("terminal.toolbar.stopSessionLog") : t("terminal.toolbar.startSessionLog")}
                     </TooltipContent>
                 </Tooltip>
@@ -327,7 +327,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                         <Zap size={12} />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>{t("terminal.toolbar.scripts")}</TooltipContent>
+                <TooltipContent side="bottom">{t("terminal.toolbar.scripts")}</TooltipContent>
             </Tooltip>
 
             {/* Overflow menu — keeps lower-frequency opener-style actions
@@ -355,7 +355,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             </Button>
                         </PopoverTrigger>
                     </TooltipTrigger>
-                    <TooltipContent>{t("terminal.toolbar.more")}</TooltipContent>
+                    <TooltipContent side="bottom">{t("terminal.toolbar.more")}</TooltipContent>
                 </Tooltip>
                 <PopoverContent
                     className="w-48 p-1"
@@ -485,7 +485,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <X size={11} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent>
+                    <TooltipContent side="bottom">
                         {closeRestoresTab
                             ? t("terminal.toolbar.detach")
                             : t("terminal.toolbar.closeSession")}

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -246,12 +246,11 @@ test("hidden host information reveals actions without permanently covering termi
   assert.match(source, /id=\{`terminal-actions-\$\{sessionId\}`\}/);
   assert.match(source, /onClick=\{\(\) => setCompactActionsOpen/);
   assert.match(source, /right: terminalRightInset/);
-  // Compact strip opens below the ⋯ toggle (top-8), not beside it (top-0 right-8),
-  // so the full toolbar is visible instead of stacking on the toggle.
-  assert.match(source, /absolute right-1 top-8/);
-  assert.match(source, /\? "visible opacity-100 pointer-events-auto"/);
-  assert.match(source, /: "invisible opacity-0"/);
-  assert.match(source, /aria-hidden=\{!showHostInfoBar && !isSearchOpen && !compactActionsOpen \? true : undefined\}/);
+  // Compact mode is a circular speed-dial: tray springs left from the toggle.
+  assert.match(source, /flex flex-row-reverse items-center/);
+  assert.match(source, /rounded-full/);
+  assert.match(source, /max-w-\[min\(100vw-3rem,40rem\)\]/);
+  assert.match(source, /max-w-0 opacity-0 scale-90/);
   assert.match(source, /document\.addEventListener\("pointerdown", handlePointerDown\)/);
   assert.match(source, /closest\('\[data-radix-popper-content-wrapper\]'\)/);
   assert.match(source, /event\.key !== "Escape"/);

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -246,7 +246,10 @@ test("hidden host information reveals actions without permanently covering termi
   assert.match(source, /id=\{`terminal-actions-\$\{sessionId\}`\}/);
   assert.match(source, /onClick=\{\(\) => setCompactActionsOpen/);
   assert.match(source, /right: terminalRightInset/);
-  assert.match(source, /\? "visible opacity-100 translate-y-0 pointer-events-auto"/);
+  // Compact strip opens below the ⋯ toggle (top-8), not beside it (top-0 right-8),
+  // so the full toolbar is visible instead of stacking on the toggle.
+  assert.match(source, /absolute right-1 top-8/);
+  assert.match(source, /\? "visible opacity-100 pointer-events-auto"/);
   assert.match(source, /: "invisible opacity-0"/);
   assert.match(source, /aria-hidden=\{!showHostInfoBar && !isSearchOpen && !compactActionsOpen \? true : undefined\}/);
   assert.match(source, /document\.addEventListener\("pointerdown", handlePointerDown\)/);

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -246,11 +246,13 @@ test("hidden host information reveals actions without permanently covering termi
   assert.match(source, /id=\{`terminal-actions-\$\{sessionId\}`\}/);
   assert.match(source, /onClick=\{\(\) => setCompactActionsOpen/);
   assert.match(source, /right: terminalRightInset/);
-  // Compact mode is a circular speed-dial: tray springs left from the toggle.
+  // Compact mode is a circular speed-dial: tray springs left via 0fr→1fr grid
+  // (must not use .terminal-topbar — container-type collapses content width).
   assert.match(source, /flex flex-row-reverse items-center/);
   assert.match(source, /rounded-full/);
-  assert.match(source, /max-w-\[min\(100vw-3rem,40rem\)\]/);
-  assert.match(source, /max-w-0 opacity-0 scale-90/);
+  assert.match(source, /grid-cols-\[1fr\]/);
+  assert.match(source, /grid-cols-\[0fr\]/);
+  assert.match(source, /Do NOT use `\.terminal-topbar`|container-type:inline-size|container-type collapses/);
   assert.match(source, /document\.addEventListener\("pointerdown", handlePointerDown\)/);
   assert.match(source, /closest\('\[data-radix-popper-content-wrapper\]'\)/);
   assert.match(source, /event\.key !== "Escape"/);

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -252,6 +252,8 @@ test("hidden host information reveals actions without permanently covering termi
   assert.match(source, /rounded-full/);
   assert.match(source, /grid-cols-\[1fr\]/);
   assert.match(source, /grid-cols-\[0fr\]/);
+  assert.match(source, /ChevronsLeft/);
+  assert.match(source, /h-7/);
   assert.match(source, /Do NOT use `\.terminal-topbar`|container-type:inline-size|container-type collapses/);
   assert.match(source, /document\.addEventListener\("pointerdown", handlePointerDown\)/);
   assert.match(source, /closest\('\[data-radix-popper-content-wrapper\]'\)/);

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -381,12 +381,12 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
           onMouseDownCapture={handleTopOverlayMouseDownCapture}
         >
           {!showHostInfoBar && !isSearchOpen && (
-            <Tooltip>
+            <Tooltip open={compactActionsOpen ? false : undefined}>
               <TooltipTrigger asChild>
                 <button
                   ref={compactActionsButtonRef}
                   type="button"
-                  className="absolute right-1 top-1 h-6 w-6 rounded-md border pointer-events-auto opacity-70 hover:opacity-100 focus-visible:opacity-100"
+                  className="absolute right-1 top-1 z-30 h-6 w-6 rounded-md border pointer-events-auto opacity-70 hover:opacity-100 focus-visible:opacity-100"
                   style={{
                     backgroundColor: 'var(--terminal-ui-bg)',
                     borderColor: 'var(--terminal-ui-border)',
@@ -417,11 +417,15 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
               "terminal-topbar flex items-center gap-1 py-0.5 backdrop-blur-md min-w-0",
               showHostInfoBar
                 ? "px-2 pointer-events-auto"
-                : "ml-auto w-fit rounded-bl-md px-1",
+                : "ml-auto w-fit rounded-md px-1",
+              // Compact mode: drop the full action strip *below* the ⋯ toggle so it
+              // does not share the top-right corner with the toggle (which made the
+              // first toolbar control + its tooltip look like the only thing that
+              // opened, stacked on the dots button).
               !showHostInfoBar && !isSearchOpen && [
-                "absolute right-8 top-0 -translate-y-1 pointer-events-none transition-[opacity,transform]",
+                "absolute right-1 top-8 z-30 max-w-[calc(100%-0.5rem)] overflow-x-auto border shadow-md pointer-events-none transition-opacity",
                 compactActionsOpen
-                  ? "visible opacity-100 translate-y-0 pointer-events-auto"
+                  ? "visible opacity-100 pointer-events-auto"
                   : "invisible opacity-0",
               ],
               !showHostInfoBar && isSearchOpen && "pointer-events-auto",

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -571,18 +571,21 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
 
             if (isCompactActionsMode) {
               // Speed-dial: circular toggle; full action strip springs out to the left.
+              // Do NOT use `.terminal-topbar` here — it sets container-type:inline-size,
+              // which size-contains the inline axis and collapses width to 0 when we
+              // animate max-width / rely on content sizing (buttons never appear).
               return (
-                <div className="absolute right-1.5 top-1.5 z-30 flex flex-row-reverse items-center pointer-events-none">
+                <div className="absolute right-1 top-1 z-30 flex flex-row-reverse items-center pointer-events-none">
                   <Tooltip open={compactActionsOpen ? false : undefined}>
                     <TooltipTrigger asChild>
                       <button
                         ref={compactActionsButtonRef}
                         type="button"
                         className={cn(
-                          "relative z-10 h-7 w-7 shrink-0 rounded-full border pointer-events-auto",
-                          "opacity-80 hover:opacity-100 focus-visible:opacity-100 shadow-sm",
-                          "transition-[transform,opacity] duration-200 ease-out",
-                          compactActionsOpen && "opacity-100 scale-105",
+                          "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border pointer-events-auto",
+                          "opacity-70 hover:opacity-100 focus-visible:opacity-100",
+                          "transition-[transform,opacity,background-color] duration-200 ease-out",
+                          compactActionsOpen && "opacity-100",
                         )}
                         style={{
                           backgroundColor: 'var(--terminal-ui-bg)',
@@ -594,34 +597,34 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                         aria-controls={`terminal-actions-${sessionId}`}
                         onClick={() => setCompactActionsOpen((open) => !open)}
                       >
-                        <span
-                          aria-hidden="true"
-                          className="mx-auto block h-3.5 w-3.5"
-                          style={{
-                            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                            backgroundSize: '4px 4px',
-                          }}
-                        />
+                        {/* Three horizontal dots — lighter than a dense 3×3 grid */}
+                        <span aria-hidden="true" className="flex items-center gap-[3px]">
+                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
+                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
+                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
+                        </span>
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">{t("terminal.toolbar.showActions")}</TooltipContent>
                   </Tooltip>
                   <div
-                    id={`terminal-actions-${sessionId}`}
-                    aria-hidden={!compactActionsOpen ? true : undefined}
                     className={cn(
-                      "terminal-topbar flex items-center min-w-0 overflow-hidden origin-right",
-                      "rounded-full border shadow-md backdrop-blur-md",
-                      "transition-[max-width,opacity,transform,margin] duration-200 ease-out",
+                      "grid min-w-0 transition-[grid-template-columns,opacity,margin] duration-200 ease-out",
                       compactActionsOpen
-                        ? "max-w-[min(100vw-3rem,40rem)] opacity-100 scale-100 translate-x-0 mr-1.5 pointer-events-auto"
-                        : "max-w-0 opacity-0 scale-90 translate-x-3 mr-0 pointer-events-none border-transparent shadow-none",
+                        ? "mr-1.5 grid-cols-[1fr] opacity-100 pointer-events-auto"
+                        : "mr-0 grid-cols-[0fr] opacity-0 pointer-events-none",
                     )}
-                    data-host-info-visible="false"
-                    style={toolbarSurfaceStyle}
                   >
-                    <div className="flex items-center gap-0.5 px-1.5 py-0.5 flex-nowrap w-max">
-                      {terminalActionsBody}
+                    <div className="min-w-0 overflow-hidden">
+                      <div
+                        id={`terminal-actions-${sessionId}`}
+                        aria-hidden={!compactActionsOpen ? true : undefined}
+                        className="flex w-max items-center gap-0.5 rounded-full border px-1.5 py-0.5 shadow-md backdrop-blur-md"
+                        data-host-info-visible="false"
+                        style={toolbarSurfaceStyle}
+                      >
+                        {terminalActionsBody}
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -380,58 +380,9 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
           className="absolute left-0 right-0 top-0 z-20 pointer-events-none"
           onMouseDownCapture={handleTopOverlayMouseDownCapture}
         >
-          {!showHostInfoBar && !isSearchOpen && (
-            <Tooltip open={compactActionsOpen ? false : undefined}>
-              <TooltipTrigger asChild>
-                <button
-                  ref={compactActionsButtonRef}
-                  type="button"
-                  className="absolute right-1 top-1 z-30 h-6 w-6 rounded-md border pointer-events-auto opacity-70 hover:opacity-100 focus-visible:opacity-100"
-                  style={{
-                    backgroundColor: 'var(--terminal-ui-bg)',
-                    borderColor: 'var(--terminal-ui-border)',
-                    color: 'var(--terminal-ui-fg)',
-                  }}
-                  aria-label={t("terminal.toolbar.showActions")}
-                  aria-expanded={compactActionsOpen}
-                  aria-controls={`terminal-actions-${sessionId}`}
-                  onClick={() => setCompactActionsOpen((open) => !open)}
-                >
-                  <span
-                    aria-hidden="true"
-                    className="mx-auto block h-3 w-3"
-                    style={{
-                      backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                      backgroundSize: '4px 4px',
-                    }}
-                  />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{t("terminal.toolbar.showActions")}</TooltipContent>
-            </Tooltip>
-          )}
-          <div
-            id={`terminal-actions-${sessionId}`}
-            aria-hidden={!showHostInfoBar && !isSearchOpen && !compactActionsOpen ? true : undefined}
-            className={cn(
-              "terminal-topbar flex items-center gap-1 py-0.5 backdrop-blur-md min-w-0",
-              showHostInfoBar
-                ? "px-2 pointer-events-auto"
-                : "ml-auto w-fit rounded-md px-1",
-              // Compact mode: drop the full action strip *below* the ⋯ toggle so it
-              // does not share the top-right corner with the toggle (which made the
-              // first toolbar control + its tooltip look like the only thing that
-              // opened, stacked on the dots button).
-              !showHostInfoBar && !isSearchOpen && [
-                "absolute right-1 top-8 z-30 max-w-[calc(100%-0.5rem)] overflow-x-auto border shadow-md pointer-events-none transition-opacity",
-                compactActionsOpen
-                  ? "visible opacity-100 pointer-events-auto"
-                  : "invisible opacity-0",
-              ],
-              !showHostInfoBar && isSearchOpen && "pointer-events-auto",
-            )}
-            data-host-info-visible={showHostInfoBar ? "true" : "false"}
-            style={{
+          {(() => {
+            const isCompactActionsMode = !showHostInfoBar && !isSearchOpen;
+            const toolbarSurfaceStyle = {
               backgroundColor: 'var(--terminal-ui-bg)',
               color: 'var(--terminal-ui-fg)',
               borderColor: 'var(--terminal-ui-border)',
@@ -440,180 +391,259 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
               ['--terminal-toolbar-btn' as never]: 'var(--terminal-ui-toolbar-btn)',
               ['--terminal-toolbar-btn-hover' as never]: 'var(--terminal-ui-toolbar-btn-hover)',
               ['--terminal-toolbar-btn-active' as never]: 'var(--terminal-ui-toolbar-btn-active)',
-            }}
-          >
-            <div
-              className={cn(
-                "flex items-center gap-1 text-[11px] font-semibold min-w-0 overflow-hidden shrink",
-                showHostInfoBar && "terminal-title-cluster",
-              )}
-            >
-              {!showHostInfoBar && inWorkspace && onDetachPointerDown && (
+            } as React.CSSProperties;
+
+            const terminalActionsBody = (
+              <>
                 <div
-                  aria-hidden="true"
-                  title={t("terminal.toolbar.dragPane")}
-                  className="h-5 w-3 rounded cursor-grab active:cursor-grabbing opacity-60 hover:opacity-100 flex-shrink-0"
-                  style={{
-                    backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                    backgroundSize: '4px 4px',
-                  }}
-                  data-terminal-detach-drag-handle="true"
-                  onPointerDown={onDetachPointerDown}
-                />
-              )}
-              {showHostInfoBar && <div
-                className={cn(
-                  "flex items-center gap-1 min-w-0",
-                  inWorkspace && onDetachPointerDown && "cursor-grab active:cursor-grabbing",
-                )}
-                data-terminal-detach-drag-handle={inWorkspace && onDetachPointerDown ? "true" : undefined}
-                onPointerDown={onDetachPointerDown}
-              >
-                <span className="whitespace-nowrap truncate min-w-0 max-w-[18rem]" title={titleConnectionAddress || sessionDisplayName || host.label}>
-                  {titleConnectionAddress || sessionDisplayName || host.label}
-                </span>
-              </div>}
-              {host.protocol !== "local" && host.hostname && host.hostname !== "localhost" && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
-                      onPointerDown={(event) => event.stopPropagation()}
-                      onClick={() => {
-                        void navigator.clipboard.writeText(host.hostname).then(() => {
-                          toast.success(t("terminal.statusbar.copyHostname.toast", { hostname: host.hostname }));
-                        }).catch(() => {
-                          toast.error(t("terminal.statusbar.copyHostname.error"));
-                        });
+                  className={cn(
+                    "flex items-center gap-1 text-[11px] font-semibold min-w-0 overflow-hidden shrink",
+                    showHostInfoBar && "terminal-title-cluster",
+                  )}
+                >
+                  {!showHostInfoBar && inWorkspace && onDetachPointerDown && (
+                    <div
+                      aria-hidden="true"
+                      title={t("terminal.toolbar.dragPane")}
+                      className="h-5 w-3 rounded cursor-grab active:cursor-grabbing opacity-60 hover:opacity-100 flex-shrink-0"
+                      style={{
+                        backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+                        backgroundSize: '4px 4px',
                       }}
-                      aria-label={t("terminal.statusbar.copyHostname.label")}
-                    >
-                      <Copy size={10} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
-                </Tooltip>
-              )}
-              {shouldShowLineTimestampToolbarToggle(lineTimestampsAvailable, onUpdateHost) && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className={cn(
-                        "ml-0.5 p-0.5 rounded transition-colors flex-shrink-0",
-                        "hover:bg-[color:var(--terminal-toolbar-btn-hover)]",
-                        showLineTimestampGutter ? "opacity-100" : "opacity-60 hover:opacity-100",
-                      )}
-                      style={
-                        showLineTimestampGutter
-                          ? {
-                            backgroundColor: 'var(--terminal-toolbar-btn-active)',
-                            color: lineTimestampColor,
+                      data-terminal-detach-drag-handle="true"
+                      onPointerDown={onDetachPointerDown}
+                    />
+                  )}
+                  {showHostInfoBar && <div
+                    className={cn(
+                      "flex items-center gap-1 min-w-0",
+                      inWorkspace && onDetachPointerDown && "cursor-grab active:cursor-grabbing",
+                    )}
+                    data-terminal-detach-drag-handle={inWorkspace && onDetachPointerDown ? "true" : undefined}
+                    onPointerDown={onDetachPointerDown}
+                  >
+                    <span className="whitespace-nowrap truncate min-w-0 max-w-[18rem]" title={titleConnectionAddress || sessionDisplayName || host.label}>
+                      {titleConnectionAddress || sessionDisplayName || host.label}
+                    </span>
+                  </div>}
+                  {host.protocol !== "local" && host.hostname && host.hostname !== "localhost" && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={() => {
+                            void navigator.clipboard.writeText(host.hostname).then(() => {
+                              toast.success(t("terminal.statusbar.copyHostname.toast", { hostname: host.hostname }));
+                            }).catch(() => {
+                              toast.error(t("terminal.statusbar.copyHostname.error"));
+                            });
+                          }}
+                          aria-label={t("terminal.statusbar.copyHostname.label")}
+                        >
+                          <Copy size={10} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{t("terminal.statusbar.copyHostname.tooltip", { hostname: host.hostname })}</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {shouldShowLineTimestampToolbarToggle(lineTimestampsAvailable, onUpdateHost) && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            "ml-0.5 p-0.5 rounded transition-colors flex-shrink-0",
+                            "hover:bg-[color:var(--terminal-toolbar-btn-hover)]",
+                            showLineTimestampGutter ? "opacity-100" : "opacity-60 hover:opacity-100",
+                          )}
+                          style={
+                            showLineTimestampGutter
+                              ? {
+                                backgroundColor: 'var(--terminal-toolbar-btn-active)',
+                                color: lineTimestampColor,
+                              }
+                              : undefined
                           }
-                          : undefined
-                      }
-                      onClick={() => onUpdateHost(getLineTimestampToggleHostUpdate(host))}
-                      aria-label={lineTimestampToggleLabel}
-                      aria-pressed={showLineTimestampGutter}
-                    >
-                      <Clock3 size={10} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{lineTimestampToggleLabel}</TooltipContent>
-                </Tooltip>
-              )}
-              {isSystemSidebarEligible && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
-                      onClick={onOpenSystem}
-                      aria-label={t("terminal.layer.system")}
-                    >
-                      <Activity size={10} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{t("terminal.layer.system")}</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
-            {showHostInfoBar && !compactToolbar && (
-              <TerminalServerStats
-                sessionId={sessionId}
-                enabled={terminalSettings?.showServerStats ?? true}
-                refreshInterval={terminalSettings?.serverStatsRefreshInterval ?? 5}
-                isSupportedOs={isSupportedOs}
-                isConnected={status === 'connected'}
-                isVisible={isVisible}
-              />
-            )}
-            {showHostInfoBar && <div className="flex-1 min-w-0" />}
-            <div className="flex items-center gap-0.5 flex-shrink-0">
-              {inWorkspace && onToggleBroadcast && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      size="icon"
-                      className={cn(
-                        "h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)]",
-                        "bg-transparent hover:bg-transparent",
-                        isBroadcastEnabled && "text-green-500",
-                      )}
-                      onClick={onToggleBroadcast}
-                      aria-label={
-                        isBroadcastEnabled
+                          onClick={() => onUpdateHost(getLineTimestampToggleHostUpdate(host))}
+                          aria-label={lineTimestampToggleLabel}
+                          aria-pressed={showLineTimestampGutter}
+                        >
+                          <Clock3 size={10} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{lineTimestampToggleLabel}</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {isSystemSidebarEligible && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="ml-0.5 p-0.5 rounded hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors opacity-60 hover:opacity-100 flex-shrink-0"
+                          onClick={onOpenSystem}
+                          aria-label={t("terminal.layer.system")}
+                        >
+                          <Activity size={10} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{t("terminal.layer.system")}</TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+                {showHostInfoBar && !compactToolbar && (
+                  <TerminalServerStats
+                    sessionId={sessionId}
+                    enabled={terminalSettings?.showServerStats ?? true}
+                    refreshInterval={terminalSettings?.serverStatsRefreshInterval ?? 5}
+                    isSupportedOs={isSupportedOs}
+                    isConnected={status === 'connected'}
+                    isVisible={isVisible}
+                  />
+                )}
+                {showHostInfoBar && <div className="flex-1 min-w-0" />}
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                  {inWorkspace && onToggleBroadcast && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          size="icon"
+                          className={cn(
+                            "h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)]",
+                            "bg-transparent hover:bg-transparent",
+                            isBroadcastEnabled && "text-green-500",
+                          )}
+                          onClick={onToggleBroadcast}
+                          aria-label={
+                            isBroadcastEnabled
+                              ? t("terminal.toolbar.broadcastDisable")
+                              : t("terminal.toolbar.broadcastEnable")
+                          }
+                        >
+                          <Radio size={12} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {isBroadcastEnabled
                           ? t("terminal.toolbar.broadcastDisable")
-                          : t("terminal.toolbar.broadcastEnable")
-                      }
-                    >
-                      <Radio size={12} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {isBroadcastEnabled
-                      ? t("terminal.toolbar.broadcastDisable")
-                      : t("terminal.toolbar.broadcastEnable")}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {inWorkspace && onDetach && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      size="icon"
-                      className="h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)] bg-transparent hover:bg-transparent"
-                      onClick={onDetach}
-                      aria-label={t('terminal.toolbar.detach')}
-                    >
-                      <SquareArrowOutUpRight size={12} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{t('terminal.toolbar.detach')}</TooltipContent>
-                </Tooltip>
-              )}
-              {inWorkspace && !isFocusMode && onExpandToFocus && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      size="icon"
-                      className="h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)] bg-transparent hover:bg-transparent"
-                      onClick={onExpandToFocus}
-                      aria-label={t("terminal.toolbar.focusMode")}
-                    >
-                      <Maximize2 size={12} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{t("terminal.toolbar.focusMode")}</TooltipContent>
-                </Tooltip>
-              )}
-              {renderControls({ showClose: inWorkspace })}
-            </div>
-          </div>
+                          : t("terminal.toolbar.broadcastEnable")}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {inWorkspace && onDetach && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          size="icon"
+                          className="h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)] bg-transparent hover:bg-transparent"
+                          onClick={onDetach}
+                          aria-label={t('terminal.toolbar.detach')}
+                        >
+                          <SquareArrowOutUpRight size={12} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{t('terminal.toolbar.detach')}</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {inWorkspace && !isFocusMode && onExpandToFocus && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="secondary"
+                          size="icon"
+                          className="h-6 w-6 p-0 shadow-none border-none text-[color:var(--terminal-toolbar-fg)] bg-transparent hover:bg-transparent"
+                          onClick={onExpandToFocus}
+                          aria-label={t("terminal.toolbar.focusMode")}
+                        >
+                          <Maximize2 size={12} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{t("terminal.toolbar.focusMode")}</TooltipContent>
+                    </Tooltip>
+                  )}
+                  {renderControls({ showClose: inWorkspace })}
+                </div>
+              </>
+            );
+
+            if (isCompactActionsMode) {
+              // Speed-dial: circular toggle; full action strip springs out to the left.
+              return (
+                <div className="absolute right-1.5 top-1.5 z-30 flex flex-row-reverse items-center pointer-events-none">
+                  <Tooltip open={compactActionsOpen ? false : undefined}>
+                    <TooltipTrigger asChild>
+                      <button
+                        ref={compactActionsButtonRef}
+                        type="button"
+                        className={cn(
+                          "relative z-10 h-7 w-7 shrink-0 rounded-full border pointer-events-auto",
+                          "opacity-80 hover:opacity-100 focus-visible:opacity-100 shadow-sm",
+                          "transition-[transform,opacity] duration-200 ease-out",
+                          compactActionsOpen && "opacity-100 scale-105",
+                        )}
+                        style={{
+                          backgroundColor: 'var(--terminal-ui-bg)',
+                          borderColor: 'var(--terminal-ui-border)',
+                          color: 'var(--terminal-ui-fg)',
+                        }}
+                        aria-label={t("terminal.toolbar.showActions")}
+                        aria-expanded={compactActionsOpen}
+                        aria-controls={`terminal-actions-${sessionId}`}
+                        onClick={() => setCompactActionsOpen((open) => !open)}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="mx-auto block h-3.5 w-3.5"
+                          style={{
+                            backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
+                            backgroundSize: '4px 4px',
+                          }}
+                        />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{t("terminal.toolbar.showActions")}</TooltipContent>
+                  </Tooltip>
+                  <div
+                    id={`terminal-actions-${sessionId}`}
+                    aria-hidden={!compactActionsOpen ? true : undefined}
+                    className={cn(
+                      "terminal-topbar flex items-center min-w-0 overflow-hidden origin-right",
+                      "rounded-full border shadow-md backdrop-blur-md",
+                      "transition-[max-width,opacity,transform,margin] duration-200 ease-out",
+                      compactActionsOpen
+                        ? "max-w-[min(100vw-3rem,40rem)] opacity-100 scale-100 translate-x-0 mr-1.5 pointer-events-auto"
+                        : "max-w-0 opacity-0 scale-90 translate-x-3 mr-0 pointer-events-none border-transparent shadow-none",
+                    )}
+                    data-host-info-visible="false"
+                    style={toolbarSurfaceStyle}
+                  >
+                    <div className="flex items-center gap-0.5 px-1.5 py-0.5 flex-nowrap w-max">
+                      {terminalActionsBody}
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+
+            return (
+              <div
+                id={`terminal-actions-${sessionId}`}
+                className={cn(
+                  "terminal-topbar flex items-center gap-1 py-0.5 backdrop-blur-md min-w-0",
+                  showHostInfoBar
+                    ? "px-2 pointer-events-auto"
+                    : "ml-auto w-fit rounded-bl-md px-1 pointer-events-auto",
+                )}
+                data-host-info-visible={showHostInfoBar ? "true" : "false"}
+                style={toolbarSurfaceStyle}
+              >
+                {terminalActionsBody}
+              </div>
+            );
+          })()}
           {isSearchOpen && (
             <div className="pointer-events-auto">
               <TerminalSearchBar

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -577,12 +577,10 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
               // animate max-width / rely on content sizing (buttons never appear).
               // Shared h-7 keeps the toggle and the action pill the same height as the
               // inner h-6 icon buttons + vertical padding.
+              // No box-shadow: the 0fr→1fr expand clip always slices shadows and
+              // looks worse than a clean border-only chrome.
               const compactChromeClass =
                 "h-7 rounded-full border backdrop-blur-md";
-              // Down-biased shadow avoids looking "cut off" against the pane's
-              // overflow:hidden top edge (box-shadow upward gets clipped).
-              const compactShadowClass =
-                "shadow-[0_2px_10px_rgba(0,0,0,0.10),0_1px_3px_rgba(0,0,0,0.06)]";
               return (
                 <div className="absolute right-1 top-1 z-30 flex flex-row-reverse items-center pointer-events-none">
                   <Tooltip open={compactActionsOpen ? false : undefined}>
@@ -593,7 +591,6 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                         className={cn(
                           "relative z-10 flex w-7 shrink-0 items-center justify-center pointer-events-auto",
                           compactChromeClass,
-                          compactShadowClass,
                           "opacity-80 hover:opacity-100 focus-visible:opacity-100",
                           "transition-[transform,opacity] duration-200 ease-out",
                           compactActionsOpen && "opacity-100",
@@ -620,30 +617,22 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                     className={cn(
                       "grid min-w-0 transition-[grid-template-columns,opacity,margin] duration-200 ease-out",
                       compactActionsOpen
-                        ? "mr-1 grid-cols-[1fr] opacity-100 pointer-events-auto"
+                        ? "mr-1.5 grid-cols-[1fr] opacity-100 pointer-events-auto"
                         : "mr-0 grid-cols-[0fr] opacity-0 pointer-events-none",
                     )}
                   >
-                    {/*
-                      overflow-hidden is required for the 0fr→1fr width animation.
-                      Inner padding keeps the pill's soft shadow inside that clip box
-                      so it is not sliced on the left/top/bottom edges.
-                    */}
                     <div className="min-w-0 overflow-hidden">
-                      <div className="p-1.5">
-                        <div
-                          id={`terminal-actions-${sessionId}`}
-                          aria-hidden={!compactActionsOpen ? true : undefined}
-                          className={cn(
-                            "flex w-max items-center gap-0.5 px-1.5",
-                            compactChromeClass,
-                            compactShadowClass,
-                          )}
-                          data-host-info-visible="false"
-                          style={toolbarSurfaceStyle}
-                        >
-                          {terminalActionsBody}
-                        </div>
+                      <div
+                        id={`terminal-actions-${sessionId}`}
+                        aria-hidden={!compactActionsOpen ? true : undefined}
+                        className={cn(
+                          "flex w-max items-center gap-0.5 px-1.5",
+                          compactChromeClass,
+                        )}
+                        data-host-info-visible="false"
+                        style={toolbarSurfaceStyle}
+                      >
+                        {terminalActionsBody}
                       </div>
                     </div>
                   </div>

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronsLeft, X as XIcon } from 'lucide-react';
 
 import { OSC7_SETUP_TARGETS } from './osc7Setup';
 import { TerminalServerStats } from './TerminalServerStats';
@@ -574,6 +575,14 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
               // Do NOT use `.terminal-topbar` here — it sets container-type:inline-size,
               // which size-contains the inline axis and collapses width to 0 when we
               // animate max-width / rely on content sizing (buttons never appear).
+              // Shared h-7 keeps the toggle and the action pill the same height as the
+              // inner h-6 icon buttons + vertical padding.
+              const compactChromeClass =
+                "h-7 rounded-full border backdrop-blur-md";
+              // Down-biased shadow avoids looking "cut off" against the pane's
+              // overflow:hidden top edge (box-shadow upward gets clipped).
+              const compactShadowClass =
+                "shadow-[0_2px_10px_rgba(0,0,0,0.10),0_1px_3px_rgba(0,0,0,0.06)]";
               return (
                 <div className="absolute right-1 top-1 z-30 flex flex-row-reverse items-center pointer-events-none">
                   <Tooltip open={compactActionsOpen ? false : undefined}>
@@ -582,9 +591,11 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                         ref={compactActionsButtonRef}
                         type="button"
                         className={cn(
-                          "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border pointer-events-auto",
-                          "opacity-70 hover:opacity-100 focus-visible:opacity-100",
-                          "transition-[transform,opacity,background-color] duration-200 ease-out",
+                          "relative z-10 flex w-7 shrink-0 items-center justify-center pointer-events-auto",
+                          compactChromeClass,
+                          compactShadowClass,
+                          "opacity-80 hover:opacity-100 focus-visible:opacity-100",
+                          "transition-[transform,opacity] duration-200 ease-out",
                           compactActionsOpen && "opacity-100",
                         )}
                         style={{
@@ -597,12 +608,10 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                         aria-controls={`terminal-actions-${sessionId}`}
                         onClick={() => setCompactActionsOpen((open) => !open)}
                       >
-                        {/* Three horizontal dots — lighter than a dense 3×3 grid */}
-                        <span aria-hidden="true" className="flex items-center gap-[3px]">
-                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
-                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
-                          <span className="block h-[3px] w-[3px] rounded-full bg-current" />
-                        </span>
+                        {/* Closed: chevrons point left (expand that way). Open: close. */}
+                        {compactActionsOpen
+                          ? <XIcon size={12} strokeWidth={2} aria-hidden="true" />
+                          : <ChevronsLeft size={13} strokeWidth={2} aria-hidden="true" />}
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">{t("terminal.toolbar.showActions")}</TooltipContent>
@@ -611,19 +620,30 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                     className={cn(
                       "grid min-w-0 transition-[grid-template-columns,opacity,margin] duration-200 ease-out",
                       compactActionsOpen
-                        ? "mr-1.5 grid-cols-[1fr] opacity-100 pointer-events-auto"
+                        ? "mr-1 grid-cols-[1fr] opacity-100 pointer-events-auto"
                         : "mr-0 grid-cols-[0fr] opacity-0 pointer-events-none",
                     )}
                   >
+                    {/*
+                      overflow-hidden is required for the 0fr→1fr width animation.
+                      Inner padding keeps the pill's soft shadow inside that clip box
+                      so it is not sliced on the left/top/bottom edges.
+                    */}
                     <div className="min-w-0 overflow-hidden">
-                      <div
-                        id={`terminal-actions-${sessionId}`}
-                        aria-hidden={!compactActionsOpen ? true : undefined}
-                        className="flex w-max items-center gap-0.5 rounded-full border px-1.5 py-0.5 shadow-md backdrop-blur-md"
-                        data-host-info-visible="false"
-                        style={toolbarSurfaceStyle}
-                      >
-                        {terminalActionsBody}
+                      <div className="p-1.5">
+                        <div
+                          id={`terminal-actions-${sessionId}`}
+                          aria-hidden={!compactActionsOpen ? true : undefined}
+                          className={cn(
+                            "flex w-max items-center gap-0.5 px-1.5",
+                            compactChromeClass,
+                            compactShadowClass,
+                          )}
+                          data-host-info-visible="false"
+                          style={toolbarSurfaceStyle}
+                        >
+                          {terminalActionsBody}
+                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- When the host info bar is hidden, terminal actions sit in a compact top-right cluster. Host keyword highlighting previously opened **above** the trigger (`side="top"`), which clipped against the window edge and stacked the blue tooltip on the button.
- Open the highlight **tooltip** and **popover** below the toolbar (`side="bottom"`), align the panel to the end of the cluster, add a bit more offset/collision padding, and **suppress the tooltip while the panel is open** so they no longer sit on top of each other.
- Same `side="bottom"` treatment for other top-toolbar tooltips so labels stay readable in compact mode.

## Test plan
- [ ] Hide host info bar (Settings → Terminal → host information bar off, or existing preference)
- [ ] Open compact actions (⋯) on a remote session
- [ ] Hover highlighter: tooltip appears **below** the button, not clipped at the title edge
- [ ] Click highlighter: panel opens **below** the toolbar, right-aligned; tooltip disappears while open
- [ ] With host info bar visible again: hover + open still work without clipping
- [ ] Other toolbar tooltips (SFTP, search, more…) open below in both modes