### PR TITLE
Update Nix release metadata for v1.1.64

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.63";
+  version = "1.1.64";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-IGvi4/57VddiZJSQa4HJz0PC8tKU3bQbQk7MXpVua+E=";
+      hash = "sha256-0KmyAHi8hIrxcmHwvqdkbG1y8uw4XZbtim8W0aCA7Hc=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-gnLIvXISnWbPyPKNZCp8veevoh9Gn5Ec/uULzsc0ivM=";
+      hash = "sha256-hG49UrjfVQlU4ehDX7EMsOqrWA5LDN1/QU01dFFayJo=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- Bumps `nix/release.nix` to **v1.1.64** AppImage hashes after the GitHub Release published.
- The release workflow’s `update Nix release metadata` job failed because `main` requires PRs (same as the previous v1.1.64 attempt).

## Test plan
- [x] Hashes generated from published `Netcatty-1.1.64-linux-{x86_64,arm64}.AppImage` artifacts
- [ ] Merge after checks pass