### PR TITLE
fix(terminal): float compact speed-dial without scrollbar gutter

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2795,6 +2795,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           onResume={() => { void resumeScriptRun(activeScriptRun.runId); }}
           onStop={() => { void stopScriptRun(activeScriptRun.runId); }}
           onDismiss={dismissScriptOverlay}
+          compactTopChrome={terminalSettings?.showHostInfoBar === false}
         />
       ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
       <ScriptSaveRecordingDialog

--- a/components/terminal/ScriptExecutionOverlay.test.ts
+++ b/components/terminal/ScriptExecutionOverlay.test.ts
@@ -14,7 +14,7 @@ test("script overlay sits lower under the full host toolbar than under compact c
   assert.ok(SCRIPT_OVERLAY_TOP_COMPACT_PX < SCRIPT_OVERLAY_TOP_DEFAULT_PX);
 });
 
-test("script overlay clears the compact speed-dial when host info is hidden", () => {
+test("script overlay covers compact speed-dial full-width instead of reserving a right gutter", () => {
   const overlaySource = readFileSync(
     fileURLToPath(new URL("./ScriptExecutionOverlay.tsx", import.meta.url)),
     "utf8",
@@ -25,7 +25,9 @@ test("script overlay clears the compact speed-dial when host info is hidden", ()
   );
 
   assert.match(overlaySource, /compactTopChrome/);
-  assert.match(overlaySource, /right-10/);
+  assert.match(overlaySource, /left-2 right-2/);
+  assert.match(overlaySource, /z-40/);
+  assert.doesNotMatch(overlaySource, /right-10/);
   assert.match(overlaySource, /SCRIPT_OVERLAY_TOP_COMPACT_PX/);
   assert.match(
     terminalSource,

--- a/components/terminal/ScriptExecutionOverlay.test.ts
+++ b/components/terminal/ScriptExecutionOverlay.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  SCRIPT_OVERLAY_TOP_COMPACT_PX,
+  SCRIPT_OVERLAY_TOP_DEFAULT_PX,
+} from "./ScriptExecutionOverlay.tsx";
+
+test("script overlay sits lower under the full host toolbar than under compact chrome", () => {
+  assert.equal(SCRIPT_OVERLAY_TOP_DEFAULT_PX, 34);
+  assert.equal(SCRIPT_OVERLAY_TOP_COMPACT_PX, 8);
+  assert.ok(SCRIPT_OVERLAY_TOP_COMPACT_PX < SCRIPT_OVERLAY_TOP_DEFAULT_PX);
+});
+
+test("script overlay clears the compact speed-dial when host info is hidden", () => {
+  const overlaySource = readFileSync(
+    fileURLToPath(new URL("./ScriptExecutionOverlay.tsx", import.meta.url)),
+    "utf8",
+  );
+  const terminalSource = readFileSync(
+    fileURLToPath(new URL("../Terminal.tsx", import.meta.url)),
+    "utf8",
+  );
+
+  assert.match(overlaySource, /compactTopChrome/);
+  assert.match(overlaySource, /right-10/);
+  assert.match(overlaySource, /SCRIPT_OVERLAY_TOP_COMPACT_PX/);
+  assert.match(
+    terminalSource,
+    /compactTopChrome=\{terminalSettings\?\.showHostInfoBar === false\}/,
+  );
+});

--- a/components/terminal/ScriptExecutionOverlay.tsx
+++ b/components/terminal/ScriptExecutionOverlay.tsx
@@ -12,9 +12,8 @@ export interface ScriptExecutionOverlayProps {
   onStop: () => void;
   onDismiss: () => void;
   /**
-   * Host info bar is hidden: top-right circular speed-dial floats over the
-   * pane. Sit the banner higher and leave a right gutter so it is not forced
-   * under the toggle.
+   * Host info bar is hidden: no full toolbar. Sit the banner higher and stack
+   * above the compact speed-dial (cover it for the run duration).
    */
   compactTopChrome?: boolean;
 }
@@ -224,11 +223,9 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
 
   return (
     <div
-      className={cn(
-        "absolute left-2 z-25 rounded-md border shadow-md backdrop-blur-md pointer-events-auto px-3 py-2",
-        // Leave room for the circular speed-dial (h-7 + right-1) when host info is hidden.
-        compactTopChrome ? "right-10" : "right-2",
-      )}
+      // z-40 sits above the compact speed-dial (z-30) so the full-width banner
+      // covers the toggle while a script is running — no right-edge gutter.
+      className="absolute left-2 right-2 z-40 rounded-md border shadow-md backdrop-blur-md pointer-events-auto px-3 py-2"
       style={{
         top: compactTopChrome ? SCRIPT_OVERLAY_TOP_COMPACT_PX : SCRIPT_OVERLAY_TOP_DEFAULT_PX,
         backgroundColor: 'color-mix(in srgb, var(--terminal-ui-bg) 92%, transparent)',

--- a/components/terminal/ScriptExecutionOverlay.tsx
+++ b/components/terminal/ScriptExecutionOverlay.tsx
@@ -11,7 +11,18 @@ export interface ScriptExecutionOverlayProps {
   onResume: () => void;
   onStop: () => void;
   onDismiss: () => void;
+  /**
+   * Host info bar is hidden: top-right circular speed-dial floats over the
+   * pane. Sit the banner higher and leave a right gutter so it is not forced
+   * under the toggle.
+   */
+  compactTopChrome?: boolean;
 }
+
+/** Default top offset under the full host-info toolbar. */
+export const SCRIPT_OVERLAY_TOP_DEFAULT_PX = 34;
+/** Top offset when only the compact speed-dial is present. */
+export const SCRIPT_OVERLAY_TOP_COMPACT_PX = 8;
 
 function formatElapsed(ms: number) {
   const seconds = Math.max(0, Math.floor(ms / 1000));
@@ -185,6 +196,7 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
   onResume,
   onStop,
   onDismiss,
+  compactTopChrome = false,
 }) => {
   const { t } = useI18n();
   const [tick, setTick] = useState(0);
@@ -212,14 +224,19 @@ export const ScriptExecutionOverlay: React.FC<ScriptExecutionOverlayProps> = ({
 
   return (
     <div
-      className="absolute left-2 right-2 z-25 rounded-md border shadow-md backdrop-blur-md pointer-events-auto px-3 py-2"
+      className={cn(
+        "absolute left-2 z-25 rounded-md border shadow-md backdrop-blur-md pointer-events-auto px-3 py-2",
+        // Leave room for the circular speed-dial (h-7 + right-1) when host info is hidden.
+        compactTopChrome ? "right-10" : "right-2",
+      )}
       style={{
-        top: 34,
+        top: compactTopChrome ? SCRIPT_OVERLAY_TOP_COMPACT_PX : SCRIPT_OVERLAY_TOP_DEFAULT_PX,
         backgroundColor: 'color-mix(in srgb, var(--terminal-ui-bg) 92%, transparent)',
         borderColor: 'var(--terminal-ui-border)',
         color: 'var(--terminal-ui-fg)',
       }}
       data-section="script-execution-overlay"
+      data-compact-top-chrome={compactTopChrome ? "true" : "false"}
     >
       <div className="flex items-center gap-2 min-w-0">
         <div className="min-w-0 flex flex-1 items-center text-[11px] leading-none">

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -203,8 +203,9 @@ test("terminal search keeps enough space when host information is hidden", () =>
   );
 });
 
-test("hidden host information reserves a side gutter for its action button", () => {
-  assert.equal(resolveTerminalRightInset({ showHostInfoBar: false, isSearchOpen: false }), 32);
+test("hidden host information does not reserve a side gutter for its floating action button", () => {
+  // Speed-dial overlays the terminal; scrollbar stays at the pane edge.
+  assert.equal(resolveTerminalRightInset({ showHostInfoBar: false, isSearchOpen: false }), 4);
   assert.equal(resolveTerminalRightInset({ showHostInfoBar: true, isSearchOpen: false }), 4);
   assert.equal(resolveTerminalRightInset({ showHostInfoBar: false, isSearchOpen: true }), 4);
 });

--- a/components/terminal/TerminalView.test.tsx
+++ b/components/terminal/TerminalView.test.tsx
@@ -229,6 +229,9 @@ test("hidden host information keeps terminal actions rendered", () => {
   assert.notEqual(actionsStart, -1);
   assert.notEqual(controls, -1);
   assert.notEqual(compactDragHandle, -1);
+  // Compact drag handle uses GripVertical, not the old radial-dot “chessboard”.
+  assert.match(source, /GripVertical/);
+  assert.ok(!source.includes("backgroundSize: '4px 4px'"));
   assert.ok(hostInfoStart < hostInfoEnd);
   assert.ok(hostInfoEnd < copyAction);
   assert.ok(copyAction < timestampAction);

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -170,15 +170,20 @@ export function resolveTerminalTopOffsets({
 }
 
 export function resolveTerminalRightInset({
-  showHostInfoBar,
-  isSearchOpen,
+  showHostInfoBar: _showHostInfoBar,
+  isSearchOpen: _isSearchOpen,
   terminalBodyInset = 4,
 }: {
   showHostInfoBar: boolean;
   isSearchOpen: boolean;
   terminalBodyInset?: number;
 }): number {
-  return terminalBodyInset + (!showHostInfoBar && !isSearchOpen ? 28 : 0);
+  // Compact speed-dial floats over the terminal (z-30 overlay). Do not reserve
+  // a right gutter for it — that pushes the xterm scrollbar left and leaves a
+  // dead strip next to the circular toggle.
+  void _showHostInfoBar;
+  void _isSearchOpen;
+  return terminalBodyInset;
 }
 
 /**

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { ChevronsLeft, X as XIcon } from 'lucide-react';
+import { ChevronsLeft, GripVertical, X as XIcon } from 'lucide-react';
 
 import { OSC7_SETUP_TARGETS } from './osc7Setup';
 import { TerminalServerStats } from './TerminalServerStats';
@@ -409,16 +409,21 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
                 >
                   {!showHostInfoBar && inWorkspace && onDetachPointerDown && (
                     <div
-                      aria-hidden="true"
+                      role="button"
+                      tabIndex={-1}
                       title={t("terminal.toolbar.dragPane")}
-                      className="h-5 w-3 rounded cursor-grab active:cursor-grabbing opacity-60 hover:opacity-100 flex-shrink-0"
-                      style={{
-                        backgroundImage: 'radial-gradient(circle, currentColor 1px, transparent 1px)',
-                        backgroundSize: '4px 4px',
-                      }}
+                      aria-label={t("terminal.toolbar.dragPane")}
+                      className={cn(
+                        "flex h-6 w-5 shrink-0 items-center justify-center rounded-md",
+                        "cursor-grab active:cursor-grabbing",
+                        "text-[color:var(--terminal-toolbar-fg)] opacity-45 hover:opacity-90",
+                        "hover:bg-[color:var(--terminal-toolbar-btn-hover)] transition-colors",
+                      )}
                       data-terminal-detach-drag-handle="true"
                       onPointerDown={onDetachPointerDown}
-                    />
+                    >
+                      <GripVertical size={12} strokeWidth={2} aria-hidden="true" />
+                    </div>
                   )}
                   {showHostInfoBar && <div
                     className={cn(


### PR DESCRIPTION
## Summary
- When the host info bar is hidden, the circular speed-dial sat in a reserved right gutter, which **pushed the terminal scrollbar left** and left a blank strip under the button.
- The toggle is meant to **float over** the terminal. Stop adding the extra 28px right inset; keep only the normal body inset.

## Test plan
- [ ] Hide host information bar
- [ ] Confirm the circular « toggle still floats top-right
- [ ] Confirm the terminal scrollbar sits at the right edge of the pane (not left of a dead strip under the button)
- [ ] Expand the speed-dial; actions still spring out to the left
- [ ] With host info bar shown again, layout unchanged