### PR TITLE
fix(nix): restore release metadata to v1.1.63

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.64";
+  version = "1.1.63";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-0KmyAHi8hIrxcmHwvqdkbG1y8uw4XZbtim8W0aCA7Hc=";
+      hash = "sha256-IGvi4/57VddiZJSQa4HJz0PC8tKU3bQbQk7MXpVua+E=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-hG49UrjfVQlU4ehDX7EMsOqrWA5LDN1/QU01dFFayJo=";
+      hash = "sha256-gnLIvXISnWbPyPKNZCp8veevoh9Gn5Ec/uULzsc0ivM=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- v1.1.64 release/tag was deleted after publish.
- #2146 already merged and left `nix/release.nix` on **1.1.64** hashes that no longer exist.
- Restore metadata to **v1.1.63** (current Latest).

## Test plan
- [x] Matches pre-#2146 `nix/release.nix` content
- [ ] Merge so flake users do not fetch deleted assets