### PR TITLE
Update Nix release metadata for v1.1.64

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -4,11 +4,11 @@
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-0KmyAHi8hIrxcmHwvqdkbG1y8uw4XZbtim8W0aCA7Hc=";
+      hash = "sha256-6VSo6FSvZUnSNsw0PZdi7/dq/AHk/XNEQdV0qEikWxE=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-hG49UrjfVQlU4ehDX7EMsOqrWA5LDN1/QU01dFFayJo=";
+      hash = "sha256-euB5E0C/4oBlQ0WP8hmcsN5IDyjo+XFnkr2Id3yPcpI=";
     };
   };
 }


### PR DESCRIPTION
## Summary
- Bumps `nix/release.nix` to the **republished** v1.1.64 AppImage hashes.
- Release job cannot push protected `main` (expected).

## Test plan
- [x] Hashes from published `Netcatty-1.1.64-linux-{x86_64,arm64}.AppImage`
- [ ] Merge after checks