### PR TITLE
fix(ssh): password-only hosts must not fall back to default keys (#2079)

### DIFF
--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -880,6 +880,9 @@ function buildAuthHandler(options) {
   // Check if we need dynamic handler (have fallback options).
   // Password-only never treats default keys as fallbacks — only unlocked
   // encrypted keys (jump-chain retry) and keyboard-interactive remain.
+  // Callers that pass onAuthAttempt still get progress callbacks on the
+  // simple ordered path (createOrderedStringAuthHandler) so jump/SFTP UIs
+  // keep showing auth attempts after #2079 (Codex review P2).
   const hasFallbackOptions = fallbackKeys.length > 0 ||
     (!hasExplicitAgent && !isPasswordOnly && sshAgentSocket) ||
     unlockedEncryptedKeys.length > 0;
@@ -897,7 +900,7 @@ function buildAuthHandler(options) {
 
     const authPhase = createAuthPhase();
     return {
-      authHandler: createOrderedStringAuthHandler(authMethods, authPhase),
+      authHandler: createOrderedStringAuthHandler(authMethods, authPhase, onAuthAttempt),
       privateKey: effectivePrivateKey,
       agent: effectiveAgent,
       usedDefaultKeys: false,
@@ -1220,14 +1223,22 @@ function shouldSkipKiPasswordAutoFill(authPhase) {
  *
  * @param {string[]} order
  * @param {{ hadPartialSuccess: boolean, passwordAlreadySucceeded?: boolean }} authPhase
+ * @param {(label: string) => void} [onAuthAttempt] - optional progress callback
+ *   (jump/SFTP connection logs). Mirrors the dynamic authHandler's onAuthAttempt.
  * @returns {(methodsLeft: string[]|null, partialSuccess: boolean, callback: Function) => void}
  */
-function createOrderedStringAuthHandler(order, authPhase) {
+function createOrderedStringAuthHandler(order, authPhase, onAuthAttempt) {
   // Methods we actually offered (server got a chance to accept/reject).
   let attempted = new Set();
   // Methods that contributed a successful factor; never retried.
   const succeeded = new Set();
   let lastOffered = null;
+
+  const attemptLabel = (method) => {
+    if (method === "none") return "none (no credentials)";
+    if (method === "agent") return "SSH agent";
+    return method;
+  };
 
   return (methodsLeft, partialSuccess, callback) => {
     if (partialSuccess) {
@@ -1236,6 +1247,10 @@ function createOrderedStringAuthHandler(order, authPhase) {
       // Drop rejected/skipped attempts so a method that was not advertised
       // earlier can be offered now that the server is asking for it.
       attempted = new Set(succeeded);
+    } else if (lastOffered && methodsLeft !== null) {
+      // Server rejected the previous method (or finished a failed factor).
+      // Skip the initial methodsLeft===null probe which is not a rejection.
+      onAuthAttempt?.(`${attemptLabel(lastOffered)} rejected`);
     }
 
     const available = Array.isArray(methodsLeft) && methodsLeft.length > 0
@@ -1253,8 +1268,10 @@ function createOrderedStringAuthHandler(order, authPhase) {
       }
       attempted.add(method);
       lastOffered = method;
+      onAuthAttempt?.(attemptLabel(method));
       return callback(method);
     }
+    onAuthAttempt?.("all methods exhausted");
     return callback(false);
   };
 }

--- a/electron/bridges/sshAuthHelper.cjs
+++ b/electron/bridges/sshAuthHelper.cjs
@@ -866,18 +866,23 @@ function buildAuthHandler(options) {
 
   // Determine fallback keys (keys to try after user's primary auth fails)
   // - If user provided a key: all default keys are fallbacks
-  // - If no explicit auth: first default key is primary, rest are fallbacks  
-  // - If password-only or agent-only: all default keys are fallbacks (tried after primary)
-  const fallbackKeys = hasExplicitKey
-    ? defaultKeys
-    : !hasExplicitAuth
-      ? defaultKeys.slice(1)
-      : defaultKeys;
+  // - If no explicit auth: first default key is primary, rest are fallbacks
+  // - If password-only: no default-key fallback (issue #266 / #2079)
+  // - If agent-only: all default keys are fallbacks (tried after primary)
+  const fallbackKeys = isPasswordOnly
+    ? []
+    : hasExplicitKey
+      ? defaultKeys
+      : !hasExplicitAuth
+        ? defaultKeys.slice(1)
+        : defaultKeys;
 
-  // Check if we need dynamic handler (have fallback options)
+  // Check if we need dynamic handler (have fallback options).
+  // Password-only never treats default keys as fallbacks — only unlocked
+  // encrypted keys (jump-chain retry) and keyboard-interactive remain.
   const hasFallbackOptions = fallbackKeys.length > 0 ||
-    (!hasExplicitAgent && sshAgentSocket) ||
-    (isPasswordOnly && defaultKeys.length > 0);
+    (!hasExplicitAgent && !isPasswordOnly && sshAgentSocket) ||
+    unlockedEncryptedKeys.length > 0;
 
   // Simple explicit auth with no fallback keys: preserve the old ordered
   // method list, but use a function handler so we can observe partialSuccess
@@ -902,14 +907,15 @@ function buildAuthHandler(options) {
 
   // Build comprehensive authMethods array with all auth options
   // Order depends on what user explicitly configured:
-  // - Password-only: password -> agent -> default keys -> keyboard-interactive
-  // - Key-only: user key -> password -> agent -> default keys -> keyboard-interactive  
+  // - Password-only: password -> keyboard-interactive (no default-key fallback)
+  // - Key-only: user key -> password -> agent -> default keys -> keyboard-interactive
   // - Agent configured: agent -> user key -> password -> default keys -> keyboard-interactive
   // - No explicit auth: agent -> default keys -> keyboard-interactive
   const authMethods = [];
 
   if (isPasswordOnly) {
-    // Password-only: respect user's explicit choice, no key/agent fallback
+    // Password-only: respect user's explicit choice, no key/agent fallback.
+    // Matches startSSHSession (issue #2079) and avoids #266 passphrase prompts.
     authMethods.push({ type: "password", id: "password" });
   } else if (isKeyOnly) {
     // Key-only: user key first, then password (if any), then agent/default keys as fallback

--- a/electron/bridges/sshAuthHelper.passwordOnly.test.cjs
+++ b/electron/bridges/sshAuthHelper.passwordOnly.test.cjs
@@ -71,6 +71,34 @@ test("buildAuthHandler password-only does not offer default SSH keys (#2079)", (
   assert.equal(labels.includes("agent"), false);
 });
 
+test("buildAuthHandler password-only still fires onAuthAttempt for jump/SFTP progress", () => {
+  const attempts = [];
+  const auth = buildAuthHandler({
+    password: "secret",
+    username: "root",
+    // Default keys on disk used to force the dynamic path for progress only;
+    // after #2079 the simple ordered path must still report attempts.
+    defaultKeys: DEFAULT_KEYS,
+    allowAgentFallback: false,
+    onAuthAttempt: (label) => attempts.push(label),
+  });
+
+  collectAuthMethods(auth.authHandler);
+  assert.ok(
+    attempts.some((label) => label === "password" || label.includes("password")),
+    `expected password attempt callback; got ${attempts.join(" | ")}`,
+  );
+  assert.ok(
+    attempts.some((label) => label.includes("keyboard-interactive") || label.includes("exhausted")),
+    `expected KI or exhaustion callback; got ${attempts.join(" | ")}`,
+  );
+  assert.equal(
+    attempts.some((label) => /id_rsa|id_ed25519|default/.test(label)),
+    false,
+    `must not report default-key probes; got ${attempts.join(" | ")}`,
+  );
+});
+
 test("buildAuthHandler with no credentials still offers default keys", () => {
   const auth = buildAuthHandler({
     username: "root",

--- a/electron/bridges/sshAuthHelper.passwordOnly.test.cjs
+++ b/electron/bridges/sshAuthHelper.passwordOnly.test.cjs
@@ -1,0 +1,127 @@
+"use strict";
+
+/**
+ * Password-only auth must not probe default ~/.ssh keys (issues #266 / #2079).
+ * Jump hosts and SFTP share buildAuthHandler; a wrong host password used to
+ * look fine on direct terminal (startSession still fell back to id_rsa) while
+ * ProxyJump / SFTP failed after password rejection alone.
+ */
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildAuthHandler } = require("./sshAuthHelper.cjs");
+
+const DEFAULT_KEYS = [
+  {
+    keyName: "id_ed25519",
+    keyPath: "/tmp/id_ed25519",
+    privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\ned\n-----END OPENSSH PRIVATE KEY-----\n",
+  },
+  {
+    keyName: "id_rsa",
+    keyPath: "/tmp/id_rsa",
+    privateKey: "-----BEGIN RSA PRIVATE KEY-----\nrsa\n-----END RSA PRIVATE KEY-----\n",
+  },
+];
+
+/**
+ * Walk the ssh2-style authHandler and collect method labels.
+ * Object methods expose type (and sometimes username/key); string methods
+ * come from the simple ordered-list path (e.g. password-only).
+ */
+function collectAuthMethods(authHandler, maxSteps = 16) {
+  const labels = [];
+  let methodsLeft = null;
+  for (let i = 0; i < maxSteps; i += 1) {
+    let offered = null;
+    authHandler(methodsLeft, false, (method) => {
+      offered = method;
+    });
+    if (offered == null || offered === false) break;
+    if (typeof offered === "string") {
+      labels.push(offered);
+    } else if (offered && typeof offered === "object") {
+      labels.push(offered.type || "unknown");
+    } else {
+      break;
+    }
+    // Keep all common methods available so the handler can walk its full list.
+    methodsLeft = ["publickey", "password", "keyboard-interactive", "agent"];
+  }
+  return labels;
+}
+
+test("buildAuthHandler password-only does not offer default SSH keys (#2079)", () => {
+  const auth = buildAuthHandler({
+    password: "wrong-or-stale-secret",
+    username: "root",
+    defaultKeys: DEFAULT_KEYS,
+    allowAgentFallback: false,
+  });
+
+  const labels = collectAuthMethods(auth.authHandler);
+  assert.ok(labels.includes("password"), `expected password; got ${labels.join(",")}`);
+  assert.ok(labels.includes("keyboard-interactive"), `expected KI; got ${labels.join(",")}`);
+  assert.equal(
+    labels.includes("publickey"),
+    false,
+    `password-only must not probe default keys; offered=${labels.join(",")}`,
+  );
+  assert.equal(labels.includes("agent"), false);
+});
+
+test("buildAuthHandler with no credentials still offers default keys", () => {
+  const auth = buildAuthHandler({
+    username: "root",
+    defaultKeys: DEFAULT_KEYS,
+    allowAgentFallback: false,
+  });
+
+  const labels = collectAuthMethods(auth.authHandler);
+  assert.ok(
+    labels.includes("publickey"),
+    `expected default-key fallback when no explicit auth; offered=${labels.join(",")}`,
+  );
+});
+
+test("buildAuthHandler key+password still allows default key fallback after user key", () => {
+  const auth = buildAuthHandler({
+    privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nuser\n-----END OPENSSH PRIVATE KEY-----\n",
+    password: "also-have-password",
+    username: "root",
+    defaultKeys: DEFAULT_KEYS,
+    allowAgentFallback: false,
+  });
+
+  const labels = collectAuthMethods(auth.authHandler);
+  assert.ok(labels.includes("publickey"), `expected publickey; offered=${labels.join(",")}`);
+  assert.ok(labels.includes("password"), `expected password; offered=${labels.join(",")}`);
+  // user key + at least one default key => multiple publickey offers
+  const publickeyCount = labels.filter((l) => l === "publickey").length;
+  assert.ok(
+    publickeyCount >= 2,
+    `key auth may still fall back to default keys; offered=${labels.join(",")}`,
+  );
+});
+
+test("buildAuthHandler password-only may still attach unlocked encrypted keys for jump retry", () => {
+  const auth = buildAuthHandler({
+    password: "host-password",
+    username: "root",
+    defaultKeys: DEFAULT_KEYS,
+    allowAgentFallback: false,
+    unlockedEncryptedKeys: [{
+      keyName: "id_encrypted",
+      privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nenc\n-----END OPENSSH PRIVATE KEY-----\n",
+      passphrase: "key-pass",
+    }],
+  });
+
+  const labels = collectAuthMethods(auth.authHandler);
+  assert.ok(labels.includes("password"), `offered=${labels.join(",")}`);
+  assert.ok(
+    labels.includes("publickey"),
+    `jump-chain retry may still offer unlocked keys; offered=${labels.join(",")}`,
+  );
+});

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -756,10 +756,15 @@ function createStartSessionApi(ctx) {
           connectOpts.password = options.password;
         }
 
-        // Always try to find default SSH keys for fallback authentication.
-        // This allows fallback even when password auth fails. The full list is
-        // scanned exactly once (kicked off above); its first entry is the
-        // preferred default key — identical to what a separate
+        // Default ~/.ssh keys are a fallback for hosts that have no explicit
+        // credentials. Password-only hosts must NOT silently fall back to local
+        // keys: jump-host / SFTP paths already honor that rule via
+        // buildAuthHandler (issue #266), and falling back only on the direct
+        // terminal path makes a wrong saved password look fine until ProxyJump
+        // or SFTP fails (issue #2079).
+        //
+        // The full list is scanned exactly once (kicked off above); its first
+        // entry is the preferred default key — identical to what a separate
         // findDefaultPrivateKey() scan would return — so derive it here instead
         // of walking ~/.ssh a second time. (Pinned by
         // sshBridge.defaultKeyEquivalence.test.cjs.)
@@ -769,8 +774,21 @@ function createStartSessionApi(ctx) {
           ? []
           : discoveredDefaultKeys;
         const defaultKeyInfo = allDefaultKeys[0] ?? null;
-        if (defaultKeyInfo) {
+        // Explicit password without a user-configured key/certificate/agent is
+        // password-only — same predicate buildAuthHandler uses for isPasswordOnly.
+        const isPasswordOnlyAuth =
+          isPasswordProvided(connectOpts.password) &&
+          !connectOpts.privateKey &&
+          !hasCertificate &&
+          !systemAuthAgent &&
+          !hasUserConfiguredKey(options);
+        if (defaultKeyInfo && !isPasswordOnlyAuth) {
           log("Found default SSH key for fallback", { keyPath: defaultKeyInfo.keyPath, keyName: defaultKeyInfo.keyName });
+        } else if (defaultKeyInfo && isPasswordOnlyAuth) {
+          log("Skipping default SSH key fallback for password-only auth", {
+            keyPath: defaultKeyInfo.keyPath,
+            keyName: defaultKeyInfo.keyName,
+          });
         }
 
         // Use unlocked encrypted keys if provided (from retry after auth failure)
@@ -815,7 +833,8 @@ function createStartSessionApi(ctx) {
           hasPrivateKey: !!connectOpts.privateKey,
           hasPassword: !!connectOpts.password,
           hasAgent: !!connectOpts.agent,
-          hasDefaultKeyFallback: !!defaultKeyInfo,
+          hasDefaultKeyFallback: !!defaultKeyInfo && !isPasswordOnlyAuth,
+          isPasswordOnlyAuth,
         });
 
         // Agent forwarding
@@ -847,9 +866,9 @@ function createStartSessionApi(ctx) {
         if (authAgent) {
           const order = ["none", "agent"];
           if (connectOpts.password) order.push("password");
-          // Add default key fallback if available and no user key configured
-          // Must also set connectOpts.privateKey for ssh2 to actually try publickey auth
-          if (defaultKeyInfo && !hasUserConfiguredKey(options)) {
+          // Default key fallback only when this is not password-only (issue #266 / #2079).
+          // Must also set connectOpts.privateKey for ssh2 to actually try publickey auth.
+          if (defaultKeyInfo && !hasUserConfiguredKey(options) && !isPasswordOnlyAuth) {
             connectOpts.privateKey = defaultKeyInfo.privateKey;
             order.push("publickey");
           }
@@ -878,30 +897,33 @@ function createStartSessionApi(ctx) {
           }
 
           // Then try ALL default SSH keys as fallback (not just the first one!)
-          // This is critical because different servers may have different keys in authorized_keys
-          if (usedDefaultKeyAsPrimary && allDefaultKeys.length > 0) {
-            for (const keyInfo of allDefaultKeys) {
+          // This is critical because different servers may have different keys in authorized_keys.
+          // Password-only hosts skip this entirely so terminal/SFTP/jump agree (issue #2079).
+          if (!isPasswordOnlyAuth) {
+            if (usedDefaultKeyAsPrimary && allDefaultKeys.length > 0) {
+              for (const keyInfo of allDefaultKeys) {
+                authMethods.push({
+                  type: "publickey",
+                  key: keyInfo.privateKey,
+                  isDefault: true,
+                  id: `publickey-default-${keyInfo.keyName}`
+                });
+              }
+            } else if (defaultKeyInfo && !hasUserConfiguredKey(options) && !usedDefaultKeyAsPrimary) {
+              // Single default key fallback (when user has configured other non-password auth)
+              authMethods.push({ type: "publickey", key: defaultKeyInfo.privateKey, isDefault: true, id: "publickey-default" });
+            }
+
+            // Add unlocked encrypted default keys (user provided passphrases for these)
+            for (const keyInfo of unlockedEncryptedKeys) {
               authMethods.push({
                 type: "publickey",
                 key: keyInfo.privateKey,
+                passphrase: keyInfo.passphrase,
                 isDefault: true,
-                id: `publickey-default-${keyInfo.keyName}`
+                id: `publickey-encrypted-${keyInfo.keyName}`
               });
             }
-          } else if (defaultKeyInfo && !hasUserConfiguredKey(options) && !usedDefaultKeyAsPrimary) {
-            // Single default key fallback (when user has configured other auth methods)
-            authMethods.push({ type: "publickey", key: defaultKeyInfo.privateKey, isDefault: true, id: "publickey-default" });
-          }
-
-          // Add unlocked encrypted default keys (user provided passphrases for these)
-          for (const keyInfo of unlockedEncryptedKeys) {
-            authMethods.push({
-              type: "publickey",
-              key: keyInfo.privateKey,
-              passphrase: keyInfo.passphrase,
-              isDefault: true,
-              id: `publickey-encrypted-${keyInfo.keyName}`
-            });
           }
 
           // Finally try keyboard-interactive

--- a/electron/bridges/sshBridge/startSession.cjs
+++ b/electron/bridges/sshBridge/startSession.cjs
@@ -898,7 +898,10 @@ function createStartSessionApi(ctx) {
 
           // Then try ALL default SSH keys as fallback (not just the first one!)
           // This is critical because different servers may have different keys in authorized_keys.
-          // Password-only hosts skip this entirely so terminal/SFTP/jump agree (issue #2079).
+          // Password-only hosts skip automatic default-key probing so terminal/SFTP/jump
+          // agree (issue #2079). Unlocked encrypted keys from an explicit passphrase
+          // retry are kept even for password-only targets when jump-host retry
+          // unlocked them (Codex review P2 on #2153 / canRetryWithEncryptedDefaultKeys).
           if (!isPasswordOnlyAuth) {
             if (usedDefaultKeyAsPrimary && allDefaultKeys.length > 0) {
               for (const keyInfo of allDefaultKeys) {
@@ -913,17 +916,19 @@ function createStartSessionApi(ctx) {
               // Single default key fallback (when user has configured other non-password auth)
               authMethods.push({ type: "publickey", key: defaultKeyInfo.privateKey, isDefault: true, id: "publickey-default" });
             }
+          }
 
-            // Add unlocked encrypted default keys (user provided passphrases for these)
-            for (const keyInfo of unlockedEncryptedKeys) {
-              authMethods.push({
-                type: "publickey",
-                key: keyInfo.privateKey,
-                passphrase: keyInfo.passphrase,
-                isDefault: true,
-                id: `publickey-encrypted-${keyInfo.keyName}`
-              });
-            }
+          // Unlocked encrypted keys always stay eligible after the user was
+          // prompted for their passphrase — discarding them here would waste
+          // that interaction when jump-host retry re-enters startSession.
+          for (const keyInfo of unlockedEncryptedKeys) {
+            authMethods.push({
+              type: "publickey",
+              key: keyInfo.privateKey,
+              passphrase: keyInfo.passphrase,
+              isDefault: true,
+              id: `publickey-encrypted-${keyInfo.keyName}`
+            });
           }
 
           // Finally try keyboard-interactive


### PR DESCRIPTION
## Summary

- **Root cause for #2079:** With a host-level password saved, direct terminal login used `startSession`, which still fell back to `~/.ssh/id_*` after password rejection. Jump hosts and SFTP use `buildAuthHandler` password-only mode and **only** try password. A wrong/stale host password therefore looked fine on direct SSH (local key succeeds) but failed ProxyJump and SFTP until the password was re-entered (e.g. via Keychain).
- Evidence from the report: password auth failed on the jump hop; default `id_rsa` was discovered for fallback; successful direct login showed multiple prior failed attempts; moving the same credentials into Keychain fixed jump/SFTP.
- Align `startSession` with the #266 password-only policy: when the host is password-only (password set, no user key/certificate/agent), do not offer default-key fallback.
- Tighten `buildAuthHandler` fallback-key selection for password-only and add regression tests.

## User-visible effect

- Direct terminal no longer silently succeeds via a local default key when the **saved host password is wrong**.
- Password failure surfaces consistently (auth retry), so fixing the host password also fixes jump/SFTP.
- Hosts that rely on default keys intentionally should leave password empty (or use key/Keychain auth), matching jump/SFTP behavior.

## Test plan

- [x] `node --test electron/bridges/sshAuthHelper.passwordOnly.test.cjs`
- [x] Related auth helper / default-key tests pass
- [ ] Manual: host with **wrong** password + working `~/.ssh/id_rsa` → direct connect should **fail** and show auth retry (not silently succeed)
- [ ] Manual: host with **correct** password → direct, SFTP, and ProxyJump all succeed
- [ ] Manual: host with no password and default key → still connects via default key
- [ ] Confirm #2079 reporter path: password-only jump host no longer fails only because terminal was masking a bad password with a local key

Fixes #2079