### PR TITLE
fix(terminal): normalize soft wraps and padding when copying selection

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -404,6 +404,9 @@ export const enCoreMessages: Messages = {
   'settings.terminal.behavior.rightClick.selectWord': 'Select word',
   'settings.terminal.behavior.copyOnSelect': 'Copy on select',
   'settings.terminal.behavior.copyOnSelect.desc': 'Automatically copy selected text. In tmux/vim with mouse mode, hold Option on macOS or Shift on Windows/Linux to select',
+  'settings.terminal.behavior.normalizeTextOnCopy': 'Normalize terminal text on copy',
+  'settings.terminal.behavior.normalizeTextOnCopy.desc':
+    'When copying from the terminal, strip display-only trailing padding and join soft-wrapped rows so pasted text matches logical output. Turn off to copy the raw screen selection (including TUI padding and visual wraps).',
   'settings.terminal.behavior.middleClickPaste': 'Middle-click paste',
   'settings.terminal.behavior.middleClickPaste.desc':
     'Paste clipboard content on middle-click',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -381,6 +381,9 @@ export const ruCoreMessages: Messages = {
   'settings.terminal.behavior.rightClick.selectWord': 'Выбрать слово',
   'settings.terminal.behavior.copyOnSelect': 'Копировать при выделении',
   'settings.terminal.behavior.copyOnSelect.desc': 'Автоматически копировать выделенный текст. В tmux/vim с режимом мыши удерживайте Option на macOS или Shift на Windows/Linux для выделения',
+  'settings.terminal.behavior.normalizeTextOnCopy': 'Нормализовать текст терминала при копировании',
+  'settings.terminal.behavior.normalizeTextOnCopy.desc':
+    'При копировании из терминала убирать отображающие хвостовые пробелы и объединять soft-wrap строки, чтобы вставка соответствовала логическому тексту. Отключите, чтобы копировать сырое выделение экрана (включая padding TUI и визуальные переносы).',
   'settings.terminal.behavior.middleClickPaste': 'Вставка средней кнопкой мыши',
   'settings.terminal.behavior.middleClickPaste.desc':
     'Вставлять содержимое буфера обмена по щелчку средней кнопкой',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -248,6 +248,9 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.behavior.rightClick.selectWord': '选择单词',
   'settings.terminal.behavior.copyOnSelect': '选择即复制',
   'settings.terminal.behavior.copyOnSelect.desc': '自动复制选中的文本。在 tmux/vim 鼠标模式下，macOS 按住 Option，Windows/Linux 按住 Shift 拖选即可选中文本',
+  'settings.terminal.behavior.normalizeTextOnCopy': '复制时规范化终端文本',
+  'settings.terminal.behavior.normalizeTextOnCopy.desc':
+    '复制终端内容时去掉仅用于显示的行尾填充空格，并拼接软换行，使粘贴结果更接近逻辑文本。关闭后按屏幕选区原样复制（含 TUI 填充空格与视觉折行）。',
   'settings.terminal.behavior.middleClickPaste': '中键粘贴',
   'settings.terminal.behavior.middleClickPaste.desc': '中键点击时粘贴剪贴板内容',
   'settings.terminal.behavior.middleClick': '中键行为',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -248,6 +248,9 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.behavior.rightClick.selectWord': '選擇單字',
   'settings.terminal.behavior.copyOnSelect': '選擇即複製',
   'settings.terminal.behavior.copyOnSelect.desc': '自動複製選取的文字。在 tmux/vim 滑鼠模式下，macOS 按住 Option，Windows/Linux 按住 Shift 拖選即可選取文字',
+  'settings.terminal.behavior.normalizeTextOnCopy': '複製時正規化終端文字',
+  'settings.terminal.behavior.normalizeTextOnCopy.desc':
+    '複製終端內容時去除僅供顯示的行尾填充空白，並拼接軟換行，使貼上結果更接近邏輯文字。關閉後依螢幕選取原樣複製（含 TUI 填充空白與視覺折行）。',
   'settings.terminal.behavior.middleClickPaste': '中鍵貼上',
   'settings.terminal.behavior.middleClickPaste.desc': '中鍵點選時貼上剪貼簿內容',
   'settings.terminal.behavior.middleClick': '中鍵行為',

--- a/application/syncPayload.ts
+++ b/application/syncPayload.ts
@@ -203,7 +203,7 @@ const SYNCABLE_TERMINAL_KEYS = [
   'altAsMeta', 'optionArrowWordJump', 'shiftEnterNewlineEnabled', 'shiftEnterNewlineText',
   'scrollOnInput', 'scrollOnOutput', 'scrollOnKeyPress', 'scrollOnPaste',
   'smoothScrolling',
-  'rightClickBehavior', 'middleClickBehavior', 'copyOnSelect', 'middleClickPaste', 'wordSeparators',
+  'rightClickBehavior', 'middleClickBehavior', 'copyOnSelect', 'normalizeTextOnCopy', 'middleClickPaste', 'wordSeparators',
   'linkModifier', 'keywordHighlightEnabled', 'keywordHighlightRules',
   'keepaliveInterval', 'keepaliveCountMax', 'disableBracketedPaste', 'clearWipesScrollback',
   'preserveSelectionOnInput', 'forcePromptNewLine', 'osc52Clipboard', 'dynamicTabTitleMode',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -103,6 +103,7 @@ import { createReplaySafeTerminalLogSanitizer } from "./terminal/replaySafeTermi
 import { createConnectionLogBuffer } from "./terminal/connectionLogBuffer";
 import { createProgrammaticCommandLogRewriter, type ProgrammaticCommandLogRewrite } from "./terminal/programmaticCommandLog";
 import { getSessionLogInitialLine } from "./terminal/sessionLogInitialLine";
+import { getNormalizedTerminalSelection } from "./terminal/normalizeTerminalSelection";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import {
   createTerminalSessionStarters,
@@ -2048,7 +2049,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   terminalContextActionsRef.current = terminalContextActions;
 
   const handleAddSelectionToAI = useCallback(() => {
-    const selection = termRef.current?.getSelection() ?? "";
+    const term = termRef.current;
+    if (!term) return;
+    const selection = getNormalizedTerminalSelection(term);
     if (!selection.trim()) return;
     onAddSelectionToAI?.(sessionId, selection);
   }, [onAddSelectionToAI, sessionId]);

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -103,7 +103,7 @@ import { createReplaySafeTerminalLogSanitizer } from "./terminal/replaySafeTermi
 import { createConnectionLogBuffer } from "./terminal/connectionLogBuffer";
 import { createProgrammaticCommandLogRewriter, type ProgrammaticCommandLogRewrite } from "./terminal/programmaticCommandLog";
 import { getSessionLogInitialLine } from "./terminal/sessionLogInitialLine";
-import { getNormalizedTerminalSelection } from "./terminal/normalizeTerminalSelection";
+import { getTerminalSelectionForClipboard } from "./terminal/normalizeTerminalSelection";
 import { useZmodemTransfer } from "./terminal/hooks/useZmodemTransfer";
 import {
   createTerminalSessionStarters,
@@ -1923,6 +1923,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   scrollOnPasteRef.current = terminalSettings?.scrollOnPaste ?? true;
   const clearWipesScrollbackRef = useRef(terminalSettings?.clearWipesScrollback ?? true);
   clearWipesScrollbackRef.current = terminalSettings?.clearWipesScrollback ?? true;
+  const normalizeTextOnCopyRef = useRef(terminalSettings?.normalizeTextOnCopy ?? true);
+  normalizeTextOnCopyRef.current = terminalSettings?.normalizeTextOnCopy ?? true;
 
   const scrollToBottomAfterProgrammaticInput = useCallback((data: string) => {
     if (termRef.current && shouldScrollOnTerminalInput(terminalSettingsRef.current, data)) {
@@ -2032,6 +2034,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onHasSelectionChange: setHasSelection,
     scrollOnPasteRef,
     clearWipesScrollbackRef,
+    normalizeTextOnCopyRef,
     isBroadcastEnabledRef,
     onBroadcastInputRef,
     isLocalConnection,
@@ -2051,10 +2054,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const handleAddSelectionToAI = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getNormalizedTerminalSelection(term);
+    const selection = getTerminalSelectionForClipboard(
+      term,
+      terminalSettings?.normalizeTextOnCopy ?? true,
+    );
     if (!selection.trim()) return;
     onAddSelectionToAI?.(sessionId, selection);
-  }, [onAddSelectionToAI, sessionId]);
+  }, [onAddSelectionToAI, sessionId, terminalSettings?.normalizeTextOnCopy]);
 
   const handleSetTerminalEncoding = useCallback((encoding: TerminalEncodingPreference) => {
     setTerminalEncoding(encoding);

--- a/components/settings/tabs/TerminalBehaviorSettings.tsx
+++ b/components/settings/tabs/TerminalBehaviorSettings.tsx
@@ -63,6 +63,16 @@ export const TerminalBehaviorSettings: React.FC<TerminalBehaviorSettingsProps> =
         </SettingRow>
 
         <SettingRow
+          label={t("settings.terminal.behavior.normalizeTextOnCopy")}
+          description={t("settings.terminal.behavior.normalizeTextOnCopy.desc")}
+        >
+          <Toggle
+            checked={terminalSettings.normalizeTextOnCopy ?? true}
+            onChange={(v) => updateTerminalSetting("normalizeTextOnCopy", v)}
+          />
+        </SettingRow>
+
+        <SettingRow
           label={t("settings.terminal.behavior.middleClick")}
           description={t("settings.terminal.behavior.middleClick.desc")}
         >

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -10,6 +10,7 @@ import {
   type RemoteClipboardImageUploadResult,
 } from "../clipboardImagePaste";
 import { handleTerminalClipboardPaste } from "../terminalClipboardPaste";
+import { getNormalizedTerminalSelection } from "../normalizeTerminalSelection";
 
 type BroadcastPasteRefs = {
   sourceSessionId: string;
@@ -74,7 +75,7 @@ export const useTerminalContextActions = ({
   const onCopy = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = term.getSelection();
+    const selection = getNormalizedTerminalSelection(term);
     if (selection) {
       navigator.clipboard.writeText(selection);
     }
@@ -138,7 +139,7 @@ export const useTerminalContextActions = ({
   const onPasteSelection = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = term.getSelection();
+    const selection = getNormalizedTerminalSelection(term);
     if (!selection || !sessionRef.current) return;
     pasteTextIntoTerminal(term, selection, {
       scrollOnPaste: scrollOnPasteRef?.current ?? false,

--- a/components/terminal/hooks/useTerminalContextActions.ts
+++ b/components/terminal/hooks/useTerminalContextActions.ts
@@ -10,7 +10,7 @@ import {
   type RemoteClipboardImageUploadResult,
 } from "../clipboardImagePaste";
 import { handleTerminalClipboardPaste } from "../terminalClipboardPaste";
-import { getNormalizedTerminalSelection } from "../normalizeTerminalSelection";
+import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
 
 type BroadcastPasteRefs = {
   sourceSessionId: string;
@@ -41,6 +41,7 @@ export const useTerminalContextActions = ({
   isLocalConnection,
   supportsRemoteImagePaste,
   clearWipesScrollbackRef,
+  normalizeTextOnCopyRef,
   terminalBackend,
   getRemoteCwd,
   scrollToBottomAfterProgrammaticInput,
@@ -56,6 +57,8 @@ export const useTerminalContextActions = ({
   isLocalConnection: boolean;
   supportsRemoteImagePaste: boolean;
   clearWipesScrollbackRef?: RefObject<boolean | undefined>;
+  /** When false, copy uses raw getSelection(). Default true when unset. */
+  normalizeTextOnCopyRef?: RefObject<boolean | undefined>;
   terminalBackend: {
     writeToSession: (sessionId: string, data: string, options?: { automated?: boolean }) => void;
   };
@@ -75,11 +78,14 @@ export const useTerminalContextActions = ({
   const onCopy = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getNormalizedTerminalSelection(term);
+    const selection = getTerminalSelectionForClipboard(
+      term,
+      normalizeTextOnCopyRef?.current ?? true,
+    );
     if (selection) {
       navigator.clipboard.writeText(selection);
     }
-  }, [termRef]);
+  }, [normalizeTextOnCopyRef, termRef]);
 
   const onPaste = useCallback(async () => {
     const term = termRef.current;
@@ -139,13 +145,16 @@ export const useTerminalContextActions = ({
   const onPasteSelection = useCallback(() => {
     const term = termRef.current;
     if (!term) return;
-    const selection = getNormalizedTerminalSelection(term);
+    const selection = getTerminalSelectionForClipboard(
+      term,
+      normalizeTextOnCopyRef?.current ?? true,
+    );
     if (!selection || !sessionRef.current) return;
     pasteTextIntoTerminal(term, selection, {
       scrollOnPaste: scrollOnPasteRef?.current ?? false,
       onPasteData: broadcastUserPasteData,
     });
-  }, [broadcastUserPasteData, sessionRef, termRef, scrollOnPasteRef]);
+  }, [broadcastUserPasteData, normalizeTextOnCopyRef, sessionRef, termRef, scrollOnPasteRef]);
 
   const onSelectAll = useCallback(() => {
     const term = termRef.current;

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -161,17 +161,22 @@ test("joinSoftWrappedRows only uses the trailing token for URL detection", () =>
   );
 });
 
-test("joinSoftWrappedRows keeps URL tokens intact when split mid-word", () => {
+test("joinSoftWrappedRows keeps path separators attached across wraps", () => {
   assert.equal(
-    joinSoftWrappedRows("https://example.com/verylongto   ", "ken"),
-    "https://example.com/verylongtoken",
+    joinSoftWrappedRows("https://example.com/very/long/   ", "path"),
+    "https://example.com/very/long/path",
+  );
+  // Complete URL + padding + next word stays two words (not mid-token glue).
+  assert.equal(
+    joinSoftWrappedRows("See https://example.com   ", "today"),
+    "See https://example.com today",
   );
 });
 
 test("joinSoftWrappedRows preserves Windows paths and URL query delimiters", () => {
   assert.equal(
-    joinSoftWrappedRows("C:\\Users\\alice\\verylongfi   ", "lename.txt"),
-    "C:\\Users\\alice\\verylongfilename.txt",
+    joinSoftWrappedRows("C:\\Users\\alice\\   ", "file.txt"),
+    "C:\\Users\\alice\\file.txt",
   );
   assert.equal(
     joinSoftWrappedRows("https://example.com/path   ", "?q=netcatty"),
@@ -190,9 +195,10 @@ test("joinSoftWrappedRows keeps sentence break after a URL", () => {
   );
 });
 
-test("joinSoftWrappedRows keeps hyphenated words intact", () => {
+test("joinSoftWrappedRows keeps hyphenated words intact at the hyphen", () => {
   assert.equal(joinSoftWrappedRows("state-   ", "of-the-art"), "state-of-the-art");
-  assert.equal(joinSoftWrappedRows("--ver   ", "bose"), "--verbose");
+  // Complete flag + next word keeps a boundary.
+  assert.equal(joinSoftWrappedRows("Use --verbose   ", "to inspect"), "Use --verbose to inspect");
 });
 
 test("preserves partial trailing spaces after wide characters using column ends", () => {

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -162,6 +162,28 @@ test("joinSoftWrappedRows keeps URL tokens intact when split mid-word", () => {
   );
 });
 
+test("joinSoftWrappedRows preserves Windows paths and URL query delimiters", () => {
+  assert.equal(
+    joinSoftWrappedRows("C:\\Users\\alice\\verylongfi   ", "lename.txt"),
+    "C:\\Users\\alice\\verylongfilename.txt",
+  );
+  assert.equal(
+    joinSoftWrappedRows("https://example.com/path   ", "?q=netcatty"),
+    "https://example.com/path?q=netcatty",
+  );
+  assert.equal(
+    joinSoftWrappedRows("https://example.com/search?   ", "q=netcatty"),
+    "https://example.com/search?q=netcatty",
+  );
+});
+
+test("joinSoftWrappedRows keeps sentence break after a URL", () => {
+  assert.equal(
+    joinSoftWrappedRows("See https://example.com.   ", "Next sentence"),
+    "See https://example.com. Next sentence",
+  );
+});
+
 test("preserves partial trailing spaces after wide characters using column ends", () => {
   // "中  X" with 中 width 2 → columns: [中][ ][ ][ ][X] roughly.
   // Select through the spaces after 中 but before X.

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -63,16 +63,30 @@ function makeTerm(
 test("trimWrittenPadding removes written trailing spaces but keeps internal ones", () => {
   assert.equal(trimWrittenPadding("hello   "), "hello");
   assert.equal(trimWrittenPadding("  hello  world  "), "  hello  world");
-  assert.equal(trimWrittenPadding("tabs\t\t"), "tabs");
 });
 
-test("joinSoftWrappedRows keeps a word-boundary space after padding trim", () => {
-  assert.equal(joinSoftWrappedRows("hello   ", "world"), "hello world");
+test("joinSoftWrappedRows keeps a single trailing space as a word separator", () => {
   assert.equal(joinSoftWrappedRows("hello ", "world"), "hello world");
 });
 
 test("joinSoftWrappedRows concatenates mid-word wraps tightly", () => {
   assert.equal(joinSoftWrappedRows("hel", "lo world"), "hello world");
+});
+
+test("joinSoftWrappedRows does not invent spaces inside URL/path tokens", () => {
+  assert.equal(
+    joinSoftWrappedRows("https://example.com/very/long/   ", "path"),
+    "https://example.com/very/long/path",
+  );
+});
+
+test("joinSoftWrappedRows does not invent spaces before CJK punctuation", () => {
+  assert.equal(joinSoftWrappedRows("你好   ", "，世界"), "你好，世界");
+});
+
+test("joinSoftWrappedRows collapses prose padding to one space", () => {
+  assert.equal(joinSoftWrappedRows("shifts   ", "across"), "shifts across");
+  assert.equal(joinSoftWrappedRows("most   ", "reliable"), "most reliable");
 });
 
 test("joinSoftWrappedRows does not invent spaces between CJK characters", () => {
@@ -108,6 +122,15 @@ test("preserves hard line breaks between non-wrapped rows while trimming padding
   assert.equal(getNormalizedTerminalSelection(term), "line one\nline two\nline three");
 });
 
+test("preserves explicitly selected trailing spaces on a partial last row", () => {
+  // "abc  def" — select columns 0..5 → "abc  " must keep the spaces.
+  const term = makeTerm(
+    [{ text: "abc  def" }],
+    { start: { x: 0, y: 0 }, end: { x: 5, y: 0 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "abc  ");
+});
+
 test("empty-cell trim from xterm still applies before written-space trim", () => {
   const term = makeTerm(
     [{ text: "hello", emptyCells: 10 }],
@@ -125,9 +148,8 @@ test("respects partial column selection on first and last rows", () => {
     { start: { x: 2, y: 0 }, end: { x: 10, y: 1 } },
   );
 
-  // first row from col 2 to line end (multi-row): "hello worldyy" (no trailing ws)
-  // last row cols 0..10: "continued " → logical trim at end of selection → "continued"
-  assert.equal(getNormalizedTerminalSelection(term), "hello worldyycontinued");
+  // Last-row end.x=10 selects "continued " (including the space); keep it.
+  assert.equal(getNormalizedTerminalSelection(term), "hello worldyycontinued ");
 });
 
 test("falls back to getSelection when position is unavailable", () => {
@@ -163,18 +185,19 @@ test("handles multi-row soft wrap chains", () => {
   assert.equal(getNormalizedTerminalSelection(term), "aaabbbccc\nddd");
 });
 
-test("preserves rectangular column selection column bounds on every row", () => {
+test("preserves rectangular column selection including right-edge spaces", () => {
   const term = makeTerm(
     [
-      { text: "abcdefghij" },
-      { text: "0123456789" },
-      { text: "ABCDEFGHIJ" },
+      { text: "ab  efghij" },
+      { text: "01  56789x" },
+      { text: "AB  EFGHIJ" },
     ],
     { start: { x: 2, y: 0 }, end: { x: 5, y: 2 } },
     { columnSelect: true },
   );
 
-  assert.equal(getNormalizedTerminalSelection(term), "cde\n234\nCDE");
+  // Columns 2..5 include the intentional spaces.
+  assert.equal(getNormalizedTerminalSelection(term), "  e\n  5\n  E");
 });
 
 test("converts non-breaking spaces to regular spaces", () => {

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -128,11 +128,10 @@ test("joinSoftWrappedRows does not invent spaces before CJK punctuation", () => 
   assert.equal(joinSoftWrappedRows("你好   ", "，世界"), "你好，世界");
 });
 
-test("joinSoftWrappedRows does not invent spaces for multi-space TUI padding", () => {
-  // Multi-space runs are display padding, not proof of a word boundary.
-  assert.equal(joinSoftWrappedRows("most   ", "reliable"), "mostreliable");
-  assert.equal(joinSoftWrappedRows("someVeryLongIdenti   ", "fier"), "someVeryLongIdentifier");
-  assert.equal(joinSoftWrappedRows("прив   ", "ет"), "привет");
+test("joinSoftWrappedRows collapses multi-space prose padding to one space", () => {
+  // Pi/TUI word-wrapped prose: padding between words must not glue them.
+  assert.equal(joinSoftWrappedRows("the most   ", "reliable"), "the most reliable");
+  assert.equal(joinSoftWrappedRows("shifts   ", "across"), "shifts across");
 });
 
 test("joinSoftWrappedRows does not invent spaces between CJK characters", () => {
@@ -151,15 +150,14 @@ test("joinSoftWrappedRows keeps a space after sentence-ending punctuation", () =
 });
 
 test("joinSoftWrappedRows only uses the trailing token for URL detection", () => {
-  // Multi-space padding after a normal word stays tight (not a URL token).
   assert.equal(
     joinSoftWrappedRows("See https://x.test for more   ", "details"),
-    "See https://x.test for moredetails",
-  );
-  // Single trailing space still preserves the word boundary.
-  assert.equal(
-    joinSoftWrappedRows("See https://x.test for more ", "details"),
     "See https://x.test for more details",
+  );
+  // Single trailing space after a URL is a real word separator.
+  assert.equal(
+    joinSoftWrappedRows("See https://example.com ", "today"),
+    "See https://example.com today",
   );
 });
 
@@ -203,7 +201,7 @@ test("preserves partial trailing spaces after wide characters using column ends"
   assert.equal(getNormalizedTerminalSelection(term), "中  ");
 });
 
-test("joins soft-wrapped rows, strips multi-space padding without inventing separators", () => {
+test("joins soft-wrapped rows and collapses prose padding to one space", () => {
   const term = makeTerm(
     [
       { text: "Pi: use /copy is the most   " },
@@ -215,7 +213,7 @@ test("joins soft-wrapped rows, strips multi-space padding without inventing sepa
 
   assert.equal(
     getNormalizedTerminalSelection(term),
-    "Pi: use /copy is the mostreliable option\nnext hard line",
+    "Pi: use /copy is the most reliable option\nnext hard line",
   );
 });
 

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getNormalizedTerminalSelection,
+  joinSoftWrappedRows,
   trimWrittenPadding,
   type SelectionBufferLine,
   type SelectionTerminal,
@@ -24,7 +25,6 @@ function makeLine(
     translateToString(trimRight = false, startColumn = 0, endColumn = full.length) {
       let end = Math.max(startColumn, Math.min(endColumn, full.length));
       if (trimRight) {
-        // Drop only empty (never-written) cells on the right — not spaces.
         while (end > startColumn && full[end - 1] === "\0") {
           end -= 1;
         }
@@ -66,8 +66,20 @@ test("trimWrittenPadding removes written trailing spaces but keeps internal ones
   assert.equal(trimWrittenPadding("tabs\t\t"), "tabs");
 });
 
-test("joins soft-wrapped rows and strips written display padding", () => {
-  // TUI pads each physical row with real spaces; empty cells alone are not the problem.
+test("joinSoftWrappedRows keeps a word-boundary space after padding trim", () => {
+  assert.equal(joinSoftWrappedRows("hello   ", "world"), "hello world");
+  assert.equal(joinSoftWrappedRows("hello ", "world"), "hello world");
+});
+
+test("joinSoftWrappedRows concatenates mid-word wraps tightly", () => {
+  assert.equal(joinSoftWrappedRows("hel", "lo world"), "hello world");
+});
+
+test("joinSoftWrappedRows does not invent spaces between CJK characters", () => {
+  assert.equal(joinSoftWrappedRows("最   ", "稳"), "最稳");
+});
+
+test("joins soft-wrapped rows, strips padding, keeps word separators", () => {
   const term = makeTerm(
     [
       { text: "Pi: use /copy is the most   " },
@@ -79,7 +91,7 @@ test("joins soft-wrapped rows and strips written display padding", () => {
 
   assert.equal(
     getNormalizedTerminalSelection(term),
-    "Pi: use /copy is the mostreliable option\nnext hard line",
+    "Pi: use /copy is the most reliable option\nnext hard line",
   );
 });
 
@@ -113,8 +125,8 @@ test("respects partial column selection on first and last rows", () => {
     { start: { x: 2, y: 0 }, end: { x: 10, y: 1 } },
   );
 
-  // first row from col 2 to line end (multi-row): "hello worldyy"
-  // last row cols 0..10: "continued " → written-space trim → "continued"
+  // first row from col 2 to line end (multi-row): "hello worldyy" (no trailing ws)
+  // last row cols 0..10: "continued " → logical trim at end of selection → "continued"
   assert.equal(getNormalizedTerminalSelection(term), "hello worldyycontinued");
 });
 
@@ -162,7 +174,6 @@ test("preserves rectangular column selection column bounds on every row", () => 
     { columnSelect: true },
   );
 
-  // Columns 2..5 on each row (not linear first-row-to-end / last-row-from-start).
   assert.equal(getNormalizedTerminalSelection(term), "cde\n234\nCDE");
 });
 
@@ -172,4 +183,15 @@ test("converts non-breaking spaces to regular spaces", () => {
     { start: { x: 0, y: 0 }, end: { x: 13, y: 0 } },
   );
   assert.equal(getNormalizedTerminalSelection(term), "hello world");
+});
+
+test("soft-wrapped CJK with padding joins without inserted spaces", () => {
+  const term = makeTerm(
+    [
+      { text: "Pi: 用 /copy 最   " },
+      { text: "稳                ", isWrapped: true },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 18, y: 1 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "Pi: 用 /copy 最稳");
 });

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -190,6 +190,11 @@ test("joinSoftWrappedRows keeps sentence break after a URL", () => {
   );
 });
 
+test("joinSoftWrappedRows keeps hyphenated words intact", () => {
+  assert.equal(joinSoftWrappedRows("state-   ", "of-the-art"), "state-of-the-art");
+  assert.equal(joinSoftWrappedRows("--ver   ", "bose"), "--verbose");
+});
+
 test("preserves partial trailing spaces after wide characters using column ends", () => {
   // "中  X" with 中 width 2 → columns: [中][ ][ ][ ][X] roughly.
   // Select through the spaces after 中 but before X.

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -41,13 +41,22 @@ function makeLine(
   return {
     isWrapped: options.isWrapped ?? false,
     length: fullCols,
-    getTrimmedLength() {
-      for (let i = cols.length - 1; i >= 0; i -= 1) {
-        if (cols[i] && cols[i] !== "\0") {
-          return i + 1;
-        }
+    getCell(x: number) {
+      if (x < 0 || x >= cols.length) return undefined;
+      const cell = cols[x];
+      if (cell === "\0" || cell === undefined) {
+        return { getChars: () => "", getCode: () => 0, getWidth: () => 1 };
       }
-      return 0;
+      if (cell === "") {
+        // Wide-character continuation column.
+        return { getChars: () => "", getCode: () => 0, getWidth: () => 0 };
+      }
+      const width = cell === "中" || /[\u3400-\u9fff]/u.test(cell) ? 2 : 1;
+      return {
+        getChars: () => cell,
+        getCode: () => cell.codePointAt(0) ?? 0,
+        getWidth: () => width,
+      };
     },
     translateToString(trimRight = false, startColumn = 0, endColumn = fullCols) {
       let end = Math.max(startColumn, Math.min(endColumn, fullCols));

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -15,28 +15,59 @@ import {
  */
 function makeLine(
   text: string,
-  options: { isWrapped?: boolean; emptyCells?: number } = {},
+  options: { isWrapped?: boolean; emptyCells?: number; cellWidths?: number[] } = {},
 ): SelectionBufferLine {
   const emptyCells = options.emptyCells ?? 0;
-  const full = text + "\0".repeat(emptyCells);
+  // Optional per-character terminal widths (default 1). Used to model CJK.
+  const widths = options.cellWidths ?? Array.from(text, () => 1);
+  let colLength = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    colLength += widths[i] ?? 1;
+  }
+  const fullCols = colLength + emptyCells;
+  // Map each terminal column to a char (wide chars occupy two cols; second is spacer).
+  const cols: string[] = [];
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]!;
+    const w = widths[i] ?? 1;
+    cols.push(ch);
+    for (let extra = 1; extra < w; extra += 1) {
+      cols.push(""); // wide-char continuation column
+    }
+  }
+  while (cols.length < fullCols) {
+    cols.push("\0");
+  }
   return {
     isWrapped: options.isWrapped ?? false,
-    length: full.length,
-    translateToString(trimRight = false, startColumn = 0, endColumn = full.length) {
-      let end = Math.max(startColumn, Math.min(endColumn, full.length));
+    length: fullCols,
+    getTrimmedLength() {
+      for (let i = cols.length - 1; i >= 0; i -= 1) {
+        if (cols[i] && cols[i] !== "\0") {
+          return i + 1;
+        }
+      }
+      return 0;
+    },
+    translateToString(trimRight = false, startColumn = 0, endColumn = fullCols) {
+      let end = Math.max(startColumn, Math.min(endColumn, fullCols));
       if (trimRight) {
-        while (end > startColumn && full[end - 1] === "\0") {
+        while (end > startColumn && (cols[end - 1] === "\0" || cols[end - 1] === "")) {
           end -= 1;
         }
       }
-      const start = Math.max(0, startColumn);
-      return full.slice(start, end).replace(/\0/g, " ");
+      let result = "";
+      for (let c = Math.max(0, startColumn); c < end; c += 1) {
+        const cell = cols[c];
+        if (cell && cell !== "\0") result += cell;
+      }
+      return result;
     },
   };
 }
 
 function makeTerm(
-  lines: Array<{ text: string; isWrapped?: boolean; emptyCells?: number }>,
+  lines: Array<{ text: string; isWrapped?: boolean; emptyCells?: number; cellWidths?: number[] }>,
   range: { start: { x: number; y: number }; end: { x: number; y: number } } | null,
   options: {
     rawSelection?: string;
@@ -44,7 +75,11 @@ function makeTerm(
   } = {},
 ): SelectionTerminal {
   const bufferLines = lines.map((line) =>
-    makeLine(line.text, { isWrapped: line.isWrapped, emptyCells: line.emptyCells }),
+    makeLine(line.text, {
+      isWrapped: line.isWrapped,
+      emptyCells: line.emptyCells,
+      cellWidths: line.cellWidths,
+    }),
   );
   return {
     getSelection: () => options.rawSelection ?? "",
@@ -91,6 +126,26 @@ test("joinSoftWrappedRows collapses prose padding to one space", () => {
 
 test("joinSoftWrappedRows does not invent spaces between CJK characters", () => {
   assert.equal(joinSoftWrappedRows("最   ", "稳"), "最稳");
+  // Single pad cell must not bypass the CJK check.
+  assert.equal(joinSoftWrappedRows("最 ", "稳"), "最稳");
+});
+
+test("joinSoftWrappedRows keeps URL tokens intact when split mid-word", () => {
+  assert.equal(
+    joinSoftWrappedRows("https://example.com/verylongto   ", "ken"),
+    "https://example.com/verylongtoken",
+  );
+});
+
+test("preserves partial trailing spaces after wide characters using column ends", () => {
+  // "中  X" with 中 width 2 → columns: [中][ ][ ][ ][X] roughly.
+  // Select through the spaces after 中 but before X.
+  const term = makeTerm(
+    [{ text: "中  X", cellWidths: [2, 1, 1, 1] }],
+    { start: { x: 0, y: 0 }, end: { x: 4, y: 0 } },
+  );
+  // end.x=4 is before content end column of X; keep selected spaces.
+  assert.equal(getNormalizedTerminalSelection(term), "中  ");
 });
 
 test("joins soft-wrapped rows, strips padding, keeps word separators", () => {

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -2,53 +2,79 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getNormalizedTerminalSelection,
+  trimWrittenPadding,
   type SelectionBufferLine,
   type SelectionTerminal,
 } from "./normalizeTerminalSelection.ts";
 
-function makeLine(text: string, isWrapped = false): SelectionBufferLine {
+/**
+ * Fake line that matches real xterm translateToString(true) semantics:
+ * trimRight only drops *empty* cells (trailing chars that were never written),
+ * not written ASCII spaces used as display padding.
+ */
+function makeLine(
+  text: string,
+  options: { isWrapped?: boolean; emptyCells?: number } = {},
+): SelectionBufferLine {
+  const emptyCells = options.emptyCells ?? 0;
+  const full = text + "\0".repeat(emptyCells);
   return {
-    isWrapped,
-    length: text.length,
-    translateToString(trimRight = false, startColumn = 0, endColumn = text.length) {
-      const start = Math.max(0, startColumn);
-      const end = Math.max(start, Math.min(endColumn, text.length));
-      let slice = text.slice(start, end);
+    isWrapped: options.isWrapped ?? false,
+    length: full.length,
+    translateToString(trimRight = false, startColumn = 0, endColumn = full.length) {
+      let end = Math.max(startColumn, Math.min(endColumn, full.length));
       if (trimRight) {
-        slice = slice.replace(/\s+$/u, "");
+        // Drop only empty (never-written) cells on the right — not spaces.
+        while (end > startColumn && full[end - 1] === "\0") {
+          end -= 1;
+        }
       }
-      return slice;
+      const start = Math.max(0, startColumn);
+      return full.slice(start, end).replace(/\0/g, " ");
     },
   };
 }
 
 function makeTerm(
-  lines: Array<{ text: string; isWrapped?: boolean }>,
+  lines: Array<{ text: string; isWrapped?: boolean; emptyCells?: number }>,
   range: { start: { x: number; y: number }; end: { x: number; y: number } } | null,
-  rawSelection = "",
+  options: {
+    rawSelection?: string;
+    columnSelect?: boolean;
+  } = {},
 ): SelectionTerminal {
-  const bufferLines = lines.map((line) => makeLine(line.text, line.isWrapped ?? false));
+  const bufferLines = lines.map((line) =>
+    makeLine(line.text, { isWrapped: line.isWrapped, emptyCells: line.emptyCells }),
+  );
   return {
-    getSelection: () => rawSelection,
+    getSelection: () => options.rawSelection ?? "",
     getSelectionPosition: () => range,
     buffer: {
       active: {
         getLine: (y) => bufferLines[y],
       },
     },
+    _core: options.columnSelect
+      ? { _selectionService: { _activeSelectionMode: 3 } }
+      : { _selectionService: { _activeSelectionMode: 0 } },
   };
 }
 
-test("joins soft-wrapped rows and trims display padding", () => {
-  // Simulates a soft-wrapped sentence padded to terminal width, then a hard line.
+test("trimWrittenPadding removes written trailing spaces but keeps internal ones", () => {
+  assert.equal(trimWrittenPadding("hello   "), "hello");
+  assert.equal(trimWrittenPadding("  hello  world  "), "  hello  world");
+  assert.equal(trimWrittenPadding("tabs\t\t"), "tabs");
+});
+
+test("joins soft-wrapped rows and strips written display padding", () => {
+  // TUI pads each physical row with real spaces; empty cells alone are not the problem.
   const term = makeTerm(
     [
-      { text: "Pi: use /copy is the most" + "   " },
-      { text: "reliable option          " + "   ", isWrapped: true },
-      { text: "next hard line           " + "   " },
+      { text: "Pi: use /copy is the most   " },
+      { text: "reliable option             ", isWrapped: true },
+      { text: "next hard line              " },
     ],
     { start: { x: 0, y: 0 }, end: { x: 28, y: 2 } },
-    "raw fallback",
   );
 
   assert.equal(
@@ -57,7 +83,7 @@ test("joins soft-wrapped rows and trims display padding", () => {
   );
 });
 
-test("preserves hard line breaks between non-wrapped rows", () => {
+test("preserves hard line breaks between non-wrapped rows while trimming padding", () => {
   const term = makeTerm(
     [
       { text: "line one   " },
@@ -70,6 +96,14 @@ test("preserves hard line breaks between non-wrapped rows", () => {
   assert.equal(getNormalizedTerminalSelection(term), "line one\nline two\nline three");
 });
 
+test("empty-cell trim from xterm still applies before written-space trim", () => {
+  const term = makeTerm(
+    [{ text: "hello", emptyCells: 10 }],
+    { start: { x: 0, y: 0 }, end: { x: 15, y: 0 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "hello");
+});
+
 test("respects partial column selection on first and last rows", () => {
   const term = makeTerm(
     [
@@ -79,13 +113,13 @@ test("respects partial column selection on first and last rows", () => {
     { start: { x: 2, y: 0 }, end: { x: 10, y: 1 } },
   );
 
-  // first row from col 2: "hello worldyy"; last row cols 0..10: "continued "
-  // with trimRight → "continued"
+  // first row from col 2 to line end (multi-row): "hello worldyy"
+  // last row cols 0..10: "continued " → written-space trim → "continued"
   assert.equal(getNormalizedTerminalSelection(term), "hello worldyycontinued");
 });
 
 test("falls back to getSelection when position is unavailable", () => {
-  const term = makeTerm([{ text: "abc" }], null, "fallback text");
+  const term = makeTerm([{ text: "abc" }], null, { rawSelection: "fallback text" });
   assert.equal(getNormalizedTerminalSelection(term), "fallback text");
 });
 
@@ -93,7 +127,6 @@ test("returns empty string for empty range and normalizes inverted ranges", () =
   const empty = makeTerm([{ text: "abc" }], { start: { x: 1, y: 0 }, end: { x: 1, y: 0 } });
   assert.equal(getNormalizedTerminalSelection(empty), "");
 
-  // Inverted (bottom-right → top-left) is rewritten to buffer order.
   const inverted = makeTerm(
     [
       { text: "alpha " },
@@ -116,4 +149,27 @@ test("handles multi-row soft wrap chains", () => {
   );
 
   assert.equal(getNormalizedTerminalSelection(term), "aaabbbccc\nddd");
+});
+
+test("preserves rectangular column selection column bounds on every row", () => {
+  const term = makeTerm(
+    [
+      { text: "abcdefghij" },
+      { text: "0123456789" },
+      { text: "ABCDEFGHIJ" },
+    ],
+    { start: { x: 2, y: 0 }, end: { x: 5, y: 2 } },
+    { columnSelect: true },
+  );
+
+  // Columns 2..5 on each row (not linear first-row-to-end / last-row-from-start).
+  assert.equal(getNormalizedTerminalSelection(term), "cde\n234\nCDE");
+});
+
+test("converts non-breaking spaces to regular spaces", () => {
+  const term = makeTerm(
+    [{ text: "hello\u00a0world  " }],
+    { start: { x: 0, y: 0 }, end: { x: 13, y: 0 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "hello world");
 });

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -137,6 +137,22 @@ test("joinSoftWrappedRows does not invent spaces between CJK characters", () => 
   assert.equal(joinSoftWrappedRows("最   ", "稳"), "最稳");
   // Single pad cell must not bypass the CJK check.
   assert.equal(joinSoftWrappedRows("最 ", "稳"), "最稳");
+  assert.equal(joinSoftWrappedRows("한   ", "글"), "한글");
+  assert.equal(joinSoftWrappedRows("你好。   ", "世界"), "你好。世界");
+});
+
+test("joinSoftWrappedRows keeps a space after sentence-ending punctuation", () => {
+  assert.equal(
+    joinSoftWrappedRows("First sentence.   ", "Next sentence"),
+    "First sentence. Next sentence",
+  );
+});
+
+test("joinSoftWrappedRows only uses the trailing token for URL detection", () => {
+  assert.equal(
+    joinSoftWrappedRows("See https://x.test for more   ", "details"),
+    "See https://x.test for more details",
+  );
 });
 
 test("joinSoftWrappedRows keeps URL tokens intact when split mid-word", () => {

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getNormalizedTerminalSelection,
+  type SelectionBufferLine,
+  type SelectionTerminal,
+} from "./normalizeTerminalSelection.ts";
+
+function makeLine(text: string, isWrapped = false): SelectionBufferLine {
+  return {
+    isWrapped,
+    length: text.length,
+    translateToString(trimRight = false, startColumn = 0, endColumn = text.length) {
+      const start = Math.max(0, startColumn);
+      const end = Math.max(start, Math.min(endColumn, text.length));
+      let slice = text.slice(start, end);
+      if (trimRight) {
+        slice = slice.replace(/\s+$/u, "");
+      }
+      return slice;
+    },
+  };
+}
+
+function makeTerm(
+  lines: Array<{ text: string; isWrapped?: boolean }>,
+  range: { start: { x: number; y: number }; end: { x: number; y: number } } | null,
+  rawSelection = "",
+): SelectionTerminal {
+  const bufferLines = lines.map((line) => makeLine(line.text, line.isWrapped ?? false));
+  return {
+    getSelection: () => rawSelection,
+    getSelectionPosition: () => range,
+    buffer: {
+      active: {
+        getLine: (y) => bufferLines[y],
+      },
+    },
+  };
+}
+
+test("joins soft-wrapped rows and trims display padding", () => {
+  // Simulates a soft-wrapped sentence padded to terminal width, then a hard line.
+  const term = makeTerm(
+    [
+      { text: "Pi: use /copy is the most" + "   " },
+      { text: "reliable option          " + "   ", isWrapped: true },
+      { text: "next hard line           " + "   " },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 28, y: 2 } },
+    "raw fallback",
+  );
+
+  assert.equal(
+    getNormalizedTerminalSelection(term),
+    "Pi: use /copy is the mostreliable option\nnext hard line",
+  );
+});
+
+test("preserves hard line breaks between non-wrapped rows", () => {
+  const term = makeTerm(
+    [
+      { text: "line one   " },
+      { text: "line two   " },
+      { text: "line three " },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 11, y: 2 } },
+  );
+
+  assert.equal(getNormalizedTerminalSelection(term), "line one\nline two\nline three");
+});
+
+test("respects partial column selection on first and last rows", () => {
+  const term = makeTerm(
+    [
+      { text: "xxhello worldyy" },
+      { text: "continued here!", isWrapped: true },
+    ],
+    { start: { x: 2, y: 0 }, end: { x: 10, y: 1 } },
+  );
+
+  // first row from col 2: "hello worldyy"; last row cols 0..10: "continued "
+  // with trimRight → "continued"
+  assert.equal(getNormalizedTerminalSelection(term), "hello worldyycontinued");
+});
+
+test("falls back to getSelection when position is unavailable", () => {
+  const term = makeTerm([{ text: "abc" }], null, "fallback text");
+  assert.equal(getNormalizedTerminalSelection(term), "fallback text");
+});
+
+test("returns empty string for empty range and normalizes inverted ranges", () => {
+  const empty = makeTerm([{ text: "abc" }], { start: { x: 1, y: 0 }, end: { x: 1, y: 0 } });
+  assert.equal(getNormalizedTerminalSelection(empty), "");
+
+  // Inverted (bottom-right → top-left) is rewritten to buffer order.
+  const inverted = makeTerm(
+    [
+      { text: "alpha " },
+      { text: "beta  " },
+    ],
+    { start: { x: 6, y: 1 }, end: { x: 0, y: 0 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(inverted), "alpha\nbeta");
+});
+
+test("handles multi-row soft wrap chains", () => {
+  const term = makeTerm(
+    [
+      { text: "aaa" },
+      { text: "bbb", isWrapped: true },
+      { text: "ccc", isWrapped: true },
+      { text: "ddd" },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 3, y: 3 } },
+  );
+
+  assert.equal(getNormalizedTerminalSelection(term), "aaabbbccc\nddd");
+});

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getNormalizedTerminalSelection,
+  getTerminalSelectionForClipboard,
   joinSoftWrappedRows,
   trimWrittenPadding,
   type SelectionBufferLine,
@@ -285,6 +286,19 @@ test("respects partial column selection on first and last rows", () => {
 test("falls back to getSelection when position is unavailable", () => {
   const term = makeTerm([{ text: "abc" }], null, { rawSelection: "fallback text" });
   assert.equal(getNormalizedTerminalSelection(term), "fallback text");
+});
+
+test("getTerminalSelectionForClipboard respects normalize flag", () => {
+  const term = makeTerm(
+    [
+      { text: "hello   " },
+      { text: "world   ", isWrapped: true },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 8, y: 1 } },
+    { rawSelection: "hello   \nworld   " },
+  );
+  assert.equal(getTerminalSelectionForClipboard(term, true), "hello world");
+  assert.equal(getTerminalSelectionForClipboard(term, false), "hello   \nworld   ");
 });
 
 test("returns empty string for empty range and normalizes inverted ranges", () => {

--- a/components/terminal/normalizeTerminalSelection.test.ts
+++ b/components/terminal/normalizeTerminalSelection.test.ts
@@ -128,9 +128,11 @@ test("joinSoftWrappedRows does not invent spaces before CJK punctuation", () => 
   assert.equal(joinSoftWrappedRows("你好   ", "，世界"), "你好，世界");
 });
 
-test("joinSoftWrappedRows collapses prose padding to one space", () => {
-  assert.equal(joinSoftWrappedRows("shifts   ", "across"), "shifts across");
-  assert.equal(joinSoftWrappedRows("most   ", "reliable"), "most reliable");
+test("joinSoftWrappedRows does not invent spaces for multi-space TUI padding", () => {
+  // Multi-space runs are display padding, not proof of a word boundary.
+  assert.equal(joinSoftWrappedRows("most   ", "reliable"), "mostreliable");
+  assert.equal(joinSoftWrappedRows("someVeryLongIdenti   ", "fier"), "someVeryLongIdentifier");
+  assert.equal(joinSoftWrappedRows("прив   ", "ет"), "привет");
 });
 
 test("joinSoftWrappedRows does not invent spaces between CJK characters", () => {
@@ -149,8 +151,14 @@ test("joinSoftWrappedRows keeps a space after sentence-ending punctuation", () =
 });
 
 test("joinSoftWrappedRows only uses the trailing token for URL detection", () => {
+  // Multi-space padding after a normal word stays tight (not a URL token).
   assert.equal(
     joinSoftWrappedRows("See https://x.test for more   ", "details"),
+    "See https://x.test for moredetails",
+  );
+  // Single trailing space still preserves the word boundary.
+  assert.equal(
+    joinSoftWrappedRows("See https://x.test for more ", "details"),
     "See https://x.test for more details",
   );
 });
@@ -195,7 +203,7 @@ test("preserves partial trailing spaces after wide characters using column ends"
   assert.equal(getNormalizedTerminalSelection(term), "中  ");
 });
 
-test("joins soft-wrapped rows, strips padding, keeps word separators", () => {
+test("joins soft-wrapped rows, strips multi-space padding without inventing separators", () => {
   const term = makeTerm(
     [
       { text: "Pi: use /copy is the most   " },
@@ -207,8 +215,19 @@ test("joins soft-wrapped rows, strips padding, keeps word separators", () => {
 
   assert.equal(
     getNormalizedTerminalSelection(term),
-    "Pi: use /copy is the most reliable option\nnext hard line",
+    "Pi: use /copy is the mostreliable option\nnext hard line",
   );
+});
+
+test("keeps a single trailing space as a word-boundary soft wrap", () => {
+  const term = makeTerm(
+    [
+      { text: "hello " },
+      { text: "world   ", isWrapped: true },
+    ],
+    { start: { x: 0, y: 0 }, end: { x: 8, y: 1 } },
+  );
+  assert.equal(getNormalizedTerminalSelection(term), "hello world");
 });
 
 test("preserves hard line breaks between non-wrapped rows while trimming padding", () => {

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -6,10 +6,10 @@
  * Those written spaces survive copy and corrupt pasted paragraphs/code blocks.
  *
  * This helper rebuilds the selection from buffer coordinates so we can:
- * - strip written trailing padding on each physical row
+ * - strip written trailing padding on completed physical rows
  * - join only rows marked soft-wrapped by xterm
  * - keep genuine hard line breaks
- * - preserve rectangular (column) selections
+ * - preserve rectangular (column) selections and partial end-column spaces
  * - convert non-breaking spaces like xterm's selectionText path
  */
 
@@ -50,6 +50,9 @@ export type SelectionTerminal = {
 /** Matches xterm SelectionMode.COLUMN */
 const SELECTION_MODE_COLUMN = 3;
 const ALL_NON_BREAKING_SPACE_REGEX = /\u00a0/g;
+/** Characters that usually mean the next soft-wrapped row continues the same token. */
+const TOKEN_CONTINUATION_END = new Set("\\/-_.:@?#&=+%".split(""));
+const TOKEN_CONTINUATION_START = new Set("\\/-_.".split(""));
 
 /**
  * Return clipboard-ready text for the current terminal selection.
@@ -96,7 +99,8 @@ function buildColumnSelection(
       rows.push("");
       continue;
     }
-    rows.push(trimWrittenPadding(line.translateToString(true, startCol, endCol)));
+    // Keep right-edge spaces: the user selected those columns on purpose.
+    rows.push(line.translateToString(true, startCol, endCol));
   }
 
   return normalizeClipboardText(rows.join("\n"));
@@ -114,7 +118,7 @@ function buildLinearSelection(
     const line = buffer.getLine(y);
     if (!line) {
       if (current.length > 0 || logicalLines.length > 0) {
-        logicalLines.push(trimWrittenPadding(current));
+        logicalLines.push(trimCompletedRowPadding(current));
         current = "";
       }
       continue;
@@ -124,8 +128,6 @@ function buildLinearSelection(
     // Match xterm: on multi-row selections the first row runs to the line end
     // (undefined endCol → line length), not only to the selection's end.x.
     const endCol = y === end.y ? end.x : undefined;
-    // Keep written trailing spaces on the raw row so soft-wrap joins can tell
-    // word-boundary wraps ("hello " + "world") apart from mid-word wraps.
     const rowText =
       endCol === undefined
         ? line.translateToString(true, startCol)
@@ -141,58 +143,117 @@ function buildLinearSelection(
       continue;
     }
 
-    logicalLines.push(trimWrittenPadding(current));
+    logicalLines.push(trimCompletedRowPadding(current));
     current = rowText;
   }
 
-  logicalLines.push(trimWrittenPadding(current));
+  // Last logical segment: only strip padding when the selection ends at/after
+  // the buffer line's content end (full-row copy). Partial end columns keep
+  // explicitly selected trailing spaces.
+  const lastLine = buffer.getLine(end.y);
+  const selectionEndsAtRowEnd =
+    !lastLine || end.x >= lastLine.length || end.x >= measureContentEnd(lastLine);
+  logicalLines.push(
+    selectionEndsAtRowEnd ? trimCompletedRowPadding(current) : current,
+  );
   return normalizeClipboardText(logicalLines.join("\n"));
 }
 
 /**
  * Join two physical rows that xterm marked as a soft wrap.
  *
- * - Mid-word wrap (no trailing whitespace on previous row): concatenate tightly.
- * - Word-boundary wrap or TUI padding (trailing whitespace): collapse boundary
- *   whitespace to a single separator space, except between CJK characters where
- *   a space must not be invented.
+ * Trailing whitespace on the previous row may be a real word separator (one
+ * space) or TUI display padding (often many spaces). Padding alone is not
+ * treated as proof of a word boundary — token-like continuations (URLs, paths,
+ * CJK) stay tight; only clear prose-style boundaries get a single space.
  */
 export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): string {
-  const left = trimWrittenPadding(previousRaw);
-  const hadTrailingWhitespace = left.length < previousRaw.length;
-
-  if (!hadTrailingWhitespace) {
-    return left + nextRaw;
-  }
+  const trailingWhitespace = countTrailingHorizontalWhitespace(previousRaw);
+  const left = trailingWhitespace > 0 ? previousRaw.slice(0, -trailingWhitespace) : previousRaw;
 
   if (!nextRaw) {
     return left;
   }
 
-  if (/^\s/u.test(nextRaw)) {
-    // Next row already carries leading whitespace; don't double-insert.
+  if (trailingWhitespace === 0) {
     return left + nextRaw;
   }
 
-  if (left.length === 0) {
+  if (/^\s/u.test(nextRaw)) {
+    return left + nextRaw;
+  }
+
+  if (!left) {
     return nextRaw;
   }
 
-  if (endsWithCjk(left) && startsWithCjk(nextRaw)) {
+  // A single trailing space is the common soft-wrap-at-word-boundary case.
+  if (trailingWhitespace === 1) {
+    return `${left} ${nextRaw}`;
+  }
+
+  // Multi-space runs are usually TUI padding. Do not invent a separator when
+  // the next row clearly continues the same token (URL/path/CJK/punctuation).
+  if (isTokenContinuation(left, nextRaw)) {
     return left + nextRaw;
   }
 
+  // Prose-style padding wrap: collapse padding to one space.
   return `${left} ${nextRaw}`;
 }
 
-function endsWithCjk(text: string): boolean {
-  if (!text) return false;
-  return isCjkCodePoint(text.codePointAt(text.length - 1) ?? 0);
+function isTokenContinuation(left: string, next: string): boolean {
+  const leftEnd = lastCodePointChar(left);
+  const nextStart = firstCodePointChar(next);
+  if (!leftEnd || !nextStart) return false;
+
+  if (isCjkCodePoint(leftEnd.codePointAt(0) ?? 0)) {
+    // CJK runs and CJK punctuation should not gain Latin-style spaces.
+    return isCjkCodePoint(nextStart.codePointAt(0) ?? 0) || isCjkPunctuation(nextStart);
+  }
+
+  if (TOKEN_CONTINUATION_END.has(leftEnd)) {
+    return true;
+  }
+
+  if (TOKEN_CONTINUATION_START.has(nextStart) && isAsciiWordChar(leftEnd)) {
+    return true;
+  }
+
+  return false;
 }
 
-function startsWithCjk(text: string): boolean {
-  if (!text) return false;
-  return isCjkCodePoint(text.codePointAt(0) ?? 0);
+function isAsciiWordChar(char: string): boolean {
+  return /^[A-Za-z0-9]$/u.test(char);
+}
+
+function isCjkPunctuation(char: string): boolean {
+  const cp = char.codePointAt(0) ?? 0;
+  // Common fullwidth / CJK punctuation used after ideographs.
+  return (
+    (cp >= 0x3000 && cp <= 0x303f) ||
+    (cp >= 0xff01 && cp <= 0xff60) ||
+    char === "，" ||
+    char === "。" ||
+    char === "、" ||
+    char === "：" ||
+    char === "；" ||
+    char === "！" ||
+    char === "？"
+  );
+}
+
+function firstCodePointChar(text: string): string {
+  if (!text) return "";
+  const cp = text.codePointAt(0);
+  if (cp === undefined) return "";
+  return String.fromCodePoint(cp);
+}
+
+function lastCodePointChar(text: string): string {
+  if (!text) return "";
+  const chars = Array.from(text);
+  return chars[chars.length - 1] ?? "";
 }
 
 function isCjkCodePoint(cp: number): boolean {
@@ -204,12 +265,35 @@ function isCjkCodePoint(cp: number): boolean {
   );
 }
 
+function countTrailingHorizontalWhitespace(text: string): number {
+  let count = 0;
+  for (let i = text.length - 1; i >= 0; i -= 1) {
+    const ch = text[i];
+    if (ch === " " || ch === "\t" || ch === "\f" || ch === "\v") {
+      count += 1;
+      continue;
+    }
+    break;
+  }
+  return count;
+}
+
 /**
  * Strip written display-padding spaces that survive xterm's empty-cell trim.
- * Only trailing whitespace is removed so intentional leading/internal spaces stay.
+ * Only trailing horizontal whitespace is removed.
  */
 export function trimWrittenPadding(text: string): string {
   return text.replace(/[ \t\f\v]+$/u, "");
+}
+
+/** Alias used when a completed physical/hard row may still carry TUI padding. */
+function trimCompletedRowPadding(text: string): string {
+  return trimWrittenPadding(text);
+}
+
+function measureContentEnd(line: SelectionBufferLine): number {
+  // Empty-cell trim length of the full line — selection ending here is "full row".
+  return line.translateToString(true).length;
 }
 
 function normalizeClipboardText(text: string): string {

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -114,7 +114,7 @@ function buildLinearSelection(
     const line = buffer.getLine(y);
     if (!line) {
       if (current.length > 0 || logicalLines.length > 0) {
-        logicalLines.push(current);
+        logicalLines.push(trimWrittenPadding(current));
         current = "";
       }
       continue;
@@ -124,11 +124,12 @@ function buildLinearSelection(
     // Match xterm: on multi-row selections the first row runs to the line end
     // (undefined endCol → line length), not only to the selection's end.x.
     const endCol = y === end.y ? end.x : undefined;
-    const rowText = trimWrittenPadding(
+    // Keep written trailing spaces on the raw row so soft-wrap joins can tell
+    // word-boundary wraps ("hello " + "world") apart from mid-word wraps.
+    const rowText =
       endCol === undefined
         ? line.translateToString(true, startCol)
-        : line.translateToString(true, startCol, endCol),
-    );
+        : line.translateToString(true, startCol, endCol);
 
     if (y === start.y) {
       current = rowText;
@@ -136,17 +137,71 @@ function buildLinearSelection(
     }
 
     if (line.isWrapped) {
-      // Soft wrap: padding was already stripped from the previous physical row.
-      current += rowText;
+      current = joinSoftWrappedRows(current, rowText);
       continue;
     }
 
-    logicalLines.push(current);
+    logicalLines.push(trimWrittenPadding(current));
     current = rowText;
   }
 
-  logicalLines.push(current);
+  logicalLines.push(trimWrittenPadding(current));
   return normalizeClipboardText(logicalLines.join("\n"));
+}
+
+/**
+ * Join two physical rows that xterm marked as a soft wrap.
+ *
+ * - Mid-word wrap (no trailing whitespace on previous row): concatenate tightly.
+ * - Word-boundary wrap or TUI padding (trailing whitespace): collapse boundary
+ *   whitespace to a single separator space, except between CJK characters where
+ *   a space must not be invented.
+ */
+export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): string {
+  const left = trimWrittenPadding(previousRaw);
+  const hadTrailingWhitespace = left.length < previousRaw.length;
+
+  if (!hadTrailingWhitespace) {
+    return left + nextRaw;
+  }
+
+  if (!nextRaw) {
+    return left;
+  }
+
+  if (/^\s/u.test(nextRaw)) {
+    // Next row already carries leading whitespace; don't double-insert.
+    return left + nextRaw;
+  }
+
+  if (left.length === 0) {
+    return nextRaw;
+  }
+
+  if (endsWithCjk(left) && startsWithCjk(nextRaw)) {
+    return left + nextRaw;
+  }
+
+  return `${left} ${nextRaw}`;
+}
+
+function endsWithCjk(text: string): boolean {
+  if (!text) return false;
+  return isCjkCodePoint(text.codePointAt(text.length - 1) ?? 0);
+}
+
+function startsWithCjk(text: string): boolean {
+  if (!text) return false;
+  return isCjkCodePoint(text.codePointAt(0) ?? 0);
+}
+
+function isCjkCodePoint(cp: number): boolean {
+  return (
+    (cp >= 0x3040 && cp <= 0x30ff) || // Hiragana / Katakana
+    (cp >= 0x3400 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xff66 && cp <= 0xff9d) // Half-width Katakana
+  );
 }
 
 /**

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -264,11 +264,25 @@ function isStrongTokenContinuation(left: string, next: string): boolean {
     }
   }
 
-  // URL/path joiners (- _ :) — not "." (sentence end after URL).
+  // URL/path joiners (_ :) — not "." (sentence end after URL).
   if (
     looksLikeUrlOrPath(trailingToken) &&
     isAsciiWordChar(nextStart) &&
-    (leftEnd === "-" || leftEnd === "_" || leftEnd === ":")
+    (leftEnd === "_" || leftEnd === ":")
+  ) {
+    return true;
+  }
+
+  // Hyphenated words: "state-" + "of-the-art".
+  if (leftEnd === "-" && (isAsciiWordChar(nextStart) || nextStart === "-")) {
+    return true;
+  }
+
+  // CLI flags / options split mid-token: "--ver" + "bose".
+  if (
+    trailingToken.startsWith("-") &&
+    isAsciiWordChar(leftEnd) &&
+    isAsciiWordChar(nextStart)
   ) {
     return true;
   }
@@ -398,7 +412,24 @@ export function measureContentEnd(line: SelectionBufferLine): number {
 }
 
 function normalizeClipboardText(text: string): string {
-  return text.replace(ALL_NON_BREAKING_SPACE_REGEX, " ");
+  const normalized = text.replace(ALL_NON_BREAKING_SPACE_REGEX, " ");
+  // Match xterm selectionText: Windows uses CRLF between logical lines.
+  if (isWindowsPlatform() && normalized.includes("\n") && !normalized.includes("\r\n")) {
+    return normalized.replace(/\n/g, "\r\n");
+  }
+  return normalized;
+}
+
+function isWindowsPlatform(): boolean {
+  if (typeof navigator !== "undefined") {
+    const platform = navigator.platform || "";
+    const ua = navigator.userAgent || "";
+    if (/Win/i.test(platform) || /Windows/i.test(ua)) return true;
+  }
+  if (typeof process !== "undefined" && typeof process.platform === "string") {
+    return process.platform === "win32";
+  }
+  return false;
 }
 
 function normalizeSelectionRange(range: SelectionPosition): SelectionPosition {

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -177,12 +177,12 @@ function buildLinearSelection(
 /**
  * Join two physical rows that xterm marked as a soft wrap.
  *
- * Trailing whitespace on the previous row may be a real word separator (one
- * space) or TUI display padding (often many spaces). Multi-space padding alone
- * is never treated as proof of a word boundary — inventing a space would split
- * identifiers, URLs, and non-Latin words. A single trailing space is the common
- * soft-wrap-at-word-boundary case and keeps one separator, except for token
- * continuations (CJK / URL / path) which stay tight.
+ * Trailing whitespace is either a real word separator or TUI display padding.
+ * Policy (tuned for #2162 Pi/TUI prose + common tokens):
+ * - no trailing ws → mid-word auto-wrap, concatenate tightly
+ * - strong token continuation (CJK / path punctuation / URL query) → tight
+ * - multi-space padding on a URL/path mid-token (alnum|alnum) → tight
+ * - otherwise (single or multi-space between ordinary words) → one space
  */
 export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): string {
   const trailingWhitespace = countTrailingHorizontalWhitespace(previousRaw);
@@ -204,26 +204,25 @@ export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): strin
     return nextRaw;
   }
 
-  // Token continuations always join tightly (even with a single pad cell).
-  if (isTokenContinuation(left, nextRaw)) {
+  // Strong continuations (CJK, path/URL punctuation) ignore pad spaces.
+  if (isStrongTokenContinuation(left, nextRaw)) {
     return left + nextRaw;
   }
 
-  // Exactly one trailing space → classic word-boundary soft wrap.
-  if (trailingWhitespace === 1) {
-    return `${left} ${nextRaw}`;
+  // Multi-space padding mid-URL/path (not a word boundary after the token).
+  // A single trailing space after a URL is a real separator ("…com today").
+  if (
+    trailingWhitespace > 1 &&
+    isUrlOrPathMidTokenContinuation(left, nextRaw)
+  ) {
+    return left + nextRaw;
   }
 
-  // Multi-space TUI padding: do not invent separators for mid-token wraps
-  // (identifiers, URLs, non-Latin words). Keep a separator only after clear
-  // sentence-ending punctuation so "…com. Next" stays two sentences.
-  if (/[.!?…]$/u.test(left)) {
-    return `${left} ${nextRaw}`;
-  }
-  return left + nextRaw;
+  // Prose word boundary: single-space wrap or multi-space TUI padding between words.
+  return `${left} ${nextRaw}`;
 }
 
-function isTokenContinuation(left: string, next: string): boolean {
+function isStrongTokenContinuation(left: string, next: string): boolean {
   const leftEnd = lastCodePointChar(left);
   const nextStart = firstCodePointChar(next);
   if (!leftEnd || !nextStart) return false;
@@ -236,7 +235,6 @@ function isTokenContinuation(left: string, next: string): boolean {
     return isCjkRelatedCodePoint(nextStartCp) || isCjkPunctuation(nextStart);
   }
 
-  // Only the token immediately before the wrap (after the last whitespace).
   const trailingToken = getTrailingToken(left);
 
   // Path/URL fragment separators at the end of the trailing token.
@@ -259,24 +257,14 @@ function isTokenContinuation(left: string, next: string): boolean {
     return true;
   }
 
-  // e.g. "foo/" + "bar", or mid-URL when trailing token is URL-like.
+  // e.g. "foo/" + "bar" when trailing token is path/URL-like.
   if (PATH_TOKEN_START.has(nextStart) && (isAsciiWordChar(leftEnd) || "/\\-_:.".includes(leftEnd))) {
     if (looksLikeUrlOrPath(trailingToken) || leftEnd === "/" || leftEnd === "\\") {
       return true;
     }
   }
 
-  // URL/path split mid-token between alphanumerics (common at terminal width).
-  if (
-    isAsciiWordChar(leftEnd) &&
-    isAsciiWordChar(nextStart) &&
-    looksLikeUrlOrPath(trailingToken)
-  ) {
-    return true;
-  }
-
-  // Trailing token ends with URL-ish joiners (- _ :) and next continues the token.
-  // Do not include "." here: "https://example.com." + "Next" is a sentence break.
+  // URL/path joiners (- _ :) — not "." (sentence end after URL).
   if (
     looksLikeUrlOrPath(trailingToken) &&
     isAsciiWordChar(nextStart) &&
@@ -286,6 +274,15 @@ function isTokenContinuation(left: string, next: string): boolean {
   }
 
   return false;
+}
+
+/** Mid-token URL/path split between alphanumerics (multi-space pad only). */
+function isUrlOrPathMidTokenContinuation(left: string, next: string): boolean {
+  const leftEnd = lastCodePointChar(left);
+  const nextStart = firstCodePointChar(next);
+  if (!leftEnd || !nextStart) return false;
+  if (!isAsciiWordChar(leftEnd) || !isAsciiWordChar(nextStart)) return false;
+  return looksLikeUrlOrPath(getTrailingToken(left));
 }
 
 function getTrailingToken(text: string): string {

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -234,8 +234,23 @@ function isTokenContinuation(left: string, next: string): boolean {
     return true;
   }
 
-  // e.g. "foo/" + "bar", or mid-URL "com." + "path" when trailing token is URL-like.
-  if (PATH_TOKEN_START.has(nextStart) && (isAsciiWordChar(leftEnd) || "/-_:.".includes(leftEnd))) {
+  // Query/fragment delimiters after a URL/path token.
+  if (
+    looksLikeUrlOrPath(trailingToken) &&
+    (nextStart === "?" || nextStart === "#" || nextStart === "&")
+  ) {
+    return true;
+  }
+  if (
+    looksLikeUrlOrPath(trailingToken) &&
+    (leftEnd === "?" || leftEnd === "#" || leftEnd === "&") &&
+    (isAsciiWordChar(nextStart) || nextStart === "=" || nextStart === "-" || nextStart === "_")
+  ) {
+    return true;
+  }
+
+  // e.g. "foo/" + "bar", or mid-URL when trailing token is URL-like.
+  if (PATH_TOKEN_START.has(nextStart) && (isAsciiWordChar(leftEnd) || "/\\-_:.".includes(leftEnd))) {
     if (looksLikeUrlOrPath(trailingToken) || leftEnd === "/" || leftEnd === "\\") {
       return true;
     }
@@ -250,11 +265,12 @@ function isTokenContinuation(left: string, next: string): boolean {
     return true;
   }
 
-  // Trailing token ends with URL-ish punctuation and next continues the token.
+  // Trailing token ends with URL-ish joiners (- _ :) and next continues the token.
+  // Do not include "." here: "https://example.com." + "Next" is a sentence break.
   if (
     looksLikeUrlOrPath(trailingToken) &&
     isAsciiWordChar(nextStart) &&
-    (leftEnd === "." || leftEnd === "-" || leftEnd === "_" || leftEnd === ":")
+    (leftEnd === "-" || leftEnd === "_" || leftEnd === ":")
   ) {
     return true;
   }
@@ -274,6 +290,10 @@ function looksLikeUrlOrPath(token: string): boolean {
   // Absolute or deep relative paths: /usr/local/... or foo/bar/baz
   if (token.startsWith("/") || token.startsWith("./") || token.startsWith("../")) return true;
   if ((token.match(/\//g) ?? []).length >= 1 && /[A-Za-z0-9]/u.test(token)) return true;
+  // Windows / UNC paths: C:\Users\... or \\server\share
+  if (/^[A-Za-z]:[\\/]/u.test(token)) return true;
+  if (token.startsWith("\\\\")) return true;
+  if ((token.match(/\\/g) ?? []).length >= 1 && /[A-Za-z0-9]/u.test(token)) return true;
   return false;
 }
 

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -13,14 +13,20 @@
  * - convert non-breaking spaces like xterm's selectionText path
  */
 
+export type SelectionBufferCell = {
+  getChars?: () => string;
+  getCode?: () => number;
+  getWidth?: () => number;
+};
+
 export type SelectionBufferLine = {
   isWrapped?: boolean;
   length: number;
   /**
-   * xterm: column index after the last non-empty cell (terminal columns, not
-   * UTF-16 length). Used to decide whether a selection ends at the row edge.
+   * Public xterm API — preferred for column-accurate content-end measurement
+   * (wide characters, empty cells).
    */
-  getTrimmedLength?: () => number;
+  getCell?: (x: number, cell?: SelectionBufferCell) => SelectionBufferCell | undefined;
   /**
    * xterm semantics: trimRight only drops empty cells (getTrimmedLength),
    * not written ASCII spaces used as display padding.
@@ -306,11 +312,23 @@ function trimCompletedRowPadding(text: string): string {
   return trimWrittenPadding(text);
 }
 
-function measureContentEnd(line: SelectionBufferLine): number {
-  // Prefer xterm's column-based trimmed length so wide/combining characters
-  // don't make string.length disagree with selection end.x (also columns).
-  if (typeof line.getTrimmedLength === "function") {
-    return line.getTrimmedLength();
+/**
+ * Column after the last non-empty cell on the line (public xterm cell widths).
+ * Falls back to string length only when getCell is unavailable (tests/fakes).
+ */
+export function measureContentEnd(line: SelectionBufferLine): number {
+  if (typeof line.getCell === "function") {
+    for (let x = line.length - 1; x >= 0; x -= 1) {
+      const cell = line.getCell(x);
+      if (!cell) continue;
+      const chars = cell.getChars?.() ?? "";
+      const code = cell.getCode?.() ?? 0;
+      if (chars.length > 0 || code !== 0) {
+        const width = cell.getWidth?.() ?? 1;
+        return x + Math.max(1, width);
+      }
+    }
+    return 0;
   }
   return line.translateToString(true).length;
 }

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -204,17 +204,10 @@ export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): strin
     return nextRaw;
   }
 
-  // Strong continuations (CJK, path/URL punctuation) ignore pad spaces.
+  // Strong continuations (CJK, path/URL punctuation, trailing hyphen) ignore pad
+  // spaces. Deliberately do NOT treat "complete URL/flag + padding + next word"
+  // as a mid-token join — multi-space pad after a finished token is a word boundary.
   if (isStrongTokenContinuation(left, nextRaw)) {
-    return left + nextRaw;
-  }
-
-  // Multi-space padding mid-URL/path (not a word boundary after the token).
-  // A single trailing space after a URL is a real separator ("…com today").
-  if (
-    trailingWhitespace > 1 &&
-    isUrlOrPathMidTokenContinuation(left, nextRaw)
-  ) {
     return left + nextRaw;
   }
 
@@ -273,30 +266,13 @@ function isStrongTokenContinuation(left: string, next: string): boolean {
     return true;
   }
 
-  // Hyphenated words: "state-" + "of-the-art".
+  // Hyphenated words at the hyphen: "state-" + "of-the-art".
+  // Do not join complete flags like "--verbose" + "to" (left ends with a letter).
   if (leftEnd === "-" && (isAsciiWordChar(nextStart) || nextStart === "-")) {
     return true;
   }
 
-  // CLI flags / options split mid-token: "--ver" + "bose".
-  if (
-    trailingToken.startsWith("-") &&
-    isAsciiWordChar(leftEnd) &&
-    isAsciiWordChar(nextStart)
-  ) {
-    return true;
-  }
-
   return false;
-}
-
-/** Mid-token URL/path split between alphanumerics (multi-space pad only). */
-function isUrlOrPathMidTokenContinuation(left: string, next: string): boolean {
-  const leftEnd = lastCodePointChar(left);
-  const nextStart = firstCodePointChar(next);
-  if (!leftEnd || !nextStart) return false;
-  if (!isAsciiWordChar(leftEnd) || !isAsciiWordChar(nextStart)) return false;
-  return looksLikeUrlOrPath(getTrailingToken(left));
 }
 
 function getTrailingToken(text: string): string {

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -1,16 +1,25 @@
 /**
- * Normalize an xterm selection into logical text for the clipboard.
+ * Normalize an xterm selection into clipboard-ready logical text.
  *
- * xterm's getSelection() joins every physical buffer row with a hard newline,
- * so soft-wrapped rows (isWrapped) become real line breaks and display-padding
- * spaces on each row can survive as trailing whitespace. This helper rebuilds
- * the selection from buffer coordinates: trim row padding, join soft wraps,
- * and preserve genuine hard line breaks.
+ * xterm's getSelection() already joins soft-wrapped rows (isWrapped) and trims
+ * *empty* buffer cells, but TUI apps often pad rows with real space characters.
+ * Those written spaces survive copy and corrupt pasted paragraphs/code blocks.
+ *
+ * This helper rebuilds the selection from buffer coordinates so we can:
+ * - strip written trailing padding on each physical row
+ * - join only rows marked soft-wrapped by xterm
+ * - keep genuine hard line breaks
+ * - preserve rectangular (column) selections
+ * - convert non-breaking spaces like xterm's selectionText path
  */
 
 export type SelectionBufferLine = {
   isWrapped?: boolean;
   length: number;
+  /**
+   * xterm semantics: trimRight only drops empty cells (getTrimmedLength),
+   * not written ASCII spaces used as display padding.
+   */
   translateToString(trimRight?: boolean, startColumn?: number, endColumn?: number): string;
 };
 
@@ -29,7 +38,18 @@ export type SelectionTerminal = {
   buffer: {
     active: SelectionBuffer;
   };
+  /** Present on real xterm Terminal instances; used only to detect column select. */
+  _core?: {
+    _selectionService?: {
+      /** xterm SelectionMode: NORMAL=0, WORD=1, LINE=2, COLUMN=3 */
+      _activeSelectionMode?: number;
+    };
+  };
 };
+
+/** Matches xterm SelectionMode.COLUMN */
+const SELECTION_MODE_COLUMN = 3;
+const ALL_NON_BREAKING_SPACE_REGEX = /\u00a0/g;
 
 /**
  * Return clipboard-ready text for the current terminal selection.
@@ -38,7 +58,7 @@ export type SelectionTerminal = {
 export function getNormalizedTerminalSelection(term: SelectionTerminal): string {
   const range = term.getSelectionPosition?.() ?? null;
   if (!range) {
-    return term.getSelection?.() ?? "";
+    return normalizeClipboardText(term.getSelection?.() ?? "");
   }
 
   const { start, end } = normalizeSelectionRange(range);
@@ -46,7 +66,47 @@ export function getNormalizedTerminalSelection(term: SelectionTerminal): string 
     return "";
   }
 
-  const buffer = term.buffer.active;
+  if (isColumnSelectionMode(term)) {
+    return buildColumnSelection(term.buffer.active, start, end);
+  }
+
+  return buildLinearSelection(term.buffer.active, start, end);
+}
+
+function isColumnSelectionMode(term: SelectionTerminal): boolean {
+  return term._core?._selectionService?._activeSelectionMode === SELECTION_MODE_COLUMN;
+}
+
+function buildColumnSelection(
+  buffer: SelectionBuffer,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): string {
+  if (start.x === end.x) {
+    return "";
+  }
+
+  const startCol = Math.min(start.x, end.x);
+  const endCol = Math.max(start.x, end.x);
+  const rows: string[] = [];
+
+  for (let y = start.y; y <= end.y; y += 1) {
+    const line = buffer.getLine(y);
+    if (!line) {
+      rows.push("");
+      continue;
+    }
+    rows.push(trimWrittenPadding(line.translateToString(true, startCol, endCol)));
+  }
+
+  return normalizeClipboardText(rows.join("\n"));
+}
+
+function buildLinearSelection(
+  buffer: SelectionBuffer,
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): string {
   const logicalLines: string[] = [];
   let current = "";
 
@@ -61,11 +121,14 @@ export function getNormalizedTerminalSelection(term: SelectionTerminal): string 
     }
 
     const startCol = y === start.y ? start.x : 0;
-    const endCol = y === end.y ? end.x : Math.max(line.length, startCol);
-    // Always trim display-padding trailing spaces within the selected columns.
-    // Soft-wrapped continuation rows (isWrapped) are concatenated without a
-    // newline so visual wraps do not become hard breaks in the clipboard.
-    const rowText = line.translateToString(true, startCol, endCol);
+    // Match xterm: on multi-row selections the first row runs to the line end
+    // (undefined endCol → line length), not only to the selection's end.x.
+    const endCol = y === end.y ? end.x : undefined;
+    const rowText = trimWrittenPadding(
+      endCol === undefined
+        ? line.translateToString(true, startCol)
+        : line.translateToString(true, startCol, endCol),
+    );
 
     if (y === start.y) {
       current = rowText;
@@ -73,6 +136,7 @@ export function getNormalizedTerminalSelection(term: SelectionTerminal): string 
     }
 
     if (line.isWrapped) {
+      // Soft wrap: padding was already stripped from the previous physical row.
       current += rowText;
       continue;
     }
@@ -82,7 +146,19 @@ export function getNormalizedTerminalSelection(term: SelectionTerminal): string 
   }
 
   logicalLines.push(current);
-  return logicalLines.join("\n");
+  return normalizeClipboardText(logicalLines.join("\n"));
+}
+
+/**
+ * Strip written display-padding spaces that survive xterm's empty-cell trim.
+ * Only trailing whitespace is removed so intentional leading/internal spaces stay.
+ */
+export function trimWrittenPadding(text: string): string {
+  return text.replace(/[ \t\f\v]+$/u, "");
+}
+
+function normalizeClipboardText(text: string): string {
+  return text.replace(ALL_NON_BREAKING_SPACE_REGEX, " ");
 }
 
 function normalizeSelectionRange(range: SelectionPosition): SelectionPosition {
@@ -93,7 +169,6 @@ function normalizeSelectionRange(range: SelectionPosition): SelectionPosition {
       end: { x: Math.max(0, end.x), y: end.y },
     };
   }
-  // Defensive: some selection APIs can return an inverted range.
   return {
     start: { x: Math.max(0, end.x), y: end.y },
     end: { x: Math.max(0, start.x), y: start.y },

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -1,0 +1,101 @@
+/**
+ * Normalize an xterm selection into logical text for the clipboard.
+ *
+ * xterm's getSelection() joins every physical buffer row with a hard newline,
+ * so soft-wrapped rows (isWrapped) become real line breaks and display-padding
+ * spaces on each row can survive as trailing whitespace. This helper rebuilds
+ * the selection from buffer coordinates: trim row padding, join soft wraps,
+ * and preserve genuine hard line breaks.
+ */
+
+export type SelectionBufferLine = {
+  isWrapped?: boolean;
+  length: number;
+  translateToString(trimRight?: boolean, startColumn?: number, endColumn?: number): string;
+};
+
+export type SelectionBuffer = {
+  getLine(y: number): SelectionBufferLine | undefined;
+};
+
+export type SelectionPosition = {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+};
+
+export type SelectionTerminal = {
+  getSelection?: () => string;
+  getSelectionPosition?: () => SelectionPosition | undefined | null;
+  buffer: {
+    active: SelectionBuffer;
+  };
+};
+
+/**
+ * Return clipboard-ready text for the current terminal selection.
+ * Falls back to term.getSelection() when position/buffer APIs are unavailable.
+ */
+export function getNormalizedTerminalSelection(term: SelectionTerminal): string {
+  const range = term.getSelectionPosition?.() ?? null;
+  if (!range) {
+    return term.getSelection?.() ?? "";
+  }
+
+  const { start, end } = normalizeSelectionRange(range);
+  if (end.y < start.y) {
+    return "";
+  }
+
+  const buffer = term.buffer.active;
+  const logicalLines: string[] = [];
+  let current = "";
+
+  for (let y = start.y; y <= end.y; y += 1) {
+    const line = buffer.getLine(y);
+    if (!line) {
+      if (current.length > 0 || logicalLines.length > 0) {
+        logicalLines.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    const startCol = y === start.y ? start.x : 0;
+    const endCol = y === end.y ? end.x : Math.max(line.length, startCol);
+    // Always trim display-padding trailing spaces within the selected columns.
+    // Soft-wrapped continuation rows (isWrapped) are concatenated without a
+    // newline so visual wraps do not become hard breaks in the clipboard.
+    const rowText = line.translateToString(true, startCol, endCol);
+
+    if (y === start.y) {
+      current = rowText;
+      continue;
+    }
+
+    if (line.isWrapped) {
+      current += rowText;
+      continue;
+    }
+
+    logicalLines.push(current);
+    current = rowText;
+  }
+
+  logicalLines.push(current);
+  return logicalLines.join("\n");
+}
+
+function normalizeSelectionRange(range: SelectionPosition): SelectionPosition {
+  const { start, end } = range;
+  if (start.y < end.y || (start.y === end.y && start.x <= end.x)) {
+    return {
+      start: { x: Math.max(0, start.x), y: start.y },
+      end: { x: Math.max(0, end.x), y: end.y },
+    };
+  }
+  // Defensive: some selection APIs can return an inverted range.
+  return {
+    start: { x: Math.max(0, end.x), y: end.y },
+    end: { x: Math.max(0, start.x), y: start.y },
+  };
+}

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -17,6 +17,11 @@ export type SelectionBufferLine = {
   isWrapped?: boolean;
   length: number;
   /**
+   * xterm: column index after the last non-empty cell (terminal columns, not
+   * UTF-16 length). Used to decide whether a selection ends at the row edge.
+   */
+  getTrimmedLength?: () => number;
+  /**
    * xterm semantics: trimRight only drops empty cells (getTrimmedLength),
    * not written ASCII spaces used as display padding.
    */
@@ -187,18 +192,14 @@ export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): strin
     return nextRaw;
   }
 
-  // A single trailing space is the common soft-wrap-at-word-boundary case.
-  if (trailingWhitespace === 1) {
-    return `${left} ${nextRaw}`;
-  }
-
-  // Multi-space runs are usually TUI padding. Do not invent a separator when
-  // the next row clearly continues the same token (URL/path/CJK/punctuation).
+  // Token continuations (CJK, URL/path, boundary punctuation) always join
+  // tightly — even when the previous row had exactly one trailing pad cell.
   if (isTokenContinuation(left, nextRaw)) {
     return left + nextRaw;
   }
 
-  // Prose-style padding wrap: collapse padding to one space.
+  // A single trailing space is the common soft-wrap-at-word-boundary case.
+  // Multi-space runs are usually TUI padding collapsed to one prose separator.
   return `${left} ${nextRaw}`;
 }
 
@@ -220,6 +221,20 @@ function isTokenContinuation(left: string, next: string): boolean {
     return true;
   }
 
+  // URL/path split mid-token between alphanumerics (common at terminal width).
+  if (isAsciiWordChar(leftEnd) && isAsciiWordChar(nextStart) && looksLikeUrlOrPath(left)) {
+    return true;
+  }
+
+  return false;
+}
+
+function looksLikeUrlOrPath(text: string): boolean {
+  if (/[a-z][a-z0-9+.-]*:\/\//i.test(text)) return true;
+  if (text.includes("www.")) return true;
+  // Absolute or deep relative paths: /usr/local/... or foo/bar/baz
+  if (text.startsWith("/") || text.startsWith("./") || text.startsWith("../")) return true;
+  if ((text.match(/\//g) ?? []).length >= 2) return true;
   return false;
 }
 
@@ -292,7 +307,11 @@ function trimCompletedRowPadding(text: string): string {
 }
 
 function measureContentEnd(line: SelectionBufferLine): number {
-  // Empty-cell trim length of the full line — selection ending here is "full row".
+  // Prefer xterm's column-based trimmed length so wide/combining characters
+  // don't make string.length disagree with selection end.x (also columns).
+  if (typeof line.getTrimmedLength === "function") {
+    return line.getTrimmedLength();
+  }
   return line.translateToString(true).length;
 }
 

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -61,9 +61,13 @@ export type SelectionTerminal = {
 /** Matches xterm SelectionMode.COLUMN */
 const SELECTION_MODE_COLUMN = 3;
 const ALL_NON_BREAKING_SPACE_REGEX = /\u00a0/g;
-/** Characters that usually mean the next soft-wrapped row continues the same token. */
-const TOKEN_CONTINUATION_END = new Set("\\/-_.:@?#&=+%".split(""));
-const TOKEN_CONTINUATION_START = new Set("\\/-_.".split(""));
+/**
+ * Characters that strongly mean the next soft-wrapped row continues the same
+ * token (path/URL fragment). Sentence punctuation like `.` `?` `:` is NOT
+ * included here — those need surrounding URL/path context.
+ */
+const PATH_TOKEN_END = new Set("\\/@#&=+%".split(""));
+const PATH_TOKEN_START = new Set("\\/-_.".split(""));
 
 /**
  * Return clipboard-ready text for the current terminal selection.
@@ -214,33 +218,62 @@ function isTokenContinuation(left: string, next: string): boolean {
   const nextStart = firstCodePointChar(next);
   if (!leftEnd || !nextStart) return false;
 
-  if (isCjkCodePoint(leftEnd.codePointAt(0) ?? 0)) {
-    // CJK runs and CJK punctuation should not gain Latin-style spaces.
-    return isCjkCodePoint(nextStart.codePointAt(0) ?? 0) || isCjkPunctuation(nextStart);
+  const leftEndCp = leftEnd.codePointAt(0) ?? 0;
+  const nextStartCp = nextStart.codePointAt(0) ?? 0;
+
+  // CJK / Hangul runs and CJK punctuation should not gain Latin-style spaces.
+  if (isCjkRelatedCodePoint(leftEndCp) || isCjkPunctuation(leftEnd)) {
+    return isCjkRelatedCodePoint(nextStartCp) || isCjkPunctuation(nextStart);
   }
 
-  if (TOKEN_CONTINUATION_END.has(leftEnd)) {
+  // Only the token immediately before the wrap (after the last whitespace).
+  const trailingToken = getTrailingToken(left);
+
+  // Path/URL fragment separators at the end of the trailing token.
+  if (PATH_TOKEN_END.has(leftEnd) && looksLikeUrlOrPath(trailingToken)) {
     return true;
   }
 
-  if (TOKEN_CONTINUATION_START.has(nextStart) && isAsciiWordChar(leftEnd)) {
-    return true;
+  // e.g. "foo/" + "bar", or mid-URL "com." + "path" when trailing token is URL-like.
+  if (PATH_TOKEN_START.has(nextStart) && (isAsciiWordChar(leftEnd) || "/-_:.".includes(leftEnd))) {
+    if (looksLikeUrlOrPath(trailingToken) || leftEnd === "/" || leftEnd === "\\") {
+      return true;
+    }
   }
 
   // URL/path split mid-token between alphanumerics (common at terminal width).
-  if (isAsciiWordChar(leftEnd) && isAsciiWordChar(nextStart) && looksLikeUrlOrPath(left)) {
+  if (
+    isAsciiWordChar(leftEnd) &&
+    isAsciiWordChar(nextStart) &&
+    looksLikeUrlOrPath(trailingToken)
+  ) {
+    return true;
+  }
+
+  // Trailing token ends with URL-ish punctuation and next continues the token.
+  if (
+    looksLikeUrlOrPath(trailingToken) &&
+    isAsciiWordChar(nextStart) &&
+    (leftEnd === "." || leftEnd === "-" || leftEnd === "_" || leftEnd === ":")
+  ) {
     return true;
   }
 
   return false;
 }
 
-function looksLikeUrlOrPath(text: string): boolean {
-  if (/[a-z][a-z0-9+.-]*:\/\//i.test(text)) return true;
-  if (text.includes("www.")) return true;
+function getTrailingToken(text: string): string {
+  const match = text.match(/(\S+)$/u);
+  return match?.[1] ?? text;
+}
+
+function looksLikeUrlOrPath(token: string): boolean {
+  if (!token) return false;
+  if (/[a-z][a-z0-9+.-]*:\/\//i.test(token)) return true;
+  if (token.includes("www.")) return true;
   // Absolute or deep relative paths: /usr/local/... or foo/bar/baz
-  if (text.startsWith("/") || text.startsWith("./") || text.startsWith("../")) return true;
-  if ((text.match(/\//g) ?? []).length >= 2) return true;
+  if (token.startsWith("/") || token.startsWith("./") || token.startsWith("../")) return true;
+  if ((token.match(/\//g) ?? []).length >= 1 && /[A-Za-z0-9]/u.test(token)) return true;
   return false;
 }
 
@@ -277,12 +310,16 @@ function lastCodePointChar(text: string): string {
   return chars[chars.length - 1] ?? "";
 }
 
-function isCjkCodePoint(cp: number): boolean {
+function isCjkRelatedCodePoint(cp: number): boolean {
   return (
+    (cp >= 0x1100 && cp <= 0x11ff) || // Hangul Jamo
     (cp >= 0x3040 && cp <= 0x30ff) || // Hiragana / Katakana
+    (cp >= 0x3130 && cp <= 0x318f) || // Hangul Compatibility Jamo
     (cp >= 0x3400 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xac00 && cp <= 0xd7af) || // Hangul Syllables
     (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
-    (cp >= 0xff66 && cp <= 0xff9d) // Half-width Katakana
+    (cp >= 0xff66 && cp <= 0xff9d) || // Half-width Katakana
+    (cp >= 0x20000 && cp <= 0x2ceaf) // CJK Extension B–F (supplementary planes)
   );
 }
 

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -70,6 +70,21 @@ const PATH_TOKEN_END = new Set("\\/@#&=+%".split(""));
 const PATH_TOKEN_START = new Set("\\/-_.".split(""));
 
 /**
+ * Selection text for clipboard / paste-selection / AI attach.
+ * When `normalize` is false, returns raw xterm getSelection() (screen cells).
+ * When true (default), strips display padding and joins soft wraps.
+ */
+export function getTerminalSelectionForClipboard(
+  term: SelectionTerminal,
+  normalize = true,
+): string {
+  if (!normalize) {
+    return term.getSelection?.() ?? "";
+  }
+  return getNormalizedTerminalSelection(term);
+}
+
+/**
  * Return clipboard-ready text for the current terminal selection.
  * Falls back to term.getSelection() when position/buffer APIs are unavailable.
  */

--- a/components/terminal/normalizeTerminalSelection.ts
+++ b/components/terminal/normalizeTerminalSelection.ts
@@ -178,9 +178,11 @@ function buildLinearSelection(
  * Join two physical rows that xterm marked as a soft wrap.
  *
  * Trailing whitespace on the previous row may be a real word separator (one
- * space) or TUI display padding (often many spaces). Padding alone is not
- * treated as proof of a word boundary — token-like continuations (URLs, paths,
- * CJK) stay tight; only clear prose-style boundaries get a single space.
+ * space) or TUI display padding (often many spaces). Multi-space padding alone
+ * is never treated as proof of a word boundary — inventing a space would split
+ * identifiers, URLs, and non-Latin words. A single trailing space is the common
+ * soft-wrap-at-word-boundary case and keeps one separator, except for token
+ * continuations (CJK / URL / path) which stay tight.
  */
 export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): string {
   const trailingWhitespace = countTrailingHorizontalWhitespace(previousRaw);
@@ -202,15 +204,23 @@ export function joinSoftWrappedRows(previousRaw: string, nextRaw: string): strin
     return nextRaw;
   }
 
-  // Token continuations (CJK, URL/path, boundary punctuation) always join
-  // tightly — even when the previous row had exactly one trailing pad cell.
+  // Token continuations always join tightly (even with a single pad cell).
   if (isTokenContinuation(left, nextRaw)) {
     return left + nextRaw;
   }
 
-  // A single trailing space is the common soft-wrap-at-word-boundary case.
-  // Multi-space runs are usually TUI padding collapsed to one prose separator.
-  return `${left} ${nextRaw}`;
+  // Exactly one trailing space → classic word-boundary soft wrap.
+  if (trailingWhitespace === 1) {
+    return `${left} ${nextRaw}`;
+  }
+
+  // Multi-space TUI padding: do not invent separators for mid-token wraps
+  // (identifiers, URLs, non-Latin words). Keep a separator only after clear
+  // sentence-ending punctuation so "…com. Next" stays two sentences.
+  if (/[.!?…]$/u.test(left)) {
+    return `${left} ${nextRaw}`;
+  }
+  return left + nextRaw;
 }
 
 function isTokenContinuation(left: string, next: string): boolean {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -461,6 +461,24 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
 
   term.open(ctx.container);
 
+  // Intercept native copy (Edit > Copy, browser/Electron copy event) before
+  // xterm's built-in handler writes the unnormalized selectionText.
+  const handleNativeCopy = (event: ClipboardEvent) => {
+    if (!term.hasSelection()) return;
+    const selection = getNormalizedTerminalSelection(term);
+    if (!selection) return;
+    if (event.clipboardData) {
+      event.clipboardData.setData("text/plain", selection);
+    } else {
+      void navigator.clipboard.writeText(selection).catch((err) => {
+        logger.warn("[XTerm] Normalized native copy failed:", err);
+      });
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+  term.element?.addEventListener("copy", handleNativeCopy, true);
+
   let webglAddon: WebglAddon | null = null;
   let webglLoaded = false;
   const scopedWindow = window as Window & {
@@ -1418,6 +1436,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     ensureWebglRenderer: loadWebglRenderer,
     suspendWebglRenderer,
     dispose: () => {
+      term.element?.removeEventListener("copy", handleNativeCopy, true);
       ctx.container.removeEventListener(
         "wheel",
         handleForcedHistoryScrollWheel,

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -38,6 +38,7 @@ import {
   clearTerminalViewport,
   installEraseInDisplayHandlers,
 } from "../clearTerminalViewport";
+import { getNormalizedTerminalSelection } from "../normalizeTerminalSelection";
 import {
   createKittyKeyboardModeState,
   encodeKittyControlKey,
@@ -1078,7 +1079,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           e.stopPropagation();
           switch (action) {
             case "copy": {
-              const selection = term.getSelection();
+              const selection = getNormalizedTerminalSelection(term);
               if (selection) navigator.clipboard.writeText(selection);
               break;
             }
@@ -1095,7 +1096,7 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "pasteSelection": {
-              const selection = term.getSelection();
+              const selection = getNormalizedTerminalSelection(term);
               const id = ctx.sessionRef.current;
               if (selection && id) {
                 pasteTextIntoTerminal(term, selection, {

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -38,7 +38,7 @@ import {
   clearTerminalViewport,
   installEraseInDisplayHandlers,
 } from "../clearTerminalViewport";
-import { getNormalizedTerminalSelection } from "../normalizeTerminalSelection";
+import { getTerminalSelectionForClipboard } from "../normalizeTerminalSelection";
 import {
   createKittyKeyboardModeState,
   encodeKittyControlKey,
@@ -462,10 +462,12 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
   term.open(ctx.container);
 
   // Intercept native copy (Edit > Copy, browser/Electron copy event) before
-  // xterm's built-in handler writes the unnormalized selectionText.
+  // xterm's built-in handler writes selectionText, so normalizeTextOnCopy applies.
   const handleNativeCopy = (event: ClipboardEvent) => {
     if (!term.hasSelection()) return;
-    const selection = getNormalizedTerminalSelection(term);
+    const normalize = ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true;
+    if (!normalize) return; // let xterm write raw selectionText
+    const selection = getTerminalSelectionForClipboard(term, true);
     if (!selection) return;
     if (event.clipboardData) {
       event.clipboardData.setData("text/plain", selection);
@@ -1097,7 +1099,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
           e.stopPropagation();
           switch (action) {
             case "copy": {
-              const selection = getNormalizedTerminalSelection(term);
+              const selection = getTerminalSelectionForClipboard(
+                term,
+                ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true,
+              );
               if (selection) navigator.clipboard.writeText(selection);
               break;
             }
@@ -1114,7 +1119,10 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
               break;
             }
             case "pasteSelection": {
-              const selection = getNormalizedTerminalSelection(term);
+              const selection = getTerminalSelectionForClipboard(
+                term,
+                ctx.terminalSettingsRef.current?.normalizeTextOnCopy ?? true,
+              );
               const id = ctx.sessionRef.current;
               if (selection && id) {
                 pasteTextIntoTerminal(term, selection, {

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -1310,9 +1310,11 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       scheduleSelectionOverlayPosition();
 
       if (hasText && terminalSettings?.copyOnSelect && !isRestoringSelectionRef.current) {
+        // Capture now so a later buffer redraw during the debounce cannot
+        // change what gets copied (selection-change may not fire again).
+        const selection = getNormalizedTerminalSelection(term);
+        if (!selection) return;
         copyTimer = setTimeout(() => {
-          const selection = getNormalizedTerminalSelection(term);
-          if (!selection) return;
           navigator.clipboard.writeText(selection).catch((err) => {
             logger.warn("Copy on select failed:", err);
           });

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -20,6 +20,7 @@ import {
   resolveTerminalHibernateEnabled,
 } from '../../domain/terminalHibernate';
 import { applyUserCursorBlinkPreference } from './runtime/cursorPreference';
+import { getNormalizedTerminalSelection } from './normalizeTerminalSelection';
 import { getFlowControllerForTerm } from './runtime/terminalSessionAttachment';
 import {
   prioritizeTerminalInput,
@@ -1287,8 +1288,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
     };
 
     const onSelectionChange = () => {
-      const selection = term.getSelection();
-      const hasText = !!selection && selection.length > 0;
+      // hasSelection uses raw getSelection for cheap emptiness checks; the
+      // clipboard write path normalizes soft wraps + display padding.
+      const rawSelection = term.getSelection();
+      const hasText = !!rawSelection && rawSelection.length > 0;
       if (lastHasSelection !== hasText) {
         lastHasSelection = hasText;
         setHasSelection(hasText);
@@ -1308,6 +1311,8 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
 
       if (hasText && terminalSettings?.copyOnSelect && !isRestoringSelectionRef.current) {
         copyTimer = setTimeout(() => {
+          const selection = getNormalizedTerminalSelection(term);
+          if (!selection) return;
           navigator.clipboard.writeText(selection).catch((err) => {
             logger.warn("Copy on select failed:", err);
           });

--- a/components/terminal/useTerminalEffects.ts
+++ b/components/terminal/useTerminalEffects.ts
@@ -20,7 +20,7 @@ import {
   resolveTerminalHibernateEnabled,
 } from '../../domain/terminalHibernate';
 import { applyUserCursorBlinkPreference } from './runtime/cursorPreference';
-import { getNormalizedTerminalSelection } from './normalizeTerminalSelection';
+import { getTerminalSelectionForClipboard } from './normalizeTerminalSelection';
 import { getFlowControllerForTerm } from './runtime/terminalSessionAttachment';
 import {
   prioritizeTerminalInput,
@@ -1312,7 +1312,10 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       if (hasText && terminalSettings?.copyOnSelect && !isRestoringSelectionRef.current) {
         // Capture now so a later buffer redraw during the debounce cannot
         // change what gets copied (selection-change may not fire again).
-        const selection = getNormalizedTerminalSelection(term);
+        const selection = getTerminalSelectionForClipboard(
+          term,
+          terminalSettings?.normalizeTextOnCopy ?? true,
+        );
         if (!selection) return;
         copyTimer = setTimeout(() => {
           navigator.clipboard.writeText(selection).catch((err) => {
@@ -1344,7 +1347,7 @@ export function useTerminalEffects(ctx: TerminalEffectsContext) {
       resizeDisposable?.dispose();
       resizeObserver?.disconnect();
     };
-  }, [terminalSettings?.copyOnSelect, isSearchOpen, isVisible, isResizing]);
+  }, [terminalSettings?.copyOnSelect, terminalSettings?.normalizeTextOnCopy, isSearchOpen, isVisible, isResizing]);
 
 
   // Track whether the terminal application has enabled mouse tracking

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -69,6 +69,12 @@ export interface TerminalSettings {
   rightClickBehavior: RightClickBehavior;
   middleClickBehavior: MiddleClickBehavior;
   copyOnSelect: boolean; // Automatically copy selected text
+  /**
+   * When true, terminal copy paths strip display-padding spaces and join
+   * soft-wrapped rows before writing the clipboard. When false, use raw
+   * xterm getSelection() (screen-cell layout as-is).
+   */
+  normalizeTextOnCopy: boolean;
   middleClickPaste: boolean; // Legacy mirror for older settings payloads
   wordSeparators: string; // Characters for word selection
   linkModifier: LinkModifier; // Modifier key to click links
@@ -350,6 +356,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   rightClickBehavior: 'context-menu',
   middleClickBehavior: 'paste',
   copyOnSelect: false,
+  normalizeTextOnCopy: true, // Clean soft wraps + padding on copy (opt-out available)
   middleClickPaste: true,
   wordSeparators: DEFAULT_TERMINAL_WORD_SEPARATORS,
   linkModifier: 'none',

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -109,6 +109,11 @@ test("normalizeTerminalSettings defaults middle-click behavior to paste", () => 
   assert.equal(settings.middleClickPaste, true);
 });
 
+test("normalizeTerminalSettings enables normalizeTextOnCopy by default", () => {
+  assert.equal(normalizeTerminalSettings().normalizeTextOnCopy, true);
+  assert.equal(normalizeTerminalSettings({ normalizeTextOnCopy: false }).normalizeTextOnCopy, false);
+});
+
 test("normalizeTerminalSettings defaults word separators to xterm-compatible boundaries", () => {
   assert.equal(normalizeTerminalSettings().wordSeparators, " ()[]{}'\"");
 });


### PR DESCRIPTION
## Summary
- Terminal copy paths previously wrote `term.getSelection()` straight to the clipboard. xterm joins every physical buffer row with a hard newline, so soft-wrapped TUI output (e.g. Pi agent responses) pastes with broken wraps and row padding.
- Add a shared `getNormalizedTerminalSelection()` helper that rebuilds the selection from buffer coordinates: trim display padding, join `isWrapped` rows, keep real hard breaks.
- Wire it into copy-on-select, context-menu/hotkey copy, paste-selection, and add-selection-to-AI.

## Test plan
- [x] Unit tests for soft-wrap join, hard breaks, partial columns, inverted range, and fallback
- [ ] Manually: run a long soft-wrapped Pi/TUI response, select + copy (manual and copy-on-select), paste into an editor — wraps should join, padding gone, real line breaks kept
- [ ] Manually: multi-line shell output with real newlines still pastes with those newlines

Fixes #2162