### PR TITLE
fix(terminal): prune line timestamps in bulk under flood output

### DIFF
--- a/components/terminal/TerminalTimestampGutter.test.ts
+++ b/components/terminal/TerminalTimestampGutter.test.ts
@@ -120,6 +120,21 @@ test("timestamp gutter render signature is stable and changes only for visible i
   );
 });
 
+test("timestamp gutter flood throttle advances even when the paint signature is unchanged", () => {
+  const source = readFileSync(new URL("./TerminalTimestampGutter.tsx", import.meta.url), "utf8");
+  // lastFloodRenderAt must move on every render attempt, before the signature early-return.
+  const renderStart = source.indexOf("const render = () => {");
+  const signatureReturn = source.indexOf("if (signature === lastRenderSignature) return;", renderStart);
+  const floodAdvance = source.indexOf("lastFloodRenderAt = performance.now();", renderStart);
+  assert.notEqual(renderStart, -1);
+  assert.notEqual(signatureReturn, -1);
+  assert.notEqual(floodAdvance, -1);
+  assert.ok(
+    floodAdvance < signatureReturn,
+    "flood throttle clock must advance before the unchanged-signature early return",
+  );
+});
+
 test("timestamp gutter reuses row nodes across paints instead of rebuilding the tree", () => {
   const gutter = {
     children: [] as Array<Record<string, unknown>>,

--- a/components/terminal/TerminalTimestampGutter.test.ts
+++ b/components/terminal/TerminalTimestampGutter.test.ts
@@ -139,9 +139,11 @@ test("timestamp gutter throttles output-driven scroll events under flood pressur
   const source = readFileSync(new URL("./TerminalTimestampGutter.tsx", import.meta.url), "utf8");
   assert.match(source, /term\.onScroll\?\.\(\(\) => \{/);
   assert.match(source, /getTerminalOutputPressure\(term\)/);
-  assert.match(
+  // largeOutput only (time-bounded); longLine must not sticky-throttle user scrolls.
+  assert.match(source, /scheduleRender\(pressure\.largeOutput \? "normal" : "immediate"\)/);
+  assert.doesNotMatch(
     source,
-    /pressure\.largeOutput \|\| pressure\.longLine \? "normal" : "immediate"/,
+    /onScroll[\s\S]{0,200}pressure\.largeOutput \|\| pressure\.longLine/,
   );
 });
 

--- a/components/terminal/TerminalTimestampGutter.test.ts
+++ b/components/terminal/TerminalTimestampGutter.test.ts
@@ -135,6 +135,16 @@ test("timestamp gutter flood throttle advances even when the paint signature is 
   );
 });
 
+test("timestamp gutter throttles output-driven scroll events under flood pressure", () => {
+  const source = readFileSync(new URL("./TerminalTimestampGutter.tsx", import.meta.url), "utf8");
+  assert.match(source, /term\.onScroll\?\.\(\(\) => \{/);
+  assert.match(source, /getTerminalOutputPressure\(term\)/);
+  assert.match(
+    source,
+    /pressure\.largeOutput \|\| pressure\.longLine \? "normal" : "immediate"/,
+  );
+});
+
 test("timestamp gutter reuses row nodes across paints instead of rebuilding the tree", () => {
   const gutter = {
     children: [] as Array<Record<string, unknown>>,

--- a/components/terminal/TerminalTimestampGutter.test.ts
+++ b/components/terminal/TerminalTimestampGutter.test.ts
@@ -9,6 +9,7 @@ import {
   resolveTerminalTimestampGutterRenderSignature,
   resolveTerminalTimestampGutterColor,
   resolveTerminalTimestampGutterWidth,
+  syncTerminalTimestampGutterRows,
 } from "./TerminalTimestampGutter.tsx";
 
 test("timestamp gutter uses a bright color from the active terminal theme", () => {
@@ -117,4 +118,78 @@ test("timestamp gutter render signature is stable and changes only for visible i
     }),
     base,
   );
+});
+
+test("timestamp gutter reuses row nodes across paints instead of rebuilding the tree", () => {
+  const gutter = {
+    children: [] as Array<Record<string, unknown>>,
+    appendChild(node: Record<string, unknown>) {
+      this.children.push(node);
+      return node;
+    },
+  };
+
+  const createElement = (tag: string) => {
+    assert.equal(tag, "div");
+    return {
+      textContent: "",
+      className: "",
+      style: {} as Record<string, string>,
+    };
+  };
+
+  const previousCreateElement = globalThis.document?.createElement;
+  (globalThis as { document?: { createElement: typeof createElement } }).document = {
+    createElement,
+  };
+
+  try {
+    const layout = {
+      screenTop: 0,
+      cellHeight: 16,
+      color: "#66e8ff",
+      fontFamily: "monospace",
+      fontSize: 14,
+      fontWeight: 400,
+    };
+
+    syncTerminalTimestampGutterRows(
+      gutter as never,
+      [
+        { row: 0, label: "10:00:00" },
+        { row: 1, label: "10:00:01" },
+      ],
+      layout,
+    );
+    assert.equal(gutter.children.length, 2);
+    const firstNode = gutter.children[0];
+    assert.equal(firstNode.textContent, "10:00:00");
+
+    syncTerminalTimestampGutterRows(
+      gutter as never,
+      [
+        { row: 0, label: "10:00:02" },
+        { row: 2, label: "10:00:03" },
+      ],
+      layout,
+    );
+    assert.equal(gutter.children.length, 2);
+    assert.equal(gutter.children[0], firstNode);
+    assert.equal(firstNode.textContent, "10:00:02");
+    assert.equal(gutter.children[1].textContent, "10:00:03");
+
+    syncTerminalTimestampGutterRows(
+      gutter as never,
+      [{ row: 0, label: "10:00:04" }],
+      layout,
+    );
+    assert.equal(gutter.children.length, 2);
+    assert.equal((gutter.children[1].style as Record<string, string>).display, "none");
+  } finally {
+    if (previousCreateElement) {
+      (globalThis as { document: { createElement: typeof previousCreateElement } }).document = {
+        createElement: previousCreateElement,
+      };
+    }
+  }
 });

--- a/components/terminal/TerminalTimestampGutter.tsx
+++ b/components/terminal/TerminalTimestampGutter.tsx
@@ -282,6 +282,10 @@ export function TerminalTimestampGutter({
 
     const render = () => {
       rafId = null;
+      // Always advance the flood clock when a render attempt runs — even if the
+      // signature is unchanged. Otherwise same-second labels during sustained
+      // output leave lastFloodRenderAt stale and the throttle stops limiting work.
+      lastFloodRenderAt = performance.now();
       const term = termRef.current;
       const container = containerRef.current;
       if (!enabled || !term || !container) {
@@ -312,7 +316,6 @@ export function TerminalTimestampGutter({
       });
       if (signature === lastRenderSignature) return;
       lastRenderSignature = signature;
-      lastFloodRenderAt = performance.now();
 
       syncTerminalTimestampGutterRows(gutter, visibleRows, {
         screenTop,

--- a/components/terminal/TerminalTimestampGutter.tsx
+++ b/components/terminal/TerminalTimestampGutter.tsx
@@ -380,7 +380,15 @@ export function TerminalTimestampGutter({
       }
 
       disposables = [
-        term.onScroll?.(() => scheduleRender("immediate")),
+        // xterm fires onScroll for output-driven scrolling too (not only user
+        // wheel/trackpad). During flood pressure, treat scroll as throttled so
+        // a multi-line write cannot clear the 100ms paint budget every frame.
+        term.onScroll?.(() => {
+          const pressure = getTerminalOutputPressure(term);
+          scheduleRender(
+            pressure.largeOutput || pressure.longLine ? "normal" : "immediate",
+          );
+        }),
         term.onRender?.(() => scheduleRender("normal")),
         term.onResize?.(() => scheduleRender("immediate")),
       ].filter(Boolean) as DisposableLike[];

--- a/components/terminal/TerminalTimestampGutter.tsx
+++ b/components/terminal/TerminalTimestampGutter.tsx
@@ -381,13 +381,12 @@ export function TerminalTimestampGutter({
 
       disposables = [
         // xterm fires onScroll for output-driven scrolling too (not only user
-        // wheel/trackpad). During flood pressure, treat scroll as throttled so
-        // a multi-line write cannot clear the 100ms paint budget every frame.
+        // wheel/trackpad). Throttle only while large-output pressure is active
+        // (time-bounded). Do not use longLine here — it sticks until the next
+        // data chunk and would lag genuine user scrolling after output stops.
         term.onScroll?.(() => {
           const pressure = getTerminalOutputPressure(term);
-          scheduleRender(
-            pressure.largeOutput || pressure.longLine ? "normal" : "immediate",
-          );
+          scheduleRender(pressure.largeOutput ? "normal" : "immediate");
         }),
         term.onRender?.(() => scheduleRender("normal")),
         term.onResize?.(() => scheduleRender("immediate")),

--- a/components/terminal/TerminalTimestampGutter.tsx
+++ b/components/terminal/TerminalTimestampGutter.tsx
@@ -7,10 +7,15 @@ import {
   onTerminalLineTimestampsChange,
 } from "./runtime/terminalLineTimestamps";
 import type { TerminalTimestampGutterRow } from "./runtime/terminalLineTimestamps";
+import { getTerminalOutputPressure } from "./runtime/terminalOutputPressure";
 
 export const TERMINAL_TIMESTAMP_GUTTER_MIN_WIDTH = 56;
 export const TERMINAL_TIMESTAMP_GUTTER_HORIZONTAL_PADDING = 16;
 export const TERMINAL_TIMESTAMP_SAMPLE_LABEL = "88:88:88";
+/** Cap gutter paint rate while large-output pressure is active (rAF still coalesces). */
+export const TERMINAL_TIMESTAMP_GUTTER_FLOOD_MIN_INTERVAL_MS = 100;
+const GUTTER_ROW_CLASS =
+  "absolute left-0 right-0 px-2 text-right tabular-nums whitespace-nowrap";
 
 type TerminalTimestampGutterProps = {
   termRef: RefObject<XTerm | null>;
@@ -46,6 +51,86 @@ const clearElement = (element: HTMLElement) => {
   while (element.firstChild) {
     element.removeChild(element.firstChild);
   }
+};
+
+const applyGutterRowStyles = (
+  item: HTMLElement,
+  {
+    row,
+    label,
+    screenTop,
+    cellHeight,
+    color,
+    fontFamily,
+    fontSize,
+    fontWeight,
+  }: {
+    row: number;
+    label: string;
+    screenTop: number;
+    cellHeight: number;
+    color: string;
+    fontFamily: string;
+    fontSize: number;
+    fontWeight: string | number;
+  },
+) => {
+  if (item.textContent !== label) {
+    item.textContent = label;
+  }
+  item.style.top = `${screenTop + row * cellHeight}px`;
+  item.style.height = `${cellHeight}px`;
+  item.style.lineHeight = `${cellHeight}px`;
+  item.style.color = color;
+  item.style.fontFamily = fontFamily;
+  item.style.fontSize = `${fontSize}px`;
+  item.style.fontWeight = String(fontWeight);
+  item.style.fontVariantNumeric = "tabular-nums";
+  item.style.display = "";
+};
+
+/**
+ * Reuse a fixed pool of row divs instead of clear+create on every paint.
+ * Returns the number of visible nodes kept after the update.
+ */
+export const syncTerminalTimestampGutterRows = (
+  gutter: HTMLElement,
+  rows: readonly TerminalTimestampGutterRow[],
+  layout: {
+    screenTop: number;
+    cellHeight: number;
+    color: string;
+    fontFamily: string;
+    fontSize: number;
+    fontWeight: string | number;
+  },
+): number => {
+  const existing = gutter.children;
+  let index = 0;
+  for (; index < rows.length; index += 1) {
+    const { row, label } = rows[index];
+    let item = existing[index] as HTMLElement | undefined;
+    if (!item) {
+      item = document.createElement("div");
+      item.className = GUTTER_ROW_CLASS;
+      gutter.appendChild(item);
+    }
+    applyGutterRowStyles(item, {
+      row,
+      label,
+      screenTop: layout.screenTop,
+      cellHeight: layout.cellHeight,
+      color: layout.color,
+      fontFamily: layout.fontFamily,
+      fontSize: layout.fontSize,
+      fontWeight: layout.fontWeight,
+    });
+  }
+  // Hide surplus pooled nodes (keep them for the next paint).
+  for (; index < existing.length; index += 1) {
+    (existing[index] as HTMLElement).style.display = "none";
+  }
+  return rows.length;
 };
 
 export const resolveTerminalTimestampGutterColor = (
@@ -184,9 +269,11 @@ export function TerminalTimestampGutter({
     let disposed = false;
     let rafId: number | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let floodThrottleTimer: ReturnType<typeof setTimeout> | null = null;
     let disposables: DisposableLike[] = [];
     let resizeObserver: ResizeObserver | null = null;
     let lastRenderSignature = "";
+    let lastFloodRenderAt = 0;
 
     const clearGutter = () => {
       lastRenderSignature = "";
@@ -225,35 +312,56 @@ export function TerminalTimestampGutter({
       });
       if (signature === lastRenderSignature) return;
       lastRenderSignature = signature;
+      lastFloodRenderAt = performance.now();
 
-      const fragment = document.createDocumentFragment();
-
-      for (const { row, label } of visibleRows) {
-        const item = document.createElement("div");
-        item.textContent = label;
-        item.className = "absolute left-0 right-0 px-2 text-right tabular-nums whitespace-nowrap";
-        item.style.top = `${screenTop + row * cellHeight}px`;
-        item.style.height = `${cellHeight}px`;
-        item.style.lineHeight = `${cellHeight}px`;
-        item.style.color = color;
-        item.style.fontFamily = typography.fontFamily;
-        item.style.fontSize = `${typography.fontSize}px`;
-        item.style.fontWeight = String(typography.fontWeight);
-        item.style.fontVariantNumeric = "tabular-nums";
-        fragment.appendChild(item);
-      }
-
-      clearElement(gutter);
-      gutter.appendChild(fragment);
+      syncTerminalTimestampGutterRows(gutter, visibleRows, {
+        screenTop,
+        cellHeight,
+        color,
+        fontFamily: typography.fontFamily,
+        fontSize: typography.fontSize,
+        fontWeight: typography.fontWeight,
+      });
     };
 
-    const scheduleRender = () => {
+    const queueRafRender = () => {
       if (disposed || rafId !== null) return;
       if (typeof requestAnimationFrame === "function") {
         rafId = requestAnimationFrame(render);
       } else {
         render();
       }
+    };
+
+    /**
+     * immediate: user scroll/resize — paint ASAP.
+     * normal: output/render pressure — throttle while flood pressure is active.
+     */
+    const scheduleRender = (priority: "immediate" | "normal" = "normal") => {
+      if (disposed) return;
+      if (priority === "normal") {
+        const term = termRef.current;
+        if (term) {
+          const pressure = getTerminalOutputPressure(term);
+          if (pressure.largeOutput || pressure.longLine) {
+            const now = performance.now();
+            const elapsed = now - lastFloodRenderAt;
+            if (elapsed < TERMINAL_TIMESTAMP_GUTTER_FLOOD_MIN_INTERVAL_MS) {
+              if (floodThrottleTimer === null) {
+                floodThrottleTimer = setTimeout(() => {
+                  floodThrottleTimer = null;
+                  queueRafRender();
+                }, TERMINAL_TIMESTAMP_GUTTER_FLOOD_MIN_INTERVAL_MS - elapsed);
+              }
+              return;
+            }
+          }
+        }
+      } else if (floodThrottleTimer !== null) {
+        clearTimeout(floodThrottleTimer);
+        floodThrottleTimer = null;
+      }
+      queueRafRender();
     };
 
     const attach = () => {
@@ -269,19 +377,21 @@ export function TerminalTimestampGutter({
       }
 
       disposables = [
-        term.onScroll?.(scheduleRender),
-        term.onRender?.(scheduleRender),
-        term.onResize?.(scheduleRender),
+        term.onScroll?.(() => scheduleRender("immediate")),
+        term.onRender?.(() => scheduleRender("normal")),
+        term.onResize?.(() => scheduleRender("immediate")),
       ].filter(Boolean) as DisposableLike[];
-      disposables.push({ dispose: onTerminalLineTimestampsChange(term, scheduleRender) });
+      disposables.push({
+        dispose: onTerminalLineTimestampsChange(term, () => scheduleRender("normal")),
+      });
 
       if (typeof ResizeObserver !== "undefined") {
-        resizeObserver = new ResizeObserver(scheduleRender);
+        resizeObserver = new ResizeObserver(() => scheduleRender("immediate"));
         resizeObserver.observe(container);
         resizeObserver.observe(getTerminalScreen(container));
       }
 
-      scheduleRender();
+      scheduleRender("immediate");
     };
 
     attach();
@@ -293,6 +403,9 @@ export function TerminalTimestampGutter({
       }
       if (retryTimer) {
         clearTimeout(retryTimer);
+      }
+      if (floodThrottleTimer !== null) {
+        clearTimeout(floodThrottleTimer);
       }
       for (const disposable of disposables) {
         disposable.dispose();

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -755,7 +755,7 @@ test("tryMeasureVisualRows rejects unmeasurable escape sequences", () => {
   );
 });
 
-test("gutter row resolution still finds viewport labels with binary search window", () => {
+test("gutter row resolution finds viewport labels across a large entry list", () => {
   const entries = Array.from({ length: 1000 }, (_, index) => ({
     marker: { line: index },
     label: `t-${index}`,
@@ -771,6 +771,25 @@ test("gutter row resolution still finds viewport labels with binary search windo
       { row: 1, label: "t-501" },
       { row: 2, label: "t-502" },
       { row: 3, label: "t-503" },
+    ],
+  );
+});
+
+test("gutter prefers the latest label when a later marker rewrites an earlier line", () => {
+  // Cursor-up / reposition can append a newer marker on a lower line index.
+  assert.deepEqual(
+    resolveTerminalTimestampGutterRows({
+      viewportY: 0,
+      rows: 2,
+      entries: [
+        { marker: { line: 0 }, label: "10:00:00" },
+        { marker: { line: 1 }, label: "10:00:01" },
+        { marker: { line: 0 }, label: "10:00:02" },
+      ],
+    }),
+    [
+      { row: 0, label: "10:00:02" },
+      { row: 1, label: "10:00:01" },
     ],
   );
 });

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -4,20 +4,30 @@ import assert from "node:assert/strict";
 import {
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
+  getTerminalLineTimestampEntryCount,
   onTerminalLineTimestampsChange,
+  resolveTerminalLineTimestampCapacity,
   resolveTerminalTimestampGutterRows,
   type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
 
-const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {}) => {
+const createFakeTerm = (options: {
+  cols?: number;
+  wraparoundMode?: boolean;
+  scrollback?: number;
+  rows?: number;
+} = {}) => {
   const writes: string[] = [];
   const markerLines: number[] = [];
   const disposedMarkerLines: number[] = [];
+  const liveMarkers: Array<{ line: number; isDisposed: boolean; dispose: () => void }> = [];
   let cursorLine = 0;
   let cursorColumn = 0;
   const cols = options.cols ?? Number.POSITIVE_INFINITY;
   let wraparoundMode = options.wraparoundMode ?? true;
+  const scrollback = options.scrollback;
+  const rows = options.rows ?? 24;
   const isCombiningMark = (char: string): boolean => {
     const code = char.codePointAt(0);
     return code !== undefined && /\p{Mark}/u.test(String.fromCodePoint(code));
@@ -76,6 +86,17 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
       return cellWidth(String.fromCodePoint(codePoint));
     },
   };
+  const trimMarkersToScrollback = () => {
+    if (!Number.isFinite(scrollback) || scrollback === undefined || scrollback < 0) return;
+    // Approximate xterm: keep the newest (scrollback + rows) buffer lines.
+    const keepFromLine = Math.max(0, cursorLine - (scrollback + rows) + 1);
+    for (const marker of liveMarkers) {
+      if (!marker.isDisposed && marker.line < keepFromLine) {
+        marker.dispose();
+      }
+    }
+  };
+
   const term = {
     _core: {
       unicodeService,
@@ -84,10 +105,11 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
       active: { type: "normal", viewportY: 0 },
     },
     cols,
+    options: Number.isFinite(scrollback) ? { scrollback } : {},
     get modes() {
       return { wraparoundMode };
     },
-    rows: 24,
+    rows,
     write(data: string, callback?: () => void) {
       writes.push(data);
       for (let index = 0; index < data.length; index += 1) {
@@ -132,6 +154,7 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
             : cursorColumn + width;
         }
       }
+      trimMarkersToScrollback();
       callback?.();
     },
     registerMarker(offset: number) {
@@ -141,15 +164,17 @@ const createFakeTerm = (options: { cols?: number; wraparoundMode?: boolean } = {
         line,
         isDisposed: false,
         dispose() {
+          if (marker.isDisposed) return;
           marker.isDisposed = true;
           disposedMarkerLines.push(line);
         },
       };
+      liveMarkers.push(marker);
       return marker;
     },
   };
 
-  return { term, writes, markerLines, disposedMarkerLines };
+  return { term, writes, markerLines, disposedMarkerLines, liveMarkers };
 };
 
 test("segments terminal output into raw bytes plus timestamp markers", () => {
@@ -622,4 +647,75 @@ test("timestamps a prompt after split alternate-screen enter and leave in one ch
 
   assert.equal(writes.join(""), "\x1b[?1049hvim screen\x1b[?1049lprompt");
   assert.deepEqual(markerLines, [0]);
+});
+
+test("capacity follows terminal scrollback so flood output cannot retain unbounded markers", () => {
+  assert.equal(
+    resolveTerminalLineTimestampCapacity({
+      rows: 24,
+      options: { scrollback: 1000 },
+    } as never),
+    1000 + 24 + 64,
+  );
+  assert.equal(
+    resolveTerminalLineTimestampCapacity({
+      rows: 24,
+      options: { scrollback: 200000 },
+    } as never),
+    50000,
+  );
+});
+
+test("always records timestamps without a gutter listener so expanding later still has history", () => {
+  const { term, markerLines } = createFakeTerm();
+
+  // No onTerminalLineTimestampsChange subscription — gutter is hidden.
+  writeTerminalDataWithLineTimestamps(term as never, "a\r\nb\r\nc", () => {});
+
+  assert.deepEqual(markerLines, [0, 1, 2]);
+  assert.equal(getTerminalLineTimestampEntryCount(term as never), 3);
+
+  let notifications = 0;
+  const unsubscribe = onTerminalLineTimestampsChange(term as never, () => {
+    notifications += 1;
+  });
+  // Late subscriber must still see the already-recorded markers.
+  assert.equal(getTerminalLineTimestampEntryCount(term as never), 3);
+  writeTerminalDataWithLineTimestamps(term as never, "\r\nd", () => {});
+  unsubscribe();
+  assert.equal(notifications, 1);
+  assert.equal(getTerminalLineTimestampEntryCount(term as never), 4);
+});
+
+test("prunes disposed markers in bulk under scrollback pressure without retaining all flood lines", () => {
+  const scrollback = 200;
+  const rows = 24;
+  const { term } = createFakeTerm({ scrollback, rows });
+  const lineCount = 5000;
+  const lines = Array.from({ length: lineCount }, (_, index) => `line-${index}`).join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(term as never, lines, () => {});
+
+  const live = getTerminalLineTimestampEntryCount(term as never);
+  const capacity = resolveTerminalLineTimestampCapacity(term as never);
+  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
+  // Must not retain near the full flood (old O(n) store grew with every line).
+  assert.ok(live < lineCount / 2, `expected aggressive prune, got ${live} of ${lineCount}`);
+});
+
+test("large multi-chunk flood stays within capacity across writes", () => {
+  const scrollback = 500;
+  const { term } = createFakeTerm({ scrollback, rows: 24 });
+
+  for (let chunk = 0; chunk < 40; chunk += 1) {
+    const lines = Array.from(
+      { length: 200 },
+      (_, index) => `c${chunk}-l${index}`,
+    ).join("\r\n");
+    writeTerminalDataWithLineTimestamps(term as never, `${lines}\r\n`, () => {});
+  }
+
+  const live = getTerminalLineTimestampEntryCount(term as never);
+  const capacity = resolveTerminalLineTimestampCapacity(term as never);
+  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
 });

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -793,3 +793,25 @@ test("gutter prefers the latest label when a later marker rewrites an earlier li
     ],
   );
 });
+
+test("capacity prune dedupes rewritten lines so unique history is not dropped", () => {
+  const scrollback = 100;
+  const rows = 1;
+  const { term } = createFakeTerm({ scrollback, rows, cols: 80 });
+
+  // Fill unique lines up to roughly the capacity window.
+  const seed = Array.from({ length: scrollback + rows }, (_, index) => `line-${index}`).join("\r\n");
+  writeTerminalDataWithLineTimestamps(term as never, seed, () => {});
+
+  // Rewrite the same line many times via cursor-up (segmented path).
+  for (let index = 0; index < 200; index += 1) {
+    writeTerminalDataWithLineTimestamps(term as never, "\x1b[Ax\r\n", () => {});
+  }
+
+  const live = getTerminalLineTimestampEntryCount(term as never);
+  const capacity = resolveTerminalLineTimestampCapacity(term as never);
+  assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
+  // Unique-line history should still fit under capacity; rewrite noise must not
+  // push older unique lines out purely by duplicate count.
+  assert.ok(live >= Math.min(capacity, 20), `expected meaningful unique history, got ${live}`);
+});

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -665,7 +665,7 @@ test("capacity follows terminal scrollback so flood output cannot retain unbound
       rows: 24,
       options: { scrollback: 200000 },
     } as never),
-    100000 + 256,
+    100000 + 2048,
   );
   assert.equal(
     resolveTerminalLineTimestampCapacity({
@@ -673,6 +673,13 @@ test("capacity follows terminal scrollback so flood output cannot retain unbound
       options: { scrollback: 80000 },
     } as never),
     80000 + 24 + 64,
+  );
+  assert.equal(
+    resolveTerminalLineTimestampCapacity({
+      rows: 400,
+      options: { scrollback: 100000 },
+    } as never),
+    100000 + 400 + 64,
   );
 });
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -659,12 +659,20 @@ test("capacity follows terminal scrollback so flood output cannot retain unbound
     } as never),
     1000 + 24 + 64,
   );
+  // Unlimited scrollback cap (50000) plus viewport headroom.
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
       options: { scrollback: 200000 },
     } as never),
-    50000,
+    50000 + 256,
+  );
+  assert.equal(
+    resolveTerminalLineTimestampCapacity({
+      rows: 24,
+      options: { scrollback: 50000 },
+    } as never),
+    50000 + 24 + 64,
   );
 });
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -802,6 +802,27 @@ test("gutter prefers the latest label when a later marker rewrites an earlier li
   );
 });
 
+test("bulk timestamp batching is disabled inside a partial scrolling region", () => {
+  const { term, writes } = createFakeTerm({ cols: 80, rows: 24 });
+  (term as { _core?: { buffer?: { scrollTop: number; scrollBottom: number } } })._core = {
+    buffer: { scrollTop: 1, scrollBottom: 10 },
+  };
+  const steps: string[] = [];
+  const lines = Array.from({ length: 80 }, (_, index) => `line-${index}`).join("\r\n");
+
+  writeTerminalDataWithLineTimestamps(
+    term as never,
+    lines,
+    () => {},
+    { onStep: (step) => steps.push(step.kind) },
+  );
+
+  assert.equal(steps.includes("batched-write"), false);
+  assert.equal(steps.includes("segmented-write"), true);
+  // Segmented path still emits the original bytes.
+  assert.equal(writes.join(""), lines);
+});
+
 test("capacity prune dedupes rewritten lines so unique history is not dropped", () => {
   const scrollback = 100;
   const rows = 1;

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -659,20 +659,20 @@ test("capacity follows terminal scrollback so flood output cannot retain unbound
     } as never),
     1000 + 24 + 64,
   );
-  // Unlimited scrollback cap (50000) plus viewport headroom.
+  // Settings UI allows up to 100000 scrollback rows.
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
       options: { scrollback: 200000 },
     } as never),
-    50000 + 256,
+    100000 + 256,
   );
   assert.equal(
     resolveTerminalLineTimestampCapacity({
       rows: 24,
-      options: { scrollback: 50000 },
+      options: { scrollback: 80000 },
     } as never),
-    50000 + 24 + 64,
+    80000 + 24 + 64,
   );
 });
 

--- a/components/terminal/runtime/terminalLineTimestamps.test.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.test.ts
@@ -5,9 +5,11 @@ import {
   createTerminalLineTimestampSegmenter,
   formatTerminalLineTimestamp,
   getTerminalLineTimestampEntryCount,
+  isSimpleAsciiControlText,
   onTerminalLineTimestampsChange,
   resolveTerminalLineTimestampCapacity,
   resolveTerminalTimestampGutterRows,
+  tryMeasureVisualRows,
   type TerminalLineTimestampPerfStep,
   writeTerminalDataWithLineTimestamps,
 } from "./terminalLineTimestamps.ts";
@@ -718,4 +720,57 @@ test("large multi-chunk flood stays within capacity across writes", () => {
   const live = getTerminalLineTimestampEntryCount(term as never);
   const capacity = resolveTerminalLineTimestampCapacity(term as never);
   assert.ok(live <= capacity, `expected <= ${capacity} live entries, got ${live}`);
+});
+
+test("simple ASCII control text gate matches seq-style floods", () => {
+  assert.equal(isSimpleAsciiControlText("1\n2\n3\n"), true);
+  assert.equal(isSimpleAsciiControlText("line-0\r\nline-1\r\n"), true);
+  assert.equal(isSimpleAsciiControlText("a\tb\b c"), true);
+  assert.equal(isSimpleAsciiControlText("hello\x1b[0m"), false);
+  assert.equal(isSimpleAsciiControlText("界"), false);
+});
+
+test("tryMeasureVisualRows matches hard-newline accounting for short ASCII lines", () => {
+  const { term } = createFakeTerm({ cols: 80 });
+  const data = Array.from({ length: 100 }, (_, index) => `line-${index}`).join("\r\n");
+  const measured = tryMeasureVisualRows(term as never, data, 0, 80, true);
+  assert.ok(measured);
+  assert.equal(measured?.rowOffset, 99);
+  assert.equal(measured?.column, "line-99".length);
+});
+
+test("tryMeasureVisualRows accounts for soft wraps on long ASCII lines", () => {
+  const { term } = createFakeTerm({ cols: 5 });
+  const measured = tryMeasureVisualRows(term as never, "abcdefghij", 0, 5, true);
+  assert.ok(measured);
+  assert.equal(measured?.rowOffset, 1);
+  assert.equal(measured?.column, 5);
+});
+
+test("tryMeasureVisualRows rejects unmeasurable escape sequences", () => {
+  const { term } = createFakeTerm({ cols: 80 });
+  assert.equal(
+    tryMeasureVisualRows(term as never, "\x1b[Aup", 0, 80, true),
+    null,
+  );
+});
+
+test("gutter row resolution still finds viewport labels with binary search window", () => {
+  const entries = Array.from({ length: 1000 }, (_, index) => ({
+    marker: { line: index },
+    label: `t-${index}`,
+  }));
+  assert.deepEqual(
+    resolveTerminalTimestampGutterRows({
+      viewportY: 500,
+      rows: 4,
+      entries,
+    }),
+    [
+      { row: 0, label: "t-500" },
+      { row: 1, label: "t-501" },
+      { row: 2, label: "t-502" },
+      { row: 3, label: "t-503" },
+    ],
+  );
 });

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -41,6 +41,11 @@ type TimestampStore = {
    * unboundedly.
    */
   entries: TimestampEntry[];
+  /**
+   * Markers dropped from `entries` but not yet disposed. Drained with a per-pass
+   * budget so rewrite storms do not O(n²)-freeze on xterm marker list splices.
+   */
+  orphanedMarkers: TimestampMarker[];
   listeners: Set<() => void>;
   timestampOnlyPrefix: string;
   /** Amortize prune cost across many registerMarker calls. */
@@ -117,6 +122,11 @@ const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = XTERM_UNLIMITED_SCROLLBACK_CAP + 256;
 /** Compact disposed holes at least this often during flood writes. */
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
+/** Max xterm marker.dispose() calls per prune/write pass (amortize O(n) splices). */
+const TIMESTAMP_ORPHAN_DISPOSE_BUDGET = 64;
+/** When orphan backlog grows large, spend a bigger budget to catch up. */
+const TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD = 512;
+const TIMESTAMP_ORPHAN_CATCHUP_BUDGET = 256;
 
 const pad2 = (value: number): string => value.toString().padStart(2, "0");
 
@@ -432,6 +442,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       // Placeholder; replaced immediately with an interning segmenter below.
       segmenter: createTerminalLineTimestampSegmenter(),
       entries: [],
+      orphanedMarkers: [],
       listeners: new Set(),
       timestampOnlyPrefix: "",
       recordsSincePrune: 0,
@@ -460,6 +471,36 @@ const internTerminalLineTimestampLabel = (
   store.labelCacheKey = key;
   store.labelCacheValue = label;
   return label;
+};
+
+const enqueueOrphanedMarker = (
+  store: TimestampStore,
+  marker: TimestampMarker,
+): void => {
+  if (marker.isDisposed) return;
+  store.orphanedMarkers.push(marker);
+};
+
+/**
+ * Dispose a bounded number of orphaned xterm markers. Full mass-dispose of
+ * thousands of markers freezes (xterm splice is O(markers) each); amortizing
+ * keeps rewrite/flood sessions responsive while still retiring superseded
+ * markers that scrollback will never trim (e.g. DECSTBM row rewrites).
+ */
+const drainOrphanedMarkers = (
+  store: TimestampStore,
+  budget = TIMESTAMP_ORPHAN_DISPOSE_BUDGET,
+): void => {
+  let remaining = budget;
+  if (store.orphanedMarkers.length >= TIMESTAMP_ORPHAN_CATCHUP_THRESHOLD) {
+    remaining = Math.max(remaining, TIMESTAMP_ORPHAN_CATCHUP_BUDGET);
+  }
+  while (remaining > 0 && store.orphanedMarkers.length > 0) {
+    const marker = store.orphanedMarkers.pop();
+    remaining -= 1;
+    if (!marker || marker.isDisposed) continue;
+    marker.dispose?.();
+  }
 };
 
 /**
@@ -492,8 +533,7 @@ const pruneDisposedEntries = (
       const entry = entries[index];
       const line = entry.marker.line;
       if (seenLines.has(line)) {
-        // Abandon the older duplicate without marker.dispose() — xterm dispose
-        // is O(markers) and rewrite storms would otherwise reintroduce freezes.
+        enqueueOrphanedMarker(store, entry.marker);
         continue;
       }
       seenLines.add(line);
@@ -505,13 +545,13 @@ const pruneDisposedEntries = (
 
   const live = store.entries;
   if (capacity > 0 && live.length > capacity) {
-    // Drop from our store only — do NOT call marker.dispose() for each excess
-    // entry. xterm removes disposed markers with a linear scan/splice, so
-    // mass-disposing after a flood (e.g. seq 1 500000) is effectively O(n²)
-    // and reintroduces the freeze this path is meant to prevent. Abandoned
-    // markers leave with scrollback trim; we stop tracking them here.
-    live.splice(0, live.length - capacity);
+    const drop = live.length - capacity;
+    for (let index = 0; index < drop; index += 1) {
+      enqueueOrphanedMarker(store, live[index].marker);
+    }
+    live.splice(0, drop);
   }
+  drainOrphanedMarkers(store);
   store.recordsSincePrune = 0;
 };
 
@@ -535,7 +575,11 @@ const resetTimestampStore = (store: TimestampStore) => {
   for (const entry of store.entries) {
     entry.marker.dispose?.();
   }
+  for (const marker of store.orphanedMarkers) {
+    if (!marker.isDisposed) marker.dispose?.();
+  }
   store.entries = [];
+  store.orphanedMarkers = [];
   store.segmenter.reset();
   store.timestampOnlyPrefix = "";
   store.recordsSincePrune = 0;

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -905,27 +905,6 @@ export const onTerminalLineTimestampsChange = (
   };
 };
 
-/**
- * Lower-bound index of the first entry whose marker.line >= `line`.
- * Entries are append-only by write order and stay sorted by line after prune.
- */
-const findFirstTimestampEntryAtOrAfterLine = (
-  entries: readonly TerminalTimestampGutterEntry[],
-  line: number,
-): number => {
-  let lo = 0;
-  let hi = entries.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (entries[mid].marker.line < line) {
-      lo = mid + 1;
-    } else {
-      hi = mid;
-    }
-  }
-  return lo;
-};
-
 export const resolveTerminalTimestampGutterRows = ({
   viewportY,
   rows,
@@ -954,17 +933,14 @@ export const resolveTerminalTimestampGutterRows = ({
     }
   }
 
+  // Full scan (not binary search): cursor-up / reposition writes can append a
+  // newer marker on an earlier buffer line, so entries are not always sorted by
+  // marker.line. Later entries win for the same line.
   const labelByLine = new Map<number, string>();
-  // Binary-search into the sorted marker list, then scan only the viewport window.
-  for (
-    let index = findFirstTimestampEntryAtOrAfterLine(entries, firstRelevantLine);
-    index < entries.length;
-    index += 1
-  ) {
-    const entry = entries[index];
+  for (const entry of entries) {
     if (entry.marker.isDisposed) continue;
     const line = entry.marker.line;
-    if (line > viewportEnd) break;
+    if (line < firstRelevantLine || line > viewportEnd) continue;
     labelByLine.set(line, entry.label);
   }
 

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -13,6 +13,8 @@ export type TerminalLineTimestampSegmenter = {
 
 type TerminalLineTimestampSegmenterOptions = {
   now?: () => Date;
+  /** Optional label factory (used to intern same-second strings). */
+  formatLabel?: (date: Date) => string;
 };
 
 type TimestampMarker = {
@@ -25,14 +27,25 @@ type TimestampMarker = {
 type TimestampEntry = {
   marker: TimestampMarker;
   label: string;
-  disposeListener?: { dispose: () => void };
 };
 
 type TimestampStore = {
   segmenter: TerminalLineTimestampSegmenter;
+  /**
+   * Dense ring of live markers. Always records (even when the gutter is off)
+   * so expanding timestamps later still shows history — same product model as
+   * iTerm2, where per-line time lives in buffer metadata and display is a
+   * view toggle. Capacity is capped to scrollback so flood output cannot grow
+   * unboundedly.
+   */
   entries: TimestampEntry[];
   listeners: Set<() => void>;
   timestampOnlyPrefix: string;
+  /** Amortize prune cost across many registerMarker calls. */
+  recordsSincePrune: number;
+  /** Intern HH:MM:SS for the current wall-clock second. */
+  labelCacheKey: number | null;
+  labelCacheValue: string;
 };
 
 type XTermWithUnicodeService = XTerm & {
@@ -95,12 +108,36 @@ export type TerminalLineTimestampDiagnostics = {
 const stores = new WeakMap<XTerm, TimestampStore>();
 const MAX_SEGMENTED_TIMESTAMP_WRITES = 64;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
+/** Match XTERM_UNLIMITED_SCROLLBACK_CAP — never keep more timestamps than useful history. */
+export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 50000;
+/** Compact disposed holes at least this often during flood writes. */
+const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 
 const pad2 = (value: number): string => value.toString().padStart(2, "0");
 
 export const formatTerminalLineTimestamp = (date: Date): string => (
   `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
 );
+
+/**
+ * Resolve how many line timestamps to retain for a terminal.
+ * Prefer the live scrollback option so a smaller history trims timestamps too.
+ */
+export const resolveTerminalLineTimestampCapacity = (
+  term: XTerm,
+  fallback = MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
+): number => {
+  const options = (term as XTerm & { options?: { scrollback?: number } }).options;
+  const scrollback = options?.scrollback;
+  const rows = Number.isFinite(term.rows) && term.rows > 0 ? term.rows : 24;
+  if (Number.isFinite(scrollback) && Number(scrollback) > 0) {
+    return Math.min(
+      MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
+      Math.floor(Number(scrollback)) + rows + 64,
+    );
+  }
+  return Math.min(MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES, fallback);
+};
 
 const isCsiFinalByte = (char: string): boolean => char >= "@" && char <= "~";
 const STRING_TERMINATOR = "\u009c";
@@ -270,6 +307,7 @@ export const createTerminalLineTimestampSegmenter = (
   options: TerminalLineTimestampSegmenterOptions = {},
 ): TerminalLineTimestampSegmenter => {
   const now = options.now ?? (() => new Date());
+  const formatLabel = options.formatLabel ?? formatTerminalLineTimestamp;
   let atLineStart = true;
   let currentLineStamped = false;
   let pendingEscapeSequence = "";
@@ -286,7 +324,7 @@ export const createTerminalLineTimestampSegmenter = (
     atLineStart = false;
     segments.push({
       kind: "timestamp",
-      label: formatTerminalLineTimestamp(now()),
+      label: formatLabel(now()),
     });
   };
 
@@ -375,6 +413,7 @@ export const createTerminalLineTimestampSegmenter = (
 };
 
 const notifyTimestampStore = (store: TimestampStore) => {
+  if (store.listeners.size === 0) return;
   for (const listener of store.listeners) {
     listener();
   }
@@ -383,29 +422,95 @@ const notifyTimestampStore = (store: TimestampStore) => {
 const getTimestampStore = (term: XTerm): TimestampStore => {
   let store = stores.get(term);
   if (!store) {
-    store = {
+    const created: TimestampStore = {
+      // Placeholder; replaced immediately with an interning segmenter below.
       segmenter: createTerminalLineTimestampSegmenter(),
       entries: [],
       listeners: new Set(),
       timestampOnlyPrefix: "",
+      recordsSincePrune: 0,
+      labelCacheKey: null,
+      labelCacheValue: "",
     };
-    stores.set(term, store);
+    created.segmenter = createTerminalLineTimestampSegmenter({
+      formatLabel: (date) => internTerminalLineTimestampLabel(created, date),
+    });
+    stores.set(term, created);
+    store = created;
   }
   return store;
 };
 
-const pruneDisposedEntries = (store: TimestampStore) => {
-  store.entries = store.entries.filter((entry) => !entry.marker.isDisposed);
+const internTerminalLineTimestampLabel = (
+  store: TimestampStore,
+  date: Date,
+): string => {
+  // Same wall-clock second → identical label; avoid allocating 50万× "12:34:56".
+  const key = Math.floor(date.getTime() / 1000);
+  if (store.labelCacheKey === key) {
+    return store.labelCacheValue;
+  }
+  const label = formatTerminalLineTimestamp(date);
+  store.labelCacheKey = key;
+  store.labelCacheValue = label;
+  return label;
+};
+
+/**
+ * Compact disposed markers and enforce a hard capacity in one linear pass.
+ * Avoids the previous O(n) filter on *every* individual marker dispose during
+ * scrollback trim (which turned seq 1 500000 into ~O(n²) main-thread work).
+ */
+const pruneDisposedEntries = (
+  store: TimestampStore,
+  capacity = MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES,
+): void => {
+  const entries = store.entries;
+  let write = 0;
+  for (let read = 0; read < entries.length; read += 1) {
+    const entry = entries[read];
+    if (entry.marker.isDisposed) continue;
+    entries[write] = entry;
+    write += 1;
+  }
+  entries.length = write;
+
+  if (capacity > 0 && entries.length > capacity) {
+    const drop = entries.length - capacity;
+    for (let index = 0; index < drop; index += 1) {
+      entries[index].marker.dispose?.();
+    }
+    entries.splice(0, drop);
+  }
+  store.recordsSincePrune = 0;
+};
+
+const maybePruneTimestampEntries = (
+  term: XTerm,
+  store: TimestampStore,
+  force = false,
+): void => {
+  const capacity = resolveTerminalLineTimestampCapacity(term);
+  store.recordsSincePrune += 1;
+  if (
+    force
+    || store.recordsSincePrune >= TIMESTAMP_PRUNE_EVERY_RECORDS
+    || store.entries.length > capacity * 1.25
+  ) {
+    pruneDisposedEntries(store, capacity);
+  }
 };
 
 const resetTimestampStore = (store: TimestampStore) => {
   for (const entry of store.entries) {
-    entry.disposeListener?.dispose();
     entry.marker.dispose?.();
   }
   store.entries = [];
   store.segmenter.reset();
   store.timestampOnlyPrefix = "";
+  store.recordsSincePrune = 0;
+  store.labelCacheKey = null;
+  store.labelCacheValue = "";
   notifyTimestampStore(store);
 };
 
@@ -420,17 +525,26 @@ const recordTerminalLineTimestamp = (
   const marker = registerMarker?.call(term, cursorYOffset);
   if (!marker) return false;
 
-  const entry: TimestampEntry = { marker, label };
-  entry.disposeListener = marker.onDispose?.(() => {
-    store.entries = store.entries.filter((candidate) => candidate !== entry);
-    entry.disposeListener?.dispose();
-    notifyTimestampStore(store);
-  });
-  store.entries.push(entry);
+  // Intentionally no per-marker onDispose → filter(entries). xterm still
+  // marks isDisposed when scrollback trims; we compact lazily in bulk.
+  store.entries.push({ marker, label });
+  maybePruneTimestampEntries(term, store);
   if (notify) {
     notifyTimestampStore(store);
   }
   return true;
+};
+
+/** Test/diagnostics helper: live entry count after optional prune. */
+export const getTerminalLineTimestampEntryCount = (
+  term: XTerm,
+  options: { prune?: boolean } = {},
+): number => {
+  const store = getTimestampStore(term);
+  if (options.prune !== false) {
+    pruneDisposedEntries(store, resolveTerminalLineTimestampCapacity(term));
+  }
+  return store.entries.length;
 };
 
 const countLineFeeds = (data: string): number => {
@@ -689,6 +803,9 @@ const writeBatchedTimestampSegments = (
         timestamp.rowOffset - rowOffset,
       ) || timestampRecorded;
     }
+    // Compact once after bulk marker registration (scrollback may already have
+    // disposed older markers while this flood was writing).
+    maybePruneTimestampEntries(term, store, true);
     if (timestampRecorded) {
       notifyTimestampStore(store);
     }
@@ -788,7 +905,7 @@ export const getVisibleTerminalLineTimestampRows = (
     return [];
   }
   const store = getTimestampStore(term);
-  pruneDisposedEntries(store);
+  pruneDisposedEntries(store, resolveTerminalLineTimestampCapacity(term));
   return resolveTerminalTimestampGutterRows({
     viewportY: term.buffer.active.viewportY,
     rows: term.rows,

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -1,5 +1,7 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
+import { XTERM_UNLIMITED_SCROLLBACK_CAP } from "../../../infrastructure/config/xtermPerformance";
+
 export type TerminalLineTimestampSegment =
   | { kind: "data"; data: string }
   | { kind: "timestamp"; label: string };
@@ -108,8 +110,11 @@ export type TerminalLineTimestampDiagnostics = {
 const stores = new WeakMap<XTerm, TimestampStore>();
 const MAX_SEGMENTED_TIMESTAMP_WRITES = 64;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
-/** Match XTERM_UNLIMITED_SCROLLBACK_CAP — never keep more timestamps than useful history. */
-export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 50000;
+/**
+ * Hard ceiling for retained timestamps: unlimited scrollback cap plus a small
+ * viewport headroom so the oldest still-visible rows keep labels.
+ */
+export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = XTERM_UNLIMITED_SCROLLBACK_CAP + 256;
 /** Compact disposed holes at least this often during flood writes. */
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 
@@ -122,6 +127,7 @@ export const formatTerminalLineTimestamp = (date: Date): string => (
 /**
  * Resolve how many line timestamps to retain for a terminal.
  * Prefer the live scrollback option so a smaller history trims timestamps too.
+ * Capacity is scrollback + viewport (+slack), matching xterm's retained lines.
  */
 export const resolveTerminalLineTimestampCapacity = (
   term: XTerm,
@@ -498,11 +504,12 @@ const pruneDisposedEntries = (
 
   const live = store.entries;
   if (capacity > 0 && live.length > capacity) {
-    const drop = live.length - capacity;
-    for (let index = 0; index < drop; index += 1) {
-      live[index].marker.dispose?.();
-    }
-    live.splice(0, drop);
+    // Drop from our store only — do NOT call marker.dispose() for each excess
+    // entry. xterm removes disposed markers with a linear scan/splice, so
+    // mass-disposing after a flood (e.g. seq 1 500000) is effectively O(n²)
+    // and reintroduces the freeze this path is meant to prevent. Abandoned
+    // markers leave with scrollback trim; we stop tracking them here.
+    live.splice(0, live.length - capacity);
   }
   store.recordsSincePrune = 0;
 };
@@ -880,8 +887,19 @@ const writeBatchedTimestampSegments = (
   term.write(data, () => {
     const writeCallbackMs = shouldMeasureDiagnostics ? performance.now() - writeStartedAt : 0;
     const markerStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
+    const capacity = resolveTerminalLineTimestampCapacity(term);
+    // Only register markers we can retain. Creating then disposing hundreds of
+    // thousands of xterm markers is quadratic inside xterm's marker list.
+    const timestampsToRecord = timestamps.length > capacity
+      ? timestamps.slice(timestamps.length - capacity)
+      : timestamps;
+    if (timestampsToRecord.length >= capacity) {
+      // This flood alone fills history — drop prior bookkeeping without
+      // mass-disposing markers (see pruneDisposedEntries).
+      store.entries.length = 0;
+    }
     let timestampRecorded = false;
-    for (const timestamp of timestamps) {
+    for (const timestamp of timestampsToRecord) {
       timestampRecorded = recordTerminalLineTimestamp(
         term,
         store,

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -115,9 +115,9 @@ const MAX_SEGMENTED_TIMESTAMP_WRITES = 64;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
  * Hard ceiling for retained timestamps. Matches Settings UI max scrollback
- * (100000) plus viewport headroom so the oldest still-visible rows keep labels.
+ * (100000) plus generous viewport headroom for very tall terminals.
  */
-export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 100000 + 256;
+export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 100000 + 2048;
 /** Compact disposed holes at least this often during flood writes. */
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 /** Max xterm marker.dispose() calls per prune/write pass (amortize O(n) splices). */
@@ -501,6 +501,19 @@ const drainOrphanedMarkers = (
   }
 };
 
+/** Cheap pass for paint paths: drop disposed holes only (no dedupe / capacity). */
+const compactDisposedMarkersOnly = (store: TimestampStore): void => {
+  const entries = store.entries;
+  let write = 0;
+  for (let read = 0; read < entries.length; read += 1) {
+    const entry = entries[read];
+    if (entry.marker.isDisposed) continue;
+    entries[write] = entry;
+    write += 1;
+  }
+  entries.length = write;
+};
+
 /**
  * Compact disposed markers, collapse rewritten lines to their latest label,
  * and enforce a hard capacity in linear passes.
@@ -592,6 +605,7 @@ const recordTerminalLineTimestamp = (
   label: string,
   notify = true,
   cursorYOffset = 0,
+  options: { skipPrune?: boolean } = {},
 ): boolean => {
   const registerMarker = (term as XTerm & { registerMarker?: (offset: number) => TimestampMarker | undefined }).registerMarker;
   const marker = registerMarker?.call(term, cursorYOffset);
@@ -600,7 +614,9 @@ const recordTerminalLineTimestamp = (
   // Intentionally no per-marker onDispose → filter(entries). xterm still
   // marks isDisposed when scrollback trims; we compact lazily in bulk.
   store.entries.push({ marker, label });
-  maybePruneTimestampEntries(term, store);
+  if (!options.skipPrune) {
+    maybePruneTimestampEntries(term, store);
+  }
   if (notify) {
     notifyTimestampStore(store);
   }
@@ -970,10 +986,10 @@ const writeBatchedTimestampSegments = (
         timestamp.label,
         false,
         timestamp.rowOffset - rowOffset,
+        { skipPrune: true },
       ) || timestampRecorded;
     }
-    // Compact once after bulk marker registration (scrollback may already have
-    // disposed older markers while this flood was writing).
+    // Single prune after bulk registration (intermediate prunes dominate large floods).
     maybePruneTimestampEntries(term, store, true);
     if (timestampRecorded) {
       notifyTimestampStore(store);
@@ -1075,7 +1091,8 @@ export const getVisibleTerminalLineTimestampRows = (
     return [];
   }
   const store = getTimestampStore(term);
-  pruneDisposedEntries(store, resolveTerminalLineTimestampCapacity(term));
+  // Paint path: only drop disposed holes. Full dedupe/capacity runs on write.
+  compactDisposedMarkersOnly(store);
   return resolveTerminalTimestampGutterRows({
     viewportY: term.buffer.active.viewportY,
     rows: term.rows,

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -1,7 +1,5 @@
 import type { Terminal as XTerm } from "@xterm/xterm";
 
-import { XTERM_UNLIMITED_SCROLLBACK_CAP } from "../../../infrastructure/config/xtermPerformance";
-
 export type TerminalLineTimestampSegment =
   | { kind: "data"; data: string }
   | { kind: "timestamp"; label: string };
@@ -116,10 +114,10 @@ const stores = new WeakMap<XTerm, TimestampStore>();
 const MAX_SEGMENTED_TIMESTAMP_WRITES = 64;
 const BULK_TIMESTAMP_BATCH_MIN_BYTES = 4096;
 /**
- * Hard ceiling for retained timestamps: unlimited scrollback cap plus a small
- * viewport headroom so the oldest still-visible rows keep labels.
+ * Hard ceiling for retained timestamps. Matches Settings UI max scrollback
+ * (100000) plus viewport headroom so the oldest still-visible rows keep labels.
  */
-export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = XTERM_UNLIMITED_SCROLLBACK_CAP + 256;
+export const MAX_TERMINAL_LINE_TIMESTAMP_ENTRIES = 100000 + 256;
 /** Compact disposed holes at least this often during flood writes. */
 const TIMESTAMP_PRUNE_EVERY_RECORDS = 256;
 /** Max xterm marker.dispose() calls per prune/write pass (amortize O(n) splices). */

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -602,6 +602,29 @@ const getTerminalWraparoundMode = (term: XTerm): boolean => (
   ((term as XTerm & { modes?: { wraparoundMode?: boolean } }).modes?.wraparoundMode) !== false
 );
 
+/**
+ * True when DECSTBM (or equivalent) leaves a partial scrolling region.
+ * Bulk row-offset measurement assumes full-buffer advancement; inside a
+ * region, newlines recycle rows and measured offsets would invent fake
+ * history and evict still-valid scrollback timestamps.
+ */
+export const hasPartialScrollingRegion = (term: XTerm): boolean => {
+  const core = (term as XTerm & {
+    _core?: { buffer?: { scrollTop?: number; scrollBottom?: number } };
+  })._core;
+  const scrollTop = core?.buffer?.scrollTop;
+  const scrollBottom = core?.buffer?.scrollBottom;
+  const rows = Number.isFinite(term.rows) && term.rows > 0 ? term.rows : 0;
+  if (
+    !Number.isFinite(scrollTop)
+    || !Number.isFinite(scrollBottom)
+    || rows <= 0
+  ) {
+    return false;
+  }
+  return Number(scrollTop) > 0 || Number(scrollBottom) < rows - 1;
+};
+
 const isUnsafeGraphemeSequenceCodePoint = (codePoint: number): boolean => (
   codePoint === 0x200d
   || codePoint === 0x20e3
@@ -1084,6 +1107,7 @@ export const writeTerminalDataWithLineTimestamps = (
   if (
     timestampOnlyPrefix.length === 0
     && parsedData === dataForTimestamps
+    && !hasPartialScrollingRegion(term)
     && (
       dataSegmentCount > MAX_SEGMENTED_TIMESTAMP_WRITES
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -457,7 +457,8 @@ const internTerminalLineTimestampLabel = (
 };
 
 /**
- * Compact disposed markers and enforce a hard capacity in one linear pass.
+ * Compact disposed markers, collapse rewritten lines to their latest label,
+ * and enforce a hard capacity in linear passes.
  * Avoids the previous O(n) filter on *every* individual marker dispose during
  * scrollback trim (which turned seq 1 500000 into ~O(n²) main-thread work).
  */
@@ -475,12 +476,33 @@ const pruneDisposedEntries = (
   }
   entries.length = write;
 
-  if (capacity > 0 && entries.length > capacity) {
-    const drop = entries.length - capacity;
-    for (let index = 0; index < drop; index += 1) {
-      entries[index].marker.dispose?.();
+  // Cursor-up / reposition can append many live markers on the same buffer
+  // line. Keep only the latest label per line so the capacity budget tracks
+  // unique visible history instead of rewrite noise.
+  if (entries.length > 1) {
+    const kept: TimestampEntry[] = [];
+    const seenLines = new Set<number>();
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index];
+      const line = entry.marker.line;
+      if (seenLines.has(line)) {
+        entry.marker.dispose?.();
+        continue;
+      }
+      seenLines.add(line);
+      kept.push(entry);
     }
-    entries.splice(0, drop);
+    kept.reverse();
+    store.entries = kept;
+  }
+
+  const live = store.entries;
+  if (capacity > 0 && live.length > capacity) {
+    const drop = live.length - capacity;
+    for (let index = 0; index < drop; index += 1) {
+      live[index].marker.dispose?.();
+    }
+    live.splice(0, drop);
   }
   store.recordsSincePrune = 0;
 };

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -492,7 +492,8 @@ const pruneDisposedEntries = (
       const entry = entries[index];
       const line = entry.marker.line;
       if (seenLines.has(line)) {
-        entry.marker.dispose?.();
+        // Abandon the older duplicate without marker.dispose() — xterm dispose
+        // is O(markers) and rewrite storms would otherwise reintroduce freezes.
         continue;
       }
       seenLines.add(line);

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -890,14 +890,12 @@ const writeBatchedTimestampSegments = (
     const capacity = resolveTerminalLineTimestampCapacity(term);
     // Only register markers we can retain. Creating then disposing hundreds of
     // thousands of xterm markers is quadratic inside xterm's marker list.
+    // Do NOT wipe prior store entries here: DECSTBM scrolling regions can emit
+    // many newlines without trimming normal scrollback, and clearing would drop
+    // timestamps for lines still in history. pruneDisposedEntries trims excess.
     const timestampsToRecord = timestamps.length > capacity
       ? timestamps.slice(timestamps.length - capacity)
       : timestamps;
-    if (timestampsToRecord.length >= capacity) {
-      // This flood alone fills history — drop prior bookkeeping without
-      // mass-disposing markers (see pruneDisposedEntries).
-      store.entries.length = 0;
-    }
     let timestampRecorded = false;
     for (const timestamp of timestampsToRecord) {
       timestampRecorded = recordTerminalLineTimestamp(

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -27,6 +27,7 @@ type TimestampMarker = {
 type TimestampEntry = {
   marker: TimestampMarker;
   label: string;
+  disposeListener?: { dispose: () => void };
 };
 
 type TimestampStore = {
@@ -48,6 +49,8 @@ type TimestampStore = {
   timestampOnlyPrefix: string;
   /** Amortize prune cost across many registerMarker calls. */
   recordsSincePrune: number;
+  /** Disposed markers since last compact (drives write-path cleanup). */
+  disposedPendingCompact: number;
   /** Intern HH:MM:SS for the current wall-clock second. */
   labelCacheKey: number | null;
   labelCacheValue: string;
@@ -444,6 +447,7 @@ const getTimestampStore = (term: XTerm): TimestampStore => {
       listeners: new Set(),
       timestampOnlyPrefix: "",
       recordsSincePrune: 0,
+      disposedPendingCompact: 0,
       labelCacheKey: null,
       labelCacheValue: "",
     };
@@ -501,17 +505,26 @@ const drainOrphanedMarkers = (
   }
 };
 
-/** Cheap pass for paint paths: drop disposed holes only (no dedupe / capacity). */
+/** Cheap pass for paint/write paths: drop disposed holes only (no dedupe / capacity). */
 const compactDisposedMarkersOnly = (store: TimestampStore): void => {
+  if (store.disposedPendingCompact <= 0) {
+    // Still drop any disposed holes we notice, but skip the scan when we have
+    // no dispose signals and the list is empty.
+    if (store.entries.length === 0) return;
+  }
   const entries = store.entries;
   let write = 0;
   for (let read = 0; read < entries.length; read += 1) {
     const entry = entries[read];
-    if (entry.marker.isDisposed) continue;
+    if (entry.marker.isDisposed) {
+      entry.disposeListener?.dispose();
+      continue;
+    }
     entries[write] = entry;
     write += 1;
   }
   entries.length = write;
+  store.disposedPendingCompact = 0;
 };
 
 /**
@@ -584,6 +597,7 @@ const maybePruneTimestampEntries = (
 
 const resetTimestampStore = (store: TimestampStore) => {
   for (const entry of store.entries) {
+    entry.disposeListener?.dispose();
     entry.marker.dispose?.();
   }
   for (const marker of store.orphanedMarkers) {
@@ -594,6 +608,7 @@ const resetTimestampStore = (store: TimestampStore) => {
   store.segmenter.reset();
   store.timestampOnlyPrefix = "";
   store.recordsSincePrune = 0;
+  store.disposedPendingCompact = 0;
   store.labelCacheKey = null;
   store.labelCacheValue = "";
   notifyTimestampStore(store);
@@ -611,9 +626,15 @@ const recordTerminalLineTimestamp = (
   const marker = registerMarker?.call(term, cursorYOffset);
   if (!marker) return false;
 
-  // Intentionally no per-marker onDispose → filter(entries). xterm still
-  // marks isDisposed when scrollback trims; we compact lazily in bulk.
-  store.entries.push({ marker, label });
+  // Lightweight dispose signal only — never filter(entries) per dispose.
+  // Compaction happens in bulk on write/paint via compactDisposedMarkersOnly.
+  const entry: TimestampEntry = { marker, label };
+  entry.disposeListener = marker.onDispose?.(() => {
+    store.disposedPendingCompact += 1;
+    entry.disposeListener?.dispose();
+    entry.disposeListener = undefined;
+  });
+  store.entries.push(entry);
   if (!options.skipPrune) {
     maybePruneTimestampEntries(term, store);
   }
@@ -1130,10 +1151,11 @@ export const writeTerminalDataWithLineTimestamps = (
   }
 
   const store = getTimestampStore(term);
-  // Clears / scrollback wipes dispose markers without recording new stamps;
-  // compact disposed holes on every write so the store cannot retain 100k
-  // dead entries while the gutter is off.
-  compactDisposedMarkersOnly(store);
+  // Clears / scrollback wipes dispose markers without new stamps. Compact only
+  // when dispose signals arrived — not on every tiny write against a full store.
+  if (store.disposedPendingCompact > 0) {
+    compactDisposedMarkersOnly(store);
+  }
   store.segmenter.setAlternateScreenActive(
     ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
   );

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -970,14 +970,19 @@ const writeBatchedTimestampSegments = (
     const writeCallbackMs = shouldMeasureDiagnostics ? performance.now() - writeStartedAt : 0;
     const markerStartedAt = shouldMeasureDiagnostics ? performance.now() : 0;
     const capacity = resolveTerminalLineTimestampCapacity(term);
-    // Only register markers we can retain. Creating then disposing hundreds of
-    // thousands of xterm markers is quadratic inside xterm's marker list.
-    // Do NOT wipe prior store entries here: DECSTBM scrolling regions can emit
-    // many newlines without trimming normal scrollback, and clearing would drop
-    // timestamps for lines still in history. pruneDisposedEntries trims excess.
-    const timestampsToRecord = timestamps.length > capacity
-      ? timestamps.slice(timestamps.length - capacity)
-      : timestamps;
+    // Only register markers that land in the retained visual-row window.
+    // Slice by timestamp count is wrong for soft-wrapped floods (many stamps
+    // can map outside the buffer while fewer visual rows remain). Prefer the
+    // last `capacity` visual rows by measured rowOffset.
+    const minRowOffset = Math.max(0, rowOffset - capacity + 1);
+    let timestampsToRecord = timestamps.filter(
+      (timestamp) => timestamp.rowOffset >= minRowOffset,
+    );
+    if (timestampsToRecord.length > capacity) {
+      timestampsToRecord = timestampsToRecord.slice(
+        timestampsToRecord.length - capacity,
+      );
+    }
     let timestampRecorded = false;
     for (const timestamp of timestampsToRecord) {
       timestampRecorded = recordTerminalLineTimestamp(
@@ -1125,6 +1130,10 @@ export const writeTerminalDataWithLineTimestamps = (
   }
 
   const store = getTimestampStore(term);
+  // Clears / scrollback wipes dispose markers without recording new stamps;
+  // compact disposed holes on every write so the store cannot retain 100k
+  // dead entries while the gutter is off.
+  compactDisposedMarkersOnly(store);
   store.segmenter.setAlternateScreenActive(
     ((term.buffer?.active as { type?: string } | undefined)?.type) === "alternate",
   );

--- a/components/terminal/runtime/terminalLineTimestamps.ts
+++ b/components/terminal/runtime/terminalLineTimestamps.ts
@@ -616,40 +616,10 @@ const getCodePointCellWidth = (term: XTerm, codePoint: number): 0 | 1 | 2 | null
   }
 };
 
-const canMeasureVisualRows = (term: XTerm, data: string): boolean => {
-  for (let index = 0; index < data.length; index += 1) {
-    const char = data[index];
-    const codePoint = data.codePointAt(index);
-    if (codePoint === undefined) return false;
-    if (char === "\x1b") {
-      const sequence = readEscapeSequence(data, index);
-      if (!sequence?.complete || !isBulkMeasurableEscapeSequence(sequence.sequence)) {
-        return false;
-      }
-      index = sequence.endIndex;
-      continue;
-    }
-    if (char === "\n" || char === "\r" || char === "\b" || char === "\t") {
-      continue;
-    }
-    if (
-      codePoint < 0x20
-      || codePoint === 0x7f
-      || (codePoint >= 0x80 && codePoint <= 0x9f)
-      || isUnsafeGraphemeSequenceCodePoint(codePoint)
-      || isUnsafeFormatCodePoint(codePoint)
-      || isContextSensitiveGraphemeCodePoint(codePoint)
-    ) {
-      return false;
-    }
-    if (getCodePointCellWidth(term, codePoint) === null) {
-      return false;
-    }
-    if (codePoint > 0xffff) {
-      index += 1;
-    }
-  }
-  return true;
+type MeasuredTerminalRows = {
+  rowOffset: number;
+  column: number;
+  wraparoundMode: boolean;
 };
 
 const advanceMeasuredColumns = (
@@ -694,26 +664,96 @@ const advanceMeasuredTab = (
   return Math.min(nextTabStop, columns - 1);
 };
 
-const measureTerminalRows = (
+/**
+ * Fast gate for flood output like `seq`: printable ASCII + CR/LF/TAB/BS only.
+ * Avoids escape parsing and unicode width lookups entirely.
+ */
+export const isSimpleAsciiControlText = (data: string): boolean => {
+  for (let index = 0; index < data.length; index += 1) {
+    const code = data.charCodeAt(index);
+    if (code === 0x0a || code === 0x0d || code === 0x09 || code === 0x08) continue;
+    if (code >= 0x20 && code <= 0x7e) continue;
+    return false;
+  }
+  return true;
+};
+
+const measureSimpleAsciiRows = (
+  data: string,
+  startColumn: number,
+  columns: number,
+  startWraparoundMode: boolean,
+): MeasuredTerminalRows => {
+  let rowOffset = 0;
+  let column = startColumn;
+  const wraparoundMode = startWraparoundMode;
+
+  for (let index = 0; index < data.length; index += 1) {
+    const code = data.charCodeAt(index);
+    if (code === 0x0a) {
+      rowOffset += 1;
+      if (Number.isFinite(columns) && column >= columns) {
+        column = columns - 1;
+      }
+      continue;
+    }
+    if (code === 0x0d) {
+      column = 0;
+      continue;
+    }
+    if (code === 0x08) {
+      column = Math.max(0, column - 1);
+      continue;
+    }
+    if (code === 0x09) {
+      column = advanceMeasuredTab(column, columns);
+      continue;
+    }
+    // Printable ASCII is always width 1.
+    ({ column, rowOffset } = advanceMeasuredColumns(
+      column,
+      rowOffset,
+      columns,
+      1,
+      wraparoundMode,
+    ));
+  }
+
+  return { rowOffset, column, wraparoundMode };
+};
+
+/**
+ * Validate + measure visual rows in a single pass.
+ * Returns null when the chunk contains sequences we cannot bulk-measure safely
+ * (caller falls back to line-feed counting / segmented writes).
+ */
+export const tryMeasureVisualRows = (
   term: XTerm,
   data: string,
   startColumn: number,
   columns: number,
   startWraparoundMode: boolean,
-): { rowOffset: number; column: number; wraparoundMode: boolean } => {
+): MeasuredTerminalRows | null => {
+  if (isSimpleAsciiControlText(data)) {
+    return measureSimpleAsciiRows(data, startColumn, columns, startWraparoundMode);
+  }
+
   let rowOffset = 0;
   let column = startColumn;
   let wraparoundMode = startWraparoundMode;
 
   for (let index = 0; index < data.length; index += 1) {
-    const sequence = readEscapeSequence(data, index);
-    if (sequence?.complete) {
+    const char = data[index];
+    if (char === "\x1b") {
+      const sequence = readEscapeSequence(data, index);
+      if (!sequence?.complete || !isBulkMeasurableEscapeSequence(sequence.sequence)) {
+        return null;
+      }
       wraparoundMode = getWraparoundAction(sequence.sequence) ?? wraparoundMode;
       index = sequence.endIndex;
       continue;
     }
 
-    const char = data[index];
     if (char === "\n") {
       rowOffset += 1;
       if (Number.isFinite(columns) && column >= columns) {
@@ -733,17 +773,21 @@ const measureTerminalRows = (
       column = advanceMeasuredTab(column, columns);
       continue;
     }
-    if (char < " " || char === "\u007f") {
-      continue;
-    }
+
     const codePoint = data.codePointAt(index);
-    if (codePoint === undefined) {
-      continue;
+    if (codePoint === undefined) return null;
+    if (
+      codePoint < 0x20
+      || codePoint === 0x7f
+      || (codePoint >= 0x80 && codePoint <= 0x9f)
+      || isUnsafeGraphemeSequenceCodePoint(codePoint)
+      || isUnsafeFormatCodePoint(codePoint)
+      || isContextSensitiveGraphemeCodePoint(codePoint)
+    ) {
+      return null;
     }
     const width = getCodePointCellWidth(term, codePoint);
-    if (width === null) {
-      continue;
-    }
+    if (width === null) return null;
     ({ column, rowOffset } = advanceMeasuredColumns(
       column,
       rowOffset,
@@ -758,6 +802,18 @@ const measureTerminalRows = (
 
   return { rowOffset, column, wraparoundMode };
 };
+
+/** @deprecated Prefer tryMeasureVisualRows — kept for call-site clarity in gates. */
+const canMeasureVisualRows = (term: XTerm, data: string): boolean => (
+  isSimpleAsciiControlText(data)
+  || tryMeasureVisualRows(
+    term,
+    data,
+    0,
+    Number.POSITIVE_INFINITY,
+    true,
+  ) !== null
+);
 
 const writeBatchedTimestampSegments = (
   term: XTerm,
@@ -780,9 +836,18 @@ const writeBatchedTimestampSegments = (
       timestamps.push({ label: segment.label, rowOffset });
       continue;
     }
-    const measured = canMeasureVisualRows(term, segment.data)
-      ? measureTerminalRows(term, segment.data, column, columns, wraparoundMode)
-      : { rowOffset: countLineFeeds(segment.data), column, wraparoundMode };
+    const measured = tryMeasureVisualRows(
+      term,
+      segment.data,
+      column,
+      columns,
+      wraparoundMode,
+    ) ?? {
+      // Unmeasurable chunk: preserve prior column/wrap state and count hard newlines only.
+      rowOffset: countLineFeeds(segment.data),
+      column,
+      wraparoundMode,
+    };
     rowOffset += measured.rowOffset;
     column = measured.column;
     wraparoundMode = measured.wraparoundMode;
@@ -840,6 +905,27 @@ export const onTerminalLineTimestampsChange = (
   };
 };
 
+/**
+ * Lower-bound index of the first entry whose marker.line >= `line`.
+ * Entries are append-only by write order and stay sorted by line after prune.
+ */
+const findFirstTimestampEntryAtOrAfterLine = (
+  entries: readonly TerminalTimestampGutterEntry[],
+  line: number,
+): number => {
+  let lo = 0;
+  let hi = entries.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (entries[mid].marker.line < line) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+};
+
 export const resolveTerminalTimestampGutterRows = ({
   viewportY,
   rows,
@@ -869,19 +955,25 @@ export const resolveTerminalTimestampGutterRows = ({
   }
 
   const labelByLine = new Map<number, string>();
-  for (const entry of entries) {
+  // Binary-search into the sorted marker list, then scan only the viewport window.
+  for (
+    let index = findFirstTimestampEntryAtOrAfterLine(entries, firstRelevantLine);
+    index < entries.length;
+    index += 1
+  ) {
+    const entry = entries[index];
     if (entry.marker.isDisposed) continue;
     const line = entry.marker.line;
-    if (line < firstRelevantLine || line > viewportEnd) continue;
+    if (line > viewportEnd) break;
     labelByLine.set(line, entry.label);
   }
 
-  const rowLabels = new Map<number, string>();
+  const visible: TerminalTimestampGutterRow[] = [];
   for (let row = 0; row < rows; row += 1) {
     const line = viewportY + row;
     const directLabel = labelByLine.get(line);
     if (directLabel) {
-      rowLabels.set(row, directLabel);
+      visible.push({ row, label: directLabel });
       continue;
     }
 
@@ -889,13 +981,11 @@ export const resolveTerminalTimestampGutterRows = ({
     if (sourceLine === undefined) continue;
     const wrappedLabel = labelByLine.get(sourceLine);
     if (wrappedLabel) {
-      rowLabels.set(row, wrappedLabel);
+      visible.push({ row, label: wrappedLabel });
     }
   }
 
-  return [...rowLabels.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([row, label]) => ({ row, label }));
+  return visible;
 };
 
 export const getVisibleTerminalLineTimestampRows = (
@@ -980,10 +1070,14 @@ export const writeTerminalDataWithLineTimestamps = (
   if (
     timestampOnlyPrefix.length === 0
     && parsedData === dataForTimestamps
-    && canMeasureVisualRows(term, data)
     && (
       dataSegmentCount > MAX_SEGMENTED_TIMESTAMP_WRITES
       || data.length >= BULK_TIMESTAMP_BATCH_MIN_BYTES
+    )
+    // Cheap ASCII gate first (seq / log floods); otherwise one validate+measure probe.
+    && (
+      isSimpleAsciiControlText(data)
+      || canMeasureVisualRows(term, data)
     )
   ) {
     writeBatchedTimestampSegments(term, store, data, segments, done, diagnostics);


### PR DESCRIPTION
## Summary
- Fix terminal freezes on flood output (`seq 1 500000`) caused by always-on line-timestamp bookkeeping: O(n) per-marker dispose filters, unbounded marker growth, and heavy gutter paints.
- Keep **always-on recording** so toggling the gutter still shows history (iTerm2-style: record always, display is a view toggle).
- Speed up the flood path: ASCII measure fast-path, bulk marker registration limited by visual-row capacity, amortized orphan dispose, gated dispose compaction, and flood-aware gutter paint throttling with DOM node reuse.

## Codex review
Local `codex review --base origin/main` was run in a fix loop until clean:

1. Initial review → fixed binary-search correctness + flood throttle clock
2. → throttle output-driven scrolls; dedupe rewritten lines
3. → avoid mass xterm dispose; capacity includes viewport
4. → preserve history under DECSTBM; unstick longLine scroll throttle
5. → skip bulk measure in partial scrolling regions
6. → amortize orphan marker dispose
7. → capacity matches settings max (100k)
8. → defer bulk prune; lighten gutter paint
9. → compact disposed only when dispose signals fire
10. **Final review: "No clear defects were found."**

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/terminalLineTimestamps.test.ts components/terminal/TerminalTimestampGutter.test.ts` (53 pass)
- [x] Manual: `seq 1 500000` completes without whole-app freeze
- [ ] Manual: timestamps off then on still shows recent history
- [ ] Manual: scroll during/after flood remains responsive with gutter on