### PR TITLE
fix(terminal): restore workspace pane X to close session

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2475,16 +2475,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }) ? () => setOsc7SetupOpen(true) : undefined}
       onUpdateHost={handleUpdateHostFromTerminal}
       showClose={opts?.showClose}
-      // In a workspace, the toolbar X means "return this pane to its own tab"
-      // (detach), not destroy the session. Context-menu Close still kills it.
-      onClose={() => {
-        if (inWorkspace && onDetach) {
-          onDetach();
-          return;
-        }
-        onCloseSession?.(sessionId);
-      }}
-      closeRestoresTab={Boolean(inWorkspace && onDetach)}
+      // Workspace toolbar X closes/destroys this pane session. Detach to a
+      // standalone tab remains a separate control (SquareArrowOutUpRight).
+      onClose={() => onCloseSession?.(sessionId)}
       isSearchOpen={isSearchOpen}
       onToggleSearch={handleToggleSearch}
       showLogButton
@@ -2531,7 +2524,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     isSessionLogging,
     isWorkspaceComposeBarOpen,
     onCloseSession,
-    onDetach,
     onOpenScripts,
     onOpenHistory,
     onOpenTheme,

--- a/components/terminal/TerminalToolbar.tsx
+++ b/components/terminal/TerminalToolbar.tsx
@@ -31,8 +31,6 @@ export interface TerminalToolbarProps {
     onUpdateHost?: (host: Host) => void;
     showClose?: boolean;
     onClose?: () => void;
-    /** When true, close is "return pane to its own tab" rather than kill the session. */
-    closeRestoresTab?: boolean;
     // Search functionality
     isSearchOpen?: boolean;
     onToggleSearch?: () => void;
@@ -68,7 +66,6 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
     onUpdateHost,
     showClose,
     onClose,
-    closeRestoresTab = false,
     isSearchOpen,
     onToggleSearch,
     showLogButton = false,
@@ -485,11 +482,7 @@ export const TerminalToolbar: React.FC<TerminalToolbarProps> = ({
                             <X size={11} />
                         </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                        {closeRestoresTab
-                            ? t("terminal.toolbar.detach")
-                            : t("terminal.toolbar.closeSession")}
-                    </TooltipContent>
+                    <TooltipContent side="bottom">{t("terminal.toolbar.closeSession")}</TooltipContent>
                 </Tooltip>
             )}
         </TooltipProvider>


### PR DESCRIPTION
## Summary
- Restores the workspace terminal toolbar **X** button to **close/destroy the pane session** (`onCloseSession`), matching the pre-#2106 behavior.
- Removes the `closeRestoresTab` / detach wiring on that control so it no longer duplicates the existing **Detach to standalone tab** (↗) button.
- Leaves #2106’s session-state hardening for real close/detach paths untouched.

## Context
#2106 (`09cd907b`) intentionally rewired the workspace pane X to detach (“return pane to its own tab”). That made X and the dedicated detach control do the same thing. Users expect X to close the terminal pane.

## Test plan
- [ ] Open a multi-pane workspace tab
- [ ] Click the **↗** detach control on a pane → pane becomes its own tab (unchanged)
- [ ] Click the toolbar **X** on a pane → that session is closed/destroyed (not detached)
- [ ] Hover X → tooltip shows “Close session” / “关闭会话”, not detach
- [ ] Context-menu close and close-session shortcut still kill the pane as before
- [ ] Closing the last pane in a 2-pane workspace still dissolves correctly