### PR TITLE
fix(ai): add Codex GPT-5.6 models and upgrade codex-sdk

### DIFF
--- a/application/state/useAgentDiscovery.ts
+++ b/application/state/useAgentDiscovery.ts
@@ -164,10 +164,17 @@ export function useAgentDiscovery(
         const envChanged =
           (match.command === 'claude' && ea.env?.CLAUDE_CODE_EXECUTABLE !== matchPath)
           || (match.command === 'opencode' && ea.env?.OPENCODE_BIN !== matchPath);
-        if (currentArgs !== newArgs || backendChanged || envChanged) {
+        const versionChanged = Boolean(match.version) && ea.cliVersion !== match.version;
+        if (currentArgs !== newArgs || backendChanged || envChanged || versionChanged) {
           changed = true;
           const { acpCommand: _legacyCommand, acpArgs: _legacyArgs, ...rest } = ea;
-          return { ...rest, args: match.args, sdkBackend: backend, ...(env ? { env } : {}) };
+          return {
+            ...rest,
+            args: match.args,
+            sdkBackend: backend,
+            ...(match.version ? { cliVersion: match.version } : {}),
+            ...(env ? { env } : {}),
+          };
         }
         return ea;
       });
@@ -194,6 +201,7 @@ export function useAgentDiscovery(
         icon: agent.icon,
         enabled: true,
         sdkBackend: backend,
+        ...(agent.version ? { cliVersion: agent.version } : {}),
         ...(agent.command === 'claude'
           ? { env: { CLAUDE_CODE_EXECUTABLE: agent.binPath || agent.path || '' } }
           : agent.command === 'opencode'

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -13,7 +13,12 @@ import type {
   ExternalAgentConfig,
 } from '../infrastructure/ai/types';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
-import { getAgentModelPresets, resolveAgentModelSelection } from '../infrastructure/ai/types';
+import {
+  filterAgentModelPresetsForCliVersion,
+  getAgentModelPresets,
+  resolveAgentModelSelection,
+  resolveDiscoveredAgentCliVersion,
+} from '../infrastructure/ai/types';
 import { getExternalAgentSdkBackend, getManualAgentCommand, matchesManagedAgentConfig } from '../infrastructure/ai/managedAgents';
 import { useAgentDiscovery } from '../application/state/useAgentDiscovery';
 import {
@@ -854,8 +859,19 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       }
       return [];
     }
-    return runtimePresets ?? getAgentModelPresets(currentAgentConfig?.command);
-  }, [currentAgentConfig?.command, currentAgentId, runtimeAgentModelPresets, hasCodexCustomConfig, codexConfigModel]);
+    if (runtimePresets) return runtimePresets;
+    const presets = getAgentModelPresets(currentAgentConfig?.command);
+    // BYO Codex CLI: hide GPT-5.6 when discovery reports CLI < 0.144.0.
+    const cliVersion = resolveDiscoveredAgentCliVersion(currentAgentConfig, discoveredAgents);
+    return filterAgentModelPresetsForCliVersion(presets, cliVersion);
+  }, [
+    currentAgentConfig,
+    currentAgentId,
+    runtimeAgentModelPresets,
+    hasCodexCustomConfig,
+    codexConfigModel,
+    discoveredAgents,
+  ]);
 
   const selectedAgentModel = useMemo(() => {
     const stored = agentModelMap[currentAgentId];

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -13,7 +13,7 @@ import type {
   ExternalAgentConfig,
 } from '../infrastructure/ai/types';
 import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
-import { getAgentModelPresets } from '../infrastructure/ai/types';
+import { getAgentModelPresets, resolveAgentModelSelection } from '../infrastructure/ai/types';
 import { getExternalAgentSdkBackend, getManualAgentCommand, matchesManagedAgentConfig } from '../infrastructure/ai/managedAgents';
 import { useAgentDiscovery } from '../application/state/useAgentDiscovery';
 import {
@@ -863,11 +863,9 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       return stored;
     }
     if (agentModelPresets.length > 0) {
-      const first = agentModelPresets[0];
-      if (first.thinkingLevels?.length) {
-        return `${first.id}/${first.thinkingLevels[first.thinkingLevels.length - 1]}`;
-      }
-      return first.id;
+      // Use catalog defaultThinkingLevel — do not pick last array entry
+      // (that made GPT-5.6 Sol default to ultra).
+      return resolveAgentModelSelection(agentModelPresets[0]);
     }
     return undefined;
   }, [currentAgentConfig, currentAgentId, agentModelMap, agentModelPresets]);

--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -16,8 +16,8 @@ import type { ExecutorContext } from '../infrastructure/ai/cattyAgent/executor';
 import {
   filterAgentModelPresetsForCliVersion,
   getAgentModelPresets,
+  resolveAgentCliVersion,
   resolveAgentModelSelection,
-  resolveDiscoveredAgentCliVersion,
 } from '../infrastructure/ai/types';
 import { getExternalAgentSdkBackend, getManualAgentCommand, matchesManagedAgentConfig } from '../infrastructure/ai/managedAgents';
 import { useAgentDiscovery } from '../application/state/useAgentDiscovery';
@@ -861,8 +861,8 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     }
     if (runtimePresets) return runtimePresets;
     const presets = getAgentModelPresets(currentAgentConfig?.command);
-    // BYO Codex CLI: hide GPT-5.6 when discovery reports CLI < 0.144.0.
-    const cliVersion = resolveDiscoveredAgentCliVersion(currentAgentConfig, discoveredAgents);
+    // BYO Codex CLI: hide GPT-5.6 when CLI < 0.144.0 (stored probe or discovery).
+    const cliVersion = resolveAgentCliVersion(currentAgentConfig, discoveredAgents);
     return filterAgentModelPresetsForCliVersion(presets, cliVersion);
   }, [
     currentAgentConfig,

--- a/components/ai/managedAgentState.test.ts
+++ b/components/ai/managedAgentState.test.ts
@@ -101,6 +101,7 @@ test('buildManagedAgentState stores SDK backend keys for discovered managed agen
   );
 
   assert.equal(codexState.agents[0].sdkBackend, 'codex');
+  assert.equal(codexState.agents[0].cliVersion, '1.0.0');
   assert.equal(copilotState.agents[0].sdkBackend, 'copilot');
   assert.equal(copilotState.agents[0].acpArgs, undefined);
 });

--- a/components/settings/tabs/ai/managedAgentState.ts
+++ b/components/settings/tabs/ai/managedAgentState.ts
@@ -106,6 +106,9 @@ export function buildManagedAgentState(
     id: managedId,
     command: pathInfo.path,
     commandSource,
+    // Persist probed --version so the chat model picker can gate GPT-5.6+
+    // even when this custom path is not the PATH discovery binary.
+    ...(pathInfo.version ? { cliVersion: pathInfo.version } : {}),
     ...(managedEnv ? { env: managedEnv } : {}),
     available: true,
     enabled: managedAgents.length === 0

--- a/electron/bridges/aiBridge/sdk/codexDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/codexDriver.cjs
@@ -72,8 +72,16 @@ function buildCodexConstructorOptions({ codexPath, env, apiKey, injectedMcpServe
   return options;
 }
 
-// codex-sdk reasoning-effort levels.
-const CODEX_REASONING_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"]);
+// codex-sdk reasoning-effort levels (GPT-5.6 also advertises max/ultra).
+const CODEX_REASONING_EFFORTS = new Set([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+]);
 
 function buildCodexThreadOptions({ cwd, model }) {
   // model + sandboxMode + workingDirectory belong to ThreadOptions (startThread).

--- a/electron/bridges/aiBridge/sdk/codexDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/codexDriver.test.cjs
@@ -272,6 +272,13 @@ test("buildCodexThreadOptions splits <model>/<effort> into model + modelReasonin
   const t = buildCodexThreadOptions({ model: "gpt-5.5/high" });
   assert.equal(t.model, "gpt-5.5");
   assert.equal(t.modelReasoningEffort, "high");
+  // GPT-5.6 advertises max/ultra reasoning efforts in the Codex catalog.
+  const solMax = buildCodexThreadOptions({ model: "gpt-5.6-sol/max" });
+  assert.equal(solMax.model, "gpt-5.6-sol");
+  assert.equal(solMax.modelReasoningEffort, "max");
+  const solUltra = buildCodexThreadOptions({ model: "gpt-5.6-sol/ultra" });
+  assert.equal(solUltra.model, "gpt-5.6-sol");
+  assert.equal(solUltra.modelReasoningEffort, "ultra");
   // a trailing segment that isn't a valid effort (custom/OpenRouter id) is kept whole
   const c = buildCodexThreadOptions({ model: "openrouter/some-model" });
   assert.equal(c.model, "openrouter/some-model");

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -6,6 +6,7 @@ import {
   CODEBUDDY_MODEL_PRESETS,
   CODEX_MODEL_PRESETS,
   getAgentModelPresets,
+  resolveAgentModelSelection,
 } from './types';
 
 test('getAgentModelPresets returns CodeBuddy fallback models for command paths', () => {
@@ -32,9 +33,13 @@ test('CODEX_MODEL_PRESETS lists GPT-5.6 Sol/Terra/Luna with official reasoning l
       'gpt-5.5',
       'gpt-5.4',
       'gpt-5.4-mini',
+      'gpt-5.2',
     ],
   );
   assert.equal(byId['gpt-5.6-sol']?.description, 'Latest');
+  assert.equal(byId['gpt-5.6-sol']?.defaultThinkingLevel, 'low');
+  assert.equal(byId['gpt-5.6-terra']?.defaultThinkingLevel, 'medium');
+  assert.equal(byId['gpt-5.6-luna']?.defaultThinkingLevel, 'medium');
   assert.deepEqual(byId['gpt-5.6-sol']?.thinkingLevels, [
     'low',
     'medium',
@@ -62,6 +67,27 @@ test('CODEX_MODEL_PRESETS lists GPT-5.6 Sol/Terra/Luna with official reasoning l
   assert.deepEqual(byId['gpt-5.5']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
   assert.deepEqual(byId['gpt-5.4']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
   assert.deepEqual(byId['gpt-5.4-mini']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
+  assert.deepEqual(byId['gpt-5.2']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
+});
+
+test('resolveAgentModelSelection uses catalog default effort, not last array entry', () => {
+  assert.equal(resolveAgentModelSelection(CODEX_MODEL_PRESETS[0]!), 'gpt-5.6-sol/low');
+  assert.equal(
+    resolveAgentModelSelection(CODEX_MODEL_PRESETS.find((m) => m.id === 'gpt-5.6-terra')!),
+    'gpt-5.6-terra/medium',
+  );
+  assert.equal(
+    resolveAgentModelSelection({
+      id: 'custom',
+      name: 'Custom',
+      thinkingLevels: ['low', 'high'],
+    }),
+    'custom/low',
+  );
+  assert.equal(
+    resolveAgentModelSelection({ id: 'plain', name: 'Plain' }),
+    'plain',
+  );
 });
 
 test('getAgentModelPresets resolves Windows command paths with backslashes', () => {

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -4,9 +4,13 @@ import assert from 'node:assert/strict';
 import {
   CLAUDE_MODEL_PRESETS,
   CODEBUDDY_MODEL_PRESETS,
+  CODEX_GPT_5_6_MIN_CLI_VERSION,
   CODEX_MODEL_PRESETS,
+  extractCliSemver,
+  filterAgentModelPresetsForCliVersion,
   getAgentModelPresets,
   resolveAgentModelSelection,
+  resolveDiscoveredAgentCliVersion,
 } from './types';
 
 test('getAgentModelPresets returns CodeBuddy fallback models for command paths', () => {
@@ -87,6 +91,44 @@ test('resolveAgentModelSelection uses catalog default effort, not last array ent
   assert.equal(
     resolveAgentModelSelection({ id: 'plain', name: 'Plain' }),
     'plain',
+  );
+});
+
+test('filterAgentModelPresetsForCliVersion gates GPT-5.6 on CLI < 0.144.0', () => {
+  assert.equal(extractCliSemver('codex-cli 0.136.0'), '0.136.0');
+  assert.equal(CODEX_GPT_5_6_MIN_CLI_VERSION, '0.144.0');
+
+  const oldCli = filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, '0.136.0');
+  assert.deepEqual(
+    oldCli.map((model) => model.id),
+    ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.2'],
+  );
+  assert.equal(resolveAgentModelSelection(oldCli[0]!), 'gpt-5.5/medium');
+
+  const newCli = filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, 'codex-cli 0.144.1');
+  assert.equal(newCli[0]?.id, 'gpt-5.6-sol');
+
+  // Unknown version: keep full list so the picker is not empty pre-discovery.
+  assert.equal(
+    filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, undefined).length,
+    CODEX_MODEL_PRESETS.length,
+  );
+});
+
+test('resolveDiscoveredAgentCliVersion matches command path or sdk backend', () => {
+  assert.equal(
+    resolveDiscoveredAgentCliVersion(
+      { command: '/usr/local/bin/codex', sdkBackend: 'codex' },
+      [{ command: 'codex', path: '/usr/local/bin/codex', binPath: '/usr/local/bin/codex', sdkBackend: 'codex', version: '0.144.1' }],
+    ),
+    '0.144.1',
+  );
+  assert.equal(
+    resolveDiscoveredAgentCliVersion(
+      { command: 'codex', sdkBackend: 'codex' },
+      [{ command: 'claude', path: '/bin/claude', binPath: '/bin/claude', sdkBackend: 'claude', version: '1.0.0' }],
+    ),
+    undefined,
   );
 });
 

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -21,6 +21,49 @@ test('getAgentModelPresets keeps Codex presets separate from CodeBuddy presets',
   assert.notDeepEqual(CODEBUDDY_MODEL_PRESETS, CODEX_MODEL_PRESETS);
 });
 
+test('CODEX_MODEL_PRESETS lists GPT-5.6 Sol/Terra/Luna with official reasoning levels', () => {
+  const byId = Object.fromEntries(CODEX_MODEL_PRESETS.map((model) => [model.id, model]));
+  assert.deepEqual(
+    CODEX_MODEL_PRESETS.map((model) => model.id),
+    [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+    ],
+  );
+  assert.equal(byId['gpt-5.6-sol']?.description, 'Latest');
+  assert.deepEqual(byId['gpt-5.6-sol']?.thinkingLevels, [
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+    'ultra',
+  ]);
+  assert.deepEqual(byId['gpt-5.6-terra']?.thinkingLevels, [
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+    'ultra',
+  ]);
+  // Luna omits ultra per openai/codex models-manager catalog (+ lobehub).
+  assert.deepEqual(byId['gpt-5.6-luna']?.thinkingLevels, [
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+  ]);
+  assert.deepEqual(byId['gpt-5.5']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
+  assert.deepEqual(byId['gpt-5.4']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
+  assert.deepEqual(byId['gpt-5.4-mini']?.thinkingLevels, ['low', 'medium', 'high', 'xhigh']);
+});
+
 test('getAgentModelPresets resolves Windows command paths with backslashes', () => {
   assert.deepEqual(
     getAgentModelPresets('C\\Users\\foo\\AppData\\Roaming\\npm\\codex.cmd'),

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -9,6 +9,7 @@ import {
   extractCliSemver,
   filterAgentModelPresetsForCliVersion,
   getAgentModelPresets,
+  resolveAgentCliVersion,
   resolveAgentModelSelection,
   resolveDiscoveredAgentCliVersion,
 } from './types';
@@ -146,6 +147,25 @@ test('resolveDiscoveredAgentCliVersion matches command path or sdk backend', () 
     ),
     '0.144.1',
   );
+});
+
+test('resolveAgentCliVersion prefers stored cliVersion over discovery', () => {
+  assert.equal(
+    resolveAgentCliVersion(
+      { command: '/opt/custom/codex', sdkBackend: 'codex', cliVersion: 'codex-cli 0.144.3' },
+      [{ command: 'codex', path: '/usr/local/bin/codex', binPath: '/usr/local/bin/codex', sdkBackend: 'codex', version: '0.136.0' }],
+    ),
+    'codex-cli 0.144.3',
+  );
+  // Custom path with stored probe unlocks GPT-5.6 even when not on PATH.
+  const gated = filterAgentModelPresetsForCliVersion(
+    CODEX_MODEL_PRESETS,
+    resolveAgentCliVersion(
+      { command: '/opt/custom/codex', sdkBackend: 'codex', cliVersion: '0.144.0' },
+      [],
+    ),
+  );
+  assert.equal(gated[0]?.id, 'gpt-5.6-sol');
 });
 
 test('getAgentModelPresets resolves Windows command paths with backslashes', () => {

--- a/infrastructure/ai/types.test.ts
+++ b/infrastructure/ai/types.test.ts
@@ -108,10 +108,11 @@ test('filterAgentModelPresetsForCliVersion gates GPT-5.6 on CLI < 0.144.0', () =
   const newCli = filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, 'codex-cli 0.144.1');
   assert.equal(newCli[0]?.id, 'gpt-5.6-sol');
 
-  // Unknown version: keep full list so the picker is not empty pre-discovery.
-  assert.equal(
-    filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, undefined).length,
-    CODEX_MODEL_PRESETS.length,
+  // Unknown version: hide version-gated models so pre-discovery cannot
+  // auto-default old installs onto Sol. Ungated presets keep the picker usable.
+  assert.deepEqual(
+    filterAgentModelPresetsForCliVersion(CODEX_MODEL_PRESETS, undefined).map((m) => m.id),
+    ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.2'],
   );
 });
 
@@ -123,12 +124,27 @@ test('resolveDiscoveredAgentCliVersion matches command path or sdk backend', () 
     ),
     '0.144.1',
   );
+  // Manual path must not inherit PATH discovery version for a different binary.
+  assert.equal(
+    resolveDiscoveredAgentCliVersion(
+      { command: '/opt/old/codex', sdkBackend: 'codex' },
+      [{ command: 'codex', path: '/usr/local/bin/codex', binPath: '/usr/local/bin/codex', sdkBackend: 'codex', version: '0.144.1' }],
+    ),
+    undefined,
+  );
   assert.equal(
     resolveDiscoveredAgentCliVersion(
       { command: 'codex', sdkBackend: 'codex' },
       [{ command: 'claude', path: '/bin/claude', binPath: '/bin/claude', sdkBackend: 'claude', version: '1.0.0' }],
     ),
     undefined,
+  );
+  assert.equal(
+    resolveDiscoveredAgentCliVersion(
+      { command: 'codex', sdkBackend: 'codex' },
+      [{ command: 'codex', path: '/usr/local/bin/codex', binPath: '/usr/local/bin/codex', sdkBackend: 'codex', version: '0.144.1' }],
+    ),
+    '0.144.1',
   );
 });
 

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -446,6 +446,11 @@ export interface AgentModelPreset {
    * UI lists levels low→high but catalog defaults are usually mid-range.
    */
   defaultThinkingLevel?: string;
+  /**
+   * Minimum agent CLI version that advertises this model (semver core).
+   * Netcatty is BYO-CLI: the packaged SDK does not replace the user's binary.
+   */
+  minCliVersion?: string;
 }
 
 export const CLAUDE_MODEL_PRESETS: AgentModelPreset[] = [
@@ -463,35 +468,86 @@ const CODEX_REASONING_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
 // Sol/Terra advertise ultra; Luna stops at max (official catalog + lobehub).
 const CODEX_REASONING_LEVELS_5_6 = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
 const CODEX_REASONING_LEVELS_5_6_LUNA = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+/** Official catalog `minimal_client_version` for GPT-5.6 family. */
+export const CODEX_GPT_5_6_MIN_CLI_VERSION = '0.144.0';
 
 function codexPreset(
   id: string,
   name: string,
   thinkingLevels: readonly string[],
   defaultThinkingLevel: string,
-  description?: string,
+  options?: { description?: string; minCliVersion?: string },
 ): AgentModelPreset {
   return {
     id,
     name,
-    description,
+    description: options?.description,
     thinkingLevels: [...thinkingLevels],
     defaultThinkingLevel,
+    minCliVersion: options?.minCliVersion,
   };
 }
 
 export const CODEX_MODEL_PRESETS: AgentModelPreset[] = [
-  // default_reasoning_level from openai/codex models-manager catalog
-  codexPreset('gpt-5.6-sol', 'GPT-5.6 Sol', CODEX_REASONING_LEVELS_5_6, 'low', 'Latest'),
-  codexPreset('gpt-5.6-terra', 'GPT-5.6 Terra', CODEX_REASONING_LEVELS_5_6, 'medium', 'Balanced'),
-  codexPreset('gpt-5.6-luna', 'GPT-5.6 Luna', CODEX_REASONING_LEVELS_5_6_LUNA, 'medium', 'Fast'),
+  // default_reasoning_level + minimal_client_version from openai/codex catalog
+  codexPreset('gpt-5.6-sol', 'GPT-5.6 Sol', CODEX_REASONING_LEVELS_5_6, 'low', {
+    description: 'Latest',
+    minCliVersion: CODEX_GPT_5_6_MIN_CLI_VERSION,
+  }),
+  codexPreset('gpt-5.6-terra', 'GPT-5.6 Terra', CODEX_REASONING_LEVELS_5_6, 'medium', {
+    description: 'Balanced',
+    minCliVersion: CODEX_GPT_5_6_MIN_CLI_VERSION,
+  }),
+  codexPreset('gpt-5.6-luna', 'GPT-5.6 Luna', CODEX_REASONING_LEVELS_5_6_LUNA, 'medium', {
+    description: 'Fast',
+    minCliVersion: CODEX_GPT_5_6_MIN_CLI_VERSION,
+  }),
   codexPreset('gpt-5.5', 'GPT-5.5', CODEX_REASONING_LEVELS, 'medium'),
   codexPreset('gpt-5.4', 'GPT-5.4', CODEX_REASONING_LEVELS, 'medium'),
-  codexPreset('gpt-5.4-mini', 'GPT-5.4 Mini', CODEX_REASONING_LEVELS, 'medium', 'Small & fast'),
+  codexPreset('gpt-5.4-mini', 'GPT-5.4 Mini', CODEX_REASONING_LEVELS, 'medium', {
+    description: 'Small & fast',
+  }),
   // Still visibility:list in upstream catalog; keep selectable so stored
   // gpt-5.2/* selections are not silently forced onto Sol.
   codexPreset('gpt-5.2', 'GPT-5.2', CODEX_REASONING_LEVELS, 'medium'),
 ];
+
+/** Extract `major.minor.patch` from CLI --version output (e.g. "codex-cli 0.144.1"). */
+export function extractCliSemver(versionText: string | null | undefined): string | null {
+  if (!versionText) return null;
+  const match = String(versionText).match(/(\d+)\.(\d+)\.(\d+)/);
+  return match ? `${match[1]}.${match[2]}.${match[3]}` : null;
+}
+
+function compareSemverCore(a: string, b: string): number {
+  const pa = a.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const pb = b.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}
+
+/**
+ * Drop presets whose minCliVersion exceeds the installed CLI.
+ * When the CLI version is unknown, keep the full list (optimistic) so the
+ * picker is not empty before discovery finishes.
+ */
+export function filterAgentModelPresetsForCliVersion(
+  presets: AgentModelPreset[],
+  cliVersionText: string | null | undefined,
+): AgentModelPreset[] {
+  const cliSemver = extractCliSemver(cliVersionText);
+  if (!cliSemver) return presets;
+  return presets.filter((preset) => {
+    if (!preset.minCliVersion) return true;
+    return compareSemverCore(cliSemver, preset.minCliVersion) >= 0;
+  });
+}
 
 /** Resolve the model id (with optional /effort) for auto-selection. */
 export function resolveAgentModelSelection(preset: AgentModelPreset): string {
@@ -503,6 +559,35 @@ export function resolveAgentModelSelection(preset: AgentModelPreset): string {
   }
   // Conservative fallback: first listed effort (usually the cheapest/fastest).
   return `${preset.id}/${levels[0]}`;
+}
+
+/** Match a configured agent to a discovery row to read its probed CLI version. */
+export function resolveDiscoveredAgentCliVersion(
+  agent: Pick<ExternalAgentConfig, 'command' | 'sdkBackend'> | null | undefined,
+  discovered: Array<Pick<DiscoveredAgent, 'command' | 'path' | 'binPath' | 'sdkBackend' | 'version'>>,
+): string | undefined {
+  if (!agent || discovered.length === 0) return undefined;
+  const command = agent.command || '';
+  const basename = command.split(/[\\/]/).pop()?.toLowerCase() ?? '';
+  const match = discovered.find((entry) => {
+    if (agent.sdkBackend && entry.sdkBackend && agent.sdkBackend === entry.sdkBackend) {
+      if (
+        entry.path === command
+        || entry.binPath === command
+        || entry.command === basename
+        || entry.command === command
+      ) {
+        return true;
+      }
+    }
+    return (
+      entry.path === command
+      || entry.binPath === command
+      || entry.command === basename
+      || entry.command === command
+    );
+  });
+  return match?.version || undefined;
 }
 
 export const CURSOR_MODEL_PRESETS: AgentModelPreset[] = [

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -440,6 +440,12 @@ export interface AgentModelPreset {
   description?: string;
   /** Codex thinking levels (model ID sent as `id/thinking`) */
   thinkingLevels?: string[];
+  /**
+   * Default effort used when auto-selecting a model with thinkingLevels.
+   * Must be one of `thinkingLevels` when set. Do not infer from array order —
+   * UI lists levels low→high but catalog defaults are usually mid-range.
+   */
+  defaultThinkingLevel?: string;
 }
 
 export const CLAUDE_MODEL_PRESETS: AgentModelPreset[] = [
@@ -458,34 +464,46 @@ const CODEX_REASONING_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
 const CODEX_REASONING_LEVELS_5_6 = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
 const CODEX_REASONING_LEVELS_5_6_LUNA = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 
+function codexPreset(
+  id: string,
+  name: string,
+  thinkingLevels: readonly string[],
+  defaultThinkingLevel: string,
+  description?: string,
+): AgentModelPreset {
+  return {
+    id,
+    name,
+    description,
+    thinkingLevels: [...thinkingLevels],
+    defaultThinkingLevel,
+  };
+}
+
 export const CODEX_MODEL_PRESETS: AgentModelPreset[] = [
-  {
-    id: 'gpt-5.6-sol',
-    name: 'GPT-5.6 Sol',
-    description: 'Latest',
-    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6],
-  },
-  {
-    id: 'gpt-5.6-terra',
-    name: 'GPT-5.6 Terra',
-    description: 'Balanced',
-    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6],
-  },
-  {
-    id: 'gpt-5.6-luna',
-    name: 'GPT-5.6 Luna',
-    description: 'Fast',
-    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6_LUNA],
-  },
-  { id: 'gpt-5.5', name: 'GPT-5.5', thinkingLevels: [...CODEX_REASONING_LEVELS] },
-  { id: 'gpt-5.4', name: 'GPT-5.4', thinkingLevels: [...CODEX_REASONING_LEVELS] },
-  {
-    id: 'gpt-5.4-mini',
-    name: 'GPT-5.4 Mini',
-    description: 'Small & fast',
-    thinkingLevels: [...CODEX_REASONING_LEVELS],
-  },
+  // default_reasoning_level from openai/codex models-manager catalog
+  codexPreset('gpt-5.6-sol', 'GPT-5.6 Sol', CODEX_REASONING_LEVELS_5_6, 'low', 'Latest'),
+  codexPreset('gpt-5.6-terra', 'GPT-5.6 Terra', CODEX_REASONING_LEVELS_5_6, 'medium', 'Balanced'),
+  codexPreset('gpt-5.6-luna', 'GPT-5.6 Luna', CODEX_REASONING_LEVELS_5_6_LUNA, 'medium', 'Fast'),
+  codexPreset('gpt-5.5', 'GPT-5.5', CODEX_REASONING_LEVELS, 'medium'),
+  codexPreset('gpt-5.4', 'GPT-5.4', CODEX_REASONING_LEVELS, 'medium'),
+  codexPreset('gpt-5.4-mini', 'GPT-5.4 Mini', CODEX_REASONING_LEVELS, 'medium', 'Small & fast'),
+  // Still visibility:list in upstream catalog; keep selectable so stored
+  // gpt-5.2/* selections are not silently forced onto Sol.
+  codexPreset('gpt-5.2', 'GPT-5.2', CODEX_REASONING_LEVELS, 'medium'),
 ];
+
+/** Resolve the model id (with optional /effort) for auto-selection. */
+export function resolveAgentModelSelection(preset: AgentModelPreset): string {
+  const levels = preset.thinkingLevels;
+  if (!levels?.length) return preset.id;
+  const preferred = preset.defaultThinkingLevel;
+  if (preferred && levels.includes(preferred)) {
+    return `${preset.id}/${preferred}`;
+  }
+  // Conservative fallback: first listed effort (usually the cheapest/fastest).
+  return `${preset.id}/${levels[0]}`;
+}
 
 export const CURSOR_MODEL_PRESETS: AgentModelPreset[] = [
   { id: 'composer-2.5', name: 'Composer 2.5', description: 'Recommended' },

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -448,17 +448,43 @@ export const CLAUDE_MODEL_PRESETS: AgentModelPreset[] = [
   { id: 'haiku', name: 'Haiku 4.5', description: 'Fastest' },
 ];
 
-// Curated codex model list (codex-sdk has no enumeration API). Mirrors the
-// craft agent's `openai-codex` set. The codex driver splits "<id>/<effort>"
-// into model + modelReasoningEffort, so thinkingLevels work via codex-sdk.
+// Curated codex model list (codex-sdk has no enumeration API). IDs/efforts
+// mirror openai/codex `models-manager/models.json` and peer open-source presets
+// (pi openai-codex.models, lobehub agencyConfig, paperclip codex_local, suna
+// codex-models, cherry-studio openai-codex). GPT-5.6 needs CLI >= 0.144.0.
+// The codex driver splits "<id>/<effort>" into model + modelReasoningEffort.
+const CODEX_REASONING_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+// Sol/Terra advertise ultra; Luna stops at max (official catalog + lobehub).
+const CODEX_REASONING_LEVELS_5_6 = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
+const CODEX_REASONING_LEVELS_5_6_LUNA = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+
 export const CODEX_MODEL_PRESETS: AgentModelPreset[] = [
-  { id: 'gpt-5.5', name: 'GPT-5.5', description: 'Latest', thinkingLevels: ['low', 'medium', 'high', 'xhigh'] },
-  { id: 'gpt-5.2', name: 'GPT-5.2', thinkingLevels: ['low', 'medium', 'high', 'xhigh'] },
-  { id: 'gpt-5.1', name: 'GPT-5.1', thinkingLevels: ['low', 'medium', 'high', 'xhigh'] },
-  { id: 'gpt-5', name: 'GPT-5', thinkingLevels: ['low', 'medium', 'high', 'xhigh'] },
-  { id: 'o4-mini', name: 'o4-mini', description: 'Fast reasoning' },
-  { id: 'o3', name: 'o3', description: 'Reasoning' },
-  { id: 'gpt-4o', name: 'GPT-4o' },
+  {
+    id: 'gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
+    description: 'Latest',
+    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6],
+  },
+  {
+    id: 'gpt-5.6-terra',
+    name: 'GPT-5.6 Terra',
+    description: 'Balanced',
+    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6],
+  },
+  {
+    id: 'gpt-5.6-luna',
+    name: 'GPT-5.6 Luna',
+    description: 'Fast',
+    thinkingLevels: [...CODEX_REASONING_LEVELS_5_6_LUNA],
+  },
+  { id: 'gpt-5.5', name: 'GPT-5.5', thinkingLevels: [...CODEX_REASONING_LEVELS] },
+  { id: 'gpt-5.4', name: 'GPT-5.4', thinkingLevels: [...CODEX_REASONING_LEVELS] },
+  {
+    id: 'gpt-5.4-mini',
+    name: 'GPT-5.4 Mini',
+    description: 'Small & fast',
+    thinkingLevels: [...CODEX_REASONING_LEVELS],
+  },
 ];
 
 export const CURSOR_MODEL_PRESETS: AgentModelPreset[] = [

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -534,17 +534,18 @@ function compareSemverCore(a: string, b: string): number {
 
 /**
  * Drop presets whose minCliVersion exceeds the installed CLI.
- * When the CLI version is unknown, keep the full list (optimistic) so the
- * picker is not empty before discovery finishes.
+ * When the CLI version is unknown (pre-discovery / probe failed), also drop
+ * version-gated presets so old installs cannot auto-default to Sol before
+ * discovery finishes. Older ungated presets keep the picker non-empty.
  */
 export function filterAgentModelPresetsForCliVersion(
   presets: AgentModelPreset[],
   cliVersionText: string | null | undefined,
 ): AgentModelPreset[] {
   const cliSemver = extractCliSemver(cliVersionText);
-  if (!cliSemver) return presets;
   return presets.filter((preset) => {
     if (!preset.minCliVersion) return true;
+    if (!cliSemver) return false;
     return compareSemverCore(cliSemver, preset.minCliVersion) >= 0;
   });
 }
@@ -561,31 +562,46 @@ export function resolveAgentModelSelection(preset: AgentModelPreset): string {
   return `${preset.id}/${levels[0]}`;
 }
 
+function looksLikeFilesystemPath(command: string): boolean {
+  return /[\\/]/.test(command) || /^[A-Za-z]:/.test(command);
+}
+
+function normalizeCliPathKey(pathText: string): string {
+  // Case-fold on Windows-style paths; keep POSIX case-sensitive otherwise.
+  const trimmed = pathText.trim();
+  if (/^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.includes('\\')) {
+    return trimmed.replace(/\\/g, '/').toLowerCase();
+  }
+  return trimmed;
+}
+
 /** Match a configured agent to a discovery row to read its probed CLI version. */
 export function resolveDiscoveredAgentCliVersion(
   agent: Pick<ExternalAgentConfig, 'command' | 'sdkBackend'> | null | undefined,
   discovered: Array<Pick<DiscoveredAgent, 'command' | 'path' | 'binPath' | 'sdkBackend' | 'version'>>,
 ): string | undefined {
   if (!agent || discovered.length === 0) return undefined;
-  const command = agent.command || '';
-  const basename = command.split(/[\\/]/).pop()?.toLowerCase() ?? '';
+  const command = (agent.command || '').trim();
+  if (!command) return undefined;
+
+  // Absolute/relative path configs must match the exact discovered binary —
+  // basename-only matching would gate against PATH codex while the driver
+  // launches a different manual binary.
+  if (looksLikeFilesystemPath(command)) {
+    const wanted = normalizeCliPathKey(command);
+    const pathMatch = discovered.find((entry) => {
+      const candidates = [entry.path, entry.binPath].filter(Boolean) as string[];
+      return candidates.some((candidate) => normalizeCliPathKey(candidate) === wanted);
+    });
+    return pathMatch?.version || undefined;
+  }
+
+  const basename = command.split(/[\\/]/).pop()?.toLowerCase() ?? command.toLowerCase();
   const match = discovered.find((entry) => {
-    if (agent.sdkBackend && entry.sdkBackend && agent.sdkBackend === entry.sdkBackend) {
-      if (
-        entry.path === command
-        || entry.binPath === command
-        || entry.command === basename
-        || entry.command === command
-      ) {
-        return true;
-      }
+    if (agent.sdkBackend && entry.sdkBackend && agent.sdkBackend !== entry.sdkBackend) {
+      return false;
     }
-    return (
-      entry.path === command
-      || entry.binPath === command
-      || entry.command === basename
-      || entry.command === command
-    );
+    return entry.command === basename || entry.command === command;
   });
   return match?.version || undefined;
 }

--- a/infrastructure/ai/types.ts
+++ b/infrastructure/ai/types.ts
@@ -239,6 +239,12 @@ export interface ExternalAgentConfig {
   sdkBackend?: string;
   /** Internal: whether the managed command was set manually or auto-detected. */
   commandSource?: "manual" | "auto";
+  /**
+   * Last probed CLI --version output for this agent binary (from settings
+   * resolve-cli or discovery). Used to gate version-specific model presets
+   * when the configured path is not on PATH discovery.
+   */
+  cliVersion?: string;
   /** @deprecated Legacy persisted field from the pre-SDK migration. Read only for compatibility. */
   acpCommand?: string;
   /** @deprecated Legacy persisted field from the pre-SDK migration. */
@@ -604,6 +610,19 @@ export function resolveDiscoveredAgentCliVersion(
     return entry.command === basename || entry.command === command;
   });
   return match?.version || undefined;
+}
+
+/**
+ * Prefer the version stored on the agent config (settings resolve-cli / enable),
+ * then fall back to a matching discovery probe.
+ */
+export function resolveAgentCliVersion(
+  agent: Pick<ExternalAgentConfig, 'command' | 'sdkBackend' | 'cliVersion'> | null | undefined,
+  discovered: Array<Pick<DiscoveredAgent, 'command' | 'path' | 'binPath' | 'sdkBackend' | 'version'>>,
+): string | undefined {
+  const stored = agent?.cliVersion?.trim();
+  if (stored) return stored;
+  return resolveDiscoveredAgentCliVersion(agent, discovered);
 }
 
 export const CURSOR_MODEL_PRESETS: AgentModelPreset[] = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@mdxeditor/editor": "^4.0.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@monaco-editor/react": "^4.7.0",
-        "@openai/codex-sdk": "^0.136.0",
+        "@openai/codex-sdk": "^0.144.3",
         "@radix-ui/react-collapsible": "1.1.12",
         "@radix-ui/react-context-menu": "2.2.16",
         "@radix-ui/react-dialog": "1.1.15",
@@ -335,29 +335,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
-      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1288,6 +1265,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1893,6 +1871,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -1982,6 +1961,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -1991,6 +1971,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.1.tgz",
       "integrity": "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -2003,6 +1984,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
       "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
@@ -2454,7 +2436,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2476,7 +2457,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3895,6 +3875,7 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -4177,6 +4158,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -4327,9 +4309,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0.tgz",
-      "integrity": "sha512-yu+diXznSOt8h296/CDOf2CNi55z1raA7aZ6sejjGy1QWPqn72YkBc2ByTzZG6G+1yiUqlm2G5Hid54hm3/kaA==",
+      "version": "0.144.3",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3.tgz",
+      "integrity": "sha512-8Re3wp5CdYiM7nsF4StFa5js6IT11N7srhxfvwtol7ENHDht05C+HS4e1CTmYjqkhgsUzl2R1gB27iN2pdbVnA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -4338,19 +4320,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.136.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.136.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.136.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.136.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.136.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.136.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.3-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.3-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.3-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.3-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.3-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.3-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-arm64.tgz",
-      "integrity": "sha512-9xnEohnUO9l6qtPSDbG0Y2UXX5mBZ9Lsn0VMgjtkREGfWL9TawNC1d7D1ERMSJtHTlVvieoaFyK9LHPLQCO9Vw==",
+      "version": "0.144.3-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-arm64.tgz",
+      "integrity": "sha512-v/yT1wqslBcwquUvUPZvAdYyiZcCBIUL+pE4ymHpbUMVduwDJBw1EjLroOhe9FkYFDHzWGyv7YEw7iIV4k+0dA==",
       "cpu": [
         "arm64"
       ],
@@ -4365,9 +4347,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-darwin-x64.tgz",
-      "integrity": "sha512-HD9YLalPg0cv+CiZSmRWOl/8sefuJlxJcAmxyzb8mSaAMchD3V+2yS6M6E1Z2I6NX1irp4Polt1fPsjGdlHYhQ==",
+      "version": "0.144.3-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-darwin-x64.tgz",
+      "integrity": "sha512-308U0s7AeRg3AlnxJtmJk03yRRriEplC6ceFoB3OpWh+przqt8/u6MKDVU3KHdjb+vasa0IpmDWv5VrFw3oJAw==",
       "cpu": [
         "x64"
       ],
@@ -4382,9 +4364,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-arm64.tgz",
-      "integrity": "sha512-xDxTOk5ClEX/nzlQseqEoiubjIzVZfcWKn9nmKkHOLKknz+c7n6tbmw7eY4mwt29zTAAoFoecdRnbbsPZUHJ1g==",
+      "version": "0.144.3-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-arm64.tgz",
+      "integrity": "sha512-mJgDUmoPMry9a7g6ywsMQ4uQko2K0uHLqzEITUJMXiNNbCRBQKS+PxDWBlSK0bF0v72uAhWRRRGvPXslwhIdyg==",
       "cpu": [
         "arm64"
       ],
@@ -4399,9 +4381,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-linux-x64.tgz",
-      "integrity": "sha512-Q6yZHRtUWD+27B5yAiOYyPAtM0BzW0Mm23YGaXDmfNEO5BYgHuUT80VDofUpjSyo2+ShYoZQUFVQAsNPKqd+Sw==",
+      "version": "0.144.3-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-linux-x64.tgz",
+      "integrity": "sha512-xtDY5sWQPbYBj2lLWZJvc0jBre0XQ7ZmN4VbSEvazbQ2X7uHhm1D/0oZ7AI+SgC/VfZrUhvxRHd43/AmXSaAzA==",
       "cpu": [
         "x64"
       ],
@@ -4415,12 +4397,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.136.0.tgz",
-      "integrity": "sha512-qrSirrVxrpVHR1YIQQ4WSouneaQrQrRAAlQWJYRflvMCcruFXorsmIPeIbDqFXOa8A9H9FHHyc+2U4tdbEGGiQ==",
+      "version": "0.144.3",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.3.tgz",
+      "integrity": "sha512-WPtEx38iVyksWujOwmsxnJznRR8T/YF+lAJghMhHL1xIWdJrrvZ1iafhIsw4egY5CRoRmFm2ta8NQsK4f4XDZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.136.0"
+        "@openai/codex": "0.144.3"
       },
       "engines": {
         "node": ">=18"
@@ -4428,9 +4410,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.136.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-arm64.tgz",
-      "integrity": "sha512-mAHZXfygQxBg1JjZ9+bAZfBXe6fg8MabJhuDYhj5z0VF++orKSFsC1lMiv6PksQN36ikQefgVjc9EOlaE4lt7g==",
+      "version": "0.144.3-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-arm64.tgz",
+      "integrity": "sha512-uvgBLuBX58GIq58CquhvhEmwLlH9Lc46rLmE5/CkEf1vQiCvWqVHxL28t7P9cmWGoeMuxsrIwqJgyzmRu6wZMQ==",
       "cpu": [
         "arm64"
       ],
@@ -4445,9 +4427,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.136.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.136.0-win32-x64.tgz",
-      "integrity": "sha512-zS6DAmvjdWeAB1CL9KTUMkwzTwfXtxHy8GAtePw2a93jIqawoG07fBxAXuyoHZ3QXQkwEgqBx1zEEh33gdIKAw==",
+      "version": "0.144.3-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.3-win32-x64.tgz",
+      "integrity": "sha512-0o8LpbZuBvqcAdIqMh96pECFTtfkgMT2sP/Q2IKYUOOlSudq3ulvdDW6zARq04HhbOxSsU9TBYDkdqtDs2YcYQ==",
       "cpu": [
         "x64"
       ],
@@ -7590,8 +7572,7 @@
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -8201,6 +8182,7 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -8230,6 +8212,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8589,6 +8572,7 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.220.tgz",
       "integrity": "sha512-rwEKE75wfwfNWeGnjl0iQRA1W50HigKoGcGMeF3o5CqDSdI9IjmwzpV9xHXqLH6CYj6s9N1g6bbKFVDou9dJ/A==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "addons/*"
       ]
@@ -8653,6 +8637,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9352,6 +9337,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10177,8 +10163,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -10475,6 +10460,7 @@
       "integrity": "sha512-fMkjRqKyPtsz4Kzu/qGP0BGjqzMCIgp+/7kw/u6YH6lvn/8hvL3c0TXhoFayBoYdpPCnEinnCHztd4bW7/jetA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.2",
         "builder-util": "26.15.0",
@@ -10756,7 +10742,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10777,7 +10762,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10793,7 +10777,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -10804,7 +10787,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -11029,6 +11011,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11482,8 +11465,7 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -12420,6 +12402,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12874,7 +12857,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12996,7 +12978,6 @@
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -13154,7 +13135,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14115,6 +14095,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -15235,7 +15216,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -15255,6 +15235,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -16005,7 +15986,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -16023,7 +16003,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -16328,6 +16307,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16337,6 +16317,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17657,7 +17638,6 @@
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -17963,7 +17943,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17990,7 +17969,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18065,6 +18043,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18159,8 +18138,7 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -18187,6 +18165,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -18298,6 +18277,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18338,6 +18318,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -18713,6 +18694,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18806,6 +18788,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19093,6 +19076,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@mdxeditor/editor": "^4.0.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.7.0",
-    "@openai/codex-sdk": "^0.136.0",
+    "@openai/codex-sdk": "^0.144.3",
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-context-menu": "2.2.16",
     "@radix-ui/react-dialog": "1.1.15",


### PR DESCRIPTION
## Summary
- Add GPT-5.6 Sol / Terra / Luna to curated `CODEX_MODEL_PRESETS` (codex-sdk still has no model catalog API).
- Align the list with the official Codex catalog and peer open-source presets: Sol/Terra/Luna, GPT-5.5, GPT-5.4, GPT-5.4 Mini; drop stale older entries.
- Support GPT-5.6 reasoning efforts `max` / `ultra` in the codex driver (`model/effort` split).
- Upgrade `@openai/codex-sdk` (and bundled `@openai/codex` CLI) from `0.136.0` → `0.144.3` so runtime meets the official `minimal_client_version: 0.144.0` for GPT-5.6.

Fixes #2169

## Test plan
- [x] `node --test --import tsx infrastructure/ai/types.test.ts electron/bridges/aiBridge/sdk/codexDriver.test.cjs` (20/20)
- [ ] In app: open Codex agent model picker and confirm GPT-5.6 Sol/Terra/Luna appear
- [ ] Select Sol with medium / max / ultra effort and verify a turn starts (ChatGPT auth with 5.6 access)
- [ ] Confirm Luna effort list stops at max (no ultra)