### PR TITLE
feat(terminal): configurable su/sudo password prompt assist (#2156)

### DIFF
--- a/application/i18n/locales/en/core.ts
+++ b/application/i18n/locales/en/core.ts
@@ -576,6 +576,15 @@ export const enCoreMessages: Messages = {
   'settings.terminal.autocomplete.popupMenu': 'Popup menu',
   'settings.terminal.autocomplete.popupMenu.desc': 'Show a floating list of multiple suggestions.',
 
+  // Settings > Terminal > Password prompt assist (sudo/su)
+  'settings.terminal.section.passwordPromptAssist': 'Password prompt assist',
+  'settings.terminal.passwordPromptAssist.mode': 'Assist mode',
+  'settings.terminal.passwordPromptAssist.mode.desc':
+    'When sudo or su asks for a password, offer a saved credential. Never auto-sends without confirmation.',
+  'settings.terminal.passwordPromptAssist.off': 'Off',
+  'settings.terminal.passwordPromptAssist.hint': 'Quick fill (Enter)',
+  'settings.terminal.passwordPromptAssist.picker': 'Credential picker',
+
   // Settings > Shortcuts
   'settings.shortcuts.section.scheme': 'Hotkey Scheme',
   'settings.shortcuts.scheme.label': 'Keyboard shortcuts',

--- a/application/i18n/locales/en/terminal.ts
+++ b/application/i18n/locales/en/terminal.ts
@@ -1,7 +1,9 @@
 import type { Messages } from '../types';
 
 export const enTerminalMessages: Messages = {
-  'terminal.sudoHint.pressEnter': 'Press Enter to paste sudo password',
+  'terminal.sudoHint.pressEnter': 'Press Enter to paste saved password',
+  'terminal.passwordPicker.title': 'Saved passwords',
+  'terminal.passwordPicker.empty': 'No saved passwords',
   // Terminal toolbar / search / context menu / auth
   'terminal.toolbar.openSftp': 'Open SFTP',
   'terminal.toolbar.availableAfterConnect': 'Available after connect',

--- a/application/i18n/locales/ru/core.ts
+++ b/application/i18n/locales/ru/core.ts
@@ -537,6 +537,15 @@ export const ruCoreMessages: Messages = {
   'settings.terminal.autocomplete.popupMenu': 'Всплывающее меню',
   'settings.terminal.autocomplete.popupMenu.desc': 'Показывать плавающий список из нескольких подсказок.',
 
+  // Settings > Terminal > Password prompt assist (sudo/su)
+  'settings.terminal.section.passwordPromptAssist': 'Подсказки пароля',
+  'settings.terminal.passwordPromptAssist.mode': 'Режим подсказки',
+  'settings.terminal.passwordPromptAssist.mode.desc':
+    'Когда sudo или su запрашивают пароль, предложить сохранённые учётные данные. Никогда не отправляет пароль без подтверждения.',
+  'settings.terminal.passwordPromptAssist.off': 'Выкл.',
+  'settings.terminal.passwordPromptAssist.hint': 'Быстрая вставка (Enter)',
+  'settings.terminal.passwordPromptAssist.picker': 'Список учётных данных',
+
   // Settings > Shortcuts
   'settings.shortcuts.section.scheme': 'Схема горячих клавиш',
   'settings.shortcuts.scheme.label': 'Сочетания клавиш',

--- a/application/i18n/locales/ru/terminal.ts
+++ b/application/i18n/locales/ru/terminal.ts
@@ -1,7 +1,9 @@
 import type { Messages } from '../types';
 
 export const ruTerminalMessages: Messages = {
-  'terminal.sudoHint.pressEnter': 'Нажмите Enter, чтобы вставить пароль sudo',
+  'terminal.sudoHint.pressEnter': 'Нажмите Enter, чтобы вставить сохранённый пароль',
+  'terminal.passwordPicker.title': 'Сохранённые пароли',
+  'terminal.passwordPicker.empty': 'Нет сохранённых паролей',
   // Connection logs
   'logs.table.date': 'Дата',
   'logs.table.user': 'Пользователь',

--- a/application/i18n/locales/zh-CN/terminal.ts
+++ b/application/i18n/locales/zh-CN/terminal.ts
@@ -1,7 +1,9 @@
 import type { Messages } from '../types';
 
 export const zhCNTerminalMessages: Messages = {
-  'terminal.sudoHint.pressEnter': '按 Enter 粘贴 sudo 密码',
+  'terminal.sudoHint.pressEnter': '按 Enter 粘贴已保存的密码',
+  'terminal.passwordPicker.title': '已保存的密码',
+  'terminal.passwordPicker.empty': '没有已保存的密码',
   'terminal.menu.rename': '重命名',
   'terminal.menu.uploadClipboardImage': '上传剪贴板图片',
   'terminal.clipboardImageUpload.noImage': '剪贴板中没有图片',
@@ -412,6 +414,13 @@ export const zhCNTerminalMessages: Messages = {
   'settings.terminal.autocomplete.ghostText.desc': '在光标后显示灰色的建议文本（类似 fish shell）。',
   'settings.terminal.autocomplete.popupMenu': '弹出菜单',
   'settings.terminal.autocomplete.popupMenu.desc': '显示包含多个建议的浮动列表。',
+  'settings.terminal.section.passwordPromptAssist': '密码提示辅助',
+  'settings.terminal.passwordPromptAssist.mode': '辅助模式',
+  'settings.terminal.passwordPromptAssist.mode.desc':
+    '当 sudo 或 su 要求输入密码时，提供已保存的凭据。不会在未经确认时自动发送。',
+  'settings.terminal.passwordPromptAssist.off': '关闭',
+  'settings.terminal.passwordPromptAssist.hint': '快速填充（Enter）',
+  'settings.terminal.passwordPromptAssist.picker': '凭据选择列表',
 
   // Settings > Shortcuts
   'settings.shortcuts.section.scheme': '快捷键方案',

--- a/application/i18n/locales/zh-TW/terminal.ts
+++ b/application/i18n/locales/zh-TW/terminal.ts
@@ -1,7 +1,9 @@
 import type { Messages } from '../types';
 
 export const zhTWTerminalMessages: Messages = {
-  'terminal.sudoHint.pressEnter': '按 Enter 貼上 sudo 密碼',
+  'terminal.sudoHint.pressEnter': '按 Enter 貼上已儲存的密碼',
+  'terminal.passwordPicker.title': '已儲存的密碼',
+  'terminal.passwordPicker.empty': '沒有已儲存的密碼',
   'terminal.menu.rename': '重新命名',
   'terminal.menu.uploadClipboardImage': '上傳剪貼簿圖片',
   'terminal.clipboardImageUpload.noImage': '剪貼簿中沒有圖片',
@@ -412,6 +414,13 @@ export const zhTWTerminalMessages: Messages = {
   'settings.terminal.autocomplete.ghostText.desc': '在游標後顯示灰色的建議文字（類似 fish shell）。',
   'settings.terminal.autocomplete.popupMenu': '彈出選單',
   'settings.terminal.autocomplete.popupMenu.desc': '顯示包含多個建議的浮動列表。',
+  'settings.terminal.section.passwordPromptAssist': '密碼提示輔助',
+  'settings.terminal.passwordPromptAssist.mode': '輔助模式',
+  'settings.terminal.passwordPromptAssist.mode.desc':
+    '當 sudo 或 su 要求輸入密碼時，提供已儲存的憑證。不會在未經確認時自動傳送。',
+  'settings.terminal.passwordPromptAssist.off': '關閉',
+  'settings.terminal.passwordPromptAssist.hint': '快速填入（Enter）',
+  'settings.terminal.passwordPromptAssist.picker': '憑證選擇列表',
 
   // Settings > Shortcuts
   'settings.shortcuts.section.scheme': '快捷鍵方案',

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -882,6 +882,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     const mode = terminalSettings?.passwordPromptAssist ?? "hint";
     sudoAutofillRef.current?.updateMode(mode);
   }, [terminalSettings?.passwordPromptAssist]);
+  // Drop a stale picker if the session disconnects/reconnects — exit teardown
+  // nulls sudoAutofillRef without calling onPicker(false).
+  useEffect(() => {
+    if (status === "disconnected" || status === "connecting") {
+      setPasswordPickerState(null);
+    }
+  }, [status]);
   const sessionStartersRef = useRef<ReturnType<typeof createTerminalSessionStarters> | null>(null);
   const auth = useTerminalAuthState({
     host,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1402,6 +1402,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     disposeRuntimeOnly();
     beginHibernatedSessionListeners(backendId);
     hibernatedRef.current = true;
+    // Hibernation rebuilds the autofill controller on wake; drop any open
+    // picker so it cannot stay visible against a non-pending controller.
+    setPasswordPickerState(null);
     logger.info("[Terminal] Hibernated runtime", {
       sessionId,
       snapshotChars: hibernateSnapshotRef.current.length,
@@ -2711,6 +2714,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     }
 
     wakeInProgressRef.current = true;
+    setPasswordPickerState(null);
 
     const stopHibernateListeners = () => {
       const backendId = sessionRef.current;

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1612,8 +1612,6 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sshDebugLogEnabled,
     sudoAutofillPassword: resolvedSudoAutofillPassword,
     sudoAutofillPasswordRef,
-    sudoAutofillCandidates: resolvedSudoAutofillCandidates,
-    sudoAutofillCandidatesRef,
   });
   sessionStartersRef.current = sessionStarters;
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -889,6 +889,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       setPasswordPickerState(null);
     }
   }, [status]);
+  const handlePasswordPickerSelect = useCallback((id: string) => {
+    sudoAutofillRef.current?.confirmFill(id);
+  }, []);
+  const passwordPickerTitle = t("terminal.passwordPicker.title");
+  const passwordPickerEmptyText = t("terminal.passwordPicker.empty");
+  const sudoHintText = t("terminal.sudoHint.pressEnter");
   const sessionStartersRef = useRef<ReturnType<typeof createTerminalSessionStarters> | null>(null);
   const auth = useTerminalAuthState({
     host,
@@ -2832,9 +2838,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           onDismiss={dismissScriptOverlay}
           compactTopChrome={terminalSettings?.showHostInfoBar === false}
         />
-      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), passwordPickerState, onPasswordPickerSelect: (id: string) => {
-        sudoAutofillRef.current?.confirmFill(id);
-      }, passwordPickerTitle: t("terminal.passwordPicker.title"), passwordPickerEmptyText: t("terminal.passwordPicker.empty"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
+      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText, passwordPickerState, onPasswordPickerSelect: handlePasswordPickerSelect, passwordPickerTitle, passwordPickerEmptyText, t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
       <ScriptSaveRecordingDialog
         open={saveRecordingOpen}
         code={recordedCode}

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -119,6 +119,7 @@ import {
 } from "./terminal/runtime/promptLineBreak";
 import {
   prepareSudoAutofillInput,
+  type PasswordPromptPickerState,
   type SudoPasswordAutofill,
 } from "./terminal/runtime/terminalSudoAutofill";
 import {
@@ -266,6 +267,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   sessionLog,
   sshDebugLogEnabled,
   sudoAutofillPassword,
+  sudoAutofillCandidates,
   showSelectionAIAction = true,
   onAddSelectionToAI,
   sessionDisplayName,
@@ -607,6 +609,16 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const sudoAutofillRef = useRef<SudoPasswordAutofill | null>(null);
   const sudoAutofillPasswordRef = useRef(sudoAutofillPassword);
   sudoAutofillPasswordRef.current = sudoAutofillPassword;
+  const sudoAutofillCandidatesRef = useRef(sudoAutofillCandidates);
+  sudoAutofillCandidatesRef.current = sudoAutofillCandidates;
+  const [passwordPickerState, setPasswordPickerState] = useState<PasswordPromptPickerState | null>(null);
+  const passwordPickerRef = useRef<
+    ((active: boolean, state: PasswordPromptPickerState | null) => boolean) | undefined
+  >(undefined);
+  passwordPickerRef.current = (active, state) => {
+    setPasswordPickerState(active && state ? state : null);
+    return true;
+  };
 
   const [chainProgress, setChainProgress] = useState<{
     currentHop: number;
@@ -863,6 +875,13 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   useEffect(() => {
     sudoAutofillRef.current?.updatePassword(sudoAutofillPassword);
   }, [sudoAutofillPassword]);
+  useEffect(() => {
+    sudoAutofillRef.current?.updateCandidates(sudoAutofillCandidates ?? []);
+  }, [sudoAutofillCandidates]);
+  useEffect(() => {
+    const mode = terminalSettings?.passwordPromptAssist ?? "hint";
+    sudoAutofillRef.current?.updateMode(mode);
+  }, [terminalSettings?.passwordPromptAssist]);
   const sessionStartersRef = useRef<ReturnType<typeof createTerminalSessionStarters> | null>(null);
   const auth = useTerminalAuthState({
     host,
@@ -1482,6 +1501,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     promptLineBreakStateRef,
     sudoAutofillRef,
     onSudoHint: (active: boolean) => sudoHintRef.current?.(active) ?? false,
+    onPasswordPromptPicker: (active, state) => passwordPickerRef.current?.(active, state) ?? false,
+    sudoAutofillCandidates,
+    sudoAutofillCandidatesRef,
     updateStatus,
     setStatus,
     setError,
@@ -1559,6 +1581,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sshDebugLogEnabled,
     sudoAutofillPassword,
     sudoAutofillPasswordRef,
+    // candidates already assigned above via sudoAutofillCandidates / Ref
   });
   sessionStartersRef.current = sessionStarters;
 
@@ -2798,7 +2821,9 @@ const TerminalComponent: React.FC<TerminalProps> = ({
           onDismiss={dismissScriptOverlay}
           compactTopChrome={terminalSettings?.showHostInfoBar === false}
         />
-      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
+      ) : null, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText: t("terminal.sudoHint.pressEnter"), passwordPickerState, onPasswordPickerSelect: (id: string) => {
+        sudoAutofillRef.current?.confirmFill(id);
+      }, passwordPickerTitle: t("terminal.passwordPicker.title"), passwordPickerEmptyText: t("terminal.passwordPicker.empty"), t, termRef, terminalBackend, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem }} />
       <ScriptSaveRecordingDialog
         open={saveRecordingOpen}
         code={recordedCode}

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -44,7 +44,8 @@ import {
 import { classifyDistroId, shouldProbeSessionCwd } from "../domain/host";
 import { resolveHostSshConnectionTimeouts } from "../domain/sshConnectionTimeouts";
 import { supportsZmodemTerminalDragDrop } from "../lib/zmodemDragDrop";
-import { resolveHostAuth } from "../domain/sshAuth";
+import { resolveHostAuth, resolveHostAutofillPassword } from "../domain/sshAuth";
+import { listPasswordPromptFillCandidates } from "../domain/passwordPromptAssist";
 import { useTerminalBackend } from "../application/state/useTerminalBackend";
 import {
   TERMINAL_AUTO_RECONNECT_DELAY_MS,
@@ -607,10 +608,24 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const getSessionConnectedRef = useRef(() => statusRef.current === "connected" && Boolean(sessionRef.current));
   getSessionConnectedRef.current = () => statusRef.current === "connected" && Boolean(sessionRef.current);
   const sudoAutofillRef = useRef<SudoPasswordAutofill | null>(null);
-  const sudoAutofillPasswordRef = useRef(sudoAutofillPassword);
-  sudoAutofillPasswordRef.current = sudoAutofillPassword;
-  const sudoAutofillCandidatesRef = useRef(sudoAutofillCandidates);
-  sudoAutofillCandidatesRef.current = sudoAutofillCandidates;
+  // Prefer parent-supplied candidates (TerminalLayer); otherwise derive from
+  // host/keys/identities so standalone popups (TerminalPopupPage) still work.
+  const resolvedSudoAutofillCandidates = useMemo(
+    () =>
+      sudoAutofillCandidates
+      ?? listPasswordPromptFillCandidates({ host, keys, identities }),
+    [sudoAutofillCandidates, host, keys, identities],
+  );
+  const resolvedSudoAutofillPassword = useMemo(
+    () =>
+      sudoAutofillPassword
+      ?? resolveHostAutofillPassword({ host, keys, identities }),
+    [sudoAutofillPassword, host, keys, identities],
+  );
+  const sudoAutofillPasswordRef = useRef(resolvedSudoAutofillPassword);
+  sudoAutofillPasswordRef.current = resolvedSudoAutofillPassword;
+  const sudoAutofillCandidatesRef = useRef(resolvedSudoAutofillCandidates);
+  sudoAutofillCandidatesRef.current = resolvedSudoAutofillCandidates;
   const [passwordPickerState, setPasswordPickerState] = useState<PasswordPromptPickerState | null>(null);
   const passwordPickerRef = useRef<
     ((active: boolean, state: PasswordPromptPickerState | null) => boolean) | undefined
@@ -873,11 +888,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const pendingAuthRef = useRef<PendingAuth>(null);
   useEffect(() => {
-    sudoAutofillRef.current?.updatePassword(sudoAutofillPassword);
-  }, [sudoAutofillPassword]);
+    sudoAutofillRef.current?.updatePassword(resolvedSudoAutofillPassword);
+  }, [resolvedSudoAutofillPassword]);
   useEffect(() => {
-    sudoAutofillRef.current?.updateCandidates(sudoAutofillCandidates ?? []);
-  }, [sudoAutofillCandidates]);
+    sudoAutofillRef.current?.updateCandidates(resolvedSudoAutofillCandidates);
+  }, [resolvedSudoAutofillCandidates]);
   useEffect(() => {
     const mode = terminalSettings?.passwordPromptAssist ?? "hint";
     sudoAutofillRef.current?.updateMode(mode);
@@ -1518,7 +1533,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     sudoAutofillRef,
     onSudoHint: (active: boolean) => sudoHintRef.current?.(active) ?? false,
     onPasswordPromptPicker: (active, state) => passwordPickerRef.current?.(active, state) ?? false,
-    sudoAutofillCandidates,
+    sudoAutofillCandidates: resolvedSudoAutofillCandidates,
     sudoAutofillCandidatesRef,
     updateStatus,
     setStatus,
@@ -1595,9 +1610,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     onCommandSubmitted,
     sessionLog,
     sshDebugLogEnabled,
-    sudoAutofillPassword,
+    sudoAutofillPassword: resolvedSudoAutofillPassword,
     sudoAutofillPasswordRef,
-    // candidates already assigned above via sudoAutofillCandidates / Ref
+    sudoAutofillCandidates: resolvedSudoAutofillCandidates,
+    sudoAutofillCandidatesRef,
   });
   sessionStartersRef.current = sessionStarters;
 

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -892,16 +892,18 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
   const sessionSudoAutofillPasswordsMap = useMemo(() => {
     const map = new Map<string, string | undefined>();
     for (const session of sessions) {
-      const rawHost = hostMap.get(session.hostId);
-      if (rawHost) {
+      // Use the effective session host (group defaults / proxy materialization
+      // applied) so a password inherited from group settings is available.
+      const sessionHost = sessionHostsMap.get(session.id);
+      if (sessionHost) {
         // Resolve through identity references too (host.identityId), not just
         // host.password, so a password stored in a Keychain identity is filled
         // (issue #1284) — same resolution SSH login uses.
-        map.set(session.id, resolveHostAutofillPassword({ host: rawHost, keys, identities }));
+        map.set(session.id, resolveHostAutofillPassword({ host: sessionHost, keys, identities }));
       }
     }
     return map;
-  }, [hostMap, sessions, keys, identities]);
+  }, [sessionHostsMap, sessions, keys, identities]);
 
   const sessionSudoAutofillCandidatesMap = useMemo(() => {
     const map = new Map<
@@ -909,16 +911,16 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
       ReturnType<typeof listPasswordPromptFillCandidates> | undefined
     >();
     for (const session of sessions) {
-      const rawHost = hostMap.get(session.hostId);
-      if (rawHost) {
+      const sessionHost = sessionHostsMap.get(session.id);
+      if (sessionHost) {
         map.set(
           session.id,
-          listPasswordPromptFillCandidates({ host: rawHost, keys, identities }),
+          listPasswordPromptFillCandidates({ host: sessionHost, keys, identities }),
         );
       }
     }
     return map;
-  }, [hostMap, sessions, keys, identities]);
+  }, [sessionHostsMap, sessions, keys, identities]);
 
   const handleTerminalFontSizeChange = useCallback((sessionId: string, nextFontSize: number) => {
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);

--- a/components/TerminalLayer.tsx
+++ b/components/TerminalLayer.tsx
@@ -38,6 +38,7 @@ import type { DropEntry } from '../lib/sftpFileUtils';
 import { Host, KnownHost, TerminalSession, Workspace } from '../types';
 import { applySessionFontSizeToHost } from '../domain/terminalAppearance';
 import { resolveHostAutofillPassword } from '../domain/sshAuth';
+import { listPasswordPromptFillCandidates } from '../domain/passwordPromptAssist';
 import {
   resolveEffectiveTerminalHost,
   resolveTerminalChainHosts,
@@ -902,6 +903,23 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     return map;
   }, [hostMap, sessions, keys, identities]);
 
+  const sessionSudoAutofillCandidatesMap = useMemo(() => {
+    const map = new Map<
+      string,
+      ReturnType<typeof listPasswordPromptFillCandidates> | undefined
+    >();
+    for (const session of sessions) {
+      const rawHost = hostMap.get(session.hostId);
+      if (rawHost) {
+        map.set(
+          session.id,
+          listPasswordPromptFillCandidates({ host: rawHost, keys, identities }),
+        );
+      }
+    }
+    return map;
+  }, [hostMap, sessions, keys, identities]);
+
   const handleTerminalFontSizeChange = useCallback((sessionId: string, nextFontSize: number) => {
     const session = sessionsRef.current.find((candidate) => candidate.id === sessionId);
     const sessionHost = sessionHostsMapRef.current.get(sessionId);
@@ -1708,6 +1726,7 @@ const TerminalLayerInner: React.FC<TerminalLayerProps> = ({
     resolvedSessionHostIds,
     sessionLogConfig,
     sessionSudoAutofillPasswordsMap,
+    sessionSudoAutofillCandidatesMap,
     sessions,
     sessionsRef,
     setEditorWordWrap,

--- a/components/settings/tabs/SettingsTerminalTab.tsx
+++ b/components/settings/tabs/SettingsTerminalTab.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState, useMemo } from "react"
 import { AlertCircle, Import, Minus, Palette, Pencil, Plus, Trash2 } from "lucide-react";
 import type {
   CursorShape,
+  PasswordPromptAssistMode,
   TerminalEmulationType,
   TerminalSettings,
 } from "../../../domain/models";
@@ -1176,6 +1177,27 @@ function SettingsTerminalTab(props: {
             checked={terminalSettings.autocompletePopupMenu}
             onChange={handleAutocompletePopupMenuChange}
             disabled={!terminalSettings.autocompleteEnabled}
+          />
+        </SettingRow>
+      </div>
+
+      <SectionHeader title={t("settings.terminal.section.passwordPromptAssist")} />
+      <div className="space-y-0 divide-y divide-border rounded-lg border bg-card px-4">
+        <SettingRow
+          label={t("settings.terminal.passwordPromptAssist.mode")}
+          description={t("settings.terminal.passwordPromptAssist.mode.desc")}
+        >
+          <Select
+            value={terminalSettings.passwordPromptAssist ?? "hint"}
+            onChange={(v) =>
+              updateTerminalSetting("passwordPromptAssist", v as PasswordPromptAssistMode)
+            }
+            options={[
+              { value: "off", label: t("settings.terminal.passwordPromptAssist.off") },
+              { value: "hint", label: t("settings.terminal.passwordPromptAssist.hint") },
+              { value: "picker", label: t("settings.terminal.passwordPromptAssist.picker") },
+            ]}
+            className="w-48"
           />
         </SettingRow>
       </div>

--- a/components/terminal/PasswordCredentialPicker.tsx
+++ b/components/terminal/PasswordCredentialPicker.tsx
@@ -1,0 +1,93 @@
+/**
+ * Floating credential list for sudo/su password-prompt assist (picker mode).
+ * Renders near the bottom of the terminal container. Secrets are never shown.
+ */
+import React, { memo, useEffect, useRef } from "react";
+import { KeyRound } from "lucide-react";
+import type { PasswordPromptPickerItem } from "./runtime/terminalSudoAutofill";
+
+export type PasswordCredentialPickerProps = {
+  items: PasswordPromptPickerItem[];
+  selectedIndex: number;
+  visible: boolean;
+  onSelect: (id: string) => void;
+  title: string;
+  emptyText: string;
+  themeColors?: {
+    background?: string;
+    foreground?: string;
+    selection?: string;
+  };
+};
+
+const PasswordCredentialPicker: React.FC<PasswordCredentialPickerProps> = ({
+  items,
+  selectedIndex,
+  visible,
+  onSelect,
+  title,
+  emptyText,
+  themeColors,
+}) => {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [visible, selectedIndex]);
+
+  if (!visible) return null;
+
+  const background = themeColors?.background ?? "hsl(var(--popover))";
+  const foreground = themeColors?.foreground ?? "hsl(var(--popover-foreground))";
+  const selection = themeColors?.selection ?? "hsl(var(--accent))";
+
+  return (
+    <div
+      className="pointer-events-auto absolute bottom-3 left-1/2 z-40 w-[min(360px,calc(100%-1.5rem))] -translate-x-1/2 overflow-hidden rounded-md border border-border/70 shadow-lg"
+      style={{ background, color: foreground }}
+      role="listbox"
+      aria-label={title}
+      data-testid="password-credential-picker"
+    >
+      <div className="flex items-center gap-1.5 border-b border-border/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide opacity-70">
+        <KeyRound size={12} />
+        <span>{title}</span>
+      </div>
+      <div ref={listRef} className="max-h-48 overflow-y-auto py-1">
+        {items.length === 0 ? (
+          <div className="px-3 py-2 text-xs opacity-70">{emptyText}</div>
+        ) : (
+          items.map((item, index) => {
+            const selected = index === selectedIndex;
+            return (
+              <button
+                key={item.id}
+                ref={selected ? selectedRef : undefined}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors"
+                style={selected ? { background: selection } : undefined}
+                onMouseDown={(e) => {
+                  // Prevent terminal blur / focus loss before select fires.
+                  e.preventDefault();
+                }}
+                onClick={() => onSelect(item.id)}
+              >
+                <span className="min-w-0 flex-1 truncate font-medium">{item.label}</span>
+                {item.username ? (
+                  <span className="shrink-0 font-mono text-xs opacity-70">{item.username}</span>
+                ) : null}
+                <span className="shrink-0 font-mono text-xs opacity-50">••••••••</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default memo(PasswordCredentialPicker);

--- a/components/terminal/PasswordCredentialPicker.tsx
+++ b/components/terminal/PasswordCredentialPicker.tsx
@@ -1,10 +1,19 @@
 /**
  * Floating credential list for sudo/su password-prompt assist (picker mode).
- * Renders near the bottom of the terminal container. Secrets are never shown.
+ * Positioned next to the terminal cursor using the same anchor/placement
+ * helpers as AutocompletePopup. Secrets are never shown.
  */
-import React, { memo, useEffect, useRef } from "react";
+import React, { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import ReactDOM from "react-dom";
 import { KeyRound } from "lucide-react";
+import type { Terminal as XTerm } from "@xterm/xterm";
 import type { PasswordPromptPickerItem } from "./runtime/terminalSudoAutofill";
+import {
+  clampAutocompletePopupGeometry,
+  computeAutocompletePopupPlacement,
+  resolveAutocompleteAnchorInViewport,
+  resolveAutocompleteClampViewport,
+} from "./autocomplete/terminalAutocompleteLayout";
 
 export type PasswordCredentialPickerProps = {
   items: PasswordPromptPickerItem[];
@@ -17,8 +26,18 @@ export type PasswordCredentialPickerProps = {
     background?: string;
     foreground?: string;
     selection?: string;
+    cursor?: string;
   };
+  termRef?: React.RefObject<XTerm | null>;
+  containerRef?: React.RefObject<HTMLDivElement | null>;
 };
+
+const ROW_HEIGHT = 28;
+const HEADER_HEIGHT = 32;
+const LIST_PADDING = 8;
+const MAX_LIST_HEIGHT = 192;
+const POPUP_MIN_WIDTH = 240;
+const POPUP_MAX_WIDTH = 360;
 
 const PasswordCredentialPicker: React.FC<PasswordCredentialPickerProps> = ({
   items,
@@ -28,34 +47,197 @@ const PasswordCredentialPicker: React.FC<PasswordCredentialPickerProps> = ({
   title,
   emptyText,
   themeColors,
+  termRef,
+  containerRef,
 }) => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const selectedRef = useRef<HTMLButtonElement | null>(null);
+  const [anchorTick, setAnchorTick] = useState(0);
+  const [measuredSize, setMeasuredSize] = useState<{ width: number; height: number } | null>(null);
+
+  const requestReposition = useCallback(() => {
+    setAnchorTick((n) => n + 1);
+  }, []);
 
   useEffect(() => {
     if (!visible) return;
     selectedRef.current?.scrollIntoView({ block: "nearest" });
   }, [visible, selectedIndex]);
 
+  // Recalculate when the terminal/container resizes or the window moves.
+  useEffect(() => {
+    if (!visible) return;
+
+    let frameId = 0;
+    const schedule = () => {
+      if (frameId) cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        frameId = 0;
+        requestReposition();
+      });
+    };
+
+    const container = containerRef?.current;
+    const observer = container ? new ResizeObserver(schedule) : null;
+    if (container) observer?.observe(container);
+    window.addEventListener("resize", schedule);
+    window.addEventListener("scroll", schedule, true);
+
+    // Two rAFs so xterm has finished layout after the password line paints.
+    let first = 0;
+    let second = 0;
+    first = requestAnimationFrame(() => {
+      requestReposition();
+      second = requestAnimationFrame(requestReposition);
+    });
+
+    return () => {
+      if (frameId) cancelAnimationFrame(frameId);
+      if (first) cancelAnimationFrame(first);
+      if (second) cancelAnimationFrame(second);
+      observer?.disconnect();
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("scroll", schedule, true);
+    };
+  }, [visible, containerRef, requestReposition, items.length]);
+
+  const itemCount = Math.max(1, items.length);
+  const estimatedListHeight = Math.min(MAX_LIST_HEIGHT, itemCount * ROW_HEIGHT + LIST_PADDING);
+  const estimatedPopupHeight = estimatedListHeight + HEADER_HEIGHT;
+
+  const placement = useMemo(() => {
+    // anchorTick forces recompute when the cursor/container moves.
+    void anchorTick;
+    const term = termRef?.current ?? null;
+    const container = containerRef?.current ?? null;
+    const clampViewport = resolveAutocompleteClampViewport(container);
+    const empty = {
+      left: clampViewport.left + 8,
+      top: clampViewport.top + 8,
+      maxHeight: MAX_LIST_HEIGHT,
+      renderUpward: true,
+    };
+    if (!term || !visible) return empty;
+
+    const anchor = resolveAutocompleteAnchorInViewport(term, container, itemCount);
+    const result = computeAutocompletePopupPlacement({
+      anchorTop: anchor.anchorTop,
+      anchorBottom: anchor.anchorBottom,
+      anchorLeft: anchor.anchorLeft,
+      viewportWidth: clampViewport.width,
+      viewportHeight: clampViewport.height,
+      clampViewport,
+      desiredHeight: estimatedPopupHeight,
+      totalWidth: POPUP_MAX_WIDTH,
+      clampWidth: POPUP_MAX_WIDTH,
+      maxHeight: estimatedPopupHeight,
+      anchorGap: 8,
+      viewportPadding: 8,
+      // Password prompts sit on the input line; prefer opening upward so the
+      // list does not cover what the user is about to type.
+      expandUpwardHint: true,
+    });
+    return {
+      left: result.left,
+      top: result.top,
+      maxHeight: Math.max(ROW_HEIGHT + LIST_PADDING, result.maxHeight - HEADER_HEIGHT),
+      renderUpward: result.renderUpward,
+    };
+  }, [
+    anchorTick,
+    termRef,
+    containerRef,
+    visible,
+    itemCount,
+    estimatedPopupHeight,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!visible) {
+      setMeasuredSize((current) => (current === null ? current : null));
+      return;
+    }
+    const rect = wrapperRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return;
+    setMeasuredSize((current) => {
+      if (
+        current
+        && Math.abs(current.width - rect.width) < 0.5
+        && Math.abs(current.height - rect.height) < 0.5
+      ) {
+        return current;
+      }
+      return { width: rect.width, height: rect.height };
+    });
+  }, [visible, placement.left, placement.top, items.length, selectedIndex]);
+
   if (!visible) return null;
+
+  const clampViewport = resolveAutocompleteClampViewport(containerRef?.current ?? null);
+  const finalGeometry = measuredSize
+    ? clampAutocompletePopupGeometry({
+        left: placement.left,
+        top: placement.top,
+        width: measuredSize.width,
+        height: measuredSize.height,
+        clampViewport,
+        viewportPadding: 8,
+      })
+    : { left: placement.left, top: placement.top };
 
   const background = themeColors?.background ?? "hsl(var(--popover))";
   const foreground = themeColors?.foreground ?? "hsl(var(--popover-foreground))";
   const selection = themeColors?.selection ?? "hsl(var(--accent))";
+  const border = themeColors?.cursor
+    ? `${themeColors.cursor}55`
+    : "hsl(var(--border))";
 
-  return (
+  const node = (
     <div
-      className="pointer-events-auto absolute bottom-3 left-1/2 z-40 w-[min(360px,calc(100%-1.5rem))] -translate-x-1/2 overflow-hidden rounded-md border border-border/70 shadow-lg"
-      style={{ background, color: foreground }}
+      ref={wrapperRef}
       role="listbox"
       aria-label={title}
       data-testid="password-credential-picker"
+      style={{
+        position: "fixed",
+        left: `${finalGeometry.left}px`,
+        top: `${finalGeometry.top}px`,
+        zIndex: 10000,
+        minWidth: POPUP_MIN_WIDTH,
+        maxWidth: POPUP_MAX_WIDTH,
+        overflow: "hidden",
+        borderRadius: 6,
+        border: `1px solid ${border}`,
+        background,
+        color: foreground,
+        boxShadow: placement.renderUpward
+          ? "0 -2px 6px rgba(0, 0, 0, 0.15)"
+          : "0 2px 6px rgba(0, 0, 0, 0.15)",
+        fontSize: 13,
+        pointerEvents: "auto",
+      }}
+      onMouseDown={(e) => {
+        // Keep terminal focus; prevent selection loss before click select.
+        e.preventDefault();
+        e.stopPropagation();
+      }}
     >
-      <div className="flex items-center gap-1.5 border-b border-border/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide opacity-70">
+      <div
+        className="flex items-center gap-1.5 border-b px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide opacity-70"
+        style={{ borderColor: border, height: HEADER_HEIGHT, boxSizing: "border-box" }}
+      >
         <KeyRound size={12} />
         <span>{title}</span>
       </div>
-      <div ref={listRef} className="max-h-48 overflow-y-auto py-1">
+      <div
+        ref={listRef}
+        style={{
+          maxHeight: `${placement.maxHeight}px`,
+          overflowY: "auto",
+          padding: "4px 0",
+        }}
+      >
         {items.length === 0 ? (
           <div className="px-3 py-2 text-xs opacity-70">{emptyText}</div>
         ) : (
@@ -69,10 +251,10 @@ const PasswordCredentialPicker: React.FC<PasswordCredentialPickerProps> = ({
                 role="option"
                 aria-selected={selected}
                 className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors"
-                style={selected ? { background: selection } : undefined}
-                onMouseDown={(e) => {
-                  // Prevent terminal blur / focus loss before select fires.
-                  e.preventDefault();
+                style={{
+                  background: selected ? selection : undefined,
+                  height: ROW_HEIGHT,
+                  boxSizing: "border-box",
                 }}
                 onClick={() => onSelect(item.id)}
               >
@@ -88,6 +270,10 @@ const PasswordCredentialPicker: React.FC<PasswordCredentialPickerProps> = ({
       </div>
     </div>
   );
+
+  // Portal to body so overflow:hidden on terminal chrome cannot clip the list
+  // (same pattern as AutocompletePopup).
+  return ReactDOM.createPortal(node, document.body);
 };
 
 export default memo(PasswordCredentialPicker);

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -790,6 +790,8 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
             title={passwordPickerTitle ?? "Saved passwords"}
             emptyText={passwordPickerEmptyText ?? "No saved passwords"}
             themeColors={effectiveTheme.colors}
+            termRef={termRef}
+            containerRef={containerRef}
           />
 
           {scriptExecutionOverlay}

--- a/components/terminal/TerminalView.tsx
+++ b/components/terminal/TerminalView.tsx
@@ -3,6 +3,7 @@ import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronsLeft, GripVertical, X as XIcon } from 'lucide-react';
 
 import { OSC7_SETUP_TARGETS } from './osc7Setup';
+import PasswordCredentialPicker from './PasswordCredentialPicker';
 import { TerminalServerStats } from './TerminalServerStats';
 import {
   TerminalTimestampGutter,
@@ -211,7 +212,7 @@ function terminalViewCtxEqual(
 }
 
 function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
-  const { Activity, Button, Clock3, Copy, Maximize2, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isConnectionAwaitingUserInput, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onCloseSession, onDetach, onDetachPointerDown, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onToggleBroadcast, onUpdateHost, osc52ReadPromptVisible, osc7SetupOpen, osc7SetupRunning, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scriptExecutionOverlay, searchMatchCount, searchFocusToken, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText, t, termRef, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem } = ctx;
+  const { Activity, Button, Clock3, Copy, Maximize2, Radio, Sparkles, SquareArrowOutUpRight, TerminalAutocomplete, TerminalComposeBar, TerminalConnectionDialog, TerminalContextMenu, TerminalSearchBar, Tooltip, TooltipContent, TooltipTrigger, ZmodemOverwriteDialog, ZmodemProgressIndicator, auth, autocompleteAcceptTextRef, autocompleteCloseRef, autocompleteHostOs, autocompleteInputRef, autocompleteKeyEventRef, autocompleteRepositionRef, autocompleteSettings, chainProgress, cn, compactToolbar, lineTimestampsAvailable, containerRef, effectiveFontSize, effectiveFontWeight, effectiveTheme, error, executeSnippet, executeSnippetCommand, handleAddSelectionToAI, handleCancelConnect, handleCloseDisconnectedSession, handleCloseSearch, handleDismissDisconnectedDialog, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, handleFindNext, handleFindPrevious, handleHostKeyAddAndContinue, handleHostKeyClose, handleHostKeyContinue, handleOsc52ReadResponse, handleOsc7SetupConfirm, handleOsc7SetupOpenChange, handleReceiveYmodem, handleRetry, handleSearch, handleSendYmodem, handleTopOverlayMouseDownCapture, hasMouseTracking, hasSelection, host, hotkeyScheme, inWorkspace, isBroadcastEnabled, isCancelling, isComposeBarOpen, isConnectionAwaitingUserInput, isDraggingOver, isFocusMode, isLocalConnection, remoteDragDropUsesZmodem, isSerialConnection, isSearchOpen, isSupportedOs, isSystemSidebarEligible, isVisible, keyBindings, keys, knownCwdRef, needsHostKeyVerification, onCloseSession, onDetach, onDetachPointerDown, onExpandToFocus, onOpenSystem, onRename, onSplitHorizontal, onSplitVertical, onToggleBroadcast, onUpdateHost, osc52ReadPromptVisible, osc7SetupOpen, osc7SetupRunning, pendingHostKeyInfo, progressLogs, progressValue, renderControls, resolvedFontFamily, restoreState, scriptExecutionOverlay, searchMatchCount, searchFocusToken, selectionOverlayPosition, sessionDisplayName, sessionId, sessionRef, setIsComposeBarOpen, setShowLogs, shouldShowConnectionDialog, showLogs, showSelectionAIAction, snippets, status, sudoHintRef, sudoHintText, passwordPickerState, onPasswordPickerSelect, passwordPickerTitle, passwordPickerEmptyText, t, termRef, terminalContextActions, terminalCwdTracker, terminalPreviewVars, terminalSettings, timeLeft, toast, zmodem } = ctx;
   const ymodemActionEnabled = shouldEnableYmodemAction({
     isSerialConnection,
     status,
@@ -779,6 +780,16 @@ function TerminalViewInner({ ctx }: { ctx: TerminalViewContext }) {
             closeRef={autocompleteCloseRef}
             sudoHintRef={sudoHintRef}
             sudoHintText={sudoHintText}
+          />
+
+          <PasswordCredentialPicker
+            visible={Boolean(passwordPickerState)}
+            items={passwordPickerState?.items ?? []}
+            selectedIndex={passwordPickerState?.selectedIndex ?? 0}
+            onSelect={(id) => onPasswordPickerSelect?.(id)}
+            title={passwordPickerTitle ?? "Saved passwords"}
+            emptyText={passwordPickerEmptyText ?? "No saved passwords"}
+            themeColors={effectiveTheme.colors}
           />
 
           {scriptExecutionOverlay}

--- a/components/terminal/runtime/createTerminalSessionStarters.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.ts
@@ -121,6 +121,9 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     return sanitizeCredentialValue(ctx.sudoAutofillPassword);
   };
 
+  const resolveSudoAutofillCandidates = () =>
+    ctx.sudoAutofillCandidatesRef?.current ?? ctx.sudoAutofillCandidates ?? [];
+
   const clearTelnetEchoMode = ({ resetLocalEcho = true }: { resetLocalEcho?: boolean } = {}) => {
     ctx.disposeTelnetEchoModeRef?.current?.();
     if (ctx.disposeTelnetEchoModeRef) ctx.disposeTelnetEchoModeRef.current = null;
@@ -631,6 +634,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         onExitMessage: (evt) =>
           `\r\n[session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
         sudoAutofillPassword: resolveSavedSudoAutofillPassword(),
+        sudoAutofillCandidates: resolveSudoAutofillCandidates(),
       })) {
         abortSessionStartAfterUnmount();
         return;
@@ -1012,6 +1016,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         onExitMessage: (evt) =>
           `\r\n[Mosh session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
         sudoAutofillPassword: resolveSavedSudoAutofillPassword(),
+        sudoAutofillCandidates: resolveSudoAutofillCandidates(),
       })) {
         abortSessionStartAfterUnmount();
         return;
@@ -1300,6 +1305,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
         onExitMessage: (evt) =>
           `\r\n[EternalTerminal session closed${evt?.exitCode !== undefined ? ` (code ${evt.exitCode})` : ""}]`,
         sudoAutofillPassword: resolveSavedSudoAutofillPassword(),
+        sudoAutofillCandidates: resolveSudoAutofillCandidates(),
       })) {
         abortSessionStartAfterUnmount();
         return;
@@ -1495,6 +1501,7 @@ export const createTerminalSessionStarters = (ctx: TerminalSessionStartersContex
     attachSessionToTerminal(ctx, term, id, {
       convertLfToCrlf: isSerial,
       sudoAutofillPassword: ctx.sudoAutofillPassword,
+      sudoAutofillCandidates: resolveSudoAutofillCandidates(),
     });
     attachTelnetEchoMode(id, { resetLocalEcho: false });
     ctx.hasConnectedRef.current = true;

--- a/components/terminal/runtime/createTerminalSessionStarters.types.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.types.ts
@@ -3,7 +3,11 @@ import type { SerializeAddon } from "@xterm/addon-serialize";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import type { Host, Identity, KnownHost, SerialConfig, SSHKey, TerminalSession, TerminalSettings } from "../../../types";
 import type { PromptLineBreakState } from "./promptLineBreak";
-import type { SudoPasswordAutofill } from "./terminalSudoAutofill";
+import type {
+  PasswordPromptPickerState,
+  SudoPasswordAutofill,
+  SudoPasswordAutofillCandidate,
+} from "./terminalSudoAutofill";
 import type { ProgrammaticCommandLogRewrite } from "../programmaticCommandLog";
 
 export type TerminalBackendApi = {
@@ -128,7 +132,13 @@ export type TerminalSessionStartersContext = {
   sshDebugLogEnabled?: boolean;
   sudoAutofillPassword?: string;
   sudoAutofillPasswordRef?: RefObject<string | undefined>;
+  sudoAutofillCandidates?: SudoPasswordAutofillCandidate[];
+  sudoAutofillCandidatesRef?: RefObject<SudoPasswordAutofillCandidate[] | undefined>;
   onSudoHint?: (active: boolean) => boolean;
+  onPasswordPromptPicker?: (
+    active: boolean,
+    state: PasswordPromptPickerState | null,
+  ) => boolean;
   isVisibleRef?: RefObject<boolean>;
   /** False after unmount/teardown so in-flight session starts skip attach. */
   isBootActiveRef?: RefObject<boolean>;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -978,11 +978,23 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
       if (shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current)) {
         sudoAutofill.cancelHint();
         // fall through: Shift+Enter sends the configured terminal text
-      } else if (e.key === "ArrowDown" && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      } else if (
+        sudoAutofill.isPickerPending()
+        && e.key === "ArrowDown"
+        && !e.altKey
+        && !e.ctrlKey
+        && !e.metaKey
+      ) {
         e.preventDefault();
         sudoAutofill.moveSelection(1);
         return false;
-      } else if (e.key === "ArrowUp" && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      } else if (
+        sudoAutofill.isPickerPending()
+        && e.key === "ArrowUp"
+        && !e.altKey
+        && !e.ctrlKey
+        && !e.metaKey
+      ) {
         e.preventDefault();
         sudoAutofill.moveSelection(-1);
         return false;

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -969,15 +969,23 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     }
     hideHistoryPreview();
 
-    // Sudo password hint: while a hint is pending, Enter confirms (paste the
-    // saved password + submit); any other visible key dismisses it so the user
-    // can type the password manually. Checked before autocomplete so Enter
-    // pastes the password instead of submitting an empty line.
+    // Password prompt assist (sudo/su): while pending, Enter confirms the
+    // selected/host password; arrows move the picker; any other visible key
+    // dismisses so the user can type manually. Checked before autocomplete so
+    // Enter pastes the password instead of submitting an empty line.
     const sudoAutofill = ctx.sudoAutofillRef?.current;
     if (sudoAutofill?.isPromptPending()) {
       if (shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current)) {
         sudoAutofill.cancelHint();
         // fall through: Shift+Enter sends the configured terminal text
+      } else if (e.key === "ArrowDown" && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        sudoAutofill.moveSelection(1);
+        return false;
+      } else if (e.key === "ArrowUp" && !e.altKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        sudoAutofill.moveSelection(-1);
+        return false;
       } else if (
         e.key === "Enter" &&
         !e.altKey &&

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -970,9 +970,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     hideHistoryPreview();
 
     // Password prompt assist (sudo/su): while pending, Enter confirms the
-    // selected/host password; arrows move the picker; any other visible key
-    // dismisses so the user can type manually. Checked before autocomplete so
-    // Enter pastes the password instead of submitting an empty line.
+    // selected/host password; arrows move the picker; Esc soft-dismisses (keeps
+    // arm so the list can re-open). Checked before autocomplete so Enter pastes
+    // the password instead of submitting an empty line.
     const sudoAutofill = ctx.sudoAutofillRef?.current;
     if (sudoAutofill?.isPromptPending()) {
       if (shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current)) {
@@ -1017,6 +1017,20 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         sudoAutofill.cancelHint();
         // fall through: key becomes the first char of the manually typed password
       }
+    } else if (
+      sudoAutofill?.canReshowAssist()
+      && !e.altKey
+      && !e.ctrlKey
+      && !e.metaKey
+      && (e.key === "Escape" || e.key === "ArrowDown" || e.key === "ArrowUp")
+    ) {
+      // Soft-dismissed but still on Password: — Esc/arrows re-open the assist.
+      e.preventDefault();
+      if (sudoAutofill.tryReshowAssist()) {
+        if (e.key === "ArrowDown") sudoAutofill.moveSelection(1);
+        if (e.key === "ArrowUp") sudoAutofill.moveSelection(-1);
+      }
+      return false;
     }
 
     // Autocomplete key handler (must be checked before other handlers)

--- a/components/terminal/runtime/terminalSessionAttachment.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.ts
@@ -31,7 +31,10 @@ import {
   resetTerminalOutputPressure,
   setTerminalOutputPressureVisibility,
 } from "./terminalOutputPressure";
-import { createSudoPasswordAutofill } from "./terminalSudoAutofill";
+import {
+  createSudoPasswordAutofill,
+  type SudoPasswordAutofillCandidate,
+} from "./terminalSudoAutofill";
 import {
   filterTerminalSessionData,
   resetTerminalSyncBlockFilter,
@@ -601,6 +604,7 @@ export const tryAttachSessionToTerminal = (
     onExit?: (evt: { exitCode?: number; signal?: number; error?: string; reason?: string }) => void;
     convertLfToCrlf?: boolean;
     sudoAutofillPassword?: string;
+    sudoAutofillCandidates?: SudoPasswordAutofillCandidate[];
   },
 ): boolean => {
   if (!isTerminalBootActive(ctx)) {
@@ -651,6 +655,7 @@ export const attachSessionToTerminal = (
     onExit?: (evt: { exitCode?: number; signal?: number; error?: string; reason?: string }) => void;
     convertLfToCrlf?: boolean;
     sudoAutofillPassword?: string;
+    sudoAutofillCandidates?: SudoPasswordAutofillCandidate[];
   },
 ) => {
   if (!isTerminalBootActive(ctx)) {
@@ -666,10 +671,26 @@ export const attachSessionToTerminal = (
   resetTerminalLineTimestamps(term);
   resetTerminalOutputPressure(term);
   ctx.onSessionAttached?.(id);
+  const assistMode =
+    ctx.terminalSettingsRef?.current?.passwordPromptAssist
+    ?? ctx.terminalSettings?.passwordPromptAssist
+    ?? "hint";
+  const candidates =
+    opts?.sudoAutofillCandidates
+    ?? ctx.sudoAutofillCandidatesRef?.current
+    ?? ctx.sudoAutofillCandidates
+    ?? [];
+  const password =
+    opts?.sudoAutofillPassword
+    ?? ctx.sudoAutofillPasswordRef?.current
+    ?? ctx.sudoAutofillPassword;
   const sudoAutofill = createSudoPasswordAutofill({
-    password: opts?.sudoAutofillPassword,
+    mode: assistMode,
+    password,
+    candidates,
     write: (data) => ctx.terminalBackend.writeToSession(id, data, { automated: true }),
     onHint: (active) => ctx.onSudoHint?.(active) ?? false,
+    onPicker: (active, state) => ctx.onPasswordPromptPicker?.(active, state) ?? false,
   });
   if (ctx.sudoAutofillRef) {
     ctx.sudoAutofillRef.current = sudoAutofill;

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -415,6 +415,20 @@ test("picker reopens after a wrong password when still armed", () => {
   assert.deepEqual(writes, ["wrong\n", "right\n"]);
 });
 
+test("does not re-assist a child password prompt after successful fill", () => {
+  // `sudo mysql -p`: after the sudo password is accepted, mysql's own
+  // "Enter password:" must not reopen assist with the host secret.
+  const { autofill, hints, writes } = make();
+  autofill.armForCommand("sudo mysql -p");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.deepEqual(hints, [true]);
+  autofill.confirmFill();
+  assert.deepEqual(writes, ["secret\n"]);
+  autofill.handleOutput("\r\nEnter password: ");
+  assert.equal(autofill.isPromptPending(), false);
+  assert.deepEqual(hints, [true, false]); // only the original sudo hint
+});
+
 test("picker mode requires arm before offering the full keychain list", () => {
   // Unarmed explicit [sudo] must not surface every identity — a remote can
   // forge that line. Host-password hint remains allowed (#2156 security).

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -330,6 +330,15 @@ test("mode off never hints even for explicit sudo prompts", () => {
   assert.equal(autofill.isPromptPending(), false);
 });
 
+test("isPickerPending is false during hint mode", () => {
+  const { autofill } = make();
+  autofill.armForCommand("sudo whoami");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.equal(autofill.isPromptPending(), true);
+  assert.equal(autofill.isPickerPending(), false);
+  assert.equal(autofill.moveSelection(1), false);
+});
+
 test("picker mode opens the credential list and fills the selected secret", () => {
   const writes: string[] = [];
   const pickerStates: Array<{ items: { id: string }[]; selectedIndex: number } | null> = [];
@@ -352,7 +361,8 @@ test("picker mode opens the credential list and fills the selected secret", () =
   assert.equal(pickerStates[0]?.items.length, 2);
   assert.equal(pickerStates[0]?.selectedIndex, 0);
 
-  autofill.moveSelection(1);
+  assert.equal(autofill.isPickerPending(), true);
+  assert.equal(autofill.moveSelection(1), true);
   assert.equal(pickerStates.at(-1)?.selectedIndex, 1);
 
   autofill.confirmFill();

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -430,6 +430,7 @@ test("picker mode does not expose passwords in onPicker payload", () => {
       return true;
     },
   });
+  autofill.armForCommand("sudo whoami");
   autofill.handleOutput("[sudo] password for alice: ");
   assert.ok(seen && typeof seen === "object");
   const json = JSON.stringify(seen);

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -140,10 +140,17 @@ test("does not arm when the hint cannot be shown (overlay unavailable)", () => {
   assert.deepEqual(writes, []);
 });
 
-test("a bare Password prompt does not hint until a sudo command is submitted", () => {
+test("a bare Password prompt does not hint until a su command is submitted", () => {
   const { autofill, hints } = make();
   autofill.handleOutput("Password: ");
   assert.deepEqual(hints, []);
+  // sudo-armed bare Password: is too generic (mysql/ssh); su-armed is expected
+  autofill.armForCommand("sudo whoami");
+  autofill.handleOutput("Password: ");
+  assert.deepEqual(hints, []);
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.deepEqual(hints, [true]);
 });
 
 test("an explicit [sudo] prompt hints without a recorded sudo command", () => {
@@ -171,22 +178,36 @@ test("hint fires once across chunked prompt output", () => {
   assert.deepEqual(hints, [true]);
 });
 
-test("relaxed detection still only hints, never auto-fills child prompts", () => {
-  // sudo creds warm -> mysql asks for its own password. We may hint, but we
-  // must not send anything without an explicit confirm.
+test("cached sudo then child Enter password does not assist", () => {
+  // sudo auth already cached: `sudo mysql -p` goes straight to mysql's
+  // "Enter password:" — must not offer the host SSH password.
   const { autofill, hints, writes } = make();
   autofill.armForCommand("sudo mysql -p");
   autofill.handleOutput("Enter password: ");
-  assert.deepEqual(hints, [true]);
+  assert.deepEqual(hints, []);
   assert.deepEqual(writes, []);
+  assert.equal(autofill.isPromptPending(), false);
+});
+
+test("sudo-scoped bare prompts still assist when armed", () => {
+  // Kylin / PAM without [sudo] tag (#1293)
+  const kylink = make();
+  kylink.autofill.armForCommand("sudo -s");
+  kylink.autofill.handleOutput("输入密码");
+  assert.deepEqual(kylink.hints, [true]);
+
+  const scoped = make();
+  scoped.autofill.armForCommand("sudo whoami");
+  scoped.autofill.handleOutput("password for alice: ");
+  assert.deepEqual(scoped.hints, [true]);
 });
 
 test("a later non-sudo command disarms the pending hint", () => {
   const { autofill, writes, hints } = make();
-  autofill.armForCommand("sudo -n true");
+  autofill.armForCommand("su -");
   autofill.handleOutput("Password: ");
   assert.deepEqual(hints, [true]);
-  autofill.armForCommand("mysql -p"); // non-sudo command clears the arm
+  autofill.armForCommand("mysql -p"); // non-sudo/su command clears the arm
   assert.deepEqual(hints, [true, false]);
   autofill.confirmFill();
   assert.deepEqual(writes, []);
@@ -227,7 +248,7 @@ test("an expired arm shows no hint for a bare prompt", () => {
       return true;
     },
   });
-  autofill.armForCommand("sudo whoami");
+  autofill.armForCommand("su -");
   now += 31_000;
   autofill.handleOutput("Password: ");
   assert.deepEqual(hints, []);
@@ -427,6 +448,28 @@ test("does not re-assist a child password prompt after successful fill", () => {
   autofill.handleOutput("\r\nEnter password: ");
   assert.equal(autofill.isPromptPending(), false);
   assert.deepEqual(hints, [true, false]); // only the original sudo hint
+});
+
+test("picker does not open for Enter password when sudo is already cached", () => {
+  const writes: string[] = [];
+  const pickerActives: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: (active) => {
+      pickerActives.push(active);
+      return true;
+    },
+  });
+  autofill.armForCommand("sudo mysql -p");
+  autofill.handleOutput("Enter password: ");
+  assert.equal(autofill.isPickerPending(), false);
+  assert.deepEqual(pickerActives, []);
+  assert.deepEqual(writes, []);
 });
 
 test("picker mode requires arm before offering the full keychain list", () => {

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -363,13 +363,19 @@ test("isPickerPending is false during hint mode", () => {
 test("picker mode opens the credential list and fills the selected secret", () => {
   const writes: string[] = [];
   const pickerStates: Array<{ items: { id: string }[]; selectedIndex: number } | null> = [];
+  const hints: boolean[] = [];
   const autofill = createSudoPasswordAutofill({
     mode: "picker",
+    password: "host-secret",
     candidates: [
       { id: "host", label: "Host", username: "alice", password: "host-secret" },
       { id: "identity:root", label: "Root", username: "root", password: "root-secret" },
     ],
     write: (d) => writes.push(d),
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
     onPicker: (active, state) => {
       pickerStates.push(active ? { items: state!.items, selectedIndex: state!.selectedIndex } : null);
       return true;
@@ -389,6 +395,29 @@ test("picker mode opens the credential list and fills the selected secret", () =
   autofill.confirmFill();
   assert.deepEqual(writes, ["root-secret\n"]);
   assert.equal(pickerStates.at(-1), null);
+
+  // sudo never opens the multi-identity picker — host-password hint only
+  const sudoPicker = createSudoPasswordAutofill({
+    mode: "picker",
+    password: "host-secret",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: () => {},
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
+    onPicker: (active, state) => {
+      pickerStates.push(active ? { items: state!.items, selectedIndex: state!.selectedIndex } : null);
+      return true;
+    },
+  });
+  sudoPicker.armForCommand("sudo whoami");
+  sudoPicker.handleOutput("[sudo] password for alice: ");
+  assert.equal(sudoPicker.isPickerPending(), false);
+  assert.equal(sudoPicker.isPromptPending(), true);
 });
 
 test("picker confirmFill can target a specific candidate id", () => {
@@ -557,8 +586,8 @@ test("picker mode does not expose passwords in onPicker payload", () => {
       return true;
     },
   });
-  autofill.armForCommand("sudo whoami");
-  autofill.handleOutput("[sudo] password for alice: ");
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
   assert.ok(seen && typeof seen === "object");
   const json = JSON.stringify(seen);
   assert.equal(json.includes("top-secret"), false);

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -222,7 +222,10 @@ test("an expired arm shows no hint for a bare prompt", () => {
     password: "secret",
     now: () => now,
     write: (d) => writes.push(d),
-    onHint: (a) => hints.push(a),
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
   });
   autofill.armForCommand("sudo whoami");
   now += 31_000;
@@ -244,10 +247,125 @@ test("getSingleBracketedPasteLine extracts single-line bracketed paste content",
   assert.equal(getSingleBracketedPasteLine("\x1b[200~sudo whoami\rpwd\x1b[201~"), null);
 });
 
-test("shouldArmSudoPasswordAutofill only arms direct sudo commands", () => {
+test("shouldArmSudoPasswordAutofill arms direct sudo and su commands", () => {
   assert.equal(shouldArmSudoPasswordAutofill("sudo whoami"), true);
   assert.equal(shouldArmSudoPasswordAutofill("command sudo whoami"), true);
   assert.equal(shouldArmSudoPasswordAutofill("builtin sudo whoami"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("su"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("su -"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("su root"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("su - root"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("su -l alice"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("command su -"), true);
+  assert.equal(shouldArmSudoPasswordAutofill("builtin su"), true);
   assert.equal(shouldArmSudoPasswordAutofill("echo '[sudo] password for alice:'"), false);
   assert.equal(shouldArmSudoPasswordAutofill("cat sudo.log"), false);
+  // Word-boundary: do not arm unrelated commands that only start with "su"
+  assert.equal(shouldArmSudoPasswordAutofill("sum file"), false);
+  assert.equal(shouldArmSudoPasswordAutofill("suspend"), false);
+  assert.equal(shouldArmSudoPasswordAutofill("suricata -T"), false);
+  assert.equal(shouldArmSudoPasswordAutofill("echo su"), false);
+});
+
+test("shows a hint for su Password prompt when armed", () => {
+  // su asks for the target account password with a bare "Password:" line
+  // (no [sudo] tag), so arming is required (#2156).
+  const { autofill, writes, hints } = make();
+  autofill.armForCommand("su -");
+  assert.equal(autofill.handleOutput("Password: "), "Password: ");
+  assert.deepEqual(hints, [true]);
+  assert.deepEqual(writes, []);
+  assert.equal(autofill.isPromptPending(), true);
+  autofill.confirmFill();
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("su to a named user arms the same confirm-to-fill path", () => {
+  const { autofill, writes, hints } = make();
+  autofill.armForCommand("su alice");
+  autofill.handleOutput("Password: ");
+  assert.deepEqual(hints, [true]);
+  autofill.confirmFill();
+  assert.deepEqual(writes, ["secret\n"]);
+});
+
+test("mode off never hints even for explicit sudo prompts", () => {
+  const writes: string[] = [];
+  const hints: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "off",
+    password: "secret",
+    write: (d) => writes.push(d),
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
+  });
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.deepEqual(hints, []);
+  assert.equal(autofill.isPromptPending(), false);
+});
+
+test("picker mode opens the credential list and fills the selected secret", () => {
+  const writes: string[] = [];
+  const pickerStates: Array<{ items: { id: string }[]; selectedIndex: number } | null> = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", username: "alice", password: "host-secret" },
+      { id: "identity:root", label: "Root", username: "root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: (active, state) => {
+      pickerStates.push(active ? { items: state!.items, selectedIndex: state!.selectedIndex } : null);
+      return true;
+    },
+  });
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPromptPending(), true);
+  assert.equal(pickerStates.length, 1);
+  assert.equal(pickerStates[0]?.items.length, 2);
+  assert.equal(pickerStates[0]?.selectedIndex, 0);
+
+  autofill.moveSelection(1);
+  assert.equal(pickerStates.at(-1)?.selectedIndex, 1);
+
+  autofill.confirmFill();
+  assert.deepEqual(writes, ["root-secret\n"]);
+  assert.equal(pickerStates.at(-1), null);
+});
+
+test("picker confirmFill can target a specific candidate id", () => {
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: () => true,
+  });
+  autofill.armForCommand("su root");
+  autofill.handleOutput("Password: ");
+  autofill.confirmFill("identity:root");
+  assert.deepEqual(writes, ["root-secret\n"]);
+});
+
+test("picker mode does not expose passwords in onPicker payload", () => {
+  let seen: unknown = null;
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [{ id: "host", label: "Host", password: "top-secret" }],
+    write: () => {},
+    onPicker: (_active, state) => {
+      seen = state;
+      return true;
+    },
+  });
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.ok(seen && typeof seen === "object");
+  const json = JSON.stringify(seen);
+  assert.equal(json.includes("top-secret"), false);
 });

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -117,6 +117,37 @@ test("cancelHint clears the hint without filling", () => {
   assert.equal(autofill.isPromptPending(), false);
 });
 
+test("Esc soft-dismiss keeps arm so assist can re-open on the same Password prompt", () => {
+  const writes: string[] = [];
+  const pickerActives: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: (active) => {
+      pickerActives.push(active);
+      return true;
+    },
+  });
+  autofill.armForCommand("su root");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.cancelHint();
+  assert.equal(autofill.isPickerPending(), false);
+  assert.equal(autofill.canReshowAssist(), true);
+  // Same static prompt: more output without a new line must not auto-reopen
+  autofill.handleOutput("");
+  assert.equal(autofill.isPickerPending(), false);
+  // Explicit re-open (Esc / arrows in the UI)
+  assert.equal(autofill.tryReshowAssist(), true);
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.confirmFill("host");
+  assert.deepEqual(writes, ["host-secret\n"]);
+});
+
 test("confirmFill does nothing when no prompt is pending", () => {
   const { autofill, writes } = make();
   autofill.confirmFill();

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -472,6 +472,48 @@ test("picker does not open for Enter password when sudo is already cached", () =
   assert.deepEqual(writes, []);
 });
 
+test("picker does not open for database-style Password for user prompts after sudo", () => {
+  const hints: boolean[] = [];
+  const pickerActives: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    password: "host-secret",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: () => {},
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
+    onPicker: (active) => {
+      pickerActives.push(active);
+      return true;
+    },
+  });
+  autofill.armForCommand("sudo -u postgres psql -h db");
+  autofill.handleOutput("Password for user postgres: ");
+  assert.equal(autofill.isPickerPending(), false);
+  assert.deepEqual(pickerActives, []);
+  assert.deepEqual(hints, []);
+});
+
+test("picker opens for su bare Password after arm", () => {
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: () => {},
+    onPicker: () => true,
+  });
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+});
+
 test("picker mode requires arm before offering the full keychain list", () => {
   // Unarmed explicit [sudo] must not surface every identity — a remote can
   // forge that line. Host-password hint remains allowed (#2156 security).

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -543,6 +543,22 @@ test("picker opens for su bare Password after arm", () => {
   assert.equal(autofill.isPickerPending(), true);
 });
 
+test("passwordless su -c ssh does not open picker for remote password", () => {
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:other", label: "Other", password: "other-secret" },
+    ],
+    write: () => {},
+    onPicker: () => true,
+  });
+  autofill.armForCommand("su bob -c 'ssh other-host'");
+  autofill.handleOutput("bob@other-host's password: ");
+  assert.equal(autofill.isPickerPending(), false);
+  assert.equal(autofill.isPromptPending(), false);
+});
+
 test("picker mode requires arm before offering the full keychain list", () => {
   // Unarmed explicit [sudo] must not surface every identity — a remote can
   // forge that line. Host-password hint remains allowed (#2156 security).

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -387,6 +387,38 @@ test("picker confirmFill can target a specific candidate id", () => {
   assert.deepEqual(writes, ["root-secret\n"]);
 });
 
+test("picker mode requires arm before offering the full keychain list", () => {
+  // Unarmed explicit [sudo] must not surface every identity — a remote can
+  // forge that line. Host-password hint remains allowed (#2156 security).
+  const writes: string[] = [];
+  const pickerStates: Array<unknown> = [];
+  const hints: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    password: "host-secret",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:other", label: "Other", password: "other-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
+    onPicker: (_active, state) => {
+      pickerStates.push(state);
+      return true;
+    },
+  });
+  // No armForCommand — forged remote prompt only
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.equal(autofill.isPickerPending(), false);
+  assert.deepEqual(pickerStates, []);
+  assert.deepEqual(hints, [true]);
+  autofill.confirmFill();
+  assert.deepEqual(writes, ["host-secret\n"]);
+});
+
 test("picker mode does not expose passwords in onPicker payload", () => {
   let seen: unknown = null;
   const autofill = createSudoPasswordAutofill({

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -387,6 +387,34 @@ test("picker confirmFill can target a specific candidate id", () => {
   assert.deepEqual(writes, ["root-secret\n"]);
 });
 
+test("picker reopens after a wrong password when still armed", () => {
+  const writes: string[] = [];
+  const pickerActives: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "wrong" },
+      { id: "identity:root", label: "Root", password: "right" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: (active) => {
+      pickerActives.push(active);
+      return true;
+    },
+  });
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.confirmFill("host");
+  assert.deepEqual(writes, ["wrong\n"]);
+  assert.equal(autofill.isPickerPending(), false);
+  // Remote rejects and re-prompts — picker should open again for another pick
+  autofill.handleOutput("\r\nSorry, try again.\r\nPassword: ");
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.confirmFill("identity:root");
+  assert.deepEqual(writes, ["wrong\n", "right\n"]);
+});
+
 test("picker mode requires arm before offering the full keychain list", () => {
   // Unarmed explicit [sudo] must not surface every identity — a remote can
   // forge that line. Host-password hint remains allowed (#2156 security).

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -289,6 +289,30 @@ test("su to a named user arms the same confirm-to-fill path", () => {
   assert.deepEqual(writes, ["secret\n"]);
 });
 
+test("hint mode does not fall back to an unrelated keychain identity", () => {
+  // Without a session password, hint must stay silent even when password
+  // identities exist — Enter would otherwise paste the wrong secret.
+  const writes: string[] = [];
+  const hints: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "hint",
+    candidates: [
+      { id: "identity:root", label: "Root", username: "root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onHint: (a) => {
+      hints.push(a);
+      return true;
+    },
+  });
+  autofill.armForCommand("sudo whoami");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.deepEqual(hints, []);
+  assert.equal(autofill.isPromptPending(), false);
+  autofill.confirmFill();
+  assert.deepEqual(writes, []);
+});
+
 test("mode off never hints even for explicit sudo prompts", () => {
   const writes: string[] = [];
   const hints: boolean[] = [];

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -28,16 +28,23 @@ const SUDO_PROMPT_PATTERN =
 // Colon is optional for Kylin (#1293).
 const EXPLICIT_SUDO_PROMPT_PATTERN =
   /(?:^|[\r\n])[^\r\n]*?\[sudo[^\]]*\][^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*(?:[:：]\s*)?$/i;
-// Arm for direct sudo *and* su commands (#2156). `su(?:do)?` matches `su` or
-// `sudo` as a whole word (trailing space/end), so `sum`/`suspend`/`suuser` stay
-// out. Bare su prompts are just "Password:", so they only hint inside the arm
-// window — same safety model as a non-[sudo] password line after sudo.
+// Arm for direct sudo *and* su commands (#2156). Trailing space/end keeps
+// `sum`/`suspend`/`suuser` out. `sudo` is checked before bare `su`.
+const SUDO_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?sudo(?:\s|$)/;
+const SU_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?su(?:\s|$)/;
 const SUDO_OR_SU_COMMAND_PATTERN =
   /^\s*(?:builtin\s+|command\s+)?su(?:do)?(?:\s|$)/;
 // Used after confirm-to-fill: only re-open assist on a real auth retry, not on a
 // subsequent child-program password prompt (e.g. `sudo mysql -p`).
 const AUTH_RETRY_FAILURE_PATTERN =
   /sorry,\s*try\s*again|incorrect\s+password|authentication\s+failure|auth(?:entication)?\s+fail|密码(?:错误|不正确)|认证失败|鉴权失败|口令错误/i;
+// Sudo without the [sudo] tag (Kylin #1293) still scopes the prompt to the user
+// ("password for alice", "输入密码"). Generic "Enter password:" / bare
+// "Password:" is left for child programs after a cached sudo auth.
+const SUDO_SCOPED_BARE_PROMPT_PATTERN =
+  /(?:password\s+for\b|的密码|输入密码|input\s+password)/i;
+
+type ArmedCommandKind = "sudo" | "su";
 
 export const stripTerminalControlSequences = (data: string): string =>
   data.replace(OSC_PATTERN, "").replace(ANSI_PATTERN, "");
@@ -54,6 +61,20 @@ export const isExplicitSudoPrompt = (data: string): boolean => {
 
 export const shouldArmSudoPasswordAutofill = (command: string): boolean =>
   SUDO_OR_SU_COMMAND_PATTERN.test(command);
+
+export const resolveArmedCommandKind = (command: string): ArmedCommandKind | null => {
+  if (SUDO_COMMAND_PATTERN.test(command)) return "sudo";
+  if (SU_COMMAND_PATTERN.test(command)) return "su";
+  return null;
+};
+
+/** Sudo prompts without [sudo] that still look like sudo/PAM, not mysql/ssh. */
+export const isSudoScopedBarePasswordPrompt = (data: string): boolean => {
+  if (CONCEAL_PATTERN.test(data)) return false;
+  const plain = stripTerminalControlSequences(data);
+  if (!isSudoPasswordPrompt(plain)) return false;
+  return SUDO_SCOPED_BARE_PROMPT_PATTERN.test(plain);
+};
 
 /** Public picker row — never includes the secret. */
 export type PasswordPromptPickerItem = {
@@ -177,6 +198,7 @@ export const createSudoPasswordAutofill = (_options: {
   const armWindowMs = 10_000;
   let tail = "";
   let armedUntil = Number.NEGATIVE_INFINITY;
+  let armedKind: ArmedCommandKind | null = null;
   let pending = false;
   let selectedIndex = 0;
   let pendingUi: "hint" | "picker" | null = null;
@@ -213,6 +235,7 @@ export const createSudoPasswordAutofill = (_options: {
 
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
+    armedKind = null;
     postFillRetry = false;
     tail = "";
     selectedIndex = 0;
@@ -220,6 +243,17 @@ export const createSudoPasswordAutofill = (_options: {
       pending = false;
       hideUi();
     }
+  };
+
+  const isArmedPromptLine = (line: string, armActive: boolean): boolean => {
+    if (isExplicitSudoPrompt(line)) return true;
+    if (!armActive) return false;
+    // su always prompts with a bare Password: line.
+    if (armedKind === "su") return isSudoPasswordPrompt(line);
+    // sudo: only sudo-scoped prompts, never generic "Enter password:" from
+    // child programs when sudo credentials are already cached.
+    if (armedKind === "sudo") return isSudoScopedBarePasswordPrompt(line);
+    return false;
   };
 
   const showHostPasswordHint = (): boolean => {
@@ -256,7 +290,9 @@ export const createSudoPasswordAutofill = (_options: {
       // Clear any prior arm/hint first: a non-sudo/su command must not leave a
       // stale hint that a later prompt could satisfy.
       disarm();
-      if (!hasFillMaterial() || !shouldArmSudoPasswordAutofill(command)) return;
+      const kind = resolveArmedCommandKind(command);
+      if (!hasFillMaterial() || !kind) return;
+      armedKind = kind;
       armedUntil = options.now() + armWindowMs;
       tail = "";
     },
@@ -279,14 +315,13 @@ export const createSudoPasswordAutofill = (_options: {
       const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
       let armActive =
         armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
-      if (!armActive) postFillRetry = false;
-      // Explicit "[sudo] …" prompts are sudo-specific → assist regardless of arm,
-      // so it's reliable even when arming didn't fire (#1284). Bare "Password:"
-      // only assists inside the arm window, to avoid noise on unrelated prompts
-      // (ssh, mysql, …). Unarmed explicit prompts still only expose the host
-      // session password (never the full keychain picker).
-      const isPrompt =
-        isExplicitSudoPrompt(lastLine) || (armActive && isSudoPasswordPrompt(lastLine));
+      if (!armActive) {
+        postFillRetry = false;
+        armedKind = null;
+      }
+      // Explicit "[sudo] …" always; su arm accepts bare Password:; sudo arm only
+      // accepts sudo-scoped bare prompts (not generic Enter password from mysql).
+      const isPrompt = isArmedPromptLine(lastLine, armActive);
       if (pending) {
         // The prompt moved on: a new line arrived and the latest line is no
         // longer a password prompt (sudo timed out / failed / returned to the
@@ -301,18 +336,26 @@ export const createSudoPasswordAutofill = (_options: {
         // Password: from a child program after successful sudo must not reopen.
         if (postFillRetry) {
           const looksLikeAuthRetry =
-            isExplicitSudoPrompt(lastLine) || AUTH_RETRY_FAILURE_PATTERN.test(tail);
+            isExplicitSudoPrompt(lastLine)
+            || (armedKind === "su" && AUTH_RETRY_FAILURE_PATTERN.test(tail))
+            || (armedKind === "sudo" && (
+              isExplicitSudoPrompt(lastLine) || AUTH_RETRY_FAILURE_PATTERN.test(tail)
+            ));
           if (!looksLikeAuthRetry) {
             postFillRetry = false;
             armedUntil = Number.NEGATIVE_INFINITY;
+            armedKind = null;
             return data;
           }
           armActive = true;
         }
+        // Full picker only when we armed a real su/sudo command. Unarmed
+        // explicit [sudo] is host-password-only.
+        const allowFullPicker = armActive && armedKind !== null;
         // Only mark pending if the UI actually rendered. If the overlay is
         // unavailable, don't intercept Enter — the user would have no visible
         // cue and could leak the password.
-        if (showAssist(armActive)) {
+        if (showAssist(allowFullPicker)) {
           pending = true;
           postFillRetry = false;
         }

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -174,15 +174,15 @@ export const createSudoPasswordAutofill = (_options: {
 
   const hasFillMaterial = (): boolean => {
     if (mode === "off") return false;
-    // Host password alone is enough for hint (and for picker fall-back to hint
-    // when no keychain candidates were supplied).
-    return Boolean(password) || candidates.length > 0;
+    // Hint mode only uses the session host password — never an arbitrary
+    // keychain identity (that would silently send the wrong secret on Enter).
+    // Picker mode uses the full candidate list.
+    if (mode === "hint") return Boolean(password);
+    return candidates.length > 0 || Boolean(password);
   };
 
-  const defaultPassword = (): string => {
-    if (password) return password;
-    return candidates[0]?.password ?? "";
-  };
+  /** Hint / single-password path: session password only (not candidates[0]). */
+  const defaultPassword = (): string => password || "";
 
   const notifyPicker = (active: boolean): boolean => {
     if (!active) {
@@ -212,15 +212,25 @@ export const createSudoPasswordAutofill = (_options: {
 
   const showAssist = (): boolean => {
     if (mode === "off" || !hasFillMaterial()) return false;
-    if (mode === "picker" && candidates.length > 0) {
-      selectedIndex = Math.min(selectedIndex, candidates.length - 1);
-      if (notifyPicker(true)) {
-        pendingUi = "picker";
+    if (mode === "picker") {
+      if (candidates.length > 0) {
+        selectedIndex = Math.min(selectedIndex, candidates.length - 1);
+        if (notifyPicker(true)) {
+          pendingUi = "picker";
+          return true;
+        }
+        return false;
+      }
+      // Picker with only a host password and no multi-candidate list: fall
+      // back to the single-password hint so the user still gets assist.
+      if (!defaultPassword()) return false;
+      if (options.onHint(true)) {
+        pendingUi = "hint";
         return true;
       }
       return false;
     }
-    // hint mode (or picker with no candidates but a host password)
+    // hint mode: host session password only
     if (!defaultPassword()) return false;
     if (options.onHint(true)) {
       pendingUi = "hint";
@@ -289,6 +299,7 @@ export const createSudoPasswordAutofill = (_options: {
       } else if (pendingUi === "picker" && candidates.length > 0) {
         secret = candidates[selectedIndex]?.password ?? "";
       } else {
+        // Hint path: only the explicit session password.
         secret = defaultPassword();
       }
       if (!secret) {

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -313,7 +313,15 @@ export const createSudoPasswordAutofill = (_options: {
         return;
       }
       options.write(`${secret}\n`);
-      disarm();
+      // Clear the pending UI but keep (and refresh) the arm window so a
+      // wrong-password re-prompt can reopen the full picker / hint. Full
+      // disarm would force unarmed host-only fallback on the next [sudo] line.
+      pending = false;
+      hideUi();
+      if (hasFillMaterial()) {
+        armedUntil = options.now() + armWindowMs;
+        tail = "";
+      }
     },
     cancelHint: () => {
       if (!pending) return;

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -1,3 +1,5 @@
+import type { PasswordPromptAssistMode } from "../../../domain/models";
+
 const ESCAPE_SEQUENCE = "\\x" + "1b";
 const BELL_SEQUENCE = "\\x" + "07";
 const BRACKETED_PASTE_START = "\x1b[200~";
@@ -26,7 +28,12 @@ const SUDO_PROMPT_PATTERN =
 // Colon is optional for Kylin (#1293).
 const EXPLICIT_SUDO_PROMPT_PATTERN =
   /(?:^|[\r\n])[^\r\n]*?\[sudo[^\]]*\][^\r\n]*?(?:\bpassword\b|密\s*码|口\s*令)[^\r\n:：]*(?:[:：]\s*)?$/i;
-const SUDO_COMMAND_PATTERN = /^\s*(?:builtin\s+|command\s+)?sudo(?:\s|$)/;
+// Arm for direct sudo *and* su commands (#2156). `su(?:do)?` matches `su` or
+// `sudo` as a whole word (trailing space/end), so `sum`/`suspend`/`suuser` stay
+// out. Bare su prompts are just "Password:", so they only hint inside the arm
+// window — same safety model as a non-[sudo] password line after sudo.
+const SUDO_OR_SU_COMMAND_PATTERN =
+  /^\s*(?:builtin\s+|command\s+)?su(?:do)?(?:\s|$)/;
 
 export const stripTerminalControlSequences = (data: string): string =>
   data.replace(OSC_PATTERN, "").replace(ANSI_PATTERN, "");
@@ -42,15 +49,37 @@ export const isExplicitSudoPrompt = (data: string): boolean => {
 };
 
 export const shouldArmSudoPasswordAutofill = (command: string): boolean =>
-  SUDO_COMMAND_PATTERN.test(command);
+  SUDO_OR_SU_COMMAND_PATTERN.test(command);
+
+/** Public picker row — never includes the secret. */
+export type PasswordPromptPickerItem = {
+  id: string;
+  label: string;
+  username?: string;
+};
+
+/** Internal candidate with password for confirm-to-fill. */
+export type SudoPasswordAutofillCandidate = PasswordPromptPickerItem & {
+  password: string;
+};
+
+export type PasswordPromptPickerState = {
+  items: PasswordPromptPickerItem[];
+  selectedIndex: number;
+};
 
 export type SudoPasswordAutofill = {
   armForCommand: (command: string) => void;
   handleOutput: (data: string) => string;
-  confirmFill: () => void;
+  /** Confirm with the selected (or host) password, or a specific candidate id. */
+  confirmFill: (candidateId?: string) => void;
   cancelHint: () => void;
   isPromptPending: () => boolean;
+  /** Picker mode: move selection while the list is open. */
+  moveSelection: (delta: number) => void;
   updatePassword: (password?: string) => void;
+  updateCandidates: (candidates: SudoPasswordAutofillCandidate[]) => void;
+  updateMode: (mode: PasswordPromptAssistMode) => void;
 };
 
 const unwrapBracketedPaste = (data: string): string => {
@@ -80,8 +109,8 @@ export const getSingleBracketedPasteLine = (data: string): string | null => {
   return text;
 };
 
-// Arm the autofill when a sudo command is submitted. The user's input is sent to
-// the remote verbatim — we never rewrite it — so the terminal echo and cursor
+// Arm the autofill when a sudo/su command is submitted. The user's input is sent
+// to the remote verbatim — we never rewrite it — so the terminal echo and cursor
 // stay correct.
 export const prepareSudoAutofillInput = (
   data: string,
@@ -101,50 +130,116 @@ export const prepareSudoAutofillInput = (
   return data;
 };
 
-// Confirm-to-fill model: when a sudo command is armed and a password prompt is
-// seen, we DON'T send the password — we raise a hint (onHint(true)) so the UI can
-// offer "press Enter to paste". The password is only written when the user
-// confirms via confirmFill(). This makes over-broad detection safe: a misfire
-// just shows a dismissable hint instead of leaking the password.
+const toPickerItems = (
+  candidates: SudoPasswordAutofillCandidate[],
+): PasswordPromptPickerItem[] =>
+  candidates.map(({ id, label, username }) => ({ id, label, username }));
+
+// Confirm-to-fill model: when a sudo/su command is armed and a password prompt is
+// seen, we DON'T send the password — we raise a hint or picker so the UI can
+// offer confirmation. The password is only written when the user confirms via
+// confirmFill(). This makes over-broad detection safe: a misfire just shows a
+// dismissable UI instead of leaking the password.
 export const createSudoPasswordAutofill = (_options: {
+  mode?: PasswordPromptAssistMode;
+  /** Hint-mode default password (host session password). */
   password?: string;
+  /** Picker-mode candidates (host + keychain password identities). */
+  candidates?: SudoPasswordAutofillCandidate[];
   write: (data: string) => void;
-  /** Show/hide the inline hint. Returns whether the hint actually rendered;
-   *  false (e.g. no overlay available) means we must not arm a confirmation. */
+  /** Show/hide the inline hint. Returns whether the hint actually rendered. */
   onHint?: (active: boolean) => boolean;
+  /**
+   * Show/hide the credential picker. Returns whether the picker actually
+   * rendered. `state` is null when hiding.
+   */
+  onPicker?: (active: boolean, state: PasswordPromptPickerState | null) => boolean;
   now?: () => number;
 }): SudoPasswordAutofill => {
   const options = {
     now: () => Date.now(),
-    onHint: () => false,
+    onHint: (_active: boolean) => false,
+    onPicker: (_active: boolean, _state: PasswordPromptPickerState | null) => false,
     ..._options,
   };
+  let mode: PasswordPromptAssistMode = options.mode ?? "hint";
   let password = options.password ?? "";
+  let candidates: SudoPasswordAutofillCandidate[] = options.candidates ?? [];
   const armWindowMs = 10_000;
   let tail = "";
   let armedUntil = Number.NEGATIVE_INFINITY;
   let pending = false;
+  let selectedIndex = 0;
+  let pendingUi: "hint" | "picker" | null = null;
+
+  const hasFillMaterial = (): boolean => {
+    if (mode === "off") return false;
+    // Host password alone is enough for hint (and for picker fall-back to hint
+    // when no keychain candidates were supplied).
+    return Boolean(password) || candidates.length > 0;
+  };
+
+  const defaultPassword = (): string => {
+    if (password) return password;
+    return candidates[0]?.password ?? "";
+  };
+
+  const notifyPicker = (active: boolean): boolean => {
+    if (!active) {
+      return options.onPicker(false, null);
+    }
+    return options.onPicker(true, {
+      items: toPickerItems(candidates),
+      selectedIndex,
+    });
+  };
+
+  const hideUi = () => {
+    if (pendingUi === "hint") options.onHint(false);
+    if (pendingUi === "picker") options.onPicker(false, null);
+    pendingUi = null;
+  };
 
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
     tail = "";
+    selectedIndex = 0;
     if (pending) {
       pending = false;
-      options.onHint(false);
+      hideUi();
     }
+  };
+
+  const showAssist = (): boolean => {
+    if (mode === "off" || !hasFillMaterial()) return false;
+    if (mode === "picker" && candidates.length > 0) {
+      selectedIndex = Math.min(selectedIndex, candidates.length - 1);
+      if (notifyPicker(true)) {
+        pendingUi = "picker";
+        return true;
+      }
+      return false;
+    }
+    // hint mode (or picker with no candidates but a host password)
+    if (!defaultPassword()) return false;
+    if (options.onHint(true)) {
+      pendingUi = "hint";
+      return true;
+    }
+    return false;
   };
 
   return {
     armForCommand: (command: string) => {
-      // Clear any prior arm/hint first: a non-sudo command must not leave a
+      // Clear any prior arm/hint first: a non-sudo/su command must not leave a
       // stale hint that a later prompt could satisfy.
       disarm();
-      if (!password || !shouldArmSudoPasswordAutofill(command)) return;
+      if (!hasFillMaterial() || !shouldArmSudoPasswordAutofill(command)) return;
       armedUntil = options.now() + armWindowMs;
       tail = "";
     },
     handleOutput: (data: string) => {
-      if (!password) return data;
+      if (!hasFillMaterial()) return data;
       tail = `${tail}${data}`.slice(-1024);
       // Fast path for bulk output: a prompt line ends in a colon, so a chunk
       // with no colon can't be completing one. Skip the regex work unless a hint
@@ -162,33 +257,45 @@ export const createSudoPasswordAutofill = (_options: {
       const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
       const armActive =
         armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
-      // Explicit "[sudo] …" prompts are sudo-specific → hint regardless of arm,
+      // Explicit "[sudo] …" prompts are sudo-specific → assist regardless of arm,
       // so it's reliable even when arming didn't fire (#1284). Bare "Password:"
-      // only hints inside the arm window, to avoid noise on unrelated prompts
+      // only assists inside the arm window, to avoid noise on unrelated prompts
       // (ssh, mysql, …).
       const isPrompt =
         isExplicitSudoPrompt(lastLine) || (armActive && isSudoPasswordPrompt(lastLine));
       if (pending) {
         // The prompt moved on: a new line arrived and the latest line is no
         // longer a password prompt (sudo timed out / failed / returned to the
-        // shell). Clear the pending hint — otherwise a later Enter would send
+        // shell). Clear the pending UI — otherwise a later Enter would send
         // the password to whatever is now reading input.
         if (!isPrompt && /[\r\n]/.test(data)) disarm();
         return data;
       }
       if (isPrompt) {
-        // Only mark pending if the hint actually rendered. If the overlay is
-        // unavailable (e.g. autocomplete disabled), don't intercept Enter — the
-        // user would have no visible cue and could leak the password.
-        if (options.onHint(true)) {
+        // Only mark pending if the UI actually rendered. If the overlay is
+        // unavailable, don't intercept Enter — the user would have no visible
+        // cue and could leak the password.
+        if (showAssist()) {
           pending = true;
         }
       }
       return data;
     },
-    confirmFill: () => {
+    confirmFill: (candidateId?: string) => {
       if (!pending) return;
-      options.write(`${password}\n`);
+      let secret = "";
+      if (candidateId) {
+        secret = candidates.find((c) => c.id === candidateId)?.password ?? "";
+      } else if (pendingUi === "picker" && candidates.length > 0) {
+        secret = candidates[selectedIndex]?.password ?? "";
+      } else {
+        secret = defaultPassword();
+      }
+      if (!secret) {
+        disarm();
+        return;
+      }
+      options.write(`${secret}\n`);
       disarm();
     },
     cancelHint: () => {
@@ -196,9 +303,44 @@ export const createSudoPasswordAutofill = (_options: {
       disarm();
     },
     isPromptPending: () => pending,
+    moveSelection: (delta: number) => {
+      if (!pending || pendingUi !== "picker" || candidates.length === 0) return;
+      const next =
+        (selectedIndex + delta + candidates.length * 10) % candidates.length;
+      if (next === selectedIndex) return;
+      selectedIndex = next;
+      notifyPicker(true);
+    },
     updatePassword: (nextPassword?: string) => {
       password = nextPassword ?? "";
-      if (!password) disarm();
+      if (!hasFillMaterial()) disarm();
+    },
+    updateCandidates: (next) => {
+      candidates = next ?? [];
+      if (selectedIndex >= candidates.length) {
+        selectedIndex = Math.max(0, candidates.length - 1);
+      }
+      if (!hasFillMaterial()) {
+        disarm();
+        return;
+      }
+      if (pending && pendingUi === "picker") {
+        notifyPicker(true);
+      }
+    },
+    updateMode: (nextMode) => {
+      mode = nextMode;
+      if (!hasFillMaterial()) {
+        disarm();
+        return;
+      }
+      // Mode change while pending: re-show the appropriate UI.
+      if (pending) {
+        hideUi();
+        if (!showAssist()) {
+          pending = false;
+        }
+      }
     },
   };
 };

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -75,8 +75,13 @@ export type SudoPasswordAutofill = {
   confirmFill: (candidateId?: string) => void;
   cancelHint: () => void;
   isPromptPending: () => boolean;
-  /** Picker mode: move selection while the list is open. */
-  moveSelection: (delta: number) => void;
+  /** True only while the multi-credential picker UI is open (not the hint). */
+  isPickerPending: () => boolean;
+  /**
+   * Picker mode: move selection while the list is open.
+   * Returns true when the selection changed so callers can consume the key.
+   */
+  moveSelection: (delta: number) => boolean;
   updatePassword: (password?: string) => void;
   updateCandidates: (candidates: SudoPasswordAutofillCandidate[]) => void;
   updateMode: (mode: PasswordPromptAssistMode) => void;
@@ -314,13 +319,15 @@ export const createSudoPasswordAutofill = (_options: {
       disarm();
     },
     isPromptPending: () => pending,
+    isPickerPending: () => pending && pendingUi === "picker",
     moveSelection: (delta: number) => {
-      if (!pending || pendingUi !== "picker" || candidates.length === 0) return;
+      if (!pending || pendingUi !== "picker" || candidates.length === 0) return false;
       const next =
         (selectedIndex + delta + candidates.length * 10) % candidates.length;
-      if (next === selectedIndex) return;
+      if (next === selectedIndex) return false;
       selectedIndex = next;
       notifyPicker(true);
+      return true;
     },
     updatePassword: (nextPassword?: string) => {
       password = nextPassword ?? "";

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -79,13 +79,23 @@ export const isSudoScopedBarePasswordPrompt = (data: string): boolean => {
   return SUDO_SCOPED_BARE_PROMPT_PATTERN.test(plain);
 };
 
-/** su typically prints a bare Password: line (not "Enter password" / DB style). */
+/**
+ * su typically prints a short bare Password: / 密码： line.
+ * Reject SSH/scp style "user@host's password:" and long child prompts even
+ * while an su command arm is still active (e.g. passwordless su -c ssh).
+ */
 export const isSuBarePasswordPrompt = (data: string): boolean => {
   if (CONCEAL_PATTERN.test(data)) return false;
-  const plain = stripTerminalControlSequences(data);
-  if (!isSudoPasswordPrompt(plain)) return false;
+  const plain = stripTerminalControlSequences(data).replace(/\s+/g, " ").trim();
+  if (!plain) return false;
   if (CHILD_PROGRAM_PASSWORD_PROMPT_PATTERN.test(plain)) return false;
-  return true;
+  // SSH/scp/rsync remote password prompts always include user@host.
+  if (plain.includes("@")) return false;
+  if (!isSudoPasswordPrompt(plain)) return false;
+  // Whole line should be essentially the password word (+ optional colon).
+  // Keep a small budget for locale variants like "Password: " / "密码：".
+  if (plain.length > 24) return false;
+  return /^(?:password|passwd|密\s*码|口\s*令)\s*[:：]?\s*$/i.test(plain);
 };
 
 /** Public picker row — never includes the secret. */

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -353,10 +353,13 @@ export const createSudoPasswordAutofill = (_options: {
         disarm();
         return;
       }
-      // Mode change while pending: re-show the appropriate UI.
+      // Mode change while pending: re-show the appropriate UI. Keep the full
+      // picker available only while the command arm is still valid.
       if (pending) {
+        const armStillActive =
+          armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
         hideUi();
-        if (!showAssist()) {
+        if (!showAssist(armStillActive)) {
           pending = false;
         }
       }

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -268,15 +268,15 @@ export const createSudoPasswordAutofill = (_options: {
     return false;
   };
 
-  /** Full keychain picker only when the prompt is clearly su/sudo, not a child. */
+  /**
+   * Full keychain picker is only for armed `su` prompts (#2156). Sudo keeps
+   * host-password quick-fill only — a multi-identity list after `sudo …` is
+   * too easy to confuse with a child-program password prompt (or a forged
+   * [sudo] line once auth is cached).
+   */
   const allowFullPickerForLine = (line: string, armActive: boolean): boolean => {
-    if (!armActive || !armedKind) return false;
-    if (isExplicitSudoPrompt(line)) return true;
-    // su Password: is the normal su UX; DB-style lines are rejected above.
-    if (armedKind === "su") return isSuBarePasswordPrompt(line);
-    // For sudo, only the [sudo] tag is strong enough for the multi-identity
-    // picker. Kylin bare "输入密码" still gets host-password hint only.
-    return false;
+    if (!armActive || armedKind !== "su") return false;
+    return isSuBarePasswordPrompt(line);
   };
 
   const showHostPasswordHint = (): boolean => {

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -120,10 +120,19 @@ export type SudoPasswordAutofill = {
   handleOutput: (data: string) => string;
   /** Confirm with the selected (or host) password, or a specific candidate id. */
   confirmFill: (candidateId?: string) => void;
+  /** Dismiss the open UI without clearing the su/sudo arm (Esc). */
   cancelHint: () => void;
   isPromptPending: () => boolean;
   /** True only while the multi-credential picker UI is open (not the hint). */
   isPickerPending: () => boolean;
+  /**
+   * True when the user dismissed the UI with Esc but the command arm is still
+   * live and the last line still looks like a password prompt — Esc/↑/↓ can
+   * re-open the assist without re-running su/sudo.
+   */
+  canReshowAssist: () => boolean;
+  /** Re-open assist after a soft dismiss. Returns whether the UI showed. */
+  tryReshowAssist: () => boolean;
   /**
    * Picker mode: move selection while the list is open.
    * Returns true when the selection changed so callers can consume the key.
@@ -226,6 +235,13 @@ export const createSudoPasswordAutofill = (_options: {
   let pendingUi: "hint" | "picker" | null = null;
   /** True after confirmFill until we see success (non-prompt output) or expire. */
   let postFillRetry = false;
+  /**
+   * User hit Esc while a prompt assist was open. Keep the arm so they can
+   * re-open (Esc/arrows) or so a real re-prompt can auto-show again — but do
+   * not immediately re-fire on the same static Password: line with no new
+   * output.
+   */
+  let dismissedWhileArmed = false;
 
   const hasFillMaterial = (): boolean => {
     if (mode === "off") return false;
@@ -255,16 +271,36 @@ export const createSudoPasswordAutofill = (_options: {
     pendingUi = null;
   };
 
+  const isArmActiveNow = (): boolean =>
+    armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
+
+  const lastPromptLine = (): string => tail.split(/[\r\n]/).pop() ?? tail;
+
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
     armedKind = null;
     postFillRetry = false;
+    dismissedWhileArmed = false;
     tail = "";
     selectedIndex = 0;
     if (pending) {
       pending = false;
       hideUi();
     }
+  };
+
+  const tryShowForCurrentTail = (): boolean => {
+    const armActive = isArmActiveNow();
+    const lastLine = lastPromptLine();
+    // Explicit [sudo] may show host-password hint without an arm; full picker
+    // still requires armed su (allowFullPickerForLine).
+    if (!isArmedPromptLine(lastLine, armActive)) return false;
+    const allowFullPicker = allowFullPickerForLine(lastLine, armActive);
+    if (!showAssist(allowFullPicker)) return false;
+    pending = true;
+    postFillRetry = false;
+    dismissedWhileArmed = false;
+    return true;
   };
 
   const isArmedPromptLine = (line: string, armActive: boolean): boolean => {
@@ -345,11 +381,11 @@ export const createSudoPasswordAutofill = (_options: {
       ) {
         return data;
       }
-      const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
-      let armActive =
-        armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
+      const lastLine = lastPromptLine();
+      let armActive = isArmActiveNow();
       if (!armActive) {
         postFillRetry = false;
+        dismissedWhileArmed = false;
         armedKind = null;
       }
       // Explicit "[sudo] …" always; su arm accepts bare Password:; sudo arm only
@@ -364,6 +400,15 @@ export const createSudoPasswordAutofill = (_options: {
         return data;
       }
       if (isPrompt) {
+        // Soft-dismissed (Esc): do not auto-reopen on the same static prompt
+        // with no new line. A real re-prompt (newline / auth-failure text)
+        // clears the dismiss flag and may show again.
+        if (dismissedWhileArmed) {
+          const looksLikeNewPromptCycle =
+            /[\r\n]/.test(data) || AUTH_RETRY_FAILURE_PATTERN.test(tail);
+          if (!looksLikeNewPromptCycle) return data;
+          dismissedWhileArmed = false;
+        }
         // After a fill, only re-assist when this looks like a real auth retry
         // (explicit [sudo] again, or failure text in the tail). A bare
         // Password: from a child program after successful sudo must not reopen.
@@ -384,14 +429,7 @@ export const createSudoPasswordAutofill = (_options: {
         }
         // Full picker only with strong evidence the prompt is su/sudo itself.
         // Unarmed / Kylin bare / ambiguous lines stay host-password hint only.
-        const allowFullPicker = allowFullPickerForLine(lastLine, armActive);
-        // Only mark pending if the UI actually rendered. If the overlay is
-        // unavailable, don't intercept Enter — the user would have no visible
-        // cue and could leak the password.
-        if (showAssist(allowFullPicker)) {
-          pending = true;
-          postFillRetry = false;
-        }
+        tryShowForCurrentTail();
       }
       return data;
     },
@@ -416,6 +454,7 @@ export const createSudoPasswordAutofill = (_options: {
       // Password: (e.g. after `sudo mysql -p`) will not (#2156 review).
       pending = false;
       hideUi();
+      dismissedWhileArmed = false;
       postFillRetry = true;
       if (hasFillMaterial()) {
         armedUntil = options.now() + armWindowMs;
@@ -424,10 +463,31 @@ export const createSudoPasswordAutofill = (_options: {
     },
     cancelHint: () => {
       if (!pending) return;
-      disarm();
+      // Soft dismiss: hide UI but keep arm + tail so Esc/arrows can re-open
+      // while still on the Password: line, and so a re-prompt can auto-show.
+      pending = false;
+      hideUi();
+      dismissedWhileArmed = isArmActiveNow();
+      if (!dismissedWhileArmed) {
+        armedKind = null;
+        armedUntil = Number.NEGATIVE_INFINITY;
+      }
     },
     isPromptPending: () => pending,
     isPickerPending: () => pending && pendingUi === "picker",
+    canReshowAssist: () => {
+      if (pending || !dismissedWhileArmed || !hasFillMaterial()) return false;
+      if (!isArmActiveNow()) return false;
+      return isArmedPromptLine(lastPromptLine(), true);
+    },
+    tryReshowAssist: () => {
+      if (pending || !hasFillMaterial()) return false;
+      if (!isArmActiveNow()) {
+        dismissedWhileArmed = false;
+        return false;
+      }
+      return tryShowForCurrentTail();
+    },
     moveSelection: (delta: number) => {
       if (!pending || pendingUi !== "picker" || candidates.length === 0) return false;
       const next =

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -39,10 +39,12 @@ const SUDO_OR_SU_COMMAND_PATTERN =
 const AUTH_RETRY_FAILURE_PATTERN =
   /sorry,\s*try\s*again|incorrect\s+password|authentication\s+failure|auth(?:entication)?\s+fail|密码(?:错误|不正确)|认证失败|鉴权失败|口令错误/i;
 // Sudo without the [sudo] tag (Kylin #1293) still scopes the prompt to the user
-// ("password for alice", "输入密码"). Generic "Enter password:" / bare
-// "Password:" is left for child programs after a cached sudo auth.
+// ("password for alice", "输入密码"). Generic child-program prompts are excluded:
+// "Enter password:", "Password for user postgres:", etc.
 const SUDO_SCOPED_BARE_PROMPT_PATTERN =
   /(?:password\s+for\b|的密码|输入密码|input\s+password)/i;
+const CHILD_PROGRAM_PASSWORD_PROMPT_PATTERN =
+  /(?:enter\s+password\b|password\s+for\s+user\b)/i;
 
 type ArmedCommandKind = "sudo" | "su";
 
@@ -68,12 +70,22 @@ export const resolveArmedCommandKind = (command: string): ArmedCommandKind | nul
   return null;
 };
 
-/** Sudo prompts without [sudo] that still look like sudo/PAM, not mysql/ssh. */
+/** Sudo prompts without [sudo] that still look like sudo/PAM, not mysql/psql. */
 export const isSudoScopedBarePasswordPrompt = (data: string): boolean => {
   if (CONCEAL_PATTERN.test(data)) return false;
   const plain = stripTerminalControlSequences(data);
   if (!isSudoPasswordPrompt(plain)) return false;
+  if (CHILD_PROGRAM_PASSWORD_PROMPT_PATTERN.test(plain)) return false;
   return SUDO_SCOPED_BARE_PROMPT_PATTERN.test(plain);
+};
+
+/** su typically prints a bare Password: line (not "Enter password" / DB style). */
+export const isSuBarePasswordPrompt = (data: string): boolean => {
+  if (CONCEAL_PATTERN.test(data)) return false;
+  const plain = stripTerminalControlSequences(data);
+  if (!isSudoPasswordPrompt(plain)) return false;
+  if (CHILD_PROGRAM_PASSWORD_PROMPT_PATTERN.test(plain)) return false;
+  return true;
 };
 
 /** Public picker row — never includes the secret. */
@@ -248,11 +260,22 @@ export const createSudoPasswordAutofill = (_options: {
   const isArmedPromptLine = (line: string, armActive: boolean): boolean => {
     if (isExplicitSudoPrompt(line)) return true;
     if (!armActive) return false;
-    // su always prompts with a bare Password: line.
-    if (armedKind === "su") return isSudoPasswordPrompt(line);
+    // su always prompts with a bare Password: line (not Enter password / DB).
+    if (armedKind === "su") return isSuBarePasswordPrompt(line);
     // sudo: only sudo-scoped prompts, never generic "Enter password:" from
     // child programs when sudo credentials are already cached.
     if (armedKind === "sudo") return isSudoScopedBarePasswordPrompt(line);
+    return false;
+  };
+
+  /** Full keychain picker only when the prompt is clearly su/sudo, not a child. */
+  const allowFullPickerForLine = (line: string, armActive: boolean): boolean => {
+    if (!armActive || !armedKind) return false;
+    if (isExplicitSudoPrompt(line)) return true;
+    // su Password: is the normal su UX; DB-style lines are rejected above.
+    if (armedKind === "su") return isSuBarePasswordPrompt(line);
+    // For sudo, only the [sudo] tag is strong enough for the multi-identity
+    // picker. Kylin bare "输入密码" still gets host-password hint only.
     return false;
   };
 
@@ -349,9 +372,9 @@ export const createSudoPasswordAutofill = (_options: {
           }
           armActive = true;
         }
-        // Full picker only when we armed a real su/sudo command. Unarmed
-        // explicit [sudo] is host-password-only.
-        const allowFullPicker = armActive && armedKind !== null;
+        // Full picker only with strong evidence the prompt is su/sudo itself.
+        // Unarmed / Kylin bare / ambiguous lines stay host-password hint only.
+        const allowFullPicker = allowFullPickerForLine(lastLine, armActive);
         // Only mark pending if the UI actually rendered. If the overlay is
         // unavailable, don't intercept Enter — the user would have no visible
         // cue and could leak the password.

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -451,12 +451,13 @@ export const createSudoPasswordAutofill = (_options: {
         return;
       }
       // Mode change while pending: re-show the appropriate UI. Keep the full
-      // picker available only while the command arm is still valid.
+      // picker available only for armed su (same gate as first detection).
       if (pending) {
         const armStillActive =
           armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
+        const allowFullPicker = armStillActive && armedKind === "su";
         hideUi();
-        if (!showAssist(armStillActive)) {
+        if (!showAssist(allowFullPicker)) {
           pending = false;
         }
       }

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -34,6 +34,10 @@ const EXPLICIT_SUDO_PROMPT_PATTERN =
 // window — same safety model as a non-[sudo] password line after sudo.
 const SUDO_OR_SU_COMMAND_PATTERN =
   /^\s*(?:builtin\s+|command\s+)?su(?:do)?(?:\s|$)/;
+// Used after confirm-to-fill: only re-open assist on a real auth retry, not on a
+// subsequent child-program password prompt (e.g. `sudo mysql -p`).
+const AUTH_RETRY_FAILURE_PATTERN =
+  /sorry,\s*try\s*again|incorrect\s+password|authentication\s+failure|auth(?:entication)?\s+fail|密码(?:错误|不正确)|认证失败|鉴权失败|口令错误/i;
 
 export const stripTerminalControlSequences = (data: string): string =>
   data.replace(OSC_PATTERN, "").replace(ANSI_PATTERN, "");
@@ -176,6 +180,8 @@ export const createSudoPasswordAutofill = (_options: {
   let pending = false;
   let selectedIndex = 0;
   let pendingUi: "hint" | "picker" | null = null;
+  /** True after confirmFill until we see success (non-prompt output) or expire. */
+  let postFillRetry = false;
 
   const hasFillMaterial = (): boolean => {
     if (mode === "off") return false;
@@ -207,6 +213,7 @@ export const createSudoPasswordAutofill = (_options: {
 
   const disarm = () => {
     armedUntil = Number.NEGATIVE_INFINITY;
+    postFillRetry = false;
     tail = "";
     selectedIndex = 0;
     if (pending) {
@@ -270,8 +277,9 @@ export const createSudoPasswordAutofill = (_options: {
         return data;
       }
       const lastLine = tail.split(/[\r\n]/).pop() ?? tail;
-      const armActive =
+      let armActive =
         armedUntil !== Number.NEGATIVE_INFINITY && options.now() <= armedUntil;
+      if (!armActive) postFillRetry = false;
       // Explicit "[sudo] …" prompts are sudo-specific → assist regardless of arm,
       // so it's reliable even when arming didn't fire (#1284). Bare "Password:"
       // only assists inside the arm window, to avoid noise on unrelated prompts
@@ -288,11 +296,25 @@ export const createSudoPasswordAutofill = (_options: {
         return data;
       }
       if (isPrompt) {
+        // After a fill, only re-assist when this looks like a real auth retry
+        // (explicit [sudo] again, or failure text in the tail). A bare
+        // Password: from a child program after successful sudo must not reopen.
+        if (postFillRetry) {
+          const looksLikeAuthRetry =
+            isExplicitSudoPrompt(lastLine) || AUTH_RETRY_FAILURE_PATTERN.test(tail);
+          if (!looksLikeAuthRetry) {
+            postFillRetry = false;
+            armedUntil = Number.NEGATIVE_INFINITY;
+            return data;
+          }
+          armActive = true;
+        }
         // Only mark pending if the UI actually rendered. If the overlay is
         // unavailable, don't intercept Enter — the user would have no visible
         // cue and could leak the password.
         if (showAssist(armActive)) {
           pending = true;
+          postFillRetry = false;
         }
       }
       return data;
@@ -313,11 +335,12 @@ export const createSudoPasswordAutofill = (_options: {
         return;
       }
       options.write(`${secret}\n`);
-      // Clear the pending UI but keep (and refresh) the arm window so a
-      // wrong-password re-prompt can reopen the full picker / hint. Full
-      // disarm would force unarmed host-only fallback on the next [sudo] line.
+      // Clear pending UI. Keep a short arm + postFillRetry flag so a real
+      // sudo/su rejection re-prompt can reopen assist, but a later child
+      // Password: (e.g. after `sudo mysql -p`) will not (#2156 review).
       pending = false;
       hideUi();
+      postFillRetry = true;
       if (hasFillMaterial()) {
         armedUntil = options.now() + armWindowMs;
         tail = "";

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -215,33 +215,33 @@ export const createSudoPasswordAutofill = (_options: {
     }
   };
 
-  const showAssist = (): boolean => {
-    if (mode === "off" || !hasFillMaterial()) return false;
-    if (mode === "picker") {
-      if (candidates.length > 0) {
-        selectedIndex = Math.min(selectedIndex, candidates.length - 1);
-        if (notifyPicker(true)) {
-          pendingUi = "picker";
-          return true;
-        }
-        return false;
-      }
-      // Picker with only a host password and no multi-candidate list: fall
-      // back to the single-password hint so the user still gets assist.
-      if (!defaultPassword()) return false;
-      if (options.onHint(true)) {
-        pendingUi = "hint";
-        return true;
-      }
-      return false;
-    }
-    // hint mode: host session password only
+  const showHostPasswordHint = (): boolean => {
     if (!defaultPassword()) return false;
     if (options.onHint(true)) {
       pendingUi = "hint";
       return true;
     }
     return false;
+  };
+
+  /**
+   * @param allowFullPicker When false (unarmed explicit [sudo] path), only
+   * the session host password may be offered — never the full keychain list.
+   * A forged remote `[sudo] password…` line must not surface other systems'
+   * secrets even though filling still requires a user click (#2156 review).
+   */
+  const showAssist = (allowFullPicker: boolean): boolean => {
+    if (mode === "off" || !hasFillMaterial()) return false;
+    if (mode === "picker" && allowFullPicker && candidates.length > 0) {
+      selectedIndex = Math.min(selectedIndex, candidates.length - 1);
+      if (notifyPicker(true)) {
+        pendingUi = "picker";
+        return true;
+      }
+      return false;
+    }
+    // hint mode, or picker without arm / without multi candidates
+    return showHostPasswordHint();
   };
 
   return {
@@ -275,7 +275,8 @@ export const createSudoPasswordAutofill = (_options: {
       // Explicit "[sudo] …" prompts are sudo-specific → assist regardless of arm,
       // so it's reliable even when arming didn't fire (#1284). Bare "Password:"
       // only assists inside the arm window, to avoid noise on unrelated prompts
-      // (ssh, mysql, …).
+      // (ssh, mysql, …). Unarmed explicit prompts still only expose the host
+      // session password (never the full keychain picker).
       const isPrompt =
         isExplicitSudoPrompt(lastLine) || (armActive && isSudoPasswordPrompt(lastLine));
       if (pending) {
@@ -290,7 +291,7 @@ export const createSudoPasswordAutofill = (_options: {
         // Only mark pending if the UI actually rendered. If the overlay is
         // unavailable, don't intercept Enter — the user would have no visible
         // cue and could leak the password.
-        if (showAssist()) {
+        if (showAssist(armActive)) {
           pending = true;
         }
       }

--- a/components/terminal/terminalHelpers.ts
+++ b/components/terminal/terminalHelpers.ts
@@ -208,6 +208,8 @@ export interface TerminalProps {
   sessionLog?: { enabled: boolean; directory: string; format: string; timestampsEnabled?: boolean };
   sshDebugLogEnabled?: boolean;
   sudoAutofillPassword?: string;
+  /** Host + keychain password identities for picker mode (#2156). */
+  sudoAutofillCandidates?: import("./runtime/terminalSudoAutofill").SudoPasswordAutofillCandidate[];
   showSelectionAIAction?: boolean;
   onAddSelectionToAI?: (sessionId: string, selection: string) => void;
   /** Override display name for the pane title bar (customName || hostLabel) */

--- a/components/terminal/terminalMemo.ts
+++ b/components/terminal/terminalMemo.ts
@@ -53,6 +53,7 @@ export const terminalPropsAreEqual = (
   && prev.sessionLog === next.sessionLog
   && prev.sshDebugLogEnabled === next.sshDebugLogEnabled
   && prev.sudoAutofillPassword === next.sudoAutofillPassword
+  && prev.sudoAutofillCandidates === next.sudoAutofillCandidates
   && prev.showSelectionAIAction === next.showSelectionAIAction
   && prev.onHotkeyAction === next.onHotkeyAction
   && prev.onTerminalFontSizeChange === next.onTerminalFontSizeChange

--- a/components/terminalLayer/TerminalLayerSupport.tsx
+++ b/components/terminalLayer/TerminalLayerSupport.tsx
@@ -701,6 +701,7 @@ interface TerminalPaneProps {
   sessionHostResolved: boolean;
   chainHosts?: Host[];
   sudoAutofillPassword?: string;
+  sudoAutofillCandidates?: import("../terminal/runtime/terminalSudoAutofill").SudoPasswordAutofillCandidate[];
   workspaceById: Map<string, Workspace>;
   workspaceRectsById: Map<string, Record<string, WorkspaceRect>>;
   isTerminalLayerVisible: boolean;
@@ -829,6 +830,7 @@ const terminalPanePropsAreEqual = (
   prev.sessionHostResolved === next.sessionHostResolved &&
   prev.chainHosts === next.chainHosts &&
   prev.sudoAutofillPassword === next.sudoAutofillPassword &&
+  prev.sudoAutofillCandidates === next.sudoAutofillCandidates &&
   prev.workspaceById === next.workspaceById &&
   workspaceRectsEqual(getPaneRenderedWorkspaceRect(prev), getPaneRenderedWorkspaceRect(next)) &&
   prev.isTerminalLayerVisible === next.isTerminalLayerVisible &&
@@ -899,6 +901,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
   sessionHostResolved,
   chainHosts,
   sudoAutofillPassword,
+  sudoAutofillCandidates,
   workspaceById,
   workspaceRectsById,
   isTerminalLayerVisible,
@@ -1412,6 +1415,7 @@ const TerminalPane: React.FC<TerminalPaneProps> = memo(({
         sessionLog={sessionLog}
         sshDebugLogEnabled={sshDebugLogEnabled}
         sudoAutofillPassword={sudoAutofillPassword}
+        sudoAutofillCandidates={sudoAutofillCandidates}
         sessionDisplayName={resolveSessionTabTitle(session, terminalSettings?.dynamicTabTitleMode)}
         showSelectionAIAction={showSelectionAIAction}
         onAddSelectionToAI={onAddSelectionToAI}
@@ -1433,6 +1437,10 @@ interface TerminalPanesHostProps {
   sessionHostsMap: Map<string, Host>;
   sessionChainHostsMap: Map<string, Host[]>;
   sessionSudoAutofillPasswordsMap: Map<string, string | undefined>;
+  sessionSudoAutofillCandidatesMap: Map<
+    string,
+    import("../terminal/runtime/terminalSudoAutofill").SudoPasswordAutofillCandidate[] | undefined
+  >;
   resolvedSessionHostIds: Set<string>;
   workspaceById: Map<string, Workspace>;
   workspaceRectsById: Map<string, Record<string, WorkspaceRect>>;
@@ -1518,6 +1526,7 @@ const terminalPanesHostPropsAreEqual = (
   if (prev.sessionHostsMap !== next.sessionHostsMap) return false;
   if (prev.sessionChainHostsMap !== next.sessionChainHostsMap) return false;
   if (prev.sessionSudoAutofillPasswordsMap !== next.sessionSudoAutofillPasswordsMap) return false;
+  if (prev.sessionSudoAutofillCandidatesMap !== next.sessionSudoAutofillCandidatesMap) return false;
   if (prev.resolvedSessionHostIds !== next.resolvedSessionHostIds) return false;
   if (prev.workspaceById !== next.workspaceById) return false;
   if (prev.isTerminalLayerVisible !== next.isTerminalLayerVisible) return false;
@@ -1609,6 +1618,7 @@ export const TerminalPanesHost: React.FC<TerminalPanesHostProps> = memo(({
   sessionHostsMap,
   sessionChainHostsMap,
   sessionSudoAutofillPasswordsMap,
+  sessionSudoAutofillCandidatesMap,
   resolvedSessionHostIds,
   ...sharedProps
 }) => {
@@ -1630,6 +1640,7 @@ export const TerminalPanesHost: React.FC<TerminalPanesHostProps> = memo(({
             sessionHostResolved={resolvedSessionHostIds.has(session.id)}
             chainHosts={sessionChainHostsMap.get(session.id)}
             sudoAutofillPassword={sessionSudoAutofillPasswordsMap.get(session.id)}
+            sudoAutofillCandidates={sessionSudoAutofillCandidatesMap.get(session.id)}
             showSelectionAIAction={showSelectionAIAction}
             {...sharedProps}
           />

--- a/components/terminalLayer/TerminalLayerTabBridge.tsx
+++ b/components/terminalLayer/TerminalLayerTabBridge.tsx
@@ -530,6 +530,7 @@ export function TerminalLayerTabBridge({ stableRef }: { stableRef: StableRef }) 
     resolvedSessionHostIds: s.resolvedSessionHostIds,
     sessionLogConfig: s.sessionLogConfig,
     sessionSudoAutofillPasswordsMap: s.sessionSudoAutofillPasswordsMap,
+    sessionSudoAutofillCandidatesMap: s.sessionSudoAutofillCandidatesMap,
     sessions,
     setDropHint,
     setEditorWordWrap: s.setEditorWordWrap,

--- a/components/terminalLayer/TerminalLayerWorkspaceSection.test.ts
+++ b/components/terminalLayer/TerminalLayerWorkspaceSection.test.ts
@@ -32,6 +32,7 @@ test("workspace section passes resolved session host ids to terminal panes", () 
     sessionHostsMap: new Map(),
     sessionChainHostsMap: new Map(),
     sessionSudoAutofillPasswordsMap: new Map(),
+    sessionSudoAutofillCandidatesMap: new Map(),
     resolvedSessionHostIds,
     workspaceById: new Map(),
     workspaceRectsById: new Map(),

--- a/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
+++ b/components/terminalLayer/TerminalLayerWorkspaceSection.tsx
@@ -20,6 +20,7 @@ function TerminalLayerWorkspaceSectionInner({ ctx }: { ctx: WorkspaceContext }) 
     sessionHostsMap,
     sessionChainHostsMap,
     sessionSudoAutofillPasswordsMap,
+    sessionSudoAutofillCandidatesMap,
     resolvedSessionHostIds,
     workspaceById,
     workspaceRectsById,
@@ -144,6 +145,7 @@ function TerminalLayerWorkspaceSectionInner({ ctx }: { ctx: WorkspaceContext }) 
           sessionHostsMap={sessionHostsMap}
           sessionChainHostsMap={sessionChainHostsMap}
           sessionSudoAutofillPasswordsMap={sessionSudoAutofillPasswordsMap}
+          sessionSudoAutofillCandidatesMap={sessionSudoAutofillCandidatesMap}
           resolvedSessionHostIds={resolvedSessionHostIds}
           workspaceById={workspaceById}
           workspaceRectsById={workspaceRectsById}

--- a/components/terminalLayer/terminalLayerViewMemo.ts
+++ b/components/terminalLayer/terminalLayerViewMemo.ts
@@ -300,6 +300,7 @@ const WORKSPACE_CTX_KEYS = [
   'sessionHostsMap',
   'sessionChainHostsMap',
   'sessionSudoAutofillPasswordsMap',
+  'sessionSudoAutofillCandidatesMap',
   'workspaceById',
   'workspaceRectsById',
   'isTerminalLayerVisible',

--- a/domain/models/terminal.ts
+++ b/domain/models/terminal.ts
@@ -14,6 +14,13 @@ export type MiddleClickBehavior = 'context-menu' | 'paste' | 'disabled';
 export type LinkModifier = 'none' | 'ctrl' | 'alt' | 'meta';
 export type TerminalEmulationType = 'xterm-256color' | 'xterm-16color' | 'xterm';
 export type DynamicTabTitleMode = 'off' | 'agent' | 'all';
+/**
+ * How to assist when a sudo/su password prompt appears (#2156).
+ * - off: no assist
+ * - hint: ghost "press Enter" fill of the host session password
+ * - picker: WindTerm-like list of host + keychain password identities
+ */
+export type PasswordPromptAssistMode = 'off' | 'hint' | 'picker';
 
 export const DEFAULT_TERMINAL_WORD_SEPARATORS = ' ()[]{}\'"';
 
@@ -160,6 +167,12 @@ export interface TerminalSettings {
   autocompleteDebounceMs: number; // Debounce delay for fetching suggestions (ms)
   autocompleteMinChars: number; // Minimum characters before showing suggestions
   autocompleteMaxSuggestions: number; // Maximum suggestions in popup menu
+
+  /**
+   * Assist for sudo/su password prompts: off, quick Enter-to-paste (hint),
+   * or multi-credential picker. Default hint preserves historical sudo UX.
+   */
+  passwordPromptAssist: PasswordPromptAssistMode;
 }
 
 const STRICT_IPV4_OCTET_PATTERN = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)';
@@ -282,6 +295,12 @@ const isDynamicTabTitleMode = (value: unknown): value is DynamicTabTitleMode => 
   value === 'all'
 );
 
+const isPasswordPromptAssistMode = (value: unknown): value is PasswordPromptAssistMode => (
+  value === 'off' ||
+  value === 'hint' ||
+  value === 'picker'
+);
+
 export const normalizeTerminalSettings = (
   settings?: Partial<TerminalSettings> | null,
 ): TerminalSettings => {
@@ -302,6 +321,9 @@ export const normalizeTerminalSettings = (
     dynamicTabTitleMode: isDynamicTabTitleMode(settings?.dynamicTabTitleMode)
       ? settings.dynamicTabTitleMode
       : DEFAULT_TERMINAL_SETTINGS.dynamicTabTitleMode,
+    passwordPromptAssist: isPasswordPromptAssistMode(settings?.passwordPromptAssist)
+      ? settings.passwordPromptAssist
+      : DEFAULT_TERMINAL_SETTINGS.passwordPromptAssist,
   };
 
   // Migrate legacy 'canvas' renderer to 'dom' (canvas removed in xterm.js 6.0)
@@ -403,6 +425,7 @@ const DEFAULT_TERMINAL_SETTINGS: TerminalSettings = {
   autocompleteDebounceMs: 100, // 100ms debounce
   autocompleteMinChars: 1, // Start suggesting after 1 character
   autocompleteMaxSuggestions: 8, // Show up to 8 suggestions
+  passwordPromptAssist: 'hint', // Historical sudo confirm-to-fill; picker is opt-in (#2156)
 };
 
 export interface TerminalTheme {

--- a/domain/passwordPromptAssist.test.ts
+++ b/domain/passwordPromptAssist.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Host, Identity } from "./models";
+import {
+  listPasswordPromptFillCandidates,
+  resolveDefaultPasswordPromptFillPassword,
+} from "./passwordPromptAssist";
+
+const baseHost = (overrides: Partial<Host> = {}): Host =>
+  ({
+    id: "h1",
+    label: "Prod",
+    hostname: "prod.example",
+    port: 22,
+    username: "alice",
+    protocol: "ssh",
+    ...overrides,
+  }) as Host;
+
+const identity = (overrides: Partial<Identity> & Pick<Identity, "id">): Identity =>
+  ({
+    label: overrides.label ?? overrides.id,
+    username: overrides.username ?? "user",
+    authMethod: overrides.authMethod ?? "password",
+    created: overrides.created ?? 1,
+    ...overrides,
+  }) as Identity;
+
+test("listPasswordPromptFillCandidates includes host password first", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: "host-secret" }),
+    keys: [],
+    identities: [],
+  });
+  assert.equal(candidates.length, 1);
+  assert.deepEqual(
+    {
+      id: candidates[0].id,
+      source: candidates[0].source,
+      label: candidates[0].label,
+      username: candidates[0].username,
+      password: candidates[0].password,
+    },
+    {
+      id: "host",
+      source: "host",
+      label: "Prod",
+      username: "alice",
+      password: "host-secret",
+    },
+  );
+});
+
+test("listPasswordPromptFillCandidates includes password identities", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: "host-secret" }),
+    keys: [],
+    identities: [
+      identity({ id: "i-root", label: "Root", username: "root", password: "root-secret", order: 2 }),
+      identity({ id: "i-bob", label: "Bob", username: "bob", password: "bob-secret", order: 1 }),
+    ],
+  });
+  assert.equal(candidates.length, 3);
+  assert.equal(candidates[0].id, "host");
+  assert.equal(candidates[1].id, "identity:i-bob");
+  assert.equal(candidates[2].id, "identity:i-root");
+  assert.equal(candidates[1].password, "bob-secret");
+});
+
+test("listPasswordPromptFillCandidates skips key-only identities and placeholders", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: "enc:v1:djEwAAAA" }),
+    keys: [],
+    identities: [
+      identity({ id: "key", authMethod: "key", password: undefined }),
+      identity({ id: "bad", password: "enc:v1:djEwAAAA" }),
+      identity({ id: "ok", password: "ok-secret" }),
+    ],
+  });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "identity:ok");
+});
+
+test("listPasswordPromptFillCandidates respects host savePassword opt-out", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: "host-secret", savePassword: false }),
+    keys: [],
+    identities: [identity({ id: "i1", password: "id-secret" })],
+  });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].id, "identity:i1");
+});
+
+test("listPasswordPromptFillCandidates dedupes identical passwords", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: "same" }),
+    keys: [],
+    identities: [identity({ id: "i1", label: "Same as host", password: "same" })],
+  });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].source, "host");
+});
+
+test("listPasswordPromptFillCandidates resolves host password from referenced identity", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ password: undefined, identityId: "i1" }),
+    keys: [],
+    identities: [identity({ id: "i1", username: "alice", password: "via-identity" })],
+  });
+  // Host resolves via identityId → host candidate; identity also listed but
+  // same password is deduped, so only one entry remains (host first).
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].source, "host");
+  assert.equal(candidates[0].password, "via-identity");
+});
+
+test("resolveDefaultPasswordPromptFillPassword prefers host", () => {
+  assert.equal(
+    resolveDefaultPasswordPromptFillPassword([
+      { id: "host", source: "host", label: "H", password: "h" },
+      { id: "identity:x", source: "identity", label: "X", password: "x" },
+    ]),
+    "h",
+  );
+  assert.equal(
+    resolveDefaultPasswordPromptFillPassword([
+      { id: "identity:x", source: "identity", label: "X", password: "x" },
+    ]),
+    "x",
+  );
+  assert.equal(resolveDefaultPasswordPromptFillPassword([]), undefined);
+});

--- a/domain/passwordPromptAssist.test.ts
+++ b/domain/passwordPromptAssist.test.ts
@@ -114,6 +114,18 @@ test("listPasswordPromptFillCandidates resolves host password from referenced id
   assert.equal(candidates[0].password, "via-identity");
 });
 
+test("listPasswordPromptFillCandidates uses the resolved identity username for host row", () => {
+  const candidates = listPasswordPromptFillCandidates({
+    host: baseHost({ username: "stale-host-user", password: undefined, identityId: "i-root" }),
+    keys: [],
+    identities: [identity({ id: "i-root", username: "root", password: "root-secret", label: "Root ID" })],
+  });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].source, "host");
+  assert.equal(candidates[0].username, "root");
+  assert.equal(candidates[0].password, "root-secret");
+});
+
 test("resolveDefaultPasswordPromptFillPassword prefers host", () => {
   assert.equal(
     resolveDefaultPasswordPromptFillPassword([

--- a/domain/passwordPromptAssist.ts
+++ b/domain/passwordPromptAssist.ts
@@ -1,0 +1,85 @@
+import type { Host, Identity, SSHKey } from "./models";
+import { sanitizeCredentialValue } from "./credentials";
+import { resolveHostAutofillPassword } from "./sshAuth";
+
+export type PasswordPromptFillCandidate = {
+  id: string;
+  source: "host" | "identity";
+  label: string;
+  username?: string;
+  /** Sanitized plaintext. Callers must not log or render this in UI. */
+  password: string;
+};
+
+const hostCandidateId = "host";
+const identityCandidateId = (identityId: string) => `identity:${identityId}`;
+
+/**
+ * Build the credential list for sudo/su password-prompt assist (#2156).
+ * Host session password first, then every decryptable keychain password
+ * identity. Dedupes by password value so the same secret is not listed twice.
+ */
+export const listPasswordPromptFillCandidates = (args: {
+  host: Host;
+  keys: SSHKey[];
+  identities?: Identity[];
+}): PasswordPromptFillCandidate[] => {
+  const candidates: PasswordPromptFillCandidate[] = [];
+  const seenPasswords = new Set<string>();
+
+  const push = (candidate: PasswordPromptFillCandidate) => {
+    if (!candidate.password || seenPasswords.has(candidate.password)) return;
+    seenPasswords.add(candidate.password);
+    candidates.push(candidate);
+  };
+
+  const hostPassword = resolveHostAutofillPassword(args);
+  if (hostPassword) {
+    const hostLabel =
+      args.host.label?.trim()
+      || args.host.hostname?.trim()
+      || args.host.username?.trim()
+      || "Host";
+    push({
+      id: hostCandidateId,
+      source: "host",
+      label: hostLabel,
+      username: args.host.username?.trim() || undefined,
+      password: hostPassword,
+    });
+  }
+
+  const identities = args.identities ?? [];
+  // Stable order: explicit order field, then created, then id.
+  const ordered = [...identities].sort((a, b) => {
+    const ao = a.order ?? Number.MAX_SAFE_INTEGER;
+    const bo = b.order ?? Number.MAX_SAFE_INTEGER;
+    if (ao !== bo) return ao - bo;
+    if (a.created !== b.created) return a.created - b.created;
+    return a.id.localeCompare(b.id);
+  });
+
+  for (const identity of ordered) {
+    if (identity.authMethod !== "password") continue;
+    const password = sanitizeCredentialValue(identity.password);
+    if (!password) continue;
+    const label = identity.label?.trim() || identity.username?.trim() || identity.id;
+    push({
+      id: identityCandidateId(identity.id),
+      source: "identity",
+      label,
+      username: identity.username?.trim() || undefined,
+      password,
+    });
+  }
+
+  return candidates;
+};
+
+/** Prefer host candidate password; fall back to first available candidate. */
+export const resolveDefaultPasswordPromptFillPassword = (
+  candidates: PasswordPromptFillCandidate[],
+): string | undefined => {
+  const host = candidates.find((c) => c.source === "host");
+  return host?.password ?? candidates[0]?.password;
+};

--- a/domain/passwordPromptAssist.ts
+++ b/domain/passwordPromptAssist.ts
@@ -1,6 +1,6 @@
 import type { Host, Identity, SSHKey } from "./models";
 import { sanitizeCredentialValue } from "./credentials";
-import { resolveHostAutofillPassword } from "./sshAuth";
+import { resolveHostAuth, resolveHostAutofillPassword } from "./sshAuth";
 
 export type PasswordPromptFillCandidate = {
   id: string;
@@ -33,18 +33,22 @@ export const listPasswordPromptFillCandidates = (args: {
     candidates.push(candidate);
   };
 
+  // Same resolution path as login so group-inherited identities and identityId
+  // references surface the correct username next to the session password.
+  const resolvedAuth = resolveHostAuth(args);
   const hostPassword = resolveHostAutofillPassword(args);
   if (hostPassword) {
     const hostLabel =
       args.host.label?.trim()
       || args.host.hostname?.trim()
+      || resolvedAuth.username?.trim()
       || args.host.username?.trim()
       || "Host";
     push({
       id: hostCandidateId,
       source: "host",
       label: hostLabel,
-      username: args.host.username?.trim() || undefined,
+      username: resolvedAuth.username?.trim() || args.host.username?.trim() || undefined,
       password: hostPassword,
     });
   }

--- a/domain/sshAuth.ts
+++ b/domain/sshAuth.ts
@@ -214,11 +214,12 @@ export const resolveHostAuthMethodForPersistence = (args: {
 };
 
 /**
- * Resolve the password to use for sudo autofill the same way SSH login does
+ * Resolve the password to use for sudo/su autofill the same way SSH login does
  * (through resolveHostAuth), so a password stored in a referenced Keychain
  * identity (host.identityId) is found — not just host.password (issue #1284).
  * Returns undefined when the host opts out of saving its password, or none is
  * available (pure key auth, or an undecryptable placeholder).
+ * Used for both sudo and su confirm-to-fill hints (#2156).
  */
 export const resolveHostAutofillPassword = (args: {
   host: Host;

--- a/domain/terminalSettings.test.ts
+++ b/domain/terminalSettings.test.ts
@@ -9,6 +9,23 @@ test("normalizeTerminalSettings disables prompt line breaks by default", () => {
   assert.equal(settings.forcePromptNewLine, false);
 });
 
+test("normalizeTerminalSettings defaults password prompt assist to hint", () => {
+  assert.equal(normalizeTerminalSettings().passwordPromptAssist, "hint");
+});
+
+test("normalizeTerminalSettings preserves password prompt assist modes", () => {
+  assert.equal(normalizeTerminalSettings({ passwordPromptAssist: "off" }).passwordPromptAssist, "off");
+  assert.equal(normalizeTerminalSettings({ passwordPromptAssist: "hint" }).passwordPromptAssist, "hint");
+  assert.equal(normalizeTerminalSettings({ passwordPromptAssist: "picker" }).passwordPromptAssist, "picker");
+});
+
+test("normalizeTerminalSettings falls back for unsupported password prompt assist modes", () => {
+  assert.equal(
+    normalizeTerminalSettings({ passwordPromptAssist: "legacy" as never }).passwordPromptAssist,
+    "hint",
+  );
+});
+
 test("normalizeTerminalSettings enables Shift+Enter newline by default", () => {
   const settings = normalizeTerminalSettings();
 


### PR DESCRIPTION
## Summary
- Extend the existing sudo confirm-to-fill assist so `su` / `su -` / `su user` also arm password prompts (#2156).
- Add **Settings → Terminal → Password prompt assist** with three modes:
  - **Off**
  - **Quick fill (Enter)** (default — preserves current sudo UX; host session password only)
  - **Credential picker** (WindTerm-like list for **armed `su` prompts** — host password + keychain password identities)
- Never auto-sends; fill only on explicit Enter/click. Arrow keys navigate the picker. Secrets never shown plaintext.

## Security gates (from Codex review loop)
- Hint mode never falls back to an arbitrary keychain identity.
- Full multi-identity picker only after an **armed `su`** and a short bare `Password:` / `密码` line.
- Sudo keeps host-password quick-fill only (`[sudo]` / Kylin-scoped prompts); not the full picker.
- Rejects child prompts: `Enter password:`, `Password for user …`, `user@host's password:`.
- Unarmed forged `[sudo]` lines only get host-password hint, not the full keychain.
- After fill, only real auth retries re-open assist (not `sudo mysql -p` child prompts).

## Scope notes
- Broader onekey for ssh/scp remains #1997.
- Default mode is `hint`.

## Test plan
- [x] Unit: arm `su`/`sudo`, not `sum`/`suspend`
- [x] Unit: hint / picker / off; su-only full picker; child-prompt rejections
- [x] Unit: candidates from host + identities; resolved username; group host path
- [x] Unit: `passwordPromptAssist` normalize defaults
- [x] Codex `review --base main` clean (no concrete findings)
- [ ] Manual: Settings → Credential picker → `su -` shows list including keychain identities
- [ ] Manual: `sudo -k true` → Enter fills host password
- [ ] Manual: Esc/typing dismisses without sending password

Closes #2156