### PR TITLE
fix(terminal): prevent osc7_cwd errors after su

### DIFF
--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -285,7 +285,7 @@ test("buildOsc7SetupCommand configures bash once and prompt loading stays idempo
     assert.match(bashrc, /PROMPT_COMMAND/);
     assert.match(bashrc, /__netcatty_osc7_prompt/);
     assert.match(bashrc, /netcatty-osc7-version: 2/);
-    assert.match(bashrc, /declare \+x PROMPT_COMMAND/);
+    assert.match(bashrc, /declare -\[A-Za-z\]\*a|declare -p PROMPT_COMMAND/);
 
     const output = execFileSync(
       "/bin/bash",

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -483,6 +483,29 @@ test("buildOsc7SetupCommand recovers when version line exists with unbalanced ma
   });
 });
 
+test("buildOsc7SetupCommand ignores marker text embedded in echo commands", () => {
+  withTempHome("netcatty-osc7-bash-echo-marker-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        'echo "# >>> Netcatty OSC 7 cwd tracking >>>"',
+        "alias keep_me='yes'",
+        'echo "# <<< Netcatty OSC 7 cwd tracking <<<"',
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /alias keep_me=/);
+    assert.match(bashrc, /echo "# >>> Netcatty OSC 7 cwd tracking >>>"/);
+    assert.match(bashrc, /echo "# <<< Netcatty OSC 7 cwd tracking <<<"/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+  });
+});
+
 test("buildOsc7SetupCommand upgrades a legacy block wrapped in control flow in place", () => {
   withTempHome("netcatty-osc7-bash-if-wrap-", (home) => {
     const bashrcPath = join(home, ".bashrc");

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -483,6 +483,40 @@ test("buildOsc7SetupCommand recovers when version line exists with unbalanced ma
   });
 });
 
+test("buildOsc7SetupCommand upgrades a legacy block wrapped in control flow in place", () => {
+  withTempHome("netcatty-osc7-bash-if-wrap-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "if true; then",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "osc7_cwd() { :; }",
+        'PROMPT_COMMAND="osc7_cwd"',
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "fi",
+        "echo after",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /if true; then/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.match(bashrc, /^fi$/m);
+    assert.match(bashrc, /echo after/);
+    // v2 stays inside the if/fi, not only after it.
+    const ifIdx = bashrc.indexOf("if true; then");
+    const fiIdx = bashrc.indexOf("\nfi\n");
+    const v2Idx = bashrc.indexOf("netcatty-osc7-version: 2");
+    assert.ok(ifIdx >= 0 && fiIdx > ifIdx && v2Idx > ifIdx && v2Idx < fiIdx);
+    execFileSync("/bin/bash", ["-n", bashrcPath], { stdio: "pipe" });
+  });
+});
+
 test("buildOsc7SetupCommand upgrades a read-only legacy bashrc in one atomic write", () => {
   withTempHome("netcatty-osc7-bash-readonly-", (home) => {
     const bashrcPath = join(home, ".bashrc");

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -1,7 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
@@ -352,7 +364,7 @@ test("buildOsc7SetupCommand does not truncate bashrc when start marker lacks end
     assert.match(bashrc, /alias ll=/);
     assert.match(bashrc, /netcatty-osc7-version: 2/);
     assert.match(bashrc, /__netcatty_osc7_prompt/);
-    // Incomplete open block was left in place; a complete v2 block was appended.
+    // Open region kept + complete v2 appended (no truncation of user lines).
     assert.equal((bashrc.match(/# >>> Netcatty OSC 7 cwd tracking >>>/g) || []).length, 2);
     assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 1);
   });
@@ -381,9 +393,164 @@ test("buildOsc7SetupCommand appends when markers are present but unbalanced", ()
     assert.match(bashrc, /alias ll=/);
     assert.match(bashrc, /netcatty-osc7-version: 2/);
     assert.match(bashrc, /__netcatty_osc7_prompt/);
-    // Original unbalanced markers kept; one complete v2 block appended.
+    // Original markers kept; complete v2 appended.
     assert.equal((bashrc.match(/# >>> Netcatty OSC 7 cwd tracking >>>/g) || []).length, 2);
     assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 2);
+  });
+});
+
+test("buildOsc7SetupCommand recovers from partial v2 write missing end marker", () => {
+  withTempHome("netcatty-osc7-bash-partial-v2-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# keep-me",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "# netcatty-osc7-version: 2",
+        "osc7_cwd() { :; }",
+        "# interrupted before end marker",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /# keep-me/);
+    assert.match(bashrc, /# interrupted before end marker/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.match(bashrc, /declare -F __netcatty_osc7_prompt/);
+    // Partial open kept + one recovered complete block; second setup is a no-op.
+    assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 1);
+    assert.equal((bashrc.match(/# netcatty-osc7-version: 2/g) || []).length, 2);
+  });
+});
+
+test("buildOsc7SetupCommand preserves user lines after mid-construct interruption", () => {
+  withTempHome("netcatty-osc7-bash-mid-construct-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# keep-me",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "# netcatty-osc7-version: 2",
+        "osc7_cwd() {",
+        "alias keep_user_alias='yes'",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    // Do not rewrite/truncate even if the partial body is already unusable.
+    assert.match(bashrc, /# keep-me/);
+    assert.match(bashrc, /alias keep_user_alias=/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+  });
+});
+
+test("buildOsc7SetupCommand recovers when version line exists with unbalanced markers", () => {
+  withTempHome("netcatty-osc7-bash-version-unbalanced-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    // Orphan end + open start with version: grepping version+end alone would
+    // falsely treat this as complete; balanced/complete-v2 checks must force append.
+    writeFileSync(
+      bashrcPath,
+      [
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "# netcatty-osc7-version: 2",
+        "osc7_cwd() { :; }",
+        "# interrupted before end marker",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /# interrupted before end marker/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.match(bashrc, /declare -F __netcatty_osc7_prompt/);
+    // Orphan end + one recovered complete block; second run no-ops.
+    assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 2);
+    assert.equal((bashrc.match(/# netcatty-osc7-version: 2/g) || []).length, 2);
+  });
+});
+
+test("buildOsc7SetupCommand upgrades a read-only legacy bashrc in one atomic write", () => {
+  withTempHome("netcatty-osc7-bash-readonly-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# before",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "legacy",
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "# after",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(bashrcPath, 0o444);
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    assert.equal(lstatSync(bashrcPath).mode & 0o777, 0o444);
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /# before/);
+    assert.match(bashrc, /# after/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.doesNotMatch(bashrc, /^legacy$/m);
+  });
+});
+
+test("buildOsc7SetupCommand upgrades through a symlinked bashrc without replacing the link", () => {
+  withTempHome("netcatty-osc7-bash-symlink-", (home) => {
+    const realPath = join(home, "dotfiles", "bashrc.real");
+    const midLink = join(home, "dotfiles", "bashrc.link");
+    const bashrcPath = join(home, ".bashrc");
+    mkdirSync(join(home, "dotfiles"), { recursive: true });
+    writeFileSync(
+      realPath,
+      [
+        "# managed-preamble",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "osc7_cwd() {",
+        "  printf 'legacy'\\n",
+        "}",
+        'PROMPT_COMMAND="osc7_cwd"',
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "# managed-epilogue",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(realPath, 0o644);
+    // Chain: ~/.bashrc -> dotfiles/bashrc.link -> bashrc.real
+    symlinkSync("bashrc.real", midLink);
+    symlinkSync(join("dotfiles", "bashrc.link"), bashrcPath);
+    assert.ok(lstatSync(bashrcPath).isSymbolicLink());
+    assert.ok(lstatSync(midLink).isSymbolicLink());
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    assert.ok(lstatSync(bashrcPath).isSymbolicLink(), "bashrc must remain a symlink");
+    assert.ok(lstatSync(midLink).isSymbolicLink(), "intermediate link must remain a symlink");
+    assert.equal(readlinkSync(bashrcPath), join("dotfiles", "bashrc.link"));
+    assert.equal(readlinkSync(midLink), "bashrc.real");
+    assert.equal(lstatSync(realPath).mode & 0o777, 0o644, "target mode should be preserved");
+    const content = readFileSync(realPath, "utf8");
+    assert.match(content, /# managed-preamble/);
+    assert.match(content, /# managed-epilogue/);
+    assert.match(content, /netcatty-osc7-version: 2/);
+    assert.match(content, /__netcatty_osc7_prompt/);
+    assert.doesNotMatch(content, /printf 'legacy'/);
   });
 });
 

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -679,6 +679,33 @@ test("bash snippet unexports PROMPT_COMMAND after install", () => {
   });
 });
 
+test("bash snippet dedupes hooks across array PROMPT_COMMAND elements", () => {
+  withTempHome("netcatty-osc7-bash-array-pc-", (home) => {
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    const bashrcPath = join(home, ".bashrc");
+    const output = execFileSync(
+      "/bin/bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        [
+          'PROMPT_COMMAND=("first" "osc7_cwd" "echo KEEP")',
+          `source ${JSON.stringify(bashrcPath)}`,
+          `source ${JSON.stringify(bashrcPath)}`,
+          'declare -p PROMPT_COMMAND',
+        ].join("; "),
+      ],
+      { env: { ...process.env, HOME: home } },
+    ).toString("utf8");
+
+    assert.match(output, /first/);
+    assert.match(output, /echo KEEP/);
+    assert.equal(output.split("declare -F __netcatty_osc7_prompt").length - 1, 1);
+    assert.doesNotMatch(output, /\[1\]="osc7_cwd"/);
+  });
+});
+
 test("buildOsc7SetupCommand preserves setup failure status", () => {
   withTempHome("netcatty-osc7-unsupported-shell-", (home) => {
     const result = spawnSync("/bin/sh", ["-c", buildOsc7SetupCommand()], {

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -271,6 +271,9 @@ test("buildOsc7SetupCommand configures bash once and prompt loading stays idempo
     const bashrc = readFileSync(bashrcPath, "utf8");
     assert.equal(markerCount(bashrc), 2);
     assert.match(bashrc, /PROMPT_COMMAND/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /declare \+x PROMPT_COMMAND/);
 
     const output = execFileSync(
       "/bin/bash",
@@ -281,7 +284,116 @@ test("buildOsc7SetupCommand configures bash once and prompt loading stays idempo
       { env: { ...process.env, HOME: home } },
     ).toString("utf8");
 
-    assert.equal(output.split("osc7_cwd").length - 1, 1);
+    assert.match(output, /existing/);
+    // Guarded hook installed once even after double-source.
+    assert.equal(output.split("declare -F __netcatty_osc7_prompt").length - 1, 1);
+    // Bare v1 hook must not remain in PROMPT_COMMAND (only the function body may mention osc7_cwd).
+    assert.doesNotMatch(output, /(^|\n)osc7_cwd(\n|$)/);
+  });
+});
+
+test("buildOsc7SetupCommand upgrades legacy bash snippet in place", () => {
+  withTempHome("netcatty-osc7-bash-upgrade-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# user preamble",
+        "",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "osc7_cwd() {",
+        "  printf 'legacy'\\n",
+        "}",
+        'PROMPT_COMMAND="osc7_cwd"',
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "",
+        "# user epilogue",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.equal(markerCount(bashrc), 2);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    assert.match(bashrc, /# user preamble/);
+    assert.match(bashrc, /# user epilogue/);
+    assert.doesNotMatch(bashrc, /printf 'legacy'/);
+    assert.equal(bashrc.split("PROMPT_COMMAND=\"osc7_cwd\"").length - 1, 0);
+
+    // Second run is a no-op once version 2 is present.
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    assert.equal(markerCount(readFileSync(bashrcPath, "utf8")), 2);
+  });
+});
+
+test("bash snippet does not error when PROMPT_COMMAND is inherited without osc7_cwd", () => {
+  withTempHome("netcatty-osc7-bash-su-inherit-", (home) => {
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    const bashrcPath = join(home, ".bashrc");
+
+    // Simulate non-login su: child gets exported PROMPT_COMMAND but no function defs.
+    const result = spawnSync(
+      "/bin/bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        [
+          `source ${JSON.stringify(bashrcPath)}`,
+          "export PROMPT_COMMAND",
+          // Child env has PROMPT_COMMAND but not the function (fresh bash -c without rc).
+          `env PROMPT_COMMAND="$PROMPT_COMMAND" /bin/bash --noprofile --norc -c 'eval "$PROMPT_COMMAND"; echo OK'`,
+        ].join("; "),
+      ],
+      {
+        env: { ...process.env, HOME: home },
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /OK/);
+    assert.doesNotMatch(result.stderr + result.stdout, /command not found/);
+  });
+});
+
+test("bash snippet still emits OSC 7 when functions are defined", () => {
+  withTempHome("netcatty-osc7-bash-emit-", (home) => {
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    const bashrcPath = join(home, ".bashrc");
+    const output = execFileSync(
+      "/bin/bash",
+      ["-lc", `source ${JSON.stringify(bashrcPath)}; __netcatty_osc7_prompt; true`],
+      { env: { ...process.env, HOME: home, PWD: home }, cwd: home },
+    ).toString("utf8");
+
+    assert.ok(output.includes("\u001b]7;file://"), "expected OSC 7 output");
+    assert.equal(realpathSync(extractOsc7Path(output)), realpathSync(home));
+  });
+});
+
+test("bash snippet unexports PROMPT_COMMAND after install", () => {
+  withTempHome("netcatty-osc7-bash-unexport-", (home) => {
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    const bashrcPath = join(home, ".bashrc");
+    const output = execFileSync(
+      "/bin/bash",
+      [
+        "-lc",
+        [
+          "export PROMPT_COMMAND=preexisting",
+          `source ${JSON.stringify(bashrcPath)}`,
+          'if declare -p PROMPT_COMMAND 2>/dev/null | grep -q "declare -x"; then echo EXPORTED; else echo LOCAL; fi',
+        ].join("; "),
+      ],
+      { env: { ...process.env, HOME: home } },
+    ).toString("utf8");
+
+    assert.match(output, /LOCAL/);
+    assert.doesNotMatch(output, /EXPORTED/);
   });
 });
 
@@ -513,12 +625,21 @@ test("buildOsc7SetupCommand honors zsh ZDOTDIR captured from the current shell",
     const zshrc = readFileSync(zshrcPath, "utf8");
     assert.equal(markerCount(zshrc), 2);
     assert.match(zshrc, /precmd_functions/);
+    assert.match(zshrc, /netcatty-osc7-version: 2/);
+    assert.match(zshrc, /__netcatty_osc7_prompt/);
     assert.equal(existsSync(join(home, ".zshrc")), false);
 
-    execFileSync(zshPath, ["-uc", `source ${JSON.stringify(zshrcPath)}; print -r -- "\${precmd_functions[*]}"`], {
-      env: { ...process.env, HOME: home, ZDOTDIR: zdotdir },
-      stdio: "pipe",
-    });
+    const precmd = execFileSync(
+      zshPath,
+      ["-uc", `source ${JSON.stringify(zshrcPath)}; source ${JSON.stringify(zshrcPath)}; print -r -- "\${precmd_functions[*]}"`],
+      {
+        env: { ...process.env, HOME: home, ZDOTDIR: zdotdir },
+        stdio: "pipe",
+      },
+    ).toString("utf8");
+    assert.match(precmd, /__netcatty_osc7_prompt/);
+    assert.equal(precmd.trim().split(/\s+/).filter((name) => name === "__netcatty_osc7_prompt").length, 1);
+    assert.doesNotMatch(precmd, /(?:^|\s)osc7_cwd(?:\s|$)/);
   });
 });
 

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -329,6 +329,64 @@ test("buildOsc7SetupCommand upgrades legacy bash snippet in place", () => {
   });
 });
 
+test("buildOsc7SetupCommand does not truncate bashrc when start marker lacks end", () => {
+  withTempHome("netcatty-osc7-bash-incomplete-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# keep-me-before",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "osc7_cwd() { :; }",
+        "# important-user-config-after-open-marker",
+        "alias ll='ls -la'",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /# keep-me-before/);
+    assert.match(bashrc, /# important-user-config-after-open-marker/);
+    assert.match(bashrc, /alias ll=/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    // Incomplete open block was left in place; a complete v2 block was appended.
+    assert.equal((bashrc.match(/# >>> Netcatty OSC 7 cwd tracking >>>/g) || []).length, 2);
+    assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 1);
+  });
+});
+
+test("buildOsc7SetupCommand appends when markers are present but unbalanced", () => {
+  withTempHome("netcatty-osc7-bash-unbalanced-", (home) => {
+    const bashrcPath = join(home, ".bashrc");
+    writeFileSync(
+      bashrcPath,
+      [
+        "# orphan end first",
+        "# <<< Netcatty OSC 7 cwd tracking <<<",
+        "# user config",
+        "# >>> Netcatty OSC 7 cwd tracking >>>",
+        "alias ll='ls -la'",
+        "",
+      ].join("\n"),
+    );
+
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+
+    const bashrc = readFileSync(bashrcPath, "utf8");
+    assert.match(bashrc, /# orphan end first/);
+    assert.match(bashrc, /# user config/);
+    assert.match(bashrc, /alias ll=/);
+    assert.match(bashrc, /netcatty-osc7-version: 2/);
+    assert.match(bashrc, /__netcatty_osc7_prompt/);
+    // Original unbalanced markers kept; one complete v2 block appended.
+    assert.equal((bashrc.match(/# >>> Netcatty OSC 7 cwd tracking >>>/g) || []).length, 2);
+    assert.equal((bashrc.match(/# <<< Netcatty OSC 7 cwd tracking <<</g) || []).length, 2);
+  });
+});
+
 test("bash snippet does not error when PROMPT_COMMAND is inherited without osc7_cwd", () => {
   withTempHome("netcatty-osc7-bash-su-inherit-", (home) => {
     runSetup({ HOME: home, SHELL: "/bin/bash" });

--- a/components/terminal/osc7Setup.test.ts
+++ b/components/terminal/osc7Setup.test.ts
@@ -657,8 +657,8 @@ test("bash snippet still emits OSC 7 when functions are defined", () => {
   });
 });
 
-test("bash snippet unexports PROMPT_COMMAND after install", () => {
-  withTempHome("netcatty-osc7-bash-unexport-", (home) => {
+test("bash snippet preserves an intentional PROMPT_COMMAND export", () => {
+  withTempHome("netcatty-osc7-bash-export-", (home) => {
     runSetup({ HOME: home, SHELL: "/bin/bash" });
     const bashrcPath = join(home, ".bashrc");
     const output = execFileSync(
@@ -674,8 +674,7 @@ test("bash snippet unexports PROMPT_COMMAND after install", () => {
       { env: { ...process.env, HOME: home } },
     ).toString("utf8");
 
-    assert.match(output, /LOCAL/);
-    assert.doesNotMatch(output, /EXPORTED/);
+    assert.match(output, /EXPORTED/);
   });
 });
 
@@ -703,6 +702,32 @@ test("bash snippet dedupes hooks across array PROMPT_COMMAND elements", () => {
     assert.match(output, /echo KEEP/);
     assert.equal(output.split("declare -F __netcatty_osc7_prompt").length - 1, 1);
     assert.doesNotMatch(output, /\[1\]="osc7_cwd"/);
+  });
+});
+
+test("bash snippet handles exported array PROMPT_COMMAND", () => {
+  withTempHome("netcatty-osc7-bash-ax-pc-", (home) => {
+    runSetup({ HOME: home, SHELL: "/bin/bash" });
+    const bashrcPath = join(home, ".bashrc");
+    const output = execFileSync(
+      "/bin/bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        [
+          'declare -ax PROMPT_COMMAND=("echo one" "osc7_cwd")',
+          `source ${JSON.stringify(bashrcPath)}`,
+          `source ${JSON.stringify(bashrcPath)}`,
+          'declare -p PROMPT_COMMAND',
+        ].join("; "),
+      ],
+      { env: { ...process.env, HOME: home } },
+    ).toString("utf8");
+
+    assert.match(output, /echo one/);
+    assert.equal(output.split("declare -F __netcatty_osc7_prompt").length - 1, 1);
+    assert.doesNotMatch(output, /osc7_cwd"/);
   });
 });
 

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -442,27 +442,42 @@ if grep -F "$marker" "$config" >/dev/null 2>&1; then
     # At least one complete v2 block exists (even if older junk markers remain).
     need_write=0
   elif netcatty_osc7_markers_balanced "$config"; then
-    # Complete balanced block without v2 (legacy). Build the final file in a
-    # temp (strip + v2), then atomically replace so read-only modes cannot
-    # leave the config stripped without the new snippet.
+    # Complete balanced block without v2 (legacy). Replace the marked region
+    # in place (not strip-then-append-at-EOF) so surrounding control flow such
+    # as if/then/fi wrappers stay valid. Build the full file in a temp, then
+    # atomically replace so read-only modes cannot lose the block without the
+    # replacement.
     __netcatty_osc7_target=$(netcatty_osc7_resolve_path "$config")
     __netcatty_osc7_dir=$(dirname "$__netcatty_osc7_target")
     __netcatty_osc7_mode=$(netcatty_osc7_file_mode "$__netcatty_osc7_target" || true)
     __netcatty_osc7_tmp=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7.XXXXXX") || exit 1
-    if awk -v start="$marker" -v end="$end_marker" '
-      index($0, start) { skip=1; next }
-      index($0, end) { skip=0; next }
+    __netcatty_osc7_snip=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7-snip.XXXXXX") || exit 1
+    : > "$__netcatty_osc7_snip"
+    netcatty_osc7_append_v2 "$__netcatty_osc7_snip"
+    if awk -v start="$marker" -v end="$end_marker" -v snip="$__netcatty_osc7_snip" '
+      index($0, start) {
+        # Re-open the snippet each time so multiple complete legacy blocks are
+        # each replaced in place rather than only the first.
+        while ((getline line < snip) > 0) print line
+        close(snip)
+        skip = 1
+        next
+      }
+      index($0, end) {
+        skip = 0
+        next
+      }
       !skip { print }
     ' "$config" > "$__netcatty_osc7_tmp"
     then
-      netcatty_osc7_append_v2 "$__netcatty_osc7_tmp"
+      rm -f "$__netcatty_osc7_snip"
       if [ -n "${DOLLAR}{__netcatty_osc7_mode:-}" ]; then
         chmod "$__netcatty_osc7_mode" "$__netcatty_osc7_tmp" 2>/dev/null || true
       fi
       mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
       need_write=0
     else
-      rm -f "$__netcatty_osc7_tmp"
+      rm -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_snip"
       need_write=1
     fi
   else

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -258,55 +258,86 @@ touch "$config"
 # login does not inherit a bare osc7_cwd call into another user's shell.
 snippet_version_marker="netcatty-osc7-version: 2"
 end_marker="# <<< Netcatty OSC 7 cwd tracking <<<"
-need_write=1
-if grep -F "$marker" "$config" >/dev/null 2>&1; then
-  if grep -F "$snippet_version_marker" "$config" >/dev/null 2>&1; then
-    need_write=0
-  elif ! grep -F "$end_marker" "$config" >/dev/null 2>&1; then
-    # Incomplete block (start without end). Do not rewrite/truncate: a half-open
-    # skip would drop every line after the start marker and corrupt the rc file.
-    # Append a complete v2 block instead so tracking still installs.
-    need_write=1
-  else
-    # Replace outdated complete blocks in place (v1 called osc7_cwd directly
-    # from PROMPT_COMMAND / precmd and broke after su when the function was missing).
-    __netcatty_osc7_tmp=$(mktemp) || exit 1
-    # Only commit the rewrite when awk closed every start with a matching end.
-    # Otherwise keep the original file untouched.
-    if awk -v start="$marker" -v end="$end_marker" '
-      index($0, start) {
-        if (skip) { incomplete=1; next }
-        skip=1
-        next
-      }
-      index($0, end) {
-        if (!skip) { incomplete=1; next }
-        skip=0
-        next
-      }
-      !skip { print }
-      END {
-        if (skip) incomplete=1
-        exit incomplete ? 1 : 0
-      }
-    ' "$config" > "$__netcatty_osc7_tmp"
-    then
-      mv "$__netcatty_osc7_tmp" "$config"
-      need_write=1
-    else
-      # Malformed marker layout (e.g. orphan end before open start). Keep the
-      # original file and still append a complete v2 block so setup installs
-      # tracking without truncating user config.
-      rm -f "$__netcatty_osc7_tmp"
-      need_write=1
+# Returns 0 when every start marker is closed by a matching end marker.
+netcatty_osc7_markers_balanced() {
+  awk -v start="$marker" -v end="$end_marker" '
+    index($0, start) {
+      if (skip) { incomplete=1; next }
+      skip=1
+      next
+    }
+    index($0, end) {
+      if (!skip) { incomplete=1; next }
+      skip=0
+      next
+    }
+    END {
+      if (skip) incomplete=1
+      exit incomplete ? 1 : 0
+    }
+  ' "$1"
+}
+
+# Returns 0 when at least one contiguous start..end region contains the v2
+# version marker. Older malformed markers outside that region are ignored so
+# recovery appends stay idempotent.
+netcatty_osc7_has_complete_v2_block() {
+  awk -v start="$marker" -v end="$end_marker" -v ver="$snippet_version_marker" '
+    index($0, start) {
+      skip=1
+      has_ver=0
+      next
+    }
+    skip && index($0, ver) { has_ver=1 }
+    index($0, end) {
+      if (skip && has_ver) found=1
+      skip=0
+      has_ver=0
+      next
+    }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+# Resolve config to a real path so upgrades rewrite the final target of a
+# symlink chain without replacing intermediate links.
+netcatty_osc7_resolve_path() {
+  _path="$1"
+  if command -v realpath >/dev/null 2>&1; then
+    _resolved=$(realpath "$_path" 2>/dev/null || true)
+    if [ -n "$_resolved" ]; then
+      printf '%s\n' "$_resolved"
+      return 0
     fi
   fi
-fi
+  _depth=0
+  while [ -L "$_path" ] && [ "$_depth" -lt 32 ]; do
+    _link=$(readlink "$_path" 2>/dev/null || true)
+    [ -n "$_link" ] || break
+    case "$_link" in
+      /*) _path="$_link" ;;
+      *) _path="$(dirname "$_path")/$_link" ;;
+    esac
+    _depth=$((_depth + 1))
+  done
+  printf '%s\n' "$_path"
+}
 
-if [ "$need_write" = 1 ]; then
+# Best-effort portable mode bits for chmod after atomic replace.
+netcatty_osc7_file_mode() {
+  if stat -c '%a' "$1" >/dev/null 2>&1; then
+    stat -c '%a' "$1"
+  elif stat -f '%OLp' "$1" >/dev/null 2>&1; then
+    stat -f '%OLp' "$1"
+  fi
+}
+
+# Append the v2 snippet to the given file path ($1).
+netcatty_osc7_append_v2() {
+  __netcatty_osc7_dest="$1"
   case "$shell_name" in
     bash)
-      cat >> "$config" <<'NETCATTY_OSC7_BASH'
+      cat >> "$__netcatty_osc7_dest" <<'NETCATTY_OSC7_BASH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
 # netcatty-osc7-version: 2
@@ -361,7 +392,7 @@ declare +x PROMPT_COMMAND 2>/dev/null || true
 NETCATTY_OSC7_BASH
       ;;
     zsh)
-      cat >> "$config" <<'NETCATTY_OSC7_ZSH'
+      cat >> "$__netcatty_osc7_dest" <<'NETCATTY_OSC7_ZSH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
 # netcatty-osc7-version: 2
@@ -389,7 +420,7 @@ fi
 NETCATTY_OSC7_ZSH
       ;;
     fish)
-      cat >> "$config" <<'NETCATTY_OSC7_FISH'
+      cat >> "$__netcatty_osc7_dest" <<'NETCATTY_OSC7_FISH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
 # netcatty-osc7-version: 2
@@ -403,6 +434,46 @@ end
 NETCATTY_OSC7_FISH
       ;;
   esac
+}
+
+need_write=1
+if grep -F "$marker" "$config" >/dev/null 2>&1; then
+  if netcatty_osc7_has_complete_v2_block "$config"; then
+    # At least one complete v2 block exists (even if older junk markers remain).
+    need_write=0
+  elif netcatty_osc7_markers_balanced "$config"; then
+    # Complete balanced block without v2 (legacy). Build the final file in a
+    # temp (strip + v2), then atomically replace so read-only modes cannot
+    # leave the config stripped without the new snippet.
+    __netcatty_osc7_target=$(netcatty_osc7_resolve_path "$config")
+    __netcatty_osc7_dir=$(dirname "$__netcatty_osc7_target")
+    __netcatty_osc7_mode=$(netcatty_osc7_file_mode "$__netcatty_osc7_target" || true)
+    __netcatty_osc7_tmp=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7.XXXXXX") || exit 1
+    if awk -v start="$marker" -v end="$end_marker" '
+      index($0, start) { skip=1; next }
+      index($0, end) { skip=0; next }
+      !skip { print }
+    ' "$config" > "$__netcatty_osc7_tmp"
+    then
+      netcatty_osc7_append_v2 "$__netcatty_osc7_tmp"
+      if [ -n "${DOLLAR}{__netcatty_osc7_mode:-}" ]; then
+        chmod "$__netcatty_osc7_mode" "$__netcatty_osc7_tmp" 2>/dev/null || true
+      fi
+      mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
+      need_write=0
+    else
+      rm -f "$__netcatty_osc7_tmp"
+      need_write=1
+    fi
+  else
+    # Incomplete or unbalanced markers and no complete v2 yet.
+    # Never rewrite/truncate: append a complete v2 block only.
+    need_write=1
+  fi
+fi
+
+if [ "$need_write" = 1 ]; then
+  netcatty_osc7_append_v2 "$config"
 fi
 
 if [ -z "$forced_shell" ]; then

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -254,31 +254,82 @@ __netcatty_osc7_url_path() {
 
 mkdir -p "$(dirname "$config")"
 touch "$config"
+# Snippet v2: guarded prompt entry + unexport PROMPT_COMMAND so su without
+# login does not inherit a bare osc7_cwd call into another user's shell.
+snippet_version_marker="netcatty-osc7-version: 2"
+end_marker="# <<< Netcatty OSC 7 cwd tracking <<<"
+need_write=1
 if grep -F "$marker" "$config" >/dev/null 2>&1; then
-  :
-else
+  if grep -F "$snippet_version_marker" "$config" >/dev/null 2>&1; then
+    need_write=0
+  else
+    # Replace outdated blocks in place (v1 called osc7_cwd directly from
+    # PROMPT_COMMAND / precmd and broke after su when the function was missing).
+    __netcatty_osc7_tmp=$(mktemp) || exit 1
+    awk -v start="$marker" -v end="$end_marker" '
+      index($0, start) { skip=1; next }
+      index($0, end) { skip=0; next }
+      !skip { print }
+    ' "$config" > "$__netcatty_osc7_tmp"
+    mv "$__netcatty_osc7_tmp" "$config"
+    need_write=1
+  fi
+fi
+
+if [ "$need_write" = 1 ]; then
   case "$shell_name" in
     bash)
       cat >> "$config" <<'NETCATTY_OSC7_BASH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
+# netcatty-osc7-version: 2
 __netcatty_osc7_url_path() {
   printf "%s" "$1" | LC_ALL=C awk '${URL_PATH_AWK_SCRIPT}'
 }
 osc7_cwd() {
   printf '\033]7;file://%s%s\a' "${DOLLAR}{HOSTNAME:-localhost}" "$(__netcatty_osc7_url_path "$PWD")"
 }
+# Safe prompt hook: no-op when helpers are missing (PROMPT_COMMAND string may
+# be inherited across su without this rc file).
+__netcatty_osc7_prompt() {
+  if declare -F osc7_cwd >/dev/null 2>&1; then
+    osc7_cwd
+  fi
+}
+# Drop legacy v1 bare osc7_cwd lines from the current session's PROMPT_COMMAND.
+if [ -n "${DOLLAR}{PROMPT_COMMAND+x}" ]; then
+  __netcatty_osc7_pc=""
+  __netcatty_osc7_sep=""
+  while IFS= read -r __netcatty_osc7_line || [ -n "${DOLLAR}{__netcatty_osc7_line}" ]; do
+    case "${DOLLAR}{__netcatty_osc7_line}" in
+      osc7_cwd|__netcatty_osc7_prompt) continue ;;
+      *)
+        __netcatty_osc7_pc="${DOLLAR}{__netcatty_osc7_pc}${DOLLAR}{__netcatty_osc7_sep}${DOLLAR}{__netcatty_osc7_line}"
+        __netcatty_osc7_sep="
+"
+        ;;
+    esac
+  done <<EOF
+${DOLLAR}{PROMPT_COMMAND-}
+EOF
+  PROMPT_COMMAND="${DOLLAR}{__netcatty_osc7_pc}"
+  unset __netcatty_osc7_pc __netcatty_osc7_sep __netcatty_osc7_line 2>/dev/null || true
+fi
+# Guarded entry: if this string is inherited without function defs, declare -F
+# fails quietly and the hook is skipped (no "command not found").
 case "${DOLLAR}{PROMPT_COMMAND:-}" in
-  *osc7_cwd*) ;;
+  *'declare -F __netcatty_osc7_prompt'*) ;;
   *)
     if [ -n "${DOLLAR}{PROMPT_COMMAND:-}" ]; then
       PROMPT_COMMAND="${DOLLAR}{PROMPT_COMMAND}
-osc7_cwd"
+declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt"
     else
-      PROMPT_COMMAND="osc7_cwd"
+      PROMPT_COMMAND="declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt"
     fi
     ;;
 esac
+# Keep PROMPT_COMMAND shell-local so non-login su does not leak the hook.
+declare +x PROMPT_COMMAND 2>/dev/null || true
 # <<< Netcatty OSC 7 cwd tracking <<<
 NETCATTY_OSC7_BASH
       ;;
@@ -286,19 +337,26 @@ NETCATTY_OSC7_BASH
       cat >> "$config" <<'NETCATTY_OSC7_ZSH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
+# netcatty-osc7-version: 2
 __netcatty_osc7_url_path() {
   printf "%s" "$1" | LC_ALL=C awk '${URL_PATH_AWK_SCRIPT}'
 }
 osc7_cwd() {
   printf '\033]7;file://%s%s\a' "${DOLLAR}{HOST:-${DOLLAR}{HOSTNAME:-localhost}}" "$(__netcatty_osc7_url_path "$PWD")"
 }
+__netcatty_osc7_prompt() {
+  if typeset -f osc7_cwd >/dev/null 2>&1; then
+    osc7_cwd
+  fi
+}
 if (( ${DOLLAR}{+precmd_functions} )); then
+  precmd_functions=(${DOLLAR}{precmd_functions:#osc7_cwd})
   case " ${DOLLAR}{precmd_functions[*]} " in
-    *" osc7_cwd "*) ;;
-    *) precmd_functions+=(osc7_cwd) ;;
+    *" __netcatty_osc7_prompt "*) ;;
+    *) precmd_functions+=(__netcatty_osc7_prompt) ;;
   esac
 else
-  precmd_functions=(osc7_cwd)
+  precmd_functions=(__netcatty_osc7_prompt)
 fi
 # <<< Netcatty OSC 7 cwd tracking <<<
 NETCATTY_OSC7_ZSH
@@ -307,6 +365,7 @@ NETCATTY_OSC7_ZSH
       cat >> "$config" <<'NETCATTY_OSC7_FISH'
 
 # >>> Netcatty OSC 7 cwd tracking >>>
+# netcatty-osc7-version: 2
 function __netcatty_osc7_url_path
     printf "%s" "$argv[1]" | LC_ALL=C awk '${URL_PATH_AWK_SCRIPT}'
 end

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -350,6 +350,15 @@ netcatty_osc7_file_mode() {
   fi
 }
 
+# Best-effort portable owner:group for chown after atomic replace.
+netcatty_osc7_file_owner() {
+  if stat -c '%u:%g' "$1" >/dev/null 2>&1; then
+    stat -c '%u:%g' "$1"
+  elif stat -f '%u:%g' "$1" >/dev/null 2>&1; then
+    stat -f '%u:%g' "$1"
+  fi
+}
+
 # Append the v2 snippet to the given file path ($1).
 netcatty_osc7_append_v2() {
   __netcatty_osc7_dest="$1"
@@ -473,6 +482,7 @@ if awk -v start="$marker" '
     __netcatty_osc7_target=$(netcatty_osc7_resolve_path "$config")
     __netcatty_osc7_dir=$(dirname "$__netcatty_osc7_target")
     __netcatty_osc7_mode=$(netcatty_osc7_file_mode "$__netcatty_osc7_target" || true)
+    __netcatty_osc7_owner=$(netcatty_osc7_file_owner "$__netcatty_osc7_target" || true)
     __netcatty_osc7_tmp=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7.XXXXXX") || exit 1
     __netcatty_osc7_snip=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7-snip.XXXXXX") || exit 1
     : > "$__netcatty_osc7_snip"
@@ -502,6 +512,9 @@ if awk -v start="$marker" '
       rm -f "$__netcatty_osc7_snip"
       if [ -n "${DOLLAR}{__netcatty_osc7_mode:-}" ]; then
         chmod "$__netcatty_osc7_mode" "$__netcatty_osc7_tmp" 2>/dev/null || true
+      fi
+      if [ -n "${DOLLAR}{__netcatty_osc7_owner:-}" ]; then
+        chown "$__netcatty_osc7_owner" "$__netcatty_osc7_tmp" 2>/dev/null || true
       fi
       mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
       need_write=0

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -381,38 +381,57 @@ __netcatty_osc7_prompt() {
     osc7_cwd
   fi
 }
-# Drop legacy v1 bare osc7_cwd lines from the current session's PROMPT_COMMAND.
-if [ -n "${DOLLAR}{PROMPT_COMMAND+x}" ]; then
-  __netcatty_osc7_pc=""
-  __netcatty_osc7_sep=""
-  while IFS= read -r __netcatty_osc7_line || [ -n "${DOLLAR}{__netcatty_osc7_line}" ]; do
-    case "${DOLLAR}{__netcatty_osc7_line}" in
+# Install/dedupe the guarded prompt hook for both scalar and array PROMPT_COMMAND.
+__netcatty_osc7_hook='declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt'
+if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
+  __netcatty_osc7_new=()
+  __netcatty_osc7_has_hook=0
+  for __netcatty_osc7_el in "${DOLLAR}{PROMPT_COMMAND[@]}"; do
+    case "${DOLLAR}{__netcatty_osc7_el}" in
       osc7_cwd|__netcatty_osc7_prompt) continue ;;
-      *)
-        __netcatty_osc7_pc="${DOLLAR}{__netcatty_osc7_pc}${DOLLAR}{__netcatty_osc7_sep}${DOLLAR}{__netcatty_osc7_line}"
-        __netcatty_osc7_sep="
-"
+      *'declare -F __netcatty_osc7_prompt'*)
+        if [ "${DOLLAR}{__netcatty_osc7_has_hook}" -eq 0 ]; then
+          __netcatty_osc7_new+=("${DOLLAR}{__netcatty_osc7_hook}")
+          __netcatty_osc7_has_hook=1
+        fi
         ;;
+      *) __netcatty_osc7_new+=("${DOLLAR}{__netcatty_osc7_el}") ;;
     esac
-  done <<EOF
+  done
+  if [ "${DOLLAR}{__netcatty_osc7_has_hook}" -eq 0 ]; then
+    __netcatty_osc7_new+=("${DOLLAR}{__netcatty_osc7_hook}")
+  fi
+  PROMPT_COMMAND=("${DOLLAR}{__netcatty_osc7_new[@]}")
+  unset __netcatty_osc7_new __netcatty_osc7_has_hook __netcatty_osc7_el 2>/dev/null || true
+else
+  if [ -n "${DOLLAR}{PROMPT_COMMAND+x}" ]; then
+    __netcatty_osc7_pc=""
+    __netcatty_osc7_sep=""
+    while IFS= read -r __netcatty_osc7_line || [ -n "${DOLLAR}{__netcatty_osc7_line}" ]; do
+      case "${DOLLAR}{__netcatty_osc7_line}" in
+        osc7_cwd|__netcatty_osc7_prompt) continue ;;
+        *'declare -F __netcatty_osc7_prompt'*) continue ;;
+        *)
+          __netcatty_osc7_pc="${DOLLAR}{__netcatty_osc7_pc}${DOLLAR}{__netcatty_osc7_sep}${DOLLAR}{__netcatty_osc7_line}"
+          __netcatty_osc7_sep="
+"
+          ;;
+      esac
+    done <<EOF
 ${DOLLAR}{PROMPT_COMMAND-}
 EOF
-  PROMPT_COMMAND="${DOLLAR}{__netcatty_osc7_pc}"
-  unset __netcatty_osc7_pc __netcatty_osc7_sep __netcatty_osc7_line 2>/dev/null || true
-fi
-# Guarded entry: if this string is inherited without function defs, declare -F
-# fails quietly and the hook is skipped (no "command not found").
-case "${DOLLAR}{PROMPT_COMMAND:-}" in
-  *'declare -F __netcatty_osc7_prompt'*) ;;
-  *)
-    if [ -n "${DOLLAR}{PROMPT_COMMAND:-}" ]; then
-      PROMPT_COMMAND="${DOLLAR}{PROMPT_COMMAND}
-declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt"
+    if [ -n "${DOLLAR}{__netcatty_osc7_pc}" ]; then
+      PROMPT_COMMAND="${DOLLAR}{__netcatty_osc7_pc}
+${DOLLAR}{__netcatty_osc7_hook}"
     else
-      PROMPT_COMMAND="declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt"
+      PROMPT_COMMAND="${DOLLAR}{__netcatty_osc7_hook}"
     fi
-    ;;
-esac
+    unset __netcatty_osc7_pc __netcatty_osc7_sep __netcatty_osc7_line 2>/dev/null || true
+  else
+    PROMPT_COMMAND="${DOLLAR}{__netcatty_osc7_hook}"
+  fi
+fi
+unset __netcatty_osc7_hook 2>/dev/null || true
 # Keep PROMPT_COMMAND shell-local so non-login su does not leak the hook.
 declare +x PROMPT_COMMAND 2>/dev/null || true
 # <<< Netcatty OSC 7 cwd tracking <<<
@@ -514,10 +533,18 @@ if awk -v start="$marker" '
         chmod "$__netcatty_osc7_mode" "$__netcatty_osc7_tmp" 2>/dev/null || true
       fi
       if [ -n "${DOLLAR}{__netcatty_osc7_owner:-}" ]; then
-        chown "$__netcatty_osc7_owner" "$__netcatty_osc7_tmp" 2>/dev/null || true
+        # If we cannot restore ownership, leave the original file untouched.
+        if ! chown "$__netcatty_osc7_owner" "$__netcatty_osc7_tmp" 2>/dev/null; then
+          rm -f "$__netcatty_osc7_tmp"
+          need_write=1
+        else
+          mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
+          need_write=0
+        fi
+      else
+        mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
+        need_write=0
       fi
-      mv -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_target"
-      need_write=0
     else
       rm -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_snip"
       need_write=1

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -504,8 +504,14 @@ if awk -v start="$marker" '
     __netcatty_osc7_dir=$(dirname "$__netcatty_osc7_target")
     __netcatty_osc7_mode=$(netcatty_osc7_file_mode "$__netcatty_osc7_target" || true)
     __netcatty_osc7_owner=$(netcatty_osc7_file_owner "$__netcatty_osc7_target" || true)
-    __netcatty_osc7_tmp=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7.XXXXXX") || exit 1
-    __netcatty_osc7_snip=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7-snip.XXXXXX") || exit 1
+    # Prefer same-dir atomic replace. If the directory is not writable
+    # (managed homes), fall back to append without aborting setup.
+    __netcatty_osc7_tmp=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7.XXXXXX" 2>/dev/null || true)
+    __netcatty_osc7_snip=$(mktemp "$__netcatty_osc7_dir/.netcatty-osc7-snip.XXXXXX" 2>/dev/null || true)
+    if [ -z "${DOLLAR}{__netcatty_osc7_tmp:-}" ] || [ -z "${DOLLAR}{__netcatty_osc7_snip:-}" ]; then
+      rm -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_snip" 2>/dev/null || true
+      need_write=1
+    else
     : > "$__netcatty_osc7_snip"
     netcatty_osc7_append_v2 "$__netcatty_osc7_snip"
     if awk -v start="$marker" -v end="$end_marker" -v snip="$__netcatty_osc7_snip" '
@@ -550,6 +556,7 @@ if awk -v start="$marker" '
     else
       rm -f "$__netcatty_osc7_tmp" "$__netcatty_osc7_snip"
       need_write=1
+    fi
     fi
   else
     # Incomplete or unbalanced markers and no complete v2 yet.

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -259,41 +259,59 @@ touch "$config"
 snippet_version_marker="netcatty-osc7-version: 2"
 end_marker="# <<< Netcatty OSC 7 cwd tracking <<<"
 # Returns 0 when every start marker is closed by a matching end marker.
+# Markers must be whole lines (optional indent) so an echo of the marker text
+# does not count as a block boundary.
 netcatty_osc7_markers_balanced() {
   awk -v start="$marker" -v end="$end_marker" '
-    index($0, start) {
-      if (skip) { incomplete=1; next }
-      skip=1
-      next
+    function trim(s) {
+      sub(/^[ \t]+/, "", s)
+      sub(/[ \t]+$/, "", s)
+      return s
     }
-    index($0, end) {
-      if (!skip) { incomplete=1; next }
-      skip=0
-      next
+    {
+      t = trim($0)
+      if (t == start) {
+        if (skip) incomplete = 1
+        else skip = 1
+        next
+      }
+      if (t == end) {
+        if (!skip) incomplete = 1
+        else skip = 0
+        next
+      }
     }
     END {
-      if (skip) incomplete=1
+      if (skip) incomplete = 1
       exit incomplete ? 1 : 0
     }
   ' "$1"
 }
 
 # Returns 0 when at least one contiguous start..end region contains the v2
-# version marker. Older malformed markers outside that region are ignored so
-# recovery appends stay idempotent.
+# version marker line. Older malformed markers outside that region are ignored
+# so recovery appends stay idempotent.
 netcatty_osc7_has_complete_v2_block() {
-  awk -v start="$marker" -v end="$end_marker" -v ver="$snippet_version_marker" '
-    index($0, start) {
-      skip=1
-      has_ver=0
-      next
+  awk -v start="$marker" -v end="$end_marker" -v ver_line="# $snippet_version_marker" '
+    function trim(s) {
+      sub(/^[ \t]+/, "", s)
+      sub(/[ \t]+$/, "", s)
+      return s
     }
-    skip && index($0, ver) { has_ver=1 }
-    index($0, end) {
-      if (skip && has_ver) found=1
-      skip=0
-      has_ver=0
-      next
+    {
+      t = trim($0)
+      if (t == start) {
+        skip = 1
+        has_ver = 0
+        next
+      }
+      if (skip && t == ver_line) has_ver = 1
+      if (t == end) {
+        if (skip && has_ver) found = 1
+        skip = 0
+        has_ver = 0
+        next
+      }
     }
     END { exit found ? 0 : 1 }
   ' "$1"
@@ -437,7 +455,12 @@ NETCATTY_OSC7_FISH
 }
 
 need_write=1
-if grep -F "$marker" "$config" >/dev/null 2>&1; then
+# Whole-line marker presence only (not substring matches inside echo etc.).
+if awk -v start="$marker" '
+  function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+  trim($0) == start { found = 1; exit }
+  END { exit found ? 0 : 1 }
+' "$config"; then
   if netcatty_osc7_has_complete_v2_block "$config"; then
     # At least one complete v2 block exists (even if older junk markers remain).
     need_write=0
@@ -455,19 +478,25 @@ if grep -F "$marker" "$config" >/dev/null 2>&1; then
     : > "$__netcatty_osc7_snip"
     netcatty_osc7_append_v2 "$__netcatty_osc7_snip"
     if awk -v start="$marker" -v end="$end_marker" -v snip="$__netcatty_osc7_snip" '
-      index($0, start) {
-        # Re-open the snippet each time so multiple complete legacy blocks are
-        # each replaced in place rather than only the first.
-        while ((getline line < snip) > 0) print line
-        close(snip)
-        skip = 1
-        next
+      function trim(s) {
+        sub(/^[ \t]+/, "", s)
+        sub(/[ \t]+$/, "", s)
+        return s
       }
-      index($0, end) {
-        skip = 0
-        next
+      {
+        t = trim($0)
+        if (t == start) {
+          while ((getline line < snip) > 0) print line
+          close(snip)
+          skip = 1
+          next
+        }
+        if (t == end) {
+          skip = 0
+          next
+        }
+        if (!skip) print
       }
-      !skip { print }
     ' "$config" > "$__netcatty_osc7_tmp"
     then
       rm -f "$__netcatty_osc7_snip"

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -262,17 +262,44 @@ need_write=1
 if grep -F "$marker" "$config" >/dev/null 2>&1; then
   if grep -F "$snippet_version_marker" "$config" >/dev/null 2>&1; then
     need_write=0
-  else
-    # Replace outdated blocks in place (v1 called osc7_cwd directly from
-    # PROMPT_COMMAND / precmd and broke after su when the function was missing).
-    __netcatty_osc7_tmp=$(mktemp) || exit 1
-    awk -v start="$marker" -v end="$end_marker" '
-      index($0, start) { skip=1; next }
-      index($0, end) { skip=0; next }
-      !skip { print }
-    ' "$config" > "$__netcatty_osc7_tmp"
-    mv "$__netcatty_osc7_tmp" "$config"
+  elif ! grep -F "$end_marker" "$config" >/dev/null 2>&1; then
+    # Incomplete block (start without end). Do not rewrite/truncate: a half-open
+    # skip would drop every line after the start marker and corrupt the rc file.
+    # Append a complete v2 block instead so tracking still installs.
     need_write=1
+  else
+    # Replace outdated complete blocks in place (v1 called osc7_cwd directly
+    # from PROMPT_COMMAND / precmd and broke after su when the function was missing).
+    __netcatty_osc7_tmp=$(mktemp) || exit 1
+    # Only commit the rewrite when awk closed every start with a matching end.
+    # Otherwise keep the original file untouched.
+    if awk -v start="$marker" -v end="$end_marker" '
+      index($0, start) {
+        if (skip) { incomplete=1; next }
+        skip=1
+        next
+      }
+      index($0, end) {
+        if (!skip) { incomplete=1; next }
+        skip=0
+        next
+      }
+      !skip { print }
+      END {
+        if (skip) incomplete=1
+        exit incomplete ? 1 : 0
+      }
+    ' "$config" > "$__netcatty_osc7_tmp"
+    then
+      mv "$__netcatty_osc7_tmp" "$config"
+      need_write=1
+    else
+      # Malformed marker layout (e.g. orphan end before open start). Keep the
+      # original file and still append a complete v2 block so setup installs
+      # tracking without truncating user config.
+      rm -f "$__netcatty_osc7_tmp"
+      need_write=1
+    fi
   fi
 fi
 

--- a/components/terminal/osc7Setup.ts
+++ b/components/terminal/osc7Setup.ts
@@ -383,7 +383,8 @@ __netcatty_osc7_prompt() {
 }
 # Install/dedupe the guarded prompt hook for both scalar and array PROMPT_COMMAND.
 __netcatty_osc7_hook='declare -F __netcatty_osc7_prompt >/dev/null 2>&1 && __netcatty_osc7_prompt'
-if declare -p PROMPT_COMMAND 2>/dev/null | grep -q '^declare -a'; then
+# Match declare -a / -ax / -ar etc. (array flag may appear with other flags).
+if declare -p PROMPT_COMMAND 2>/dev/null | grep -Eq 'declare -[A-Za-z]*a'; then
   __netcatty_osc7_new=()
   __netcatty_osc7_has_hook=0
   for __netcatty_osc7_el in "${DOLLAR}{PROMPT_COMMAND[@]}"; do
@@ -432,8 +433,9 @@ ${DOLLAR}{__netcatty_osc7_hook}"
   fi
 fi
 unset __netcatty_osc7_hook 2>/dev/null || true
-# Keep PROMPT_COMMAND shell-local so non-login su does not leak the hook.
-declare +x PROMPT_COMMAND 2>/dev/null || true
+# Do not force-unexport PROMPT_COMMAND: the guarded hook is safe if inherited
+# across non-login su (declare -F fails quietly), and users may intentionally
+# export PROMPT_COMMAND for child shells.
 # <<< Netcatty OSC 7 cwd tracking <<<
 NETCATTY_OSC7_BASH
       ;;


### PR DESCRIPTION
## Summary
- OSC 7 directory tracking no longer installs a bare `osc7_cwd` call in `PROMPT_COMMAND`, which could print `osc7_cwd: command not found` after non-login `su` when the function definition was not inherited.
- Bash/zsh snippets are now **version 2**: guarded prompt hook (`declare -F … && __netcatty_osc7_prompt`), `declare +x PROMPT_COMMAND` to avoid leaking the hook across `su`, and in-place upgrade of older rc blocks when setup is re-run.
- Adds tests for legacy upgrade, PROMPT_COMMAND inheritance without functions, OSC 7 emit, and unexport behavior.

## Context
Users who configured Netcatty OSC 7 tracking, then ran `su otheruser`, saw:
```text
osc7_cwd: command not found
```
That name comes from our injected bashrc/zshrc hook (`components/terminal/osc7Setup.ts`).

## Test plan
- [x] `node --test --import tsx components/terminal/osc7Setup.test.ts` (30 passed)
- [ ] Manual: enable directory tracking on a remote bash session as root, run `su ubuntu`, confirm no `command not found`
- [ ] Manual: re-run setup on a host that still has the v1 bashrc block; confirm single v2 block and preamble/epilogue preserved
- [ ] Manual: `cd` after setup still updates SFTP/cwd tracking for the configured user