### PR TITLE
fix(ai): stop OpenCode process spawn storms when unused (#2184)

### DIFF
--- a/components/AIChatSidePanel.tsx
+++ b/components/AIChatSidePanel.tsx
@@ -686,24 +686,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     };
   }, []);
 
-  const buildDiscoveredAgentRuntimeModelTarget = useCallback((agent: DiscoveredAgent): SdkRuntimeModelTarget | null => {
-    const sdkBackend = agent.sdkBackend ?? agent.command;
-    if (sdkBackend !== 'opencode') return null;
-    const command = agent.binPath || agent.path || agent.command;
-    const agentId = `discovered_${agent.command}`;
-    return {
-      agentId,
-      cacheKey: buildSdkRuntimeModelCacheKey({
-        id: agentId,
-        command,
-        sdkBackend,
-        env: command ? { OPENCODE_BIN: command } : undefined,
-      }),
-      sdkBackend,
-      agentCommand: command,
-    };
-  }, []);
-
   const applySdkRuntimeModelCatalog = useCallback((
     agentId: string,
     catalog: SdkRuntimeModelCatalog,
@@ -781,10 +763,12 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
       applySdkRuntimeModelCatalog(target.agentId, cached);
     }
 
+    // Respect renderer TTL / in-flight coalescing for all SDK agents including
+    // OpenCode. Forced refresh used to re-spawn opencode on every effect re-run
+    // even when the user never selected OpenCode (#2184). Manual refresh still
+    // passes force via the model selector path.
     let cancelled = false;
-    void loadSdkRuntimeModelCatalog(target, {
-      force: target.sdkBackend === 'opencode',
-    }).then((catalog) => {
+    void loadSdkRuntimeModelCatalog(target).then((catalog) => {
       if (cancelled || !catalog) return;
       applySdkRuntimeModelCatalog(target.agentId, catalog, { adoptCurrentModel: true });
     });
@@ -797,51 +781,6 @@ const AIChatSidePanelActive: React.FC<AIChatSidePanelProps> = ({
     currentAgentConfig,
     isCodexManagedAgent,
     buildExternalAgentRuntimeModelTarget,
-    loadSdkRuntimeModelCatalog,
-    applySdkRuntimeModelCatalog,
-  ]);
-
-  useEffect(() => {
-    if (!isVisible) return;
-    const targets = new Map<string, SdkRuntimeModelTarget>();
-    const configuredTargetCacheKeys = new Set<string>();
-
-    for (const agent of externalAgents) {
-      if (!agent.enabled || getExternalAgentSdkBackend(agent) !== 'opencode') continue;
-      const target = buildExternalAgentRuntimeModelTarget(agent);
-      if (target) {
-        targets.set(target.cacheKey, target);
-        configuredTargetCacheKeys.add(target.cacheKey);
-      }
-    }
-
-    for (const agent of discoveredAgents) {
-      const target = buildDiscoveredAgentRuntimeModelTarget(agent);
-      if (target) targets.set(target.cacheKey, target);
-    }
-
-    if (targets.size === 0) return;
-
-    let cancelled = false;
-    for (const target of targets.values()) {
-      void loadSdkRuntimeModelCatalog(target, { logErrors: false })
-        .then((catalog) => {
-          if (cancelled || !catalog) return;
-          if (configuredTargetCacheKeys.has(target.cacheKey)) {
-            applySdkRuntimeModelCatalog(target.agentId, catalog);
-          }
-        });
-    }
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    isVisible,
-    externalAgents,
-    discoveredAgents,
-    buildExternalAgentRuntimeModelTarget,
-    buildDiscoveredAgentRuntimeModelTarget,
     loadSdkRuntimeModelCatalog,
     applySdkRuntimeModelCatalog,
   ]);

--- a/components/AIChatSidePanelHelpers.ts
+++ b/components/AIChatSidePanelHelpers.ts
@@ -20,7 +20,20 @@ type SdkRuntimeModelRefreshOptions = {
 };
 
 const SDK_RUNTIME_MODEL_CACHE_TTL_MS = 5 * 60 * 1000;
-const MODEL_CACHE_ENV_HINTS = ['CLAUDE_CODE_EXECUTABLE', 'CODEBUDDY_CODE_PATH', 'OPENCODE_BIN'] as const;
+// Keep in sync with main-process SDK_MODEL_CACHE_ENV_KEYS: profile-affecting
+// env must bust the renderer cache so we re-query after OpenCode config switches.
+const MODEL_CACHE_ENV_HINTS = [
+  'HOME',
+  'USERPROFILE',
+  'XDG_CONFIG_HOME',
+  'OPENCODE_BIN',
+  'OPENCODE_CONFIG',
+  'OPENCODE_CONFIG_DIR',
+  'OPENCODE_CONFIG_CONTENT',
+  'CLAUDE_CODE_EXECUTABLE',
+  'CODEBUDDY_CODE_PATH',
+  'CURSOR_API_KEY',
+] as const;
 
 function cloneCatalog(catalog: SdkRuntimeModelCatalog): SdkRuntimeModelCatalog {
   return {

--- a/electron/bridges/aiBridge/sdk/index.cjs
+++ b/electron/bridges/aiBridge/sdk/index.cjs
@@ -148,7 +148,12 @@ const DRIVER_REGISTRY = {
       });
     },
     async listModels(ctx) {
-      return opencode.listOpenCodeModels({ env: ctx.env, binPath: ctx.binPath });
+      return opencode.listOpenCodeModels({
+        env: ctx.env,
+        binPath: ctx.binPath,
+        abortController: ctx.abortController,
+        signal: ctx.abortController?.signal || ctx.signal,
+      });
     },
   },
 };

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -460,30 +460,42 @@ async function createDefaultOpenCode(options, env, binPath) {
     process.env[key] = String(value);
   }
 
-  const restoreEnv = () => {
-    if (restoreEnv.done) return;
-    restoreEnv.done = true;
+  // Restore the Electron main-process environment as soon as the child has been
+  // spawned. Keeping PATH/OPENCODE_BIN pointed at a temporary shim for the
+  // server lifetime (or list-models idle window) can leak into later turns and
+  // other spawns; see #2184 review. The on-disk shim stays until close() so a
+  // still-running child that re-resolves helpers does not race a deleted path.
+  const restoreProcessEnv = () => {
+    if (restoreProcessEnv.done) return;
+    restoreProcessEnv.done = true;
     for (const key of Object.keys(nextEnv)) {
       if (previous[key] === undefined) delete process.env[key];
       else process.env[key] = previous[key];
     }
+  };
+
+  const cleanup = () => {
+    if (cleanup.done) return;
+    cleanup.done = true;
+    restoreProcessEnv();
     cleanupShim();
   };
 
   try {
     const opencode = await sdk.createOpencode(options);
+    restoreProcessEnv();
     const originalClose = opencode.server?.close?.bind(opencode.server);
     if (typeof originalClose === "function") {
       opencode.server.close = () => {
         try { originalClose(); } catch {}
-        restoreEnv();
+        cleanup();
       };
     } else {
-      restoreEnv();
+      cleanup();
     }
     return opencode;
   } catch (error) {
-    restoreEnv();
+    cleanup();
     throw error;
   }
 }
@@ -722,13 +734,33 @@ function whenAborted(signal) {
   });
 }
 
+// Env vars that can change which OpenCode config / provider catalog is visible.
+const OPENCODE_CATALOG_ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+  "OPENCODE_BIN",
+  "OPENCODE_CONFIG",
+  "OPENCODE_CONFIG_DIR",
+  "OPENCODE_CONFIG_CONTENT",
+];
+
+function buildOpenCodeCatalogEnvFingerprint(env) {
+  return OPENCODE_CATALOG_ENV_KEYS
+    .map((key) => `${key}=${env?.[key] == null ? "" : String(env[key])}`)
+    .join("\u0000");
+}
+
 function buildOpenCodeListServerKey(binPath, env) {
-  return String(
+  const resolvedBin = String(
     resolveUsableOpenCodeBinPath(binPath, env)
     || binPath
     || env?.OPENCODE_BIN
     || "default",
   );
+  // Same binary + different HOME/XDG/OpenCode config must not share a catalog
+  // server or cache entry (multi-agent / multi-profile setups).
+  return `${resolvedBin}\u0000${buildOpenCodeCatalogEnvFingerprint(env)}`;
 }
 
 // Shared list-models servers: coalesce concurrent catalog loads for the same

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.cjs
@@ -443,6 +443,10 @@ async function withOpenCodeServerPort(options = {}) {
   return { ...options, port: await getAvailablePort(options.hostname || "127.0.0.1") };
 }
 
+function closeOpenCodeInstance(opencode) {
+  try { opencode?.server?.close?.(); } catch {}
+}
+
 async function createDefaultOpenCode(options, env, binPath) {
   let sdk;
   try { sdk = await import("@opencode-ai/sdk"); } catch {
@@ -656,7 +660,7 @@ async function runOpenCodeTurn({
     return { sessionId };
   } finally {
     removeAbortListener?.();
-    try { opencode?.server?.close?.(); } catch {}
+    closeOpenCodeInstance(opencode);
   }
 }
 
@@ -700,12 +704,161 @@ function getOpenCodeDefaultModelId(response) {
   return null;
 }
 
-async function listOpenCodeModels({ env, binPath, openCodeFactory } = {}) {
-  let opencode = null;
-  try {
+function emptyOpenCodeModelCatalog() {
+  return { currentModelId: null, models: [] };
+}
+
+function abortError(signal) {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new Error(String(signal?.reason || "aborted"));
+}
+
+function whenAborted(signal) {
+  if (!signal) return new Promise(() => {});
+  if (signal.aborted) return Promise.reject(abortError(signal));
+  return new Promise((_, reject) => {
+    signal.addEventListener("abort", () => reject(abortError(signal)), { once: true });
+  });
+}
+
+function buildOpenCodeListServerKey(binPath, env) {
+  return String(
+    resolveUsableOpenCodeBinPath(binPath, env)
+    || binPath
+    || env?.OPENCODE_BIN
+    || "default",
+  );
+}
+
+// Shared list-models servers: coalesce concurrent catalog loads for the same
+// binary, then tear down after a short idle so idle Netcatty does not keep
+// opencode processes around (issue #2184).
+const OPENCODE_LIST_SERVER_IDLE_MS = 1500;
+const openCodeListServers = new Map();
+
+function clearOpenCodeListServerIdle(entry) {
+  if (!entry?.idleTimer) return;
+  clearTimeout(entry.idleTimer);
+  entry.idleTimer = null;
+}
+
+function disposeOpenCodeListServer(key, entry) {
+  const current = openCodeListServers.get(key);
+  if (current && current !== entry) return;
+  openCodeListServers.delete(key);
+  clearOpenCodeListServerIdle(entry);
+  try { entry?.createAbort?.abort?.(); } catch {}
+  closeOpenCodeInstance(entry?.opencode);
+  entry.opencode = null;
+}
+
+function releaseOpenCodeListServer(key) {
+  const entry = openCodeListServers.get(key);
+  if (!entry) return;
+  entry.refs = Math.max(0, (entry.refs || 0) - 1);
+  if (entry.refs > 0) return;
+
+  // Create still in flight with no waiters: abort so the SDK kills the child.
+  if (!entry.opencode && entry.createAbort && !entry.createAbort.signal.aborted) {
+    try { entry.createAbort.abort(); } catch {}
+    disposeOpenCodeListServer(key, entry);
+    return;
+  }
+
+  clearOpenCodeListServerIdle(entry);
+  entry.idleTimer = setTimeout(() => {
+    const current = openCodeListServers.get(key);
+    if (!current || current !== entry || current.refs > 0) return;
+    disposeOpenCodeListServer(key, entry);
+  }, OPENCODE_LIST_SERVER_IDLE_MS);
+  if (typeof entry.idleTimer.unref === "function") entry.idleTimer.unref();
+}
+
+async function acquireOpenCodeListServer({ env, binPath, openCodeFactory, signal } = {}) {
+  if (signal?.aborted) throw abortError(signal);
+
+  const key = buildOpenCodeListServerKey(binPath, env);
+  let entry = openCodeListServers.get(key);
+
+  if (entry) {
+    clearOpenCodeListServerIdle(entry);
+  } else {
+    const createAbort = new AbortController();
+    entry = {
+      key,
+      refs: 0,
+      opencode: null,
+      ready: null,
+      idleTimer: null,
+      createAbort,
+    };
     const factory = openCodeFactory || ((options) => createDefaultOpenCode(options, env, binPath));
-    opencode = await factory(await withOpenCodeServerPort({ config: { autoupdate: false }, timeout: 10000 }));
-    const response = await opencode.client.config.providers();
+    entry.ready = (async () => {
+      const options = await withOpenCodeServerPort({
+        config: { autoupdate: false },
+        timeout: 10000,
+        signal: createAbort.signal,
+      });
+      const opencode = await factory(options);
+      // If the last waiter cancelled while create was finishing, kill immediately
+      // so the process cannot leak outside the pool map.
+      if (createAbort.signal.aborted) {
+        closeOpenCodeInstance(opencode);
+        throw abortError(createAbort.signal);
+      }
+      entry.opencode = opencode;
+      return opencode;
+    })().catch((error) => {
+      // Drop a failed create immediately so the next list-models can retry.
+      disposeOpenCodeListServer(key, entry);
+      throw error;
+    });
+    openCodeListServers.set(key, entry);
+  }
+
+  entry.refs += 1;
+  try {
+    const opencode = await Promise.race([
+      entry.ready,
+      whenAborted(signal),
+    ]);
+    if (signal?.aborted) throw abortError(signal);
+    return { key, opencode };
+  } catch (error) {
+    entry.refs = Math.max(0, entry.refs - 1);
+    if (entry.refs <= 0) {
+      // Last waiter left before ready: abort spawn so the SDK child is killed.
+      try { entry.createAbort?.abort?.(); } catch {}
+      disposeOpenCodeListServer(key, entry);
+    }
+    throw error;
+  }
+}
+
+function resetOpenCodeListServerPool() {
+  for (const [key, entry] of openCodeListServers.entries()) {
+    disposeOpenCodeListServer(key, entry);
+  }
+  openCodeListServers.clear();
+}
+
+async function listOpenCodeModels({ env, binPath, openCodeFactory, abortController, signal } = {}) {
+  const effectiveSignal = signal || abortController?.signal;
+  let acquired = null;
+  try {
+    if (effectiveSignal?.aborted) return emptyOpenCodeModelCatalog();
+    acquired = await acquireOpenCodeListServer({
+      env,
+      binPath,
+      openCodeFactory,
+      signal: effectiveSignal,
+    });
+    if (effectiveSignal?.aborted) return emptyOpenCodeModelCatalog();
+    const response = await Promise.race([
+      acquired.opencode.client.config.providers(),
+      whenAborted(effectiveSignal),
+    ]);
     if (response?.error) {
       throw new Error(extractOpenCodeErrorMessage(response.error) || "OpenCode providers unavailable");
     }
@@ -715,9 +868,9 @@ async function listOpenCodeModels({ env, binPath, openCodeFactory } = {}) {
       models: mapOpenCodeModels(data),
     };
   } catch {
-    return { currentModelId: null, models: [] };
+    return emptyOpenCodeModelCatalog();
   } finally {
-    try { opencode?.server?.close?.(); } catch {}
+    if (acquired) releaseOpenCodeListServer(acquired.key);
   }
 }
 
@@ -725,13 +878,16 @@ module.exports = {
   buildOpenCodeConfig,
   buildOpenCodePromptParts,
   classifyOpenCodeSpawnError,
+  closeOpenCodeInstance,
   createOpenCodeProcessEnv,
   withOpenCodeProcessEnv,
   listOpenCodeModels,
   mapOpenCodeModels,
   parseOpenCodeModel,
   resolveUsableOpenCodeBinPath,
+  resetOpenCodeListServerPool,
   runOpenCodeTurn,
   toOpenCodeMcpConfig,
   translateOpenCodeEvent,
+  OPENCODE_LIST_SERVER_IDLE_MS,
 };

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -876,6 +876,42 @@ test("listOpenCodeModels returns empty immediately when already aborted", async 
   resetOpenCodeListServerPool();
 });
 
+test("listOpenCodeModels does not share a pooled server across different catalog env", async () => {
+  resetOpenCodeListServerPool();
+  let createCount = 0;
+  const openCodeFactory = async () => {
+    createCount += 1;
+    const id = createCount;
+    return {
+      client: {
+        config: {
+          providers: async () => ({
+            providers: [],
+            default: { openai: `profile-${id}` },
+          }),
+        },
+      },
+      server: { close() {} },
+    };
+  };
+
+  const first = await listOpenCodeModels({
+    binPath: "/tmp/opencode-env-pool",
+    env: { HOME: "/Users/a", OPENCODE_CONFIG_DIR: "/a/config" },
+    openCodeFactory,
+  });
+  const second = await listOpenCodeModels({
+    binPath: "/tmp/opencode-env-pool",
+    env: { HOME: "/Users/b", OPENCODE_CONFIG_DIR: "/b/config" },
+    openCodeFactory,
+  });
+
+  assert.equal(createCount, 2);
+  assert.deepEqual(first, { currentModelId: "openai/profile-1", models: [] });
+  assert.deepEqual(second, { currentModelId: "openai/profile-2", models: [] });
+  resetOpenCodeListServerPool();
+});
+
 test("classifyOpenCodeSpawnError recognizes missing opencode CLI", () => {
   assert.equal(classifyOpenCodeSpawnError(Object.assign(new Error("spawn opencode ENOENT"), { code: "ENOENT" })).isSpawnEnoent, true);
   assert.equal(classifyOpenCodeSpawnError(new Error("other")).isSpawnEnoent, false);

--- a/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
+++ b/electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs
@@ -8,8 +8,11 @@ const {
   buildOpenCodePromptParts,
   classifyOpenCodeSpawnError,
   createOpenCodeProcessEnv,
+  listOpenCodeModels,
   mapOpenCodeModels,
+  OPENCODE_LIST_SERVER_IDLE_MS,
   parseOpenCodeModel,
+  resetOpenCodeListServerPool,
   resolveUsableOpenCodeBinPath,
   runOpenCodeTurn,
   translateOpenCodeEvent,
@@ -742,8 +745,10 @@ test("createOpenCodeProcessEnv prefers an existing opencode binary", () => {
 });
 
 test("listOpenCodeModels passes an explicit non-default port to the OpenCode SDK factory", async () => {
+  resetOpenCodeListServerPool();
   let capturedPort;
-  const models = await require("./opencodeDriver.cjs").listOpenCodeModels({
+  const models = await listOpenCodeModels({
+    binPath: "/tmp/opencode-port-test",
     openCodeFactory: async (options) => {
       capturedPort = options.port;
       return {
@@ -756,6 +761,119 @@ test("listOpenCodeModels passes an explicit non-default port to the OpenCode SDK
   assert.deepEqual(models, { currentModelId: "openai/gpt-5.1", models: [] });
   assert.equal(typeof capturedPort, "number");
   assert.notEqual(capturedPort, 4096);
+  resetOpenCodeListServerPool();
+});
+
+test("listOpenCodeModels aborts a hanging providers() call and tears down the pooled server", async () => {
+  resetOpenCodeListServerPool();
+  const abortController = new AbortController();
+  let closeCount = 0;
+  let sawAbortSignal = false;
+  let releaseProviders;
+
+  const running = listOpenCodeModels({
+    binPath: "/tmp/opencode-abort-test",
+    signal: abortController.signal,
+    openCodeFactory: async (options) => {
+      sawAbortSignal = Boolean(options.signal);
+      return {
+        client: {
+          config: {
+            providers: () => new Promise((resolve) => {
+              releaseProviders = resolve;
+            }),
+          },
+        },
+        server: {
+          close() { closeCount += 1; },
+        },
+      };
+    },
+  });
+
+  // Let the factory settle, then abort while providers() is pending.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  abortController.abort(new Error("list-models timed out"));
+  const models = await running;
+  assert.deepEqual(models, { currentModelId: null, models: [] });
+  assert.equal(sawAbortSignal, true);
+
+  // Release schedules a short idle close; force dispose for a deterministic assert.
+  resetOpenCodeListServerPool();
+  assert.equal(closeCount, 1);
+
+  // Unblock any leftover resolver so the test process can exit cleanly.
+  releaseProviders?.({ providers: [], default: {} });
+});
+
+test("listOpenCodeModels reuses one pooled OpenCode server for concurrent loads", async () => {
+  resetOpenCodeListServerPool();
+  let createCount = 0;
+  let closeCount = 0;
+  let releaseProviders;
+  const providersGate = new Promise((resolve) => { releaseProviders = resolve; });
+
+  const openCodeFactory = async () => {
+    createCount += 1;
+    return {
+      client: {
+        config: {
+          providers: async () => providersGate,
+        },
+      },
+      server: {
+        close() { closeCount += 1; },
+      },
+    };
+  };
+
+  const first = listOpenCodeModels({
+    binPath: "/tmp/opencode-pool-test",
+    openCodeFactory,
+  });
+  const second = listOpenCodeModels({
+    binPath: "/tmp/opencode-pool-test",
+    openCodeFactory,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(createCount, 1);
+
+  releaseProviders({
+    providers: [],
+    default: { openai: "gpt-5.1" },
+  });
+  const [a, b] = await Promise.all([first, second]);
+  assert.deepEqual(a, { currentModelId: "openai/gpt-5.1", models: [] });
+  assert.deepEqual(b, { currentModelId: "openai/gpt-5.1", models: [] });
+  assert.equal(createCount, 1);
+
+  resetOpenCodeListServerPool();
+  assert.equal(closeCount, 1);
+  assert.ok(OPENCODE_LIST_SERVER_IDLE_MS >= 0);
+});
+
+test("listOpenCodeModels returns empty immediately when already aborted", async () => {
+  resetOpenCodeListServerPool();
+  let createCount = 0;
+  const abortController = new AbortController();
+  abortController.abort(new Error("pre-aborted"));
+  const models = await listOpenCodeModels({
+    binPath: "/tmp/opencode-preabort-test",
+    signal: abortController.signal,
+    openCodeFactory: async () => {
+      createCount += 1;
+      return {
+        client: { config: { providers: async () => ({ providers: [] }) } },
+        server: { close() {} },
+      };
+    },
+  });
+  assert.deepEqual(models, { currentModelId: null, models: [] });
+  assert.equal(createCount, 0);
+  resetOpenCodeListServerPool();
 });
 
 test("classifyOpenCodeSpawnError recognizes missing opencode CLI", () => {

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -11,12 +11,16 @@ const { realpathSync } = require("node:fs");
 
 const VALID_BACKENDS = new Set(listBackends());
 
-// Pre-flight model catalog cache. claude/copilot enumerate models via the SDK
-// (supportedModels / listModels); spawning the CLI is ~1-2s, so cache per backend
-// and always degrade to [] on error/timeout (the renderer keeps its presets).
+// Pre-flight model catalog cache. SDK listModels often spawns a CLI/server
+// (~1-2s+), so cache per backend+binPath and coalesce in-flight loads.
+// Always degrade to [] on error/timeout (the renderer keeps its presets).
+// OpenCode is included: catalogs can drift outside Netcatty, but a short TTL
+// is far cheaper than spawning a new opencode process on every panel render
+// (issue #2184).
 const MODEL_CACHE_TTL_MS = 5 * 60 * 1000;
 const MODEL_LIST_TIMEOUT_MS = 10000;
 const sdkModelCache = new Map();
+const sdkModelInFlight = new Map();
 const { parseSdkSessionIdentity: parseSdkSessionIdentityPayload, SDK_SESSION_ID_PREFIX } = require("../../../shared/sdkSessionIdentity.cjs");
 const { isPathLikeCommand } = require("../../../shared/pathLikeCommand.cjs");
 
@@ -42,8 +46,8 @@ function buildSdkModelCacheKey(backendKey, binPath) {
   return [String(backendKey || ""), String(binPath || "")].join("\u0000");
 }
 
-function shouldCacheSdkRuntimeModels(backendKey) {
-  return backendKey !== "opencode";
+function shouldCacheSdkRuntimeModels(_backendKey) {
+  return true;
 }
 
 function normalizeSdkListModelsResult(raw) {
@@ -83,10 +87,14 @@ function resolveSdkResumeSessionId({
   return existingSessionId && !hasConfiguredCommand ? existingSessionId : undefined;
 }
 
-function withTimeout(promise, ms) {
+function withTimeout(promise, ms, abortController) {
   let timer;
   const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`list-models timed out after ${ms}ms`)), ms);
+    timer = setTimeout(() => {
+      const error = new Error(`list-models timed out after ${ms}ms`);
+      try { abortController?.abort?.(error); } catch {}
+      reject(error);
+    }, ms);
   });
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
@@ -474,20 +482,47 @@ function registerSdkStreamHandlers(ctx) {
           resolveCodexExecutableForSdk,
           resolveCodebuddyExecutableForSdk,
         });
-        // claude/copilot enumerate models via the SDK; codex has no catalog (its
-        // driver returns []), so the renderer falls back to curated presets.
-        // OpenCode model catalogs are user-config driven and can change outside
-        // Netcatty, so do not cache them behind the generic SDK cache.
+        // claude/copilot/opencode enumerate models via the SDK; codex has no
+        // catalog (its driver returns []), so the renderer falls back to curated
+        // presets. Cache + in-flight coalescing avoid spawn storms (#2184).
         const cacheKey = buildSdkModelCacheKey(backendKey, binPath);
         const shouldCacheModels = shouldCacheSdkRuntimeModels(backendKey);
         const cached = shouldCacheModels ? sdkModelCache.get(cacheKey) : null;
         if (cached && Date.now() - cached.at < MODEL_CACHE_TTL_MS) {
           return { ok: true, currentModelId: cached.currentModelId || null, models: cached.models };
         }
-        const raw = await withTimeout(driver.listModels({ binPath, env }), MODEL_LIST_TIMEOUT_MS);
-        const { currentModelId, models } = normalizeSdkListModelsResult(raw);
-        if (shouldCacheModels) sdkModelCache.set(cacheKey, { at: Date.now(), currentModelId, models });
-        return { ok: true, currentModelId, models };
+
+        const existing = sdkModelInFlight.get(cacheKey);
+        if (existing) return await existing;
+
+        const loadPromise = (async () => {
+          const abortController = new AbortController();
+          try {
+            const raw = await withTimeout(
+              driver.listModels({ binPath, env, abortController }),
+              MODEL_LIST_TIMEOUT_MS,
+              abortController,
+            );
+            const { currentModelId, models } = normalizeSdkListModelsResult(raw);
+            if (shouldCacheModels) {
+              sdkModelCache.set(cacheKey, { at: Date.now(), currentModelId, models });
+            }
+            return { ok: true, currentModelId, models };
+          } catch (err) {
+            // Degrade to [] so the renderer keeps its curated presets (never empty).
+            console.debug(`[sdk] list-models(${backendKey}) unavailable, using curated presets`);
+            return { ok: true, currentModelId: null, models: [] };
+          }
+        })();
+
+        sdkModelInFlight.set(cacheKey, loadPromise);
+        try {
+          return await loadPromise;
+        } finally {
+          if (sdkModelInFlight.get(cacheKey) === loadPromise) {
+            sdkModelInFlight.delete(cacheKey);
+          }
+        }
       } catch (err) {
         // Degrade to [] so the renderer keeps its curated presets (never empty).
         console.debug(`[sdk] list-models(${backendKey}) unavailable, using curated presets`);

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -42,8 +42,26 @@ function buildSdkSessionKey(chatSessionId, backendKey, binPath) {
   ].join("\u0000");
 }
 
-function buildSdkModelCacheKey(backendKey, binPath) {
-  return [String(backendKey || ""), String(binPath || "")].join("\u0000");
+// Environment that can change an SDK agent's model catalog without changing the
+// binary path (especially OpenCode HOME / XDG / config overrides).
+const SDK_MODEL_CACHE_ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "XDG_CONFIG_HOME",
+  "OPENCODE_BIN",
+  "OPENCODE_CONFIG",
+  "OPENCODE_CONFIG_DIR",
+  "OPENCODE_CONFIG_CONTENT",
+  "CLAUDE_CODE_EXECUTABLE",
+  "CODEBUDDY_CODE_PATH",
+  "CURSOR_API_KEY",
+];
+
+function buildSdkModelCacheKey(backendKey, binPath, env) {
+  const envFingerprint = SDK_MODEL_CACHE_ENV_KEYS
+    .map((key) => `${key}=${env?.[key] == null ? "" : String(env[key])}`)
+    .join("\u0000");
+  return [String(backendKey || ""), String(binPath || ""), envFingerprint].join("\u0000");
 }
 
 function shouldCacheSdkRuntimeModels(_backendKey) {
@@ -485,7 +503,7 @@ function registerSdkStreamHandlers(ctx) {
         // claude/copilot/opencode enumerate models via the SDK; codex has no
         // catalog (its driver returns []), so the renderer falls back to curated
         // presets. Cache + in-flight coalescing avoid spawn storms (#2184).
-        const cacheKey = buildSdkModelCacheKey(backendKey, binPath);
+        const cacheKey = buildSdkModelCacheKey(backendKey, binPath, env);
         const shouldCacheModels = shouldCacheSdkRuntimeModels(backendKey);
         const cached = shouldCacheModels ? sdkModelCache.get(cacheKey) : null;
         if (cached && Date.now() - cached.at < MODEL_CACHE_TTL_MS) {

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.cjs
@@ -522,7 +522,11 @@ function registerSdkStreamHandlers(ctx) {
               abortController,
             );
             const { currentModelId, models } = normalizeSdkListModelsResult(raw);
-            if (shouldCacheModels) {
+            // Do not cache degraded empty catalogs: listOpenCodeModels and
+            // other drivers often return [] on timeout/startup failure, and
+            // pinning that for TTL would block recovery (matches renderer
+            // sdkRuntimeModelCache behavior).
+            if (shouldCacheModels && (models.length > 0 || currentModelId)) {
               sdkModelCache.set(cacheKey, { at: Date.now(), currentModelId, models });
             }
             return { ok: true, currentModelId, models };

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -43,6 +43,17 @@ test("SDK model cache keys include resolved CLI path", () => {
   );
 });
 
+test("SDK model cache keys include catalog-affecting agent environment", () => {
+  assert.notEqual(
+    buildSdkModelCacheKey("opencode", "/usr/bin/opencode", { HOME: "/Users/a", OPENCODE_CONFIG_DIR: "/a/config" }),
+    buildSdkModelCacheKey("opencode", "/usr/bin/opencode", { HOME: "/Users/b", OPENCODE_CONFIG_DIR: "/b/config" }),
+  );
+  assert.equal(
+    buildSdkModelCacheKey("opencode", "/usr/bin/opencode", { HOME: "/Users/a" }),
+    buildSdkModelCacheKey("opencode", "/usr/bin/opencode", { HOME: "/Users/a" }),
+  );
+});
+
 test("normalizeSdkListModelsResult preserves current model ids from object results", () => {
   assert.deepEqual(normalizeSdkListModelsResult({
     currentModelId: "openai/gpt-5.1",

--- a/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
+++ b/electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs
@@ -57,10 +57,13 @@ test("normalizeSdkListModelsResult preserves current model ids from object resul
   });
 });
 
-test("shouldCacheSdkRuntimeModels skips OpenCode model catalogs", () => {
-  assert.equal(shouldCacheSdkRuntimeModels("opencode"), false);
+test("shouldCacheSdkRuntimeModels caches all SDK backends including OpenCode", () => {
+  // OpenCode used to skip the cache, which re-spawned opencode servers on every
+  // model-catalog probe (#2184). TTL still bounds staleness.
+  assert.equal(shouldCacheSdkRuntimeModels("opencode"), true);
   assert.equal(shouldCacheSdkRuntimeModels("claude"), true);
   assert.equal(shouldCacheSdkRuntimeModels("codebuddy"), true);
+  assert.equal(shouldCacheSdkRuntimeModels("copilot"), true);
 });
 
 test("SDK resume only uses the current backend/path session key", () => {


### PR DESCRIPTION
## Summary

- Fixes #2184: Netcatty could spawn many `opencode` processes even when the user never selected OpenCode.
- Stop background model-catalog preloads for discovered/unselected OpenCode agents; only load catalogs for the currently selected agent.
- Cache + coalesce OpenCode `list-models`, abort and tear down on timeout, and reuse a short-lived per-binary list-models server pool.

## Root cause (plain language)

Opening the AI panel caused Netcatty to start OpenCode just to fetch model lists. That could happen after auto-discovery even if OpenCode was not the active agent, and failed/timeout cleanup left processes behind.

## Test plan

- [x] `node --test electron/bridges/aiBridge/sdk/opencodeDriver.test.cjs electron/bridges/aiBridge/sdk/sdkStreamHandlers.test.cjs`
- [ ] Manual: install OpenCode, open Netcatty with AI panel visible, select a non-OpenCode agent (or Catty), watch Activity Monitor — no opencode process pile-up over several minutes
- [ ] Manual: select OpenCode as agent, open model list once — at most one short-lived server; switching away / idle should release it
- [ ] Manual: force a slow/timeout list-models path — no orphan opencode processes after timeout