### PR TITLE
fix(ci): pin @anthropic-ai/sdk so npm ci stays in sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ai-sdk/anthropic": "^4.0.0",
         "@ai-sdk/google": "^4.0.0",
         "@ai-sdk/openai": "^4.0.0",
+        "@anthropic-ai/sdk": "0.111.0",
         "@aws-sdk/client-s3": "^3.956.0",
         "@connectrpc/connect": "^1.7.0",
         "@fontsource/jetbrains-mono": "^5.2.8",
@@ -335,6 +336,28 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -7571,8 +7594,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -11464,8 +11486,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense",
-      "optional": true
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -12977,7 +12998,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -17637,7 +17657,6 @@
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
       "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
@@ -18137,8 +18156,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@ai-sdk/anthropic": "^4.0.0",
     "@ai-sdk/google": "^4.0.0",
     "@ai-sdk/openai": "^4.0.0",
+    "@anthropic-ai/sdk": "0.111.0",
     "@aws-sdk/client-s3": "^3.956.0",
     "@connectrpc/connect": "^1.7.0",
     "@fontsource/jetbrains-mono": "^5.2.8",


### PR DESCRIPTION
## Summary
- Pin `@anthropic-ai/sdk@0.111.0` and restore its package-lock entry.
- Unblocks `npm ci` on GitHub Actions after the Codex SDK upgrade dropped the optional peer lock entry (release packaging for v1.1.66 failed with `Missing: @anthropic-ai/sdk@0.111.0 from lock file`).

## Test plan
- [x] Local `npm ci --ignore-scripts` succeeds with the package present
- [ ] CI build-packages Install deps green on this PR