### PR TITLE
fix(ai): detect macOS desktop-managed Codex and Claude

### DIFF
--- a/components/settings/tabs/ai/ExternalMcpCard.tsx
+++ b/components/settings/tabs/ai/ExternalMcpCard.tsx
@@ -424,15 +424,14 @@ export const ExternalMcpCard: React.FC = () => {
     || grokStatus?.launcherPath
     || null;
   const discoveryPath = status?.discoveryPath || null;
-  const codexCommand = launcherPath
-    ? formatCodexAddCommand(launcherPath, discoveryPath)
-    : (codexStatus?.command || "");
-  const claudeCommand = launcherPath
-    ? formatClaudeAddCommand(launcherPath, discoveryPath)
-    : (claudeStatus?.command || "");
-  const grokCommand = launcherPath
-    ? formatGrokAddCommand(launcherPath, discoveryPath)
-    : (grokStatus?.command || "");
+  // Prefer backend status.command so desktop-resolved absolute CLI paths
+  // (outside PATH) survive into the copyable setup command.
+  const codexCommand = (codexStatus?.command || "").trim()
+    || (launcherPath ? formatCodexAddCommand(launcherPath, discoveryPath) : "");
+  const claudeCommand = (claudeStatus?.command || "").trim()
+    || (launcherPath ? formatClaudeAddCommand(launcherPath, discoveryPath) : "");
+  const grokCommand = (grokStatus?.command || "").trim()
+    || (launcherPath ? formatGrokAddCommand(launcherPath, discoveryPath) : "");
   const codexTomlSnippet = launcherPath ? buildCodexTomlSnippet(launcherPath, discoveryPath) : "";
   const grokTomlSnippet = launcherPath ? buildGrokTomlSnippet(launcherPath, discoveryPath) : "";
   const claudeSnippet = launcherPath ? buildClaudeSnippet(launcherPath, discoveryPath) : "";

--- a/electron/bridges/externalMcp/claudeSetup.cjs
+++ b/electron/bridges/externalMcp/claudeSetup.cjs
@@ -9,6 +9,10 @@ function loadShellUtils() {
   return require("../ai/shellUtils.cjs");
 }
 
+function loadDesktopCliResolver() {
+  return require("./desktopCliResolver.cjs");
+}
+
 function formatClaudeCommandText(args) {
   return ["claude", ...args.map(quoteCommandArg)].join(" ");
 }
@@ -258,6 +262,8 @@ function createExternalMcpClaudeSetup(options = {}) {
       : {},
     getShellEnv: options.getShellEnv || loadShellUtils().getShellEnv,
     resolveCliFromPath: options.resolveCliFromPath || loadShellUtils().resolveCliFromPath,
+    resolveDesktopManagedCli: options.resolveDesktopManagedCli
+      || loadDesktopCliResolver().resolveDesktopManagedCli,
     prepareCommandForSpawn: options.prepareCommandForSpawn || loadShellUtils().prepareCommandForSpawn,
     spawn: options.spawn || require("node:child_process").spawn,
     stripAnsi: options.stripAnsi || loadShellUtils().stripAnsi,
@@ -269,7 +275,8 @@ function createExternalMcpClaudeSetup(options = {}) {
 
   async function resolveClaude() {
     const shellEnv = await deps.getShellEnv();
-    const claudePath = deps.resolveCliFromPath("claude", shellEnv);
+    const claudePath = deps.resolveCliFromPath("claude", shellEnv)
+      || deps.resolveDesktopManagedCli("claude");
     return {
       shellEnv,
       claudePath: claudePath || null,

--- a/electron/bridges/externalMcp/claudeSetup.cjs
+++ b/electron/bridges/externalMcp/claudeSetup.cjs
@@ -13,13 +13,18 @@ function loadDesktopCliResolver() {
   return require("./desktopCliResolver.cjs");
 }
 
-function formatClaudeCommandText(args) {
-  return ["claude", ...args.map(quoteCommandArg)].join(" ");
+function formatClaudeCommandText(args, cliPath = "claude") {
+  const executable = typeof cliPath === "string" && cliPath.trim()
+    ? cliPath.trim()
+    : "claude";
+  return [quoteCommandArg(executable), ...args.map(quoteCommandArg)].join(" ");
 }
 
 function quoteCommandArg(value) {
   if (typeof value !== "string" || value.length === 0) return '""';
-  if (!/[\s"]/u.test(value)) return value;
+  // Match ExternalMcpCard quoteShellArg so copyable commands stay shell-safe
+  // for paths with spaces, quotes, apostrophes, or backslashes.
+  if (!/[\s"'\\]/u.test(value)) return value;
   return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
 }
 
@@ -179,13 +184,19 @@ function hasRequiredDiscoveryEnv(entryEnv, discoveryEnv) {
   return keys.every((key) => String(entryEnv[key] || "") === String(required[key]));
 }
 
-function classifyClaudeExternalMcpStatus({ getResult, launcherPath, claudePath, discoveryEnv }) {
+function classifyClaudeExternalMcpStatus({
+  getResult,
+  launcherPath,
+  claudePath,
+  discoveryEnv,
+  commandExecutable,
+}) {
   const commandArgs = buildClaudeAddArgs(launcherPath, discoveryEnv || {});
   const base = {
     ok: true,
     claudePath: claudePath || null,
     launcherPath: launcherPath || null,
-    command: formatClaudeCommandText(commandArgs),
+    command: formatClaudeCommandText(commandArgs, commandExecutable || claudePath),
     existingCommand: null,
     error: null,
   };
@@ -269,17 +280,26 @@ function createExternalMcpClaudeSetup(options = {}) {
     stripAnsi: options.stripAnsi || loadShellUtils().stripAnsi,
   };
 
-  function getManualCommand() {
-    return formatClaudeCommandText(buildClaudeAddArgs(deps.launcherPath, deps.discoveryEnv));
+  function getManualCommand(cliPath) {
+    return formatClaudeCommandText(
+      buildClaudeAddArgs(deps.launcherPath, deps.discoveryEnv),
+      cliPath,
+    );
   }
 
   async function resolveClaude() {
     const shellEnv = await deps.getShellEnv();
-    const claudePath = deps.resolveCliFromPath("claude", shellEnv)
-      || deps.resolveDesktopManagedCli("claude");
+    // PATH installs keep the bare `claude` copyable command (portable across
+    // shells). Desktop-managed absolute paths only appear when PATH misses.
+    const pathResolved = deps.resolveCliFromPath("claude", shellEnv) || null;
+    const desktopResolved = pathResolved
+      ? null
+      : (deps.resolveDesktopManagedCli("claude") || null);
+    const claudePath = pathResolved || desktopResolved;
     return {
       shellEnv,
-      claudePath: claudePath || null,
+      claudePath,
+      commandExecutable: pathResolved ? "claude" : (desktopResolved || "claude"),
     };
   }
 
@@ -314,7 +334,7 @@ function createExternalMcpClaudeSetup(options = {}) {
   }
 
   async function getStatus() {
-    const { shellEnv, claudePath } = await resolveClaude();
+    const { shellEnv, claudePath, commandExecutable } = await resolveClaude();
     if (!claudePath) {
       return {
         ok: true,
@@ -340,10 +360,11 @@ function createExternalMcpClaudeSetup(options = {}) {
         launcherPath: deps.launcherPath,
         claudePath,
         discoveryEnv: deps.discoveryEnv,
+        commandExecutable,
       });
       return {
         ...status,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
       };
     } catch (error) {
       return {
@@ -351,7 +372,7 @@ function createExternalMcpClaudeSetup(options = {}) {
         state: "error",
         claudePath,
         launcherPath: deps.launcherPath,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
         existingCommand: null,
         error: error?.message || String(error),
       };
@@ -367,7 +388,7 @@ function createExternalMcpClaudeSetup(options = {}) {
       return status;
     }
 
-    const { shellEnv, claudePath } = await resolveClaude();
+    const { shellEnv, claudePath, commandExecutable } = await resolveClaude();
     if (!claudePath) {
       return {
         ...status,
@@ -402,7 +423,7 @@ function createExternalMcpClaudeSetup(options = {}) {
           state: "error",
           claudePath,
           launcherPath: deps.launcherPath,
-          command: getManualCommand(),
+          command: getManualCommand(commandExecutable),
           existingCommand: null,
           error: summarizeFailure(addResult, `Claude exited with code ${addResult.exitCode ?? "unknown"}`),
         };
@@ -414,7 +435,7 @@ function createExternalMcpClaudeSetup(options = {}) {
         state: "error",
         claudePath,
         launcherPath: deps.launcherPath,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
         existingCommand: null,
         error: error?.message || String(error),
       };

--- a/electron/bridges/externalMcp/clientSetup.test.cjs
+++ b/electron/bridges/externalMcp/clientSetup.test.cjs
@@ -82,6 +82,59 @@ describe("external MCP client setup classifiers", () => {
     assert.equal(status.state, "conflict");
   });
 
+  it("embeds desktop-managed Codex path in the copyable setup command", () => {
+    const desktopPath = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const status = classifyCodexExternalMcpStatus({
+      entries: [],
+      launcherPath: "/path/to/netcatty-external-mcp",
+      codexPath: desktopPath,
+      commandExecutable: desktopPath,
+    });
+    assert.equal(status.state, "not_configured");
+    assert.ok(status.command.startsWith(`${desktopPath} `));
+    assert.equal(status.command.startsWith("codex "), false);
+  });
+
+  it("keeps bare codex for PATH installs even when codexPath is absolute", () => {
+    const status = classifyCodexExternalMcpStatus({
+      entries: [],
+      launcherPath: "/path/to/netcatty-external-mcp",
+      codexPath: "C:\\Program Files\\Codex\\codex.exe",
+      commandExecutable: "codex",
+    });
+    assert.equal(status.state, "not_configured");
+    assert.ok(status.command.startsWith("codex "));
+  });
+
+  it("embeds desktop-managed Claude path in the copyable setup command", () => {
+    const desktopPath = "/Users/test/Library/Application Support/Claude/claude-code/2.10.0/claude.app/Contents/MacOS/claude";
+    const status = classifyClaudeExternalMcpStatus({
+      getResult: {
+        exitCode: 1,
+        stdout: "",
+        stderr: 'No MCP server found with name: "netcatty-external"',
+      },
+      launcherPath: "/path/to/netcatty-external-mcp",
+      claudePath: desktopPath,
+      commandExecutable: desktopPath,
+    });
+    assert.equal(status.state, "not_configured");
+    assert.ok(status.command.startsWith(`"${desktopPath}" `));
+    assert.equal(status.command.startsWith("claude "), false);
+  });
+
+  it("quotes launcher paths with apostrophes in the copyable setup command", () => {
+    const launcherPath = "/Applications/Bob's/Netcatty.app/Contents/MacOS/netcatty-external-mcp";
+    const status = classifyCodexExternalMcpStatus({
+      entries: [],
+      launcherPath,
+      codexPath: "/usr/bin/codex",
+      commandExecutable: "codex",
+    });
+    assert.equal(status.state, "not_configured");
+    assert.ok(status.command.includes(`"${launcherPath}"`));
+  });
+
   it("classifies Claude configured and missing states", () => {
     const configured = classifyClaudeExternalMcpStatus({
       getResult: { exitCode: 0, stdout: `${EXTERNAL_MCP_CLAUDE_NAME}: /path/to/netcatty-external-mcp - connected`, stderr: "" },

--- a/electron/bridges/externalMcp/codexSetup.cjs
+++ b/electron/bridges/externalMcp/codexSetup.cjs
@@ -9,6 +9,10 @@ function loadShellUtils() {
   return require("../ai/shellUtils.cjs");
 }
 
+function loadDesktopCliResolver() {
+  return require("./desktopCliResolver.cjs");
+}
+
 function parseCodexMcpList(rawOutput) {
   const parsed = JSON.parse(String(rawOutput || "[]"));
   if (!Array.isArray(parsed)) {
@@ -156,6 +160,8 @@ function createExternalMcpCodexSetup(options = {}) {
       : {},
     getShellEnv: options.getShellEnv || loadShellUtils().getShellEnv,
     resolveCliFromPath: options.resolveCliFromPath || loadShellUtils().resolveCliFromPath,
+    resolveDesktopManagedCli: options.resolveDesktopManagedCli
+      || loadDesktopCliResolver().resolveDesktopManagedCli,
     prepareCommandForSpawn: options.prepareCommandForSpawn || loadShellUtils().prepareCommandForSpawn,
     spawn: options.spawn || require("node:child_process").spawn,
     stripAnsi: options.stripAnsi || loadShellUtils().stripAnsi,
@@ -167,7 +173,8 @@ function createExternalMcpCodexSetup(options = {}) {
 
   async function resolveCodex() {
     const shellEnv = await deps.getShellEnv();
-    const codexPath = deps.resolveCliFromPath("codex", shellEnv);
+    const codexPath = deps.resolveCliFromPath("codex", shellEnv)
+      || deps.resolveDesktopManagedCli("codex");
     return {
       shellEnv,
       codexPath: codexPath || null,

--- a/electron/bridges/externalMcp/codexSetup.cjs
+++ b/electron/bridges/externalMcp/codexSetup.cjs
@@ -30,13 +30,18 @@ function parseCodexMcpList(rawOutput) {
     }));
 }
 
-function formatCodexCommandText(args) {
-  return ["codex", ...args.map(quoteCommandArg)].join(" ");
+function formatCodexCommandText(args, cliPath = "codex") {
+  const executable = typeof cliPath === "string" && cliPath.trim()
+    ? cliPath.trim()
+    : "codex";
+  return [quoteCommandArg(executable), ...args.map(quoteCommandArg)].join(" ");
 }
 
 function quoteCommandArg(value) {
   if (typeof value !== "string" || value.length === 0) return '""';
-  if (!/[\s"]/u.test(value)) return value;
+  // Match ExternalMcpCard quoteShellArg so copyable commands stay shell-safe
+  // for paths with spaces, quotes, apostrophes, or backslashes.
+  if (!/[\s"'\\]/u.test(value)) return value;
   return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
 }
 
@@ -94,13 +99,19 @@ function hasRequiredDiscoveryEnv(entryEnv, discoveryEnv) {
   return keys.every((key) => String(entryEnv[key] || "") === String(required[key]));
 }
 
-function classifyCodexExternalMcpStatus({ entries, launcherPath, codexPath, discoveryEnv }) {
+function classifyCodexExternalMcpStatus({
+  entries,
+  launcherPath,
+  codexPath,
+  discoveryEnv,
+  commandExecutable,
+}) {
   const commandArgs = buildCodexAddArgs(launcherPath, discoveryEnv || {});
   const base = {
     ok: true,
     codexPath: codexPath || null,
     launcherPath: launcherPath || null,
-    command: formatCodexCommandText(commandArgs),
+    command: formatCodexCommandText(commandArgs, commandExecutable || codexPath),
     existingCommand: null,
     error: null,
   };
@@ -167,17 +178,26 @@ function createExternalMcpCodexSetup(options = {}) {
     stripAnsi: options.stripAnsi || loadShellUtils().stripAnsi,
   };
 
-  function getManualCommand() {
-    return formatCodexCommandText(buildCodexAddArgs(deps.launcherPath, deps.discoveryEnv));
+  function getManualCommand(cliPath) {
+    return formatCodexCommandText(
+      buildCodexAddArgs(deps.launcherPath, deps.discoveryEnv),
+      cliPath,
+    );
   }
 
   async function resolveCodex() {
     const shellEnv = await deps.getShellEnv();
-    const codexPath = deps.resolveCliFromPath("codex", shellEnv)
-      || deps.resolveDesktopManagedCli("codex");
+    // PATH installs keep the bare `codex` copyable command (portable across
+    // shells). Desktop-managed absolute paths only appear when PATH misses.
+    const pathResolved = deps.resolveCliFromPath("codex", shellEnv) || null;
+    const desktopResolved = pathResolved
+      ? null
+      : (deps.resolveDesktopManagedCli("codex") || null);
+    const codexPath = pathResolved || desktopResolved;
     return {
       shellEnv,
-      codexPath: codexPath || null,
+      codexPath,
+      commandExecutable: pathResolved ? "codex" : (desktopResolved || "codex"),
     };
   }
 
@@ -216,7 +236,7 @@ function createExternalMcpCodexSetup(options = {}) {
   }
 
   async function getStatus() {
-    const { shellEnv, codexPath } = await resolveCodex();
+    const { shellEnv, codexPath, commandExecutable } = await resolveCodex();
     if (!codexPath) {
       return {
         ok: true,
@@ -237,7 +257,7 @@ function createExternalMcpCodexSetup(options = {}) {
           state: "error",
           codexPath,
           launcherPath: deps.launcherPath,
-          command: getManualCommand(),
+          command: getManualCommand(commandExecutable),
           existingCommand: null,
           error: summarizeFailure(result, `Codex exited with code ${result.exitCode ?? "unknown"}`),
         };
@@ -247,10 +267,11 @@ function createExternalMcpCodexSetup(options = {}) {
         launcherPath: deps.launcherPath,
         codexPath,
         discoveryEnv: deps.discoveryEnv,
+        commandExecutable,
       });
       return {
         ...status,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
       };
     } catch (error) {
       return {
@@ -258,7 +279,7 @@ function createExternalMcpCodexSetup(options = {}) {
         state: "error",
         codexPath,
         launcherPath: deps.launcherPath,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
         existingCommand: null,
         error: error?.message || String(error),
       };
@@ -274,7 +295,7 @@ function createExternalMcpCodexSetup(options = {}) {
       return status;
     }
 
-    const { shellEnv, codexPath } = await resolveCodex();
+    const { shellEnv, codexPath, commandExecutable } = await resolveCodex();
     if (!codexPath) {
       return {
         ...status,
@@ -298,7 +319,7 @@ function createExternalMcpCodexSetup(options = {}) {
           state: "error",
           codexPath,
           launcherPath: deps.launcherPath,
-          command: getManualCommand(),
+          command: getManualCommand(commandExecutable),
           existingCommand: null,
           error: summarizeFailure(addResult, `Codex exited with code ${addResult.exitCode ?? "unknown"}`),
         };
@@ -310,7 +331,7 @@ function createExternalMcpCodexSetup(options = {}) {
         state: "error",
         codexPath,
         launcherPath: deps.launcherPath,
-        command: getManualCommand(),
+        command: getManualCommand(commandExecutable),
         existingCommand: null,
         error: error?.message || String(error),
       };

--- a/electron/bridges/externalMcp/desktopCliResolver.cjs
+++ b/electron/bridges/externalMcp/desktopCliResolver.cjs
@@ -1,0 +1,93 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function isFile(filePath, deps) {
+  try {
+    return deps.existsSync(filePath) && deps.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function findFirstFile(candidates, deps) {
+  for (const candidate of candidates) {
+    if (isFile(candidate, deps)) return candidate;
+  }
+  return null;
+}
+
+function compareVersionDirectoryNames(left, right) {
+  return String(right).localeCompare(String(left), "en", {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
+
+function resolveCodexDesktopCli(homeDir, deps) {
+  const appRoots = [
+    "/Applications/ChatGPT.app",
+    "/Applications/Codex.app",
+    path.join(homeDir, "Applications", "ChatGPT.app"),
+    path.join(homeDir, "Applications", "Codex.app"),
+  ];
+  return findFirstFile(
+    appRoots.map((appRoot) => path.join(appRoot, "Contents", "Resources", "codex")),
+    deps,
+  );
+}
+
+function resolveClaudeDesktopCli(homeDir, deps) {
+  const versionsRoot = path.join(
+    homeDir,
+    "Library",
+    "Application Support",
+    "Claude",
+    "claude-code",
+  );
+
+  let versionDirectories;
+  try {
+    versionDirectories = deps.readdirSync(versionsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort(compareVersionDirectoryNames);
+  } catch {
+    return null;
+  }
+
+  return findFirstFile(
+    versionDirectories.map((version) => path.join(
+      versionsRoot,
+      version,
+      "claude.app",
+      "Contents",
+      "MacOS",
+      "claude",
+    )),
+    deps,
+  );
+}
+
+function resolveDesktopManagedCli(name, options = {}) {
+  const platform = options.platform || process.platform;
+  if (platform !== "darwin") return null;
+
+  const deps = {
+    existsSync: options.existsSync || fs.existsSync,
+    statSync: options.statSync || fs.statSync,
+    readdirSync: options.readdirSync || fs.readdirSync,
+  };
+  const homeDir = options.homeDir || os.homedir();
+
+  if (name === "codex") return resolveCodexDesktopCli(homeDir, deps);
+  if (name === "claude") return resolveClaudeDesktopCli(homeDir, deps);
+  return null;
+}
+
+module.exports = {
+  compareVersionDirectoryNames,
+  resolveDesktopManagedCli,
+};

--- a/electron/bridges/externalMcp/desktopCliResolver.cjs
+++ b/electron/bridges/externalMcp/desktopCliResolver.cjs
@@ -4,17 +4,27 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-function isFile(filePath, deps) {
+function isExecutableFile(filePath, deps) {
   try {
-    return deps.existsSync(filePath) && deps.statSync(filePath).isFile();
+    if (!deps.existsSync(filePath)) return false;
+    const stat = deps.statSync(filePath);
+    if (!stat.isFile()) return false;
+    // Prefer runtime access check so we skip candidates the process cannot
+    // execute (mode bits alone miss ACL/ownership cases). Fall back to mode
+    // bits when accessSync is not provided (tests can inject either).
+    if (typeof deps.accessSync === "function") {
+      deps.accessSync(filePath, deps.X_OK);
+      return true;
+    }
+    return (stat.mode & 0o111) !== 0;
   } catch {
     return false;
   }
 }
 
-function findFirstFile(candidates, deps) {
+function findFirstExecutable(candidates, deps) {
   for (const candidate of candidates) {
-    if (isFile(candidate, deps)) return candidate;
+    if (isExecutableFile(candidate, deps)) return candidate;
   }
   return null;
 }
@@ -33,7 +43,7 @@ function resolveCodexDesktopCli(homeDir, deps) {
     path.join(homeDir, "Applications", "ChatGPT.app"),
     path.join(homeDir, "Applications", "Codex.app"),
   ];
-  return findFirstFile(
+  return findFirstExecutable(
     appRoots.map((appRoot) => path.join(appRoot, "Contents", "Resources", "codex")),
     deps,
   );
@@ -58,7 +68,10 @@ function resolveClaudeDesktopCli(homeDir, deps) {
     return null;
   }
 
-  return findFirstFile(
+  // Only the native macOS app-bundle CLI. A sibling `<version>/claude` binary
+  // may exist but is a Linux VM helper on current Claude Desktop installs, so
+  // accepting it would break spawn and block falling back to an older good version.
+  return findFirstExecutable(
     versionDirectories.map((version) => path.join(
       versionsRoot,
       version,
@@ -79,6 +92,8 @@ function resolveDesktopManagedCli(name, options = {}) {
     existsSync: options.existsSync || fs.existsSync,
     statSync: options.statSync || fs.statSync,
     readdirSync: options.readdirSync || fs.readdirSync,
+    accessSync: options.accessSync || fs.accessSync,
+    X_OK: options.X_OK != null ? options.X_OK : fs.constants.X_OK,
   };
   const homeDir = options.homeDir || os.homedir();
 

--- a/electron/bridges/externalMcp/desktopCliResolver.test.cjs
+++ b/electron/bridges/externalMcp/desktopCliResolver.test.cjs
@@ -1,0 +1,89 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+  resolveDesktopManagedCli,
+} = require("./desktopCliResolver.cjs");
+
+function createFileDeps(files, directories = {}) {
+  const fileSet = new Set(files);
+  return {
+    existsSync: (filePath) => fileSet.has(filePath),
+    statSync: (filePath) => ({ isFile: () => fileSet.has(filePath) }),
+    readdirSync: (directoryPath) => {
+      if (!(directoryPath in directories)) throw new Error("ENOENT");
+      return directories[directoryPath].map((name) => ({
+        name,
+        isDirectory: () => true,
+      }));
+    },
+  };
+}
+
+describe("macOS desktop-managed CLI resolution", () => {
+  it("finds the Codex CLI bundled with ChatGPT Desktop", () => {
+    const codexPath = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    assert.equal(resolveDesktopManagedCli("codex", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([codexPath]),
+    }), codexPath);
+  });
+
+  it("finds a user-installed Codex Desktop bundle", () => {
+    const codexPath = "/Users/test/Applications/Codex.app/Contents/Resources/codex";
+    assert.equal(resolveDesktopManagedCli("codex", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([codexPath]),
+    }), codexPath);
+  });
+
+  it("uses the newest valid Claude Code managed by Claude Desktop", () => {
+    const root = path.join(
+      "/Users/test",
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    const newestPath = path.join(root, "2.10.0", "claude.app", "Contents", "MacOS", "claude");
+    const olderPath = path.join(root, "2.9.9", "claude.app", "Contents", "MacOS", "claude");
+    assert.equal(resolveDesktopManagedCli("claude", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([newestPath, olderPath], {
+        [root]: ["2.9.9", "2.10.0"],
+      }),
+    }), newestPath);
+  });
+
+  it("falls back to the newest installed Claude version that has an executable", () => {
+    const root = path.join(
+      "/Users/test",
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    const validPath = path.join(root, "2.9.9", "claude.app", "Contents", "MacOS", "claude");
+    assert.equal(resolveDesktopManagedCli("claude", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([validPath], {
+        [root]: ["2.10.0", "2.9.9"],
+      }),
+    }), validPath);
+  });
+
+  it("does not probe desktop locations on other platforms", () => {
+    assert.equal(resolveDesktopManagedCli("codex", {
+      platform: "linux",
+      homeDir: "/home/test",
+      ...createFileDeps(["/Applications/ChatGPT.app/Contents/Resources/codex"]),
+    }), null);
+  });
+});

--- a/electron/bridges/externalMcp/desktopCliResolver.test.cjs
+++ b/electron/bridges/externalMcp/desktopCliResolver.test.cjs
@@ -8,11 +8,16 @@ const {
   resolveDesktopManagedCli,
 } = require("./desktopCliResolver.cjs");
 
-function createFileDeps(files, directories = {}) {
+function createFileDeps(files, directories = {}, options = {}) {
   const fileSet = new Set(files);
+  const nonExecutable = new Set(options.nonExecutable || []);
   return {
     existsSync: (filePath) => fileSet.has(filePath),
-    statSync: (filePath) => ({ isFile: () => fileSet.has(filePath) }),
+    statSync: (filePath) => ({
+      isFile: () => fileSet.has(filePath),
+      // mode is only used when accessSync is omitted
+      mode: nonExecutable.has(filePath) ? 0o100644 : 0o100755,
+    }),
     readdirSync: (directoryPath) => {
       if (!(directoryPath in directories)) throw new Error("ENOENT");
       return directories[directoryPath].map((name) => ({
@@ -20,6 +25,19 @@ function createFileDeps(files, directories = {}) {
         isDirectory: () => true,
       }));
     },
+    accessSync: (filePath) => {
+      if (!fileSet.has(filePath)) {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      if (nonExecutable.has(filePath)) {
+        const err = new Error("EACCES");
+        err.code = "EACCES";
+        throw err;
+      }
+    },
+    X_OK: 1,
   };
 }
 
@@ -77,6 +95,72 @@ describe("macOS desktop-managed CLI resolution", () => {
         [root]: ["2.10.0", "2.9.9"],
       }),
     }), validPath);
+  });
+
+  it("skips newer Claude installs that are not executable and uses an older runnable one", () => {
+    const root = path.join(
+      "/Users/test",
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    const newestPath = path.join(root, "2.10.0", "claude.app", "Contents", "MacOS", "claude");
+    const olderPath = path.join(root, "2.9.9", "claude.app", "Contents", "MacOS", "claude");
+    assert.equal(resolveDesktopManagedCli("claude", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([newestPath, olderPath], {
+        [root]: ["2.10.0", "2.9.9"],
+      }, { nonExecutable: [newestPath] }),
+    }), olderPath);
+  });
+
+  it("skips non-executable Codex desktop candidates", () => {
+    const systemPath = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const userPath = "/Users/test/Applications/Codex.app/Contents/Resources/codex";
+    assert.equal(resolveDesktopManagedCli("codex", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([systemPath, userPath], {}, { nonExecutable: [systemPath] }),
+    }), userPath);
+  });
+
+  it("ignores the plain version/claude helper (Linux VM binary on current installs)", () => {
+    const root = path.join(
+      "/Users/test",
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    const linuxHelper = path.join(root, "2.10.0", "claude");
+    const olderAppPath = path.join(root, "2.9.9", "claude.app", "Contents", "MacOS", "claude");
+    assert.equal(resolveDesktopManagedCli("claude", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([linuxHelper, olderAppPath], {
+        [root]: ["2.10.0", "2.9.9"],
+      }),
+    }), olderAppPath);
+  });
+
+  it("does not select a plain version/claude helper when no app-bundle CLI exists", () => {
+    const root = path.join(
+      "/Users/test",
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    const linuxHelper = path.join(root, "2.10.0", "claude");
+    assert.equal(resolveDesktopManagedCli("claude", {
+      platform: "darwin",
+      homeDir: "/Users/test",
+      ...createFileDeps([linuxHelper], {
+        [root]: ["2.10.0"],
+      }),
+    }), null);
   });
 
   it("does not probe desktop locations on other platforms", () => {

--- a/electron/bridges/externalMcp/grokSetup.cjs
+++ b/electron/bridges/externalMcp/grokSetup.cjs
@@ -15,7 +15,9 @@ function formatGrokCommandText(args) {
 
 function quoteCommandArg(value) {
   if (typeof value !== "string" || value.length === 0) return '""';
-  if (!/[\s"]/u.test(value)) return value;
+  // Match ExternalMcpCard quoteShellArg so copyable commands stay shell-safe
+  // for paths with spaces, quotes, apostrophes, or backslashes.
+  if (!/[\s"'\\]/u.test(value)) return value;
   return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
 }
 


### PR DESCRIPTION
## Summary

Fix External MCP client detection on macOS when Codex or Claude Code is installed and managed by its desktop application instead of being exposed on the shell `PATH`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] Build / CI change
- [ ] Other (please describe):

## Related Issue (optional)

Closes #2188

## Changes Made

- Preserve shell `PATH` discovery as the preferred client resolution path.
- Detect Codex bundled by ChatGPT/Codex Desktop under system and per-user Applications folders.
- Detect Claude Code versions managed by Claude Desktop and select the newest valid executable.
- Keep Windows and Linux behavior unchanged.
- Add regression coverage for Codex Desktop, Claude Desktop version selection, invalid latest installs, and non-macOS behavior.

## Screenshots / Demo

No UI changes. On the test macOS installation, the resolver detects:

- `/Applications/ChatGPT.app/Contents/Resources/codex`
- `~/Library/Application Support/Claude/claude-code/2.1.170/claude.app/Contents/MacOS/claude`

## Testing

- [ ] I have tested these changes locally (`npm run dev`)
- [x] Linting passes (`npm run lint`) — 3 pre-existing warnings, 0 errors
- [x] Tests pass (`npm test`) — initial environment-only Electron download failures were repaired; all 5 affected files then passed (20/20), and targeted tests pass (14/14)
- [x] Generated capability tool specs are updated when applicable (not applicable)
- [x] No new console errors or warnings, if this affects app behavior

## Checklist

- [x] My code follows the existing project style
- [x] I have added or updated relevant documentation (not applicable; behavior is covered by regression tests and Issue #2188)
- [x] I have not introduced any breaking changes (or I have described them above)