### PR TITLE
fix(terminal): re-arm su password assist after history and Ctrl+C (#2191)

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -187,6 +187,18 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "sudo whoami",
   );
+  // Empty Enter on themed decoration must not invent a command (#2191 review).
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  git ") as never),
+    "",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("➜  netcatty git:(main) ✗ ") as never,
+    ),
+    "",
+  );
 });
 
 test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -278,6 +278,26 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     resolveSubmittedShellCommand("", createFakeTerm("➜  Project (old) su -") as never),
     "su -",
   );
+  // Ordinary commands ending in "su -" must not be peeled to privilege-only.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("❯  echo su -") as never),
+    "echo su -",
+  );
+  // No-space prompt on first history recall (no lastPromptText cache).
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("user@host:~$su -") as never),
+    "su -",
+  );
+  // Themed multi-word dir resolves and still records for arming.
+  {
+    const commandBufferRef = { current: "" };
+    const recorded = recordTerminalCommandExecution("", {
+      host: { id: "h", label: "H" },
+      sessionId: "s",
+      commandBufferRef,
+    }, createFakeTerm("➜  My Project su -") as never);
+    assert.equal(recorded, "su -");
+  }
   // Incomplete remote echo of a longer typed word: trust keystrokes.
   assert.equal(
     resolveSubmittedShellCommand(

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -142,6 +142,31 @@ test("resolveSubmittedShellCommand recovers ↑ history when keystroke buffer is
   );
 });
 
+test("resolveSubmittedShellCommand strips themed prompt chrome via cached prompt (#2191)", () => {
+  // Without cache, themed cwd decoration must not become the command (#806).
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  git su -") as never),
+    "",
+  );
+  // After a prior typed command, lastPromptText includes the decoration.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("➜  git su -") as never,
+      "➜  git ",
+    ),
+    "su -",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("➜  ~ sudo whoami") as never,
+      "➜  ~ ",
+    ),
+    "sudo whoami",
+  );
+});
+
 test("recordTerminalCommandExecution arms su after empty-buffer history recall (#2191)", () => {
   const commandBufferRef = { current: "" };
   const recorded: string[] = [];
@@ -174,6 +199,33 @@ test("recordTerminalCommandExecution arms su after empty-buffer history recall (
   assert.equal(autofill.isPickerPending(), true);
   autofill.confirmFill("host");
   assert.deepEqual(writes, ["host-secret\n"]);
+});
+
+test("recordTerminalCommandExecution arms su from themed history using lastPromptText (#2191)", () => {
+  const promptState = createPromptLineBreakState();
+  promptState.lastPromptText = "➜  git ";
+  const commandBufferRef = { current: "" };
+  const recordedCommand = recordTerminalCommandExecution("", {
+    host: { id: "host-1", label: "Host" },
+    sessionId: "session-1",
+    commandBufferRef,
+    promptLineBreakStateRef: { current: promptState },
+  }, createFakeTerm("➜  git su -") as never);
+
+  assert.equal(recordedCommand, "su -");
+
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: () => {},
+    onPicker: () => true,
+  });
+  prepareSudoAutofillInput("\r", recordedCommand, autofill);
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
 });
 
 test("command execution caches the current prompt instead of prompt-like command text", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -229,6 +229,28 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "su -",
   );
+  // Stale partial cache on empty themed prompt must not record git chrome.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("➜  netcatty git:(main) ✗ ") as never,
+      "➜  netcatty ",
+    ),
+    "",
+  );
+  // Prefixed themed terminator + cwd token is not a command.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("⚡ ➜  git ") as never),
+    "",
+  );
+  // Stale buffer aligned to mid-line prefix after history recall.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "s",
+      createFakeTerm("user@host:~$ su -", "user@host:~$ s".length) as never,
+    ),
+    "su -",
+  );
 });
 
 test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -220,6 +220,15 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "sudo whoami",
   );
+  // No trailing space after $: recover via lastPromptText (#2191 review).
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("user@host:~$su -") as never,
+      "user@host:~$",
+    ),
+    "su -",
+  );
 });
 
 test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -5,7 +5,10 @@ import {
   createSudoPasswordAutofill,
   prepareSudoAutofillInput,
 } from "./terminalSudoAutofill";
-import { recordTerminalCommandExecution } from "./terminalCommandExecution";
+import {
+  recordTerminalCommandExecution,
+  resolveSubmittedShellCommand,
+} from "./terminalCommandExecution";
 import { createPromptLineBreakState } from "./promptLineBreak";
 
 function createFakeTerm(lineText = "$ echo ok", cursorX = lineText.length) {
@@ -120,6 +123,57 @@ test("command execution arms prompt line break even without command history call
   assert.equal(commandBufferRef.current, "");
   assert.equal(recordedCommand, "echo ok");
   assert.equal(promptState.pendingCommand, true);
+});
+
+test("resolveSubmittedShellCommand recovers ↑ history when keystroke buffer is empty (#2191)", () => {
+  // Shell history redraws the line remotely; commandBuffer never sees "su -".
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("user@host:~$ su -") as never),
+    "su -",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("user@host:~$ sudo whoami") as never),
+    "sudo whoami",
+  );
+  // Prefer the typed buffer when present
+  assert.equal(
+    resolveSubmittedShellCommand("ls", createFakeTerm("user@host:~$ ls") as never),
+    "ls",
+  );
+});
+
+test("recordTerminalCommandExecution arms su after empty-buffer history recall (#2191)", () => {
+  const commandBufferRef = { current: "" };
+  const recorded: string[] = [];
+  const recordedCommand = recordTerminalCommandExecution("", {
+    host: { id: "host-1", label: "Host" },
+    sessionId: "session-1",
+    commandBufferRef,
+    onCommandExecuted(cmd) {
+      recorded.push(cmd);
+    },
+  }, createFakeTerm("user@host:~$ su -") as never);
+
+  assert.equal(recordedCommand, "su -");
+  assert.deepEqual(recorded, ["su -"]);
+  assert.equal(commandBufferRef.current, "");
+
+  // Full Enter path: empty buffer + live line still arms sudo autofill
+  const writes: string[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: (d) => writes.push(d),
+    onPicker: () => true,
+  });
+  prepareSudoAutofillInput("\r", recordedCommand, autofill);
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.confirmFill("host");
+  assert.deepEqual(writes, ["host-secret\n"]);
 });
 
 test("command execution caches the current prompt instead of prompt-like command text", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -212,13 +212,38 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "/bin/ls",
   );
-  // Cursor mid-line still submits the full recalled command.
+  // Cursor mid-line: empty buffer does not absorb post-cursor paint (autosuggest).
+  // At EOL with empty buffer, the full recalled line is already in userInput.
   assert.equal(
     resolveSubmittedShellCommand(
       "",
-      createFakeTerm("user@host:~$ sudo whoami", "user@host:~$ sudo".length) as never,
+      createFakeTerm("user@host:~$ sudo whoami") as never,
     ),
     "sudo whoami",
+  );
+  // zsh-style suggestion after the cursor must not be recorded as input.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "git",
+      createFakeTerm("user@host:~$ git status", "user@host:~$ git".length) as never,
+    ),
+    "git",
+  );
+  // Incomplete remote echo of a longer typed word: trust keystrokes.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "sudo",
+      createFakeTerm("user@host:~$ su") as never,
+    ),
+    "sudo",
+  );
+  // History shortened a multi-word typed buffer to a different short command.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "sudo whoami",
+      createFakeTerm("user@host:~$ su") as never,
+    ),
+    "su",
   );
   // No trailing space after $: recover via lastPromptText (#2191 review).
   assert.equal(

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -170,6 +170,23 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "su -",
   );
+  // Partial cache after git status appears must peel remaining decoration.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("➜  netcatty git:(main) ✗ su -") as never,
+      "➜  netcatty ",
+    ),
+    "su -",
+  );
+  // Complete Powerline prompts isolate multiword sudo already.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("\uE0B6 root \uE0B0 ~ \uE0B0 sudo whoami") as never,
+    ),
+    "sudo whoami",
+  );
 });
 
 test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -204,6 +204,25 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     resolveSubmittedShellCommand("", createFakeTerm("❯ su") as never),
     "su",
   );
+  // Double-space after glyph must not peel "su" into decoration.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("❯  su -") as never),
+    "su -",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("❯  sudo whoami") as never),
+    "sudo whoami",
+  );
+  // Multi-word themed directory without cache.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  My Project su -") as never),
+    "su -",
+  );
+  // Directory token "su " with trailing pad is chrome, not a command.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  su ") as never),
+    "",
+  );
   // Absolute path commands on normal prompts are real, not decoration.
   assert.equal(
     resolveSubmittedShellCommand(

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -248,6 +248,36 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "git",
   );
+  // Same-token autosuggest (typed "g", paint "git status") must stay "g".
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "g",
+      createFakeTerm("user@host:~$ git status", "user@host:~$ g".length) as never,
+    ),
+    "g",
+  );
+  // Stale typed prefix after history to privilege command.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "s",
+      createFakeTerm("user@host:~$ su -") as never,
+    ),
+    "su -",
+  );
+  // Double-space glyph + non-privilege history keeps the first word.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("❯  git status") as never),
+    "git status",
+  );
+  // Unicode / punctuated themed directories before su.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  项目 su -") as never),
+    "su -",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  Project (old) su -") as never),
+    "su -",
+  );
   // Incomplete remote echo of a longer typed word: trust keystrokes.
   assert.equal(
     resolveSubmittedShellCommand(

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -199,6 +199,27 @@ test("resolveSubmittedShellCommand strips themed prompt chrome without stale cac
     ),
     "",
   );
+  // One-word su at a glyph-only prompt must still arm (#2191 review).
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("❯ su") as never),
+    "su",
+  );
+  // Absolute path commands on normal prompts are real, not decoration.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("user@host:~$ /bin/ls") as never,
+    ),
+    "/bin/ls",
+  );
+  // Cursor mid-line still submits the full recalled command.
+  assert.equal(
+    resolveSubmittedShellCommand(
+      "",
+      createFakeTerm("user@host:~$ sudo whoami", "user@host:~$ sudo".length) as never,
+    ),
+    "sudo whoami",
+  );
 });
 
 test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {

--- a/components/terminal/runtime/createXTermRuntime.test.ts
+++ b/components/terminal/runtime/createXTermRuntime.test.ts
@@ -142,13 +142,17 @@ test("resolveSubmittedShellCommand recovers ↑ history when keystroke buffer is
   );
 });
 
-test("resolveSubmittedShellCommand strips themed prompt chrome via cached prompt (#2191)", () => {
-  // Without cache, themed cwd decoration must not become the command (#806).
+test("resolveSubmittedShellCommand strips themed prompt chrome without stale cache (#2191)", () => {
+  // Themed decoration must not become the command (#806); peel via reconcile.
   assert.equal(
     resolveSubmittedShellCommand("", createFakeTerm("➜  git su -") as never),
-    "",
+    "su -",
   );
-  // After a prior typed command, lastPromptText includes the decoration.
+  assert.equal(
+    resolveSubmittedShellCommand("", createFakeTerm("➜  ~ sudo whoami") as never),
+    "sudo whoami",
+  );
+  // Cached prompt still works when present (including after prompt-changing cd).
   assert.equal(
     resolveSubmittedShellCommand(
       "",
@@ -157,13 +161,31 @@ test("resolveSubmittedShellCommand strips themed prompt chrome via cached prompt
     ),
     "su -",
   );
+  // Stale cache from before `cd` must not block themed history recall.
   assert.equal(
     resolveSubmittedShellCommand(
       "",
-      createFakeTerm("➜  ~ sudo whoami") as never,
+      createFakeTerm("➜  git su -") as never,
       "➜  ~ ",
     ),
-    "sudo whoami",
+    "su -",
+  );
+});
+
+test("resolveSubmittedShellCommand prefers live line when history replaces a typed prefix (#2191)", () => {
+  // User typed "s" then ↑ recalled "su -" — buffer still holds the stale prefix.
+  assert.equal(
+    resolveSubmittedShellCommand("s", createFakeTerm("user@host:~$ su -") as never),
+    "su -",
+  );
+  assert.equal(
+    resolveSubmittedShellCommand("s", createFakeTerm("➜  git su -") as never),
+    "su -",
+  );
+  // Echo lag: buffer ahead of live echo keeps the typed command.
+  assert.equal(
+    resolveSubmittedShellCommand("su -", createFakeTerm("user@host:~$ su") as never),
+    "su -",
   );
 });
 

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -888,6 +888,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         } else if (data === "\x03") {
           ctx.commandBufferRef.current = "";
           ctx.scriptRecorderRef?.current?.recordClearLine();
+          // Hard-abort password assist when Ctrl+C reaches the input path
+          // (e.g. broadcast peers) so a later su re-arms cleanly (#2191).
+          ctx.sudoAutofillRef?.current?.abort();
         } else if (data === "\x15") {
           ctx.commandBufferRef.current = "";
           ctx.scriptRecorderRef?.current?.recordClearLine();
@@ -1013,7 +1016,15 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         sudoAutofill.cancelHint();
         return false; // dismiss without forwarding the byte to the no-echo prompt
       }
-      if (e.key.length === 1) {
+      // Unmodified printable keys: soft-dismiss so the user can type a password.
+      // Ctrl/Meta/Alt combos (including Ctrl+C) must not soft-dismiss — that
+      // leaves dismissedWhileArmed and blocks the next bare Password: (#2191).
+      if (
+        e.key.length === 1
+        && !e.ctrlKey
+        && !e.metaKey
+        && !e.altKey
+      ) {
         sudoAutofill.cancelHint();
         // fall through: key becomes the first char of the manually typed password
       }
@@ -1045,6 +1056,9 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         const rendererKeyAt = Date.now();
         e.preventDefault();
         e.stopPropagation();
+        // Abort password assist: user is cancelling the remote command, not
+        // soft-dismissing the UI. A later su must re-arm cleanly (#2191).
+        sudoAutofill?.abort();
         const priority = prioritizeTerminalInput(
           term,
           id,

--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -1016,14 +1016,13 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
         sudoAutofill.cancelHint();
         return false; // dismiss without forwarding the byte to the no-echo prompt
       }
-      // Unmodified printable keys: soft-dismiss so the user can type a password.
-      // Ctrl/Meta/Alt combos (including Ctrl+C) must not soft-dismiss — that
-      // leaves dismissedWhileArmed and blocks the next bare Password: (#2191).
+      // Printable keys soft-dismiss so the user can type a password manually.
+      // Keep soft-dismiss for AltGr/Option-produced characters (they report
+      // Ctrl/Alt modifiers on Windows/macOS). Only plain Ctrl+C skips this —
+      // the interrupt path hard-aborts instead (#2191).
       if (
         e.key.length === 1
-        && !e.ctrlKey
-        && !e.metaKey
-        && !e.altKey
+        && !shouldUseUrgentTerminalInterrupt(e, { hasSelection: term.hasSelection() })
       ) {
         sudoAutofill.cancelHint();
         // fall through: key becomes the first char of the manually typed password

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -83,7 +83,8 @@ const readFullLineAfterPrompt = (
 
 /**
  * detectPrompt truncates userInput at the cursor. Enter submits the whole line,
- * so expand to the full text after the prompt (including wrapped rows).
+ * so expand past the cursor when the tail still looks like the same command
+ * (not zsh autosuggest / right-prompt chrome).
  */
 const expandPromptUserInputToFullLine = (
   term: XTerm,
@@ -93,16 +94,29 @@ const expandPromptUserInputToFullLine = (
   const fullInput = readFullLineAfterPrompt(term, prompt.promptText);
   if (fullInput === null || fullInput === prompt.userInput) return prompt;
   if (
-    fullInput.length > prompt.userInput.length
-    && fullInput.startsWith(prompt.userInput)
+    fullInput.length <= prompt.userInput.length
+    || !fullInput.startsWith(prompt.userInput)
   ) {
-    return {
-      ...prompt,
-      userInput: fullInput,
-      cursorOffset: fullInput.length,
-    };
+    return prompt;
   }
-  return prompt;
+  const tail = fullInput.slice(prompt.userInput.length);
+  // Continue same token (sudo|whoami mid-word) or next argv ("su" + " -").
+  // Skip likely autosuggest/RPROMPT blobs that start a new unrelated word
+  // after the cursor without the user having typed into them.
+  const okContinuation =
+    tail.startsWith(" ")
+    || tail.startsWith("-")
+    || (
+      !prompt.userInput.endsWith(" ")
+      && /^[\w@./:-]+/.test(tail)
+      && !/\s{2,}/.test(tail)
+    );
+  if (!okContinuation) return prompt;
+  return {
+    ...prompt,
+    userInput: fullInput,
+    cursorOffset: fullInput.length,
+  };
 };
 
 /** Status / cwd chrome that must not be recorded as a submitted command. */
@@ -225,26 +239,30 @@ export const resolveLiveSubmittedCommand = (
   const direct = getCommandToRecordOnEnter(prompt, null, "", true);
   if (direct) return direct;
 
-  // Incomplete bare-glyph split (➜  + cwd/git in userInput): peel chrome.
-  if (isBareThemedTerminator(prompt.promptText)) {
-    const peeled = peelThemedCommandFromPrompt(prompt);
-    if (peeled) return peeled;
-  }
-
-  // Cached full prompt: accept remainder only when it reconciles on the
-  // original line (partial cache after git:(main) must not win).
+  // Cached full prompt first: handles space-containing dirs ("➜  My Project ")
+  // before peel can mis-split on the path (#2191 review).
   const cachedPrompt = lastPromptText ?? "";
   if (cachedPrompt) {
     const fullLine = `${prompt.promptText}${prompt.userInput}`;
     if (fullLine.startsWith(cachedPrompt)) {
       const remainder = fullLine.slice(cachedPrompt.length).trim();
-      if (remainder && prompt.userInput.endsWith(remainder)) {
-        const reconciled = reconcilePromptWithTypedInput(prompt, remainder);
-        if (reconciled !== prompt && reconciled.userInput.trim() === remainder) {
-          return remainder;
+      if (remainder && !isDecorationOnlyCommand(remainder)) {
+        if (prompt.userInput.endsWith(remainder)) {
+          const reconciled = reconcilePromptWithTypedInput(prompt, remainder);
+          if (reconciled !== prompt && reconciled.userInput.trim() === remainder) {
+            return remainder;
+          }
         }
+        // Exact cache prefix on the rendered line (no-space / multi-word dirs).
+        return remainder;
       }
     }
+  }
+
+  // Incomplete bare-glyph split (➜  + cwd/git in userInput): peel chrome.
+  if (isBareThemedTerminator(prompt.promptText)) {
+    const peeled = peelThemedCommandFromPrompt(prompt);
+    if (peeled) return peeled;
   }
 
   // Themed prompts (including prefixed terminators like "⚡ ➜ "): peel cwd/path
@@ -329,12 +347,17 @@ export const resolveSubmittedShellCommand = (
 
   const aligned = alignedResult.alignedTyped?.trim() ?? "";
   // Aligned buffer can match a stale mid-line prefix after history recall
-  // (typed "s", recalled "su -", cursor after "s"). Prefer the longer live line.
+  // (typed "s", recalled "su -", cursor after "s"), or only a suffix when
+  // history prepended text (typed "whoami", recalled "sudo whoami").
   if (aligned) {
     if (
       liveFromPrompt
-      && liveFromPrompt.startsWith(aligned)
       && liveFromPrompt.length > aligned.length
+      && (
+        liveFromPrompt.startsWith(aligned)
+        || liveFromPrompt.endsWith(aligned)
+        || liveFromPrompt.endsWith(` ${aligned}`)
+      )
     ) {
       return liveFromPrompt;
     }
@@ -384,12 +407,16 @@ export const resolveSubmittedShellCommand = (
     return live;
   }
 
-  // Live still has path chrome but ends with the typed command — keep buffer
-  // (e.g. themed dir "~/My Project" + typed "su -" → live "Project su -").
-  if (
-    live.endsWith(buffered)
-    || live.endsWith(` ${buffered}`)
-  ) {
+  // Live ends with the typed buffer: either path chrome + typed command
+  // ("Project su -" + "su -") or history that grew leftward ("sudo whoami"
+  // after typing "whoami"). Prefer live for sudo/su wrappers; else buffer.
+  if (live.endsWith(buffered) || live.endsWith(` ${buffered}`)) {
+    if (
+      live !== buffered
+      && /^(?:sudo|su|doas|command|builtin)\s/i.test(live)
+    ) {
+      return live;
+    }
     return buffered;
   }
 

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -82,41 +82,84 @@ const readFullLineAfterPrompt = (
 };
 
 /**
- * detectPrompt truncates userInput at the cursor. Enter submits the whole line,
- * so expand past the cursor when the tail still looks like the same command
- * (not zsh autosuggest / right-prompt chrome).
+ * detectPrompt truncates userInput at the cursor. Expand carefully:
+ *
+ * - Empty buffer: never absorb post-cursor paint (zsh autosuggest / RPROMPT).
+ * - Buffer longer than visible prefix: incomplete remote echo — use buffer.
+ * - Buffer is a strict prefix of the painted line and the next painted char
+ *   continues the same token (`s` → `su -`): history mid-line — use full line.
+ * - Buffer is a strict prefix and the next painted char is whitespace
+ *   (`git` → `git status`): treat as autosuggest — keep buffer only.
  */
 const expandPromptUserInputToFullLine = (
   term: XTerm,
   prompt: PromptDetectionResult,
+  typedBuffer: string,
 ): PromptDetectionResult => {
   if (!prompt.isAtPrompt || !prompt.promptText) return prompt;
+  const buffered = typedBuffer.trim();
+  if (!buffered) return prompt;
+
   const fullInput = readFullLineAfterPrompt(term, prompt.promptText);
-  if (fullInput === null || fullInput === prompt.userInput) return prompt;
+  if (fullInput === null) return prompt;
+
+  // Incomplete echo: keystrokes ahead of what the line shows.
+  // - visible "su", buffer "sudo" (same single word still typing)
+  // - visible "su", buffer "su -" (more argv)
+  // Not: visible "su", buffer "sudo whoami" (history may have shortened).
   if (
-    fullInput.length <= prompt.userInput.length
-    || !fullInput.startsWith(prompt.userInput)
+    prompt.userInput.length > 0
+    && buffered.startsWith(prompt.userInput)
+    && buffered.length > prompt.userInput.length
   ) {
-    return prompt;
+    const next = buffered[prompt.userInput.length] ?? "";
+    const singleWordEchoLag =
+      !buffered.includes(" ")
+      && /[\w@./:-]/.test(next);
+    const moreArgsEchoLag = next === " " || next === "\t";
+    if (singleWordEchoLag || moreArgsEchoLag) {
+      return {
+        ...prompt,
+        userInput: buffered,
+        cursorOffset: buffered.length,
+      };
+    }
   }
-  const tail = fullInput.slice(prompt.userInput.length);
-  // Continue same token (sudo|whoami mid-word) or next argv ("su" + " -").
-  // Skip likely autosuggest/RPROMPT blobs that start a new unrelated word
-  // after the cursor without the user having typed into them.
-  const okContinuation =
-    tail.startsWith(" ")
-    || tail.startsWith("-")
-    || (
-      !prompt.userInput.endsWith(" ")
-      && /^[\w@./:-]+/.test(tail)
-      && !/\s{2,}/.test(tail)
-    );
-  if (!okContinuation) return prompt;
-  return {
-    ...prompt,
-    userInput: fullInput,
-    cursorOffset: fullInput.length,
-  };
+
+  if (fullInput === buffered) {
+    if (prompt.userInput === buffered) return prompt;
+    return {
+      ...prompt,
+      userInput: buffered,
+      cursorOffset: buffered.length,
+    };
+  }
+
+  // Painted line longer than buffer: history continuation vs autosuggest.
+  if (fullInput.startsWith(buffered) && fullInput.length > buffered.length) {
+    const next = fullInput[buffered.length] ?? "";
+    if (next === " " || next === "\t") {
+      // "git" + " status" suggestion — do not absorb.
+      if (prompt.userInput.startsWith(buffered)) {
+        return {
+          ...prompt,
+          userInput: buffered,
+          cursorOffset: buffered.length,
+        };
+      }
+      return prompt;
+    }
+    // Same-token continuation on the line (history "s" + "u -").
+    if (/[\w@./:-]/.test(next)) {
+      return {
+        ...prompt,
+        userInput: fullInput,
+        cursorOffset: fullInput.length,
+      };
+    }
+  }
+
+  return prompt;
 };
 
 /** Status / cwd chrome that must not be recorded as a submitted command. */
@@ -174,7 +217,7 @@ export const shouldRecordShellHistory = (
 
   const trimmed = command.trim();
   const alignedResult = getAlignedPrompt(term, command, true);
-  const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
+  const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt, command);
   if (!prompt.isAtPrompt) return false;
   if (alignedResult.alignedTyped?.trim() === trimmed) return true;
 
@@ -339,8 +382,12 @@ export const resolveSubmittedShellCommand = (
 
   const alignedResult = getAlignedPrompt(term, commandBuffer, true);
 
-  // Expand past the cursor / across wraps so Enter sees the full recalled command.
-  const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
+  // Expand only when keystrokes confirm the span (never paint-only suggestions).
+  const prompt = expandPromptUserInputToFullLine(
+    term,
+    alignedResult.prompt,
+    commandBuffer,
+  );
   const liveFromPrompt = prompt.isAtPrompt
     ? resolveLiveSubmittedCommand(prompt, lastPromptText)
     : "";
@@ -396,14 +443,26 @@ export const resolveSubmittedShellCommand = (
     return live;
   }
 
-  // Echo lag: live is a same-command prefix of the buffer (e.g. "su" → "su -").
-  // Do not treat accidental word prefixes as lag ("su" vs "sudo whoami").
+  // Echo lag: live is a visible prefix of what the user typed.
+  // - "su" + buffer "su -" → same command, more argv → buffer
+  // - "su" + buffer "sudo" → incomplete echo of the same word → buffer
+  // - "su" + buffer "sudo whoami" → history shortened the line → live
   if (buffered.startsWith(live) && buffered.length > live.length) {
     const next = buffered[live.length] ?? "";
     if (next === " " || next === "" || live.length === 0) {
       return buffered;
     }
-    // History replaced a longer typed command with a shorter different one.
+    const liveFirst = live.split(/\s+/)[0] ?? "";
+    const bufFirst = buffered.split(/\s+/)[0] ?? "";
+    // Single-word buffer still extending the echoed prefix: trust keystrokes.
+    if (
+      !buffered.includes(" ")
+      && bufFirst.startsWith(liveFirst)
+      && bufFirst !== liveFirst
+    ) {
+      return buffered;
+    }
+    // Multi-word typed buffer vs shorter live command: history replaced it.
     return live;
   }
 

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -200,8 +200,24 @@ export const shouldRecordShellHistory = (
   if (liveCommand.length === 0) {
     return !isNonPromptLine(`${prompt.promptText}${trimmed}`);
   }
-  return liveCommand === trimmed;
+  if (liveCommand === trimmed) return true;
+
+  // Themed multi-word / unicode dirs: resolver peels to "su -" but the raw
+  // userInput is still " My Project su -". Accept trailing resolved commands
+  // so password assist still arms (#2191 review).
+  if (
+    liveCommand === trimmed
+    || liveCommand.endsWith(` ${trimmed}`)
+    || liveCommand.endsWith(trimmed)
+  ) {
+    return true;
+  }
+  return false;
 };
+
+/** Common shell verbs that are commands, not themed directory names. */
+const LOOKS_LIKE_SHELL_COMMAND_PREFIX =
+  /^(?:echo|printf|ls|cd|pwd|cat|grep|find|sed|awk|vim|nvim|nano|git|npm|yarn|pnpm|node|python|pip|docker|make|curl|wget|ssh|scp|rsync|tar|zip|unzip|chmod|chown|cp|mv|rm|mkdir|touch|tail|head|less|more|man|which|type|alias|export|source|bash|zsh|fish|sh|env|ps|top|htop|kill|df|du|free|uname|whoami|id|date|clear|history|exit|logout|true|false|test|expr|seq|sleep|yes|nohup|time|env|sudo|su|doas)\b/i;
 
 /** Path / git-status chrome that may sit between a glyph prompt and the command. */
 const isPlausiblePathDecoration = (text: string): boolean => {
@@ -210,11 +226,46 @@ const isPlausiblePathDecoration = (text: string): boolean => {
   if (s === "~" || s.startsWith("~/") || s.startsWith("/")) return true;
   if (/^git:\([^)]*\)/.test(s)) return true;
   if (/[✗✔]/.test(s)) return true;
-  // Bare or multi-word directory tokens (My Project / 项目 / Project (old)),
-  // but not privilege verbs.
+  // Privilege verbs in the prefix are never directory chrome.
   if (/\b(?:su|sudo|doas)\b/i.test(s)) return false;
-  // Allow unicode letters and common path punctuation in directory names.
+
+  const words = s.split(/\s+/).filter(Boolean);
+  // Single token: common cwd names may collide with commands (git, node).
+  // Ordinary verbs (echo, ls, cat) are almost never directory chrome.
+  if (words.length === 1) {
+    if (
+      LOOKS_LIKE_SHELL_COMMAND_PREFIX.test(s)
+      && !/^[./~]/.test(s)
+      && s !== "~"
+      && !/^(?:git|node|go|npm|yarn|pnpm|docker|src|app|bin|lib|test|tmp|home|user|root|www|html|dist|build|target|main|dev|prod|staging)$/i.test(s)
+    ) {
+      return false;
+    }
+    return /^(?:[^\s\\]|[./~_()-])+$/u.test(s);
+  }
+  // Multi-word: reject shell verbs (`echo foo`) but allow `My Project` / `项目 a`.
+  if (LOOKS_LIKE_SHELL_COMMAND_PREFIX.test(words[0] ?? "")) return false;
   return /^(?:[^\s\\]|[./~_()-])+(?:\s+(?:[^\s\\]|[./~_()-])+)*$/u.test(s);
+};
+
+/**
+ * Recover a privilege command from a line with no space after the prompt marker
+ * (`user@host:~$su -`) when prompt detection and lastPromptText both fail.
+ */
+const resolveNoSpacePromptPrivilegeCommand = (term: XTerm): string => {
+  try {
+    const buffer = term.buffer.active;
+    const cursorY = buffer.cursorY + buffer.baseY;
+    const line = buffer.getLine(cursorY);
+    if (!line) return "";
+    const raw = line.translateToString(false).replace(/\s+$/g, "");
+    const match = raw.match(/^(.*?[$#%>])((?:sudo|su|doas)(?:\s.*)?)$/i);
+    if (!match) return "";
+    const command = match[2].trim();
+    return shouldArmSudoPasswordAutofill(command) ? command : "";
+  } catch {
+    return "";
+  }
 };
 
 /**
@@ -464,9 +515,13 @@ export const resolveSubmittedShellCommand = (
 
   if (!prompt.isAtPrompt) {
     // No-space prompts (`user@host:~$su -`) often fail boundary detection;
-    // recover via the last fully-detected prompt prefix (#2191 review).
+    // recover via the last fully-detected prompt prefix, then a direct
+    // privilege-command scan for the first history recall before any cache.
     if (!buffered) {
-      return resolveFromCachedPromptPrefix(term, lastPromptText);
+      return (
+        resolveFromCachedPromptPrefix(term, lastPromptText)
+        || resolveNoSpacePromptPrivilegeCommand(term)
+      );
     }
     return buffered;
   }

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -149,6 +149,32 @@ export const resolveLiveSubmittedCommand = (
 };
 
 /**
+ * True when a live "command" is really empty-prompt chrome (cwd / git status)
+ * left in userInput by the detector — not a history-recalled command.
+ */
+const isEmptyPromptDecoration = (
+  live: string,
+  prompt: PromptDetectionResult,
+): boolean => {
+  const command = live.trim();
+  if (!command) return true;
+  if (command === "~" || command.startsWith("~/") || command.startsWith("/")) {
+    return true;
+  }
+  if (/^git:\([^)]*\)/.test(command)) return true;
+  if (/^[✗✔+*!]$/.test(command)) return true;
+
+  // Bare-glyph themes often leave a single cwd token in userInput (" git ").
+  // A real history recall has decoration + command (multiple tokens) before peel.
+  if (isBareThemedTerminator(prompt.promptText)) {
+    const rawTokens = prompt.userInput.trim().split(/\s+/).filter(Boolean);
+    if (rawTokens.length <= 1) return true;
+  }
+
+  return false;
+};
+
+/**
  * Resolve the command that Enter is submitting.
  *
  * The keystroke buffer alone is incomplete for shell history recall (↑/↓ /
@@ -170,7 +196,12 @@ export const resolveSubmittedShellCommand = (
   if (!prompt.isAtPrompt) return buffered;
 
   const live = resolveLiveSubmittedCommand(prompt, lastPromptText);
-  if (!buffered) return live;
+  if (!buffered) {
+    // Empty Enter on a themed prompt must not treat cwd/git chrome as a command
+    // (would pollute history and can false-arm su/sudo assist).
+    if (!live || isEmptyPromptDecoration(live, prompt)) return "";
+    return live;
+  }
   if (!live || live === buffered) return buffered || live;
 
   // Direct send / incomplete echo: keystroke buffer is the real command even

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -10,6 +10,7 @@ import {
   isNonPromptLine,
   reconcilePromptWithExternalCommand,
 } from "../autocomplete/promptDetector";
+import { getCommandToRecordOnEnter } from "../autocomplete/terminalAutocompletePrompt";
 
 type TerminalCommandExecutionContext = {
   host: Pick<Host, "id" | "label">;
@@ -56,10 +57,17 @@ export const shouldRecordShellHistory = (
  * those keys redraw the line remotely and never append the recalled text to
  * commandBuffer. Fall back to the live prompt line so su/sudo arming, shell
  * history, and command hooks still see the real command (#2191).
+ *
+ * Prefer the last fully-reconciled prompt text (including themed cwd
+ * decorations like `➜  git `) so empty-buffer history does not prefix the
+ * command with prompt chrome. When that cache is missing, reuse the same
+ * policy as autocomplete Enter-record so themed decoration is not treated
+ * as the command (#806).
  */
 export const resolveSubmittedShellCommand = (
   commandBuffer: string,
   term?: XTerm | null,
+  lastPromptText?: string,
 ): string => {
   const buffered = commandBuffer.trim();
   if (!term) return buffered;
@@ -67,14 +75,23 @@ export const resolveSubmittedShellCommand = (
   const { prompt, alignedTyped } = getAlignedPrompt(term, commandBuffer, true);
   const aligned = alignedTyped?.trim() ?? "";
   if (aligned) return aligned;
+  if (buffered) return buffered;
+  if (!prompt.isAtPrompt) return "";
 
-  if (prompt.isAtPrompt) {
-    const live = prompt.userInput.trim();
-    // Empty buffer + live line: classic ↑ history recall before Enter.
-    if (live && !buffered) return live;
+  // Empty buffer: shell history recall. Prefer cached full prompt so themed
+  // decorations (➜  ~ / ➜  git ) stay out of the command (#2191 + #806).
+  const cachedPrompt = lastPromptText ?? "";
+  if (cachedPrompt) {
+    const fullLine = `${prompt.promptText}${prompt.userInput}`;
+    if (fullLine.startsWith(cachedPrompt)) {
+      const fromCachedPrompt = fullLine.slice(cachedPrompt.length).trim();
+      if (fromCachedPrompt) return fromCachedPrompt;
+    }
   }
 
-  return buffered;
+  // Same live-line policy as autocomplete Enter-record: accepts clean
+  // standard prompts, refuses themed decoration pollution.
+  return getCommandToRecordOnEnter(prompt, null, "", true) ?? "";
 };
 
 export const recordTerminalCommandExecution = (
@@ -82,7 +99,8 @@ export const recordTerminalCommandExecution = (
   ctx: TerminalCommandExecutionContext,
   term?: XTerm | null,
 ): string | null => {
-  const cmd = resolveSubmittedShellCommand(command, term);
+  const lastPromptText = ctx.promptLineBreakStateRef?.current?.lastPromptText;
+  const cmd = resolveSubmittedShellCommand(command, term, lastPromptText);
   if (cmd) {
     ctx.onCommandSubmitted?.(cmd, ctx.host.id, ctx.host.label, ctx.sessionId);
   }

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -42,38 +42,81 @@ const isBareThemedTerminator = (promptText: string): boolean => {
 };
 
 /**
+ * Read the full logical input after the prompt, including wrapped continuation
+ * rows and text past the cursor (Enter submits the whole line, not the prefix).
+ */
+const readFullLineAfterPrompt = (
+  term: XTerm,
+  promptText: string,
+): string | null => {
+  if (!promptText) return null;
+  try {
+    const buffer = term.buffer.active;
+    const cursorY = buffer.cursorY + buffer.baseY;
+    let promptRow = cursorY;
+    let line = buffer.getLine(promptRow);
+    if (!line) return null;
+
+    // Walk up through wrapped continuation rows to the prompt row.
+    while (line.isWrapped && promptRow > 0) {
+      promptRow -= 1;
+      const prev = buffer.getLine(promptRow);
+      if (!prev) return null;
+      line = prev;
+    }
+
+    let combined = "";
+    for (let row = promptRow; ; row += 1) {
+      const rowLine = buffer.getLine(row);
+      if (!rowLine) break;
+      combined += rowLine.translateToString(false);
+      const next = buffer.getLine(row + 1);
+      if (!next?.isWrapped) break;
+    }
+
+    if (!combined.startsWith(promptText)) return null;
+    return combined.slice(promptText.length).replace(/\s+$/g, "");
+  } catch {
+    return null;
+  }
+};
+
+/**
  * detectPrompt truncates userInput at the cursor. Enter submits the whole line,
- * so expand to the full text after the prompt when the cursor is mid-line.
+ * so expand to the full text after the prompt (including wrapped rows).
  */
 const expandPromptUserInputToFullLine = (
   term: XTerm,
   prompt: PromptDetectionResult,
 ): PromptDetectionResult => {
   if (!prompt.isAtPrompt || !prompt.promptText) return prompt;
-  try {
-    const buffer = term.buffer.active;
-    const cursorY = buffer.cursorY + buffer.baseY;
-    const line = buffer.getLine(cursorY);
-    if (!line) return prompt;
-    const raw = line.translateToString(false);
-    if (!raw.startsWith(prompt.promptText)) return prompt;
-    // Drop xterm cell padding; keep intentional trailing spaces out of history.
-    const fullInput = raw.slice(prompt.promptText.length).replace(/\s+$/g, "");
-    if (fullInput === prompt.userInput) return prompt;
-    if (
-      fullInput.length > prompt.userInput.length
-      && fullInput.startsWith(prompt.userInput)
-    ) {
-      return {
-        ...prompt,
-        userInput: fullInput,
-        cursorOffset: fullInput.length,
-      };
-    }
-  } catch {
-    // ignore buffer read failures
+  const fullInput = readFullLineAfterPrompt(term, prompt.promptText);
+  if (fullInput === null || fullInput === prompt.userInput) return prompt;
+  if (
+    fullInput.length > prompt.userInput.length
+    && fullInput.startsWith(prompt.userInput)
+  ) {
+    return {
+      ...prompt,
+      userInput: fullInput,
+      cursorOffset: fullInput.length,
+    };
   }
   return prompt;
+};
+
+/**
+ * When the prompt has no trailing space (`user@host:~$su -`), the detector
+ * may not find a boundary. Fall back to the last known prompt prefix.
+ */
+const resolveFromCachedPromptPrefix = (
+  term: XTerm,
+  lastPromptText: string | undefined,
+): string => {
+  const cached = lastPromptText ?? "";
+  if (!cached) return "";
+  const fullInput = readFullLineAfterPrompt(term, cached);
+  return fullInput?.trim() ?? "";
 };
 
 export const shouldRecordShellHistory = (
@@ -232,15 +275,25 @@ export const resolveSubmittedShellCommand = (
   const aligned = alignedResult.alignedTyped?.trim() ?? "";
   if (aligned) return aligned;
 
-  // Expand past the cursor so mid-line Enter still sees the full recalled command.
+  // Expand past the cursor / across wraps so Enter sees the full recalled command.
   const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
-  if (!prompt.isAtPrompt) return buffered;
+  if (!prompt.isAtPrompt) {
+    // No-space prompts (`user@host:~$su -`) often fail boundary detection;
+    // recover via the last fully-detected prompt prefix (#2191 review).
+    if (!buffered) {
+      return resolveFromCachedPromptPrefix(term, lastPromptText);
+    }
+    return buffered;
+  }
 
   const live = resolveLiveSubmittedCommand(prompt, lastPromptText);
   if (!buffered) {
     // Empty Enter on a themed prompt must not treat cwd/git chrome as a command
     // (would pollute history and can false-arm su/sudo assist).
-    if (!live || isEmptyPromptDecoration(live, prompt)) return "";
+    if (!live || isEmptyPromptDecoration(live, prompt)) {
+      // Last chance: no-space / partial detect with a known prompt prefix.
+      return resolveFromCachedPromptPrefix(term, lastPromptText);
+    }
     return live;
   }
   if (!live || live === buffered) return buffered || live;

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -247,10 +247,15 @@ export const resolveLiveSubmittedCommand = (
     }
   }
 
-  // Complete themed / Powerline prompts already isolate the command in
-  // userInput (including multiword sudo whoami). getCommandToRecordOnEnter
-  // refuses multiword themed input, so accept the detector split here —
-  // but never treat a lone cwd token as a command (⚡ ➜  git ).
+  // Themed prompts (including prefixed terminators like "⚡ ➜ "): peel cwd/path
+  // chrome before accepting userInput (⚡ ➜  ~ su - → su -).
+  if (hasThemedPromptMarker(prompt.promptText)) {
+    const peeled = peelThemedCommandFromPrompt(prompt);
+    if (peeled) return peeled;
+  }
+
+  // Complete Powerline / multi-glyph prompts may already isolate multiword
+  // commands (sudo whoami) when peel has nothing left to strip.
   if (!isBareThemedTerminator(prompt.promptText)) {
     const liveTrimmed = prompt.userInput.trim();
     if (
@@ -264,8 +269,7 @@ export const resolveLiveSubmittedCommand = (
         && hasThemedPromptMarker(prompt.promptText)
         && !/^(?:su|sudo|doas)$/i.test(liveTrimmed)
       ) {
-        // Single bare word after a themed prompt is usually cwd chrome.
-        return peelThemedCommandFromPrompt(prompt);
+        return "";
       }
       return liveTrimmed;
     }
@@ -369,8 +373,23 @@ export const resolveSubmittedShellCommand = (
     return live;
   }
 
-  // Echo lag: user typed more than the line has echoed yet — keep buffer.
+  // Echo lag: live is a same-command prefix of the buffer (e.g. "su" → "su -").
+  // Do not treat accidental word prefixes as lag ("su" vs "sudo whoami").
   if (buffered.startsWith(live) && buffered.length > live.length) {
+    const next = buffered[live.length] ?? "";
+    if (next === " " || next === "" || live.length === 0) {
+      return buffered;
+    }
+    // History replaced a longer typed command with a shorter different one.
+    return live;
+  }
+
+  // Live still has path chrome but ends with the typed command — keep buffer
+  // (e.g. themed dir "~/My Project" + typed "su -" → live "Project su -").
+  if (
+    live.endsWith(buffered)
+    || live.endsWith(` ${buffered}`)
+  ) {
     return buffered;
   }
 

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -105,6 +105,37 @@ const expandPromptUserInputToFullLine = (
   return prompt;
 };
 
+/** Status / cwd chrome that must not be recorded as a submitted command. */
+const isDecorationOnlyCommand = (command: string): boolean => {
+  const t = command.trim();
+  if (!t) return true;
+  if (t === "~" || t.startsWith("~/")) return true;
+  if (/^[✗✔+*!]$/.test(t)) return true;
+  if (/^git:\([^)]*\)/.test(t)) return true;
+  // "git:(main) ✗" leftovers after a partial cache strip
+  if (/git:\([^)]*\)/.test(t) || /[✗✔]/.test(t)) {
+    const stripped = t
+      .replace(/git:\([^)]*\)/g, " ")
+      .replace(/[✗✔+*!]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!stripped) return true;
+    if (/^(?:su|sudo|doas)(?:\s|$)/i.test(stripped)) return false;
+    if (!/\s/.test(stripped) && !/^(?:su|sudo|doas)$/i.test(stripped)) return true;
+  }
+  return false;
+};
+
+const hasThemedPromptMarker = (promptText: string): boolean => {
+  if (isBareThemedTerminator(promptText)) return true;
+  if (/[❯❮→➜➤⟩»›]/.test(promptText)) return true;
+  for (const ch of promptText) {
+    const code = ch.charCodeAt(0);
+    if (code >= 0xE000 && code <= 0xF8FF) return true;
+  }
+  return false;
+};
+
 /**
  * When the prompt has no trailing space (`user@host:~$su -`), the detector
  * may not find a boundary. Fall back to the last known prompt prefix.
@@ -115,8 +146,10 @@ const resolveFromCachedPromptPrefix = (
 ): string => {
   const cached = lastPromptText ?? "";
   if (!cached) return "";
-  const fullInput = readFullLineAfterPrompt(term, cached);
-  return fullInput?.trim() ?? "";
+  const fullInput = readFullLineAfterPrompt(term, cached)?.trim() ?? "";
+  // Reject partial-cache leftovers like "git:(main) ✗" (#2191 review).
+  if (!fullInput || isDecorationOnlyCommand(fullInput)) return "";
+  return fullInput;
 };
 
 export const shouldRecordShellHistory = (
@@ -216,10 +249,24 @@ export const resolveLiveSubmittedCommand = (
 
   // Complete themed / Powerline prompts already isolate the command in
   // userInput (including multiword sudo whoami). getCommandToRecordOnEnter
-  // refuses multiword themed input, so accept the detector split here.
+  // refuses multiword themed input, so accept the detector split here —
+  // but never treat a lone cwd token as a command (⚡ ➜  git ).
   if (!isBareThemedTerminator(prompt.promptText)) {
     const liveTrimmed = prompt.userInput.trim();
-    if (liveTrimmed && prompt.promptText.trim().length > 0) {
+    if (
+      liveTrimmed
+      && prompt.promptText.trim().length > 0
+      && !isDecorationOnlyCommand(liveTrimmed)
+    ) {
+      const rawTokens = liveTrimmed.split(/\s+/).filter(Boolean);
+      if (
+        rawTokens.length <= 1
+        && hasThemedPromptMarker(prompt.promptText)
+        && !/^(?:su|sudo|doas)$/i.test(liveTrimmed)
+      ) {
+        // Single bare word after a themed prompt is usually cwd chrome.
+        return peelThemedCommandFromPrompt(prompt);
+      }
       return liveTrimmed;
     }
   }
@@ -230,7 +277,6 @@ export const resolveLiveSubmittedCommand = (
 /**
  * True when a live "command" is really empty-prompt chrome (cwd / git status)
  * left in userInput by the detector — not a history-recalled command.
- * Only applies to bare-glyph themed prompts where that pollution happens.
  */
 const isEmptyPromptDecoration = (
   live: string,
@@ -238,17 +284,15 @@ const isEmptyPromptDecoration = (
 ): boolean => {
   const command = live.trim();
   if (!command) return true;
-  if (!isBareThemedTerminator(prompt.promptText)) return false;
+  if (isDecorationOnlyCommand(command)) return true;
 
-  if (command === "~" || command.startsWith("~/")) return true;
-  if (/^git:\([^)]*\)/.test(command)) return true;
-  if (/^[✗✔+*!]$/.test(command)) return true;
+  // Bare glyph or multi-glyph themed prompts can leave a single cwd token.
+  if (!hasThemedPromptMarker(prompt.promptText)) return false;
 
   const rawTokens = prompt.userInput.trim().split(/\s+/).filter(Boolean);
   if (rawTokens.length <= 1) {
     // One-word history of su/sudo/doas must still arm password assist (❯ su).
     if (/^(?:su|sudo|doas)$/i.test(command)) return false;
-    // Single cwd token left in userInput (" git " / " netcatty ").
     return true;
   }
 
@@ -272,11 +316,27 @@ export const resolveSubmittedShellCommand = (
   if (!term) return buffered;
 
   const alignedResult = getAlignedPrompt(term, commandBuffer, true);
-  const aligned = alignedResult.alignedTyped?.trim() ?? "";
-  if (aligned) return aligned;
 
   // Expand past the cursor / across wraps so Enter sees the full recalled command.
   const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
+  const liveFromPrompt = prompt.isAtPrompt
+    ? resolveLiveSubmittedCommand(prompt, lastPromptText)
+    : "";
+
+  const aligned = alignedResult.alignedTyped?.trim() ?? "";
+  // Aligned buffer can match a stale mid-line prefix after history recall
+  // (typed "s", recalled "su -", cursor after "s"). Prefer the longer live line.
+  if (aligned) {
+    if (
+      liveFromPrompt
+      && liveFromPrompt.startsWith(aligned)
+      && liveFromPrompt.length > aligned.length
+    ) {
+      return liveFromPrompt;
+    }
+    return aligned;
+  }
+
   if (!prompt.isAtPrompt) {
     // No-space prompts (`user@host:~$su -`) often fail boundary detection;
     // recover via the last fully-detected prompt prefix (#2191 review).
@@ -286,7 +346,7 @@ export const resolveSubmittedShellCommand = (
     return buffered;
   }
 
-  const live = resolveLiveSubmittedCommand(prompt, lastPromptText);
+  const live = liveFromPrompt;
   if (!buffered) {
     // Empty Enter on a themed prompt must not treat cwd/git chrome as a command
     // (would pollute history and can false-arm su/sudo assist).

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -49,22 +49,50 @@ export const shouldRecordShellHistory = (
   return liveCommand === command.trim();
 };
 
+/**
+ * Resolve the command that Enter is submitting.
+ *
+ * The keystroke buffer alone is incomplete for shell history recall (↑/↓):
+ * those keys redraw the line remotely and never append the recalled text to
+ * commandBuffer. Fall back to the live prompt line so su/sudo arming, shell
+ * history, and command hooks still see the real command (#2191).
+ */
+export const resolveSubmittedShellCommand = (
+  commandBuffer: string,
+  term?: XTerm | null,
+): string => {
+  const buffered = commandBuffer.trim();
+  if (!term) return buffered;
+
+  const { prompt, alignedTyped } = getAlignedPrompt(term, commandBuffer, true);
+  const aligned = alignedTyped?.trim() ?? "";
+  if (aligned) return aligned;
+
+  if (prompt.isAtPrompt) {
+    const live = prompt.userInput.trim();
+    // Empty buffer + live line: classic ↑ history recall before Enter.
+    if (live && !buffered) return live;
+  }
+
+  return buffered;
+};
+
 export const recordTerminalCommandExecution = (
   command: string,
   ctx: TerminalCommandExecutionContext,
   term?: XTerm | null,
 ): string | null => {
-  const cmd = command.trim();
+  const cmd = resolveSubmittedShellCommand(command, term);
   if (cmd) {
     ctx.onCommandSubmitted?.(cmd, ctx.host.id, ctx.host.label, ctx.sessionId);
   }
   if (cmd && shouldRecordShellHistory(cmd, term)) {
     ctx.onCommandExecuted?.(cmd, ctx.host.id, ctx.host.label, ctx.sessionId);
     ctx.commandBufferRef.current = "";
-    markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, command);
+    markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, cmd);
     return cmd;
   }
   ctx.commandBufferRef.current = "";
-  markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, command);
+  markPromptLineBreakCommandPending(ctx.promptLineBreakStateRef, term, cmd || command);
   return null;
 };

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -239,28 +239,74 @@ export const shouldRecordShellHistory = (
   return liveCommand === trimmed;
 };
 
+/** Path / git-status chrome that may sit between a glyph prompt and the command. */
+const isPlausiblePathDecoration = (text: string): boolean => {
+  const s = text.trim();
+  if (!s) return true;
+  if (s === "~" || s.startsWith("~/") || s.startsWith("/")) return true;
+  if (/^git:\([^)]*\)/.test(s)) return true;
+  if (/[✗✔]/.test(s)) return true;
+  // Bare or multi-word directory tokens (My Project), but not privilege verbs.
+  if (/\b(?:su|sudo|doas)\b/i.test(s)) return false;
+  return /^[\w./~-]+(?:\s+[\w./~-]+)*$/.test(s);
+};
+
 /**
- * Peel themed cwd/git chrome from userInput by trying space-aligned suffixes
- * and keeping the split that attributes the most text to the prompt.
+ * Peel themed cwd/git chrome from userInput.
+ *
+ * Prefer a trailing privilege command (su/sudo/doas) when the prefix looks like
+ * path decoration — longest-prompt peel alone turns `❯  su -` into `-` and
+ * `➜  My Project su -` into `Project su -` (#2191 review).
  */
 const peelThemedCommandFromPrompt = (
   prompt: PromptDetectionResult,
 ): string => {
   const live = prompt.userInput;
-  let best: { command: string; promptLength: number } | null = null;
+  const trimmedStart = live.trimStart();
+  if (!trimmedStart) return "";
+
+  const privilegeMatch = trimmedStart.match(
+    /(?:^|\s)((?:sudo|su|doas)(?:\s+.*)?)$/i,
+  );
+  if (privilegeMatch) {
+    const command = privilegeMatch[1].trim();
+    const before = trimmedStart
+      .slice(0, trimmedStart.length - privilegeMatch[1].length)
+      .trim();
+    if (isPlausiblePathDecoration(before)) {
+      return command;
+    }
+  }
+
+  // Reconcile peel: prefer the longest command (avoid over-peeling to "-").
+  let best: { command: string; length: number } | null = null;
   for (let start = 0; start < live.length; start += 1) {
     if (start > 0 && live[start - 1] !== " ") continue;
     const candidate = live.slice(start);
     if (!candidate.trim()) continue;
+    const extra = live.slice(0, start);
+    // Never treat privilege words as path chrome in the stripped prefix.
+    if (/\b(?:su|sudo|doas)\b/i.test(extra)) continue;
     const reconciled = reconcilePromptWithTypedInput(prompt, candidate);
     if (reconciled === prompt || reconciled.userInput !== candidate) continue;
     const command = candidate.trim();
     if (!command) continue;
-    if (!best || reconciled.promptText.length > best.promptLength) {
-      best = { command, promptLength: reconciled.promptText.length };
+    if (!best || command.length > best.length) {
+      best = { command, length: command.length };
     }
   }
-  return best?.command ?? "";
+  if (best) return best.command;
+
+  // Bare leading spaces before a simple command: ` su -` → `su -`.
+  const trimmed = live.trim();
+  if (
+    trimmed
+    && live.endsWith(trimmed)
+    && /^\s+$/.test(live.slice(0, live.length - trimmed.length))
+  ) {
+    return trimmed;
+  }
+  return "";
 };
 
 /**
@@ -356,7 +402,10 @@ const isEmptyPromptDecoration = (
 
   const rawTokens = prompt.userInput.trim().split(/\s+/).filter(Boolean);
   if (rawTokens.length <= 1) {
-    // One-word history of su/sudo/doas must still arm password assist (❯ su).
+    // Cwd chrome often keeps a trailing space after the directory token
+    // (" git "). A real one-word history command usually has no trailing pad.
+    if (/\s$/.test(prompt.userInput)) return true;
+    // One-word history of su/sudo/doas (❯ su) with no trailing pad.
     if (/^(?:su|sudo|doas)$/i.test(command)) return false;
     return true;
   }

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -13,6 +13,7 @@ import {
   type PromptDetectionResult,
 } from "../autocomplete/promptDetector";
 import { getCommandToRecordOnEnter } from "../autocomplete/terminalAutocompletePrompt";
+import { shouldArmSudoPasswordAutofill } from "./terminalSudoAutofill";
 
 type TerminalCommandExecutionContext = {
   host: Pick<Host, "id" | "label">;
@@ -82,14 +83,13 @@ const readFullLineAfterPrompt = (
 };
 
 /**
- * detectPrompt truncates userInput at the cursor. Expand carefully:
+ * detectPrompt truncates userInput at the cursor.
  *
- * - Empty buffer: never absorb post-cursor paint (zsh autosuggest / RPROMPT).
- * - Buffer longer than visible prefix: incomplete remote echo — use buffer.
- * - Buffer is a strict prefix of the painted line and the next painted char
- *   continues the same token (`s` → `su -`): history mid-line — use full line.
- * - Buffer is a strict prefix and the next painted char is whitespace
- *   (`git` → `git status`): treat as autosuggest — keep buffer only.
+ * Never absorb painted tails into the command when the keystroke buffer is
+ * non-empty: zsh same-token autosuggest (`g` + paint `git status`) must stay
+ * as `g`. Incomplete remote echo (keystrokes ahead of the line) may promote
+ * the buffer into userInput. History that rewrote the line is handled later
+ * via live-line comparison (#2191 review).
  */
 const expandPromptUserInputToFullLine = (
   term: XTerm,
@@ -99,9 +99,6 @@ const expandPromptUserInputToFullLine = (
   if (!prompt.isAtPrompt || !prompt.promptText) return prompt;
   const buffered = typedBuffer.trim();
   if (!buffered) return prompt;
-
-  const fullInput = readFullLineAfterPrompt(term, prompt.promptText);
-  if (fullInput === null) return prompt;
 
   // Incomplete echo: keystrokes ahead of what the line shows.
   // - visible "su", buffer "sudo" (same single word still typing)
@@ -122,39 +119,6 @@ const expandPromptUserInputToFullLine = (
         ...prompt,
         userInput: buffered,
         cursorOffset: buffered.length,
-      };
-    }
-  }
-
-  if (fullInput === buffered) {
-    if (prompt.userInput === buffered) return prompt;
-    return {
-      ...prompt,
-      userInput: buffered,
-      cursorOffset: buffered.length,
-    };
-  }
-
-  // Painted line longer than buffer: history continuation vs autosuggest.
-  if (fullInput.startsWith(buffered) && fullInput.length > buffered.length) {
-    const next = fullInput[buffered.length] ?? "";
-    if (next === " " || next === "\t") {
-      // "git" + " status" suggestion — do not absorb.
-      if (prompt.userInput.startsWith(buffered)) {
-        return {
-          ...prompt,
-          userInput: buffered,
-          cursorOffset: buffered.length,
-        };
-      }
-      return prompt;
-    }
-    // Same-token continuation on the line (history "s" + "u -").
-    if (/[\w@./:-]/.test(next)) {
-      return {
-        ...prompt,
-        userInput: fullInput,
-        cursorOffset: fullInput.length,
       };
     }
   }
@@ -246,9 +210,11 @@ const isPlausiblePathDecoration = (text: string): boolean => {
   if (s === "~" || s.startsWith("~/") || s.startsWith("/")) return true;
   if (/^git:\([^)]*\)/.test(s)) return true;
   if (/[✗✔]/.test(s)) return true;
-  // Bare or multi-word directory tokens (My Project), but not privilege verbs.
+  // Bare or multi-word directory tokens (My Project / 项目 / Project (old)),
+  // but not privilege verbs.
   if (/\b(?:su|sudo|doas)\b/i.test(s)) return false;
-  return /^[\w./~-]+(?:\s+[\w./~-]+)*$/.test(s);
+  // Allow unicode letters and common path punctuation in directory names.
+  return /^(?:[^\s\\]|[./~_()-])+(?:\s+(?:[^\s\\]|[./~_()-])+)*$/u.test(s);
 };
 
 /**
@@ -278,6 +244,17 @@ const peelThemedCommandFromPrompt = (
     }
   }
 
+  // Leading whitespace only (❯␠␠git status / ❯␠␠su -): the whole trimmed
+  // line is the command — do this before reconcile peel can drop the first word.
+  const trimmed = live.trim();
+  if (
+    trimmed
+    && live.endsWith(trimmed)
+    && /^\s+$/.test(live.slice(0, live.length - trimmed.length))
+  ) {
+    return trimmed;
+  }
+
   // Reconcile peel: prefer the longest command (avoid over-peeling to "-").
   let best: { command: string; length: number } | null = null;
   for (let start = 0; start < live.length; start += 1) {
@@ -295,18 +272,7 @@ const peelThemedCommandFromPrompt = (
       best = { command, length: command.length };
     }
   }
-  if (best) return best.command;
-
-  // Bare leading spaces before a simple command: ` su -` → `su -`.
-  const trimmed = live.trim();
-  if (
-    trimmed
-    && live.endsWith(trimmed)
-    && /^\s+$/.test(live.slice(0, live.length - trimmed.length))
-  ) {
-    return trimmed;
-  }
-  return "";
+  return best?.command ?? "";
 };
 
 /**
@@ -431,31 +397,67 @@ export const resolveSubmittedShellCommand = (
 
   const alignedResult = getAlignedPrompt(term, commandBuffer, true);
 
-  // Expand only when keystrokes confirm the span (never paint-only suggestions).
+  // Expand only for incomplete echo (never same-token autosuggest paint).
   const prompt = expandPromptUserInputToFullLine(
     term,
     alignedResult.prompt,
     commandBuffer,
   );
-  const liveFromPrompt = prompt.isAtPrompt
+  const liveFromCursor = prompt.isAtPrompt
     ? resolveLiveSubmittedCommand(prompt, lastPromptText)
     : "";
+
+  // Full painted line (for history that rewrote past a stale typed prefix).
+  // Only adopt it over the buffer when it is a privilege command the buffer
+  // is not — autosuggest `g`→`git status` stays on the buffer.
+  let liveFromFull = liveFromCursor;
+  if (prompt.isAtPrompt && prompt.promptText) {
+    const fullInput = readFullLineAfterPrompt(term, prompt.promptText);
+    if (fullInput && fullInput !== prompt.userInput) {
+      liveFromFull = resolveLiveSubmittedCommand(
+        {
+          ...prompt,
+          userInput: fullInput,
+          cursorOffset: fullInput.length,
+        },
+        lastPromptText,
+      );
+    }
+  }
+
+  const preferFullOverBuffer = (
+    buffer: string,
+    fullLive: string,
+  ): boolean => {
+    if (!fullLive || fullLive === buffer) return false;
+    if (!fullLive.startsWith(buffer) || fullLive.length <= buffer.length) {
+      return false;
+    }
+    // History to privilege command from a non-privilege typed prefix ("s"→"su -").
+    return (
+      shouldArmSudoPasswordAutofill(fullLive)
+      && !shouldArmSudoPasswordAutofill(buffer)
+    );
+  };
 
   const aligned = alignedResult.alignedTyped?.trim() ?? "";
   // Aligned buffer can match a stale mid-line prefix after history recall
   // (typed "s", recalled "su -", cursor after "s"), or only a suffix when
   // history prepended text (typed "whoami", recalled "sudo whoami").
   if (aligned) {
+    if (preferFullOverBuffer(aligned, liveFromFull)) {
+      return liveFromFull;
+    }
     if (
-      liveFromPrompt
-      && liveFromPrompt.length > aligned.length
+      liveFromCursor
+      && liveFromCursor.length > aligned.length
       && (
-        liveFromPrompt.startsWith(aligned)
-        || liveFromPrompt.endsWith(aligned)
-        || liveFromPrompt.endsWith(` ${aligned}`)
+        liveFromCursor.startsWith(aligned)
+        || liveFromCursor.endsWith(aligned)
+        || liveFromCursor.endsWith(` ${aligned}`)
       )
     ) {
-      return liveFromPrompt;
+      return liveFromCursor;
     }
     return aligned;
   }
@@ -469,15 +471,18 @@ export const resolveSubmittedShellCommand = (
     return buffered;
   }
 
-  const live = liveFromPrompt;
+  const live = liveFromCursor;
   if (!buffered) {
-    // Empty Enter on a themed prompt must not treat cwd/git chrome as a command
-    // (would pollute history and can false-arm su/sudo assist).
-    if (!live || isEmptyPromptDecoration(live, prompt)) {
-      // Last chance: no-space / partial detect with a known prompt prefix.
+    // Empty buffer: submitted text is the painted command (history at EOL or
+    // mid-line). Keystroke autosuggest always leaves a non-empty buffer.
+    const emptyLive = liveFromFull || live;
+    if (!emptyLive || isEmptyPromptDecoration(emptyLive, prompt)) {
       return resolveFromCachedPromptPrefix(term, lastPromptText);
     }
-    return live;
+    return emptyLive;
+  }
+  if (preferFullOverBuffer(buffered, liveFromFull)) {
+    return liveFromFull;
   }
   if (!live || live === buffered) return buffered || live;
 
@@ -490,6 +495,9 @@ export const resolveSubmittedShellCommand = (
   // History / reverse-search replaced a typed prefix (buffer "s", live "su -").
   if (live.startsWith(buffered) && live.length > buffered.length) {
     return live;
+  }
+  if (preferFullOverBuffer(buffered, liveFromFull)) {
+    return liveFromFull;
   }
 
   // Echo lag: live is a visible prefix of what the user typed.

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -39,48 +39,44 @@ export const shouldRecordShellHistory = (
 ): boolean => {
   if (!term) return true;
 
+  const trimmed = command.trim();
   const { prompt, alignedTyped } = getAlignedPrompt(term, command, true);
   if (!prompt.isAtPrompt) return false;
-  if (alignedTyped?.trim() === command.trim()) return true;
+  if (alignedTyped?.trim() === trimmed) return true;
 
   if (reconcilePromptWithExternalCommand(prompt, command)) return true;
 
-  const liveCommand = prompt.userInput.trim();
-  if (liveCommand.length === 0) {
-    return !isNonPromptLine(`${prompt.promptText}${command.trim()}`);
-  }
-  return liveCommand === command.trim();
-};
-
-/**
- * Read the command currently shown on the prompt line, stripping themed
- * prompt chrome (➜  ~ / git status decorations) when needed.
- *
- * Uses lastPromptText when it still matches; otherwise peels decoration via
- * the same reconcile rules as autocomplete so a stale cache after `cd` does
- * not leave su/sudo unarmed (#2191).
- */
-export const resolveLiveSubmittedCommand = (
-  prompt: PromptDetectionResult,
-  lastPromptText?: string,
-): string => {
-  if (!prompt.isAtPrompt) return "";
-
-  const cachedPrompt = lastPromptText ?? "";
-  if (cachedPrompt) {
-    const fullLine = `${prompt.promptText}${prompt.userInput}`;
-    if (fullLine.startsWith(cachedPrompt)) {
-      const fromCachedPrompt = fullLine.slice(cachedPrompt.length).trim();
-      if (fromCachedPrompt) return fromCachedPrompt;
+  // History recall on themed prompts: live userInput still includes cwd/git
+  // chrome, but reconcile can attribute it back to the prompt (#2191).
+  if (trimmed) {
+    const reconciled = reconcilePromptWithTypedInput(prompt, trimmed);
+    if (reconciled !== prompt && reconciled.userInput.trim() === trimmed) {
+      return true;
     }
   }
 
-  // Clean standard prompts (user@host:~$ su -).
-  const direct = getCommandToRecordOnEnter(prompt, null, "", true);
-  if (direct) return direct;
+  const liveCommand = prompt.userInput.trim();
+  if (liveCommand.length === 0) {
+    return !isNonPromptLine(`${prompt.promptText}${trimmed}`);
+  }
+  return liveCommand === trimmed;
+};
 
-  // Themed prompts: try space-aligned suffixes and keep the split that
-  // attributes the most text to the prompt (fullest decoration strip).
+/** Bare omz/p10k glyph alone — detector often leaves cwd/git chrome in userInput. */
+const isBareThemedTerminator = (promptText: string): boolean => {
+  const trimmed = promptText.trim();
+  if (trimmed.length !== 1) return false;
+  const code = trimmed.charCodeAt(0);
+  return /[❯❮→➜➤⟩»›]/.test(trimmed) || (code >= 0xE000 && code <= 0xF8FF);
+};
+
+/**
+ * Peel themed cwd/git chrome from userInput by trying space-aligned suffixes
+ * and keeping the split that attributes the most text to the prompt.
+ */
+const peelThemedCommandFromPrompt = (
+  prompt: PromptDetectionResult,
+): string => {
   const live = prompt.userInput;
   let best: { command: string; promptLength: number } | null = null;
   for (let start = 0; start < live.length; start += 1) {
@@ -96,6 +92,60 @@ export const resolveLiveSubmittedCommand = (
     }
   }
   return best?.command ?? "";
+};
+
+/**
+ * Read the command currently shown on the prompt line, stripping themed
+ * prompt chrome (➜  ~ / git status decorations) when needed.
+ *
+ * lastPromptText is only trusted when the remainder reconciles against the
+ * original detector split (avoids partial-cache pollution and over-peeling
+ * a clean remainder down to "-"). Complete Powerline prompts keep the
+ * detector's multiword userInput (#2191).
+ */
+export const resolveLiveSubmittedCommand = (
+  prompt: PromptDetectionResult,
+  lastPromptText?: string,
+): string => {
+  if (!prompt.isAtPrompt) return "";
+
+  // Clean standard prompts (user@host:~$ su -).
+  const direct = getCommandToRecordOnEnter(prompt, null, "", true);
+  if (direct) return direct;
+
+  // Incomplete bare-glyph split (➜  + cwd/git in userInput): peel chrome.
+  if (isBareThemedTerminator(prompt.promptText)) {
+    const peeled = peelThemedCommandFromPrompt(prompt);
+    if (peeled) return peeled;
+  }
+
+  // Cached full prompt: accept remainder only when it reconciles on the
+  // original line (partial cache after git:(main) must not win).
+  const cachedPrompt = lastPromptText ?? "";
+  if (cachedPrompt) {
+    const fullLine = `${prompt.promptText}${prompt.userInput}`;
+    if (fullLine.startsWith(cachedPrompt)) {
+      const remainder = fullLine.slice(cachedPrompt.length).trim();
+      if (remainder && prompt.userInput.endsWith(remainder)) {
+        const reconciled = reconcilePromptWithTypedInput(prompt, remainder);
+        if (reconciled !== prompt && reconciled.userInput.trim() === remainder) {
+          return remainder;
+        }
+      }
+    }
+  }
+
+  // Complete themed / Powerline prompts already isolate the command in
+  // userInput (including multiword sudo whoami). getCommandToRecordOnEnter
+  // refuses multiword themed input, so accept the detector split here.
+  if (!isBareThemedTerminator(prompt.promptText)) {
+    const liveTrimmed = prompt.userInput.trim();
+    if (liveTrimmed && prompt.promptText.trim().length > 0) {
+      return liveTrimmed;
+    }
+  }
+
+  return peelThemedCommandFromPrompt(prompt);
 };
 
 /**

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -219,32 +219,39 @@ export const shouldRecordShellHistory = (
 const LOOKS_LIKE_SHELL_COMMAND_PREFIX =
   /^(?:echo|printf|ls|cd|pwd|cat|grep|find|sed|awk|vim|nvim|nano|git|npm|yarn|pnpm|node|python|pip|docker|make|curl|wget|ssh|scp|rsync|tar|zip|unzip|chmod|chown|cp|mv|rm|mkdir|touch|tail|head|less|more|man|which|type|alias|export|source|bash|zsh|fish|sh|env|ps|top|htop|kill|df|du|free|uname|whoami|id|date|clear|history|exit|logout|true|false|test|expr|seq|sleep|yes|nohup|time|env|sudo|su|doas)\b/i;
 
+const CWD_NAME_COMMAND_COLLISION =
+  /^(?:git|node|go|npm|yarn|pnpm|docker|src|app|bin|lib|test|tmp|home|user|root|www|html|dist|build|target|main|dev|prod|staging)$/i;
+
 /** Path / git-status chrome that may sit between a glyph prompt and the command. */
 const isPlausiblePathDecoration = (text: string): boolean => {
   const s = text.trim();
   if (!s) return true;
   if (s === "~" || s.startsWith("~/") || s.startsWith("/")) return true;
-  if (/^git:\([^)]*\)/.test(s)) return true;
-  if (/[✗✔]/.test(s)) return true;
   // Privilege verbs in the prefix are never directory chrome.
   if (/\b(?:su|sudo|doas)\b/i.test(s)) return false;
 
   const words = s.split(/\s+/).filter(Boolean);
-  // Single token: common cwd names may collide with commands (git, node).
-  // Ordinary verbs (echo, ls, cat) are almost never directory chrome.
-  if (words.length === 1) {
+  // Any ordinary shell verb in the prefix means this is command text, not cwd
+  // chrome — including after git-status markers (`git:(main) ✗ echo …`).
+  for (const word of words) {
+    const token = word.replace(/^git:\([^)]*\)$/i, "").replace(/[✗✔+*!]/g, "");
+    if (!token) continue;
     if (
-      LOOKS_LIKE_SHELL_COMMAND_PREFIX.test(s)
-      && !/^[./~]/.test(s)
-      && s !== "~"
-      && !/^(?:git|node|go|npm|yarn|pnpm|docker|src|app|bin|lib|test|tmp|home|user|root|www|html|dist|build|target|main|dev|prod|staging)$/i.test(s)
+      LOOKS_LIKE_SHELL_COMMAND_PREFIX.test(token)
+      && !CWD_NAME_COMMAND_COLLISION.test(token)
+      && !/^[./~]/.test(token)
     ) {
       return false;
     }
-    return /^(?:[^\s\\]|[./~_()-])+$/u.test(s);
   }
-  // Multi-word: reject shell verbs (`echo foo`) but allow `My Project` / `项目 a`.
-  if (LOOKS_LIKE_SHELL_COMMAND_PREFIX.test(words[0] ?? "")) return false;
+
+  // Pure git-status / status glyph chrome.
+  if (/^git:\([^)]*\)/.test(s) || /^[✗✔+*!]+$/.test(s)) return true;
+  if (words.every((w) => /^git:\([^)]*\)$/i.test(w) || /^[✗✔+*!]+$/.test(w))) {
+    return true;
+  }
+
+  // Allow unicode letters and common path punctuation in directory names.
   return /^(?:[^\s\\]|[./~_()-])+(?:\s+(?:[^\s\\]|[./~_()-])+)*$/u.test(s);
 };
 
@@ -295,14 +302,34 @@ const peelThemedCommandFromPrompt = (
     }
   }
 
-  // Leading whitespace only (❯␠␠git status / ❯␠␠su -): the whole trimmed
-  // line is the command — do this before reconcile peel can drop the first word.
+  // Leading whitespace only: try path-prefix + trailing command before taking
+  // the whole line (avoids ` My Project ls` → recording the directory too).
   const trimmed = live.trim();
   if (
     trimmed
     && live.endsWith(trimmed)
     && /^\s+$/.test(live.slice(0, live.length - trimmed.length))
   ) {
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+    if (parts.length === 1 || shouldArmSudoPasswordAutofill(trimmed)) {
+      return trimmed;
+    }
+    for (let i = 1; i < parts.length; i += 1) {
+      const before = parts.slice(0, i).join(" ");
+      const command = parts.slice(i).join(" ");
+      if (!command || !isPlausiblePathDecoration(before)) continue;
+      // Privilege after any path chrome, or ordinary commands only after a
+      // multi-word / path-sigil directory (not `git status` → `status`).
+      if (
+        shouldArmSudoPasswordAutofill(command)
+        || before.includes(" ")
+        || before === "~"
+        || before.startsWith("~/")
+        || before.startsWith("/")
+      ) {
+        return command;
+      }
+    }
     return trimmed;
   }
 

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -33,6 +33,49 @@ type TerminalCommandExecutionContext = {
   promptLineBreakStateRef?: RefObject<PromptLineBreakState>;
 };
 
+/** Bare omz/p10k glyph alone — detector often leaves cwd/git chrome in userInput. */
+const isBareThemedTerminator = (promptText: string): boolean => {
+  const trimmed = promptText.trim();
+  if (trimmed.length !== 1) return false;
+  const code = trimmed.charCodeAt(0);
+  return /[❯❮→➜➤⟩»›]/.test(trimmed) || (code >= 0xE000 && code <= 0xF8FF);
+};
+
+/**
+ * detectPrompt truncates userInput at the cursor. Enter submits the whole line,
+ * so expand to the full text after the prompt when the cursor is mid-line.
+ */
+const expandPromptUserInputToFullLine = (
+  term: XTerm,
+  prompt: PromptDetectionResult,
+): PromptDetectionResult => {
+  if (!prompt.isAtPrompt || !prompt.promptText) return prompt;
+  try {
+    const buffer = term.buffer.active;
+    const cursorY = buffer.cursorY + buffer.baseY;
+    const line = buffer.getLine(cursorY);
+    if (!line) return prompt;
+    const raw = line.translateToString(false);
+    if (!raw.startsWith(prompt.promptText)) return prompt;
+    // Drop xterm cell padding; keep intentional trailing spaces out of history.
+    const fullInput = raw.slice(prompt.promptText.length).replace(/\s+$/g, "");
+    if (fullInput === prompt.userInput) return prompt;
+    if (
+      fullInput.length > prompt.userInput.length
+      && fullInput.startsWith(prompt.userInput)
+    ) {
+      return {
+        ...prompt,
+        userInput: fullInput,
+        cursorOffset: fullInput.length,
+      };
+    }
+  } catch {
+    // ignore buffer read failures
+  }
+  return prompt;
+};
+
 export const shouldRecordShellHistory = (
   command: string,
   term?: XTerm | null,
@@ -40,9 +83,10 @@ export const shouldRecordShellHistory = (
   if (!term) return true;
 
   const trimmed = command.trim();
-  const { prompt, alignedTyped } = getAlignedPrompt(term, command, true);
+  const alignedResult = getAlignedPrompt(term, command, true);
+  const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
   if (!prompt.isAtPrompt) return false;
-  if (alignedTyped?.trim() === trimmed) return true;
+  if (alignedResult.alignedTyped?.trim() === trimmed) return true;
 
   if (reconcilePromptWithExternalCommand(prompt, command)) return true;
 
@@ -60,14 +104,6 @@ export const shouldRecordShellHistory = (
     return !isNonPromptLine(`${prompt.promptText}${trimmed}`);
   }
   return liveCommand === trimmed;
-};
-
-/** Bare omz/p10k glyph alone — detector often leaves cwd/git chrome in userInput. */
-const isBareThemedTerminator = (promptText: string): boolean => {
-  const trimmed = promptText.trim();
-  if (trimmed.length !== 1) return false;
-  const code = trimmed.charCodeAt(0);
-  return /[❯❮→➜➤⟩»›]/.test(trimmed) || (code >= 0xE000 && code <= 0xF8FF);
 };
 
 /**
@@ -151,6 +187,7 @@ export const resolveLiveSubmittedCommand = (
 /**
  * True when a live "command" is really empty-prompt chrome (cwd / git status)
  * left in userInput by the detector — not a history-recalled command.
+ * Only applies to bare-glyph themed prompts where that pollution happens.
  */
 const isEmptyPromptDecoration = (
   live: string,
@@ -158,17 +195,18 @@ const isEmptyPromptDecoration = (
 ): boolean => {
   const command = live.trim();
   if (!command) return true;
-  if (command === "~" || command.startsWith("~/") || command.startsWith("/")) {
-    return true;
-  }
+  if (!isBareThemedTerminator(prompt.promptText)) return false;
+
+  if (command === "~" || command.startsWith("~/")) return true;
   if (/^git:\([^)]*\)/.test(command)) return true;
   if (/^[✗✔+*!]$/.test(command)) return true;
 
-  // Bare-glyph themes often leave a single cwd token in userInput (" git ").
-  // A real history recall has decoration + command (multiple tokens) before peel.
-  if (isBareThemedTerminator(prompt.promptText)) {
-    const rawTokens = prompt.userInput.trim().split(/\s+/).filter(Boolean);
-    if (rawTokens.length <= 1) return true;
+  const rawTokens = prompt.userInput.trim().split(/\s+/).filter(Boolean);
+  if (rawTokens.length <= 1) {
+    // One-word history of su/sudo/doas must still arm password assist (❯ su).
+    if (/^(?:su|sudo|doas)$/i.test(command)) return false;
+    // Single cwd token left in userInput (" git " / " netcatty ").
+    return true;
   }
 
   return false;
@@ -190,9 +228,12 @@ export const resolveSubmittedShellCommand = (
   const buffered = commandBuffer.trim();
   if (!term) return buffered;
 
-  const { prompt, alignedTyped } = getAlignedPrompt(term, commandBuffer, true);
-  const aligned = alignedTyped?.trim() ?? "";
+  const alignedResult = getAlignedPrompt(term, commandBuffer, true);
+  const aligned = alignedResult.alignedTyped?.trim() ?? "";
   if (aligned) return aligned;
+
+  // Expand past the cursor so mid-line Enter still sees the full recalled command.
+  const prompt = expandPromptUserInputToFullLine(term, alignedResult.prompt);
   if (!prompt.isAtPrompt) return buffered;
 
   const live = resolveLiveSubmittedCommand(prompt, lastPromptText);

--- a/components/terminal/runtime/terminalCommandExecution.ts
+++ b/components/terminal/runtime/terminalCommandExecution.ts
@@ -9,6 +9,8 @@ import {
   getAlignedPrompt,
   isNonPromptLine,
   reconcilePromptWithExternalCommand,
+  reconcilePromptWithTypedInput,
+  type PromptDetectionResult,
 } from "../autocomplete/promptDetector";
 import { getCommandToRecordOnEnter } from "../autocomplete/terminalAutocompletePrompt";
 
@@ -51,18 +53,58 @@ export const shouldRecordShellHistory = (
 };
 
 /**
+ * Read the command currently shown on the prompt line, stripping themed
+ * prompt chrome (➜  ~ / git status decorations) when needed.
+ *
+ * Uses lastPromptText when it still matches; otherwise peels decoration via
+ * the same reconcile rules as autocomplete so a stale cache after `cd` does
+ * not leave su/sudo unarmed (#2191).
+ */
+export const resolveLiveSubmittedCommand = (
+  prompt: PromptDetectionResult,
+  lastPromptText?: string,
+): string => {
+  if (!prompt.isAtPrompt) return "";
+
+  const cachedPrompt = lastPromptText ?? "";
+  if (cachedPrompt) {
+    const fullLine = `${prompt.promptText}${prompt.userInput}`;
+    if (fullLine.startsWith(cachedPrompt)) {
+      const fromCachedPrompt = fullLine.slice(cachedPrompt.length).trim();
+      if (fromCachedPrompt) return fromCachedPrompt;
+    }
+  }
+
+  // Clean standard prompts (user@host:~$ su -).
+  const direct = getCommandToRecordOnEnter(prompt, null, "", true);
+  if (direct) return direct;
+
+  // Themed prompts: try space-aligned suffixes and keep the split that
+  // attributes the most text to the prompt (fullest decoration strip).
+  const live = prompt.userInput;
+  let best: { command: string; promptLength: number } | null = null;
+  for (let start = 0; start < live.length; start += 1) {
+    if (start > 0 && live[start - 1] !== " ") continue;
+    const candidate = live.slice(start);
+    if (!candidate.trim()) continue;
+    const reconciled = reconcilePromptWithTypedInput(prompt, candidate);
+    if (reconciled === prompt || reconciled.userInput !== candidate) continue;
+    const command = candidate.trim();
+    if (!command) continue;
+    if (!best || reconciled.promptText.length > best.promptLength) {
+      best = { command, promptLength: reconciled.promptText.length };
+    }
+  }
+  return best?.command ?? "";
+};
+
+/**
  * Resolve the command that Enter is submitting.
  *
- * The keystroke buffer alone is incomplete for shell history recall (↑/↓):
- * those keys redraw the line remotely and never append the recalled text to
- * commandBuffer. Fall back to the live prompt line so su/sudo arming, shell
- * history, and command hooks still see the real command (#2191).
- *
- * Prefer the last fully-reconciled prompt text (including themed cwd
- * decorations like `➜  git `) so empty-buffer history does not prefix the
- * command with prompt chrome. When that cache is missing, reuse the same
- * policy as autocomplete Enter-record so themed decoration is not treated
- * as the command (#806).
+ * The keystroke buffer alone is incomplete for shell history recall (↑/↓ /
+ * Ctrl+R): those keys redraw the line remotely and never rewrite
+ * commandBuffer. Prefer an aligned buffer when reliable; otherwise prefer
+ * the live line when it disagrees with a stale prefix (#2191).
  */
 export const resolveSubmittedShellCommand = (
   commandBuffer: string,
@@ -75,23 +117,30 @@ export const resolveSubmittedShellCommand = (
   const { prompt, alignedTyped } = getAlignedPrompt(term, commandBuffer, true);
   const aligned = alignedTyped?.trim() ?? "";
   if (aligned) return aligned;
-  if (buffered) return buffered;
-  if (!prompt.isAtPrompt) return "";
+  if (!prompt.isAtPrompt) return buffered;
 
-  // Empty buffer: shell history recall. Prefer cached full prompt so themed
-  // decorations (➜  ~ / ➜  git ) stay out of the command (#2191 + #806).
-  const cachedPrompt = lastPromptText ?? "";
-  if (cachedPrompt) {
-    const fullLine = `${prompt.promptText}${prompt.userInput}`;
-    if (fullLine.startsWith(cachedPrompt)) {
-      const fromCachedPrompt = fullLine.slice(cachedPrompt.length).trim();
-      if (fromCachedPrompt) return fromCachedPrompt;
-    }
+  const live = resolveLiveSubmittedCommand(prompt, lastPromptText);
+  if (!buffered) return live;
+  if (!live || live === buffered) return buffered || live;
+
+  // Direct send / incomplete echo: keystroke buffer is the real command even
+  // when the themed line still only shows decoration (➜  netcatty  + "ls").
+  if (reconcilePromptWithExternalCommand(prompt, buffered)) {
+    return buffered;
   }
 
-  // Same live-line policy as autocomplete Enter-record: accepts clean
-  // standard prompts, refuses themed decoration pollution.
-  return getCommandToRecordOnEnter(prompt, null, "", true) ?? "";
+  // History / reverse-search replaced a typed prefix (buffer "s", live "su -").
+  if (live.startsWith(buffered) && live.length > buffered.length) {
+    return live;
+  }
+
+  // Echo lag: user typed more than the line has echoed yet — keep buffer.
+  if (buffered.startsWith(live) && buffered.length > live.length) {
+    return buffered;
+  }
+
+  // Completely different commands: trust the live line (history replaced it).
+  return live;
 };
 
 export const recordTerminalCommandExecution = (

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -148,6 +148,37 @@ test("Esc soft-dismiss keeps arm so assist can re-open on the same Password prom
   assert.deepEqual(writes, ["host-secret\n"]);
 });
 
+test("abort hard-disarms so a later bare Password requires a fresh su arm (#2191)", () => {
+  // Ctrl+C aborts the remote su. Soft-dismiss would leave dismissedWhileArmed
+  // and block the next bare Password: without a leading newline.
+  const pickerActives: boolean[] = [];
+  const autofill = createSudoPasswordAutofill({
+    mode: "picker",
+    candidates: [
+      { id: "host", label: "Host", password: "host-secret" },
+      { id: "identity:root", label: "Root", password: "root-secret" },
+    ],
+    write: () => {},
+    onPicker: (active) => {
+      pickerActives.push(active);
+      return true;
+    },
+  });
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+  autofill.abort();
+  assert.equal(autofill.isPickerPending(), false);
+  assert.equal(autofill.canReshowAssist(), false);
+  // Stale arm gone: bare Password without a new su must not open the picker
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), false);
+  // Fresh arm after interrupt works again
+  autofill.armForCommand("su -");
+  autofill.handleOutput("Password: ");
+  assert.equal(autofill.isPickerPending(), true);
+});
+
 test("confirmFill does nothing when no prompt is pending", () => {
   const { autofill, writes } = make();
   autofill.confirmFill();

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -122,6 +122,12 @@ export type SudoPasswordAutofill = {
   confirmFill: (candidateId?: string) => void;
   /** Dismiss the open UI without clearing the su/sudo arm (Esc). */
   cancelHint: () => void;
+  /**
+   * Hard-abort: hide UI and clear the arm (Ctrl+C / interrupt / disconnect).
+   * Unlike cancelHint, a later Password: line will not re-open assist until
+   * a fresh su/sudo command is armed (#2191).
+   */
+  abort: () => void;
   isPromptPending: () => boolean;
   /** True only while the multi-credential picker UI is open (not the hint). */
   isPickerPending: () => boolean;
@@ -472,6 +478,9 @@ export const createSudoPasswordAutofill = (_options: {
         armedKind = null;
         armedUntil = Number.NEGATIVE_INFINITY;
       }
+    },
+    abort: () => {
+      disarm();
     },
     isPromptPending: () => pending,
     isPickerPending: () => pending && pendingUi === "picker",


### PR DESCRIPTION
## Summary

Fixes #2191 — credential-list password assist failed to open in two cases:

1. **Shell history recall (↑ then Enter)** — history keys only redraw the remote line; they never update `commandBuffer`. Enter therefore never armed `su`, and bare `Password:` prompts require an arm (unlike explicit `[sudo]`).
2. **Ctrl+C then re-run `su`** — while the picker was open, Ctrl+C took the “printable key” soft-dismiss path (`e.key === "c"`), leaving `dismissedWhileArmed`. A later bare `Password:` without a leading newline did not re-open the assist.

### Changes
- Resolve the submitted command from the live prompt line when the keystroke buffer is empty (`resolveSubmittedShellCommand`).
- Add `abort()` for hard-disarm; call it on urgent interrupt and on `\x03` input.
- Soft-dismiss only on unmodified printable keys (ignore Ctrl/Meta/Alt).

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/terminalSudoAutofill.test.ts components/terminal/runtime/createXTermRuntime.test.ts` (61 pass)
- [ ] Settings → password assist = credential picker; connect to a Linux host with a saved password
- [ ] `su` once, then ↑ history + Enter → picker opens
- [ ] At `Password:`, Ctrl+C, then type `su` again → picker opens again
- [ ] Esc still soft-dismisses and can re-open with arrows on the same prompt