### PR TITLE
fix(terminal): dismiss sudo password assist on clipboard paste

### DIFF
--- a/components/terminal/runtime/createXTermRuntime.ts
+++ b/components/terminal/runtime/createXTermRuntime.ts
@@ -764,6 +764,11 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     data: string,
     options?: { source?: "terminal" | "shift-enter" },
   ) => {
+    // Clipboard paste / typed password while assist is open must dismiss the
+    // hint first. Otherwise Enter is still hijacked for confirmFill and can
+    // append the host session password after the user's pasted secret (#2198).
+    ctx.sudoAutofillRef?.current?.dismissOnUserContentInput(data);
+
     const inputSource = options?.source ?? "terminal";
     const id = ctx.sessionRef.current;
     const dataToWrite = data;
@@ -973,6 +978,8 @@ export const createXTermRuntime = (ctx: CreateXTermRuntimeContext): XTermRuntime
     // selected/host password; arrows move the picker; Esc soft-dismisses (keeps
     // arm so the list can re-open). Checked before autocomplete so Enter pastes
     // the password instead of submitting an empty line.
+    // Paste is handled in handleTerminalInputData (dismissOnUserContentInput)
+    // because clipboard paste does not go through this key handler (#2198).
     const sudoAutofill = ctx.sudoAutofillRef?.current;
     if (sudoAutofill?.isPromptPending()) {
       if (shouldSendShiftEnterText(e, ctx.terminalSettingsRef.current)) {

--- a/components/terminal/runtime/terminalSudoAutofill.test.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.test.ts
@@ -6,6 +6,7 @@ import {
   isExplicitSudoPrompt,
   isSudoPasswordPrompt,
   shouldArmSudoPasswordAutofill,
+  shouldDismissPasswordAssistOnInput,
 } from "./terminalSudoAutofill";
 
 // --- isSudoPasswordPrompt: relaxed — any password/密码/口令 line ending in a
@@ -115,6 +116,60 @@ test("cancelHint clears the hint without filling", () => {
   assert.deepEqual(writes, []);
   assert.deepEqual(hints, [true, false]);
   assert.equal(autofill.isPromptPending(), false);
+});
+
+// --- paste dismisses assist so Enter is not hijacked (#2198) ---
+
+test("shouldDismissPasswordAssistOnInput detects paste and typed content", () => {
+  assert.equal(shouldDismissPasswordAssistOnInput("remote-secret"), true);
+  assert.equal(shouldDismissPasswordAssistOnInput("\x1b[200~remote-secret\x1b[201~"), true);
+  assert.equal(shouldDismissPasswordAssistOnInput("x"), true);
+  // Enter is confirmFill, not user content
+  assert.equal(shouldDismissPasswordAssistOnInput("\r"), false);
+  assert.equal(shouldDismissPasswordAssistOnInput("\n"), false);
+  // Control keys are handled separately
+  assert.equal(shouldDismissPasswordAssistOnInput("\x7f"), false);
+  assert.equal(shouldDismissPasswordAssistOnInput("\x1b"), false);
+  assert.equal(shouldDismissPasswordAssistOnInput(""), false);
+});
+
+test("clipboard paste dismisses pending hint so confirmFill no longer fires", () => {
+  // Nested SSH: assist offers jump-host password, user pastes the remote host
+  // password from clipboard, then presses Enter — Enter must submit the paste,
+  // not append the saved host password (#2198).
+  const { autofill, writes, hints } = make("jump-host-password");
+  autofill.armForCommand("sudo whoami");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.equal(autofill.isPromptPending(), true);
+
+  assert.equal(
+    autofill.dismissOnUserContentInput("\x1b[200~remote-host-password\x1b[201~"),
+    true,
+  );
+  assert.equal(autofill.isPromptPending(), false);
+  assert.deepEqual(hints, [true, false]);
+
+  // Simulated Enter after paste must not inject the jump-host password
+  autofill.confirmFill();
+  assert.deepEqual(writes, []);
+});
+
+test("plain multi-char paste dismisses pending hint", () => {
+  const { autofill, writes, hints } = make("jump-host-password");
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.equal(autofill.dismissOnUserContentInput("remote-host-password"), true);
+  assert.equal(autofill.isPromptPending(), false);
+  assert.deepEqual(hints, [true, false]);
+  autofill.confirmFill();
+  assert.deepEqual(writes, []);
+});
+
+test("Enter alone does not dismiss via dismissOnUserContentInput", () => {
+  const { autofill, hints } = make();
+  autofill.handleOutput("[sudo] password for alice: ");
+  assert.equal(autofill.dismissOnUserContentInput("\r"), false);
+  assert.equal(autofill.isPromptPending(), true);
+  assert.deepEqual(hints, [true]);
 });
 
 test("Esc soft-dismiss keeps arm so assist can re-open on the same Password prompt", () => {

--- a/components/terminal/runtime/terminalSudoAutofill.ts
+++ b/components/terminal/runtime/terminalSudoAutofill.ts
@@ -122,6 +122,12 @@ export type SudoPasswordAutofill = {
   confirmFill: (candidateId?: string) => void;
   /** Dismiss the open UI without clearing the su/sudo arm (Esc). */
   cancelHint: () => void;
+  /**
+   * Soft-dismiss when the user pastes or types their own secret so Enter is
+   * not hijacked for confirmFill after clipboard paste (#2198).
+   * Returns true when the assist UI was dismissed.
+   */
+  dismissOnUserContentInput: (data: string) => boolean;
   isPromptPending: () => boolean;
   /** True only while the multi-credential picker UI is open (not the hint). */
   isPickerPending: () => boolean;
@@ -168,6 +174,36 @@ export const getSingleBracketedPasteLine = (data: string): string | null => {
   const text = unwrapBracketedPaste(data);
   if (!text || /[\r\n]/.test(text)) return null;
   return text;
+};
+
+/**
+ * True when terminal input is the user supplying their own password text
+ * (typed char or clipboard paste), not Enter confirmation or Esc/Backspace.
+ *
+ * Used to dismiss password-prompt assist so a later Enter submits what the
+ * user pasted instead of hijacking Enter for the host session password
+ * (nested SSH / jump host, #2198).
+ */
+export const shouldDismissPasswordAssistOnInput = (data: string): boolean => {
+  if (!data) return false;
+  // Enter alone is handled by the key handler as confirmFill — do not dismiss.
+  if (data === "\r" || data === "\n" || data === "\r\n") return false;
+  // Bracketed paste always means the user is inserting their own text.
+  if (data.startsWith(BRACKETED_PASTE_START) || data.includes(BRACKETED_PASTE_START)) {
+    return true;
+  }
+  // Plain multi-char paste (no leading ESC / CSI).
+  if (data.length > 1 && !data.startsWith("\x1b")) {
+    return true;
+  }
+  // Single printable character — mirrors the key handler's cancelHint path.
+  // Exclude DEL (0x7f); Backspace/Esc are handled separately and must not
+  // count as "user password content" for onData-side dismissal.
+  const code = data.charCodeAt(0);
+  if (data.length === 1 && code >= 32 && code !== 0x7f) {
+    return true;
+  }
+  return false;
 };
 
 // Arm the autofill when a sudo/su command is submitted. The user's input is sent
@@ -354,6 +390,18 @@ export const createSudoPasswordAutofill = (_options: {
     return showHostPasswordHint();
   };
 
+  /** Soft dismiss: hide UI but keep arm + tail so Esc/arrows can re-open. */
+  const softDismissPendingUi = () => {
+    if (!pending) return;
+    pending = false;
+    hideUi();
+    dismissedWhileArmed = isArmActiveNow();
+    if (!dismissedWhileArmed) {
+      armedKind = null;
+      armedUntil = Number.NEGATIVE_INFINITY;
+    }
+  };
+
   return {
     armForCommand: (command: string) => {
       // Clear any prior arm/hint first: a non-sudo/su command must not leave a
@@ -462,16 +510,12 @@ export const createSudoPasswordAutofill = (_options: {
       }
     },
     cancelHint: () => {
-      if (!pending) return;
-      // Soft dismiss: hide UI but keep arm + tail so Esc/arrows can re-open
-      // while still on the Password: line, and so a re-prompt can auto-show.
-      pending = false;
-      hideUi();
-      dismissedWhileArmed = isArmActiveNow();
-      if (!dismissedWhileArmed) {
-        armedKind = null;
-        armedUntil = Number.NEGATIVE_INFINITY;
-      }
+      softDismissPendingUi();
+    },
+    dismissOnUserContentInput: (data: string) => {
+      if (!pending || !shouldDismissPasswordAssistOnInput(data)) return false;
+      softDismissPendingUi();
+      return true;
     },
     isPromptPending: () => pending,
     isPickerPending: () => pending && pendingUi === "picker",


### PR DESCRIPTION
## Summary
- Fixes [#2198](https://github.com/binaricat/Netcatty/issues/2198): after nested SSH (jump host A → host B), pasting B’s password at a `sudo` prompt then pressing Enter could fail because Enter was still bound to “paste saved password” for host A.
- Clipboard paste / multi-char input now soft-dismisses password-prompt assist (same idea as typing a character), so a following Enter submits the user’s paste instead of `confirmFill` injecting the session host password.
- Leaves Enter-to-fill behavior intact when the user has not pasted/typed their own secret.

## Test plan
- [x] `node --test --import tsx components/terminal/runtime/terminalSudoAutofill.test.ts`
- [ ] Manual: connect to host A with a saved password → SSH to B → `sudo` → paste B’s password → Enter → should authenticate with the paste
- [ ] Manual: same setup → press Enter without pasting → still fills A’s saved password (hint path unchanged)
- [ ] Manual: Esc still dismisses the hint; typing a char still dismisses the hint