### PR TITLE
fix(sftp): keep sidebar path sticky across terminal focus and reconnect

### DIFF
--- a/application/state/sftp/sftpReopenLocation.test.ts
+++ b/application/state/sftp/sftpReopenLocation.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   getSftpCurrentPathMemoryKey,
   getSftpReopenMemoryKey,
+  resolveSftpAutoConnectPath,
   resolveSftpOpenLocation,
 } from "./sftpReopenLocation.ts";
 
@@ -118,5 +119,34 @@ test("path changes for non-reusable sessions still use the focused terminal sess
       focusedSessionId: "mosh-session-1",
     }),
     "mosh-session-1",
+  );
+});
+
+test("auto-connect prefers explicit open path over remembered browse path", () => {
+  assert.equal(
+    resolveSftpAutoConnectPath({
+      explicitPath: "/tmp/upload",
+      rememberedPath: "/home/deploy/projects",
+    }),
+    "/tmp/upload",
+  );
+});
+
+test("auto-connect restores remembered path when nothing explicit is requested", () => {
+  assert.equal(
+    resolveSftpAutoConnectPath({
+      rememberedPath: "/home/deploy/projects/app",
+    }),
+    "/home/deploy/projects/app",
+  );
+});
+
+test("auto-connect ignores empty remembered paths", () => {
+  assert.equal(
+    resolveSftpAutoConnectPath({
+      explicitPath: "",
+      rememberedPath: "",
+    }),
+    undefined,
   );
 });

--- a/application/state/sftp/sftpReopenLocation.ts
+++ b/application/state/sftp/sftpReopenLocation.ts
@@ -48,3 +48,19 @@ export function resolveSftpOpenLocation(params: {
 
   return terminalCwd && terminalCwd.length > 0 ? terminalCwd : undefined;
 }
+
+/**
+ * Path used when the side panel auto-connects / rebinds (not a user open).
+ * Prefer an explicit open target, then the last browsed path for this endpoint.
+ * Terminal cwd is intentionally omitted here so "follow off" stays sticky;
+ * follow mode navigates after connect via the follow sync effect.
+ */
+export function resolveSftpAutoConnectPath(params: {
+  explicitPath?: string | null;
+  rememberedPath?: string | null;
+}): string | undefined {
+  const explicit = params.explicitPath?.length ? params.explicitPath : undefined;
+  if (explicit) return explicit;
+  const remembered = params.rememberedPath?.length ? params.rememberedPath : undefined;
+  return remembered;
+}

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -627,8 +627,9 @@ export const useSftpConnections = ({
               dirCacheRef.current.delete(provisionalCacheKey);
             }
             // Fall back to homeDir, then "/", chaining attempts.
+            // Remembered/reconnect paths can be stale even when shared cache is gone.
             let fallbackSucceeded = false;
-            if (sharedHostCache && startPath !== homeDir) {
+            if (startPath !== homeDir) {
               try {
                 startPath = homeDir;
                 files = await listRemoteFiles(sftpId, startPath, filenameEncoding);

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -205,18 +205,31 @@ export const useSftpConnections = ({
 
       if (!activeTabId) return;
 
-      // Capture path/host before we replace the connection so same-endpoint
+      // Capture path/endpoint before we replace the connection so same-endpoint
       // auto-reconnect can land back where the user was browsing instead of home.
-      // Do not inherit path across hosts if a reconnect flag is still set while
-      // the user switches to a different target.
+      // Do not inherit path across endpoints (including same hostId with different
+      // hostname/port/user) if a reconnect flag is still set while switching.
       const previousConnection = getActivePane(side)?.connection;
       const previousPath = previousConnection?.currentPath;
-      const previousHostId = previousConnection?.isLocal ? "local" : previousConnection?.hostId;
-      const targetHostId = host === "local" ? "local" : host.id;
+      const previousConnectionKey = !previousConnection
+        ? null
+        : previousConnection.isLocal
+          ? "local"
+          : (connectionCacheKeyMapRef.current.get(previousConnection.id) ?? null);
+      const targetConnectionKey = host === "local"
+        ? "local"
+        : buildCacheKey(
+          host.id,
+          host.hostname,
+          host.port,
+          host.protocol,
+          host.sftpSudo,
+          host.username,
+        );
       if (
         reconnectingRef.current[side]
-        && previousHostId
-        && previousHostId !== targetHostId
+        && previousConnectionKey
+        && previousConnectionKey !== targetConnectionKey
       ) {
         reconnectingRef.current[side] = false;
       }
@@ -224,7 +237,7 @@ export const useSftpConnections = ({
       const sameEndpointReconnect =
         isReconnectAttempt
         && !!previousPath
-        && previousHostId === targetHostId;
+        && previousConnectionKey === targetConnectionKey;
       const effectiveInitialPath =
         options?.initialPath
         ?? (sameEndpointReconnect ? previousPath : undefined);

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -206,6 +206,12 @@ export const useSftpConnections = ({
       if (!activeTabId) return;
 
       const isReconnectAttempt = reconnectingRef.current[side];
+      // Capture path before we replace the connection so auto-reconnect can
+      // land back where the user was browsing instead of home.
+      const previousPath = getActivePane(side)?.connection?.currentPath;
+      const effectiveInitialPath =
+        options?.initialPath
+        ?? (isReconnectAttempt && previousPath ? previousPath : undefined);
 
       // Notify caller of the tab ID synchronously, before any async work.
       // This allows callers to map metadata (e.g. connection keys) to the tab
@@ -289,7 +295,7 @@ export const useSftpConnections = ({
           homeDir = isWindows ? "C:\\Users\\damao" : "/Users/damao";
         }
 
-        const startPath = options?.initialPath || homeDir;
+        const startPath = effectiveInitialPath || homeDir;
 
         const connection: SftpConnection = {
           id: connectionId,
@@ -343,7 +349,7 @@ export const useSftpConnections = ({
         const { initialPath, sharedHostCache, cachedStartPath } = resolveRemoteSftpStartState({
           filenameEncoding,
           ignoreSharedCache: options?.ignoreSharedCache,
-          initialPath: options?.initialPath,
+          initialPath: effectiveInitialPath,
           sharedHostCacheCandidate,
         });
 

--- a/application/state/sftp/useSftpConnections.ts
+++ b/application/state/sftp/useSftpConnections.ts
@@ -205,13 +205,29 @@ export const useSftpConnections = ({
 
       if (!activeTabId) return;
 
+      // Capture path/host before we replace the connection so same-endpoint
+      // auto-reconnect can land back where the user was browsing instead of home.
+      // Do not inherit path across hosts if a reconnect flag is still set while
+      // the user switches to a different target.
+      const previousConnection = getActivePane(side)?.connection;
+      const previousPath = previousConnection?.currentPath;
+      const previousHostId = previousConnection?.isLocal ? "local" : previousConnection?.hostId;
+      const targetHostId = host === "local" ? "local" : host.id;
+      if (
+        reconnectingRef.current[side]
+        && previousHostId
+        && previousHostId !== targetHostId
+      ) {
+        reconnectingRef.current[side] = false;
+      }
       const isReconnectAttempt = reconnectingRef.current[side];
-      // Capture path before we replace the connection so auto-reconnect can
-      // land back where the user was browsing instead of home.
-      const previousPath = getActivePane(side)?.connection?.currentPath;
+      const sameEndpointReconnect =
+        isReconnectAttempt
+        && !!previousPath
+        && previousHostId === targetHostId;
       const effectiveInitialPath =
         options?.initialPath
-        ?? (isReconnectAttempt && previousPath ? previousPath : undefined);
+        ?? (sameEndpointReconnect ? previousPath : undefined);
 
       // Notify caller of the tab ID synchronously, before any async work.
       // This allows callers to map metadata (e.g. connection keys) to the tab

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -160,6 +160,15 @@ export const useSftpState = (
     right: null,
   });
 
+  // Keep reconnect metadata in sync when auto-connect reuses an existing tab
+  // without calling connect() (selectTab alone does not update this ref).
+  const setLastConnectedHost = useCallback((
+    side: "left" | "right",
+    host: Host | "local" | null,
+  ) => {
+    lastConnectedHostRef.current[side] = host;
+  }, []);
+
   const handleSessionError = useSftpSessionErrors({
     getActivePane,
     leftTabsRef,
@@ -418,6 +427,7 @@ export const useSftpState = (
     resolveConflict: resolveAnyConflict,
     getSftpIdForConnection,
     getConnectionCacheKey,
+    setLastConnectedHost,
     reportSessionError: handleSessionError,
     rejectHostKeyVerification,
     acceptHostKeyVerification,
@@ -480,6 +490,7 @@ export const useSftpState = (
     resolveConflict: resolveAnyConflict,
     getSftpIdForConnection,
     getConnectionCacheKey,
+    setLastConnectedHost,
     reportSessionError: handleSessionError,
     rejectHostKeyVerification,
     acceptHostKeyVerification,
@@ -556,6 +567,7 @@ export const useSftpState = (
     resolveConflict: (...args: Parameters<typeof resolveAnyConflict>) => methodsRef.current.resolveConflict(...args),
     getSftpIdForConnection: (...args: Parameters<typeof getSftpIdForConnection>) => methodsRef.current.getSftpIdForConnection(...args),
     getConnectionCacheKey: (...args: Parameters<typeof getConnectionCacheKey>) => methodsRef.current.getConnectionCacheKey(...args),
+    setLastConnectedHost: (...args: Parameters<typeof setLastConnectedHost>) => methodsRef.current.setLastConnectedHost(...args),
     reportSessionError: (...args: Parameters<typeof handleSessionError>) => methodsRef.current.reportSessionError(...args),
     rejectHostKeyVerification: () => methodsRef.current.rejectHostKeyVerification(),
     acceptHostKeyVerification: () => methodsRef.current.acceptHostKeyVerification(),

--- a/application/state/useSftpState.ts
+++ b/application/state/useSftpState.ts
@@ -146,6 +146,11 @@ export const useSftpState = (
   // share the same hostId with different session-time overrides.
   const connectionCacheKeyMapRef = useRef<Map<string, string>>(new Map());
 
+  // Full endpoint key captured at connect time (hostId:hostname:port:…).
+  const getConnectionCacheKey = useCallback((connectionId: string) => {
+    return connectionCacheKeyMapRef.current.get(connectionId) ?? null;
+  }, []);
+
   // Store last connected host info for reconnection
   const lastConnectedHostRef = useRef<{
     left: Host | "local" | null;
@@ -412,6 +417,7 @@ export const useSftpState = (
     dismissTransfer,
     resolveConflict: resolveAnyConflict,
     getSftpIdForConnection,
+    getConnectionCacheKey,
     reportSessionError: handleSessionError,
     rejectHostKeyVerification,
     acceptHostKeyVerification,
@@ -473,6 +479,7 @@ export const useSftpState = (
     dismissTransfer,
     resolveConflict: resolveAnyConflict,
     getSftpIdForConnection,
+    getConnectionCacheKey,
     reportSessionError: handleSessionError,
     rejectHostKeyVerification,
     acceptHostKeyVerification,
@@ -548,6 +555,7 @@ export const useSftpState = (
     dismissTransfer: (...args: Parameters<typeof dismissTransfer>) => methodsRef.current.dismissTransfer(...args),
     resolveConflict: (...args: Parameters<typeof resolveAnyConflict>) => methodsRef.current.resolveConflict(...args),
     getSftpIdForConnection: (...args: Parameters<typeof getSftpIdForConnection>) => methodsRef.current.getSftpIdForConnection(...args),
+    getConnectionCacheKey: (...args: Parameters<typeof getConnectionCacheKey>) => methodsRef.current.getConnectionCacheKey(...args),
     reportSessionError: (...args: Parameters<typeof handleSessionError>) => methodsRef.current.reportSessionError(...args),
     rejectHostKeyVerification: () => methodsRef.current.rejectHostKeyVerification(),
     acceptHostKeyVerification: () => methodsRef.current.acceptHostKeyVerification(),

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -399,9 +399,11 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     }
 
     const currentConn = s.leftPane.connection;
-    // Replace in place only for the same endpoint. A different endpoint (even
-    // under the same hostId) keeps the old tab so promoted editors still have
-    // a live connection to save against.
+    // Replace in place only when it is safe. Keep the old tab when:
+    // - local is active (distinct endpoint)
+    // - the target endpoint key differs
+    // - same-endpoint rebind would drop a connection still used by promoted
+    //   editor tabs (they save via the old connection id)
     const currentConnectionKey = currentConn && !currentConn.isLocal
       ? (
         s.getConnectionCacheKey?.(currentConn.id)
@@ -409,17 +411,20 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         ?? null
       )
       : null;
+    const hasEditorBoundToCurrentConnection = !!(
+      currentConn
+      && editorTabStore.getTabs().some((tab) => tab.sessionId === currentConn.id)
+    );
     const needsNewTab = !!(
       currentConn
       && currentConn.status === "connected"
       && (
-        // Local is its own endpoint; never overwrite it in place when moving
-        // to a remote host (promoted editors keep the old connection id).
         currentConn.isLocal
         || (
           currentConnectionKey
           && currentConnectionKey !== connectionKey
         )
+        || (sessionChanged && hasEditorBoundToCurrentConnection)
       )
     );
     const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -387,8 +387,15 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const needsNewTab = !!(
       currentConn
       && currentConn.status === "connected"
-      && currentConnectionKey
-      && currentConnectionKey !== connectionKey
+      && (
+        // Local is its own endpoint; never overwrite it in place when moving
+        // to a remote host (promoted editors keep the old connection id).
+        currentConn.isLocal
+        || (
+          currentConnectionKey
+          && currentConnectionKey !== connectionKey
+        )
+      )
     );
     const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);
     const initialPath = resolveSftpAutoConnectPath({

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -339,16 +339,16 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     });
 
     const tabs = s.leftTabs.tabs;
-    const existingTab = sessionChanged
-      ? null
-      : findReusableSftpSidePanelTab(
-        tabs,
-        activeHost.id,
-        connectionKey,
-        tabConnectionKeyMapRef.current,
-        hasBackendSession,
-        (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
-      );
+    // Prefer an existing healthy tab for this endpoint even after a terminal
+    // focus change — otherwise alternating sessions forceNewTab forever.
+    const existingTab = findReusableSftpSidePanelTab(
+      tabs,
+      activeHost.id,
+      connectionKey,
+      tabConnectionKeyMapRef.current,
+      hasBackendSession,
+      (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
+    );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;
@@ -357,7 +357,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     }
 
     const currentConn = s.leftPane.connection;
-    const needsNewTab = !!(currentConn && currentConn.status === "connected");
+    // Replace the active connection in place when possible so session switches
+    // do not accumulate orphaned SFTP tabs/channels.
+    const needsNewTab = !!(
+      currentConn
+      && currentConn.status === "connected"
+      && currentConn.hostId !== activeHost.id
+    );
     const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);
     const initialPath = resolveSftpAutoConnectPath({
       explicitPath:

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -351,6 +351,9 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
+      // selectTab does not update reconnect metadata; keep lastConnectedHost
+      // aligned with the tab we just activated so channel drops rebind correctly.
+      s.setLastConnectedHost?.("left", activeHost);
       connectedKeyRef.current = connectionKey;
       connectedHostObjRef.current = activeHost;
       // Session memory keys are per terminal session; republish the visible

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -293,9 +293,6 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       lastSourceSessionIdRef.current,
       activeSessionId,
     );
-    if (activeSessionId) {
-      lastSourceSessionIdRef.current = activeSessionId;
-    }
 
     const hasBackendSession = (connectionId: string) => !!s.getSftpIdForConnection(connectionId);
     const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
@@ -321,9 +318,17 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         activeTabConnectionKey,
       )
     ) {
+      if (activeSessionId) {
+        lastSourceSessionIdRef.current = activeSessionId;
+      }
       return;
     }
+    // Defer advancing the session cursor while interactive work blocks rebind,
+    // so sessionChanged stays true once the editor/dialog closes.
     if (hasActiveWork) return;
+    if (activeSessionId) {
+      lastSourceSessionIdRef.current = activeSessionId;
+    }
 
     logger.info("[SftpSidePanel] Auto-connect triggered", {
       hostId: activeHost.id,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -22,6 +22,7 @@ import { useSftpBackend } from "../application/state/useSftpBackend";
 import { useSftpFileAssociations } from "../application/state/useSftpFileAssociations";
 import { getParentPath, isConcreteTransferTargetPath } from "../application/state/sftp/utils";
 import { buildCacheKey } from "../application/state/sftp/sharedRemoteHostCache";
+import { resolveSftpAutoConnectPath } from "../application/state/sftp/sftpReopenLocation";
 import { logger } from "../lib/logger";
 import type { DropEntry } from "../lib/sftpFileUtils";
 import { Host, Identity, KnownHost, SSHKey } from "../types";
@@ -235,6 +236,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   const lastAppliedInitialLocationKeyRef = useRef<string | null>(null);
   const handledPendingUploadIdRef = useRef<string | null>(null);
   const tabConnectionKeyMapRef = useRef<Map<string, string>>(new Map());
+  /** Last browsed path per endpoint — survives session switches while the panel stays open. */
+  const lastBrowsedPathByConnectionKeyRef = useRef<Map<string, string>>(new Map());
   const [interactiveWorkActive, setInteractiveWorkActive] = useState(false);
   const [sftpUiReady, setSftpUiReady] = useState(false);
 
@@ -289,9 +292,6 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       lastSourceSessionIdRef.current,
       activeSessionId,
     );
-    if (sessionChanged) {
-      connectedKeyRef.current = null;
-    }
     if (activeSessionId) {
       lastSourceSessionIdRef.current = activeSessionId;
     }
@@ -299,9 +299,10 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const hasBackendSession = (connectionId: string) => !!s.getSftpIdForConnection(connectionId);
     const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
     const activeConnectionId = activeTab?.connection?.id;
+    // Same-host terminal focus changes used to force a reconnect (and often
+    // dropped back to $HOME). Keep a healthy tab for this endpoint instead.
     if (
-      !sessionChanged
-      && shouldSkipSftpSidePanelAutoConnect(
+      shouldSkipSftpSidePanelAutoConnect(
         connectionKey,
         connectedKeyRef.current,
         activeTab,
@@ -317,18 +318,17 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       hostLabel: activeHost.label,
       protocol: activeHost.protocol,
       hostname: activeHost.hostname,
+      sessionChanged,
     });
 
     const tabs = s.leftTabs.tabs;
-    const existingTab = sessionChanged
-      ? null
-      : findReusableSftpSidePanelTab(
-        tabs,
-        activeHost.id,
-        connectionKey,
-        tabConnectionKeyMapRef.current,
-        hasBackendSession,
-      );
+    const existingTab = findReusableSftpSidePanelTab(
+      tabs,
+      activeHost.id,
+      connectionKey,
+      tabConnectionKeyMapRef.current,
+      hasBackendSession,
+    );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;
@@ -338,17 +338,24 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
 
     const currentConn = s.leftPane.connection;
     const needsNewTab = !!(currentConn && currentConn.status === "connected");
+    const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);
+    const initialPath = resolveSftpAutoConnectPath({
+      explicitPath:
+        initialLocation?.hostId === activeHost.id ? initialLocation.path : null,
+      rememberedPath,
+    });
 
     connectedKeyRef.current = connectionKey;
     connectedHostObjRef.current = activeHost;
     s.connect("left", activeHost, {
       sourceSessionId: activeSessionId ?? undefined,
+      ...(initialPath ? { initialPath } : undefined),
       ...(needsNewTab ? { forceNewTab: true } : undefined),
       onTabCreated: (tabId) => {
         tabConnectionKeyMapRef.current.set(tabId, connectionKey);
       },
     });
-  }, [activeHost, activeSessionId, interactiveWorkActive]);
+  }, [activeHost, activeSessionId, initialLocation, interactiveWorkActive]);
 
   useEffect(() => {
     if (!activeHost || !isVisible) return;
@@ -409,6 +416,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     if (!connection.currentPath) return;
     const connectionKey = tabConnectionKeyMapRef.current.get(sftp.leftPane.id);
     if (!connectionKey) return;
+    lastBrowsedPathByConnectionKeyRef.current.set(connectionKey, connection.currentPath);
     onCurrentPathChangeRef.current?.({
       hostId: connection.hostId,
       connectionKey,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -415,6 +415,16 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       currentConn
       && editorTabStore.getTabs().some((tab) => tab.sessionId === currentConn.id)
     );
+    const hasActiveTransferOnCurrentConnection = !!(
+      currentConn
+      && s.transfers.some((task) => (
+        (task.status === "pending" || task.status === "transferring")
+        && (
+          task.sourceConnectionId === currentConn.id
+          || task.targetConnectionId === currentConn.id
+        )
+      ))
+    );
     const needsNewTab = !!(
       currentConn
       && currentConn.status === "connected"
@@ -424,7 +434,12 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
           currentConnectionKey
           && currentConnectionKey !== connectionKey
         )
-        || (sessionChanged && hasEditorBoundToCurrentConnection)
+        // Same-endpoint rebind closes the old connection in place; keep a tab
+        // when editors or in-flight transfers still depend on that connection id.
+        || (
+          sessionChanged
+          && (hasEditorBoundToCurrentConnection || hasActiveTransferOnCurrentConnection)
+        )
       )
     );
     const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -308,10 +308,12 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     if (activeTab && activeTabConnectionKey) {
       tabConnectionKeyMapRef.current.set(activeTab.id, activeTabConnectionKey);
     }
-    // Same-host terminal focus changes used to force a reconnect (and often
-    // dropped back to $HOME). Keep a healthy tab for this endpoint instead.
+    // Rebind when the focused terminal session changes: saved host keys can lag
+    // live session endpoints (edited host / unsaved user). Still keep the
+    // browsed path sticky via remembered initialPath below.
     if (
-      shouldSkipSftpSidePanelAutoConnect(
+      !sessionChanged
+      && shouldSkipSftpSidePanelAutoConnect(
         connectionKey,
         connectedKeyRef.current,
         activeTab,
@@ -332,14 +334,16 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     });
 
     const tabs = s.leftTabs.tabs;
-    const existingTab = findReusableSftpSidePanelTab(
-      tabs,
-      activeHost.id,
-      connectionKey,
-      tabConnectionKeyMapRef.current,
-      hasBackendSession,
-      (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
-    );
+    const existingTab = sessionChanged
+      ? null
+      : findReusableSftpSidePanelTab(
+        tabs,
+        activeHost.id,
+        connectionKey,
+        tabConnectionKeyMapRef.current,
+        hasBackendSession,
+        (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
+      );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -339,16 +339,20 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     });
 
     const tabs = s.leftTabs.tabs;
-    // Prefer an existing healthy tab for this endpoint even after a terminal
-    // focus change — otherwise alternating sessions forceNewTab forever.
-    const existingTab = findReusableSftpSidePanelTab(
-      tabs,
-      activeHost.id,
-      connectionKey,
-      tabConnectionKeyMapRef.current,
-      hasBackendSession,
-      (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
-    );
+    // Session focus changes must rebind SFTP onto the new terminal SSH session
+    // (proxy/jump path can differ even when hostId/hostname/port/user match).
+    // Same-endpoint rebind happens in place below with remembered initialPath so
+    // we keep the browsed directory without stacking tabs.
+    const existingTab = sessionChanged
+      ? null
+      : findReusableSftpSidePanelTab(
+        tabs,
+        activeHost.id,
+        connectionKey,
+        tabConnectionKeyMapRef.current,
+        hasBackendSession,
+        (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
+      );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
       // selectTab does not update reconnect metadata; keep lastConnectedHost
@@ -371,6 +375,27 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         });
       }
       return;
+    }
+
+    // Capture the visible path before rebind so session switches keep it even
+    // if the path-memory effect has not written this endpoint yet.
+    if (
+      sessionChanged
+      && activeTab?.connection
+      && !activeTab.connection.isLocal
+      && activeTab.connection.status === "connected"
+      && activeTab.connection.currentPath
+      && activeTabConnectionKey === connectionKey
+    ) {
+      lastBrowsedPathByConnectionKeyRef.current.set(
+        connectionKey,
+        activeTab.connection.currentPath,
+      );
+      onCurrentPathChangeRef.current?.({
+        hostId: activeTab.connection.hostId,
+        connectionKey,
+        path: activeTab.connection.currentPath,
+      });
     }
 
     const currentConn = s.leftPane.connection;

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -353,6 +353,20 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       s.selectTab("left", existingTab.id);
       connectedKeyRef.current = connectionKey;
       connectedHostObjRef.current = activeHost;
+      // Session memory keys are per terminal session; republish the visible
+      // path so reopening SFTP from the newly focused session keeps this dir.
+      const path = existingTab.connection?.currentPath;
+      if (
+        path
+        && existingTab.connection
+        && !existingTab.connection.isLocal
+      ) {
+        onCurrentPathChangeRef.current?.({
+          hostId: existingTab.connection.hostId,
+          connectionKey,
+          path,
+        });
+      }
       return;
     }
 

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -300,9 +300,14 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const hasBackendSession = (connectionId: string) => !!s.getSftpIdForConnection(connectionId);
     const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
     const activeConnectionId = activeTab?.connection?.id;
-    const activeTabConnectionKey = activeTab
-      ? tabConnectionKeyMapRef.current.get(activeTab.id) ?? null
+    const liveConnectionKey = activeConnectionId
+      ? s.getConnectionCacheKey?.(activeConnectionId) ?? null
       : null;
+    const activeTabConnectionKey = liveConnectionKey
+      ?? (activeTab ? tabConnectionKeyMapRef.current.get(activeTab.id) ?? null : null);
+    if (activeTab && activeTabConnectionKey) {
+      tabConnectionKeyMapRef.current.set(activeTab.id, activeTabConnectionKey);
+    }
     // Same-host terminal focus changes used to force a reconnect (and often
     // dropped back to $HOME). Keep a healthy tab for this endpoint instead.
     if (
@@ -333,6 +338,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       connectionKey,
       tabConnectionKeyMapRef.current,
       hasBackendSession,
+      (connectionId) => s.getConnectionCacheKey?.(connectionId) ?? null,
     );
     if (existingTab) {
       s.selectTab("left", existingTab.id);
@@ -420,13 +426,13 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     if (connection.status !== "connected") return;
     if (!connection.currentPath) return;
 
-    // Prefer the live host endpoint over a stale tab map entry. Host-picker
-    // reconnects keep the same tab id but switch hosts, and only auto-connect
-    // used to write the map.
-    const mappedKey = tabConnectionKeyMapRef.current.get(sftp.leftPane.id);
+    // Prefer the connect-time endpoint map (includes session overrides / picker
+    // switches). Fall back to rebuilding from the host object only when missing.
     let connectionKey =
-      connectionKeyMatchesHost(mappedKey, connection.hostId) ? mappedKey! : null;
-    if (!connectionKey) {
+      sftp.getConnectionCacheKey?.(connection.id)
+      ?? tabConnectionKeyMapRef.current.get(sftp.leftPane.id)
+      ?? null;
+    if (!connectionKeyMatchesHost(connectionKey, connection.hostId)) {
       const host =
         (activeHost?.id === connection.hostId ? activeHost : null)
         ?? hosts.find((candidate) => candidate.id === connection.hostId)
@@ -440,8 +446,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         host.sftpSudo,
         host.username,
       );
-      tabConnectionKeyMapRef.current.set(sftp.leftPane.id, connectionKey);
     }
+    tabConnectionKeyMapRef.current.set(sftp.leftPane.id, connectionKey);
 
     lastBrowsedPathByConnectionKeyRef.current.set(connectionKey, connection.currentPath);
     onCurrentPathChangeRef.current?.({
@@ -452,6 +458,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
   }, [
     activeHost,
     hosts,
+    sftp,
     sftp.leftPane.connection,
     sftp.leftPane.connection?.currentPath,
     sftp.leftPane.connection?.hostId,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -50,6 +50,7 @@ import {
   type SftpFollowTerminalCwdBlock,
 } from "./sftp/sftpFollowTerminalCwd";
 import {
+  connectionKeyMatchesHost,
   findReusableSftpSidePanelTab,
   shouldResetSftpSidePanelSourceSession,
   shouldSkipSftpSidePanelAutoConnect,
@@ -299,6 +300,9 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     const hasBackendSession = (connectionId: string) => !!s.getSftpIdForConnection(connectionId);
     const activeTab = s.leftTabs.tabs.find((tab) => tab.id === s.leftTabs.activeTabId) ?? null;
     const activeConnectionId = activeTab?.connection?.id;
+    const activeTabConnectionKey = activeTab
+      ? tabConnectionKeyMapRef.current.get(activeTab.id) ?? null
+      : null;
     // Same-host terminal focus changes used to force a reconnect (and often
     // dropped back to $HOME). Keep a healthy tab for this endpoint instead.
     if (
@@ -307,6 +311,7 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
         connectedKeyRef.current,
         activeTab,
         activeConnectionId ? hasBackendSession(activeConnectionId) : false,
+        activeTabConnectionKey,
       )
     ) {
       return;
@@ -414,8 +419,30 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     if (!connection || connection.isLocal) return;
     if (connection.status !== "connected") return;
     if (!connection.currentPath) return;
-    const connectionKey = tabConnectionKeyMapRef.current.get(sftp.leftPane.id);
-    if (!connectionKey) return;
+
+    // Prefer the live host endpoint over a stale tab map entry. Host-picker
+    // reconnects keep the same tab id but switch hosts, and only auto-connect
+    // used to write the map.
+    const mappedKey = tabConnectionKeyMapRef.current.get(sftp.leftPane.id);
+    let connectionKey =
+      connectionKeyMatchesHost(mappedKey, connection.hostId) ? mappedKey! : null;
+    if (!connectionKey) {
+      const host =
+        (activeHost?.id === connection.hostId ? activeHost : null)
+        ?? hosts.find((candidate) => candidate.id === connection.hostId)
+        ?? null;
+      if (!host) return;
+      connectionKey = buildCacheKey(
+        host.id,
+        host.hostname,
+        host.port,
+        host.protocol,
+        host.sftpSudo,
+        host.username,
+      );
+      tabConnectionKeyMapRef.current.set(sftp.leftPane.id, connectionKey);
+    }
+
     lastBrowsedPathByConnectionKeyRef.current.set(connectionKey, connection.currentPath);
     onCurrentPathChangeRef.current?.({
       hostId: connection.hostId,
@@ -423,6 +450,8 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
       path: connection.currentPath,
     });
   }, [
+    activeHost,
+    hosts,
     sftp.leftPane.connection,
     sftp.leftPane.connection?.currentPath,
     sftp.leftPane.connection?.hostId,

--- a/components/SftpSidePanel.tsx
+++ b/components/SftpSidePanel.tsx
@@ -374,12 +374,21 @@ const SftpSidePanelInner: React.FC<SftpSidePanelProps> = ({
     }
 
     const currentConn = s.leftPane.connection;
-    // Replace the active connection in place when possible so session switches
-    // do not accumulate orphaned SFTP tabs/channels.
+    // Replace in place only for the same endpoint. A different endpoint (even
+    // under the same hostId) keeps the old tab so promoted editors still have
+    // a live connection to save against.
+    const currentConnectionKey = currentConn && !currentConn.isLocal
+      ? (
+        s.getConnectionCacheKey?.(currentConn.id)
+        ?? tabConnectionKeyMapRef.current.get(s.leftPane.id)
+        ?? null
+      )
+      : null;
     const needsNewTab = !!(
       currentConn
       && currentConn.status === "connected"
-      && currentConn.hostId !== activeHost.id
+      && currentConnectionKey
+      && currentConnectionKey !== connectionKey
     );
     const rememberedPath = lastBrowsedPathByConnectionKeyRef.current.get(connectionKey);
     const initialPath = resolveSftpAutoConnectPath({

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -84,15 +84,22 @@ test("shouldResetSftpSidePanelSourceSession detects terminal session changes", (
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", null), false);
 });
 
-test("shouldSkipSftpSidePanelAutoConnect returns false after terminal session changes", () => {
+test("healthy same-endpoint tabs still skip auto-connect after a terminal session change", () => {
   const tab = remoteConnectedTab();
+  // Session focus changes must not tear down a healthy SFTP tab for the same host.
+  assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"), true);
   assert.equal(
     shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true),
     true,
   );
-  // Caller gates on sessionChanged before invoking skip — stale reuse must not win.
   assert.equal(
-    shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"),
-    true,
+    findReusableSftpSidePanelTab(
+      [tab],
+      "host-1",
+      "host-key",
+      new Map([[tab.id, "host-key"]]),
+      () => true,
+    ),
+    tab,
   );
 });

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -107,22 +107,15 @@ test("shouldResetSftpSidePanelSourceSession detects terminal session changes", (
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", null), false);
 });
 
-test("healthy same-endpoint tabs still skip auto-connect after a terminal session change", () => {
+test("session change still requires rebind even when the endpoint key matches", () => {
   const tab = remoteConnectedTab();
-  // Session focus changes must not tear down a healthy SFTP tab for the same host.
+  // Callers must not skip auto-connect solely because the tab is healthy —
+  // a new focused terminal session can share a saved host key while the live
+  // endpoint (user/host overrides) differs. Path stickiness is handled by
+  // remembered initialPath on reconnect.
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"), true);
   assert.equal(
     shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true, "host-key"),
     true,
-  );
-  assert.equal(
-    findReusableSftpSidePanelTab(
-      [tab],
-      "host-1",
-      "host-key",
-      new Map([[tab.id, "host-key"]]),
-      () => true,
-    ),
-    tab,
   );
 });

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { SftpPane } from "../../application/state/sftp/types";
 import {
+  connectionKeyMatchesHost,
   findReusableSftpSidePanelTab,
   isRemoteSftpTabHealthy,
   shouldResetSftpSidePanelSourceSession,
@@ -54,9 +55,31 @@ test("isRemoteSftpTabHealthy rejects connecting tabs", () => {
 test("shouldSkipSftpSidePanelAutoConnect returns false for stale connected keys", () => {
   const tab = remoteConnectedTab({ loading: true });
   assert.equal(
-    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true),
+    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true, "host-key"),
     false,
   );
+});
+
+test("shouldSkipSftpSidePanelAutoConnect rejects a healthy tab mapped to another endpoint", () => {
+  const tab = remoteConnectedTab();
+  assert.equal(
+    shouldSkipSftpSidePanelAutoConnect("host-a-key", "host-a-key", tab, true, "host-b-key"),
+    false,
+  );
+});
+
+test("shouldSkipSftpSidePanelAutoConnect rejects when the active tab has no endpoint map", () => {
+  const tab = remoteConnectedTab();
+  assert.equal(
+    shouldSkipSftpSidePanelAutoConnect("host-a-key", "host-a-key", tab, true, null),
+    false,
+  );
+});
+
+test("connectionKeyMatchesHost accepts host-id prefix keys", () => {
+  assert.equal(connectionKeyMatchesHost("host-1:server:22:ssh::root", "host-1"), true);
+  assert.equal(connectionKeyMatchesHost("host-2:server:22:ssh::root", "host-1"), false);
+  assert.equal(connectionKeyMatchesHost(null, "host-1"), false);
 });
 
 test("findReusableSftpSidePanelTab ignores tabs stuck in loading after SSH disconnect", () => {
@@ -89,7 +112,7 @@ test("healthy same-endpoint tabs still skip auto-connect after a terminal sessio
   // Session focus changes must not tear down a healthy SFTP tab for the same host.
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"), true);
   assert.equal(
-    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true),
+    shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true, "host-key"),
     true,
   );
   assert.equal(

--- a/components/sftp/sftpSidePanelAutoConnect.test.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.test.ts
@@ -110,12 +110,23 @@ test("shouldResetSftpSidePanelSourceSession detects terminal session changes", (
 test("session change still requires rebind even when the endpoint key matches", () => {
   const tab = remoteConnectedTab();
   // Callers must not skip auto-connect solely because the tab is healthy —
-  // a new focused terminal session can share a saved host key while the live
-  // endpoint (user/host overrides) differs. Path stickiness is handled by
-  // remembered initialPath on reconnect.
+  // a new focused terminal may share host/port/user while proxy/jump differs.
+  // Path stickiness is handled by remembered initialPath on reconnect.
   assert.equal(shouldResetSftpSidePanelSourceSession("sess-a", "sess-b"), true);
   assert.equal(
     shouldSkipSftpSidePanelAutoConnect("host-key", "host-key", tab, true, "host-key"),
     true,
+  );
+  // Reuse lookup still finds the tab, but callers pass sessionChanged and skip
+  // it so connect rebinds with the new sourceSessionId.
+  assert.equal(
+    findReusableSftpSidePanelTab(
+      [tab],
+      "host-1",
+      "host-key",
+      new Map([[tab.id, "host-key"]]),
+      () => true,
+    ),
+    tab,
   );
 });

--- a/components/sftp/sftpSidePanelAutoConnect.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.ts
@@ -46,7 +46,7 @@ export function findReusableSftpSidePanelTab(
   return candidate;
 }
 
-/** True when the linked terminal SSH session changed and SFTP must rebind. */
+/** True when the linked terminal SSH session id changed. */
 export function shouldResetSftpSidePanelSourceSession(
   previousSessionId: string | null | undefined,
   nextSessionId: string | null | undefined,

--- a/components/sftp/sftpSidePanelAutoConnect.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.ts
@@ -15,16 +15,31 @@ export function isRemoteSftpTabHealthy(
   return true;
 }
 
-/** Skip auto-connect only when the active tab is already bound to this endpoint and healthy. */
+/**
+ * Skip auto-connect only when the active tab is already bound to this endpoint
+ * and healthy. `activeTabConnectionKey` must match so a manually selected tab
+ * for a different host cannot be kept just because `connectedKey` is stale.
+ */
 export function shouldSkipSftpSidePanelAutoConnect(
   connectionKey: string,
   connectedKey: string | null,
   activeTab: SftpSidePanelTabHealth | null | undefined,
   hasBackendSession: boolean,
+  activeTabConnectionKey?: string | null,
 ): boolean {
   if (connectedKey !== connectionKey) return false;
   if (!activeTab) return false;
+  if (activeTabConnectionKey !== connectionKey) return false;
   return isRemoteSftpTabHealthy(activeTab, hasBackendSession);
+}
+
+/** Whether a stored endpoint key still belongs to the live connection's host. */
+export function connectionKeyMatchesHost(
+  connectionKey: string | null | undefined,
+  hostId: string,
+): boolean {
+  if (!connectionKey) return false;
+  return connectionKey === hostId || connectionKey.startsWith(`${hostId}:`);
 }
 
 export function findReusableSftpSidePanelTab(

--- a/components/sftp/sftpSidePanelAutoConnect.ts
+++ b/components/sftp/sftpSidePanelAutoConnect.ts
@@ -48,11 +48,14 @@ export function findReusableSftpSidePanelTab(
   connectionKey: string,
   tabConnectionKeyMap: ReadonlyMap<string, string>,
   hasBackendSession: (connectionId: string) => boolean,
+  getConnectionKey?: (connectionId: string) => string | null,
 ): SftpPane | null {
   const candidate = tabs.find((tab) => {
     if (!tab.connection || tab.connection.hostId !== hostId) return false;
     if (tab.connection.status === "error" || tab.connection.status === "disconnected") return false;
-    return tabConnectionKeyMap.get(tab.id) === connectionKey;
+    const liveKey = getConnectionKey?.(tab.connection.id) ?? null;
+    const tabKey = liveKey ?? tabConnectionKeyMap.get(tab.id) ?? null;
+    return tabKey === connectionKey;
   });
   if (!candidate?.connection) return null;
   if (!isRemoteSftpTabHealthy(candidate, hasBackendSession(candidate.connection.id))) {


### PR DESCRIPTION
## Summary
- Keep a healthy same-host SFTP sidebar tab when switching terminal focus instead of forcing a reconnect that often lands on `$HOME`.
- Remember the last browsed path per endpoint while the panel is open, and pass it as `initialPath` when a reconnect is still required.
- On automatic SFTP reconnect, restore the previous `currentPath` instead of falling through to home after the short-lived shared host cache expires.

## Test plan
- [ ] Open SFTP on a remote host, navigate deep, disable "follow terminal directory".
- [ ] Focus another terminal on the same host — path should stay put.
- [ ] Wait >60s, then switch terminals again — path should still not jump to home.
- [ ] Simulate SFTP channel drop/reconnect — should return to the last browsed path.
- [ ] Enable follow mode and `cd` in the terminal — follow behavior still works.
- [ ] `node --import tsx --test application/state/sftp/sftpReopenLocation.test.ts components/sftp/sftpSidePanelAutoConnect.test.ts application/state/sftp/sftpConnectStartPath.test.ts components/sftp/sftpFollowTerminalCwd.test.ts`

Fixes #2193