### PR TITLE
fix(ui): align quick-connect continue dropdown with auth dialog

### DIFF
--- a/components/QuickConnectWizard.tsx
+++ b/components/QuickConnectWizard.tsx
@@ -845,7 +845,7 @@ const QuickConnectWizard: React.FC<QuickConnectWizardProps> = ({
                     </Button>
                   </DropdownTrigger>
                 </div>
-                <DropdownContent className="w-44 p-1" align="end" side="top">
+                <DropdownContent className="w-44 p-1 z-50" align="end">
                   <button
                     className="w-full px-3 py-2 text-sm text-left hover:bg-secondary rounded-md"
                     onClick={() => handleConnect(true)}

--- a/components/ui/dropdown.tsx
+++ b/components/ui/dropdown.tsx
@@ -140,6 +140,7 @@ const DropdownContent: React.FC<DropdownContentProps> = ({
   const [position, setPosition] = useState<{
     top: number;
     left: number;
+    maxHeight?: number;
   } | null>(null);
 
   // Calculate position function
@@ -156,20 +157,54 @@ const DropdownContent: React.FC<DropdownContentProps> = ({
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const contentEl = contentRef.current;
 
-    let top: number;
-    let left: number;
-
     const contentHeight = contentEl?.offsetHeight ?? 0;
     const contentWidth = contentEl?.offsetWidth ?? 0;
+    const viewportMargin = 8;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const spaceBelow = Math.max(
+      0,
+      viewportHeight - triggerRect.bottom - sideOffset - viewportMargin,
+    );
+    const spaceAbove = Math.max(
+      0,
+      triggerRect.top - sideOffset - viewportMargin,
+    );
 
-    // Vertical: open below or fully above the trigger (not overlapping it).
+    // Prefer requested side when it fits; otherwise pick the side with more room.
+    // Never bounce oversized menus off-screen by flipping twice.
+    let placeBelow: boolean;
     if (side === "bottom") {
+      if (contentHeight <= spaceBelow || spaceBelow >= spaceAbove) {
+        placeBelow = true;
+      } else {
+        placeBelow = false;
+      }
+    } else if (contentHeight <= spaceAbove || spaceAbove > spaceBelow) {
+      placeBelow = false;
+    } else {
+      placeBelow = true;
+    }
+
+    const available = placeBelow ? spaceBelow : spaceAbove;
+    const maxHeight =
+      contentHeight > available && available > 0
+        ? available
+        : undefined;
+    const effectiveHeight = maxHeight ?? contentHeight;
+
+    let top: number;
+    if (placeBelow) {
       top = triggerRect.bottom + sideOffset;
     } else {
-      top = triggerRect.top - contentHeight - sideOffset;
+      top = triggerRect.top - effectiveHeight - sideOffset;
+      if (top < viewportMargin) {
+        top = viewportMargin;
+      }
     }
 
     // Use anchor element (parent or trigger) for horizontal positioning
+    let left: number;
     if (align === "start") {
       left = rect.left;
     } else if (align === "end") {
@@ -181,26 +216,16 @@ const DropdownContent: React.FC<DropdownContentProps> = ({
       }
     }
 
-    // Keep within viewport; flip vertical side when needed
     if (contentEl) {
-      const viewportWidth = window.innerWidth;
-      const viewportHeight = window.innerHeight;
-
-      if (left + contentWidth > viewportWidth - 8) {
-        left = viewportWidth - contentWidth - 8;
+      if (left + contentWidth > viewportWidth - viewportMargin) {
+        left = viewportWidth - contentWidth - viewportMargin;
       }
-      if (left < 8) {
-        left = 8;
-      }
-      if (top + contentHeight > viewportHeight - 8) {
-        top = triggerRect.top - contentHeight - sideOffset;
-      }
-      if (top < 8) {
-        top = triggerRect.bottom + sideOffset;
+      if (left < viewportMargin) {
+        left = viewportMargin;
       }
     }
 
-    return { top, left };
+    return { top, left, maxHeight };
   }, [align, sideOffset, side, alignToParent, triggerRef]);
 
   // Calculate position synchronously after DOM updates
@@ -271,6 +296,8 @@ const DropdownContent: React.FC<DropdownContentProps> = ({
       style={{
         top: position?.top ?? -9999,
         left: position?.left ?? -9999,
+        maxHeight: position?.maxHeight,
+        overflowY: position?.maxHeight ? "auto" : undefined,
         visibility: position ? "visible" : "hidden",
       }}
     >

--- a/components/ui/dropdown.tsx
+++ b/components/ui/dropdown.tsx
@@ -159,41 +159,44 @@ const DropdownContent: React.FC<DropdownContentProps> = ({
     let top: number;
     let left: number;
 
-    // Use trigger's bottom for vertical positioning (not parent's)
+    const contentHeight = contentEl?.offsetHeight ?? 0;
+    const contentWidth = contentEl?.offsetWidth ?? 0;
+
+    // Vertical: open below or fully above the trigger (not overlapping it).
     if (side === "bottom") {
       top = triggerRect.bottom + sideOffset;
     } else {
-      top = triggerRect.top - sideOffset;
+      top = triggerRect.top - contentHeight - sideOffset;
     }
 
     // Use anchor element (parent or trigger) for horizontal positioning
     if (align === "start") {
       left = rect.left;
     } else if (align === "end") {
-      left = rect.right;
-      if (contentEl) {
-        left = rect.right - contentEl.offsetWidth;
-      }
+      left = contentEl ? rect.right - contentWidth : rect.right;
     } else {
       left = rect.left + rect.width / 2;
       if (contentEl) {
-        left -= contentEl.offsetWidth / 2;
+        left -= contentWidth / 2;
       }
     }
 
-    // Keep within viewport
+    // Keep within viewport; flip vertical side when needed
     if (contentEl) {
       const viewportWidth = window.innerWidth;
       const viewportHeight = window.innerHeight;
 
-      if (left + contentEl.offsetWidth > viewportWidth - 8) {
-        left = viewportWidth - contentEl.offsetWidth - 8;
+      if (left + contentWidth > viewportWidth - 8) {
+        left = viewportWidth - contentWidth - 8;
       }
       if (left < 8) {
         left = 8;
       }
-      if (top + contentEl.offsetHeight > viewportHeight - 8) {
-        top = rect.top - contentEl.offsetHeight - sideOffset;
+      if (top + contentHeight > viewportHeight - 8) {
+        top = triggerRect.top - contentHeight - sideOffset;
+      }
+      if (top < 8) {
+        top = triggerRect.bottom + sideOffset;
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix `DropdownContent` `side="top"` positioning so the menu opens fully above the trigger instead of overlapping/covering the Continue button.
- Align Quick Connect auth step continue/save split-button dropdown with `TerminalAuthDialog` (open below, shared `z-50` styling).

## Context
Fixes #2194 — on quick connect password step, expanding the Continue chevron caused "Continue & Save" to cover the primary Continue control. Auth retry dialog already looked correct.

## Test plan
- [ ] Open quick connect from search, enter password, open Continue chevron dropdown — menu should open below (or cleanly above if flipped for viewport) without covering the Continue button
- [ ] Choose Continue and Continue & Save; both still work
- [ ] Force auth failure retry dialog; confirm continue/save dropdown still matches
- [ ] Smoke other dropdowns (vault sort/filter) still position correctly