### PR TITLE
fix(vault): clear selected host on blank click

### DIFF
--- a/components/vault/VaultHostListSection.tsx
+++ b/components/vault/VaultHostListSection.tsx
@@ -16,6 +16,7 @@ import {
   hostCardFocusClassName,
   resolveGroupActivateAction,
   resolveHostActivateAction,
+  shouldClearHostFocusOnBackgroundClick,
   type HostClickBehavior,
 } from "../../domain/hostClickBehavior";
 import type { Host } from "../../domain/models";
@@ -88,6 +89,22 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
     setSelectedGroupPath(groupPath);
   }, [focusedGroupPath, hostClickBehavior, setSelectedGroupPath]);
 
+  const handleHostListClick = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target;
+    const clickedWithinHostList = target instanceof Node
+      && event.currentTarget.contains(target);
+    const clickedHostOrGroup = target instanceof Element
+      && !!target.closest("[data-host-id], [data-group-path]");
+    if (!shouldClearHostFocusOnBackgroundClick({
+      behavior: hostClickBehavior,
+      isMultiSelectMode,
+      clickedWithinHostList,
+      clickedHostOrGroup,
+    })) return;
+    setFocusedHostId(null);
+    setFocusedGroupPath(null);
+  }, [hostClickBehavior, isMultiSelectMode]);
+
 
   const handleHostDragStart = React.useCallback((e: React.DragEvent, hostId: string) => {
     e.dataTransfer.effectAllowed = "move";
@@ -150,6 +167,7 @@ export function VaultHostListSection({ ctx }: { ctx: VaultHostListSectionContext
             !isHostsSectionActive && "hidden",
           )}
           data-section="vault-host-list"
+          onClick={handleHostListClick}
           onDragOverCapture={(e) => {
             const target = (e.target as Element | null)?.closest("[data-host-id], [data-group-path]");
             if (target) e.preventDefault();

--- a/domain/hostClickBehavior.test.ts
+++ b/domain/hostClickBehavior.test.ts
@@ -7,6 +7,7 @@ import {
   isHostClickBehavior,
   resolveGroupActivateAction,
   resolveHostActivateAction,
+  shouldClearHostFocusOnBackgroundClick,
 } from './hostClickBehavior';
 
 test('default host click behavior is connect (legacy single-click)', () => {
@@ -116,6 +117,54 @@ test('resolveGroupActivateAction: select mode focuses then opens', () => {
       groupPath: 'prod',
     }),
     'open',
+  );
+});
+
+test('background clicks clear focus only in select-before-connect mode', () => {
+  assert.equal(
+    shouldClearHostFocusOnBackgroundClick({
+      behavior: 'select',
+      isMultiSelectMode: false,
+      clickedWithinHostList: true,
+      clickedHostOrGroup: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldClearHostFocusOnBackgroundClick({
+      behavior: 'select',
+      isMultiSelectMode: false,
+      clickedWithinHostList: true,
+      clickedHostOrGroup: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldClearHostFocusOnBackgroundClick({
+      behavior: 'select',
+      isMultiSelectMode: true,
+      clickedWithinHostList: true,
+      clickedHostOrGroup: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldClearHostFocusOnBackgroundClick({
+      behavior: 'connect',
+      isMultiSelectMode: false,
+      clickedWithinHostList: true,
+      clickedHostOrGroup: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldClearHostFocusOnBackgroundClick({
+      behavior: 'select',
+      isMultiSelectMode: false,
+      clickedWithinHostList: false,
+      clickedHostOrGroup: false,
+    }),
+    false,
   );
 });
 

--- a/domain/hostClickBehavior.ts
+++ b/domain/hostClickBehavior.ts
@@ -34,6 +34,20 @@ export function resolveGroupActivateAction(input: {
   return 'select';
 }
 
+export function shouldClearHostFocusOnBackgroundClick(input: {
+  behavior: HostClickBehavior;
+  isMultiSelectMode: boolean;
+  clickedWithinHostList: boolean;
+  clickedHostOrGroup: boolean;
+}): boolean {
+  return (
+    input.behavior === 'select' &&
+    !input.isMultiSelectMode &&
+    input.clickedWithinHostList &&
+    !input.clickedHostOrGroup
+  );
+}
+
 /**
  * Focus styles for vault host/group cards.
  * - Grid: recolor existing soft-card border to accent.


### PR DESCRIPTION
## What changed

- Clear the highlighted host or group when blank space is clicked in select-before-connect mode.
- Keep normal host and group actions unchanged.
- Preserve the highlight when using the right-click action menu.

## Why

In select-before-connect mode, a highlighted item could not be returned to the unselected state without choosing another item.

## Verification

- Full test suite: 5135 passed, 0 failed, 3 skipped
- Production build passed
- Targeted lint and tests passed
- Verified host, group, blank-space, and right-click menu behavior in the running app
- Two-round local Codex review completed; final round clean from both reviewers

Closes #2204