### PR TITLE
fix(sync): prevent WebDAV vault JSON trailing-byte corruption (#2223)

### DIFF
--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -1,4 +1,5 @@
 const { createClient, AuthType } = require("webdav");
+const crypto = require("crypto");
 const https = require("https");
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const {
@@ -13,6 +14,69 @@ const {
 } = require("./httpNetworkProxyAgent.cjs");
 
 const SYNC_FILE_NAME = "netcatty-vault.json";
+
+/**
+ * Some WebDAV servers (esp. lightweight / local ones) overwrite existing
+ * files without truncating when the new body is shorter. That leaves trailing
+ * bytes from the previous longer body and breaks JSON.parse on download
+ * (#2223). Prefer an atomic temp-PUT + MOVE replace; fall back to DELETE +
+ * PUT so the target is recreated at the correct length.
+ */
+const serializeSyncedFileBody = (syncedFile) =>
+  Buffer.from(JSON.stringify(syncedFile), "utf8");
+
+const safeDeleteWebdavPath = async (client, path) => {
+  try {
+    if (await client.exists(path)) {
+      await client.deleteFile(path);
+    }
+  } catch {
+    // Best-effort cleanup / pre-replace delete.
+  }
+};
+
+const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
+  const tmpPath = `${path}.tmp-${crypto.randomBytes(8).toString("hex")}`;
+  let tmpWritten = false;
+  try {
+    await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
+    tmpWritten = true;
+    await client.moveFile(tmpPath, path, { overwrite: true });
+    return;
+  } catch {
+    if (tmpWritten) {
+      await safeDeleteWebdavPath(client, tmpPath);
+    }
+  }
+
+  // Fallback for servers without reliable MOVE, or if temp write failed.
+  await safeDeleteWebdavPath(client, path);
+  await client.putFileContents(path, bodyBuffer, { overwrite: true });
+};
+
+/**
+ * Recover from trailing garbage left by non-truncating WebDAV PUT overwrites.
+ * Node/V8 reports: "Unexpected non-whitespace character after JSON at position N".
+ */
+const parseSyncedFileJson = (raw) => {
+  const text = String(raw ?? "");
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = /Unexpected non-whitespace character after JSON at position (\d+)/i.exec(
+      message
+    );
+    if (match) {
+      const pos = Number(match[1]);
+      if (Number.isFinite(pos) && pos > 0 && pos <= text.length) {
+        return JSON.parse(text.slice(0, pos));
+      }
+    }
+    throw error;
+  }
+};
 
 let electronModuleRef = null;
 
@@ -208,7 +272,8 @@ const handleWebdavUpload = async (config, syncedFile) => {
   try {
     const client = await buildWebdavClient(config);
     const path = getWebdavPath();
-    await client.putFileContents(path, JSON.stringify(syncedFile), { overwrite: true });
+    const body = serializeSyncedFileBody(syncedFile);
+    await putWebdavFileReplacing(client, path, body);
     return { resourceId: path };
   } catch (error) {
     throw wrapWebdavError("upload", error, config);
@@ -223,7 +288,7 @@ const handleWebdavDownload = async (config) => {
     if (!exists) return { syncedFile: null };
     const data = await client.getFileContents(path, { format: "text" });
     if (!data) return { syncedFile: null };
-    return { syncedFile: JSON.parse(String(data)) };
+    return { syncedFile: parseSyncedFileJson(data) };
   } catch (error) {
     throw wrapWebdavError("download", error, config);
   }
@@ -350,6 +415,10 @@ module.exports = {
   registerHandlers,
   // Exposed for tests
   handleWebdavInitialize,
+  handleWebdavUpload,
+  handleWebdavDownload,
+  parseSyncedFileJson,
+  putWebdavFileReplacing,
   buildBasicAuthHeader,
   buildS3Client,
 };

--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -46,6 +46,17 @@ const padBodyToAtLeast = (bodyBuffer, minLength) => {
   return Buffer.concat([bodyBuffer, Buffer.alloc(minLength - bodyBuffer.length, 0x20)]);
 };
 
+/**
+ * Strict upload check: remote must be exactly the intended body, optionally
+ * followed only by whitespace. Do NOT use parseSyncedFileJson here — that
+ * helper intentionally recovers trailing garbage on download.
+ */
+const remoteMatchesUploadedBody = (remoteText, bodyBuffer) => {
+  const bodyText = bodyBuffer.toString("utf8");
+  if (!remoteText.startsWith(bodyText)) return false;
+  return /^\s*$/.test(remoteText.slice(bodyText.length));
+};
+
 const readExistingByteLengthStrict = async (client, path) => {
   let exists = false;
   try {
@@ -71,30 +82,46 @@ const readExistingByteLengthStrict = async (client, path) => {
   }
 };
 
+const readRemoteText = async (client, path) => {
+  const remote = await client.getFileContents(path, { format: "text" });
+  return String(remote ?? "");
+};
+
 const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
   // Fixed temp name so failed cleanups cannot accumulate one full vault per sync.
   const tmpPath = `${path}.tmp`;
 
-  // Optional atomic path: temp file then MOVE into place.
+  // Optional atomic path: pad temp (in case a stale non-truncated .tmp remains),
+  // MOVE into place, then strictly verify the destination.
   try {
-    await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
+    let tmpMinLen = 0;
+    try {
+      tmpMinLen = await readExistingByteLengthStrict(client, tmpPath);
+    } catch {
+      tmpMinLen = 0;
+    }
+    await client.putFileContents(tmpPath, padBodyToAtLeast(bodyBuffer, tmpMinLen), {
+      overwrite: true,
+    });
     await client.moveFile(tmpPath, path, { overwrite: true });
-    return;
+    const movedText = await readRemoteText(client, path);
+    if (remoteMatchesUploadedBody(movedText, bodyBuffer)) {
+      return;
+    }
   } catch {
-    await safeDeleteWebdavPath(client, tmpPath);
+    // fall through to padded in-place PUT
   }
+  await safeDeleteWebdavPath(client, tmpPath);
 
-  // Keep the canonical path visible. Pad + verify so non-truncating servers
-  // and concurrent writers that grow the remote cannot leave invalid JSON.
+  // Keep the canonical path visible. Pad + strict verify so non-truncating
+  // servers and concurrent writers that grow the remote cannot leave garbage.
   let minLen = await readExistingByteLengthStrict(client, path);
-  let lastVerifyError = null;
   for (let attempt = 0; attempt < 3; attempt++) {
     const payload = padBodyToAtLeast(bodyBuffer, minLen);
     await client.putFileContents(path, payload, { overwrite: true });
     let remoteText = "";
     try {
-      const remote = await client.getFileContents(path, { format: "text" });
-      remoteText = String(remote ?? "");
+      remoteText = await readRemoteText(client, path);
     } catch (error) {
       throw new Error(
         `WebDAV upload verification failed: could not re-read file (${
@@ -102,20 +129,13 @@ const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
         })`
       );
     }
-    try {
-      parseSyncedFileJson(remoteText);
+    if (remoteMatchesUploadedBody(remoteText, bodyBuffer)) {
       return;
-    } catch (error) {
-      lastVerifyError = error;
-      minLen = Math.max(minLen, Buffer.byteLength(remoteText, "utf8"), bodyBuffer.length);
     }
+    minLen = Math.max(minLen, Buffer.byteLength(remoteText, "utf8"), bodyBuffer.length);
   }
-  const detail =
-    lastVerifyError instanceof Error ? lastVerifyError.message : String(lastVerifyError || "");
   throw new Error(
-    `WebDAV upload verification failed: remote file still not valid JSON after padded PUT${
-      detail ? ` (${detail})` : ""
-    }`
+    "WebDAV upload verification failed: remote file still does not match uploaded body after padded PUT"
   );
 };
 

--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -83,15 +83,30 @@ const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
     return;
   } catch {
     // MOVE unsupported or failed — fall through to DELETE + PUT using the
-    // already-validated temp body. Clean up temp in finally.
+    // already-validated temp body.
+  }
+
+  // Only after a successful temp write: remove destination, then recreate it.
+  // If delete fails, leave the old vault alone and do not attempt in-place PUT.
+  try {
+    await deleteWebdavPathForReplace(client, path);
+  } catch (error) {
+    await safeDeleteWebdavPath(client, tmpPath);
+    throw error;
   }
 
   try {
-    await deleteWebdavPathForReplace(client, path);
     await client.putFileContents(path, bodyBuffer, { overwrite: true });
-  } finally {
-    await safeDeleteWebdavPath(client, tmpPath);
+  } catch (error) {
+    // Destination is already gone. Retry once; keep temp if still failing.
+    try {
+      await client.putFileContents(path, bodyBuffer, { overwrite: true });
+    } catch {
+      throw error;
+    }
   }
+  // Only remove temp after destination holds the new body.
+  await safeDeleteWebdavPath(client, tmpPath);
 };
 
 /**

--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -1,5 +1,4 @@
 const { createClient, AuthType } = require("webdav");
-const crypto = require("crypto");
 const https = require("https");
 const { NodeHttpHandler } = require("@smithy/node-http-handler");
 const {
@@ -22,11 +21,11 @@ const SYNC_FILE_NAME = "netcatty-vault.json";
  * (#2223).
  *
  * Strategy:
- * 1) Prefer temp PUT + MOVE (atomic, exact size) when the server supports it.
- * 2) Otherwise in-place PUT with trailing space padding up to the previous
- *    length. JSON.parse ignores trailing whitespace, so non-truncating
- *    servers stay parseable without a DELETE gap (no empty-file race for
- *    concurrent clients).
+ * 1) Prefer fixed-name temp PUT + MOVE (atomic, exact size) when supported.
+ * 2) Otherwise in-place PUT padded with spaces to at least the previous
+ *    length, then re-read and verify JSON. Retry with a larger pad if a
+ *    concurrent writer grew the file (stale-length race). JSON.parse
+ *    ignores trailing whitespace, so the canonical path never needs DELETE.
  */
 const serializeSyncedFileBody = (syncedFile) =>
   Buffer.from(JSON.stringify(syncedFile), "utf8");
@@ -47,39 +46,77 @@ const padBodyToAtLeast = (bodyBuffer, minLength) => {
   return Buffer.concat([bodyBuffer, Buffer.alloc(minLength - bodyBuffer.length, 0x20)]);
 };
 
-const readExistingByteLength = async (client, path) => {
+const readExistingByteLengthStrict = async (client, path) => {
+  let exists = false;
   try {
-    if (!(await client.exists(path))) return 0;
+    exists = await client.exists(path);
+  } catch (error) {
+    throw new Error(
+      `WebDAV replace aborted: could not check existing file (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
+  }
+  if (!exists) return 0;
+  try {
     const existing = await client.getFileContents(path, { format: "text" });
     if (existing == null) return 0;
     return Buffer.byteLength(String(existing), "utf8");
-  } catch {
-    return 0;
+  } catch (error) {
+    throw new Error(
+      `WebDAV replace aborted: could not read existing file length (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
   }
 };
 
 const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
-  const tmpPath = `${path}.tmp-${crypto.randomBytes(8).toString("hex")}`;
+  // Fixed temp name so failed cleanups cannot accumulate one full vault per sync.
+  const tmpPath = `${path}.tmp`;
 
   // Optional atomic path: temp file then MOVE into place.
   try {
     await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
-    try {
-      await client.moveFile(tmpPath, path, { overwrite: true });
-      return;
-    } catch {
-      await safeDeleteWebdavPath(client, tmpPath);
-    }
+    await client.moveFile(tmpPath, path, { overwrite: true });
+    return;
   } catch {
-    // Temp write or cleanup failed — fall through to padded in-place PUT.
     await safeDeleteWebdavPath(client, tmpPath);
   }
 
-  // Keep the canonical path visible: pad shorter bodies so buggy servers that
-  // do not truncate still leave only JSON-legal trailing whitespace.
-  const existingLen = await readExistingByteLength(client, path);
-  const payload = padBodyToAtLeast(bodyBuffer, existingLen);
-  await client.putFileContents(path, payload, { overwrite: true });
+  // Keep the canonical path visible. Pad + verify so non-truncating servers
+  // and concurrent writers that grow the remote cannot leave invalid JSON.
+  let minLen = await readExistingByteLengthStrict(client, path);
+  let lastVerifyError = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const payload = padBodyToAtLeast(bodyBuffer, minLen);
+    await client.putFileContents(path, payload, { overwrite: true });
+    let remoteText = "";
+    try {
+      const remote = await client.getFileContents(path, { format: "text" });
+      remoteText = String(remote ?? "");
+    } catch (error) {
+      throw new Error(
+        `WebDAV upload verification failed: could not re-read file (${
+          error instanceof Error ? error.message : String(error)
+        })`
+      );
+    }
+    try {
+      parseSyncedFileJson(remoteText);
+      return;
+    } catch (error) {
+      lastVerifyError = error;
+      minLen = Math.max(minLen, Buffer.byteLength(remoteText, "utf8"), bodyBuffer.length);
+    }
+  }
+  const detail =
+    lastVerifyError instanceof Error ? lastVerifyError.message : String(lastVerifyError || "");
+  throw new Error(
+    `WebDAV upload verification failed: remote file still not valid JSON after padded PUT${
+      detail ? ` (${detail})` : ""
+    }`
+  );
 };
 
 /**

--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -19,8 +19,10 @@ const SYNC_FILE_NAME = "netcatty-vault.json";
  * Some WebDAV servers (esp. lightweight / local ones) overwrite existing
  * files without truncating when the new body is shorter. That leaves trailing
  * bytes from the previous longer body and breaks JSON.parse on download
- * (#2223). Prefer an atomic temp-PUT + MOVE replace; fall back to DELETE +
- * PUT so the target is recreated at the correct length.
+ * (#2223). Prefer an atomic temp-PUT + MOVE replace; only fall back to
+ * DELETE + PUT after the temp body is known-good. Never destroy the existing
+ * vault just because the new upload itself failed, and never fall back to
+ * in-place PUT if destination delete fails (that reintroduces #2223).
  */
 const serializeSyncedFileBody = (syncedFile) =>
   Buffer.from(JSON.stringify(syncedFile), "utf8");
@@ -31,27 +33,65 @@ const safeDeleteWebdavPath = async (client, path) => {
       await client.deleteFile(path);
     }
   } catch {
-    // Best-effort cleanup / pre-replace delete.
+    // Best-effort cleanup only (temp files).
+  }
+};
+
+/** Delete target if present; throw if it still exists afterward. */
+const deleteWebdavPathForReplace = async (client, path) => {
+  let exists = false;
+  try {
+    exists = await client.exists(path);
+  } catch (error) {
+    throw new Error(
+      `WebDAV replace aborted: could not check existing file before overwrite (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
+  }
+  if (!exists) return;
+  try {
+    await client.deleteFile(path);
+  } catch (error) {
+    throw new Error(
+      `WebDAV replace aborted: could not delete existing file before overwrite (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    );
+  }
+  let stillExists = false;
+  try {
+    stillExists = await client.exists(path);
+  } catch {
+    stillExists = true;
+  }
+  if (stillExists) {
+    throw new Error(
+      "WebDAV replace aborted: existing file still present after delete; refusing in-place overwrite"
+    );
   }
 };
 
 const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
   const tmpPath = `${path}.tmp-${crypto.randomBytes(8).toString("hex")}`;
-  let tmpWritten = false;
+
+  // Write temp first. If this fails, leave the existing vault untouched.
+  await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
+
   try {
-    await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
-    tmpWritten = true;
     await client.moveFile(tmpPath, path, { overwrite: true });
     return;
   } catch {
-    if (tmpWritten) {
-      await safeDeleteWebdavPath(client, tmpPath);
-    }
+    // MOVE unsupported or failed — fall through to DELETE + PUT using the
+    // already-validated temp body. Clean up temp in finally.
   }
 
-  // Fallback for servers without reliable MOVE, or if temp write failed.
-  await safeDeleteWebdavPath(client, path);
-  await client.putFileContents(path, bodyBuffer, { overwrite: true });
+  try {
+    await deleteWebdavPathForReplace(client, path);
+    await client.putFileContents(path, bodyBuffer, { overwrite: true });
+  } finally {
+    await safeDeleteWebdavPath(client, tmpPath);
+  }
 };
 
 /**

--- a/electron/bridges/cloudSyncBridge.cjs
+++ b/electron/bridges/cloudSyncBridge.cjs
@@ -18,11 +18,15 @@ const SYNC_FILE_NAME = "netcatty-vault.json";
 /**
  * Some WebDAV servers (esp. lightweight / local ones) overwrite existing
  * files without truncating when the new body is shorter. That leaves trailing
- * bytes from the previous longer body and breaks JSON.parse on download
- * (#2223). Prefer an atomic temp-PUT + MOVE replace; only fall back to
- * DELETE + PUT after the temp body is known-good. Never destroy the existing
- * vault just because the new upload itself failed, and never fall back to
- * in-place PUT if destination delete fails (that reintroduces #2223).
+ * non-whitespace bytes from the previous longer body and breaks JSON.parse
+ * (#2223).
+ *
+ * Strategy:
+ * 1) Prefer temp PUT + MOVE (atomic, exact size) when the server supports it.
+ * 2) Otherwise in-place PUT with trailing space padding up to the previous
+ *    length. JSON.parse ignores trailing whitespace, so non-truncating
+ *    servers stay parseable without a DELETE gap (no empty-file race for
+ *    concurrent clients).
  */
 const serializeSyncedFileBody = (syncedFile) =>
   Buffer.from(JSON.stringify(syncedFile), "utf8");
@@ -37,76 +41,45 @@ const safeDeleteWebdavPath = async (client, path) => {
   }
 };
 
-/** Delete target if present; throw if it still exists afterward. */
-const deleteWebdavPathForReplace = async (client, path) => {
-  let exists = false;
+/** Pad body with spaces so non-truncating PUTs cannot leave garbage. */
+const padBodyToAtLeast = (bodyBuffer, minLength) => {
+  if (!minLength || minLength <= bodyBuffer.length) return bodyBuffer;
+  return Buffer.concat([bodyBuffer, Buffer.alloc(minLength - bodyBuffer.length, 0x20)]);
+};
+
+const readExistingByteLength = async (client, path) => {
   try {
-    exists = await client.exists(path);
-  } catch (error) {
-    throw new Error(
-      `WebDAV replace aborted: could not check existing file before overwrite (${
-        error instanceof Error ? error.message : String(error)
-      })`
-    );
-  }
-  if (!exists) return;
-  try {
-    await client.deleteFile(path);
-  } catch (error) {
-    throw new Error(
-      `WebDAV replace aborted: could not delete existing file before overwrite (${
-        error instanceof Error ? error.message : String(error)
-      })`
-    );
-  }
-  let stillExists = false;
-  try {
-    stillExists = await client.exists(path);
+    if (!(await client.exists(path))) return 0;
+    const existing = await client.getFileContents(path, { format: "text" });
+    if (existing == null) return 0;
+    return Buffer.byteLength(String(existing), "utf8");
   } catch {
-    stillExists = true;
-  }
-  if (stillExists) {
-    throw new Error(
-      "WebDAV replace aborted: existing file still present after delete; refusing in-place overwrite"
-    );
+    return 0;
   }
 };
 
 const putWebdavFileReplacing = async (client, path, bodyBuffer) => {
   const tmpPath = `${path}.tmp-${crypto.randomBytes(8).toString("hex")}`;
 
-  // Write temp first. If this fails, leave the existing vault untouched.
-  await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
-
+  // Optional atomic path: temp file then MOVE into place.
   try {
-    await client.moveFile(tmpPath, path, { overwrite: true });
-    return;
-  } catch {
-    // MOVE unsupported or failed — fall through to DELETE + PUT using the
-    // already-validated temp body.
-  }
-
-  // Only after a successful temp write: remove destination, then recreate it.
-  // If delete fails, leave the old vault alone and do not attempt in-place PUT.
-  try {
-    await deleteWebdavPathForReplace(client, path);
-  } catch (error) {
-    await safeDeleteWebdavPath(client, tmpPath);
-    throw error;
-  }
-
-  try {
-    await client.putFileContents(path, bodyBuffer, { overwrite: true });
-  } catch (error) {
-    // Destination is already gone. Retry once; keep temp if still failing.
+    await client.putFileContents(tmpPath, bodyBuffer, { overwrite: true });
     try {
-      await client.putFileContents(path, bodyBuffer, { overwrite: true });
+      await client.moveFile(tmpPath, path, { overwrite: true });
+      return;
     } catch {
-      throw error;
+      await safeDeleteWebdavPath(client, tmpPath);
     }
+  } catch {
+    // Temp write or cleanup failed — fall through to padded in-place PUT.
+    await safeDeleteWebdavPath(client, tmpPath);
   }
-  // Only remove temp after destination holds the new body.
-  await safeDeleteWebdavPath(client, tmpPath);
+
+  // Keep the canonical path visible: pad shorter bodies so buggy servers that
+  // do not truncate still leave only JSON-legal trailing whitespace.
+  const existingLen = await readExistingByteLength(client, path);
+  const payload = padBodyToAtLeast(bodyBuffer, existingLen);
+  await client.putFileContents(path, payload, { overwrite: true });
 };
 
 /**

--- a/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
@@ -1,0 +1,247 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const { URL } = require("node:url");
+
+const {
+  handleWebdavUpload,
+  handleWebdavDownload,
+  parseSyncedFileJson,
+} = require("./cloudSyncBridge.cjs");
+
+/**
+ * Minimal WebDAV mock that reproduces #2223:
+ * in-place PUT overwrites existing content WITHOUT truncating when the new
+ * body is shorter — leaving trailing bytes from the previous longer body.
+ *
+ * MOVE replaces the destination resource wholesale (correct server behavior
+ * for rename/replace). DELETE removes the resource.
+ */
+function startBuggyTruncateWebdavServer() {
+  /** @type {Map<string, Buffer>} */
+  const files = new Map();
+
+  const normalizePath = (reqUrl) => {
+    const u = new URL(reqUrl, "http://127.0.0.1");
+    let p = decodeURIComponent(u.pathname);
+    if (!p.startsWith("/")) p = `/${p}`;
+    return p;
+  };
+
+  const propfindResponse = (path, length) =>
+    `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>${path}</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>${path.split("/").pop()}</D:displayname>
+        <D:getlastmodified>Sat, 10 May 2026 00:00:00 GMT</D:getlastmodified>
+        <D:getcontentlength>${length}</D:getcontentlength>
+        <D:resourcetype/>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+  const readBody = (req) =>
+    new Promise((resolve, reject) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => resolve(Buffer.concat(chunks)));
+      req.on("error", reject);
+    });
+
+  const server = http.createServer(async (req, res) => {
+    const path = normalizePath(req.url || "/");
+    const method = (req.method || "GET").toUpperCase();
+
+    try {
+      if (method === "PROPFIND") {
+        if (!files.has(path)) {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end("Not Found");
+          return;
+        }
+        const body = files.get(path);
+        res.writeHead(207, { "Content-Type": "application/xml; charset=utf-8" });
+        res.end(propfindResponse(path, body.length));
+        return;
+      }
+
+      if (method === "PUT") {
+        const incoming = await readBody(req);
+        const existing = files.get(path);
+        if (existing && incoming.length < existing.length) {
+          // Buggy non-truncate overwrite: keep the tail of the old file.
+          const merged = Buffer.alloc(existing.length);
+          existing.copy(merged);
+          incoming.copy(merged, 0, 0, incoming.length);
+          files.set(path, merged);
+        } else {
+          files.set(path, incoming);
+        }
+        res.writeHead(201, { "Content-Type": "text/plain" });
+        res.end("Created");
+        return;
+      }
+
+      if (method === "GET") {
+        if (!files.has(path)) {
+          res.writeHead(404);
+          res.end("Not Found");
+          return;
+        }
+        const body = files.get(path);
+        res.writeHead(200, {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": String(body.length),
+        });
+        res.end(body);
+        return;
+      }
+
+      if (method === "DELETE") {
+        files.delete(path);
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      if (method === "MOVE") {
+        const destHeader = req.headers.destination;
+        if (!destHeader) {
+          res.writeHead(400);
+          res.end("Missing Destination");
+          return;
+        }
+        const destUrl = new URL(destHeader);
+        const destPath = normalizePath(destUrl.pathname);
+        if (!files.has(path)) {
+          res.writeHead(404);
+          res.end("Not Found");
+          return;
+        }
+        // Correct replace: destination becomes an exact copy of source.
+        files.set(destPath, Buffer.from(files.get(path)));
+        files.delete(path);
+        res.writeHead(201);
+        res.end("Created");
+        return;
+      }
+
+      res.writeHead(405);
+      res.end("Method Not Allowed");
+    } catch (err) {
+      res.writeHead(500);
+      res.end(String(err && err.message ? err.message : err));
+    }
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        endpoint: `http://127.0.0.1:${port}`,
+        files,
+      });
+    });
+  });
+}
+
+const longSyncedFile = {
+  meta: {
+    version: 1,
+    updatedAt: 1,
+    deviceId: "dev-a",
+    deviceName: "A",
+    appVersion: "1.0.0",
+    iv: "aaaaaaaaaaaaaaaaaaaaaa==",
+    salt: "bbbbbbbbbbbbbbbbbbbbbb==",
+    algorithm: "AES-256-GCM",
+    kdf: "PBKDF2",
+    kdfIterations: 100000,
+  },
+  // Long payload so a shorter follow-up upload would leave a tail on buggy servers.
+  payload:
+    "KgdTYoctay9qud8Tq0QdtU6p1CGK8pppQrevpTErSMXqEnKtnJjEUrthXYI+zOcM3vaJ3J/0rzqhF0IglLU9MUToId6yE3GhT5FWWmSWCLei+UIjkaXnKBVxZ4VgrbX9R/IuJ/x5Ah80Oym1elVnWICNBrfjuhv3O8PWjR6TvEUvhG6jXAlok/akJjVLaPgDtU4jARH770BBO+U/W8AKdwNjdEipS0llY=n9lPHR9rL64LuAxzCMbND55onY+j9mCvRibnNm4lUX3ybfZLeqq+9cG/od4CrcdVGcde9FKYZ8UVS9g1UtxGzwW8zMW1kTH3L950WGQqrDosKusj+wTabh6lLdMdMRF7TOiMjmgRzMvQ==",
+};
+
+const shortSyncedFile = {
+  ...longSyncedFile,
+  meta: { ...longSyncedFile.meta, version: 2, updatedAt: 2 },
+  payload: "KgdTYoctay9qud8Tq0QdtU6p1CGK8pppQrevpTErSMXqEnKtnJjEUrthXYI+zOcM3vaJ3J/0rzqhF0IglLU9MUToId6yE3GhT5FWWmSWCLei+UIjkaXnKBVxZ4VgrbX9R/IuJ/x5Ah80Oym1elVnWICNBrfjuhv3O8PWjR6TvEUvhG6jXAlok/akJjVLaPgDtU4jARH770BBO+U/W8AKdwNjdEipS0llY=",
+};
+
+test("parseSyncedFileJson recovers trailing garbage after valid JSON (#2223)", () => {
+  const good = JSON.stringify({ meta: { version: 1 }, payload: "abc" });
+  const corrupt = `${good}n9lPHR9rL64LuAxzCMbND55onY+j9mCvRibnNm4lUX3ybfZLeqq+9cG/od4CrcdVGcde9FKYZ8UVS9g1UtxGzwW8zMW1kTH3L950WGQqrDosKusj+wTabh6lLdMdMRF7TOiMjmgRzMvQ=="}`;
+  assert.throws(() => JSON.parse(corrupt));
+  const recovered = parseSyncedFileJson(corrupt);
+  assert.deepEqual(recovered, { meta: { version: 1 }, payload: "abc" });
+});
+
+test("parseSyncedFileJson rethrows genuine JSON errors", () => {
+  assert.throws(() => parseSyncedFileJson("{not-json"), /JSON|Unexpected|Expected/i);
+});
+
+test("handleWebdavUpload replaces shorter body without trailing garbage on buggy servers (#2223)", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer();
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    // First upload (create) — full long body.
+    await handleWebdavUpload(config, longSyncedFile);
+    const afterLong = files.get("/netcatty-vault.json");
+    assert.ok(afterLong);
+    assert.equal(afterLong.toString("utf8"), JSON.stringify(longSyncedFile));
+
+    // Second upload — shorter body. Direct non-truncating PUT would corrupt;
+    // atomic replace (temp + MOVE) must leave clean JSON only.
+    await handleWebdavUpload(config, shortSyncedFile);
+    const afterShort = files.get("/netcatty-vault.json");
+    assert.ok(afterShort);
+    const text = afterShort.toString("utf8");
+    assert.equal(text, JSON.stringify(shortSyncedFile));
+    // No leftover temp files.
+    for (const key of files.keys()) {
+      assert.ok(!key.includes(".tmp-"), `leftover temp file: ${key}`);
+    }
+
+    const downloaded = await handleWebdavDownload(config);
+    assert.deepEqual(downloaded.syncedFile, shortSyncedFile);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("handleWebdavDownload recovers already-corrupt remote JSON (#2223)", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer();
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    const good = JSON.stringify(shortSyncedFile);
+    const corrupt = Buffer.from(
+      `${good}n9lPHR9rL64LuAxzCMbND55onY+j9mCvRibnNm4lUX3ybfZLeqq+9cG/od4CrcdVGcde9FKYZ8UVS9g1UtxGzwW8zMW1kTH3L950WGQqrDosKusj+wTabh6lLdMdMRF7TOiMjmgRzMvQ=="}`,
+      "utf8"
+    );
+    files.set("/netcatty-vault.json", corrupt);
+
+    const downloaded = await handleWebdavDownload(config);
+    assert.deepEqual(downloaded.syncedFile, shortSyncedFile);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
@@ -346,3 +346,33 @@ test("DELETE denied aborts fallback instead of non-truncating in-place PUT", asy
     await new Promise((resolve) => server.close(resolve));
   }
 });
+
+test("final PUT failure keeps temp recovery copy (does not wipe remote vault)", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
+    denyMove: true,
+    // Final path only — temp paths end with .tmp-<hex>
+    rejectPutMatching: /\/netcatty-vault\.json$/,
+  });
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
+    await assert.rejects(
+      () => handleWebdavUpload(config, shortSyncedFile),
+      /WebDAV upload failed|507|Insufficient/i
+    );
+    // Destination was deleted as part of fallback; final PUT failed.
+    assert.equal(files.has("/netcatty-vault.json"), false);
+    // Known-good body must remain on a temp recovery path.
+    const tmpKeys = [...files.keys()].filter((k) => k.includes(".tmp-"));
+    assert.equal(tmpKeys.length, 1);
+    assert.equal(files.get(tmpKeys[0]).toString("utf8"), JSON.stringify(shortSyncedFile));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
@@ -290,9 +290,8 @@ test("padded in-place PUT keeps JSON parseable when MOVE is unsupported (#2223)"
     assert.equal(afterShort.length, Buffer.byteLength(JSON.stringify(longSyncedFile), "utf8"));
     assert.match(text, /^\{[\s\S]*\}\s*$/);
     assert.deepEqual(JSON.parse(text), shortSyncedFile);
-    for (const key of files.keys()) {
-      assert.ok(!key.includes(".tmp-"), `leftover temp file: ${key}`);
-    }
+    // Fixed temp name must be cleaned up when DELETE works.
+    assert.equal(files.has("/netcatty-vault.json.tmp"), false);
     const downloaded = await handleWebdavDownload(config);
     assert.deepEqual(downloaded.syncedFile, shortSyncedFile);
   } finally {
@@ -303,7 +302,7 @@ test("padded in-place PUT keeps JSON parseable when MOVE is unsupported (#2223)"
 test("padded fallback still works when temp PUT is rejected", async () => {
   const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
     denyMove: true,
-    rejectPutMatching: /\.tmp-/,
+    rejectPutMatching: /\.tmp$/,
   });
   const config = {
     endpoint,
@@ -323,7 +322,7 @@ test("padded fallback still works when temp PUT is rejected", async () => {
   }
 });
 
-test("canonical vault stays present during padded fallback (no DELETE gap)", async () => {
+test("canonical vault stays present; fixed temp does not accumulate when DELETE denied", async () => {
   const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
     denyMove: true,
     denyDelete: true,
@@ -338,9 +337,50 @@ test("canonical vault stays present during padded fallback (no DELETE gap)", asy
   try {
     files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
     await handleWebdavUpload(config, shortSyncedFile);
+    await handleWebdavUpload(config, shortSyncedFile);
     const remaining = files.get("/netcatty-vault.json");
     assert.ok(remaining, "vault must never disappear during fallback");
     assert.deepEqual(JSON.parse(remaining.toString("utf8")), shortSyncedFile);
+    // At most one fixed temp path — never one random full vault per sync.
+    const tmpKeys = [...files.keys()].filter((k) => k.includes(".tmp"));
+    assert.ok(tmpKeys.length <= 1);
+    assert.deepEqual(tmpKeys, tmpKeys.length ? ["/netcatty-vault.json.tmp"] : tmpKeys);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("read length failure aborts instead of unpadded corrupt PUT", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
+    denyMove: true,
+  });
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  // Break GET so length read fails after MOVE fallback.
+  const original = server.listeners("request")[0];
+  server.removeAllListeners("request");
+  server.on("request", (req, res) => {
+    if ((req.method || "").toUpperCase() === "GET") {
+      res.writeHead(500);
+      res.end("boom");
+      return;
+    }
+    original.call(server, req, res);
+  });
+
+  try {
+    files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
+    await assert.rejects(
+      () => handleWebdavUpload(config, shortSyncedFile),
+      /could not read existing file length|WebDAV upload failed/i
+    );
+    // Original vault must remain untouched (GET failed before PUT).
+    assert.equal(files.get("/netcatty-vault.json").toString("utf8"), JSON.stringify(longSyncedFile));
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
@@ -269,7 +269,7 @@ test("handleWebdavDownload recovers already-corrupt remote JSON (#2223)", async 
   }
 });
 
-test("DELETE+PUT fallback still produces clean JSON when MOVE is unsupported", async () => {
+test("padded in-place PUT keeps JSON parseable when MOVE is unsupported (#2223)", async () => {
   const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
     denyMove: true,
   });
@@ -285,18 +285,24 @@ test("DELETE+PUT fallback still produces clean JSON when MOVE is unsupported", a
     await handleWebdavUpload(config, shortSyncedFile);
     const afterShort = files.get("/netcatty-vault.json");
     assert.ok(afterShort);
-    assert.equal(afterShort.toString("utf8"), JSON.stringify(shortSyncedFile));
+    const text = afterShort.toString("utf8");
+    // Non-truncating server keeps length; padding is trailing spaces only.
+    assert.equal(afterShort.length, Buffer.byteLength(JSON.stringify(longSyncedFile), "utf8"));
+    assert.match(text, /^\{[\s\S]*\}\s*$/);
+    assert.deepEqual(JSON.parse(text), shortSyncedFile);
     for (const key of files.keys()) {
       assert.ok(!key.includes(".tmp-"), `leftover temp file: ${key}`);
     }
+    const downloaded = await handleWebdavDownload(config);
+    assert.deepEqual(downloaded.syncedFile, shortSyncedFile);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
 });
 
-test("temp PUT failure leaves the existing vault untouched", async () => {
+test("padded fallback still works when temp PUT is rejected", async () => {
   const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
-    // Reject only temp uploads; final path would still accept (but must not be tried).
+    denyMove: true,
     rejectPutMatching: /\.tmp-/,
   });
   const config = {
@@ -308,19 +314,16 @@ test("temp PUT failure leaves the existing vault untouched", async () => {
 
   try {
     files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
-    await assert.rejects(
-      () => handleWebdavUpload(config, shortSyncedFile),
-      /WebDAV upload failed|507|Insufficient/i
-    );
+    await handleWebdavUpload(config, shortSyncedFile);
     const remaining = files.get("/netcatty-vault.json");
     assert.ok(remaining);
-    assert.equal(remaining.toString("utf8"), JSON.stringify(longSyncedFile));
+    assert.deepEqual(JSON.parse(remaining.toString("utf8")), shortSyncedFile);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
 });
 
-test("DELETE denied aborts fallback instead of non-truncating in-place PUT", async () => {
+test("canonical vault stays present during padded fallback (no DELETE gap)", async () => {
   const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
     denyMove: true,
     denyDelete: true,
@@ -334,44 +337,10 @@ test("DELETE denied aborts fallback instead of non-truncating in-place PUT", asy
 
   try {
     files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
-    await assert.rejects(
-      () => handleWebdavUpload(config, shortSyncedFile),
-      /replace aborted|could not delete|WebDAV upload failed/i
-    );
+    await handleWebdavUpload(config, shortSyncedFile);
     const remaining = files.get("/netcatty-vault.json");
-    assert.ok(remaining);
-    // Must remain the original long file — not a non-truncated hybrid.
-    assert.equal(remaining.toString("utf8"), JSON.stringify(longSyncedFile));
-  } finally {
-    await new Promise((resolve) => server.close(resolve));
-  }
-});
-
-test("final PUT failure keeps temp recovery copy (does not wipe remote vault)", async () => {
-  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
-    denyMove: true,
-    // Final path only — temp paths end with .tmp-<hex>
-    rejectPutMatching: /\/netcatty-vault\.json$/,
-  });
-  const config = {
-    endpoint,
-    authType: "basic",
-    username: "u",
-    password: "p",
-  };
-
-  try {
-    files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
-    await assert.rejects(
-      () => handleWebdavUpload(config, shortSyncedFile),
-      /WebDAV upload failed|507|Insufficient/i
-    );
-    // Destination was deleted as part of fallback; final PUT failed.
-    assert.equal(files.has("/netcatty-vault.json"), false);
-    // Known-good body must remain on a temp recovery path.
-    const tmpKeys = [...files.keys()].filter((k) => k.includes(".tmp-"));
-    assert.equal(tmpKeys.length, 1);
-    assert.equal(files.get(tmpKeys[0]).toString("utf8"), JSON.stringify(shortSyncedFile));
+    assert.ok(remaining, "vault must never disappear during fallback");
+    assert.deepEqual(JSON.parse(remaining.toString("utf8")), shortSyncedFile);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
+++ b/electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs
@@ -14,10 +14,17 @@ const {
  * in-place PUT overwrites existing content WITHOUT truncating when the new
  * body is shorter — leaving trailing bytes from the previous longer body.
  *
- * MOVE replaces the destination resource wholesale (correct server behavior
- * for rename/replace). DELETE removes the resource.
+ * Options:
+ * - denyMove: MOVE returns 405 (forces DELETE + PUT fallback)
+ * - denyDelete: DELETE returns 403 (fallback must abort, not in-place PUT)
+ * - rejectPutMatching: regex tested against path; matching PUT returns 507
  */
-function startBuggyTruncateWebdavServer() {
+function startBuggyTruncateWebdavServer(options = {}) {
+  const {
+    denyMove = false,
+    denyDelete = false,
+    rejectPutMatching = null,
+  } = options;
   /** @type {Map<string, Buffer>} */
   const files = new Map();
 
@@ -71,6 +78,12 @@ function startBuggyTruncateWebdavServer() {
       }
 
       if (method === "PUT") {
+        if (rejectPutMatching && rejectPutMatching.test(path)) {
+          await readBody(req);
+          res.writeHead(507, { "Content-Type": "text/plain" });
+          res.end("Insufficient Storage");
+          return;
+        }
         const incoming = await readBody(req);
         const existing = files.get(path);
         if (existing && incoming.length < existing.length) {
@@ -103,6 +116,11 @@ function startBuggyTruncateWebdavServer() {
       }
 
       if (method === "DELETE") {
+        if (denyDelete) {
+          res.writeHead(403, { "Content-Type": "text/plain" });
+          res.end("Forbidden");
+          return;
+        }
         files.delete(path);
         res.writeHead(204);
         res.end();
@@ -110,6 +128,11 @@ function startBuggyTruncateWebdavServer() {
       }
 
       if (method === "MOVE") {
+        if (denyMove) {
+          res.writeHead(405, { "Content-Type": "text/plain" });
+          res.end("Method Not Allowed");
+          return;
+        }
         const destHeader = req.headers.destination;
         if (!destHeader) {
           res.writeHead(400);
@@ -241,6 +264,84 @@ test("handleWebdavDownload recovers already-corrupt remote JSON (#2223)", async 
 
     const downloaded = await handleWebdavDownload(config);
     assert.deepEqual(downloaded.syncedFile, shortSyncedFile);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("DELETE+PUT fallback still produces clean JSON when MOVE is unsupported", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
+    denyMove: true,
+  });
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    await handleWebdavUpload(config, longSyncedFile);
+    await handleWebdavUpload(config, shortSyncedFile);
+    const afterShort = files.get("/netcatty-vault.json");
+    assert.ok(afterShort);
+    assert.equal(afterShort.toString("utf8"), JSON.stringify(shortSyncedFile));
+    for (const key of files.keys()) {
+      assert.ok(!key.includes(".tmp-"), `leftover temp file: ${key}`);
+    }
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("temp PUT failure leaves the existing vault untouched", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
+    // Reject only temp uploads; final path would still accept (but must not be tried).
+    rejectPutMatching: /\.tmp-/,
+  });
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
+    await assert.rejects(
+      () => handleWebdavUpload(config, shortSyncedFile),
+      /WebDAV upload failed|507|Insufficient/i
+    );
+    const remaining = files.get("/netcatty-vault.json");
+    assert.ok(remaining);
+    assert.equal(remaining.toString("utf8"), JSON.stringify(longSyncedFile));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("DELETE denied aborts fallback instead of non-truncating in-place PUT", async () => {
+  const { server, endpoint, files } = await startBuggyTruncateWebdavServer({
+    denyMove: true,
+    denyDelete: true,
+  });
+  const config = {
+    endpoint,
+    authType: "basic",
+    username: "u",
+    password: "p",
+  };
+
+  try {
+    files.set("/netcatty-vault.json", Buffer.from(JSON.stringify(longSyncedFile), "utf8"));
+    await assert.rejects(
+      () => handleWebdavUpload(config, shortSyncedFile),
+      /replace aborted|could not delete|WebDAV upload failed/i
+    );
+    const remaining = files.get("/netcatty-vault.json");
+    assert.ok(remaining);
+    // Must remain the original long file — not a non-truncated hybrid.
+    assert.equal(remaining.toString("utf8"), JSON.stringify(longSyncedFile));
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -25,6 +25,68 @@ const normalizeEndpoint = (endpoint: string): string => {
 const ensureLeadingSlash = (value: string): string =>
   value.startsWith('/') ? value : `/${value}`;
 
+/**
+ * Recover from trailing garbage left by non-truncating WebDAV PUT overwrites
+ * (#2223). Node/V8: "Unexpected non-whitespace character after JSON at position N".
+ */
+const parseSyncedFileJson = (raw: string): SyncedFile => {
+  try {
+    return JSON.parse(raw) as SyncedFile;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const match = /Unexpected non-whitespace character after JSON at position (\d+)/i.exec(
+      message,
+    );
+    if (match) {
+      const pos = Number(match[1]);
+      if (Number.isFinite(pos) && pos > 0 && pos <= raw.length) {
+        return JSON.parse(raw.slice(0, pos)) as SyncedFile;
+      }
+    }
+    throw error;
+  }
+};
+
+/**
+ * Atomic replace: temp PUT + MOVE, fallback DELETE + PUT.
+ * Avoids trailing-byte corruption when a shorter body overwrites a longer file
+ * on WebDAV servers that do not truncate on PUT (#2223).
+ */
+const putWebdavFileReplacing = async (
+  client: WebDAVClient,
+  path: string,
+  body: string,
+): Promise<void> => {
+  const suffix = `${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
+  const tmpPath = `${path}.tmp-${suffix}`;
+  let tmpWritten = false;
+  try {
+    await client.putFileContents(tmpPath, body, { overwrite: true });
+    tmpWritten = true;
+    await client.moveFile(tmpPath, path, { overwrite: true });
+    return;
+  } catch {
+    if (tmpWritten) {
+      try {
+        if (await client.exists(tmpPath)) {
+          await client.deleteFile(tmpPath);
+        }
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  try {
+    if (await client.exists(path)) {
+      await client.deleteFile(path);
+    }
+  } catch {
+    // continue; put with overwrite may still work
+  }
+  await client.putFileContents(path, body, { overwrite: true });
+};
+
 export class WebDAVAdapter {
   private config: WebDAVConfig | null;
   private resource: string | null;
@@ -91,7 +153,7 @@ export class WebDAVAdapter {
       }
       const client = this.getClient();
       const path = this.getSyncPath();
-      await client.putFileContents(path, JSON.stringify(syncedFile), { overwrite: true });
+      await putWebdavFileReplacing(client, path, JSON.stringify(syncedFile));
       this.resource = path;
       return path;
     });
@@ -113,7 +175,7 @@ export class WebDAVAdapter {
       if (!exists) return null;
       const data = await client.getFileContents(path, { format: 'text' });
       if (!data) return null;
-      return JSON.parse(data as string) as SyncedFile;
+      return parseSyncedFileJson(data as string);
     });
   }
 

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -52,9 +52,15 @@ const utf8ByteLength = (value: string): number =>
     ? Buffer.byteLength(value, 'utf8')
     : new TextEncoder().encode(value).length;
 
+/** Strict: intended body plus optional trailing whitespace only. */
+const remoteMatchesUploadedBody = (remoteText: string, body: string): boolean => {
+  if (!remoteText.startsWith(body)) return false;
+  return /^\s*$/.test(remoteText.slice(body.length));
+};
+
 /**
- * Prefer fixed-name temp PUT + MOVE; else padded in-place PUT with verify
- * so non-truncating / concurrent writers cannot leave invalid JSON (#2223).
+ * Prefer fixed-name temp PUT + MOVE (with pad + verify); else padded in-place
+ * PUT with strict body match so non-truncating servers cannot leave garbage.
  */
 const putWebdavFileReplacing = async (
   client: WebDAVClient,
@@ -74,32 +80,22 @@ const putWebdavFileReplacing = async (
     }
   };
 
-  try {
-    await client.putFileContents(tmpPath, body, { overwrite: true });
-    await client.moveFile(tmpPath, path, { overwrite: true });
-    return;
-  } catch {
-    await cleanupTemp();
-  }
-
-  let exists = false;
-  try {
-    exists = await client.exists(path);
-  } catch (error) {
-    throw new Error(
-      `WebDAV replace aborted: could not check existing file (${
-        error instanceof Error ? error.message : String(error)
-      })`,
-    );
-  }
-
-  let minLen = bodyLen;
-  if (exists) {
+  const readLen = async (target: string): Promise<number> => {
+    let exists = false;
     try {
-      const existing = await client.getFileContents(path, { format: 'text' });
-      if (existing != null) {
-        minLen = Math.max(minLen, utf8ByteLength(String(existing)));
-      }
+      exists = await client.exists(target);
+    } catch (error) {
+      throw new Error(
+        `WebDAV replace aborted: could not check existing file (${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      );
+    }
+    if (!exists) return 0;
+    try {
+      const existing = await client.getFileContents(target, { format: 'text' });
+      if (existing == null) return 0;
+      return utf8ByteLength(String(existing));
     } catch (error) {
       throw new Error(
         `WebDAV replace aborted: could not read existing file length (${
@@ -107,17 +103,35 @@ const putWebdavFileReplacing = async (
         })`,
       );
     }
-  }
+  };
 
-  let lastVerifyError: unknown = null;
+  try {
+    let tmpMin = 0;
+    try {
+      tmpMin = await readLen(tmpPath);
+    } catch {
+      tmpMin = 0;
+    }
+    const tmpBody = tmpMin > bodyLen ? body + ' '.repeat(tmpMin - bodyLen) : body;
+    await client.putFileContents(tmpPath, tmpBody, { overwrite: true });
+    await client.moveFile(tmpPath, path, { overwrite: true });
+    const moved = String((await client.getFileContents(path, { format: 'text' })) ?? '');
+    if (remoteMatchesUploadedBody(moved, body)) {
+      return;
+    }
+  } catch {
+    // fall through
+  }
+  await cleanupTemp();
+
+  let minLen = await readLen(path);
+  minLen = Math.max(minLen, bodyLen);
   for (let attempt = 0; attempt < 3; attempt++) {
-    const payload =
-      minLen > bodyLen ? body + ' '.repeat(minLen - bodyLen) : body;
+    const payload = minLen > bodyLen ? body + ' '.repeat(minLen - bodyLen) : body;
     await client.putFileContents(path, payload, { overwrite: true });
     let remoteText = '';
     try {
-      const remote = await client.getFileContents(path, { format: 'text' });
-      remoteText = String(remote ?? '');
+      remoteText = String((await client.getFileContents(path, { format: 'text' })) ?? '');
     } catch (error) {
       throw new Error(
         `WebDAV upload verification failed: could not re-read file (${
@@ -125,22 +139,13 @@ const putWebdavFileReplacing = async (
         })`,
       );
     }
-    try {
-      parseSyncedFileJson(remoteText);
+    if (remoteMatchesUploadedBody(remoteText, body)) {
       return;
-    } catch (error) {
-      lastVerifyError = error;
-      minLen = Math.max(minLen, utf8ByteLength(remoteText), bodyLen);
     }
+    minLen = Math.max(minLen, utf8ByteLength(remoteText), bodyLen);
   }
-  const detail =
-    lastVerifyError instanceof Error
-      ? lastVerifyError.message
-      : String(lastVerifyError || '');
   throw new Error(
-    `WebDAV upload verification failed: remote file still not valid JSON after padded PUT${
-      detail ? ` (${detail})` : ''
-    }`,
+    'WebDAV upload verification failed: remote file still does not match uploaded body after padded PUT',
   );
 };
 

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -70,6 +70,17 @@ const putWebdavFileReplacing = async (
     // fall through to DELETE + PUT
   }
 
+  const cleanupTemp = async () => {
+    try {
+      if (await client.exists(tmpPath)) {
+        await client.deleteFile(tmpPath);
+      }
+    } catch {
+      // best-effort temp cleanup
+    }
+  };
+
+  // If delete fails, leave the old vault alone (no in-place PUT).
   try {
     let exists = false;
     try {
@@ -103,16 +114,22 @@ const putWebdavFileReplacing = async (
         );
       }
     }
+  } catch (error) {
+    await cleanupTemp();
+    throw error;
+  }
+
+  try {
     await client.putFileContents(path, body, { overwrite: true });
-  } finally {
+  } catch (error) {
+    // Destination is already gone. Retry once; keep temp if still failing.
     try {
-      if (await client.exists(tmpPath)) {
-        await client.deleteFile(tmpPath);
-      }
+      await client.putFileContents(path, body, { overwrite: true });
     } catch {
-      // best-effort temp cleanup
+      throw error;
     }
   }
+  await cleanupTemp();
 };
 
 export class WebDAVAdapter {

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -47,20 +47,22 @@ const parseSyncedFileJson = (raw: string): SyncedFile => {
   }
 };
 
+const utf8ByteLength = (value: string): number =>
+  typeof Buffer !== 'undefined'
+    ? Buffer.byteLength(value, 'utf8')
+    : new TextEncoder().encode(value).length;
+
 /**
- * Prefer temp PUT + MOVE; fall back to in-place PUT padded with spaces up to
- * the previous length so non-truncating servers leave only JSON-legal
- * whitespace (no DELETE empty-file race) (#2223).
+ * Prefer fixed-name temp PUT + MOVE; else padded in-place PUT with verify
+ * so non-truncating / concurrent writers cannot leave invalid JSON (#2223).
  */
 const putWebdavFileReplacing = async (
   client: WebDAVClient,
   path: string,
   body: string,
 ): Promise<void> => {
-  const suffix = `${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
-  const tmpPath = `${path}.tmp-${suffix}`;
-  const bodyBuffer =
-    typeof Buffer !== 'undefined' ? Buffer.from(body, 'utf8') : null;
+  const tmpPath = `${path}.tmp`;
+  const bodyLen = utf8ByteLength(body);
 
   const cleanupTemp = async () => {
     try {
@@ -74,41 +76,72 @@ const putWebdavFileReplacing = async (
 
   try {
     await client.putFileContents(tmpPath, body, { overwrite: true });
-    try {
-      await client.moveFile(tmpPath, path, { overwrite: true });
-      return;
-    } catch {
-      await cleanupTemp();
-    }
+    await client.moveFile(tmpPath, path, { overwrite: true });
+    return;
   } catch {
     await cleanupTemp();
   }
 
-  let existingLen = 0;
+  let exists = false;
   try {
-    if (await client.exists(path)) {
-      const existing = await client.getFileContents(path, { format: 'text' });
-      if (existing != null) {
-        existingLen =
-          typeof Buffer !== 'undefined'
-            ? Buffer.byteLength(String(existing), 'utf8')
-            : new TextEncoder().encode(String(existing)).length;
-      }
-    }
-  } catch {
-    existingLen = 0;
+    exists = await client.exists(path);
+  } catch (error) {
+    throw new Error(
+      `WebDAV replace aborted: could not check existing file (${
+        error instanceof Error ? error.message : String(error)
+      })`,
+    );
   }
 
-  const bodyLen =
-    bodyBuffer != null
-      ? bodyBuffer.length
-      : new TextEncoder().encode(body).length;
-  if (existingLen > bodyLen) {
-    const pad = ' '.repeat(existingLen - bodyLen);
-    await client.putFileContents(path, body + pad, { overwrite: true });
-  } else {
-    await client.putFileContents(path, body, { overwrite: true });
+  let minLen = bodyLen;
+  if (exists) {
+    try {
+      const existing = await client.getFileContents(path, { format: 'text' });
+      if (existing != null) {
+        minLen = Math.max(minLen, utf8ByteLength(String(existing)));
+      }
+    } catch (error) {
+      throw new Error(
+        `WebDAV replace aborted: could not read existing file length (${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      );
+    }
   }
+
+  let lastVerifyError: unknown = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const payload =
+      minLen > bodyLen ? body + ' '.repeat(minLen - bodyLen) : body;
+    await client.putFileContents(path, payload, { overwrite: true });
+    let remoteText = '';
+    try {
+      const remote = await client.getFileContents(path, { format: 'text' });
+      remoteText = String(remote ?? '');
+    } catch (error) {
+      throw new Error(
+        `WebDAV upload verification failed: could not re-read file (${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      );
+    }
+    try {
+      parseSyncedFileJson(remoteText);
+      return;
+    } catch (error) {
+      lastVerifyError = error;
+      minLen = Math.max(minLen, utf8ByteLength(remoteText), bodyLen);
+    }
+  }
+  const detail =
+    lastVerifyError instanceof Error
+      ? lastVerifyError.message
+      : String(lastVerifyError || '');
+  throw new Error(
+    `WebDAV upload verification failed: remote file still not valid JSON after padded PUT${
+      detail ? ` (${detail})` : ''
+    }`,
+  );
 };
 
 export class WebDAVAdapter {

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -48,9 +48,9 @@ const parseSyncedFileJson = (raw: string): SyncedFile => {
 };
 
 /**
- * Atomic replace: temp PUT + MOVE, fallback DELETE + PUT.
- * Avoids trailing-byte corruption when a shorter body overwrites a longer file
- * on WebDAV servers that do not truncate on PUT (#2223).
+ * Atomic replace: temp PUT + MOVE; only if MOVE fails after a successful temp
+ * write, DELETE + PUT. Never touch the existing vault if temp PUT fails, and
+ * never fall back to in-place PUT when destination delete fails (#2223).
  */
 const putWebdavFileReplacing = async (
   client: WebDAVClient,
@@ -59,32 +59,60 @@ const putWebdavFileReplacing = async (
 ): Promise<void> => {
   const suffix = `${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
   const tmpPath = `${path}.tmp-${suffix}`;
-  let tmpWritten = false;
+
+  // If temp write fails, leave the existing vault untouched.
+  await client.putFileContents(tmpPath, body, { overwrite: true });
+
   try {
-    await client.putFileContents(tmpPath, body, { overwrite: true });
-    tmpWritten = true;
     await client.moveFile(tmpPath, path, { overwrite: true });
     return;
   } catch {
-    if (tmpWritten) {
-      try {
-        if (await client.exists(tmpPath)) {
-          await client.deleteFile(tmpPath);
-        }
-      } catch {
-        // best-effort cleanup
-      }
-    }
+    // fall through to DELETE + PUT
   }
 
   try {
-    if (await client.exists(path)) {
-      await client.deleteFile(path);
+    let exists = false;
+    try {
+      exists = await client.exists(path);
+    } catch (error) {
+      throw new Error(
+        `WebDAV replace aborted: could not check existing file before overwrite (${
+          error instanceof Error ? error.message : String(error)
+        })`,
+      );
     }
-  } catch {
-    // continue; put with overwrite may still work
+    if (exists) {
+      try {
+        await client.deleteFile(path);
+      } catch (error) {
+        throw new Error(
+          `WebDAV replace aborted: could not delete existing file before overwrite (${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        );
+      }
+      let stillExists = false;
+      try {
+        stillExists = await client.exists(path);
+      } catch {
+        stillExists = true;
+      }
+      if (stillExists) {
+        throw new Error(
+          'WebDAV replace aborted: existing file still present after delete; refusing in-place overwrite',
+        );
+      }
+    }
+    await client.putFileContents(path, body, { overwrite: true });
+  } finally {
+    try {
+      if (await client.exists(tmpPath)) {
+        await client.deleteFile(tmpPath);
+      }
+    } catch {
+      // best-effort temp cleanup
+    }
   }
-  await client.putFileContents(path, body, { overwrite: true });
 };
 
 export class WebDAVAdapter {

--- a/infrastructure/services/adapters/WebDAVAdapter.ts
+++ b/infrastructure/services/adapters/WebDAVAdapter.ts
@@ -48,9 +48,9 @@ const parseSyncedFileJson = (raw: string): SyncedFile => {
 };
 
 /**
- * Atomic replace: temp PUT + MOVE; only if MOVE fails after a successful temp
- * write, DELETE + PUT. Never touch the existing vault if temp PUT fails, and
- * never fall back to in-place PUT when destination delete fails (#2223).
+ * Prefer temp PUT + MOVE; fall back to in-place PUT padded with spaces up to
+ * the previous length so non-truncating servers leave only JSON-legal
+ * whitespace (no DELETE empty-file race) (#2223).
  */
 const putWebdavFileReplacing = async (
   client: WebDAVClient,
@@ -59,16 +59,8 @@ const putWebdavFileReplacing = async (
 ): Promise<void> => {
   const suffix = `${Date.now().toString(16)}${Math.random().toString(16).slice(2, 10)}`;
   const tmpPath = `${path}.tmp-${suffix}`;
-
-  // If temp write fails, leave the existing vault untouched.
-  await client.putFileContents(tmpPath, body, { overwrite: true });
-
-  try {
-    await client.moveFile(tmpPath, path, { overwrite: true });
-    return;
-  } catch {
-    // fall through to DELETE + PUT
-  }
+  const bodyBuffer =
+    typeof Buffer !== 'undefined' ? Buffer.from(body, 'utf8') : null;
 
   const cleanupTemp = async () => {
     try {
@@ -76,60 +68,47 @@ const putWebdavFileReplacing = async (
         await client.deleteFile(tmpPath);
       }
     } catch {
-      // best-effort temp cleanup
+      // best-effort
     }
   };
 
-  // If delete fails, leave the old vault alone (no in-place PUT).
   try {
-    let exists = false;
+    await client.putFileContents(tmpPath, body, { overwrite: true });
     try {
-      exists = await client.exists(path);
-    } catch (error) {
-      throw new Error(
-        `WebDAV replace aborted: could not check existing file before overwrite (${
-          error instanceof Error ? error.message : String(error)
-        })`,
-      );
+      await client.moveFile(tmpPath, path, { overwrite: true });
+      return;
+    } catch {
+      await cleanupTemp();
     }
-    if (exists) {
-      try {
-        await client.deleteFile(path);
-      } catch (error) {
-        throw new Error(
-          `WebDAV replace aborted: could not delete existing file before overwrite (${
-            error instanceof Error ? error.message : String(error)
-          })`,
-        );
-      }
-      let stillExists = false;
-      try {
-        stillExists = await client.exists(path);
-      } catch {
-        stillExists = true;
-      }
-      if (stillExists) {
-        throw new Error(
-          'WebDAV replace aborted: existing file still present after delete; refusing in-place overwrite',
-        );
-      }
-    }
-  } catch (error) {
+  } catch {
     await cleanupTemp();
-    throw error;
   }
 
+  let existingLen = 0;
   try {
-    await client.putFileContents(path, body, { overwrite: true });
-  } catch (error) {
-    // Destination is already gone. Retry once; keep temp if still failing.
-    try {
-      await client.putFileContents(path, body, { overwrite: true });
-    } catch {
-      throw error;
+    if (await client.exists(path)) {
+      const existing = await client.getFileContents(path, { format: 'text' });
+      if (existing != null) {
+        existingLen =
+          typeof Buffer !== 'undefined'
+            ? Buffer.byteLength(String(existing), 'utf8')
+            : new TextEncoder().encode(String(existing)).length;
+      }
     }
+  } catch {
+    existingLen = 0;
   }
-  await cleanupTemp();
+
+  const bodyLen =
+    bodyBuffer != null
+      ? bodyBuffer.length
+      : new TextEncoder().encode(body).length;
+  if (existingLen > bodyLen) {
+    const pad = ' '.repeat(existingLen - bodyLen);
+    await client.putFileContents(path, body + pad, { overwrite: true });
+  } else {
+    await client.putFileContents(path, body, { overwrite: true });
+  }
 };
 
 export class WebDAVAdapter {


### PR DESCRIPTION
## Summary
- Fixes [#2223](https://github.com/binaricat/Netcatty/issues/2223): after several WebDAV syncs, download fails with `Unexpected non-whitespace character after JSON at position …`.
- **Root cause:** some WebDAV servers (especially lightweight/local ones) apply in-place `PUT` **without truncating** when the new body is shorter. Leftover non-whitespace bytes from the previous longer vault JSON remain after `}`, so the remote file is no longer valid JSON.
- **Upload strategy:**
  1. Prefer fixed-name temp `PUT` + `MOVE` (pad the temp if a stale `.tmp` remains), then strictly verify the destination.
  2. Fall back to in-place `PUT` padded with spaces to at least the previous length (JSON allows trailing whitespace), re-read, and require an exact body match (body + optional spaces only). Retry if a concurrent writer grew the file.
  3. Never open a DELETE gap on the canonical vault path.
- **Download:** if parse fails with V8’s trailing-garbage error, slice to the reported position so already-corrupt remotes can still be read; the next successful upload rewrites a clean file.

## Test plan
- [x] `node --test electron/bridges/cloudSyncBridge.webdavTruncate.test.cjs electron/bridges/cloudSyncBridge.webdavBasicAuth.test.cjs`
- [x] Mock non-truncating WebDAV: long → short upload stays parseable (MOVE and padded fallback)
- [x] Download recovers pre-corrupted remote content
- [x] Length-read failure aborts instead of unpadded corrupt PUT
- [x] Fixed `.tmp` does not accumulate when DELETE is denied
- [x] Codex CLI `review --base main` clean (no blocking findings)
- [ ] Manual: point Netcatty at a local WebDAV, sync repeatedly while shrinking vault data, confirm no parse errors