### PR TITLE
feat(terminal): reconnect sessions from tab menu

### DIFF
--- a/application/state/terminalReconnectRegistry.test.ts
+++ b/application/state/terminalReconnectRegistry.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createTerminalReconnectRegistry } from './terminalReconnectRegistry';
+
+test('a registered terminal session can be reconnected on request', () => {
+  const registry = createTerminalReconnectRegistry();
+  const requestedSessionIds: string[] = [];
+
+  registry.register('session-1', () => requestedSessionIds.push('session-1'));
+
+  assert.equal(registry.request('session-1'), true);
+  assert.deepEqual(requestedSessionIds, ['session-1']);
+});
+
+test('requesting a terminal session without a mounted handler is a no-op', () => {
+  const registry = createTerminalReconnectRegistry();
+
+  assert.equal(registry.request('missing-session'), false);
+});
+
+test('cleanup only removes the handler that created it', () => {
+  const registry = createTerminalReconnectRegistry();
+  const requests: string[] = [];
+  const unregisterOldHandler = registry.register('session-1', () => requests.push('old'));
+
+  registry.register('session-1', () => requests.push('current'));
+  unregisterOldHandler();
+
+  assert.equal(registry.request('session-1'), true);
+  assert.deepEqual(requests, ['current']);
+});

--- a/application/state/terminalReconnectRegistry.test.ts
+++ b/application/state/terminalReconnectRegistry.test.ts
@@ -13,10 +13,16 @@ test('a registered terminal session can be reconnected on request', () => {
   assert.deepEqual(requestedSessionIds, ['session-1']);
 });
 
-test('requesting a terminal session without a mounted handler is a no-op', () => {
+test('requesting a terminal session before its handler mounts reconnects after registration', () => {
   const registry = createTerminalReconnectRegistry();
+  const requests: string[] = [];
 
-  assert.equal(registry.request('missing-session'), false);
+  assert.equal(registry.request('session-1'), true);
+  assert.deepEqual(requests, []);
+
+  registry.register('session-1', () => requests.push('session-1'));
+
+  assert.deepEqual(requests, ['session-1']);
 });
 
 test('cleanup only removes the handler that created it', () => {

--- a/application/state/terminalReconnectRegistry.ts
+++ b/application/state/terminalReconnectRegistry.ts
@@ -1,0 +1,25 @@
+type TerminalReconnectHandler = () => void;
+
+export const createTerminalReconnectRegistry = () => {
+  const handlers = new Map<string, TerminalReconnectHandler>();
+
+  const register = (sessionId: string, handler: TerminalReconnectHandler): (() => void) => {
+    handlers.set(sessionId, handler);
+    return () => {
+      if (handlers.get(sessionId) === handler) {
+        handlers.delete(sessionId);
+      }
+    };
+  };
+
+  const request = (sessionId: string): boolean => {
+    const handler = handlers.get(sessionId);
+    if (!handler) return false;
+    handler();
+    return true;
+  };
+
+  return { register, request };
+};
+
+export const terminalReconnectRegistry = createTerminalReconnectRegistry();

--- a/application/state/terminalReconnectRegistry.ts
+++ b/application/state/terminalReconnectRegistry.ts
@@ -2,9 +2,13 @@ type TerminalReconnectHandler = () => void;
 
 export const createTerminalReconnectRegistry = () => {
   const handlers = new Map<string, TerminalReconnectHandler>();
+  const pendingRequests = new Set<string>();
 
   const register = (sessionId: string, handler: TerminalReconnectHandler): (() => void) => {
     handlers.set(sessionId, handler);
+    if (pendingRequests.delete(sessionId)) {
+      handler();
+    }
     return () => {
       if (handlers.get(sessionId) === handler) {
         handlers.delete(sessionId);
@@ -14,7 +18,10 @@ export const createTerminalReconnectRegistry = () => {
 
   const request = (sessionId: string): boolean => {
     const handler = handlers.get(sessionId);
-    if (!handler) return false;
+    if (!handler) {
+      pendingRequests.add(sessionId);
+      return true;
+    }
     handler();
     return true;
   };

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -378,6 +378,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const hibernateRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fullHibernateRuntimeRef = useRef<(() => Promise<boolean>) | null>(null);
   const wakeInProgressRef = useRef(false);
+  const wakePromiseRef = useRef<Promise<boolean> | null>(null);
   const sessionRef = useRef<string | null>(null);
   const isBootActiveRef = useRef(false);
   const hasConnectedRef = useRef(false);
@@ -395,6 +396,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const startReconnectRef = useRef<((mode: "manual" | "auto") => void) | null>(null);
   const wakeHibernatedRuntimeForReconnectRef = useRef<(() => Promise<boolean>) | null>(null);
   const reconnectWakeInFlightRef = useRef(false);
+  const reconnectWakeTokenRef = useRef<symbol | null>(null);
   const manualReconnectRequestRef = useRef<() => void>(() => {});
   const terminalDataCapturedRef = useRef(false);
   const connectionLogBufferRef = useRef(createConnectionLogBuffer(MAX_CONNECTION_LOG_DATA_CHARS));
@@ -407,6 +409,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const mouseTrackingRef = useRef(false);
   const serialLineBufferRef = useRef<string>("");
   const telnetLocalEchoRef = useRef(false);
+
+  useEffect(() => () => {
+    reconnectWakeTokenRef.current = null;
+  }, [sessionId]);
 
   const terminalSettingsRef = useRef(terminalSettings);
   terminalSettingsRef.current = terminalSettings;
@@ -2341,8 +2347,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         return;
       }
       reconnectWakeInFlightRef.current = true;
+      const wakeToken = Symbol();
+      reconnectWakeTokenRef.current = wakeToken;
       updateStatus("connecting");
       void wakeForReconnect().then((woke) => {
+        if (reconnectWakeTokenRef.current !== wakeToken) return;
+        reconnectWakeTokenRef.current = null;
         reconnectWakeInFlightRef.current = false;
         if (woke) {
           startReconnectRef.current?.(mode);
@@ -2350,6 +2360,8 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         }
         updateStatus("disconnected");
       }).catch(() => {
+        if (reconnectWakeTokenRef.current !== wakeToken) return;
+        reconnectWakeTokenRef.current = null;
         reconnectWakeInFlightRef.current = false;
         updateStatus("disconnected");
       });
@@ -2770,10 +2782,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
     getPayload: () => TerminalHibernateWakePayload,
     options: { sessionConnected: boolean },
   ): boolean | Promise<boolean> => {
-    if (wakeInProgressRef.current || hasRuntimeRef.current) {
+    if (wakeInProgressRef.current) {
+      return wakePromiseRef.current ?? false;
+    }
+    if (hasRuntimeRef.current) {
       logger.warn("[Terminal] Wake skipped", {
         sessionId,
-        wakeInProgress: wakeInProgressRef.current,
         hasRuntime: hasRuntimeRef.current,
       });
       return false;
@@ -2809,7 +2823,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
     };
 
-    return wakeTerminalFromHibernate({
+    const wakePromise = wakeTerminalFromHibernate({
       refs: terminalRuntimeRefs,
       runtimeContext,
       container,
@@ -2833,7 +2847,12 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       return false;
     }).finally(() => {
       wakeInProgressRef.current = false;
+      if (wakePromiseRef.current === wakePromise) {
+        wakePromiseRef.current = null;
+      }
     });
+    wakePromiseRef.current = wakePromise;
+    return wakePromise;
   }, [sessionId, terminalBackend, terminalRuntimeRefs, resizeSession, terminalSettings]);
 
   wakeHibernatedRuntimeForReconnectRef.current = async () => {

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -57,6 +57,7 @@ import { useStoredBoolean } from "../application/state/useStoredBoolean";
 import { readOptionalStoredStringValue, useStoredString } from "../application/state/useStoredString";
 import { useSessionLogBackend } from "../application/state/useSessionLogBackend";
 import { useTerminalLayoutSuppressActive } from "../application/state/terminalLayoutSuppressStore";
+import { terminalReconnectRegistry } from "../application/state/terminalReconnectRegistry";
 // SFTPModal removed - SFTP is now handled by SftpSidePanel in TerminalLayer
 import { Button } from "./ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "./ui/hover-card";
@@ -393,6 +394,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const autoReconnectAttemptRef = useRef(0);
   const startReconnectRef = useRef<((mode: "manual" | "auto") => void) | null>(null);
   const wakeHibernatedRuntimeForReconnectRef = useRef<(() => Promise<boolean>) | null>(null);
+  const manualReconnectRequestRef = useRef<() => void>(() => {});
   const terminalDataCapturedRef = useRef(false);
   const connectionLogBufferRef = useRef(createConnectionLogBuffer(MAX_CONNECTION_LOG_DATA_CHARS));
   const terminalLogSanitizerRef = useRef(createReplaySafeTerminalLogSanitizer());
@@ -2330,7 +2332,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   };
 
   const startReconnect = (mode: "manual" | "auto" = "manual") => {
-    if (!termRef.current && mode === "auto" && hibernatedRef.current) {
+    if (!termRef.current && hibernatedRef.current) {
       const wakeForReconnect = wakeHibernatedRuntimeForReconnectRef.current;
       if (!wakeForReconnect) {
         updateStatus("disconnected");
@@ -2338,7 +2340,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       }
       void wakeForReconnect().then((woke) => {
         if (woke) {
-          startReconnectRef.current?.("auto");
+          startReconnectRef.current?.(mode);
           return;
         }
         updateStatus("disconnected");
@@ -2437,6 +2439,11 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const handleRetry = () => {
     startReconnect("manual");
   };
+  manualReconnectRequestRef.current = handleRetry;
+  useEffect(() => terminalReconnectRegistry.register(
+    sessionId,
+    () => manualReconnectRequestRef.current(),
+  ), [sessionId]);
 
   const shouldShowConnectionDialog = shouldShowTerminalConnectionDialog({
     status,
@@ -2834,7 +2841,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       alternateScreen: hibernateAlternateScreenRef.current,
     });
 
-    logger.info("[Terminal] Waking hibernated runtime for auto reconnect", {
+    logger.info("[Terminal] Waking hibernated runtime for reconnect", {
       sessionId,
       snapshotChars: hibernateSnapshotRef.current.length,
       viewportChars: hibernateViewportSnapshotRef.current.length,

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2351,7 +2351,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
       reconnectWakeTokenRef.current = wakeToken;
       updateStatus("connecting");
       void wakeForReconnect().then((woke) => {
-        if (reconnectWakeTokenRef.current !== wakeToken) return;
+        if (reconnectWakeTokenRef.current !== wakeToken) {
+          disposeRuntimeOnly();
+          return;
+        }
         reconnectWakeTokenRef.current = null;
         reconnectWakeInFlightRef.current = false;
         if (woke) {
@@ -2360,7 +2363,10 @@ const TerminalComponent: React.FC<TerminalProps> = ({
         }
         updateStatus("disconnected");
       }).catch(() => {
-        if (reconnectWakeTokenRef.current !== wakeToken) return;
+        if (reconnectWakeTokenRef.current !== wakeToken) {
+          disposeRuntimeOnly();
+          return;
+        }
         reconnectWakeTokenRef.current = null;
         reconnectWakeInFlightRef.current = false;
         updateStatus("disconnected");

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -394,6 +394,7 @@ const TerminalComponent: React.FC<TerminalProps> = ({
   const autoReconnectAttemptRef = useRef(0);
   const startReconnectRef = useRef<((mode: "manual" | "auto") => void) | null>(null);
   const wakeHibernatedRuntimeForReconnectRef = useRef<(() => Promise<boolean>) | null>(null);
+  const reconnectWakeInFlightRef = useRef(false);
   const manualReconnectRequestRef = useRef<() => void>(() => {});
   const terminalDataCapturedRef = useRef(false);
   const connectionLogBufferRef = useRef(createConnectionLogBuffer(MAX_CONNECTION_LOG_DATA_CHARS));
@@ -2333,16 +2334,23 @@ const TerminalComponent: React.FC<TerminalProps> = ({
 
   const startReconnect = (mode: "manual" | "auto" = "manual") => {
     if (!termRef.current && hibernatedRef.current) {
+      if (reconnectWakeInFlightRef.current) return;
       const wakeForReconnect = wakeHibernatedRuntimeForReconnectRef.current;
       if (!wakeForReconnect) {
         updateStatus("disconnected");
         return;
       }
+      reconnectWakeInFlightRef.current = true;
+      updateStatus("connecting");
       void wakeForReconnect().then((woke) => {
+        reconnectWakeInFlightRef.current = false;
         if (woke) {
           startReconnectRef.current?.(mode);
           return;
         }
+        updateStatus("disconnected");
+      }).catch(() => {
+        reconnectWakeInFlightRef.current = false;
         updateStatus("disconnected");
       });
       return;

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -100,22 +100,37 @@ test("auto reconnect connected history ref is initialized after status state exi
 
 test("reconnect wakes a hibernated terminal before requiring a terminal instance", () => {
   const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const wakePromiseRefIndex = source.indexOf("const wakePromiseRef = useRef<Promise<boolean> | null>(null)");
   const wakeGuardRefIndex = source.indexOf("const reconnectWakeInFlightRef = useRef(false)");
+  const wakeTokenRefIndex = source.indexOf("const reconnectWakeTokenRef = useRef<symbol | null>(null)");
+  const wakeTokenCleanupIndex = source.indexOf("reconnectWakeTokenRef.current = null", wakeTokenRefIndex);
   const reconnectIndex = source.indexOf("const startReconnect = ");
   const hibernatedBranchIndex = source.indexOf('!termRef.current && hibernatedRef.current', reconnectIndex);
   const duplicateWakeGuardIndex = source.indexOf("if (reconnectWakeInFlightRef.current) return", hibernatedBranchIndex);
   const markWakeInFlightIndex = source.indexOf("reconnectWakeInFlightRef.current = true", duplicateWakeGuardIndex);
   const connectingIndex = source.indexOf('updateStatus("connecting")', markWakeInFlightIndex);
   const wakeCallIndex = source.indexOf("wakeHibernatedRuntimeForReconnectRef.current", hibernatedBranchIndex);
+  const wakeInvocationIndex = source.indexOf("void wakeForReconnect()", wakeCallIndex);
+  const wakeJoinIndex = source.indexOf("return wakePromiseRef.current ?? false", source.indexOf("const wakeFromHibernateRuntime"));
+  const wakeTokenIndex = source.indexOf("const wakeToken = Symbol()", hibernatedBranchIndex);
+  const staleWakeGuardIndex = source.indexOf("reconnectWakeTokenRef.current !== wakeToken", wakeInvocationIndex);
   const missingTermReturnIndex = source.indexOf("if (!termRef.current) return;", reconnectIndex);
 
+  assert.notEqual(wakePromiseRefIndex, -1);
   assert.notEqual(wakeGuardRefIndex, -1);
+  assert.notEqual(wakeTokenRefIndex, -1);
+  assert.notEqual(wakeTokenCleanupIndex, -1);
+  assert.ok(wakeTokenCleanupIndex < reconnectIndex);
   assert.notEqual(reconnectIndex, -1);
   assert.notEqual(hibernatedBranchIndex, -1);
   assert.notEqual(duplicateWakeGuardIndex, -1);
   assert.notEqual(markWakeInFlightIndex, -1);
   assert.notEqual(connectingIndex, -1);
   assert.notEqual(wakeCallIndex, -1);
+  assert.notEqual(wakeInvocationIndex, -1);
+  assert.notEqual(wakeJoinIndex, -1);
+  assert.notEqual(wakeTokenIndex, -1);
+  assert.notEqual(staleWakeGuardIndex, -1);
   assert.notEqual(missingTermReturnIndex, -1);
   assert.ok(
     hibernatedBranchIndex < missingTermReturnIndex && wakeCallIndex < missingTermReturnIndex,
@@ -124,6 +139,10 @@ test("reconnect wakes a hibernated terminal before requiring a terminal instance
   assert.ok(
     duplicateWakeGuardIndex < markWakeInFlightIndex && markWakeInFlightIndex < connectingIndex,
     "hibernated reconnect must block duplicate requests before beginning an asynchronous wake",
+  );
+  assert.ok(
+    wakeTokenIndex < wakeInvocationIndex && wakeInvocationIndex < staleWakeGuardIndex,
+    "closing a terminal must be able to invalidate a pending hibernated reconnect",
   );
 });
 

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -98,20 +98,20 @@ test("auto reconnect connected history ref is initialized after status state exi
   );
 });
 
-test("auto reconnect wakes a hibernated terminal before requiring a terminal instance", () => {
+test("reconnect wakes a hibernated terminal before requiring a terminal instance", () => {
   const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
   const reconnectIndex = source.indexOf("const startReconnect = ");
-  const hibernatedAutoBranchIndex = source.indexOf('mode === "auto" && hibernatedRef.current', reconnectIndex);
-  const wakeCallIndex = source.indexOf("wakeHibernatedRuntimeForReconnectRef.current", hibernatedAutoBranchIndex);
+  const hibernatedBranchIndex = source.indexOf('!termRef.current && hibernatedRef.current', reconnectIndex);
+  const wakeCallIndex = source.indexOf("wakeHibernatedRuntimeForReconnectRef.current", hibernatedBranchIndex);
   const missingTermReturnIndex = source.indexOf("if (!termRef.current) return;", reconnectIndex);
 
   assert.notEqual(reconnectIndex, -1);
-  assert.notEqual(hibernatedAutoBranchIndex, -1);
+  assert.notEqual(hibernatedBranchIndex, -1);
   assert.notEqual(wakeCallIndex, -1);
   assert.notEqual(missingTermReturnIndex, -1);
   assert.ok(
-    hibernatedAutoBranchIndex < missingTermReturnIndex && wakeCallIndex < missingTermReturnIndex,
-    "auto reconnect must wake fully hibernated SSH sessions before the terminal guard can stop the retry",
+    hibernatedBranchIndex < missingTermReturnIndex && wakeCallIndex < missingTermReturnIndex,
+    "manual and auto reconnect must wake fully hibernated sessions before the terminal guard can stop the retry",
   );
 });
 

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -100,18 +100,30 @@ test("auto reconnect connected history ref is initialized after status state exi
 
 test("reconnect wakes a hibernated terminal before requiring a terminal instance", () => {
   const source = readFileSync(new URL("../Terminal.tsx", import.meta.url), "utf8");
+  const wakeGuardRefIndex = source.indexOf("const reconnectWakeInFlightRef = useRef(false)");
   const reconnectIndex = source.indexOf("const startReconnect = ");
   const hibernatedBranchIndex = source.indexOf('!termRef.current && hibernatedRef.current', reconnectIndex);
+  const duplicateWakeGuardIndex = source.indexOf("if (reconnectWakeInFlightRef.current) return", hibernatedBranchIndex);
+  const markWakeInFlightIndex = source.indexOf("reconnectWakeInFlightRef.current = true", duplicateWakeGuardIndex);
+  const connectingIndex = source.indexOf('updateStatus("connecting")', markWakeInFlightIndex);
   const wakeCallIndex = source.indexOf("wakeHibernatedRuntimeForReconnectRef.current", hibernatedBranchIndex);
   const missingTermReturnIndex = source.indexOf("if (!termRef.current) return;", reconnectIndex);
 
+  assert.notEqual(wakeGuardRefIndex, -1);
   assert.notEqual(reconnectIndex, -1);
   assert.notEqual(hibernatedBranchIndex, -1);
+  assert.notEqual(duplicateWakeGuardIndex, -1);
+  assert.notEqual(markWakeInFlightIndex, -1);
+  assert.notEqual(connectingIndex, -1);
   assert.notEqual(wakeCallIndex, -1);
   assert.notEqual(missingTermReturnIndex, -1);
   assert.ok(
     hibernatedBranchIndex < missingTermReturnIndex && wakeCallIndex < missingTermReturnIndex,
     "manual and auto reconnect must wake fully hibernated sessions before the terminal guard can stop the retry",
+  );
+  assert.ok(
+    duplicateWakeGuardIndex < markWakeInFlightIndex && markWakeInFlightIndex < connectingIndex,
+    "hibernated reconnect must block duplicate requests before beginning an asynchronous wake",
   );
 });
 

--- a/components/terminal/restoredSessionGate.test.ts
+++ b/components/terminal/restoredSessionGate.test.ts
@@ -114,6 +114,7 @@ test("reconnect wakes a hibernated terminal before requiring a terminal instance
   const wakeJoinIndex = source.indexOf("return wakePromiseRef.current ?? false", source.indexOf("const wakeFromHibernateRuntime"));
   const wakeTokenIndex = source.indexOf("const wakeToken = Symbol()", hibernatedBranchIndex);
   const staleWakeGuardIndex = source.indexOf("reconnectWakeTokenRef.current !== wakeToken", wakeInvocationIndex);
+  const staleWakeDisposeIndex = source.indexOf("disposeRuntimeOnly();", staleWakeGuardIndex);
   const missingTermReturnIndex = source.indexOf("if (!termRef.current) return;", reconnectIndex);
 
   assert.notEqual(wakePromiseRefIndex, -1);
@@ -131,6 +132,7 @@ test("reconnect wakes a hibernated terminal before requiring a terminal instance
   assert.notEqual(wakeJoinIndex, -1);
   assert.notEqual(wakeTokenIndex, -1);
   assert.notEqual(staleWakeGuardIndex, -1);
+  assert.notEqual(staleWakeDisposeIndex, -1);
   assert.notEqual(missingTermReturnIndex, -1);
   assert.ok(
     hibernatedBranchIndex < missingTermReturnIndex && wakeCallIndex < missingTermReturnIndex,
@@ -143,6 +145,10 @@ test("reconnect wakes a hibernated terminal before requiring a terminal instance
   assert.ok(
     wakeTokenIndex < wakeInvocationIndex && wakeInvocationIndex < staleWakeGuardIndex,
     "closing a terminal must be able to invalidate a pending hibernated reconnect",
+  );
+  assert.ok(
+    staleWakeGuardIndex < staleWakeDisposeIndex,
+    "an invalidated hibernated wake must dispose any runtime created after unmount cleanup",
   );
 });
 

--- a/components/terminalLayer/TerminalFocusSidebar.tsx
+++ b/components/terminalLayer/TerminalFocusSidebar.tsx
@@ -2,6 +2,7 @@ import { Circle, Columns2, Plus, Search, Server } from 'lucide-react';
 import React, { memo, useCallback, useMemo, useState, type DragEvent, type MouseEvent } from 'react';
 
 import { useStoredNumber } from '../../application/state/useStoredNumber';
+import { terminalReconnectRegistry } from '../../application/state/terminalReconnectRegistry';
 import { resolveWorkspaceFocusSessionOrder } from '../../domain/workspace';
 import { resolveSessionTabTitle } from '../../domain/sessionTabTitle';
 import type { DynamicTabTitleMode } from '../../domain/models';
@@ -204,6 +205,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
         onCopySession={onCopySession}
         onCopySessionToNewWindow={onCopySessionToNewWindow}
         onDetachSession={onDetachSessionFromWorkspace}
+        onReconnectSession={terminalReconnectRegistry.request}
         onRenameSession={onStartRename}
         t={t}
       />

--- a/components/terminalLayer/TerminalFocusSidebar.tsx
+++ b/components/terminalLayer/TerminalFocusSidebar.tsx
@@ -206,6 +206,7 @@ const WorkspaceFocusSessionRow = memo<WorkspaceFocusSessionRowProps>(({
         onCopySessionToNewWindow={onCopySessionToNewWindow}
         onDetachSession={onDetachSessionFromWorkspace}
         onReconnectSession={terminalReconnectRegistry.request}
+        sessionStatus={session.status}
         onRenameSession={onStartRename}
         t={t}
       />

--- a/components/top-tabs/SessionTabContextMenuContent.test.ts
+++ b/components/top-tabs/SessionTabContextMenuContent.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSessionReconnectDisabled } from './SessionTabContextMenuContent';
+
+test('reconnect is disabled while a session is still connecting', () => {
+  assert.equal(isSessionReconnectDisabled('connecting'), true);
+  assert.equal(isSessionReconnectDisabled('connected'), false);
+  assert.equal(isSessionReconnectDisabled('disconnected'), false);
+});

--- a/components/top-tabs/SessionTabContextMenuContent.tsx
+++ b/components/top-tabs/SessionTabContextMenuContent.tsx
@@ -11,6 +11,7 @@ interface SessionTabContextMenuContentProps {
   onCopySession?: (sessionId: string) => void;
   onCopySessionToNewWindow?: (sessionId: string) => void;
   onDetachSession?: (sessionId: string) => void;
+  onReconnectSession: (sessionId: string) => void;
   onRenameSession: (sessionId: string) => void;
   renderBulkCloseItems?: (anchorId: string) => React.ReactNode;
   t: TranslateFn;
@@ -22,12 +23,16 @@ export function SessionTabContextMenuContent({
   onCopySession,
   onCopySessionToNewWindow,
   onDetachSession,
+  onReconnectSession,
   onRenameSession,
   renderBulkCloseItems,
   t,
 }: SessionTabContextMenuContentProps) {
   return (
     <ContextMenuContent>
+      <ContextMenuItem onClick={() => onReconnectSession(sessionId)}>
+        {t('terminal.menu.reconnect')}
+      </ContextMenuItem>
       <ContextMenuItem onClick={() => onRenameSession(sessionId)}>
         {t('common.rename')}
       </ContextMenuItem>

--- a/components/top-tabs/SessionTabContextMenuContent.tsx
+++ b/components/top-tabs/SessionTabContextMenuContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type { useI18n } from '../../application/i18n/I18nProvider';
+import type { TerminalSession } from '../../types';
 import { ContextMenuContent, ContextMenuItem } from '../ui/context-menu';
 
 type TranslateFn = ReturnType<typeof useI18n>['t'];
@@ -12,6 +13,7 @@ interface SessionTabContextMenuContentProps {
   onCopySessionToNewWindow?: (sessionId: string) => void;
   onDetachSession?: (sessionId: string) => void;
   onReconnectSession: (sessionId: string) => void;
+  sessionStatus: TerminalSession['status'];
   onRenameSession: (sessionId: string) => void;
   renderBulkCloseItems?: (anchorId: string) => React.ReactNode;
   t: TranslateFn;
@@ -24,13 +26,17 @@ export function SessionTabContextMenuContent({
   onCopySessionToNewWindow,
   onDetachSession,
   onReconnectSession,
+  sessionStatus,
   onRenameSession,
   renderBulkCloseItems,
   t,
 }: SessionTabContextMenuContentProps) {
   return (
     <ContextMenuContent>
-      <ContextMenuItem onClick={() => onReconnectSession(sessionId)}>
+      <ContextMenuItem
+        disabled={isSessionReconnectDisabled(sessionStatus)}
+        onClick={() => onReconnectSession(sessionId)}
+      >
         {t('terminal.menu.reconnect')}
       </ContextMenuItem>
       <ContextMenuItem onClick={() => onRenameSession(sessionId)}>
@@ -58,3 +64,7 @@ export function SessionTabContextMenuContent({
     </ContextMenuContent>
   );
 }
+
+export const isSessionReconnectDisabled = (status: TerminalSession['status']): boolean => (
+  status === 'connecting'
+);

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -687,6 +687,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
         onCopySession={onCopySession}
         onCopySessionToNewWindow={onCopySessionToNewWindow}
         onReconnectSession={terminalReconnectRegistry.request}
+        sessionStatus={session.status}
         onRenameSession={onRenameSession}
         renderBulkCloseItems={renderBulkCloseItems}
         t={t}

--- a/components/top-tabs/TopTabItems.tsx
+++ b/components/top-tabs/TopTabItems.tsx
@@ -4,6 +4,7 @@ import { activeTabStore, useActiveTabId, useIsTabActive } from '../../applicatio
 import type { EditorTab } from '../../application/state/editorTabStore';
 import type { LogView } from '../../application/state/logViewState';
 import { useWindowControls } from '../../application/state/useWindowControls';
+import { terminalReconnectRegistry } from '../../application/state/terminalReconnectRegistry';
 import { useI18n } from '../../application/i18n/I18nProvider';
 import { getEffectiveHostDistro } from '../../domain/host';
 import { resolveHostIconAppearance, resolveHostIconColorAppearance } from '../../domain/hostIcon';
@@ -685,6 +686,7 @@ export const SessionTopTab: React.FC<SessionTopTabProps> = memo(({
         onCloseSession={onCloseSession}
         onCopySession={onCopySession}
         onCopySessionToNewWindow={onCopySessionToNewWindow}
+        onReconnectSession={terminalReconnectRegistry.request}
         onRenameSession={onRenameSession}
         renderBulkCloseItems={renderBulkCloseItems}
         t={t}


### PR DESCRIPTION
## Summary

- add a Reconnect action to terminal tab context menus
- route tab reconnects through the existing terminal reconnect flow
- wake hibernated terminals before a manual reconnect

## Validation

- npm test (5,411 passed, 3 skipped)
- npm run lint (no errors; 3 pre-existing warnings)
- npm run build
- manually verified the menu action reconnects a live local terminal

Closes #1905