### PR TITLE
fix(mosh): restore Windows auth ACL helper

### DIFF
--- a/electron/bridges/terminalBridge.bundledMosh.test.cjs
+++ b/electron/bridges/terminalBridge.bundledMosh.test.cjs
@@ -84,7 +84,7 @@ test("bundledMoshClient uses .exe basename on win32 (when running on a POSIX hos
   assert.equal(result, winBin);
 });
 
-test("bundledMoshClient ignores non-executable matches", () => {
+test("bundledMoshClient ignores non-executable matches", { skip: process.platform === "win32" }, () => {
   const projectRoot = makeTmp();
   const candidate = path.join(projectRoot, "resources", "mosh", "linux-x64", "mosh-client");
   fs.mkdirSync(path.dirname(candidate), { recursive: true });

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -1,4 +1,6 @@
 /* eslint-disable no-undef */
+const { execFile } = require("node:child_process");
+const { promisify } = require("node:util");
 const { emitTerminalSessionData } = require("../emitTerminalSessionData.cjs");
 const {
   setBufferedOutputBytes,
@@ -7,6 +9,8 @@ const {
 } = require("../terminalFlowAck.cjs");
 const { createSshConnExecProbe } = require("../ai/sessionShellKind.cjs");
 const { orderSshIdentityNames, SSH_KEY_PATTERN } = require("../sshAuthHelper.cjs");
+
+const execFileAsync = promisify(execFile);
 
 // MoshCatty normally emits this cleanup together with an alternate-screen
 // exit. Netcatty keeps the primary screen, so restore only terminal modes that


### PR DESCRIPTION
## Summary

- Define `execFileAsync` inside the extracted Mosh session module so Windows ACL hardening for temporary auth files can run when Mosh uses agent-selected public keys or temp key material.
- Skip the POSIX execute-bit bundled-client assertion on Windows, where the runtime intentionally treats regular files as spawn candidates.

## Root Cause

`moshSession.cjs` was split out from `terminalBridge.cjs` but still called `execFileAsync` from the old module scope. On Windows, the temp auth file permission path could fail with `execFileAsync is not defined` before OpenSSH was started.

## Validation

- `node --test electron\bridges\terminalBridge.bundledMosh.test.cjs electron\bridges\terminalBridge.bareMoshClient.test.cjs`
- `node --test electron\bridges\moshHandshake.test.cjs electron\bridges\terminalBridge.moshHandshakeSession.test.cjs`
- Live Windows Mosh smoke test against the provided host using current `main` + MoshCatty `0.1.7`
- `npm run dev` starts successfully with `MOSH_BIN_RELEASE=moshcatty-0.1.7` and `ET_BIN_RELEASE=et-bin-6.2.10-1`