### PR TITLE
fix(mosh): clear SSH bootstrap residue on handoff

### DIFF
--- a/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
+++ b/electron/bridges/terminalBridge.moshHandshakeSession.test.cjs
@@ -595,6 +595,32 @@ test("startMoshSession tags handshake output and emits ready after mosh-client s
   assert.equal(h.sessions.get("mosh-test-session")?.moshHandshakePhase, "mosh-client");
 });
 
+test("startMoshSession clears successful SSH bootstrap output before the Mosh screen", async (t) => {
+  const h = makeHarness(t);
+  await h.bridge.startMoshSession(h.event, h.options, { moshClientLookup: h.lookupOpts });
+
+  h.spawns[0].emitData(
+    "Welcome to Ubuntu\r\nmosh-server (mosh 1.4.0)\r\nLicense GPLv3+\r\n",
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  h.spawns[0].emitData("MOSH CONNECT 60002 ABCDEFGHIJKLMNOPQRSTUV==\r\n");
+  h.spawns[0].emitExit({ exitCode: 0, signal: 0 });
+  h.spawns[1].emitData(Buffer.from("root@example:~# "));
+  await new Promise((resolve) => h.sessions.get("mosh-test-session").flushPendingData(resolve));
+
+  const terminalData = h.sent
+    .filter((evt) => evt.channel === "netcatty:data")
+    .map((evt) => evt.payload.data)
+    .join("");
+  const bootstrapIndex = terminalData.indexOf("Welcome to Ubuntu");
+  const clearIndex = terminalData.indexOf("\x1b[2J\x1b[H");
+  const promptIndex = terminalData.indexOf("root@example:~# ");
+
+  assert.ok(bootstrapIndex >= 0, "the interactive SSH bootstrap should remain visible while connecting");
+  assert.ok(clearIndex > bootstrapIndex, "the successful handoff should clear bootstrap cells");
+  assert.ok(promptIndex > clearIndex, "the Mosh screen should render onto the cleared viewport");
+});
+
 test("startMoshSession stashes stats-companion auth after a successful handshake", async (t) => {
   const h = makeHarness(t);
   await h.bridge.startMoshSession(

--- a/electron/bridges/terminalBridge/moshSession.cjs
+++ b/electron/bridges/terminalBridge/moshSession.cjs
@@ -19,6 +19,13 @@ const MOSH_PRIMARY_SCREEN_RESET = "\x1b[?1l\x1b[0m\x1b[?25h"
   + "\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l"
   + "\x1b[?1015l\x1b[?1006l\x1b[?1005l";
 
+// The interactive SSH bootstrap can paint password prompts, MOTD text, and
+// mosh-server diagnostics into Netcatty's primary screen. MoshCatty then
+// reconstructs only the cells present in the remote Mosh state, so untouched
+// bootstrap cells would remain visible around the new shell. Clear the current
+// viewport at the successful handoff while preserving primary-screen scrollback.
+const MOSH_HANDSHAKE_VIEWPORT_RESET = "\x1b[2J\x1b[H";
+
 function withShellProbeTimeout(promise, timeoutMs) {
   const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 3000;
   let timer = null;
@@ -668,6 +675,11 @@ function createMoshSessionApi(ctx) {
       session.proc = mcPty;
       session.pty = mcPty;
       session.moshHandshakePhase = "mosh-client";
+
+      // Establish the blank terminal baseline that mosh-client expects before
+      // its first reconstructed frame. Keep this ordered through the same
+      // output buffer as both the SSH bootstrap and Mosh client data.
+      bufferData(MOSH_HANDSHAKE_VIEWPORT_RESET);
 
       // Notify the renderer that the interactive mosh shell is ready. This is
       // distinct from the first SSH-handshake bytes (which can mark the


### PR DESCRIPTION
## What changed

- Clear the visible SSH bootstrap screen at the successful Mosh handoff.
- Keep interactive login prompts visible while connecting and preserve scrollback.
- Add a regression test covering Ubuntu MOTD and mosh-server text followed by the Mosh shell.

## Why

The SSH bootstrap and Mosh client share Netcatty's primary terminal screen. The Mosh client reconstructs only cells present in its remote state, so untouched SSH bootstrap cells could remain visible around the new shell.

## User impact

Mosh sessions no longer retain login banners, mosh-server diagnostics, or other stale text after connecting.

## Validation

- Reproduced in Netcatty Dev on macOS before the fix.
- Confirmed visually by the reporter after the fix.
- `npm test`: 5494 tests, 0 failures.
- `npm run lint`: 0 errors.
- `npm run build`: passed.
