### PR TITLE
chore: clear remaining lint warnings

### DIFF
--- a/application/state/settingsStorageSync.ts
+++ b/application/state/settingsStorageSync.ts
@@ -496,6 +496,7 @@ export function useSettingsStorageSync({
     setEditorWordWrapState,
     setFollowAppTerminalThemeState,
     setGlobalHotkeyEnabled,
+    setHostClickBehaviorState,
     setWindowOpacity,
     setAppIconVariant,
     setHotkeyScheme,

--- a/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.et.test.ts
@@ -333,31 +333,6 @@ test("startEt connects with a single resolved jump host", async () => {
   assert.deepEqual(jumpHosts[0]?.identityFilePaths, ["/Users/alice/.ssh/jump_ed25519"]);
 });
 
-test("startEt forwards MFA mode for target and jump host", async () => {
-  let captured: Record<string, unknown> | null = null;
-  const backend = makeBackend((options) => { captured = options; });
-  const ctx = makeCtx(
-    {
-      authMethod: "password",
-      password: "target-secret",
-      hostChain: { hostIds: ["jump-1"] },
-    },
-    [{
-      id: "jump-1",
-      label: "Jump",
-      hostname: "jump.example.test",
-      username: "jumper",
-      authMethod: "password",
-      password: "jump-secret",
-    }],
-    backend,
-  );
-
-  await createTerminalSessionStarters(ctx as never).startEt(term as never);
-
-  const jumpHosts = captured?.jumpHosts as Array<Record<string, unknown>>;
-});
-
 test("startEt forwards a jump host's custom ET port", async () => {
   let captured: Record<string, unknown> | null = null;
   const backend = makeBackend((options) => { captured = options; });

--- a/components/terminal/runtime/createTerminalSessionStarters.test.ts
+++ b/components/terminal/runtime/createTerminalSessionStarters.test.ts
@@ -231,36 +231,6 @@ for (const protocol of ["Mosh", "ET"] as const) {
   });
 }
 
-test("Mosh forwards host MFA mode to the bridge", async () => {
-  let capturedOptions: Record<string, unknown> | null = null;
-  const terminalBackend = {
-    moshAvailable: () => true,
-    startMoshSession: async (options: Record<string, unknown>) => {
-      capturedOptions = options;
-      return "mosh-session";
-    },
-    onMoshSessionReady: () => noop,
-    onSessionData: () => noop,
-    onSessionExit: () => noop,
-    writeToSession: noop,
-    resizeSession: noop,
-  };
-  const ctx = createStarterContext({
-    host: {
-      id: "host-1",
-      label: "Mosh MFA host",
-      hostname: "mosh-mfa.example.test",
-      username: "alice",
-      authMethod: "password",
-      password: "saved-secret",
-    },
-    terminalBackend,
-  });
-
-  await createTerminalSessionStarters(ctx as never).startMosh(createTermStub() as never);
-
-});
-
 for (const protocol of ["Mosh", "ET"] as const) {
   test(`${protocol} keeps an imported private key when agent filtering is unavailable`, async () => {
     let capturedOptions: Record<string, unknown> | null = null;

--- a/components/terminal/runtime/terminalSessionAttachment.test.ts
+++ b/components/terminal/runtime/terminalSessionAttachment.test.ts
@@ -456,7 +456,7 @@ test("writeSessionData keeps the current perf trace when hidden output is flushe
     logs.push(String(message));
   };
   try {
-    withAnimationFrameQueue((schedule) => {
+    withAnimationFrameQueue(() => {
       withDocumentVisibility("hidden", () => {
         writeSessionData(ctx as never, term, payload, payload.length, {
           terminalPerf: {

--- a/components/terminalLayer/TerminalLayerSidePanelSection.tsx
+++ b/components/terminalLayer/TerminalLayerSidePanelSection.tsx
@@ -293,7 +293,7 @@ function TerminalLayerSidePanelInner({ ctx }: { ctx: SidePanelContext }) {
       };
     }
     return parts;
-  }, [activeSidePanelTab, partitionSidePanelTabs, sidePanelTabLayout]);
+  }, [activeSidePanelTab, partitionSidePanelTabs]);
 
   const sidePanelCustomizeItems = useMemo(
     () =>


### PR DESCRIPTION
## What changed

- Add the missing cross-window host-click dependency.
- Remove a redundant side-panel dependency and an unused test callback parameter.
- Delete two obsolete MFA tests that had no assertions after the host MFA switch was removed.

## Why

The remaining lint warnings mixed real dependency drift with stale test scaffolding. Keeping the suite warning-free makes new issues visible instead of hiding them in known noise.

## User impact

No product behavior changes. Cross-window host-click syncing keeps its complete dependency list, while stale no-op test cases are removed.

## Validation

- `npm run lint`: 0 warnings, 0 errors.
- `npm test`: 5492 tests, 0 failures.
- `npm run build`: passed.
