### PR TITLE
Update Nix release metadata for v1.1.67

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,14 +1,14 @@
 {
-  version = "1.1.64";
+  version = "1.1.67";
 
   sources = {
     x86_64-linux = {
       appImageArch = "x86_64";
-      hash = "sha256-6VSo6FSvZUnSNsw0PZdi7/dq/AHk/XNEQdV0qEikWxE=";
+      hash = "sha256-DYE1/TwtKh/cW/mnLZRe4dJjrH3KotlqXDn7FjXOpuk=";
     };
     aarch64-linux = {
       appImageArch = "arm64";
-      hash = "sha256-euB5E0C/4oBlQ0WP8hmcsN5IDyjo+XFnkr2Id3yPcpI=";
+      hash = "sha256-SpAQnUQw366XMjj98XB4vE77g8Seuq78DMSF0tqogV4=";
     };
   };
 }


### PR DESCRIPTION
## What changed

- update Nix release metadata to v1.1.67
- use the published x64 and ARM64 AppImage hashes

## Why

The release job generated this update successfully, but the automatic direct push was rejected because `main` is protected and requires a pull request.

## Validation

- Nix metadata test passed
- both hashes match the SHA-256 digests on the published v1.1.67 AppImage assets